### PR TITLE
[8_0_X] Support vector<string> data products in friendly class name

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -42,6 +42,8 @@ namespace edm {
     static boost::regex const reWrapper("edm::Wrapper<(.*)>");
     static boost::regex const reString("std::basic_string<char>");
     static boost::regex const reString2("std::string");
+    static boost::regex const reStringCXX11("std::__cxx11::basic_string<char>");
+    static boost::regex const reString2CXX11("std::__cxx11::basic_string<char,std::char_traits<char> >");
     static boost::regex const reSorted("edm::SortedCollection<(.*), *edm::StrictWeakOrdering<\\1 *> >");
     static boost::regex const reULongLong("ULong64_t");
     static boost::regex const reLongLong("Long64_t");
@@ -77,6 +79,8 @@ namespace edm {
        name = regex_replace(name,reAIKR,"");
        name = regex_replace(name,reString,"String");
        name = regex_replace(name,reString2,"String");
+       name = regex_replace(name,reStringCXX11,"String");
+       name = regex_replace(name,reString2CXX11,"String");
        name = regex_replace(name,reSorted,"sSorted<$1>");
        name = regex_replace(name,reULongLong,"ull");
        name = regex_replace(name,reLongLong,"ll");

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -48,6 +48,8 @@ namespace edm {
     static boost::regex const reUnsigned("unsigned ");
     static boost::regex const reLong("long ");
     static boost::regex const reVector("std::vector");
+    static boost::regex const reSharedPtr("std::shared_ptr");
+    static boost::regex const reUniquePtr("std::unique_ptr");
     static boost::regex const reAIKR(", *edm::helper::AssociationIdenticalKeyReference"); //this is a default so can replaced with empty
     //force first argument to also be the argument to edm::ClonePolicy so that if OwnVector is within
     // a template it will not eat all the remaining '>'s
@@ -67,6 +69,7 @@ namespace edm {
     static boost::regex const reToRefs2("edm::RefVector< *(.*) *, *(.*) *, *edm::refhelper::FindUsingAdvance< *\\1, *\\2 *> *>");
     static boost::regex const reToRefsAssoc("edm::RefVector< *Association(.*) *, *edm::helper(.*), *Association(.*)::Find>");
     
+    
     std::string standardRenames(std::string const& iIn) {
        using boost::regex_replace;
        using boost::regex;
@@ -80,6 +83,8 @@ namespace edm {
        name = regex_replace(name,reUnsigned,"u");
        name = regex_replace(name,reLong,"l");
        name = regex_replace(name,reVector,"s");
+       name = regex_replace(name,reSharedPtr,"SharedPtr");
+       name = regex_replace(name,reUniquePtr,"UniquePtr");
        name = regex_replace(name,reOwnVector,"sOwned<$1>");
        name = regex_replace(name,reToVector,"AssociationVector<$1,To,$2>");
        name = regex_replace(name,reOneToOne,"Association<$1,ToOne,$2>");

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -42,8 +42,9 @@ namespace edm {
     static boost::regex const reWrapper("edm::Wrapper<(.*)>");
     static boost::regex const reString("std::basic_string<char>");
     static boost::regex const reString2("std::string");
-    static boost::regex const reStringCXX11("std::__cxx11::basic_string<char>");
-    static boost::regex const reString2CXX11("std::__cxx11::basic_string<char,std::char_traits<char> >");
+    static boost::regex const reString3("std::basic_string<char,std::char_traits<char> >");
+    //The c++11 abi for gcc internally uses a different namespace for standard classes
+    static boost::regex const reCXX11("std::__cxx11::");
     static boost::regex const reSorted("edm::SortedCollection<(.*), *edm::StrictWeakOrdering<\\1 *> >");
     static boost::regex const reULongLong("ULong64_t");
     static boost::regex const reLongLong("Long64_t");
@@ -77,10 +78,10 @@ namespace edm {
        using boost::regex;
        std::string name = regex_replace(iIn, reWrapper, "$1");
        name = regex_replace(name,reAIKR,"");
+      name = regex_replace(name,reCXX11,"std::");
        name = regex_replace(name,reString,"String");
        name = regex_replace(name,reString2,"String");
-       name = regex_replace(name,reStringCXX11,"String");
-       name = regex_replace(name,reString2CXX11,"String");
+       name = regex_replace(name,reString3,"String");
        name = regex_replace(name,reSorted,"sSorted<$1>");
        name = regex_replace(name,reULongLong,"ull");
        name = regex_replace(name,reLongLong,"ll");

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -40,6 +40,10 @@ void testfriendlyName::test()
   classToFriendly.insert( Values("std::vector<bar::Foo>","barFoos") );
   classToFriendly.insert( Values("std::shared_ptr<Foo>","FooSharedPtr"));
   classToFriendly.insert( Values("std::shared_ptr<bar::Foo>","barFooSharedPtr"));
+  classToFriendly.insert( Values("std::basic_string<char>","String"));
+  classToFriendly.insert( Values("std::string","String"));
+  classToFriendly.insert( Values("std::__cxx11::basic_string<char>","String"));
+  classToFriendly.insert( Values("std::__cxx11::basic_string<char,std::char_traits<char> >","String"));
   classToFriendly.insert( Values("std::vector<std::shared_ptr<bar::Foo>>","barFooSharedPtrs"));
   classToFriendly.insert( Values("std::unique_ptr<Foo>","FooUniquePtr"));
   classToFriendly.insert( Values("std::unique_ptr<bar::Foo>","barFooUniquePtr"));

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -38,6 +38,12 @@ void testfriendlyName::test()
   classToFriendly.insert( Values("bar::Foo","barFoo") );
   classToFriendly.insert( Values("std::vector<Foo>","Foos") );
   classToFriendly.insert( Values("std::vector<bar::Foo>","barFoos") );
+  classToFriendly.insert( Values("std::shared_ptr<Foo>","FooSharedPtr"));
+  classToFriendly.insert( Values("std::shared_ptr<bar::Foo>","barFooSharedPtr"));
+  classToFriendly.insert( Values("std::vector<std::shared_ptr<bar::Foo>>","barFooSharedPtrs"));
+  classToFriendly.insert( Values("std::unique_ptr<Foo>","FooUniquePtr"));
+  classToFriendly.insert( Values("std::unique_ptr<bar::Foo>","barFooUniquePtr"));
+  classToFriendly.insert( Values("std::vector<std::unique_ptr<bar::Foo>>","barFooUniquePtrs"));
   classToFriendly.insert( Values("V<A,B>","ABV") );
   classToFriendly.insert( Values("edm::ExtCollection<std::vector<reco::SuperCluster>,reco::SuperClusterRefProds>","recoSuperClustersrecoSuperClusterRefProdsedmExtCollection") );
   classToFriendly.insert( Values("edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >","EcalUncalibratedRecHitsSorted") );

--- a/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
+++ b/FWCore/Utilities/test/friendlyname_t.cppunit.cpp
@@ -44,7 +44,11 @@ void testfriendlyName::test()
   classToFriendly.insert( Values("std::string","String"));
   classToFriendly.insert( Values("std::__cxx11::basic_string<char>","String"));
   classToFriendly.insert( Values("std::__cxx11::basic_string<char,std::char_traits<char> >","String"));
+  classToFriendly.insert( Values("std::list<int>","intstdlist"));
+  classToFriendly.insert( Values("std::__cxx11::list<int>","intstdlist"));
   classToFriendly.insert( Values("std::vector<std::shared_ptr<bar::Foo>>","barFooSharedPtrs"));
+  classToFriendly.insert( Values("std::vector<std::basic_string<char>>","Strings"));
+  classToFriendly.insert( Values("std::__cxx11::vector<std::__cxx11::basic_string<char>>","Strings"));
   classToFriendly.insert( Values("std::unique_ptr<Foo>","FooUniquePtr"));
   classToFriendly.insert( Values("std::unique_ptr<bar::Foo>","barFooUniquePtr"));
   classToFriendly.insert( Values("std::vector<std::unique_ptr<bar::Foo>>","barFooUniquePtrs"));


### PR DESCRIPTION
#### PR description:

This PR backports
* #16221 (from 8_1_X)
* #17139 (from 9_0_X)
* #17371 (from 9_0_X)

as a possible solution for problem described in https://its.cern.ch/jira/browse/CMSCOMPPR-22029. In short, there a 10_6_X release is used for GEN, SIM, and DIGI steps, and 8_0_33_UL is used for the HLT step. The SIM step adds a product `std::vector<std::string>` that the HLT step is unable to read because the friendly class name (that is part of the TTree branch name) is different. The friendly class name for `vector<string>` in 8_0_X is currently `charcharstdchar_traitsstdbasic_strings`, which can not be used for persistent data products because of the underscore.

An alternative solution would be to redesign the workflow to give only the RAW input to the HLT step, and using two-file solution in the RECO step to read in DIGI and HLT outputs. I'm making a backport anyway in case it would be useful (since it was rather easy to do).

#### PR validation:

Local test of HLT step of https://its.cern.ch/jira/browse/CMSCOMPPR-22029 succeeds. `FWCore/Utilities` unit tests pass.