### PR TITLE
get rid of CMSDEPRECATED_X warnings from `EventFilter/Si*RawToDigi`

### DIFF
--- a/EventFilter/SiPixelRawToDigi/test/FedErrorDumper.cc
+++ b/EventFilter/SiPixelRawToDigi/test/FedErrorDumper.cc
@@ -7,7 +7,7 @@
  * Works for CMSSW7X (bytoken)d.k.
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -312,17 +312,15 @@ int MyDecode::data(int word, int &fedChannel, int fed, bool print) {
 
 ////////////////////////////////////////////////////////////////////////////
 
-class FedErrorDumper : public edm::EDAnalyzer {
+class FedErrorDumper : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// ctor
   explicit FedErrorDumper(const edm::ParameterSet &cfg);
 
   /// dtor
-  virtual ~FedErrorDumper() {}
+  virtual ~FedErrorDumper() = default;
 
   void beginJob();
-
-  //void beginRun( const edm::EventSetup& ) {}
 
   // end of job
   void endJob();
@@ -359,6 +357,7 @@ FedErrorDumper::FedErrorDumper(const edm::ParameterSet &cfg) : theConfig(cfg) {
 
   // For the ByToken method
   fedErrorContainer = consumes<edm::DetSetVector<SiPixelRawDataError> >(src);
+  usesResource(TFileService::kSharedResource);
 }
 
 //---------------------------------

--- a/EventFilter/SiPixelRawToDigi/test/SiPixelRawDumper.cc
+++ b/EventFilter/SiPixelRawToDigi/test/SiPixelRawDumper.cc
@@ -6,7 +6,7 @@
  * Works with v7x, comment out the digis access.
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -504,7 +504,7 @@ int MyDecode::data(int word, int &fedChannel, int fed, int &stat1, int &stat2, b
 }
 ////////////////////////////////////////////////////////////////////////////
 
-class SiPixelRawDumper : public edm::EDAnalyzer {
+class SiPixelRawDumper : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// ctor
   explicit SiPixelRawDumper(const edm::ParameterSet &cfg);
@@ -513,11 +513,9 @@ public:
   //consumes<FEDRawDataCollection>(theConfig.getUntrackedParameter<std::string>("InputLabel","source"));}
 
   /// dtor
-  virtual ~SiPixelRawDumper() {}
+  virtual ~SiPixelRawDumper() = default;
 
   void beginJob();
-
-  //void beginRun( const edm::EventSetup& ) {}
 
   // end of job
   void endJob();
@@ -582,6 +580,7 @@ SiPixelRawDumper::SiPixelRawDumper(const edm::ParameterSet &cfg) : theConfig(cfg
   string label = theConfig.getUntrackedParameter<std::string>("InputLabel", "source");
   // For the ByToken method
   rawData = consumes<FEDRawDataCollection>(label);
+  usesResource(TFileService::kSharedResource);
 }
 //----------------------------------------------------------------------------------------
 void SiPixelRawDumper::endJob() {

--- a/EventFilter/SiPixelRawToDigi/test/findHotPixels.cc
+++ b/EventFilter/SiPixelRawToDigi/test/findHotPixels.cc
@@ -3,7 +3,7 @@
  * Works in  v352
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -426,7 +426,7 @@ void HotPixels::print(int events, int fed_id) {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Main program
-class findHotPixels : public edm::EDAnalyzer {
+class findHotPixels : public edm::one::EDAnalyzer<> {
 public:
   /// ctor
   explicit findHotPixels(const edm::ParameterSet &cfg) : theConfig(cfg) {
@@ -434,11 +434,9 @@ public:
   }
 
   /// dtor
-  virtual ~findHotPixels() {}
+  virtual ~findHotPixels() = default;
 
   void beginJob();
-
-  //void beginRun( const edm::EventSetup& ) {}
 
   // end of job
   void endJob();

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiAnalyzer.cc
@@ -5,8 +5,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
-#include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
@@ -64,7 +62,7 @@ void SiStripTrivialDigiAnalysis::print(stringstream& ss) {
 // -----------------------------------------------------------------------------
 //
 SiStripDigiAnalyzer::SiStripDigiAnalyzer(const edm::ParameterSet& pset)
-    : inputModuleLabel_(pset.getParameter<string>("InputModuleLabel")) {
+    : esTokenCabling_(esConsumes()), inputModuleLabel_(pset.getParameter<string>("InputModuleLabel")) {
   consumes<edm::DetSetVector<SiStripRawDigi> >(edm::InputTag(inputModuleLabel_, "VirginRaw"));
   consumes<edm::DetSetVector<SiStripRawDigi> >(edm::InputTag(inputModuleLabel_, "ProcessedRaw"));
   consumes<edm::DetSetVector<SiStripRawDigi> >(edm::InputTag(inputModuleLabel_, "ScopeMode"));
@@ -119,8 +117,7 @@ void SiStripDigiAnalyzer::analyze(const edm::Event& event, const edm::EventSetup
                                   << " Analyzing run " << event.id().run() << " and event " << event.id().event();
 
   // Retrieve FED (reatout) and FEC (control) cabling
-  edm::ESHandle<SiStripFedCabling> fed_cabling;
-  setup.get<SiStripFedCablingRcd>().get(fed_cabling);
+  edm::ESHandle<SiStripFedCabling> fed_cabling = setup.getHandle(esTokenCabling_);
 
   // Retrieve "real" digis
   edm::Handle<edm::DetSetVector<SiStripRawDigi> > vr;

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiAnalyzer.h
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripDigiAnalyzer.h
@@ -1,7 +1,9 @@
 #ifndef EventFilter_SiStripRawToDigi_test_AnalyzeSiStripDigis_H
 #define EventFilter_SiStripRawToDigi_test_AnalyzeSiStripDigis_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include <string>
 #include <sstream>
 #include <vector>
@@ -43,7 +45,7 @@ private:
   std::vector<uint16_t> adc_;
 };
 
-class SiStripDigiAnalyzer : public edm::EDAnalyzer {
+class SiStripDigiAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   SiStripDigiAnalyzer(const edm::ParameterSet&);
   ~SiStripDigiAnalyzer();
@@ -53,6 +55,7 @@ public:
   void endJob();
 
 private:
+  const edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> esTokenCabling_;
   std::string inputModuleLabel_;
 
   SiStripTrivialDigiAnalysis anal_;

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.cc
@@ -1,9 +1,6 @@
-#include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
-#include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
-#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.h"
 #include "EventFilter/SiStripRawToDigi/interface/SiStripFEDBuffer.h"
@@ -19,7 +16,7 @@ using namespace std;
 // -----------------------------------------------------------------------------
 //
 SiStripFEDRawDataAnalyzer::SiStripFEDRawDataAnalyzer(const edm::ParameterSet& pset)
-    : label_(pset.getParameter<edm::InputTag>("InputLabel")) {
+    : esTokenCabling_(esConsumes()), label_(pset.getParameter<edm::InputTag>("InputLabel")) {
   LogDebug("SiStripFEDRawDataAnalyzer") << "[SiStripFEDRawDataAnalyzer::" << __func__ << "]"
                                         << "Constructing object...";
   consumes<FEDRawDataCollection>(label_);
@@ -48,8 +45,7 @@ void SiStripFEDRawDataAnalyzer::endJob() {
 //
 void SiStripFEDRawDataAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   // Retrieve FED cabling object
-  edm::ESHandle<SiStripFedCabling> cabling;
-  setup.get<SiStripFedCablingRcd>().get(cabling);
+  edm::ESHandle<SiStripFedCabling> cabling = setup.getHandle(esTokenCabling_);
 
   // Retrieve FEDRawData collection
   edm::Handle<FEDRawDataCollection> buffers;

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.h
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripFEDRawDataAnalyzer.h
@@ -1,10 +1,12 @@
 #ifndef EventFilter_SiStripRawToDigi_SiStripFEDRawDataAnalyzer_H
 #define EventFilter_SiStripRawToDigi_SiStripFEDRawDataAnalyzer_H
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include <utility>
 #include <vector>
 
@@ -13,7 +15,7 @@
    @brief Analyzes contents of FEDRawData collection
 */
 
-class SiStripFEDRawDataAnalyzer : public edm::EDAnalyzer {
+class SiStripFEDRawDataAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   typedef std::pair<uint16_t, uint16_t> Fed;
   typedef std::vector<Fed> Feds;
@@ -28,6 +30,7 @@ public:
   void endJob();
 
 private:
+  const edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> esTokenCabling_;
   edm::InputTag label_;
 };
 

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.cc
@@ -1,9 +1,7 @@
 #include "EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.h"
-#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
 
 SiStripTrivialClusterSource::SiStripTrivialClusterSource(const edm::ParameterSet& pset)
-    :
-
+    : esTokenCabling_(esConsumes<edm::Transition::BeginRun>()),
       minocc_(pset.getUntrackedParameter<double>("MinOccupancy", 0.001)),
       maxocc_(pset.getUntrackedParameter<double>("MaxOccupancy", 0.03)),
       mincluster_(pset.getUntrackedParameter<unsigned int>("MinCluster", 4)),
@@ -16,10 +14,10 @@ SiStripTrivialClusterSource::SiStripTrivialClusterSource(const edm::ParameterSet
   produces<edm::DetSetVector<SiStripDigi>>();
 }
 
-SiStripTrivialClusterSource::~SiStripTrivialClusterSource() {}
+SiStripTrivialClusterSource::~SiStripTrivialClusterSource() = default;
 
 void SiStripTrivialClusterSource::beginRun(const edm::Run&, const edm::EventSetup& setup) {
-  setup.get<SiStripDetCablingRcd>().get(cabling_);
+  cabling_ = setup.getHandle(esTokenCabling_);
   cabling_->addAllDetectorsRawIds(detids_);
   for (unsigned int i = 0; i < detids_.size(); i++) {
     nstrips_ += cabling_->getConnections(detids_[i]).size() * 256;

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.h
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialClusterSource.h
@@ -1,7 +1,7 @@
 #ifndef EventFilter_SiStripRawToDigi_SiStripTrivialClusterSource_H
 #define EventFilter_SiStripRawToDigi_SiStripTrivialClusterSource_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -11,6 +11,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
+#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
 #include "TRandom.h"
 #include <vector>
 
@@ -22,7 +23,7 @@
     to test the final DigiToRaw and RawToDigi/RawToCluster converters.  
  */
 
-class SiStripTrivialClusterSource : public edm::EDProducer {
+class SiStripTrivialClusterSource : public edm::stream::EDProducer<> {
 public:
   SiStripTrivialClusterSource(const edm::ParameterSet&);
   ~SiStripTrivialClusterSource() override;
@@ -36,6 +37,9 @@ private:
 
   /** Add cluster to module */
   void addcluster(edm::DetSet<SiStripDigi>&, const uint16_t, const uint16_t);
+
+  /** token */
+  const edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> esTokenCabling_;
 
   /** Configurables */
   double minocc_;

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.cc
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.cc
@@ -1,7 +1,4 @@
-
 #include "EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.h"
-#include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
-#include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
@@ -24,7 +21,8 @@
 // -----------------------------------------------------------------------------
 //
 SiStripTrivialDigiSource::SiStripTrivialDigiSource(const edm::ParameterSet& pset)
-    : meanOcc_(pset.getUntrackedParameter<double>("MeanOccupancy", 1.)),
+    : esTokenCabling_(esConsumes()),
+      meanOcc_(pset.getUntrackedParameter<double>("MeanOccupancy", 1.)),
       rmsOcc_(pset.getUntrackedParameter<double>("RmsOccupancy", 0.1)),
       ped_(pset.getUntrackedParameter<int>("PedestalLevel", 100)),
       raw_(pset.getUntrackedParameter<bool>("FedRawDataMode", false)),
@@ -43,13 +41,12 @@ SiStripTrivialDigiSource::~SiStripTrivialDigiSource() {
 
 // -----------------------------------------------------------------------------
 //
-void SiStripTrivialDigiSource::produce(edm::Event& event, const edm::EventSetup& setup) {
+void SiStripTrivialDigiSource::produce(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const {
   LogTrace("TrivialDigiSource") << "[SiStripRawToDigiModule::" << __func__ << "]"
                                 << " Analyzing run/event " << event.id().run() << "/" << event.id().event();
 
   // Retrieve cabling
-  edm::ESHandle<SiStripFedCabling> cabling;
-  setup.get<SiStripFedCablingRcd>().get(cabling);
+  edm::ESHandle<SiStripFedCabling> cabling = setup.getHandle(esTokenCabling_);
 
   // Temp container
   typedef std::vector<edm::DetSet<SiStripDigi>> digi_work_vector;

--- a/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.h
+++ b/EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.h
@@ -1,8 +1,9 @@
-
 #ifndef EventFilter_SiStripRawToDigi_SiStripTrivialDigiSource_H
 #define EventFilter_SiStripRawToDigi_SiStripTrivialDigiSource_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 
 /**
     @file EventFilter/SiStripRawToDigi/test/plugins/SiStripTrivialDigiSource.h
@@ -12,26 +13,20 @@
     number generators and attaches the collection to the Event. Allows
     to test the final DigiToRaw and RawToDigi converters.  
 */
-class SiStripTrivialDigiSource : public edm::EDProducer {
+class SiStripTrivialDigiSource : public edm::global::EDProducer<> {
 public:
   SiStripTrivialDigiSource(const edm::ParameterSet&);
   ~SiStripTrivialDigiSource();
 
-  virtual void beginJob() { ; }
-  virtual void endJob() { ; }
-
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
-  float meanOcc_;
-
-  float rmsOcc_;
-
-  int ped_;
-
-  bool raw_;
-
-  bool useFedKey_;
+  const edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> esTokenCabling_;
+  const float meanOcc_;
+  const float rmsOcc_;
+  const int ped_;
+  const bool raw_;
+  const bool useFedKey_;
 };
 
 #endif  // EventFilter_SiStripRawToDigi_SiStripTrivialDigiSource_H


### PR DESCRIPTION
#### PR description:
Part of the migration in #31061 and #36404.
Went systematically through all of the CMSDEPRECATED_X warnings in the `EventFilter/Si*RawToDigi` subsystem from `CMSSW_12_3_CMSDEPRECATED_X_2022-01-10-2300` and removed deprecated API calls.
 * removed unnecessary header includes;
 * added `esConsumes`;

#### PR validation:

`cmssw` compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A