### PR TITLE
Migrate to EventSetup with ESGetToken in GEMCSCSegmentProducer

### DIFF
--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
@@ -38,14 +38,14 @@ void GEMCSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup
   LogDebug("GEMCSCSegment") << "start producing segments for " << ++iev << "th event w/ gem and csc data";
 
   // find the geometry (& conditions?) for this event & cache it in the builder
-  const edm::ESHandle<CSCGeometry>&& cscg = setup.getHandle(kCSCGeometryToken_);
+  const auto cscg = setup.getHandle(kCSCGeometryToken_);
   if (not cscg.isValid()) {
     edm::LogError("GEMCSCSegment") << "invalid CSCGeometry";
     return;
   }
   const CSCGeometry* cgeom = &*cscg;
 
-  const edm::ESHandle<GEMGeometry>&& gemg = setup.getHandle(kGEMGeometryToken_);
+  const auto gemg = setup.getHandle(kGEMGeometryToken_);
   if (not gemg.isValid()) {
     edm::LogError("GEMCSCSegment") << "invalid GEMGeometry";
     return;
@@ -59,13 +59,13 @@ void GEMCSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup
   segmentBuilder_->LinkGEMRollsToCSCChamberIndex(ggeom, cgeom);
 
   // get the collection of CSCSegment and GEMRecHits
-  const edm::Handle<CSCSegmentCollection>&& cscSegment = ev.getHandle(kCSCSegmentCollectionToken_);
+  const auto cscSegment = ev.getHandle(kCSCSegmentCollectionToken_);
   if (not cscSegment.isValid()) {
     edm::LogError("GEMCSCSegment") << "invalid CSCSegmentCollection";
     return;
   }
 
-  const edm::Handle<GEMRecHitCollection>&& gemRecHits = ev.getHandle(kGEMRecHitCollectionToken_);
+  const auto gemRecHits = ev.getHandle(kGEMRecHitCollectionToken_);
   if (not gemRecHits.isValid()) {
     edm::LogError("GEMCSCSegment") << "invalid GEMRecHitCollection";
     return;

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
@@ -9,8 +9,6 @@
 #include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
-
 #include <DataFormats/GEMRecHit/interface/GEMRecHitCollection.h>
 #include <DataFormats/GEMRecHit/interface/GEMCSCSegmentCollection.h>
 #include <DataFormats/GEMRecHit/interface/GEMCSCSegment.h>
@@ -19,9 +17,12 @@
 #include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegment.h>
 
-GEMCSCSegmentProducer::GEMCSCSegmentProducer(const edm::ParameterSet& pas) : iev(0) {
-  csc_token = consumes<CSCSegmentCollection>(pas.getParameter<edm::InputTag>("inputObjectsCSC"));
-  gem_token = consumes<GEMRecHitCollection>(pas.getParameter<edm::InputTag>("inputObjectsGEM"));
+GEMCSCSegmentProducer::GEMCSCSegmentProducer(const edm::ParameterSet& pas)
+    : kCSCGeometryToken_(esConsumes<CSCGeometry, MuonGeometryRecord>()),
+      kGEMGeometryToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
+      kCSCSegmentCollectionToken_(consumes<CSCSegmentCollection>(pas.getParameter<edm::InputTag>("inputObjectsCSC"))),
+      kGEMRecHitCollectionToken_(consumes<GEMRecHitCollection>(pas.getParameter<edm::InputTag>("inputObjectsGEM"))),
+      iev(0) {
   segmentBuilder_ = new GEMCSCSegmentBuilder(pas);  // pass on the parameterset
 
   // register what this produces
@@ -37,12 +38,18 @@ void GEMCSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup
   LogDebug("GEMCSCSegment") << "start producing segments for " << ++iev << "th event w/ gem and csc data";
 
   // find the geometry (& conditions?) for this event & cache it in the builder
-  edm::ESHandle<CSCGeometry> cscg;
-  setup.get<MuonGeometryRecord>().get(cscg);
+  const edm::ESHandle<CSCGeometry>&& cscg = setup.getHandle(kCSCGeometryToken_);
+  if (not cscg.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid CSCGeometry";
+    return;
+  }
   const CSCGeometry* cgeom = &*cscg;
 
-  edm::ESHandle<GEMGeometry> gemg;
-  setup.get<MuonGeometryRecord>().get(gemg);
+  const edm::ESHandle<GEMGeometry>&& gemg = setup.getHandle(kGEMGeometryToken_);
+  if (not gemg.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid GEMGeometry";
+    return;
+  }
   const GEMGeometry* ggeom = &*gemg;
 
   // cache the geometry in the builder
@@ -52,10 +59,17 @@ void GEMCSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup
   segmentBuilder_->LinkGEMRollsToCSCChamberIndex(ggeom, cgeom);
 
   // get the collection of CSCSegment and GEMRecHits
-  edm::Handle<CSCSegmentCollection> cscSegment;
-  ev.getByToken(csc_token, cscSegment);
-  edm::Handle<GEMRecHitCollection> gemRecHits;
-  ev.getByToken(gem_token, gemRecHits);
+  const edm::Handle<CSCSegmentCollection>&& cscSegment = ev.getHandle(kCSCSegmentCollectionToken_);
+  if (not cscSegment.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid CSCSegmentCollection";
+    return;
+  }
+
+  const edm::Handle<GEMRecHitCollection>&& gemRecHits = ev.getHandle(kGEMRecHitCollectionToken_);
+  if (not gemRecHits.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid GEMRecHitCollection";
+    return;
+  }
 
   // create empty collection of GEMCSC Segments
   auto oc = std::make_unique<GEMCSCSegmentCollection>();

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.h
@@ -12,11 +12,16 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+
+#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 
 class GEMCSCSegmentBuilder;
 
@@ -30,10 +35,13 @@ public:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> kCSCGeometryToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> kGEMGeometryToken_;
+  const edm::EDGetTokenT<CSCSegmentCollection> kCSCSegmentCollectionToken_;
+  const edm::EDGetTokenT<GEMRecHitCollection> kGEMRecHitCollectionToken_;
+
   int iev;  // events through
   GEMCSCSegmentBuilder* segmentBuilder_;
-  edm::EDGetTokenT<CSCSegmentCollection> csc_token;
-  edm::EDGetTokenT<GEMRecHitCollection> gem_token;
 };
 
 #endif

--- a/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
@@ -976,13 +976,13 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer() {
 
 // ------------ method called for each event  ------------
 void TestGEMCSCSegmentAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  const edm::ESHandle<GEMGeometry>&& gemGeom = iSetup.getHandle(kGEMGeometryToken_);
+  const auto gemGeom = iSetup.getHandle(kGEMGeometryToken_);
   if (not gemGeom.isValid()) {
     edm::LogError("GEMCSCSegment") << "invalid GEMGeometry";
     return;
   }
 
-  const edm::ESHandle<CSCGeometry>&& cscGeom = iSetup.getHandle(kCSCGeometryToken_);
+  const auto cscGeom = iSetup.getHandle(kCSCGeometryToken_);
   if (not cscGeom.isValid()) {
     edm::LogError("GEMCSCSegment") << "invalid CSCGeometry";
     return;

--- a/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
@@ -349,8 +349,7 @@ private:
 //
 TestGEMCSCSegmentAnalyzer::TestGEMCSCSegmentAnalyzer(const edm::ParameterSet& iConfig)
     : kCSCGeometryToken_(esConsumes<CSCGeometry, MuonGeometryRecord>()),
-      kGEMGeometryToken_(esConsumes<GEMGeometry, MuonGeometryRecord>())
-{
+      kGEMGeometryToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()) {
   //now do what ever initialization is needed
   debug = iConfig.getUntrackedParameter<bool>("Debug");
   rootFileName = iConfig.getUntrackedParameter<std::string>("RootFileName");

--- a/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
@@ -30,7 +30,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -64,7 +64,7 @@
 using namespace std;
 using namespace edm;
 
-class TestGEMCSCSegmentAnalyzer : public edm::EDAnalyzer {
+class TestGEMCSCSegmentAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit TestGEMCSCSegmentAnalyzer(const edm::ParameterSet&);
   ~TestGEMCSCSegmentAnalyzer();
@@ -355,7 +355,8 @@ TestGEMCSCSegmentAnalyzer::TestGEMCSCSegmentAnalyzer(const edm::ParameterSet& iC
   rootFileName = iConfig.getUntrackedParameter<std::string>("RootFileName");
 
   // outputfile = new TFile(rootFileName.c_str(), "RECREATE" );
-  outputfile.reset(TFile::Open(rootFileName.c_str()));
+  outputfile.reset(TFile::Open(rootFileName.c_str(), "CREATE"));
+  outputfile->cd();
 
   SimTrack_Token = consumes<edm::SimTrackContainer>(edm::InputTag("g4SimHits"));
   CSCSegment_Token = consumes<CSCSegmentCollection>(edm::InputTag("cscSegments"));

--- a/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc
@@ -90,6 +90,8 @@ private:
   bool debug;
   std::string rootFileName;
 
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> kCSCGeometryToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> kGEMGeometryToken_;
   edm::EDGetTokenT<edm::SimTrackContainer> SimTrack_Token;
   edm::EDGetTokenT<CSCSegmentCollection> CSCSegment_Token;
   edm::EDGetTokenT<GEMCSCSegmentCollection> GEMCSCSegment_Token;
@@ -346,7 +348,8 @@ private:
 // constructors and destructor
 //
 TestGEMCSCSegmentAnalyzer::TestGEMCSCSegmentAnalyzer(const edm::ParameterSet& iConfig)
-
+    : kCSCGeometryToken_(esConsumes<CSCGeometry, MuonGeometryRecord>()),
+      kGEMGeometryToken_(esConsumes<GEMGeometry, MuonGeometryRecord>())
 {
   //now do what ever initialization is needed
   debug = iConfig.getUntrackedParameter<bool>("Debug");
@@ -973,8 +976,17 @@ TestGEMCSCSegmentAnalyzer::~TestGEMCSCSegmentAnalyzer() {
 
 // ------------ method called for each event  ------------
 void TestGEMCSCSegmentAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  iSetup.get<MuonGeometryRecord>().get(gemGeom);
-  iSetup.get<MuonGeometryRecord>().get(cscGeom);
+  const edm::ESHandle<GEMGeometry>&& gemGeom = iSetup.getHandle(kGEMGeometryToken_);
+  if (not gemGeom.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid GEMGeometry";
+    return;
+  }
+
+  const edm::ESHandle<CSCGeometry>&& cscGeom = iSetup.getHandle(kCSCGeometryToken_);
+  if (not cscGeom.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid CSCGeometry";
+    return;
+  }
   const CSCGeometry* cscGeom_ = &*cscGeom;
 
   // ================


### PR DESCRIPTION
#### PR description:
`GEMCSCSegmentProducer` is using `EventSetup::get` to retrieve the geometry from `EventSetup`. However, `EventSetup::get` has been deprecated in favor of methods that take `ESGetToken` as an argument, such as `EventSetup::getHandle`. As a result, `GEMCSCSegment` reconstruction throws `MustUseESGetToken` exception. Therefore, this PR migrates to using `EventSetup` with `ESGetToken`.


#### PR validation:
The GEMCSCSegment reconstruction is not included in RECO. So, we can't verify this PR with any wf. So, I added it to step3 of 11850.0 for testing and ran [RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc](https://github.com/seungjin-yang/cmssw/blob/Fix-GEMCSCSegmentProducer-Geometry-Loading__from-CMSSW_12_3_0_pre2/RecoLocalMuon/GEMCSCSegment/test/TestGEMCSCSegmentAnalyzer.cc). See more details on the last page of [this slide](https://indico.cern.ch/event/1105924/contributions/4652889/attachments/2368910/4045551/220104__GEM_DPG__Fix_GEMCSCSegmentProducer_Geometry_Loading.pdf).

The figures below are some of the results.
<img src="https://raw.githubusercontent.com/seungjin-yang/GEM-Workspace/main/SW-Dev/211227_GEMCSCSegmentProducer-Geometry-Loading/test/plots/NumGMCSCSeg.png" width="400">

<img src="https://raw.githubusercontent.com/seungjin-yang/GEM-Workspace/2319ba1d096f719b395c28156ab34dd2d706a505/SW-Dev/211227_GEMCSCSegmentProducer-Geometry-Loading/test/plots/NumCSCRH.png" width="400">


<img src="https://raw.githubusercontent.com/seungjin-yang/GEM-Workspace/main/SW-Dev/211227_GEMCSCSegmentProducer-Geometry-Loading/test/plots/NumGEMRH.png" width="400">


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A