### PR TITLE
L1T run-3: Store EMTF displacement info in L1TNtuples TFTree

### DIFF
--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuon.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeTfMuon.h
@@ -13,15 +13,15 @@ namespace L1Analysis {
     ~L1AnalysisL1UpgradeTfMuon();
     void Reset() {
       l1upgradetfmuon_.Reset();
-      isKalman_ = false;
+      isRun3_ = false;
     }
-    void SetKalmanMuon() { isKalman_ = true; }
+    void SetRun3Muons() { isRun3_ = true; }
     void SetTfMuon(const l1t::RegionalMuonCandBxCollection& muon, unsigned maxL1UpgradeTfMuon);
     L1AnalysisL1UpgradeTfMuonDataFormat* getData() { return &l1upgradetfmuon_; }
 
   private:
     L1AnalysisL1UpgradeTfMuonDataFormat l1upgradetfmuon_;
-    bool isKalman_{false};
+    bool isRun3_{false};
   };
 }  // namespace L1Analysis
 #endif

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
@@ -160,9 +160,10 @@ void L1UpgradeTfMuonTreeProducer::analyze(const edm::Event& iEvent, const edm::E
 
   l1UpgradeBmtf.Reset();
   l1UpgradeKBmtf.Reset();
-  l1UpgradeKBmtf.SetKalmanMuon();
+  l1UpgradeKBmtf.SetRun3Muons();
   l1UpgradeOmtf.Reset();
   l1UpgradeEmtf.Reset();
+  l1UpgradeEmtf.SetRun3Muons();
   l1UpgradeBmtfInputs.Reset();
 
   edm::Handle<l1t::RegionalMuonCandBxCollection> bmtfMuon;

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1UpgradeTfMuon.cc
@@ -12,7 +12,7 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuon::SetTfMuon(const l1t::RegionalMuonCan
          ++it) {
       if (it->hwPt() > 0) {
         l1upgradetfmuon_.tfMuonHwPt.push_back(it->hwPt());
-        if (isKalman_) {
+        if (isRun3_) {
           l1upgradetfmuon_.tfMuonHwPtUnconstrained.push_back(it->hwPtUnconstrained());
           l1upgradetfmuon_.tfMuonHwDxy.push_back(it->hwDXY());
         }
@@ -65,7 +65,7 @@ void L1Analysis::L1AnalysisL1UpgradeTfMuon::SetTfMuon(const l1t::RegionalMuonCan
         }
         l1upgradetfmuon_.tfMuonDecodedTrAdd.push_back(decoded_track_address);
         l1upgradetfmuon_.tfMuonHwTrAdd.push_back(
-            l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it, isKalman_));
+            l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(*it, isRun3_));
         l1upgradetfmuon_.nTfMuons++;
       }
     }


### PR DESCRIPTION
#### PR description:

displacement info from EMTF stored in the L1TNtuples

#### PR validation:

Ran the L1TNtuples creating workflow and verified that displacement information is now stored for EMTF as well as kBMTF (but not for OMTF).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Rebase of https://github.com/cms-l1t-offline/cmssw/pull/924
