### PR TITLE
Run3-sim101A Remove some compilation warnings in classes from SimCalorimetry and SimGeneral

### DIFF
--- a/SimCalorimetry/EcalEBTrigPrimProducers/plugins/EcalEBTrigPrimAnalyzer.cc
+++ b/SimCalorimetry/EcalEBTrigPrimProducers/plugins/EcalEBTrigPrimAnalyzer.cc
@@ -3,7 +3,6 @@
 #include <utility>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.h
+++ b/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.h
@@ -1,7 +1,7 @@
 #ifndef ESDigisReferenceDistrib_H
 #define ESDigisReferenceDistrib_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -22,7 +22,7 @@
 #include "TH1F.h"
 #include "TH3F.h"
 
-class ESDigisReferenceDistrib : public edm::EDAnalyzer {
+class ESDigisReferenceDistrib : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   ESDigisReferenceDistrib(const edm::ParameterSet &ps);

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPInputAnalyzer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPInputAnalyzer.cc
@@ -19,7 +19,6 @@
 #include <utility>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPInputAnalyzer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTPInputAnalyzer.h
@@ -16,7 +16,7 @@
 //
 
 // system include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -32,7 +32,7 @@
 // class declaration
 //
 
-class EcalTPInputAnalyzer : public edm::EDAnalyzer {
+class EcalTPInputAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit EcalTPInputAnalyzer(const edm::ParameterSet &);
   ~EcalTPInputAnalyzer() override;

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimAnalyzer.cc
@@ -19,7 +19,6 @@
 #include <utility>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 

--- a/SimGeneral/MixingModule/plugins/InputAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/InputAnalyzer.cc
@@ -21,7 +21,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -22,7 +22,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimGeneral/MixingModule/plugins/TestMix.cc
+++ b/SimGeneral/MixingModule/plugins/TestMix.cc
@@ -20,7 +20,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimGeneral/MixingModule/plugins/TestMixedSource.cc
+++ b/SimGeneral/MixingModule/plugins/TestMixedSource.cc
@@ -21,7 +21,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimGeneral/NoiseGenerators/test/GaussianTailNoiseGeneratorTest.cc
+++ b/SimGeneral/NoiseGenerators/test/GaussianTailNoiseGeneratorTest.cc
@@ -1,7 +1,7 @@
 // system include files
 #include <memory>
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -19,7 +19,7 @@
 #include <TH1F.h>
 #include <TROOT.h>
 
-class GaussianTailNoiseGeneratorTest : public edm::EDAnalyzer {
+class GaussianTailNoiseGeneratorTest : public edm::one::EDAnalyzer<> {
 public:
   explicit GaussianTailNoiseGeneratorTest(const edm::ParameterSet &);
   ~GaussianTailNoiseGeneratorTest() override;

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
@@ -36,7 +36,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
#### PR description:

Remove some compilation warnings in classes from SimCalorimetry (EcalEBTrigPrimProducers, EcalSimProducers, EcalTrigPrimProducer)  and SimGeneral (MixingModukem NoiseGenerators, PileUpInformation)

#### PR validation:
Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special