### PR TITLE
Removed CMS deprecated warnings from RecoTracker/TrackProducer

### DIFF
--- a/RecoTracker/TrackProducer/plugins/DAFTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/DAFTrackProducer.cc
@@ -37,6 +37,11 @@ DAFTrackProducer::DAFTrackProducer(const edm::ParameterSet& iConfig)
   produces<reco::TrackExtraCollection>("afterDAF").setBranchAlias(alias_ + "TrackExtrasAfterDAF");
 
   TrajAnnSaving_ = iConfig.getParameter<bool>("TrajAnnealingSaving");
+  ttopoToken_ = esConsumes();
+  std::string measurementCollectorName = getConf().getParameter<std::string>("MeasurementCollector");
+  measurementCollectorToken_ = esConsumes(edm::ESInputTag("", measurementCollectorName));
+  std::string updatorName = getConf().getParameter<std::string>("UpdatorName");
+  updatorToken_ = esConsumes(edm::ESInputTag("", updatorName));
 }
 
 void DAFTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup) {
@@ -72,16 +77,11 @@ void DAFTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
-  edm::ESHandle<TrackerTopology> httopo;
-  setup.get<TrackerTopologyRcd>().get(httopo);
+  edm::ESHandle<TrackerTopology> httopo = setup.getHandle(ttopoToken_);
 
   //get additional es_modules needed by the DAF
-  edm::ESHandle<MultiRecHitCollector> measurementCollectorHandle;
-  std::string measurementCollectorName = getConf().getParameter<std::string>("MeasurementCollector");
-  setup.get<MultiRecHitRecord>().get(measurementCollectorName, measurementCollectorHandle);
-  edm::ESHandle<SiTrackerMultiRecHitUpdator> updatorHandle;
-  std::string updatorName = getConf().getParameter<std::string>("UpdatorName");
-  setup.get<MultiRecHitRecord>().get(updatorName, updatorHandle);
+  edm::ESHandle<MultiRecHitCollector> measurementCollectorHandle = setup.getHandle(measurementCollectorToken_);
+  edm::ESHandle<SiTrackerMultiRecHitUpdator> updatorHandle = setup.getHandle(updatorToken_);
 
   //get MeasurementTrackerEvent
   edm::Handle<MeasurementTrackerEvent> mte;

--- a/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
@@ -14,6 +14,8 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TrajAnnealing.h"
 
+class MultiRecHitRecord;
+
 class DAFTrackProducer : public KfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
   typedef std::vector<Trajectory> TrajectoryCollection;
@@ -32,7 +34,10 @@ private:
                        std::unique_ptr<TrajAnnealingCollection>& selTrajAnn);
 
   bool TrajAnnSaving_;
-  edm::EDGetToken srcTT_;
+  edm::EDGetTokenT<TrajTrackAssociationCollection> srcTT_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
+  edm::ESGetToken<MultiRecHitCollector, MultiRecHitRecord> measurementCollectorToken_;
+  edm::ESGetToken<SiTrackerMultiRecHitUpdator, MultiRecHitRecord> updatorToken_;
 };
 
 #endif

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
@@ -45,6 +45,8 @@ GsfTrackRefitter::GsfTrackRefitter(const edm::ParameterSet& iConfig)
   produces<TrackingRecHitCollection>().setBranchAlias(alias_ + "RecHits");
   produces<std::vector<Trajectory>>();
   produces<TrajGsfTrackAssociationCollection>();
+
+  ttopoToken_ = esConsumes();
 }
 
 void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup) {
@@ -70,8 +72,7 @@ void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup, theG, theMF, theFitter, thePropagator, theMeasTk, theBuilder);
 
-  edm::ESHandle<TrackerTopology> httopo;
-  setup.get<TrackerTopologyRcd>().get(httopo);
+  edm::ESHandle<TrackerTopology> httopo = setup.getHandle(ttopoToken_);
 
   //
   //declare and get TrackCollection to be retrieved from the event

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
@@ -28,6 +28,7 @@ private:
   };
   Constraint constraint_;
   edm::EDGetTokenT<GsfTrackVtxConstraintAssociationCollection> gsfTrackVtxConstraintTag_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> ttopoToken_;
 };
 
 #endif

--- a/RecoTracker/TrackProducer/test/TrackAnalyzer.cc
+++ b/RecoTracker/TrackProducer/test/TrackAnalyzer.cc
@@ -1,7 +1,7 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -22,9 +22,9 @@
 
 using namespace edm;
 
-class TrackAnalyzer : public edm::EDAnalyzer {
+class TrackAnalyzer : public edm::one::EDAnalyzer<> {
 public:
-  TrackAnalyzer(const edm::ParameterSet& pset) {}
+  TrackAnalyzer(const edm::ParameterSet& pset) : theGToken_(esConsumes()) {}
 
   ~TrackAnalyzer() {}
 
@@ -32,8 +32,7 @@ public:
     //
     // extract tracker geometry
     //
-    edm::ESHandle<TrackerGeometry> theG;
-    setup.get<TrackerDigiGeometryRecord>().get(theG);
+    edm::ESHandle<TrackerGeometry> theG = setup.getHandle(theGToken_);
 
     using namespace std;
 
@@ -79,6 +78,9 @@ public:
       }
     }
   }
+
+private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> theGToken_;
 };
 
 DEFINE_FWK_MODULE(TrackAnalyzer);


### PR DESCRIPTION
#### PR description:

- moved away from legacy module types
- added esConsumes

#### PR validation:

Code compiles and does not issue warnings.