### PR TITLE
Run3-sim101B Remove some compilation warnings in SimGeneral/TrackingAnalysis

### DIFF
--- a/SimGeneral/TrackingAnalysis/interface/MuonPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/MuonPSimHitSelector.h
@@ -14,7 +14,8 @@ public:
 
      /param[in] pset with the configuration values
   */
- MuonPSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector & iC) : PSimHitSelector(config, iC), cscBadToken_(iC.esConsumes()) {}
+  MuonPSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector &iC)
+      : PSimHitSelector(config, iC), cscBadToken_(iC.esConsumes()) {}
 
   //! Pre-process event information
   void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;

--- a/SimGeneral/TrackingAnalysis/interface/MuonPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/MuonPSimHitSelector.h
@@ -1,6 +1,9 @@
 #ifndef TrackingAnalysis_MuonPSimHitSelector_h
 #define TrackingAnalysis_MuonPSimHitSelector_h
 
+#include "CondFormats/CSCObjects/interface/CSCBadChambers.h"
+#include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
+
 #include "SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h"
 
 //! MuonPSimHitSelector class
@@ -11,10 +14,13 @@ public:
 
      /param[in] pset with the configuration values
   */
-  MuonPSimHitSelector(edm::ParameterSet const &config) : PSimHitSelector(config) {}
+ MuonPSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector & iC) : PSimHitSelector(config, iC), cscBadToken_(iC.esConsumes()) {}
 
   //! Pre-process event information
   void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
+
+private:
+  const edm::ESGetToken<CSCBadChambers, CSCBadChambersRcd> cscBadToken_;
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -21,11 +22,11 @@ public:
 
      /param[in] pset with the configuration values
   */
-  PSimHitSelector(edm::ParameterSet const &);
+  PSimHitSelector(edm::ParameterSet const &, edm::ConsumesCollector &);
   std::string mixLabel_;
 
   //! Virtual destructor.
-  virtual ~PSimHitSelector() {}
+  virtual ~PSimHitSelector() = default;
 
   //! Select the psimhit add them to a PSimHitCollection
   virtual void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const;

--- a/SimGeneral/TrackingAnalysis/interface/PixelPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/PixelPSimHitSelector.h
@@ -1,6 +1,9 @@
 #ifndef TrackingAnalysis_PixelPSimHitSelector_h
 #define TrackingAnalysis_PixelPSimHitSelector_h
 
+#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+
 #include "SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h"
 
 //! PixelPSimHitSelector class
@@ -11,10 +14,13 @@ public:
 
      /param[in] pset with the configuration values
   */
-  PixelPSimHitSelector(edm::ParameterSet const &config) : PSimHitSelector(config) {}
+ PixelPSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector & iC) : PSimHitSelector(config, iC), badModuleToken_(iC.esConsumes()) {}
 
   //! Pre-process event information
   void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
+
+private:
+  edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> badModuleToken_;
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/PixelPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/PixelPSimHitSelector.h
@@ -14,7 +14,8 @@ public:
 
      /param[in] pset with the configuration values
   */
- PixelPSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector & iC) : PSimHitSelector(config, iC), badModuleToken_(iC.esConsumes()) {}
+  PixelPSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector &iC)
+      : PSimHitSelector(config, iC), badModuleToken_(iC.esConsumes()) {}
 
   //! Pre-process event information
   void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;

--- a/SimGeneral/TrackingAnalysis/interface/TrackerPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/TrackerPSimHitSelector.h
@@ -13,14 +13,14 @@ public:
 
      /param[in] pset with the configuration values
   */
- TrackerPSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector &iC) : PSimHitSelector(config, iC), cableToken_(iC.esConsumes()) {}
+  TrackerPSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector &iC)
+      : PSimHitSelector(config, iC), cableToken_(iC.esConsumes()) {}
 
   //! Pre-process event information
   void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
 
 private:
   edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> cableToken_;
-
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/interface/TrackerPSimHitSelector.h
+++ b/SimGeneral/TrackingAnalysis/interface/TrackerPSimHitSelector.h
@@ -2,6 +2,8 @@
 #define TrackingAnalysis_TrackerPSimHitSelector_h
 
 #include "SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
