### PR TITLE
Fix CMS deprecated warnings in DQM/SiStripMonitorHardware

### DIFF
--- a/DQM/SiStripMonitorHardware/interface/SiStripFEDEmulator.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripFEDEmulator.h
@@ -71,7 +71,7 @@ namespace sistrip {
     void printMeds(std::ostream& aOs);
 
   private:
-    static const char* messageLabel_;
+    static const char* const messageLabel_;
 
     bool byModule_;
 

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -171,7 +171,7 @@ namespace sistrip {
     std::unique_ptr<edm::VectorInputSource> const source_;
     std::unique_ptr<edm::ProcessConfiguration> processConfiguration_;
     std::unique_ptr<edm::EventPrincipal> eventPrincipal_;
-    static const char* mlLabel_;
+    static const char* const mlLabel_;
   };
 
   template <class T>

--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyUnpacker.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyUnpacker.h
@@ -47,7 +47,7 @@ namespace sistrip {
                      const std::vector<uint32_t>& ids,
                      Counters* pTotalEventCounts,
                      Counters* pL1ACounts,
-                     uint32_t* aRunRef);
+                     uint32_t* aRunRef) const;
 
   private:
     // Configuration

--- a/DQM/SiStripMonitorHardware/src/BuildTrackerMap.cc
+++ b/DQM/SiStripMonitorHardware/src/BuildTrackerMap.cc
@@ -26,7 +26,7 @@
 #include "TPaveStats.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -51,7 +51,7 @@
 // Class declaration
 //
 
