### PR TITLE
Run3-alca214 Test automatic setting ECAL RecHit thresholds as defined by PFlow group

### DIFF
--- a/Calibration/HcalCalibAlgos/python/hcalTestThreshold_cff.py
+++ b/Calibration/HcalCalibAlgos/python/hcalTestThreshold_cff.py
@@ -5,23 +5,23 @@ from Calibration.HcalCalibAlgos.hcalTestThreshold_cfi import *
 from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
 
 run2_ECAL_2017.toModify(hcalTestThreshold,
-  EBHitEnergyThreshold    = cms.double(0.18),
-  EEHitEnergyThreshold0   = cms.double(-206.074),
-  EEHitEnergyThreshold1   = cms.double(357.671),
-  EEHitEnergyThreshold2   = cms.double(-204.978),
-  EEHitEnergyThreshold3   = cms.double(39.033),
-  EEHitEnergyThresholdLow = cms.double(1.25),
-  EEHitEnergyThresholdHigh= cms.double(10.0),
+  EBHitEnergyThreshold    = 0.18,
+  EEHitEnergyThreshold0   = -206.074,
+  EEHitEnergyThreshold1   = 357.671,
+  EEHitEnergyThreshold2   = -204.978,
+  EEHitEnergyThreshold3   = 39.033,
+  EEHitEnergyThresholdLow = 1.25,
+  EEHitEnergyThresholdHigh= 10.0,
 )
 
 from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
 
 run2_HCAL_2018.toModify(hcalTestThreshold,
-  EBHitEnergyThreshold    = cms.double(0.10),
-  EEHitEnergyThreshold0   = cms.double(-41.0664),
-  EEHitEnergyThreshold1   = cms.double(68.795),
-  EEHitEnergyThreshold2   = cms.double(-38.1483),
-  EEHitEnergyThreshold3   = cms.double(7.04303),
-  EEHitEnergyThresholdLow = cms.double(0.11),
-  EEHitEnergyThresholdHigh= cms.double(15.4),
+  EBHitEnergyThreshold    = 0.10,
+  EEHitEnergyThreshold0   = -41.0664,
+  EEHitEnergyThreshold1   = 68.795,
+  EEHitEnergyThreshold2   = -38.1483,
+  EEHitEnergyThreshold3   = 7.04303,
+  EEHitEnergyThresholdLow = 0.11,
+  EEHitEnergyThresholdHigh= 15.4,
 )

--- a/Calibration/HcalCalibAlgos/python/hcalTestThreshold_cff.py
+++ b/Calibration/HcalCalibAlgos/python/hcalTestThreshold_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from Calibration.HcalCalibAlgos.hcalTestThreshold_cfi import *
+
+from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
+
+run2_ECAL_2017.toModify(hcalTestThreshold,
+  EBHitEnergyThreshold    = cms.double(0.18),
+  EEHitEnergyThreshold0   = cms.double(-206.074),
+  EEHitEnergyThreshold1   = cms.double(357.671),
+  EEHitEnergyThreshold2   = cms.double(-204.978),
+  EEHitEnergyThreshold3   = cms.double(39.033),
+  EEHitEnergyThresholdLow = cms.double(1.25),
+  EEHitEnergyThresholdHigh= cms.double(10.0),
+)
+
+from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+
+run2_HCAL_2018.toModify(hcalTestThreshold,
+  EBHitEnergyThreshold    = cms.double(0.10),
+  EEHitEnergyThreshold0   = cms.double(-41.0664),
+  EEHitEnergyThreshold1   = cms.double(68.795),
+  EEHitEnergyThreshold2   = cms.double(-38.1483),
+  EEHitEnergyThreshold3   = cms.double(7.04303),
+  EEHitEnergyThresholdLow = cms.double(0.11),
+  EEHitEnergyThresholdHigh= cms.double(15.4),
+)

--- a/Calibration/HcalCalibAlgos/test/BuildFile.xml
+++ b/Calibration/HcalCalibAlgos/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="Calibration/HcalCalibAlgos"/>
 <use name="SimDataFormats/Track"/>