+#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
 
 //! TrackerPSimHitSelector class
 class TrackerPSimHitSelector : public PSimHitSelector {
@@ -11,10 +13,14 @@ public:
 
      /param[in] pset with the configuration values
   */
-  TrackerPSimHitSelector(edm::ParameterSet const &config) : PSimHitSelector(config) {}
+ TrackerPSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector &iC) : PSimHitSelector(config, iC), cableToken_(iC.esConsumes()) {}
 
   //! Pre-process event information
   void select(PSimHitCollection &, edm::Event const &, edm::EventSetup const &) const override;
+
+private:
+  edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> cableToken_;
+
 };
 
 #endif

--- a/SimGeneral/TrackingAnalysis/src/MuonPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/MuonPSimHitSelector.cc
@@ -1,7 +1,4 @@
 
-#include "CondFormats/CSCObjects/interface/CSCBadChambers.h"
-#include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
-
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
@@ -35,8 +32,7 @@ void MuonPSimHitSelector::select(PSimHitCollection &selection,
   std::unique_ptr<MixCollection<PSimHit>> pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
   // Get CSC Bad Chambers (ME4/2)
-  edm::ESHandle<CSCBadChambers> cscBadChambers;
-  setup.get<CSCBadChambersRcd>().get(cscBadChambers);
+  edm::ESHandle<CSCBadChambers> cscBadChambers = setup.getHandle(cscBadToken_);
 
   // Select only psimhits from alive modules
   for (MixCollection<PSimHit>::MixItr pSimHit = pSimHits->begin(); pSimHit != pSimHits->end(); ++pSimHit) {

--- a/SimGeneral/TrackingAnalysis/src/PSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/PSimHitSelector.cc
@@ -4,7 +4,7 @@
 
 #include "SimGeneral/TrackingAnalysis/interface/PSimHitSelector.h"
 
-PSimHitSelector::PSimHitSelector(edm::ParameterSet const &config) {
+PSimHitSelector::PSimHitSelector(edm::ParameterSet const &config, edm::ConsumesCollector &) {
   // Initilize psimhit collection discriminated by sub systems
   edm::ParameterSet pSimHitCollections = config.getParameter<edm::ParameterSet>("simHitCollections");
 

--- a/SimGeneral/TrackingAnalysis/src/PixelPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/PixelPSimHitSelector.cc
@@ -1,7 +1,4 @@
 
-#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
-
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
@@ -33,8 +30,7 @@ void PixelPSimHitSelector::select(PSimHitCollection &selection,
   std::unique_ptr<MixCollection<PSimHit>> pSimHits(new MixCollection<PSimHit>(cfPSimHitProductPointers));
 
   // Accessing dead pixel modules from DB:
-  edm::ESHandle<SiPixelQuality> siPixelBadModule;
-  setup.get<SiPixelQualityRcd>().get(siPixelBadModule);
+  edm::ESHandle<SiPixelQuality> siPixelBadModule = setup.getHandle(badModuleToken_);
 
   // Reading the DB information
   std::vector<SiPixelQuality::disabledModuleType> badModules(siPixelBadModule->getBadComponentList());

--- a/SimGeneral/TrackingAnalysis/src/TrackerPSimHitSelector.cc
+++ b/SimGeneral/TrackingAnalysis/src/TrackerPSimHitSelector.cc
@@ -1,8 +1,3 @@
-
-
-#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
-#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
-
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
@@ -37,8 +32,7 @@ void TrackerPSimHitSelector::select(PSimHitCollection &selection,
 
   // Setup the cabling mapping
   std::map<uint32_t, std::vector<int>> theDetIdList;
-  edm::ESHandle<SiStripDetCabling> detCabling;
-  setup.get<SiStripDetCablingRcd>().get(detCabling);
+  edm::ESHandle<SiStripDetCabling> detCabling = setup.getHandle(cableToken_);
   detCabling->addConnected(theDetIdList);
 
   // Select only psimhits from alive modules

--- a/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.cc
+++ b/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.cc
@@ -1,5 +1,4 @@
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.h
+++ b/SimGeneral/TrackingAnalysis/test/TrackingTruthOutputTest.h
@@ -1,9 +1,9 @@
 #ifndef TrackingTruthOutputTest_h
 #define TrackingTruthOutputTest_h
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class TrackingTruthOutputTest : public edm::EDAnalyzer {
+class TrackingTruthOutputTest : public edm::one::EDAnalyzer<> {
 public:
   explicit TrackingTruthOutputTest(const edm::ParameterSet &conf);
 


### PR DESCRIPTION
#### PR description:

Remove some compilation warnings in SimGeneral/TrackingAnalysis using ESGetToken
 
#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special