### PR TITLE
L1T run-3: caloParams_2021_v0_2: Updated Layer 1 SF + MET PUM

### DIFF
--- a/L1Trigger/Configuration/python/customiseSettings.py
+++ b/L1Trigger/Configuration/python/customiseSettings.py
@@ -2,6 +2,10 @@ from __future__ import print_function
 import os.path
 import FWCore.ParameterSet.Config as cms
 
+def L1TSettingsToCaloParams_2021_v0_2(process):
+    process.load("L1Trigger.L1TCalorimeter.caloParams_2021_v0_2_cfi")
+    return process
+
 def L1TSettingsToCaloParams_2021_v0_1(process):
     process.load("L1Trigger.L1TCalorimeter.caloParams_2021_v0_1_cfi")
     return process

--- a/L1Trigger/L1TCalorimeter/macros/deriveMETPUM.cxx
+++ b/L1Trigger/L1TCalorimeter/macros/deriveMETPUM.cxx
@@ -1,3 +1,18 @@
+// derive MET pileup mitigation
+
+// 1) produce nVtx vs nTT4 plot to find pu bins
+//    root -l -b -q 'deriveMETPUM.cxx(1,0,0,1)' # doTow, doLUT, doFit, doMC
+// 2) fit nVtx vs nTT4 plot
+//    root -l -b -q 'deriveMETPUM.cxx(0,0,1,1)' # doTow, doLUT, doFit, doMC
+// 3) check fitting of plot and calculate pu binning, copy into "vector<int> puBinBs   = "
+//    and run the filling of the pileup binned tower energy histogram arrays
+//    root -l -b -q 'deriveMETPUM.cxx(0,0,0,1)' # doTow, doLUT, doFit, doMC 
+// 4) produce LUT containing eta and pileup binned MET tower energy thresholds
+//    root -l -b -q 'deriveMETPUM.cxx(0,1,0,1)' # doTow, doLUT, doFit, doMC 
+
+// nb for MC only RAWEMU is needed. for data, AOD reco vertex information is needed
+
+
 #include "TMath.h"
 #include "TFile.h"
 #include "TTree.h"
