### PR TITLE
technical fix for value of L1T's `caloParams.jetPUSUsePhiRing`

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_1_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_1_cfi.py
@@ -77,7 +77,7 @@ caloStage2Params.jetLsb                = cms.double(0.5)
 caloStage2Params.jetSeedThreshold      = cms.double(4.0)
 caloStage2Params.jetNeighbourThreshold = cms.double(0.)
 caloStage2Params.jetPUSType            = cms.string("PhiRing1")
-caloStage2Params.jetPUSUsePhiRing      = cms.uint32(True)
+caloStage2Params.jetPUSUsePhiRing      = cms.uint32(1)
 caloStage2Params.jetBypassPUS          = cms.uint32(0)
 
 # Calibration options

--- a/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_2018_v1_4_cfi.py
@@ -77,7 +77,7 @@ caloStage2Params.jetLsb                = cms.double(0.5)
 caloStage2Params.jetSeedThreshold      = cms.double(4.0)
 caloStage2Params.jetNeighbourThreshold = cms.double(0.)
 caloStage2Params.jetPUSType            = cms.string("PhiRing1")
-caloStage2Params.jetPUSUsePhiRing      = cms.uint32(True)
+caloStage2Params.jetPUSUsePhiRing      = cms.uint32(1)
 caloStage2Params.jetBypassPUS          = cms.uint32(0)
 
 # Calibration options

--- a/L1Trigger/L1TCalorimeter/python/caloParams_2019_v1_0_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_2019_v1_0_cfi.py
@@ -76,7 +76,7 @@ caloStage2Params.jetLsb                = cms.double(0.5)
 caloStage2Params.jetSeedThreshold      = cms.double(4.0)
 caloStage2Params.jetNeighbourThreshold = cms.double(0.)
 caloStage2Params.jetPUSType            = cms.string("ChunkyDonut")
-caloStage2Params.jetPUSUsePhiRing      = cms.uint32(False)
+caloStage2Params.jetPUSUsePhiRing      = cms.uint32(0)
 caloStage2Params.jetBypassPUS          = cms.uint32(0)
 
 # Calibration options

--- a/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloParams_cfi.py
@@ -107,7 +107,7 @@ caloParams = cms.ESProducer(
     jetCompressEtaLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_eta_compress.txt"),
     jetCalibrationLUTFile    = cms.FileInPath("L1Trigger/L1TCalorimeter/data/lut_add_mult.txt"),
     jetBypassPUS             = cms.uint32(0),
-    jetPUSUsePhiRing         = cms.uint32(False),
+    jetPUSUsePhiRing         = cms.uint32(0),
 
     # sums
     etSumLsb                 = cms.double(0.5),


### PR DESCRIPTION
#### PR description:

Simple fix for a type mismatch of one parameter in the `cfi` files of `L1Trigger/L1TCalorimeter`.

This misconfiguration causes unnecessary warnings [*] in an application used by HLT (i.e. `ConfDB`) outside CMSSW. It would also result in that parameter being misconfigured to "`None`" in `ConfDB`, if instances of that ESProducer were to be used in HLT configs, which is currently not the case.

I think `ConfDB` takes the values from `caloParams_2018_v1_0_ECALZS_inconsistent_cfi`, which inherits the misconfigured parameter from `caloParams_cfi`, so fixing only the latter would suffice. On the other hand, the fix is applied also to other `cfi`s, as I saw no disadvantage in doing that.

This PR only contains the minimal fix needed for `ConfDB`. The removal of type-specifications for parameter values of cloned modules is not applied, and is left to the maintainers of this package (coincidentally, this is being discussed in https://github.com/cms-sw/cmssw/pull/36644#pullrequestreview-847155305).

Merely technical. No changes expected.

FYI: @Martin-Grunewald

[*] `UInt32Parameter.setValue NumberFormatException: For input string: "False"`

#### PR validation:

```
$ python3
>>> import FWCore.ParameterSet.Config as cms
>>> a = cms.uint32(0)
>>> b = cms.uint32(False)
>>> a == b
True
>>> a = cms.uint32(1)
>>> b = cms.uint32(True)
>>> a == b
True
```

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A