### PR TITLE
PPS transport update

### DIFF
--- a/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
@@ -41,37 +41,37 @@ protected:
   enum class TransportMode { HECTOR, TOTEM, OPTICALFUNCTIONS };
   TransportMode MODE;
 
-  int NEvent;
-  CLHEP::HepRandomEngine* engine_;
+  int NEvent{0};
+  CLHEP::HepRandomEngine* engine_{nullptr};
   std::vector<LHCTransportLink> m_CorrespondenceMap;
   std::map<unsigned int, TLorentzVector> m_beamPart;
   std::map<unsigned int, double> m_xAtTrPoint;
   std::map<unsigned int, double> m_yAtTrPoint;
 
-  bool verbosity_;
-  bool bApplyZShift;
-  bool useBeamPositionFromLHCInfo_;
-  bool produceHitsRelativeToBeam_;
+  bool verbosity_{false};
+  bool bApplyZShift{false};
+  bool useBeamPositionFromLHCInfo_{false};
+  bool produceHitsRelativeToBeam_{false};
 
-  std::string beam1Filename_;
-  std::string beam2Filename_;
+  std::string beam1Filename_{""};
+  std::string beam2Filename_{""};
 
-  double fPPSRegionStart_45;
-  double fPPSRegionStart_56;
-  double fCrossingAngleX_45;
-  double fCrossingAngleX_56;
-  double fCrossingAngleY_45;
-  double fCrossingAngleY_56;
+  double fPPSRegionStart_45{0.0};
+  double fPPSRegionStart_56{0.0};
+  double fCrossingAngleX_45{0.0};
+  double fCrossingAngleX_56{0.0};
+  double fCrossingAngleY_45{0.0};
+  double fCrossingAngleY_56{0.0};
 
-  double beamMomentum_;
-  double beamEnergy_;
-  double etaCut_;
-  double momentumCut_;
+  double beamMomentum_{0.0};
+  double beamEnergy_{0.0};
+  double etaCut_{0.0};
+  double momentumCut_{0.0};
 
-  double m_sigmaSTX;
-  double m_sigmaSTY;
-  double m_sigmaSX;
-  double m_sigmaSY;
-  double m_sig_E;
+  double m_sigmaSTX{0.0};
+  double m_sigmaSTY{0.0};
+  double m_sigmaSX{0.0};
+  double m_sigmaSY{0.0};
+  double m_sig_E{0.0};
 };
 #endif

--- a/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
@@ -33,6 +33,26 @@ public:
   double beamMomentum() { return beamMomentum_; };
 
 protected:
+  setBeamFileNames(const std::string& nam1, const std::string& nam2) {
+    beam1Filename_ = nam1;
+    beam2Filename_ = nam2;
+  };
+
+  setBeamParameters(double stx, double sty, double sx, double sy, double se) {
+    m_sigmaSTX = stx;
+    m_sigmaSTY = sty;
+    m_sigmaSX = sx;
+    m_sigmaSY = sy;
+    m_sig_E = se;
+  };
+
+  setCrossingAngles(double cx45, double cx56, double cy45, double cy56) {
+    fCrossingAngleX_45_ = cx45;
+    fCrossingAngleX_56_ = cx56;
+    fCrossingAngleY_45_ = cy45;
+    fCrossingAngleY_56_ = cy56;
+  };
+
   enum class TransportMode { HECTOR, TOTEM, OPTICALFUNCTIONS };
   TransportMode MODE;
 
@@ -47,25 +67,28 @@ protected:
   bool useBeamPositionFromLHCInfo_;
   bool produceHitsRelativeToBeam_;
 
-  std::string beam1Filename_;
-  std::string beam2Filename_;
+  std::string beam1Filename_{""};
+  std::string beam2Filename_{""};
 
-  double fPPSRegionStart_45_;
-  double fPPSRegionStart_56_;
-  double fCrossingAngleX_45_;
-  double fCrossingAngleX_56_;
-  double fCrossingAngleY_45_;
-  double fCrossingAngleY_56_;
+  double fCrossingAngleX_45_{0.0};
+  double fCrossingAngleX_56_{0.0};
+  double fCrossingAngleY_45_{0.0};
+  double fCrossingAngleY_56_{0.0};
 
-  double beamMomentum_;
-  double beamEnergy_;
   double etaCut_;
   double momentumCut_;
 
-  double m_sigmaSTX;
-  double m_sigmaSTY;
-  double m_sigmaSX;
-  double m_sigmaSY;
-  double m_sig_E;
+private:
+  double fPPSRegionStart_45_;
+  double fPPSRegionStart_56_;
+
+  double beamMomentum_;
+  double beamEnergy_;
+
+  double m_sigmaSTX{0.0};
+  double m_sigmaSTY{0.0};
+  double m_sigmaSX{0.0};
+  double m_sigmaSY{0.0};
+  double m_sig_E{0.0};
 };
 #endif

