### PR TITLE
Drop type specs for Alignment and EGamma

### DIFF
--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -67,8 +67,8 @@ ALCARECOTkAlZMuMuHITrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-    allTrackProducer = cms.InputTag( "hiGeneralTracks" ),
-    primaryVertex = cms.InputTag('hiSelectedVertex'),
+    allTrackProducer = "hiGeneralTracks" ,
+    primaryVertex = 'hiSelectedVertex'
 )
 
 ALCARECOTkAlZMuMuHITkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
@@ -76,8 +76,8 @@ ALCARECOTkAlZMuMuHITkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-    ReferenceTrackProducer= cms.InputTag( "hiGeneralTracks" ),
-    CaloJetCollection= cms.InputTag( "iterativeConePu5CaloJets" ),
+    ReferenceTrackProducer= "hiGeneralTracks",
+    CaloJetCollection= "iterativeConePu5CaloJets"
 )
 
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlZMuMuHI_cff import ALCARECOTkAlZMuMuHIHLT
@@ -96,7 +96,7 @@ ALCARECOTkAlZMuMuHIDQM = cms.Sequence( ALCARECOTkAlZMuMuHITrackingDQM + ALCARECO
 #########################################################
 __selectionName = 'TkAlZMuMuPA'
 ALCARECOTkAlZMuMuPATrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
@@ -104,7 +104,7 @@ ALCARECOTkAlZMuMuPATrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
 )
 
 ALCARECOTkAlZMuMuPATkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName
@@ -126,20 +126,20 @@ ALCARECOTkAlZMuMuPADQM = cms.Sequence( ALCARECOTkAlZMuMuPATrackingDQM + ALCARECO
 #########################################################
 __selectionName = 'TkAlJpsiMuMu'
 ALCARECOTkAlJpsiMuMuTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-# margins and settings
+    # margins and settings
     TrackPtMax = 50
 )
 ALCARECOTkAlJpsiMuMuTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-# margins and settings
+    # margins and settings
     MassMin = 2.5,
     MassMax = 4.0,
     TrackPtMax = 50
@@ -161,14 +161,14 @@ ALCARECOTkAlJpsiMuMuDQM = cms.Sequence( ALCARECOTkAlJpsiMuMuTrackingDQM + ALCARE
 #########################################################
 __selectionName = 'TkAlJpsiMuMuHI'
 ALCARECOTkAlJpsiMuMuHITrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-    allTrackProducer = cms.InputTag( "hiGeneralTracks" ),
-    primaryVertex = cms.InputTag('hiSelectedVertex'),
-# margins and settings
+    allTrackProducer = "hiGeneralTracks",
+    primaryVertex = 'hiSelectedVertex',
+    # margins and settings
     TrackPtMax = 50
 )
 
@@ -177,8 +177,8 @@ ALCARECOTkAlJpsiMuMuHITkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-    ReferenceTrackProducer= cms.InputTag( "hiGeneralTracks" ),
-    CaloJetCollection= cms.InputTag( "iterativeConePu5CaloJets" ),
+    ReferenceTrackProducer= "hiGeneralTracks",
+    CaloJetCollection= "iterativeConePu5CaloJets",
 # margins and settings
     MassMin = 2.5,
     MassMax = 4.0,
@@ -235,25 +235,25 @@ ALCARECOTkAlUpsilonMuMuDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuTrackingDQM + 
 ############################################################
 __selectionName = 'TkAlUpsilonMuMuHI'
 ALCARECOTkAlUpsilonMuMuHITrackingDQM = ALCARECOTkAlJpsiMuMuHITrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-    allTrackProducer = cms.InputTag( "hiGeneralTracks" ),
-    primaryVertex = cms.InputTag('hiSelectedVertex'),
-# margins and settings
+    allTrackProducer = "hiGeneralTracks",
+    primaryVertex = 'hiSelectedVertex',
+    # margins and settings
     TrackPtMax = 50
 )
 
 ALCARECOTkAlUpsilonMuMuHITkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-    ReferenceTrackProducer= cms.InputTag( "hiGeneralTracks" ),
