### PR TITLE
Converted modules to thread efficient types in  HLTrigger/special

### DIFF
--- a/HLTrigger/special/plugins/BuildFile.xml
+++ b/HLTrigger/special/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="tbb"/>
 <use name="root"/>
 <use name="CalibCalorimetry/EcalLaserCorrection"/>
 <use name="CalibCalorimetry/EcalTPGTools"/>

--- a/HLTrigger/special/plugins/EcalMIPRecHitFilter.cc
+++ b/HLTrigger/special/plugins/EcalMIPRecHitFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
@@ -52,15 +52,14 @@
 // class declaration
 //
 
-class EcalMIPRecHitFilter : public edm::EDFilter {
+class EcalMIPRecHitFilter : public edm::global::EDFilter<> {
 public:
   explicit EcalMIPRecHitFilter(const edm::ParameterSet&);
-  ~EcalMIPRecHitFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  bool filter(edm::Event&, edm::EventSetup const&) override;
+  bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
   // ----------member data ---------------------------
   const edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopologyRecordToken_;
@@ -94,17 +93,12 @@ EcalMIPRecHitFilter::EcalMIPRecHitFilter(const edm::ParameterSet& iConfig)
   // now do what ever initialization is needed
 }
 
-EcalMIPRecHitFilter::~EcalMIPRecHitFilter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
 
 // ------------ method called on each new Event  ------------
-bool EcalMIPRecHitFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSetup) {
+bool EcalMIPRecHitFilter::filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const& iSetup) const {
   using namespace edm;
 
   // getting very basic uncalRH

--- a/HLTrigger/special/plugins/EcalSimpleUncalibRecHitFilter.cc
+++ b/HLTrigger/special/plugins/EcalSimpleUncalibRecHitFilter.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -38,7 +38,7 @@
 // class declaration
 //
 
-class EcalSimpleUncalibRecHitFilter : public edm::EDFilter {
+class EcalSimpleUncalibRecHitFilter : public edm::global::EDFilter<> {
 public:
   explicit EcalSimpleUncalibRecHitFilter(const edm::ParameterSet &);
   ~EcalSimpleUncalibRecHitFilter() override;
@@ -46,7 +46,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
 private:
-  bool filter(edm::Event &, edm::EventSetup const &) override;
+  bool filter(edm::StreamID, edm::Event &, edm::EventSetup const &) const override;
 
   // ----------member data ---------------------------
   const edm::EDGetTokenT<EcalUncalibratedRecHitCollection> EcalUncalibRecHitToken_;
@@ -77,7 +77,7 @@ EcalSimpleUncalibRecHitFilter::~EcalSimpleUncalibRecHitFilter() {
 //
 
 // ------------ method called on each new Event  ------------
-bool EcalSimpleUncalibRecHitFilter::filter(edm::Event &iEvent, edm::EventSetup const &iSetup) {
+bool EcalSimpleUncalibRecHitFilter::filter(edm::StreamID, edm::Event &iEvent, edm::EventSetup const &iSetup) const {
   using namespace edm;
 
   // getting very basic uncalRH

--- a/HLTrigger/special/plugins/HLTCountNumberOfObject.h
+++ b/HLTrigger/special/plugins/HLTCountNumberOfObject.h
@@ -10,7 +10,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/HLTrigger/special/plugins/HLTDTROMonitorFilter.cc
+++ b/HLTrigger/special/plugins/HLTDTROMonitorFilter.cc
@@ -17,7 +17,7 @@
 using namespace edm;
 
 HLTDTROMonitorFilter::HLTDTROMonitorFilter(const edm::ParameterSet& pset) {
-  inputLabel = pset.getParameter<InputTag>("inputLabel");
+  auto inputLabel = pset.getParameter<InputTag>("inputLabel");
   inputToken = consumes<FEDRawDataCollection>(inputLabel);
 }
 
@@ -29,7 +29,7 @@ void HLTDTROMonitorFilter::fillDescriptions(edm::ConfigurationDescriptions& desc
   descriptions.add("hltDTROMonitorFilter", desc);
 }
 
-bool HLTDTROMonitorFilter::filter(edm::Event& event, const edm::EventSetup& setup) {
+bool HLTDTROMonitorFilter::filter(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const {
   // get the raw data
   edm::Handle<FEDRawDataCollection> rawdata;
   event.getByToken(inputToken, rawdata);

--- a/HLTrigger/special/plugins/HLTDTROMonitorFilter.h
+++ b/HLTrigger/special/plugins/HLTDTROMonitorFilter.h
@@ -9,7 +9,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -21,7 +21,7 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-class HLTDTROMonitorFilter : public edm::EDFilter {
+class HLTDTROMonitorFilter : public edm::global::EDFilter<> {
 public:
   /// Constructor
   HLTDTROMonitorFilter(const edm::ParameterSet&);
@@ -30,12 +30,10 @@ public:
   ~HLTDTROMonitorFilter() override;
 
   // Operations
-  bool filter(edm::Event& event, const edm::EventSetup& setup) override;
+  bool filter(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-protected:
 private:
-  edm::InputTag inputLabel;
   edm::EDGetTokenT<FEDRawDataCollection> inputToken;
 };
 #endif

--- a/HLTrigger/special/plugins/HLTDummyCollections.cc
+++ b/HLTrigger/special/plugins/HLTDummyCollections.cc
@@ -21,7 +21,7 @@ Implementation:
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -66,18 +66,17 @@ Implementation:
 // class decleration
 //
 
-class HLTDummyCollections : public edm::EDProducer {
+class HLTDummyCollections : public edm::global::EDProducer<> {
 public:
   explicit HLTDummyCollections(const edm::ParameterSet&);
   ~HLTDummyCollections() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
 
-  std::string action_;
   //bool doEcal_ ;
   bool doHcal_;
   bool unpackZDC_;
@@ -103,19 +102,19 @@ private:
 // constructors and destructor
 //
 HLTDummyCollections::HLTDummyCollections(const edm::ParameterSet& iConfig) {
-  action_ = iConfig.getParameter<std::string>("action");
+  auto action = iConfig.getParameter<std::string>("action");
   unpackZDC_ = iConfig.getParameter<bool>("UnpackZDC");
   ESdigiCollection_ = iConfig.getParameter<std::string>("ESdigiCollection");
 
-  //  doEcal_           = ( action_ == "doEcal");
-  doHcal_ = (action_ == "doHcal");
-  doEcalPreshower_ = (action_ == "doEcalPreshower");
-  doMuonDTDigis_ = (action_ == "doMuonDT");
-  doMuonCSCDigis_ = (action_ == "doMuonCSC");
-  doSiPixelDigis_ = (action_ == "doSiPixel");
-  doSiStrip_ = (action_ == "doSiStrip");
-  doObjectMap_ = (action_ == "doObjectMap");
-  doGCT_ = (action_ == "doGCT");
+  //  doEcal_           = ( action == "doEcal");
+  doHcal_ = (action == "doHcal");
+  doEcalPreshower_ = (action == "doEcalPreshower");
+  doMuonDTDigis_ = (action == "doMuonDT");
+  doMuonCSCDigis_ = (action == "doMuonCSC");
+  doSiPixelDigis_ = (action == "doSiPixel");
+  doSiStrip_ = (action == "doSiStrip");
+  doObjectMap_ = (action == "doObjectMap");
+  doGCT_ = (action == "doGCT");
 
   /* This interface is out of data and I do not know what is the proper replacement
   if (doEcal_) {
@@ -201,7 +200,7 @@ void HLTDummyCollections::fillDescriptions(edm::ConfigurationDescriptions& descr
 //
 
 // ------------ method called to produce the data  ------------
-void HLTDummyCollections::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void HLTDummyCollections::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   /*

--- a/HLTrigger/special/plugins/HLTEcalResonanceFilter.cc
+++ b/HLTrigger/special/plugins/HLTEcalResonanceFilter.cc
@@ -108,7 +108,7 @@ HLTEcalResonanceFilter::HLTEcalResonanceFilter(const edm::ParameterSet &iConfig)
     mip_ = preshowerSelection.getParameter<double>("preshCalibMIP");
 
     // ES algo constructor:
-    presh_algo_ = new PreshowerClusterAlgo(preshStripECut, preshClustECut, preshSeededNst);
+    presh_algo_ = std::make_unique<PreshowerClusterAlgo>(preshStripECut, preshClustECut, preshSeededNst);
 
     ESHits_ = preshowerSelection.getParameter<std::string>("ESCollection");
     produces<ESRecHitCollection>(ESHits_);
@@ -117,11 +117,7 @@ HLTEcalResonanceFilter::HLTEcalResonanceFilter(const edm::ParameterSet &iConfig)
   debug_ = iConfig.getParameter<int>("debugLevel");
 }
 
-HLTEcalResonanceFilter::~HLTEcalResonanceFilter() {
-  if (storeRecHitES_) {
-    delete presh_algo_;
-  }
-}
+HLTEcalResonanceFilter::~HLTEcalResonanceFilter() {}
 
 void HLTEcalResonanceFilter::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;

--- a/HLTrigger/special/plugins/HLTEcalResonanceFilter.h
+++ b/HLTrigger/special/plugins/HLTEcalResonanceFilter.h
@@ -17,7 +17,7 @@ Description: Producer for EcalRecHits to be used for pi0/eta ECAL calibration.
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -64,7 +64,7 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-class HLTEcalResonanceFilter : public edm::EDFilter {
+class HLTEcalResonanceFilter : public edm::stream::EDFilter<> {
 public:
   explicit HLTEcalResonanceFilter(const edm::ParameterSet &);
   ~HLTEcalResonanceFilter() override;
@@ -186,7 +186,7 @@ private:
   double mip_;
   double gamma_;
 
-  PreshowerClusterAlgo *presh_algo_;  // algorithm doing the real work
+  std::unique_ptr<PreshowerClusterAlgo> presh_algo_;  // algorithm doing the real work
 
   std::map<DetId, EcalRecHit> m_esrechit_map;
   std::set<DetId> m_used_strips;

--- a/HLTrigger/special/plugins/HLTEventNumberFilter.cc
+++ b/HLTrigger/special/plugins/HLTEventNumberFilter.cc
@@ -36,11 +36,6 @@ HLTEventNumberFilter::HLTEventNumberFilter(const edm::ParameterSet& iConfig) {
   invert_ = iConfig.getParameter<bool>("invert");
 }
 
-HLTEventNumberFilter::~HLTEventNumberFilter() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 void HLTEventNumberFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<int>("period", 4096);
@@ -53,7 +48,7 @@ void HLTEventNumberFilter::fillDescriptions(edm::ConfigurationDescriptions& desc
 //
 
 // ------------ method called on each new Event  ------------
-bool HLTEventNumberFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool HLTEventNumberFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
   if (iEvent.isRealData()) {

--- a/HLTrigger/special/plugins/HLTEventNumberFilter.h
+++ b/HLTrigger/special/plugins/HLTEventNumberFilter.h
@@ -22,7 +22,7 @@ Implementation:
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include <string>
 
@@ -34,14 +34,13 @@ namespace edm {
 // class declaration
 //
 
-class HLTEventNumberFilter : public edm::EDFilter {
+class HLTEventNumberFilter : public edm::global::EDFilter<> {
 public:
   explicit HLTEventNumberFilter(const edm::ParameterSet&);
-  ~HLTEventNumberFilter() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
 

--- a/HLTrigger/special/plugins/HLTHFAsymmetryFilter.cc
+++ b/HLTrigger/special/plugins/HLTHFAsymmetryFilter.cc
@@ -2,13 +2,11 @@
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-HLTHFAsymmetryFilter::HLTHFAsymmetryFilter(const edm::ParameterSet& iConfig) {
-  HFHits_ = iConfig.getParameter<edm::InputTag>("HFHitCollection");
-  eCut_HF_ = iConfig.getParameter<double>("ECut_HF");
-  os_asym_ = iConfig.getParameter<double>("OS_Asym_max");
-  ss_asym_ = iConfig.getParameter<double>("SS_Asym_min");
-  HFHitsToken_ = consumes<HFRecHitCollection>(HFHits_);
-}
+HLTHFAsymmetryFilter::HLTHFAsymmetryFilter(const edm::ParameterSet& iConfig)
+    : HFHitsToken_(consumes(iConfig.getParameter<edm::InputTag>("HFHitCollection"))),
+      eCut_HF_(iConfig.getParameter<double>("ECut_HF")),
+      os_asym_(iConfig.getParameter<double>("OS_Asym_max")),
+      ss_asym_(iConfig.getParameter<double>("SS_Asym_min")) {}
 
 HLTHFAsymmetryFilter::~HLTHFAsymmetryFilter() = default;
 
@@ -22,7 +20,7 @@ void HLTHFAsymmetryFilter::fillDescriptions(edm::ConfigurationDescriptions& desc
 }
 
 // ------------ method called to produce the data  ------------
-bool HLTHFAsymmetryFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+bool HLTHFAsymmetryFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   edm::Handle<HFRecHitCollection> HFRecHitsH;
   iEvent.getByToken(HFHitsToken_, HFRecHitsH);
 

--- a/HLTrigger/special/plugins/HLTHFAsymmetryFilter.h
+++ b/HLTrigger/special/plugins/HLTHFAsymmetryFilter.h
@@ -35,7 +35,7 @@
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -45,22 +45,21 @@
 // class decleration
 //
 
-class HLTHFAsymmetryFilter : public edm::EDFilter {
+class HLTHFAsymmetryFilter : public edm::global::EDFilter<> {
 public:
   explicit HLTHFAsymmetryFilter(const edm::ParameterSet &);
   ~HLTHFAsymmetryFilter() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
-  bool filter(edm::Event &, const edm::EventSetup &) override;
+  bool filter(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
 private:
   // ----------member data ---------------------------
 
-  edm::EDGetTokenT<HFRecHitCollection> HFHitsToken_;
-  edm::InputTag HFHits_;
-  double eCut_HF_;
-  double os_asym_;
-  double ss_asym_;
+  const edm::EDGetTokenT<HFRecHitCollection> HFHitsToken_;
+  const double eCut_HF_;
+  const double os_asym_;
+  const double ss_asym_;
 };
 
 #endif  // _HLTHFAsymmetryFilter_H

--- a/HLTrigger/special/plugins/HLTLogMonitorFilter.cc
+++ b/HLTrigger/special/plugins/HLTLogMonitorFilter.cc
@@ -17,12 +17,13 @@
 
 // system include files
 #include <cstdint>
-#include <map>
+#include <tbb/concurrent_unordered_map.h>
+#include <set>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Provenance/interface/EventID.h"
@@ -33,7 +34,7 @@
 // class declaration
 //
 
-class HLTLogMonitorFilter : public edm::EDFilter {
+class HLTLogMonitorFilter : public edm::global::EDFilter<> {
 public:
   explicit HLTLogMonitorFilter(const edm::ParameterSet&);
   ~HLTLogMonitorFilter() override;
@@ -41,44 +42,67 @@ public:
   struct CategoryEntry {
     uint32_t
         threshold;  // configurable threshold, after which messages in this Category start to be logarithmically prescaled
-    uint32_t prescale;  // current prescale for this Category
-    uint64_t counter;   // number of events that fired this Category
-    uint64_t accepted;  // number of events acepted for this Category
-    bool done;          // track if this Category has already been seen in the current event
+    std::atomic<uint32_t> maxPrescale;  // maximum prescale used for this Category
+    std::atomic<uint64_t> counter;      // number of events that fired this Category
+    std::atomic<uint64_t> accepted;     // number of events acepted for this Category
+    uint32_t id;                        // monotonically increasing unique id for this Category
 
-    CategoryEntry(uint32_t t = 0)
+    CategoryEntry(uint32_t iID = 0, uint32_t t = 0)
         : threshold(
               t),  // default-constructed entries have the threshold set to 0, which means the associated Category is disabled
-          prescale(1),
+          maxPrescale(1),
           counter(0),
           accepted(0),
-          done(false) {}
+          id(iID) {}
 
+    CategoryEntry(CategoryEntry const& iOther)
+        : threshold(iOther.threshold),
+          maxPrescale(iOther.maxPrescale.load()),
+          counter(iOther.counter.load()),
+          accepted(iOther.counter.load()),
+          id(iOther.id) {}
+
+    // caller guarantees this is called just once per event
     bool accept() {
-      if (not done) {
-        done = true;
-        ++counter;
-      }
+      auto tCounter = ++counter;
 
       // fail if the prescaler is disabled (threshold == 0), or if the counter is not a multiple of the prescale
-      if ((threshold == 0) or (counter % prescale))
+      if (threshold == 0) {
         return false;
+      }
 
-      // quasi-logarithmic increase in the prescale factor (should be safe even if threshold is 1)
-      if (counter == prescale * threshold)
-        prescale *= threshold;
+      if (threshold == 1) {
+        ++accepted;
+        return true;
+      }
+
+      uint64_t dynPrescale = 1;
+      // quasi-logarithmic increase in the prescale factor
+      // dynamically calculating the prescale is mulit-thread stable
+      while (tCounter > dynPrescale * threshold) {
+        dynPrescale *= threshold;
+      }
+
+      auto tMaxPrescale = maxPrescale.load();
+      while (tMaxPrescale < dynPrescale) {
+        maxPrescale.compare_exchange_strong(tMaxPrescale, dynPrescale);
+      }
+
+      if (0 != tCounter % dynPrescale) {
+        return false;
+      }
 
       ++accepted;
       return true;
     }
   };
 
-  typedef std::map<std::string, CategoryEntry> CategoryMap;
+  typedef tbb::concurrent_unordered_map<std::string, CategoryEntry> CategoryMap;
 
   // ---------- private methods -----------------------
 
   /// EDFilter accept method
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   /// EDFilter beginJob method
   void beginJob() override;
@@ -86,21 +110,19 @@ public:
   /// EDFilter endJob method
   void endJob() override;
 
-  /// check if the requested category has a valid entry
-  bool knownCategory(const std::string& category);
-
   /// create a new entry for the given category, with the given threshold value
   CategoryEntry& addCategory(const std::string& category, uint32_t threshold);
 
   /// return the entry for requested category, if it exists, or create a new one with the default threshold value
-  CategoryEntry& getCategory(const std::string& category);
+  CategoryEntry& getCategory(const std::string& category) const;
 
   /// summarize to LogInfo
-  void summary();
+  void summary() const;
 
   // ---------- member data ---------------------------
   uint32_t m_prescale;  // default threshold, after which messages in each Category start to be logarithmically prescaled
-  CategoryMap m_data;   // map each category name to its prescale data
+  mutable std::atomic<uint32_t> m_nextEntryID = 0;
+  CMS_THREAD_SAFE mutable CategoryMap m_data;  // map each category name to its prescale data
   edm::EDPutTokenT<std::vector<edm::ErrorSummaryEntry>> m_putToken;
 };
 
@@ -139,14 +161,18 @@ HLTLogMonitorFilter::~HLTLogMonitorFilter() = default;
 //
 
 // ------------ method called on each new Event  ------------
-bool HLTLogMonitorFilter::filter(edm::Event& event, const edm::EventSetup& setup) {
+bool HLTLogMonitorFilter::filter(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const {
   // no LogErrors or LogWarnings, skip processing and reject the event
   if (not edm::FreshErrorsExist(event.streamID().value()))
     return false;
 
-  // clear "done" flag in all Categories
-  for (auto& entry : m_data)
-    entry.second.done = false;
+  //keep track of which errors have already been seen this event
+  struct Cache {
+    Cache() : done(false), cachedValue(false) {}
+    bool done;
+    bool cachedValue;
+  };
+  std::vector<Cache> doneCache(m_nextEntryID);
 
   // look at the LogErrors and LogWarnings, and accept the event if at least one is under threshold or matches the prescale
   bool accept = false;
@@ -164,7 +190,16 @@ bool HLTLogMonitorFilter::filter(edm::Event& event, const edm::EventSetup& setup
       category.assign(i->begin(), i->end());
 
       // access the message category, or create a new one as needed, and check the prescale
-      if (getCategory(category).accept())
+      auto& cat = getCategory(category);
+      if (cat.id >= doneCache.size()) {
+        //new categories were added so need to grow
+        doneCache.resize(cat.id);
+      }
+      if (not doneCache[cat.id].done) {
+        doneCache[cat.id].cachedValue = cat.accept();
+        doneCache[cat.id].done = true;
+      }
+      if (doneCache[cat.id].cachedValue)
         accept = true;
     }
   }
@@ -195,38 +230,45 @@ void HLTLogMonitorFilter::endJob() {
   summary();
 }
 
-/// check if the requested category has a valid entry
-bool HLTLogMonitorFilter::knownCategory(const std::string& category) { return (m_data.find(category) != m_data.end()); }
-
 /// create a new entry for the given category, with the given threshold value
 HLTLogMonitorFilter::CategoryEntry& HLTLogMonitorFilter::addCategory(const std::string& category, uint32_t threshold) {
   // check after inserting, as either the new CategoryEntry is needed, or an error condition is raised
-  std::pair<CategoryMap::iterator, bool> result = m_data.insert(std::make_pair(category, CategoryEntry(threshold)));
+  auto id = m_nextEntryID++;
+  std::pair<CategoryMap::iterator, bool> result = m_data.insert(std::make_pair(category, CategoryEntry(id, threshold)));
   if (not result.second)
     throw cms::Exception("Configuration") << "Duplicate entry for category " << category;
   return result.first->second;
 }
 
 /// return the entry for requested category, if it exists, or create a new one with the default threshold value
-HLTLogMonitorFilter::CategoryEntry& HLTLogMonitorFilter::getCategory(const std::string& category) {
+HLTLogMonitorFilter::CategoryEntry& HLTLogMonitorFilter::getCategory(const std::string& category) const {
   // check before inserting, to avoid the construction of a CategoryEntry object
   auto i = m_data.find(category);
   if (i != m_data.end())
     return i->second;
-  else
-    return m_data.insert(std::make_pair(category, CategoryEntry(m_prescale))).first->second;
+  else {
+    auto id = m_nextEntryID++;
+    return m_data.insert(std::make_pair(category, CategoryEntry(id, m_prescale))).first->second;
+  }
 }
 
 /// summarize to LogInfo
-void HLTLogMonitorFilter::summary() {
+void HLTLogMonitorFilter::summary() const {
   std::stringstream out;
   out << "Log-Report ---------- HLTLogMonitorFilter Summary ------------\n"
       << "Log-Report  Threshold   Prescale     Issued   Accepted   Rejected Category\n";
+
+  std::set<std::string> sortedCategories;
   for (auto const& entry : m_data) {
-    out << "Log-Report " << std::right << std::setw(10) << entry.second.threshold << ' ' << std::setw(10)
-        << entry.second.prescale << ' ' << std::setw(10) << entry.second.counter << ' ' << std::setw(10)
-        << entry.second.accepted << ' ' << std::setw(10) << (entry.second.counter - entry.second.accepted) << ' '
-        << std::left << entry.first << '\n';
+    sortedCategories.insert(entry.first);
+  }
+
+  for (auto const& cat : sortedCategories) {
+    auto entry = m_data.find(cat);
+    out << "Log-Report " << std::right << std::setw(10) << entry->second.threshold << ' ' << std::setw(10)
+        << entry->second.maxPrescale << ' ' << std::setw(10) << entry->second.counter << ' ' << std::setw(10)
+        << entry->second.accepted << ' ' << std::setw(10) << (entry->second.counter - entry->second.accepted) << ' '
+        << std::left << cat << '\n';
   }
   edm::LogVerbatim("Report") << out.str();
 }

--- a/HLTrigger/special/plugins/HLTPhysicsDeclared.cc
+++ b/HLTrigger/special/plugins/HLTPhysicsDeclared.cc
@@ -9,7 +9,7 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -21,14 +21,14 @@
 // class declaration
 //
 
-class HLTPhysicsDeclared : public edm::EDFilter {
+class HLTPhysicsDeclared : public edm::global::EDFilter<> {
 public:
   explicit HLTPhysicsDeclared(const edm::ParameterSet&);
   ~HLTPhysicsDeclared() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   bool m_invert;
   edm::InputTag m_gtDigis;
@@ -58,7 +58,7 @@ void HLTPhysicsDeclared::fillDescriptions(edm::ConfigurationDescriptions& descri
   descriptions.add("hltPhysicsDeclared", desc);
 }
 
-bool HLTPhysicsDeclared::filter(edm::Event& event, const edm::EventSetup& setup) {
+bool HLTPhysicsDeclared::filter(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const {
   bool accept = false;
 
   if (event.isRealData()) {

--- a/HLTrigger/special/plugins/HLTTrackWithHits.h
+++ b/HLTrigger/special/plugins/HLTTrackWithHits.h
@@ -10,7 +10,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/HLTrigger/special/test/ArbitraryLogError.cc
+++ b/HLTrigger/special/test/ArbitraryLogError.cc
@@ -18,10 +18,11 @@ Implementation:
 
 // system include files
 #include <stdint.h>
+#include <atomic>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -30,20 +31,20 @@ Implementation:
 // class decleration
 //
 
-class ArbitraryLogError : public edm::EDAnalyzer {
+class ArbitraryLogError : public edm::global::EDAnalyzer<> {
 public:
   explicit ArbitraryLogError(const edm::ParameterSet&);
   ~ArbitraryLogError() override;
 
 private:
   void beginJob() override;
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
   void endJob() override;
 
   const std::string m_category;
   const bool m_severity;
   const uint32_t m_rate;
-  uint32_t m_counter;
+  mutable std::atomic<uint32_t> m_counter;
 };
 
 // CTOR
@@ -57,7 +58,7 @@ ArbitraryLogError::ArbitraryLogError(const edm::ParameterSet& config)
 ArbitraryLogError::~ArbitraryLogError() = default;
 
 // ------------ method called to for each event  ------------
-void ArbitraryLogError::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void ArbitraryLogError::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   if (not(++m_counter % m_rate)) {
     if (m_severity)
       (edm::LogError(m_category));

--- a/HLTrigger/special/test/BuildFile.xml
+++ b/HLTrigger/special/test/BuildFile.xml
@@ -4,3 +4,5 @@
   <use name="FWCore/ParameterSet"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<test name="testHLTriggerspecialLogMonitorFilter" command="testLogMonitorFilter.sh"/>

--- a/HLTrigger/special/test/testLogMonitorFilter.sh
+++ b/HLTrigger/special/test/testLogMonitorFilter.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ; echo === Log file === ; cat ${3:-/dev/null} ; echo === End log file === ; exit $2; }
+
+
+TESTDIR=${LOCALTOP}/src/HLTrigger/special/test
+
+cmsRun ${TESTDIR}/testLogMonitorFilter.py >& log_log_monitor_filter || die "Failure using testLogMonitorFilter.py" $? log_log_monitor_filter
+
+cat <<EOF  > expected_log_report
+Log-Report ---------- HLTLogMonitorFilter Summary ------------
+Log-Report  Threshold   Prescale     Issued   Accepted   Rejected Category
+Log-Report         10        100       1000         28        972 Other
+Log-Report          0          1       1000          0       1000 Test
+Log-Report          1          1       1000       1000          0 TestError
+Log-Report         20       8000      10000         58       9942 TestWarning
+EOF
+
+grep 'Log-Report ' log_log_monitor_filter | diff expected_log_report - || die "differences in expected log report" $?
+


### PR DESCRIPTION
#### PR description:

- fixed all CMS deprecated warnings
- changed some algorithm to do calculations each event rather than caching results from previous events
- added a unit test

#### PR validation:

- Code compiles without issuing deprecated warnings
- tested algorthm changes by either writing simple python script to test the results were the same or to implement a full unit test.

