### PR TITLE
Move common code to use oneapi/tbb headers

### DIFF
--- a/CommonTools/Utils/interface/MethodInvoker.h
+++ b/CommonTools/Utils/interface/MethodInvoker.h
@@ -11,7 +11,7 @@
 #include <map>
 #include <vector>
 
-#include "tbb/concurrent_unordered_map.h"
+#include "oneapi/tbb/concurrent_unordered_map.h"
 
 namespace edm {
   struct TypeIDHasher {

--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -1,4 +1,4 @@
-#include <tbb/concurrent_unordered_map.h>
+#include <oneapi/tbb/concurrent_unordered_map.h>
 #include <boost/algorithm/string.hpp>
 
 #include "DataFormats/Common/interface/TriggerResults.h"


### PR DESCRIPTION
#### PR description:

The old header declarations are deprecated in TBB

#### PR validation:

Code compiles.