### PR TITLE
 [12.2.X] Further optimization of the SiPixel LA PCL workflow

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -37,7 +37,11 @@ public:
 
   // per-sector measurements
   dqm::reco::MonitorElement* h_bySectOccupancy_;
+  dqm::reco::MonitorElement* h_bySectMeasLA_;
+  dqm::reco::MonitorElement* h_bySectSetLA_;
+  dqm::reco::MonitorElement* h_bySectRejectLA_;
   dqm::reco::MonitorElement* h_bySectLA_;
+  dqm::reco::MonitorElement* h_bySectDeltaLA_;
   dqm::reco::MonitorElement* h_bySectChi2_;
 };
 

--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -13,7 +13,7 @@ public:
   int nlay;
   std::vector<int> nModules_;
   std::vector<std::string> BPixnewmodulename_;
-  std::vector<int> BPixnewDetIds_;
+  std::vector<unsigned int> BPixnewDetIds_;
   std::vector<int> BPixnewModule_;
   std::vector<int> BPixnewLayer_;
 
@@ -37,6 +37,8 @@ public:
 
   // per-sector measurements
   dqm::reco::MonitorElement* h_bySectOccupancy_;
+  dqm::reco::MonitorElement* h_bySectLA_;
+  dqm::reco::MonitorElement* h_bySectChi2_;
 };
 
 #endif

--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -30,6 +30,10 @@ public:
   MonitorMap h_mean_;
 
   dqm::reco::MonitorElement* h_tracks_;
+  dqm::reco::MonitorElement* h_trackEta_;
+  dqm::reco::MonitorElement* h_trackPhi_;
+  dqm::reco::MonitorElement* h_trackPt_;
+  dqm::reco::MonitorElement* h_trackChi2_;
 };
 
 #endif

--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -34,6 +34,11 @@ public:
   dqm::reco::MonitorElement* h_trackPhi_;
   dqm::reco::MonitorElement* h_trackPt_;
   dqm::reco::MonitorElement* h_trackChi2_;
+
+  // per-sector measurements
+  dqm::reco::MonitorElement* h_bySectOccupancy_;
+  dqm::reco::MonitorElement* h_bySectLA_;
+  dqm::reco::MonitorElement* h_bySectChi2_;
 };
 
 #endif

--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -37,8 +37,6 @@ public:
 
   // per-sector measurements
   dqm::reco::MonitorElement* h_bySectOccupancy_;
-  dqm::reco::MonitorElement* h_bySectLA_;
-  dqm::reco::MonitorElement* h_bySectChi2_;
 };
 
 #endif

--- a/CalibTracker/SiPixelLorentzAngle/python/SiPixelLorentzAnglePCLHarvester_cfi.py
+++ b/CalibTracker/SiPixelLorentzAngle/python/SiPixelLorentzAnglePCLHarvester_cfi.py
@@ -1,11 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 from CalibTracker.SiPixelLorentzAngle.SiPixelLorentzAnglePCLWorker_cfi import SiPixelLorentzAnglePCLWorker as worker
+from CalibTracker.SiPixelLorentzAngle.siPixelLorentzAnglePCLHarvester_cfi import siPixelLorentzAnglePCLHarvester as _defaultHarvester
 
-SiPixelLorentzAnglePCLHarvester = DQMEDHarvester(
-    "SiPixelLorentzAnglePCLHarvester",
-    newmodulelist = cms.vstring(worker.newmodulelist.value()), # taken from worker configuration, need to stay in synch
-    dqmDir = cms.string(worker.folder.value()), # taken from worker configuration, need to stay in synch
-    record = cms.string("SiPixelLorentzAngleRcd"),
-    fitProbCut = cms.double(0.5)
+SiPixelLorentzAnglePCLHarvester = _defaultHarvester.clone(
+    newmodulelist = worker.newmodulelist.value(), # taken from worker configuration, need to stay in synch
+    dqmDir = worker.folder.value(), # taken from worker configuration, need to stay in synch
 )

--- a/CalibTracker/SiPixelLorentzAngle/python/SiPixelLorentzAnglePCLWorker_cfi.py
+++ b/CalibTracker/SiPixelLorentzAngle/python/SiPixelLorentzAnglePCLWorker_cfi.py
@@ -6,14 +6,7 @@ SiPixelLorentzAnglePCLWorker = DQMEDAnalyzer(
     folder = cms.string('AlCaReco/SiPixelLorentzAngle'),
     notInPCL = cms.bool(False),
     fileName = cms.string('testrun.root'),
-    newmodulelist = cms.vstring("BPix_BmI_SEC7_LYR2_LDR12F_MOD1",
-                                "BPix_BmI_SEC8_LYR2_LDR14F_MOD1",
-                                "BPix_BmO_SEC3_LYR2_LDR5F_MOD1",
-                                "BPix_BmO_SEC3_LYR2_LDR5F_MOD2",
-                                "BPix_BmO_SEC3_LYR2_LDR5F_MOD3",
-                                "BPix_BpO_SEC1_LYR2_LDR1F_MOD1",
-                                "BPix_BpO_SEC1_LYR2_LDR1F_MOD2",
-                                "BPix_BpO_SEC1_LYR2_LDR1F_MOD3"),
+    newmodulelist = cms.vstring(),
     src = cms.InputTag("TrackRefitter"),
     binsDepth    = cms.int32(50),
     binsDrift =    cms.int32(200),
@@ -25,3 +18,25 @@ SiPixelLorentzAnglePCLWorker = DQMEDAnalyzer(
     residualMax = cms.double(0.005),
     clustChargeMaxPerLength = cms.double(50000)
 )
+
+## modules replaced over 2017/2018 EOY shutdown, "new" in 2018
+from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018
+run2_SiPixel_2018.toModify(SiPixelLorentzAnglePCLWorker, newmodulelist = ["BPix_BpO_SEC1_LYR1_LDR1F_MOD3", # 303054876
+                                                                          "BPix_BpO_SEC4_LYR1_LDR3F_MOD3", # 303063068
+                                                                          "BPix_BmO_SEC2_LYR1_LDR1F_MOD1", # 303054864
+                                                                          "BPix_BmO_SEC1_LYR1_LDR1F_MOD3", # 303054856
+                                                                          "BPix_BmO_SEC4_LYR1_LDR3F_MOD1", # 303063056
+                                                                          "BPix_BmO_SEC7_LYR1_LDR5F_MOD1"  # 303071248
+                                                                          ])
+
+## modules replaced over LS2 ("new from 2021 onwards)
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(SiPixelLorentzAnglePCLWorker, newmodulelist = ["BPix_BmI_SEC7_LYR2_LDR12F_MOD1", # 304185360
+                                                                    "BPix_BmI_SEC8_LYR2_LDR14F_MOD1", # 304177168
+                                                                    "BPix_BmO_SEC3_LYR2_LDR5F_MOD1",  # 304136208
+                                                                    "BPix_BmO_SEC3_LYR2_LDR5F_MOD2",  # 304136204
+                                                                    "BPix_BmO_SEC3_LYR2_LDR5F_MOD3",  # 304136200
+                                                                    "BPix_BpO_SEC1_LYR2_LDR1F_MOD1",  # 304119828
+                                                                    "BPix_BpO_SEC1_LYR2_LDR1F_MOD2",  # 304119832
+                                                                    "BPix_BpO_SEC1_LYR2_LDR1F_MOD3"   # 304119836
+                                                                    ])

--- a/CalibTracker/SiPixelLorentzAngle/python/SiPixelLorentzAnglePCLWorker_cfi.py
+++ b/CalibTracker/SiPixelLorentzAngle/python/SiPixelLorentzAnglePCLWorker_cfi.py
@@ -1,23 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-SiPixelLorentzAnglePCLWorker = DQMEDAnalyzer(
-    "SiPixelLorentzAnglePCLWorker",
-    folder = cms.string('AlCaReco/SiPixelLorentzAngle'),
-    notInPCL = cms.bool(False),
-    fileName = cms.string('testrun.root'),
-    newmodulelist = cms.vstring(),
-    src = cms.InputTag("TrackRefitter"),
-    binsDepth    = cms.int32(50),
-    binsDrift =    cms.int32(200),
-    ptMin = cms.double(3),
-    normChi2Max = cms.double(2),
-    clustSizeYMin = cms.int32(4),
-    clustSizeYMinL4 = cms.int32(3),
-    clustSizeXMax = cms.int32(5),
-    residualMax = cms.double(0.005),
-    clustChargeMaxPerLength = cms.double(50000)
-)
+from CalibTracker.SiPixelLorentzAngle.siPixelLorentzAnglePCLWorker_cfi import siPixelLorentzAnglePCLWorker as _defaultWorker
+SiPixelLorentzAnglePCLWorker = _defaultWorker.clone()
 
 ## modules replaced over 2017/2018 EOY shutdown, "new" in 2018
 from Configuration.Eras.Modifier_run2_SiPixel_2018_cff import run2_SiPixel_2018

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
@@ -29,7 +29,6 @@
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "SiPixelLorentzAngle.h"
-int lower_bin_;
 
 using namespace std;
 using namespace edm;

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -103,6 +103,10 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
     }
   }
 
