### PR TITLE
fixes for recent updates to `CkfTrackCandidateMaker`

### DIFF
--- a/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedQuadStep_cff.py
@@ -124,12 +124,12 @@ hiDetachedQuadStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimato
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiDetachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = dict(refToPSet_ = 'hiDetachedQuadStepTrajectoryFilter'),
-    maxCand = 4,#4 for pp
+    maxCand = 4, # 4 for pp
     estimator = 'hiDetachedQuadStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),#2.0 for pp
+    maxDPhiForLooperReconstruction = 2.0, # 2.0 for pp
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (B=3.8T)
-    maxPtForLooperReconstruction = cms.double(0.7),# 0.7 for pp
+    maxPtForLooperReconstruction = 0.7, # 0.7 for pp
     alwaysUseInvalidHits = False
 )
 

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -147,8 +147,8 @@ hiDetachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajec
     trajectoryFilter = dict(refToPSet_ = 'hiDetachedTripletStepTrajectoryFilter'),
     maxCand = 2,
     estimator = 'hiDetachedTripletStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(0),
-    maxPtForLooperReconstruction   = cms.double(0),
+    maxDPhiForLooperReconstruction = 0.,
+    maxPtForLooperReconstruction   = 0.,
     alwaysUseInvalidHits = False
 )
 
@@ -157,8 +157,8 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 hiDetachedTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'hiDetachedTripletStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet = dict(refToPSet_ = 'hiDetachedTripletStepTrajectoryBuilder'),
     clustersToSkip = 'hiDetachedTripletStepClusters',
     doSeedingRegionRebuilding = True,
@@ -256,4 +256,3 @@ hiDetachedTripletStepTask_Phase1 = hiDetachedTripletStepTask.copy()
 hiDetachedTripletStepTask_Phase1.replace(hiDetachedTripletStepTracksHitDoublets, hiDetachedTripletStepTracksHitDoubletsCA)
 hiDetachedTripletStepTask_Phase1.replace(hiDetachedTripletStepTracksHitTriplets, hiDetachedTripletStepTracksHitTripletsCA)
 trackingPhase1.toReplaceWith(hiDetachedTripletStepTask, hiDetachedTripletStepTask_Phase1)
-

--- a/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiHighPtTripletStep_cff.py
@@ -123,12 +123,12 @@ hiHighPtTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimat
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiHighPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = dict(refToPSet_ = 'hiHighPtTripletStepTrajectoryFilter'),
-    maxCand = 3,#3 for pp
+    maxCand = 3, # 3 for pp
     estimator = 'hiHighPtTripletStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),#2.0 for pp
+    maxDPhiForLooperReconstruction = 2.0, # 2.0 for pp
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (B=3.8T)
-    maxPtForLooperReconstruction = cms.double(0.7),# 0.7 for pp
+    maxPtForLooperReconstruction = 0.7, # 0.7 for pp
     alwaysUseInvalidHits = False
 )
 

--- a/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
+++ b/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
@@ -125,8 +125,8 @@ hiJetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajec
     trajectoryFilter = dict(refToPSet_ = 'hiJetCoreRegionalStepTrajectoryFilter'),
     maxCand = 50,
     estimator = 'hiJetCoreRegionalStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7)
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction = 0.7,
 )
 
 # MAKING OF TRACK CANDIDATES
@@ -134,7 +134,7 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 hiJetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'hiJetCoreRegionalStepSeeds',
     maxSeedsBeforeCleaning = 10000,
-    TrajectoryBuilderPSet = dict( refToPSet_ = 'hiJetCoreRegionalStepTrajectoryBuilder'),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'hiJetCoreRegionalStepTrajectoryBuilder'),
     NavigationSchool = 'SimpleNavigationSchool',
 )
 

--- a/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtQuadStep_cff.py
@@ -127,12 +127,12 @@ hiLowPtQuadStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_c
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiLowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = dict(refToPSet_ = 'hiLowPtQuadStepTrajectoryFilter'),
-    maxCand = 4,#4 for pp
+    maxCand = 4, # 4 for pp
     estimator = 'hiLowPtQuadStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),#2.0 for pp
