### PR TITLE
Small fix in ECAL recHit collection names in PFECALSuperClusterProducer

### DIFF
--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -363,8 +363,8 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<double>("thresh_PFClusterES", 0.0);
   desc.add<bool>("seedThresholdIsET", true);
   desc.add<bool>("isOOTCollection", false);
-  desc.add<edm::InputTag>("barrelRecHits", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
-  desc.add<edm::InputTag>("endcapRecHits", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+  desc.add<edm::InputTag>("barrelRecHits", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+  desc.add<edm::InputTag>("endcapRecHits", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
   desc.add<std::string>("PFSuperClusterCollectionEndcapWithPreshower",
                         "particleFlowSuperClusterECALEndcapWithPreshower");
   desc.add<bool>("dropUnseedable", false);


### PR DESCRIPTION
#### PR description:

A trivial fix is done in ECAL recHit collection names in `PFECALSuperClusterProducer`. As far as I'm aware, this bug was not affecting anything until now, so no reco change is expected. But I'm not fully sure, so looking forward to the outcome of the PR tests. These two parameters are used only for OOT photons, so if anything changes in reco then I guess it would be in OOT photons.