+  // list of modules already filled
+  if (!hists.detIdsList.empty())
+    return;
+
   std::vector<uint32_t> treatedIndices;
 
   for (auto det : geom->detsPXB()) {
@@ -121,6 +125,14 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
       treatedIndices.push_back(i_index);
     }
   }
+
+  uint count = 0;
+  for (const auto& i : treatedIndices) {
+    for (const auto& id : hists.detIdsList.at(i)) {
+      count++;
+    };
+  }
+  std::cout << "Stored a total of " << count << " detIds." << std::endl;
 }
 
 //------------------------------------------------------------------------------
@@ -376,6 +388,12 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
                                     << "\t" << tan_LA << "\t" << error_LA << std::endl;
 
       const auto& detIdsToFill = hists.detIdsList.at(i_index);
+
+      std::cout << "index: " << i_index << " i_module: " << i_module << " i_layer: " << i_layer << std::endl;
+      for (const auto& id : detIdsToFill) {
+        std::cout << id << ",";
+      }
+      std::cout << std::endl;
 
       GlobalPoint center(0.0, 0.0, 0.0);
       float theMagField = magField->inTesla(center).mag();

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -129,12 +129,14 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   iGetter.cd();
   iGetter.setCurrentFolder(dqmDir_);
 
+  // fetch the 2D histograms
   for (int i_layer = 1; i_layer <= hists.nlay; i_layer++) {
+    const auto& prefix_ = fmt::sprintf("%s/BPixLayer%i", dqmDir_, i_layer);
     for (int i_module = 1; i_module <= hists.nModules_[i_layer - 1]; i_module++) {
       int i_index = i_module + (i_layer - 1) * hists.nModules_[i_layer - 1];
 
       hists.h_drift_depth_[i_index] =
-          iGetter.get(fmt::format("{}/h_drift_depth_layer{}_module{}", dqmDir_, i_layer, i_module));
+          iGetter.get(fmt::format("{}/h_drift_depth_layer{}_module{}", prefix_, i_layer, i_module));
 
       if (hists.h_drift_depth_[i_index] == nullptr) {
         edm::LogError("SiPixelLorentzAnglePCLHarvester::dqmEndJob")
@@ -143,13 +145,13 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
       }
 
       hists.h_drift_depth_adc_[i_index] =
-          iGetter.get(fmt::format("{}/h_drift_depth_adc_layer{}_module{}", dqmDir_, i_layer, i_module));
+          iGetter.get(fmt::format("{}/h_drift_depth_adc_layer{}_module{}", prefix_, i_layer, i_module));
 
       hists.h_drift_depth_adc2_[i_index] =
-          iGetter.get(fmt::format("{}/h_drift_depth_adc2_layer{}_module{}", dqmDir_, i_layer, i_module));
+          iGetter.get(fmt::format("{}/h_drift_depth_adc2_layer{}_module{}", prefix_, i_layer, i_module));
 
       hists.h_drift_depth_noadc_[i_index] =
-          iGetter.get(fmt::format("{}/h_drift_depth_noadc_layer{}_module{}", dqmDir_, i_layer, i_module));
+          iGetter.get(fmt::format("{}/h_drift_depth_noadc_layer{}_module{}", prefix_, i_layer, i_module));
 
       hists.h_mean_[i_index] = iGetter.get(fmt::format("{}/h_mean_layer{}_module{}", dqmDir_, i_layer, i_module));
 
@@ -158,11 +160,12 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     }
   }
 