+    maxDPhiForLooperReconstruction = 2.0, # 2.0 for pp
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (B=3.8T)
-    maxPtForLooperReconstruction = cms.double(0.7),# 0.7 for pp
+    maxPtForLooperReconstruction = 0.7, # 0.7 for pp
     alwaysUseInvalidHits = False
 )
 

--- a/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiLowPtTripletStep_cff.py
@@ -139,10 +139,10 @@ hiLowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajector
     trajectoryFilter = dict(refToPSet_ = 'hiLowPtTripletStepTrajectoryFilter'),
     maxCand = 3,
     estimator = 'hiLowPtTripletStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxDPhiForLooperReconstruction = 2.0,
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
-    # of the outermost Tracker barrel layer (with B=3.8T)  
-    maxPtForLooperReconstruction = cms.double(0.7)
+    # of the outermost Tracker barrel layer (with B=3.8T)
+    maxPtForLooperReconstruction = 0.7,
 )
 
 # MAKING OF TRACK CANDIDATES

--- a/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
+++ b/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
@@ -140,8 +140,8 @@ hiPixelPairTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
     trajectoryFilter = dict(refToPSet_ = 'hiPixelPairTrajectoryFilter'),
     maxCand = 3,
     estimator = 'hiPixelPairChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7)
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction = 0.7,
 )
 
 # MAKING OF TRACK CANDIDATES

--- a/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
+++ b/RecoTracker/CkfPattern/python/GroupedCkfTrajectoryBuilder_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-#to resolve the refToPSet_
+# to resolve the refToPSet_
 from TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff import CkfBaseTrajectoryFilter_block
 
 GroupedCkfTrajectoryBuilder = cms.PSet(
@@ -37,7 +37,7 @@ GroupedCkfTrajectoryBuilder = cms.PSet(
     # Out-in tracking will not be attempted unless this many hits
     # are on track after in-out tracking phase.
     minNrOfHitsForRebuild = cms.int32(5),
-    seedAs5DHit  = cms.bool(False)
+    seedAs5DHit = cms.bool(False),
+    maxPtForLooperReconstruction = cms.double(0.),
+    maxDPhiForLooperReconstruction = cms.double(2.),
 )
-
-

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
@@ -222,8 +222,7 @@ import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 conv2CkfTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = dict(refToPSet_ = 'conv2CkfTrajectoryFilter'),
     minNrOfHitsForRebuild = 3,
-    clustersToSkip        = cms.InputTag('conv2Clusters'),
-    maxCand               = 2
+    maxCand               = 2,
 )
 
 # MAKING OF TRACK CANDIDATES

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -155,8 +155,8 @@ detachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryB
     maxCand = 3,
     alwaysUseInvalidHits = True,
     estimator = 'detachedQuadStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7)
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction = 0.7,
 )
 trackingNoLoopers.toModify(detachedQuadStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
@@ -178,8 +178,8 @@ detachedQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.
     src = 'detachedQuadStepSeeds',
     clustersToSkip = 'detachedQuadStepClusters',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
     TrajectoryBuilderPSet = dict(refToPSet_ = 'detachedQuadStepTrajectoryBuilder'),
     TrajectoryCleaner = 'detachedQuadStepTrajectoryCleanerBySharedHits',
     doSeedingRegionRebuilding = True,

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -182,13 +182,13 @@ _tracker_apv_vfp30_2016.toModify(detachedTripletStepChi2Est,
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 detachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('detachedTripletStepTrajectoryFilter')),
+    trajectoryFilter = dict(refToPSet_ = 'detachedTripletStepTrajectoryFilter'),
     maxCand = 3,
     alwaysUseInvalidHits = True,
     estimator = 'detachedTripletStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7) 
-    )
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction = 0.7,
+)
 trackingNoLoopers.toModify(detachedTripletStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
 trackingLowPU.toModify(detachedTripletStepTrajectoryBuilder,
@@ -201,14 +201,14 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 # Give handle for CKF for HI
 _detachedTripletStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'detachedTripletStepSeeds',
-    clustersToSkip = cms.InputTag('detachedTripletStepClusters'),
+    clustersToSkip = 'detachedTripletStepClusters',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('detachedTripletStepTrajectoryBuilder')),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'detachedTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True
-    )
+)
 detachedTripletStepTrackCandidates = _detachedTripletStepTrackCandidatesCkf.clone()
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits

