### PR TITLE
pre-select high purity tracks as input for muon reco in pp_on_AA era

### DIFF
--- a/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuonPPonly_cff.py
@@ -27,7 +27,8 @@ from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *
 from RecoMuon.Configuration.iterativeTkDisplaced_cff import *
 displacedGlobalMuons = globalMuons.clone(
     MuonCollectionLabel = 'displacedStandAloneMuons:',
-    TrackerCollectionLabel = 'displacedTracks'
+    TrackerCollectionLabel = 'displacedTracks',
+    selectHighPurity = False
 )
 
 # TeV refinement

--- a/RecoMuon/Configuration/python/RecoMuon_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuon_cff.py
@@ -25,7 +25,9 @@ muonsFromCosmics = RecoMuon.MuonIdentification.muons1stStep_cfi.muons1stStep.clo
     TimingFillerParameters = dict(
 	MatchParameters = dict(DTsegments = 'dt4DCosmicSegments'),
 	DTTimingParameters = dict(PruneCut = 9999),
-	CSCTimingParameters = dict(PruneCut = 9999))
+	CSCTimingParameters = dict(PruneCut = 9999)),
+    selectHighPurity = False,
+    minPt = 0.5
 )
 
 #add regional cosmic tracks here
@@ -56,7 +58,9 @@ muonsFromCosmics1Leg = muons1stStep.clone(
     TimingFillerParameters = dict(
         MatchParameters = dict(DTsegments = 'dt4DCosmicSegments'),
         DTTimingParameters = dict(PruneCut = 9999),
-        CSCTimingParameters = dict(PruneCut = 9999))
+        CSCTimingParameters = dict(PruneCut = 9999)),
+    selectHighPurity = False,
+    minPt = 0.5
 )
 
 muoncosmicreco1legSTATask = cms.Task(CosmicMuonSeed,cosmicMuons1Leg)
@@ -84,6 +88,3 @@ phase2_tracker.toModify(muonReducedTrackExtras, outputClusters = False)
 
 muonshighlevelrecoTask = cms.Task(muonPFIsolationTask,muons,muonReducedTrackExtras)
 muonshighlevelreco = cms.Sequence(muonshighlevelrecoTask)
-
-from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(muons1stStep, minPt = 0.8, selectHighPurity = True)

--- a/RecoMuon/Configuration/python/RecoMuon_cff.py
+++ b/RecoMuon/Configuration/python/RecoMuon_cff.py
@@ -84,3 +84,6 @@ phase2_tracker.toModify(muonReducedTrackExtras, outputClusters = False)
 
 muonshighlevelrecoTask = cms.Task(muonPFIsolationTask,muons,muonReducedTrackExtras)
 muonshighlevelreco = cms.Sequence(muonshighlevelrecoTask)
+
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(muons1stStep, minPt = 0.8, selectHighPurity = True)

--- a/RecoMuon/Configuration/python/SETRecoMuon_cff.py
+++ b/RecoMuon/Configuration/python/SETRecoMuon_cff.py
@@ -6,7 +6,8 @@ from RecoMuon.StandAloneMuonProducer.standAloneMuons_cff import standAloneSETMuo
 
 from RecoMuon.GlobalMuonProducer.GlobalMuonProducer_cff import *
 globalSETMuons = globalMuons.clone(
-    MuonCollectionLabel = 'standAloneSETMuons:UpdatedAtVtx'
+    MuonCollectionLabel = 'standAloneSETMuons:UpdatedAtVtx',
+    selectHighPurity = False
 )
 muontracking_with_SET_Task = cms.Task(SETMuonSeed,standAloneSETMuons,globalSETMuons)
 muontracking_with_SET = cms.Sequence(muontracking_with_SET_Task)
@@ -16,7 +17,9 @@ muonsWithSET = muons1stStep.clone(
     inputCollectionLabels = ['generalTracks', 
                              'globalSETMuons', 
                              'standAloneSETMuons:UpdatedAtVtx'],
-    inputCollectionTypes = ['inner tracks', 'links', 'outer tracks']
+    inputCollectionTypes = ['inner tracks', 'links', 'outer tracks'],
+    selectHighPurity = False,
+    minPt = 0.5
 )
 #muonreco_with_SET = cms.Sequence(muontracking_with_SET*muonsWithSET)
 #run only the tracking part for SET, after that it should be merged with the main ones at some point