--- a/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
@@ -17,7 +17,7 @@ namespace CLHEP {
 class BaseProtonTransport {
 public:
   BaseProtonTransport(const edm::ParameterSet& iConfig);
-  virtual ~BaseProtonTransport() { this->clear(); };
+  virtual ~BaseProtonTransport();
 
   std::vector<LHCTransportLink>& getCorrespondenceMap() { return m_CorrespondenceMap; }
   virtual void process(const HepMC::GenEvent* ev, const edm::EventSetup& es, CLHEP::HepRandomEngine* engine) = 0;
@@ -41,32 +41,31 @@ protected:
   enum class TransportMode { HECTOR, TOTEM, OPTICALFUNCTIONS };
   TransportMode MODE;
 
-  int NEvent{0};
   CLHEP::HepRandomEngine* engine_{nullptr};
   std::vector<LHCTransportLink> m_CorrespondenceMap;
   std::map<unsigned int, TLorentzVector> m_beamPart;
   std::map<unsigned int, double> m_xAtTrPoint;
   std::map<unsigned int, double> m_yAtTrPoint;
 
-  bool verbosity_{false};
-  bool bApplyZShift{false};
-  bool useBeamPositionFromLHCInfo_{false};
-  bool produceHitsRelativeToBeam_{false};
+  bool verbosity_;
+  bool bApplyZShift_;
+  bool useBeamPositionFromLHCInfo_;
+  bool produceHitsRelativeToBeam_;
 
   std::string beam1Filename_{""};
   std::string beam2Filename_{""};
 
-  double fPPSRegionStart_45{0.0};
-  double fPPSRegionStart_56{0.0};
-  double fCrossingAngleX_45{0.0};
-  double fCrossingAngleX_56{0.0};
-  double fCrossingAngleY_45{0.0};
-  double fCrossingAngleY_56{0.0};
+  double fPPSRegionStart_45_;
+  double fPPSRegionStart_56_;
+  double fCrossingAngleX_45_{0.0};
+  double fCrossingAngleX_56_{0.0};
+  double fCrossingAngleY_45_{0.0};
+  double fCrossingAngleY_56_{0.0};
 
-  double beamMomentum_{0.0};
-  double beamEnergy_{0.0};
-  double etaCut_{0.0};
-  double momentumCut_{0.0};
+  double beamMomentum_;
+  double beamEnergy_;
+  double etaCut_;
+  double momentumCut_;
 
   double m_sigmaSTX{0.0};
   double m_sigmaSTY{0.0};

--- a/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
@@ -29,11 +29,6 @@ public:
   void ApplyBeamCorrection(HepMC::GenParticle* p);
   void ApplyBeamCorrection(TLorentzVector& p);
 
-  void setBeamEnergy(double e) {
-    beamEnergy_ = e;
-    beamMomentum_ = sqrt(beamEnergy_ * beamEnergy_ - ProtonMassSQ);
-  }
-
   double beamEnergy() { return beamEnergy_; };
   double beamMomentum() { return beamMomentum_; };
 
@@ -52,25 +47,25 @@ protected:
   bool useBeamPositionFromLHCInfo_;
   bool produceHitsRelativeToBeam_;
 
-  std::string beam1Filename_{""};
-  std::string beam2Filename_{""};
+  std::string beam1Filename_;
+  std::string beam2Filename_;
 
   double fPPSRegionStart_45_;
   double fPPSRegionStart_56_;
-  double fCrossingAngleX_45_{0.0};
-  double fCrossingAngleX_56_{0.0};
-  double fCrossingAngleY_45_{0.0};
-  double fCrossingAngleY_56_{0.0};
+  double fCrossingAngleX_45_;
+  double fCrossingAngleX_56_;
+  double fCrossingAngleY_45_;
+  double fCrossingAngleY_56_;
 
   double beamMomentum_;
   double beamEnergy_;
   double etaCut_;
   double momentumCut_;
 
-  double m_sigmaSTX{0.0};
-  double m_sigmaSTY{0.0};
-  double m_sigmaSX{0.0};
-  double m_sigmaSY{0.0};
-  double m_sig_E{0.0};
+  double m_sigmaSTX;
+  double m_sigmaSTY;
+  double m_sigmaSX;
+  double m_sigmaSY;
+  double m_sig_E;
 };
 #endif

--- a/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h
@@ -33,12 +33,12 @@ public:
   double beamMomentum() { return beamMomentum_; };
 
 protected:
-  setBeamFileNames(const std::string& nam1, const std::string& nam2) {
+  void setBeamFileNames(const std::string& nam1, const std::string& nam2) {
     beam1Filename_ = nam1;
     beam2Filename_ = nam2;
   };
 
-  setBeamParameters(double stx, double sty, double sx, double sy, double se) {
+  void setBeamParameters(double stx, double sty, double sx, double sy, double se) {
     m_sigmaSTX = stx;
     m_sigmaSTY = sty;
     m_sigmaSX = sx;
@@ -46,7 +46,7 @@ protected:
     m_sig_E = se;
   };
 
-  setCrossingAngles(double cx45, double cx56, double cy45, double cy56) {
+  void setCrossingAngles(double cx45, double cx56, double cy45, double cy56) {
     fCrossingAngleX_45_ = cx45;
     fCrossingAngleX_56_ = cx56;
     fCrossingAngleY_45_ = cy45;
@@ -70,6 +70,8 @@ protected:
   std::string beam1Filename_{""};
   std::string beam2Filename_{""};
 
+  double fPPSRegionStart_45_;
+  double fPPSRegionStart_56_;
   double fCrossingAngleX_45_{0.0};
   double fCrossingAngleX_56_{0.0};
   double fCrossingAngleY_45_{0.0};
@@ -79,9 +81,6 @@ protected:
   double momentumCut_;
 
 private:
-  double fPPSRegionStart_45_;
-  double fPPSRegionStart_56_;
-
   double beamMomentum_;
   double beamEnergy_;
 

--- a/SimTransport/PPSProtonTransport/interface/HectorTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/HectorTransport.h
@@ -44,15 +44,13 @@ public:
   void process(const HepMC::GenEvent* ev, const edm::EventSetup& es, CLHEP::HepRandomEngine* engine) override;
 
 private:
-  bool m_verbosity;
 
   static constexpr double fPPSBeamLineLength_ = 250.;  // default beam line length
 
   //!propagate the particles through a beamline to PPS
   bool transportProton(const HepMC::GenParticle*);
 
-  // New function to calculate the LorentzBoost
-
+  // function to calculate the LorentzBoost
   bool setBeamLine();
   // Defaults
 
@@ -66,7 +64,7 @@ private:
   edm::ESGetToken<CTPPSBeamParameters, CTPPSBeamParametersRcd> beamParametersToken_;
   edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> beamspotToken_;
 
-  const CTPPSBeamParameters* beamParameters_;
-  const BeamSpotObjects* beamspot_;
+  const CTPPSBeamParameters* beamParameters_{nullptr};
+  const BeamSpotObjects* beamspot_{nullptr};
 };
 #endif

--- a/SimTransport/PPSProtonTransport/interface/HectorTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/HectorTransport.h
@@ -7,7 +7,8 @@
 #include "CondFormats/PPSObjects/interface/CTPPSBeamParameters.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+//#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -51,10 +52,6 @@ private:
 
   // function to calculate the LorentzBoost
   bool setBeamLine();
-  // Defaults
-
-  double m_fEtacut;
-  double m_fMomentumMin;
 
   // PPSHector
   std::unique_ptr<H_BeamLine> m_beamline45;

--- a/SimTransport/PPSProtonTransport/interface/HectorTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/HectorTransport.h
@@ -8,7 +8,6 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
-//#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/SimTransport/PPSProtonTransport/interface/HectorTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/HectorTransport.h
@@ -44,7 +44,6 @@ public:
   void process(const HepMC::GenEvent* ev, const edm::EventSetup& es, CLHEP::HepRandomEngine* engine) override;
 
 private:
-
   static constexpr double fPPSBeamLineLength_ = 250.;  // default beam line length
 
   //!propagate the particles through a beamline to PPS

--- a/SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h
@@ -16,14 +16,10 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimTransport/PPSProtonTransport/interface/BaseProtonTransport.h"
 
-#include <array>
-#include <unordered_map>
-#include <cmath>
-
 class OpticalFunctionsTransport : public BaseProtonTransport {
 public:
   OpticalFunctionsTransport(const edm::ParameterSet& ps, edm::ConsumesCollector iC);
-  ~OpticalFunctionsTransport() override{};
+  ~OpticalFunctionsTransport() override;
 
   void process(const HepMC::GenEvent* ev, const edm::EventSetup& es, CLHEP::HepRandomEngine* engine) override;
 
@@ -43,12 +39,10 @@ private:
   unsigned int optFunctionId45_{0};
   unsigned int optFunctionId56_{0};
 
-  bool useEmpiricalApertures_{false};
-  double empiricalAperture45_xi0_int_{0.0}, empiricalAperture45_xi0_slp_{0.0}, empiricalAperture45_a_int_{0.0},
-      empiricalAperture45_a_slp_{0.0};
-  double empiricalAperture56_xi0_int_{0.0}, empiricalAperture56_xi0_slp_{0.0}, empiricalAperture56_a_int_{0.0},
-      empiricalAperture56_a_slp_{0.0};
-
-  bool produceHitsRelativeToBeam_{false};
+  bool useEmpiricalApertures_;
+  double empiricalAperture45_xi0_int_, empiricalAperture45_xi0_slp_, empiricalAperture45_a_int_,
+      empiricalAperture45_a_slp_;
+  double empiricalAperture56_xi0_int_, empiricalAperture56_xi0_slp_, empiricalAperture56_a_int_,
+      empiricalAperture56_a_slp_;
 };
 #endif

--- a/SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h
@@ -35,20 +35,20 @@ private:
   edm::ESGetToken<LHCInterpolatedOpticalFunctionsSetCollection, CTPPSInterpolatedOpticsRcd> opticsToken_;
   edm::ESGetToken<BeamSpotObjects, BeamSpotObjectsRcd> beamspotToken_;
 
-  const LHCInfo* lhcInfo_;
-  const CTPPSBeamParameters* beamParameters_;
-  const LHCInterpolatedOpticalFunctionsSetCollection* opticalFunctions_;
-  const BeamSpotObjects* beamspot_;
+  const LHCInfo* lhcInfo_{nullptr};
+  const CTPPSBeamParameters* beamParameters_{nullptr};
+  const LHCInterpolatedOpticalFunctionsSetCollection* opticalFunctions_{nullptr};
+  const BeamSpotObjects* beamspot_{nullptr};
 
-  unsigned int optFunctionId45_;
-  unsigned int optFunctionId56_;
+  unsigned int optFunctionId45_{0};
+  unsigned int optFunctionId56_{0};
 
-  bool useEmpiricalApertures_;
-  double empiricalAperture45_xi0_int_, empiricalAperture45_xi0_slp_, empiricalAperture45_a_int_,
-      empiricalAperture45_a_slp_;
-  double empiricalAperture56_xi0_int_, empiricalAperture56_xi0_slp_, empiricalAperture56_a_int_,
-      empiricalAperture56_a_slp_;
+  bool useEmpiricalApertures_{false};
+  double empiricalAperture45_xi0_int_{0.0}, empiricalAperture45_xi0_slp_{0.0}, empiricalAperture45_a_int_{0.0},
+      empiricalAperture45_a_slp_{0.0};
+  double empiricalAperture56_xi0_int_{0.0}, empiricalAperture56_xi0_slp_{0.0}, empiricalAperture56_a_int_{0.0},
+      empiricalAperture56_a_slp_{0.0};
 
-  bool produceHitsRelativeToBeam_;
+  bool produceHitsRelativeToBeam_{false};
 };
 #endif

--- a/SimTransport/PPSProtonTransport/interface/TotemTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/TotemTransport.h
@@ -11,10 +11,6 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
-
-#include <unordered_map>
-#include <array>
 
 namespace CLHEP {
   class HepRandomEngine;
@@ -23,7 +19,7 @@ namespace CLHEP {
 class TotemTransport : public BaseProtonTransport {
 public:
   TotemTransport(const edm::ParameterSet& ps);
-  ~TotemTransport() override{};
+  ~TotemTransport() override;
   // look for scattered protons, propagates them, add them to the event
   void process(const HepMC::GenEvent* ev, const edm::EventSetup& es, CLHEP::HepRandomEngine* engine) override;
 
@@ -31,14 +27,12 @@ private:
   bool transportProton(HepMC::GenParticle*);
   LHCOpticsApproximator* ReadParameterization(const std::string&, const std::string&);
 
-  LHCOpticsApproximator* m_aprox_ip_150_r{nullptr};
-  LHCOpticsApproximator* m_aprox_ip_150_l{nullptr};
+  LHCOpticsApproximator* m_aprox_ip_150_r_;
+  LHCOpticsApproximator* m_aprox_ip_150_l_;
 
-  std::string m_model_ip_150_r_name{""};
-  std::string m_model_ip_150_l_name{""};
+  std::string m_model_ip_150_r_name_;
+  std::string m_model_ip_150_l_name_;
 
-  double m_beampipe_aperture_radius{0.0};
-  double m_fEtacut{0.0};
-  double m_fMomentumMin{0.0};
+  double m_beampipe_aperture_radius_;
 };
 #endif

--- a/SimTransport/PPSProtonTransport/interface/TotemTransport.h
+++ b/SimTransport/PPSProtonTransport/interface/TotemTransport.h
@@ -28,17 +28,17 @@ public:
   void process(const HepMC::GenEvent* ev, const edm::EventSetup& es, CLHEP::HepRandomEngine* engine) override;
 
 private:
-  bool transportProton(const HepMC::GenParticle*);
+  bool transportProton(HepMC::GenParticle*);
   LHCOpticsApproximator* ReadParameterization(const std::string&, const std::string&);
 
-  LHCOpticsApproximator* m_aprox_ip_150_r = nullptr;
-  LHCOpticsApproximator* m_aprox_ip_150_l = nullptr;
+  LHCOpticsApproximator* m_aprox_ip_150_r{nullptr};
+  LHCOpticsApproximator* m_aprox_ip_150_l{nullptr};
 
-  std::string m_model_ip_150_r_name;
-  std::string m_model_ip_150_l_name;
+  std::string m_model_ip_150_r_name{""};
+  std::string m_model_ip_150_l_name{""};
 
-  double m_beampipe_aperture_radius;
-  double m_fEtacut;
-  double m_fMomentumMin;
+  double m_beampipe_aperture_radius{0.0};
+  double m_fEtacut{0.0};
+  double m_fMomentumMin{0.0};
 };
 #endif

--- a/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
@@ -41,18 +41,19 @@ void BaseProtonTransport::ApplyBeamCorrection(TLorentzVector& p_out) {
   if (MODE == TransportMode::TOTEM)
     thetax += (p_out.Pz() > 0) ? fCrossingAngleX_45 * urad : fCrossingAngleX_56 * urad;
 
-  double dtheta_x = (double)CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTX);
-  double dtheta_y = (double)CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTY);
-  double denergy = (double)CLHEP::RandGauss::shoot(engine_, 0., m_sig_E);
+  double dtheta_x = CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTX);
+  double dtheta_y = CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTY);
+  double denergy  = CLHEP::RandGauss::shoot(engine_, 0., m_sig_E);
 
-  double s_theta = sqrt(pow(thetax + dtheta_x * urad, 2) + pow(thetay + dtheta_y * urad, 2));
-  double s_phi = atan2(thetay + dtheta_y * urad, thetax + dtheta_x * urad);
+  double s_theta = std::sqrt(pow(thetax + dtheta_x * urad, 2) + std::pow(thetay + dtheta_y * urad, 2));
+  double s_phi = std::atan2(thetay + dtheta_y * urad, thetax + dtheta_x * urad);
   energy += denergy;
-  double p = sqrt(pow(energy, 2) - ProtonMassSQ);
+  double p = std::sqrt(std::pow(energy, 2) - ProtonMassSQ);
+  double sint = std::sin(s_theta);
 
-  p_out.SetPx((double)p * sin(s_theta) * cos(s_phi));
-  p_out.SetPy((double)p * sin(s_theta) * sin(s_phi));
-  p_out.SetPz((double)p * (cos(s_theta)) * direction);
+  p_out.SetPx(p * sint * std::cos(s_phi));
+  p_out.SetPy(p * sint * std::sin(s_phi));
+  p_out.SetPz(p * std::cos(s_theta) * direction);
   p_out.SetE(energy);
 }
 void BaseProtonTransport::addPartToHepMC(const HepMC::GenEvent* in_evt, HepMC::GenEvent* evt) {

--- a/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
@@ -3,7 +3,6 @@
 #include "Utilities/PPS/interface/PPSUnitConversion.h"
 #include <CLHEP/Random/RandGauss.h>
 #include <CLHEP/Units/GlobalSystemOfUnits.h>
-//#include <cctype>
 
 BaseProtonTransport::BaseProtonTransport(const edm::ParameterSet& iConfig)
     : verbosity_(iConfig.getParameter<bool>("Verbosity")),

--- a/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
@@ -43,7 +43,7 @@ void BaseProtonTransport::ApplyBeamCorrection(TLorentzVector& p_out) {
 
   double dtheta_x = CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTX);
   double dtheta_y = CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTY);