--- a/RecoTracker/IterativeTracking/python/DisplacedGeneralStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DisplacedGeneralStep_cff.py
@@ -117,11 +117,10 @@ displacedGeneralStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_
     src = 'displacedGeneralStepSeeds',
     TrajectoryCleaner = 'displacedGeneralStepTrajectoryCleanerBySharedHits',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(False),
-
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('displacedGeneralStepTrajectoryBuilder')),
-    clustersToSkip = cms.InputTag('displacedGeneralStepClusters'),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = False,
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'displacedGeneralStepTrajectoryBuilder'),
+    clustersToSkip = 'displacedGeneralStepClusters',
     doSeedingRegionRebuilding = True,
     useHitsSplitting = True,
     cleanTrajectoryAfterInOut = True
@@ -146,7 +145,7 @@ displacedGeneralStepFitterSmoother = TrackingTools.TrackFitters.RungeKuttaFitter
     MinNumberOfHits = 8,
     Fitter = 'displacedGeneralStepRKFitter',
     Smoother = 'displacedGeneralStepRKSmoother'
-    )
+)
 
 
 
@@ -180,7 +179,7 @@ displacedGeneralStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackPr
     src = 'displacedGeneralStepTrackCandidates',
     AlgorithmName = 'displacedGeneralStep',
     Fitter = 'generalDisplacedFlexibleKFFittingSmoother',
-    )
+)
 
 
 #---------------------------------------- TRACK SELECTION AND QUALITY FLAG SETTING.

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -194,10 +194,10 @@ highPtTripletStepTrajectoryBuilder = _GroupedCkfTrajectoryBuilder_cfi.GroupedCkf
     alwaysUseInvalidHits = True,
     maxCand              = 3,
     estimator            = 'highPtTripletStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxDPhiForLooperReconstruction = 2.0,
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (with B=3.8T)
-    maxPtForLooperReconstruction = cms.double(0.7)
+    maxPtForLooperReconstruction = 0.7
 )
 trackingNoLoopers.toModify(highPtTripletStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -107,7 +107,7 @@ _tracker_apv_vfp30_2016.toModify(initialStepChi2EstPreSplitting,
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilderPreSplitting = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryFilterPreSplitting')),
+    trajectoryFilter = dict(refToPSet_ = 'initialStepTrajectoryFilterPreSplitting'),
     alwaysUseInvalidHits = True,
     maxCand   = 3,
     estimator = 'initialStepChi2Est',
@@ -117,11 +117,11 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 initialStepTrackCandidatesPreSplitting = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'initialStepSeedsPreSplitting',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryBuilderPreSplitting')),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'initialStepTrajectoryBuilderPreSplitting'),
     doSeedingRegionRebuilding = True,
-    useHitsSplitting = True
+    useHitsSplitting = True,
 )
 initialStepTrackCandidatesPreSplitting.MeasurementTrackerEvent = 'MeasurementTrackerEventPreSplitting'
 

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -198,12 +198,12 @@ trackingPhase2PU140.toModify(initialStepChi2Est,
 
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryFilter')),
+    trajectoryFilter = dict(refToPSet_ = 'initialStepTrajectoryFilter'),
     alwaysUseInvalidHits = True,
     maxCand = 3,
     estimator = 'initialStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7)
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction = 0.7,
 )
 trackingNoLoopers.toModify(initialStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
@@ -222,11 +222,11 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 _initialStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'initialStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryBuilder')),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'initialStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
-    useHitsSplitting = True
+    useHitsSplitting = True,
 )
 initialStepTrackCandidates = _initialStepTrackCandidatesCkf.clone()
 