--- a/RecoMuon/GlobalMuonProducer/python/globalMuons_cfi.py
+++ b/RecoMuon/GlobalMuonProducer/python/globalMuons_cfi.py
@@ -10,7 +10,9 @@ globalMuons = cms.EDProducer("GlobalMuonProducer",
         GlobalTrajectoryBuilderCommon
     ),
     TrackerCollectionLabel = cms.InputTag("generalTracks"),
-    MuonCollectionLabel = cms.InputTag("standAloneMuons","UpdatedAtVtx")
+    MuonCollectionLabel = cms.InputTag("standAloneMuons","UpdatedAtVtx"),
+    VertexCollectionLabel = cms.InputTag("offlinePrimaryVertices"),
+    selectHighPurity = cms.bool(False)
 )
 
 globalMuons.GLBTrajBuilderParameters.GlobalMuonTrackMatcher.Propagator = 'SmartPropagatorRK'
@@ -28,3 +30,6 @@ fastSim.toModify(globalMuons,
                                                 GlobalMuonTrackMatcher = dict(Propagator = 'SmartPropagator') 
                                                 )
 )
+
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(globalMuons, selectHighPurity = True)

--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
@@ -39,6 +39,10 @@ GlobalMuonProducer::GlobalMuonProducer(const ParameterSet& parameterSet) {
   ParameterSet trajectoryBuilderParameters = parameterSet.getParameter<ParameterSet>("GLBTrajBuilderParameters");
   InputTag trackCollectionTag = parameterSet.getParameter<InputTag>("TrackerCollectionLabel");
   trajectoryBuilderParameters.addParameter<InputTag>("TrackerCollectionLabel", trackCollectionTag);
+  InputTag vertexCollectionTag = parameterSet.getParameter<InputTag>("VertexCollectionLabel");
+  trajectoryBuilderParameters.addParameter<InputTag>("VertexCollectionLabel", vertexCollectionTag);
+  bool selectHighPurity_ = parameterSet.getParameter<bool>("selectHighPurity");
+  trajectoryBuilderParameters.addParameter<bool>("selectHighPurity", selectHighPurity_);
 
   // STA Muon Collection Label
   theSTACollectionLabel = parameterSet.getParameter<InputTag>("MuonCollectionLabel");

--- a/RecoMuon/GlobalTrackFinder/interface/GlobalMuonTrajectoryBuilder.h
+++ b/RecoMuon/GlobalTrackFinder/interface/GlobalMuonTrajectoryBuilder.h
@@ -14,6 +14,7 @@
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
 
 namespace edm {
   class ParameterSet;
@@ -48,5 +49,9 @@ private:
   edm::InputTag theTkTrackLabel;
   edm::EDGetTokenT<reco::TrackCollection> allTrackerTracksToken;
   edm::Handle<reco::TrackCollection> allTrackerTracks;
+  edm::InputTag thePrimaryVtxLabel;
+  edm::EDGetTokenT<reco::VertexCollection> primaryVertexToken;
+  edm::Handle<reco::VertexCollection> vertexCollection;
+  bool selectHighPurity_;
 };
 #endif

--- a/RecoMuon/GlobalTrackFinder/src/GlobalMuonTrajectoryBuilder.cc
+++ b/RecoMuon/GlobalTrackFinder/src/GlobalMuonTrajectoryBuilder.cc
@@ -158,6 +158,10 @@ vector<GlobalMuonTrajectoryBuilder::TrackCand> GlobalMuonTrajectoryBuilder::make
   for (unsigned int position = 0; position != allTrackerTracks->size(); ++position) {
     reco::TrackRef tkTrackRef(allTrackerTracks, position);
     TrackCand tkCand = TrackCand((Trajectory*)nullptr, tkTrackRef);
+    if(selectHighPurity_ && !tkTrackRef->quality(reco::TrackBase::highPurity)) {
+      const reco::VertexCollection *recoVertices = vertexCollection.product();
+      if(!(*recoVertices)[0].isFake()) continue;
+    }
     tkTrackCands.push_back(tkCand);
   }
 

--- a/RecoMuon/GlobalTrackFinder/src/GlobalMuonTrajectoryBuilder.cc
+++ b/RecoMuon/GlobalTrackFinder/src/GlobalMuonTrajectoryBuilder.cc
@@ -158,9 +158,10 @@ vector<GlobalMuonTrajectoryBuilder::TrackCand> GlobalMuonTrajectoryBuilder::make
   for (unsigned int position = 0; position != allTrackerTracks->size(); ++position) {
     reco::TrackRef tkTrackRef(allTrackerTracks, position);
     TrackCand tkCand = TrackCand((Trajectory*)nullptr, tkTrackRef);
-    if(selectHighPurity_ && !tkTrackRef->quality(reco::TrackBase::highPurity)) {
-      const reco::VertexCollection *recoVertices = vertexCollection.product();
-      if(!(*recoVertices)[0].isFake()) continue;
+    if (selectHighPurity_ && !tkTrackRef->quality(reco::TrackBase::highPurity)) {
+      const reco::VertexCollection* recoVertices = vertexCollection.product();
+      if (!(*recoVertices)[0].isFake())
+        continue;
     }
     tkTrackCands.push_back(tkCand);
   }

--- a/RecoMuon/GlobalTrackFinder/src/GlobalMuonTrajectoryBuilder.cc
+++ b/RecoMuon/GlobalTrackFinder/src/GlobalMuonTrajectoryBuilder.cc
@@ -61,6 +61,9 @@ GlobalMuonTrajectoryBuilder::GlobalMuonTrajectoryBuilder(const edm::ParameterSet
 {
   theTkTrackLabel = par.getParameter<edm::InputTag>("TrackerCollectionLabel");
   allTrackerTracksToken = iC.consumes<reco::TrackCollection>(theTkTrackLabel);
+  thePrimaryVtxLabel = par.getParameter<edm::InputTag>("VertexCollectionLabel");
+  primaryVertexToken = iC.mayConsume<reco::VertexCollection>(thePrimaryVtxLabel);
+  selectHighPurity_ = par.getParameter<bool>("selectHighPurity");
 }
 
 //--------------
@@ -80,6 +83,10 @@ void GlobalMuonTrajectoryBuilder::setEvent(const edm::Event& event) {
   // get tracker TrackCollection from Event
   event.getByToken(allTrackerTracksToken, allTrackerTracks);
   LogDebug(category) << " Found " << allTrackerTracks->size() << " tracker Tracks with label " << theTkTrackLabel;
+
+  // get primary vertex from Event
+  event.getByToken(primaryVertexToken, vertexCollection);
+  LogDebug(category) << " Found " << vertexCollection->size() << " tracker Tracks with label " << thePrimaryVtxLabel;
 }
 
 //

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -157,6 +157,11 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
         std::make_unique<MuonKinkFinder>(iConfig.getParameter<edm::ParameterSet>("TrackerKinkFinderParameters"), iC);
   }
 
+  if (selectHighPurity_) {
+    const auto& pvTag = iConfig.getParameter<edm::InputTag>("pvInputTag");
+    pvToken_ = mayConsume<reco::VertexCollection>(pvTag);
+  }
+
   //create mesh holder
   meshAlgo_ = std::make_unique<MuonMesh>(iConfig.getParameter<edm::ParameterSet>("arbitrationCleanerOptions"));
 
@@ -253,6 +258,8 @@ void MuonIdProducer::init(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iEvent.getByToken(rpcHitToken_, rpcHitHandle_);
   if (fillGlobalTrackQuality_)
     iEvent.getByToken(glbQualToken_, glbQualHandle_);
+  if (selectHighPurity_)
+    iEvent.getByToken(pvToken_, pvHandle_);
 }
 
 reco::Muon MuonIdProducer::makeMuon(edm::Event& iEvent,
@@ -540,6 +547,11 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
       const reco::Track& track = innerTrackCollectionHandle_->at(i);
       if (!isGoodTrack(track))
         continue;
+      if (selectHighPurity_ && !track.quality(reco::TrackBase::highPurity)) {
+        const reco::VertexCollection* recoVertices = pvHandle_.product();
+        if (!recoVertices->at(0).isFake())
+          continue;
+      }
       const auto& trackRef = reco::TrackRef(innerTrackCollectionHandle_, i);
       bool splitTrack = false;
       if (track.extra().isAvailable() && TrackDetectorAssociator::crossedIP(track))

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -1409,6 +1409,7 @@ void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<bool>("arbitrateTrackerMuons", false);
   desc.add<bool>("storeCrossedHcalRecHits", false);
   desc.add<bool>("fillShowerDigis", false);
+  desc.add<bool>("selectHighPurity", false);
 
   edm::ParameterSetDescription descTrkAsoPar;
   descTrkAsoPar.add<edm::InputTag>("GEMSegmentCollectionLabel", edm::InputTag("gemSegments"));

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -64,6 +64,7 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
   fillGlobalTrackQuality_ = iConfig.getParameter<bool>("fillGlobalTrackQuality");
   fillGlobalTrackRefits_ = iConfig.getParameter<bool>("fillGlobalTrackRefits");
   arbitrateTrackerMuons_ = iConfig.getParameter<bool>("arbitrateTrackerMuons");
+  selectHighPurity_ = iConfig.getParameter<bool>("selectHighPurity");
   //SK: (maybe temporary) run it only if the global is also run
   fillTrackerKink_ = false;
   if (fillGlobalTrackQuality_)

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -550,7 +550,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
         continue;
       if (selectHighPurity_ && !track.quality(reco::TrackBase::highPurity)) {
         const reco::VertexCollection* recoVertices = pvHandle_.product();
-        if (!recoVertices->at(0).isFake())
+        if (!(*recoVertices)[0].isFake())
           continue;
       }
       const auto& trackRef = reco::TrackRef(innerTrackCollectionHandle_, i);
@@ -1409,7 +1409,10 @@ void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<bool>("arbitrateTrackerMuons", false);
   desc.add<bool>("storeCrossedHcalRecHits", false);
   desc.add<bool>("fillShowerDigis", false);
-  desc.add<bool>("selectHighPurity", false);
+  desc.ifValue(
+      edm::ParameterDescription<bool>("selectHighPurity", false, true),
+      true >> (edm::ParameterDescription<edm::InputTag>("pvInputTag", edm::InputTag("offlinePrimaryVertices"), true)) or
+          false >> (edm::ParameterDescription<edm::InputTag>("pvInputTag", edm::InputTag(""), true)));
 
   edm::ParameterSetDescription descTrkAsoPar;
   descTrkAsoPar.add<edm::InputTag>("GEMSegmentCollectionLabel", edm::InputTag("gemSegments"));

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -36,6 +36,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackToTrackMap.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -231,6 +232,7 @@ private:
   edm::Handle<reco::TrackToTrackMap> tpfmsCollectionHandle_;
   edm::Handle<reco::TrackToTrackMap> pickyCollectionHandle_;
   edm::Handle<reco::TrackToTrackMap> dytCollectionHandle_;
+  edm::Handle<reco::VertexCollection> pvHandle_;
 
   edm::EDGetTokenT<reco::TrackCollection> innerTrackCollectionToken_;
   edm::EDGetTokenT<reco::TrackCollection> outerTrackCollectionToken_;
@@ -239,6 +241,7 @@ private:
   edm::EDGetTokenT<reco::TrackToTrackMap> tpfmsCollectionToken_;
   edm::EDGetTokenT<reco::TrackToTrackMap> pickyCollectionToken_;
   edm::EDGetTokenT<reco::TrackToTrackMap> dytCollectionToken_;
+  edm::EDGetTokenT<reco::VertexCollection> pvToken_;
 
   edm::EDGetTokenT<RPCRecHitCollection> rpcHitToken_;
   edm::EDGetTokenT<edm::ValueMap<reco::MuonQuality> > glbQualToken_;
@@ -264,6 +267,8 @@ private:
   bool fillGlobalTrackRefits_;
   edm::InputTag globalTrackQualityInputTag_;
 
+  edm::InputTag pvInputTag_;
+  bool selectHighPurity_;
   bool fillTrackerKink_;
   std::unique_ptr<MuonKinkFinder> trackerKinkFinder_;
 

--- a/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
+++ b/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
@@ -17,7 +17,8 @@ earlyMuons = muons1stStep.clone(
     TrackAssociatorParameters = dict(
 	useHO   = False,
 	useEcal = False,
-	useHcal = False)
+	useHcal = False),
+    selectHighPurity = False
 )
 earlyDisplacedMuons = earlyMuons.clone(
     inputCollectionLabels = ['earlyGeneralTracks','displacedStandAloneMuons:']

--- a/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
+++ b/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
@@ -17,7 +17,8 @@ earlyMuons = muons1stStep.clone(
     TrackAssociatorParameters = dict(
 	useHO   = False,
 	useEcal = False,
-	useHcal = False)
+	useHcal = False),
+    pvInputTag = "firstStepPrimaryVertices" #Not used, but needed to avoid circular dependency in schedule
 )
 earlyDisplacedMuons = earlyMuons.clone(
     inputCollectionLabels = ['earlyGeneralTracks','displacedStandAloneMuons:']

--- a/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
+++ b/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
@@ -17,8 +17,7 @@ earlyMuons = muons1stStep.clone(
     TrackAssociatorParameters = dict(
 	useHO   = False,
 	useEcal = False,
-	useHcal = False),
-    pvInputTag = "firstStepPrimaryVertices" #Not used, but needed to avoid circular dependency in schedule
+	useHcal = False)
 )
 earlyDisplacedMuons = earlyMuons.clone(
     inputCollectionLabels = ['earlyGeneralTracks','displacedStandAloneMuons:']

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -66,6 +66,8 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
     # global quality
     fillGlobalTrackQuality = cms.bool(False), #input depends on external module output --> set to True where the sequence is defined
     globalTrackQualityInputTag = cms.InputTag('glbTrackQual'),
+    selectHighPurity = cms.bool(False),
+    pvInputTag = cms.InputTag('offlinePrimaryVertices'),
 
     # tracker kink finding
     fillTrackerKink = cms.bool(True),
@@ -100,7 +102,7 @@ muonEcalDetIds = cms.EDProducer("InterestingEcalDetIdProducer",
 )
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(muons1stStep, minPt = 0.8)
+pp_on_AA.toModify(muons1stStep, minPt = 0.8, selectHighPurity = True)
 
 from Configuration.ProcessModifiers.recoFromReco_cff import recoFromReco
 recoFromReco.toModify(muons1stStep,fillShowerDigis = False)

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -101,8 +101,6 @@ muonEcalDetIds = cms.EDProducer("InterestingEcalDetIdProducer",
                                 inputCollection = cms.InputTag("muons1stStep")
 )
 
-from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(muons1stStep, minPt = 0.8, selectHighPurity = True)
 
 from Configuration.ProcessModifiers.recoFromReco_cff import recoFromReco
 recoFromReco.toModify(muons1stStep,fillShowerDigis = False)

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -101,6 +101,8 @@ muonEcalDetIds = cms.EDProducer("InterestingEcalDetIdProducer",
                                 inputCollection = cms.InputTag("muons1stStep")
 )
 
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(muons1stStep, minPt = 0.8, selectHighPurity = True)
 
 from Configuration.ProcessModifiers.recoFromReco_cff import recoFromReco
 recoFromReco.toModify(muons1stStep,fillShowerDigis = False)


### PR DESCRIPTION
#### PR description:

This PR selects out highPurity tracks as input to the muon reconstruction for heavy ions.  It was noticed that the efficiency of global muons dropped in central (high multiplicity) events.  This inefficiency is larger than that observed for tracker tracks, which is modest, or for stand-alone muons, which are basically unaffected by centrality.  We surmised that poor quality tracks must be interfering with the matching.  It was found that by switching to highPurity tracks, we increased the efficiency of muon reconstruction at low momentum, without any effect at high momentum.   

The highPurity requirement is dropped when the primary vertex is not found.  This occurs in very low multiplicity events, particularly ultra-peripheral collisions.   Primary vertex information is used in the track quality assignment, which leads to tracks often failing to be assigned as highPurity.   The  fake track contribution is such collisions is negligible, however, so this requirement can simply be dropped, reverting to the default behavior used for pp reconstruction.

This development was presented to the muon POG:
https://indico.cern.ch/event/1094481/#10-low-pt-reco-muon-efficiency
https://indico.cern.ch/event/1100342/contributions/4629173/attachments/2356132/4020819/muonRecoRun3_30112021.pdf    

@flodamas

#### PR validation:

Tested with wfs 158 and 159




