### PR TITLE
Remove CMS deprecated warnings from RecoRomanPot/RecoFP420

### DIFF
--- a/RecoRomanPot/RecoFP420/interface/ClusterProducerFP420.h
+++ b/RecoRomanPot/RecoFP420/interface/ClusterProducerFP420.h
@@ -23,16 +23,16 @@ public:
   std::vector<ClusterFP420> clusterizeDetUnit(HDigiFP420Iter begin,
                                               HDigiFP420Iter end,
                                               unsigned int detid,
-                                              const ElectrodNoiseVector& vnoise);
+                                              const ElectrodNoiseVector& vnoise) const;
   std::vector<ClusterFP420> clusterizeDetUnitPixels(HDigiFP420Iter begin,
                                                     HDigiFP420Iter end,
                                                     unsigned int detid,
                                                     const ElectrodNoiseVector& vnoise,
                                                     unsigned int xytype,
-                                                    int verb);
+                                                    int verb) const;
 
-  int difNarr(unsigned int xytype, HDigiFP420Iter ichannel, HDigiFP420Iter jchannel);
-  int difWide(unsigned int xytype, HDigiFP420Iter ichannel, HDigiFP420Iter jchannel);
+  int difNarr(unsigned int xytype, HDigiFP420Iter ichannel, HDigiFP420Iter jchannel) const;
+  int difWide(unsigned int xytype, HDigiFP420Iter ichannel, HDigiFP420Iter jchannel) const;
 
   float channelThresholdInNoiseSigma() const { return theChannelThreshold; }
   float seedThresholdInNoiseSigma() const { return theSeedThreshold; }