--- a/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/JetCoreRegionalStep_cff.py
@@ -149,22 +149,20 @@ import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 CkfBaseTrajectoryFilter_block = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.CkfBaseTrajectoryFilter_block
 jetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = dict(refToPSet_ = 'jetCoreRegionalStepTrajectoryFilter'),
-    #clustersToSkip = 'jetCoreRegionalStepClusters',
     maxCand = 50,
     estimator = 'jetCoreRegionalStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7)
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction = 0.7,
 )
 trackingNoLoopers.toModify(jetCoreRegionalStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)    
 jetCoreRegionalStepBarrelTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = dict(refToPSet_ = 'jetCoreRegionalStepBarrelTrajectoryFilter'),
-    #clustersToSkip = 'jetCoreRegionalStepClusters',
     maxCand = 50,
     estimator = 'jetCoreRegionalStepChi2Est',
     keepOriginalIfRebuildFails = True,
     lockHits = False,
-    requireSeedHitsInRebuild = False
+    requireSeedHitsInRebuild = False,
 )
 trackingNoLoopers.toModify(jetCoreRegionalStepBarrelTrajectoryBuilder,
                            maxPtForLooperReconstruction = cms.double(0.0))    
@@ -196,11 +194,11 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 jetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src                    = 'jetCoreRegionalStepSeeds',
     maxSeedsBeforeCleaning = 10000,
-    TrajectoryBuilderPSet  = cms.PSet( refToPSet_ = cms.string('jetCoreRegionalStepTrajectoryBuilder')),
+    TrajectoryBuilderPSet  = dict(refToPSet_ = 'jetCoreRegionalStepTrajectoryBuilder'),
     NavigationSchool       = 'SimpleNavigationSchool',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    #numHitsForSeedCleaner = cms.int32(50),
-    #onlyPixelHitsForSeedCleaner = cms.bool(True),
+    #numHitsForSeedCleaner = 50,
+    #onlyPixelHitsForSeedCleaner = True,
 )
 jetCoreRegionalStepBarrelTrackCandidates = jetCoreRegionalStepTrackCandidates.clone(
     src                    = 'jetCoreRegionalStepSeedsBarrel',

--- a/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtBarrelTripletStep_cff.py
@@ -62,15 +62,15 @@ import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 lowPtBarrelTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = dict(refToPSet_ = 'lowPtBarrelTripletStepTrajectoryFilter'),
     clustersToSkip = 'lowPtBarrelTripletStepClusters',
-    maxCand        = 3,
-    #lostHitPenalty = cms.double(10.0), 
+    maxCand = 3,
+    #lostHitPenalty = 10.,
     estimator = 'lowPtBarrelTripletStepChi2Est',
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (with B=3.8T)
-    maxPtForLooperReconstruction = cms.double(0.63) 
-    # set the variable to a negative value to turn-off the looper reconstruction 
-    #maxPtForLooperReconstruction = cms.double(-1.) 
-    )
+    maxPtForLooperReconstruction = 0.63,
+    # set the variable to a negative value to turn-off the looper reconstruction
+    #maxPtForLooperReconstruction = -1.,
+)
 trackingNoLoopers.toModify(lowPtBarrelTripletStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
 # MAKING OF TRACK CANDIDATES
@@ -78,15 +78,15 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 lowPtBarrelTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'lowPtBarrelTripletStepSeeds',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('lowPtBarrelTripletStepTrajectoryBuilder')),
+    numHitsForSeedCleaner = 50,
+    onlyPixelHitsForSeedCleaner = True,
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'lowPtBarrelTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
-    useHitsSplitting          = True,
+    useHitsSplitting = True,
     TransientInitialStateEstimatorParameters = cms.PSet(
-        propagatorAlongTISE      = cms.string('PropagatorWithMaterialForLoopers'),
-        propagatorOppositeTISE   = cms.string('PropagatorWithMaterialForLoopersOpposite'),
-        numberMeasurementsForFit = cms.int32(4)
+        propagatorAlongTISE = 'PropagatorWithMaterialForLoopers',
+        propagatorOppositeTISE = 'PropagatorWithMaterialForLoopersOpposite',
+        numberMeasurementsForFit = 4,
     )
 )
 

