### PR TITLE
Fixed CMS Deprecated warnings in RecoTracker/DebugTools

### DIFF
--- a/RecoTracker/DebugTools/plugins/TestHits.h
+++ b/RecoTracker/DebugTools/plugins/TestHits.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <string>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -46,7 +46,7 @@
 #include <TH1F.h>
 #include <TH2F.h>
 
-class TestHits : public edm::EDAnalyzer {
+class TestHits : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit TestHits(const edm::ParameterSet&);
   ~TestHits() override;
@@ -54,6 +54,7 @@ public:
 private:
   void beginRun(edm::Run const& run, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endRun(edm::Run const& run, const edm::EventSetup&) override {}
   void endJob() override;
 
   std::pair<LocalPoint, LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
@@ -73,6 +74,14 @@ private:
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   edm::ESHandle<TrajectoryFitter> fit;
   edm::Handle<TrackCandidateCollection> theTCCollection;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theGToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMFToken;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theBuilderToken;
+  edm::ESGetToken<TrajectoryFitter, TrajectoryFitter::Record> fitToken;
+  edm::EDGetTokenT<TrackCandidateCollection> theTCCollectionToken;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken;
 
   TFile* file;
   std::stringstream title;

--- a/RecoTracker/DebugTools/plugins/TestSmoothHits.h
+++ b/RecoTracker/DebugTools/plugins/TestSmoothHits.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <string>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -47,7 +47,7 @@
 #include <TH1F.h>
 #include <TH2F.h>
 
-class TestSmoothHits : public edm::EDAnalyzer {
+class TestSmoothHits : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit TestSmoothHits(const edm::ParameterSet&);
   ~TestSmoothHits() override;
@@ -55,6 +55,7 @@ public:
 private:
   void beginRun(edm::Run const& run, const edm::EventSetup&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endRun(edm::Run const& run, const edm::EventSetup&) override {}
   void endJob() override;
 
   std::pair<LocalPoint, LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
@@ -76,6 +77,15 @@ private:
   edm::Handle<TrackCandidateCollection> theTCCollection;
   edm::ESHandle<TrajectoryFitter> fit;
   edm::ESHandle<TrajectorySmoother> smooth;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theGToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMFToken;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theBuilderToken;
+  edm::EDGetTokenT<TrackCandidateCollection> theTCCollectionToken;
+  edm::ESGetToken<TrajectoryFitter, TrajectoryFitter::Record> fitToken;
+  edm::ESGetToken<TrajectorySmoother, TrajectoryFitter::Record> smoothToken;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken;
 
   TFile* file;
   std::stringstream title;

--- a/RecoTracker/DebugTools/plugins/TestTrackHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestTrackHits.cc
@@ -23,6 +23,12 @@ TestTrackHits::TestTrackHits(const edm::ParameterSet& iConfig) : trackerHitAssoc
   tpName = iConfig.getParameter<std::string>("tpname");
   updatorName = iConfig.getParameter<std::string>("updator");
   out = iConfig.getParameter<std::string>("out");
+  theGToken = esConsumes<edm::Transition::BeginRun>();
+  theMFToken = esConsumes<edm::Transition::BeginRun>();
+  thePropagatorToken = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", propagatorName));
+  theBuilderToken = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", builderName));
+  theUpdatorToken = esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", updatorName));
+  theTopoToken = esConsumes();
   //   ParameterSet cuts = iConfig.getParameter<ParameterSet>("RecoTracksCuts");
   //   selectRecoTracks = RecoTrackSelector(cuts.getParameter<double>("ptMin"),
   // 				       cuts.getParameter<double>("minRapidity"),
@@ -36,11 +42,11 @@ TestTrackHits::TestTrackHits(const edm::ParameterSet& iConfig) : trackerHitAssoc
 TestTrackHits::~TestTrackHits() {}
 
 void TestTrackHits::beginRun(edm::Run const& run, const edm::EventSetup& iSetup) {
-  iSetup.get<TrackerDigiGeometryRecord>().get(theG);
-  iSetup.get<IdealMagneticFieldRecord>().get(theMF);
-  iSetup.get<TrackingComponentsRecord>().get(propagatorName, thePropagator);
-  iSetup.get<TransientRecHitRecord>().get(builderName, theBuilder);
-  iSetup.get<TrackingComponentsRecord>().get(updatorName, theUpdator);
+  theG = iSetup.getHandle(theGToken);
+  theMF = iSetup.getHandle(theMFToken);
+  thePropagator = iSetup.getHandle(thePropagatorToken);
+  theBuilder = iSetup.getHandle(theBuilderToken);
+  theUpdator = iSetup.getHandle(theUpdatorToken);
 
   file = new TFile(out.c_str(), "recreate");
   for (int i = 0; i != 6; i++)
@@ -253,8 +259,7 @@ void TestTrackHits::beginRun(edm::Run const& run, const edm::EventSetup& iSetup)
 
 void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopo;
-  iSetup.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo = iSetup.getHandle(theTopoToken);
 
   LogDebug("TestTrackHits") << "new event";
   iEvent.getByLabel(srcName, trajCollectionHandle);

--- a/RecoTracker/DebugTools/plugins/TestTrackHits.h
+++ b/RecoTracker/DebugTools/plugins/TestTrackHits.h
@@ -21,7 +21,7 @@
 #include <memory>
 #include <vector>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -51,7 +51,7 @@
 //#include "PhysicsTools/RecoAlgos/interface/RecoTrackSelector.h"
 #include <sstream>
 
-class TestTrackHits : public edm::EDAnalyzer {
+class TestTrackHits : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit TestTrackHits(const edm::ParameterSet &);
   ~TestTrackHits() override;
@@ -59,6 +59,7 @@ public:
 private:
   void beginRun(edm::Run const &run, const edm::EventSetup &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
+  void endRun(edm::Run const &run, const edm::EventSetup &) override {}
   void endJob() override;
 
   std::pair<LocalPoint, LocalVector> projectHit(const PSimHit &, const StripGeomDetUnit *, const BoundPlane &);
@@ -94,6 +95,12 @@ private:
   edm::ESHandle<Propagator> thePropagator;
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   edm::ESHandle<TrajectoryStateUpdator> theUpdator;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theGToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMFToken;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theBuilderToken;
+  edm::ESGetToken<TrajectoryStateUpdator, TrackingComponentsRecord> theUpdatorToken;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTopoToken;
   edm::Handle<reco::TrackToTrackingParticleAssociator> trackAssociator;
   edm::Handle<std::vector<Trajectory> > trajCollectionHandle;
   edm::Handle<edm::View<reco::Track> > trackCollectionHandle;

--- a/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.cc
+++ b/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.cc
@@ -12,6 +12,7 @@ TrackAlgoCompareUtil::TrackAlgoCompareUtil(const edm::ParameterSet& iConfig)
       trackingParticleLabel_effic(
           consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticleLabel_effic"))),
       beamSpotLabel(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotLabel"))),
+      magField(esConsumes()),
       UseAssociators(iConfig.getParameter<bool>("UseAssociators")),
       UseVertex(iConfig.getParameter<bool>("UseVertex")) {
   //now do what ever other initialization is needed
@@ -117,9 +118,7 @@ void TrackAlgoCompareUtil::produce(edm::StreamID, edm::Event& iEvent, const edm:
   std::vector<std::pair<reco::TrackBaseRef, double>> associatedRecoTracks;
 
   // Get the magnetic field data from the event (used to calculate the point of closest TrackingParticle)
-  edm::ESHandle<MagneticField> theMagneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(theMagneticField);
-  const MagneticField* magneticField = theMagneticField.product();
+  const MagneticField* magneticField = &iSetup.getData(magField);
 
   // fill collection algoA
   for (View<reco::Track>::size_type i = 0; i < trackCollAlgoA->size(); ++i) {

--- a/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.h
+++ b/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.h
@@ -64,19 +64,20 @@ private:
                                RecoTracktoTP &RTTP) const;
 
   // ----------member data ---------------------------
-  edm::EDGetTokenT<edm::View<reco::Track>> trackLabel_algoA;
-  edm::EDGetTokenT<edm::View<reco::Track>> trackLabel_algoB;
-  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleLabel_fakes;
-  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleLabel_effic;
+  const edm::EDGetTokenT<edm::View<reco::Track>> trackLabel_algoA;
+  const edm::EDGetTokenT<edm::View<reco::Track>> trackLabel_algoB;
+  const edm::EDGetTokenT<TrackingParticleCollection> trackingParticleLabel_fakes;
+  const edm::EDGetTokenT<TrackingParticleCollection> trackingParticleLabel_effic;
   edm::EDGetTokenT<reco::VertexCollection> vertexLabel_algoA;
   edm::EDGetTokenT<reco::VertexCollection> vertexLabel_algoB;
-  edm::EDGetTokenT<reco::BeamSpot> beamSpotLabel;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotLabel;
   edm::EDGetTokenT<reco::RecoToSimCollection> associatormap_algoA_recoToSim;
   edm::EDGetTokenT<reco::RecoToSimCollection> associatormap_algoB_recoToSim;
   edm::EDGetTokenT<reco::SimToRecoCollection> associatormap_algoA_simToReco;
   edm::EDGetTokenT<reco::SimToRecoCollection> associatormap_algoB_simToReco;
   edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> assocLabel_algoA;
   edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> assocLabel_algoB;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magField;
   const bool UseAssociators;
   const bool UseVertex;
 };


### PR DESCRIPTION
#### PR description:

- moved modules away from legacy base classes
- added esConsumes (and some consumes)
- removed unused CkfDebugger class

#### PR validation:

Code compiles and no longer issues the warnings.