-  double denergy  = CLHEP::RandGauss::shoot(engine_, 0., m_sig_E);
+  double denergy = CLHEP::RandGauss::shoot(engine_, 0., m_sig_E);
 
   double s_theta = std::sqrt(pow(thetax + dtheta_x * urad, 2) + std::pow(thetay + dtheta_y * urad, 2));
   double s_phi = std::atan2(thetay + dtheta_y * urad, thetax + dtheta_x * urad);

--- a/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
@@ -9,25 +9,16 @@ BaseProtonTransport::BaseProtonTransport(const edm::ParameterSet& iConfig)
       bApplyZShift_(iConfig.getParameter<bool>("ApplyZShift")),
       useBeamPositionFromLHCInfo_(iConfig.getParameter<bool>("useBeamPositionFromLHCInfo")),
       produceHitsRelativeToBeam_(iConfig.getParameter<bool>("produceHitsRelativeToBeam")),
-      beam1Filename_(iConfig.getParameter<std::string>("Beam1Filename")),
-      beam2Filename_(iConfig.getParameter<std::string>("Beam2Filename")),
-      fPPSRegionStart_45_(iConfig.getParameter<double>("PPSRegionStart_45")),
-      fPPSRegionStart_56_(iConfig.getParameter<double>("PPSRegionStart_56")),
-      fCrossingAngleX_45_(iConfig.getParameter<double>("halfCrossingAngleXSector45")),
-      fCrossingAngleX_56_(iConfig.getParameter<double>("halfCrossingAngleXSector56")),
-      fCrossingAngleY_45_(iConfig.getParameter<double>("halfCrossingAngleYSector45")),
-      fCrossingAngleY_56_(iConfig.getParameter<double>("halfCrossingAngleYSector56")),
-      beamEnergy_(iConfig.getParameter<double>("BeamEnergy")),
       etaCut_(iConfig.getParameter<double>("EtaCut")),
       momentumCut_(iConfig.getParameter<double>("MomentumCut")),
