### PR TITLE
Drop type specs for RecoMuon

### DIFF
--- a/Validation/RecoMuon/python/PostProcessorHLT_cff.py
+++ b/Validation/RecoMuon/python/PostProcessorHLT_cff.py
@@ -4,9 +4,9 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 from Validation.RecoMuon.PostProcessor_cff import postProcessorMuonTrack
-postProcessorMuonTrackHLT = postProcessorMuonTrack.clone()
-postProcessorMuonTrackHLT.subDirs = cms.untracked.vstring("HLT/Muon/MuonTrack/*")
-
+postProcessorMuonTrackHLT = postProcessorMuonTrack.clone(
+    subDirs = ["HLT/Muon/MuonTrack/*"]
+)
 postProcessorMuonTrackHLTComp = DQMEDHarvester(
     "DQMGenericClient",
     subDirs = cms.untracked.vstring("HLT/Muon/MuonTrack/"), 

--- a/Validation/RecoMuon/python/PostProcessor_RecoMuonValidator_cff.py
+++ b/Validation/RecoMuon/python/PostProcessor_RecoMuonValidator_cff.py
@@ -34,27 +34,27 @@ postProcessorRecoMuon = DQMEDHarvester("DQMGenericClient",
 )
 
 # for each type monitored
-postProcessorRecoMuonGlb = postProcessorRecoMuon.clone()
-postProcessorRecoMuonGlb.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Glb")
-
-postProcessorRecoMuonTrk = postProcessorRecoMuon.clone()
-postProcessorRecoMuonTrk.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Trk")
-
-postProcessorRecoMuonSta = postProcessorRecoMuon.clone()
-postProcessorRecoMuonSta.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Sta")
-
-postProcessorRecoMuonTgt = postProcessorRecoMuon.clone()
-postProcessorRecoMuonTgt.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_Tgt")
-
-postProcessorRecoMuonGlbPF = postProcessorRecoMuon.clone()
-postProcessorRecoMuonGlbPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_GlbPF")
-
-postProcessorRecoMuonTrkPF = postProcessorRecoMuon.clone()
-postProcessorRecoMuonTrkPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_TrkPF")
-
-postProcessorRecoMuonStaPF = postProcessorRecoMuon.clone()
-postProcessorRecoMuonStaPF.subDirs = cms.untracked.vstring("Muons/RecoMuonV/RecoMuon_MuonAssoc_StaPF")
-
+postProcessorRecoMuonGlb = postProcessorRecoMuon.clone(
+    subDirs = ["Muons/RecoMuonV/RecoMuon_MuonAssoc_Glb"]
+)
+postProcessorRecoMuonTrk = postProcessorRecoMuon.clone(
+    subDirs = ["Muons/RecoMuonV/RecoMuon_MuonAssoc_Trk"]
+)
+postProcessorRecoMuonSta = postProcessorRecoMuon.clone(
+    subDirs = ["Muons/RecoMuonV/RecoMuon_MuonAssoc_Sta"]
+)
+postProcessorRecoMuonTgt = postProcessorRecoMuon.clone(
+    subDirs = ["Muons/RecoMuonV/RecoMuon_MuonAssoc_Tgt"]
+)
+postProcessorRecoMuonGlbPF = postProcessorRecoMuon.clone(
+    subDirs = ["Muons/RecoMuonV/RecoMuon_MuonAssoc_GlbPF"]
+)
+postProcessorRecoMuonTrkPF = postProcessorRecoMuon.clone(
+    subDirs = ["Muons/RecoMuonV/RecoMuon_MuonAssoc_TrkPF"]
+)
+postProcessorRecoMuonStaPF = postProcessorRecoMuon.clone(
+    subDirs = ["Muons/RecoMuonV/RecoMuon_MuonAssoc_StaPF"]
+)
 #not sure about this one, which types are monitored
 postProcessorRecoMuonComp = DQMEDHarvester(
     "DQMGenericClient",

--- a/Validation/RecoMuon/python/RecoMuonValidator_cff.py
+++ b/Validation/RecoMuon/python/RecoMuonValidator_cff.py
@@ -11,60 +11,65 @@ from SimMuon.MCTruth.muonAssociatorByHitsNoSimHitsHelper_cfi import *
 from SimMuon.MCTruth.MuonAssociatorByHits_cfi import muonAssociatorByHitsCommonParameters
 
 #tracker
-muonAssociatorByHitsNoSimHitsHelperTrk = muonAssociatorByHitsNoSimHitsHelper.clone()
-muonAssociatorByHitsNoSimHitsHelperTrk.UseTracker = True
-muonAssociatorByHitsNoSimHitsHelperTrk.UseMuon  = False
-recoMuonVMuAssoc_trk = recoMuonValidator.clone()
-recoMuonVMuAssoc_trk.subDir = 'Muons/RecoMuonV/RecoMuon_MuonAssoc_Trk'
-recoMuonVMuAssoc_trk.muAssocLabel = 'muonAssociatorByHitsNoSimHitsHelperTrk'
-recoMuonVMuAssoc_trk.trackType = 'inner'
-recoMuonVMuAssoc_trk.selection = "isTrackerMuon"
-recoMuonVMuAssoc_trk.simLabel = ("TPmu")
-recoMuonVMuAssoc_trk.tpRefVector = True
+muonAssociatorByHitsNoSimHitsHelperTrk = muonAssociatorByHitsNoSimHitsHelper.clone(
+    UseTracker = True,
+    UseMuon  = False
+)
+recoMuonVMuAssoc_trk = recoMuonValidator.clone(
+    subDir = 'Muons/RecoMuonV/RecoMuon_MuonAssoc_Trk',
+    muAssocLabel = 'muonAssociatorByHitsNoSimHitsHelperTrk',
+    trackType = 'inner',
+    selection = "isTrackerMuon",
+    simLabel = ("TPmu"),
+    tpRefVector = True
+)
 recoMuonVMuAssoc_trk.tpSelector.src = ("TPmu")
-
 #standalone
-muonAssociatorByHitsNoSimHitsHelperStandalone = muonAssociatorByHitsNoSimHitsHelper.clone()
-muonAssociatorByHitsNoSimHitsHelperStandalone.UseTracker = False
-muonAssociatorByHitsNoSimHitsHelperStandalone.UseMuon  = True
-recoMuonVMuAssoc_sta = recoMuonValidator.clone()
-recoMuonVMuAssoc_sta.subDir = 'Muons/RecoMuonV/RecoMuon_MuonAssoc_Sta'
-recoMuonVMuAssoc_sta.muAssocLabel = 'muonAssociatorByHitsNoSimHitsHelperStandalone'
-recoMuonVMuAssoc_sta.trackType = 'outer'
-recoMuonVMuAssoc_sta.selection = "isStandAloneMuon"
-recoMuonVMuAssoc_sta.simLabel = ("TPmu")
-recoMuonVMuAssoc_sta.tpRefVector = True
+muonAssociatorByHitsNoSimHitsHelperStandalone = muonAssociatorByHitsNoSimHitsHelper.clone(
+    UseTracker = False,
+    UseMuon  = True
+)
+recoMuonVMuAssoc_sta = recoMuonValidator.clone(
+    subDir = 'Muons/RecoMuonV/RecoMuon_MuonAssoc_Sta',
+    muAssocLabel = 'muonAssociatorByHitsNoSimHitsHelperStandalone',
+    trackType = 'outer',
+    selection = "isStandAloneMuon",
+    simLabel = ("TPmu"),
+    tpRefVector = True
+
+)
 recoMuonVMuAssoc_sta.tpSelector.src = ("TPmu")
-
 #global
-muonAssociatorByHitsNoSimHitsHelperGlobal = muonAssociatorByHitsNoSimHitsHelper.clone()
-muonAssociatorByHitsNoSimHitsHelperGlobal.UseTracker = True
-muonAssociatorByHitsNoSimHitsHelperGlobal.UseMuon  = True
-recoMuonVMuAssoc_glb = recoMuonValidator.clone()
-recoMuonVMuAssoc_glb.subDir = 'Muons/RecoMuonV/RecoMuon_MuonAssoc_Glb'
-recoMuonVMuAssoc_glb.muAssocLabel = 'muonAssociatorByHitsNoSimHitsHelperGlobal'
-recoMuonVMuAssoc_glb.trackType = 'global'
-recoMuonVMuAssoc_glb.selection = "isGlobalMuon"
-recoMuonVMuAssoc_glb.simLabel = ("TPmu")
-recoMuonVMuAssoc_glb.tpRefVector = True
+muonAssociatorByHitsNoSimHitsHelperGlobal = muonAssociatorByHitsNoSimHitsHelper.clone(
+    UseTracker = True,
+    UseMuon  = True
+)
+recoMuonVMuAssoc_glb = recoMuonValidator.clone(
+    subDir = 'Muons/RecoMuonV/RecoMuon_MuonAssoc_Glb',
+    muAssocLabel = 'muonAssociatorByHitsNoSimHitsHelperGlobal',
+    trackType = 'global',
+    selection = "isGlobalMuon",
+    simLabel = ("TPmu"),
+    tpRefVector = True,
+)
 recoMuonVMuAssoc_glb.tpSelector.src = ("TPmu")
-
 #tight
-muonAssociatorByHitsNoSimHitsHelperTight = muonAssociatorByHitsNoSimHitsHelper.clone()
-muonAssociatorByHitsNoSimHitsHelperTight.UseTracker = True
-muonAssociatorByHitsNoSimHitsHelperTight.UseMuon  = True
-recoMuonVMuAssoc_tgt = recoMuonValidator.clone()
-recoMuonVMuAssoc_tgt.subDir = 'Muons/RecoMuonV/RecoMuon_MuonAssoc_Tgt'
-recoMuonVMuAssoc_tgt.muAssocLabel = 'muonAssociatorByHitsNoSimHitsHelperTight'
-recoMuonVMuAssoc_tgt.trackType = 'global'
-recoMuonVMuAssoc_tgt.selection = 'isGlobalMuon'
-recoMuonVMuAssoc_tgt.wantTightMuon = True
-recoMuonVMuAssoc_tgt.beamSpot = 'offlineBeamSpot'
-recoMuonVMuAssoc_tgt.primaryVertex = 'offlinePrimaryVertices'
-recoMuonVMuAssoc_tgt.simLabel = ("TPmu")
-recoMuonVMuAssoc_tgt.tpRefVector = True
+muonAssociatorByHitsNoSimHitsHelperTight = muonAssociatorByHitsNoSimHitsHelper.clone(
+    UseTracker = True,
+    UseMuon  = True
+)
+recoMuonVMuAssoc_tgt = recoMuonValidator.clone(
+    subDir = 'Muons/RecoMuonV/RecoMuon_MuonAssoc_Tgt',
+    muAssocLabel = 'muonAssociatorByHitsNoSimHitsHelperTight',
+    trackType = 'global',
+    selection = 'isGlobalMuon',
+    wantTightMuon = True,
+    beamSpot = 'offlineBeamSpot',
+    primaryVertex = 'offlinePrimaryVertices',
+    simLabel = ("TPmu"),
+    tpRefVector = True,
+)
 recoMuonVMuAssoc_tgt.tpSelector.src = ("TPmu")
-
 ##########################################################################
 # Muon validation sequence using RecoMuonValidator
 #

--- a/Validation/RecoMuon/python/associators_cff.py
+++ b/Validation/RecoMuon/python/associators_cff.py
@@ -11,162 +11,162 @@ trackAssociatorByHits = SimTracker.TrackAssociatorProducers.quickTrackAssociator
 
 from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi import trackingParticleRecoTrackAsssociation as _trackingParticleRecoTrackAsssociation
 tpToTkmuTrackAssociation = _trackingParticleRecoTrackAsssociation.clone(
-    associator = cms.InputTag('trackAssociatorByHits'),
-#    label_tr = cms.InputTag('generalTracks')
-    label_tr = cms.InputTag('probeTracks')
+    associator = 'trackAssociatorByHits',
+#    label_tr = 'generalTracks',
+    label_tr = 'probeTracks'
 )
 
 #
 # MuonAssociatorByHits used for all track collections
 #
 import SimMuon.MCTruth.MuonAssociatorByHits_cfi
-MABH = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
+MABH = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone(
 # DEFAULTS ###################################
-#    EfficiencyCut_track = cms.double(0.),
-#    PurityCut_track = cms.double(0.),
-#    EfficiencyCut_muon = cms.double(0.),
-#    PurityCut_muon = cms.double(0.),
-#    includeZeroHitMuons = cms.bool(True),
-#    acceptOneStubMatchings = cms.bool(False),
-#    rejectBadGlobal = cms.bool(True),
-#    tpTag = cms.InputTag("mix","MergedTrackTruth")
-#    tpRefVector = cms.bool(False)
+#    EfficiencyCut_track = 0.,
+#    PurityCut_track = 0.,
+#    EfficiencyCut_muon = 0.,
+#    PurityCut_muon = 0.,
+#    includeZeroHitMuons = True,
+#    acceptOneStubMatchings = False,
+#    rejectBadGlobal = True,
+#    tpTag = "mix","MergedTrackTruth",
+#    tpRefVector = False
 ##############################################
-MABH.EfficiencyCut_track = 0.5
-MABH.PurityCut_track = 0.75
-MABH.EfficiencyCut_muon = 0.5
-MABH.PurityCut_muon = 0.75
-MABH.includeZeroHitMuons = False
-MABH.tpTag = ("TPmu")
-MABH.tpRefVector = True
+    EfficiencyCut_track = 0.5,
+    PurityCut_track = 0.75,
+    EfficiencyCut_muon = 0.5,
+    PurityCut_muon = 0.75,
+    includeZeroHitMuons = False,
+    tpTag = ("TPmu"),
+    tpRefVector = True
 ##############################################
-
-tpToTkMuonAssociation = MABH.clone()
-#tpToTkMuonAssociation.tracksTag = 'generalTracks'
-tpToTkMuonAssociation.tracksTag ='probeTracks'
-tpToTkMuonAssociation.UseTracker = True
-tpToTkMuonAssociation.UseMuon = False
-tpToTkMuonAssociation.tpTag = ("TPtrack")
-
-tpToStaSeedAssociation = MABH.clone()
-tpToStaSeedAssociation.tracksTag = 'seedsOfSTAmuons'
-tpToStaSeedAssociation.UseTracker = False
-tpToStaSeedAssociation.UseMuon = True
-tpToStaSeedAssociation.EfficiencyCut_muon = 0.
-
-tpToStaMuonAssociation = MABH.clone()
-tpToStaMuonAssociation.tracksTag = 'standAloneMuons'
-tpToStaMuonAssociation.UseTracker = False
-tpToStaMuonAssociation.UseMuon = True
-
-tpToStaUpdMuonAssociation = MABH.clone()
-tpToStaUpdMuonAssociation.tracksTag = 'standAloneMuons:UpdatedAtVtx'
-tpToStaUpdMuonAssociation.UseTracker = False
-tpToStaUpdMuonAssociation.UseMuon = True
-
-tpToGlbMuonAssociation = MABH.clone()
-tpToGlbMuonAssociation.tracksTag = 'globalMuons'
-tpToGlbMuonAssociation.UseTracker = True
-tpToGlbMuonAssociation.UseMuon = True
-
-tpToStaRefitMuonAssociation = MABH.clone()
-tpToStaRefitMuonAssociation.tracksTag = 'refittedStandAloneMuons'
-tpToStaRefitMuonAssociation.UseTracker = False
-tpToStaRefitMuonAssociation.UseMuon = True
-
-tpToStaRefitUpdMuonAssociation = MABH.clone()
-tpToStaRefitUpdMuonAssociation.tracksTag = 'refittedStandAloneMuons:UpdatedAtVtx'
-tpToStaRefitUpdMuonAssociation.UseTracker = False
-tpToStaRefitUpdMuonAssociation.UseMuon = True
-
-tpToDisplacedTrkMuonAssociation = MABH.clone()
-tpToDisplacedTrkMuonAssociation.tracksTag = 'displacedTracks'
-tpToDisplacedTrkMuonAssociation.UseTracker = True
-tpToDisplacedTrkMuonAssociation.UseMuon = False
-tpToDisplacedTrkMuonAssociation.tpTag = ("TPtrack")
-
-tpToDisplacedStaSeedAssociation = MABH.clone()
-tpToDisplacedStaSeedAssociation.tracksTag = 'seedsOfDisplacedSTAmuons'
-tpToDisplacedStaSeedAssociation.UseTracker = False
-tpToDisplacedStaSeedAssociation.UseMuon = True
-tpToDisplacedStaSeedAssociation.EfficiencyCut_muon = 0.
-
-tpToDisplacedStaMuonAssociation = MABH.clone()
-tpToDisplacedStaMuonAssociation.tracksTag = 'displacedStandAloneMuons'
-tpToDisplacedStaMuonAssociation.UseTracker = False
-tpToDisplacedStaMuonAssociation.UseMuon = True
-
-tpToDisplacedGlbMuonAssociation = MABH.clone()
-tpToDisplacedGlbMuonAssociation.tracksTag = 'displacedGlobalMuons'
-tpToDisplacedGlbMuonAssociation.UseTracker = True
-tpToDisplacedGlbMuonAssociation.UseMuon = True
-
-tpToTevFirstMuonAssociation = MABH.clone()
-tpToTevFirstMuonAssociation.tracksTag = 'tevMuons:firstHit'
-tpToTevFirstMuonAssociation.UseTracker = True
-tpToTevFirstMuonAssociation.UseMuon = True
-tpToTevFirstMuonAssociation.EfficiencyCut_muon = 0.
-
-tpToTevPickyMuonAssociation = MABH.clone()
-tpToTevPickyMuonAssociation.tracksTag = 'tevMuons:picky'
-tpToTevPickyMuonAssociation.UseTracker = True
-tpToTevPickyMuonAssociation.UseMuon = True
-tpToTevPickyMuonAssociation.EfficiencyCut_muon = 0.
-
-tpToTevDytMuonAssociation = MABH.clone()
-tpToTevDytMuonAssociation.tracksTag = 'tevMuons:dyt'
-tpToTevDytMuonAssociation.UseTracker = True
-tpToTevDytMuonAssociation.UseMuon = True
-tpToTevDytMuonAssociation.EfficiencyCut_muon = 0.
-tpToTevDytMuonAssociation.rejectBadGlobal = False
-
+)
+tpToTkMuonAssociation = MABH.clone(
+    #tracksTag = 'generalTracks',
+    tracksTag ='probeTracks',
+    UseTracker = True,
+    UseMuon = False,
+    tpTag = ("TPtrack")
+)
+tpToStaSeedAssociation = MABH.clone(
+    tracksTag = 'seedsOfSTAmuons',
+    UseTracker = False,
+    UseMuon = True,
+    EfficiencyCut_muon = 0.
+)
+tpToStaMuonAssociation = MABH.clone(
+    tracksTag = 'standAloneMuons',
+    UseTracker = False,
+    UseMuon = True
+)
+tpToStaUpdMuonAssociation = MABH.clone(
+    tracksTag = 'standAloneMuons:UpdatedAtVtx',
+    UseTracker = False,
+    UseMuon = True
+)
+tpToGlbMuonAssociation = MABH.clone(
+    tracksTag = 'globalMuons',
+    UseTracker = True,
+    UseMuon = True
+)
+tpToStaRefitMuonAssociation = MABH.clone(
+    tracksTag = 'refittedStandAloneMuons',
+    UseTracker = False,
+    UseMuon = True
+)
+tpToStaRefitUpdMuonAssociation = MABH.clone(
+    tracksTag = 'refittedStandAloneMuons:UpdatedAtVtx',
+    UseTracker = False,
+    UseMuon = True
+)
+tpToDisplacedTrkMuonAssociation = MABH.clone(
+    tracksTag = 'displacedTracks',
+    UseTracker = True,
+    UseMuon = False,
+    tpTag = ("TPtrack")
+)
+tpToDisplacedStaSeedAssociation = MABH.clone(
+    tracksTag = 'seedsOfDisplacedSTAmuons',
+    UseTracker = False,
+    UseMuon = True,
+    EfficiencyCut_muon = 0.
+)
+tpToDisplacedStaMuonAssociation = MABH.clone(
+    tracksTag = 'displacedStandAloneMuons',
+    UseTracker = False,
+    UseMuon = True
+)
+tpToDisplacedGlbMuonAssociation = MABH.clone(
+    tracksTag = 'displacedGlobalMuons',
+    UseTracker = True,
+    UseMuon = True
+)
+tpToTevFirstMuonAssociation = MABH.clone(
+    tracksTag = 'tevMuons:firstHit',
+    UseTracker = True,
+    UseMuon = True,
+    EfficiencyCut_muon = 0.
+)
+tpToTevPickyMuonAssociation = MABH.clone(
+    tracksTag = 'tevMuons:picky',
+    UseTracker = True,
+    UseMuon = True,
+    EfficiencyCut_muon = 0.
+)
+tpToTevDytMuonAssociation = MABH.clone(
+    tracksTag = 'tevMuons:dyt',
+    UseTracker = True,
+    UseMuon = True,
+    EfficiencyCut_muon = 0.,
+    rejectBadGlobal = False
+)
 # tuneP (GlobalMuons with TuneP definition)
-tpToTunePMuonAssociation = MABH.clone()
-tpToTunePMuonAssociation.tracksTag = 'tunepMuonTracks'
-tpToTunePMuonAssociation.UseTracker = True
-tpToTunePMuonAssociation.UseMuon = True
-tpToTunePMuonAssociation.EfficiencyCut_muon = 0.
-tpToTunePMuonAssociation.rejectBadGlobal = False
-
+tpToTunePMuonAssociation = MABH.clone(
+    tracksTag = 'tunepMuonTracks',
+    UseTracker = True,
+    UseMuon = True,
+    EfficiencyCut_muon = 0.,
+    rejectBadGlobal = False
+)
 # PFMuons
-tpToPFMuonAssociation = MABH.clone()
-tpToPFMuonAssociation.tracksTag = 'pfMuonTracks'
-tpToPFMuonAssociation.UseTracker = True
-tpToPFMuonAssociation.UseMuon = True
-tpToPFMuonAssociation.tpTag = ("TPpfmu")
-tpToPFMuonAssociation.EfficiencyCut_muon = 0.
-tpToPFMuonAssociation.rejectBadGlobal = False
-
+tpToPFMuonAssociation = MABH.clone(
+    tracksTag = 'pfMuonTracks',
+    UseTracker = True,
+    UseMuon = True,
+    tpTag = ("TPpfmu"),
+    EfficiencyCut_muon = 0.,
+    rejectBadGlobal = False
+)
 # all offline reco::Muons with loose cuts
 # note in this case muons can be of any type: set UseTracker=UseMuon=true and rejectBadGlobal=false,
 # then define the logic in the muon track producer, run beforehand.
-tpTorecoMuonMuonAssociation = MABH.clone()
-tpTorecoMuonMuonAssociation.tracksTag = 'recoMuonTracks'
-tpTorecoMuonMuonAssociation.UseTracker = True
-tpTorecoMuonMuonAssociation.UseMuon = True
-tpTorecoMuonMuonAssociation.EfficiencyCut_track = 0.
-tpTorecoMuonMuonAssociation.EfficiencyCut_muon = 0.
-# matching to a skimmed TP collection needs a purity cut to avoid pathological cases
-#tpTorecoMuonMuonAssociation.PurityCut_track = 0.
-#tpTorecoMuonMuonAssociation.PurityCut_muon = 0.
-tpTorecoMuonMuonAssociation.includeZeroHitMuons = True
-tpTorecoMuonMuonAssociation.rejectBadGlobal = False
-
+tpTorecoMuonMuonAssociation = MABH.clone(
+    tracksTag = 'recoMuonTracks',
+    UseTracker = True,
+    UseMuon = True,
+    EfficiencyCut_track = 0.,
+    EfficiencyCut_muon = 0.,
+    # matching to a skimmed TP collection needs a purity cut to avoid pathological cases
+    #PurityCut_track = 0.,
+    #PurityCut_muon = 0.,
+    includeZeroHitMuons = True,
+    rejectBadGlobal = False
+)
 # ME0Muons
-tpToME0MuonMuonAssociation = MABH.clone()
-tpToME0MuonMuonAssociation.tracksTag = 'extractMe0Muons'
-tpToME0MuonMuonAssociation.UseTracker = True
-tpToME0MuonMuonAssociation.UseMuon = False
-
+tpToME0MuonMuonAssociation = MABH.clone(
+    tracksTag = 'extractMe0Muons',
+    UseTracker = True,
+    UseMuon = False
+)
 # GEMmuons
-tpToGEMMuonMuonAssociation = MABH.clone()
-tpToGEMMuonMuonAssociation.tracksTag = 'extractGemMuons'
-tpToGEMMuonMuonAssociation.UseTracker = True
-tpToGEMMuonMuonAssociation.UseMuon = False
-
+tpToGEMMuonMuonAssociation = MABH.clone(
+    tracksTag = 'extractGemMuons',
+    UseTracker = True,
+    UseMuon = False
+)
 # === HLT muon tracks 
 #
-MABHhlt = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
+MABHhlt = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone(
 # DEFAULTS ###################################
 #    EfficiencyCut_track = cms.double(0.), # backup solution as UseGrouped/UseSplitting are always assumed to be true
 #    EfficiencyCut_muon = cms.double(0.),  # | loose matching requests for triggering
@@ -174,112 +174,115 @@ MABHhlt = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 #    acceptOneStubMatchings = cms.bool(False),
 #    rejectBadGlobal = cms.bool(True),
 ##############################################
-MABHhlt.PurityCut_track = 0.75
-MABHhlt.PurityCut_muon = 0.75
-MABHhlt.DTrechitTag = 'hltDt1DRecHits'
-MABHhlt.ignoreMissingTrackCollection = True
-MABHhlt.tpTag = ("TPmu")
-MABHhlt.tpRefVector = True
+    PurityCut_track = 0.75,
+    PurityCut_muon = 0.75,
+    DTrechitTag = 'hltDt1DRecHits',
+    ignoreMissingTrackCollection = True,
+    tpTag = ("TPmu"),
+    tpRefVector = True
+)
 ##############################################
 
-tpToL2MuonAssociation = MABHhlt.clone()
-tpToL2MuonAssociation.tracksTag = 'hltL2Muons'
-tpToL2MuonAssociation.UseTracker = False
-tpToL2MuonAssociation.UseMuon = True
+tpToL2MuonAssociation = MABHhlt.clone(
+    tracksTag = 'hltL2Muons',
+    UseTracker = False,
+    UseMuon = True
+)
+tpToL2UpdMuonAssociation = MABHhlt.clone(
+    tracksTag = 'hltL2Muons:UpdatedAtVtx',
+    UseTracker = False,
+    UseMuon = True
+)
+tpToL3OITkMuonAssociation = MABHhlt.clone(
+    tracksTag = 'hltIterL3OIMuonTrackSelectionHighPurity',
+    UseTracker = True,
+    UseMuon = False
+)
+tpToL3TkMuonAssociation = MABHhlt.clone(
+    tracksTag = 'hltIterL3MuonMerged',
+    UseTracker = True,
+    UseMuon = False
+)
+tpToL3FromL1TkMuonAssociation = MABHhlt.clone(
+    tracksTag = 'hltIterL3MuonAndMuonFromL1Merged',
+    UseTracker = True,
+    UseMuon = False
+)
+tpToL3GlbMuonAssociation = MABHhlt.clone(
+    tracksTag = 'hltIterL3GlbMuon',
+    UseTracker = True,
+    UseMuon = True
+)
+tpToL3NoIDMuonAssociation = MABHhlt.clone(
+    tracksTag = 'hltIterL3MuonsNoIDTracks',
+    UseTracker = True,
+    UseMuon = True,
+    rejectBadGlobal = False
+)
+tpToL3MuonAssociation = MABHhlt.clone(
+    tracksTag = 'hltIterL3MuonsTracks',
+    UseTracker = True,
+    UseMuon = True,
+    rejectBadGlobal = False
+)
 
-tpToL2UpdMuonAssociation = MABHhlt.clone()
-tpToL2UpdMuonAssociation.tracksTag = 'hltL2Muons:UpdatedAtVtx'
-tpToL2UpdMuonAssociation.UseTracker = False
-tpToL2UpdMuonAssociation.UseMuon = True
-
-tpToL3OITkMuonAssociation = MABHhlt.clone()
-tpToL3OITkMuonAssociation.tracksTag = 'hltIterL3OIMuonTrackSelectionHighPurity'
-tpToL3OITkMuonAssociation.UseTracker = True
-tpToL3OITkMuonAssociation.UseMuon = False
-
-tpToL3TkMuonAssociation = MABHhlt.clone()
-tpToL3TkMuonAssociation.tracksTag = 'hltIterL3MuonMerged'
-tpToL3TkMuonAssociation.UseTracker = True
-tpToL3TkMuonAssociation.UseMuon = False
-
-tpToL3FromL1TkMuonAssociation = MABHhlt.clone()
-tpToL3FromL1TkMuonAssociation.tracksTag = 'hltIterL3MuonAndMuonFromL1Merged'
-tpToL3FromL1TkMuonAssociation.UseTracker = True
-tpToL3FromL1TkMuonAssociation.UseMuon = False
-
-tpToL3GlbMuonAssociation = MABHhlt.clone()
-tpToL3GlbMuonAssociation.tracksTag = 'hltIterL3GlbMuon'
-tpToL3GlbMuonAssociation.UseTracker = True
-tpToL3GlbMuonAssociation.UseMuon = True
-
-tpToL3NoIDMuonAssociation = MABHhlt.clone()
-tpToL3NoIDMuonAssociation.tracksTag = 'hltIterL3MuonsNoIDTracks'
-tpToL3NoIDMuonAssociation.UseTracker = True
-tpToL3NoIDMuonAssociation.UseMuon = True
-tpToL3NoIDMuonAssociation.rejectBadGlobal = False
-
-tpToL3MuonAssociation = MABHhlt.clone()
-tpToL3MuonAssociation.tracksTag = 'hltIterL3MuonsTracks'
-tpToL3MuonAssociation.UseTracker = True
-tpToL3MuonAssociation.UseMuon = True
-tpToL3MuonAssociation.rejectBadGlobal = False
-# ===
 
 #
 # COSMICS reco
-MABHcosmic = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
+MABHcosmic = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone(
 # DEFAULTS ###################################
-#    acceptOneStubMatchings = cms.bool(False),
-#    rejectBadGlobal = cms.bool(True),
-#    tpTag = cms.InputTag("mix","MergedTrackTruth")
-#    tpRefVector = cms.bool(False)
+#    acceptOneStubMatchings = False,
+#    rejectBadGlobal = True,
+#    tpTag = "mix:MergedTrackTruth",
+#    tpRefVector = False,
 ###############################################
-MABHcosmic.EfficiencyCut_track = 0.5
-MABHcosmic.PurityCut_track = 0.75
-MABHcosmic.EfficiencyCut_muon = 0.5
-MABHcosmic.PurityCut_muon = 0.75
-MABHcosmic.includeZeroHitMuons = False
+    EfficiencyCut_track = 0.5,
+    PurityCut_track = 0.75,
+    EfficiencyCut_muon = 0.5,
+    PurityCut_muon = 0.75,
+    includeZeroHitMuons = False
+)
 ################################################
 #
 # 2-legs cosmics reco: simhits can be twice the reconstructed ones in any single leg
 # (Quality cut have to be set at 0.25, purity cuts can stay at default value 0.75)
 # T.B.D. upper and lower leg should be analyzed separately 
 #
-tpToTkCosmicSelMuonAssociation = MABHcosmic.clone()
-tpToTkCosmicSelMuonAssociation.tracksTag = 'ctfWithMaterialTracksP5LHCNavigation'
-tpToTkCosmicSelMuonAssociation.UseTracker = True
-tpToTkCosmicSelMuonAssociation.UseMuon = False
-tpToTkCosmicSelMuonAssociation.EfficiencyCut_track = 0.25
-
-tpToStaCosmicSelMuonAssociation = MABHcosmic.clone()
-tpToStaCosmicSelMuonAssociation.tracksTag = 'cosmicMuons'
-tpToStaCosmicSelMuonAssociation.UseTracker = False
-tpToStaCosmicSelMuonAssociation.UseMuon = True
-tpToStaCosmicSelMuonAssociation.EfficiencyCut_muon = 0.25
-
-tpToGlbCosmicSelMuonAssociation = MABHcosmic.clone()
-tpToGlbCosmicSelMuonAssociation.tracksTag = 'globalCosmicMuons'
-tpToGlbCosmicSelMuonAssociation.UseTracker = True
-tpToGlbCosmicSelMuonAssociation.UseMuon = True
-tpToGlbCosmicSelMuonAssociation.EfficiencyCut_track = 0.25
-tpToGlbCosmicSelMuonAssociation.EfficiencyCut_muon = 0.25
-
+tpToTkCosmicSelMuonAssociation = MABHcosmic.clone(
+    tracksTag = 'ctfWithMaterialTracksP5LHCNavigation',
+    UseTracker = True,
+    UseMuon = False,
+    EfficiencyCut_track = 0.25
+)
+tpToStaCosmicSelMuonAssociation = MABHcosmic.clone(
+    tracksTag = 'cosmicMuons',
+    UseTracker = False,
+    UseMuon = True,
+    EfficiencyCut_muon = 0.25
+)
+tpToGlbCosmicSelMuonAssociation = MABHcosmic.clone(
+    tracksTag = 'globalCosmicMuons',
+    UseTracker = True,
+    UseMuon = True,
+    EfficiencyCut_track = 0.25,
+    EfficiencyCut_muon = 0.25
+)
 # 1-leg cosmics reco
-tpToTkCosmic1LegSelMuonAssociation = MABHcosmic.clone()
-tpToTkCosmic1LegSelMuonAssociation.tracksTag = 'ctfWithMaterialTracksP5'
-tpToTkCosmic1LegSelMuonAssociation.UseTracker = True
-tpToTkCosmic1LegSelMuonAssociation.UseMuon = False
-
-tpToStaCosmic1LegSelMuonAssociation = MABHcosmic.clone()
-tpToStaCosmic1LegSelMuonAssociation.tracksTag = 'cosmicMuons1Leg'
-tpToStaCosmic1LegSelMuonAssociation.UseTracker = False
-tpToStaCosmic1LegSelMuonAssociation.UseMuon = True
-
-tpToGlbCosmic1LegSelMuonAssociation = MABHcosmic.clone()
-tpToGlbCosmic1LegSelMuonAssociation.tracksTag = 'globalCosmicMuons1Leg'
-tpToGlbCosmic1LegSelMuonAssociation.UseTracker = True
-tpToGlbCosmic1LegSelMuonAssociation.UseMuon = True
-
+tpToTkCosmic1LegSelMuonAssociation = MABHcosmic.clone(
+    tracksTag = 'ctfWithMaterialTracksP5',
+    UseTracker = True,
+    UseMuon = False
+)
+tpToStaCosmic1LegSelMuonAssociation = MABHcosmic.clone(
+    tracksTag = 'cosmicMuons1Leg',
+    UseTracker = False,
+    UseMuon = True
+)
+tpToGlbCosmic1LegSelMuonAssociation = MABHcosmic.clone(
+    tracksTag = 'globalCosmicMuons1Leg',
+    UseTracker = True,
+    UseMuon = True
+)
 #
 # The full-sim association sequences
 #

--- a/Validation/RecoMuon/python/histoParameters_cff.py
+++ b/Validation/RecoMuon/python/histoParameters_cff.py
@@ -105,334 +105,350 @@ defaultMuonHistoParameters = cms.PSet(
 
 #####################################################################################
 # TRK tracks
-trkMuonHistoParameters =  defaultMuonHistoParameters.clone()
-trkMuonHistoParameters.usetracker = True
-trkMuonHistoParameters.usemuon = False
-trkMuonHistoParameters.nintNHit = 41
-trkMuonHistoParameters.maxNHit = 40.5
-trkMuonHistoParameters.do_TRKhitsPlots = True
-trkMuonHistoParameters.do_MUOhitsPlots = False
+trkMuonHistoParameters =  defaultMuonHistoParameters.clone(
+    usetracker = True,
+    usemuon = False,
+    nintNHit = 41,
+    maxNHit = 40.5,
+    do_TRKhitsPlots = True,
+    do_MUOhitsPlots = False
+)
 #####################################################################################
 # GEMmuon tracks
-gemMuonHistoParameters =  trkMuonHistoParameters.clone()
-gemMuonHistoParameters.usetracker = True
-gemMuonHistoParameters.usemuon = False
-gemMuonHistoParameters.minEta = -2.8
-gemMuonHistoParameters.maxEta = +2.8
-gemMuonHistoParameters.nintEta = 48
-#gemMuonHistoParameters.nintNHit = 41   # this is the tracker default
-#gemMuonHistoParameters.maxNHit = 40.5
-gemMuonHistoParameters.do_TRKhitsPlots = True
-gemMuonHistoParameters.do_MUOhitsPlots = True  # is this used in the current code ?
+gemMuonHistoParameters =  trkMuonHistoParameters.clone(
+    usetracker = True,
+    usemuon = False,
+    minEta = -2.8,
+    maxEta = +2.8,
+    nintEta = 48,
+    #nintNHit = 41,   # this is the tracker default
+    #maxNHit = 40.5,
+    do_TRKhitsPlots = True,
+    do_MUOhitsPlots = True  # is this used in the current code ?
+)
 #####################################################################################
 # ME0muon tracks
-me0MuonHistoParameters =  trkMuonHistoParameters.clone()
-me0MuonHistoParameters.usetracker = True
-me0MuonHistoParameters.usemuon = False
-me0MuonHistoParameters.minEta = -2.8
-me0MuonHistoParameters.maxEta = +2.8
-me0MuonHistoParameters.nintEta = 56
-#me0MuonHistoParameters.nintNHit = 41   # this is the tracker default
-#me0MuonHistoParameters.maxNHit = 40.5
-me0MuonHistoParameters.do_TRKhitsPlots = True
-me0MuonHistoParameters.do_MUOhitsPlots = True  # is this used in the current code ?
+me0MuonHistoParameters =  trkMuonHistoParameters.clone(
+    usetracker = True,
+    usemuon = False,
+    minEta = -2.8,
+    maxEta = +2.8,
+    nintEta = 56,
+    #nintNHit = 41,   # this is the tracker default
+    #maxNHit = 40.5,
+    do_TRKhitsPlots = True,
+    do_MUOhitsPlots = True  # is this used in the current code ?
+)
 #####################################################################################
 # STA tracks
-staMuonHistoParameters = defaultMuonHistoParameters.clone()
-staMuonHistoParameters.usetracker = False
-staMuonHistoParameters.usemuon = True
-staMuonHistoParameters.nintNHit = 61
-staMuonHistoParameters.maxNHit = 60.5
-staMuonHistoParameters.do_TRKhitsPlots = False
-staMuonHistoParameters.do_MUOhitsPlots = True
-##
-staMuonHistoParameters.nintDxy = 40
-staMuonHistoParameters.minDxy = -10.
-staMuonHistoParameters.maxDxy = 10.
-##
-staMuonHistoParameters.ptRes_nbin = 200
-staMuonHistoParameters.ptRes_rangeMin = -1.
-staMuonHistoParameters.ptRes_rangeMax = 5.
-##
-staMuonHistoParameters.phiRes_nbin = 200
-staMuonHistoParameters.phiRes_rangeMin = -0.1
-staMuonHistoParameters.phiRes_rangeMax = 0.1
-##
-staMuonHistoParameters.etaRes_nbin = 100
-staMuonHistoParameters.etaRes_rangeMin = -0.1
-staMuonHistoParameters.etaRes_rangeMax = 0.1
-##
-staMuonHistoParameters.cotThetaRes_nbin = 100
-staMuonHistoParameters.cotThetaRes_rangeMin = -0.1
-staMuonHistoParameters.cotThetaRes_rangeMax = 0.1
-##
-staMuonHistoParameters.dxyRes_nbin = 100
-staMuonHistoParameters.dxyRes_rangeMin = -10.
-staMuonHistoParameters.dxyRes_rangeMax = 10.
-##
-staMuonHistoParameters.dzRes_nbin = 100
-staMuonHistoParameters.dzRes_rangeMin = -25.
-staMuonHistoParameters.dzRes_rangeMax = 25.
+staMuonHistoParameters = defaultMuonHistoParameters.clone(
+    usetracker = False,
+    usemuon = True,
+    nintNHit = 61,
+    maxNHit = 60.5,
+    do_TRKhitsPlots = False,
+    do_MUOhitsPlots = True,
+    ##
+    nintDxy = 40,
+    minDxy = -10.,
+    maxDxy = 10.,
+    ##
+    ptRes_nbin = 200,
+    ptRes_rangeMin = -1.,
+    ptRes_rangeMax = 5.,
+    ##
+    phiRes_nbin = 200,
+    phiRes_rangeMin = -0.1,
+    phiRes_rangeMax = 0.1,
+    ##
+    etaRes_nbin = 100,
+    etaRes_rangeMin = -0.1,
+    etaRes_rangeMax = 0.1,
+    ##
+    cotThetaRes_nbin = 100,
+    cotThetaRes_rangeMin = -0.1,
+    cotThetaRes_rangeMax = 0.1,
+    ##
+    dxyRes_nbin = 100,
+    dxyRes_rangeMin = -10.,
+    dxyRes_rangeMax = 10.,
+    ##
+    dzRes_nbin = 100,
+    dzRes_rangeMin = -25.,
+    dzRes_rangeMax = 25.
+)
 #####################################################################################
 # STA seeds (here hits are counting DT,CSC segments rather than individual hit layers)
-staSeedMuonHistoParameters = staMuonHistoParameters.clone()
-staSeedMuonHistoParameters.nintNHit = 7
-staSeedMuonHistoParameters.maxNHit = 6.5
-staSeedMuonHistoParameters.nintDTHit = 7
-staSeedMuonHistoParameters.maxDTHit = 6.5
-staSeedMuonHistoParameters.nintCSCHit = 7
-staSeedMuonHistoParameters.maxCSCHit = 6.5
-staSeedMuonHistoParameters.nintRPCHit = 7
-staSeedMuonHistoParameters.maxRPCHit = 6.5
+staSeedMuonHistoParameters = staMuonHistoParameters.clone(
+    nintNHit = 7,
+    maxNHit = 6.5,
+    nintDTHit = 7,
+    maxDTHit = 6.5,
+    nintCSCHit = 7,
+    maxCSCHit = 6.5,
+    nintRPCHit = 7,
+    maxRPCHit = 6.5
+)
 #####################################################################################
 # STA Upd tracks
-staUpdMuonHistoParameters = staMuonHistoParameters.clone()
-staUpdMuonHistoParameters.dxyRes_nbin = 100
-staUpdMuonHistoParameters.dxyRes_rangeMin = -1.
-staUpdMuonHistoParameters.dxyRes_rangeMax = 1.
+staUpdMuonHistoParameters = staMuonHistoParameters.clone(
+    dxyRes_nbin = 100,
+    dxyRes_rangeMin = -1.,
+    dxyRes_rangeMax = 1.
+)
 #####################################################################################
 # GLB tracks
-glbMuonHistoParameters =  defaultMuonHistoParameters.clone()
-glbMuonHistoParameters.usetracker = True
-glbMuonHistoParameters.usemuon = True
-glbMuonHistoParameters.nintNHit = 81
-glbMuonHistoParameters.maxNHit = 80.5
-glbMuonHistoParameters.do_TRKhitsPlots = True
-glbMuonHistoParameters.do_MUOhitsPlots = True
-
+glbMuonHistoParameters =  defaultMuonHistoParameters.clone(
+    usetracker = True,
+    usemuon = True,
+    nintNHit = 81,
+    maxNHit = 80.5,
+    do_TRKhitsPlots = True,
+    do_MUOhitsPlots = True
+)
 #####################################################################################                                             
 # Reco Muon tracks                                                                                                                
-recoMuonHistoParameters =  defaultMuonHistoParameters.clone()                                                                     
-recoMuonHistoParameters.usetracker = True                                                                                         
-recoMuonHistoParameters.usemuon = True                                                                                            
-recoMuonHistoParameters.nintNHit = 81                                                                                             
-recoMuonHistoParameters.maxNHit = 80.5                                                                                            
-recoMuonHistoParameters.do_TRKhitsPlots = True                                                                                    
-recoMuonHistoParameters.do_MUOhitsPlots = True         
-
+recoMuonHistoParameters =  defaultMuonHistoParameters.clone(                                                                     
+    usetracker = True,                                                                                         
+    usemuon = True,                                                                                        
+    nintNHit = 81,                                                                                             
+    maxNHit = 80.5,                                                                                            
+    do_TRKhitsPlots = True,                                                                                    
+    do_MUOhitsPlots = True         
+)
 #####################################################################################
 # Displaced TRK tracks
-displacedTrkMuonHistoParameters = trkMuonHistoParameters.clone()
-displacedTrkMuonHistoParameters.nintDxy = 85
-displacedTrkMuonHistoParameters.minDxy = -85.
-displacedTrkMuonHistoParameters.maxDxy = 85.
-#
-displacedTrkMuonHistoParameters.nintDz = 84
-displacedTrkMuonHistoParameters.minDz = -210.
-displacedTrkMuonHistoParameters.maxDz = 210.
-#
-displacedTrkMuonHistoParameters.nintRpos = 85
-displacedTrkMuonHistoParameters.minRpos = 0.
-displacedTrkMuonHistoParameters.maxRpos = 85.
-#
-displacedTrkMuonHistoParameters.nintZpos = 84
-displacedTrkMuonHistoParameters.minZpos = -210.
-displacedTrkMuonHistoParameters.maxZpos = 210.
+displacedTrkMuonHistoParameters = trkMuonHistoParameters.clone(
+    nintDxy = 85,
+    minDxy = -85.,
+    maxDxy = 85.,
+    #
+    nintDz = 84,
+    minDz = -210.,
+    maxDz = 210.,
+    #
+    nintRpos = 85,
+    minRpos = 0.,
+    maxRpos = 85.,
+    #
+    nintZpos = 84,
+    minZpos = -210.,
+    maxZpos = 210.
+)
 #####################################################################################
 # Displaced muons: STA tracks
-displacedStaMuonHistoParameters = staMuonHistoParameters.clone()
-displacedStaMuonHistoParameters.nintDxy = 85
-displacedStaMuonHistoParameters.minDxy = -85.
-displacedStaMuonHistoParameters.maxDxy = 85.
-#
-displacedStaMuonHistoParameters.nintDz = 84
-displacedStaMuonHistoParameters.minDz = -210.
-displacedStaMuonHistoParameters.maxDz = 210.
-#
-displacedStaMuonHistoParameters.nintRpos = 85
-displacedStaMuonHistoParameters.minRpos = 0.
-displacedStaMuonHistoParameters.maxRpos = 85.
-#
-displacedStaMuonHistoParameters.nintZpos = 84
-displacedStaMuonHistoParameters.minZpos = -210.
-displacedStaMuonHistoParameters.maxZpos = 210.
+displacedStaMuonHistoParameters = staMuonHistoParameters.clone(
+    nintDxy = 85,
+    minDxy = -85.,
+    maxDxy = 85.,
+    #
+    nintDz = 84,
+    minDz = -210.,
+    maxDz = 210.,
+    #
+    nintRpos = 85,
+    minRpos = 0.,
+    maxRpos = 85.,
+    #
+    nintZpos = 84,
+    minZpos = -210.,
+    maxZpos = 210.
+)
 #####################################################################################
 # Displaced muons: STA seeds (here hits are counting DT,CSC segments rather than individual hit layers)
-displacedStaSeedMuonHistoParameters = displacedStaMuonHistoParameters.clone()
-displacedStaSeedMuonHistoParameters.nintNHit = 7
-displacedStaSeedMuonHistoParameters.maxNHit = 6.5
-displacedStaSeedMuonHistoParameters.nintDTHit = 7
-displacedStaSeedMuonHistoParameters.maxDTHit = 6.5
-displacedStaSeedMuonHistoParameters.nintCSCHit = 7
-displacedStaSeedMuonHistoParameters.maxCSCHit = 6.5
-displacedStaSeedMuonHistoParameters.nintRPCHit = 7
-displacedStaSeedMuonHistoParameters.maxRPCHit = 6.5
+displacedStaSeedMuonHistoParameters = displacedStaMuonHistoParameters.clone(
+    nintNHit = 7,
+    maxNHit = 6.5,
+    nintDTHit = 7,
+    maxDTHit = 6.5,
+    nintCSCHit = 7,
+    maxCSCHit = 6.5,
+    nintRPCHit = 7,
+    maxRPCHit = 6.5
+)
 #####################################################################################
 # Displaced muons: GLB tracks
-displacedGlbMuonHistoParameters = glbMuonHistoParameters.clone()
-displacedGlbMuonHistoParameters.nintDxy = 85
-displacedGlbMuonHistoParameters.minDxy = -85.
-displacedGlbMuonHistoParameters.maxDxy = 85.
-#
-displacedGlbMuonHistoParameters.nintDz = 84
-displacedGlbMuonHistoParameters.minDz = -210.
-displacedGlbMuonHistoParameters.maxDz = 210.
-#
-displacedGlbMuonHistoParameters.nintRpos = 85
-displacedGlbMuonHistoParameters.minRpos = 0.
-displacedGlbMuonHistoParameters.maxRpos = 85.
-#
-displacedGlbMuonHistoParameters.nintZpos = 84
-displacedGlbMuonHistoParameters.minZpos = -210.
-displacedGlbMuonHistoParameters.maxZpos = 210.
+displacedGlbMuonHistoParameters = glbMuonHistoParameters.clone(
+    nintDxy = 85,
+    minDxy = -85.,
+    maxDxy = 85.,
+    #
+    nintDz = 84,
+    minDz = -210.,
+    maxDz = 210.,
+    #
+    nintRpos = 85,
+    minRpos = 0.,
+    maxRpos = 85.,
+    #
+    nintZpos = 84,
+    minZpos = -210.,
+    maxZpos = 210.
+)
 #####################################################################################
 # COSMIC muons
 #####################################################################################
 # cosmics: TRK tracks (2-legs)
-trkCosmicMuonHistoParameters = trkMuonHistoParameters.clone()
-trkCosmicMuonHistoParameters.nintDxy = 40
-trkCosmicMuonHistoParameters.minDxy = -10. 
-trkCosmicMuonHistoParameters.maxDxy = 10.
-#
-trkCosmicMuonHistoParameters.nintDz = 50
-trkCosmicMuonHistoParameters.minDz = -50.
-trkCosmicMuonHistoParameters.maxDz = 50.
-#
-trkCosmicMuonHistoParameters.nintRpos = 40 
-trkCosmicMuonHistoParameters.minRpos = 0.
-trkCosmicMuonHistoParameters.maxRpos = 10.
-#
-trkCosmicMuonHistoParameters.nintZpos = 50
-trkCosmicMuonHistoParameters.minZpos = -50.
-trkCosmicMuonHistoParameters.maxZpos = 50.
+trkCosmicMuonHistoParameters = trkMuonHistoParameters.clone(
+    nintDxy = 40,
+    minDxy = -10., 
+    maxDxy = 10.,
+    #
+    nintDz = 50,
+    minDz = -50.,
+    maxDz = 50.,
+    #
+    nintRpos = 40, 
+    minRpos = 0.,
+    maxRpos = 10.,
+    #
+    nintZpos = 50,
+    minZpos = -50.,
+    maxZpos = 50.
+)
 #####################################################################################
 # cosmics: STA tracks (2-legs)
-staCosmicMuonHistoParameters = staMuonHistoParameters.clone()
-staCosmicMuonHistoParameters.nintDxy = 40
-staCosmicMuonHistoParameters.minDxy = -10. 
-staCosmicMuonHistoParameters.maxDxy = 10.
-#
-staCosmicMuonHistoParameters.nintDz = 50
-staCosmicMuonHistoParameters.minDz = -50.
-staCosmicMuonHistoParameters.maxDz = 50.
-#
-staCosmicMuonHistoParameters.nintRpos = 40 
-staCosmicMuonHistoParameters.minRpos = 0.
-staCosmicMuonHistoParameters.maxRpos = 10.
-#
-staCosmicMuonHistoParameters.nintZpos = 50
-staCosmicMuonHistoParameters.minZpos = -50.
-staCosmicMuonHistoParameters.maxZpos = 50.
+staCosmicMuonHistoParameters = staMuonHistoParameters.clone(
+    nintDxy = 40,
+    minDxy = -10., 
+    maxDxy = 10.,
+    #,
+    nintDz = 50,
+    minDz = -50.,
+    maxDz = 50.,
+    #
+    nintRpos = 40, 
+    minRpos = 0.,
+    maxRpos = 10.,
+    #
+    nintZpos = 50,
+    minZpos = -50.,
+    maxZpos = 50.
+)
 #####################################################################################
 # cosmics: GLB tracks (2-legs)
-glbCosmicMuonHistoParameters = glbMuonHistoParameters.clone()
-glbCosmicMuonHistoParameters.nintDxy = 40
-glbCosmicMuonHistoParameters.minDxy = -10. 
-glbCosmicMuonHistoParameters.maxDxy = 10.
-#
-glbCosmicMuonHistoParameters.nintDz = 50
-glbCosmicMuonHistoParameters.minDz = -50.
-glbCosmicMuonHistoParameters.maxDz = 50.
-#
-glbCosmicMuonHistoParameters.nintRpos = 40 
-glbCosmicMuonHistoParameters.minRpos = 0.
-glbCosmicMuonHistoParameters.maxRpos = 10.
-#
-glbCosmicMuonHistoParameters.nintZpos = 50
-glbCosmicMuonHistoParameters.minZpos = -50.
-glbCosmicMuonHistoParameters.maxZpos = 50.
+glbCosmicMuonHistoParameters = glbMuonHistoParameters.clone(
+    nintDxy = 40,
+    minDxy = -10., 
+    maxDxy = 10.,
+    #
+    nintDz = 50,
+    minDz = -50.,
+    maxDz = 50.,
+    #
+    nintRpos = 40, 
+    minRpos = 0.,
+    maxRpos = 10.,
+    #
+    nintZpos = 50,
+    minZpos = -50.,
+    maxZpos = 50.
+)
 #####################################################################################
 # cosmics: TRK tracks (1-leg)
-trkCosmic1LegMuonHistoParameters = trkCosmicMuonHistoParameters.clone()
-trkCosmic1LegMuonHistoParameters.nintNHit = 81
-trkCosmic1LegMuonHistoParameters.maxNHit = 80.5
-#
-trkCosmic1LegMuonHistoParameters.nintLayers = 31
-trkCosmic1LegMuonHistoParameters.maxLayers = 30.5
-#
-trkCosmic1LegMuonHistoParameters.nintPixels = 11
-trkCosmic1LegMuonHistoParameters.maxPixels = 10.5
+trkCosmic1LegMuonHistoParameters = trkCosmicMuonHistoParameters.clone(
+    nintNHit = 81,
+    maxNHit = 80.5,
+    #
+    nintLayers = 31,
+    maxLayers = 30.5,
+    #
+    nintPixels = 11,
+    maxPixels = 10.5
+)
 #####################################################################################
 # cosmics: STA tracks (1-leg)
-staCosmic1LegMuonHistoParameters = staCosmicMuonHistoParameters.clone()
-staCosmic1LegMuonHistoParameters.nintNHit = 121
-staCosmic1LegMuonHistoParameters.maxNHit = 120.5
-#
-staCosmic1LegMuonHistoParameters.nintDTHit = 101
-staCosmic1LegMuonHistoParameters.maxDTHit = 100.5
-#
-staCosmic1LegMuonHistoParameters.nintCSCHit = 101
-staCosmic1LegMuonHistoParameters.maxCSCHit = 100.5
-#
-staCosmic1LegMuonHistoParameters.nintRPCHit = 21
-staCosmic1LegMuonHistoParameters.maxRPCHit = 20.5
+staCosmic1LegMuonHistoParameters = staCosmicMuonHistoParameters.clone(
+    nintNHit = 121,
+    maxNHit = 120.5,
+    #
+    nintDTHit = 101,
+    maxDTHit = 100.5,
+    #
+    nintCSCHit = 101,
+    maxCSCHit = 100.5,
+    #
+    nintRPCHit = 21,
+    maxRPCHit = 20.5
+)
 #####################################################################################
 # cosmics: GLB tracks (1-leg)
-glbCosmic1LegMuonHistoParameters = glbCosmicMuonHistoParameters.clone()
-glbCosmic1LegMuonHistoParameters.nintNHit = 161
-glbCosmic1LegMuonHistoParameters.maxNHit = 160.5
-#
-glbCosmic1LegMuonHistoParameters.nintDTHit = 101
-glbCosmic1LegMuonHistoParameters.maxDTHit = 100.5
-#
-glbCosmic1LegMuonHistoParameters.nintCSCHit = 101
-glbCosmic1LegMuonHistoParameters.maxCSCHit = 100.5
-#
-glbCosmic1LegMuonHistoParameters.nintRPCHit = 21
-glbCosmic1LegMuonHistoParameters.maxRPCHit = 20.5
-#
-glbCosmic1LegMuonHistoParameters.nintLayers = 31 
-glbCosmic1LegMuonHistoParameters.maxLayers = 30.5
-#
-glbCosmic1LegMuonHistoParameters.nintPixels = 11
-glbCosmic1LegMuonHistoParameters.maxPixels = 10.5
-
+glbCosmic1LegMuonHistoParameters = glbCosmicMuonHistoParameters.clone(
+    nintNHit = 161,
+    maxNHit = 160.5,
+    #
+    nintDTHit = 101,
+    maxDTHit = 100.5,
+    #
+    nintCSCHit = 101,
+    maxCSCHit = 100.5,
+    #
+    nintRPCHit = 21,
+    maxRPCHit = 20.5,
+    #
+    nintLayers = 31, 
+    maxLayers = 30.5,
+    #
+    nintPixels = 11,
+    maxPixels = 10.5
+)
 
 ## Customize ranges for phase 2 samples 
 # TRK tracks                                                                                                                     
-trkMuonHistoParameters_phase2 = trkMuonHistoParameters.clone()
-trkMuonHistoParameters_phase2.minPU = 150
-trkMuonHistoParameters_phase2.maxPU = 250
-
+trkMuonHistoParameters_phase2 = trkMuonHistoParameters.clone(
+    minPU = 150,
+    maxPU = 250
+)
 # GEMmuon tracks                                                                                                                 
-gemMuonHistoParameters_phase2 = gemMuonHistoParameters.clone()       
-gemMuonHistoParameters_phase2.minPU = 150
-gemMuonHistoParameters_phase2.maxPU = 250
-gemMuonHistoParameters_phase2.maxNTracks = 150
-gemMuonHistoParameters_phase2.nintNTracks = 100
-gemMuonHistoParameters_phase2.maxFTracks = 50
-gemMuonHistoParameters_phase2.nintFTracks = 50
-
+gemMuonHistoParameters_phase2 = gemMuonHistoParameters.clone(       
+    minPU = 150,
+    maxPU = 250,
+    maxNTracks = 150,
+    nintNTracks = 100,
+    maxFTracks = 50,
+    nintFTracks = 50
+)
 # STA tracks                                                                                                                      
-staMuonHistoParameters_phase2 = staMuonHistoParameters.clone()
-staMuonHistoParameters_phase2.minPU = 150
-staMuonHistoParameters_phase2.maxPU = 250
-
+staMuonHistoParameters_phase2 = staMuonHistoParameters.clone(
+    minPU = 150,
+    maxPU = 250
+)
 # STA seeds (here hits are counting DT,CSC segments rather than individual hit layers)                                            
-staSeedMuonHistoParameters_phase2 = staSeedMuonHistoParameters.clone()
-staSeedMuonHistoParameters_phase2.minPU = 150
-staSeedMuonHistoParameters_phase2.maxPU = 250
-
+staSeedMuonHistoParameters_phase2 = staSeedMuonHistoParameters.clone(
+    minPU = 150,
+    maxPU = 250
+)
 # STA Upd tracks                                                                                                                  
-staUpdMuonHistoParameters_phase2 = staUpdMuonHistoParameters.clone()
-staUpdMuonHistoParameters_phase2.minPU = 150 
-staUpdMuonHistoParameters_phase2.maxPU = 250
-
+staUpdMuonHistoParameters_phase2 = staUpdMuonHistoParameters.clone(
+    minPU = 150, 
+    maxPU = 250
+)
 # GLB tracks                                                                                                                      
-glbMuonHistoParameters_phase2 = glbMuonHistoParameters.clone()
-glbMuonHistoParameters_phase2.minPU = 150
-glbMuonHistoParameters_phase2.maxPU = 250
-
+glbMuonHistoParameters_phase2 = glbMuonHistoParameters.clone(
+    minPU = 150,
+    maxPU = 250
+)
 #RecoMuon tracks
-recoMuonHistoParameters_phase2 = recoMuonHistoParameters.clone()
-recoMuonHistoParameters_phase2.minPU = 150
-recoMuonHistoParameters_phase2.maxPU = 250
-recoMuonHistoParameters_phase2.maxNTracks = 150 
-recoMuonHistoParameters_phase2.nintNTracks = 100
-recoMuonHistoParameters_phase2.maxFTracks = 50
-recoMuonHistoParameters_phase2.nintFTracks = 50
-
+recoMuonHistoParameters_phase2 = recoMuonHistoParameters.clone(
+    minPU = 150,
+    maxPU = 250,
+    maxNTracks = 150,
+    nintNTracks = 100,
+    maxFTracks = 50,
+    nintFTracks = 50
+)
 # Displaced TRK tracks  
-displacedTrkMuonHistoParameters_phase2 = displacedTrkMuonHistoParameters.clone()
-displacedTrkMuonHistoParameters_phase2.minPU = 150
-displacedTrkMuonHistoParameters_phase2.maxPU = 250
-
+displacedTrkMuonHistoParameters_phase2 = displacedTrkMuonHistoParameters.clone(
+    minPU = 150,
+    maxPU = 250
+)
 # Displaced muons: STA tracks                                                                                                    
-displacedStaMuonHistoParameters_phase2 = displacedStaMuonHistoParameters.clone()
-displacedStaMuonHistoParameters_phase2.minPU = 150
-displacedStaMuonHistoParameters_phase2.maxPU = 250
-
+displacedStaMuonHistoParameters_phase2 = displacedStaMuonHistoParameters.clone(
+    minPU = 150,
+    maxPU = 250
+)
 # Displaced muons: GLB tracks                                                                                                     
-displacedGlbMuonHistoParameters_phase2 = displacedGlbMuonHistoParameters.clone()
-displacedGlbMuonHistoParameters_phase2.minPU = 150
-displacedGlbMuonHistoParameters_phase2.maxPU = 250
+displacedGlbMuonHistoParameters_phase2 = displacedGlbMuonHistoParameters.clone(
+    minPU = 150,
+    maxPU = 250
+)

--- a/Validation/RecoMuon/python/muonValidationHLT_cff.py
+++ b/Validation/RecoMuon/python/muonValidationHLT_cff.py
@@ -6,60 +6,61 @@ from Validation.RecoMuon.associators_cff import *
 from Validation.RecoMuon.histoParameters_cff import *
 
 import Validation.RecoMuon.MuonTrackValidator_cfi
-MTVhlt = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
+MTVhlt = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone(
 # DEFAULTS ###################################
-#    label_tp = cms.InputTag("mix","MergedTrackTruth"),
-#    label_tp_refvector = cms.bool(False),
-#    muonTPSelector = cms.PSet(muonTPSet),
+#    label_tp = "mix:MergedTrackTruth",
+#    label_tp_refvector = False,
+#    muonTPSelector = dict(muonTPSet),
 ##############################################
-MTVhlt.label_tp = ("TPmu")
-MTVhlt.label_tp_refvector = True
+label_tp = ("TPmu"),
+label_tp_refvector = True,
+dirName = 'HLT/Muon/MuonTrack/',
+#beamSpot = 'hltOfflineBeamSpot',
+ignoremissingtrackcollection=True
+)
 MTVhlt.muonTPSelector.src = ("TPmu")
-MTVhlt.dirName = 'HLT/Muon/MuonTrack/'
-#MTVhlt.beamSpot = 'hltOfflineBeamSpot'
-MTVhlt.ignoremissingtrackcollection=True
 ################################################
 
-l2MuonMuTrackV = MTVhlt.clone()
-l2MuonMuTrackV.associatormap = 'tpToL2MuonAssociation'
-l2MuonMuTrackV.label = ('hltL2Muons',)
-l2MuonMuTrackV.muonHistoParameters = staMuonHistoParameters
-
-l2UpdMuonMuTrackV = MTVhlt.clone()
-l2UpdMuonMuTrackV.associatormap = 'tpToL2UpdMuonAssociation'
-l2UpdMuonMuTrackV.label = ('hltL2Muons:UpdatedAtVtx',)
-l2UpdMuonMuTrackV.muonHistoParameters = staUpdMuonHistoParameters
-
-l3OITkMuonMuTrackV = MTVhlt.clone()
-l3OITkMuonMuTrackV.associatormap = 'tpToL3OITkMuonAssociation'
-l3OITkMuonMuTrackV.label = ('hltIterL3OIMuonTrackSelectionHighPurity:',)
-l3OITkMuonMuTrackV.muonHistoParameters = trkMuonHistoParameters
-
-l3TkMuonMuTrackV = MTVhlt.clone()
-l3TkMuonMuTrackV.associatormap = 'tpToL3TkMuonAssociation'
-l3TkMuonMuTrackV.label = ('hltIterL3MuonMerged:',)
-l3TkMuonMuTrackV.muonHistoParameters = trkMuonHistoParameters
-
-l3IOFromL1TkMuonMuTrackV = MTVhlt.clone()
-l3IOFromL1TkMuonMuTrackV.associatormap = 'tpToL3FromL1TkMuonAssociation'
-l3IOFromL1TkMuonMuTrackV.label = ('hltIterL3MuonAndMuonFromL1Merged:',)
-l3IOFromL1TkMuonMuTrackV.muonHistoParameters = trkMuonHistoParameters
-
-l3GlbMuonMuTrackV = MTVhlt.clone()
-l3GlbMuonMuTrackV.associatormap = 'tpToL3GlbMuonAssociation'
-l3GlbMuonMuTrackV.label = ('hltIterL3GlbMuon:',)
-l3GlbMuonMuTrackV.muonHistoParameters = glbMuonHistoParameters
-
-l3NoIDMuonMuTrackV = MTVhlt.clone()
-l3NoIDMuonMuTrackV.associatormap = 'tpToL3NoIDMuonAssociation'
-l3NoIDMuonMuTrackV.label = ('hltIterL3MuonsNoIDTracks:',)
-l3NoIDMuonMuTrackV.muonHistoParameters = glbMuonHistoParameters
-
-l3MuonMuTrackV = MTVhlt.clone()
-l3MuonMuTrackV.associatormap = 'tpToL3MuonAssociation'
-l3MuonMuTrackV.label = ('hltIterL3MuonsTracks:',)
-l3MuonMuTrackV.muonHistoParameters = glbMuonHistoParameters
-
+l2MuonMuTrackV = MTVhlt.clone(
+    associatormap = 'tpToL2MuonAssociation',
+    label = ('hltL2Muons',),
+    muonHistoParameters = staMuonHistoParameters
+)
+l2UpdMuonMuTrackV = MTVhlt.clone(
+    associatormap = 'tpToL2UpdMuonAssociation',
+    label = ('hltL2Muons:UpdatedAtVtx',),
+    muonHistoParameters = staUpdMuonHistoParameters
+)
+l3OITkMuonMuTrackV = MTVhlt.clone(
+    associatormap = 'tpToL3OITkMuonAssociation',
+    label = ('hltIterL3OIMuonTrackSelectionHighPurity:',),
+    muonHistoParameters = trkMuonHistoParameters
+)
+l3TkMuonMuTrackV = MTVhlt.clone(
+    associatormap = 'tpToL3TkMuonAssociation',
+    label = ('hltIterL3MuonMerged:',),
+    muonHistoParameters = trkMuonHistoParameters
+)
+l3IOFromL1TkMuonMuTrackV = MTVhlt.clone(
+    associatormap = 'tpToL3FromL1TkMuonAssociation',
+    label = ('hltIterL3MuonAndMuonFromL1Merged:',),
+    muonHistoParameters = trkMuonHistoParameters
+)
+l3GlbMuonMuTrackV = MTVhlt.clone(
+    associatormap = 'tpToL3GlbMuonAssociation',
+    label = ('hltIterL3GlbMuon:',),
+    muonHistoParameters = glbMuonHistoParameters
+)
+l3NoIDMuonMuTrackV = MTVhlt.clone(
+    associatormap = 'tpToL3NoIDMuonAssociation',
+    label = ('hltIterL3MuonsNoIDTracks:',),
+    muonHistoParameters = glbMuonHistoParameters
+)
+l3MuonMuTrackV = MTVhlt.clone(
+    associatormap = 'tpToL3MuonAssociation',
+    label = ('hltIterL3MuonsTracks:',),
+    muonHistoParameters = glbMuonHistoParameters
+)
 #
 # The full Muon HLT validation sequence
 #

--- a/Validation/RecoMuon/python/muonValidation_cff.py
+++ b/Validation/RecoMuon/python/muonValidation_cff.py
@@ -11,228 +11,235 @@ from Validation.RecoMuon.histoParameters_cff import *
 from Validation.RecoMuon.RecoMuonValidator_cff import *
 
 import Validation.RecoMuon.MuonTrackValidator_cfi
-MTV = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
+MTV = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone(
 # DEFAULTS ###################################
-#    label_tp = cms.InputTag("mix","MergedTrackTruth"),
-#    label_tp_refvector = cms.bool(False),
+#    label_tp = "mix:MergedTrackTruth",
+#    label_tp_refvector = False,
 #    muonTPSelector = cms.PSet(muonTPSet),
 ##############################################
-MTV.label_tp = ("TPmu")
-MTV.label_tp_refvector = True
+    label_tp = ("TPmu"),
+    label_tp_refvector = True
+)
 MTV.muonTPSelector.src = ("TPmu")
 ##############################################
 
-trkMuonTrackVTrackAssoc = MTV.clone()
-trkMuonTrackVTrackAssoc.associatormap = 'tpToTkmuTrackAssociation'
-trkMuonTrackVTrackAssoc.associators = ('trackAssociatorByHits',)
-#trkMuonTrackVTrackAssoc.label = ('generalTracks',)
-trkMuonTrackVTrackAssoc.label = ('probeTracks',)
-trkMuonTrackVTrackAssoc.label_tp = ("TPtrack")
+trkMuonTrackVTrackAssoc = MTV.clone(
+    associatormap = 'tpToTkmuTrackAssociation',
+    associators = ('trackAssociatorByHits',),
+    #label = ('generalTracks',),
+    label = ('probeTracks',),
+    label_tp = ("TPtrack"),
+    muonHistoParameters = trkMuonHistoParameters
+)
 trkMuonTrackVTrackAssoc.muonTPSelector.src = ("TPtrack")
-trkMuonTrackVTrackAssoc.muonHistoParameters = trkMuonHistoParameters
-
 # MuonAssociatorByHits used for all track collections
 
-trkProbeTrackVMuonAssoc = MTV.clone()
-trkProbeTrackVMuonAssoc.associatormap = 'tpToTkMuonAssociation'
-#trkProbeTrackVMuonAssoc.label = ('generalTracks',)
-trkProbeTrackVMuonAssoc.label = ('probeTracks',)
-trkProbeTrackVMuonAssoc.label_tp = ("TPtrack")
+trkProbeTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToTkMuonAssociation',
+    #label = ('generalTracks',),
+    label = ('probeTracks',),
+    label_tp = ("TPtrack"),
+    muonHistoParameters = trkMuonHistoParameters
+)
 trkProbeTrackVMuonAssoc.muonTPSelector.src = ("TPtrack")
-trkProbeTrackVMuonAssoc.muonHistoParameters = trkMuonHistoParameters
-
-staSeedTrackVMuonAssoc = MTV.clone()
-staSeedTrackVMuonAssoc.associatormap = 'tpToStaSeedAssociation'
-staSeedTrackVMuonAssoc.label = ('seedsOfSTAmuons',)
-staSeedTrackVMuonAssoc.muonHistoParameters = staSeedMuonHistoParameters
-
-staMuonTrackVMuonAssoc = MTV.clone()
-staMuonTrackVMuonAssoc.associatormap = 'tpToStaMuonAssociation'
-staMuonTrackVMuonAssoc.label = ('standAloneMuons',)
-staMuonTrackVMuonAssoc.muonHistoParameters = staMuonHistoParameters
-
-staUpdMuonTrackVMuonAssoc = MTV.clone()
-staUpdMuonTrackVMuonAssoc.associatormap = 'tpToStaUpdMuonAssociation'
-staUpdMuonTrackVMuonAssoc.label = ('standAloneMuons:UpdatedAtVtx',)
-staUpdMuonTrackVMuonAssoc.muonHistoParameters = staUpdMuonHistoParameters
-
-glbMuonTrackVMuonAssoc = MTV.clone()
-glbMuonTrackVMuonAssoc.associatormap = 'tpToGlbMuonAssociation'
-glbMuonTrackVMuonAssoc.label = ('globalMuons',)
-glbMuonTrackVMuonAssoc.muonHistoParameters = glbMuonHistoParameters
-
-staRefitMuonTrackVMuonAssoc = MTV.clone()
-staRefitMuonTrackVMuonAssoc.associatormap = 'tpToStaRefitMuonAssociation'
-staRefitMuonTrackVMuonAssoc.label = ('refittedStandAloneMuons',)
-staRefitMuonTrackVMuonAssoc.muonHistoParameters = staMuonHistoParameters
-
-staRefitUpdMuonTrackVMuonAssoc = MTV.clone()
-staRefitUpdMuonTrackVMuonAssoc.associatormap = 'tpToStaRefitUpdMuonAssociation'
-staRefitUpdMuonTrackVMuonAssoc.label = ('refittedStandAloneMuons:UpdatedAtVtx',)
-staRefitUpdMuonTrackVMuonAssoc.muonHistoParameters = staUpdMuonHistoParameters
-
-displacedTrackVMuonAssoc = MTV.clone()
-displacedTrackVMuonAssoc.associatormap = 'tpToDisplacedTrkMuonAssociation'
-displacedTrackVMuonAssoc.label = ('displacedTracks',)
-displacedTrackVMuonAssoc.label_tp = ("TPtrack")
-displacedTrackVMuonAssoc.muonTPSelector = displacedMuonTPSet
+staSeedTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToStaSeedAssociation',
+    label = ('seedsOfSTAmuons',),
+    muonHistoParameters = staSeedMuonHistoParameters
+)
+staMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToStaMuonAssociation',
+    label = ('standAloneMuons',),
+    muonHistoParameters = staMuonHistoParameters
+)
+staUpdMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToStaUpdMuonAssociation',
+    label = ('standAloneMuons:UpdatedAtVtx',),
+    muonHistoParameters = staUpdMuonHistoParameters
+)
+glbMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToGlbMuonAssociation',
+    label = ('globalMuons',),
+    muonHistoParameters = glbMuonHistoParameters
+)
+staRefitMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToStaRefitMuonAssociation',
+    label = ('refittedStandAloneMuons',),
+    muonHistoParameters = staMuonHistoParameters
+)
+staRefitUpdMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToStaRefitUpdMuonAssociation',
+    label = ('refittedStandAloneMuons:UpdatedAtVtx',),
+    muonHistoParameters = staUpdMuonHistoParameters
+)
+displacedTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToDisplacedTrkMuonAssociation',
+    label = ('displacedTracks',),
+    label_tp = ("TPtrack"),
+    muonTPSelector = displacedMuonTPSet,
+    muonHistoParameters = displacedTrkMuonHistoParameters
+)
 displacedTrackVMuonAssoc.muonTPSelector.src = ("TPtrack")
