### PR TITLE
Drop type specs for L1Trigger

### DIFF
--- a/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
@@ -64,8 +64,7 @@ l1tEGammaEfficiency = DQMEDHarvester(
 )
 
 l1tEGammaEmuEfficiency = l1tEGammaEfficiency.clone(
-    subDirs=cms.untracked.vstring(
-        'L1TEMU/L1TObjects/L1TEGamma/L1TriggerVsReco'),
+    subDirs = ('L1TEMU/L1TObjects/L1TEGamma/L1TriggerVsReco',)
 )
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017

--- a/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaEfficiency_cfi.py
@@ -64,7 +64,7 @@ l1tEGammaEfficiency = DQMEDHarvester(
 )
 
 l1tEGammaEmuEfficiency = l1tEGammaEfficiency.clone(
-    subDirs = ('L1TEMU/L1TObjects/L1TEGamma/L1TriggerVsReco',)
+    subDirs = ['L1TEMU/L1TObjects/L1TEGamma/L1TriggerVsReco']
 )
 
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017

--- a/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEGammaOffline_cfi.py
@@ -92,7 +92,6 @@ ppRef_2017.toModify(
 
 # emulator module
 l1tEGammaOfflineDQMEmu = l1tEGammaOfflineDQM.clone(
-    stage2CaloLayer2EGammaSource=cms.InputTag("simCaloStage2Digis"),
-
-    histFolder=cms.string('L1TEMU/L1TObjects/L1TEGamma/L1TriggerVsReco'),
+    stage2CaloLayer2EGammaSource = "simCaloStage2Digis",
+    histFolder = 'L1TEMU/L1TObjects/L1TEGamma/L1TriggerVsReco'
 )

--- a/DQMOffline/L1Trigger/python/L1TEmulatorMonitorOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TEmulatorMonitorOffline_cff.py
@@ -10,26 +10,26 @@ from DQM.L1TMonitor.L1TEmulatorMonitor_cff import *
 
 from DQM.L1TMonitor.L1TStage2Emulator_cff import *
 # add calo layer 2 emulation with inputs from the calo layer 1 emulator since the full unpacked data to emulate layer 2 is only available for validation events
-valCaloStage2Layer2DigisOffline = valCaloStage2Layer2Digis.clone()
-valCaloStage2Layer2DigisOffline.towerToken = cms.InputTag("valCaloStage2Layer1Digis")
-
+valCaloStage2Layer2DigisOffline = valCaloStage2Layer2Digis.clone(
+    towerToken = "valCaloStage2Layer1Digis"
+)
 Stage2L1HardwareValidationForOfflineCalo = cms.Sequence(valCaloStage2Layer2DigisOffline)
 
 # Calo layer 2 emulator DQM modules for offline
 from DQM.L1TMonitor.L1TdeStage2CaloLayer2_cfi import *
-l1tdeStage2CaloLayer2Offline = l1tdeStage2CaloLayer2.clone()
-l1tdeStage2CaloLayer2Offline.calol2JetCollectionEmul = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tdeStage2CaloLayer2Offline.calol2EGammaCollectionEmul = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tdeStage2CaloLayer2Offline.calol2TauCollectionEmul = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tdeStage2CaloLayer2Offline.calol2EtSumCollectionEmul = cms.InputTag("valCaloStage2Layer2DigisOffline")
-
+l1tdeStage2CaloLayer2Offline = l1tdeStage2CaloLayer2.clone(
+    calol2JetCollectionEmul = "valCaloStage2Layer2DigisOffline",
+    calol2EGammaCollectionEmul = "valCaloStage2Layer2DigisOffline",
+    calol2TauCollectionEmul = "valCaloStage2Layer2DigisOffline",
+    calol2EtSumCollectionEmul = "valCaloStage2Layer2DigisOffline"
+)
 from DQM.L1TMonitor.L1TStage2CaloLayer2Emul_cfi import *
-l1tStage2CaloLayer2EmulOffline = l1tStage2CaloLayer2Emul.clone()
-l1tStage2CaloLayer2EmulOffline.stage2CaloLayer2JetSource = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tStage2CaloLayer2EmulOffline.stage2CaloLayer2EGammaSource = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tStage2CaloLayer2EmulOffline.stage2CaloLayer2TauSource = cms.InputTag("valCaloStage2Layer2DigisOffline")
-l1tStage2CaloLayer2EmulOffline.stage2CaloLayer2EtSumSource = cms.InputTag("valCaloStage2Layer2DigisOffline")
-
+l1tStage2CaloLayer2EmulOffline = l1tStage2CaloLayer2Emul.clone(
+    stage2CaloLayer2JetSource = "valCaloStage2Layer2DigisOffline",
+    stage2CaloLayer2EGammaSource = "valCaloStage2Layer2DigisOffline",
+    stage2CaloLayer2TauSource = "valCaloStage2Layer2DigisOffline",
+    stage2CaloLayer2EtSumSource = "valCaloStage2Layer2DigisOffline"
+)
 l1tStage2EmulatorOfflineDQMForCalo = cms.Sequence(
     l1tdeStage2CaloLayer2Offline +
     l1tStage2CaloLayer2EmulOffline

--- a/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
@@ -31,7 +31,7 @@ l1tEtSumEfficiency = DQMEDHarvester(
 )
 
 l1tEtSumEmuEfficiency = l1tEtSumEfficiency.clone(
-    subDirs = ('L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco',)
+    subDirs = ['L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco']
 )
 
 # modifications for the pp reference run

--- a/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumEfficiency_cfi.py
@@ -31,8 +31,7 @@ l1tEtSumEfficiency = DQMEDHarvester(
 )
 
 l1tEtSumEmuEfficiency = l1tEtSumEfficiency.clone(
-    subDirs=cms.untracked.vstring(
-        'L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco'),
+    subDirs = ('L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco',)
 )
 
 # modifications for the pp reference run

--- a/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TEtSumJetOffline_cfi.py
@@ -87,8 +87,8 @@ goodPFJetsForL1T = cms.EDFilter(
 from L1Trigger.L1TNtuples.L1TPFMetNoMuProducer_cfi import l1tPFMetNoMu
 
 l1tPFMetNoMuForDQM = l1tPFMetNoMu.clone(
-    pfMETCollection=cms.InputTag('pfMETT1'),
-    muonCollection=cms.InputTag('muons'),
+    pfMETCollection= 'pfMETT1',
+    muonCollection= 'muons'
 )
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
@@ -168,11 +168,11 @@ ppRef_2017.toModify(
 
 # emulator module
 l1tEtSumJetOfflineDQMEmu = l1tEtSumJetOfflineDQM.clone(
-    stage2CaloLayer2JetSource=cms.InputTag("simCaloStage2Digis"),
-    stage2CaloLayer2EtSumSource=cms.InputTag("simCaloStage2Digis"),
+    stage2CaloLayer2JetSource = "simCaloStage2Digis",
+    stage2CaloLayer2EtSumSource = "simCaloStage2Digis",
 
-    histFolderEtSum=cms.string('L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco'),
-    histFolderJet=cms.string('L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco'),
+    histFolderEtSum = 'L1TEMU/L1TObjects/L1TEtSum/L1TriggerVsReco',
+    histFolderJet= 'L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco'
 )
 
 # sequences

--- a/DQMOffline/L1Trigger/python/L1TJetEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TJetEfficiency_cfi.py
@@ -26,7 +26,7 @@ l1tJetEfficiency = DQMEDHarvester(
 )
 
 l1tJetEmuEfficiency = l1tJetEfficiency.clone(
-    subDirs= ('L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco',)
+    subDirs= ['L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco']
 )
 
 # modifications for the pp reference run

--- a/DQMOffline/L1Trigger/python/L1TJetEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TJetEfficiency_cfi.py
@@ -26,8 +26,7 @@ l1tJetEfficiency = DQMEDHarvester(
 )
 
 l1tJetEmuEfficiency = l1tJetEfficiency.clone(
-    subDirs=cms.untracked.vstring(
-        'L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco'),
+    subDirs= ('L1TEMU/L1TObjects/L1TJet/L1TriggerVsReco',)
 )
 
 # modifications for the pp reference run

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMEfficiency_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMEfficiency_cff.py
@@ -48,7 +48,7 @@ l1tMuonDQMEfficiency = DQMEDHarvester("DQMGenericClient",
 
 # emulator efficiency
 l1tMuonDQMEmuEfficiency = l1tMuonDQMEfficiency.clone(
-    subDirs = cms.untracked.vstring("L1TEMU/L1TObjects/L1TMuon/L1TriggerVsReco/")
+    subDirs = ("L1TEMU/L1TObjects/L1TMuon/L1TriggerVsReco/",)
 )
 
 # modifications for the pp reference run

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMEfficiency_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMEfficiency_cff.py
@@ -48,7 +48,7 @@ l1tMuonDQMEfficiency = DQMEDHarvester("DQMGenericClient",
 
 # emulator efficiency
 l1tMuonDQMEmuEfficiency = l1tMuonDQMEfficiency.clone(
-    subDirs = ("L1TEMU/L1TObjects/L1TMuon/L1TriggerVsReco/",)
+    subDirs = ["L1TEMU/L1TObjects/L1TMuon/L1TriggerVsReco/"]
 )
 
 # modifications for the pp reference run

--- a/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TMuonDQMOffline_cfi.py
@@ -73,8 +73,8 @@ l1tMuonDQMOffline = DQMEDAnalyzer('L1TMuonDQMOffline',
 
 # emulator module
 l1tMuonDQMOfflineEmu = l1tMuonDQMOffline.clone(
-    gmtInputTag  = cms.untracked.InputTag("simGmtStage2Digis"),
-    histFolder = cms.untracked.string('L1TEMU/L1TObjects/L1TMuon/L1TriggerVsReco')
+    gmtInputTag  = "simGmtStage2Digis",
+    histFolder = 'L1TEMU/L1TObjects/L1TMuon/L1TriggerVsReco'
 )
 
 # modifications for the pp reference run

--- a/DQMOffline/L1Trigger/python/L1TSync_Harvest_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TSync_Harvest_cff.py
@@ -3,18 +3,19 @@ import FWCore.ParameterSet.Config as cms
 # filter to select HLT events
 from HLTrigger.HLTfilters.hltHighLevel_cfi import *
 
-l1tSyncHltFilter = hltHighLevel.clone(TriggerResultsTag ="TriggerResults::HLT")
-l1tSyncHltFilter.throw = cms.bool(False)
-l1tSyncHltFilter.HLTPaths = ['HLT_ZeroBias_v*',
-                             'HLT_L1ETM30_v*',
-                             'HLT_L1MultiJet_v*',
-                             'HLT_L1SingleEG12_v',
-                             'HLT_L1SingleEG5_v*',
-                             'HLT_L1SingleJet16_v*',
-                             'HLT_L1SingleJet36_v*',
-                             'HLT_L1SingleMu10_v*',
-                             'HLT_L1SingleMu20_v*'
-                             ]
-
+l1tSyncHltFilter = hltHighLevel.clone(
+    TriggerResultsTag ="TriggerResults::HLT",
+    throw = False,
+    HLTPaths = ['HLT_ZeroBias_v*',
+                'HLT_L1ETM30_v*',
+                'HLT_L1MultiJet_v*',
+                'HLT_L1SingleEG12_v',
+                'HLT_L1SingleEG5_v*',
+                'HLT_L1SingleJet16_v*',
+                'HLT_L1SingleJet36_v*',
+                'HLT_L1SingleMu10_v*',
+                'HLT_L1SingleMu20_v*'
+            ]
+)
 
 

--- a/DQMOffline/L1Trigger/python/L1TSync_Offline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TSync_Offline_cff.py
@@ -3,19 +3,20 @@ import FWCore.ParameterSet.Config as cms
 # filter to select HLT events
 from HLTrigger.HLTfilters.hltHighLevel_cfi import *
 
-l1tSyncHltFilter = hltHighLevel.clone(TriggerResultsTag ="TriggerResults::HLT")
-l1tSyncHltFilter.throw = cms.bool(False)
-l1tSyncHltFilter.HLTPaths = ['HLT_ZeroBias_v*',
-                             'HLT_L1ETM30_v*',
-                             'HLT_L1MultiJet_v*',
-                             'HLT_L1SingleEG12_v',
-                             'HLT_L1SingleEG5_v*',
-                             'HLT_L1SingleJet16_v*',
-                             'HLT_L1SingleJet36_v*',
-                             'HLT_L1SingleMu10_v*',
-                             'HLT_L1SingleMu20_v*'
-                             ]
-
+l1tSyncHltFilter = hltHighLevel.clone(
+    TriggerResultsTag ="TriggerResults::HLT",
+    throw = False,
+    HLTPaths = ['HLT_ZeroBias_v*',
+                'HLT_L1ETM30_v*',
+                'HLT_L1MultiJet_v*',
+                'HLT_L1SingleEG12_v',
+                'HLT_L1SingleEG5_v*',
+                'HLT_L1SingleJet16_v*',
+                'HLT_L1SingleJet36_v*',
+                'HLT_L1SingleMu10_v*',
+                'HLT_L1SingleMu20_v*'
+            ]
+)
 # L1 synchronization DQM module
 from DQMOffline.L1Trigger.L1TSync_Offline_cfi import *
 

--- a/DQMOffline/L1Trigger/python/L1TTauEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TTauEfficiency_cfi.py
@@ -33,6 +33,5 @@ l1tTauEfficiency = DQMEDHarvester(
 )
 
 l1tTauEmuEfficiency = l1tTauEfficiency.clone(
-    subDirs=cms.untracked.vstring(
-        'L1TEMU/L1TObjects/L1TTau/L1TriggerVsReco'),
+    subDirs= ('L1TEMU/L1TObjects/L1TTau/L1TriggerVsReco',)
 )

--- a/DQMOffline/L1Trigger/python/L1TTauEfficiency_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TTauEfficiency_cfi.py
@@ -33,5 +33,5 @@ l1tTauEfficiency = DQMEDHarvester(
 )
 
 l1tTauEmuEfficiency = l1tTauEfficiency.clone(
-    subDirs= ('L1TEMU/L1TObjects/L1TTau/L1TriggerVsReco',)
+    subDirs= ['L1TEMU/L1TObjects/L1TTau/L1TriggerVsReco']
 )

--- a/DQMOffline/L1Trigger/python/L1TTauOffline_cfi.py
+++ b/DQMOffline/L1Trigger/python/L1TTauOffline_cfi.py
@@ -36,6 +36,7 @@ l1tTauOfflineDQM = DQMEDAnalyzer(
     trigProcess        = cms.untracked.string("HLT"),
     trigProcess_token  = cms.untracked.InputTag("TriggerResults","","HLT"),
 
+    stage2CaloLayer2TauSource=cms.InputTag("simCaloStage2Digis"),
     histFolder=cms.string('L1T/L1TObjects/L1TTau/L1TriggerVsReco'),
 
     tauEfficiencyThresholds=cms.vint32(tauEfficiencyThresholds),
@@ -50,7 +51,7 @@ l1tTauOfflineDQM = DQMEDAnalyzer(
 )
 
 l1tTauOfflineDQMEmu = l1tTauOfflineDQM.clone(
-    stage2CaloLayer2TauSource=cms.InputTag("simCaloStage2Digis"),
+    stage2CaloLayer2TauSource= "simCaloStage2Digis",
 
-    histFolder=cms.string('L1TEMU/L1TObjects/L1TTau/L1TriggerVsReco'),
+    histFolder= 'L1TEMU/L1TObjects/L1TTau/L1TriggerVsReco'
 )

--- a/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
+++ b/DQMOffline/L1Trigger/python/L1TriggerDqmOffline_cff.py
@@ -18,9 +18,9 @@ import FWCore.ParameterSet.Config as cms
 #
 
 import DQMServices.Components.DQMEnvironment_cfi
-dqmEnvL1T = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
-dqmEnvL1T.subSystemFolder = 'L1T'
-
+dqmEnvL1T = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone(
+    subSystemFolder = 'L1T'
+)
 # DQM online L1 Trigger modules, with offline configuration
 from DQMOffline.L1Trigger.L1TMonitorOffline_cff import *
 from DQMOffline.L1Trigger.L1TMonitorClientOffline_cff import *
@@ -29,18 +29,18 @@ from DQMOffline.L1Trigger.L1TMonitorClientOffline_cff import *
 # DQM offline L1 Trigger versus Reco modules
 
 import DQMServices.Components.DQMEnvironment_cfi
-dqmEnvL1TriggerReco = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
-dqmEnvL1TriggerReco.subSystemFolder = 'L1T/L1TriggerVsReco'
-
+dqmEnvL1TriggerReco = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone(
+    subSystemFolder = 'L1T/L1TriggerVsReco'
+)
 #
 # DQM L1 Trigger Emulator in offline environment
 # Run also the L1HwVal producers (L1 Trigger emulators)
 #
 
 import DQMServices.Components.DQMEnvironment_cfi
-dqmEnvL1TEMU = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
-dqmEnvL1TEMU.subSystemFolder = 'L1TEMU'
-
+dqmEnvL1TEMU = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone(
+    subSystemFolder = 'L1TEMU'
+)
 # DQM Offline Step 1 cfi/cff imports
 from DQMOffline.L1Trigger.L1TRate_Offline_cfi import *
 from DQMOffline.L1Trigger.L1TSync_Offline_cfi import *


### PR DESCRIPTION
#### PR description:
Drop type specs in DQMOffline/L1Trigger python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone


#### PR validation:
Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all --ibeos




