### PR TITLE
Run3-gex109E Avoid compilation warnings in some Validation classes in EventGenerator, Mixing and MtdValidation

### DIFF
--- a/Validation/EventGenerator/interface/DuplicationChecker.h
+++ b/Validation/EventGenerator/interface/DuplicationChecker.h
@@ -9,7 +9,6 @@
  */
 
 // framework & common header files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Run.h"

--- a/Validation/EventGenerator/interface/WValidation.h
+++ b/Validation/EventGenerator/interface/WValidation.h
@@ -9,7 +9,6 @@
  */
 
 // framework & common header files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Run.h"

--- a/Validation/Mixing/interface/TestSuite.h
+++ b/Validation/Mixing/interface/TestSuite.h
@@ -14,7 +14,7 @@
 //
 
 // system include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -42,7 +42,7 @@ class TFile;
 // class declaration
 //
 
-class TestSuite : public edm::EDAnalyzer {
+class TestSuite : public edm::one::EDAnalyzer<> {
 public:
   typedef dqm::legacy::DQMStore DQMStore;
   typedef dqm::legacy::MonitorElement MonitorElement;

--- a/Validation/Mixing/src/GlobalTest.cc
+++ b/Validation/Mixing/src/GlobalTest.cc
@@ -24,7 +24,6 @@
 #include <fmt/format.h>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/Validation/Mixing/src/MixCollectionValidation.cc
+++ b/Validation/Mixing/src/MixCollectionValidation.cc
@@ -2,7 +2,6 @@
 #include "Validation/Mixing/interface/MixCollectionValidation.h"
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -5,7 +5,6 @@
 #include <algorithm>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/Common/interface/ValidHandle.h"


### PR DESCRIPTION
#### PR description:

Avoid compilation warnings in some Validation classes in EventGenerator, Mixing and MtdValidation

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special