-displacedTrackVMuonAssoc.muonHistoParameters = displacedTrkMuonHistoParameters
 
-displacedStaSeedTrackVMuonAssoc = MTV.clone()
-displacedStaSeedTrackVMuonAssoc.associatormap = 'tpToDisplacedStaSeedAssociation'
-displacedStaSeedTrackVMuonAssoc.label = ('seedsOfDisplacedSTAmuons',)
-displacedStaSeedTrackVMuonAssoc.muonTPSelector = displacedMuonTPSet
+displacedStaSeedTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToDisplacedStaSeedAssociation',
+    label = ('seedsOfDisplacedSTAmuons',),
+    muonTPSelector = displacedMuonTPSet,
+    muonHistoParameters = displacedStaSeedMuonHistoParameters
+)
 displacedStaSeedTrackVMuonAssoc.muonTPSelector.src = ("TPmu")
-displacedStaSeedTrackVMuonAssoc.muonHistoParameters = displacedStaSeedMuonHistoParameters
 
-displacedStaMuonTrackVMuonAssoc = MTV.clone()
-displacedStaMuonTrackVMuonAssoc.associatormap = 'tpToDisplacedStaMuonAssociation'
-displacedStaMuonTrackVMuonAssoc.label = ('displacedStandAloneMuons',)
-displacedStaMuonTrackVMuonAssoc.muonTPSelector = displacedMuonTPSet
+displacedStaMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToDisplacedStaMuonAssociation',
+    label = ('displacedStandAloneMuons',),
+    muonTPSelector = displacedMuonTPSet,
+    muonHistoParameters = displacedStaMuonHistoParameters
+)
 displacedStaMuonTrackVMuonAssoc.muonTPSelector.src = ("TPmu")
