### PR TITLE
Fix TEST_DIR in a CalibPPS/TimingCalibration unit test

### DIFF
--- a/CalibPPS/TimingCalibration/test/test_timing_LUT_cal.sh
+++ b/CalibPPS/TimingCalibration/test/test_timing_LUT_cal.sh
@@ -3,7 +3,10 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-TEST_DIR=src/CondTools/CTPPS/test
+TEST_DIR=$CMSSW_RELEASE_BASE/src/CondTools/CTPPS/test
+if [ -e $CMSSW_BASE/src/CondTools/CTPPS/test ] ; then
+   TEST_DIR=$CMSSW_BASE/src/CondTools/CTPPS/test
+fi
 
 cmsRun $TEST_DIR/ppsTimingCalibrationLUTWriter_cfg.py || die "LUT writer failed" $?
 echo "LUT writer succeeded"


### PR DESCRIPTION
#### PR description:

That unit test cannot work because it points to a non existing test dir
Not clear why it does not fail in IBs, but it does in some test PR results, for example #36675

#### PR validation:

Tested that the unit test runs without error if this fix is implemented, while it fails in the original version as:
```
===== Test "testDiamondLUTCalibration" ====
----- Begin Fatal Exception 11-Jan-2022 19:10:41 UTC-----------------------
An exception of category 'StdException' occurred while
   [0] Processing the python configuration file named src/CondTools/CTPPS/test/ppsTimingCalibrationLUTWriter_cfg.py
Exception Message:
A std::exception was thrown.
File "src/CondTools/CTPPS/test/ppsTimingCalibrationLUTWriter_cfg.py" could not be opened!
----- End Fatal Exception -------------------------------------------------
LUT writer failed: status 66

---> test testDiamondLUTCalibration had ERRORS
TestTime:1
^^^^ End Test testDiamondLUTCalibration ^^^^
```
