### PR TITLE
Fixing issue of PS cluster matched to  >1 EE cluster in DBG_X IBs

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -418,7 +418,8 @@ void PFECALSuperClusterAlgo::buildSuperCluster(CalibClusterPtr& seed, CalibClust
         edm::Ptr<reco::PFCluster> psclus(i_ps->second);
 #ifdef EDM_ML_DEBUG
 
-	auto found_pscluster = std::find(new_sc.preshowerClustersBegin(), new_sc.preshowerClustersEnd(), reco::CaloClusterPtr(psclus));
+        auto found_pscluster =
+            std::find(new_sc.preshowerClustersBegin(), new_sc.preshowerClustersEnd(), reco::CaloClusterPtr(psclus));
 
         if (found_pscluster == new_sc.preshowerClustersEnd()) {
 #endif

--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -417,9 +417,9 @@ void PFECALSuperClusterAlgo::buildSuperCluster(CalibClusterPtr& seed, CalibClust
       for (auto i_ps = clustops.first; i_ps != clustops.second; ++i_ps) {
         edm::Ptr<reco::PFCluster> psclus(i_ps->second);
 #ifdef EDM_ML_DEBUG
-        auto found_pscluster = std::find_if(new_sc.preshowerClustersBegin(),
-                                            new_sc.preshowerClustersEnd(),
-                                            [&i_ps](const auto& i) { return i.key() == i_ps->first; });
+
+	auto found_pscluster = std::find(new_sc.preshowerClustersBegin(), new_sc.preshowerClustersEnd(), reco::CaloClusterPtr(psclus));
+
         if (found_pscluster == new_sc.preshowerClustersEnd()) {
 #endif
           new_sc.addPreshowerCluster(psclus);

--- a/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
@@ -25,6 +25,7 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "TrackingTools/GsfTools/interface/GetComponents.h"
 
 // #define VI_DEBUG
 // #define STAT_TSB
@@ -285,7 +286,8 @@ bool TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter* 
   }
   std::ostringstream ss;
   auto dc = [&](TrajectoryStateOnSurface const& tsos) {
-    std::vector<TrajectoryStateOnSurface> const& components = tsos.components();
+    GetComponents comps(tsos);
+    auto const& components = comps();
     auto sinTheta = std::sin(tsos.globalMomentum().theta());
     for (auto const& ic : components)
       ss << ic.weight() << "/";
@@ -298,10 +300,16 @@ bool TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter* 
   };
   ss << "\ninner comps\n";
   dc(innertsos);
+  GetComponents icomps(innertsos);
+  auto const& tsosComponentsInner = icomps();
+
   ss << "\nouter comps\n";
   dc(outertsos);
-  LogDebug("TrackProducer") << "Nr. of first / last states = " << innertsos.components().size() << " "
-                            << outertsos.components().size() << ss.str();
+  GetComponents ocomps(outertsos);
+  auto const& tsosComponentsOuter = ocomps();
+
+  LogDebug("TrackProducer") << "Nr. of first / last states = " << tsosComponentsInner.size() << " "
+                            << tsosComponentsOuter.size() << ss.str();
 #endif
 
   ndof = 0;


### PR DESCRIPTION
#### PR description:

Currently several workflows of debug IBs fail with the error message `Found a PS cluster matched to more than one EE cluster!`. This was reported in https://github.com/cms-sw/cmssw/issues/34097 and https://github.com/cms-sw/cmssw/pull/35524 . This PR is aimed at fixing this. 

It looks like the problem was here:
https://github.com/cms-sw/cmssw/blob/b4bb14f6573e803ecbe516d306d651d9774d48b7/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc#L420-L422

In particular, `i.key()` seems to give a garbage value. To bypass the issue, `std::find_if` is replaced by `std::find` in a way that we do not need to access `.key()` of `CaloCluster` anymore. This is similar to what was done here: https://github.com/cms-sw/cmssw/blob/cc5a950c6e11d1b3a4dd39b8dff8a9161ecd1037/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc#L1869-L1870

This small change seems to solve the problem.

#### PR validation:

Tested from `CMSSW_12_3_DBG_X_2022-01-06-2300` using workflows `117.0` and `11630.0`.

This PR is not a backport.
Backport not needed.


_PS: After the first round of tests, another crash was found in DBG build (only in WF `25202.0`):_ 
```
%MSG-e BasicSingleTrajectoryState:  GsfTrackProducer:lowPtGsfEleGsfTracks  09-Jan-2022 17:26:01 UTC Run: 1 Event: 1
asking for componenets to a SingleTrajectoryState
%MSG
cmsRun: /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/4cd3ceaede4e18eb9ab43f14fe009004/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_3_DBG_X_2022-01-06-2300/src/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc:248: virtual const Components& BasicSingleTrajectoryState::components() const: Assertion `false' failed.
```
_I took the opportunity to fix that as well._