### PR TITLE
Move GeneratorInterface to use oneapi/tbb headers

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -17,8 +17,8 @@ Implementation:
 //
 
 // system include files
-#include "tbb/task_arena.h"
-#include "tbb/task_group.h"
+#include "oneapi/tbb/task_arena.h"
+#include "oneapi/tbb/task_group.h"
 #include <cstdio>
 #include <cstdlib>
 #include <dirent.h>


### PR DESCRIPTION
#### PR description:

The old header declarations are deprecated in TBB

#### PR validation:

Code compiles.