### PR TITLE
Added a unique ID to ComponentDescription

### DIFF
--- a/FWCore/Framework/interface/ComponentDescription.h
+++ b/FWCore/Framework/interface/ComponentDescription.h
@@ -30,18 +30,24 @@ namespace edm {
     struct ComponentDescription {
       std::string label_;  // A human friendly string that uniquely identifies the label
       std::string type_;   // A human friendly string that uniquely identifies the name
-      bool isSource_;
-      bool isLooper_;
 
       // ID of parameter set of the creator
       ParameterSetID pid_;
 
+      unsigned int id_;
+
+      bool isSource_;
+      bool isLooper_;
+
       /* ----------- end of provenance information ------------- */
 
-      ComponentDescription() : label_(), type_(), isSource_(false), isLooper_(false), pid_() {}
+      ComponentDescription() : label_(), type_(), pid_(), id_(unknownID()), isSource_(false), isLooper_(false) {}
 
-      ComponentDescription(std::string const& iType, std::string const& iLabel, bool iIsSource, bool iIsLooper = false)
-          : label_(iLabel), type_(iType), isSource_(iIsSource), isLooper_(iIsLooper), pid_() {}
+      ComponentDescription(
+          std::string const& iType, std::string const& iLabel, unsigned int iId, bool iIsSource, bool iIsLooper = false)
+          : label_(iLabel), type_(iType), pid_(), id_(iId), isSource_(iIsSource), isLooper_(iIsLooper) {}
+
+      [[nodiscard]] static constexpr unsigned int unknownID() noexcept { return 0xFFFFFFFF; }
 
       bool operator<(ComponentDescription const& iRHS) const {
         return (type_ == iRHS.type_) ? (label_ < iRHS.label_) : (type_ < iRHS.type_);

--- a/FWCore/Framework/src/ComponentMaker.cc
+++ b/FWCore/Framework/src/ComponentMaker.cc
@@ -2,6 +2,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <string>
+#include <atomic>
 
 namespace edm {
   namespace eventsetup {
@@ -12,6 +13,9 @@ namespace edm {
       description.label_ = iConfiguration.getParameter<std::string>("@module_label");
 
       description.pid_ = iConfiguration.id();
+      static std::atomic<unsigned int> s_id{0};
+      description.id_ = s_id++;
+
       return description;
     }
 

--- a/FWCore/Framework/src/EventSetupProviderMaker.cc
+++ b/FWCore/Framework/src/EventSetupProviderMaker.cc
@@ -84,6 +84,7 @@ namespace edm {
         }
         preferInfo[ComponentDescription(preferPSet.getParameter<std::string>("@module_type"),
                                         preferPSet.getParameter<std::string>("@module_label"),
+                                        ComponentDescription::unknownID(),
                                         false)] = recordToData;
       }
       return std::make_unique<EventSetupProvider>(activityRegistry, subProcessIndex, &preferInfo);

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -819,7 +819,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
 
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", 0, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -829,7 +829,7 @@ void testdependentrecord::getDataWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DepRecordProxyProviderWithData", "testTwo", true);
+      edm::eventsetup::ComponentDescription description("DepRecordProxyProviderWithData", "testTwo", 1, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
       ps.addParameter<std::string>("appendToDataLabel", "blah");
@@ -966,7 +966,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
 
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", 0, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -976,7 +976,7 @@ void testdependentrecord::getHandleWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DepRecordProxyProviderWithData", "testTwo", true);
+      edm::eventsetup::ComponentDescription description("DepRecordProxyProviderWithData", "testTwo", 1, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
       ps.addParameter<std::string>("appendToDataLabel", "blah");
@@ -1130,7 +1130,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
 
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", 0, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -1140,7 +1140,7 @@ void testdependentrecord::getTransientHandleWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DepRecordProxyProviderWithData", "testTwo", true);
+      edm::eventsetup::ComponentDescription description("DepRecordProxyProviderWithData", "testTwo", 1, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
       ps.addParameter<std::string>("appendToDataLabel", "blah");

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -344,7 +344,7 @@ void testEventsetup::producerConflictTest() {
   edm::ParameterSet pset = createDummyPset();
   EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", false);
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 0, false);
 
   {
     auto dummyProv = std::make_shared<DummyProxyProvider>();
@@ -365,7 +365,7 @@ void testEventsetup::sourceConflictTest() {
   edm::ParameterSet pset = createDummyPset();
   EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 0, true);
 
   {
     auto dummyProv = std::make_shared<DummyProxyProvider>();
@@ -386,7 +386,7 @@ void testEventsetup::twoSourceTest() {
   edm::ParameterSet pset = createDummyPset();
   EventSetupProvider& provider = *controller.makeProvider(pset, &activityRegistry);
 
-  edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
+  edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 0, true);
   {
     auto dummyProv = std::make_shared<DummyProxyProvider>();
     dummyProv->setDescription(description);
@@ -396,7 +396,7 @@ void testEventsetup::twoSourceTest() {
     auto dummyProv = std::make_shared<edm::DummyEventSetupRecordRetriever>();
     std::shared_ptr<eventsetup::DataProxyProvider> providerPtr(dummyProv);
     std::shared_ptr<edm::EventSetupRecordIntervalFinder> finderPtr(dummyProv);
-    edm::eventsetup::ComponentDescription description2("DummyEventSetupRecordRetriever", "", true);
+    edm::eventsetup::ComponentDescription description2("DummyEventSetupRecordRetriever", "", 0, true);
     dummyProv->setDescription(description2);
     provider.add(providerPtr);
     provider.add(finderPtr);
@@ -454,7 +454,7 @@ void testEventsetup::provenanceTest() {
 
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 0, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -464,7 +464,7 @@ void testEventsetup::provenanceTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testLabel", false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testLabel", 1, false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
       ps.registerIt();
@@ -635,7 +635,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
 
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", 0, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -645,7 +645,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testTwo", false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testTwo", 1, false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
       ps.addParameter<std::string>("appendToDataLabel", "blah");
@@ -657,7 +657,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("ConsumesProducer", "consumes", false);
+      edm::eventsetup::ComponentDescription description("ConsumesProducer", "consumes", 2, false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "consumes");
       ps.registerIt();
@@ -668,7 +668,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("ConsumesFromProducer", "consumesFrom", false);
+      edm::eventsetup::ComponentDescription description("ConsumesFromProducer", "consumesFrom", 3, false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "consumesFrom");
       ps.registerIt();
@@ -679,7 +679,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("SetMayConsumeProducer", "setMayConsumeSuceed", false);
+      edm::eventsetup::ComponentDescription description("SetMayConsumeProducer", "setMayConsumeSuceed", 4, false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "setMayConsumeSuceed");
       ps.registerIt();
@@ -690,7 +690,7 @@ void testEventsetup::getDataWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("SetMayConsumeProducer", "setMayConsumeFail", false);
+      edm::eventsetup::ComponentDescription description("SetMayConsumeProducer", "setMayConsumeFail", 5, false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "setMayConsumeFail");
       ps.registerIt();
@@ -820,7 +820,7 @@ void testEventsetup::getHandleWithESGetTokenTest() {
   edm::ESParentContext pc;
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", 0, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -830,7 +830,7 @@ void testEventsetup::getHandleWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testTwo", false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testTwo", 1, false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
       ps.addParameter<std::string>("appendToDataLabel", "blah");
@@ -916,7 +916,7 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
   edm::ESParentContext pc;
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testOne", 0, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -926,7 +926,7 @@ void testEventsetup::getTransientHandleWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testTwo", false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "testTwo", 1, false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test22");
       ps.addParameter<std::string>("appendToDataLabel", "blah");
@@ -1016,13 +1016,13 @@ void testEventsetup::sourceProducerResolutionTest() {
 
     edm::ESParentContext pc;
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 0, true);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 1, false);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
@@ -1049,13 +1049,13 @@ void testEventsetup::sourceProducerResolutionTest() {
     dummyFinder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
     provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(dummyFinder));
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", false);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 0, false);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 1, true);
       auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
       dummyProv->setDescription(description);
       provider.add(dummyProv);
@@ -1090,16 +1090,17 @@ void testEventsetup::preferTest() {
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
       //default means use all proxies
-      preferInfo[ComponentDescription("DummyProxyProvider", "", false)] = recordToData;
+      preferInfo[ComponentDescription("DummyProxyProvider", "", ComponentDescription::unknownID(), false)] =
+          recordToData;
       provider.setPreferredProviderInfo(preferInfo);
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "bad", false);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "bad", 0, false);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", false);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 1, false);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
@@ -1125,16 +1126,17 @@ void testEventsetup::preferTest() {
       EventSetupProvider::PreferredProviderInfo preferInfo;
       EventSetupProvider::RecordToDataMap recordToData;
       //default means use all proxies
-      preferInfo[ComponentDescription("DummyProxyProvider", "", false)] = recordToData;
+      preferInfo[ComponentDescription("DummyProxyProvider", "", ComponentDescription::unknownID(), false)] =
+          recordToData;
       provider.setPreferredProviderInfo(preferInfo);
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 0, true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "bad", true);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "bad", 1, true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
@@ -1161,16 +1163,17 @@ void testEventsetup::preferTest() {
       EventSetupProvider::RecordToDataMap recordToData;
       recordToData.insert(
           std::make_pair(std::string("DummyRecord"), std::make_pair(std::string("DummyData"), std::string())));
-      preferInfo[ComponentDescription("DummyProxyProvider", "", false)] = recordToData;
+      preferInfo[ComponentDescription("DummyProxyProvider", "", ComponentDescription::unknownID(), false)] =
+          recordToData;
       provider.setPreferredProviderInfo(preferInfo);
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 0, true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kGood);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
       }
       {
-        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "bad", true);
+        edm::eventsetup::ComponentDescription description("DummyProxyProvider", "bad", 1, true);
         auto dummyProv = std::make_shared<DummyProxyProvider>(kBad);
         dummyProv->setDescription(description);
         provider.add(dummyProv);
@@ -1205,7 +1208,7 @@ void testEventsetup::introspectionTest() {
   edm::ESParentContext pc;
   try {
     {
-      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", true);
+      edm::eventsetup::ComponentDescription description("DummyProxyProvider", "", 0, true);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "test11");
       ps.registerIt();
@@ -1300,7 +1303,7 @@ void testEventsetup::resetProxiesTest() {
   finder->setInterval(ValidityInterval(IOVSyncValue(Timestamp(2)), IOVSyncValue(Timestamp(3))));
   provider.add(std::shared_ptr<edm::EventSetupRecordIntervalFinder>(finder));
 
-  ComponentDescription description("DummyProxyProvider", "", true);
+  ComponentDescription description("DummyProxyProvider", "", 0, true);
   ParameterSet ps;
   ps.addParameter<std::string>("name", "test11");
   ps.registerIt();

--- a/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
@@ -70,7 +70,7 @@ void testEventsetupplugin::finderTest()
   dummyFinderPSet.registerIt();
   SourceFactory::get()->addTo(esController, provider, dummyFinderPSet);
 
-  ComponentDescription descFinder("LoadableDummyFinder", "", true);
+  ComponentDescription descFinder("LoadableDummyFinder", "", ComponentDescription::unknownID(), true);
   std::set<ComponentDescription> descriptions(provider.proxyProviderDescriptions());
   //should not be found since not a provider
   CPPUNIT_ASSERT(descriptions.find(descFinder) == descriptions.end());
@@ -81,7 +81,7 @@ void testEventsetupplugin::finderTest()
   dummyProviderPSet.registerIt();
   ModuleFactory::get()->addTo(esController, provider, dummyProviderPSet);
 
-  ComponentDescription desc("LoadableDummyProvider", "", false);
+  ComponentDescription desc("LoadableDummyProvider", "", ComponentDescription::unknownID(), false);
   descriptions = provider.proxyProviderDescriptions();
   CPPUNIT_ASSERT(descriptions.find(desc) != descriptions.end());
   CPPUNIT_ASSERT(*(descriptions.find(desc)) == desc);
@@ -92,7 +92,7 @@ void testEventsetupplugin::finderTest()
   dummySourcePSet.registerIt();
   SourceFactory::get()->addTo(esController, provider, dummySourcePSet);
 
-  ComponentDescription descSource("LoadableDummyESSource", "", true);
+  ComponentDescription descSource("LoadableDummyESSource", "", ComponentDescription::unknownID(), true);
   descriptions = provider.proxyProviderDescriptions();
   CPPUNIT_ASSERT(descriptions.find(descSource) != descriptions.end());
   CPPUNIT_ASSERT(*(descriptions.find(descSource)) == descSource);


### PR DESCRIPTION
#### PR description:

Each ES module now gets a unique numeric ID. This is intended to be used by Services.

#### PR validation:

Code compiles and all framework unit tests pass.