+  // fetch the new modules 2D histograms
   for (int i = 0; i < (int)hists.BPixnewDetIds_.size(); i++) {
     int new_index = i + 1 + hists.nModules_[hists.nlay - 1] + (hists.nlay - 1) * hists.nModules_[hists.nlay - 1];
 
     hists.h_drift_depth_adc_[new_index] =
-        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_{}", dqmDir_, hists.BPixnewmodulename_[i]));
+        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_{}", dqmDir_ + "/NewModules", hists.BPixnewmodulename_[i]));
 
     if (hists.h_drift_depth_adc_[new_index] == nullptr) {
       edm::LogError("SiPixelLorentzAnglePCLHarvester::dqmEndJob")
@@ -170,14 +173,14 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
       continue;
     }
 
-    hists.h_drift_depth_adc2_[new_index] =
-        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_adc_{}", dqmDir_, hists.BPixnewmodulename_[i]));
+    hists.h_drift_depth_adc2_[new_index] = iGetter.get(
+        fmt::format("{}/h_BPixnew_drift_depth_adc_{}", dqmDir_ + "/NewModules", hists.BPixnewmodulename_[i]));
 
-    hists.h_drift_depth_noadc_[new_index] =
-        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_adc2_{}", dqmDir_, hists.BPixnewmodulename_[i]));
+    hists.h_drift_depth_noadc_[new_index] = iGetter.get(
+        fmt::format("{}/h_BPixnew_drift_depth_adc2_{}", dqmDir_ + "/NewModules", hists.BPixnewmodulename_[i]));
 
-    hists.h_drift_depth_[new_index] =
-        iGetter.get(fmt::format("{}/h_BPixnew_drift_depth_noadc_{}", dqmDir_, hists.BPixnewmodulename_[i]));
+    hists.h_drift_depth_[new_index] = iGetter.get(
+        fmt::format("{}/h_BPixnew_drift_depth_noadc_{}", dqmDir_ + "/NewModules", hists.BPixnewmodulename_[i]));
 
     hists.h_mean_[new_index] = iGetter.get(fmt::format("{}/h_BPixnew_mean_{}", dqmDir_, hists.BPixnewmodulename_[i]));
 
@@ -496,7 +499,7 @@ void SiPixelLorentzAnglePCLHarvester::fillDescriptions(edm::ConfigurationDescrip
   desc.setComment("Harvester module of the SiPixel Lorentz Angle PCL monitoring workflow");
   desc.add<std::vector<std::string>>("newmodulelist", {})->setComment("the list of DetIds for new sensors");
   desc.add<std::string>("dqmDir", "AlCaReco/SiPixelLorentzAngle")->setComment("the directory of PCL Worker output");
-  desc.add<double>("fitProbCut", 0.5)->setComment("cut on fit chi2 probabiblity to accept measurement");
+  desc.add<double>("fitProbCut", 0.1)->setComment("cut on fit chi2 probabiblity to accept measurement");
   desc.add<std::string>("record", "SiPixelLorentzAngleRcd")->setComment("target DB record");
   descriptions.addWithDefaultLabel(desc);
 }

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -109,10 +109,10 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
 
   uint count = 0;
   for (const auto& id : hists.BPixnewDetIds_) {
-    LogDebug("SiPixelLorentzAnglePCLHarvester") << id << std::endl;
+    LogDebug("SiPixelLorentzAnglePCLHarvester") << id;
     count++;
   }
-  LogDebug("SiPixelLorentzAnglePCLHarvester") << "Stored a total of " << count << " new detIds." << std::endl;
+  LogDebug("SiPixelLorentzAnglePCLHarvester") << "Stored a total of " << count << " new detIds.";
 
   // list of modules already filled, return (we already entered here)
   if (!hists.detIdsList.empty())
@@ -144,11 +144,11 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
   count = 0;
   for (const auto& i : treatedIndices) {
     for (const auto& id : hists.detIdsList.at(i)) {
-      LogDebug("SiPixelLorentzAnglePCLHarvester") << id << std::endl;
+      LogDebug("SiPixelLorentzAnglePCLHarvester") << id;
       count++;
     };
   }
-  LogDebug("SiPixelLorentzAnglePCLHarvester") << "Stored a total of " << count << " detIds." << std::endl;
+  LogDebug("SiPixelLorentzAnglePCLHarvester") << "Stored a total of " << count << " detIds.";
 }
 
 //------------------------------------------------------------------------------
@@ -255,7 +255,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
                                 << "p5" << "\t" << "e5" << "\t"
                                 << "chi2" << "\t" << "prob" << "\t"
                                 << "newDetId" << "\t" << "tan(LA)" << "\t"
-                                << "Error(LA)" << std::endl;
+                                << "Error(LA)" ;
   // clang-format on
 
   std::unique_ptr<SiPixelLorentzAngle> LorentzAngle = std::make_unique<SiPixelLorentzAngle>();
@@ -334,7 +334,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
                                   << "\t" << e1 / p1 * 100. << "\t" << (p1 - p1_simul_newmodule) / e1 << "\t" << p2
                                   << "\t" << e2 << "\t" << p3 << "\t" << e3 << "\t" << p4 << "\t" << e4 << "\t" << p5
                                   << "\t" << e5 << "\t" << chi2 << "\t" << prob << "\t" << hists.BPixnewDetIds_[j]
-                                  << "\t" << tan_LA << "\t" << error_LA << std::endl;
+                                  << "\t" << tan_LA << "\t" << error_LA;
 
     float bPixLorentzAnglePerTesla_;
     // if the fit quality is OK
@@ -342,15 +342,14 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
       bPixLorentzAnglePerTesla_ = tan_LA / theMagField;
       if (!LorentzAngle->putLorentzAngle(rawId, bPixLorentzAnglePerTesla_)) {
         edm::LogError("SiPixelLorentzAnglePCLHarvester")
-            << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling new modules: detid already exists" << std::endl;
+            << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling new modules: detid already exists";
       }
     } else {
       // just copy the values from the existing payload
       bPixLorentzAnglePerTesla_ = currentLorentzAngle->getLorentzAngle(rawId);
       if (!LorentzAngle->putLorentzAngle(rawId, bPixLorentzAnglePerTesla_)) {
         edm::LogError("SiPixelLorentzAnglePCLHarvester")
-            << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling new modules (from current): detid already exists"
-            << std::endl;
+            << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling new modules (from current): detid already exists";
       }
     }
   }  // loop on BPix new modules
