### PR TITLE
Add HLT filter to select online pf taus based on their impact parameter

### DIFF
--- a/RecoTauTag/HLTProducers/src/HLTPFTauIPFilter.cc
+++ b/RecoTauTag/HLTProducers/src/HLTPFTauIPFilter.cc
@@ -1,7 +1,7 @@
-/** \class HLTTauDxyFilter
+/** \class HLTPFTauIPFilter
  *
- *  This class is an HLTFilter implementing
- *  a minimum/maximum dxy cut on the tau object
+ *  This class is an HLTFilter able to implement
+ *  generic cuts on the tau IP variables available in the PFTauTransverseImpactParameter collection
  *
  */
 
@@ -11,17 +11,16 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterAssociation.h"
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
-
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 #include <vector>
 
-class HLTTauDxyFilter : public HLTFilter {
+class HLTPFTauIPFilter : public HLTFilter {
 public:
-  explicit HLTTauDxyFilter(const edm::ParameterSet& config);
+  explicit HLTPFTauIPFilter(const edm::ParameterSet& config);
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   bool hltFilter(edm::Event& event,
                  const edm::EventSetup& setup,
@@ -33,62 +32,61 @@ private:
   const edm::EDGetTokenT<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>
       m_TausTIPToken;
 
-  const double m_MinDxy, m_MaxDxy;  // dxy cuts applied to each tau
-  const int m_MinTaus;              // min. number of taus required to pass the cuts
+  const int m_MinTaus;  // min. number of taus required to pass the cuts
+  const std::string m_tauTIPSelectorString;
+  const StringCutObjectSelector<reco::PFTauTransverseImpactParameter> m_tauTIPSelector;
   const int m_TriggerType;
 };
 
-HLTTauDxyFilter::HLTTauDxyFilter(const edm::ParameterSet& config)
+HLTPFTauIPFilter::HLTPFTauIPFilter(const edm::ParameterSet& config)
     : HLTFilter(config),
       m_TausInputTag(config.getParameter<edm::InputTag>("Taus")),
       m_TausToken(consumes(m_TausInputTag)),
       m_TausTIPToken(consumes(config.getParameter<edm::InputTag>("TausIP"))),
-      m_MinDxy(config.getParameter<double>("MinDxy")),
-      m_MaxDxy(config.getParameter<double>("MaxDxy")),
       m_MinTaus(config.getParameter<int>("MinN")),
+      m_tauTIPSelectorString(config.getParameter<std::string>("Cut")),
+      m_tauTIPSelector(m_tauTIPSelectorString),
       m_TriggerType(config.getParameter<int>("TriggerType")) {
-  edm::LogInfo("") << " (HLTTauDxyFilter) trigger cuts: " << std::endl
-                   << "\tmin/max dxy value: [" << m_MinDxy << ".." << m_MaxDxy << "]" << std::endl
-                   << "\tmin no. passing taus: " << m_MinTaus << "\tTriggerType: " << m_TriggerType;
+  edm::LogInfo("") << " (HLTPFTauIPFilter) trigger cuts:\n"
+                   << " cut string value: [" << m_tauTIPSelectorString << "]\n"
+                   << " min no. passing taus: " << m_MinTaus << ", TriggerType: " << m_TriggerType;
 }
 
-void HLTTauDxyFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void HLTPFTauIPFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("Taus", edm::InputTag("hltTauCollection"));
   desc.add<edm::InputTag>("TausIP", edm::InputTag("hltTauIPCollection"));
-  desc.add<double>("MinDxy", -999999.0);
-  desc.add<double>("MaxDxy", 999999.0);
   desc.add<int>("MinN", 1);
   desc.add<int>("TriggerType", 84);
+  desc.add<std::string>("Cut", "dxy > -999.");
   descriptions.addWithDefaultLabel(desc);
 }
 
-bool HLTTauDxyFilter::hltFilter(edm::Event& event,
-                                const edm::EventSetup& setup,
-                                trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+bool HLTPFTauIPFilter::hltFilter(edm::Event& event,
+                                 const edm::EventSetup& setup,
+                                 trigger::TriggerFilterObjectWithRefs& filterproduct) const {
   auto const h_Taus = event.getHandle(m_TausToken);
   if (saveTags())
     filterproduct.addCollectionTag(m_TausInputTag);
 
-  auto const h_TausTIP = event.getHandle(m_TausTIPToken);
+  auto const& TausTIP = event.get(m_TausTIPToken);
 
   int nTau = 0;
   for (reco::PFTauCollection::size_type iPFTau = 0; iPFTau < h_Taus->size(); iPFTau++) {
     reco::PFTauRef tauref(h_Taus, iPFTau);
-    auto const theTIP = h_TausTIP->value(tauref.key());
-    auto const tau_dxy = theTIP->dxy();
-    if ((m_MinDxy <= tau_dxy) and (tau_dxy <= m_MaxDxy)) {
+
+    if (m_tauTIPSelector(*TausTIP[tauref])) {
       ++nTau;
       filterproduct.addObject(m_TriggerType, tauref);
     }
   }
 
   // filter decision
-  bool accept = (nTau >= m_MinTaus);
-  edm::LogInfo("") << " trigger accept ? = " << accept << " nTau = " << nTau << std::endl;
+  bool const accept = (nTau >= m_MinTaus);
+  edm::LogInfo("") << " trigger accept ? = " << accept << " nTau = " << nTau;
 
   return accept;
 }
 
-DEFINE_FWK_MODULE(HLTTauDxyFilter);
+DEFINE_FWK_MODULE(HLTPFTauIPFilter);

--- a/RecoTauTag/HLTProducers/src/HLTTauDxyFilter.cc
+++ b/RecoTauTag/HLTProducers/src/HLTTauDxyFilter.cc
@@ -1,0 +1,94 @@
+/** \class HLTTauDxyFilter
+ *
+ *  This class is an HLTFilter implementing
+ *  a minimum/maximum dxy cut on the tau object
+ *
+ */
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/TauReco/interface/PFTauFwd.h"
+#include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterAssociation.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+
+#include <vector>
+
+class HLTTauDxyFilter : public HLTFilter {
+public:
+  explicit HLTTauDxyFilter(const edm::ParameterSet& config);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event& event,
+                 const edm::EventSetup& setup,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+private:
+  const edm::InputTag m_TausInputTag;
+  const edm::EDGetTokenT<reco::PFTauCollection> m_TausToken;
+  const edm::EDGetTokenT<edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef>>>
+      m_TausTIPToken;
+
+  const double m_MinDxy, m_MaxDxy;  // dxy cuts applied to each tau
+  const int m_MinTaus;              // min. number of taus required to pass the cuts
+  const int m_TriggerType;
+};
+
+HLTTauDxyFilter::HLTTauDxyFilter(const edm::ParameterSet& config)
+    : HLTFilter(config),
+      m_TausInputTag(config.getParameter<edm::InputTag>("Taus")),
+      m_TausToken(consumes(m_TausInputTag)),
+      m_TausTIPToken(consumes(config.getParameter<edm::InputTag>("TausIP"))),
+      m_MinDxy(config.getParameter<double>("MinDxy")),
+      m_MaxDxy(config.getParameter<double>("MaxDxy")),
+      m_MinTaus(config.getParameter<int>("MinN")),
+      m_TriggerType(config.getParameter<int>("TriggerType")) {
+  edm::LogInfo("") << " (HLTTauDxyFilter) trigger cuts: " << std::endl
+                   << "\tmin/max dxy value: [" << m_MinDxy << ".." << m_MaxDxy << "]" << std::endl
+                   << "\tmin no. passing taus: " << m_MinTaus << "\tTriggerType: " << m_TriggerType;
+}
+
+void HLTTauDxyFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("Taus", edm::InputTag("hltTauCollection"));
+  desc.add<edm::InputTag>("TausIP", edm::InputTag("hltTauIPCollection"));
+  desc.add<double>("MinDxy", -999999.0);
+  desc.add<double>("MaxDxy", 999999.0);
+  desc.add<int>("MinN", 1);
+  desc.add<int>("TriggerType", 84);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+bool HLTTauDxyFilter::hltFilter(edm::Event& event,
+                                const edm::EventSetup& setup,
+                                trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  auto const h_Taus = event.getHandle(m_TausToken);
+  if (saveTags())
+    filterproduct.addCollectionTag(m_TausInputTag);
+
+  auto const h_TausTIP = event.getHandle(m_TausTIPToken);
+
+  int nTau = 0;
+  for (reco::PFTauCollection::size_type iPFTau = 0; iPFTau < h_Taus->size(); iPFTau++) {
+    reco::PFTauRef tauref(h_Taus, iPFTau);
+    auto const theTIP = h_TausTIP->value(tauref.key());
+    auto const tau_dxy = theTIP->dxy();
+    if ((m_MinDxy <= tau_dxy) and (tau_dxy <= m_MaxDxy)) {
+      ++nTau;
+      filterproduct.addObject(m_TriggerType, tauref);
+    }
+  }
+
+  // filter decision
+  bool accept = (nTau >= m_MinTaus);
+  edm::LogInfo("") << " trigger accept ? = " << accept << " nTau = " << nTau << std::endl;
+
+  return accept;
+}
+
+DEFINE_FWK_MODULE(HLTTauDxyFilter);


### PR DESCRIPTION
#### PR description:

A new HLTFilter is added in order to be able to apply cuts on the PF tau impact parameters values as calculated by the PFTauTransverseImpactParameter class .
The purpose is to use this filter in an HLT path for Run3 targeting displaced taus.