-displacedStaMuonTrackVMuonAssoc.muonHistoParameters = displacedStaMuonHistoParameters
 
-displacedGlbMuonTrackVMuonAssoc = MTV.clone()
-displacedGlbMuonTrackVMuonAssoc.associatormap = 'tpToDisplacedGlbMuonAssociation'
-displacedGlbMuonTrackVMuonAssoc.label = ('displacedGlobalMuons',)
-displacedGlbMuonTrackVMuonAssoc.muonTPSelector = displacedMuonTPSet
+displacedGlbMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToDisplacedGlbMuonAssociation',
+    label = ('displacedGlobalMuons',),
+    muonTPSelector = displacedMuonTPSet,
+    muonHistoParameters = displacedGlbMuonHistoParameters
+)
 displacedGlbMuonTrackVMuonAssoc.muonTPSelector.src = ("TPmu")
-displacedGlbMuonTrackVMuonAssoc.muonHistoParameters = displacedGlbMuonHistoParameters
 
-tevMuonFirstTrackVMuonAssoc = MTV.clone()
-tevMuonFirstTrackVMuonAssoc.associatormap = 'tpToTevFirstMuonAssociation'
-tevMuonFirstTrackVMuonAssoc.label = ('tevMuons:firstHit',)
-tevMuonFirstTrackVMuonAssoc.muonHistoParameters = glbMuonHistoParameters
-
-tevMuonPickyTrackVMuonAssoc = MTV.clone()
-tevMuonPickyTrackVMuonAssoc.associatormap = 'tpToTevPickyMuonAssociation'
-tevMuonPickyTrackVMuonAssoc.label = ('tevMuons:picky',)
-tevMuonPickyTrackVMuonAssoc.muonHistoParameters = glbMuonHistoParameters
-
-tevMuonDytTrackVMuonAssoc = MTV.clone()
-tevMuonDytTrackVMuonAssoc.associatormap = 'tpToTevDytMuonAssociation'
-tevMuonDytTrackVMuonAssoc.label = ('tevMuons:dyt',)
-tevMuonDytTrackVMuonAssoc.muonHistoParameters = glbMuonHistoParameters
-
-tunepMuonTrackVMuonAssoc = MTV.clone()
-tunepMuonTrackVMuonAssoc.associatormap = 'tpToTunePMuonAssociation'
-tunepMuonTrackVMuonAssoc.label = ('tunepMuonTracks',)
-tunepMuonTrackVMuonAssoc.muonHistoParameters = glbMuonHistoParameters
-
-pfMuonTrackVMuonAssoc = MTV.clone()
-pfMuonTrackVMuonAssoc.associatormap = 'tpToPFMuonAssociation'
-pfMuonTrackVMuonAssoc.label = ('pfMuonTracks',)
-pfMuonTrackVMuonAssoc.label_tp = ("TPpfmu")
+tevMuonFirstTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToTevFirstMuonAssociation',
+    label = ('tevMuons:firstHit',),
+    muonHistoParameters = glbMuonHistoParameters
+)
+tevMuonPickyTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToTevPickyMuonAssociation',
+    label = ('tevMuons:picky',),
+    muonHistoParameters = glbMuonHistoParameters
+)
+tevMuonDytTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToTevDytMuonAssociation',
+    label = ('tevMuons:dyt',),
+    muonHistoParameters = glbMuonHistoParameters
+)
+tunepMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToTunePMuonAssociation',
+    label = ('tunepMuonTracks',),
+    muonHistoParameters = glbMuonHistoParameters
+)
+pfMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToPFMuonAssociation',
+    label = ('pfMuonTracks',),
+    label_tp = ("TPpfmu"),
+    muonHistoParameters = glbMuonHistoParameters
+)
 pfMuonTrackVMuonAssoc.muonTPSelector.src = ("TPpfmu")