@@ -439,16 +438,16 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
                                     << e2 << "\t" << p3 << "\t" << e3 << "\t" << p4 << "\t" << e4 << "\t" << p5 << "\t"
                                     << e5 << "\t" << chi2 << "\t" << prob << "\t"
                                     << "null"
-                                    << "\t" << tan_LA << "\t" << error_LA << std::endl;
+                                    << "\t" << tan_LA << "\t" << error_LA;
 
       const auto& detIdsToFill = hists.detIdsList.at(i_index);
 
       LogDebug("SiPixelLorentzAnglePCLHarvester")
-          << "index: " << i_index << " i_module: " << i_module << " i_layer: " << i_layer << std::endl;
+          << "index: " << i_index << " i_module: " << i_module << " i_layer: " << i_layer;
       for (const auto& id : detIdsToFill) {
         LogDebug("SiPixelLorentzAnglePCLHarvester") << id << ",";
       }
-      LogDebug("SiPixelLorentzAnglePCLHarvester") << std::endl;
+      LogDebug("SiPixelLorentzAnglePCLHarvester");
 
       float bPixLorentzAnglePerTesla_;
       // if the fit quality is OK
@@ -457,7 +456,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
           bPixLorentzAnglePerTesla_ = tan_LA / theMagField;
           if (!LorentzAngle->putLorentzAngle(id, bPixLorentzAnglePerTesla_)) {
             edm::LogError("SiPixelLorentzAnglePCLHarvester")
-                << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling BPix: detid already exists" << std::endl;
+                << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling BPix: detid already exists";
           }
         }
       } else {
@@ -466,8 +465,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
           bPixLorentzAnglePerTesla_ = currentLorentzAngle->getLorentzAngle(id);
           if (!LorentzAngle->putLorentzAngle(id, bPixLorentzAnglePerTesla_)) {
             edm::LogError("SiPixelLorentzAnglePCLHarvester")
-                << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling BPix (from current): detid already exists"
-                << std::endl;
+                << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling BPix (from current): detid already exists";
           }
         }
       }
@@ -498,7 +496,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     float fPixLorentzAnglePerTesla_ = currentLorentzAngle->getLorentzAngle(id);
     if (!LorentzAngle->putLorentzAngle(id, fPixLorentzAnglePerTesla_)) {
       edm::LogError("SiPixelLorentzAnglePCLHarvester")
-          << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling rest of payload: detid already exists" << std::endl;
+          << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling rest of payload: detid already exists";
     }
   }
 
@@ -518,12 +516,12 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     try {
       mydbservice->writeOneIOV(*LorentzAngle, mydbservice->currentTime(), recordName_);
     } catch (const cond::Exception& er) {
-      edm::LogError("SiPixelLorentzAngleDB") << er.what() << std::endl;
+      edm::LogError("SiPixelLorentzAngleDB") << er.what();
     } catch (const std::exception& er) {
-      edm::LogError("SiPixelLorentzAngleDB") << "caught std::exception " << er.what() << std::endl;
+      edm::LogError("SiPixelLorentzAngleDB") << "caught std::exception " << er.what();
     }
   } else {
-    edm::LogError("SiPixelLorentzAngleDB") << "Service is unavailable" << std::endl;
+    edm::LogError("SiPixelLorentzAngleDB") << "Service is unavailable";
   }
 }
 

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -220,6 +220,9 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
         hists.h_drift_depth_adc_[new_index], hists.h_drift_depth_noadc_[new_index], 1., 1., "");
   }
 
+  hists.h_bySectLA_ = iGetter.get(fmt::format("{}/h_bySectorLA", dqmDir_ + "/SectorMonitoring"));
+  hists.h_bySectChi2_ = iGetter.get(fmt::format("{}/h_bySectorChi2", dqmDir_ + "/SectorMonitoring"));
+
   int hist_drift_;
   int hist_depth_;
   double min_drift_;
@@ -306,7 +309,9 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     double p5 = f1->GetParameter(5);
     double e5 = f1->GetParError(5);
     double chi2 = f1->GetChisquare();
+    int ndf = f1->GetNDF();
     double prob = f1->GetProb();
+    double redChi2 = ndf > 0. ? chi2 / ndf : 0.;
 
     double f1_halfwidth = p0 + p1 * half_width + p2 * pow(half_width, 2) + p3 * pow(half_width, 3) +
                           p4 * pow(half_width, 4) + p5 * pow(half_width, 5);
@@ -319,6 +324,10 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
                        pow((half_width * half_width * half_width * e4), 2) +
                        pow((half_width * half_width * half_width * half_width * e5), 2));  // Propagation of uncertainty
     double error_LA = sqrt(errsq_LA);
+
+    hists.h_bySectLA_->setBinContent(new_index, (tan_LA / theMagField));
+    hists.h_bySectLA_->setBinError(new_index, (error_LA / theMagField));
+    hists.h_bySectChi2_->setBinContent(new_index, redChi2);
 
     edm::LogPrint("LorentzAngle") << std::setprecision(4) << hists.BPixnewModule_[j] << "\t" << hists.BPixnewLayer_[j]
                                   << "\t" << p0 << "\t" << e0 << "\t" << p1 << std::setprecision(3) << "\t" << e1
@@ -404,6 +413,8 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
       double e5 = f1->GetParError(5);
       double chi2 = f1->GetChisquare();
       double prob = f1->GetProb();
+      int ndf = f1->GetNDF();
+      double redChi2 = ndf > 0. ? chi2 / ndf : 0.;
 
       double f1_halfwidth = p0 + p1 * half_width + p2 * pow(half_width, 2) + p3 * pow(half_width, 3) +
                             p4 * pow(half_width, 4) + p5 * pow(half_width, 5);
