### PR TITLE
Drop type specs for Muon and RecoB

### DIFF
--- a/DQMOffline/Muon/python/muonCosmicAnalyzer_cff.py
+++ b/DQMOffline/Muon/python/muonCosmicAnalyzer_cff.py
@@ -7,13 +7,15 @@ from DQMOffline.Muon.segmentTrackAnalyzer_cfi import *
 from DQMOffline.Muon.muonSeedsAnalyzer_cfi import * 
 
 # Cloning the modules that need some changes...
-muonCosmicSeedAnalyzer          = muonSeedsAnalyzer.clone()
-muonCosmicGlbSegmentAnalyzer    = glbMuonSegmentAnalyzer.clone()
-muonCosmicStaSegmentAnalyzer    = staMuonSegmentAnalyzer.clone()
-
-muonCosmicSeedAnalyzer.SeedCollection          = cms.InputTag('CosmicMuonSeed')
-muonCosmicGlbSegmentAnalyzer.MuTrackCollection = cms.InputTag('globalCosmicMuons')
-muonCosmicStaSegmentAnalyzer.MuTrackCollection = cms.InputTag('cosmicMuons')
+muonCosmicSeedAnalyzer = muonSeedsAnalyzer.clone(
+    SeedCollection  = 'CosmicMuonSeed'
+)
+muonCosmicGlbSegmentAnalyzer    = glbMuonSegmentAnalyzer.clone(
+    MuTrackCollection = 'globalCosmicMuons'
+)
+muonCosmicStaSegmentAnalyzer    = staMuonSegmentAnalyzer.clone(
+    MuTrackCollection = 'cosmicMuons'
+)
 
 muonCosmicAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
                                   muonCosmicSeedAnalyzer*

--- a/DQMOffline/Muon/python/muonTestSummaryCosmics_cfi.py
+++ b/DQMOffline/Muon/python/muonTestSummaryCosmics_cfi.py
@@ -1,13 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
 import DQMOffline.Muon.muonTestSummary_cfi
-muonCosmicTestSummary = DQMOffline.Muon.muonTestSummary_cfi.muonTestSummary.clone()
-muonCosmicTestSummary.etaExpected = cms.double(0.5)
-muonCosmicTestSummary.phiExpected = cms.double(0.01)
-muonCosmicTestSummary.expMultiplicityGlb_min = cms.double(0.)
-muonCosmicTestSummary.expMultiplicityGlb_max = cms.double(0.1)
-muonCosmicTestSummary.expMultiplicityTk_min = cms.double(0.)
-muonCosmicTestSummary.expMultiplicityTk_max = cms.double(0.045)
-muonCosmicTestSummary.expMultiplicitySta_min = cms.double(0.75)
-muonCosmicTestSummary.expMultiplicitySta_max = cms.double(0.95)
-
+muonCosmicTestSummary = DQMOffline.Muon.muonTestSummary_cfi.muonTestSummary.clone(
+    etaExpected = 0.5,
+    phiExpected = 0.01,
+    expMultiplicityGlb_min = 0.,
+    expMultiplicityGlb_max = 0.1,
+    expMultiplicityTk_min = 0.,
+    expMultiplicityTk_max = 0.045,
+    expMultiplicitySta_min = 0.75,
+    expMultiplicitySta_max = 0.95
+)

--- a/DQMOffline/RecoB/python/PixelVertexMonitor_cff.py
+++ b/DQMOffline/RecoB/python/PixelVertexMonitor_cff.py
@@ -4,5 +4,5 @@ from DQMOffline.RecoB.PrimaryVertexMonitor_cff import pvMonitor as _pvMonitor
 pixelPVMonitor = _pvMonitor.clone(
     TopFolderName = "OfflinePixelPV",
     vertexLabel = "pixelVertices",
-    ndof        = cms.int32( 1 )
+    ndof        = 1 
 )