-pfMuonTrackVMuonAssoc.muonHistoParameters = glbMuonHistoParameters
 
-recomuMuonTrackVMuonAssoc = MTV.clone()
-recomuMuonTrackVMuonAssoc.associatormap = 'tpTorecoMuonMuonAssociation'
-recomuMuonTrackVMuonAssoc.label = ('recoMuonTracks',)
-recomuMuonTrackVMuonAssoc.muonHistoParameters = glbMuonHistoParameters
-
-gemMuonTrackVMuonAssoc = MTV.clone()
-gemMuonTrackVMuonAssoc.associatormap = 'tpToGEMMuonMuonAssociation'
-gemMuonTrackVMuonAssoc.label = ('extractGemMuons',)
-gemMuonTrackVMuonAssoc.muonHistoParameters = gemMuonHistoParameters
-
-me0MuonTrackVMuonAssoc = MTV.clone()
-me0MuonTrackVMuonAssoc.associatormap = 'tpToME0MuonMuonAssociation'
-me0MuonTrackVMuonAssoc.label = ('extractMe0Muons',)
-me0MuonTrackVMuonAssoc.muonTPSelector = me0MuonTPSet
+recomuMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpTorecoMuonMuonAssociation',
+    label = ('recoMuonTracks',),
+    muonHistoParameters = glbMuonHistoParameters
+)
+gemMuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToGEMMuonMuonAssociation',
+    label = ('extractGemMuons',),
+    muonHistoParameters = gemMuonHistoParameters
+)
+me0MuonTrackVMuonAssoc = MTV.clone(
+    associatormap = 'tpToME0MuonMuonAssociation',
+    label = ('extractMe0Muons',),
+    muonTPSelector = me0MuonTPSet,
+    muonHistoParameters = me0MuonHistoParameters
+)
 me0MuonTrackVMuonAssoc.muonTPSelector.src = ("TPmu")