@@ -417,6 +428,10 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
            pow((half_width * half_width * half_width * e4), 2) +
            pow((half_width * half_width * half_width * half_width * e5), 2));  // Propagation of uncertainty
       double error_LA = sqrt(errsq_LA);
+
+      hists.h_bySectLA_->setBinContent(i_index, (tan_LA / theMagField));
+      hists.h_bySectLA_->setBinError(i_index, (error_LA / theMagField));
+      hists.h_bySectChi2_->setBinContent(i_index, redChi2);
 
       edm::LogPrint("LorentzAngle") << std::setprecision(4) << i_module << "\t" << i_layer << "\t" << p0 << "\t" << e0
                                     << "\t" << p1 << std::setprecision(3) << "\t" << e1 << "\t" << e1 / p1 * 100.

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -1,7 +1,26 @@
+// -*- C++ -*-
+//
+// Package:    CalibTracker/SiPixelLorentzAnglePCLHarvester
+// Class:      SiPixelLorentzAnglePCLHarvester
+//
+/**\class SiPixelLorentzAnglePCLHarvester SiPixelLorentzAnglePCLHarvester.cc CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+ Description: reads the intermediate ALCAPROMPT DQMIO-like dataset and performs the fitting of the SiPixel Lorentz Angle in the Prompt Calibration Loop
+ Implementation:
+     Reads the 2D histograms of the drift vs depth created by SiPixelLorentzAnglePCLWorker modules and generates 1D profiles which are then fit
+     with a 5th order polinomial. The extracted value of the tan(theta_L)/B are stored in an output sqlite file which is then uploaded to the conditions database
+*/
+//
+// Original Author:  mmusich
+//         Created:  Sat, 29 May 2021 14:46:19 GMT
+//
+//
+
+// system includes
 #include <fmt/format.h>
 #include <fmt/printf.h>
 #include <fstream>
 
