### PR TITLE
Run3-Sim101E Remove warnings in a few classes of SimTracker/SiPixelDigitizer

### DIFF
--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -48,7 +48,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/SimTracker/SiPixelDigitizer/test/PixelDigisTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelDigisTest.cc
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -103,7 +103,7 @@ using namespace std;
 // class decleration
 //
 
-class PixelDigisTest : public edm::EDAnalyzer {
+class PixelDigisTest : public edm::one::EDAnalyzer<> {
 public:
   explicit PixelDigisTest(const edm::ParameterSet &);
   ~PixelDigisTest() override;

--- a/SimTracker/SiPixelDigitizer/test/PixelDigisTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelDigisTest.cc
@@ -103,7 +103,7 @@ using namespace std;
 // class decleration
 //
 
-class PixelDigisTest : public edm::one::EDAnalyzer<> {
+class PixelDigisTest : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit PixelDigisTest(const edm::ParameterSet &);
   ~PixelDigisTest() override;
@@ -169,6 +169,8 @@ private:
 // constructors and destructor
 //
 PixelDigisTest::PixelDigisTest(const edm::ParameterSet &iConfig) {
+  usesResource(TFileService::kSharedResource);
+
   //We put this here for the moment since there is no better place
   //edm::Service<MonitorDaemon> daemon;
   //daemon.operator->();

--- a/SimTracker/SiPixelDigitizer/test/PixelMixedSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelMixedSimHitsTest.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -63,7 +63,7 @@ using namespace edm;
 
 //#define CHECK_GEOM
 
-class PixelMixedSimHitsTest : public edm::EDAnalyzer {
+class PixelMixedSimHitsTest : public edm::one::EDAnalyzer {
 public:
   explicit PixelMixedSimHitsTest(const edm::ParameterSet &);
   ~PixelMixedSimHitsTest();

--- a/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
@@ -25,7 +25,7 @@ New det-id.
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -70,7 +70,7 @@ using namespace edm;
 
 //#define CHECK_GEOM
 
-class PixelSimHitsTest : public edm::EDAnalyzer {
+class PixelSimHitsTest : public edm::one::EDAnalyzer<> {
 public:
   explicit PixelSimHitsTest(const edm::ParameterSet &);
   ~PixelSimHitsTest() override;

--- a/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
@@ -70,7 +70,7 @@ using namespace edm;
 
 //#define CHECK_GEOM
 
-class PixelSimHitsTest : public edm::one::EDAnalyzer<> {
+class PixelSimHitsTest : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit PixelSimHitsTest(const edm::ParameterSet &);
   ~PixelSimHitsTest() override;
@@ -117,6 +117,8 @@ private:
 };
 //
 PixelSimHitsTest::PixelSimHitsTest(const edm::ParameterSet &iConfig) : conf_(iConfig) {
+  usesResource(TFileService::kSharedResource);
+
   std::string src_, list_;
   src_ = iConfig.getParameter<std::string>("src");
   list_ = iConfig.getParameter<std::string>("list");

--- a/SimTracker/SiPixelDigitizer/test/PixelSimHitsTestForward.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelSimHitsTestForward.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -62,7 +62,7 @@ using namespace edm;
 // class decleration
 //
 
-class PixelSimHitsTestForward : public edm::EDAnalyzer {
+class PixelSimHitsTestForward : public edm::one::EDAnalyzer<> {
 public:
   explicit PixelSimHitsTestForward(const edm::ParameterSet &);
   ~PixelSimHitsTestForward();


### PR DESCRIPTION
#### PR description:

Remove warnings in a few classes of SimTracker/SiPixelDigitizer

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special