-me0MuonTrackVMuonAssoc.muonHistoParameters = me0MuonHistoParameters
 
-
-MTVcosmic = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
+MTVcosmic = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone(
 # DEFAULTS ###################################
-#    label_tp = cms.InputTag("mix","MergedTrackTruth"),
-#    label_tp_refvector = cms.bool(False),
+#    label_tp = "mix:MergedTrackTruth",
+#    label_tp_refvector = False,
 ##############################################
-MTVcosmic.parametersDefiner = cms.string('CosmicParametersDefinerForTP')
-MTVcosmic.muonTPSelector = cosmicMuonTPSet
+    parametersDefiner = 'CosmicParametersDefinerForTP',
+    muonTPSelector = cosmicMuonTPSet
+)
 ##############################################
 
 # cosmics 2-leg reco
-trkCosmicMuonTrackVSelMuonAssoc = MTVcosmic.clone()
-trkCosmicMuonTrackVSelMuonAssoc.associatormap = 'tpToTkCosmicSelMuonAssociation'
-trkCosmicMuonTrackVSelMuonAssoc.label = ('ctfWithMaterialTracksP5LHCNavigation',)
-trkCosmicMuonTrackVSelMuonAssoc.BiDirectional_RecoToSim_association = False
-trkCosmicMuonTrackVSelMuonAssoc.muonHistoParameters = trkCosmicMuonHistoParameters
-
-staCosmicMuonTrackVSelMuonAssoc = MTVcosmic.clone()
-staCosmicMuonTrackVSelMuonAssoc.associatormap = 'tpToStaCosmicSelMuonAssociation'
-staCosmicMuonTrackVSelMuonAssoc.label = ('cosmicMuons',)
-staCosmicMuonTrackVSelMuonAssoc.BiDirectional_RecoToSim_association = False
-staCosmicMuonTrackVSelMuonAssoc.muonHistoParameters = staCosmicMuonHistoParameters
-
-glbCosmicMuonTrackVSelMuonAssoc = MTVcosmic.clone()
-glbCosmicMuonTrackVSelMuonAssoc.associatormap = 'tpToGlbCosmicSelMuonAssociation'
-glbCosmicMuonTrackVSelMuonAssoc.label = ('globalCosmicMuons',)
-glbCosmicMuonTrackVSelMuonAssoc.BiDirectional_RecoToSim_association = False
-glbCosmicMuonTrackVSelMuonAssoc.muonHistoParameters = glbCosmicMuonHistoParameters
-
+trkCosmicMuonTrackVSelMuonAssoc = MTVcosmic.clone(
+    associatormap = 'tpToTkCosmicSelMuonAssociation',
+    label = ('ctfWithMaterialTracksP5LHCNavigation',),
+    BiDirectional_RecoToSim_association = False,
+    muonHistoParameters = trkCosmicMuonHistoParameters
+)
+staCosmicMuonTrackVSelMuonAssoc = MTVcosmic.clone(
+    associatormap = 'tpToStaCosmicSelMuonAssociation',
+    label = ('cosmicMuons',),
+    BiDirectional_RecoToSim_association = False,
+    muonHistoParameters = staCosmicMuonHistoParameters
+)
+glbCosmicMuonTrackVSelMuonAssoc = MTVcosmic.clone(
+    associatormap = 'tpToGlbCosmicSelMuonAssociation',
+    label = ('globalCosmicMuons',),
+    BiDirectional_RecoToSim_association = False,
+    muonHistoParameters = glbCosmicMuonHistoParameters
+)
 # cosmics 1-leg reco