@@ -51,7 +51,7 @@ class AboveSeed {
 public:
   AboveSeed(float aseed, const ElectrodNoiseVector& vnoise) : verb(0), seed(aseed), vnoise_(vnoise){};
 
-  bool operator()(const HDigiFP420& digi) {
+  bool operator()(const HDigiFP420& digi) const {
     return (!vnoise_[digi.channel()].getDisable() && digi.adc() >= seed * vnoise_[digi.channel()].getNoise());
   }
 

--- a/RecoRomanPot/RecoFP420/interface/ClusterizerFP420.h
+++ b/RecoRomanPot/RecoFP420/interface/ClusterizerFP420.h
@@ -1,7 +1,7 @@
 #ifndef ClusterizerFP420_h
 #define ClusterizerFP420_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -19,37 +19,27 @@
 #include "DataFormats/FP420Cluster/interface/ClusterFP420.h"
 #include "DataFormats/FP420Cluster/interface/ClusterCollectionFP420.h"
 
-#include <CLHEP/Vector/ThreeVector.h>
 #include <string>
 #include <vector>
 #include <map>
 #include <iostream>
 
 namespace cms {
-  class ClusterizerFP420 : public edm::EDProducer {
+  class ClusterizerFP420 : public edm::global::EDProducer<> {
   public:
     explicit ClusterizerFP420(const edm::ParameterSet& conf);
 
-    ~ClusterizerFP420() override;
-
     void beginJob() override;
 
-    //  virtual void produce(DigiCollectionFP420*, ClusterCollectionFP420 &);
-    // virtual void produce(DigiCollectionFP420 &, ClusterCollectionFP420 &);
-
-    void produce(edm::Event& e, const edm::EventSetup& c) override;
+    void produce(edm::StreamID, edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
     typedef std::vector<std::string> vstring;
 
-    edm::ParameterSet conf_;
     vstring trackerContainers;
 
-    FP420ClusterMain* sClusterizerFP420_;
+    std::unique_ptr<const FP420ClusterMain> sClusterizerFP420_;
 
-    ClusterCollectionFP420* soutput;
-
-    std::vector<ClusterNoiseFP420> noise;
     bool UseNoiseBadElectrodeFlagFromDB_;
     int sn0, pn0, dn0, rn0;
     int verbosity;

--- a/RecoRomanPot/RecoFP420/interface/FP420ClusterMain.h
+++ b/RecoRomanPot/RecoFP420/interface/FP420ClusterMain.h
@@ -3,31 +3,24 @@
 
 #include <string>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "SimG4CMS/FP420/interface/FP420NumberingScheme.h"
 #include "DataFormats/FP420Digi/interface/DigiCollectionFP420.h"
 #include "DataFormats/FP420Cluster/interface/ClusterCollectionFP420.h"
 #include "RecoRomanPot/RecoFP420/interface/ClusterNoiseFP420.h"
 #include "DataFormats/FP420Cluster/interface/ClusterFP420.h"
+#include "RecoRomanPot/RecoFP420/interface/ClusterProducerFP420.h"
 #include <iostream>
 #include <vector>
+#include <memory>
 
 class ClusterNoiseFP420;
-class ClusterProducerFP420;
 
 class FP420ClusterMain {
 public:
   FP420ClusterMain(const edm::ParameterSet &conf, int dn, int sn, int pn, int rn);
   //  FP420ClusterMain();
-
-  ~FP420ClusterMain();
 
   /// Runs the algorithm
 
@@ -35,12 +28,10 @@ public:
   //       	   ClusterCollectionFP420 &soutput,
   //       	   const std::vector<ClusterNoiseFP420>& noise
   //     	   );
-  void run(edm::Handle<DigiCollectionFP420> &input,
-           ClusterCollectionFP420 *soutput,
-           std::vector<ClusterNoiseFP420> &noise);
+  void run(edm::Handle<DigiCollectionFP420> &input, ClusterCollectionFP420 *soutput) const;
 
 private:
-  ClusterProducerFP420 *threeThreshold_;
+  std::unique_ptr<const ClusterProducerFP420> threeThreshold_;
   std::string clusterMode_;
 
   //std::vector<HDigiFP420> collector;
@@ -59,16 +50,12 @@ private:
 
   double ldriftX;
   double ldriftY;
-  double ldrift;
   double pitchX;                // pitchX
   double pitchY;                // pitchY
-  double pitch;                 // pitch automatic
   float moduleThicknessX;       // plate thicknessX
   float moduleThicknessY;       // plate thicknessY
-  float moduleThickness;        // plate thickness
   int numStripsX, numStripsXW;  // number of strips in the moduleX
   int numStripsY, numStripsYW;  // number of strips in the moduleY
-  int numStrips;                // number of strips in the module
 
   float Thick300;
 

--- a/RecoRomanPot/RecoFP420/interface/FP420ClusterMain.h
+++ b/RecoRomanPot/RecoFP420/interface/FP420ClusterMain.h
@@ -35,7 +35,6 @@ private:
   std::string clusterMode_;
 
   //std::vector<HDigiFP420> collector;
-  edm::ParameterSet conf_;
 
   bool validClusterizer_;
   double ElectronPerADC_;

--- a/RecoRomanPot/RecoFP420/interface/FP420RecoMain.h
+++ b/RecoRomanPot/RecoFP420/interface/FP420RecoMain.h
@@ -3,14 +3,7 @@
 
 #include <string>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/FP420Cluster/interface/TrackFP420.h"
 #include "DataFormats/FP420Cluster/interface/TrackCollectionFP420.h"

--- a/RecoRomanPot/RecoFP420/interface/FP420TrackMain.h
+++ b/RecoRomanPot/RecoFP420/interface/FP420TrackMain.h
@@ -3,14 +3,7 @@
 
 #include <string>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/FP420Cluster/interface/ClusterCollectionFP420.h"
 #include "DataFormats/FP420Cluster/interface/TrackCollectionFP420.h"
@@ -24,7 +17,7 @@ public:
   ~FP420TrackMain();
 
   /// Runs the algorithm
-  void run(edm::Handle<ClusterCollectionFP420> &input, TrackCollectionFP420 *toutput);
+  void run(edm::Handle<ClusterCollectionFP420> &input, TrackCollectionFP420 *toutput) const;
 
 private:
   edm::ParameterSet conf_;

--- a/RecoRomanPot/RecoFP420/interface/FP420TrackMain.h
+++ b/RecoRomanPot/RecoFP420/interface/FP420TrackMain.h
@@ -20,8 +20,7 @@ public:
   void run(edm::Handle<ClusterCollectionFP420> &input, TrackCollectionFP420 *toutput) const;
 
 private:
-  edm::ParameterSet conf_;
-  TrackProducerFP420 *finderParameters_;
+  TrackProducerFP420 const *finderParameters_;
   std::string trackMode_;
 
   bool validTrackerizer_;

--- a/RecoRomanPot/RecoFP420/interface/ReconstructerFP420.h
+++ b/RecoRomanPot/RecoFP420/interface/ReconstructerFP420.h
@@ -1,7 +1,7 @@
 #ifndef ReconstructerFP420_h
 #define ReconstructerFP420_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 //#include "FWCore/Framework/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -20,14 +20,12 @@
 #include <iostream>
 
 namespace cms {
-  class ReconstructerFP420 : public edm::EDProducer {
+  class ReconstructerFP420 : public edm::stream::EDProducer<> {
   public:
     explicit ReconstructerFP420(const edm::ParameterSet& conf);
     //ReconstructerFP420();
 
     ~ReconstructerFP420() override;
-
-    void beginJob() override;
 
     //  virtual void produce(ClusterCollectionFP420 &, RecoCollectionFP420 &);
     void produce(edm::Event& e, const edm::EventSetup& c) override;

--- a/RecoRomanPot/RecoFP420/interface/TrackProducerFP420.h
+++ b/RecoRomanPot/RecoFP420/interface/TrackProducerFP420.h
@@ -3,14 +3,7 @@
 
 #include <string>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/FP420Cluster/interface/TrackFP420.h"
 #include "DataFormats/FP420Cluster/interface/ClusterFP420.h"
@@ -62,7 +55,7 @@ public:
   //  //std::vector<TrackFP420> trackFinderVar2(ClusterCollectionFP420 input);
 
   //    std::vector<TrackFP420> trackFinderSophisticated(ClusterCollectionFP420 input);
-  std::vector<TrackFP420> trackFinderSophisticated(edm::Handle<ClusterCollectionFP420> input, int det);
+  std::vector<TrackFP420> trackFinderSophisticated(edm::Handle<ClusterCollectionFP420> input, int det) const;
 
   //  std::vector<TrackFP420> trackFinder3D(ClusterCollectionFP420 input);
 

--- a/RecoRomanPot/RecoFP420/interface/TrackerizerFP420.h
+++ b/RecoRomanPot/RecoFP420/interface/TrackerizerFP420.h
@@ -1,7 +1,7 @@
 #ifndef TrackerizerFP420_h
 #define TrackerizerFP420_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 //#include "FWCore/Framework/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -23,24 +23,19 @@
 #include <iostream>
 
 namespace cms {
-  class TrackerizerFP420 : public edm::EDProducer {
+  class TrackerizerFP420 : public edm::global::EDProducer<> {
   public:
     explicit TrackerizerFP420(const edm::ParameterSet& conf);
     //TrackerizerFP420();
 
-    ~TrackerizerFP420() override;
-
-    void beginJob() override;
-
     //  virtual void produce(ClusterCollectionFP420 &, TrackCollectionFP420 &);
-    void produce(edm::Event& e, const edm::EventSetup& c) override;
+    void produce(edm::StreamID, edm::Event& e, const edm::EventSetup& c) const override;
 
   private:
     typedef std::vector<std::string> vstring;
-    edm::ParameterSet conf_;
     vstring trackerContainers;
 
-    FP420TrackMain* sFP420TrackMain_;
+    const FP420TrackMain sFP420TrackMain_;
     //  FP420TrackMain startFP420TrackMain_;
     //bool UseNoiseBadElectrodeFlagFromDB_;
     int verbosity;

--- a/RecoRomanPot/RecoFP420/plugins/ClusterizerFP420.cc
+++ b/RecoRomanPot/RecoFP420/plugins/ClusterizerFP420.cc
@@ -8,7 +8,6 @@
 #include <string>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -38,7 +37,7 @@
 using namespace std;
 
 namespace cms {
-  ClusterizerFP420::ClusterizerFP420(const edm::ParameterSet& conf) : conf_(conf) {
+  ClusterizerFP420::ClusterizerFP420(const edm::ParameterSet& conf) {
     std::string alias(conf.getParameter<std::string>("@module_label"));
 
     produces<ClusterCollectionFP420>().setBranchAlias(alias);
@@ -46,21 +45,18 @@ namespace cms {
     trackerContainers.clear();
     trackerContainers = conf.getParameter<std::vector<std::string> >("ROUList");
 
-    verbosity = conf_.getUntrackedParameter<int>("VerbosityLevel");
-    dn0 = conf_.getParameter<int>("NumberFP420Detectors");
-    sn0 = conf_.getParameter<int>("NumberFP420Stations");
-    pn0 = conf_.getParameter<int>("NumberFP420SPlanes");
+    verbosity = conf.getUntrackedParameter<int>("VerbosityLevel");
+    dn0 = conf.getParameter<int>("NumberFP420Detectors");
+    sn0 = conf.getParameter<int>("NumberFP420Stations");
+    pn0 = conf.getParameter<int>("NumberFP420SPlanes");
     rn0 = 7;
     if (verbosity > 0) {
       std::cout << "Creating a ClusterizerFP420" << std::endl;
       std::cout << "ClusterizerFP420: dn0=" << dn0 << " sn0=" << sn0 << " pn0=" << pn0 << " rn0=" << rn0 << std::endl;
     }
 
-    sClusterizerFP420_ = new FP420ClusterMain(conf_, dn0, sn0, pn0, rn0);
+    sClusterizerFP420_ = std::make_unique<FP420ClusterMain>(conf, dn0, sn0, pn0, rn0);
   }
-
-  // Virtual destructor needed.
-  ClusterizerFP420::~ClusterizerFP420() { delete sClusterizerFP420_; }
 
   //Get at the beginning
   void ClusterizerFP420::beginJob() {
@@ -96,7 +92,7 @@ namespace cms {
     //    }
   }
 
-  void ClusterizerFP420::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  void ClusterizerFP420::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
     //  beginJob;
     // be lazy and include the appropriate namespaces
     using namespace edm;
@@ -200,7 +196,7 @@ namespace cms {
     if (verbosity > 0) {
       std::cout << "ClusterizerFP420: OK2" << std::endl;
     }
-    sClusterizerFP420_->run(input, soutput.get(), noise);
+    sClusterizerFP420_->run(input, soutput.get());
 
     if (verbosity > 0) {
       std::cout << "ClusterizerFP420: OK3" << std::endl;

--- a/RecoRomanPot/RecoFP420/plugins/ReconstructerFP420.cc
+++ b/RecoRomanPot/RecoFP420/plugins/ReconstructerFP420.cc
@@ -7,7 +7,6 @@
 #include <memory>
 #include <string>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -53,13 +52,6 @@ namespace cms {
       std::cout << "ReconstructerFP420:delete FP420RecoMain" << std::endl;
     }
     delete sFP420RecoMain_;
-  }
-
-  //Get at the beginning
-  void ReconstructerFP420::beginJob() {
-    if (verbosity > 0) {
-      std::cout << "ReconstructerFP420:BeginJob method " << std::endl;
-    }
   }
 
   void ReconstructerFP420::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/RecoRomanPot/RecoFP420/plugins/TrackerizerFP420.cc
+++ b/RecoRomanPot/RecoFP420/plugins/TrackerizerFP420.cc
@@ -7,7 +7,6 @@
 #include <memory>
 #include <string>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -23,7 +22,7 @@ using namespace std;
 
 //
 namespace cms {
-  TrackerizerFP420::TrackerizerFP420(const edm::ParameterSet& conf) : conf_(conf) {
+  TrackerizerFP420::TrackerizerFP420(const edm::ParameterSet& conf) : sFP420TrackMain_(conf) {
     std::string alias(conf.getParameter<std::string>("@module_label"));
 
     produces<TrackCollectionFP420>().setBranchAlias(alias);
@@ -31,26 +30,13 @@ namespace cms {
     trackerContainers.clear();
     trackerContainers = conf.getParameter<std::vector<std::string> >("ROUList");
 
-    verbosity = conf_.getUntrackedParameter<int>("VerbosityLevel");
+    verbosity = conf.getUntrackedParameter<int>("VerbosityLevel");
     if (verbosity > 0) {
       std::cout << "Creating a TrackerizerFP420" << std::endl;
     }
-
-    // Initialization:
-    sFP420TrackMain_ = new FP420TrackMain(conf_);
   }
 
-  // Virtual destructor needed.
-  TrackerizerFP420::~TrackerizerFP420() { delete sFP420TrackMain_; }
-
-  //Get at the beginning
-  void TrackerizerFP420::beginJob() {
-    if (verbosity > 0) {
-      std::cout << "BeginJob method " << std::endl;
-    }
-  }
-
-  void TrackerizerFP420::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  void TrackerizerFP420::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
     //  beginJob;
     // be lazy and include the appropriate namespaces
     using namespace edm;
@@ -99,7 +85,7 @@ namespace cms {
 
     //                                RUN now:                                                                                 !!!!!!
     //   startFP420TrackMain_.run(input, toutput);
-    sFP420TrackMain_->run(input, toutput.get());
+    sFP420TrackMain_.run(input, toutput.get());
     // std::cout <<"=======           TrackerizerFP420:                    end of produce     " << std::endl;
 
     // Step D: write output to file

--- a/RecoRomanPot/RecoFP420/src/ClusterProducerFP420.cc
+++ b/RecoRomanPot/RecoFP420/src/ClusterProducerFP420.cc
@@ -38,7 +38,7 @@ bool ClusterProducerFP420::badChannel(int channel, const std::vector<short>& bad
 std::vector<ClusterFP420> ClusterProducerFP420::clusterizeDetUnit(HDigiFP420Iter begin,
                                                                   HDigiFP420Iter end,
                                                                   unsigned int detid,
-                                                                  const ElectrodNoiseVector& vnoise) {
+                                                                  const ElectrodNoiseVector& vnoise) const {
   //                                                 const std::vector<short>& badChannels)
 
   //reminder:	  int zScale=2;  unsigned int detID = sScale*(sector - 1)+zScale*(zmodule - 1)+xytype;
@@ -149,7 +149,7 @@ std::vector<ClusterFP420> ClusterProducerFP420::clusterizeDetUnit(HDigiFP420Iter
   return rhits;
 }
 
-int ClusterProducerFP420::difNarr(unsigned int xytype, HDigiFP420Iter ichannel, HDigiFP420Iter jchannel) {
+int ClusterProducerFP420::difNarr(unsigned int xytype, HDigiFP420Iter ichannel, HDigiFP420Iter jchannel) const {
   int d = 9999;
   if (xytype == 2) {
     d = ichannel->stripV() - jchannel->stripV();
@@ -162,7 +162,7 @@ int ClusterProducerFP420::difNarr(unsigned int xytype, HDigiFP420Iter ichannel, 
   }
   return d;
 }
-int ClusterProducerFP420::difWide(unsigned int xytype, HDigiFP420Iter ichannel, HDigiFP420Iter jchannel) {
+int ClusterProducerFP420::difWide(unsigned int xytype, HDigiFP420Iter ichannel, HDigiFP420Iter jchannel) const {
   int d = 9999;
   if (xytype == 2) {
     d = ichannel->stripVW() - jchannel->stripVW();
@@ -181,7 +181,7 @@ std::vector<ClusterFP420> ClusterProducerFP420::clusterizeDetUnitPixels(HDigiFP4
                                                                         unsigned int detid,
                                                                         const ElectrodNoiseVector& vnoise,
                                                                         unsigned int xytype,
-                                                                        int verb) {
+                                                                        int verb) const {
   //                                                 const std::vector<short>& badChannels)
 
   //reminder:	  int zScale=2;  unsigned int detID = sScale*(sector - 1)+zScale*(zmodule - 1)+xytype;

--- a/RecoRomanPot/RecoFP420/src/FP420ClusterMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420ClusterMain.cc
@@ -7,8 +7,8 @@
 #include <vector>
 #include <iostream>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
+#include "DataFormats/Common/interface/Handle.h"
 #include "RecoRomanPot/RecoFP420/interface/FP420ClusterMain.h"
 #include "DataFormats/FP420Digi/interface/HDigiFP420.h"
 #include "DataFormats/FP420Cluster/interface/ClusterFP420.h"
@@ -93,7 +93,8 @@ FP420ClusterMain::FP420ClusterMain(const edm::ParameterSet& conf, int dn, int sn
     //   SeedThreshold       = 7.0;//was 3.7.0  8 20
     // ClusterThreshold    = 7.0;// was 2. 7.0 8 20
     // MaxVoidsInCluster   = 1;
-    threeThreshold_ = new ClusterProducerFP420(ChannelThreshold, SeedThreshold, ClusterThreshold, MaxVoidsInCluster);
+    threeThreshold_ =
+        std::make_unique<ClusterProducerFP420>(ChannelThreshold, SeedThreshold, ClusterThreshold, MaxVoidsInCluster);
     validClusterizer_ = true;
   } else {
     std::cout << "ERROR:FP420ClusterMain: No valid clusterizer selected" << std::endl;
@@ -101,17 +102,9 @@ FP420ClusterMain::FP420ClusterMain(const edm::ParameterSet& conf, int dn, int sn
   }
 }
 
-FP420ClusterMain::~FP420ClusterMain() {
-  if (threeThreshold_ != nullptr) {
-    delete threeThreshold_;
-  }
-}
-
 //void FP420ClusterMain::run(const DigiCollectionFP420 *input, ClusterCollectionFP420 *soutput,
 //			   const std::vector<ClusterNoiseFP420>& electrodnoise)
-void FP420ClusterMain::run(edm::Handle<DigiCollectionFP420>& input,
-                           ClusterCollectionFP420* soutput,
-                           std::vector<ClusterNoiseFP420>& electrodnoise)
+void FP420ClusterMain::run(edm::Handle<DigiCollectionFP420>& input, ClusterCollectionFP420* soutput) const
 
 {
   // unpack from iu:
@@ -144,19 +137,17 @@ void FP420ClusterMain::run(edm::Handle<DigiCollectionFP420>& input,
             if (verbosity > 0) {
               std::cout << " FP420ClusterMain:1 run loop   index no  iu = " << detID << std::endl;
             }
+            float moduleThickness = 0;  // plate thickness
+            int numStrips = 0;          // number of strips in the module
             // Y:
             if (xytype == 1) {
               numStrips = numStripsY * numStripsYW;
               moduleThickness = moduleThicknessY;
-              pitch = pitchY;
-              ldrift = ldriftX;
             }
             // X:
             if (xytype == 2) {
               numStrips = numStripsX * numStripsXW;
               moduleThickness = moduleThicknessX;
-              pitch = pitchX;
-              ldrift = ldriftY;
             }
 
             //    for ( std::vector<unsigned int>::const_iterator detunit_iterator = detIDs.begin(); detunit_iterator != detIDs.end(); ++detunit_iterator ) {

--- a/RecoRomanPot/RecoFP420/src/FP420ClusterMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420ClusterMain.cc
@@ -20,14 +20,14 @@
 using namespace std;
 
 FP420ClusterMain::FP420ClusterMain(const edm::ParameterSet& conf, int dn, int sn, int pn, int rn)
-    : conf_(conf), dn0(dn), sn0(sn), pn0(pn), rn0(rn) {
-  verbosity = conf_.getUntrackedParameter<int>("VerbosityLevel");
-  ElectronPerADC_ = conf_.getParameter<double>("ElectronFP420PerAdc");
-  clusterMode_ = conf_.getParameter<std::string>("ClusterModeFP420");
-  ChannelThreshold = conf_.getParameter<double>("ChannelFP420Threshold");  //6
-  SeedThreshold = conf_.getParameter<double>("SeedFP420Threshold");        //7
-  ClusterThreshold = conf_.getParameter<double>("ClusterFP420Threshold");  //7
-  MaxVoidsInCluster = conf_.getParameter<int>("MaxVoidsFP420InCluster");   //1
+    : dn0(dn), sn0(sn), pn0(pn), rn0(rn) {
+  verbosity = conf.getUntrackedParameter<int>("VerbosityLevel");
+  ElectronPerADC_ = conf.getParameter<double>("ElectronFP420PerAdc");
+  clusterMode_ = conf.getParameter<std::string>("ClusterModeFP420");
+  ChannelThreshold = conf.getParameter<double>("ChannelFP420Threshold");  //6
+  SeedThreshold = conf.getParameter<double>("SeedFP420Threshold");        //7
+  ClusterThreshold = conf.getParameter<double>("ClusterFP420Threshold");  //7
+  MaxVoidsInCluster = conf.getParameter<int>("MaxVoidsFP420InCluster");   //1
 
   if (verbosity > 0) {
     std::cout << "FP420ClusterMain constructor: ElectronPerADC = " << ElectronPerADC_ << std::endl;

--- a/RecoRomanPot/RecoFP420/src/FP420RecoMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420RecoMain.cc
@@ -11,6 +11,7 @@
 
 #include "RecoRomanPot/RecoFP420/interface/FP420RecoMain.h"
 
+#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FP420Cluster/interface/TrackFP420.h"
 #include "DataFormats/FP420Cluster/interface/TrackCollectionFP420.h"
 #include "DataFormats/FP420Cluster/interface/RecoFP420.h"

--- a/RecoRomanPot/RecoFP420/src/FP420TrackMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420TrackMain.cc
@@ -21,21 +21,21 @@ using namespace std;
 //#define mytrackdebug0
 
 //FP420TrackMain::FP420TrackMain(){
-FP420TrackMain::FP420TrackMain(const edm::ParameterSet &conf) : conf_(conf) {
-  verbosity = conf_.getUntrackedParameter<int>("VerbosityLevel");
-  trackMode_ = conf_.getParameter<std::string>("TrackModeFP420");
-  dn0 = conf_.getParameter<int>("NumberFP420Detectors");
-  sn0_ = conf_.getParameter<int>("NumberFP420Stations");
-  pn0_ = conf_.getParameter<int>("NumberFP420SPlanes");
+FP420TrackMain::FP420TrackMain(const edm::ParameterSet &conf) {
+  verbosity = conf.getUntrackedParameter<int>("VerbosityLevel");
+  trackMode_ = conf.getParameter<std::string>("TrackModeFP420");
+  dn0 = conf.getParameter<int>("NumberFP420Detectors");
+  sn0_ = conf.getParameter<int>("NumberFP420Stations");
+  pn0_ = conf.getParameter<int>("NumberFP420SPlanes");
   rn0_ = 7;
-  xytype_ = conf_.getParameter<int>("NumberFP420SPTypes");
-  z420_ = conf_.getParameter<double>("z420");
-  zD2_ = conf_.getParameter<double>("zD2");
-  zD3_ = conf_.getParameter<double>("zD3");
-  dXX_ = conf_.getParameter<double>("dXXFP420");
-  dYY_ = conf_.getParameter<double>("dYYFP420");
-  chiCutX_ = conf_.getParameter<double>("chiCutX420");
-  chiCutY_ = conf_.getParameter<double>("chiCutY420");
+  xytype_ = conf.getParameter<int>("NumberFP420SPTypes");
+  z420_ = conf.getParameter<double>("z420");
+  zD2_ = conf.getParameter<double>("zD2");
+  zD3_ = conf.getParameter<double>("zD3");
+  dXX_ = conf.getParameter<double>("dXXFP420");
+  dYY_ = conf.getParameter<double>("dYYFP420");
+  chiCutX_ = conf.getParameter<double>("chiCutX420");
+  chiCutY_ = conf.getParameter<double>("chiCutY420");
 
   if (verbosity > 0) {
     std::cout << "FP420TrackMain constructor::" << std::endl;

--- a/RecoRomanPot/RecoFP420/src/FP420TrackMain.cc
+++ b/RecoRomanPot/RecoFP420/src/FP420TrackMain.cc
@@ -9,6 +9,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "RecoRomanPot/RecoFP420/interface/FP420TrackMain.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FP420Cluster/interface/ClusterFP420.h"
 #include "DataFormats/FP420Cluster/interface/TrackFP420.h"
 #include "RecoRomanPot/RecoFP420/interface/TrackProducerFP420.h"
@@ -148,7 +149,7 @@ FP420TrackMain::~FP420TrackMain() {
   }
 }
 
-void FP420TrackMain::run(edm::Handle<ClusterCollectionFP420> &input, TrackCollectionFP420 *toutput) {
+void FP420TrackMain::run(edm::Handle<ClusterCollectionFP420> &input, TrackCollectionFP420 *toutput) const {
   if (validTrackerizer_) {
     int number_detunits = 0;
     int number_localelectroderechits = 0;

--- a/RecoRomanPot/RecoFP420/src/TrackProducerFP420.cc
+++ b/RecoRomanPot/RecoFP420/src/TrackProducerFP420.cc
@@ -5,6 +5,7 @@
 // Modifications:
 ///////////////////////////////////////////////////////////////////////////////
 #include "RecoRomanPot/RecoFP420/interface/TrackProducerFP420.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include <cstdio>
 #include <gsl/gsl_fit.h>
 #include <vector>
@@ -104,7 +105,7 @@ TrackProducerFP420::TrackProducerFP420(int asn0,
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 std::vector<TrackFP420> TrackProducerFP420::trackFinderSophisticated(edm::Handle<ClusterCollectionFP420> input,
-                                                                     int det) {
+                                                                     int det) const {
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   std::vector<TrackFP420> rhits;


### PR DESCRIPTION
#### PR description:

- Reworked some helper classes to be const correct
- Removed unnecessary includes
- Moved away from legacy module types

#### PR validation:

Code compiles and does not issue warnings anymore.