--- a/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtForwardTripletStep_cff.py
@@ -70,9 +70,9 @@ lowPtForwardTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTraj
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 lowPtForwardTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src                       = 'lowPtForwardTripletStepSeeds',
-    TrajectoryBuilderPSet     = cms.PSet(refToPSet_ = cms.string('lowPtForwardTripletStepTrajectoryBuilder')),
+    TrajectoryBuilderPSet     = dict(refToPSet_ = 'lowPtForwardTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
-    useHitsSplitting          = True
+    useHitsSplitting          = True,
 )
 
 # TRACK FITTING

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -141,10 +141,10 @@ lowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuil
     trajectoryFilter       = dict(refToPSet_ = 'lowPtQuadStepTrajectoryFilter'),
     maxCand                = 4,
     estimator              = 'lowPtQuadStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxDPhiForLooperReconstruction = 2.0,
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (with B=3.8T)
-    maxPtForLooperReconstruction = cms.double(0.7) 
+    maxPtForLooperReconstruction = 0.7,
 )
 trackingNoLoopers.toModify(lowPtQuadStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
@@ -173,7 +173,7 @@ lowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckf
     TrajectoryCleaner           = 'lowPtQuadStepTrajectoryCleanerBySharedHits',
     clustersToSkip              = 'lowPtQuadStepClusters',
     doSeedingRegionRebuilding   = True,
-    useHitsSplitting            = True
+    useHitsSplitting            = True,
 )
 trackingPhase2PU140.toModify(lowPtQuadStepTrackCandidates,
     clustersToSkip       = '',

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -213,10 +213,10 @@ lowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryB
     trajectoryFilter       = dict(refToPSet_ = 'lowPtTripletStepTrajectoryFilter'),
     maxCand                = 4,
     estimator              = 'lowPtTripletStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxDPhiForLooperReconstruction = 2.0,
     # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
     # of the outermost Tracker barrel layer (with B=3.8T)
-    maxPtForLooperReconstruction = cms.double(0.7) 
+    maxPtForLooperReconstruction = 0.7,
 )
 trackingNoLoopers.toModify(lowPtTripletStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
@@ -235,11 +235,11 @@ _lowPtTripletStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner       = 50,
     onlyPixelHitsForSeedCleaner = True,
-    TrajectoryBuilderPSet       = cms.PSet(refToPSet_ = cms.string('lowPtTripletStepTrajectoryBuilder')),
+    TrajectoryBuilderPSet       = dict(refToPSet_ = 'lowPtTripletStepTrajectoryBuilder'),
     clustersToSkip              = 'lowPtTripletStepClusters',
     doSeedingRegionRebuilding   = True,
     useHitsSplitting            = True,
-    TrajectoryCleaner           = 'lowPtTripletStepTrajectoryCleanerBySharedHits'
+    TrajectoryCleaner           = 'lowPtTripletStepTrajectoryCleanerBySharedHits',
 )
 lowPtTripletStepTrackCandidates = _lowPtTripletStepTrackCandidatesCkf.clone()
 

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -275,8 +275,8 @@ mixedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryB
     propagatorOpposite     = 'mixedTripletStepPropagatorOpposite',
     maxCand                = 2,
     estimator              = 'mixedTripletStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7) 
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction = 0.7,
 )
 trackingNoLoopers.toModify(mixedTripletStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
@@ -285,15 +285,14 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 # Give handle for CKF for HI
 _mixedTripletStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src            = 'mixedTripletStepSeeds',
-    clustersToSkip = cms.InputTag('mixedTripletStepClusters'),
+    clustersToSkip = 'mixedTripletStepClusters',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner     = cms.int32(50),
-    #onlyPixelHitsForSeedCleaner = cms.bool(True),
-
-    TrajectoryBuilderPSet     = cms.PSet(refToPSet_ = cms.string('mixedTripletStepTrajectoryBuilder')),
+    numHitsForSeedCleaner     = 50,
+    #onlyPixelHitsForSeedCleaner = True,
+    TrajectoryBuilderPSet     = dict(refToPSet_ = 'mixedTripletStepTrajectoryBuilder'),
     doSeedingRegionRebuilding = True,
     useHitsSplitting          = True,
-    TrajectoryCleaner         = 'mixedTripletStepTrajectoryCleanerBySharedHits'
+    TrajectoryCleaner         = 'mixedTripletStepTrajectoryCleanerBySharedHits',
 )
 mixedTripletStepTrackCandidates = _mixedTripletStepTrackCandidatesCkf.clone()
 

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -67,26 +67,26 @@ muonSeededTrajectoryFilterForOutIn = muonSeededTrajectoryFilterForInOut.clone(
 ###------------- TrajectoryBuilders ----------------
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 muonSeededTrajectoryBuilderForInOut = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    foundHitBonus    = 1000.0,  
-    lostHitPenalty   = 1.0,   
+    foundHitBonus    = 1000.0,
+    lostHitPenalty   = 1.0,
     maxCand          = 5,
     estimator        = 'muonSeededMeasurementEstimatorForInOut',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForInOut')),
-    inOutTrajectoryFilter      = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForInOut')), # not sure if it is used
+    trajectoryFilter = dict(refToPSet_ = 'muonSeededTrajectoryFilterForInOut'),
+    inOutTrajectoryFilter      = dict(refToPSet_ = 'muonSeededTrajectoryFilterForInOut'), # not sure if it is used
     minNrOfHitsForRebuild      = 2,
     requireSeedHitsInRebuild   = True, 
     keepOriginalIfRebuildFails = True, 
 )
 muonSeededTrajectoryBuilderForOutIn = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    foundHitBonus    = 1000.0,  
