### PR TITLE
Include PF HLT Calibration and new EGM Regression in mcRun3 and mcRun4 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,19 +64,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v2',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v2',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v2',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v2',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v2',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v2',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v3',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '123X_mcRun4_realistic_v2'
+    'phase2_realistic'             : '123X_mcRun4_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR is to include in the mcRun3 and mcRun4 GTs the PF calibration HLT tag as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4572.html and new EGM Regression as requested in https://cms-talk.web.cern.ch/t/mc-update-of-new-egm-regression-conditions/4637 .

The PF tag is ```PFCalibration_120X_mcRun3_2021_hlt```.

For EGM, there 24 tags, listed below:
`electron_eb_ecalTrk_1To500_0p2To2_mean_Run3_120X_V1`
`electron_ee_ecalTrk_1To500_0p2To2_mean_Run3_120X_V1`
`electron_eb_ecalTrk_1To500_0p0002To0p5_sigma_Run3_120X_V1`
`electron_ee_ecalTrk_1To500_0p0002To0p5_sigma_Run3_120X_V1`
`photon_eb_ecalOnly_5To500_0p2To2_mean_Run3_120X_V1`
`photon_ee_ecalOnly_5To500_0p2To2_mean_Run3_120X_V1`
`photon_eb_ecalOnly_5To500_0p0002To0p5_sigma_Run3_120X_V1`
`photon_ee_ecalOnly_5To500_0p0002To0p5_sigma_Run3_120X_V1`
`electron_eb_ecalOnly_1To500_0p2To2_mean_Run3_120X_V1`
`electron_ee_ecalOnly_1To500_0p2To2_mean_Run3_120X_V1`
`electron_eb_ecalOnly_1To500_0p0002To0p5_sigma_Run3_120X_V1`
`electron_ee_ecalOnly_1To500_0p0002To0p5_sigma_Run3_120X_V1`
`pfscecal_EBCorrection_offline_v2_Run3_120X_V1`
`pfscecal_EECorrection_offline_v2_Run3_120X_V1`
`pfscecal_EBUncertainty_offline_v2_Run3_120X_V1`
`pfscecal_EEUncertainty_offline_v2_Run3_120X_V1`
`GEDelectron_EBCorrection_120X_EGM_v1`
`GEDelectron_EBUncertainty_120X_EGM_v1`
`GEDelectron_EECorrection_120X_EGM_v1`
`GEDelectron_EEUncertainty_120X_EGM_v1`
`GEDphoton_EBCorrection_120X_EGM_v1`
`GEDphoton_EBUncertainty_120X_EGM_v1`
`GEDphoton_EECorrection_120X_EGM_v1`
`GEDphoton_EEUncertainty_120X_EGM_v1`

The GT diff wrt the previous ones in autoCond are:

**phase1_2021_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_design_v3/123X_mcRun3_2021_design_v2

**phase1_2021_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_realistic_v3/123X_mcRun3_2021_realistic_v2

**phase1_2021_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021cosmics_realistic_deco_v3/123X_mcRun3_2021cosmics_realistic_deco_v2

**phase1_2021_realistic_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_realistic_HI_v3/123X_mcRun3_2021_realistic_HI_v2

**phase1_2023_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2023_realistic_v3/123X_mcRun3_2023_realistic_v2

**phase1_2024_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2024_realistic_v3/123X_mcRun3_2024_realistic_v2

**phase2_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun4_realistic_v3/123X_mcRun4_realistic_v2

#### PR validation:

runTheMatrix -l 12034.0,7.23,12834.0 --ibeos -j16

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport.