-      m_sigmaSTX(iConfig.getParameter<double>("BeamDivergenceX")),
-      m_sigmaSTY(iConfig.getParameter<double>("BeamDivergenceY")),
-      m_sigmaSX(iConfig.getParameter<double>("BeamSigmaX")),
-      m_sigmaSY(iConfig.getParameter<double>("BeamSigmaY")),
-      m_sig_E(iConfig.getParameter<double>("BeamEnergyDispersion")) {
+      fPPSRegionStart_45_(iConfig.getParameter<double>("PPSRegionStart_45")),
+      fPPSRegionStart_56_(iConfig.getParameter<double>("PPSRegionStart_56")),
+      beamEnergy_(iConfig.getParameter<double>("BeamEnergy")) {
   beamMomentum_ = std::sqrt(beamEnergy_ * beamEnergy_ - ProtonMassSQ);
 }
+
 BaseProtonTransport::~BaseProtonTransport() { clear(); }
+
 void BaseProtonTransport::ApplyBeamCorrection(HepMC::GenParticle* p) {
   TLorentzVector p_out;
   p_out.SetPx(p->momentum().px());
@@ -37,6 +28,7 @@ void BaseProtonTransport::ApplyBeamCorrection(HepMC::GenParticle* p) {
   ApplyBeamCorrection(p_out);
   p->set_momentum(HepMC::FourVector(p_out.Px(), p_out.Py(), p_out.Pz(), p_out.E()));
 }
+
 void BaseProtonTransport::ApplyBeamCorrection(TLorentzVector& p_out) {
   double thetax = atan(p_out.Px() / fabs(p_out.Pz()));
   double thetay = atan(p_out.Py() / fabs(p_out.Pz()));
@@ -63,6 +55,7 @@ void BaseProtonTransport::ApplyBeamCorrection(TLorentzVector& p_out) {
   p_out.SetPz(p * std::cos(s_theta) * direction);
   p_out.SetE(energy);
 }
+
 void BaseProtonTransport::addPartToHepMC(const HepMC::GenEvent* in_evt, HepMC::GenEvent* evt) {
   m_CorrespondenceMap.clear();
 

--- a/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
@@ -9,12 +9,23 @@ BaseProtonTransport::BaseProtonTransport(const edm::ParameterSet& iConfig)
       bApplyZShift_(iConfig.getParameter<bool>("ApplyZShift")),
       useBeamPositionFromLHCInfo_(iConfig.getParameter<bool>("useBeamPositionFromLHCInfo")),
       produceHitsRelativeToBeam_(iConfig.getParameter<bool>("produceHitsRelativeToBeam")),
+      beam1Filename_(iConfig.getParameter<std::string>("Beam1Filename")),
+      beam2Filename_(iConfig.getParameter<std::string>("Beam2Filename")),
       fPPSRegionStart_45_(iConfig.getParameter<double>("PPSRegionStart_45")),
       fPPSRegionStart_56_(iConfig.getParameter<double>("PPSRegionStart_56")),
+      fCrossingAngleX_45_(iConfig.getParameter<double>("halfCrossingAngleXSector45")),
+      fCrossingAngleX_56_(iConfig.getParameter<double>("halfCrossingAngleXSector56")),
+      fCrossingAngleY_45_(iConfig.getParameter<double>("halfCrossingAngleYSector45")),
+      fCrossingAngleY_56_(iConfig.getParameter<double>("halfCrossingAngleYSector56")),
       beamEnergy_(iConfig.getParameter<double>("BeamEnergy")),
       etaCut_(iConfig.getParameter<double>("EtaCut")),
-      momentumCut_(iConfig.getParameter<double>("MomentumCut")) {
-  setBeamEnergy(beamEnergy_);
+      momentumCut_(iConfig.getParameter<double>("MomentumCut")),
+      m_sigmaSTX(iConfig.getParameter<double>("BeamDivergenceX")),
+      m_sigmaSTY(iConfig.getParameter<double>("BeamDivergenceY")),
+      m_sigmaSX(iConfig.getParameter<double>("BeamSigmaX")),
+      m_sigmaSY(iConfig.getParameter<double>("BeamSigmaY")),
+      m_sig_E(iConfig.getParameter<double>("BeamEnergyDispersion")) {
+  beamMomentum_ = std::sqrt(beamEnergy_ * beamEnergy_ - ProtonMassSQ);
 }
 BaseProtonTransport::~BaseProtonTransport() { clear(); }
 void BaseProtonTransport::ApplyBeamCorrection(HepMC::GenParticle* p) {

--- a/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
@@ -9,10 +9,10 @@ BaseProtonTransport::BaseProtonTransport(const edm::ParameterSet& iConfig)
       bApplyZShift_(iConfig.getParameter<bool>("ApplyZShift")),
       useBeamPositionFromLHCInfo_(iConfig.getParameter<bool>("useBeamPositionFromLHCInfo")),
       produceHitsRelativeToBeam_(iConfig.getParameter<bool>("produceHitsRelativeToBeam")),
-      etaCut_(iConfig.getParameter<double>("EtaCut")),
-      momentumCut_(iConfig.getParameter<double>("MomentumCut")),
       fPPSRegionStart_45_(iConfig.getParameter<double>("PPSRegionStart_45")),
       fPPSRegionStart_56_(iConfig.getParameter<double>("PPSRegionStart_56")),
+      etaCut_(iConfig.getParameter<double>("EtaCut")),
+      momentumCut_(iConfig.getParameter<double>("MomentumCut")),
       beamEnergy_(iConfig.getParameter<double>("BeamEnergy")) {
   beamMomentum_ = std::sqrt(beamEnergy_ * beamEnergy_ - ProtonMassSQ);
 }

--- a/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
@@ -17,9 +17,7 @@ BaseProtonTransport::BaseProtonTransport(const edm::ParameterSet& iConfig)
       momentumCut_(iConfig.getParameter<double>("MomentumCut")) {
   setBeamEnergy(beamEnergy_);
 }
-BaseProtonTransport::~BaseProtonTransport() {
-  clear();
-}
+BaseProtonTransport::~BaseProtonTransport() { clear(); }
 void BaseProtonTransport::ApplyBeamCorrection(HepMC::GenParticle* p) {
   TLorentzVector p_out;
   p_out.SetPx(p->momentum().px());

--- a/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/BaseProtonTransport.cc
@@ -27,7 +27,6 @@ void BaseProtonTransport::ApplyBeamCorrection(HepMC::GenParticle* p) {
   p->set_momentum(HepMC::FourVector(p_out.Px(), p_out.Py(), p_out.Pz(), p_out.E()));
 }
 void BaseProtonTransport::ApplyBeamCorrection(TLorentzVector& p_out) {
-  double theta = p_out.Theta();
   double thetax = atan(p_out.Px() / fabs(p_out.Pz()));
   double thetay = atan(p_out.Py() / fabs(p_out.Pz()));
   double energy = p_out.E();
@@ -35,15 +34,12 @@ void BaseProtonTransport::ApplyBeamCorrection(TLorentzVector& p_out) {
 
   int direction = (p_out.Pz() > 0) ? 1 : -1;
 
-  if (p_out.Pz() < 0)
-    theta = TMath::Pi() - theta;
-
   if (MODE == TransportMode::TOTEM)
     thetax += (p_out.Pz() > 0) ? fCrossingAngleX_45 * urad : fCrossingAngleX_56 * urad;
 
-  double dtheta_x = CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTX);
-  double dtheta_y = CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTY);
-  double denergy = CLHEP::RandGauss::shoot(engine_, 0., m_sig_E);
+  double dtheta_x = (m_sigmaSTX <= 0.0) ? 0.0 : CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTX);
+  double dtheta_y = (m_sigmaSTY <= 0.0) ? 0.0 : CLHEP::RandGauss::shoot(engine_, 0., m_sigmaSTY);
+  double denergy = (m_sig_E <= 0.0) ? 0.0 : CLHEP::RandGauss::shoot(engine_, 0., m_sig_E);
 
   double s_theta = std::sqrt(pow(thetax + dtheta_x * urad, 2) + std::pow(thetay + dtheta_y * urad, 2));
   double s_phi = std::atan2(thetay + dtheta_y * urad, thetax + dtheta_x * urad);

--- a/SimTransport/PPSProtonTransport/src/HectorTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/HectorTransport.cc
@@ -76,7 +76,7 @@ void HectorTransport::process(const HepMC::GenEvent* evt,
   }
 }
 bool HectorTransport::transportProton(const HepMC::GenParticle* gpart) {
-  edm::LogInfo("ProtonTransport") << "Starting proton transport using HECTOR method\n";
+  edm::LogVerbatim("ProtonTransport") << "Starting proton transport using HECTOR method\n";
 
   double px, py, pz, e;
   unsigned int line = (gpart)->barcode();
@@ -120,7 +120,6 @@ bool HectorTransport::transportProton(const HepMC::GenParticle* gpart) {
   YforPosition = YforPosition - ZforPosition * (py / pz + fCrossingAngleY * urad);
   XforPosition -= (-vtxXoffset_);  // X was already in the LHC ref. frame
   YforPosition -= vtxYoffset_;
-  ZforPosition = 0.;
 
   // set position, but do not invert the coordinate for the angles (TX,TY) because it is done by set4Momentum
   h_p.setPosition(XforPosition * mm_to_um, YforPosition * mm_to_um, h_p.getTX(), h_p.getTY(), 0.);
@@ -169,7 +168,7 @@ bool HectorTransport::transportProton(const HepMC::GenParticle* gpart) {
     thy -= p_beam.getTY();
     x1_ctpps -= p_beam.getX();
     y1_ctpps -= p_beam.getY();
-    edm::LogInfo("HectorTransportEventProcessing")
+    edm::LogVerbatim("HectorTransportEventProcessing")
         << "Shifting the hit relative to beam :  X = " << p_beam.getX() << "(mm)      Y = " << p_beam.getY() << "(mm)";
   }
 

--- a/SimTransport/PPSProtonTransport/src/HectorTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/HectorTransport.cc
@@ -33,9 +33,10 @@ HectorTransport::HectorTransport(const edm::ParameterSet& iConfig, edm::Consumes
   m_sig_E = iConfig.getParameter<double>("BeamEnergyDispersion");
 
   //PPS
-  edm::LogVerbatim("ProtonTransport") << "=============================================================================\n"
-                                      << "             Bulding LHC Proton transporter based on HECTOR model\n"
-                                      << "=============================================================================\n";
+  edm::LogVerbatim("ProtonTransport")
+      << "=============================================================================\n"
+      << "             Bulding LHC Proton transporter based on HECTOR model\n"
+      << "=============================================================================\n";
   setBeamLine();
 }
 //
@@ -233,7 +234,7 @@ bool HectorTransport::setBeamLine() {
                                              << "                  Forward beam line elements \n";
     m_beamline45->showElements();
     edm::LogVerbatim("HectorTransportSetup") << "===================================================================\n"
-					     << "                 Backward beam line elements \n";
+                                             << "                 Backward beam line elements \n";
     m_beamline56->showElements();
   }
   return true;

--- a/SimTransport/PPSProtonTransport/src/HectorTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/HectorTransport.cc
@@ -33,9 +33,9 @@ HectorTransport::HectorTransport(const edm::ParameterSet& iConfig, edm::Consumes
   m_sig_E = iConfig.getParameter<double>("BeamEnergyDispersion");
 
   //PPS
-  edm::LogInfo("ProtonTransport") << "=============================================================================\n"
-                                  << "             Bulding LHC Proton transporter based on HECTOR model\n"
-                                  << "=============================================================================\n";
+  edm::LogVerbatim("ProtonTransport") << "=============================================================================\n"
+                                      << "             Bulding LHC Proton transporter based on HECTOR model\n"
+                                      << "=============================================================================\n";
   setBeamLine();
 }
 //
@@ -229,13 +229,11 @@ bool HectorTransport::setBeamLine() {
                                          << " PPS Region Start 44   =  " << fPPSRegionStart_45 << "\n"
                                          << " PPS Region Start 56   =  " << fPPSRegionStart_56 << "\n"
                                          << "===================================================================\n";
-  }
-  if (verbosity_) {
-    edm::LogInfo("HectorTransportSetup") << "====================================================================\n"
-                                         << "                  Forward beam line elements \n";
+    edm::LogVerbatim("HectorTransportSetup") << "===================================================================\n"
+                                             << "                  Forward beam line elements \n";
     m_beamline45->showElements();
-    edm::LogInfo("HectorTransportSetup") << "====================================================================\n"
-                                         << "                 Backward beam line elements \n";
+    edm::LogVerbatim("HectorTransportSetup") << "===================================================================\n"
+					     << "                 Backward beam line elements \n";
     m_beamline56->showElements();
   }
   return true;

--- a/SimTransport/PPSProtonTransport/src/HectorTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/HectorTransport.cc
@@ -14,21 +14,7 @@ HectorTransport::HectorTransport(const edm::ParameterSet& iConfig, edm::Consumes
       m_beamline56(nullptr),
       beamParametersToken_(iC.esConsumes()),
       beamspotToken_(iC.esConsumes()) {
-  // Create LHC beam line
-
-  MODE = TransportMode::HECTOR;  // defines the MODE for the transport
-  beam1Filename_ = iConfig.getParameter<std::string>("Beam1Filename");
-  beam2Filename_ = iConfig.getParameter<std::string>("Beam2Filename");
-  fCrossingAngleX_45_ = iConfig.getParameter<double>("halfCrossingAngleXSector45");
-  fCrossingAngleX_56_ = iConfig.getParameter<double>("halfCrossingAngleXSector56");
-  fCrossingAngleY_45_ = iConfig.getParameter<double>("halfCrossingAngleYSector45");
-  fCrossingAngleY_56_ = iConfig.getParameter<double>("halfCrossingAngleYSector56");
-  m_sigmaSTX = iConfig.getParameter<double>("BeamDivergenceX");
-  m_sigmaSTY = iConfig.getParameter<double>("BeamDivergenceY");
-  m_sigmaSX = iConfig.getParameter<double>("BeamSigmaX");
-  m_sigmaSY = iConfig.getParameter<double>("BeamSigmaY");
-  m_sig_E = iConfig.getParameter<double>("BeamEnergyDispersion");
-
+  MODE = TransportMode::HECTOR;
   //PPS
   edm::LogVerbatim("ProtonTransport")
       << "=============================================================================\n"

--- a/SimTransport/PPSProtonTransport/src/HectorTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/HectorTransport.cc
@@ -1,6 +1,5 @@
 #include "SimTransport/PPSProtonTransport/interface/HectorTransport.h"
 #include "Utilities/PPS/interface/PPSUtilities.h"
-#include <CLHEP/Random/RandGauss.h>
 #include "TLorentzVector.h"
 //Hector headers
 #include "H_BeamLine.h"

--- a/SimTransport/PPSProtonTransport/src/HectorTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/HectorTransport.cc
@@ -15,6 +15,20 @@ HectorTransport::HectorTransport(const edm::ParameterSet& iConfig, edm::Consumes
       beamParametersToken_(iC.esConsumes()),
       beamspotToken_(iC.esConsumes()) {
   MODE = TransportMode::HECTOR;
+  std::string s1 = iConfig.getParameter<std::string>("Beam1Filename");
+  std::string s2 = iConfig.getParameter<std::string>("Beam2Filename");
+  setBeamFileNames(s1, s2);
+  double cax45 = iConfig.getParameter<double>("halfCrossingAngleXSector45");
+  double cax56 = iConfig.getParameter<double>("halfCrossingAngleXSector56");
+  double cay45 = iConfig.getParameter<double>("halfCrossingAngleYSector45");
+  double cay56 = iConfig.getParameter<double>("halfCrossingAngleYSector56");
+  setCrossingAngles(cax45, cax56, cay45, cay56);
+  double stx = iConfig.getParameter<double>("BeamDivergenceX");
+  double sty = iConfig.getParameter<double>("BeamDivergenceY");
+  double sx = iConfig.getParameter<double>("BeamSigmaX");
+  double sy = iConfig.getParameter<double>("BeamSigmaY");
+  double se = iConfig.getParameter<double>("BeamEnergyDispersion");
+  setBeamParameters(stx, sty, sx, sy, se);
   //PPS
   edm::LogVerbatim("ProtonTransport")
       << "=============================================================================\n"
@@ -141,7 +155,7 @@ bool HectorTransport::transportProton(const HepMC::GenParticle* gpart) {
 
   if (produceHitsRelativeToBeam_) {
     H_BeamParticle p_beam(mass, charge);
-    p_beam.set4Momentum(0., 0., beamMomentum_, beamEnergy_);
+    p_beam.set4Momentum(0., 0., beamMomentum(), beamEnergy());
     p_beam.setPosition(0., 0., fCrossingAngleX * urad, fCrossingAngleY * urad, 0.);
     p_beam.computePath(&*beamline);
     thx -= p_beam.getTX();

--- a/SimTransport/PPSProtonTransport/src/OpticalFunctionsTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/OpticalFunctionsTransport.cc
@@ -18,10 +18,12 @@ OpticalFunctionsTransport::OpticalFunctionsTransport(const edm::ParameterSet& iC
       empiricalAperture56_a_slp_(iConfig.getParameter<double>("empiricalAperture56_a_slp")) {
   MODE = TransportMode::OPTICALFUNCTIONS;
 }
+OpticalFunctionsTransport::~OpticalFunctionsTransport() {}
+
 void OpticalFunctionsTransport::process(const HepMC::GenEvent* evt,
                                         const edm::EventSetup& iSetup,
-                                        CLHEP::HepRandomEngine* _engine) {
-  this->clear();
+                                        CLHEP::HepRandomEngine* engine) {
+  clear();
 
   lhcInfo_ = &iSetup.getData(lhcInfoToken_);
   beamParameters_ = &iSetup.getData(beamParametersToken_);
@@ -46,7 +48,7 @@ void OpticalFunctionsTransport::process(const HepMC::GenEvent* evt,
     }
   }
   //
-  engine_ = _engine;  // the engine needs to be updated for each event
+  engine_ = engine;  // the engine needs to be updated for each event
 
   for (HepMC::GenEvent::particle_const_iterator eventParticle = evt->particles_begin();
        eventParticle != evt->particles_end();
@@ -84,25 +86,21 @@ bool OpticalFunctionsTransport::transportProton(const HepMC::GenParticle* in_trk
   double xangle = 0.;
   double empiricalAperture_xi0_int, empiricalAperture_xi0_slp;
   double empiricalAperture_a_int, empiricalAperture_a_slp;
-  unsigned int optFunctionId_;
+  unsigned int optFunctionId;
   // get the beam position at the IP in mm and in the LHC ref. frame
-  double vtxXoffset_;
-  double vtxYoffset_;
-  double vtxZoffset_;
+  double vtxXoffset;
+  double vtxYoffset;
   if (useBeamPositionFromLHCInfo_) {
-    vtxXoffset_ = -beamParameters_->getVtxOffsetX45() * cm_to_mm;
-    vtxYoffset_ = beamParameters_->getVtxOffsetY45() * cm_to_mm;
-    vtxZoffset_ = -beamParameters_->getVtxOffsetZ45() * cm_to_mm;
+    vtxXoffset = -beamParameters_->getVtxOffsetX45() * cm_to_mm;
+    vtxYoffset = beamParameters_->getVtxOffsetY45() * cm_to_mm;
   } else {
-    vtxXoffset_ = -beamspot_->x() * cm_to_mm;
-    vtxYoffset_ = beamspot_->y() * cm_to_mm;
-    vtxZoffset_ = -beamspot_->z() * cm_to_mm;
+    vtxXoffset = -beamspot_->x() * cm_to_mm;
+    vtxYoffset = beamspot_->y() * cm_to_mm;
   }
-  vtxZoffset_ *= 1.0;   // just to avoid compilation error, should be used in the future
-                        //
+
   if (mom_lhc.z() < 0)  // sector 45
   {
-    optFunctionId_ = optFunctionId45_;
+    optFunctionId = optFunctionId45_;
     beamMomentum = beamParameters_->getBeamMom45();
     xangle = beamParameters_->getHalfXangleX45();
     empiricalAperture_xi0_int = empiricalAperture45_xi0_int_;
@@ -110,7 +108,7 @@ bool OpticalFunctionsTransport::transportProton(const HepMC::GenParticle* in_trk
     empiricalAperture_a_int = empiricalAperture45_a_int_;
     empiricalAperture_a_slp = empiricalAperture45_a_slp_;
   } else {  // sector 56
-    optFunctionId_ = optFunctionId56_;
+    optFunctionId = optFunctionId56_;
     beamMomentum = beamParameters_->getBeamMom56();
     xangle = beamParameters_->getHalfXangleX56();
     empiricalAperture_xi0_int = empiricalAperture56_xi0_int_;
@@ -125,13 +123,13 @@ bool OpticalFunctionsTransport::transportProton(const HepMC::GenParticle* in_trk
   const double xi = 1. - p / beamMomentum;
   const double th_x_phys = mom_lhc.x() / abs(mom_lhc.z()) - tan(xangle);  //"-" in the LHC ref. frame
   const double th_y_phys = mom_lhc.y() / abs(mom_lhc.z());
-  const double vtx_lhc_eff_x = vtx_lhc.x() - vtx_lhc.z() * (mom_lhc.x() / mom_lhc.z() + tan(xangle)) - (vtxXoffset_);
-  const double vtx_lhc_eff_y = vtx_lhc.y() - vtx_lhc.z() * (mom_lhc.y() / mom_lhc.z()) - (vtxYoffset_);
+  const double vtx_lhc_eff_x = vtx_lhc.x() - vtx_lhc.z() * (mom_lhc.x() / mom_lhc.z() + tan(xangle)) - (vtxXoffset);
+  const double vtx_lhc_eff_y = vtx_lhc.y() - vtx_lhc.z() * (mom_lhc.y() / mom_lhc.z()) - (vtxYoffset);
 
   if (verbosity_) {
     LogDebug("OpticalFunctionsTransport")
         << "simu: xi = " << xi << ", th_x_phys = " << th_x_phys << ", th_y_phys = " << th_y_phys
-        << ", vtx_lhc_eff_x = " << vtx_lhc_eff_x << ", vtx_lhc_eff_y = " << vtx_lhc_eff_y << std::endl;
+        << ", vtx_lhc_eff_x = " << vtx_lhc_eff_x << ", vtx_lhc_eff_y = " << vtx_lhc_eff_y;
   }
 
   // check empirical aperture
@@ -150,8 +148,8 @@ bool OpticalFunctionsTransport::transportProton(const HepMC::GenParticle* in_trk
   }
 
   // transport the proton into  pot/scoring plane
-  auto ofp = opticalFunctions_->at(optFunctionId_);
-  CTPPSDetId rpId(optFunctionId_);
+  auto ofp = opticalFunctions_->at(optFunctionId);
+  CTPPSDetId rpId(optFunctionId);
   const unsigned int rpDecId = rpId.arm() * 100 + rpId.station() * 10 + rpId.rp();
 
   if (verbosity_)
@@ -159,13 +157,13 @@ bool OpticalFunctionsTransport::transportProton(const HepMC::GenParticle* in_trk
 
   // transport proton
   LHCInterpolatedOpticalFunctionsSet::Kinematics k_in = {
-      vtx_lhc_eff_x * 1E-1, th_x_phys, vtx_lhc_eff_y * 1E-1, th_y_phys, xi};  // conversions: mm -> cm
+      vtx_lhc_eff_x * cm_to_mm, th_x_phys, vtx_lhc_eff_y * cm_to_mm, th_y_phys, xi};  // conversions: mm -> cm
 
   LHCInterpolatedOpticalFunctionsSet::Kinematics k_out;
   ofp.transport(k_in, k_out, true);
 
   // Original code uses mm, but CMS uses cm, so keep it in cm
-  double b_x = k_out.x * 1E1, b_y = k_out.y * 1E1;  // conversions: cm -> mm
+  double b_x = k_out.x * cm_to_mm, b_y = k_out.y * cm_to_mm;  // conversions: cm -> mm
   double a_x = k_out.th_x, a_y = k_out.th_y;
 
   // if needed, subtract beam position and angle
@@ -177,22 +175,21 @@ bool OpticalFunctionsTransport::transportProton(const HepMC::GenParticle* in_trk
 
     a_x -= k_be_out.th_x;
     a_y -= k_be_out.th_y;
-    b_x -= k_be_out.x * 1E1;
-    b_y -= k_be_out.y * 1E1;  // conversions: cm -> mm
+    b_x -= k_be_out.x * cm_to_mm;
+    b_y -= k_be_out.y * cm_to_mm;  // conversions: cm -> mm
   }
 
-  const double z_scoringPlane = ofp.getScoringPlaneZ() * 1E1;  // conversion: cm --> mm
+  const double z_scoringPlane = ofp.getScoringPlaneZ() * cm_to_mm;  // conversion: cm --> mm
 
   if (verbosity_) {
     LogDebug("OpticalFunctionsTransport")
         << "    proton transported: a_x = " << a_x << " rad, a_y = " << a_y << " rad, b_x = " << b_x
-        << " mm, b_y = " << b_y << " mm, z = " << z_scoringPlane << " mm" << std::endl;
+        << " mm, b_y = " << b_y << " mm, z = " << z_scoringPlane << " mm";
   }
   //
-  // Project the track back to the starting of PPS region
-  b_x -= (abs(z_scoringPlane) - (double)((z_scoringPlane < 0) ? fPPSRegionStart_45 : fPPSRegionStart_56) * 1e3) *
-         a_x;  // z_scoringPlane is in mm
-  b_y -= (abs(z_scoringPlane) - (double)((z_scoringPlane < 0) ? fPPSRegionStart_45 : fPPSRegionStart_56) * 1e3) * a_y;
+  // Project the track back to the starting of PPS region in mm
+  b_x -= (abs(z_scoringPlane) - ((z_scoringPlane < 0) ? fPPSRegionStart_45_ : fPPSRegionStart_56_) * 1e3) * a_x;
+  b_y -= (abs(z_scoringPlane) - ((z_scoringPlane < 0) ? fPPSRegionStart_45_ : fPPSRegionStart_56_) * 1e3) * a_y;
 
   unsigned int line = in_trk->barcode();
   double px = -p * a_x;

--- a/SimTransport/PPSProtonTransport/src/ProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/ProtonTransport.cc
@@ -4,8 +4,8 @@
 #include "SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h"
 #include "SimTransport/PPSProtonTransport/interface/TotemTransport.h"
 #include "Utilities/PPS/interface/PPSUnitConversion.h"
-#include <CLHEP/Random/RandGauss.h>
-#include <CLHEP/Units/GlobalSystemOfUnits.h>
+//#include <CLHEP/Random/RandGauss.h>
+//#include <CLHEP/Units/GlobalSystemOfUnits.h>
 #include <cctype>
 
 ProtonTransport::ProtonTransport(const edm::ParameterSet &iConfig, edm::ConsumesCollector iC) {

--- a/SimTransport/PPSProtonTransport/src/ProtonTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/ProtonTransport.cc
@@ -4,8 +4,6 @@
 #include "SimTransport/PPSProtonTransport/interface/OpticalFunctionsTransport.h"
 #include "SimTransport/PPSProtonTransport/interface/TotemTransport.h"
 #include "Utilities/PPS/interface/PPSUnitConversion.h"
-//#include <CLHEP/Random/RandGauss.h>
-//#include <CLHEP/Units/GlobalSystemOfUnits.h>
 #include <cctype>
 
 ProtonTransport::ProtonTransport(const edm::ParameterSet &iConfig, edm::ConsumesCollector iC) {

--- a/SimTransport/PPSProtonTransport/src/TotemTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/TotemTransport.cc
@@ -12,6 +12,19 @@ TotemTransport::TotemTransport(const edm::ParameterSet& iConfig)
       m_model_ip_150_l_name_(iConfig.getParameter<std::string>("Model_IP_150_L_Name")),
       m_beampipe_aperture_radius_(iConfig.getParameter<double>("BeampipeApertureRadius")) {
   MODE = TransportMode::TOTEM;
+  std::string s1 = iConfig.getParameter<std::string>("Beam1Filename");
+  std::string s2 = iConfig.getParameter<std::string>("Beam2Filename");
+  setBeamFileNames(s1, s2);
+  double cax45 = iConfig.getParameter<double>("halfCrossingAngleXSector45");
+  double cax56 = iConfig.getParameter<double>("halfCrossingAngleXSector56");
+  setCrossingAngles(cax45, cax56, 0.0, 0.0);
+  double stx = iConfig.getParameter<double>("BeamDivergenceX");
+  double sty = iConfig.getParameter<double>("BeamDivergenceY");
+  double sx = iConfig.getParameter<double>("BeamSigmaX");
+  double sy = iConfig.getParameter<double>("BeamSigmaY");
+  double se = iConfig.getParameter<double>("BeamEnergyDispersion");
+  setBeamParameters(stx, sty, sx, sy, se);
+
   if (fPPSRegionStart_56_ > 0)
     fPPSRegionStart_56_ *= -1;  // make sure sector 56 has negative position, as TOTEM convention
 

--- a/SimTransport/PPSProtonTransport/src/TotemTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/TotemTransport.cc
@@ -27,9 +27,9 @@ TotemTransport::TotemTransport(const edm::ParameterSet& iConfig)
   if (fPPSRegionStart_56 > 0)
     fPPSRegionStart_56 *= -1;  // make sure sector 56 has negative position, as TOTEM convention
 
-  edm::LogInfo("TotemTransport") << "=============================================================================\n"
-                                 << "             Bulding LHC Proton transporter based on TOTEM model\n"
-                                 << "=============================================================================\n";
+  edm::LogVerbatim("TotemTransport") << "=============================================================================\n"
+                                     << "             Bulding LHC Proton transporter based on TOTEM model\n"
+                                     << "=============================================================================\n";
 
   m_aprox_ip_150_r = ReadParameterization(m_model_ip_150_r_name, beam1Filename_);
   m_aprox_ip_150_l = ReadParameterization(m_model_ip_150_l_name, beam2Filename_);
@@ -37,21 +37,23 @@ TotemTransport::TotemTransport(const edm::ParameterSet& iConfig)
   if (m_aprox_ip_150_r == nullptr || m_aprox_ip_150_l == nullptr) {
     edm::LogError("TotemTransport") << "Parameterisation " << m_model_ip_150_r_name << " or " << m_model_ip_150_l_name
                                     << " missing in file. Cannot proceed. ";
-    exit(1);
+    throw edm::Exception(edm::errors::Configuration) << "TotemTransport is not properly initialized";
   }
-  edm::LogInfo("TotemTransport") << "Parameterizations read from file, pointers:" << m_aprox_ip_150_r << " "
-                                 << m_aprox_ip_150_l << " ";
+  edm::LogVerbatim("TotemTransport") << "Parameterizations read from file, pointers:" << m_aprox_ip_150_r << " "
+				     << m_aprox_ip_150_l << " ";
 }
 //
 // this method is the same for all propagator, but since transportProton is different for each derived class
 // it needes to be overriden
 //
-void TotemTransport::process(const HepMC::GenEvent* evt,
+void TotemTransport::process(const HepMC::GenEvent* ievt,
                              const edm::EventSetup& iSetup,
                              CLHEP::HepRandomEngine* _engine) {
   this->clear();
 
   engine_ = _engine;  // the engine needs to be updated for each event
+
+  HepMC::GenEvent *evt = new HepMC::GenEvent(*ievt);
 
   for (HepMC::GenEvent::particle_const_iterator eventParticle = evt->particles_begin();
        eventParticle != evt->particles_end();
@@ -79,12 +81,11 @@ void TotemTransport::process(const HepMC::GenEvent* evt,
 // here comes the real thing
 //
 //
-bool TotemTransport::transportProton(const HepMC::GenParticle* in_trk) {
+bool TotemTransport::transportProton(HepMC::GenParticle* in_trk) {
   //
+  edm::LogVerbatim("TotemTransport") << "Starting proton transport using TOTEM method\n";
   //
-  edm::LogInfo("TotemTransport") << "Starting proton transport using TOTEM method\n";
-  //
-  ApplyBeamCorrection(const_cast<HepMC::GenParticle*>(in_trk));
+  ApplyBeamCorrection(in_trk);
 
   const HepMC::GenVertex* in_pos = in_trk->production_vertex();
   const HepMC::FourVector in_mom = in_trk->momentum();
@@ -103,9 +104,9 @@ bool TotemTransport::transportProton(const HepMC::GenParticle* in_trk) {
   double in_momentum[3] = {in_mom.x(), in_mom.y(), in_mom.z()};
   double out_position[3];
   double out_momentum[3];
-  edm::LogInfo("TotemTransport") << "before transport ->"
-                                 << " position: " << in_position[0] << ", " << in_position[1] << ", " << in_position[2]
-                                 << " momentum: " << in_momentum[0] << ", " << in_momentum[1] << ", " << in_momentum[2];
+  edm::LogVerbatim("TotemTransport") << "before transport ->"
+                                     << " position: " << in_position[0] << ", " << in_position[1] << ", " << in_position[2]
+                                     << " momentum: " << in_momentum[0] << ", " << in_momentum[1] << ", " << in_momentum[2];
 
   LHCOpticsApproximator* approximator_ = nullptr;
   double m_Zin_;
@@ -129,16 +130,14 @@ bool TotemTransport::transportProton(const HepMC::GenParticle* in_trk) {
   if (!tracked)
     return false;
 
-  edm::LogInfo("TotemTransport") << "after transport -> "
-                                 << "position: " << out_position[0] << ", " << out_position[1] << ", "
-                                 << out_position[2] << "momentum: " << out_momentum[0] << ", " << out_momentum[1]
-                                 << ", " << out_momentum[2];
+  edm::LogVerbatim("TotemTransport") << "after transport -> "
+                                     << "position: " << out_position[0] << ", " << out_position[1] << ", "
+                                     << out_position[2] << "momentum: " << out_momentum[0] << ", " << out_momentum[1]
+                                     << ", " << out_momentum[2];
 
   if (out_position[0] * out_position[0] + out_position[1] * out_position[1] >
       m_beampipe_aperture_radius * m_beampipe_aperture_radius) {
-    edm::LogInfo("TotemTransport") << "Proton ouside beampipe";
-    edm::LogInfo("TotemTransport") << "===== END Transport "
-                                   << "====================";
+    edm::LogVerbatim("TotemTransport") << "Proton ouside beampipe\n" << "===== END Transport " << "====================";
     return false;
   }
 
@@ -181,7 +180,7 @@ LHCOpticsApproximator* TotemTransport::ReadParameterization(const std::string& m
     edm::LogError("TotemTransport") << "File " << fileName << " not found. Exiting.";
     return nullptr;
   }
-  edm::LogInfo("TotemTransport") << "Root file opened, pointer:" << f;
+  edm::LogVerbatim("TotemTransport") << "Root file opened, pointer:" << f;
 
   // read parametrization
   LHCOpticsApproximator* aprox = (LHCOpticsApproximator*)f->Get(m_model_name.c_str());

--- a/SimTransport/PPSProtonTransport/src/TotemTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/TotemTransport.cc
@@ -1,7 +1,6 @@
 #include "SimTransport/PPSProtonTransport/interface/TotemTransport.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 #include <CLHEP/Units/GlobalSystemOfUnits.h>
-#include <CLHEP/Random/RandGauss.h>
 #include "TLorentzVector.h"
 #include "TFile.h"
 

--- a/SimTransport/PPSProtonTransport/src/TotemTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/TotemTransport.cc
@@ -12,17 +12,6 @@ TotemTransport::TotemTransport(const edm::ParameterSet& iConfig)
       m_model_ip_150_l_name_(iConfig.getParameter<std::string>("Model_IP_150_L_Name")),
       m_beampipe_aperture_radius_(iConfig.getParameter<double>("BeampipeApertureRadius")) {
   MODE = TransportMode::TOTEM;
-  beam1Filename_ = iConfig.getParameter<std::string>("Beam1Filename");
-  beam2Filename_ = iConfig.getParameter<std::string>("Beam2Filename");
-  fCrossingAngleX_45_ = iConfig.getParameter<double>("halfCrossingAngleSector45");
-  fCrossingAngleX_56_ = iConfig.getParameter<double>("halfCrossingAngleSector56");
-  beamEnergy_ = iConfig.getParameter<double>("BeamEnergy");
-  m_sigmaSTX = iConfig.getParameter<double>("BeamDivergenceX");
-  m_sigmaSTY = iConfig.getParameter<double>("BeamDivergenceY");
-  m_sigmaSX = iConfig.getParameter<double>("BeamSigmaX");
-  m_sigmaSY = iConfig.getParameter<double>("BeamSigmaY");
-  m_sig_E = iConfig.getParameter<double>("BeamEnergyDispersion");
-
   if (fPPSRegionStart_56_ > 0)
     fPPSRegionStart_56_ *= -1;  // make sure sector 56 has negative position, as TOTEM convention
 

--- a/SimTransport/PPSProtonTransport/src/TotemTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/TotemTransport.cc
@@ -155,9 +155,10 @@ bool TotemTransport::transportProton(HepMC::GenParticle* in_trk) {
     out_mom.Print();
   }
 
-  double px = -out_momentum[0]; // calculates px by means of TH_X, which is in the LHC ref. frame.
-  double py = out_momentum[1];  // this need to be checked again, since it seems an invertion is occuring in the prop.
-  double pz = out_momentum[2];  // totem calculates output pz already in the CMS ref. frame, it doesn't need to be converted
+  double px = -out_momentum[0];  // calculates px by means of TH_X, which is in the LHC ref. frame.
+  double py = out_momentum[1];   // this need to be checked again, since it seems an invertion is occuring in the prop.
+  double pz =
+      out_momentum[2];  // totem calculates output pz already in the CMS ref. frame, it doesn't need to be converted
   double e = sqrt(px * px + py * py + pz * pz + ProtonMassSQ);
   TLorentzVector p_out(px, py, pz, e);
   double x1_ctpps = -out_position[0] * meter;  // Totem parameterization uses meter, one need it in millimeter

--- a/SimTransport/PPSProtonTransport/src/TotemTransport.cc
+++ b/SimTransport/PPSProtonTransport/src/TotemTransport.cc
@@ -27,9 +27,10 @@ TotemTransport::TotemTransport(const edm::ParameterSet& iConfig)
   if (fPPSRegionStart_56 > 0)
     fPPSRegionStart_56 *= -1;  // make sure sector 56 has negative position, as TOTEM convention
 
-  edm::LogVerbatim("TotemTransport") << "=============================================================================\n"
-                                     << "             Bulding LHC Proton transporter based on TOTEM model\n"
-                                     << "=============================================================================\n";
+  edm::LogVerbatim("TotemTransport")
+      << "=============================================================================\n"
+      << "             Bulding LHC Proton transporter based on TOTEM model\n"
+      << "=============================================================================\n";
 
   m_aprox_ip_150_r = ReadParameterization(m_model_ip_150_r_name, beam1Filename_);
   m_aprox_ip_150_l = ReadParameterization(m_model_ip_150_l_name, beam2Filename_);
@@ -40,7 +41,7 @@ TotemTransport::TotemTransport(const edm::ParameterSet& iConfig)
     throw edm::Exception(edm::errors::Configuration) << "TotemTransport is not properly initialized";
   }
   edm::LogVerbatim("TotemTransport") << "Parameterizations read from file, pointers:" << m_aprox_ip_150_r << " "
-				     << m_aprox_ip_150_l << " ";
+                                     << m_aprox_ip_150_l << " ";
 }
 //
 // this method is the same for all propagator, but since transportProton is different for each derived class
@@ -53,7 +54,7 @@ void TotemTransport::process(const HepMC::GenEvent* ievt,
 
   engine_ = _engine;  // the engine needs to be updated for each event
 
-  HepMC::GenEvent *evt = new HepMC::GenEvent(*ievt);
+  HepMC::GenEvent* evt = new HepMC::GenEvent(*ievt);
 
   for (HepMC::GenEvent::particle_const_iterator eventParticle = evt->particles_begin();
        eventParticle != evt->particles_end();
@@ -105,8 +106,9 @@ bool TotemTransport::transportProton(HepMC::GenParticle* in_trk) {
   double out_position[3];
   double out_momentum[3];
   edm::LogVerbatim("TotemTransport") << "before transport ->"
-                                     << " position: " << in_position[0] << ", " << in_position[1] << ", " << in_position[2]
-                                     << " momentum: " << in_momentum[0] << ", " << in_momentum[1] << ", " << in_momentum[2];
+                                     << " position: " << in_position[0] << ", " << in_position[1] << ", "
+                                     << in_position[2] << " momentum: " << in_momentum[0] << ", " << in_momentum[1]
+                                     << ", " << in_momentum[2];
 
   LHCOpticsApproximator* approximator_ = nullptr;
   double m_Zin_;
@@ -137,7 +139,9 @@ bool TotemTransport::transportProton(HepMC::GenParticle* in_trk) {
 
   if (out_position[0] * out_position[0] + out_position[1] * out_position[1] >
       m_beampipe_aperture_radius * m_beampipe_aperture_radius) {
-    edm::LogVerbatim("TotemTransport") << "Proton ouside beampipe\n" << "===== END Transport " << "====================";
+    edm::LogVerbatim("TotemTransport") << "Proton ouside beampipe\n"
+                                       << "===== END Transport "
+                                       << "====================";
     return false;
   }
 


### PR DESCRIPTION
#### PR description:
This PR should fix #36544 - thread safety is PPS proton transport is provided,
all class members in the sub-library are now initialized to zero, LogVerbatim is used instead of LogInfo. Because PPS transport is disabled for the time being, no change in results are expected.  
 

#### PR validation:
private
