### PR TITLE
EventSetupInitTrait can now have state

### DIFF
--- a/CommonTools/CandAlgos/interface/CandCombiner.h
+++ b/CommonTools/CandAlgos/interface/CandCombiner.h
@@ -131,6 +131,7 @@ namespace reco {
       /// constructor from parameter settypedef
       explicit CandCombiner(const edm::ParameterSet& cfg)
           : CandCombinerBase(cfg),
+            combinerInit_(consumesCollector()),
             combiner_(reco::modules::make<Selector>(cfg, consumesCollector()),
                       reco::modules::make<PairSelector>(cfg),
                       Setup(cfg),
@@ -146,7 +147,7 @@ namespace reco {
     private:
       /// process an event
       void produce(edm::Event& evt, const edm::EventSetup& es) override {
-        Init::init(combiner_.setup(), evt, es);
+        combinerInit_.init(combiner_.setup(), evt, es);
         int n = labels_.size();
         std::vector<edm::Handle<CandidateView> > colls(n);
         for (int i = 0; i < n; ++i)
@@ -168,6 +169,7 @@ namespace reco {
         evt.put(std::move(out));
       }
       /// combiner utility
+      Init combinerInit_;
       ::CandCombiner<Selector, PairSelector, Cloner, OutputCollection, Setup> combiner_;
 
       RoleNames names_;

--- a/CommonTools/RecoAlgos/interface/CandidateProducer.h
+++ b/CommonTools/RecoAlgos/interface/CandidateProducer.h
@@ -73,6 +73,7 @@ public:
   CandidateProducer(const edm::ParameterSet& cfg)
       : srcToken_(consumes<TColl>(cfg.template getParameter<edm::InputTag>("src"))),
         converter_(cfg, consumesCollector()),
+        selectorInit_(consumesCollector()),
         selector_(reco::modules::make<Selector>(cfg, consumesCollector())),
         initialized_(false) {
     produces<CColl>();
@@ -92,7 +93,7 @@ private:
   void produce(edm::Event& evt, const edm::EventSetup& es) override {
     edm::Handle<TColl> src;
     evt.getByToken(srcToken_, src);
-    Init::init(selector_, evt, es);
+    selectorInit_.init(selector_, evt, es);
     ::helper::MasterCollection<TColl> master(src, evt);
     std::unique_ptr<CColl> cands(new CColl);
     if (!src->empty()) {
@@ -110,6 +111,7 @@ private:
   /// converter helper
   Conv converter_;
   /// selector
+  Init selectorInit_;
   Selector selector_;
   /// particles initialized?
   bool initialized_;

--- a/CommonTools/UtilAlgos/interface/AssociatedVariableCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/AssociatedVariableCollectionSelector.h
@@ -66,10 +66,11 @@ namespace reco {
   namespace modules {
     template <typename S>
     struct AssociatedVariableCollectionSelectorEventSetupInit {
-      static void init(S& s, const edm::Event& evt, const edm::EventSetup& es) {
-        typedef typename EventSetupInit<typename S::selector>::type ESI;
-        ESI::init(s.select_, evt, es);
-      }
+      explicit AssociatedVariableCollectionSelectorEventSetupInit(edm::ConsumesCollector iC) : esi_(iC) {}
+
+      void init(S& s, const edm::Event& evt, const edm::EventSetup& es) { esi_.init(s.select_, evt, es); }
+      typedef typename EventSetupInit<typename S::selector>::type ESI;
+      ESI esi_;
     };
 
     template <typename I, typename V, typename S, typename O, typename C, typename R>
@@ -77,6 +78,7 @@ namespace reco {
       typedef AssociatedVariableCollectionSelectorEventSetupInit<AssociatedVariableCollectionSelector<I, V, S, O, C, R> >
           type;
     };
+
   }  // namespace modules
 }  // namespace reco
 

--- a/CommonTools/UtilAlgos/interface/EventSetupInitTrait.h
+++ b/CommonTools/UtilAlgos/interface/EventSetupInitTrait.h
@@ -2,6 +2,7 @@
 #define UtilAlgos_EventSetupInitTrait_h
 #include "CommonTools/UtilAlgos/interface/AndSelector.h"
 #include "CommonTools/UtilAlgos/interface/OrSelector.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace edm {
   class EventSetup;
@@ -17,14 +18,18 @@ namespace reco {
     /// take no action (default)
     template <typename T>
     struct NoEventSetupInit {
-      static void init(T&, const edm::Event&, const edm::EventSetup&) {}
+      explicit NoEventSetupInit(edm::ConsumesCollector) {}
+      NoEventSetupInit() = delete;
+      void init(T&, const edm::Event&, const edm::EventSetup&) {}
     };
 
     /// implement common interface defined in:
     /// https://twiki.cern.ch/twiki/bin/view/CMS/SelectorInterface
     struct CommonSelectorEventSetupInit {
+      explicit CommonSelectorEventSetupInit(edm::ConsumesCollector) {}
+      CommonSelectorEventSetupInit() = delete;
       template <typename Selector>
-      static void init(Selector& selector, const edm::Event& evt, const edm::EventSetup& es) {
+      void init(Selector& selector, const edm::Event& evt, const edm::EventSetup& es) {
         selector.newEvent(evt, es);
       }
     };
@@ -40,51 +45,68 @@ namespace reco {
               typename T4 = helpers::NullAndOperand,
               typename T5 = helpers::NullAndOperand>
     struct CombinedEventSetupInit {
+      explicit CombinedEventSetupInit(edm::ConsumesCollector iC) : t1_(iC), t2_(iC), t3_(iC), t4_(iC), t5_(iC) {}
       template <template <typename, typename, typename, typename, typename> class SelectorT>
-      static void init(SelectorT<T1, T2, T3, T4, T5>& selector, const edm::Event& evt, const edm::EventSetup& es) {
-        EventSetupInit<T1>::type::init(selector.s1_, evt, es);
-        EventSetupInit<T2>::type::init(selector.s2_, evt, es);
-        EventSetupInit<T3>::type::init(selector.s3_, evt, es);
-        EventSetupInit<T4>::type::init(selector.s4_, evt, es);
-        EventSetupInit<T5>::type::init(selector.s5_, evt, es);
+      void init(SelectorT<T1, T2, T3, T4, T5>& selector, const edm::Event& evt, const edm::EventSetup& es) {
+        t1_.init(selector.s1_, evt, es);
+        t2_.init(selector.s2_, evt, es);
+        t3_.init(selector.s3_, evt, es);
+        t4_.init(selector.s4_, evt, es);
+        t5_.init(selector.s5_, evt, es);
       }
+      typename EventSetupInit<T1>::type t1_;
+      typename EventSetupInit<T2>::type t2_;
+      typename EventSetupInit<T3>::type t3_;
+      typename EventSetupInit<T4>::type t4_;
+      typename EventSetupInit<T5>::type t5_;
     };
 
     template <typename T1, typename T2, typename T3, typename T4>
     struct CombinedEventSetupInit<T1, T2, T3, T4, helpers::NullAndOperand> {
+      explicit CombinedEventSetupInit(edm::ConsumesCollector iC) : t1_(iC), t2_(iC), t3_(iC), t4_(iC) {}
       template <template <typename, typename, typename, typename, typename> class SelectorT>
-      static void init(SelectorT<T1, T2, T3, T4, helpers::NullAndOperand>& selector,
-                       const edm::Event& evt,
-                       const edm::EventSetup& es) {
-        EventSetupInit<T1>::type::init(selector.s1_, evt, es);
-        EventSetupInit<T2>::type::init(selector.s2_, evt, es);
-        EventSetupInit<T3>::type::init(selector.s3_, evt, es);
-        EventSetupInit<T4>::type::init(selector.s4_, evt, es);
+      void init(SelectorT<T1, T2, T3, T4, helpers::NullAndOperand>& selector,
+                const edm::Event& evt,
+                const edm::EventSetup& es) {
+        t1_.init(selector.s1_, evt, es);
+        t2_.init(selector.s2_, evt, es);
+        t3_.init(selector.s3_, evt, es);
+        t4_.init(selector.s4_, evt, es);
       }
+      typename EventSetupInit<T1>::type t1_;
+      typename EventSetupInit<T2>::type t2_;
+      typename EventSetupInit<T3>::type t3_;
+      typename EventSetupInit<T4>::type t4_;
     };
 
     template <typename T1, typename T2, typename T3>
     struct CombinedEventSetupInit<T1, T2, T3, helpers::NullAndOperand, helpers::NullAndOperand> {
+      explicit CombinedEventSetupInit(edm::ConsumesCollector iC) : t1_(iC), t2_(iC), t3_(iC) {}
       template <template <typename, typename, typename, typename, typename> class SelectorT>
-      static void init(SelectorT<T1, T2, T3, helpers::NullAndOperand, helpers::NullAndOperand>& selector,
-                       const edm::Event& evt,
-                       const edm::EventSetup& es) {
-        EventSetupInit<T1>::type::init(selector.s1_, evt, es);
-        EventSetupInit<T2>::type::init(selector.s2_, evt, es);
-        EventSetupInit<T3>::type::init(selector.s3_, evt, es);
+      void init(SelectorT<T1, T2, T3, helpers::NullAndOperand, helpers::NullAndOperand>& selector,
+                const edm::Event& evt,
+                const edm::EventSetup& es) {
+        t1_.init(selector.s1_, evt, es);
+        t2_.init(selector.s2_, evt, es);
+        t3_.init(selector.s3_, evt, es);
       }
+      typename EventSetupInit<T1>::type t1_;
+      typename EventSetupInit<T2>::type t2_;
+      typename EventSetupInit<T3>::type t3_;
     };
 
     template <typename T1, typename T2>
     struct CombinedEventSetupInit<T1, T2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand> {
+      explicit CombinedEventSetupInit(edm::ConsumesCollector iC) : t1_(iC), t2_(iC) {}
       template <template <typename, typename, typename, typename, typename> class SelectorT>
-      static void init(
-          SelectorT<T1, T2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand>& selector,
-          const edm::Event& evt,
-          const edm::EventSetup& es) {
-        EventSetupInit<T1>::type::init(selector.s1_, evt, es);
-        EventSetupInit<T2>::type::init(selector.s2_, evt, es);
+      void init(SelectorT<T1, T2, helpers::NullAndOperand, helpers::NullAndOperand, helpers::NullAndOperand>& selector,
+                const edm::Event& evt,
+                const edm::EventSetup& es) {
+        t1_.init(selector.s1_, evt, es);
+        t2_.init(selector.s2_, evt, es);
       }
+      typename EventSetupInit<T1>::type t1_;
+      typename EventSetupInit<T2>::type t2_;
     };
 
     template <typename T1, typename T2, typename T3, typename T4, typename T5>

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorBase.h
@@ -38,6 +38,7 @@ public:
         srcToken_(
             this->template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
         filter_(false),
+        selectorInit_(this->consumesCollector()),
         selector_(cfg, this->consumesCollector()),
         sizeSelector_(reco::modules::make<SizeSelector>(cfg)),
         postProcessor_(cfg, this->consumesCollector()) {
@@ -54,8 +55,7 @@ public:
 private:
   /// process one event
   bool filter(edm::Event& evt, const edm::EventSetup& es) override {
-    Init::init(selector_, evt, es);
-    using namespace std;
+    selectorInit_.init(selector_, evt, es);
     edm::Handle<typename Selector::collection> source;
     evt.getByToken(srcToken_, source);
     StoreManager manager(source);
@@ -71,6 +71,7 @@ private:
   /// filter event
   bool filter_;
   /// Object collection selector
+  Init selectorInit_;
   Selector selector_;
   /// selected object collection size selector
   SizeSelector sizeSelector_;

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
@@ -34,6 +34,7 @@ public:
       : Base(cfg),
         srcToken_(
             this->template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
+        selectorInit_(this->consumesCollector()),
         selector_(cfg, this->consumesCollector()),
         postProcessor_(cfg, this->consumesCollector()) {
     postProcessor_.init(*this);
@@ -44,7 +45,7 @@ public:
 private:
   /// process one event
   void produce(edm::Event& evt, const edm::EventSetup& es) override {
-    Init::init(selector_, evt, es);
+    selectorInit_.init(selector_, evt, es);
     edm::Handle<typename Selector::collection> source;
     evt.getByToken(srcToken_, source);
     StoreManager manager(source);
@@ -56,6 +57,7 @@ private:
   /// source collection label
   edm::EDGetTokenT<typename Selector::collection> srcToken_;
   /// Object collection selector
+  Init selectorInit_;
   Selector selector_;
   /// post processor
   PostProcessor postProcessor_;

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionRefSelector.h
@@ -66,10 +66,10 @@ namespace reco {
   namespace modules {
     template <typename S>
     struct SingleElementCollectionRefSelectorEventSetupInit {
-      static void init(S& s, const edm::Event& ev, const edm::EventSetup& es) {
-        typedef typename EventSetupInit<typename S::selector>::type ESI;
-        ESI::init(s.select_, ev, es);
-      }
+      explicit SingleElementCollectionRefSelectorEventSetupInit(edm::ConsumesCollector iC) : esi_(iC) {}
+      void init(S& s, const edm::Event& ev, const edm::EventSetup& es) { esi_.init(s.select_, ev, es); }
+      typedef typename EventSetupInit<typename S::selector>::type ESI;
+      ESI esi_;
     };
 
     template <typename I, typename S, typename O, typename C, typename R>

--- a/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
+++ b/CommonTools/UtilAlgos/interface/SingleElementCollectionSelector.h
@@ -64,10 +64,10 @@ namespace reco {
   namespace modules {
     template <typename S>
     struct SingleElementCollectionSelectorEventSetupInit {
-      static void init(S& s, const edm::Event& ev, const edm::EventSetup& es) {
-        typedef typename EventSetupInit<typename S::selector>::type ESI;
-        ESI::init(s.select_, ev, es);
-      }
+      explicit SingleElementCollectionSelectorEventSetupInit(edm::ConsumesCollector iC) : esi_(iC) {}
+      typedef typename EventSetupInit<typename S::selector>::type ESI;
+      void init(S& s, const edm::Event& ev, const edm::EventSetup& es) { esi_.init(s.select_, ev, es); }
+      ESI esi_;
     };
 
     template <typename I, typename S, typename O, typename C, typename R>

--- a/PhysicsTools/RecoAlgos/interface/MassKinFitterCandProducer.h
+++ b/PhysicsTools/RecoAlgos/interface/MassKinFitterCandProducer.h
@@ -6,12 +6,12 @@
  *
  */
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "PhysicsTools/RecoUtils/interface/CandMassKinFitter.h"
 
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-class MassKinFitterCandProducer : public edm::EDProducer {
+class MassKinFitterCandProducer : public edm::stream::EDProducer<> {
 public:
   explicit MassKinFitterCandProducer(const edm::ParameterSet &, CandMassKinFitter * = nullptr);
 

--- a/PhysicsTools/RecoAlgos/plugins/CandCommonVertexFitter.h
+++ b/PhysicsTools/RecoAlgos/plugins/CandCommonVertexFitter.h
@@ -10,11 +10,11 @@ namespace reco {
   namespace modules {
     template <typename Fitter>
     struct CandVertexFitterEventSetupInit {
-      static void init(CandCommonVertexFitter<Fitter>& fitter, const edm::Event& evt, const edm::EventSetup& es) {
-        edm::ESHandle<MagneticField> h;
-        es.get<IdealMagneticFieldRecord>().get(h);
-        fitter.set(h.product());
+      explicit CandVertexFitterEventSetupInit(edm::ConsumesCollector iC) : magToken_(iC.esConsumes()) {}
+      void init(CandCommonVertexFitter<Fitter>& fitter, const edm::Event& evt, const edm::EventSetup& es) {
+        fitter.set(&es.getData(magToken_));
       }
+      edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magToken_;
     };
 
     template <typename Fitter>

--- a/PhysicsTools/RecoAlgos/plugins/CandKinematicVertexFitter.h
+++ b/PhysicsTools/RecoAlgos/plugins/CandKinematicVertexFitter.h
@@ -10,14 +10,16 @@
 namespace reco {
   namespace modules {
     struct CandKinematicVertexFitterEventSetupInit {
-      static void init(CandKinematicVertexFitter& fitter, const edm::Event& evt, const edm::EventSetup& es) {
-        edm::ESHandle<MagneticField> h;
-        es.get<IdealMagneticFieldRecord>().get(h);
-        fitter.set(h.product());
-        edm::ESHandle<ParticleDataTable> pdt;
-        es.getData(pdt);
-        fitter.set(pdt.product());
+      explicit CandKinematicVertexFitterEventSetupInit(edm::ConsumesCollector iC)
+          : magToken_(iC.esConsumes()), pdtToken_(iC.esConsumes()) {}
+
+      void init(CandKinematicVertexFitter& fitter, const edm::Event& evt, const edm::EventSetup& es) {
+        fitter.set(&es.getData(magToken_));
+        fitter.set(&es.getData(pdtToken_));
       }
+
+      edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magToken_;
+      edm::ESGetToken<ParticleDataTable, edm::DefaultRecord> pdtToken_;
     };
 
     template <>


### PR DESCRIPTION
#### PR description:

- Constructor takes edm::ConsumesCollector
- init method is no longer static
- Also moved PhysicsTools/RecoAlgos modules to stream types

This fixes all the CMS deprecated warnings in PhysicsTools/RecoAlgos.

#### PR validation:

- did `git cms-checkdeps -a` on modified code to test compilation
- all files using the modified code compile without the CMS deprecated warnings