-    CaloJetCollection= cms.InputTag( "iterativeConePu5CaloJets" ),
-# margins and settings
+    ReferenceTrackProducer= "hiGeneralTracks",
+    CaloJetCollection= "iterativeConePu5CaloJets",
+    # margins and settings
     MassMin = 8.,
     MassMax = 10,
     TrackPtMax = 50
@@ -275,21 +275,21 @@ ALCARECOTkAlUpsilonMuMuHIDQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuHITrackingDQ
 ############################################################
 __selectionName = 'TkAlUpsilonMuMuPA'
 ALCARECOTkAlUpsilonMuMuPATrackingDQM = ALCARECOTkAlUpsilonMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-# margins and settings
+    # margins and settings
     TrackPtMax = 50
 )
 
 ALCARECOTkAlUpsilonMuMuPATkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-# margins and settings
+    # margins and settings
     MassMin = 8.,
     MassMax = 10,
     TrackPtMax = 50
@@ -311,7 +311,7 @@ ALCARECOTkAlUpsilonMuMuPADQM = cms.Sequence( ALCARECOTkAlUpsilonMuMuPATrackingDQ
 #########################################################
 __selectionName = 'TkAlBeamHalo'
 ALCARECOTkAlBeamHaloTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
@@ -336,12 +336,12 @@ ALCARECOTkAlBeamHaloDQM = cms.Sequence( ALCARECOTkAlBeamHaloTrackingDQM
 ########################################################
 __selectionName = 'TkAlMinBias'
 ALCARECOTkAlMinBiasTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-# margins and settings
+    # margins and settings
     TkSizeBin = 71,
     TkSizeMin = -0.5,
     TkSizeMax = 70.5,
@@ -349,11 +349,11 @@ ALCARECOTkAlMinBiasTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
 )
 
 ALCARECOTkAlMinBiasTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-# margins and settings
+    # margins and settings
     fillInvariantMass = False,
     TrackPtMax = 30,
     SumChargeBin = 101,
@@ -386,14 +386,14 @@ ALCARECOTkAlMinBiasDQM = cms.Sequence( ALCARECOTkAlMinBiasTrackingDQM + ALCARECO
 ########################################################
 __selectionName = 'TkAlMinBiasHI'
 ALCARECOTkAlMinBiasHITrackingDQM = ALCARECOTkAlMinBiasTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
     primaryVertex = "hiSelectedVertex",
     allTrackProducer = "hiGeneralTracks",
-# margins and settings
+    # margins and settings
     TkSizeBin = 71,
     TkSizeMin = -0.5,
     TkSizeMax = 70.5,
@@ -401,13 +401,13 @@ ALCARECOTkAlMinBiasHITrackingDQM = ALCARECOTkAlMinBiasTrackingDQM.clone(
 )
 
 ALCARECOTkAlMinBiasHITkAlDQM = ALCARECOTkAlMinBiasTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     ReferenceTrackProducer = 'hiGeneralTracks',
     CaloJetCollection = 'iterativeConePu5CaloJets',
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-# margins and settings
+    # margins and settings
     fillInvariantMass = False,
     TrackPtMax = 30,
     SumChargeBin = 101,
@@ -432,12 +432,12 @@ ALCARECOTkAlMinBiasHIDQM = cms.Sequence( ALCARECOTkAlMinBiasHITrackingDQM + ALCA
 #############################################################
 __selectionName = 'TkAlMuonIsolated'
 ALCARECOTkAlMuonIsolatedTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-# margins and settings
+    # margins and settings
     TkSizeBin = 16,
     TkSizeMin = -0.5,
     TkSizeMax = 15.5
@@ -464,14 +464,14 @@ ALCARECOTkAlMuonIsolatedDQM = cms.Sequence( ALCARECOTkAlMuonIsolatedTrackingDQM 
 #############################################################
 __selectionName = 'TkAlMuonIsolatedHI'
 ALCARECOTkAlMuonIsolatedHITrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-    allTrackProducer = cms.InputTag( "hiGeneralTracks" ),
-    primaryVertex = cms.InputTag('hiSelectedVertex'),
-# margins and settings
+    allTrackProducer = "hiGeneralTracks",
+    primaryVertex = 'hiSelectedVertex',
+    # margins and settings
     TkSizeBin = 16,
     TkSizeMin = -0.5,
     TkSizeMax = 15.5
@@ -480,8 +480,8 @@ ALCARECOTkAlMuonIsolatedHITkAlDQM = ALCARECOTkAlMinBiasTkAlDQM.clone(
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
-    ReferenceTrackProducer= cms.InputTag( "hiGeneralTracks" ),
-    CaloJetCollection= cms.InputTag( "iterativeConePu5CaloJets" )
+    ReferenceTrackProducer= "hiGeneralTracks",
+    CaloJetCollection= "iterativeConePu5CaloJets" 
 )
 
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMuonIsolatedHI_cff import ALCARECOTkAlMuonIsolatedHIHLT
@@ -500,12 +500,12 @@ ALCARECOTkAlMuonIsolatedHIDQM = cms.Sequence( ALCARECOTkAlMuonIsolatedHITracking
 #############################################################
 __selectionName = 'TkAlMuonIsolatedPA'
 ALCARECOTkAlMuonIsolatedPATrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = "AlCaReco/"+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-# margins and settings
+    # margins and settings
     TkSizeBin = 16,
     TkSizeMin = -0.5,
     TkSizeMax = 15.5
@@ -556,12 +556,12 @@ ALCARECOTkAlLASDQM = cms.Sequence( ALCARECOTkAlLASDigiDQM )
 ###############################
 __selectionName = 'TkAlCosmicsInCollisions'
 ALCARECOTkAlCosmicsInCollisionsTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = 'AlCaReco/TkAlCosmicsInCollisions',
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-# margins and settings
+    # margins and settings
     TrackPtBin = 500,
     TrackPtMin = 0,
     TrackPtMax = 500
@@ -592,23 +592,23 @@ ALCARECOTkAlCosmicsInCollisionsDQM = cms.Sequence( ALCARECOTkAlCosmicsInCollisio
 ########################
 __selectionName = 'TkAlCosmicsCTF0T'
 ALCARECOTkAlCosmicsCTF0TTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = 'AlCaReco/TkAlCosmics0T',
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
-# margins and settings
+    # margins and settings
     TrackPtBin = 500,
     TrackPtMin = 0,
     TrackPtMax = 500
 )
 ALCARECOTkAlCosmicsCTF0TTkAlDQM = ALCARECOTkAlMinBiasTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     ReferenceTrackProducer = 'ctfWithMaterialTracksP5',
     AlgoName = 'ALCARECO'+__selectionName,
     FolderName = 'AlCaReco/TkAlCosmics0T',
-# margins and settings
+    # margins and settings
     useSignedR = True
 )
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlCosmics0THLT_cff import ALCARECOTkAlCosmics0THLT
@@ -709,14 +709,14 @@ ALCARECOTkAlCosmicsInCollisions0TDQM = cms.Sequence( ALCARECOTkAlCosmicsInCollis
 ######################
 __selectionName = 'TkAlCosmicsCTF'
 ALCARECOTkAlCosmicsCTFTrackingDQM = ALCARECOTkAlCosmicsCTF0TTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     FolderName = 'AlCaReco/TkAlCosmics',
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName
 )
 ALCARECOTkAlCosmicsCTFTkAlDQM = ALCARECOTkAlCosmicsCTF0TTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     FolderName = 'AlCaReco/TkAlCosmics',
     TrackProducer = 'ALCARECO'+__selectionName,
     ReferenceTrackProducer = ALCARECOTkAlCosmicsCTF0TTkAlDQM.ReferenceTrackProducer,
@@ -738,13 +738,13 @@ ALCARECOTkAlCosmicsCTFDQM = cms.Sequence( ALCARECOTkAlCosmicsCTFTrackingDQM + AL
 ###########################
 __selectionName = 'TkAlCosmicsCosmicTF'
 ALCARECOTkAlCosmicsCosmicTFTrackingDQM = ALCARECOTkAlCosmicsCTFTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot"
 )
 ALCARECOTkAlCosmicsCosmicTFTkAlDQM = ALCARECOTkAlCosmicsCosmicTF0TTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     ReferenceTrackProducer = ALCARECOTkAlCosmicsCosmicTF0TTkAlDQM.ReferenceTrackProducer,
     AlgoName = 'ALCARECO'+__selectionName
@@ -765,13 +765,13 @@ ALCARECOTkAlCosmicsCosmicTFDQM = cms.Sequence( ALCARECOTkAlCosmicsCosmicTFTracki
 ###########################
 __selectionName = 'TkAlCosmicsRegional'
 ALCARECOTkAlCosmicsRegionalTrackingDQM = ALCARECOTkAlCosmicsCTFTrackingDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     AlgoName = 'ALCARECO'+__selectionName,
     BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot"
 )
 ALCARECOTkAlCosmicsRegionalTkAlDQM = ALCARECOTkAlCosmicsRegional0TTkAlDQM.clone(
-#names and desigantions
+    #names and desigantions
     TrackProducer = 'ALCARECO'+__selectionName,
     ReferenceTrackProducer = ALCARECOTkAlCosmicsRegional0TTkAlDQM.ReferenceTrackProducer,
     AlgoName = 'ALCARECO'+__selectionName

--- a/DQMOffline/EGamma/python/cosmicPhotonAnalyzer_cfi.py
+++ b/DQMOffline/EGamma/python/cosmicPhotonAnalyzer_cfi.py
@@ -12,7 +12,5 @@ cosmicPhotonAnalysis =  DQMOffline.EGamma.photonAnalyzer_cfi.photonAnalysis.clon
     r9Max = 1.5,    
     
     barrelRecHitProducer = 'ecalRecHit',
-    barrelRecHitCollection = 'EcalRecHitsEB',
-    endcapRecHitProducer = 'ecalRecHit',
-    endcapRecHitCollection = 'EcalRecHitsEE'
+    endcapRecHitProducer = 'ecalRecHit'
 )

--- a/DQMOffline/EGamma/python/cosmicPhotonAnalyzer_cfi.py
+++ b/DQMOffline/EGamma/python/cosmicPhotonAnalyzer_cfi.py
@@ -2,16 +2,17 @@ import FWCore.ParameterSet.Config as cms
 
 import DQMOffline.EGamma.photonAnalyzer_cfi
 
-cosmicPhotonAnalysis =  DQMOffline.EGamma.photonAnalyzer_cfi.photonAnalysis.clone()
-cosmicPhotonAnalysis.ComponentName = cms.string('cosmicPhotonAnalysis')
-cosmicPhotonAnalysis.analyzerName = cms.string('stdPhotonAnalyzer')
-cosmicPhotonAnalysis.phoProducer = cms.InputTag('photons')
-cosmicPhotonAnalysis.minPhoEtCut = cms.double(0.0)
-cosmicPhotonAnalysis.eMax = cms.double(3.0)
-cosmicPhotonAnalysis.etMax = cms.double(3.0)
-cosmicPhotonAnalysis.r9Max = cms.double(1.5)    
-
-cosmicPhotonAnalysis.barrelRecHitProducer = cms.InputTag('ecalRecHit')
-cosmicPhotonAnalysis.barrelRecHitCollection = cms.InputTag('EcalRecHitsEB')
-cosmicPhotonAnalysis.endcapRecHitProducer = cms.InputTag('ecalRecHit')
-cosmicPhotonAnalysis.endcapRecHitCollection = cms.InputTag('EcalRecHitsEE')
+cosmicPhotonAnalysis =  DQMOffline.EGamma.photonAnalyzer_cfi.photonAnalysis.clone(
+    ComponentName = 'cosmicPhotonAnalysis',
+    analyzerName = 'stdPhotonAnalyzer',
+    phoProducer = 'photons',
+    minPhoEtCut = 0.0,
+    eMax = 3.0,
+    etMax = 3.0,
+    r9Max = 1.5,    
+    
+    barrelRecHitProducer = 'ecalRecHit',
+    barrelRecHitCollection = 'EcalRecHitsEB',
+    endcapRecHitProducer = 'ecalRecHit',
+    endcapRecHitCollection = 'EcalRecHitsEE'
+)

--- a/DQMOffline/EGamma/python/egammaDQMOffline_cff.py
+++ b/DQMOffline/EGamma/python/egammaDQMOffline_cff.py
@@ -14,12 +14,12 @@ photonAnalysis.standAlone = cms.bool(False)
 
 
 stdPhotonAnalysis = DQMOffline.EGamma.photonAnalyzer_cfi.photonAnalysis.clone(
-  ComponentName = cms.string('stdPhotonAnalysis'),
-  analyzerName = cms.string('stdPhotonAnalyzer'),
-  phoProducer = cms.InputTag('photons'),
-  OutputMEsInRootFile = cms.bool(False),
-  Verbosity = cms.untracked.int32(0),
-  standAlone = cms.bool(False),
+  ComponentName = 'stdPhotonAnalysis',
+  analyzerName = 'stdPhotonAnalyzer',
+  phoProducer = 'photons',
+  OutputMEsInRootFile = False,
+  Verbosity = 0,
+  standAlone = False
 )
 
 piZeroAnalysis.OutputMEsInRootFile = cms.bool(False)
@@ -27,11 +27,11 @@ piZeroAnalysis.Verbosity = cms.untracked.int32(0)
 piZeroAnalysis.standAlone = cms.bool(False)
 
 
-zmumugammaOldAnalysis = DQMOffline.EGamma.zmumugammaAnalyzer_cfi.zmumugammaAnalysis.clone()
-zmumugammaOldAnalysis.ComponentName = cms.string('zmumugammaOldAnalysis')
-zmumugammaOldAnalysis.analyzerName = cms.string('zmumugammaOldValidation')
-zmumugammaOldAnalysis.phoProducer = cms.InputTag('photons')
-
+zmumugammaOldAnalysis = DQMOffline.EGamma.zmumugammaAnalyzer_cfi.zmumugammaAnalysis.clone(
+    ComponentName = 'zmumugammaOldAnalysis',
+    analyzerName = 'zmumugammaOldValidation',
+    phoProducer = 'photons'
+)
 # HGCal customizations
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 stdPhotonAnalysisHGCal = stdPhotonAnalysis.clone(

--- a/DQMOffline/EGamma/python/electronAnalyzerSequence_cff.py
+++ b/DQMOffline/EGamma/python/electronAnalyzerSequence_cff.py
@@ -51,7 +51,7 @@ electronAnalyzerSequence = cms.Sequence(
 mergedSuperClustersHGC = mergedSuperClusters.clone(
     src = (
         ("particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel"),
-        ("particleFlowSuperClusterHGCal: ")
+        ("particleFlowSuperClusterHGCal")
     )
  )
 dqmElectronAnalysisAllElectronsHGC = dqmElectronAnalysisAllElectrons.clone(

--- a/DQMOffline/EGamma/python/electronAnalyzerSequence_cff.py
+++ b/DQMOffline/EGamma/python/electronAnalyzerSequence_cff.py
@@ -17,18 +17,18 @@ from DQMOffline.EGamma.electronAnalyzer_cfi import *
 dqmElectronAnalysis.MinEt = cms.double(10.) ;
 dqmElectronAnalysis.MaxTkIso03 = cms.double(1.) ;
 
-dqmElectronAnalysisAllElectrons = dqmElectronAnalysis.clone() ;
-dqmElectronAnalysisAllElectrons.Selection = 0 ;
-dqmElectronAnalysisAllElectrons.OutputFolderName = cms.string("Egamma/Electrons/Ele2_All") ;
-
-dqmElectronAnalysisSelectionEt = dqmElectronAnalysis.clone() ;
-dqmElectronAnalysisSelectionEt.Selection = 1 ;
-dqmElectronAnalysisSelectionEt.OutputFolderName = cms.string("Egamma/Electrons/Ele3_Et10") ;
-
-dqmElectronAnalysisSelectionEtIso = dqmElectronAnalysis.clone() ;
-dqmElectronAnalysisSelectionEtIso.Selection = 2 ;
-dqmElectronAnalysisSelectionEtIso.OutputFolderName = cms.string("Egamma/Electrons/Ele4_Et10TkIso1") ;
-
+dqmElectronAnalysisAllElectrons = dqmElectronAnalysis.clone(
+    Selection = 0,
+    OutputFolderName = "Egamma/Electrons/Ele2_All"
+)
+dqmElectronAnalysisSelectionEt = dqmElectronAnalysis.clone(
+    Selection = 1,
+    OutputFolderName = "Egamma/Electrons/Ele3_Et10"
+)
+dqmElectronAnalysisSelectionEtIso = dqmElectronAnalysis.clone(
+    Selection = 2,
+    OutputFolderName = "Egamma/Electrons/Ele4_Et10TkIso1"
+)
 #dqmElectronAnalysisSelectionEtIsoElID = dqmElectronAnalysis.clone() ;
 #dqmElectronAnalysisSelectionEtIsoElID.Selection = 3 ;
 #dqmElectronAnalysisSelectionEtIsoElID.OutputFolderName = cms.string("Egamma/Electrons/Ele4_Et10TkIso1ElID") ;
@@ -48,20 +48,21 @@ electronAnalyzerSequence = cms.Sequence(
  * dqmElectronTagProbeAnalysis
 )
 
-mergedSuperClustersHGC = mergedSuperClusters.clone()
-mergedSuperClustersHGC.src = cms.VInputTag(
-   cms.InputTag("particleFlowSuperClusterECAL","particleFlowSuperClusterECALBarrel"),
-   cms.InputTag("particleFlowSuperClusterHGCal","")
+mergedSuperClustersHGC = mergedSuperClusters.clone(
+    src = (
+        ("particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel"),
+        ("particleFlowSuperClusterHGCal: ")
+    )
  )
-dqmElectronAnalysisAllElectronsHGC = dqmElectronAnalysisAllElectrons.clone()
-dqmElectronAnalysisAllElectronsHGC.OutputFolderName = 'Egamma/Electrons/Ele2HGC_All'
-dqmElectronAnalysisAllElectronsHGC.MaxAbsEtaMatchingObject = 3.0
-dqmElectronAnalysisAllElectronsHGC.EtaMax = 3.0
-dqmElectronAnalysisAllElectronsHGC.EtaMin = -3.0
-dqmElectronAnalysisAllElectronsHGC.MaxAbsEta = 3.0
-dqmElectronAnalysisAllElectronsHGC.ElectronCollection = 'ecalDrivenGsfElectronsHGC'
-dqmElectronAnalysisAllElectronsHGC.MatchingObjectCollection = 'mergedSuperClustersHGC'
-
+dqmElectronAnalysisAllElectronsHGC = dqmElectronAnalysisAllElectrons.clone(
+    OutputFolderName = 'Egamma/Electrons/Ele2HGC_All',
+    MaxAbsEtaMatchingObject = 3.0,
+    EtaMax = 3.0,
+    EtaMin = -3.0,
+    MaxAbsEta = 3.0,
+    ElectronCollection = 'ecalDrivenGsfElectronsHGC',
+    MatchingObjectCollection = 'mergedSuperClustersHGC'
+)
 _electronAnalyzerSequenceHGC = electronAnalyzerSequence.copy()
 _electronAnalyzerSequenceHGC += cms.Sequence(mergedSuperClustersHGC+dqmElectronAnalysisAllElectronsHGC)
 

--- a/DQMOffline/EGamma/python/electronOfflineClientSequence_cff.py
+++ b/DQMOffline/EGamma/python/electronOfflineClientSequence_cff.py
@@ -2,31 +2,31 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.EGamma.electronOfflineClient_cfi import *
 
-dqmElectronClientAllElectrons = dqmElectronOfflineClient.clone() ;
-dqmElectronClientAllElectrons.InputFolderName = cms.string("Egamma/Electrons/Ele2_All") ;
-dqmElectronClientAllElectrons.OutputFolderName = cms.string("Egamma/Electrons/Ele2_All") ;
-
-dqmElectronClientAllElectronsHGC = dqmElectronOfflineClient.clone() ;
-dqmElectronClientAllElectronsHGC.InputFolderName = cms.string("Egamma/Electrons/Ele2HGC_All") ;
-dqmElectronClientAllElectronsHGC.OutputFolderName = cms.string("Egamma/Electrons/Ele2HGC_All") ;
-
-dqmElectronClientSelectionEt = dqmElectronOfflineClient.clone() ;
-dqmElectronClientSelectionEt.InputFolderName = cms.string("Egamma/Electrons/Ele3_Et10") ;
-dqmElectronClientSelectionEt.OutputFolderName = cms.string("Egamma/Electrons/Ele3_Et10") ;
-
-dqmElectronClientSelectionEtIso = dqmElectronOfflineClient.clone() ;
-dqmElectronClientSelectionEtIso.InputFolderName = cms.string("Egamma/Electrons/Ele4_Et10TkIso1") ;
-dqmElectronClientSelectionEtIso.OutputFolderName = cms.string("Egamma/Electrons/Ele4_Et10TkIso1") ;
-
-#dqmElectronClientSelectionEtIsoElID = dqmElectronOfflineClient.clone() ;
-#dqmElectronClientSelectionEtIsoElID.InputFolderName = cms.string("Egamma/Electrons/Ele4_Et10TkIso1ElID") ;
-#dqmElectronClientSelectionEtIsoElID.OutputFolderName = cms.string("Egamma/Electrons/Ele4_Et10TkIso1ElID") ;
-
-dqmElectronClientTagAndProbe = dqmElectronOfflineClient.clone() ;
-dqmElectronClientTagAndProbe.InputFolderName = cms.string("Egamma/Electrons/Ele5_TagAndProbe") ;
-dqmElectronClientTagAndProbe.OutputFolderName = cms.string("Egamma/Electrons/Ele5_TagAndProbe") ;
-dqmElectronClientTagAndProbe.EffHistoTitle = cms.string("")
-
+dqmElectronClientAllElectrons = dqmElectronOfflineClient.clone(
+    InputFolderName = "Egamma/Electrons/Ele2_All",
+    OutputFolderName = "Egamma/Electrons/Ele2_All"
+)
+dqmElectronClientAllElectronsHGC = dqmElectronOfflineClient.clone(
+    InputFolderName = "Egamma/Electrons/Ele2HGC_All",
+    OutputFolderName = "Egamma/Electrons/Ele2HGC_All"
+)
+dqmElectronClientSelectionEt = dqmElectronOfflineClient.clone(
+    InputFolderName = "Egamma/Electrons/Ele3_Et10",
+    OutputFolderName = "Egamma/Electrons/Ele3_Et10"
+)
+dqmElectronClientSelectionEtIso = dqmElectronOfflineClient.clone(
+    InputFolderName = "Egamma/Electrons/Ele4_Et10TkIso1",
+    OutputFolderName = "Egamma/Electrons/Ele4_Et10TkIso1"
+)
+#dqmElectronClientSelectionEtIsoElID = dqmElectronOfflineClient.clone(
+#InputFolderName = "Egamma/Electrons/Ele4_Et10TkIso1ElID",
+#OutputFolderName = "Egamma/Electrons/Ele4_Et10TkIso1ElID"
+#)
+dqmElectronClientTagAndProbe = dqmElectronOfflineClient.clone(
+    InputFolderName = "Egamma/Electrons/Ele5_TagAndProbe",
+    OutputFolderName = "Egamma/Electrons/Ele5_TagAndProbe",
+    EffHistoTitle = ""
+)
 electronOfflineClientSequence = cms.Sequence(
    dqmElectronClientAllElectrons
  * dqmElectronClientSelectionEt

--- a/DQMOffline/EGamma/python/photonAnalyzer_cfi.py
+++ b/DQMOffline/EGamma/python/photonAnalyzer_cfi.py
@@ -12,9 +12,7 @@ photonAnalysis = DQMEDAnalyzer('PhotonAnalyzer',
 
     barrelRecHitProducer = cms.InputTag('reducedEcalRecHitsEB'),								
     endcapRecHitProducer = cms.InputTag('reducedEcalRecHitsEE'),
-    barrelRecHitCollection = cms.InputTag (''),
-    endcapRecHitCollection = cms.InputTag(''),
-
+    
     triggerEvent = cms.InputTag("hltTriggerSummaryAOD",""),                            
     prescaleFactor = cms.untracked.int32(1),
 

--- a/DQMOffline/EGamma/python/photonAnalyzer_cfi.py
+++ b/DQMOffline/EGamma/python/photonAnalyzer_cfi.py
@@ -12,6 +12,8 @@ photonAnalysis = DQMEDAnalyzer('PhotonAnalyzer',
 
     barrelRecHitProducer = cms.InputTag('reducedEcalRecHitsEB'),								
     endcapRecHitProducer = cms.InputTag('reducedEcalRecHitsEE'),
+    barrelRecHitCollection = cms.InputTag (''),
+    endcapRecHitCollection = cms.InputTag(''),
 
     triggerEvent = cms.InputTag("hltTriggerSummaryAOD",""),                            
     prescaleFactor = cms.untracked.int32(1),

--- a/DQMOffline/EGamma/python/photonOfflineDQMClient_cff.py
+++ b/DQMOffline/EGamma/python/photonOfflineDQMClient_cff.py
@@ -4,13 +4,14 @@ from DQMOffline.EGamma.photonOfflineClient_cfi import *
 import DQMOffline.EGamma.photonOfflineClient_cfi
 
 
-stdPhotonOfflineClient = DQMOffline.EGamma.photonOfflineClient_cfi.photonOfflineClient.clone()
-stdPhotonOfflineClient.ComponentName = cms.string('stdPhotonOfflineClient')
-stdPhotonOfflineClient.analyzerName = cms.string('stdPhotonAnalyzer')
-
+stdPhotonOfflineClient = DQMOffline.EGamma.photonOfflineClient_cfi.photonOfflineClient.clone(
+    ComponentName = 'stdPhotonOfflineClient',
+    analyzerName = 'stdPhotonAnalyzer'
+)
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
-stdPhotonOfflineClientHGCal = stdPhotonOfflineClient.clone()
-stdPhotonOfflineClientHGCal.analyzerName = 'stdPhotonAnalyzerHGCal'
+stdPhotonOfflineClientHGCal = stdPhotonOfflineClient.clone(
+    analyzerName = 'stdPhotonAnalyzerHGCal'
+)
 from DQMOffline.EGamma.egammaDQMOffline_cff import stdPhotonAnalysisHGCal
 stdPhotonOfflineClientHGCal.etaBin = stdPhotonAnalysisHGCal.etaBin
 stdPhotonOfflineClientHGCal.etaMin = stdPhotonAnalysisHGCal.etaMin


### PR DESCRIPTION
#### PR description:
Drop type specs in DQMOffline/Alignment, DQMOffline/EGamma python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone


#### PR validation:
runTheMatrix.py -l limited -i all --ibeos




