### PR TITLE
Drop type specs for L1TMonitor and L1TMonitorClient

### DIFF
--- a/DQM/L1TMonitor/python/L1ExtraDQM_cff.py
+++ b/DQM/L1TMonitor/python/L1ExtraDQM_cff.py
@@ -8,7 +8,7 @@ from DQM.L1TMonitor.l1ExtraDQMStage1_cfi import *
 
 import EventFilter.GctRawToDigi.l1GctHwDigis_cfi
 dqmGctDigis = EventFilter.GctRawToDigi.l1GctHwDigis_cfi.l1GctHwDigis.clone(
-inputLabel = 'rawDataCollector'
+  inputLabel = 'rawDataCollector'
 )
 #
 # unpack all five samples
@@ -17,7 +17,7 @@ dqmGctDigis.numberOfGctSamplesToUnpack = 5
 
 import EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi
 dqmGtDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone(
-DaqGtInputTag = 'rawDataCollector'
+  DaqGtInputTag = 'rawDataCollector'
 )
 #
 # unpack all available BxInEvent, UnpackBxInEvent read from event setup
@@ -28,39 +28,39 @@ dqmGtDigis.UnpackBxInEvent = -1
 # use a clone dqmL1ExtraParticles, to not interfere with L1Reco from standard sequences
 import L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi
 dqmL1ExtraParticles = L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi.l1extraParticles.clone(
-#
-muonSource = 'dqmGtDigis',
-etTotalSource = 'dqmGctDigis',
-nonIsolatedEmSource = 'dqmGctDigis:nonIsoEm',
-etMissSource = 'dqmGctDigis',
-htMissSource = 'dqmGctDigis',
-forwardJetSource = 'dqmGctDigis:forJets',
-centralJetSource = 'dqmGctDigis:cenJets',
-tauJetSource = 'dqmGctDigis:tauJets',
-isolatedEmSource = 'dqmGctDigis:isoEm',
-etHadSource = 'dqmGctDigis',
-hfRingEtSumsSource = 'dqmGctDigis',
-hfRingBitCountsSource = 'dqmGctDigis',
-centralBxOnly = False
+  #
+  muonSource = 'dqmGtDigis',
+  etTotalSource = 'dqmGctDigis',
+  nonIsolatedEmSource = 'dqmGctDigis:nonIsoEm',
+  etMissSource = 'dqmGctDigis',
+  htMissSource = 'dqmGctDigis',
+  forwardJetSource = 'dqmGctDigis:forJets',
+  centralJetSource = 'dqmGctDigis:cenJets',
+  tauJetSource = 'dqmGctDigis:tauJets',
+  isolatedEmSource = 'dqmGctDigis:isoEm',
+  etHadSource = 'dqmGctDigis',
+  hfRingEtSumsSource = 'dqmGctDigis',
+  hfRingBitCountsSource = 'dqmGctDigis',
+  centralBxOnly = False
 )
 # get stage1 digis
 import L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi
 dqmL1ExtraParticlesStage1 = L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi.l1extraParticles.clone(
-#
-muonSource = 'dqmGtDigis',
-etTotalSource = 'caloStage1LegacyFormatDigis',
-nonIsolatedEmSource = 'caloStage1LegacyFormatDigis:nonIsoEm',
-etMissSource = 'caloStage1LegacyFormatDigis',
-htMissSource = 'caloStage1LegacyFormatDigis',
-forwardJetSource = 'caloStage1LegacyFormatDigis:forJets',
-centralJetSource = 'caloStage1LegacyFormatDigis:cenJets',
-tauJetSource = 'caloStage1LegacyFormatDigis:tauJets',
-isoTauJetSource = 'caloStage1LegacyFormatDigis:isoTauJets',
-isolatedEmSource = 'caloStage1LegacyFormatDigis:isoEm',
-etHadSource = 'caloStage1LegacyFormatDigis',
-hfRingEtSumsSource = 'caloStage1LegacyFormatDigis',
-hfRingBitCountsSource = 'caloStage1LegacyFormatDigis',
-centralBxOnly = False
+  #
+  muonSource = 'dqmGtDigis',
+  etTotalSource = 'caloStage1LegacyFormatDigis',
+  nonIsolatedEmSource = 'caloStage1LegacyFormatDigis:nonIsoEm',
+  etMissSource = 'caloStage1LegacyFormatDigis',
+  htMissSource = 'caloStage1LegacyFormatDigis',
+  forwardJetSource = 'caloStage1LegacyFormatDigis:forJets',
+  centralJetSource = 'caloStage1LegacyFormatDigis:cenJets',
+  tauJetSource = 'caloStage1LegacyFormatDigis:tauJets',
+  isoTauJetSource = 'caloStage1LegacyFormatDigis:isoTauJets',
+  isolatedEmSource = 'caloStage1LegacyFormatDigis:isoEm',
+  etHadSource = 'caloStage1LegacyFormatDigis',
+  hfRingEtSumsSource = 'caloStage1LegacyFormatDigis',
+  hfRingBitCountsSource = 'caloStage1LegacyFormatDigis',
+  centralBxOnly = False
 )
 #
 # Modify for running with the Stage 1 trigger. Note that these changes are already

--- a/DQM/L1TMonitor/python/L1ExtraDQM_cff.py
+++ b/DQM/L1TMonitor/python/L1ExtraDQM_cff.py
@@ -7,16 +7,18 @@ from DQM.L1TMonitor.l1ExtraDQMStage1_cfi import *
 # use clones dqmGctDigis and dqmGtDigis, to not interfere with RawToDigi from standard sequences
 
 import EventFilter.GctRawToDigi.l1GctHwDigis_cfi
-dqmGctDigis = EventFilter.GctRawToDigi.l1GctHwDigis_cfi.l1GctHwDigis.clone()
-dqmGctDigis.inputLabel = 'rawDataCollector'
+dqmGctDigis = EventFilter.GctRawToDigi.l1GctHwDigis_cfi.l1GctHwDigis.clone(
+inputLabel = 'rawDataCollector'
+)
 #
 # unpack all five samples
 dqmGctDigis.numberOfGctSamplesToUnpack = 5
 
 
 import EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi
-dqmGtDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone()
-dqmGtDigis.DaqGtInputTag = 'rawDataCollector'
+dqmGtDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone(
+DaqGtInputTag = 'rawDataCollector'
+)
 #
 # unpack all available BxInEvent, UnpackBxInEvent read from event setup
 dqmGtDigis.UnpackBxInEvent = -1
@@ -25,43 +27,41 @@ dqmGtDigis.UnpackBxInEvent = -1
 # import the L1Extra producer, configured to run for all BX
 # use a clone dqmL1ExtraParticles, to not interfere with L1Reco from standard sequences
 import L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi
-dqmL1ExtraParticles = L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi.l1extraParticles.clone()
+dqmL1ExtraParticles = L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi.l1extraParticles.clone(
 #
-dqmL1ExtraParticles.muonSource = 'dqmGtDigis'
-dqmL1ExtraParticles.etTotalSource = 'dqmGctDigis'
-dqmL1ExtraParticles.nonIsolatedEmSource = 'dqmGctDigis:nonIsoEm'
-dqmL1ExtraParticles.etMissSource = 'dqmGctDigis'
-dqmL1ExtraParticles.htMissSource = 'dqmGctDigis'
-dqmL1ExtraParticles.forwardJetSource = 'dqmGctDigis:forJets'
-dqmL1ExtraParticles.centralJetSource = 'dqmGctDigis:cenJets'
-dqmL1ExtraParticles.tauJetSource = 'dqmGctDigis:tauJets'
-dqmL1ExtraParticles.isolatedEmSource = 'dqmGctDigis:isoEm'
-dqmL1ExtraParticles.etHadSource = 'dqmGctDigis'
-dqmL1ExtraParticles.hfRingEtSumsSource = 'dqmGctDigis'
-dqmL1ExtraParticles.hfRingBitCountsSource = 'dqmGctDigis'
-#
-dqmL1ExtraParticles.centralBxOnly = cms.bool(False)
-
+muonSource = 'dqmGtDigis',
+etTotalSource = 'dqmGctDigis',
+nonIsolatedEmSource = 'dqmGctDigis:nonIsoEm',
+etMissSource = 'dqmGctDigis',
+htMissSource = 'dqmGctDigis',
+forwardJetSource = 'dqmGctDigis:forJets',
+centralJetSource = 'dqmGctDigis:cenJets',
+tauJetSource = 'dqmGctDigis:tauJets',
+isolatedEmSource = 'dqmGctDigis:isoEm',
+etHadSource = 'dqmGctDigis',
+hfRingEtSumsSource = 'dqmGctDigis',
+hfRingBitCountsSource = 'dqmGctDigis',
+centralBxOnly = False
+)
 # get stage1 digis
 import L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi
-dqmL1ExtraParticlesStage1 = L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi.l1extraParticles.clone()
+dqmL1ExtraParticlesStage1 = L1Trigger.L1ExtraFromDigis.l1extraParticles_cfi.l1extraParticles.clone(
 #
-dqmL1ExtraParticlesStage1.muonSource = 'dqmGtDigis'
-dqmL1ExtraParticlesStage1.etTotalSource = 'caloStage1LegacyFormatDigis'
-dqmL1ExtraParticlesStage1.nonIsolatedEmSource = 'caloStage1LegacyFormatDigis:nonIsoEm'
-dqmL1ExtraParticlesStage1.etMissSource = 'caloStage1LegacyFormatDigis'
-dqmL1ExtraParticlesStage1.htMissSource = 'caloStage1LegacyFormatDigis'
-dqmL1ExtraParticlesStage1.forwardJetSource = 'caloStage1LegacyFormatDigis:forJets'
-dqmL1ExtraParticlesStage1.centralJetSource = 'caloStage1LegacyFormatDigis:cenJets'
-dqmL1ExtraParticlesStage1.tauJetSource = 'caloStage1LegacyFormatDigis:tauJets'
-dqmL1ExtraParticlesStage1.isoTauJetSource = 'caloStage1LegacyFormatDigis:isoTauJets'
-dqmL1ExtraParticlesStage1.isolatedEmSource = 'caloStage1LegacyFormatDigis:isoEm'
-dqmL1ExtraParticlesStage1.etHadSource = 'caloStage1LegacyFormatDigis'
-dqmL1ExtraParticlesStage1.hfRingEtSumsSource = 'caloStage1LegacyFormatDigis'
-dqmL1ExtraParticlesStage1.hfRingBitCountsSource = 'caloStage1LegacyFormatDigis'
-#
-dqmL1ExtraParticlesStage1.centralBxOnly = cms.bool(False)
-
+muonSource = 'dqmGtDigis',
+etTotalSource = 'caloStage1LegacyFormatDigis',
+nonIsolatedEmSource = 'caloStage1LegacyFormatDigis:nonIsoEm',
+etMissSource = 'caloStage1LegacyFormatDigis',
+htMissSource = 'caloStage1LegacyFormatDigis',
+forwardJetSource = 'caloStage1LegacyFormatDigis:forJets',
+centralJetSource = 'caloStage1LegacyFormatDigis:cenJets',
+tauJetSource = 'caloStage1LegacyFormatDigis:tauJets',
+isoTauJetSource = 'caloStage1LegacyFormatDigis:isoTauJets',
+isolatedEmSource = 'caloStage1LegacyFormatDigis:isoEm',
+etHadSource = 'caloStage1LegacyFormatDigis',
+hfRingEtSumsSource = 'caloStage1LegacyFormatDigis',
+hfRingBitCountsSource = 'caloStage1LegacyFormatDigis',
+centralBxOnly = False
+)
 #
 # Modify for running with the Stage 1 trigger. Note that these changes are already
 # applied to l1extraParticles before it is cloned, but the changes are overwritten

