### PR TITLE
removed dummy `python/` dirs in `HLTrigger/`

### DIFF
--- a/HLTrigger/Egamma/python/_dummy.py
+++ b/HLTrigger/Egamma/python/_dummy.py
@@ -1,1 +1,0 @@
-# https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html

--- a/HLTrigger/HLTfilters/python/_dummy.py
+++ b/HLTrigger/HLTfilters/python/_dummy.py
@@ -1,1 +1,0 @@
-# https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html

--- a/HLTrigger/JetMET/python/_dummy.py
+++ b/HLTrigger/JetMET/python/_dummy.py
@@ -1,1 +1,0 @@
-# https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html

--- a/HLTrigger/Muon/python/_dummy.py
+++ b/HLTrigger/Muon/python/_dummy.py
@@ -1,1 +1,0 @@
-# https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html

--- a/HLTrigger/btau/python/_dummy.py
+++ b/HLTrigger/btau/python/_dummy.py
@@ -1,1 +1,0 @@
-# https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html


### PR DESCRIPTION
#### PR description:

Some of the `HLTrigger/*` packages currently have a `python/` directory which is basically empty (it only contains a dummy file, so that the directory can be "seen" by `git`). This was originally done to work around a shortcoming in how `scram` handled the `python/` directory of CMSSW packages (see [this HN thread](https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html) for more details).

Testing in a recent CMSSW release suggests that this workaround is not necessary anymore, so this PR removes the 'dummy' `python/` directories in `HLTrigger/`.

Merely technical. No changes expected.

PS. It looks like the relevant updates for `scram` were in [[1]](https://github.com/cms-sw/cmssw-config/blob/3c8d41b9027818345f478f3f0f0c109a59a101da/ChangeLog#L875) [[2]](https://github.com/cms-sw/cmssw-config/pull/40) [[3]](https://github.com/cms-sw/cmssw-config/commit/c82d086d491e57e25ab0901547180f2ae4902753), ~~but I do not know that for a fact.~~ (clarified by experts in the PR comments)


#### PR validation:

`addOnTests` passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A