-    lostHitPenalty   = 1.0,   
+    foundHitBonus    = 1000.0,
+    lostHitPenalty   = 1.0,
     maxCand          = 3,
     estimator        = 'muonSeededMeasurementEstimatorForOutIn',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutIn')),
-    inOutTrajectoryFilter      = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutIn')), # not sure if it is used
+    trajectoryFilter = dict(refToPSet_ = 'muonSeededTrajectoryFilterForOutIn'),
+    inOutTrajectoryFilter      = dict(refToPSet_ = 'muonSeededTrajectoryFilterForOutIn'), # not sure if it is used
     minNrOfHitsForRebuild      = 5,
-    requireSeedHitsInRebuild   = True, 
-    keepOriginalIfRebuildFails = False, 
+    requireSeedHitsInRebuild   = True,
+    keepOriginalIfRebuildFails = False,
 )
 
 ###-------------  Fitter-Smoother -------------------
@@ -101,16 +101,16 @@ muonSeededFittingSmootherWithOutliersRejectionAndRK = TrackingTools.TrackFitters
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 muonSeededTrackCandidatesInOut = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'muonSeededSeedsInOut',
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryBuilderForInOut')),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'muonSeededTrajectoryBuilderForInOut'),
     TrajectoryCleaner     = 'muonSeededTrajectoryCleanerBySharedHits',
     RedundantSeedCleaner  = 'none', 
 )
 muonSeededTrackCandidatesOutIn = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'muonSeededSeedsOutIn',
-    TrajectoryBuilderPSet       = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryBuilderForOutIn')),
+    TrajectoryBuilderPSet       = dict(refToPSet_ = 'muonSeededTrajectoryBuilderForOutIn'),
     TrajectoryCleaner           = 'muonSeededTrajectoryCleanerBySharedHits',