--- a/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
@@ -41,11 +41,11 @@ from DQM.L1TMonitor.L1TdeRCT_cfi import *
 from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(l1TdeRCT, perLSsaving=True)
 
-l1TdeRCTRun1 = l1TdeRCT.clone(
-rctSourceData = 'caloStage1Digis',
-#gctSourceData = 'caloStage1Digis',
-rctSourceEmul = 'valRctDigis'
-)
+l1TdeRCTRun1 = l1TdeRCT.clone()
+l1TdeRCT.rctSourceData = 'caloStage1Digis'
+#l1TdeRCT.gctSourceData = 'caloStage1Digis'
+l1TdeRCT.rctSourceEmul = 'valRctDigis'
+
 l1TdeRCTfromRCT = l1TdeRCT.clone(
 rctSourceData = 'rctDigis',
 HistFolder = 'L1TEMU/L1TdeRCT_FromRCT'

--- a/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
@@ -41,15 +41,15 @@ from DQM.L1TMonitor.L1TdeRCT_cfi import *
 from Configuration.ProcessModifiers.dqmPerLSsaving_cff import dqmPerLSsaving
 dqmPerLSsaving.toModify(l1TdeRCT, perLSsaving=True)
 
-l1TdeRCTRun1 = l1TdeRCT.clone()
-l1TdeRCT.rctSourceData = 'caloStage1Digis'
-#l1TdeRCT.gctSourceData = 'caloStage1Digis'
-l1TdeRCT.rctSourceEmul = 'valRctDigis'
-
-l1TdeRCTfromRCT = l1TdeRCT.clone()
-l1TdeRCTfromRCT.rctSourceData = 'rctDigis'
-l1TdeRCTfromRCT.HistFolder = cms.untracked.string('L1TEMU/L1TdeRCT_FromRCT')
-
+l1TdeRCTRun1 = l1TdeRCT.clone(
+rctSourceData = 'caloStage1Digis',
+#gctSourceData = 'caloStage1Digis',
+rctSourceEmul = 'valRctDigis'
+)
+l1TdeRCTfromRCT = l1TdeRCT.clone(
+rctSourceData = 'rctDigis',
+HistFolder = 'L1TEMU/L1TdeRCT_FromRCT'
+)
 from DQM.L1TMonitor.L1TdeCSCTF_cfi import *
 
 from DQM.L1TMonitor.L1GtHwValidation_cff import *

--- a/DQM/L1TMonitor/python/L1TMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TMonitor_cff.py
@@ -28,14 +28,14 @@ from DQM.L1TMonitor.BxTiming_cfi import *
 
 # RCT DQM module 
 from DQM.L1TMonitor.L1TRCT_cfi import *
-l1tRctRun1 = l1tRct.clone()
-l1tRct.rctSource = 'caloStage1Digis'
-#l1tRct.gctSource = 'caloStage1Digis'
-
-l1tRctfromRCT = l1tRct.clone()
-l1tRctfromRCT.rctSource = 'rctDigis'
-l1tRctfromRCT.HistFolder = cms.untracked.string('L1T/L1TRCT_FromRCT')
-
+l1tRctRun1 = l1tRct.clone(
+rctSource = 'caloStage1Digis',
+#gctSource = 'caloStage1Digis'
+)
+l1tRctfromRCT = l1tRct.clone(
+rctSource = 'rctDigis',
+HistFolder = 'L1T/L1TRCT_FromRCT'
+)
 # RCT PUM DQM
 from DQM.L1TMonitor.L1TPUM_cfi import *
 

--- a/DQM/L1TMonitor/python/L1TMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TMonitor_cff.py
@@ -28,10 +28,10 @@ from DQM.L1TMonitor.BxTiming_cfi import *
 
 # RCT DQM module 
 from DQM.L1TMonitor.L1TRCT_cfi import *
-l1tRctRun1 = l1tRct.clone(
-rctSource = 'caloStage1Digis',
-#gctSource = 'caloStage1Digis'
-)
+l1tRctRun1 = l1tRct.clone()
+l1tRct.rctSource = 'caloStage1Digis'
+#l1tRct.gctSource = 'caloStage1Digis'
+
 l1tRctfromRCT = l1tRct.clone(
 rctSource = 'rctDigis',
 HistFolder = 'L1T/L1TRCT_FromRCT'

--- a/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
@@ -31,15 +31,15 @@ l1tStage2BmtfZeroSupp = DQMEDAnalyzer(
 
 # ZS of validation events (to be used after fat event filter)
 l1tStage2BmtfZeroSuppFatEvts = l1tStage2BmtfZeroSupp.clone(
-monitorDir = "L1T/L1TStage2BMTF/zeroSuppression/FatEvts",
-maxFEDReadoutSize = 25000
+    monitorDir = "L1T/L1TStage2BMTF/zeroSuppression/FatEvts",
+    maxFEDReadoutSize = 25000
 )
 # Plots for BMTF's Secondary Algo
 l1tStage2BmtfSecond = l1tStage2Bmtf.clone(
-bmtfSource = "bmtfDigis:BMTF2",
-monitorDir = "L1T/L1TStage2BMTF/L1TStage2BMTF-Secondary",
-verbose = False,
-hasDisplacementInfo = cms.untracked.bool(True)
+    bmtfSource = "bmtfDigis:BMTF2",
+    monitorDir = "L1T/L1TStage2BMTF/L1TStage2BMTF-Secondary",
+    verbose = False,
+    hasDisplacementInfo = cms.untracked.bool(True)
 )
 # sequences
 l1tStage2BmtfOnlineDQMSeq = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2BMTF_cff.py
@@ -30,17 +30,17 @@ l1tStage2BmtfZeroSupp = DQMEDAnalyzer(
 )
 
 # ZS of validation events (to be used after fat event filter)
-l1tStage2BmtfZeroSuppFatEvts = l1tStage2BmtfZeroSupp.clone()
-l1tStage2BmtfZeroSuppFatEvts.monitorDir = cms.untracked.string("L1T/L1TStage2BMTF/zeroSuppression/FatEvts")
-l1tStage2BmtfZeroSuppFatEvts.maxFEDReadoutSize = cms.untracked.int32(25000)
-
+l1tStage2BmtfZeroSuppFatEvts = l1tStage2BmtfZeroSupp.clone(
+monitorDir = "L1T/L1TStage2BMTF/zeroSuppression/FatEvts",
+maxFEDReadoutSize = 25000
+)
 # Plots for BMTF's Secondary Algo
-l1tStage2BmtfSecond = l1tStage2Bmtf.clone()
-l1tStage2BmtfSecond.bmtfSource = cms.InputTag("bmtfDigis","BMTF2")
-l1tStage2BmtfSecond.monitorDir = cms.untracked.string("L1T/L1TStage2BMTF/L1TStage2BMTF-Secondary")
-l1tStage2BmtfSecond.verbose = cms.untracked.bool(False)
-l1tStage2BmtfSecond.hasDisplacementInfo = cms.untracked.bool(True)
-
+l1tStage2BmtfSecond = l1tStage2Bmtf.clone(
+bmtfSource = "bmtfDigis:BMTF2",
+monitorDir = "L1T/L1TStage2BMTF/L1TStage2BMTF-Secondary",
+verbose = False,
+hasDisplacementInfo = cms.untracked.bool(True)
+)
 # sequences
 l1tStage2BmtfOnlineDQMSeq = cms.Sequence(
     l1tStage2Bmtf +

--- a/DQM/L1TMonitor/python/L1TStage2FED_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2FED_cff.py
@@ -1,7 +1,7 @@
 from DQM.L1TMonitor.L1TFED_cfi import *
 
-l1tStage2Fed = l1tfed.clone()
-l1tStage2Fed.L1FEDS = cms.vint32(
+l1tStage2Fed = l1tfed.clone(
+L1FEDS = (
     1354, 1356, 1358, # CALOL1
     1360,             # CALOL2
     1376, 1377,       # BMTF
@@ -11,4 +11,4 @@ l1tStage2Fed.L1FEDS = cms.vint32(
     1402,             # GMT
     1404,             # UGT
     1405)             # UGTSPARE
-
+)

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -185,30 +185,30 @@ l1tStage2uGMTMuonVsuGMTMuonCopy1 = DQMEDAnalyzer(
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
 stage2L1Trigger_2021.toModify(l1tStage2uGMTMuonVsuGMTMuonCopy1, displacedQuantities = cms.untracked.bool(True))
 
-l1tStage2uGMTMuonVsuGMTMuonCopy2 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy2.muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy2")
-l1tStage2uGMTMuonVsuGMTMuonCopy2.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2")
-l1tStage2uGMTMuonVsuGMTMuonCopy2.muonCollection2Title = cms.untracked.string("uGMT muons copy 2")
-l1tStage2uGMTMuonVsuGMTMuonCopy2.summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 2")
-
-l1tStage2uGMTMuonVsuGMTMuonCopy3 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy3.muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy3")
-l1tStage2uGMTMuonVsuGMTMuonCopy3.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3")
-l1tStage2uGMTMuonVsuGMTMuonCopy3.muonCollection2Title = cms.untracked.string("uGMT muons copy 3")
-l1tStage2uGMTMuonVsuGMTMuonCopy3.summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 3")
-
-l1tStage2uGMTMuonVsuGMTMuonCopy4 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy4.muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy4")
-l1tStage2uGMTMuonVsuGMTMuonCopy4.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4")
-l1tStage2uGMTMuonVsuGMTMuonCopy4.muonCollection2Title = cms.untracked.string("uGMT muons copy 4")
-l1tStage2uGMTMuonVsuGMTMuonCopy4.summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 4")
-
-l1tStage2uGMTMuonVsuGMTMuonCopy5 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy5.muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy5")
-l1tStage2uGMTMuonVsuGMTMuonCopy5.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5")
-l1tStage2uGMTMuonVsuGMTMuonCopy5.muonCollection2Title = cms.untracked.string("uGMT muons copy 5")
-l1tStage2uGMTMuonVsuGMTMuonCopy5.summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 5")
-
+l1tStage2uGMTMuonVsuGMTMuonCopy2 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
+muonCollection2 = "gmtStage2Digis:MuonCopy2",
+monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2",
+muonCollection2Title = "uGMT muons copy 2",
+summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 2"
+)
+l1tStage2uGMTMuonVsuGMTMuonCopy3 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
+muonCollection2 = "gmtStage2Digis:MuonCopy3",
+monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3",
+muonCollection2Title = "uGMT muons copy 3",
+summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 3"
+)
+l1tStage2uGMTMuonVsuGMTMuonCopy4 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
+muonCollection2 = "gmtStage2Digis:MuonCopy4",
+monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4",
+muonCollection2Title = "uGMT muons copy 4",
+summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 4"
+)
+l1tStage2uGMTMuonVsuGMTMuonCopy5 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
+muonCollection2 = "gmtStage2Digis:MuonCopy5",
+monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5",
+muonCollection2Title = "uGMT muons copy 5",
+summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 5"
+)
 # sequences
 l1tStage2uGMTOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMT +

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -186,28 +186,28 @@ from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger
 stage2L1Trigger_2021.toModify(l1tStage2uGMTMuonVsuGMTMuonCopy1, displacedQuantities = cms.untracked.bool(True))
 
 l1tStage2uGMTMuonVsuGMTMuonCopy2 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
-muonCollection2 = "gmtStage2Digis:MuonCopy2",
-monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2",
-muonCollection2Title = "uGMT muons copy 2",
-summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 2"
+    muonCollection2 = "gmtStage2Digis:MuonCopy2",
+    monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy2",
+    muonCollection2Title = "uGMT muons copy 2",
+    summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 2"
 )
 l1tStage2uGMTMuonVsuGMTMuonCopy3 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
-muonCollection2 = "gmtStage2Digis:MuonCopy3",
-monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3",
-muonCollection2Title = "uGMT muons copy 3",
-summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 3"
+    muonCollection2 = "gmtStage2Digis:MuonCopy3",
+    monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy3",
+    muonCollection2Title = "uGMT muons copy 3",
+    summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 3"
 )
 l1tStage2uGMTMuonVsuGMTMuonCopy4 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
-muonCollection2 = "gmtStage2Digis:MuonCopy4",
-monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4",
-muonCollection2Title = "uGMT muons copy 4",
-summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 4"
+    muonCollection2 = "gmtStage2Digis:MuonCopy4",
+    monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy4",
+    muonCollection2Title = "uGMT muons copy 4",
+    summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 4"
 )
 l1tStage2uGMTMuonVsuGMTMuonCopy5 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