-trkCosmic1LegMuonTrackVSelMuonAssoc = MTVcosmic.clone()
-trkCosmic1LegMuonTrackVSelMuonAssoc.associatormap = 'tpToTkCosmic1LegSelMuonAssociation'
-trkCosmic1LegMuonTrackVSelMuonAssoc.label = ('ctfWithMaterialTracksP5',)
-trkCosmic1LegMuonTrackVSelMuonAssoc.muonHistoParameters = trkCosmic1LegMuonHistoParameters
-
-staCosmic1LegMuonTrackVSelMuonAssoc = MTVcosmic.clone()
-staCosmic1LegMuonTrackVSelMuonAssoc.associatormap = 'tpToStaCosmic1LegSelMuonAssociation'
-staCosmic1LegMuonTrackVSelMuonAssoc.label = ('cosmicMuons1Leg',)
-staCosmic1LegMuonTrackVSelMuonAssoc.muonHistoParameters = staCosmic1LegMuonHistoParameters
-
-glbCosmic1LegMuonTrackVSelMuonAssoc = MTVcosmic.clone()
-glbCosmic1LegMuonTrackVSelMuonAssoc.associatormap = 'tpToGlbCosmic1LegSelMuonAssociation'
-glbCosmic1LegMuonTrackVSelMuonAssoc.label = ('globalCosmicMuons1Leg',)
-glbCosmic1LegMuonTrackVSelMuonAssoc.muonHistoParameters = glbCosmic1LegMuonHistoParameters
-
+trkCosmic1LegMuonTrackVSelMuonAssoc = MTVcosmic.clone(
+    associatormap = 'tpToTkCosmic1LegSelMuonAssociation',
+    label = ('ctfWithMaterialTracksP5',),
+    muonHistoParameters = trkCosmic1LegMuonHistoParameters
+)
+staCosmic1LegMuonTrackVSelMuonAssoc = MTVcosmic.clone(
+    associatormap = 'tpToStaCosmic1LegSelMuonAssociation',
+    label = ('cosmicMuons1Leg',),
+    muonHistoParameters = staCosmic1LegMuonHistoParameters
+)
+glbCosmic1LegMuonTrackVSelMuonAssoc = MTVcosmic.clone(
+    associatormap = 'tpToGlbCosmic1LegSelMuonAssociation',
+    label = ('globalCosmicMuons1Leg',),
+    muonHistoParameters = glbCosmic1LegMuonHistoParameters
+)
 
 ##########################################################################                                                        
 ### Customization for Phase II samples                                                                                           
 ###
 