+// user includes
 #include "CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/DataRecord/interface/SiPixelLorentzAngleRcd.h"

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -196,22 +196,22 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   for (int i = 0; i < (int)hists.BPixnewDetIds_.size(); i++) {
     int new_index = i + 1 + hists.nModules_[hists.nlay - 1] + (hists.nlay - 1) * hists.nModules_[hists.nlay - 1];
 
-    hists.h_drift_depth_adc_[new_index] = iGetter.get(
+    hists.h_drift_depth_[new_index] = iGetter.get(
         fmt::format("{}/h_BPixnew_drift_depth_{}", dqmDir_ + "/BPix/NewModules", hists.BPixnewmodulename_[i]));
 
-    if (hists.h_drift_depth_adc_[new_index] == nullptr) {
+    if (hists.h_drift_depth_[new_index] == nullptr) {
       edm::LogError("SiPixelLorentzAnglePCLHarvester::dqmEndJob")
           << "Failed to retrieve electron drift over depth for new module " << hists.BPixnewmodulename_[i] << ".";
       continue;
     }
 
-    hists.h_drift_depth_adc2_[new_index] = iGetter.get(
+    hists.h_drift_depth_adc_[new_index] = iGetter.get(
         fmt::format("{}/h_BPixnew_drift_depth_adc_{}", dqmDir_ + "/BPix/NewModules", hists.BPixnewmodulename_[i]));
 
-    hists.h_drift_depth_noadc_[new_index] = iGetter.get(
+    hists.h_drift_depth_adc2_[new_index] = iGetter.get(
         fmt::format("{}/h_BPixnew_drift_depth_adc2_{}", dqmDir_ + "/BPix/NewModules", hists.BPixnewmodulename_[i]));
 
-    hists.h_drift_depth_[new_index] = iGetter.get(
+    hists.h_drift_depth_noadc_[new_index] = iGetter.get(
         fmt::format("{}/h_BPixnew_drift_depth_noadc_{}", dqmDir_ + "/BPix/NewModules", hists.BPixnewmodulename_[i]));
 
     hists.h_mean_[new_index] = iGetter.get(fmt::format("{}/h_BPixnew_mean_{}", dqmDir_, hists.BPixnewmodulename_[i]));
@@ -231,10 +231,10 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     min_drift_ = hists.h_drift_depth_adc_[1]->getAxisMin(1);
     max_drift_ = hists.h_drift_depth_adc_[1]->getAxisMax(1);
   } else {
-    hist_drift_ = 200;
+    hist_drift_ = 100;
     hist_depth_ = 50;
-    min_drift_ = -1000.;
-    max_drift_ = 1000.;
+    min_drift_ = -500.;
+    max_drift_ = 500.;
   }
 
   iBooker.setCurrentFolder("AlCaReco/SiPixelLorentzAngleHarvesting/");

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -656,6 +656,10 @@ void SiPixelLorentzAnglePCLWorker::dqmBeginRun(edm::Run const& run, edm::EventSe
     iHists.nModules_[i] = map.getPXBModules(i + 1);
   }
 
+  // list of modules already filled, then return (we already entered here)
+  if (!iHists.BPixnewDetIds_.empty() || !iHists.FPixnewDetIds_.empty())
+    return;
+
   if (!newmodulelist_.empty()) {
     for (auto const& modulename : newmodulelist_) {
       if (modulename.find("BPix_") != std::string::npos) {

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -698,11 +698,8 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
   const auto maxSect = iHists.nlay * iHists.nModules_[iHists.nlay - 1] + (int)iHists.BPixnewDetIds_.size();
 
   iBooker.setCurrentFolder(fmt::sprintf("%s/SectorMonitoring", folder_.data()));
-  iHists.h_bySectOccupancy_ =
-      iBooker.book1D("h_bySectorOccupancy", ";pixel sector;hits on track", maxSect, -0.5, maxSect + 0.5);
-  iHists.h_bySectLA_ = iBooker.book1D("h_bySectorLA", ";pixel sector;measured LA [1/T]", maxSect, -0.5, maxSect + 0.5);
-  iHists.h_bySectChi2_ =
-      iBooker.book1D("h_bySectorChi2", ";pixel sector; fit #chi^{2}/ndf", maxSect, -0.5, maxSect + 0.5);
+  iHists.h_bySectOccupancy_ = iBooker.book1D(
+      "h_bySectorOccupancy", "hit occupancy by sector;pixel sector;hits on track", maxSect, -0.5, maxSect + 0.5);
 
   iBooker.setCurrentFolder(folder_);
   static constexpr double min_depth_ = -100.;
@@ -721,8 +718,6 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
                                                << " (i_layer: " << i_layer << " i_module:" << i_module << ")";
 
       iHists.h_bySectOccupancy_->setBinLabel(i_index, binName);
-      iHists.h_bySectLA_->setBinLabel(i_index, binName);
-      iHists.h_bySectChi2_->setBinLabel(i_index, binName);
 
       sprintf(name, "h_mean_layer%i_module%i", i_layer, i_module);
       sprintf(title,
@@ -743,8 +738,6 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
     LogDebug("SiPixelLorentzAnglePCLWorker") << "i_index" << new_index << " bin name: " << iHists.BPixnewmodulename_[i];
 
     iHists.h_bySectOccupancy_->setBinLabel(new_index, iHists.BPixnewmodulename_[i]);
-    iHists.h_bySectLA_->setBinLabel(new_index, iHists.BPixnewmodulename_[i]);
-    iHists.h_bySectChi2_->setBinLabel(new_index, iHists.BPixnewmodulename_[i]);
   }
 
   //book the 2D histograms

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -425,7 +425,7 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
           // fill the trackhit info
           TrajectoryStateOnSurface tsos = itTraj.updatedState();
           if (!tsos.isValid()) {
-            edm::LogWarning("SiPixelLorentzAnglePCLWorker") << "tsos not valid" << std::endl;
+            edm::LogWarning("SiPixelLorentzAnglePCLWorker") << "tsos not valid";
             continue;
           }
           LocalVector trackdirection = tsos.localDirection();
@@ -590,7 +590,7 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
           // fill the trackhit info
           TrajectoryStateOnSurface tsos = itTraj.updatedState();
           if (!tsos.isValid()) {
-            edm::LogWarning("SiPixelLorentzAnglePCLWorker") << "tsos not valid" << std::endl;
+            edm::LogWarning("SiPixelLorentzAnglePCLWorker") << "tsos not valid";
             continue;
           }
           LocalVector trackdirection = tsos.localDirection();
@@ -654,7 +654,7 @@ void SiPixelLorentzAnglePCLWorker::dqmBeginRun(edm::Run const& run, edm::EventSe
       if (!SiPixelTemplate::pushfile(*templateDBobject_, thePixelTemp_)) {
         edm::LogError("SiPixelLorentzAnglePCLWorker")
             << "Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
-            << (*templateDBobject_).version() << std::endl;
+            << (*templateDBobject_).version();
       }
     }
   }
@@ -811,9 +811,8 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
       unsigned int i_index = i_module + (i_layer - 1) * iHists.nModules_[i_layer - 1];
       std::string binName = fmt::sprintf("BPix Layer%i Module %i", i_layer, i_module);
 
-      LogDebug("SiPixelLorentzAnglePCLWorker")
-          << " i_index: " << i_index << " bin name: " << binName << " (i_layer: " << i_layer << " i_module:" << i_module
-          << ")" << std::endl;
+      LogDebug("SiPixelLorentzAnglePCLWorker") << " i_index: " << i_index << " bin name: " << binName
+                                               << " (i_layer: " << i_layer << " i_module:" << i_module << ")";
 
       iHists.h_bySectOccupancy_->setBinLabel(i_index, binName);
       iHists.h_bySectLA_->setBinLabel(i_index, binName);
@@ -824,8 +823,7 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
   for (int i = 0; i < (int)iHists.BPixnewDetIds_.size(); i++) {
     int new_index = iHists.nModules_[iHists.nlay - 1] + (iHists.nlay - 1) * iHists.nModules_[iHists.nlay - 1] + 1 + i;
 
-    LogDebug("SiPixelLorentzAnglePCLWorker")
-        << "i_index" << new_index << " bin name: " << iHists.BPixnewmodulename_[i] << std::endl;
+    LogDebug("SiPixelLorentzAnglePCLWorker") << "i_index" << new_index << " bin name: " << iHists.BPixnewmodulename_[i];
 
     iHists.h_bySectOccupancy_->setBinLabel(new_index, iHists.BPixnewmodulename_[i]);
     iHists.h_bySectLA_->setBinLabel(new_index, iHists.BPixnewmodulename_[i]);

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -3,10 +3,10 @@
 // Package:    CalibTracker/SiPixelLorentzAnglePCLWorker
 // Class:      SiPixelLorentzAnglePCLWorker
 //
-/**\class SiPixelLorentzAnglePCLWorker SiPixelLorentzAnglePCLWorker.cc CalibTracker/SiPixelLorentzAnglePCLWorker/plugins/SiPixelLorentzAnglePCLWorker.cc
- Description: [one line class summary]
+/**\class SiPixelLorentzAnglePCLWorker SiPixelLorentzAnglePCLWorker.cc CalibTracker/SiPixelLorentzAnglePCLWorker/src/SiPixelLorentzAnglePCLWorker.cc
+ Description: generates the intermediate ALCAPROMPT dataset for the measurement of the SiPixel Lorentz Angle in the Prompt Calibration Loop
  Implementation:
-     [Notes on implementation]
+     Books and fills 2D histograms of the drift vs depth in bins of pixel module rings to be fed into the SiPixelLorentzAnglePCLHarvester
 */
 //
 // Original Author:  mmusich

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -711,7 +711,7 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
 
   //book the 2D histograms
   for (int i_layer = 1; i_layer <= iHists.nlay; i_layer++) {
-    iBooker.setCurrentFolder(fmt::sprintf("%s/BPixLayer%i", folder_.data(), i_layer));
+    iBooker.setCurrentFolder(fmt::sprintf("%s/BPix/BPixLayer%i", folder_.data(), i_layer));
     for (int i_module = 1; i_module <= iHists.nModules_[i_layer - 1]; i_module++) {
       unsigned int i_index = i_module + (i_layer - 1) * iHists.nModules_[i_layer - 1];
 
@@ -740,7 +740,7 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
   }
 
   // book the "new" modules
-  iBooker.setCurrentFolder(fmt::sprintf("%s/NewModules", folder_.data()));
+  iBooker.setCurrentFolder(fmt::sprintf("%s/BPix/NewModules", folder_.data()));
   for (int i = 0; i < (int)iHists.BPixnewDetIds_.size(); i++) {
     int new_index = iHists.nModules_[iHists.nlay - 1] + (iHists.nlay - 1) * iHists.nModules_[iHists.nlay - 1] + 1 + i;
 

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -450,12 +450,8 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
           double drdz = sqrt(1. + cotalpha * cotalpha + cotbeta * cotbeta);
           double clusterCharge_cut = clustChargeMaxPerLength_ * drdz;
 
-          float locBx = 1.;
-          if (cotbeta < 0.)
-            locBx = -1.;
-          float locBz = locBx;
-          if (cotalpha < 0.)
-            locBz = -locBx;
+          float locBx = (cotbeta < 0.) ? -1 : 1.;
+          float locBz = (cotalpha < 0.) ? -locBx : locBx;
 
           auto detId = detIdObj.rawId();
           int DetId_index = -1;

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -456,18 +456,18 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
             DetId_index = std::distance(iHists.BPixnewDetIds_.begin(), newModIt);
           }
 
-	  if(notInPCL_){
-	    // fill the template from the store (from dqmBeginRun)
-	    SiPixelTemplate theTemplate(thePixelTemp_);
+          if (notInPCL_) {
+            // fill the template from the store (from dqmBeginRun)
+            SiPixelTemplate theTemplate(thePixelTemp_);
 
-	    float locBx = (cotbeta < 0.) ? -1 : 1.;
-	    float locBz = (cotalpha < 0.) ? -locBx : locBx;
+            float locBx = (cotbeta < 0.) ? -1 : 1.;
+            float locBz = (cotalpha < 0.) ? -locBx : locBx;
 
-	    int TemplID = templateDBobject_->getTemplateID(detId);
-	    theTemplate.interpolate(TemplID, cotalpha, cotbeta, locBz, locBx);
-	    qScale_ = theTemplate.qscale();
-	    rQmQt_ = theTemplate.r_qMeas_qTrue();
-	  }
+            int TemplID = templateDBobject_->getTemplateID(detId);
+            theTemplate.interpolate(TemplID, cotalpha, cotbeta, locBz, locBx);
+            qScale_ = theTemplate.qscale();
+            rQmQt_ = theTemplate.r_qMeas_qTrue();
+          }
 
           // Surface deformation
           const auto& lp_pair = surface_deformation(topol, tsos, recHitPix);
@@ -535,14 +535,14 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
                 int i_index = module_ + (layer_ - 1) * iHists.nModules_[layer_ - 1];
                 iHists.h_drift_depth_adc_.at(i_index)->Fill(drift, depth, pixinfo_.adc[j]);
                 iHists.h_drift_depth_adc2_.at(i_index)->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
-                iHists.h_drift_depth_noadc_.at(i_index)->Fill(drift, depth);
+                iHists.h_drift_depth_noadc_.at(i_index)->Fill(drift, depth, 1.);
               } else {
                 int new_index = iHists.nModules_[iHists.nlay - 1] +
                                 (iHists.nlay - 1) * iHists.nModules_[iHists.nlay - 1] + 1 + DetId_index;
 
                 iHists.h_drift_depth_adc_.at(new_index)->Fill(drift, depth, pixinfo_.adc[j]);
                 iHists.h_drift_depth_adc2_.at(new_index)->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
-                iHists.h_drift_depth_noadc_.at(new_index)->Fill(drift, depth);
+                iHists.h_drift_depth_noadc_.at(new_index)->Fill(drift, depth, 1.);
               }
             }
           }
@@ -607,18 +607,18 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
 
           auto detId = detIdObj.rawId();
 
-	  if(notInPCL_){
-	    // fill the template from the store (from dqmBeginRun)
-	    SiPixelTemplate theTemplate(thePixelTemp_);
+          if (notInPCL_) {
+            // fill the template from the store (from dqmBeginRun)
+            SiPixelTemplate theTemplate(thePixelTemp_);
 
-	    float locBx = (cotbeta < 0.) ? -1 : 1.;
-	    float locBz = (cotalpha < 0.) ? -locBx : locBx;
+            float locBx = (cotbeta < 0.) ? -1 : 1.;
+            float locBz = (cotalpha < 0.) ? -locBx : locBx;
 
-	    int TemplID = templateDBobject_->getTemplateID(detId);
-	    theTemplate.interpolate(TemplID, cotalpha, cotbeta, locBz, locBx);
-	    qScaleF_ = theTemplate.qscale();
-	    rQmQtF_ = theTemplate.r_qMeas_qTrue();
-	  }
+            int TemplID = templateDBobject_->getTemplateID(detId);
+            theTemplate.interpolate(TemplID, cotalpha, cotbeta, locBz, locBx);
+            qScaleF_ = theTemplate.qscale();
+            rQmQtF_ = theTemplate.r_qMeas_qTrue();
+          }
 
           // Surface deformation
           const auto& lp_pair = surface_deformation(topol, tsos, recHitPix);
@@ -644,15 +644,14 @@ void SiPixelLorentzAnglePCLWorker::dqmBeginRun(edm::Run const& run, edm::EventSe
   const TrackerGeometry* geom = &iSetup.getData(geomEsToken_);
   const TrackerTopology* tTopo = &iSetup.getData(topoEsToken_);
 
-
-  if(notInPCL_){
+  if (notInPCL_) {
     // Initialize 1D templates
     if (watchSiPixelTemplateRcd_.check(iSetup)) {
       templateDBobject_ = &iSetup.getData(siPixelTemplateEsToken_);
       if (!SiPixelTemplate::pushfile(*templateDBobject_, thePixelTemp_)) {
-	edm::LogError("SiPixelLorentzAnglePCLWorker")
-          << "Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
-          << (*templateDBobject_).version() << std::endl;
+        edm::LogError("SiPixelLorentzAnglePCLWorker")
+            << "Templates not filled correctly. Check the sqlite file. Using SiPixelTemplateDBObject version "
+            << (*templateDBobject_).version() << std::endl;
       }
     }
   }
@@ -730,24 +729,24 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
       sprintf(name, "h_drift_depth_adc_layer%i_module%i", i_layer, i_module);
       sprintf(title, "depth vs drift (ADC) layer%i module%i; drift [#mum]; production depth [#mum]", i_layer, i_module);
       iHists.h_drift_depth_adc_[i_index] =
-          iBooker.book2S(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+          iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
 
       sprintf(name, "h_drift_depth_adc2_layer%i_module%i", i_layer, i_module);
       sprintf(
           title, "depth vs drift (ADC^{2}) layer%i module%i; drift [#mum]; production depth [#mum]", i_layer, i_module);
       iHists.h_drift_depth_adc2_[i_index] =
-          iBooker.book2S(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+          iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
 
       sprintf(name, "h_drift_depth_noadc_layer%i_module%i", i_layer, i_module);
       sprintf(
           title, "depth vs drift (no ADC) layer%i module%i; drift [#mum]; production depth [#mum]", i_layer, i_module);
       iHists.h_drift_depth_noadc_[i_index] =
-          iBooker.book2S(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+          iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
 
       sprintf(name, "h_drift_depth_layer%i_module%i", i_layer, i_module);
       sprintf(title, "depth vs drift layer%i module%i; drift [#mum]; production depth [#mum]", i_layer, i_module);
       iHists.h_drift_depth_[i_index] =
-          iBooker.book2S(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+          iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
     }
   }
 
@@ -760,26 +759,26 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
     sprintf(
         title, "depth vs drift (ADC) %s; drift [#mum]; production depth [#mum]", iHists.BPixnewmodulename_[i].c_str());
     iHists.h_drift_depth_adc_[new_index] =
-        iBooker.book2S(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+        iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
 
     sprintf(name, "h_BPixnew_drift_depth_adc2_%s", iHists.BPixnewmodulename_[i].c_str());
     sprintf(title,
             "depth vs drift (ADC^{2}) %s; drift [#mum]; production depth [#mum]",
             iHists.BPixnewmodulename_[i].c_str());
     iHists.h_drift_depth_adc2_[new_index] =
-        iBooker.book2S(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+        iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
 
     sprintf(name, "h_BPixnew_drift_depth_noadc_%s", iHists.BPixnewmodulename_[i].c_str());
     sprintf(title,
             "depth vs drift (no ADC)%s; drift [#mum]; production depth [#mum]",
             iHists.BPixnewmodulename_[i].c_str());
     iHists.h_drift_depth_noadc_[new_index] =
-        iBooker.book2S(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+        iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
 
     sprintf(name, "h_BPixnew_drift_depth_%s", iHists.BPixnewmodulename_[i].c_str());
     sprintf(title, "depth vs drift %s; drift [#mum]; production depth [#mum]", iHists.BPixnewmodulename_[i].c_str());
     iHists.h_drift_depth_[new_index] =
-        iBooker.book2S(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+        iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
   }
 
   // book the track monitoring plots


### PR DESCRIPTION
backport of #36565 and #36538

#### PR description:

Miscellanea updates and bug-fixes to the SiPixel LA PCL workflow that are built on top of the replay at https://github.com/dmwm/T0/pull/4635. 


   * made the processing much faster by calling `SiPixelTemplate::pushfile` in `dqmBeginRun`  instead of the `analyze` method;
   * add basic accepted tracks monitoring;
   * adding plot titles;
   * re-organize folders to have subfolders: (Top) / (BPix) / etc. ..;
   * actually *do* write to DB the values for the "new" modules when they are fit;
   * change the default cut value on the fit probability for writing out the payload from 0.5 to 0.1;
   * fix a bug that was causing populating the lists of "new" modules and modules attached to a given "sector" multiple times (this was triggering several warnings in the harvesting step when populating the DB about multiple `put`s, see https://github.com/cms-sw/cmssw/pull/36535);
   * further memory footprint reduction is achieved in commit 69b9256f3d0be42121c826f63094094fee22375a by loading the `SiPixelTemplate` object in memory on demand in the case in which the module `SiPixelLorentzAnglePCLWorker` is not run in PCL mode (`notInPCL_ = True`) and by reducing the number of bins of the 2D drift vs depth maps.
   * for Run2 replays the list of "new" modules is different. That is dealt with via era modifiers;
   * a bug that was messing up the computation of the value of the Lorentz Angle for the "new" modules is addressed;
   * monitoring of the input number of clusters and output Lorentz Angle (and fit chi2/ndf) is introduced;
   * `std::endl` at the end of LogMessages is removed as requested at https://github.com/cms-sw/cmssw/pull/36538#issuecomment-998643023 in commit 0cfb6bf446943c82b59b37bd66c4062fd3b8c080
   * some documentation is added;
    
#### PR validation:

Privately run:

```console
 cmsDriver.py testReAlCa -s ALCA:PromptCalibProdSiPixelLorentzAngle --conditions 121X_dataRun3_Express_TIER0_REPLAY_Run2_v1 --scenario pp --data --era Run2_2018 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 100000 --dasquery='file dataset=/StreamExpress/Tier0_REPLAY_2021-SiPixelCalSingleMuon-Express-v1/ALCARECO' --customise_commands='process.ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle.TriggerResultsTag = cms.InputTag ( "TriggerResults","","HLT" ) ; process.ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle.HLTPaths = ["*"]' --nThreads=4 
```

followed by:

```console
 cmsDriver.py stepHarvest -s ALCAHARVEST:SiPixelLA --conditions 121X_dataRun3_Express_TIER0_REPLAY_Run2_v1 --scenario pp --data --era Run2_2018 --filein file:PromptCalibProdSiPixelLorentzAngle.root -n -1
```

#### Profiling the RSS vs time of the job containing the `ALCA:PromptCalibProdSiPixelLorentzAngle` (run on 4 threads and 4 stream) on 100k events shows a **reduction of about 40% in RSS memory and of 20 times in computing wall-clock time**.
![memory_PR_12_2_X](https://user-images.githubusercontent.com/5082376/149547499-90c976bb-ab49-4bd7-a4ef-747bc84dc1b4.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a combined backport of PRs https://github.com/cms-sw/cmssw/pull/36565 and https://github.com/cms-sw/cmssw/pull/36538 to CMSSW_12_2_X  as agreed at https://github.com/cms-sw/cmssw/pull/36538#issuecomment-997386926 in order to perform a new Tier-0 replay.