-muonCollection2 = "gmtStage2Digis:MuonCopy5",
-monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5",
-muonCollection2Title = "uGMT muons copy 5",
-summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 5"
+    muonCollection2 = "gmtStage2Digis:MuonCopy5",
+    monitorDir = "L1T/L1TStage2uGMT/uGMTMuonCopies/uGMTMuonCopy5",
+    muonCollection2Title = "uGMT muons copy 5",
+    summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 5"
 )
 # sequences
 l1tStage2uGMTOnlineDQMSeq = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TStage2uGTBoardComp_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTBoardComp_cff.py
@@ -15,30 +15,30 @@ l1tStage2uGTMuon1vsMuon2 = DQMEDAnalyzer(
     verbose = cms.untracked.bool(False),
 )
 
-l1tStage2uGTMuon1vsMuon3 = l1tStage2uGTMuon1vsMuon2.clone()
-l1tStage2uGTMuon1vsMuon3.muonCollection2 = cms.InputTag("gtStage2Digis", "Muon3")
-l1tStage2uGTMuon1vsMuon3.muonCollection2Title = cms.untracked.string("Muons uGT Board 3")
-l1tStage2uGTMuon1vsMuon3.summaryTitle = cms.untracked.string("Summary of Comparison between Muons from uGT Board 1 and uGT Board 3")
-l1tStage2uGTMuon1vsMuon3.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/Muons")
-
-l1tStage2uGTMuon1vsMuon4 = l1tStage2uGTMuon1vsMuon2.clone()
-l1tStage2uGTMuon1vsMuon4.muonCollection2 = cms.InputTag("gtStage2Digis", "Muon4")
-l1tStage2uGTMuon1vsMuon4.muonCollection2Title = cms.untracked.string("Muons uGT Board 4")
-l1tStage2uGTMuon1vsMuon4.summaryTitle = cms.untracked.string("Summary of Comparison between Muons from uGT Board 1 and uGT Board 4")
-l1tStage2uGTMuon1vsMuon4.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/Muons")
-
-l1tStage2uGTMuon1vsMuon5 = l1tStage2uGTMuon1vsMuon2.clone()
-l1tStage2uGTMuon1vsMuon5.muonCollection2 = cms.InputTag("gtStage2Digis", "Muon5")
-l1tStage2uGTMuon1vsMuon5.muonCollection2Title = cms.untracked.string("Muons uGT Board 5")
-l1tStage2uGTMuon1vsMuon5.summaryTitle = cms.untracked.string("Summary of Comparison between Muons from uGT Board 1 and uGT Board 5")
-l1tStage2uGTMuon1vsMuon5.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/Muons")
-
-l1tStage2uGTMuon1vsMuon6 = l1tStage2uGTMuon1vsMuon2.clone()
-l1tStage2uGTMuon1vsMuon6.muonCollection2 = cms.InputTag("gtStage2Digis", "Muon6")
-l1tStage2uGTMuon1vsMuon6.muonCollection2Title = cms.untracked.string("Muons uGT Board 6")
-l1tStage2uGTMuon1vsMuon6.summaryTitle = cms.untracked.string("Summary of Comparison between Muons from uGT Board 1 and uGT Board 6")
-l1tStage2uGTMuon1vsMuon6.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/Muons")
-
+l1tStage2uGTMuon1vsMuon3 = l1tStage2uGTMuon1vsMuon2.clone(
+muonCollection2 = "gtStage2Digis:Muon3",
+muonCollection2Title = "Muons uGT Board 3",
+summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 3",
+monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/Muons"
+)
+l1tStage2uGTMuon1vsMuon4 = l1tStage2uGTMuon1vsMuon2.clone(
+muonCollection2 = "gtStage2Digis:Muon4",
+muonCollection2Title = "Muons uGT Board 4",
+summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 4",
+monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/Muons"
+)
+l1tStage2uGTMuon1vsMuon5 = l1tStage2uGTMuon1vsMuon2.clone(
+muonCollection2 = "gtStage2Digis:Muon5",
+muonCollection2Title = "Muons uGT Board 5",
+summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 5",
+monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/Muons"
+)
+l1tStage2uGTMuon1vsMuon6 = l1tStage2uGTMuon1vsMuon2.clone(
+muonCollection2 = "gtStage2Digis:Muon6",
+muonCollection2Title = "Muons uGT Board 6",
+summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 6",
+monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/Muons"
+)
 l1tStage2uGTBoardCompMuonsSeq = cms.Sequence(
     l1tStage2uGTMuon1vsMuon2 +
     l1tStage2uGTMuon1vsMuon3 +
@@ -64,38 +64,38 @@ l1tStage2uGTCalo1vsCalo2 = DQMEDAnalyzer(
     monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard2/CaloLayer2"),
 )
 
-l1tStage2uGTCalo1vsCalo3 = l1tStage2uGTCalo1vsCalo2.clone()
-l1tStage2uGTCalo1vsCalo3.collection2Title  = cms.untracked.string("uGT Board 3") 
-l1tStage2uGTCalo1vsCalo3.JetCollection2    = cms.InputTag("gtStage2Digis", "Jet3")
-l1tStage2uGTCalo1vsCalo3.EGammaCollection2 = cms.InputTag("gtStage2Digis", "EGamma3")
-l1tStage2uGTCalo1vsCalo3.TauCollection2    = cms.InputTag("gtStage2Digis", "Tau3")
-l1tStage2uGTCalo1vsCalo3.EtSumCollection2  = cms.InputTag("gtStage2Digis", "EtSum3")
-l1tStage2uGTCalo1vsCalo3.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/CaloLayer2")
-
-l1tStage2uGTCalo1vsCalo4 = l1tStage2uGTCalo1vsCalo2.clone()
-l1tStage2uGTCalo1vsCalo4.collection2Title  = cms.untracked.string("uGT Board 4") 
-l1tStage2uGTCalo1vsCalo4.JetCollection2    = cms.InputTag("gtStage2Digis", "Jet4")
-l1tStage2uGTCalo1vsCalo4.EGammaCollection2 = cms.InputTag("gtStage2Digis", "EGamma4")
-l1tStage2uGTCalo1vsCalo4.TauCollection2    = cms.InputTag("gtStage2Digis", "Tau4")
-l1tStage2uGTCalo1vsCalo4.EtSumCollection2  = cms.InputTag("gtStage2Digis", "EtSum4")
-l1tStage2uGTCalo1vsCalo4.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/CaloLayer2")
-
-l1tStage2uGTCalo1vsCalo5 = l1tStage2uGTCalo1vsCalo2.clone()
-l1tStage2uGTCalo1vsCalo5.collection2Title  = cms.untracked.string("uGT Board 5") 
-l1tStage2uGTCalo1vsCalo5.JetCollection2    = cms.InputTag("gtStage2Digis", "Jet5")
-l1tStage2uGTCalo1vsCalo5.EGammaCollection2 = cms.InputTag("gtStage2Digis", "EGamma5")
-l1tStage2uGTCalo1vsCalo5.TauCollection2    = cms.InputTag("gtStage2Digis", "Tau5")
-l1tStage2uGTCalo1vsCalo5.EtSumCollection2  = cms.InputTag("gtStage2Digis", "EtSum5")
-l1tStage2uGTCalo1vsCalo5.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/CaloLayer2")
-
-l1tStage2uGTCalo1vsCalo6 = l1tStage2uGTCalo1vsCalo2.clone()
-l1tStage2uGTCalo1vsCalo6.collection2Title  = cms.untracked.string("uGT Board 6") 
-l1tStage2uGTCalo1vsCalo6.JetCollection2    = cms.InputTag("gtStage2Digis", "Jet6")
-l1tStage2uGTCalo1vsCalo6.EGammaCollection2 = cms.InputTag("gtStage2Digis", "EGamma6")
-l1tStage2uGTCalo1vsCalo6.TauCollection2    = cms.InputTag("gtStage2Digis", "Tau6")
-l1tStage2uGTCalo1vsCalo6.EtSumCollection2  = cms.InputTag("gtStage2Digis", "EtSum6")
-l1tStage2uGTCalo1vsCalo6.monitorDir = cms.untracked.string("L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/CaloLayer2")
-
+l1tStage2uGTCalo1vsCalo3 = l1tStage2uGTCalo1vsCalo2.clone(
+collection2Title  = "uGT Board 3", 
+JetCollection2    = "gtStage2Digis:Jet3",
+EGammaCollection2 = "gtStage2Digis:EGamma3",
+TauCollection2    = "gtStage2Digis:Tau3",
+EtSumCollection2  = "gtStage2Digis:EtSum3",
+monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/CaloLayer2"
+)
+l1tStage2uGTCalo1vsCalo4 = l1tStage2uGTCalo1vsCalo2.clone(
+collection2Title  = "uGT Board 4", 
+JetCollection2    = "gtStage2Digis:Jet4",
+EGammaCollection2 = "gtStage2Digis:EGamma4",
+TauCollection2    = "gtStage2Digis:Tau4",
+EtSumCollection2  = "gtStage2Digis:EtSum4",
+monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/CaloLayer2"
+)
+l1tStage2uGTCalo1vsCalo5 = l1tStage2uGTCalo1vsCalo2.clone(
+collection2Title  = "uGT Board 5", 
+JetCollection2    = "gtStage2Digis:Jet5",
+EGammaCollection2 = "gtStage2Digis:EGamma5",
+TauCollection2    = "gtStage2Digis:Tau5",
+EtSumCollection2  = "gtStage2Digis:EtSum5",
+monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/CaloLayer2"
+)
+l1tStage2uGTCalo1vsCalo6 = l1tStage2uGTCalo1vsCalo2.clone(
+collection2Title  = "uGT Board 6", 
+JetCollection2    = "gtStage2Digis:Jet6",
+EGammaCollection2 = "gtStage2Digis:EGamma6",
+TauCollection2    = "gtStage2Digis:Tau6",
+EtSumCollection2  = "gtStage2Digis:EtSum6",
+monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/CaloLayer2"
+)
 l1tStage2uGTBoardCompCaloLayer2Seq = cms.Sequence(
     l1tStage2uGTCalo1vsCalo2 +
     l1tStage2uGTCalo1vsCalo3 +

--- a/DQM/L1TMonitor/python/L1TStage2uGTBoardComp_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGTBoardComp_cff.py
@@ -16,28 +16,28 @@ l1tStage2uGTMuon1vsMuon2 = DQMEDAnalyzer(
 )
 
 l1tStage2uGTMuon1vsMuon3 = l1tStage2uGTMuon1vsMuon2.clone(
-muonCollection2 = "gtStage2Digis:Muon3",
-muonCollection2Title = "Muons uGT Board 3",
-summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 3",
-monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/Muons"
+    muonCollection2 = "gtStage2Digis:Muon3",
+    muonCollection2Title = "Muons uGT Board 3",
+    summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 3",
+    monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/Muons"
 )
 l1tStage2uGTMuon1vsMuon4 = l1tStage2uGTMuon1vsMuon2.clone(
-muonCollection2 = "gtStage2Digis:Muon4",
-muonCollection2Title = "Muons uGT Board 4",
-summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 4",
-monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/Muons"
+    muonCollection2 = "gtStage2Digis:Muon4",
+    muonCollection2Title = "Muons uGT Board 4",
+    summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 4",
+    monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/Muons"
 )
 l1tStage2uGTMuon1vsMuon5 = l1tStage2uGTMuon1vsMuon2.clone(
-muonCollection2 = "gtStage2Digis:Muon5",
-muonCollection2Title = "Muons uGT Board 5",
-summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 5",
-monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/Muons"
+    muonCollection2 = "gtStage2Digis:Muon5",
+    muonCollection2Title = "Muons uGT Board 5",
+    summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 5",
+    monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/Muons"
 )
 l1tStage2uGTMuon1vsMuon6 = l1tStage2uGTMuon1vsMuon2.clone(
-muonCollection2 = "gtStage2Digis:Muon6",
-muonCollection2Title = "Muons uGT Board 6",
-summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 6",
-monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/Muons"
+    muonCollection2 = "gtStage2Digis:Muon6",
+    muonCollection2Title = "Muons uGT Board 6",
+    summaryTitle = "Summary of Comparison between Muons from uGT Board 1 and uGT Board 6",
+    monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/Muons"
 )
 l1tStage2uGTBoardCompMuonsSeq = cms.Sequence(
     l1tStage2uGTMuon1vsMuon2 +
@@ -65,36 +65,36 @@ l1tStage2uGTCalo1vsCalo2 = DQMEDAnalyzer(
 )
 
 l1tStage2uGTCalo1vsCalo3 = l1tStage2uGTCalo1vsCalo2.clone(
-collection2Title  = "uGT Board 3", 
-JetCollection2    = "gtStage2Digis:Jet3",
-EGammaCollection2 = "gtStage2Digis:EGamma3",
-TauCollection2    = "gtStage2Digis:Tau3",
-EtSumCollection2  = "gtStage2Digis:EtSum3",
-monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/CaloLayer2"
+    collection2Title  = "uGT Board 3", 
+    JetCollection2    = "gtStage2Digis:Jet3",
+    EGammaCollection2 = "gtStage2Digis:EGamma3",
+    TauCollection2    = "gtStage2Digis:Tau3",
+    EtSumCollection2  = "gtStage2Digis:EtSum3",
+    monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard3/CaloLayer2"
 )
 l1tStage2uGTCalo1vsCalo4 = l1tStage2uGTCalo1vsCalo2.clone(
-collection2Title  = "uGT Board 4", 
-JetCollection2    = "gtStage2Digis:Jet4",
-EGammaCollection2 = "gtStage2Digis:EGamma4",
-TauCollection2    = "gtStage2Digis:Tau4",
-EtSumCollection2  = "gtStage2Digis:EtSum4",
-monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/CaloLayer2"
+    collection2Title  = "uGT Board 4", 
+    JetCollection2    = "gtStage2Digis:Jet4",
+    EGammaCollection2 = "gtStage2Digis:EGamma4",
+    TauCollection2    = "gtStage2Digis:Tau4",
+    EtSumCollection2  = "gtStage2Digis:EtSum4",
+    monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard4/CaloLayer2"
 )
 l1tStage2uGTCalo1vsCalo5 = l1tStage2uGTCalo1vsCalo2.clone(
-collection2Title  = "uGT Board 5", 
-JetCollection2    = "gtStage2Digis:Jet5",
-EGammaCollection2 = "gtStage2Digis:EGamma5",
-TauCollection2    = "gtStage2Digis:Tau5",
-EtSumCollection2  = "gtStage2Digis:EtSum5",
-monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/CaloLayer2"
+    collection2Title  = "uGT Board 5", 
+    JetCollection2    = "gtStage2Digis:Jet5",
+    EGammaCollection2 = "gtStage2Digis:EGamma5",
+    TauCollection2    = "gtStage2Digis:Tau5",
+    EtSumCollection2  = "gtStage2Digis:EtSum5",
+    monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard5/CaloLayer2"
 )
 l1tStage2uGTCalo1vsCalo6 = l1tStage2uGTCalo1vsCalo2.clone(
-collection2Title  = "uGT Board 6", 
-JetCollection2    = "gtStage2Digis:Jet6",
-EGammaCollection2 = "gtStage2Digis:EGamma6",
-TauCollection2    = "gtStage2Digis:Tau6",
-EtSumCollection2  = "gtStage2Digis:EtSum6",
-monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/CaloLayer2"
+    collection2Title  = "uGT Board 6", 
+    JetCollection2    = "gtStage2Digis:Jet6",
+    EGammaCollection2 = "gtStage2Digis:EGamma6",
+    TauCollection2    = "gtStage2Digis:Tau6",
+    EtSumCollection2  = "gtStage2Digis:EtSum6",
+    monitorDir = "L1T/L1TStage2uGT/uGTBoardComparisons/Board1vsBoard6/CaloLayer2"
 )
 l1tStage2uGTBoardCompCaloLayer2Seq = cms.Sequence(
     l1tStage2uGTCalo1vsCalo2 +

--- a/DQM/L1TMonitor/python/L1TSync_cff.py
+++ b/DQM/L1TMonitor/python/L1TSync_cff.py
@@ -3,20 +3,20 @@ import FWCore.ParameterSet.Config as cms
 # filter to select HLT events
 from HLTrigger.HLTfilters.hltHighLevel_cfi import *
 
-l1tSyncHltFilter = hltHighLevel.clone(TriggerResultsTag ="TriggerResults::HLT")
-l1tSyncHltFilter.throw = cms.bool(False)
-l1tSyncHltFilter.HLTPaths = ['HLT_ZeroBias_v*',
-                             'HLT_L1ETM30_v*',
-                             'HLT_L1ETM40_v*',
-                             'HLT_L1ETM70_v*',
-                             'HLT_L1ETM100_v*',
-                             'HLT_L1SingleEG5_v*',
-                             'HLT_L1SingleEG12_v*',
-                             'HLT_L1SingleJet16_v*',
-                             'HLT_L1SingleJet36_v*',
-                             'HLT_L1SingleMu12_v*'
-                             ]
-
+l1tSyncHltFilter = hltHighLevel.clone(TriggerResultsTag ="TriggerResults::HLT",
+throw = False,
+HLTPaths = ('HLT_ZeroBias_v*',
+            'HLT_L1ETM30_v*',
+            'HLT_L1ETM40_v*',
+            'HLT_L1ETM70_v*',
+            'HLT_L1ETM100_v*',
+            'HLT_L1SingleEG5_v*',
+            'HLT_L1SingleEG12_v*',
+            'HLT_L1SingleJet16_v*',
+            'HLT_L1SingleJet36_v*',
+            'HLT_L1SingleMu12_v*'
+)
+)
 
 
 # L1 synchronization DQM module

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -83,7 +83,7 @@ l1tdeStage2uGMT = DQMEDAnalyzer(
     verbose = cms.untracked.bool(False),
     enable2DComp = cms.untracked.bool(True), # When true eta-phi comparison plots are also produced
     displacedQuantities = cms.untracked.bool(False),
-    ignoreBin = cms.untracked.vint32(ignoreBins),
+    ignoreBin = cms.untracked.vint32(),
 )
 
 ## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
@@ -93,43 +93,43 @@ stage2L1Trigger_2021.toModify(l1tdeStage2uGMT, displacedQuantities = cms.untrack
 # compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection
 # only muons that do not match are filled in the histograms
 l1tdeStage2uGMTIntermediateBMTF = l1tdeStage2uGMT.clone(
-    muonCollection1 = (unpackerModule, "imdMuonsBMTF")
-    muonCollection2 = (emulatorModule, "imdMuonsBMTF")
-    monitorDir = ugmtEmuImdMuDqmDir+"/BMTF/data_vs_emulator_comparison"
-    summaryTitle = "Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated"
-    ignoreBin = (ignoreBins)
+    muonCollection1 = (unpackerModule, "imdMuonsBMTF"),
+    muonCollection2 = (emulatorModule, "imdMuonsBMTF"),
+    monitorDir = ugmtEmuImdMuDqmDir+"/BMTF/data_vs_emulator_comparison",
+    summaryTitle = "Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated",
+    ignoreBin = ignoreBins
 )
 l1tdeStage2uGMTIntermediateOMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone(
-    displacedQuantities = False
-    muonCollection1 = (unpackerModule, "imdMuonsOMTFNeg")
-    muonCollection2 = (emulatorModule, "imdMuonsOMTFNeg")
-    monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison")
-    summaryTitle = ("Summary of uGMT intermediate muon from OMTF- comparison between unpacked and emulated")
-    ignoreBin = (ignoreBins)
+    displacedQuantities = False,
+    muonCollection1 = (unpackerModule, "imdMuonsOMTFNeg"),
+    muonCollection2 = (emulatorModule, "imdMuonsOMTFNeg"),
+    monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison"),
+    summaryTitle = ("Summary of uGMT intermediate muon from OMTF- comparison between unpacked and emulated"),
+    ignoreBin = ignoreBins
 )
 l1tdeStage2uGMTIntermediateOMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone(
-    displacedQuantities = False
-    muonCollection1 = (unpackerModule, "imdMuonsOMTFPos")
-    muonCollection2 = (emulatorModule, "imdMuonsOMTFPos")
-    monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison")
-    summaryTitle = "Summary of uGMT intermediate muon from OMTF+ comparison between unpacked and emulated"
-    ignoreBin = (ignoreBins)
+    displacedQuantities = False,
+    muonCollection1 = (unpackerModule, "imdMuonsOMTFPos"),
+    muonCollection2 = (emulatorModule, "imdMuonsOMTFPos"),
+    monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison"),
+    summaryTitle = "Summary of uGMT intermediate muon from OMTF+ comparison between unpacked and emulated",
+    ignoreBin = ignoreBins
 )
 l1tdeStage2uGMTIntermediateEMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone(
-    displacedQuantities = False
-    muonCollection1 = (unpackerModule, "imdMuonsEMTFNeg")
-    muonCollection2 = (emulatorModule, "imdMuonsEMTFNeg")
-    monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison")
-    summaryTitle = "Summary of uGMT intermediate muon from EMTF- comparison between unpacked and emulated"
-    ignoreBin = (ignoreBins)
+    displacedQuantities = False,
+    muonCollection1 = (unpackerModule, "imdMuonsEMTFNeg"),
+    muonCollection2 = (emulatorModule, "imdMuonsEMTFNeg"),
+    monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison"),
+    summaryTitle = "Summary of uGMT intermediate muon from EMTF- comparison between unpacked and emulated",
+    ignoreBin = ignoreBins
 )
 l1tdeStage2uGMTIntermediateEMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone(
-    displacedQuantities = False
-    muonCollection1 = (unpackerModule, "imdMuonsEMTFPos")
-    muonCollection2 = (emulatorModule, "imdMuonsEMTFPos")
-    monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison")
-    summaryTitle = "Summary of uGMT intermediate muon from EMTF+ comparison between unpacked and emulated"
-    ignoreBin = (ignoreBins)
+    displacedQuantities = False,
+    muonCollection1 = (unpackerModule, "imdMuonsEMTFPos"),
+    muonCollection2 = (emulatorModule, "imdMuonsEMTFPos"),
+    monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison"),
+    summaryTitle = "Summary of uGMT intermediate muon from EMTF+ comparison between unpacked and emulated",
+    ignoreBin = ignoreBins
 )
 # sequences
 l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -14,11 +14,11 @@ ignoreBins = [7, 8, 12, 13]
 # fills histograms with all uGMT emulated muons
 # uGMT input muon histograms from track finders are not filled since they are identical to the data DQM plots
 from DQM.L1TMonitor.L1TStage2uGMT_cfi import *
-l1tStage2uGMTEmul = l1tStage2uGMT.clone()
-l1tStage2uGMTEmul.muonProducer = cms.InputTag(emulatorModule)
-l1tStage2uGMTEmul.monitorDir = cms.untracked.string(ugmtEmuDqmDir)
-l1tStage2uGMTEmul.emulator = cms.untracked.bool(True)
-
+l1tStage2uGMTEmul = l1tStage2uGMT.clone(
+muonProducer = emulatorModule,
+monitorDir = ugmtEmuDqmDir,
+emulator = True
+)
 # the uGMT intermediate muon DQM modules
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tStage2uGMTIntermediateBMTFEmul = DQMEDAnalyzer(
@@ -92,43 +92,43 @@ stage2L1Trigger_2021.toModify(l1tdeStage2uGMT, displacedQuantities = cms.untrack
 # compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection
 # only muons that do not match are filled in the histograms
 l1tdeStage2uGMTIntermediateBMTF = l1tdeStage2uGMT.clone()
-l1tdeStage2uGMTIntermediateBMTF.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsBMTF")
-l1tdeStage2uGMTIntermediateBMTF.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsBMTF")
-l1tdeStage2uGMTIntermediateBMTF.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/BMTF/data_vs_emulator_comparison")
-l1tdeStage2uGMTIntermediateBMTF.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated")
-l1tdeStage2uGMTIntermediateBMTF.ignoreBin = cms.untracked.vint32(ignoreBins)
+muonCollection1 = (unpackerModule, "imdMuonsBMTF")
+muonCollection2 = (emulatorModule, "imdMuonsBMTF")
+monitorDir = ugmtEmuImdMuDqmDir+"/BMTF/data_vs_emulator_comparison"
+summaryTitle = "Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated"
+ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateOMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
-l1tdeStage2uGMTIntermediateOMTFNeg.displacedQuantities = cms.untracked.bool(False)
-l1tdeStage2uGMTIntermediateOMTFNeg.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsOMTFNeg")
-l1tdeStage2uGMTIntermediateOMTFNeg.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsOMTFNeg")
-l1tdeStage2uGMTIntermediateOMTFNeg.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison")
-l1tdeStage2uGMTIntermediateOMTFNeg.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from OMTF- comparison between unpacked and emulated")
-l1tdeStage2uGMTIntermediateOMTFNeg.ignoreBin = cms.untracked.vint32(ignoreBins)
+displacedQuantities = False
+muonCollection1 = (unpackerModule, "imdMuonsOMTFNeg")
+muonCollection2 = (emulatorModule, "imdMuonsOMTFNeg")
+monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison")
+summaryTitle = ("Summary of uGMT intermediate muon from OMTF- comparison between unpacked and emulated")
+ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateOMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
-l1tdeStage2uGMTIntermediateOMTFPos.displacedQuantities = cms.untracked.bool(False)
-l1tdeStage2uGMTIntermediateOMTFPos.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsOMTFPos")
-l1tdeStage2uGMTIntermediateOMTFPos.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsOMTFPos")
-l1tdeStage2uGMTIntermediateOMTFPos.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison")
-l1tdeStage2uGMTIntermediateOMTFPos.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from OMTF+ comparison between unpacked and emulated")
-l1tdeStage2uGMTIntermediateOMTFPos.ignoreBin = cms.untracked.vint32(ignoreBins)
+displacedQuantities = False
+muonCollection1 = (unpackerModule, "imdMuonsOMTFPos")
+muonCollection2 = (emulatorModule, "imdMuonsOMTFPos")
+monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison")
+summaryTitle = "Summary of uGMT intermediate muon from OMTF+ comparison between unpacked and emulated"
+ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateEMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
-l1tdeStage2uGMTIntermediateEMTFNeg.displacedQuantities = cms.untracked.bool(False)
-l1tdeStage2uGMTIntermediateEMTFNeg.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsEMTFNeg")
-l1tdeStage2uGMTIntermediateEMTFNeg.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsEMTFNeg")
-l1tdeStage2uGMTIntermediateEMTFNeg.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison")
-l1tdeStage2uGMTIntermediateEMTFNeg.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from EMTF- comparison between unpacked and emulated")
-l1tdeStage2uGMTIntermediateEMTFNeg.ignoreBin = cms.untracked.vint32(ignoreBins)
+displacedQuantities = False
+muonCollection1 = (unpackerModule, "imdMuonsEMTFNeg")
+muonCollection2 = (emulatorModule, "imdMuonsEMTFNeg")
+monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison")
+summaryTitle = "Summary of uGMT intermediate muon from EMTF- comparison between unpacked and emulated"
+ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateEMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
-l1tdeStage2uGMTIntermediateEMTFPos.displacedQuantities = cms.untracked.bool(False)
-l1tdeStage2uGMTIntermediateEMTFPos.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsEMTFPos")
-l1tdeStage2uGMTIntermediateEMTFPos.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsEMTFPos")
-l1tdeStage2uGMTIntermediateEMTFPos.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison")
-l1tdeStage2uGMTIntermediateEMTFPos.summaryTitle = cms.untracked.string("Summary of uGMT intermediate muon from EMTF+ comparison between unpacked and emulated")
-l1tdeStage2uGMTIntermediateEMTFPos.ignoreBin = cms.untracked.vint32(ignoreBins)
+displacedQuantities = False
+muonCollection1 = (unpackerModule, "imdMuonsEMTFPos")
+muonCollection2 = (emulatorModule, "imdMuonsEMTFPos")
+monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison")
+summaryTitle = "Summary of uGMT intermediate muon from EMTF+ comparison between unpacked and emulated"
+ignoreBin = cms.untracked.vint32(ignoreBins)
 
 # sequences
 l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -15,9 +15,9 @@ ignoreBins = [7, 8, 12, 13]
 # uGMT input muon histograms from track finders are not filled since they are identical to the data DQM plots
 from DQM.L1TMonitor.L1TStage2uGMT_cfi import *
 l1tStage2uGMTEmul = l1tStage2uGMT.clone(
-muonProducer = emulatorModule,
-monitorDir = ugmtEmuDqmDir,
-emulator = True
+    muonProducer = emulatorModule,
+    monitorDir = ugmtEmuDqmDir,
+    emulator = True
 )
 # the uGMT intermediate muon DQM modules
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
@@ -83,6 +83,7 @@ l1tdeStage2uGMT = DQMEDAnalyzer(
     verbose = cms.untracked.bool(False),
     enable2DComp = cms.untracked.bool(True), # When true eta-phi comparison plots are also produced
     displacedQuantities = cms.untracked.bool(False),
+    ignoreBin = cms.untracked.vint32(ignoreBins),
 )
 
 ## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
@@ -91,45 +92,45 @@ stage2L1Trigger_2021.toModify(l1tdeStage2uGMT, displacedQuantities = cms.untrack
 
 # compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection
 # only muons that do not match are filled in the histograms
-l1tdeStage2uGMTIntermediateBMTF = l1tdeStage2uGMT.clone()
-muonCollection1 = (unpackerModule, "imdMuonsBMTF")
-muonCollection2 = (emulatorModule, "imdMuonsBMTF")
-monitorDir = ugmtEmuImdMuDqmDir+"/BMTF/data_vs_emulator_comparison"
-summaryTitle = "Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated"
-ignoreBin = cms.untracked.vint32(ignoreBins)
-
-l1tdeStage2uGMTIntermediateOMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
-displacedQuantities = False
-muonCollection1 = (unpackerModule, "imdMuonsOMTFNeg")
-muonCollection2 = (emulatorModule, "imdMuonsOMTFNeg")
-monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison")
-summaryTitle = ("Summary of uGMT intermediate muon from OMTF- comparison between unpacked and emulated")
-ignoreBin = cms.untracked.vint32(ignoreBins)
-
-l1tdeStage2uGMTIntermediateOMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
-displacedQuantities = False
-muonCollection1 = (unpackerModule, "imdMuonsOMTFPos")
-muonCollection2 = (emulatorModule, "imdMuonsOMTFPos")
-monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison")
-summaryTitle = "Summary of uGMT intermediate muon from OMTF+ comparison between unpacked and emulated"
-ignoreBin = cms.untracked.vint32(ignoreBins)
-
-l1tdeStage2uGMTIntermediateEMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
-displacedQuantities = False
-muonCollection1 = (unpackerModule, "imdMuonsEMTFNeg")
-muonCollection2 = (emulatorModule, "imdMuonsEMTFNeg")
-monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison")
-summaryTitle = "Summary of uGMT intermediate muon from EMTF- comparison between unpacked and emulated"
-ignoreBin = cms.untracked.vint32(ignoreBins)
-
-l1tdeStage2uGMTIntermediateEMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
-displacedQuantities = False
-muonCollection1 = (unpackerModule, "imdMuonsEMTFPos")
-muonCollection2 = (emulatorModule, "imdMuonsEMTFPos")
-monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison")
-summaryTitle = "Summary of uGMT intermediate muon from EMTF+ comparison between unpacked and emulated"
-ignoreBin = cms.untracked.vint32(ignoreBins)
-
+l1tdeStage2uGMTIntermediateBMTF = l1tdeStage2uGMT.clone(
+    muonCollection1 = (unpackerModule, "imdMuonsBMTF")
+    muonCollection2 = (emulatorModule, "imdMuonsBMTF")
+    monitorDir = ugmtEmuImdMuDqmDir+"/BMTF/data_vs_emulator_comparison"
+    summaryTitle = "Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated"
+    ignoreBin = (ignoreBins)
+)
+l1tdeStage2uGMTIntermediateOMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone(
+    displacedQuantities = False
+    muonCollection1 = (unpackerModule, "imdMuonsOMTFNeg")
+    muonCollection2 = (emulatorModule, "imdMuonsOMTFNeg")
+    monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison")
+    summaryTitle = ("Summary of uGMT intermediate muon from OMTF- comparison between unpacked and emulated")
+    ignoreBin = (ignoreBins)
+)
+l1tdeStage2uGMTIntermediateOMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone(
+    displacedQuantities = False
+    muonCollection1 = (unpackerModule, "imdMuonsOMTFPos")
+    muonCollection2 = (emulatorModule, "imdMuonsOMTFPos")
+    monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison")
+    summaryTitle = "Summary of uGMT intermediate muon from OMTF+ comparison between unpacked and emulated"
+    ignoreBin = (ignoreBins)
+)
+l1tdeStage2uGMTIntermediateEMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone(
+    displacedQuantities = False
+    muonCollection1 = (unpackerModule, "imdMuonsEMTFNeg")
+    muonCollection2 = (emulatorModule, "imdMuonsEMTFNeg")
+    monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison")
+    summaryTitle = "Summary of uGMT intermediate muon from EMTF- comparison between unpacked and emulated"
+    ignoreBin = (ignoreBins)
+)
+l1tdeStage2uGMTIntermediateEMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone(
+    displacedQuantities = False
+    muonCollection1 = (unpackerModule, "imdMuonsEMTFPos")
+    muonCollection2 = (emulatorModule, "imdMuonsEMTFPos")
+    monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison")
+    summaryTitle = "Summary of uGMT intermediate muon from EMTF+ comparison between unpacked and emulated"
+    ignoreBin = (ignoreBins)
+)
 # sequences
 l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMTEmul +

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFClient_cff.py
@@ -19,10 +19,10 @@ l1tStage2BmtfZeroSuppRatioClient = DQMEDHarvester("L1TStage2RatioClient",
 )
 
 l1tStage2BmtfZeroSuppFatEvtsRatioClient = l1tStage2BmtfZeroSuppRatioClient.clone(
-monitorDir = bmtfZSDqmDir+'/FatEvts',
-inputNum = bmtfZSDqmDir+'/FatEvts/'+errHistNumStr,
-inputDen = bmtfZSDqmDir+'/FatEvts/'+errHistDenStr,
-ratioTitle = 'Summary of bad zero suppression rates'
+    monitorDir = bmtfZSDqmDir+'/FatEvts',
+    inputNum = bmtfZSDqmDir+'/FatEvts/'+errHistNumStr,
+    inputDen = bmtfZSDqmDir+'/FatEvts/'+errHistDenStr,
+    ratioTitle = 'Summary of bad zero suppression rates'
 )
 # sequences
 l1tStage2BmtfZeroSuppCompClient = cms.Sequence(

--- a/DQM/L1TMonitorClient/python/L1TStage2BMTFClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2BMTFClient_cff.py
@@ -18,12 +18,12 @@ l1tStage2BmtfZeroSuppRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     binomialErr = cms.untracked.bool(True)
 )
 
-l1tStage2BmtfZeroSuppFatEvtsRatioClient = l1tStage2BmtfZeroSuppRatioClient.clone()
-l1tStage2BmtfZeroSuppFatEvtsRatioClient.monitorDir = cms.untracked.string(bmtfZSDqmDir+'/FatEvts')
-l1tStage2BmtfZeroSuppFatEvtsRatioClient.inputNum = cms.untracked.string(bmtfZSDqmDir+'/FatEvts/'+errHistNumStr)
-l1tStage2BmtfZeroSuppFatEvtsRatioClient.inputDen = cms.untracked.string(bmtfZSDqmDir+'/FatEvts/'+errHistDenStr)
-l1tStage2BmtfZeroSuppFatEvtsRatioClient.ratioTitle = cms.untracked.string('Summary of bad zero suppression rates')
-
+l1tStage2BmtfZeroSuppFatEvtsRatioClient = l1tStage2BmtfZeroSuppRatioClient.clone(
+monitorDir = bmtfZSDqmDir+'/FatEvts',
+inputNum = bmtfZSDqmDir+'/FatEvts/'+errHistNumStr,
+inputDen = bmtfZSDqmDir+'/FatEvts/'+errHistDenStr,
+ratioTitle = 'Summary of bad zero suppression rates'
+)
 # sequences
 l1tStage2BmtfZeroSuppCompClient = cms.Sequence(
     l1tStage2BmtfZeroSuppRatioClient

--- a/DQM/L1TMonitorClient/python/L1TStage2MuonQualityTests_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2MuonQualityTests_cff.py
@@ -16,5 +16,5 @@ l1TStage2MuonQualityTests = DQMQualityTester(
 )
 
 l1TStage2MuonQualityTestsCollisions = l1TStage2MuonQualityTests.clone(
-qtList = 'DQM/L1TMonitorClient/data/L1TStage2MuonQualityTestsCollisions.xml'
+    qtList = 'DQM/L1TMonitorClient/data/L1TStage2MuonQualityTestsCollisions.xml'
 )

--- a/DQM/L1TMonitorClient/python/L1TStage2MuonQualityTests_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2MuonQualityTests_cff.py
@@ -15,5 +15,6 @@ l1TStage2MuonQualityTests = DQMQualityTester(
     verboseQT = cms.untracked.bool(True)
 )
 
-l1TStage2MuonQualityTestsCollisions = l1TStage2MuonQualityTests.clone()
-l1TStage2MuonQualityTestsCollisions.qtList = cms.untracked.FileInPath('DQM/L1TMonitorClient/data/L1TStage2MuonQualityTestsCollisions.xml')
+l1TStage2MuonQualityTestsCollisions = l1TStage2MuonQualityTests.clone(
+qtList = 'DQM/L1TMonitorClient/data/L1TStage2MuonQualityTestsCollisions.xml'
+)

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -9,7 +9,7 @@ ugmtZSDqmDir = ugmtDqmDir+'/zeroSuppression'
 # input histograms
 errHistNumStr = 'errorSummaryNum'
 errHistDenStr = 'errorSummaryDen'
-
+ignoreBins = []
 # Muons
 l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy1'),
@@ -18,68 +18,69 @@ l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = DQMEDHarvester("L1TStage2RatioClie
     ratioName = cms.untracked.string('mismatchRatio'),
     ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 1'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
-    binomialErr = cms.untracked.bool(True)
+    binomialErr = cms.untracked.bool(True),
+    ignoreBin = cms.untracked.vint32(ignoreBins)                                                         
 )
 
 l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
-monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy2',
-inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistNumStr,
-inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistDenStr,
-ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 2'
+    monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy2',
+    inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistNumStr,
+    inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 2'
 )
 l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
-monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy3',
-inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistNumStr,
-inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistDenStr,
-ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 3'
+    monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy3',
+    inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistNumStr,
+    inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 3'
 )
 l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
-monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy4',
-inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistNumStr,
-inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistDenStr,
-ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 4'
+    monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy4',
+    inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistNumStr,
+    inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 4'
 )
 l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
-monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy5',
-inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistNumStr,
-inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistDenStr,
-ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 5'
+    monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy5',
+    inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistNumStr,
+    inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 5'
 )
 # RegionalMuonCands
 l1tStage2BmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
-monitorDir = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput',
-inputNum = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr,
-inputDen = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr,
-ratioTitle = 'Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF',
-ignoreBin =  cms.untracked.vint32(ignoreBins['Bmtf'])
+    monitorDir = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput',
+    inputNum = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr,
+    inputDen = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF',
+    ignoreBin =  (ignoreBins)
 )
 l1tStage2OmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
-monitorDir = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput',
-inputNum = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistNumStr,
-inputDen = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistDenStr,
-ratioTitle = 'Summary of mismatch rates between OMTF output muons and uGMT input muons from OMTF',
-ignoreBin = cms.untracked.vint32(ignoreBins['Omtf'])
+    monitorDir = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput',
+    inputNum = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistNumStr,
+    inputDen = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between OMTF output muons and uGMT input muons from OMTF',
+    ignoreBin = (ignoreBins)
 )
 l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
-monitorDir = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput',
-inputNum = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistNumStr,
-inputDen = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistDenStr,
-ratioTitle = 'Summary of mismatch rates between EMTF output muons and uGMT input muons from EMTF',
-ignoreBin = cms.untracked.vint32(ignoreBins['Emtf'])
+    monitorDir = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput',
+    inputNum = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistNumStr,
+    inputDen = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between EMTF output muons and uGMT input muons from EMTF',
+    ignoreBin = (ignoreBins)
 )
 # zero suppression
 l1tStage2uGMTZeroSuppRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
-monitorDir = ugmtZSDqmDir+'/AllEvts',
-inputNum = ugmtZSDqmDir+'/AllEvts/'+errHistNumStr,
-inputDen = ugmtZSDqmDir+'/AllEvts/'+errHistDenStr,
-ratioTitle = 'Summary of bad zero suppression rates',
-yAxisTitle = '# fail / # total'
+    monitorDir = ugmtZSDqmDir+'/AllEvts',
+    inputNum = ugmtZSDqmDir+'/AllEvts/'+errHistNumStr,
+    inputDen = ugmtZSDqmDir+'/AllEvts/'+errHistDenStr,
+    ratioTitle = 'Summary of bad zero suppression rates',
+    yAxisTitle = '# fail / # total'
 )
 l1tStage2uGMTZeroSuppFatEvtsRatioClient = l1tStage2uGMTZeroSuppRatioClient.clone(
-monitorDir = ugmtZSDqmDir+'/FatEvts',
-inputNum = ugmtZSDqmDir+'/FatEvts/'+errHistNumStr,
-inputDen = ugmtZSDqmDir+'/FatEvts/'+errHistDenStr,
-ratioTitle = 'Summary of bad zero suppression rates'
+    monitorDir = ugmtZSDqmDir+'/FatEvts',
+    inputNum = ugmtZSDqmDir+'/FatEvts/'+errHistNumStr,
+    inputDen = ugmtZSDqmDir+'/FatEvts/'+errHistDenStr,
+    ratioTitle = 'Summary of bad zero suppression rates'
 )
 # sequences
 l1tStage2uGMTMuonCompClient = cms.Sequence(

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -21,66 +21,66 @@ l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = DQMEDHarvester("L1TStage2RatioClie
     binomialErr = cms.untracked.bool(True)
 )
 
-l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy2')
-l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistNumStr)
-l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistDenStr)
-l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 2')
-
-l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy3')
-l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistNumStr)
-l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistDenStr)
-l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 3')
-
-l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy4')
-l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistNumStr)
-l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistDenStr)
-l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 4')
-
-l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone()
-l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy5')
-l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.inputNum = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistNumStr)
-l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.inputDen = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistDenStr)
-l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 5')
-
+l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy2',
+inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistNumStr,
+inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy2/'+errHistDenStr,
+ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 2'
+)
+l1tStage2uGMTMuonVsuGMTMuonCopy3RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy3',
+inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistNumStr,
+inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy3/'+errHistDenStr,
+ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 3'
+)
+l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy4',
+inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistNumStr,
+inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy4/'+errHistDenStr,
+ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 4'
+)
+l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy5',
+inputNum = ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistNumStr,
+inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistDenStr,
+ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 5'
+)
 # RegionalMuonCands
