### PR TITLE
Fixing Phase-II Patatrack Failures

### DIFF
--- a/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
+++ b/CUDADataFormats/TrackingRecHit/test/TrackingRecHit2DCUDA_t.cpp
@@ -2,6 +2,7 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "Geometry/TrackerGeometryBuilder/interface/pixelTopology.h"
 
 namespace testTrackingRecHit2D {
 
@@ -16,18 +17,25 @@ int main() {
   cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
   auto nHits = 200;
-  auto nModules = 2000;
   // inner scope to deallocate memory before destroying the stream
   {
-    TrackingRecHit2DGPU tkhit(nHits, nModules, 0, nullptr, nullptr, stream);
-
+    TrackingRecHit2DGPU tkhit(nHits, false, 0, nullptr, nullptr, stream);
     testTrackingRecHit2D::runKernels(tkhit.view());
 
-    TrackingRecHit2DHost tkhitH(nHits, nModules, 0, nullptr, nullptr, stream, &tkhit);
+    TrackingRecHit2DGPU tkhitPhase2(nHits, true, 0, nullptr, nullptr, stream);
+    testTrackingRecHit2D::runKernels(tkhitPhase2.view());
+
+    TrackingRecHit2DHost tkhitH(nHits, false, 0, nullptr, nullptr, stream, &tkhit);
     cudaStreamSynchronize(stream);
     assert(tkhitH.view());
     assert(tkhitH.view()->nHits() == unsigned(nHits));
-    assert(tkhitH.view()->nMaxModules() == unsigned(nModules));
+    assert(tkhitH.view()->nMaxModules() == phase1PixelTopology::numberOfModules);
+
+    TrackingRecHit2DHost tkhitHPhase2(nHits, true, 0, nullptr, nullptr, stream, &tkhit);
+    cudaStreamSynchronize(stream);
+    assert(tkhitHPhase2.view());
+    assert(tkhitHPhase2.view()->nHits() == unsigned(nHits));
+    assert(tkhitHPhase2.view()->nMaxModules() == phase2PixelTopology::numberOfModules);
   }
 
   cudaCheck(cudaStreamDestroy(stream));

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelPhase2DigiToClusterCUDA.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelPhase2DigiToClusterCUDA.cc
@@ -54,8 +54,8 @@ private:
                edm::WaitingTaskWithArenaHolder waitingTaskHolder) override;
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> pixelDigiToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> pixelDigiToken_;
 
   edm::EDPutTokenT<cms::cuda::Product<SiPixelDigisCUDA>> digiPutToken_;
   edm::EDPutTokenT<cms::cuda::Product<SiPixelDigiErrorsCUDA>> digiErrorPutToken_;
@@ -71,7 +71,8 @@ private:
 };
 
 SiPixelPhase2DigiToClusterCUDA::SiPixelPhase2DigiToClusterCUDA(const edm::ParameterSet& iConfig)
-    : pixelDigiToken_(consumes<edm::DetSetVector<PixelDigi>>(iConfig.getParameter<edm::InputTag>("InputDigis"))),
+    : geomToken_(esConsumes()),
+      pixelDigiToken_(consumes<edm::DetSetVector<PixelDigi>>(iConfig.getParameter<edm::InputTag>("InputDigis"))),
       digiPutToken_(produces<cms::cuda::Product<SiPixelDigisCUDA>>()),
       clusterPutToken_(produces<cms::cuda::Product<SiPixelClustersCUDA>>()),
       includeErrors_(iConfig.getParameter<bool>("IncludeErrors")),

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuCalibPixel.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuCalibPixel.h
@@ -94,7 +94,6 @@ namespace gpuCalibPixel {
       if (invalidModuleId == id[i])
         continue;
 
-      printf("%d %d %d \n", id[i], adc[i]);
       constexpr int mode = (Phase2ReadoutMode < -1 ? -1 : Phase2ReadoutMode);
 
       if constexpr (mode < 0)


### PR DESCRIPTION
Fixing failures in 
- tests in TrackingRecHit2DCUDA_t in #36605
- wf 39434.502 due to esconsumes missing in SiPixelPhase2DigiToClusterCUDA #36604
