### PR TITLE
use std::isnan to avoid cs8 + boost1.78.0 build errors

### DIFF
--- a/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
@@ -748,7 +748,7 @@ bool LHCInfoPopConSourceHandler::getEcalData(cond::persistency::Session& session
         dipVal = dipValAttribute.data<std::string>();
         elementNr = elementNrAttribute.data<unsigned int>();
         value = valueNumberAttribute.data<float>();
-        if (isnan(value))
+        if (std::isnan(value))
           value = 0.;
         if (filter.process(iovTime)) {
           iovMap.insert(std::make_pair(changeTime, filter.current()->first));


### PR DESCRIPTION
This fixes the `boost 1.78.0` build errors for `cs8_amd64_gcc10` ( see https://github.com/cms-sw/cmsdist/pulls#issuecomment-1012256712 )