-l1tStage2BmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone()
-l1tStage2BmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput')
-l1tStage2BmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr)
-l1tStage2BmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr)
-l1tStage2BmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF')
-l1tStage2BmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins['Bmtf'])
-
-l1tStage2OmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone()
-l1tStage2OmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir+'/OMTFoutput_vs_uGMTinput')
-l1tStage2OmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistNumStr)
-l1tStage2OmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistDenStr)
-l1tStage2OmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between OMTF output muons and uGMT input muons from OMTF')
-l1tStage2OmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins['Omtf'])
-
-l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone()
-l1tStage2EmtfOutVsuGMTInRatioClient.monitorDir = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput')
-l1tStage2EmtfOutVsuGMTInRatioClient.inputNum = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistNumStr)
-l1tStage2EmtfOutVsuGMTInRatioClient.inputDen = cms.untracked.string(ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistDenStr)
-l1tStage2EmtfOutVsuGMTInRatioClient.ratioTitle = cms.untracked.string('Summary of mismatch rates between EMTF output muons and uGMT input muons from EMTF')
-l1tStage2EmtfOutVsuGMTInRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins['Emtf'])
-
+l1tStage2BmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+monitorDir = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput',
+inputNum = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr,
+inputDen = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr,
+ratioTitle = 'Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF',
+ignoreBin =  cms.untracked.vint32(ignoreBins['Bmtf'])
+)
+l1tStage2OmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+monitorDir = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput',
+inputNum = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistNumStr,
+inputDen = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistDenStr,
+ratioTitle = 'Summary of mismatch rates between OMTF output muons and uGMT input muons from OMTF',
+ignoreBin = cms.untracked.vint32(ignoreBins['Omtf'])
+)
+l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+monitorDir = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput',
+inputNum = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistNumStr,
+inputDen = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistDenStr,
+ratioTitle = 'Summary of mismatch rates between EMTF output muons and uGMT input muons from EMTF',
+ignoreBin = cms.untracked.vint32(ignoreBins['Emtf'])
+)
 # zero suppression
