### PR TITLE
Migrate module config in DPGAnalysis to use default cfipy

### DIFF
--- a/Configuration/EcalTB/python/reco_application_2006h2rawdata_ecalLocalReco_cfg.py
+++ b/Configuration/EcalTB/python/reco_application_2006h2rawdata_ecalLocalReco_cfg.py
@@ -44,8 +44,9 @@ process.tbunpacker = cms.EDProducer("HcalTBObjectUnpacker",
     ConfigurationFile = cms.untracked.string('configQADCTDC.txt')
 )
 
-process.ecalTBunpack = cms.EDProducer("EcalRawToDigi",
-    FEDs = cms.untracked.vint32(9),
+process.load("EventFilter.EcalRawToDigi.ecalRawToDigi_cfi")
+process.ecalTBunpack = process.ecalRawToDigi.clone(
+    FEDs = 9,
     DCCMapFile = cms.untracked.string('EventFilter/EcalRawToDigi/data/DCCMap_h2.txt'),
     EcalFirstFED = cms.untracked.int32(8)
 )

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2018_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2018_cfg.py
@@ -552,15 +552,12 @@ process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
 process.hcalDigis.FilterDataQuality = cms.bool(False)
 process.hcalDigis.InputLabel = cms.InputTag("source")
 ############################################################################
-process.hcalDigis= cms.EDProducer("HcalRawToDigi",
-#    FilterDataQuality = cms.bool(True),
-    FilterDataQuality = cms.bool(False),
-    HcalFirstFED = cms.untracked.int32(700),
-    InputLabel = cms.InputTag("source"),
-    #InputLabel = cms.InputTag("rawDataCollector"),
+process.load('EventFilter.HcalRawToDigi.hcalRawToDigi_cfi')
+process.hcalDigis= process.hcalRawToDigi.clone(
+    FilterDataQuality = False,
+    InputLabel = "source",
+    #InputLabel = "rawDataCollector",
 )
-#process.hcalDigis.FilterDataQuality = cms.bool(False)
-#process.hcalDigis.InputLabel = cms.InputTag("source")
 ############################################################################
 ##process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestal_cff")
 process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestalLocal_cff")

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2019_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2019_cfg.py
@@ -553,15 +553,12 @@ process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
 process.hcalDigis.FilterDataQuality = cms.bool(False)
 process.hcalDigis.InputLabel = cms.InputTag("source")
 ############################################################################
-process.hcalDigis= cms.EDProducer("HcalRawToDigi",
-#    FilterDataQuality = cms.bool(True),
-    FilterDataQuality = cms.bool(False),
-    HcalFirstFED = cms.untracked.int32(700),
-    InputLabel = cms.InputTag("source"),
+process.load('EventFilter.HcalRawToDigi.hcalRawToDigi_cfi')
+process.hcalDigis= process.hcalRawToDigi.clone(
+    FilterDataQuality = False,
+    InputLabel = "source",
     #InputLabel = cms.InputTag("rawDataCollector"),
 )
-#process.hcalDigis.FilterDataQuality = cms.bool(False)
-#process.hcalDigis.InputLabel = cms.InputTag("source")
 ############################################################################
 ##process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestal_cff")
 process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestalLocal_cff")

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_IterMethod_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_IterMethod_cfg.py
@@ -407,15 +407,12 @@ from Configuration.AlCa.autoCond import autoCond
 # 2019:
 process.GlobalTag.globaltag = '106X_dataRun3_HLT_v3'
 
-
-process.hcalDigis= cms.EDProducer("HcalRawToDigi",
-#    FilterDataQuality = cms.bool(True),
-    FilterDataQuality = cms.bool(False),
-    HcalFirstFED = cms.untracked.int32(700),
-    InputLabel = cms.InputTag("source"),
+process.load('EventFilter.HcalRawToDigi.hcalRawToDigi_cfi')
+process.hcalDigis= process.hcalRawToDigi.clone(
+    FilterDataQuality = False,
+    InputLabel = "source",
     #InputLabel = cms.InputTag("rawDataCollector"),
 )
-
 process.p = cms.Path(process.hcalDigis*process.Analyzer)
 
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2018_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2018_cfg.py
@@ -550,15 +550,12 @@ process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
 process.hcalDigis.FilterDataQuality = cms.bool(False)
 process.hcalDigis.InputLabel = cms.InputTag("source")
 ############################################################################
-process.hcalDigis= cms.EDProducer("HcalRawToDigi",
-#    FilterDataQuality = cms.bool(True),
-    FilterDataQuality = cms.bool(False),
-    HcalFirstFED = cms.untracked.int32(700),
-    InputLabel = cms.InputTag("source"),
+process.load('EventFilter.HcalRawToDigi.hcalRawToDigi_cfi')
+process.hcalDigis= process.hcalRawToDigi.clone(
+    FilterDataQuality = False,
+    InputLabel = "source",
     #InputLabel = cms.InputTag("rawDataCollector"),
 )
-#process.hcalDigis.FilterDataQuality = cms.bool(False)
-#process.hcalDigis.InputLabel = cms.InputTag("source")
 ############################################################################
 ##process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestal_cff")
 process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestalLocal_cff")

--- a/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2019_cfg.py
+++ b/DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2019_cfg.py
@@ -552,15 +552,12 @@ process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
 process.hcalDigis.FilterDataQuality = cms.bool(False)
 process.hcalDigis.InputLabel = cms.InputTag("source")
 ############################################################################
-process.hcalDigis= cms.EDProducer("HcalRawToDigi",
-#    FilterDataQuality = cms.bool(True),
-    FilterDataQuality = cms.bool(False),
-    HcalFirstFED = cms.untracked.int32(700),
-    InputLabel = cms.InputTag("source"),
+process.load('EventFilter.HcalRawToDigi.hcalRawToDigi_cfi')
+process.hcalDigis= process.hcalRawToDigi.clone(
+    FilterDataQuality = False,
+    InputLabel = "source",
     #InputLabel = cms.InputTag("rawDataCollector"),
 )
-#process.hcalDigis.FilterDataQuality = cms.bool(False)
-#process.hcalDigis.InputLabel = cms.InputTag("source")
 ############################################################################
 ##process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestal_cff")
 process.load("Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestalLocal_cff")


### PR DESCRIPTION
#### PR description: 
Optimization of the python configurations: Improve maintainability by cleaning up the duplicated and cloning from the default/reference configurations. 

In this PR, 6 files were changed.  Configuration/EcalTB/python/reco_application_2006h2rawdata_ecalLocalReco_cfg.py
DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2018_cfg.py
DPGAnalysis/HcalTools/python/remoteMonitoring_LASER_era2019_cfg.py
DPGAnalysis/HcalTools/python/remoteMonitoring_LED_IterMethod_cfg.py
DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2018_cfg.py
DPGAnalysis/HcalTools/python/remoteMonitoring_LED_era2019_cfg.py

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_12_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).