+<use name="CondFormats/EcalObjects"/>
 <use name="CondFormats/HcalObjects"/>
 <use name="CondFormats/L1TObjects"/>
 <use name="DQMServices/Core"/>

--- a/Calibration/HcalCalibAlgos/test/HcalTestThreshold.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalTestThreshold.cc
@@ -1,0 +1,147 @@
+// system include files
+#include <cmath>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+//#define EDM_ML_DEBUG
+
+class HcalTestThreshold : public edm::one::EDAnalyzer<> {
+public:
+  explicit HcalTestThreshold(edm::ParameterSet const&);
+  ~HcalTestThreshold() override {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void analyze(edm::Event const&, edm::EventSetup const&) override;
+  double eThreshold(const DetId& id, const CaloGeometry* geo) const;
+
+  const int etaMin_, etaMax_, phiValue_;
+  const std::vector<int> ixNumbers_, iyNumbers_;
+  const double hitEthrEB_, hitEthrEE0_, hitEthrEE1_;
+  const double hitEthrEE2_, hitEthrEE3_;
+  const double hitEthrEELo_, hitEthrEEHi_;
+
+  const edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> ecalPFRecHitThresholdsToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+};
+
+HcalTestThreshold::HcalTestThreshold(const edm::ParameterSet& iConfig)
+  : etaMin_(iConfig.getParameter<int>("etaMin")),
+    etaMax_(iConfig.getParameter<int>("etaMax")),
+    phiValue_(iConfig.getParameter<int>("phiValue")),
+    ixNumbers_(iConfig.getParameter<std::vector<int> >("ixEENumbers")),
+    iyNumbers_(iConfig.getParameter<std::vector<int> >("iyEENumbers")),
+    hitEthrEB_(iConfig.getParameter<double>("EBHitEnergyThreshold")),
+    hitEthrEE0_(iConfig.getParameter<double>("EEHitEnergyThreshold0")),
+    hitEthrEE1_(iConfig.getParameter<double>("EEHitEnergyThreshold1")),
+    hitEthrEE2_(iConfig.getParameter<double>("EEHitEnergyThreshold2")),
+    hitEthrEE3_(iConfig.getParameter<double>("EEHitEnergyThreshold3")),
+    hitEthrEELo_(iConfig.getParameter<double>("EEHitEnergyThresholdLow")),
+    hitEthrEEHi_(iConfig.getParameter<double>("EEHitEnergyThresholdHigh")),
+    ecalPFRecHitThresholdsToken_(esConsumes()),
+    caloGeometryToken_(esConsumes()) {
+
+  edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n" << "\tThreshold for EB " << hitEthrEB_ << "\t for EE "<< hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_;
+  edm::LogVerbatim("HcalIsoTrack") << "\tRange in eta for EB " << etaMin_ << ":" << etaMax_ << "\tPhi value " << phiValue_;
+  std::ostringstream st1, st2;
+  st1 << "\t" << ixNumbers_.size() << " EE ix Numbers";
+  for (const auto& ix : ixNumbers_)
+    st1 << ": " << ix;
+  edm::LogVerbatim("HcalIsoTrack") << st1.str();
+  st2 << "\t" << iyNumbers_.size() << " EE iy Numbers";
+  for (const auto& iy : iyNumbers_)
+    st2 << ": " << iy;
+  edm::LogVerbatim("HcalIsoTrack") << st2.str();
+}
+
+// ------------ method called when starting to processes a run  ------------
+void HcalTestThreshold::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+  edm::LogVerbatim("HcalIsoTrack") << "Run " << iEvent.id().run() << " Event " << iEvent.id().event();
+
+  auto const &thresholds = iSetup.getData(ecalPFRecHitThresholdsToken_);
+  auto const &geo = &iSetup.getData(caloGeometryToken_);
+  
+  // First EB
+  edm::LogVerbatim("HcalIsoTrack") << "\n\nThresholds for EB Towers";
+  for (int eta = etaMin_; eta < etaMax_; ++ eta) {
+    if (eta != 0) {
+      EBDetId id(eta, phiValue_, EBDetId::ETAPHIMODE);
+      edm::LogVerbatim("HcalIsoTrack") << id << " Eta " << (geo->getPosition(id)).eta() << " Thresholds:: old " << eThreshold(id, geo) << " new " << thresholds[id];
+    }
+  }
+
+  // Next EE
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HcalIsoTrack") << "\n\nList of " << validId.size() << " valid DetId's of EE";
+  auto const& validId = geo->getValidDetIds(DetId::Ecal, 2);
+  for (const auto& id : validId)
+    edm::LogVerbatim("HcalIsoTrack") << EEDetId(id) << " SC " << EEDetId(id).isc() << " CR " << EEDetId(id).ic() << " Eta " << (geo->getPosition(id)).eta();
+#endif
+  edm::LogVerbatim("HcalIsoTrack") << "\n\nThresholds for EE Towers";
+  for (int zside = 0; zside < 2; ++zside) {
+    int iz = 2 * zside - 1;
+    for (const auto& ix : ixNumbers_) {
+      for (const auto& iy : iyNumbers_) {
+	EEDetId id(ix, iy, iz, EEDetId::XYMODE);
+	edm::LogVerbatim("HcalIsoTrack") << id << " Eta " << (geo->getPosition(id)).eta() << " Thresholds:: old " << eThreshold(id, geo) << " new " << thresholds[id];
+      }
+    }
+  }
+}
+
+void HcalTestThreshold::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  std::vector<int> ixNumb = {1, 10, 20, 30, 39};
+  std::vector<int> iyNumb = {41, 43, 45, 47};
+  desc.add<int>("etaMin", -85);
+  desc.add<int>("etaMax", 85);
+  desc.add<int>("phiValue", 1);
+  desc.add<std::vector<int>>("ixEENumbers", ixNumb);
+  desc.add<std::vector<int>>("iyEENumbers", iyNumb);
+  // energy thershold for ECAL (from Egamma group)
+  desc.add<double>("EBHitEnergyThreshold", 0.08);
+  desc.add<double>("EEHitEnergyThreshold0", 0.30);
+  desc.add<double>("EEHitEnergyThreshold1", 0.00);
+  desc.add<double>("EEHitEnergyThreshold2", 0.00);
+  desc.add<double>("EEHitEnergyThreshold3", 0.00);
+  desc.add<double>("EEHitEnergyThresholdLow", 0.30);
+  desc.add<double>("EEHitEnergyThresholdHigh", 0.30);
+  descriptions.add("hcalTestThreshold", desc);
+}
+
+double HcalTestThreshold::eThreshold(const DetId& id, const CaloGeometry* geo) const {
+  const GlobalPoint& pos = geo->getPosition(id);
+  double eta = std::abs(pos.eta());
+  double eThr(hitEthrEB_);
+  if (id.subdetId() != EcalBarrel) {
+    eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
+    if (eThr < hitEthrEELo_)
+      eThr = hitEthrEELo_;
+    else if (eThr > hitEthrEEHi_)
+      eThr = hitEthrEEHi_;
+  }
+  return eThr;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HcalTestThreshold);