-l1tStage2uGMTZeroSuppRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone()
-l1tStage2uGMTZeroSuppRatioClient.monitorDir = cms.untracked.string(ugmtZSDqmDir+'/AllEvts')
-l1tStage2uGMTZeroSuppRatioClient.inputNum = cms.untracked.string(ugmtZSDqmDir+'/AllEvts/'+errHistNumStr)
-l1tStage2uGMTZeroSuppRatioClient.inputDen = cms.untracked.string(ugmtZSDqmDir+'/AllEvts/'+errHistDenStr)
-l1tStage2uGMTZeroSuppRatioClient.ratioTitle = cms.untracked.string('Summary of bad zero suppression rates')
-l1tStage2uGMTZeroSuppRatioClient.yAxisTitle = cms.untracked.string('# fail / # total')
-
-l1tStage2uGMTZeroSuppFatEvtsRatioClient = l1tStage2uGMTZeroSuppRatioClient.clone()
-l1tStage2uGMTZeroSuppFatEvtsRatioClient.monitorDir = cms.untracked.string(ugmtZSDqmDir+'/FatEvts')
-l1tStage2uGMTZeroSuppFatEvtsRatioClient.inputNum = cms.untracked.string(ugmtZSDqmDir+'/FatEvts/'+errHistNumStr)
-l1tStage2uGMTZeroSuppFatEvtsRatioClient.inputDen = cms.untracked.string(ugmtZSDqmDir+'/FatEvts/'+errHistDenStr)
-l1tStage2uGMTZeroSuppFatEvtsRatioClient.ratioTitle = cms.untracked.string('Summary of bad zero suppression rates')
-
+l1tStage2uGMTZeroSuppRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+monitorDir = ugmtZSDqmDir+'/AllEvts',
+inputNum = ugmtZSDqmDir+'/AllEvts/'+errHistNumStr,
+inputDen = ugmtZSDqmDir+'/AllEvts/'+errHistDenStr,
+ratioTitle = 'Summary of bad zero suppression rates',
+yAxisTitle = '# fail / # total'
+)
+l1tStage2uGMTZeroSuppFatEvtsRatioClient = l1tStage2uGMTZeroSuppRatioClient.clone(
+monitorDir = ugmtZSDqmDir+'/FatEvts',
+inputNum = ugmtZSDqmDir+'/FatEvts/'+errHistNumStr,
+inputDen = ugmtZSDqmDir+'/FatEvts/'+errHistDenStr,
+ratioTitle = 'Summary of bad zero suppression rates'
+)
 # sequences
 l1tStage2uGMTMuonCompClient = cms.Sequence(
     l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -9,7 +9,7 @@ ugmtZSDqmDir = ugmtDqmDir+'/zeroSuppression'
 # input histograms
 errHistNumStr = 'errorSummaryNum'
 errHistDenStr = 'errorSummaryDen'
-ignoreBins = []
+
 # Muons
 l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = DQMEDHarvester("L1TStage2RatioClient",
     monitorDir = cms.untracked.string(ugmtMuCpyDqmDir+'/uGMTMuonCopy1'),
@@ -19,7 +19,7 @@ l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = DQMEDHarvester("L1TStage2RatioClie
     ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT muons and uGMT muon copy 1'),
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
     binomialErr = cms.untracked.bool(True),
-    ignoreBin = cms.untracked.vint32(ignoreBins)                                                         
+    ignoreBin = cms.untracked.vint32()                                                         
 )
 
 l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
@@ -52,21 +52,21 @@ l1tStage2BmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClien
     inputNum = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistNumStr,
     inputDen = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput/'+errHistDenStr,
     ratioTitle = 'Summary of mismatch rates between BMTF output muons and uGMT input muons from BMTF',
-    ignoreBin =  (ignoreBins)
+    ignoreBin =  ignoreBins['Bmtf']
 )
 l1tStage2OmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
     monitorDir = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput',
     inputNum = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistNumStr,
     inputDen = ugmtDqmDir+'/OMTFoutput_vs_uGMTinput/'+errHistDenStr,
     ratioTitle = 'Summary of mismatch rates between OMTF output muons and uGMT input muons from OMTF',
-    ignoreBin = (ignoreBins)
+    ignoreBin = ignoreBins['Omtf']
 )
 l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
     monitorDir = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput',
     inputNum = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistNumStr,
     inputDen = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/'+errHistDenStr,
     ratioTitle = 'Summary of mismatch rates between EMTF output muons and uGMT input muons from EMTF',
