### PR TITLE
Use thread safe module types in PhysicsTools/JetMCAlgos

### DIFF
--- a/PhysicsTools/JetMCAlgos/test/jetMatch.cc
+++ b/PhysicsTools/JetMCAlgos/test/jetMatch.cc
@@ -7,7 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -31,13 +31,12 @@ using namespace reco;
 using namespace edm;
 using namespace ROOT::Math::VectorUtil;
 
-class jetMatch : public edm::EDAnalyzer {
+class jetMatch : public edm::one::EDAnalyzer<> {
 public:
   explicit jetMatch(const edm::ParameterSet&);
-  ~jetMatch() {}
-  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  virtual void beginJob();
-  virtual void endJob();
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void beginJob() override;
+  void endJob() override;
 
 private:
   EDGetTokenT<CandidateCollection> sourceToken_;

--- a/PhysicsTools/JetMCAlgos/test/matchGenHFHadrons.cc
+++ b/PhysicsTools/JetMCAlgos/test/matchGenHFHadrons.cc
@@ -5,7 +5,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -21,14 +21,13 @@
 #include <TTree.h>
 #include <Math/VectorUtil.h>
 
-class matchGenHFHadrons : public edm::EDAnalyzer {
+class matchGenHFHadrons : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit matchGenHFHadrons(const edm::ParameterSet&);
-  ~matchGenHFHadrons(){};
 
 private:
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
-  virtual void beginJob();
+  void analyze(const edm::Event& event, const edm::EventSetup& setup) override;
+  void beginJob() override;
   void bookHadronBranches(TTree* tree, const int flavour);
   void clearEventVariables();
   void clearHadronVariables();
@@ -150,7 +149,9 @@ matchGenHFHadrons::matchGenHFHadrons(const edm::ParameterSet& config)
       genCHadLeptonHadronIndexToken_(
           consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadLeptonHadronIndex"))),
       genCHadLeptonViaTauToken_(
-          consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadLeptonViaTau"))) {}
+          consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadLeptonViaTau"))) {
+  usesResource(TFileService::kSharedResource);
+}
 
 void matchGenHFHadrons::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   this->clearEventVariables();

--- a/PhysicsTools/JetMCAlgos/test/matchOneToOne.cc
+++ b/PhysicsTools/JetMCAlgos/test/matchOneToOne.cc
@@ -7,7 +7,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -30,7 +30,7 @@ using namespace reco;
 using namespace edm;
 using namespace ROOT::Math::VectorUtil;
 
-class matchOneToOne : public edm::EDAnalyzer {
+class matchOneToOne : public edm::one::EDAnalyzer<> {
 public:
   explicit matchOneToOne(const edm::ParameterSet&);
   ~matchOneToOne() {}

--- a/PhysicsTools/JetMCAlgos/test/printEvent.cc
+++ b/PhysicsTools/JetMCAlgos/test/printEvent.cc
@@ -1,6 +1,6 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -14,7 +14,7 @@
 #include "PhysicsTools/JetMCUtils/interface/JetMCTag.h"
 #include "PhysicsTools/JetMCUtils/interface/CandMCTag.h"
 
-class printEvent : public edm::EDAnalyzer {
+class printEvent : public edm::one::EDAnalyzer<> {
 public:
   explicit printEvent(const edm::ParameterSet&);
   ~printEvent(){};
@@ -23,6 +23,7 @@ public:
 private:
   edm::EDGetTokenT<edm::View<reco::Jet> > sourceToken_;
   edm::Handle<edm::View<reco::Jet> > genJets;
+  edm::ESGetToken<ParticleDataTable, edm::DefaultRecord> pdtToken_;
   edm::ESHandle<ParticleDataTable> pdt_;
 };
 
@@ -40,6 +41,7 @@ using namespace CandMCTagUtils;
 
 printEvent::printEvent(const edm::ParameterSet& iConfig) {
   sourceToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<InputTag>("src"));
+  pdtToken_ = esConsumes();
 }
 
 void printEvent::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -49,7 +51,7 @@ void printEvent::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 
   try {
     iEvent.getByToken(sourceToken_, genJets);
-    iSetup.getData(pdt_);
+    pdt_ = iSetup.getHandle(pdtToken_);
   } catch (std::exception& ce) {
     cerr << "[printGenJet] caught std::exception " << ce.what() << endl;
     return;


### PR DESCRIPTION
#### PR description:

- Swtiched to one or global module type
- Also added esConsumes when needed.

This fixes all the CMS deprecated warnings in the package.

#### PR validation:

Code compiles and no longer issues the deprecated warnings.