--- a/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
+++ b/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
@@ -74,7 +74,7 @@ addSequences(bTagMiniDQMSource,
 # Validation addSequences
 
 bTagMiniValidationGlobal = bTagMiniDQMGlobal.clone(
-    MClevel = cms.int32(1) # produce flavour plots for b, c ,light (dusg)
+    MClevel = 1 # produce flavour plots for b, c ,light (dusg)
 )
 
 bTagMiniValidationSource = cms.Sequence()

--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -21,9 +21,9 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import selectedHadronsAndPartons
 from PhysicsTools.JetMCAlgos.AK4PFJetsMCFlavourInfos_cfi import ak4JetFlavourInfos
 myak4JetFlavourInfos = ak4JetFlavourInfos.clone(
-    jets = cms.InputTag("ak4PFJetsCHS"),
-    partons = cms.InputTag("selectedHadronsAndPartons","algorithmicPartons"),
-    hadronFlavourHasPriority = cms.bool(True)
+    jets = "ak4PFJetsCHS",
+    partons = "selectedHadronsAndPartons:algorithmicPartons",
+    hadronFlavourHasPriority = True
     )
 
 #Get gen jet collection for real jets
@@ -35,10 +35,10 @@ ak4GenJetsForPUid = cms.EDFilter("GenJetSelector",
 #do reco gen - reco matching
 from PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi import patJetGenJetMatch
 newpatJetGenJetMatch = patJetGenJetMatch.clone(
-    src = cms.InputTag("ak4PFJetsCHS"),
-    matched = cms.InputTag("ak4GenJetsForPUid"),
-    maxDeltaR = cms.double(0.25),
-    resolveAmbiguities = cms.bool(True)
+    src = "ak4PFJetsCHS",
+    matched = "ak4GenJetsForPUid",
+    maxDeltaR = 0.25,
+    resolveAmbiguities = True
 )
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA

--- a/DQMOffline/RecoB/python/dqmCollector_cff.py
+++ b/DQMOffline/RecoB/python/dqmCollector_cff.py
@@ -3,18 +3,18 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.RecoB.dqmAnalyzer_cff import *
 
 #pf DATA collector
-bTagCollectorDATA = bTagHarvest.clone(ptRanges = cms.vdouble(0.0))
+bTagCollectorDATA = bTagHarvest.clone(ptRanges = (0.0,))
 # module execution
 bTagCollectorSequenceDATA = cms.Sequence(bTagCollectorDATA)
 
 #pf MC collector
 bTagCollectorMC = bTagHarvestMC.clone(
-    flavPlots = cms.string("allbcl"), #harvest all, b, c, dusg and ni histos 
-    ptRanges = cms.vdouble(0.0),
-    etaRanges = cms.vdouble(0.0),
+    flavPlots = "allbcl", #harvest all, b, c, dusg and ni histos 
+    ptRanges = (0.0,),
+    etaRanges = (0.0,),
 )
 # module execution
 bTagCollectorSequenceMC = cms.Sequence(bTagCollectorMC)
 #special sequence for fullsim, all histos havested by the DATA sequence in the dqm offline sequence
-bTagCollectorMCbcl = bTagCollectorMC.clone(flavPlots = cms.string("bcl")) #harvest b, c, dusg and ni histos, all not harvested
+bTagCollectorMCbcl = bTagCollectorMC.clone(flavPlots = "bcl") #harvest b, c, dusg and ni histos, all not harvested
 bTagCollectorSequenceMCbcl = cms.Sequence(bTagCollectorMCbcl)

--- a/DQMOffline/RecoB/python/dqmCollector_cff.py
+++ b/DQMOffline/RecoB/python/dqmCollector_cff.py
@@ -3,15 +3,15 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.RecoB.dqmAnalyzer_cff import *
 
 #pf DATA collector
-bTagCollectorDATA = bTagHarvest.clone(ptRanges = (0.0,))
+bTagCollectorDATA = bTagHarvest.clone(ptRanges = [0.0])
 # module execution
 bTagCollectorSequenceDATA = cms.Sequence(bTagCollectorDATA)
 
 #pf MC collector
 bTagCollectorMC = bTagHarvestMC.clone(
     flavPlots = "allbcl", #harvest all, b, c, dusg and ni histos 
-    ptRanges = (0.0,),
-    etaRanges = (0.0,),
+    ptRanges = [0.0],
+    etaRanges = [0.0],
 )
 # module execution
 bTagCollectorSequenceMC = cms.Sequence(bTagCollectorMC)


### PR DESCRIPTION
#### PR description:
Drop type specs in DQMOffline/Muon and DQMOffline/RecoB python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone

#### PR validation:

Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all --ibeos