-class BuildTrackerMapPlugin : public edm::EDAnalyzer {
+class BuildTrackerMapPlugin : public edm::one::EDAnalyzer<> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDataCheck.cc
@@ -16,7 +16,6 @@
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESWatcher.h"

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDDump.cc
@@ -2,7 +2,6 @@
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDEmulator.cc
@@ -10,7 +10,7 @@ using edm::LogWarning;
 
 namespace sistrip {
 
-  const char* FEDEmulator::messageLabel_ = "SiStripFEDEmulator";
+  const char* const FEDEmulator::messageLabel_ = "SiStripFEDEmulator";
 
   FEDEmulator::FEDEmulator() {
     byModule_ = false;

--- a/DQM/SiStripMonitorHardware/src/SiStripFEDEmulatorModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripFEDEmulatorModule.cc
@@ -11,7 +11,7 @@
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
@@ -54,7 +54,7 @@ namespace sistrip {
   // Class declaration
   //
 
-  class FEDEmulatorModule : public edm::EDProducer {
+  class FEDEmulatorModule : public edm::stream::EDProducer<> {
   public:
     explicit FEDEmulatorModule(const edm::ParameterSet&);
     ~FEDEmulatorModule() override;
@@ -74,7 +74,7 @@ namespace sistrip {
 
     sistrip::FEDEmulator fedEmulator_;
 
-    static const char* messageLabel_;
+    static const char* const messageLabel_;
 
     std::unique_ptr<SiStripRawProcessingAlgorithms> algorithms_;  //!< object for zero-suppression
 
@@ -100,7 +100,7 @@ namespace sistrip {
   //
   // Constructors and destructor
   //
-  const char* FEDEmulatorModule::messageLabel_ = "SiStripFEDEmulatorModule";
+  const char* const FEDEmulatorModule::messageLabel_ = "SiStripFEDEmulatorModule";
 
   FEDEmulatorModule::FEDEmulatorModule(const edm::ParameterSet& iConfig)
       : spyReorderedDigisTag_(iConfig.getParameter<edm::InputTag>("SpyReorderedDigisTag")),

--- a/DQM/SiStripMonitorHardware/src/SiStripShotFilter.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripShotFilter.cc
@@ -19,7 +19,7 @@
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
@@ -50,7 +50,7 @@
 // Class declaration
 //
 
-class SiStripShotFilter : public edm::EDFilter {
+class SiStripShotFilter : public edm::one::EDFilter<> {
 public:
   explicit SiStripShotFilter(const edm::ParameterSet&);
   ~SiStripShotFilter() override;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyDisplayModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyDisplayModule.cc
@@ -16,7 +16,7 @@
 // Framework include files
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
@@ -93,13 +93,12 @@ enum FEDSpyHistogramType {
  * for more information about the spy channel monitoring project.
  *
  */
-class SiStripSpyDisplayModule : public edm::EDAnalyzer {
+class SiStripSpyDisplayModule : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit SiStripSpyDisplayModule(const edm::ParameterSet&);
   ~SiStripSpyDisplayModule() override;
 
 private:
-  void beginRun(const edm::Run&, const edm::EventSetup&) override;
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
@@ -213,6 +212,8 @@ SiStripSpyDisplayModule::SiStripSpyDisplayModule(const edm::ParameterSet& iConfi
   inputZeroSuppressedDigiToken_ = consumes<edm::DetSetVector<SiStripDigi> >(inputZeroSuppressedDigiLabel_);
   inputCompVirginRawDigiToken_ = consumes<edm::DetSetVector<SiStripRawDigi> >(inputCompVirginRawDigiLabel_);
   inputCompZeroSuppressedDigiToken_ = consumes<edm::DetSetVector<SiStripDigi> >(inputCompZeroSuppressedDigiLabel_);
+
+  usesResource(TFileService::kSharedResource);
 }
 
 SiStripSpyDisplayModule::~SiStripSpyDisplayModule() {
@@ -228,15 +229,6 @@ SiStripSpyDisplayModule::~SiStripSpyDisplayModule() {
 void SiStripSpyDisplayModule::updateDetCabling(const SiStripDetCablingRcd& rcd) {
   detCabling_ = &rcd.get(detCablingToken_);
 }
-
-void SiStripSpyDisplayModule::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  // Retrieve FED cabling object
-  //iSetup.get<SiStripDetCablingRcd>().get( cabling_ );
-  //std::stringstream ss;
-  //cabling_->print(ss);
-  //std::cout << ss.str() << std::endl;
-
-}  // end of beginRun method.
 
 // ------------ method called once each job just before starting event loop  ------------
 void SiStripSpyDisplayModule::beginJob() {

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -31,7 +31,7 @@ using edm::LogWarning;
 
 namespace sistrip {
 
-  const char* SpyEventMatcher::mlLabel_ = "SpyEventMatcher";
+  const char* const SpyEventMatcher::mlLabel_ = "SpyEventMatcher";
 
   SpyEventMatcher::EventKey::EventKey(const uint32_t eventId, const uint8_t apvAddress)
       : eventId_(eventId), apvAddress_(apvAddress) {}

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcherModule.cc
@@ -4,7 +4,7 @@
 #ifdef SiStripMonitorHardware_BuildEventMatchingCode
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
@@ -28,11 +28,11 @@ using edm::LogInfo;
 
 namespace sistrip {
 
-  class SpyEventMatcherModule : public edm::EDFilter {
+  class SpyEventMatcherModule : public edm::stream::EDFilter<> {
   public:
     SpyEventMatcherModule(const edm::ParameterSet& config);
     ~SpyEventMatcherModule() override;
-    void beginJob() override;
+    void beginStream(edm::StreamID) override;
     bool filter(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
   private:
@@ -46,7 +46,7 @@ namespace sistrip {
                   edm::Event& event,
                   const SiStripFedCabling& cabling) const;
 
-    static const char* messageLabel_;
+    static const char* const messageLabel_;
     const bool filterNonMatchingEvents_;
     const bool doMerge_;
     const edm::InputTag primaryStreamRawDataTag_;
@@ -62,7 +62,7 @@ namespace sistrip {
 
 namespace sistrip {
 
-  const char* SpyEventMatcherModule::messageLabel_ = "SiStripSpyDataMergeModule";
+  const char* const SpyEventMatcherModule::messageLabel_ = "SiStripSpyDataMergeModule";
 
   SpyEventMatcherModule::SpyEventMatcherModule(const edm::ParameterSet& config)
       : filterNonMatchingEvents_(config.getParameter<bool>("FilterNonMatchingEvents")),
@@ -90,7 +90,7 @@ namespace sistrip {
     fedCabling_ = &rcd.get(fedCablingToken_);
   }
 
-  void SpyEventMatcherModule::beginJob() { spyEventMatcher_->initialize(); }
+  void SpyEventMatcherModule::beginStream(edm::StreamID) { spyEventMatcher_->initialize(); }
 
   bool SpyEventMatcherModule::filter(edm::Event& event, const edm::EventSetup& eventSetup) {
     cablingWatcher_.check(eventSetup);

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventSummaryProducer.cc
@@ -6,7 +6,7 @@
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -31,15 +31,14 @@ using edm::LogWarning;
 
 namespace sistrip {
 
-  class SpyEventSummaryProducer : public edm::EDProducer {
+  class SpyEventSummaryProducer : public edm::global::EDProducer<> {
   public:
     SpyEventSummaryProducer(const edm::ParameterSet& config);
-    ~SpyEventSummaryProducer() override;
-    void produce(edm::Event& event, const edm::EventSetup&) override;
+    void produce(edm::StreamID, edm::Event& event, const edm::EventSetup&) const override;
 
   private:
-    void warnAboutUnsupportedRunType();
-    static const char* messageLabel_;
+    void warnAboutUnsupportedRunType() const;
+    static const char* const messageLabel_;
     const edm::InputTag rawDataTag_;
     edm::EDGetTokenT<FEDRawDataCollection> rawDataToken_;
     const sistrip::RunType runType_;
@@ -49,7 +48,7 @@ namespace sistrip {
 
 namespace sistrip {
 
-  const char* SpyEventSummaryProducer::messageLabel_ = "SiStripSpyEventSummaryProducer";
+  const char* const SpyEventSummaryProducer::messageLabel_ = "SiStripSpyEventSummaryProducer";
 
   SpyEventSummaryProducer::SpyEventSummaryProducer(const edm::ParameterSet& config)
       : rawDataTag_(config.getParameter<edm::InputTag>("RawDataTag")),
@@ -59,9 +58,7 @@ namespace sistrip {
     warnAboutUnsupportedRunType();
   }
 
-  SpyEventSummaryProducer::~SpyEventSummaryProducer() {}
-
-  void SpyEventSummaryProducer::produce(edm::Event& event, const edm::EventSetup&) {
+  void SpyEventSummaryProducer::produce(edm::StreamID, edm::Event& event, const edm::EventSetup&) const {
     warnAboutUnsupportedRunType();
 
     //get the event number and Bx counter from the first valud FED buffer
@@ -121,7 +118,7 @@ namespace sistrip {
     event.put(std::move(pSummary));
   }
 
-  void SpyEventSummaryProducer::warnAboutUnsupportedRunType() {
+  void SpyEventSummaryProducer::warnAboutUnsupportedRunType() const {
     switch (runType_) {
       case sistrip::DAQ_SCOPE_MODE:
       case sistrip::PHYSICS:

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyExtractRunModule.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyExtractRunModule.cc
@@ -12,7 +12,7 @@
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -32,7 +32,7 @@
 //
 namespace sistrip {
 
-  class SpyExtractRunModule : public edm::EDAnalyzer {
+  class SpyExtractRunModule : public edm::one::EDAnalyzer<> {
   public:
     explicit SpyExtractRunModule(const edm::ParameterSet&);
     ~SpyExtractRunModule() override;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyIdentifyRuns.cc
@@ -12,7 +12,7 @@
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -34,7 +34,7 @@
 //
 namespace sistrip {
 
-  class SpyIdentifyRunsModule : public edm::EDAnalyzer {
+  class SpyIdentifyRunsModule : public edm::one::EDAnalyzer<> {
   public:
     explicit SpyIdentifyRunsModule(const edm::ParameterSet&);
     ~SpyIdentifyRunsModule() override;

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyUnpacker.cc
@@ -46,7 +46,7 @@ namespace sistrip {
                                 const std::vector<uint32_t>& ids,
                                 Counters* pTotalEventCounts,
                                 Counters* pL1ACounts,
-                                uint32_t* aRunRef) {
+                                uint32_t* aRunRef) const {
     //create DSV filler to fill output
 
     //As of Feb 2010, bug in DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h:


### PR DESCRIPTION
#### PR description:

- converted modules to thread friendly types
- fixed some const correctness issues
- removed some unnessary includes

#### PR validation:

Code compiles without generating the warnings.