--- a/Calibration/HcalCalibAlgos/test/HcalTestThreshold.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalTestThreshold.cc
@@ -46,23 +46,26 @@ private:
 };
 
 HcalTestThreshold::HcalTestThreshold(const edm::ParameterSet& iConfig)
-  : etaMin_(iConfig.getParameter<int>("etaMin")),
-    etaMax_(iConfig.getParameter<int>("etaMax")),
-    phiValue_(iConfig.getParameter<int>("phiValue")),
-    ixNumbers_(iConfig.getParameter<std::vector<int> >("ixEENumbers")),
-    iyNumbers_(iConfig.getParameter<std::vector<int> >("iyEENumbers")),
-    hitEthrEB_(iConfig.getParameter<double>("EBHitEnergyThreshold")),
-    hitEthrEE0_(iConfig.getParameter<double>("EEHitEnergyThreshold0")),
-    hitEthrEE1_(iConfig.getParameter<double>("EEHitEnergyThreshold1")),
-    hitEthrEE2_(iConfig.getParameter<double>("EEHitEnergyThreshold2")),
-    hitEthrEE3_(iConfig.getParameter<double>("EEHitEnergyThreshold3")),
-    hitEthrEELo_(iConfig.getParameter<double>("EEHitEnergyThresholdLow")),
-    hitEthrEEHi_(iConfig.getParameter<double>("EEHitEnergyThresholdHigh")),
-    ecalPFRecHitThresholdsToken_(esConsumes()),
-    caloGeometryToken_(esConsumes()) {
-
-  edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n" << "\tThreshold for EB " << hitEthrEB_ << "\t for EE "<< hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_;
-  edm::LogVerbatim("HcalIsoTrack") << "\tRange in eta for EB " << etaMin_ << ":" << etaMax_ << "\tPhi value " << phiValue_;
+    : etaMin_(iConfig.getParameter<int>("etaMin")),
+      etaMax_(iConfig.getParameter<int>("etaMax")),
+      phiValue_(iConfig.getParameter<int>("phiValue")),
+      ixNumbers_(iConfig.getParameter<std::vector<int>>("ixEENumbers")),
+      iyNumbers_(iConfig.getParameter<std::vector<int>>("iyEENumbers")),
+      hitEthrEB_(iConfig.getParameter<double>("EBHitEnergyThreshold")),
+      hitEthrEE0_(iConfig.getParameter<double>("EEHitEnergyThreshold0")),
+      hitEthrEE1_(iConfig.getParameter<double>("EEHitEnergyThreshold1")),
+      hitEthrEE2_(iConfig.getParameter<double>("EEHitEnergyThreshold2")),
+      hitEthrEE3_(iConfig.getParameter<double>("EEHitEnergyThreshold3")),
+      hitEthrEELo_(iConfig.getParameter<double>("EEHitEnergyThresholdLow")),
+      hitEthrEEHi_(iConfig.getParameter<double>("EEHitEnergyThresholdHigh")),
+      ecalPFRecHitThresholdsToken_(esConsumes()),
+      caloGeometryToken_(esConsumes()) {
+  edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n"
+                                   << "\tThreshold for EB " << hitEthrEB_ << "\t for EE " << hitEthrEE0_ << ":"
+                                   << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_
+                                   << ":" << hitEthrEEHi_;
+  edm::LogVerbatim("HcalIsoTrack") << "\tRange in eta for EB " << etaMin_ << ":" << etaMax_ << "\tPhi value "
+                                   << phiValue_;
   std::ostringstream st1, st2;
   st1 << "\t" << ixNumbers_.size() << " EE ix Numbers";
   for (const auto& ix : ixNumbers_)
@@ -78,15 +81,16 @@ HcalTestThreshold::HcalTestThreshold(const edm::ParameterSet& iConfig)
 void HcalTestThreshold::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   edm::LogVerbatim("HcalIsoTrack") << "Run " << iEvent.id().run() << " Event " << iEvent.id().event();
 
-  auto const &thresholds = iSetup.getData(ecalPFRecHitThresholdsToken_);
-  auto const &geo = &iSetup.getData(caloGeometryToken_);
-  
+  auto const& thresholds = iSetup.getData(ecalPFRecHitThresholdsToken_);
+  auto const& geo = &iSetup.getData(caloGeometryToken_);
+
   // First EB
   edm::LogVerbatim("HcalIsoTrack") << "\n\nThresholds for EB Towers";
-  for (int eta = etaMin_; eta < etaMax_; ++ eta) {
+  for (int eta = etaMin_; eta < etaMax_; ++eta) {
     if (eta != 0) {
       EBDetId id(eta, phiValue_, EBDetId::ETAPHIMODE);
-      edm::LogVerbatim("HcalIsoTrack") << id << " Eta " << (geo->getPosition(id)).eta() << " Thresholds:: old " << eThreshold(id, geo) << " new " << thresholds[id];
+      edm::LogVerbatim("HcalIsoTrack") << id << " Eta " << (geo->getPosition(id)).eta() << " Thresholds:: old "
+                                       << eThreshold(id, geo) << " new " << thresholds[id];
     }
   }
 
@@ -95,15 +99,17 @@ void HcalTestThreshold::analyze(edm::Event const& iEvent, edm::EventSetup const&
   edm::LogVerbatim("HcalIsoTrack") << "\n\nList of " << validId.size() << " valid DetId's of EE";
   auto const& validId = geo->getValidDetIds(DetId::Ecal, 2);
   for (const auto& id : validId)
-    edm::LogVerbatim("HcalIsoTrack") << EEDetId(id) << " SC " << EEDetId(id).isc() << " CR " << EEDetId(id).ic() << " Eta " << (geo->getPosition(id)).eta();
+    edm::LogVerbatim("HcalIsoTrack") << EEDetId(id) << " SC " << EEDetId(id).isc() << " CR " << EEDetId(id).ic()
+                                     << " Eta " << (geo->getPosition(id)).eta();
 #endif
   edm::LogVerbatim("HcalIsoTrack") << "\n\nThresholds for EE Towers";
   for (int zside = 0; zside < 2; ++zside) {
     int iz = 2 * zside - 1;
     for (const auto& ix : ixNumbers_) {
       for (const auto& iy : iyNumbers_) {
-	EEDetId id(ix, iy, iz, EEDetId::XYMODE);
-	edm::LogVerbatim("HcalIsoTrack") << id << " Eta " << (geo->getPosition(id)).eta() << " Thresholds:: old " << eThreshold(id, geo) << " new " << thresholds[id];
+        EEDetId id(ix, iy, iz, EEDetId::XYMODE);
+        edm::LogVerbatim("HcalIsoTrack") << id << " Eta " << (geo->getPosition(id)).eta() << " Thresholds:: old "
+                                         << eThreshold(id, geo) << " new " << thresholds[id];
       }
     }
   }

--- a/Calibration/HcalCalibAlgos/test/python/hcalTestThreshold_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/hcalTestThreshold_cfg.py
@@ -1,0 +1,67 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("ANALYSIS",Run2_2018)
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
+process.load("IOMC.EventVertexGenerators.VtxSmearedGauss_cfi")
+process.load('Configuration.StandardSequences.Services_cff')
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag,'auto:run2_data','')
+
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.HcalIsoTrack=dict()
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.generator.initialSeed = 456789
+process.RandomNumberGeneratorService.g4SimHits.initialSeed = 9876
+process.RandomNumberGeneratorService.VtxSmeared.initialSeed = 123456789
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.source = cms.Source("EmptySource",
+    firstRun        = cms.untracked.uint32(1),
+    firstEvent      = cms.untracked.uint32(1)
+)
+
+process.generator = cms.EDProducer("FlatRandomEGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32(211),
+        MinEta = cms.double(1.52),
+        MaxEta = cms.double(3.00),
+        MinPhi = cms.double(-3.1415926),
+        MaxPhi = cms.double(3.1415926),
+        MinE   = cms.double(100.00),
+        MaxE   = cms.double(100.00)
+    ),
+    Verbosity       = cms.untracked.int32(0),
+    AddAntiParticle = cms.bool(False)
+)
+
+process.load('Calibration.HcalCalibAlgos.hcalTestThreshold_cff')
+
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.analysis_step = cms.Path(process.hcalTestThreshold)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,
+                                process.simulation_step,
+                                process.analysis_step
+                                )
+
+# filter all path with the production filter sequence
+for path in process.paths:
+        getattr(process,path)._seq = process.generator * getattr(process,path)._seq
+


### PR DESCRIPTION
#### PR description:

Test automatic setting ECAL RecHit thresholds as defined by PFlow group. Most likely we deploy this way of assigning thresholds in a number of applications of Hcal Calibration in the future

#### PR validation:

Use test workflows in Calibration/HcalCalibAlgos/test/python

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special