### PR TITLE
Add missing includes uncovered by checking boost 1.78

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <algorithm>
 #include <memory>
+#include <cmath>
 
 EcalLaserCondTools::EcalLaserCondTools(const edm::ParameterSet& ps)
     : fout_(nullptr),
@@ -224,7 +225,7 @@ void EcalLaserCondTools::from_hdf_to_db() {
         corr.p2 = p2[iXtal];
         corr.p3 = p3[iXtal];
 
-        if (!isfinite(corr.p1) || !isfinite(corr.p2) || !isfinite(corr.p3) || corr.p1 < minP_ || corr.p1 > maxP_ ||
+        if (!std::isfinite(corr.p1) || !std::isfinite(corr.p2) || !std::isfinite(corr.p3) || corr.p1 < minP_ || corr.p1 > maxP_ ||
             corr.p2 < minP_ || corr.p2 > maxP_ || corr.p3 < minP_ || corr.p3 > maxP_) {
           fprintf(ferr_, "%d %d %f %f %f\n", t1[iIov], (int)detid, corr.p1, corr.p2, corr.p3);
           corr.p1 = corr.p2 = corr.p3 = 1;
@@ -401,7 +402,7 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
       std::cout << "Duplicate det id, for IOV " << iIov << " t1 = " << t1 << " detid = " << int(detid) << "\n";
     }
 
-    if (!isfinite(corr.p1) || !isfinite(corr.p2) || !isfinite(corr.p3) || corr.p1 < minP_ || corr.p1 > maxP_ ||
+    if (!std::isfinite(corr.p1) || !std::isfinite(corr.p2) || !std::isfinite(corr.p3) || corr.p1 < minP_ || corr.p1 > maxP_ ||
         corr.p2 < minP_ || corr.p2 > maxP_ || corr.p3 < minP_ || corr.p3 > maxP_) {
       fprintf(ferr_, "%d %d %f %f %f\n", t1, (int)detid, corr.p1, corr.p2, corr.p3);
       corr.p1 = corr.p2 = corr.p3 = 1;

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
@@ -225,8 +225,8 @@ void EcalLaserCondTools::from_hdf_to_db() {
         corr.p2 = p2[iXtal];
         corr.p3 = p3[iXtal];
 
-        if (!std::isfinite(corr.p1) || !std::isfinite(corr.p2) || !std::isfinite(corr.p3) || corr.p1 < minP_ || corr.p1 > maxP_ ||
-            corr.p2 < minP_ || corr.p2 > maxP_ || corr.p3 < minP_ || corr.p3 > maxP_) {
+        if (!std::isfinite(corr.p1) || !std::isfinite(corr.p2) || !std::isfinite(corr.p3) || corr.p1 < minP_ ||
+            corr.p1 > maxP_ || corr.p2 < minP_ || corr.p2 > maxP_ || corr.p3 < minP_ || corr.p3 > maxP_) {
           fprintf(ferr_, "%d %d %f %f %f\n", t1[iIov], (int)detid, corr.p1, corr.p2, corr.p3);
           corr.p1 = corr.p2 = corr.p3 = 1;
         }
@@ -402,8 +402,8 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
       std::cout << "Duplicate det id, for IOV " << iIov << " t1 = " << t1 << " detid = " << int(detid) << "\n";
     }
 
-    if (!std::isfinite(corr.p1) || !std::isfinite(corr.p2) || !std::isfinite(corr.p3) || corr.p1 < minP_ || corr.p1 > maxP_ ||
-        corr.p2 < minP_ || corr.p2 > maxP_ || corr.p3 < minP_ || corr.p3 > maxP_) {
+    if (!std::isfinite(corr.p1) || !std::isfinite(corr.p2) || !std::isfinite(corr.p3) || corr.p1 < minP_ ||
+        corr.p1 > maxP_ || corr.p2 < minP_ || corr.p2 > maxP_ || corr.p3 < minP_ || corr.p3 > maxP_) {
       fprintf(ferr_, "%d %d %f %f %f\n", t1, (int)detid, corr.p1, corr.p2, corr.p3);
       corr.p1 = corr.p2 = corr.p3 = 1;
     }

--- a/FWCore/SharedMemory/interface/ControllerChannel.h
+++ b/FWCore/SharedMemory/interface/ControllerChannel.h
@@ -25,6 +25,7 @@
 #include "boost/interprocess/sync/named_mutex.hpp"
 #include "boost/interprocess/sync/named_condition.hpp"
 #include "boost/interprocess/sync/scoped_lock.hpp"
+#include "boost/date_time/posix_time/posix_time_types.hpp"
 
 // user include files
 #include "FWCore/Utilities/interface/Transition.h"


### PR DESCRIPTION
Compiling cmssw with boost 1.78 gave a few errors, presumably due to improvements in things included in boost headers. This PR fixes those.