### PR TITLE
Removed CMS deprecated warnings from RecoTracker/NuclearSeedGenerator

### DIFF
--- a/RecoTracker/NuclearSeedGenerator/interface/NuclearSeedsEDProducer.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/NuclearSeedsEDProducer.h
@@ -42,6 +42,9 @@ namespace reco {
 }
 
 class Trajectory;
+class Chi2MeasurementEstimatorBase;
+class CkfComponentsRecord;
+class NavigationSchoolRecord;
 
 /** \class NuclearSeedsEDProducer
  *
@@ -57,11 +60,18 @@ private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
   // ----------member data ---------------------------
-  edm::ParameterSet conf_;
+  NuclearInteractionFinder::Config config_;
   std::unique_ptr<NuclearInteractionFinder> theNuclearInteractionFinder;
 
   bool improveSeeds;
   edm::EDGetTokenT<TrajectoryCollection> producer_;
   edm::EDGetTokenT<MeasurementTrackerEvent> mteToken_;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
+  edm::ESGetToken<Chi2MeasurementEstimatorBase, TrackingComponentsRecord> estimatorToken_;
+  edm::ESGetToken<MeasurementTracker, CkfComponentsRecord> measurementTrackerToken_;
+  edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> geomSearchTrackerToken_;
+  edm::ESGetToken<NavigationSchool, NavigationSchoolRecord> navigationToken_;
 };
 #endif

--- a/RecoTracker/NuclearSeedGenerator/interface/SeedFromNuclearInteraction.h
+++ b/RecoTracker/NuclearSeedGenerator/interface/SeedFromNuclearInteraction.h
@@ -10,8 +10,6 @@
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "RecoTracker/NuclearSeedGenerator/interface/TangentHelix.h"
 
 class FreeTrajectoryState;
@@ -25,7 +23,7 @@ private:
   typedef std::vector<ConstRecHitPointer> ConstRecHitContainer;
 
 public:
-  SeedFromNuclearInteraction(const Propagator* prop, const TrackerGeometry* geom, const edm::ParameterSet& iConfig);
+  SeedFromNuclearInteraction(const Propagator* prop, const TrackerGeometry* geom, double ptMin);
 
   virtual ~SeedFromNuclearInteraction() {}
 

--- a/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.h
+++ b/RecoTracker/NuclearSeedGenerator/plugins/NuclearTrackCorrector.h
@@ -29,7 +29,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -64,7 +64,7 @@ class TransientInitialStateEstimator;
 // class decleration
 //
 
-class NuclearTrackCorrector : public edm::EDProducer {
+class NuclearTrackCorrector : public edm::stream::EDProducer<> {
 public:
   typedef edm::RefVector<TrajectorySeedCollection> TrajectorySeedRefVector;
   typedef edm::Ref<TrajectoryCollection> TrajectoryRef;
@@ -79,7 +79,6 @@ public:
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   /// check if the trajectory has to be refitted and get the new trajectory
   bool newTrajNeeded(Trajectory& newtrajectory, const TrajectoryRef& trajRef, const reco::NuclearInteraction& ni);
@@ -116,7 +115,10 @@ private:
   edm::ESHandle<MagneticField> theMF;
   edm::ESHandle<TrajectoryFitter> theFitter;
   edm::ESHandle<Propagator> thePropagator;
-  edm::ParameterSet conf_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theGToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMFToken;
+  edm::ESGetToken<TrajectoryFitter, TrajectoryFitter::Record> theFitterToken;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
   TransientInitialStateEstimator* theInitialState;
 
   TrackProducerAlgorithm<reco::Track>* theAlgo;

--- a/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
+++ b/RecoTracker/NuclearSeedGenerator/src/SeedFromNuclearInteraction.cc
@@ -13,8 +13,8 @@
 
 SeedFromNuclearInteraction::SeedFromNuclearInteraction(const Propagator* prop,
                                                        const TrackerGeometry* geom,
-                                                       const edm::ParameterSet& iConfig)
-    : ptMin(iConfig.getParameter<double>("ptMin")), thePropagator(prop), theTrackerGeom(geom) {
+                                                       double iPtMin)
+    : ptMin(iPtMin), thePropagator(prop), theTrackerGeom(geom) {
   isValid_ = true;
   initialTSOS_ = std::make_shared<TrajectoryStateOnSurface>();
   updatedTSOS_ = std::make_shared<TrajectoryStateOnSurface>();


### PR DESCRIPTION
#### PR description:

- Removed framework code dependencies from NuclearInteractionFinder  and SeedFromNuclearInteraction.
- Moved away from legacy module type
- Added esConsumes

#### PR validation:

Code compiles and no longer generates the warnings.