-    numHitsForSeedCleaner       = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(False),
+    numHitsForSeedCleaner       = 50,
+    onlyPixelHitsForSeedCleaner = False,
 )
 
 ######## TRACK PRODUCERS 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -280,8 +280,8 @@ pixelLessStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuil
     maxCand                = 2,
     alwaysUseInvalidHits   = False,
     estimator              = 'pixelLessStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction   = cms.double(0.7)
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction   = 0.7,
 )
 trackingNoLoopers.toModify(pixelLessStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
@@ -295,8 +295,8 @@ _pixelLessStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_cfi
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = 50,
     #onlyPixelHitsForSeedCleaner = True,
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('pixelLessStepTrajectoryBuilder')),
-    TrajectoryCleaner     = 'pixelLessStepTrajectoryCleanerBySharedHits'
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'pixelLessStepTrajectoryBuilder'),
+    TrajectoryCleaner     = 'pixelLessStepTrajectoryCleanerBySharedHits',
 )
 pixelLessStepTrackCandidates = _pixelLessStepTrackCandidatesCkf.clone()
 

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -218,7 +218,7 @@ _pixelPairStepTrajectoryFilterBase = TrackingTools.TrajectoryFiltering.Trajector
 pixelPairStepTrajectoryFilterBase = _pixelPairStepTrajectoryFilterBase.clone(
     seedPairPenalty = 0,
     maxCCCLostHits  = 0,
-    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose'))
+    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutLoose')
 )
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 _tracker_apv_vfp30_2016.toModify(pixelPairStepTrajectoryFilterBase, maxCCCLostHits = 2)
@@ -261,7 +261,7 @@ pixelPairStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimator
     ComponentName    = 'pixelPairStepChi2Est',
     nSigma           = 3.0,
     MaxChi2          = 9.0,
-    clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),
+    clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutLoose'),
     pTChargeCutThreshold = 15.
 )
 _tracker_apv_vfp30_2016.toModify(pixelPairStepChi2Est,
@@ -270,7 +270,7 @@ _tracker_apv_vfp30_2016.toModify(pixelPairStepChi2Est,
 trackingLowPU.toModify(pixelPairStepChi2Est,
     clusterChargeCut = dict(refToPSet_ = 'SiStripClusterChargeCutTiny'),
 )
-highBetaStar_2018.toModify(pixelPairStepChi2Est,MaxChi2 = 30)
+highBetaStar_2018.toModify(pixelPairStepChi2Est, MaxChi2 = 30)
 
 # TRACK BUILDING
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
@@ -278,8 +278,8 @@ pixelPairStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuil
     trajectoryFilter       = dict(refToPSet_ = 'pixelPairStepTrajectoryFilter'),
     maxCand                = 3,
     estimator              = 'pixelPairStepChi2Est',
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction = cms.double(0.7) 
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction = 0.7,
 )
 trackingNoLoopers.toModify(pixelPairStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
@@ -300,10 +300,10 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 _pixelPairStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'pixelPairStepSeeds',
     clustersToSkip = 'pixelPairStepClusters',
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('pixelPairStepTrajectoryBuilder')),
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'pixelPairStepTrajectoryBuilder'),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner = 50,
-    onlyPixelHitsForSeedCleaner = True
+    onlyPixelHitsForSeedCleaner = True,
 )
 pixelPairStepTrackCandidates = _pixelPairStepTrackCandidatesCkf.clone()
 

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -249,9 +249,9 @@ tobTecStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder
     alwaysUseInvalidHits   = False,
     maxCand                = 2,
     estimator              = 'tobTecStepChi2Est',
-    #startSeedHitsInRebuild = True
-    maxDPhiForLooperReconstruction = cms.double(2.0),
-    maxPtForLooperReconstruction   = cms.double(0.7)
+    #startSeedHitsInRebuild = True,
+    maxDPhiForLooperReconstruction = 2.0,
+    maxPtForLooperReconstruction   = 0.7,
 )
 trackingNoLoopers.toModify(tobTecStepTrajectoryBuilder,
                            maxPtForLooperReconstruction = 0.0)
