### PR TITLE
Fix CMS deprecated warnings in  L1Trigger/GlobalCaloTrigger

### DIFF
--- a/L1Trigger/GlobalCaloTrigger/plugins/L1GctEmulator.cc
+++ b/L1Trigger/GlobalCaloTrigger/plugins/L1GctEmulator.cc
@@ -7,7 +7,6 @@
 // EDM includes
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ESHandle.h"

--- a/L1Trigger/GlobalCaloTrigger/plugins/L1GctPrintLuts.h
+++ b/L1Trigger/GlobalCaloTrigger/plugins/L1GctPrintLuts.h
@@ -20,7 +20,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 
@@ -42,7 +42,7 @@
 // class declaration
 //
 
-class L1GctPrintLuts : public edm::EDAnalyzer {
+class L1GctPrintLuts : public edm::one::EDAnalyzer<> {
 public:
   /// typedefs
   typedef L1GlobalCaloTrigger::lutPtr lutPtr;

--- a/L1Trigger/GlobalCaloTrigger/plugins/L1GctValidation.cc
+++ b/L1Trigger/GlobalCaloTrigger/plugins/L1GctValidation.cc
@@ -18,7 +18,9 @@ L1GctValidation::L1GctValidation(const edm::ParameterSet& iConfig)
       m_energy_tag(iConfig.getUntrackedParameter<edm::InputTag>("gctInputTag", edm::InputTag("gctDigis"))),
       m_jfParsToken(esConsumes<L1GctJetFinderParams, L1GctJetFinderParamsRcd>()),
       m_htMissScaleToken(esConsumes<L1CaloEtScale, L1HtMissScaleRcd>()),
-      m_hfRingEtScaleToken(esConsumes<L1CaloEtScale, L1HfRingEtScaleRcd>()) {}
+      m_hfRingEtScaleToken(esConsumes<L1CaloEtScale, L1HfRingEtScaleRcd>()) {
+  usesResource(TFileService::kSharedResource);
+}
 
 L1GctValidation::~L1GctValidation() {
   // do anything here that needs to be done at desctruction time

--- a/L1Trigger/GlobalCaloTrigger/plugins/L1GctValidation.h
+++ b/L1Trigger/GlobalCaloTrigger/plugins/L1GctValidation.h
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 
@@ -40,7 +40,7 @@
 // class declaration
 //
 
-class L1GctValidation : public edm::EDAnalyzer {
+class L1GctValidation : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1GctValidation(const edm::ParameterSet&);
   ~L1GctValidation() override;

--- a/L1Trigger/GlobalCaloTrigger/test/L1GctTest.h
+++ b/L1Trigger/GlobalCaloTrigger/test/L1GctTest.h
@@ -19,7 +19,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,8 +33,13 @@ class gctTestFunctions;
 //
 // class declaration
 //
+class L1GctJetFinderParamsRcd;
+class L1GctChannelMaskRcd;
+class L1JetEtScaleRcd;
+class L1HtMissScaleRcd;
+class L1HfRingEtScaleRcd;
 
-class L1GctTest : public edm::EDAnalyzer {
+class L1GctTest : public edm::one::EDAnalyzer<> {
 public:
   /// typedefs
   typedef L1GlobalCaloTrigger::lutPtr lutPtr;
@@ -56,7 +61,13 @@ private:
   L1GlobalCaloTrigger* m_gct;
   lutPtrVector m_jetEtCalibLuts;
 
-  gctTestFunctions* m_tester;
+  std::unique_ptr<gctTestFunctions> m_tester;
+
+  edm::ESGetToken<L1GctJetFinderParams, L1GctJetFinderParamsRcd> m_jfParsToken;
+  edm::ESGetToken<L1GctChannelMask, L1GctChannelMaskRcd> m_chanMaskToken;
+  edm::ESGetToken<L1CaloEtScale, L1JetEtScaleRcd> m_etScaleToken;
+  edm::ESGetToken<L1CaloEtScale, L1HtMissScaleRcd> m_htMissScaleToken;
+  edm::ESGetToken<L1CaloEtScale, L1HfRingEtScaleRcd> m_hfRingEtScaleToken;
 
   bool theElectronTestIsEnabled;
   bool theSingleEventTestIsEnabled;

--- a/L1Trigger/GlobalCaloTrigger/test/L1GctTestAnalyzer.cc
+++ b/L1Trigger/GlobalCaloTrigger/test/L1GctTestAnalyzer.cc
@@ -6,7 +6,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/L1Trigger/GlobalCaloTrigger/test/L1GctTestAnalyzer.h
+++ b/L1Trigger/GlobalCaloTrigger/test/L1GctTestAnalyzer.h
@@ -17,7 +17,7 @@
 //
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 
@@ -31,12 +31,12 @@
 // class decleration
 //
 
-class L1GctTestAnalyzer : public edm::EDAnalyzer {
+class L1GctTestAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit L1GctTestAnalyzer(const edm::ParameterSet&);
-  ~L1GctTestAnalyzer();
+  ~L1GctTestAnalyzer() override;
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void doRctEM(const edm::Event&, edm::InputTag label);
   void doInternEM(const edm::Event&, edm::InputTag label);

--- a/L1Trigger/GlobalCaloTrigger/test/gctTestFunctions.cc
+++ b/L1Trigger/GlobalCaloTrigger/test/gctTestFunctions.cc
@@ -51,8 +51,13 @@ gctTestFunctions::~gctTestFunctions() {
 //=================================================================================================================
 //
 /// Configuration method
-void gctTestFunctions::configure(const edm::EventSetup& c) {
+void gctTestFunctions::configure(const L1GctJetFinderParams& jfPars,
+                                 const L1GctChannelMask& chanMask,
+                                 const L1CaloEtScale& etScale,
+                                 const L1CaloEtScale& htMissScale,
+                                 const L1CaloEtScale& hfRingEtScale) {
   // get data from EventSetup
+  /*
   edm::ESHandle<L1GctJetFinderParams> jfPars;
   c.get<L1GctJetFinderParamsRcd>().get(jfPars);  // which record?
   edm::ESHandle<L1GctChannelMask> chanMask;
@@ -63,10 +68,11 @@ void gctTestFunctions::configure(const edm::EventSetup& c) {
   c.get<L1HtMissScaleRcd>().get(htMissScale);  // which record?
   edm::ESHandle<L1CaloEtScale> hfRingEtScale;
   c.get<L1HfRingEtScaleRcd>().get(hfRingEtScale);  // which record?
+  */
 
-  theEnergyAlgosTester->configure(chanMask.product());
-  theHtTester->configure(etScale.product(), htMissScale.product(), jfPars.product());
-  theHfEtSumsTester->configure(hfRingEtScale.product());
+  theEnergyAlgosTester->configure(&chanMask);
+  theHtTester->configure(&etScale, &htMissScale, &jfPars);
+  theHfEtSumsTester->configure(&hfRingEtScale);
 }
 
 //=================================================================================================================

--- a/L1Trigger/GlobalCaloTrigger/test/gctTestFunctions.h
+++ b/L1Trigger/GlobalCaloTrigger/test/gctTestFunctions.h
@@ -35,6 +35,10 @@ class gctTestHfEtSums;
 
 class L1GlobalCaloTrigger;
 
+class L1GctJetFinderParams;
+class L1GctChannelMask;
+class L1CaloEtScale;
+
 class gctTestFunctions {
 public:
   // structs and typedefs
@@ -44,7 +48,11 @@ public:
   ~gctTestFunctions();
 
   // Configuration method based on EventSetup - so not to be called from constructor
-  void configure(const edm::EventSetup& c);
+  void configure(const L1GctJetFinderParams& jfPars,
+                 const L1GctChannelMask& chanMask,
+                 const L1CaloEtScale& etScale,
+                 const L1CaloEtScale& htMissScale,
+                 const L1CaloEtScale& hfRingEtScale);
 
   /// Clear vectors of input data
   void reset();


### PR DESCRIPTION
#### PR description:

- moved to thread-friendly module type
- added esConsumes

#### PR validation:

Code compiles without warning message.