-trkMuonTrackVTrackAssoc_phase2 = trkMuonTrackVTrackAssoc.clone()                                                                  
-trkMuonTrackVTrackAssoc_phase2.muonHistoParameters = trkMuonHistoParameters_phase2                                                
-
-trkProbeTrackVMuonAssoc_phase2 = trkProbeTrackVMuonAssoc.clone()                                                                  
-trkProbeTrackVMuonAssoc_phase2.muonHistoParameters = trkMuonHistoParameters_phase2                                                
-
-staSeedTrackVMuonAssoc_phase2 = staSeedTrackVMuonAssoc.clone()                                                                    
-staSeedTrackVMuonAssoc_phase2.muonHistoParameters = staSeedMuonHistoParameters                                                    
-
-staMuonTrackVMuonAssoc_phase2 = staMuonTrackVMuonAssoc.clone()                                                                    
-staMuonTrackVMuonAssoc_phase2.muonHistoParameters = staMuonHistoParameters_phase2                                                 
-
-staUpdMuonTrackVMuonAssoc_phase2 = staUpdMuonTrackVMuonAssoc.clone()                                                              
-staUpdMuonTrackVMuonAssoc_phase2.muonHistoParameters = staUpdMuonHistoParameters_phase2                                          
-
-glbMuonTrackVMuonAssoc_phase2 = glbMuonTrackVMuonAssoc.clone()                                                                    
-glbMuonTrackVMuonAssoc_phase2.muonHistoParameters = glbMuonHistoParameters_phase2                                                 
-
-pfMuonTrackVMuonAssoc_phase2 = pfMuonTrackVMuonAssoc.clone()                                                                      
-pfMuonTrackVMuonAssoc_phase2.muonHistoParameters = glbMuonHistoParameters_phase2                                                  
-
-recomuMuonTrackVMuonAssoc_phase2 = recomuMuonTrackVMuonAssoc.clone()                                                              
-recomuMuonTrackVMuonAssoc_phase2.muonHistoParameters = recoMuonHistoParameters_phase2      
-
-tunepMuonTrackVMuonAssoc_phase2 = tunepMuonTrackVMuonAssoc.clone()
-tunepMuonTrackVMuonAssoc_phase2.muonHistoParameters = glbMuonHistoParameters_phase2      
-
-displacedStaMuonTrackVMuonAssoc_phase2 = displacedStaMuonTrackVMuonAssoc.clone()
-displacedStaMuonTrackVMuonAssoc_phase2.muonHistoParameters = displacedStaMuonHistoParameters_phase2   
-
-displacedGlbMuonTrackVMuonAssoc_phase2 = displacedGlbMuonTrackVMuonAssoc.clone()
-displacedGlbMuonTrackVMuonAssoc_phase2.muonHistoParameters = displacedGlbMuonHistoParameters_phase2               
-
-displacedTrackVMuonAssoc_phase2 = displacedTrackVMuonAssoc.clone()
-displacedTrackVMuonAssoc_phase2.muonHistoParameters = displacedTrkMuonHistoParameters_phase2   
-
-gemMuonTrackVMuonAssoc_phase2 = gemMuonTrackVMuonAssoc.clone()
-gemMuonTrackVMuonAssoc_phase2.muonHistoParameters = gemMuonHistoParameters_phase2 
-
+trkMuonTrackVTrackAssoc_phase2 = trkMuonTrackVTrackAssoc.clone(                                                                  
+    muonHistoParameters = trkMuonHistoParameters_phase2                                                
+)
+trkProbeTrackVMuonAssoc_phase2 = trkProbeTrackVMuonAssoc.clone(
+    muonHistoParameters = trkMuonHistoParameters_phase2                                                
+)
+staSeedTrackVMuonAssoc_phase2 = staSeedTrackVMuonAssoc.clone(
+    muonHistoParameters = staSeedMuonHistoParameters                                                    
+)
+staMuonTrackVMuonAssoc_phase2 = staMuonTrackVMuonAssoc.clone(
+    muonHistoParameters = staMuonHistoParameters_phase2                                                 
+)
+staUpdMuonTrackVMuonAssoc_phase2 = staUpdMuonTrackVMuonAssoc.clone(
+    muonHistoParameters = staUpdMuonHistoParameters_phase2                                          
+)
+glbMuonTrackVMuonAssoc_phase2 = glbMuonTrackVMuonAssoc.clone(
+    muonHistoParameters = glbMuonHistoParameters_phase2                                                 
+)
+pfMuonTrackVMuonAssoc_phase2 = pfMuonTrackVMuonAssoc.clone(                                                                      
+    muonHistoParameters = glbMuonHistoParameters_phase2                                                  
+)
+recomuMuonTrackVMuonAssoc_phase2 = recomuMuonTrackVMuonAssoc.clone(
+    muonHistoParameters = recoMuonHistoParameters_phase2      
+)
+tunepMuonTrackVMuonAssoc_phase2 = tunepMuonTrackVMuonAssoc.clone(
+    muonHistoParameters = glbMuonHistoParameters_phase2      
+)
+displacedStaMuonTrackVMuonAssoc_phase2 = displacedStaMuonTrackVMuonAssoc.clone(
+    muonHistoParameters = displacedStaMuonHistoParameters_phase2   
+)
+displacedGlbMuonTrackVMuonAssoc_phase2 = displacedGlbMuonTrackVMuonAssoc.clone(
+    muonHistoParameters = displacedGlbMuonHistoParameters_phase2               
+)
+displacedTrackVMuonAssoc_phase2 = displacedTrackVMuonAssoc.clone(
+    muonHistoParameters = displacedTrkMuonHistoParameters_phase2   
+)
+gemMuonTrackVMuonAssoc_phase2 = gemMuonTrackVMuonAssoc.clone(
+    muonHistoParameters = gemMuonHistoParameters_phase2 
+)
 
 ##################################################################################
 # Muon validation sequences using MuonTrackValidator