@@ -30,7 +45,7 @@ void fitProfile(TH1D* prof){
   TF1 *fit1 = new TF1("fit1","[0]*x+[1]");
   fit1->SetParameter(0,1.0); 
   fit1->SetParameter(1,20);   
-  fit1->SetRange(0,110);     
+  fit1->SetRange(20,120);     
   prof->Fit("fit1","R");
   TF1 *fit2 = new TF1("fit2","[0]*x+[1]");
   fit2->SetParameter(0,0.8); 
@@ -53,7 +68,7 @@ void fitProfile(TH1D* prof){
   //prof_fit4->Draw("sames");  
   gPad->Update();
   TPaveStats *st1 = (TPaveStats*)prof->FindObject("stats");
-  //TPaveStats *st2 = (TPaveStats*)prof_fit2->FindObject("stats");
+  TPaveStats *st2 = (TPaveStats*)prof_fit2->FindObject("stats");
   //TPaveStats *st3 = (TPaveStats*)prof_fit3->FindObject("stats");
   //TPaveStats *st4 = (TPaveStats*)prof_fit4->FindObject("stats");
   st1->SetY1NDC(0.75); st1->SetY2NDC(0.95); 
@@ -208,7 +223,8 @@ void makeLUT(TFile* file, int puBins){
         p5   << addr  << " "  << tp5  << "             # ieta = " << eta+1 << "\n"; 
         p05  << addr  << " "  << tp05 << "             # ieta = " << eta+1 << "\n";
       } else {
-        int ft1=floor(t1*1.5), ftp3=floor(tp3*1.5), ftp5=floor(tp5*1.5), ftp05=floor(tp05*1.5);
+	int ft1=t1*2, ftp3=tp3*2, ftp5=tp5*2, ftp05=tp05*2;
+        //int ft1=floor(t1*1.5), ftp3=floor(tp3*1.5), ftp5=floor(tp5*1.5), ftp05=floor(tp05*1.5);
         one  << addr  << " "  << ft1   << "             # ieta = " << eta+1 << "\n";
         p3   << addr  << " "  << ftp3  << "             # ieta = " << eta+1 << "\n";
         p5   << addr  << " "  << ftp5  << "             # ieta = " << eta+1 << "\n"; 
@@ -262,7 +278,7 @@ void deriveMETPUM(bool doTow, bool doLUT, bool doFit, bool doMC){
   //output filename
   string outFilename = "metPUM_out.root";
   //vector<int> puBinBs   = {0,0,0,0,0, 0, 0, 0, 1, 5,10,14,18,23,27,32,36,41,45,50, 56, 62, 68, 74, 80, 86, 93, 99,105,111,117,123,999};
-  vector<int> puBinBs   = {0,0,0,0,4,10,16,22,28,34,40,46,52,58,64,70,76,82,88,94,100,106,112,118,124,130,136,142,148,154,160,166,999};
+  vector<int> puBinBs   = {0,0,0,0,4,10,16,22,29,35,41,47,53,59,66,72,78,84,90,96,103,109,115,121,127,133,140,146,152,158,164,170,999};
 
   int puBins = puBinBs.size()-1;
 
@@ -286,7 +302,7 @@ void deriveMETPUM(bool doTow, bool doLUT, bool doFit, bool doMC){
   }
 
   //input ntuple
-  string  inputFile01 = "root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/bundocka/condor/reHcalTP_PFA1p_Nu_110X_FixGhosts_1621595179/*.root";
+  string  inputFile01 = "root://eoscms.cern.ch//eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/bundocka/condor/nu_v9NewSF_1637715475/*.root";
   
   //check file doesn't exist
   if (file!=0){

--- a/L1Trigger/L1TCalorimeter/python/caloParams_2021_v0_2_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_2021_v0_2_cfi.py
@@ -1,0 +1,201 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TCalorimeter.caloParams_cfi import caloParamsSource
+import L1Trigger.L1TCalorimeter.caloParams_cfi
+caloStage2Params = L1Trigger.L1TCalorimeter.caloParams_cfi.caloParams.clone()
+
+# towers
+caloStage2Params.towerLsbH        = cms.double(0.5)
+caloStage2Params.towerLsbE        = cms.double(0.5)
+caloStage2Params.towerLsbSum      = cms.double(0.5)
+caloStage2Params.towerNBitsH      = cms.int32(8)
+caloStage2Params.towerNBitsE      = cms.int32(8)
+caloStage2Params.towerNBitsSum    = cms.int32(9)
+caloStage2Params.towerNBitsRatio  = cms.int32(3)
+caloStage2Params.towerEncoding    = cms.bool(True)
+
+# regions
+caloStage2Params.regionLsb        = cms.double(0.5)
+caloStage2Params.regionPUSType    = cms.string("None")
+caloStage2Params.regionPUSParams  = cms.vdouble()
+
+# EG
+caloStage2Params.egLsb                      = cms.double(0.5)
+caloStage2Params.egEtaCut                   = cms.int32(28)
+caloStage2Params.egSeedThreshold            = cms.double(2.)
+caloStage2Params.egNeighbourThreshold       = cms.double(1.)
+caloStage2Params.egHcalThreshold            = cms.double(0.)
+caloStage2Params.egTrimmingLUTFile          = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egTrimmingLUT_10_v16.01.19.txt")
+caloStage2Params.egMaxHcalEt                = cms.double(0.)
+caloStage2Params.egMaxPtHOverE          = cms.double(128.)
+caloStage2Params.egMaxHOverELUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/HoverEIdentification_0.995_v15.12.23.txt")
+caloStage2Params.egHOverEcutBarrel          = cms.int32(3)
+caloStage2Params.egHOverEcutEndcap          = cms.int32(4)
+caloStage2Params.egBypassExtHOverE          = cms.uint32(0)
+caloStage2Params.egCompressShapesLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egCompressLUT_v4.txt")
+caloStage2Params.egShapeIdType              = cms.string("compressed")
+caloStage2Params.egShapeIdVersion           = cms.uint32(0)
+caloStage2Params.egShapeIdLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08.txt")#Not used any more in the current emulator version, merged with calibration LUT
+
+caloStage2Params.egPUSType                  = cms.string("None")
+caloStage2Params.egIsolationType            = cms.string("compressed")
+caloStage2Params.egIsoLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/EG_Iso_LUT_04_04_2017.2.txt")
+caloStage2Params.egIsoLUTFile2               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/EG_LoosestIso_2018.2.txt")
+caloStage2Params.egIsoAreaNrTowersEta       = cms.uint32(2)
+caloStage2Params.egIsoAreaNrTowersPhi       = cms.uint32(4)
+caloStage2Params.egIsoVetoNrTowersPhi       = cms.uint32(2)
+#caloStage2Params.egIsoPUEstTowerGranularity = cms.uint32(1)
+#caloStage2Params.egIsoMaxEtaAbsForTowerSum  = cms.uint32(4)
+#caloStage2Params.egIsoMaxEtaAbsForIsoSum    = cms.uint32(27)
+caloStage2Params.egPUSParams                = cms.vdouble(1,4,32) #Isolation window in firmware goes up to abs(ieta)=32 for now
+caloStage2Params.egCalibrationType          = cms.string("compressed")
+caloStage2Params.egCalibrationVersion       = cms.uint32(0)
+#caloStage2Params.egCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/EG_Calibration_LUT_FW_v17.04.04_shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08_correct.txt")
+caloStage2Params.egCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/corrections_Trimming10_compressedieta_compressedE_compressedshape_PANTELIS_v2_NEW_CALIBRATIONS_withShape_v17.04.04.txt")
+
+# Tau
+caloStage2Params.tauLsb                        = cms.double(0.5)
+caloStage2Params.isoTauEtaMax                  = cms.int32(25)
+caloStage2Params.tauSeedThreshold              = cms.double(0.)
+caloStage2Params.tauNeighbourThreshold         = cms.double(0.)
+caloStage2Params.tauIsoAreaNrTowersEta         = cms.uint32(2)
+caloStage2Params.tauIsoAreaNrTowersPhi         = cms.uint32(4)
+caloStage2Params.tauIsoVetoNrTowersPhi         = cms.uint32(2)
+caloStage2Params.tauPUSType                    = cms.string("None")
+caloStage2Params.tauIsoLUTFile                 = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_31_extrap_2018_FW_v10.0.0.txt")
+caloStage2Params.tauIsoLUTFile2                = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_31_extrap_2018_FW_v10.0.0.txt")
+#caloStage2Params.tauCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Calibration_LUT_2017_Layer1Calibration_FW_v12.0.0.txt")
+caloStage2Params.tauCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Calibration_LUT_2018_Layer1CalibrationNewHCAL_FW_v13.0.0.txt")
+caloStage2Params.tauCompressLUTFile            = cms.FileInPath("L1Trigger/L1TCalorimeter/data/tauCompressAllLUT_12bit_v3.txt")
+caloStage2Params.tauPUSParams                  = cms.vdouble(1,4,32)
+
+# jets
+caloStage2Params.jetLsb                = cms.double(0.5)
+caloStage2Params.jetSeedThreshold      = cms.double(4.0)
+caloStage2Params.jetNeighbourThreshold = cms.double(0.)
+caloStage2Params.jetPUSType            = cms.string("ChunkyDonut")
+caloStage2Params.jetBypassPUS          = cms.uint32(0)
+
+# Calibration options
+caloStage2Params.jetCalibrationType = cms.string("LUT")
+
+caloStage2Params.jetCompressPtLUTFile     = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_pt_compress_2017v1.txt")
+caloStage2Params.jetCompressEtaLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_eta_compress_2017v1.txt")
+caloStage2Params.jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_calib_2018v1_ECALZS_noHFJEC.txt")
+
+
+# sums: 0=ET, 1=HT, 2=MET, 3=MHT
+caloStage2Params.etSumLsb                = cms.double(0.5)
+caloStage2Params.etSumEtaMin             = cms.vint32(1, 1, 1, 1, 1)
+caloStage2Params.etSumEtaMax             = cms.vint32(28,  26, 28,  26, 28)
+caloStage2Params.etSumEtThreshold        = cms.vdouble(0.,  30.,  0.,  30., 0.) # only 2nd (HT) and 4th (MHT) values applied
+caloStage2Params.etSumMetPUSType         = cms.string("LUT") # et threshold from this LUT supercedes et threshold in line above
+caloStage2Params.etSumEttPUSType         = cms.string("None")
+caloStage2Params.etSumEcalSumPUSType     = cms.string("None")
+caloStage2Params.etSumBypassMetPUS       = cms.uint32(0)
+caloStage2Params.etSumBypassEttPUS       = cms.uint32(1)
+caloStage2Params.etSumBypassEcalSumPUS    = cms.uint32(1)
+caloStage2Params.etSumXCalibrationType    = cms.string("None")
+caloStage2Params.etSumYCalibrationType    = cms.string("None")
+caloStage2Params.etSumEttCalibrationType  = cms.string("None")
+caloStage2Params.etSumEcalSumCalibrationType = cms.string("None")
+
+caloStage2Params.etSumMetPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/newSFHBHEOnp5_METPUM_211124.txt")
+caloStage2Params.etSumEttPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt")
+caloStage2Params.etSumEcalSumPUSLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt")
+caloStage2Params.etSumXCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.etSumYCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.etSumEttCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+caloStage2Params.etSumEcalSumCalibrationLUTFile   = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+
+
+# Layer 1 SF
+caloStage2Params.layer1ECalScaleETBins = cms.vint32([3, 6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256])
+caloStage2Params.layer1ECalScaleFactors = cms.vdouble([
+1.13, 1.13, 1.13, 1.12, 1.12, 1.12, 1.12, 1.12, 1.13, 1.12, 1.13, 1.13, 1.13, 1.14, 1.14, 1.13, 1.13, 1.31, 1.15, 1.27, 1.28, 1.31, 1.31, 1.32, 1.35, 0.00, 0.00, 0.00, 
+
+1.13, 1.13, 1.13, 1.12, 1.12, 1.12, 1.12, 1.12, 1.13, 1.12, 1.13, 1.13, 1.13, 1.14, 1.14, 1.13, 1.13, 1.31, 1.15, 1.27, 1.28, 1.31, 1.31, 1.32, 1.35, 1.38, 0.00, 0.00,
+
+1.08, 1.08, 1.09, 1.08, 1.09, 1.08, 1.08, 1.09, 1.10, 1.09, 1.09, 1.10, 1.09, 1.09, 1.09, 1.10, 1.10, 1.26, 1.11, 1.21, 1.20, 1.23, 1.25, 1.28, 1.31, 1.33, 1.21, 0.00, 
+
+1.06, 1.06, 1.06, 1.06, 1.06, 1.06, 1.07, 1.07, 1.06, 1.07, 1.07, 1.07, 1.07, 1.08, 1.08, 1.07, 1.08, 1.19, 1.09, 1.16, 1.16, 1.20, 1.22, 1.23, 1.28, 1.29, 1.18, 1.09, 
+
+1.04, 1.04, 1.04, 1.05, 1.05, 1.04, 1.05, 1.05, 1.05, 1.06, 1.05, 1.06, 1.06, 1.06, 1.06, 1.06, 1.06, 1.16, 1.08, 1.15, 1.15, 1.19, 1.20, 1.22, 1.26, 1.31, 1.15, 1.08, 
+
+1.04, 1.03, 1.04, 1.04, 1.03, 1.03, 1.04, 1.04, 1.04, 1.04, 1.04, 1.05, 1.05, 1.06, 1.05, 1.05, 1.05, 1.14, 1.07, 1.12, 1.14, 1.17, 1.18, 1.21, 1.25, 1.27, 1.15, 1.07, 
+
+1.03, 1.03, 1.03, 1.03, 1.03, 1.03, 1.04, 1.03, 1.04, 1.03, 1.03, 1.03, 1.04, 1.04, 1.05, 1.05, 1.03, 1.13, 1.06, 1.11, 1.13, 1.15, 1.17, 1.20, 1.23, 1.25, 1.12, 1.08, 
+
+1.03, 1.02, 1.03, 1.02, 1.03, 1.00, 1.03, 1.03, 1.03, 1.03, 1.02, 1.03, 1.04, 1.04, 1.04, 1.04, 1.02, 1.11, 1.05, 1.11, 1.12, 1.14, 1.16, 1.18, 1.22, 1.26, 1.08, 1.05, 
+
+1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.03, 1.03, 1.03, 1.03, 1.04, 1.03, 1.03, 1.04, 1.11, 1.05, 1.11, 1.11, 1.14, 1.17, 1.17, 1.21, 1.22, 1.07, 1.05, 
+
+1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.03, 1.03, 1.03, 1.03, 1.03, 1.09, 1.05, 1.10, 1.11, 1.13, 1.15, 1.17, 1.20, 1.21, 1.06, 1.05, 
+
+1.01, 1.02, 1.01, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.03, 1.03, 1.03, 1.03, 1.09, 1.05, 1.09, 1.10, 1.12, 1.14, 1.16, 1.20, 1.23, 1.07, 1.05, 
+
+1.00, 1.01, 1.01, 1.01, 1.01, 1.01, 1.01, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.02, 1.03, 1.03, 1.08, 1.05, 1.10, 1.09, 1.12, 1.13, 1.17, 1.19, 1.23, 1.04, 1.03, 
+
+1.00, 1.01, 1.01, 1.01, 1.01, 1.01, 1.00, 1.01, 1.01, 1.02, 1.01, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.06, 1.05, 1.09, 1.09, 1.11, 1.12, 1.16, 1.18, 1.22, 1.00, 1.03, 
+
+1.00, 1.00, 1.00, 1.01, 1.01, 1.01, 1.00, 1.01, 1.01, 1.02, 1.00, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.06, 1.04, 1.08, 1.09, 1.10, 1.13, 1.15, 1.18, 1.21, 1.00, 1.03
+    ])
+
+caloStage2Params.layer1HCalScaleETBins = cms.vint32([6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256])
+caloStage2Params.layer1HCalScaleFactors = cms.vdouble([
+1.55, 1.59, 1.60, 1.60, 1.58, 1.62, 1.63, 1.63, 1.63, 1.65, 1.65, 1.71, 1.69, 1.72, 1.84, 1.98, 1.98, 1.51, 1.55, 1.56, 1.42, 1.44, 1.46, 1.46, 1.51, 1.44, 1.29, 1.23, 
+
+1.39, 1.39, 1.40, 1.42, 1.40, 1.42, 1.45, 1.43, 1.43, 1.45, 1.47, 1.49, 1.47, 1.51, 1.57, 1.67, 1.70, 1.32, 1.35, 1.36, 1.24, 1.26, 1.27, 1.30, 1.32, 1.31, 1.16, 1.10, 
+
+1.31, 1.33, 1.33, 1.34, 1.33, 1.34, 1.35, 1.37, 1.36, 1.37, 1.39, 1.39, 1.39, 1.39, 1.45, 1.54, 1.57, 1.22, 1.25, 1.27, 1.16, 1.19, 1.20, 1.22, 1.25, 1.24, 1.10, 1.05, 
+
+1.27, 1.28, 1.29, 1.29, 1.29, 1.28, 1.31, 1.31, 1.30, 1.31, 1.33, 1.34, 1.33, 1.34, 1.41, 1.46, 1.48, 1.19, 1.20, 1.20, 1.12, 1.13, 1.15, 1.17, 1.20, 1.20, 1.06, 1.01, 
+
+1.22, 1.22, 1.23, 1.23, 1.23, 1.24, 1.24, 1.26, 1.25, 1.27, 1.27, 1.28, 1.28, 1.27, 1.32, 1.38, 1.41, 1.12, 1.15, 1.16, 1.08, 1.10, 1.11, 1.13, 1.15, 1.15, 1.03, 0.98, 
+
+1.17, 1.19, 1.17, 1.19, 1.19, 1.19, 1.20, 1.22, 1.20, 1.21, 1.21, 1.22, 1.22, 1.23, 1.26, 1.31, 1.33, 1.10, 1.10, 1.10, 1.04, 1.06, 1.07, 1.09, 1.11, 1.10, 0.99, 0.95, 
+
+1.14, 1.15, 1.14, 1.15, 1.16, 1.15, 1.16, 1.17, 1.16, 1.17, 1.19, 1.18, 1.18, 1.19, 1.22, 1.26, 1.26, 1.06, 1.07, 1.08, 1.02, 1.03, 1.04, 1.06, 1.07, 1.07, 0.96, 0.92, 
+
+1.11, 1.11, 1.13, 1.12, 1.11, 1.13, 1.13, 1.13, 1.12, 1.14, 1.15, 1.15, 1.14, 1.15, 1.17, 1.20, 1.23, 1.03, 1.05, 1.05, 1.00, 1.01, 1.02, 1.03, 1.05, 1.03, 0.95, 0.91, 
+
+1.08, 1.09, 1.09, 1.08, 1.09, 1.10, 1.10, 1.11, 1.11, 1.11, 1.12, 1.11, 1.11, 1.12, 1.13, 1.17, 1.16, 1.01, 1.02, 1.03, 0.98, 0.99, 0.99, 1.01, 1.02, 1.01, 0.94, 0.89, 
+
+1.06, 1.07, 1.06, 1.07, 1.07, 1.07, 1.08, 1.08, 1.07, 1.07, 1.08, 1.08, 1.08, 1.09, 1.10, 1.14, 1.13, 1.00, 1.02, 1.02, 0.97, 0.98, 0.98, 0.99, 1.00, 1.00, 0.92, 0.87, 
+
+1.03, 1.04, 1.04, 1.04, 1.04, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1.06, 1.06, 1.09, 1.09, 0.97, 0.99, 1.00, 0.95, 0.96, 0.96, 0.97, 0.99, 0.98, 0.90, 0.85, 
+
+1.00, 1.00, 1.00, 1.01, 1.01, 1.01, 1.02, 1.02, 1.01, 1.01, 1.02, 1.02, 1.01, 0.98, 1.01, 1.02, 1.02, 0.96, 0.97, 1.00, 0.93, 0.94, 0.94, 0.95, 0.96, 0.96, 0.89, 0.82, 
+
+0.96, 0.96, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.95, 0.95, 0.95, 0.96, 0.95, 0.93, 0.95, 0.95, 0.93, 0.93, 0.94, 0.94, 0.95, 0.95, 0.88, 0.82
+    ])
+
+caloStage2Params.layer1HFScaleETBins = cms.vint32([6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256])
+
+caloStage2Params.layer1HFScaleFactors = cms.vdouble([
+1.35, 1.09, 1.12, 1.10, 1.17, 1.18, 1.19, 1.23, 1.25, 1.32, 1.61, 1.79, 
+
+1.27, 1.01, 1.09, 1.03, 1.04, 1.05, 1.09, 1.11, 1.18, 1.19, 1.48, 1.67, 
+
+1.15, 0.98, 1.05, 1.02, 1.00, 0.99, 1.03, 1.04, 1.10, 1.12, 1.39, 1.66, 
+
+1.14, 0.96, 1.03, 0.97, 0.96, 0.96, 0.98, 1.00, 1.04, 1.07, 1.35, 1.59, 
+
+1.07, 0.97, 1.00, 0.96, 0.91, 0.92, 0.95, 0.96, 1.01, 1.03, 1.28, 1.56, 
+
+1.03, 0.94, 0.97, 0.94, 0.88, 0.90, 0.92, 0.94, 0.98, 1.01, 1.27, 1.53, 
+
+1.01, 0.92, 0.96, 0.90, 0.87, 0.89, 0.91, 0.93, 0.96, 0.99, 1.23, 1.48, 
+
+0.98, 0.89, 0.96, 0.87, 0.86, 0.87, 0.89, 0.91, 0.94, 0.97, 1.19, 1.47, 
+
+0.95, 0.88, 0.94, 0.87, 0.86, 0.86, 0.88, 0.90, 0.94, 0.96, 1.16, 1.43, 
+
+0.93, 0.88, 0.93, 0.87, 0.86, 0.87, 0.88, 0.90, 0.93, 0.95, 1.14, 1.42, 
+
+0.92, 0.86, 0.90, 0.86, 0.85, 0.86, 0.88, 0.89, 0.92, 0.95, 1.12, 1.41, 
+
+0.90, 0.85, 0.90, 0.85, 0.84, 0.86, 0.88, 0.90, 0.93, 0.95, 1.09, 1.35, 
+
+0.86, 0.85, 0.89, 0.85, 0.85, 0.86, 0.88, 0.90, 0.93, 0.95, 1.10, 1.27
+    ])

--- a/L1Trigger/L1TCalorimeter/python/caloParams_2021_v0_2_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_2021_v0_2_cfi.py
@@ -2,200 +2,199 @@ import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.L1TCalorimeter.caloParams_cfi import caloParamsSource
 import L1Trigger.L1TCalorimeter.caloParams_cfi
-caloStage2Params = L1Trigger.L1TCalorimeter.caloParams_cfi.caloParams.clone()
+caloStage2Params = L1Trigger.L1TCalorimeter.caloParams_cfi.caloParams.clone(
 
-# towers
-caloStage2Params.towerLsbH        = cms.double(0.5)
-caloStage2Params.towerLsbE        = cms.double(0.5)
-caloStage2Params.towerLsbSum      = cms.double(0.5)
-caloStage2Params.towerNBitsH      = cms.int32(8)
-caloStage2Params.towerNBitsE      = cms.int32(8)
-caloStage2Params.towerNBitsSum    = cms.int32(9)
-caloStage2Params.towerNBitsRatio  = cms.int32(3)
-caloStage2Params.towerEncoding    = cms.bool(True)
+    # towers
+    #towerLsbH        = 0.5
+    #towerLsbE        = 0.5
+    #towerLsbSum      = 0.5
+    #towerNBitsH      = 8
+    #towerNBitsE      = 8
+    #towerNBitsSum    = 9
+    #towerNBitsRatio  = 3
+    #towerEncoding    = True
 
-# regions
-caloStage2Params.regionLsb        = cms.double(0.5)
-caloStage2Params.regionPUSType    = cms.string("None")
-caloStage2Params.regionPUSParams  = cms.vdouble()
+    # regions
+    #regionLsb        = 0.5
+    #regionPUSType    = "None"
+    #regionPUSParams  = []
 
-# EG
-caloStage2Params.egLsb                      = cms.double(0.5)
-caloStage2Params.egEtaCut                   = cms.int32(28)
-caloStage2Params.egSeedThreshold            = cms.double(2.)
-caloStage2Params.egNeighbourThreshold       = cms.double(1.)
-caloStage2Params.egHcalThreshold            = cms.double(0.)
-caloStage2Params.egTrimmingLUTFile          = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egTrimmingLUT_10_v16.01.19.txt")
-caloStage2Params.egMaxHcalEt                = cms.double(0.)
-caloStage2Params.egMaxPtHOverE          = cms.double(128.)
-caloStage2Params.egMaxHOverELUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/HoverEIdentification_0.995_v15.12.23.txt")
-caloStage2Params.egHOverEcutBarrel          = cms.int32(3)
-caloStage2Params.egHOverEcutEndcap          = cms.int32(4)
-caloStage2Params.egBypassExtHOverE          = cms.uint32(0)
-caloStage2Params.egCompressShapesLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/egCompressLUT_v4.txt")
-caloStage2Params.egShapeIdType              = cms.string("compressed")
-caloStage2Params.egShapeIdVersion           = cms.uint32(0)
-caloStage2Params.egShapeIdLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08.txt")#Not used any more in the current emulator version, merged with calibration LUT
+    # EG
+    #egEtaCut                   = 28
+    #egLsb                      = 0.5
+    #egSeedThreshold            = 2.
+    #egNeighbourThreshold       = 1.
+    egHcalThreshold            = 0.,
+    egTrimmingLUTFile          = "L1Trigger/L1TCalorimeter/data/egTrimmingLUT_10_v16.01.19.txt",
+    #egMaxHcalEt                = 0.
+    #egMaxPtHOverE              = 128.
+    egHOverEcutBarrel          = 3,
+    egHOverEcutEndcap          = 4,
+    egBypassExtHOverE          = 0,
+    egMaxHOverELUTFile         = "L1Trigger/L1TCalorimeter/data/HoverEIdentification_0.995_v15.12.23.txt",
+    egCompressShapesLUTFile    = "L1Trigger/L1TCalorimeter/data/egCompressLUT_v4.txt",
+    egShapeIdType              = "compressed",
+    #egShapeIdVersion           = 0
+    egShapeIdLUTFile           = "L1Trigger/L1TCalorimeter/data/shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08.txt", #Not used any more in the current emulator version, merged with calibration LUT
 
-caloStage2Params.egPUSType                  = cms.string("None")
-caloStage2Params.egIsolationType            = cms.string("compressed")
-caloStage2Params.egIsoLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/EG_Iso_LUT_04_04_2017.2.txt")
-caloStage2Params.egIsoLUTFile2               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/EG_LoosestIso_2018.2.txt")
-caloStage2Params.egIsoAreaNrTowersEta       = cms.uint32(2)
-caloStage2Params.egIsoAreaNrTowersPhi       = cms.uint32(4)
-caloStage2Params.egIsoVetoNrTowersPhi       = cms.uint32(2)
-#caloStage2Params.egIsoPUEstTowerGranularity = cms.uint32(1)
-#caloStage2Params.egIsoMaxEtaAbsForTowerSum  = cms.uint32(4)
-#caloStage2Params.egIsoMaxEtaAbsForIsoSum    = cms.uint32(27)
-caloStage2Params.egPUSParams                = cms.vdouble(1,4,32) #Isolation window in firmware goes up to abs(ieta)=32 for now
-caloStage2Params.egCalibrationType          = cms.string("compressed")
-caloStage2Params.egCalibrationVersion       = cms.uint32(0)
-#caloStage2Params.egCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/EG_Calibration_LUT_FW_v17.04.04_shapeIdentification_adapt0.99_compressedieta_compressedE_compressedshape_v15.12.08_correct.txt")
-caloStage2Params.egCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/corrections_Trimming10_compressedieta_compressedE_compressedshape_PANTELIS_v2_NEW_CALIBRATIONS_withShape_v17.04.04.txt")
+    #egPUSType                  = "None"
+    egIsolationType            = "compressed",
+    egIsoLUTFile               = "L1Trigger/L1TCalorimeter/data/EG_Iso_LUT_04_04_2017.2.txt",
+    egIsoLUTFile2              = "L1Trigger/L1TCalorimeter/data/EG_LoosestIso_2018.2.txt",
+    #egIsoAreaNrTowersEta       = 2
+    #egIsoAreaNrTowersPhi       = 4
+    egIsoVetoNrTowersPhi       = 2,
+    #egIsoPUEstTowerGranularity = cms.uint32(1)
+    #egIsoMaxEtaAbsForTowerSum  = cms.uint32(4)
+    #egIsoMaxEtaAbsForIsoSum    = cms.uint32(27)
+    egPUSParams                = cms.vdouble(1,4,32), #Isolation window in firmware goes up to abs(ieta)=32 for now
+    egCalibrationType          = "compressed",
+    egCalibrationVersion       = 0,
+    egCalibrationLUTFile       = "L1Trigger/L1TCalorimeter/data/corrections_Trimming10_compressedieta_compressedE_compressedshape_PANTELIS_v2_NEW_CALIBRATIONS_withShape_v17.04.04.txt",
 
-# Tau
-caloStage2Params.tauLsb                        = cms.double(0.5)
-caloStage2Params.isoTauEtaMax                  = cms.int32(25)
-caloStage2Params.tauSeedThreshold              = cms.double(0.)
-caloStage2Params.tauNeighbourThreshold         = cms.double(0.)
-caloStage2Params.tauIsoAreaNrTowersEta         = cms.uint32(2)
-caloStage2Params.tauIsoAreaNrTowersPhi         = cms.uint32(4)
-caloStage2Params.tauIsoVetoNrTowersPhi         = cms.uint32(2)
-caloStage2Params.tauPUSType                    = cms.string("None")
-caloStage2Params.tauIsoLUTFile                 = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_31_extrap_2018_FW_v10.0.0.txt")
-caloStage2Params.tauIsoLUTFile2                = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_31_extrap_2018_FW_v10.0.0.txt")
-#caloStage2Params.tauCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Calibration_LUT_2017_Layer1Calibration_FW_v12.0.0.txt")
-caloStage2Params.tauCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/Tau_Calibration_LUT_2018_Layer1CalibrationNewHCAL_FW_v13.0.0.txt")
-caloStage2Params.tauCompressLUTFile            = cms.FileInPath("L1Trigger/L1TCalorimeter/data/tauCompressAllLUT_12bit_v3.txt")
-caloStage2Params.tauPUSParams                  = cms.vdouble(1,4,32)
+    # Tau
+    #tauLsb                     = 0.5
+    isoTauEtaMax               = 25,
+    tauSeedThreshold           = 0.,
+    #tauNeighbourThreshold      = 0.
+    #tauIsoAreaNrTowersEta      = 2
+    #tauIsoAreaNrTowersPhi      = 4
+    #tauIsoVetoNrTowersPhi      = 2
+    #tauPUSType                 = "None"
+    tauIsoLUTFile              = "L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_31_extrap_2018_FW_v10.0.0.txt",
+    tauIsoLUTFile2             = "L1Trigger/L1TCalorimeter/data/Tau_Iso_LUT_Option_31_extrap_2018_FW_v10.0.0.txt",
+    tauCalibrationLUTFile      = "L1Trigger/L1TCalorimeter/data/Tau_Calibration_LUT_2018_Layer1CalibrationNewHCAL_FW_v13.0.0.txt",
+    tauCompressLUTFile         = "L1Trigger/L1TCalorimeter/data/tauCompressAllLUT_12bit_v3.txt",
+    tauPUSParams               = [1,4,32],
 
-# jets
-caloStage2Params.jetLsb                = cms.double(0.5)
-caloStage2Params.jetSeedThreshold      = cms.double(4.0)
-caloStage2Params.jetNeighbourThreshold = cms.double(0.)
-caloStage2Params.jetPUSType            = cms.string("ChunkyDonut")
-caloStage2Params.jetBypassPUS          = cms.uint32(0)
+    # jets
+    #jetLsb                    = 0.5
+    jetSeedThreshold           = 4.0,
+    #jetNeighbourThreshold = 0.
+    jetPUSType                 = "ChunkyDonut",
+    #jetBypassPUS          = 0
 
-# Calibration options
-caloStage2Params.jetCalibrationType = cms.string("LUT")
-
-caloStage2Params.jetCompressPtLUTFile     = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_pt_compress_2017v1.txt")
-caloStage2Params.jetCompressEtaLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_eta_compress_2017v1.txt")
-caloStage2Params.jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_calib_2018v1_ECALZS_noHFJEC.txt")
+    # Calibration options
+    jetCalibrationType         = "LUT",
+    jetCompressPtLUTFile       = "L1Trigger/L1TCalorimeter/data/lut_pt_compress_2017v1.txt",
+    jetCompressEtaLUTFile      = "L1Trigger/L1TCalorimeter/data/lut_eta_compress_2017v1.txt",
+    jetCalibrationLUTFile      = "L1Trigger/L1TCalorimeter/data/lut_calib_2018v1_ECALZS_noHFJEC.txt",
 
 
-# sums: 0=ET, 1=HT, 2=MET, 3=MHT
-caloStage2Params.etSumLsb                = cms.double(0.5)
-caloStage2Params.etSumEtaMin             = cms.vint32(1, 1, 1, 1, 1)
-caloStage2Params.etSumEtaMax             = cms.vint32(28,  26, 28,  26, 28)
-caloStage2Params.etSumEtThreshold        = cms.vdouble(0.,  30.,  0.,  30., 0.) # only 2nd (HT) and 4th (MHT) values applied
-caloStage2Params.etSumMetPUSType         = cms.string("LUT") # et threshold from this LUT supercedes et threshold in line above
-caloStage2Params.etSumEttPUSType         = cms.string("None")
-caloStage2Params.etSumEcalSumPUSType     = cms.string("None")
-caloStage2Params.etSumBypassMetPUS       = cms.uint32(0)
-caloStage2Params.etSumBypassEttPUS       = cms.uint32(1)
-caloStage2Params.etSumBypassEcalSumPUS    = cms.uint32(1)
-caloStage2Params.etSumXCalibrationType    = cms.string("None")
-caloStage2Params.etSumYCalibrationType    = cms.string("None")
-caloStage2Params.etSumEttCalibrationType  = cms.string("None")
-caloStage2Params.etSumEcalSumCalibrationType = cms.string("None")
+    # sums: 0=ET, 1=HT, 2=MET, 3=MHT
+    #etSumLsb                = 0.5
+    etSumEtaMin             = [1, 1, 1, 1, 1],
+    etSumEtaMax             = [28,  26, 28,  26, 28],
+    etSumEtThreshold        = [0.,  30.,  0.,  30., 0.], # only 2nd (HT) and 4th (MHT) values applied
+    etSumMetPUSType         = "LUT", # et threshold from this LUT supercedes et threshold in line above
+    #etSumEttPUSType         = "None"
+    #etSumEcalSumPUSType     = "None"
+    #etSumBypassMetPUS       = 0
+    etSumBypassEttPUS       = 1,
+    etSumBypassEcalSumPUS   = 1,
+    #etSumXCalibrationType   = "None"
+    #etSumYCalibrationType   = "None"
+    #etSumEttCalibrationType = "None"
+    #etSumEcalSumCalibrationType = "None"
 
-caloStage2Params.etSumMetPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/newSFHBHEOnp5_METPUM_211124.txt")
-caloStage2Params.etSumEttPUSLUTFile               = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt")
-caloStage2Params.etSumEcalSumPUSLUTFile           = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt")
-caloStage2Params.etSumXCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
-caloStage2Params.etSumYCalibrationLUTFile         = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
-caloStage2Params.etSumEttCalibrationLUTFile       = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
-caloStage2Params.etSumEcalSumCalibrationLUTFile   = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt")
+    etSumMetPUSLUTFile               = "L1Trigger/L1TCalorimeter/data/newSFHBHEOnp5_METPUM_211124.txt",
+    #etSumEttPUSLUTFile               = "L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt"
+    #etSumEcalSumPUSLUTFile           = "L1Trigger/L1TCalorimeter/data/lut_towEtThresh_dummy.txt"
+    #etSumXCalibrationLUTFile         = "L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"
+    #etSumYCalibrationLUTFile         = "L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"
+    #etSumEttCalibrationLUTFile       = "L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"
+    #etSumEcalSumCalibrationLUTFile   = "L1Trigger/L1TCalorimeter/data/lut_etSumPUS_dummy.txt"
 
 
-# Layer 1 SF
-caloStage2Params.layer1ECalScaleETBins = cms.vint32([3, 6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256])
-caloStage2Params.layer1ECalScaleFactors = cms.vdouble([
-1.13, 1.13, 1.13, 1.12, 1.12, 1.12, 1.12, 1.12, 1.13, 1.12, 1.13, 1.13, 1.13, 1.14, 1.14, 1.13, 1.13, 1.31, 1.15, 1.27, 1.28, 1.31, 1.31, 1.32, 1.35, 0.00, 0.00, 0.00, 
+    # Layer 1 SF
+    layer1ECalScaleETBins = cms.vint32([3, 6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256]),
+    layer1ECalScaleFactors = cms.vdouble([
+        1.13, 1.13, 1.13, 1.12, 1.12, 1.12, 1.12, 1.12, 1.13, 1.12, 1.13, 1.13, 1.13, 1.14, 1.14, 1.13, 1.13, 1.31, 1.15, 1.27, 1.28, 1.31, 1.31, 1.32, 1.35, 0.00, 0.00, 0.00, 
 
-1.13, 1.13, 1.13, 1.12, 1.12, 1.12, 1.12, 1.12, 1.13, 1.12, 1.13, 1.13, 1.13, 1.14, 1.14, 1.13, 1.13, 1.31, 1.15, 1.27, 1.28, 1.31, 1.31, 1.32, 1.35, 1.38, 0.00, 0.00,
+        1.13, 1.13, 1.13, 1.12, 1.12, 1.12, 1.12, 1.12, 1.13, 1.12, 1.13, 1.13, 1.13, 1.14, 1.14, 1.13, 1.13, 1.31, 1.15, 1.27, 1.28, 1.31, 1.31, 1.32, 1.35, 1.38, 0.00, 0.00,
 
-1.08, 1.08, 1.09, 1.08, 1.09, 1.08, 1.08, 1.09, 1.10, 1.09, 1.09, 1.10, 1.09, 1.09, 1.09, 1.10, 1.10, 1.26, 1.11, 1.21, 1.20, 1.23, 1.25, 1.28, 1.31, 1.33, 1.21, 0.00, 
+        1.08, 1.08, 1.09, 1.08, 1.09, 1.08, 1.08, 1.09, 1.10, 1.09, 1.09, 1.10, 1.09, 1.09, 1.09, 1.10, 1.10, 1.26, 1.11, 1.21, 1.20, 1.23, 1.25, 1.28, 1.31, 1.33, 1.21, 0.00, 
 
-1.06, 1.06, 1.06, 1.06, 1.06, 1.06, 1.07, 1.07, 1.06, 1.07, 1.07, 1.07, 1.07, 1.08, 1.08, 1.07, 1.08, 1.19, 1.09, 1.16, 1.16, 1.20, 1.22, 1.23, 1.28, 1.29, 1.18, 1.09, 
+        1.06, 1.06, 1.06, 1.06, 1.06, 1.06, 1.07, 1.07, 1.06, 1.07, 1.07, 1.07, 1.07, 1.08, 1.08, 1.07, 1.08, 1.19, 1.09, 1.16, 1.16, 1.20, 1.22, 1.23, 1.28, 1.29, 1.18, 1.09, 
 
-1.04, 1.04, 1.04, 1.05, 1.05, 1.04, 1.05, 1.05, 1.05, 1.06, 1.05, 1.06, 1.06, 1.06, 1.06, 1.06, 1.06, 1.16, 1.08, 1.15, 1.15, 1.19, 1.20, 1.22, 1.26, 1.31, 1.15, 1.08, 
+        1.04, 1.04, 1.04, 1.05, 1.05, 1.04, 1.05, 1.05, 1.05, 1.06, 1.05, 1.06, 1.06, 1.06, 1.06, 1.06, 1.06, 1.16, 1.08, 1.15, 1.15, 1.19, 1.20, 1.22, 1.26, 1.31, 1.15, 1.08, 
 
-1.04, 1.03, 1.04, 1.04, 1.03, 1.03, 1.04, 1.04, 1.04, 1.04, 1.04, 1.05, 1.05, 1.06, 1.05, 1.05, 1.05, 1.14, 1.07, 1.12, 1.14, 1.17, 1.18, 1.21, 1.25, 1.27, 1.15, 1.07, 
+        1.04, 1.03, 1.04, 1.04, 1.03, 1.03, 1.04, 1.04, 1.04, 1.04, 1.04, 1.05, 1.05, 1.06, 1.05, 1.05, 1.05, 1.14, 1.07, 1.12, 1.14, 1.17, 1.18, 1.21, 1.25, 1.27, 1.15, 1.07, 
 
-1.03, 1.03, 1.03, 1.03, 1.03, 1.03, 1.04, 1.03, 1.04, 1.03, 1.03, 1.03, 1.04, 1.04, 1.05, 1.05, 1.03, 1.13, 1.06, 1.11, 1.13, 1.15, 1.17, 1.20, 1.23, 1.25, 1.12, 1.08, 
+        1.03, 1.03, 1.03, 1.03, 1.03, 1.03, 1.04, 1.03, 1.04, 1.03, 1.03, 1.03, 1.04, 1.04, 1.05, 1.05, 1.03, 1.13, 1.06, 1.11, 1.13, 1.15, 1.17, 1.20, 1.23, 1.25, 1.12, 1.08, 
 
-1.03, 1.02, 1.03, 1.02, 1.03, 1.00, 1.03, 1.03, 1.03, 1.03, 1.02, 1.03, 1.04, 1.04, 1.04, 1.04, 1.02, 1.11, 1.05, 1.11, 1.12, 1.14, 1.16, 1.18, 1.22, 1.26, 1.08, 1.05, 
+        1.03, 1.02, 1.03, 1.02, 1.03, 1.00, 1.03, 1.03, 1.03, 1.03, 1.02, 1.03, 1.04, 1.04, 1.04, 1.04, 1.02, 1.11, 1.05, 1.11, 1.12, 1.14, 1.16, 1.18, 1.22, 1.26, 1.08, 1.05, 
 
-1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.03, 1.03, 1.03, 1.03, 1.04, 1.03, 1.03, 1.04, 1.11, 1.05, 1.11, 1.11, 1.14, 1.17, 1.17, 1.21, 1.22, 1.07, 1.05, 
+        1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.03, 1.03, 1.03, 1.03, 1.04, 1.03, 1.03, 1.04, 1.11, 1.05, 1.11, 1.11, 1.14, 1.17, 1.17, 1.21, 1.22, 1.07, 1.05, 
 
-1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.03, 1.03, 1.03, 1.03, 1.03, 1.09, 1.05, 1.10, 1.11, 1.13, 1.15, 1.17, 1.20, 1.21, 1.06, 1.05, 
+        1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.03, 1.03, 1.03, 1.03, 1.03, 1.09, 1.05, 1.10, 1.11, 1.13, 1.15, 1.17, 1.20, 1.21, 1.06, 1.05, 
 
-1.01, 1.02, 1.01, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.03, 1.03, 1.03, 1.03, 1.09, 1.05, 1.09, 1.10, 1.12, 1.14, 1.16, 1.20, 1.23, 1.07, 1.05, 
+        1.01, 1.02, 1.01, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.03, 1.03, 1.03, 1.03, 1.09, 1.05, 1.09, 1.10, 1.12, 1.14, 1.16, 1.20, 1.23, 1.07, 1.05, 
 
-1.00, 1.01, 1.01, 1.01, 1.01, 1.01, 1.01, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.02, 1.03, 1.03, 1.08, 1.05, 1.10, 1.09, 1.12, 1.13, 1.17, 1.19, 1.23, 1.04, 1.03, 
+        1.00, 1.01, 1.01, 1.01, 1.01, 1.01, 1.01, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.03, 1.02, 1.03, 1.03, 1.08, 1.05, 1.10, 1.09, 1.12, 1.13, 1.17, 1.19, 1.23, 1.04, 1.03, 
 
-1.00, 1.01, 1.01, 1.01, 1.01, 1.01, 1.00, 1.01, 1.01, 1.02, 1.01, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.06, 1.05, 1.09, 1.09, 1.11, 1.12, 1.16, 1.18, 1.22, 1.00, 1.03, 
+        1.00, 1.01, 1.01, 1.01, 1.01, 1.01, 1.00, 1.01, 1.01, 1.02, 1.01, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.06, 1.05, 1.09, 1.09, 1.11, 1.12, 1.16, 1.18, 1.22, 1.00, 1.03, 
 
-1.00, 1.00, 1.00, 1.01, 1.01, 1.01, 1.00, 1.01, 1.01, 1.02, 1.00, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.06, 1.04, 1.08, 1.09, 1.10, 1.13, 1.15, 1.18, 1.21, 1.00, 1.03
+        1.00, 1.00, 1.00, 1.01, 1.01, 1.01, 1.00, 1.01, 1.01, 1.02, 1.00, 1.01, 1.02, 1.02, 1.02, 1.02, 1.02, 1.06, 1.04, 1.08, 1.09, 1.10, 1.13, 1.15, 1.18, 1.21, 1.00, 1.03
+    ]),
+
+    layer1HCalScaleETBins = cms.vint32([6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256]),
+    layer1HCalScaleFactors = cms.vdouble([
+        1.55, 1.59, 1.60, 1.60, 1.58, 1.62, 1.63, 1.63, 1.63, 1.65, 1.65, 1.71, 1.69, 1.72, 1.84, 1.98, 1.98, 1.51, 1.55, 1.56, 1.42, 1.44, 1.46, 1.46, 1.51, 1.44, 1.29, 1.23, 
+
+        1.39, 1.39, 1.40, 1.42, 1.40, 1.42, 1.45, 1.43, 1.43, 1.45, 1.47, 1.49, 1.47, 1.51, 1.57, 1.67, 1.70, 1.32, 1.35, 1.36, 1.24, 1.26, 1.27, 1.30, 1.32, 1.31, 1.16, 1.10, 
+
+        1.31, 1.33, 1.33, 1.34, 1.33, 1.34, 1.35, 1.37, 1.36, 1.37, 1.39, 1.39, 1.39, 1.39, 1.45, 1.54, 1.57, 1.22, 1.25, 1.27, 1.16, 1.19, 1.20, 1.22, 1.25, 1.24, 1.10, 1.05, 
+
+        1.27, 1.28, 1.29, 1.29, 1.29, 1.28, 1.31, 1.31, 1.30, 1.31, 1.33, 1.34, 1.33, 1.34, 1.41, 1.46, 1.48, 1.19, 1.20, 1.20, 1.12, 1.13, 1.15, 1.17, 1.20, 1.20, 1.06, 1.01, 
+
+        1.22, 1.22, 1.23, 1.23, 1.23, 1.24, 1.24, 1.26, 1.25, 1.27, 1.27, 1.28, 1.28, 1.27, 1.32, 1.38, 1.41, 1.12, 1.15, 1.16, 1.08, 1.10, 1.11, 1.13, 1.15, 1.15, 1.03, 0.98, 
+
+        1.17, 1.19, 1.17, 1.19, 1.19, 1.19, 1.20, 1.22, 1.20, 1.21, 1.21, 1.22, 1.22, 1.23, 1.26, 1.31, 1.33, 1.10, 1.10, 1.10, 1.04, 1.06, 1.07, 1.09, 1.11, 1.10, 0.99, 0.95, 
+
+        1.14, 1.15, 1.14, 1.15, 1.16, 1.15, 1.16, 1.17, 1.16, 1.17, 1.19, 1.18, 1.18, 1.19, 1.22, 1.26, 1.26, 1.06, 1.07, 1.08, 1.02, 1.03, 1.04, 1.06, 1.07, 1.07, 0.96, 0.92, 
+
+        1.11, 1.11, 1.13, 1.12, 1.11, 1.13, 1.13, 1.13, 1.12, 1.14, 1.15, 1.15, 1.14, 1.15, 1.17, 1.20, 1.23, 1.03, 1.05, 1.05, 1.00, 1.01, 1.02, 1.03, 1.05, 1.03, 0.95, 0.91, 
+
+        1.08, 1.09, 1.09, 1.08, 1.09, 1.10, 1.10, 1.11, 1.11, 1.11, 1.12, 1.11, 1.11, 1.12, 1.13, 1.17, 1.16, 1.01, 1.02, 1.03, 0.98, 0.99, 0.99, 1.01, 1.02, 1.01, 0.94, 0.89, 
+
+        1.06, 1.07, 1.06, 1.07, 1.07, 1.07, 1.08, 1.08, 1.07, 1.07, 1.08, 1.08, 1.08, 1.09, 1.10, 1.14, 1.13, 1.00, 1.02, 1.02, 0.97, 0.98, 0.98, 0.99, 1.00, 1.00, 0.92, 0.87, 
+
+        1.03, 1.04, 1.04, 1.04, 1.04, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1.06, 1.06, 1.09, 1.09, 0.97, 0.99, 1.00, 0.95, 0.96, 0.96, 0.97, 0.99, 0.98, 0.90, 0.85, 
+
+        1.00, 1.00, 1.00, 1.01, 1.01, 1.01, 1.02, 1.02, 1.01, 1.01, 1.02, 1.02, 1.01, 0.98, 1.01, 1.02, 1.02, 0.96, 0.97, 1.00, 0.93, 0.94, 0.94, 0.95, 0.96, 0.96, 0.89, 0.82, 
+
+        0.96, 0.96, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.95, 0.95, 0.95, 0.96, 0.95, 0.93, 0.95, 0.95, 0.93, 0.93, 0.94, 0.94, 0.95, 0.95, 0.88, 0.82
+    ]),
+
+    layer1HFScaleETBins = cms.vint32([6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256]),
+
+    layer1HFScaleFactors = cms.vdouble([
+        1.35, 1.09, 1.12, 1.10, 1.17, 1.18, 1.19, 1.23, 1.25, 1.32, 1.61, 1.79, 
+
+        1.27, 1.01, 1.09, 1.03, 1.04, 1.05, 1.09, 1.11, 1.18, 1.19, 1.48, 1.67, 
+
+        1.15, 0.98, 1.05, 1.02, 1.00, 0.99, 1.03, 1.04, 1.10, 1.12, 1.39, 1.66, 
+
+        1.14, 0.96, 1.03, 0.97, 0.96, 0.96, 0.98, 1.00, 1.04, 1.07, 1.35, 1.59, 
+
+        1.07, 0.97, 1.00, 0.96, 0.91, 0.92, 0.95, 0.96, 1.01, 1.03, 1.28, 1.56, 
+
+        1.03, 0.94, 0.97, 0.94, 0.88, 0.90, 0.92, 0.94, 0.98, 1.01, 1.27, 1.53, 
+
+        1.01, 0.92, 0.96, 0.90, 0.87, 0.89, 0.91, 0.93, 0.96, 0.99, 1.23, 1.48, 
+
+        0.98, 0.89, 0.96, 0.87, 0.86, 0.87, 0.89, 0.91, 0.94, 0.97, 1.19, 1.47, 
+
+        0.95, 0.88, 0.94, 0.87, 0.86, 0.86, 0.88, 0.90, 0.94, 0.96, 1.16, 1.43, 
+
+        0.93, 0.88, 0.93, 0.87, 0.86, 0.87, 0.88, 0.90, 0.93, 0.95, 1.14, 1.42, 
+
+        0.92, 0.86, 0.90, 0.86, 0.85, 0.86, 0.88, 0.89, 0.92, 0.95, 1.12, 1.41, 
+
+        0.90, 0.85, 0.90, 0.85, 0.84, 0.86, 0.88, 0.90, 0.93, 0.95, 1.09, 1.35, 
+
+        0.86, 0.85, 0.89, 0.85, 0.85, 0.86, 0.88, 0.90, 0.93, 0.95, 1.10, 1.27
     ])
+)
 
-caloStage2Params.layer1HCalScaleETBins = cms.vint32([6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256])
-caloStage2Params.layer1HCalScaleFactors = cms.vdouble([
-1.55, 1.59, 1.60, 1.60, 1.58, 1.62, 1.63, 1.63, 1.63, 1.65, 1.65, 1.71, 1.69, 1.72, 1.84, 1.98, 1.98, 1.51, 1.55, 1.56, 1.42, 1.44, 1.46, 1.46, 1.51, 1.44, 1.29, 1.23, 
-
-1.39, 1.39, 1.40, 1.42, 1.40, 1.42, 1.45, 1.43, 1.43, 1.45, 1.47, 1.49, 1.47, 1.51, 1.57, 1.67, 1.70, 1.32, 1.35, 1.36, 1.24, 1.26, 1.27, 1.30, 1.32, 1.31, 1.16, 1.10, 
-
-1.31, 1.33, 1.33, 1.34, 1.33, 1.34, 1.35, 1.37, 1.36, 1.37, 1.39, 1.39, 1.39, 1.39, 1.45, 1.54, 1.57, 1.22, 1.25, 1.27, 1.16, 1.19, 1.20, 1.22, 1.25, 1.24, 1.10, 1.05, 
-
-1.27, 1.28, 1.29, 1.29, 1.29, 1.28, 1.31, 1.31, 1.30, 1.31, 1.33, 1.34, 1.33, 1.34, 1.41, 1.46, 1.48, 1.19, 1.20, 1.20, 1.12, 1.13, 1.15, 1.17, 1.20, 1.20, 1.06, 1.01, 
-
-1.22, 1.22, 1.23, 1.23, 1.23, 1.24, 1.24, 1.26, 1.25, 1.27, 1.27, 1.28, 1.28, 1.27, 1.32, 1.38, 1.41, 1.12, 1.15, 1.16, 1.08, 1.10, 1.11, 1.13, 1.15, 1.15, 1.03, 0.98, 
-
-1.17, 1.19, 1.17, 1.19, 1.19, 1.19, 1.20, 1.22, 1.20, 1.21, 1.21, 1.22, 1.22, 1.23, 1.26, 1.31, 1.33, 1.10, 1.10, 1.10, 1.04, 1.06, 1.07, 1.09, 1.11, 1.10, 0.99, 0.95, 
-
-1.14, 1.15, 1.14, 1.15, 1.16, 1.15, 1.16, 1.17, 1.16, 1.17, 1.19, 1.18, 1.18, 1.19, 1.22, 1.26, 1.26, 1.06, 1.07, 1.08, 1.02, 1.03, 1.04, 1.06, 1.07, 1.07, 0.96, 0.92, 
-
-1.11, 1.11, 1.13, 1.12, 1.11, 1.13, 1.13, 1.13, 1.12, 1.14, 1.15, 1.15, 1.14, 1.15, 1.17, 1.20, 1.23, 1.03, 1.05, 1.05, 1.00, 1.01, 1.02, 1.03, 1.05, 1.03, 0.95, 0.91, 
-
-1.08, 1.09, 1.09, 1.08, 1.09, 1.10, 1.10, 1.11, 1.11, 1.11, 1.12, 1.11, 1.11, 1.12, 1.13, 1.17, 1.16, 1.01, 1.02, 1.03, 0.98, 0.99, 0.99, 1.01, 1.02, 1.01, 0.94, 0.89, 
-
-1.06, 1.07, 1.06, 1.07, 1.07, 1.07, 1.08, 1.08, 1.07, 1.07, 1.08, 1.08, 1.08, 1.09, 1.10, 1.14, 1.13, 1.00, 1.02, 1.02, 0.97, 0.98, 0.98, 0.99, 1.00, 1.00, 0.92, 0.87, 
-
-1.03, 1.04, 1.04, 1.04, 1.04, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1.05, 1.06, 1.06, 1.09, 1.09, 0.97, 0.99, 1.00, 0.95, 0.96, 0.96, 0.97, 0.99, 0.98, 0.90, 0.85, 
-
-1.00, 1.00, 1.00, 1.01, 1.01, 1.01, 1.02, 1.02, 1.01, 1.01, 1.02, 1.02, 1.01, 0.98, 1.01, 1.02, 1.02, 0.96, 0.97, 1.00, 0.93, 0.94, 0.94, 0.95, 0.96, 0.96, 0.89, 0.82, 
-
-0.96, 0.96, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.97, 0.95, 0.95, 0.95, 0.96, 0.95, 0.93, 0.95, 0.95, 0.93, 0.93, 0.94, 0.94, 0.95, 0.95, 0.88, 0.82
-    ])
-
-caloStage2Params.layer1HFScaleETBins = cms.vint32([6, 9, 12, 15, 20, 25, 30, 35, 40, 45, 55, 70, 256])
-
-caloStage2Params.layer1HFScaleFactors = cms.vdouble([
-1.35, 1.09, 1.12, 1.10, 1.17, 1.18, 1.19, 1.23, 1.25, 1.32, 1.61, 1.79, 
-
-1.27, 1.01, 1.09, 1.03, 1.04, 1.05, 1.09, 1.11, 1.18, 1.19, 1.48, 1.67, 
-
-1.15, 0.98, 1.05, 1.02, 1.00, 0.99, 1.03, 1.04, 1.10, 1.12, 1.39, 1.66, 
-
-1.14, 0.96, 1.03, 0.97, 0.96, 0.96, 0.98, 1.00, 1.04, 1.07, 1.35, 1.59, 
-
-1.07, 0.97, 1.00, 0.96, 0.91, 0.92, 0.95, 0.96, 1.01, 1.03, 1.28, 1.56, 
-
-1.03, 0.94, 0.97, 0.94, 0.88, 0.90, 0.92, 0.94, 0.98, 1.01, 1.27, 1.53, 
-
-1.01, 0.92, 0.96, 0.90, 0.87, 0.89, 0.91, 0.93, 0.96, 0.99, 1.23, 1.48, 
-
-0.98, 0.89, 0.96, 0.87, 0.86, 0.87, 0.89, 0.91, 0.94, 0.97, 1.19, 1.47, 
-
-0.95, 0.88, 0.94, 0.87, 0.86, 0.86, 0.88, 0.90, 0.94, 0.96, 1.16, 1.43, 
-
-0.93, 0.88, 0.93, 0.87, 0.86, 0.87, 0.88, 0.90, 0.93, 0.95, 1.14, 1.42, 
-
-0.92, 0.86, 0.90, 0.86, 0.85, 0.86, 0.88, 0.89, 0.92, 0.95, 1.12, 1.41, 
-
-0.90, 0.85, 0.90, 0.85, 0.84, 0.86, 0.88, 0.90, 0.93, 0.95, 1.09, 1.35, 
-
-0.86, 0.85, 0.89, 0.85, 0.85, 0.86, 0.88, 0.90, 0.93, 0.95, 1.10, 1.27
-    ])


### PR DESCRIPTION
#### PR description:

Adds new caloParams_2021_v0_2, including:

    New Layer 1 SF derived using latest HCAL PFA1p and HCAL response corrections
    Updated MET pileup mitigation

#### PR validation:



#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Rebase of https://github.com/cms-l1t-offline/cmssw/pull/960