-    ignoreBin = (ignoreBins)
+    ignoreBin = ignoreBins['Emtf']
 )
 # zero suppression
 l1tStage2uGMTZeroSuppRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(

--- a/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
@@ -46,28 +46,28 @@ l1tStage2uGTMuon1vsMuon2RatioClient = DQMEDHarvester("L1TStage2RatioClient",
 )
 
 l1tStage2uGTMuon1vsMuon3RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
-monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard3/Muons',
-inputNum = ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistNumStr,
-inputDen = ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistDenStr,
-ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 3'
+    monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard3/Muons',
+    inputNum = ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistNumStr,
+    inputDen = ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistDenStr,
+    ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 3'
 )
 l1tStage2uGTMuon1vsMuon4RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
-monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard4/Muons',
-inputNum = ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistNumStr,
-inputDen = ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistDenStr,
-ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 4'
+    monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard4/Muons',
+    inputNum = ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistNumStr,
+    inputDen = ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistDenStr,
+    ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 4'
 )
 l1tStage2uGTMuon1vsMuon5RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
-monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard5/Muons',
-inputNum = ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistNumStr,
-inputDen = ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistDenStr,
-ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 5'
+    monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard5/Muons',
+    inputNum = ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistNumStr,
+    inputDen = ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistDenStr,
+    ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 5'
 )
 l1tStage2uGTMuon1vsMuon6RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
-monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard6/Muons',
-inputNum = ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistNumStr,
-inputDen = ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistDenStr,
-ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 6'
+    monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard6/Muons',
+    inputNum = ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistNumStr,
+    inputDen = ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistDenStr,
+    ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 6'
 )
 l1tStage2uGTBoardCompMuonsRatioClientSeq = cms.Sequence(
     l1tStage2uGTMuon1vsMuon2RatioClient +
@@ -78,34 +78,34 @@ l1tStage2uGTBoardCompMuonsRatioClientSeq = cms.Sequence(
 )
 
 l1tStage2uGTCalo1vsCalo2RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
-monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2',
-inputNum = ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistNumStr,
-inputDen = ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistDenStr,
-ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 2'
+    monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2',
+    inputNum = ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistNumStr,
+    inputDen = ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistDenStr,
+    ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 2'
 )
 l1tStage2uGTCalo1vsCalo3RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
-monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2',
-inputNum = ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistNumStr,
-inputDen = ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistDenStr,
-ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 3'
+    monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2',
+    inputNum = ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistNumStr,
+    inputDen = ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistDenStr,
+    ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 3'
 )
 l1tStage2uGTCalo1vsCalo4RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
-monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2',
-inputNum = ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistNumStr,
-inputDen = ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistDenStr,
-ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 4'
+    monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2',
+    inputNum = ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistNumStr,
+    inputDen = ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistDenStr,
+    ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 4'
 )
 l1tStage2uGTCalo1vsCalo5RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
-monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2',
-inputNum = ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistNumStr,
-inputDen = ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistDenStr,
-ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 5'
+    monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2',
+    inputNum = ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistNumStr,
+    inputDen = ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistDenStr,
+    ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 5'
 )
 l1tStage2uGTCalo1vsCalo6RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
-monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2',
-inputNum = ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistNumStr,
-inputDen = ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistDenStr,
-ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 6'
+    monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2',
+    inputNum = ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistNumStr,
+    inputDen = ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistDenStr,
+    ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 6'
 )
 l1tStage2uGTBoardCompCaloLayer2RatioClientSeq = cms.Sequence(
     l1tStage2uGTCalo1vsCalo2RatioClient +

--- a/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGTClient_cff.py
@@ -45,30 +45,30 @@ l1tStage2uGTMuon1vsMuon2RatioClient = DQMEDHarvester("L1TStage2RatioClient",
     binomialErr = cms.untracked.bool(True)
 )
 
-l1tStage2uGTMuon1vsMuon3RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
-l1tStage2uGTMuon1vsMuon3RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/Muons')
-l1tStage2uGTMuon1vsMuon3RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistNumStr)
-l1tStage2uGTMuon1vsMuon3RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistDenStr)
-l1tStage2uGTMuon1vsMuon3RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 3')
-
-l1tStage2uGTMuon1vsMuon4RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
-l1tStage2uGTMuon1vsMuon4RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/Muons')
-l1tStage2uGTMuon1vsMuon4RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistNumStr)
-l1tStage2uGTMuon1vsMuon4RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistDenStr)
-l1tStage2uGTMuon1vsMuon4RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 4')
-
-l1tStage2uGTMuon1vsMuon5RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
-l1tStage2uGTMuon1vsMuon5RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/Muons')
-l1tStage2uGTMuon1vsMuon5RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistNumStr)
-l1tStage2uGTMuon1vsMuon5RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistDenStr)
-l1tStage2uGTMuon1vsMuon5RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 5')
-
-l1tStage2uGTMuon1vsMuon6RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
-l1tStage2uGTMuon1vsMuon6RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/Muons')
-l1tStage2uGTMuon1vsMuon6RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistNumStr)
-l1tStage2uGTMuon1vsMuon6RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistDenStr)
-l1tStage2uGTMuon1vsMuon6RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 6')
-
+l1tStage2uGTMuon1vsMuon3RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
+monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard3/Muons',
+inputNum = ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistNumStr,
+inputDen = ugtBoardCompDqmDir+'/Board1vsBoard3/Muons/'+errHistDenStr,
+ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 3'
+)
+l1tStage2uGTMuon1vsMuon4RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
+monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard4/Muons',
+inputNum = ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistNumStr,
+inputDen = ugtBoardCompDqmDir+'/Board1vsBoard4/Muons/'+errHistDenStr,
+ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 4'
+)
+l1tStage2uGTMuon1vsMuon5RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
+monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard5/Muons',
+inputNum = ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistNumStr,
+inputDen = ugtBoardCompDqmDir+'/Board1vsBoard5/Muons/'+errHistDenStr,
+ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 5'
+)
+l1tStage2uGTMuon1vsMuon6RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
+monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard6/Muons',
+inputNum = ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistNumStr,
+inputDen = ugtBoardCompDqmDir+'/Board1vsBoard6/Muons/'+errHistDenStr,
+ratioTitle = 'Summary of Mismatch Rates between Muons from uGT Board 1 and uGT Board 6'
+)
 l1tStage2uGTBoardCompMuonsRatioClientSeq = cms.Sequence(
     l1tStage2uGTMuon1vsMuon2RatioClient +
     l1tStage2uGTMuon1vsMuon3RatioClient +
@@ -77,36 +77,36 @@ l1tStage2uGTBoardCompMuonsRatioClientSeq = cms.Sequence(
     l1tStage2uGTMuon1vsMuon6RatioClient
 )
 
-l1tStage2uGTCalo1vsCalo2RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
-l1tStage2uGTCalo1vsCalo2RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2')
-l1tStage2uGTCalo1vsCalo2RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistNumStr)
-l1tStage2uGTCalo1vsCalo2RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistDenStr)
-l1tStage2uGTCalo1vsCalo2RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 2')
-
-l1tStage2uGTCalo1vsCalo3RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
-l1tStage2uGTCalo1vsCalo3RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2')
-l1tStage2uGTCalo1vsCalo3RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistNumStr)
-l1tStage2uGTCalo1vsCalo3RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistDenStr)
-l1tStage2uGTCalo1vsCalo3RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 3')
-
-l1tStage2uGTCalo1vsCalo4RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
-l1tStage2uGTCalo1vsCalo4RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2')
-l1tStage2uGTCalo1vsCalo4RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistNumStr)
-l1tStage2uGTCalo1vsCalo4RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistDenStr)
-l1tStage2uGTCalo1vsCalo4RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 4')
-
-l1tStage2uGTCalo1vsCalo5RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
-l1tStage2uGTCalo1vsCalo5RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2')
-l1tStage2uGTCalo1vsCalo5RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistNumStr)
-l1tStage2uGTCalo1vsCalo5RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistDenStr)
-l1tStage2uGTCalo1vsCalo5RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 5')
-
-l1tStage2uGTCalo1vsCalo6RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone() 
-l1tStage2uGTCalo1vsCalo6RatioClient.monitorDir = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2')
-l1tStage2uGTCalo1vsCalo6RatioClient.inputNum = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistNumStr)
-l1tStage2uGTCalo1vsCalo6RatioClient.inputDen = cms.untracked.string(ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistDenStr)
-l1tStage2uGTCalo1vsCalo6RatioClient.ratioTitle = cms.untracked.string('Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 6')
-
+l1tStage2uGTCalo1vsCalo2RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
+monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2',
+inputNum = ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistNumStr,
+inputDen = ugtBoardCompDqmDir+'/Board1vsBoard2/CaloLayer2/'+errHistDenStr,
+ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 2'
+)
+l1tStage2uGTCalo1vsCalo3RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
+monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2',
+inputNum = ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistNumStr,
+inputDen = ugtBoardCompDqmDir+'/Board1vsBoard3/CaloLayer2/'+errHistDenStr,
+ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 3'
+)
+l1tStage2uGTCalo1vsCalo4RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
+monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2',
+inputNum = ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistNumStr,
+inputDen = ugtBoardCompDqmDir+'/Board1vsBoard4/CaloLayer2/'+errHistDenStr,
+ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 4'
+)
+l1tStage2uGTCalo1vsCalo5RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
+monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2',
+inputNum = ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistNumStr,
+inputDen = ugtBoardCompDqmDir+'/Board1vsBoard5/CaloLayer2/'+errHistDenStr,
+ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 5'
+)
+l1tStage2uGTCalo1vsCalo6RatioClient = l1tStage2uGTMuon1vsMuon2RatioClient.clone(
+monitorDir = ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2',
+inputNum = ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistNumStr,
+inputDen = ugtBoardCompDqmDir+'/Board1vsBoard6/CaloLayer2/'+errHistDenStr,
+ratioTitle = 'Summary of Mismatch Rates between CaloLayer2 Inputs from uGT Board 1 and uGT Board 6'
+)
 l1tStage2uGTBoardCompCaloLayer2RatioClientSeq = cms.Sequence(
     l1tStage2uGTCalo1vsCalo2RatioClient +
     l1tStage2uGTCalo1vsCalo3RatioClient +

--- a/DQM/L1TMonitorClient/python/L1TStage2uGTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGTEmulatorClient_cff.py
@@ -21,43 +21,53 @@ l1tStage2uGTEmulatorCompRatioClientBX0 = DQMEDHarvester("L1TStage2RatioClient",
     binomialErr = cms.untracked.bool(True)
 )
 
-l1tStage2uGTEmulatorCompRatioClientBXP1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone()
-l1tStage2uGTEmulatorCompRatioClientBXP2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone()
-l1tStage2uGTEmulatorCompRatioClientBXM1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone()
-l1tStage2uGTEmulatorCompRatioClientBXM2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone()
+l1tStage2uGTEmulatorCompRatioClientBXP1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
+inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
+inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
+ratioName = ratioHistStr
+)
 
+l1tStage2uGTEmulatorCompRatioClientBXP2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
+inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
+inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
+ratioName = ratioHistStr
+)
+
+l1tStage2uGTEmulatorCompRatioClientBXM1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
+inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
+inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
+ratioName = ratioHistStr
+)
+
+l1tStage2uGTEmulatorCompRatioClientBXM2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
+inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
+inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
+ratioName = ratioHistStr
+)
 
 BX            = 'BX1'
 errHistNumStr = 'dataEmulSummary_' + BX
 errHistDenStr = 'normalizationHisto'
 ratioHistStr  = 'dataEmulMismatchRatio_' + BX
-l1tStage2uGTEmulatorCompRatioClientBXP1.inputNum  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistNumStr)
-l1tStage2uGTEmulatorCompRatioClientBXP1.inputDen  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistDenStr)
-l1tStage2uGTEmulatorCompRatioClientBXP1.ratioName = cms.untracked.string(ratioHistStr)
+
 
 BX            = 'BX2'
 errHistNumStr = 'dataEmulSummary_' + BX
 errHistDenStr = 'normalizationHisto'
 ratioHistStr  = 'dataEmulMismatchRatio_' + BX
-l1tStage2uGTEmulatorCompRatioClientBXP2.inputNum  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistNumStr)
-l1tStage2uGTEmulatorCompRatioClientBXP2.inputDen  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistDenStr)
-l1tStage2uGTEmulatorCompRatioClientBXP2.ratioName = cms.untracked.string(ratioHistStr)
+
 
 BX            = 'BX-1'
 errHistNumStr = 'dataEmulSummary_' + BX
 errHistDenStr = 'normalizationHisto'
 ratioHistStr  = 'dataEmulMismatchRatio_' + BX
-l1tStage2uGTEmulatorCompRatioClientBXM1.inputNum  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistNumStr)
-l1tStage2uGTEmulatorCompRatioClientBXM1.inputDen  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistDenStr)
-l1tStage2uGTEmulatorCompRatioClientBXM1.ratioName = cms.untracked.string(ratioHistStr)
+
 
 BX            = 'BX-2'
 errHistNumStr = 'dataEmulSummary_' + BX
 errHistDenStr = 'normalizationHisto'
 ratioHistStr  = 'dataEmulMismatchRatio_' + BX
-l1tStage2uGTEmulatorCompRatioClientBXM2.inputNum  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistNumStr)
-l1tStage2uGTEmulatorCompRatioClientBXM2.inputDen  = cms.untracked.string(ugmtEmuDqmDir+'/'+errHistDenStr)
-l1tStage2uGTEmulatorCompRatioClientBXM2.ratioName = cms.untracked.string(ratioHistStr)
+
 
 # uGT
 

--- a/DQM/L1TMonitorClient/python/L1TStage2uGTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGTEmulatorClient_cff.py
@@ -21,53 +21,45 @@ l1tStage2uGTEmulatorCompRatioClientBX0 = DQMEDHarvester("L1TStage2RatioClient",
     binomialErr = cms.untracked.bool(True)
 )
 
-l1tStage2uGTEmulatorCompRatioClientBXP1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
-inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
-inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
-ratioName = ratioHistStr
-)
-
-l1tStage2uGTEmulatorCompRatioClientBXP2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
-inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
-inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
-ratioName = ratioHistStr
-)
-
-l1tStage2uGTEmulatorCompRatioClientBXM1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
-inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
-inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
-ratioName = ratioHistStr
-)
-
-l1tStage2uGTEmulatorCompRatioClientBXM2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
-inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
-inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
-ratioName = ratioHistStr
-)
-
 BX            = 'BX1'
 errHistNumStr = 'dataEmulSummary_' + BX
 errHistDenStr = 'normalizationHisto'
 ratioHistStr  = 'dataEmulMismatchRatio_' + BX
-
+l1tStage2uGTEmulatorCompRatioClientBXP1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
+    inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
+    inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
+    ratioName = ratioHistStr
+)
 
 BX            = 'BX2'
 errHistNumStr = 'dataEmulSummary_' + BX
 errHistDenStr = 'normalizationHisto'
 ratioHistStr  = 'dataEmulMismatchRatio_' + BX
-
+l1tStage2uGTEmulatorCompRatioClientBXP2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
+    inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
+    inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
+    ratioName = ratioHistStr
+)
 
 BX            = 'BX-1'
 errHistNumStr = 'dataEmulSummary_' + BX
 errHistDenStr = 'normalizationHisto'
 ratioHistStr  = 'dataEmulMismatchRatio_' + BX
-
+l1tStage2uGTEmulatorCompRatioClientBXM1 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
+    inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
+    inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
+    ratioName = ratioHistStr
+)
 
 BX            = 'BX-2'
 errHistNumStr = 'dataEmulSummary_' + BX
 errHistDenStr = 'normalizationHisto'
 ratioHistStr  = 'dataEmulMismatchRatio_' + BX
-
+l1tStage2uGTEmulatorCompRatioClientBXM2 = l1tStage2uGTEmulatorCompRatioClientBX0.clone(
+    inputNum  = ugmtEmuDqmDir+'/'+errHistNumStr,
+    inputDen  = ugmtEmuDqmDir+'/'+errHistDenStr,
+    ratioName = ratioHistStr
+)
 
 # uGT
 


### PR DESCRIPTION
#### PR description:
Drop type specs in DQM/L1TMonitor, DQM/L1TMonitorClient python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone


#### PR validation:
runTheMatrix.py -l limited -i all --ibeos