--- a/Validation/RecoMuon/python/selectors_cff.py
+++ b/Validation/RecoMuon/python/selectors_cff.py
@@ -8,13 +8,15 @@ TPrefs = SimMuon.MCTruth.trackingParticleMuon_cfi.trackingParticleMuon.clone()
 TPmu = TPrefs.clone()
 TPmu_seq = cms.Sequence( TPmu )
 
-TPpfmu = TPrefs.clone()
-TPpfmu.skim = 'pf'
+TPpfmu = TPrefs.clone(
+    skim = 'pf'
+)
 TPpfmu_seq = cms.Sequence( TPpfmu )
 
-TPtrack = TPrefs.clone()
-TPtrack.skim = 'track'
-TPtrack.ptmin = 2.
+TPtrack = TPrefs.clone(
+    skim = 'track',
+    ptmin = 2.
+)
 TPtrack_seq = cms.Sequence( TPtrack )
 
 # TrackingParticle selectors for signal efficiencies

--- a/Validation/RecoMuon/python/track_selectors_cff.py
+++ b/Validation/RecoMuon/python/track_selectors_cff.py
@@ -2,59 +2,67 @@ import FWCore.ParameterSet.Config as cms
 
 # select probe tracks
 import PhysicsTools.RecoAlgos.recoTrackSelector_cfi
-probeTracks = PhysicsTools.RecoAlgos.recoTrackSelector_cfi.recoTrackSelector.clone()
-#probeTracks.quality = cms.vstring('highPurity')   # previous setting
-#probeTracks.quality = cms.vstring('loose')        # default
-probeTracks.tip = cms.double(3.5)
-probeTracks.lip = cms.double(30.)
-probeTracks.ptMin = cms.double(3.0)
-probeTracks.minRapidity = cms.double(-2.4)
-probeTracks.maxRapidity = cms.double(2.4)
+probeTracks = PhysicsTools.RecoAlgos.recoTrackSelector_cfi.recoTrackSelector.clone(
+#quality = 'highPurity'   # previous setting
+#quality = ['loose']        # default
+    tip = 3.5,
+    lip = 30.,
+    ptMin = 3.0,
+    minRapidity = cms.double(-2.4),
+    maxRapidity = cms.double(2.4)
+)
 probeTracks_seq = cms.Sequence( probeTracks )
 
 # tracks extracted from reco::Muons
 import SimMuon.MCTruth.MuonTrackProducer_cfi
 
-extractGemMuons = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone()
-extractGemMuons.selectionTags = ('All',)
-extractGemMuons.trackType = "gemMuonTrack"
+extractGemMuons = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone(
+    selectionTags = ['All'],
+    trackType = "gemMuonTrack"
+)
 extractGemMuonsTracks_seq = cms.Sequence( extractGemMuons )
 
-extractMe0Muons = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone()
-extractMe0Muons.selectionTags = cms.vstring('All',)
-extractMe0Muons.trackType = "me0MuonTrack"
+extractMe0Muons = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone(
+    selectionTags = ['All'],
+    trackType = "me0MuonTrack"
+)
 extractMe0MuonsTracks_seq = cms.Sequence( extractMe0Muons )
 
-tunepMuonTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone()
-tunepMuonTracks.muonsTag = cms.InputTag("muons")
-tunepMuonTracks.selectionTags = ('All',)
-tunepMuonTracks.trackType = "tunepTrack"
+tunepMuonTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone(
+    muonsTag = "muons",
+    selectionTags = ['All'],
+    trackType = "tunepTrack"
+)
 tunepMuonTracks_seq = cms.Sequence( tunepMuonTracks )
 
-pfMuonTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone()
-pfMuonTracks.muonsTag = cms.InputTag("muons")
-pfMuonTracks.selectionTags = ('All',)
-pfMuonTracks.trackType = "pfTrack"
+pfMuonTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone(
+    muonsTag = "muons",
+    selectionTags = ['All'],
+    trackType = "pfTrack"
+)
 pfMuonTracks_seq = cms.Sequence( pfMuonTracks )
 
-recoMuonTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone()
-recoMuonTracks.muonsTag = cms.InputTag("muons")
-recoMuonTracks.selectionTags = ('All',)
-recoMuonTracks.trackType = "recomuonTrack"
+recoMuonTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone(
+    muonsTag = "muons",
+    selectionTags = ['All'],
+    trackType = "recomuonTrack"
+)
 recoMuonTracks_seq = cms.Sequence( recoMuonTracks )
 
-hltIterL3MuonsNoIDTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone()
-hltIterL3MuonsNoIDTracks.muonsTag = cms.InputTag("hltIterL3MuonsNoID")
-hltIterL3MuonsNoIDTracks.selectionTags = ('All',)
-hltIterL3MuonsNoIDTracks.trackType = "recomuonTrack"
-hltIterL3MuonsNoIDTracks.ignoreMissingMuonCollection = True
+hltIterL3MuonsNoIDTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone(
+    muonsTag = "hltIterL3MuonsNoID",
+    selectionTags = ['All'],
+    trackType = "recomuonTrack",
+    ignoreMissingMuonCollection = True
+)
 hltIterL3MuonsNoIDTracks_seq = cms.Sequence( hltIterL3MuonsNoIDTracks )
 
-hltIterL3MuonsTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone()
-hltIterL3MuonsTracks.muonsTag = cms.InputTag("hltIterL3Muons")
-hltIterL3MuonsTracks.selectionTags = ('All',)
-hltIterL3MuonsTracks.trackType = "recomuonTrack"
-hltIterL3MuonsTracks.ignoreMissingMuonCollection = True
+hltIterL3MuonsTracks = SimMuon.MCTruth.MuonTrackProducer_cfi.muonTrackProducer.clone(
+    muonsTag = "hltIterL3Muons",
+    selectionTags = ['All'],
+    trackType = "recomuonTrack",
+    ignoreMissingMuonCollection = True
+)
 hltIterL3MuonsTracks_seq = cms.Sequence( hltIterL3MuonsTracks )
 
 #
@@ -62,10 +70,11 @@ hltIterL3MuonsTracks_seq = cms.Sequence( hltIterL3MuonsTracks )
 #
 
 import SimMuon.MCTruth.SeedToTrackProducer_cfi
-seedsOfSTAmuons = SimMuon.MCTruth.SeedToTrackProducer_cfi.SeedToTrackProducer.clone()
-seedsOfSTAmuons.L2seedsCollection = cms.InputTag("ancientMuonSeed")
+seedsOfSTAmuons = SimMuon.MCTruth.SeedToTrackProducer_cfi.SeedToTrackProducer.clone(
+    L2seedsCollection = "ancientMuonSeed"
+)
 seedsOfSTAmuons_seq = cms.Sequence( seedsOfSTAmuons )
-
-seedsOfDisplacedSTAmuons = SimMuon.MCTruth.SeedToTrackProducer_cfi.SeedToTrackProducer.clone()
-seedsOfDisplacedSTAmuons.L2seedsCollection = cms.InputTag("displacedMuonSeeds")
+seedsOfDisplacedSTAmuons = SimMuon.MCTruth.SeedToTrackProducer_cfi.SeedToTrackProducer.clone(
+    L2seedsCollection = "displacedMuonSeeds"
+)
 seedsOfDisplacedSTAmuons_seq = cms.Sequence( seedsOfDisplacedSTAmuons )

--- a/Validation/RecoMuon/python/track_selectors_cff.py
+++ b/Validation/RecoMuon/python/track_selectors_cff.py
@@ -8,8 +8,8 @@ probeTracks = PhysicsTools.RecoAlgos.recoTrackSelector_cfi.recoTrackSelector.clo
     tip = 3.5,
     lip = 30.,
     ptMin = 3.0,
-    minRapidity = cms.double(-2.4),
-    maxRapidity = cms.double(2.4)
+    minRapidity = -2.4,
+    maxRapidity = 2.4
 )
 probeTracks_seq = cms.Sequence( probeTracks )
 


### PR DESCRIPTION
#### PR description:
Drop type specs in Validation/RecoMuon python configuration files.

Central DQM migration campaign for drop type spces following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone


#### PR validation:
Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all --ibeos




