### PR TITLE
Drop type specs for GEM

### DIFF
--- a/DQM/GEM/python/gemEfficiencyAnalyzerCosmics_cfi.py
+++ b/DQM/GEM/python/gemEfficiencyAnalyzerCosmics_cfi.py
@@ -6,16 +6,16 @@ from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 
 gemEfficiencyAnalyzerCosmics = _gemEfficiencyAnalyzerCosmicsDefault.clone(
     ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
-    muonTag = cms.InputTag('muons'),
-    name = cms.untracked.string('Cosmic 2-Leg STA Muon'),
-    folder = cms.untracked.string('GEM/Efficiency/type1'),
+    muonTag = 'muons',
+    name = 'Cosmic 2-Leg STA Muon',
+    folder = 'GEM/Efficiency/type1'
 )
 
 gemEfficiencyAnalyzerCosmicsOneLeg = _gemEfficiencyAnalyzerCosmicsDefault.clone(
     ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
-    muonTag = cms.InputTag('muons1Leg'),
-    name = cms.untracked.string('Cosmic 1-Leg STA Muon'),
-    folder = cms.untracked.string('GEM/Efficiency/type2'),
+    muonTag = 'muons1Leg',
+    name = 'Cosmic 1-Leg STA Muon',
+    folder = 'GEM/Efficiency/type2'
 )
 
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM

--- a/DQM/GEM/python/gemEfficiencyAnalyzer_cfi.py
+++ b/DQM/GEM/python/gemEfficiencyAnalyzer_cfi.py
@@ -27,18 +27,18 @@ gemOfflineDQMStaMuons = cms.EDFilter("MuonSelector",
 
 gemEfficiencyAnalyzerTightGlb = _gemEfficiencyAnalyzerDefault.clone(
     ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
-    folder = cms.untracked.string('GEM/Efficiency/type1'),
-    muonTag = cms.InputTag('gemOfflineDQMTightGlbMuons'),
-    name = cms.untracked.string('Tight GLB Muon'),
-    useGlobalMuon = cms.untracked.bool(True),
+    folder = 'GEM/Efficiency/type1',
+    muonTag = 'gemOfflineDQMTightGlbMuons',
+    name = 'Tight GLB Muon',
+    useGlobalMuon = True
 )
 
 gemEfficiencyAnalyzerSta = _gemEfficiencyAnalyzerDefault.clone(
     ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
-    muonTag = cms.InputTag("gemOfflineDQMStaMuons"),
-    folder = cms.untracked.string('GEM/Efficiency/type2'),
-    name = cms.untracked.string('STA Muon'),
-    useGlobalMuon = cms.untracked.bool(False),
+    muonTag = "gemOfflineDQMStaMuons",
+    folder = 'GEM/Efficiency/type2',
+    name = 'STA Muon',
+    useGlobalMuon = False
 )
 
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM

--- a/DQM/GEM/python/gemEfficiencyHarvesterCosmics_cfi.py
+++ b/DQM/GEM/python/gemEfficiencyHarvesterCosmics_cfi.py
@@ -6,9 +6,9 @@ from DQM.GEM.gemEfficiencyAnalyzerCosmics_cfi import gemEfficiencyAnalyzerCosmic
 from DQM.GEM.gemEfficiencyAnalyzerCosmics_cfi import gemEfficiencyAnalyzerCosmicsOneLeg as _gemEfficiencyAnalyzerCosmicsOneLeg
 
 gemEfficiencyHarvesterCosmics = _gemEfficiencyHarvesterDefault.clone(
-    folder = cms.untracked.string(_gemEfficiencyAnalyzerCosmics.folder.value()),
+    folder = _gemEfficiencyAnalyzerCosmics.folder.value()
 )
 
 gemEfficiencyHarvesterCosmicsOneLeg = _gemEfficiencyHarvesterDefault.clone(
-    folder = cms.untracked.string(_gemEfficiencyAnalyzerCosmicsOneLeg.folder.value()),
+    folder = _gemEfficiencyAnalyzerCosmicsOneLeg.folder.value()
 )

--- a/DQM/GEM/python/gemEfficiencyHarvester_cfi.py
+++ b/DQM/GEM/python/gemEfficiencyHarvester_cfi.py
@@ -6,9 +6,9 @@ from DQM.GEM.gemEfficiencyAnalyzer_cfi import gemEfficiencyAnalyzerTightGlb as _
 from DQM.GEM.gemEfficiencyAnalyzer_cfi import gemEfficiencyAnalyzerSta as _gemEfficiencyAnalyzerSta
 
 gemEfficiencyHarvesterTightGlb = _gemEfficiencyHarvesterDefault.clone(
-    folder = cms.untracked.string(_gemEfficiencyAnalyzerTightGlb.folder.value())
+    folder = _gemEfficiencyAnalyzerTightGlb.folder.value()
 )
 
 gemEfficiencyHarvesterSta = _gemEfficiencyHarvesterDefault.clone(
-    folder = cms.untracked.string(_gemEfficiencyAnalyzerSta.folder.value())
+    folder = _gemEfficiencyAnalyzerSta.folder.value()
 )


### PR DESCRIPTION
#### PR description:
Drop type specs in DQM/GEM python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone

#### PR validation:
Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all --ibeos




