### PR TITLE
Bugfix for DNN-based outside-in track seed generator for Muon HLT

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIDNN.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIDNN.cc
@@ -33,6 +33,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <memory>
 namespace pt = boost::property_tree;
 
@@ -391,7 +392,7 @@ void TSGForOIDNN::produce(edm::StreamID sid, edm::Event& iEvent, edm::EventSetup
     hitDoubletSeedsMade = 0;
 
     auto createSeeds = [&](auto const& layers) {
-      for (auto const& layer : layers) {
+      for (auto const& layer : boost::adaptors::reverse(layers)) {
         if (hitlessSeedsMadeIP < maxHitlessSeedsIP && numSeedsMade < maxSeeds_)
           makeSeedsWithoutHits(*layer,
                                tsosAtIP,


### PR DESCRIPTION
Fix of a bug introduced during the integration of #35237, where the ordering in which tracker layers where traversed to built seeds was mistakenly switched from outside-in to inside-out when switching everything to range-based loops. 

This fix was found to remedy the unexpected loss in efficiency reported for example in [these slides](https://indico.cern.ch/event/1099590/contributions/4626714/attachments/2357624/4023680/20211202_Run3Review_MUO.pdf) (slide 6). 

These plots show the efficiency recovery in line with expectations:

![L3Eff_OI_DY_eta](https://user-images.githubusercontent.com/4459228/147357171-4555241a-3344-4617-be1c-6a26894c70a0.png)
![L3Eff_OI_DY_pT](https://user-images.githubusercontent.com/4459228/147357172-d2337ff9-e87a-4581-ac07-252d64609415.png)