@@ -271,16 +271,15 @@ import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
 # Give handle for CKF for HI
 _tobTecStepTrackCandidatesCkf = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
     src = 'tobTecStepSeeds',
-    clustersToSkip              = cms.InputTag('tobTecStepClusters'),
+    clustersToSkip              = 'tobTecStepClusters',
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    numHitsForSeedCleaner       = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(False),
-
-    TrajectoryBuilderPSet       = cms.PSet(refToPSet_ = cms.string('tobTecStepTrajectoryBuilder')),
+    numHitsForSeedCleaner       = 50,
+    onlyPixelHitsForSeedCleaner = False,
+    TrajectoryBuilderPSet       = dict(refToPSet_ = 'tobTecStepTrajectoryBuilder'),
     doSeedingRegionRebuilding   = True,
     useHitsSplitting            = True,
     cleanTrajectoryAfterInOut   = True,
-    TrajectoryCleaner = 'tobTecStepTrajectoryCleanerBySharedHits'
+    TrajectoryCleaner = 'tobTecStepTrajectoryCleanerBySharedHits',
 )
 tobTecStepTrackCandidates = _tobTecStepTrackCandidatesCkf.clone()
 

--- a/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
+++ b/RecoTracker/SpecialSeedGenerators/python/cosmicDC_cff.py
@@ -25,24 +25,24 @@ cosmicDCSeeds = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff
 Chi2MeasurementEstimatorForCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.Chi2MeasurementEstimatorForP5.clone(
     ComponentName   = 'Chi2MeasurementEstimatorForCDC',
-    MaxDisplacement = 500
+    MaxDisplacement = 500,
 )
 
 ckfBaseTrajectoryFilterCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.ckfBaseTrajectoryFilterP5.clone(
     maxLostHits       = 10,
-    maxConsecLostHits = 10
+    maxConsecLostHits = 10,
 )
 
 GroupedCkfTrajectoryBuilderCDC = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderP5_cff.GroupedCkfTrajectoryBuilderP5.clone(
     maxCand   = 3,
     estimator = 'Chi2MeasurementEstimatorForCDC',
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('ckfBaseTrajectoryFilterCDC'))
+    trajectoryFilter = dict(refToPSet_ = 'ckfBaseTrajectoryFilterCDC'),
 )
 
 import RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff
 cosmicDCCkfTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidatesP5_cff.ckfTrackCandidatesP5.clone(
     src = 'cosmicDCSeeds',
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string('GroupedCkfTrajectoryBuilderCDC'))
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'GroupedCkfTrajectoryBuilderCDC'),
 )
 
 # Track producer

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
@@ -50,9 +50,6 @@ TrajectoryBuilderForElectrons = RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi.
     updator = 'KFUpdator'
 )
 
-from Configuration.ProcessModifiers.seedingDeepCore_cff import seedingDeepCore
-seedingDeepCore.toModify(TrajectoryBuilderForElectrons, maxPtForLooperReconstruction = cms.double(0.0) )
-
 # CKFTrackCandidateMaker
 from RecoTracker.CkfPattern.CkfTrackCandidates_cff import *
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of #36459:
 - it fixes a [failure in wf `11723.17`](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc10/CMSSW_12_3_X_2022-01-09-0000/pyRelValMatrixLogs/run/11723.17_QCD_Pt_1800_2400_14+2021_seedingDeepCore+QCD_Pt_1800_2400_14TeV_TuneCP5_GenSimINPUT+Digi+RecoNano+HARVESTNano/step3_QCD_Pt_1800_2400_14+2021_seedingDeepCore+QCD_Pt_1800_2400_14TeV_TuneCP5_GenSimINPUT+Digi+RecoNano+HARVESTNano.log#/119-119);
 - it removes unneeded type-specifications for parameters values of cloned modules, addressing https://github.com/cms-sw/cmssw/pull/36459#discussion_r780671871.

Merely technical. No changes expected.

#### PR validation:

`runTheMatrix.py` (for `-l limited` and `-l 11723.17`), and `addOnTests.py` passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A