### PR TITLE
Pattern Recognition validation for HGCal Tracksters

### DIFF
--- a/DQMServices/Components/plugins/DQMGenericClient.cc
+++ b/DQMServices/Components/plugins/DQMGenericClient.cc
@@ -656,6 +656,11 @@ void DQMGenericClient::makeAllPlots(DQMStore::IBooker& ibooker, DQMStore::IGette
                         efficOption->type,
                         efficOption->isProfile);
     }
+    if (makeGlobalEffPlot_) {
+      ME* globalEfficME = igetter.get(dirName + "/globalEfficiencies");
+      if (globalEfficME)
+        globalEfficME->getTH1F()->LabelsDeflate("X");
+    }
 
     for (vector<ResolOption>::const_iterator resolOption = resolOptions_.begin(); resolOption != resolOptions_.end();
          ++resolOption) {

--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -20,7 +20,7 @@ namespace ticl {
   public:
     typedef math::XYZVector Vector;
 
-    enum IterationIndex { TRKEM = 0, EM, TRKHAD, HAD, MIP };
+    enum IterationIndex { TRKEM = 0, EM, TRKHAD, HAD, MIP, SIM };
 
     // types considered by the particle identification
     enum class ParticleType {

--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -20,7 +20,7 @@ namespace ticl {
   public:
     typedef math::XYZVector Vector;
 
-    enum IterationIndex { TRKEM = 0, EM, TRKHAD, HAD, MIP, SIM };
+    enum IterationIndex { TRKEM = 0, EM, TRKHAD, HAD, MIP, SIM, SIM_CP };
 
     // types considered by the particle identification
     enum class ParticleType {

--- a/RecoHGCal/TICL/interface/commons.h
+++ b/RecoHGCal/TICL/interface/commons.h
@@ -64,6 +64,7 @@ namespace ticl {
 
     tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(pdgId, charge), 1.f);
     tmpTrackster.setRegressedEnergy(energy);
+    tmpTrackster.setIteration(ticl::Trackster::SIM);
     tmpTrackster.setSeed(seed, index);
     result.emplace_back(tmpTrackster);
   }

--- a/RecoHGCal/TICL/interface/commons.h
+++ b/RecoHGCal/TICL/interface/commons.h
@@ -42,6 +42,7 @@ namespace ticl {
       const int& pdgId,
       const int& charge,
       const edm::ProductID& seed,
+      const Trackster::IterationIndex iter,
       std::vector<float>& output_mask,
       std::vector<Trackster>& result) {
     if (lcVec.empty())
@@ -64,7 +65,7 @@ namespace ticl {
 
     tmpTrackster.setIdProbability(tracksterParticleTypeFromPdgId(pdgId, charge), 1.f);
     tmpTrackster.setRegressedEnergy(energy);
-    tmpTrackster.setIteration(ticl::Trackster::SIM);
+    tmpTrackster.setIteration(iter);
     tmpTrackster.setSeed(seed, index);
     result.emplace_back(tmpTrackster);
   }

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -306,6 +306,26 @@ void PatternRecognitionbyCA<TILES>::mergeTrackstersTRK(
                   std::back_inserter(outTrackster.vertex_multiplicity()));
       }
       tracksters.resize(1);
+
+      // Find duplicate LCs
+      auto& orig_vtx = outTrackster.vertices();
+      auto vtx_sorted{orig_vtx};
+      std::sort(std::begin(vtx_sorted), std::end(vtx_sorted));
+      for (unsigned int iLC = 1; iLC < vtx_sorted.size(); ++iLC) {
+        if (vtx_sorted[iLC] == vtx_sorted[iLC - 1]) {
+          // Clean up duplicate LCs
+          const auto lcIdx = vtx_sorted[iLC];
+          const auto firstEl = std::find(orig_vtx.begin(), orig_vtx.end(), lcIdx);
+          const auto firstPos = std::distance(std::begin(orig_vtx), firstEl);
+          auto iDup = std::find(std::next(firstEl), orig_vtx.end(), lcIdx);
+          while (iDup != orig_vtx.end()) {
+            orig_vtx.erase(iDup);
+            outTrackster.vertex_multiplicity().erase(outTrackster.vertex_multiplicity().begin() + std::distance(std::begin(orig_vtx), iDup));
+            outTrackster.vertex_multiplicity()[firstPos] -= 1;
+            iDup = std::find(std::next(firstEl), orig_vtx.end(), lcIdx);
+          };
+        }
+      }
     }
   }
   output.shrink_to_fit();

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -308,7 +308,7 @@ void PatternRecognitionbyCA<TILES>::mergeTrackstersTRK(
       tracksters.resize(1);
 
       // Find duplicate LCs
-      auto& orig_vtx = outTrackster.vertices();
+      auto &orig_vtx = outTrackster.vertices();
       auto vtx_sorted{orig_vtx};
       std::sort(std::begin(vtx_sorted), std::end(vtx_sorted));
       for (unsigned int iLC = 1; iLC < vtx_sorted.size(); ++iLC) {
@@ -320,7 +320,8 @@ void PatternRecognitionbyCA<TILES>::mergeTrackstersTRK(
           auto iDup = std::find(std::next(firstEl), orig_vtx.end(), lcIdx);
           while (iDup != orig_vtx.end()) {
             orig_vtx.erase(iDup);
-            outTrackster.vertex_multiplicity().erase(outTrackster.vertex_multiplicity().begin() + std::distance(std::begin(orig_vtx), iDup));
+            outTrackster.vertex_multiplicity().erase(outTrackster.vertex_multiplicity().begin() +
+                                                     std::distance(std::begin(orig_vtx), iDup));
             outTrackster.vertex_multiplicity()[firstPos] -= 1;
             iDup = std::find(std::next(firstEl), orig_vtx.end(), lcIdx);
           };

--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -144,6 +144,7 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
                    cp.pdgId(),
                    cp.charge(),
                    key.id(),
+                   ticl::Trackster::SIM,
                    *output_mask,
                    *result);
     } else {
@@ -163,6 +164,7 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
                      sc.pdgId(),
                      sc.charge(),
                      scRef.id(),
+                     ticl::Trackster::SIM,
                      *output_mask,
                      *result);
 
@@ -185,6 +187,7 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
                  cp.pdgId(),
                  cp.charge(),
                  key.id(),
+                 ticl::Trackster::SIM_CP,
                  *output_mask_fromCP,
                  *result_fromCP);
 

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
@@ -375,7 +375,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
             cpFraction = findHitIt->fraction;
         }
         cpPair.second +=
-            (rhFraction - cpFraction) * (rhFraction - cpFraction) * hitEnergyWeight * invLayerClusterEnergyWeight;
+            std::pow(std::min(rhFraction - cpFraction, rhFraction), 2) * hitEnergyWeight * invLayerClusterEnergyWeight;
       }  //End of loop over CaloParticles related the this LayerCluster.
     }    // End of loop over Hits within a LayerCluster
 #ifdef EDM_ML_DEBUG
@@ -447,7 +447,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
               lcFraction = findHitIt->fraction;
           }
           lcPair.second.second +=
-              (lcFraction - cpFraction) * (lcFraction - cpFraction) * hitEnergyWeight * invCPEnergyWeight;
+              std::pow(std::min(lcFraction - cpFraction, cpFraction), 2) * hitEnergyWeight * invCPEnergyWeight;
 #ifdef EDM_ML_DEBUG
           LogDebug("LCToCPAssociatorByEnergyScoreImpl")
               << "cpDetId:\t" << (uint32_t)cp_hitDetId << "\tlayerClusterId:\t" << layerClusterId << "\t"

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
@@ -350,7 +350,7 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
     // Compute the correct normalization
     // It is the inverse of the denominator of the LCToCP score formula. Observe that this is the sum of the squares.
     float invLayerClusterEnergyWeight = 0.f;
-    for (auto const& haf : clusters[lcId].hitsAndFractions()) {
+    for (auto const& haf : hits_and_fractions) {
       invLayerClusterEnergyWeight +=
           (haf.second * hitMap_->at(haf.first)->energy()) * (haf.second * hitMap_->at(haf.first)->energy());
     }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToCPAssociatorByEnergyScoreImpl.cc
@@ -374,8 +374,8 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
           if (findHitIt != detIdToCaloParticleId_Map[rh_detid].end())
             cpFraction = findHitIt->fraction;
         }
-        cpPair.second +=
-            std::pow(std::min(rhFraction - cpFraction, rhFraction), 2) * hitEnergyWeight * invLayerClusterEnergyWeight;
+        cpPair.second += std::min(std::pow(rhFraction - cpFraction, 2), std::pow(rhFraction, 2)) * hitEnergyWeight *
+                         invLayerClusterEnergyWeight;
       }  //End of loop over CaloParticles related the this LayerCluster.
     }    // End of loop over Hits within a LayerCluster
 #ifdef EDM_ML_DEBUG
@@ -446,8 +446,8 @@ hgcal::association LCToCPAssociatorByEnergyScoreImpl::makeConnections(
             if (findHitIt != detIdToLayerClusterId_Map[cp_hitDetId].end())
               lcFraction = findHitIt->fraction;
           }
-          lcPair.second.second +=
-              std::pow(std::min(lcFraction - cpFraction, cpFraction), 2) * hitEnergyWeight * invCPEnergyWeight;
+          lcPair.second.second += std::min(std::pow(lcFraction - cpFraction, 2), std::pow(cpFraction, 2)) *
+                                  hitEnergyWeight * invCPEnergyWeight;
 #ifdef EDM_ML_DEBUG
           LogDebug("LCToCPAssociatorByEnergyScoreImpl")
               << "cpDetId:\t" << (uint32_t)cp_hitDetId << "\tlayerClusterId:\t" << layerClusterId << "\t"

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
@@ -357,7 +357,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
     // Compute the correct normalization.
     // It is the inverse of the denominator of the LCToSC score formula. Observe that this is the sum of the squares.
     float invLayerClusterEnergyWeight = 0.f;
-    for (auto const& haf : clusters[lcId].hitsAndFractions()) {
+    for (auto const& haf : hits_and_fractions) {
       invLayerClusterEnergyWeight +=
           (haf.second * hitMap_->at(haf.first)->energy()) * (haf.second * hitMap_->at(haf.first)->energy());
     }

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
@@ -382,7 +382,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
             scFraction = findHitIt->fraction;
         }
         scPair.second +=
-            (rhFraction - scFraction) * (rhFraction - scFraction) * hitEnergyWeight * invLayerClusterEnergyWeight;
+            std::pow(std::min(rhFraction - scFraction, rhFraction), 2) * hitEnergyWeight * invLayerClusterEnergyWeight;
 #ifdef EDM_ML_DEBUG
         LogDebug("LCToSCAssociatorByEnergyScoreImpl")
             << "rh_detid:\t" << (uint32_t)rh_detid << "\tlayerClusterId:\t" << lcId << "\t"
@@ -466,7 +466,7 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
               lcFraction = findHitIt->fraction;
           }
           lcPair.second.second +=
-              (lcFraction - scFraction) * (lcFraction - scFraction) * hitEnergyWeight * invSCEnergyWeight;
+              std::pow(std::min(lcFraction - scFraction, scFraction), 2) * hitEnergyWeight * invSCEnergyWeight;
 #ifdef EDM_ML_DEBUG
           LogDebug("LCToSCAssociatorByEnergyScoreImpl")
               << "scDetId:\t" << (uint32_t)sc_hitDetId << "\tlayerClusterId:\t" << layerClusterId << "\t"

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/LCToSCAssociatorByEnergyScoreImpl.cc
@@ -381,8 +381,8 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
           if (findHitIt != detIdToSimClusterId_Map[rh_detid].end())
             scFraction = findHitIt->fraction;
         }
-        scPair.second +=
-            std::pow(std::min(rhFraction - scFraction, rhFraction), 2) * hitEnergyWeight * invLayerClusterEnergyWeight;
+        scPair.second += std::min(std::pow(rhFraction - scFraction, 2), std::pow(rhFraction, 2)) * hitEnergyWeight *
+                         invLayerClusterEnergyWeight;
 #ifdef EDM_ML_DEBUG
         LogDebug("LCToSCAssociatorByEnergyScoreImpl")
             << "rh_detid:\t" << (uint32_t)rh_detid << "\tlayerClusterId:\t" << lcId << "\t"
@@ -465,8 +465,8 @@ hgcal::association LCToSCAssociatorByEnergyScoreImpl::makeConnections(
             if (findHitIt != detIdToLayerClusterId_Map[sc_hitDetId].end())
               lcFraction = findHitIt->fraction;
           }
-          lcPair.second.second +=
-              std::pow(std::min(lcFraction - scFraction, scFraction), 2) * hitEnergyWeight * invSCEnergyWeight;
+          lcPair.second.second += std::min(std::pow(lcFraction - scFraction, 2), std::pow(scFraction, 2)) *
+                                  hitEnergyWeight * invSCEnergyWeight;
 #ifdef EDM_ML_DEBUG
           LogDebug("LCToSCAssociatorByEnergyScoreImpl")
               << "scDetId:\t" << (uint32_t)sc_hitDetId << "\tlayerClusterId:\t" << layerClusterId << "\t"

--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -62,7 +62,7 @@ protected:
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
   edm::InputTag label_lcl;
   std::vector<edm::InputTag> label_tst;
-  edm::InputTag label_simTSFromCP;
+  edm::InputTag label_simTS, label_simTSFromCP;
   edm::InputTag associator_;
   edm::InputTag associatorSim_;
   const bool SaveGeneralInfo_;
@@ -73,7 +73,7 @@ protected:
   const bool doLayerClustersPlots_;
   edm::InputTag label_layerClustersPlots_, label_LCToCPLinking_;
   const bool doTrackstersPlots_;
-  edm::InputTag label_TSToCPLinking_;
+  edm::InputTag label_TS_, label_TSToCPLinking_, label_TSToSTSPR_;
   std::vector<edm::InputTag> label_clustersmask;
   const edm::FileInPath cummatbudinxo_;
 
@@ -81,7 +81,9 @@ protected:
   edm::EDGetTokenT<std::vector<SimCluster>> simClusters_;
   edm::EDGetTokenT<reco::CaloClusterCollection> layerclusters_;
   std::vector<edm::EDGetTokenT<ticl::TracksterCollection>> label_tstTokens;
-  edm::EDGetTokenT<ticl::TracksterCollection> simTrackstersFromCPs_;
+  edm::EDGetTokenT<ticl::TracksterCollection> simTracksters_;
+  edm::EDGetTokenT<ticl::TracksterCollection> simTracksters_fromCPs_;
+  edm::EDGetTokenT<std::map<uint, std::vector<uint>>> simTrackstersMap_;
   edm::EDGetTokenT<std::vector<CaloParticle>> label_cp_effic;
   edm::EDGetTokenT<std::vector<CaloParticle>> label_cp_fake;
   edm::EDGetTokenT<std::vector<SimVertex>> simVertices_;

--- a/Validation/HGCalValidation/interface/HGCalValidator.h
+++ b/Validation/HGCalValidation/interface/HGCalValidator.h
@@ -73,7 +73,7 @@ protected:
   const bool doLayerClustersPlots_;
   edm::InputTag label_layerClustersPlots_, label_LCToCPLinking_;
   const bool doTrackstersPlots_;
-  edm::InputTag label_TS_, label_TSToCPLinking_, label_TSToSTSPR_;
+  std::string label_TS_, label_TSToCPLinking_, label_TSToSTSPR_;
   std::vector<edm::InputTag> label_clustersmask;
   const edm::FileInPath cummatbudinxo_;
 

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -149,8 +149,12 @@ struct HGVHistoProducerAlgoHistograms {
   std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_caloparticle2trackster[2];
   std::vector<dqm::reco::MonitorElement*> h_num_trackster_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_num_trackster_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_num_trackster_en[2];
+  std::vector<dqm::reco::MonitorElement*> h_num_trackster_pt[2];
   std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_en[2];
+  std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_pt[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc[2];
@@ -160,14 +164,24 @@ struct HGVHistoProducerAlgoHistograms {
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_phi[2];
   std::vector<dqm::reco::MonitorElement*> h_denom_trackster_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_denom_trackster_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_denom_trackster_en[2];
+  std::vector<dqm::reco::MonitorElement*> h_denom_trackster_pt[2];
   std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_en[2];
+  std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_pt[2];
   std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_en[2];
+  std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_pt[2];
   std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_en[2];
+  std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_pt[2];
   std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_en[2];
+  std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_pt[2];
   // Generic histograms
   std::vector<dqm::reco::MonitorElement*> h_tracksternum;
   std::vector<dqm::reco::MonitorElement*> h_conttracksternum;

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -160,8 +160,8 @@ struct HGVHistoProducerAlgoHistograms {
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_phi[2];
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_eta[2];
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc_vs_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc_vs_phi[2];
   std::vector<dqm::reco::MonitorElement*> h_denom_trackster_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_denom_trackster_phi[2];
   std::vector<dqm::reco::MonitorElement*> h_denom_trackster_en[2];

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -257,7 +257,8 @@ public:
                                    std::vector<int> thicknesses);
 
   void bookTracksterHistos(DQMStore::IBooker& ibook, Histograms& histograms, unsigned int layers);
-  void bookTracksterSTSHistos(DQMStore::IBooker& ibook, Histograms& histograms, const int i);
+  enum validationType { Linking = 0, PatternRecognition };
+  void bookTracksterSTSHistos(DQMStore::IBooker& ibook, Histograms& histograms, const validationType valType);
 
   void layerClusters_to_CaloParticles(const Histograms& histograms,
                                       edm::Handle<reco::CaloClusterCollection> clusterHandle,
@@ -271,7 +272,7 @@ public:
                                       const hgcal::RecoToSimCollection& recSimColl,
                                       const hgcal::SimToRecoCollection& simRecColl) const;
   void layerClusters_to_SimClusters(const Histograms& histograms,
-                                    int count,
+                                    const int count,
                                     edm::Handle<reco::CaloClusterCollection> clusterHandle,
                                     const reco::CaloClusterCollection& clusters,
                                     edm::Handle<std::vector<SimCluster>> simClusterHandle,
@@ -283,11 +284,11 @@ public:
                                     const hgcal::RecoToSimCollectionWithSimClusters& recSimColl,
                                     const hgcal::SimToRecoCollectionWithSimClusters& simRecColl) const;
   void tracksters_to_SimTracksters(const Histograms& histograms,
-                                   int count,
+                                   const int count,
                                    const ticl::TracksterCollection& Tracksters,
                                    const reco::CaloClusterCollection& layerClusters,
                                    const ticl::TracksterCollection& simTS,
-                                   const int val,
+                                   const validationType valType,
                                    const ticl::TracksterCollection& simTS_fromCP,
                                    std::map<uint, std::vector<uint>> const& simTrackstersMap,
                                    std::vector<SimCluster> const& sC,
@@ -305,7 +306,7 @@ public:
                                 unsigned int layers,
                                 std::unordered_map<DetId, const HGCRecHit*> const&) const;
   void fill_generic_cluster_histos(const Histograms& histograms,
-                                   int count,
+                                   const int count,
                                    edm::Handle<reco::CaloClusterCollection> clusterHandle,
                                    const reco::CaloClusterCollection& clusters,
                                    const Density& densities,
@@ -324,7 +325,7 @@ public:
                               unsigned int layers,
                               std::vector<int> thicknesses) const;
   void fill_simClusterAssociation_histos(const Histograms& histograms,
-                                         int count,
+                                         const int count,
                                          edm::Handle<reco::CaloClusterCollection> clusterHandle,
                                          const reco::CaloClusterCollection& clusters,
                                          edm::Handle<std::vector<SimCluster>> simClusterHandle,
@@ -335,9 +336,9 @@ public:
                                          unsigned int layers,
                                          const hgcal::RecoToSimCollectionWithSimClusters& recSimColl,
                                          const hgcal::SimToRecoCollectionWithSimClusters& simRecColl) const;
-  void fill_cluster_histos(const Histograms& histograms, int count, const reco::CaloCluster& cluster) const;
+  void fill_cluster_histos(const Histograms& histograms, const int count, const reco::CaloCluster& cluster) const;
   void fill_trackster_histos(const Histograms& histograms,
-                             int count,
+                             const int count,
                              const ticl::TracksterCollection& Tracksters,
                              const reco::CaloClusterCollection& layerClusters,
                              const ticl::TracksterCollection& simTS,

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -108,6 +108,7 @@ struct HGVHistoProducerAlgoHistograms {
   std::unordered_map<int, dqm::reco::MonitorElement*> h_caloparticle_firstlayer_matchedtoRecHit;
   std::unordered_map<int, dqm::reco::MonitorElement*> h_caloparticle_lastlayer_matchedtoRecHit;
   std::unordered_map<int, dqm::reco::MonitorElement*> h_caloparticle_layersnum_matchedtoRecHit;
+  std::unordered_map<int, dqm::reco::MonitorElement*> h_caloparticle_fractions, h_caloparticle_fractions_weight;
 
   //For SimClusters
   std::unordered_map<int, dqm::reco::MonitorElement*> h_simclusternum_perlayer;
@@ -141,12 +142,17 @@ struct HGVHistoProducerAlgoHistograms {
   // For Tracksters
   // Linking and Pattern Recognition
   std::vector<dqm::reco::MonitorElement*> h_score_trackster2caloparticle[2];
-  std::vector<dqm::reco::MonitorElement*> h_scoreMerge_trackster2caloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_score_trackster2bestCaloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_score_trackster2bestCaloparticle2[2];
   std::vector<dqm::reco::MonitorElement*> h_score_caloparticle2trackster[2];
   std::vector<dqm::reco::MonitorElement*> h_scorePur_caloparticle2trackster[2];
   std::vector<dqm::reco::MonitorElement*> h_scoreDupl_caloparticle2trackster[2];
   std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_trackster2caloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_trackster2bestCaloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_trackster2bestCaloparticle2[2];
   std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_caloparticle2trackster[2];
+  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_caloparticle2bestTrackster[2];
+  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_caloparticle2bestTrackster2[2];
   std::vector<dqm::reco::MonitorElement*> h_num_trackster_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_num_trackster_phi[2];
   std::vector<dqm::reco::MonitorElement*> h_num_trackster_en[2];
@@ -156,10 +162,13 @@ struct HGVHistoProducerAlgoHistograms {
   std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_en[2];
   std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_pt[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2bestCaloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2bestCaloparticle2[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc[2];
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_eta[2];
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc2[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2bestCaloparticle_vs_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2bestCaloparticle_vs_phi[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc_vs_eta[2];
   std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc_vs_phi[2];
   std::vector<dqm::reco::MonitorElement*> h_denom_trackster_eta[2];

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -257,7 +257,7 @@ public:
                                    std::vector<int> thicknesses);
 
   void bookTracksterHistos(DQMStore::IBooker& ibook, Histograms& histograms, unsigned int layers);
-  enum validationType { Linking = 0, PatternRecognition };
+  enum validationType { Linking = 0, PatternRecognition, PatternRecognition_CP };
   void bookTracksterSTSHistos(DQMStore::IBooker& ibook, Histograms& histograms, const validationType valType);
 
   void layerClusters_to_CaloParticles(const Histograms& histograms,

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -141,7 +141,10 @@ struct HGVHistoProducerAlgoHistograms {
   // For Tracksters
   // Linking and Pattern Recognition
   std::vector<dqm::reco::MonitorElement*> h_score_trackster2caloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_scoreMerge_trackster2caloparticle[2];
   std::vector<dqm::reco::MonitorElement*> h_score_caloparticle2trackster[2];
+  std::vector<dqm::reco::MonitorElement*> h_scorePur_caloparticle2trackster[2];
+  std::vector<dqm::reco::MonitorElement*> h_scoreDupl_caloparticle2trackster[2];
   std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_trackster2caloparticle[2];
   std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_caloparticle2trackster[2];
   std::vector<dqm::reco::MonitorElement*> h_num_trackster_eta[2];

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -337,7 +337,7 @@ public:
     unsigned int caloParticleId;
     float energy = 0;
     std::vector<std::pair<DetId, float>> hits_and_fractions;
-    std::unordered_map<int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
+    std::unordered_map<unsigned int, std::pair<float, float>> layerClusterIdToEnergyAndScore;
   };
 
 private:

--- a/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
+++ b/Validation/HGCalValidation/interface/HGVHistoProducerAlgo.h
@@ -138,32 +138,34 @@ struct HGVHistoProducerAlgoHistograms {
   std::vector<std::unordered_map<int, dqm::reco::MonitorElement*>> h_sharedenergy_simcluster2layercl_vs_eta_perlayer;
   std::vector<std::unordered_map<int, dqm::reco::MonitorElement*>> h_sharedenergy_simcluster2layercl_vs_phi_perlayer;
 
-  //For Tracksters
-  std::vector<dqm::reco::MonitorElement*> h_score_trackster2caloparticle;
-  std::vector<dqm::reco::MonitorElement*> h_score_caloparticle2trackster;
-  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_trackster2caloparticle;
-  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_caloparticle2trackster;
-  std::vector<dqm::reco::MonitorElement*> h_num_trackster_eta;
-  std::vector<dqm::reco::MonitorElement*> h_num_trackster_phi;
-  std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_eta;
-  std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_phi;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_eta;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_phi;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_eta;
-  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_phi;
-  std::vector<dqm::reco::MonitorElement*> h_denom_trackster_eta;
-  std::vector<dqm::reco::MonitorElement*> h_denom_trackster_phi;
-  std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_eta;
-  std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_phi;
-  std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_eta;
-  std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_phi;
-  std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_eta;
-  std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_phi;
-  std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_eta;
-  std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_phi;
+  // For Tracksters
+  // Linking and Pattern Recognition
+  std::vector<dqm::reco::MonitorElement*> h_score_trackster2caloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_score_caloparticle2trackster[2];
+  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_trackster2caloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_energy_vs_score_caloparticle2trackster[2];
+  std::vector<dqm::reco::MonitorElement*> h_num_trackster_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_num_trackster_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_numMerge_trackster_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_assoc[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_trackster2caloparticle_vs_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_sharedenergy_caloparticle2trackster_vs_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_denom_trackster_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_denom_trackster_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_numEff_caloparticle_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_num_caloparticle_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_numDup_trackster_phi[2];
+  std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_eta[2];
+  std::vector<dqm::reco::MonitorElement*> h_denom_caloparticle_phi[2];
+  // Generic histograms
   std::vector<dqm::reco::MonitorElement*> h_tracksternum;
   std::vector<dqm::reco::MonitorElement*> h_conttracksternum;
   std::vector<dqm::reco::MonitorElement*> h_nonconttracksternum;
@@ -229,7 +231,7 @@ public:
                                    std::vector<int> thicknesses);
 
   void bookTracksterHistos(DQMStore::IBooker& ibook, Histograms& histograms, unsigned int layers);
-  void bookTracksterCPLinkingHistos(DQMStore::IBooker& ibook, Histograms& histograms);
+  void bookTracksterSTSHistos(DQMStore::IBooker& ibook, Histograms& histograms, const int i);
 
   void layerClusters_to_CaloParticles(const Histograms& histograms,
                                       edm::Handle<reco::CaloClusterCollection> clusterHandle,
@@ -258,7 +260,12 @@ public:
                                    int count,
                                    const ticl::TracksterCollection& Tracksters,
                                    const reco::CaloClusterCollection& layerClusters,
-                                   const ticl::TracksterCollection& simTSFromCP,
+                                   const ticl::TracksterCollection& simTS,
+                                   const int val,
+                                   const ticl::TracksterCollection& simTS_fromCP,
+                                   std::map<uint, std::vector<uint>> const& simTrackstersMap,
+                                   std::vector<SimCluster> const& sC,
+                                   const edm::ProductID& cPHandle_id,
                                    std::vector<CaloParticle> const& cP,
                                    std::vector<size_t> const& cPIndices,
                                    std::vector<size_t> const& cPSelectedIndices,
@@ -307,7 +314,11 @@ public:
                              int count,
                              const ticl::TracksterCollection& Tracksters,
                              const reco::CaloClusterCollection& layerClusters,
-                             const ticl::TracksterCollection& simTSFromCP,
+                             const ticl::TracksterCollection& simTS,
+                             const ticl::TracksterCollection& simTS_fromCP,
+                             std::map<uint, std::vector<uint>> const& simTrackstersMap,
+                             std::vector<SimCluster> const& sC,
+                             const edm::ProductID& cPHandle_id,
                              std::vector<CaloParticle> const& cP,
                              std::vector<size_t> const& cPIndices,
                              std::vector<size_t> const& cPSelectedIndices,

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -26,9 +26,9 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
       label_layerClustersPlots_(pset.getParameter<edm::InputTag>("label_layerClusterPlots")),
       label_LCToCPLinking_(pset.getParameter<edm::InputTag>("label_LCToCPLinking")),
       doTrackstersPlots_(pset.getUntrackedParameter<bool>("doTrackstersPlots")),
-      label_TS_(pset.getParameter<edm::InputTag>("label_TS")),
-      label_TSToCPLinking_(pset.getParameter<edm::InputTag>("label_TSToCPLinking")),
-      label_TSToSTSPR_(pset.getParameter<edm::InputTag>("label_TSToSTSPR")),
+      label_TS_(pset.getParameter<std::string>("label_TS")),
+      label_TSToCPLinking_(pset.getParameter<std::string>("label_TSToCPLinking")),
+      label_TSToSTSPR_(pset.getParameter<std::string>("label_TSToSTSPR")),
       label_clustersmask(pset.getParameter<std::vector<edm::InputTag>>("LayerClustersInputMask")),
       cummatbudinxo_(pset.getParameter<edm::FileInPath>("cummatbudinxo")) {
   //In this way we can easily generalize to associations between other objects also.
@@ -206,17 +206,19 @@ void HGCalValidator::bookHistograms(DQMStore::IBooker& ibook,
 
     ibook.setCurrentFolder(dirName);
 
-    //Booking histograms concerning HGCal tracksters
+    // Booking histograms concerning HGCal tracksters
     if (doTrackstersPlots_) {
       // Generic histos
-      ibook.setCurrentFolder(dirName + "/" + label_TS_.label());
+      ibook.setCurrentFolder(dirName + "/" + label_TS_);
       histoProducerAlgo_->bookTracksterHistos(ibook, histograms.histoProducerAlgo, totallayers_to_monitor_);
       // CP Linking
-      ibook.setCurrentFolder(dirName + "/" + label_TSToCPLinking_.label());
-      histoProducerAlgo_->bookTracksterSTSHistos(ibook, histograms.histoProducerAlgo, 0);
+      ibook.setCurrentFolder(dirName + "/" + label_TSToCPLinking_);
+      histoProducerAlgo_->bookTracksterSTSHistos(
+          ibook, histograms.histoProducerAlgo, HGVHistoProducerAlgo::validationType::Linking);
       // SimTracksters Pattern Recognition
-      ibook.setCurrentFolder(dirName + "/" + label_TSToSTSPR_.label());
-      histoProducerAlgo_->bookTracksterSTSHistos(ibook, histograms.histoProducerAlgo, 1);
+      ibook.setCurrentFolder(dirName + "/" + label_TSToSTSPR_);
+      histoProducerAlgo_->bookTracksterSTSHistos(
+          ibook, histograms.histoProducerAlgo, HGVHistoProducerAlgo::validationType::PatternRecognition);
     }
   }  //end of booking Tracksters loop
 }
@@ -302,7 +304,7 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   removeCPFromPU(caloParticles, cPIndices);
 
   // ##############################################
-  // fill caloparticles histograms
+  // Fill caloparticles histograms
   // ##############################################
   // HGCRecHit are given to select the SimHits which are also reconstructed
   LogTrace("HGCalValidator") << "\n# of CaloParticles: " << caloParticles.size() << "\n" << std::endl;
@@ -342,7 +344,7 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   }
 
   // ##############################################
-  // fill simCluster histograms
+  // Fill simCluster histograms
   // ##############################################
   if (doSimClustersPlots_) {
     histoProducerAlgo_->fill_simCluster_histos(
@@ -378,7 +380,7 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   }
 
   // ##############################################
-  // fill layercluster histograms
+  // Fill layercluster histograms
   // ##############################################
   int w = 0;  //counter counting the number of sets of histograms
   if (doLayerClustersPlots_) {
@@ -408,7 +410,7 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
   }
 
   // ##############################################
-  // fill Trackster histograms
+  // Fill Trackster histograms
   // ##############################################
   for (unsigned int wml = 0; wml < label_tstTokens.size(); wml++) {
     if (doTrackstersPlots_) {

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -396,6 +396,12 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
       event.getByToken(label_tstTokens[wml], tracksterHandle);
       const ticl::TracksterCollection& tracksters = *tracksterHandle;
 
+      //General Info on Tracksters
+      LogTrace("HGCalValidator") << "\n# of Tracksters from " << label_tst[wml].process() << ":"
+                                 << label_tst[wml].label() << ":" << label_tst[wml].instance() << ": "
+                                 << tracksters.size() << "\n"
+                                 << std::endl;
+
       histoProducerAlgo_->fill_trackster_histos(histograms.histoProducerAlgo,
                                                 wml,
                                                 tracksters,
@@ -406,12 +412,6 @@ void HGCalValidator::dqmAnalyze(const edm::Event& event,
                                                 selected_cPeff,
                                                 *hitMap,
                                                 totallayers_to_monitor_);
-
-      //General Info on Tracksters
-      LogTrace("HGCalValidator") << "\n# of Tracksters with " << label_tst[wml].process() << ":"
-                                 << label_tst[wml].label() << ":" << label_tst[wml].instance() << ": "
-                                 << tracksters.size() << "\n"
-                                 << std::endl;
     }
   }  //end of loop over Trackster input labels
 }

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -11,9 +11,9 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabels, ticlIterLabelsMerge
 
 labelTst = [cms.InputTag("ticlTracksters"+iteration) for iteration in ticlIterLabelsMerge]
-labelTst.extend(["ticlSimTracksters"])
+labelTst.extend([cms.InputTag("ticlSimTracksters", "fromCPs"), cms.InputTag("ticlSimTracksters")])
 lcInputMask = [cms.InputTag("ticlTracksters"+iteration) for iteration in ticlIterLabels]
-lcInputMask.extend(["ticlSimTracksters"])
+lcInputMask.extend([cms.InputTag("ticlSimTracksters", "fromCPs"), cms.InputTag("ticlSimTracksters")])
 hgcalValidator = DQMEDAnalyzer(
     "HGCalValidator",
 

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -48,9 +48,9 @@ hgcalValidator = DQMEDAnalyzer(
     label_LCToCPLinking = cms.InputTag("LCToCP_association"),
     #Trackster related plots
     doTrackstersPlots = cms.untracked.bool(True),
-    label_TS = cms.InputTag("Morphology"),
-    label_TSToCPLinking = cms.InputTag("TSToCP_linking"),
-    label_TSToSTSPR = cms.InputTag("TSToSTS_patternRecognition"),
+    label_TS = cms.string("Morphology"),
+    label_TSToCPLinking = cms.string("TSToCP_linking"),
+    label_TSToSTSPR = cms.string("TSToSTS_patternRecognition"),
 
     #The cumulative material budget in front of each layer. To be more specific, it
     #is the material budget just in front of the active material (not including it).

--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -25,6 +25,7 @@ hgcalValidator = DQMEDAnalyzer(
     #2DLayerClusters, PFClusters, Tracksters
     label_lcl = layerClusterCaloParticleAssociation.label_lc,
     label_tst = cms.VInputTag(labelTst),
+    label_simTS = cms.InputTag("ticlSimTracksters"),
     label_simTSFromCP = cms.InputTag("ticlSimTracksters", "fromCPs"),
 
     associator = cms.untracked.InputTag("layerClusterCaloParticleAssociationProducer"),
@@ -47,7 +48,9 @@ hgcalValidator = DQMEDAnalyzer(
     label_LCToCPLinking = cms.InputTag("LCToCP_association"),
     #Trackster related plots
     doTrackstersPlots = cms.untracked.bool(True),
+    label_TS = cms.InputTag("Morphology"),
     label_TSToCPLinking = cms.InputTag("TSToCP_linking"),
+    label_TSToSTSPR = cms.InputTag("TSToSTS_patternRecognition"),
 
     #The cumulative material budget in front of each layer. To be more specific, it
     #is the material budget just in front of the active material (not including it).

--- a/Validation/HGCalValidation/python/HGVHistoProducerAlgoBlock_cfi.py
+++ b/Validation/HGCalValidation/python/HGVHistoProducerAlgoBlock_cfi.py
@@ -74,14 +74,14 @@ HGVHistoProducerAlgoBlock = cms.PSet(
     #2. Fraction of each of the calo particles energy
     #   related to a layer cluster over that layer cluster's energy.
     minSharedEneFrac = cms.double(0.),
-    maxSharedEneFrac = cms.double(1.),
-    nintSharedEneFrac = cms.int32(100),
+    maxSharedEneFrac = cms.double(1.01),
+    nintSharedEneFrac = cms.int32(101),
     minTSTSharedEneFracEfficiency = cms.double(0.5),
 
     #Same as above for tracksters
     minTSTSharedEneFrac = cms.double(0.),
-    maxTSTSharedEneFrac = cms.double(1.0),
-    nintTSTSharedEneFrac = cms.int32(100),
+    maxTSTSharedEneFrac = cms.double(1.01),
+    nintTSTSharedEneFrac = cms.int32(101),
 
     #Parameters for the total number of simclusters per thickness
     minTotNsimClsperthick = cms.double(0.),

--- a/Validation/HGCalValidation/python/HGVHistoProducerAlgoBlock_cfi.py
+++ b/Validation/HGCalValidation/python/HGVHistoProducerAlgoBlock_cfi.py
@@ -74,8 +74,8 @@ HGVHistoProducerAlgoBlock = cms.PSet(
     #2. Fraction of each of the calo particles energy
     #   related to a layer cluster over that layer cluster's energy.
     minSharedEneFrac = cms.double(0.),
-    maxSharedEneFrac = cms.double(1.01),
-    nintSharedEneFrac = cms.int32(101),
+    maxSharedEneFrac = cms.double(1.02),
+    nintSharedEneFrac = cms.int32(51),
     minTSTSharedEneFracEfficiency = cms.double(0.5),
 
     #Same as above for tracksters

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -65,11 +65,11 @@ for elem in simDict:
             V = v.capitalize()
             eff_tracksters.extend([m+"_"+v+simDict[elem]+" 'Trackster "+metrics[m][0]+" vs "+variables[v][0]+"' Num"+metrics[m][1]+"Trackster_"+V+simDict[elem]+" Denom_Trackster_"+V+simDict[elem]+fakerate])
 
-tsToCP_linking = str(hgcalValidator.label_TSToCPLinking)
+tsToCP_linking = hgcalValidator.label_TSToCPLinking.value()
 subdirsTracksters = [prefix+'ticlSimTracksters/'+tsToCP_linking, prefix+'ticlSimTracksters_fromCPs/'+tsToCP_linking]
 subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToCP_linking for iteration in ticlIterLabelsMerge)
 
-tsToSTS_patternRec = str(hgcalValidator.label_TSToSTSPR)
+tsToSTS_patternRec = hgcalValidator.label_TSToSTSPR.value()
 subdirsTracksters.extend([prefix+'ticlSimTracksters/'+tsToSTS_patternRec, prefix+'ticlSimTracksters_fromCPs/'+tsToSTS_patternRec])
 subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToSTS_patternRec for iteration in ticlIterLabelsMerge)
 

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -50,6 +50,7 @@ postProcessorHGCALsimclusters = DQMEDHarvester('DQMGenericClient',
 
 
 eff_tracksters = []
+# Must be in sync with labels in HGVHistoProducerAlgo.cc
 simDict = {"CaloParticle":"_Link", "SimTrackster":"_PR"}
 metrics = {"purity":["Purity","_"], "effic":["Efficiency","Eff_"], "fake":["Fake Rate","_"], "duplicate":["Duplicate(Split)","Dup_"], "merge":["Merge Rate","Merge_"]}
 variables = {"eta":["#eta",""], "phi":["#phi",""], "energy":["energy"," [GeV]"], "pt":["p_{T}"," [GeV]"]}

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -18,7 +18,7 @@ eff_layers.extend(["merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer
 eff_layers.extend(["merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z-' NumMerge_LayerCluster_Phi_perlayer{:02d} Denom_LayerCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z+' NumMerge_LayerCluster_Phi_perlayer{:02d} Denom_LayerCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 
 lcToCP_linking = hgcalValidator.label_LCToCPLinking._InputTag__moduleLabel
-postProcessorHGCALlayerclusters= DQMEDHarvester('DQMGenericClient',
+postProcessorHGCALlayerclusters = DQMEDHarvester('DQMGenericClient',
     subDirs = cms.untracked.vstring(prefix + hgcalValidator.label_layerClusterPlots._InputTag__moduleLabel + '/' + lcToCP_linking),
     efficiency = cms.vstring(eff_layers),
     resolution = cms.vstring(),
@@ -39,7 +39,7 @@ eff_simclusters.extend(["merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi 
 
 subdirsSim = [prefix + hgcalValidator.label_SimClusters._InputTag__moduleLabel + '/ticlTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge]
 subdirsSim.extend([prefix + hgcalValidator.label_SimClusters._InputTag__moduleLabel + '/ticlSimTracksters'])
-postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
+postProcessorHGCALsimclusters = DQMEDHarvester('DQMGenericClient',
     subDirs = cms.untracked.vstring(subdirsSim),
     efficiency = cms.vstring(eff_simclusters),
     resolution = cms.vstring(),
@@ -48,20 +48,21 @@ postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
     outputFileName = cms.untracked.string(""),
     verbose = cms.untracked.uint32(4))
 
+
 eff_tracksters = []
 simDict = {"CaloParticle":"_Link", "SimTrackster":"_PR"}
+metrics = {"purity":["Purity","_"], "effic":["Efficiency","Eff_"], "fake":["Fake Rate","_"], "duplicate":["Duplicate(Split)","Dup_"], "merge":["Merge Rate","Merge_"]}
+variables = {"eta":"#eta", "phi":"#phi", "energy":"energy", "pt":"p_{T}"}
 for elem in simDict:
-    eff_tracksters.extend(["purity_eta"+simDict[elem]+" 'Trackster Purity vs #eta' Num_"+elem+"_Eta Denom_"+elem+"_Eta"])
-    eff_tracksters.extend(["purity_phi"+simDict[elem]+" 'Trackster Purity vs #phi' Num_"+elem+"_Phi Denom_"+elem+"_Phi"])
-    eff_tracksters.extend(["effic_eta"+simDict[elem]+" 'Trackster Efficiency vs #eta' NumEff_"+elem+"_Eta Denom_"+elem+"_Eta"])
-    eff_tracksters.extend(["effic_phi"+simDict[elem]+" 'Trackster Efficiency vs #phi' NumEff_"+elem+"_Phi Denom_"+elem+"_Phi"])
-    eff_tracksters.extend(["fake_eta"+simDict[elem]+" 'Trackster Fake Rate vs #eta' Num_Trackster_Eta"+simDict[elem]+" Denom_Trackster_Eta"+simDict[elem]+" fake"])
-    eff_tracksters.extend(["fake_phi"+simDict[elem]+" 'Trackster Fake Rate vs #phi'  Num_Trackster_Phi"+simDict[elem]+" Denom_Trackster_Phi"+simDict[elem]+" fake"])
-    eff_tracksters.extend(["duplicate_eta"+simDict[elem]+" 'Trackster Duplicate(Split) Rate vs #eta' NumDup_Trackster_Eta"+simDict[elem]+" Denom_Trackster_Eta"+simDict[elem]])
-    eff_tracksters.extend(["duplicate_phi"+simDict[elem]+" 'Trackster Duplicate(Split) Rate vs #phi' NumDup_Trackster_Phi"+simDict[elem]+" Denom_Trackster_Phi"+simDict[elem]])
-    eff_tracksters.extend(["merge_eta"+simDict[elem]+" 'Trackster Merge Rate vs #eta' NumMerge_Trackster_Eta"+simDict[elem]+" Denom_Trackster_Eta"+simDict[elem]])
-    eff_tracksters.extend(["merge_phi"+simDict[elem]+" 'Trackster Merge Rate vs #phi' NumMerge_Trackster_Phi"+simDict[elem]+" Denom_Trackster_Phi"+simDict[elem]])
-
+    for m in list(metrics.keys())[:2]:
+        for v in variables:
+            V = v.capitalize()
+            eff_tracksters.extend([m+"_"+v+simDict[elem]+" 'Trackster "+metrics[m][0]+" vs "+variables[v]+"' Num"+metrics[m][1]+elem+"_"+V+" Denom_"+elem+"_"+V])
+    for m in list(metrics.keys())[2:]:
+        fakerate = " fake" if (m == "fake") else ""
+        for v in variables:
+            V = v.capitalize()
+            eff_tracksters.extend([m+"_"+v+simDict[elem]+" 'Trackster "+metrics[m][0]+" vs "+variables[v]+"' Num"+metrics[m][1]+"Trackster_"+V+simDict[elem]+" Denom_Trackster_"+V+simDict[elem]+fakerate])
 
 tsToCP_linking = hgcalValidator.label_TSToCPLinking._InputTag__moduleLabel
 subdirsTracksters = [prefix+'ticlSimTracksters/'+tsToCP_linking, prefix+'ticlSimTracksters_fromCPs/'+tsToCP_linking]

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -52,17 +52,17 @@ postProcessorHGCALsimclusters = DQMEDHarvester('DQMGenericClient',
 eff_tracksters = []
 simDict = {"CaloParticle":"_Link", "SimTrackster":"_PR"}
 metrics = {"purity":["Purity","_"], "effic":["Efficiency","Eff_"], "fake":["Fake Rate","_"], "duplicate":["Duplicate(Split)","Dup_"], "merge":["Merge Rate","Merge_"]}
-variables = {"eta":"#eta", "phi":"#phi", "energy":"energy", "pt":"p_{T}"}
+variables = {"eta":["#eta",""], "phi":["#phi",""], "energy":["energy"," [GeV]"], "pt":["p_{T}"," [GeV]"]}
 for elem in simDict:
     for m in list(metrics.keys())[:2]:
         for v in variables:
             V = v.capitalize()
-            eff_tracksters.extend([m+"_"+v+simDict[elem]+" 'Trackster "+metrics[m][0]+" vs "+variables[v]+"' Num"+metrics[m][1]+elem+"_"+V+" Denom_"+elem+"_"+V])
+            eff_tracksters.extend([m+"_"+v+simDict[elem]+" 'Trackster "+metrics[m][0]+" vs "+variables[v][0]+"' Num"+metrics[m][1]+elem+"_"+V+" Denom_"+elem+"_"+V])
     for m in list(metrics.keys())[2:]:
         fakerate = " fake" if (m == "fake") else ""
         for v in variables:
             V = v.capitalize()
-            eff_tracksters.extend([m+"_"+v+simDict[elem]+" 'Trackster "+metrics[m][0]+" vs "+variables[v]+"' Num"+metrics[m][1]+"Trackster_"+V+simDict[elem]+" Denom_Trackster_"+V+simDict[elem]+fakerate])
+            eff_tracksters.extend([m+"_"+v+simDict[elem]+" 'Trackster "+metrics[m][0]+" vs "+variables[v][0]+"' Num"+metrics[m][1]+"Trackster_"+V+simDict[elem]+" Denom_Trackster_"+V+simDict[elem]+fakerate])
 
 tsToCP_linking = hgcalValidator.label_TSToCPLinking._InputTag__moduleLabel
 subdirsTracksters = [prefix+'ticlSimTracksters/'+tsToCP_linking, prefix+'ticlSimTracksters_fromCPs/'+tsToCP_linking]

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -64,11 +64,11 @@ for elem in simDict:
 
 
 tsToCP_linking = hgcalValidator.label_TSToCPLinking._InputTag__moduleLabel
-subdirsTracksters = [prefix+'hgcalTracksters/'+tsToCP_linking, prefix+'ticlSimTracksters/'+tsToCP_linking]
+subdirsTracksters = [prefix+'ticlSimTracksters/'+tsToCP_linking, prefix+'ticlSimTracksters_fromCPs/'+tsToCP_linking]
 subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToCP_linking for iteration in ticlIterLabelsMerge)
 
 tsToSTS_patternRec = hgcalValidator.label_TSToSTSPR._InputTag__moduleLabel
-subdirsTracksters.extend([prefix+'hgcalTracksters/'+tsToSTS_patternRec, prefix+'ticlSimTracksters/'+tsToSTS_patternRec])
+subdirsTracksters.extend([prefix+'ticlSimTracksters/'+tsToSTS_patternRec, prefix+'ticlSimTracksters_fromCPs/'+tsToSTS_patternRec])
 subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToSTS_patternRec for iteration in ticlIterLabelsMerge)
 
 postProcessorHGCALTracksters = DQMEDHarvester('DQMGenericClient',

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -65,11 +65,11 @@ for elem in simDict:
             V = v.capitalize()
             eff_tracksters.extend([m+"_"+v+simDict[elem]+" 'Trackster "+metrics[m][0]+" vs "+variables[v][0]+"' Num"+metrics[m][1]+"Trackster_"+V+simDict[elem]+" Denom_Trackster_"+V+simDict[elem]+fakerate])
 
-tsToCP_linking = hgcalValidator.label_TSToCPLinking._InputTag__moduleLabel
+tsToCP_linking = str(hgcalValidator.label_TSToCPLinking)
 subdirsTracksters = [prefix+'ticlSimTracksters/'+tsToCP_linking, prefix+'ticlSimTracksters_fromCPs/'+tsToCP_linking]
 subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToCP_linking for iteration in ticlIterLabelsMerge)
 
-tsToSTS_patternRec = hgcalValidator.label_TSToSTSPR._InputTag__moduleLabel
+tsToSTS_patternRec = str(hgcalValidator.label_TSToSTSPR)
 subdirsTracksters.extend([prefix+'ticlSimTracksters/'+tsToSTS_patternRec, prefix+'ticlSimTracksters_fromCPs/'+tsToSTS_patternRec])
 subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToSTS_patternRec for iteration in ticlIterLabelsMerge)
 

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -48,20 +48,28 @@ postProcessorHGCALsimclusters= DQMEDHarvester('DQMGenericClient',
     outputFileName = cms.untracked.string(""),
     verbose = cms.untracked.uint32(4))
 
-eff_tracksters = ["purity_eta 'Trackster Purity vs #eta' Num_CaloParticle_Eta Denom_CaloParticle_Eta"]
-eff_tracksters.extend(["purity_phi 'Trackster Purity vs #phi' Num_CaloParticle_Phi Denom_CaloParticle_Phi"])
-eff_tracksters.extend(["effic_eta 'Trackster Efficiency vs #eta' NumEff_CaloParticle_Eta Denom_CaloParticle_Eta"])
-eff_tracksters.extend(["effic_phi 'Trackster Efficiency vs #phi' NumEff_CaloParticle_Phi Denom_CaloParticle_Phi"])
-eff_tracksters.extend(["duplicate_eta 'Trackster Duplicate(Split) Rate vs #eta' NumDup_Trackster_Eta Denom_Trackster_Eta"])
-eff_tracksters.extend(["duplicate_phi 'Trackster Duplicate(Split) Rate vs #phi' NumDup_Trackster_Phi Denom_Trackster_Phi"])
-eff_tracksters.extend(["fake_eta 'Trackster Fake Rate vs #eta' Num_Trackster_Eta Denom_Trackster_Eta fake"])
-eff_tracksters.extend(["fake_phi 'Trackster Fake Rate vs #phi'  Num_Trackster_Phi Denom_Trackster_Phi fake"])
-eff_tracksters.extend(["merge_eta 'Trackster Merge Rate vs #eta' NumMerge_Trackster_Eta Denom_Trackster_Eta"])
-eff_tracksters.extend(["merge_phi 'Trackster Merge Rate vs #phi' NumMerge_Trackster_Phi Denom_Trackster_Phi"])
+eff_tracksters = []
+simDict = {"CaloParticle":"_Link", "SimTrackster":"_PR"}
+for elem in simDict:
+    eff_tracksters.extend(["purity_eta"+simDict[elem]+" 'Trackster Purity vs #eta' Num_"+elem+"_Eta Denom_"+elem+"_Eta"])
+    eff_tracksters.extend(["purity_phi"+simDict[elem]+" 'Trackster Purity vs #phi' Num_"+elem+"_Phi Denom_"+elem+"_Phi"])
+    eff_tracksters.extend(["effic_eta"+simDict[elem]+" 'Trackster Efficiency vs #eta' NumEff_"+elem+"_Eta Denom_"+elem+"_Eta"])
+    eff_tracksters.extend(["effic_phi"+simDict[elem]+" 'Trackster Efficiency vs #phi' NumEff_"+elem+"_Phi Denom_"+elem+"_Phi"])
+    eff_tracksters.extend(["fake_eta"+simDict[elem]+" 'Trackster Fake Rate vs #eta' Num_Trackster_Eta"+simDict[elem]+" Denom_Trackster_Eta"+simDict[elem]+" fake"])
+    eff_tracksters.extend(["fake_phi"+simDict[elem]+" 'Trackster Fake Rate vs #phi'  Num_Trackster_Phi"+simDict[elem]+" Denom_Trackster_Phi"+simDict[elem]+" fake"])
+    eff_tracksters.extend(["duplicate_eta"+simDict[elem]+" 'Trackster Duplicate(Split) Rate vs #eta' NumDup_Trackster_Eta"+simDict[elem]+" Denom_Trackster_Eta"+simDict[elem]])
+    eff_tracksters.extend(["duplicate_phi"+simDict[elem]+" 'Trackster Duplicate(Split) Rate vs #phi' NumDup_Trackster_Phi"+simDict[elem]+" Denom_Trackster_Phi"+simDict[elem]])
+    eff_tracksters.extend(["merge_eta"+simDict[elem]+" 'Trackster Merge Rate vs #eta' NumMerge_Trackster_Eta"+simDict[elem]+" Denom_Trackster_Eta"+simDict[elem]])
+    eff_tracksters.extend(["merge_phi"+simDict[elem]+" 'Trackster Merge Rate vs #phi' NumMerge_Trackster_Phi"+simDict[elem]+" Denom_Trackster_Phi"+simDict[elem]])
+
 
 tsToCP_linking = hgcalValidator.label_TSToCPLinking._InputTag__moduleLabel
 subdirsTracksters = [prefix+'hgcalTracksters/'+tsToCP_linking, prefix+'ticlSimTracksters/'+tsToCP_linking]
 subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToCP_linking for iteration in ticlIterLabelsMerge)
+
+tsToSTS_patternRec = hgcalValidator.label_TSToSTSPR._InputTag__moduleLabel
+subdirsTracksters.extend([prefix+'hgcalTracksters/'+tsToSTS_patternRec, prefix+'ticlSimTracksters/'+tsToSTS_patternRec])
+subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToSTS_patternRec for iteration in ticlIterLabelsMerge)
 
 postProcessorHGCALTracksters = DQMEDHarvester('DQMGenericClient',
   subDirs = cms.untracked.vstring(subdirsTracksters),

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1572,6 +1572,7 @@ _common_score = {"stat": False, "legend": False
                  ,"lineWidth": 1
                  ,"ylog": True
                  ,"xlog": True
+                 ,"xtitle": "Default"
                 }
 _common_score.update(_legend_common)
 
@@ -1582,7 +1583,7 @@ for score in score_to_trackster:
     _score_caloparticle_to_tracksters.append(Plot("Score"+score+"_caloparticle2trackster", **_common_score))
     _score_simtrackster_to_tracksters.append(Plot("Score"+score+"_simtrackster2trackster", **_common_score))
 
-score_trackster_to = ["","Merge"]
+score_trackster_to = ["","Fake","Merge"]
 _score_trackster_to_caloparticles = PlotGroup("ScoreTrackstersToCaloParticles", [], ncols=len(score_trackster_to))
 _score_trackster_to_simtracksters = PlotGroup("ScoreTrackstersToSimTracksters", [], ncols=len(score_trackster_to))
 for score in score_trackster_to:
@@ -1590,18 +1591,31 @@ for score in score_trackster_to:
     _score_trackster_to_simtracksters.append(Plot("Score"+score+"_trackster2simtrackster", **_common_score))
 
 
-_common_shared = {"stat": False, "legend": False}
+_common_shared = {"stat": False, "legend": False, "xtitle": 'Default', "ytitle": 'Default'}
 _common_shared.update(_legend_common)
+_common_energy_score = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d", drawStyle="COLZ", adjustMarginRight=0.1, xtitle='Default', ytitle='Default')
+_common_energy_score["ymax"] = 1.
+_common_energy_score["xmax"] = 1.0
+
 _sharedEnergy_to_trackster = []
 _sharedEnergy_trackster_to = []
-versions = {"":"energy fraction", "_assoc":"energy fraction", "_assoc_vs_eta":"#eta", "_assoc_vs_phi":"#phi"}
+versions = ["", "_assoc", "_assoc_vs_eta", "_assoc_vs_phi"]
+
+_energyscore_to_trackster = []
+_energyscore_trackster_to = []
+en_vs_score = ["","best","secBest"]
 for val in simDict:
     _sharedEnergy_to_trackster.append(PlotGroup("SharedEnergy_"+val+"ToTrackster", [], ncols=2))
     _sharedEnergy_trackster_to.append(PlotGroup("SharedEnergy_TracksterTo"+val, [], ncols=2))
     for ver in versions:
-        _sharedEnergy_to_trackster[-1].append(Plot("SharedEnergy_"+val.lower()+"2trackster"+ver, xtitle=val+" "+versions[ver], **_common_shared))
-        _sharedEnergy_trackster_to[-1].append(Plot("SharedEnergy_trackster2"+val.lower()+ver, xtitle="Trackster "+versions[ver], **_common_shared))
+        _sharedEnergy_to_trackster[-1].append(Plot("SharedEnergy_"+val.lower()+"2trackster"+ver, **_common_shared))
+        _sharedEnergy_trackster_to[-1].append(Plot("SharedEnergy_trackster2"+val.lower()+ver, **_common_shared))
 
+    _energyscore_to_trackster.append(PlotGroup("Energy_vs_Score_"+val+"ToTracksters", [], ncols=len(en_vs_score)))
+    _energyscore_trackster_to.append(PlotGroup("Energy_vs_Score_TrackstersTo"+val, [], ncols=len(en_vs_score)))
+    for ver in en_vs_score:
+        _energyscore_to_trackster[-1].append(Plot("Energy_vs_Score_"+val.lower()+"2"+ver+"Trackster", **_common_energy_score))
+        _energyscore_trackster_to[-1].append(Plot("Energy_vs_Score_trackster2"+ver+val, **_common_energy_score))
 
 _common_assoc = {#"title": "Cell Association Table",
                  "stat": False,
@@ -1649,37 +1663,27 @@ for val in simDict:
     _merges.append(PlotGroup("MergeRate"+simDict[val], _mergeplots, ncols=3))
 
 
-_common_energy_score = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d")
-_common_energy_score["ymax"] = 1.
-_common_energy_score["xmax"] = 1.0
-_energyscore_cp2ts = PlotOnSideGroup("Energy_vs_Score_CaloParticlesToTracksters", Plot("Energy_vs_Score_caloparticle2trackster", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
-_energyscore_sts2ts = PlotOnSideGroup("Energy_vs_Score_SimTrackstersToTracksters", Plot("Energy_vs_Score_simtrackster2trackster", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
-_common_energy_score["ymax"] = 1.
-_common_energy_score["xmax"] = 1.0
-_energyscore_ts2cp = PlotOnSideGroup("Energy_vs_Score_TrackstersToCaloParticles", Plot("Energy_vs_Score_trackster2caloparticle", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
-_energyscore_ts2sts = PlotOnSideGroup("Energy_vs_Score_TrackstersToSimTracksters", Plot("Energy_vs_Score_trackster2simtrackster", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
-
 #Coming back to the usual box definition
-_common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
+_common = {"stat": True, "drawStyle": "hist", "staty": 0.65, "xtitle": "Default"}
 
 _tottracksternum = PlotGroup("TotalNumberofTracksters", [
-  Plot("tottracksternum", xtitle="", **_common)
+  Plot("tottracksternum", **_common)
 ],ncols=1)
 
-_trackster_layernum_plots = [Plot("trackster_firstlayer", xtitle="Trackster First Layer", **_common)]
-_trackster_layernum_plots.extend([Plot("trackster_lastlayer", xtitle="Trackster Last Layer", **_common)])
-_trackster_layernum_plots.extend([Plot("trackster_layersnum", xtitle="Trackster Number of Layers", **_common)])
+_trackster_layernum_plots = [Plot("trackster_firstlayer", **_common)]
+_trackster_layernum_plots.extend([Plot("trackster_lastlayer", **_common)])
+_trackster_layernum_plots.extend([Plot("trackster_layersnum", **_common)])
 _trackster_layernum = PlotGroup("LayerNumbersOfTrackster", _trackster_layernum_plots, ncols=3)
 
 _common["xmax"] = 50
 _clusternum_in_trackster = PlotGroup("NumberofLayerClustersinTrackster",[
-  Plot("clusternum_in_trackster", xtitle="", **_common)
+  Plot("clusternum_in_trackster", **_common)
 ],ncols=1)
 
-_common = {"stat": True, "drawStyle": "pcolz", "staty": 0.65}
+_common = {"stat": True, "drawStyle": "pcolz", "staty": 0.65, "xtitle": "Default", "ytitle": "Default"}
 
 _clusternum_in_trackster_vs_layer = PlotGroup("NumberofLayerClustersinTracksterPerLayer",[
-  Plot("clusternum_in_trackster_vs_layer", xtitle="Layer number", ytitle = "<2d Layer Clusters in Trackster>",  **_common)
+  Plot("clusternum_in_trackster_vs_layer", **_common)
 ],ncols=1)
 
 _common["scale"] = 100.
@@ -1688,13 +1692,13 @@ _multiplicity_numberOfEventsHistogram = hgcVal_dqm + "ticlTrackstersMerge/multip
 _multiplicity_zminus_numberOfEventsHistogram = hgcVal_dqm + "ticlTrackstersMerge/multiplicity_zminus_numberOfEventsHistogram"
 _multiplicity_zplus_numberOfEventsHistogram = hgcVal_dqm + "ticlTrackstersMerge/multiplicity_zplus_numberOfEventsHistogram"
 
-_multiplicityOfLCinTST_plots = [Plot("multiplicityOfLCinTST", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Cluster size (n_{hit})", 
+_multiplicityOfLCinTST_plots = [Plot("multiplicityOfLCinTST",
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)]
-_multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layerclusterenergy", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Cluster Energy (GeV)", 
+_multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layerclusterenergy",
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)]) 
-_multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layercluster_zplus", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Layer Number", 
+_multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layercluster_zplus",
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)])
-_multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layercluster_zminus", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Layer Number", 
+_multiplicityOfLCinTST_plots.extend([Plot("multiplicityOfLCinTST_vs_layercluster_zminus",
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)])
 _multiplicityOfLCinTST = PlotGroup("MultiplicityofLCinTST", _multiplicityOfLCinTST_plots, ncols=2)
 
@@ -1730,18 +1734,18 @@ _clusternum_in_trackster_perlayer_zplus_BH = PlotGroup("NumberofLayerClustersinT
 ], ncols=7)
 
 # Coming back to the usual box definition
-_common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
+_common = {"stat": True, "drawStyle": "hist", "staty": 0.65, "xtitle": "Default"}
 
 # Some tracksters quantities
-_trackster_eppe_plots = [Plot("trackster_eta", xtitle="Trackster #eta", **_common)]
-_trackster_eppe_plots.extend([Plot("trackster_phi", xtitle="Trackster #phi", **_common)])
-_trackster_eppe_plots.extend([Plot("trackster_pt", xtitle="Trackster p_{T}", **_common)])
-_trackster_eppe_plots.extend([Plot("trackster_energy", xtitle="Trackster Energy", **_common)])
+_trackster_eppe_plots = [Plot("trackster_eta", **_common)]
+_trackster_eppe_plots.extend([Plot("trackster_phi", **_common)])
+_trackster_eppe_plots.extend([Plot("trackster_pt", **_common)])
+_trackster_eppe_plots.extend([Plot("trackster_energy", **_common)])
 _trackster_eppe = PlotGroup("EtaPhiPtEnergy", _trackster_eppe_plots, ncols=2)
 
-_trackster_xyz_plots = [Plot("trackster_x", xtitle="Trackster x", **_common)]
-_trackster_xyz_plots.extend([Plot("trackster_y", xtitle="Trackster y", **_common)])
-_trackster_xyz_plots.extend([Plot("trackster_z", xtitle="Trackster z", **_common)])
+_trackster_xyz_plots = [Plot("trackster_x", **_common)]
+_trackster_xyz_plots.extend([Plot("trackster_y", **_common)])
+_trackster_xyz_plots.extend([Plot("trackster_z", **_common)])
 _trackster_xyz = PlotGroup("XYZ", _trackster_xyz_plots, ncols=3)
 
 #--------------------------------------------------------------------------------------------
@@ -2442,8 +2446,8 @@ _trackstersToCPLinkPlots = [
   _score_trackster_to_caloparticles,
   _sharedEnergy_to_trackster[0],
   _sharedEnergy_trackster_to[0],
-  _energyscore_cp2ts,
-  _energyscore_ts2cp,
+  _energyscore_to_trackster[0],
+  _energyscore_trackster_to[0],
 ]
 
 _trackstersToSTSPRPlots = [
@@ -2456,8 +2460,8 @@ _trackstersToSTSPRPlots = [
   _score_trackster_to_simtracksters,
   _sharedEnergy_to_trackster[1],
   _sharedEnergy_trackster_to[1],
-  _energyscore_sts2ts,
-  _energyscore_ts2sts,
+  _energyscore_to_trackster[1],
+  _energyscore_trackster_to[1],
 ]
 hgcalTrackstersPlotter = Plotter()
 def append_hgcalTrackstersPlots(collection = 'ticlTrackstersMerge', name_collection = "TrackstersMerge"):
@@ -2506,7 +2510,7 @@ def append_hgcalTrackstersPlots(collection = 'ticlTrackstersMerge', name_collect
   #            ))
 
 #=================================================================================================
-_common_Calo = {"stat": False, "drawStyle": "hist", "staty": 0.65, "ymin": 0.0, "ylog": False}
+_common_Calo = {"stat": False, "drawStyle": "hist", "staty": 0.65, "ymin": 0.0, "ylog": False, "xtitle": "Default", "ytitle": "Default"}
 
 hgcalCaloParticlesPlotter = Plotter()
 def append_hgcalCaloParticlesPlots(files, collection = '-211', name_collection = "pion-"):
@@ -2530,7 +2534,6 @@ def append_hgcalCaloParticlesPlots(files, collection = '-211', name_collection =
     fileName.ReplaceAll(" ","_")
     pg = PlotGroup(fileName.Data(),[
                   Plot(name,
-                       xtitle=obj.GetXaxis().GetTitle(), ytitle=obj.GetYaxis().GetTitle(),
                        drawCommand = "",
                        normalizeToNumberOfEvents = True, **_common_Calo)
                   ],
@@ -2539,7 +2542,6 @@ def append_hgcalCaloParticlesPlots(files, collection = '-211', name_collection =
     if name in list_2D_histos :
         pg = PlotOnSideGroup(plotName.Data(),
                       Plot(name,
-                           xtitle=obj.GetXaxis().GetTitle(), ytitle=obj.GetYaxis().GetTitle(),
                            drawCommand = "COLZ",
                            normalizeToNumberOfEvents = True, **_common_Calo)
                       ,
@@ -2587,7 +2589,7 @@ def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', nam
         for group in grouped:
             if group+groupingFlag in name:
                 grouped[group].append(Plot(name,
-                                           xtitle=obj.GetXaxis().GetTitle(), ytitle=obj.GetYaxis().GetTitle(),
+                                           xtitle="Default", ytitle="Default",
                                            **_common)
                                      )
     else:
@@ -2595,14 +2597,14 @@ def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', nam
         if obj.InheritsFrom("TH2"):
             pg = PlotOnSideGroup(plotName.Data(),
                                  Plot(name,
-                                      xtitle=obj.GetXaxis().GetTitle(), ytitle=obj.GetYaxis().GetTitle(),
+                                      xtitle="Default", ytitle="Default",
                                       drawCommand = "COLZ",
                                       **_common),
                                  ncols=1)
         elif obj.InheritsFrom("TH1"):
             pg = PlotGroup(plotName.Data(),
                            [Plot(name,
-                                 xtitle=obj.GetXaxis().GetTitle(), ytitle=obj.GetYaxis().GetTitle(),
+                                 xtitle="Default", ytitle="Default",
                                  drawCommand = "COLZ", # ineffective for TH1
                                  **_common)
                            ],
@@ -2631,7 +2633,7 @@ def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', nam
   return hgcalTrackstersPlotter
 
 #=================================================================================================
-_common_Calo = {"stat": False, "drawStyle": "hist", "staty": 0.65, "ymin": 0.0, "ylog": False}
+_common_Calo = {"stat": False, "drawStyle": "hist", "staty": 0.65, "ymin": 0.0, "ylog": False, "xtitle": "Default", "ytitle": "Default"}
 
 hgcalCaloParticlesPlotter = Plotter()
 
@@ -2652,14 +2654,12 @@ def append_hgcalCaloParticlesPlots(files, collection = '-211', name_collection =
     if obj.InheritsFrom("TH2"):
         pg = PlotOnSideGroup(plotName.Data(),
                       Plot(name,
-                           xtitle=obj.GetXaxis().GetTitle(), ytitle=obj.GetYaxis().GetTitle(),
                            drawCommand = "COLZ",
                            normalizeToNumberOfEvents = True, **_common_Calo),
                       ncols=1)
     elif obj.InheritsFrom("TH1"):
         pg = PlotGroup(plotName.Data(),[
                       Plot(name,
-                           xtitle=obj.GetXaxis().GetTitle(), ytitle=obj.GetYaxis().GetTitle(),
                            drawCommand = "", # may want to customize for TH2 (colz, etc.)
                            normalizeToNumberOfEvents = True, **_common_Calo)
                       ],

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1567,7 +1567,7 @@ _common_score = {"stat": False, "legend": False
                  ,"ymin": 0.1
                  ,"ymax": 100000
                  ,"xmin": 0
-                 ,"xmax": 1.0
+                 #,"xmax": 1.0
                  ,"drawStyle": "hist"
                  ,"lineWidth": 1
                  ,"ylog": True
@@ -1593,9 +1593,9 @@ for score in score_trackster_to:
 
 _common_shared = {"stat": False, "legend": False, "xtitle": 'Default', "ytitle": 'Default'}
 _common_shared.update(_legend_common)
-_common_energy_score = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d", drawStyle="COLZ", adjustMarginRight=0.1, xtitle='Default', ytitle='Default')
-_common_energy_score["ymax"] = 1.
-_common_energy_score["xmax"] = 1.0
+_common_energy_score = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d", drawStyle="COLZ", adjustMarginRight=0.1, legend=False, xtitle='Default', ytitle='Default')
+#_common_energy_score["ymax"] = 1.
+#_common_energy_score["xmax"] = 1.0
 
 _sharedEnergy_to_trackster = []
 _sharedEnergy_trackster_to = []
@@ -2479,7 +2479,11 @@ def append_hgcalTrackstersPlots(collection = 'ticlTrackstersMerge', name_collect
               ], PlotFolder(
               *_trackstersToCPLinkPlots,
               loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page=tsToCP_linking.replace('TSToCP_','TICL-'), section=name_collection))
+              purpose=PlotPurpose.Timing
+              #,page=tsToCP_linking.replace('TSToCP_','TICL-')
+              ,page=tsToCP_linking.replace('TSToCP_','Test-TICL').replace('linking','')
+              ,section=name_collection)
+              )
 
   # Appending plots for Tracksters Pattern Recognition
   hgcalTrackstersPlotter.append(collection, [

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -19,6 +19,8 @@ import Validation.RecoTrack.plotting.html as html
 from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
 from Validation.HGCalValidation.PostProcessorHGCAL_cfi import lcToCP_linking, simDict, tsToCP_linking, tsToSTS_patternRec, variables
 
+hgcVal_dqm = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/"
+
 #To be able to spot any issues both in -z and +z a layer id was introduced
 #that spans from 0 to 103 for hgcal_v9 geometry. The mapping for hgcal_v9 is:
 #-z: 0->51
@@ -38,7 +40,7 @@ if not os.path.isfile(theDQMfile):
 
 #Take general info from the first file is sufficient.
 thefile = TFile( theDQMfile )
-GeneralInfoDirectory = 'DQMData/Run 1/HGCAL/Run summary/HGCalValidator/GeneralInfo'
+GeneralInfoDirectory = hgcVal_dqm + 'GeneralInfo'
 
 if not gDirectory.GetDirectory( GeneralInfoDirectory ):
   print("Error: GeneralInfo directory not found in DQM file, exit")
@@ -1682,9 +1684,9 @@ _clusternum_in_trackster_vs_layer = PlotGroup("NumberofLayerClustersinTracksterP
 
 _common["scale"] = 100.
 #, ztitle = "% of clusters" normalizeToUnitArea=True
-_multiplicity_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlTrackstersMerge/multiplicity_numberOfEventsHistogram"
-_multiplicity_zminus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlTrackstersMerge/multiplicity_zminus_numberOfEventsHistogram"
-_multiplicity_zplus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlTrackstersMerge/multiplicity_zplus_numberOfEventsHistogram"
+_multiplicity_numberOfEventsHistogram = hgcVal_dqm + "ticlTrackstersMerge/multiplicity_numberOfEventsHistogram"
+_multiplicity_zminus_numberOfEventsHistogram = hgcVal_dqm + "ticlTrackstersMerge/multiplicity_zminus_numberOfEventsHistogram"
+_multiplicity_zplus_numberOfEventsHistogram = hgcVal_dqm + "ticlTrackstersMerge/multiplicity_zplus_numberOfEventsHistogram"
 
 _multiplicityOfLCinTST_plots = [Plot("multiplicityOfLCinTST", xtitle="Layer Cluster multiplicity in Tracksters", ytitle = "Cluster size (n_{hit})", 
                                 drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)]
@@ -2412,7 +2414,7 @@ def append_hgcalSimClustersPlots(collection, name_collection):
 
 #=================================================================================================
 def _hgcalFolders(lastDirName="hgcalLayerClusters"):
-    return "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/"+lastDirName
+    return hgcVal_dqm + lastDirName
 
 _trackstersPlots = [
   _trackster_eppe,
@@ -2513,7 +2515,7 @@ def append_hgcalCaloParticlesPlots(files, collection = '-211', name_collection =
                     "Energy of Rec-matched Hits vs layer (1SC)",
                     "Rec-matched Hits Sum Energy vs layer"]
 
-  dqmfolder = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/SelectedCaloParticles/" + collection
+  dqmfolder = hgcVal_dqm + "SelectedCaloParticles/" + collection
   templateFile = ROOT.TFile.Open(files[0]) # assuming all files have same structure
   if not gDirectory.GetDirectory(dqmfolder):
     print("Error: GeneralInfo directory %s not found in DQM file, exit"%dqmfolder)
@@ -2563,7 +2565,7 @@ def create_hgcalTrackstersPlotter(files, collection = 'ticlTrackstersMerge', nam
   groupingFlag = " on Layer "
 
   hgcalTrackstersPlotter = Plotter()
-  dqmfolder = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/" + collection
+  dqmfolder = hgcVal_dqm + collection
   #_multiplicity_tracksters_numberOfEventsHistogram = dqmfolder+"/Number of Trackster per Event"
 
   _common["ymin"] = 0.0
@@ -2634,7 +2636,7 @@ _common_Calo = {"stat": False, "drawStyle": "hist", "staty": 0.65, "ymin": 0.0, 
 hgcalCaloParticlesPlotter = Plotter()
 
 def append_hgcalCaloParticlesPlots(files, collection = '-211', name_collection = "pion-"):
-  dqmfolder = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/SelectedCaloParticles/" + collection
+  dqmfolder = hgcVal_dqm + "SelectedCaloParticles/" + collection
   print(dqmfolder)
 #  _common["ymin"] = 0.0
   templateFile = ROOT.TFile.Open(files[0]) # assuming all files have same structure

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -17,7 +17,7 @@ import Validation.RecoTrack.plotting.validation as validation
 import Validation.RecoTrack.plotting.html as html
 
 from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
-from Validation.HGCalValidation.PostProcessorHGCAL_cfi import lcToCP_linking, simDict, tsToCP_linking, tsToSTS_patternRec
+from Validation.HGCalValidation.PostProcessorHGCAL_cfi import lcToCP_linking, simDict, tsToCP_linking, tsToSTS_patternRec, variables
 
 #To be able to spot any issues both in -z and +z a layer id was introduced
 #that spans from 0 to 103 for hgcal_v9 geometry. The mapping for hgcal_v9 is:
@@ -1669,29 +1669,23 @@ _duplicates = []
 _fakes = []
 _merges = []
 for val in simDict:
-    _effplots = [Plot("effic_eta"+simDict[val], xtitle="", **_common_eff)]
-    _effplots.extend([Plot("effic_phi"+simDict[val], xtitle="", **_common_eff)])
-    _effplots.extend([Plot("globalEfficiencies", xtitle="", **_common_eff)])
+    _effplots = [Plot("globalEfficiencies", xtitle="", **_common_eff)]
+    _purityplots = [Plot("globalEfficiencies", xtitle="", **_common_purity)]
+    _dupplots = [Plot("globalEfficiencies", xtitle="", **_common_dup)]
+    _fakeplots = [Plot("globalEfficiencies", xtitle="", **_common_fake)]
+    _mergeplots = [Plot("globalEfficiencies", xtitle="", **_common_merge)]
+
+    for v in variables:
+        _effplots.extend([Plot("effic_"+v+simDict[val], xtitle="", **_common_eff)])
+        _purityplots.extend([Plot("purity_"+v+simDict[val], xtitle="", **_common_purity)])
+        _dupplots.extend([Plot("duplicate_"+v+simDict[val], xtitle="", **_common_dup)])
+        _fakeplots.extend([Plot("fake_"+v+simDict[val], xtitle="", **_common_fake)])
+        _mergeplots.extend([Plot("merge_"+v+simDict[val], xtitle="", **_common_merge)])
+
     _efficiencies.append(PlotGroup("Efficiencies"+simDict[val], _effplots, ncols=3))
-
-    _purityplots = [Plot("purity_eta"+simDict[val], xtitle="", **_common_purity)]
-    _purityplots.extend([Plot("purity_phi"+simDict[val], xtitle="", **_common_purity)])
-    _purityplots.extend([Plot("globalEfficiencies", xtitle="", **_common_purity)])
     _purities.append(PlotGroup("Purities"+simDict[val], _purityplots, ncols=3))
-
-    _dupplots = [Plot("duplicate_eta"+simDict[val], xtitle="", **_common_dup)]
-    _dupplots.extend([Plot("duplicate_phi"+simDict[val], xtitle="", **_common_dup)])
-    _dupplots.extend([Plot("globalEfficiencies", xtitle="", **_common_dup)])
     _duplicates.append(PlotGroup("Duplicates"+simDict[val], _dupplots, ncols=3))
-
-    _fakeplots = [Plot("fake_eta"+simDict[val], xtitle="", **_common_fake)]
-    _fakeplots.extend([Plot("fake_phi"+simDict[val], xtitle="", **_common_fake)])
-    _fakeplots.extend([Plot("globalEfficiencies", xtitle="", **_common_fake)])
     _fakes.append(PlotGroup("FakeRate"+simDict[val], _fakeplots, ncols=3))
-
-    _mergeplots = [Plot("merge_eta"+simDict[val], xtitle="", **_common_merge)]
-    _mergeplots.extend([Plot("merge_phi"+simDict[val], xtitle="", **_common_merge)])
-    _mergeplots.extend([Plot("globalEfficiencies", xtitle="", **_common_merge)])
     _merges.append(PlotGroup("MergeRate"+simDict[val], _mergeplots, ncols=3))
 
 

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1559,87 +1559,46 @@ _merges_sc_zplus = PlotGroup("Eff_Dup_Fake_Merge_Global_zplus", _mergeplots_sc_z
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 
 #--------------------------------------------------------------------------------------------
-# MULTICLUSTERS
+# TRACKSTERS
 #--------------------------------------------------------------------------------------------
-_common_score = {#"title": "Score CaloParticle/SimTrackster to Tracksters",
-                 "stat": False,
-                 "ymin": 0.1,
-                 "ymax": 100000,
-                 "xmin": 0,
-                 "xmax": 1.0,
-                 "drawStyle": "hist",
-                 "lineWidth": 1,
-                 "ylog": True
+_common_score = {"stat": False, "legend": False
+                 ,"ymin": 0.1
+                 ,"ymax": 100000
+                 ,"xmin": 0
+                 ,"xmax": 1.0
+                 ,"drawStyle": "hist"
+                 ,"lineWidth": 1
+                 ,"ylog": True
+                 ,"xlog": True
                 }
 _common_score.update(_legend_common)
-_score_caloparticle_to_tracksters = PlotGroup("ScoreCaloParticlesToTracksters", [
-        Plot("Score_caloparticle2trackster", **_common_score)
-        ], ncols=1)
-_score_simtrackster_to_tracksters = PlotGroup("ScoreSimTrackstersToTracksters", [
-        Plot("Score_simtrackster2trackster", **_common_score)
-        ], ncols=1)
-_score_trackster_to_caloparticles = PlotGroup("ScoreTrackstersToCaloParticles", [
-        Plot("Score_trackster2caloparticle", **_common_score)
-        ], ncols=1)
-_score_trackster_to_simtracksters = PlotGroup("ScoreTrackstersToSimTracksters", [
-        Plot("Score_trackster2simtrackster", **_common_score)
-        ], ncols=1)
 
-_common_shared_Link= {"title": "Shared Energy CaloParticle To Trackster ",
-                 "stat": False,
-                 "legend": True,
-                 "xmin": 0,
-                 "xmax": 1.0,
-               }
-_common_shared_Link.update(_legend_common)
-_shared_plots = [ Plot("SharedEnergy_caloparticle2trackster", **_common_shared_Link) ]
-_common_shared_Link["xmin"] = -4.0
-_common_shared_Link["xmax"] = 4.0
-_shared_plots.extend([Plot("SharedEnergy_caloparticle2trackster_vs_eta", xtitle="CaloParticle #eta", **_common_shared_Link)])
-_shared_plots.extend([Plot("SharedEnergy_caloparticle2trackster_vs_phi", xtitle="CaloParticle #phi", **_common_shared_Link)])
-_sharedEnergy_caloparticle_to_trackster = PlotGroup("SharedEnergy_CaloParticleToTrackster", _shared_plots, ncols=3)
+score_to_trackster = ["","Pur","Dupl"]
+_score_caloparticle_to_tracksters = PlotGroup("ScoreCaloParticlesToTracksters", [], ncols=len(score_to_trackster))
+_score_simtrackster_to_tracksters = PlotGroup("ScoreSimTrackstersToTracksters", [], ncols=len(score_to_trackster))
+for score in score_to_trackster:
+    _score_caloparticle_to_tracksters.append(Plot("Score"+score+"_caloparticle2trackster", **_common_score))
+    _score_simtrackster_to_tracksters.append(Plot("Score"+score+"_simtrackster2trackster", **_common_score))
 
-_common_shared_Link= {"title": "Shared Energy Trackster To CaloParticle ",
-                 "stat": False,
-                 "legend": True,
-                 "xmin": 0,
-                 "xmax": 1.0,
-                }
-_common_shared_Link.update(_legend_common)
-_shared_plots2 = [Plot("SharedEnergy_trackster2caloparticle", **_common_shared_Link)]
-_common_shared_Link["xmin"] = -4.0
-_common_shared_Link["xmax"] = 4.0
-_shared_plots2.extend([Plot("SharedEnergy_trackster2caloparticle_vs_eta", xtitle="Trackster #eta", **_common_shared_Link)])
-_shared_plots2.extend([Plot("SharedEnergy_trackster2caloparticle_vs_phi", xtitle="Trackster #phi", **_common_shared_Link)])
-_sharedEnergy_trackster_to_caloparticle = PlotGroup("SharedEnergy_TracksterToCaloParticle", _shared_plots2, ncols=3)
+score_trackster_to = ["","Merge"]
+_score_trackster_to_caloparticles = PlotGroup("ScoreTrackstersToCaloParticles", [], ncols=len(score_trackster_to))
+_score_trackster_to_simtracksters = PlotGroup("ScoreTrackstersToSimTracksters", [], ncols=len(score_trackster_to))
+for score in score_trackster_to:
+    _score_trackster_to_caloparticles.append(Plot("Score"+score+"_trackster2caloparticle", **_common_score))
+    _score_trackster_to_simtracksters.append(Plot("Score"+score+"_trackster2simtrackster", **_common_score))
 
-_common_shared_PR= {"title": "Shared Energy SimTrackster To Trackster ",
-                 "stat": False,
-                 "legend": True,
-                 "xmin": 0,
-                 "xmax": 1.0,
-               }
-_common_shared_PR.update(_legend_common)
-_shared_plots = [ Plot("SharedEnergy_simtrackster2trackster", **_common_shared_PR) ]
-_common_shared_PR["xmin"] = -4.0
-_common_shared_PR["xmax"] = 4.0
-_shared_plots.extend([Plot("SharedEnergy_simtrackster2trackster_vs_eta", xtitle="SimTrackster #eta", **_common_shared_PR)])
-_shared_plots.extend([Plot("SharedEnergy_simtrackster2trackster_vs_phi", xtitle="SimTrackster #phi", **_common_shared_PR)])
-_sharedEnergy_simtrackster_to_trackster = PlotGroup("SharedEnergy_SimTracksterToTrackster", _shared_plots, ncols=3)
 
-_common_shared_PR= {"title": "Shared Energy Trackster To SimTrackster ",
-                 "stat": False,
-                 "legend": True,
-                 "xmin": 0,
-                 "xmax": 1.0,
-                }
-_common_shared_PR.update(_legend_common)
-_shared_plots2 = [Plot("SharedEnergy_trackster2simtrackster", **_common_shared_PR)]
-_common_shared_PR["xmin"] = -4.0
-_common_shared_PR["xmax"] = 4.0
-_shared_plots2.extend([Plot("SharedEnergy_trackster2simtrackster_vs_eta", xtitle="Trackster #eta", **_common_shared_PR)])
-_shared_plots2.extend([Plot("SharedEnergy_trackster2simtrackster_vs_phi", xtitle="Trackster #phi", **_common_shared_PR)])
-_sharedEnergy_trackster_to_simtrackster = PlotGroup("SharedEnergy_TracksterToSimTrackster", _shared_plots2, ncols=3)
+_common_shared = {"stat": False, "legend": False}
+_common_shared.update(_legend_common)
+_sharedEnergy_to_trackster = []
+_sharedEnergy_trackster_to = []
+versions = {"":"energy fraction", "_assoc":"energy fraction", "_assoc_vs_eta":"#eta", "_assoc_vs_phi":"#phi"}
+for val in simDict:
+    _sharedEnergy_to_trackster.append(PlotGroup("SharedEnergy_"+val+"ToTrackster", [], ncols=2))
+    _sharedEnergy_trackster_to.append(PlotGroup("SharedEnergy_TracksterTo"+val, [], ncols=2))
+    for ver in versions:
+        _sharedEnergy_to_trackster[-1].append(Plot("SharedEnergy_"+val.lower()+"2trackster"+ver, xtitle=val+" "+versions[ver], **_common_shared))
+        _sharedEnergy_trackster_to[-1].append(Plot("SharedEnergy_trackster2"+val.lower()+ver, xtitle="Trackster "+versions[ver], **_common_shared))
 
 
 _common_assoc = {#"title": "Cell Association Table",
@@ -1657,11 +1616,9 @@ _cell_association_table = PlotGroup("cellAssociation_table", [
         ], ncols=8 )
 
 # Trackster plots
-_common_eff = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
-_common_purity = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
-_common_dup = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
-_common_fake = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
-_common_merge = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
+_common_metric = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
+_common_metric_logx = _common_metric.copy()
+_common_metric_logx["xlog"] = True
 
 _efficiencies = []
 _purities = []
@@ -1669,18 +1626,19 @@ _duplicates = []
 _fakes = []
 _merges = []
 for val in simDict:
-    _effplots = [Plot("globalEfficiencies", xtitle="", **_common_eff)]
-    _purityplots = [Plot("globalEfficiencies", xtitle="", **_common_purity)]
-    _dupplots = [Plot("globalEfficiencies", xtitle="", **_common_dup)]
-    _fakeplots = [Plot("globalEfficiencies", xtitle="", **_common_fake)]
-    _mergeplots = [Plot("globalEfficiencies", xtitle="", **_common_merge)]
+    _effplots = [Plot("globalEfficiencies", xtitle="", **_common_metric)]
+    _purityplots = [Plot("globalEfficiencies", xtitle="", **_common_metric)]
+    _dupplots = [Plot("globalEfficiencies", xtitle="", **_common_metric)]
+    _fakeplots = [Plot("globalEfficiencies", xtitle="", **_common_metric)]
+    _mergeplots = [Plot("globalEfficiencies", xtitle="", **_common_metric)]
 
     for v in variables:
-        _effplots.extend([Plot("effic_"+v+simDict[val], xtitle="", **_common_eff)])
-        _purityplots.extend([Plot("purity_"+v+simDict[val], xtitle="", **_common_purity)])
-        _dupplots.extend([Plot("duplicate_"+v+simDict[val], xtitle="", **_common_dup)])
-        _fakeplots.extend([Plot("fake_"+v+simDict[val], xtitle="", **_common_fake)])
-        _mergeplots.extend([Plot("merge_"+v+simDict[val], xtitle="", **_common_merge)])
+        kwargs = _common_metric_logx if v in ["energy","pt"] else _common_metric
+        _effplots.extend([Plot("effic_"+v+simDict[val], xtitle = variables[v][0]+variables[v][1], **kwargs)])
+        _purityplots.extend([Plot("purity_"+v+simDict[val], xtitle = variables[v][0]+variables[v][1], **kwargs)])
+        _dupplots.extend([Plot("duplicate_"+v+simDict[val], xtitle = variables[v][0]+variables[v][1], **kwargs)])
+        _fakeplots.extend([Plot("fake_"+v+simDict[val], xtitle = variables[v][0]+variables[v][1], **kwargs)])
+        _mergeplots.extend([Plot("merge_"+v+simDict[val], xtitle = variables[v][0]+variables[v][1], **kwargs)])
 
     _efficiencies.append(PlotGroup("Efficiencies"+simDict[val], _effplots, ncols=3))
     _purities.append(PlotGroup("Purities"+simDict[val], _purityplots, ncols=3))
@@ -1716,7 +1674,6 @@ _clusternum_in_trackster = PlotGroup("NumberofLayerClustersinTrackster",[
   Plot("clusternum_in_trackster", xtitle="", **_common)
 ],ncols=1)
 
-_common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 _common = {"stat": True, "drawStyle": "pcolz", "staty": 0.65}
 
 _clusternum_in_trackster_vs_layer = PlotGroup("NumberofLayerClustersinTracksterPerLayer",[
@@ -1770,10 +1727,10 @@ _clusternum_in_trackster_perlayer_zplus_BH = PlotGroup("NumberofLayerClustersinT
   Plot("clusternum_in_trackster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
-#Coming back to the usual box definition
+# Coming back to the usual box definition
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 
-#Some tracksters quantities
+# Some tracksters quantities
 _trackster_eppe_plots = [Plot("trackster_eta", xtitle="Trackster #eta", **_common)]
 _trackster_eppe_plots.extend([Plot("trackster_phi", xtitle="Trackster #phi", **_common)])
 _trackster_eppe_plots.extend([Plot("trackster_pt", xtitle="Trackster p_{T}", **_common)])
@@ -2481,8 +2438,8 @@ _trackstersToCPLinkPlots = [
   _merges[0],
   _score_caloparticle_to_tracksters,
   _score_trackster_to_caloparticles,
-  _sharedEnergy_caloparticle_to_trackster,
-  _sharedEnergy_trackster_to_caloparticle,
+  _sharedEnergy_to_trackster[0],
+  _sharedEnergy_trackster_to[0],
   _energyscore_cp2ts,
   _energyscore_ts2cp,
 ]
@@ -2495,8 +2452,8 @@ _trackstersToSTSPRPlots = [
   _merges[1],
   _score_simtrackster_to_tracksters,
   _score_trackster_to_simtracksters,
-  _sharedEnergy_simtrackster_to_trackster,
-  _sharedEnergy_trackster_to_simtrackster,
+  _sharedEnergy_to_trackster[1],
+  _sharedEnergy_trackster_to[1],
   _energyscore_sts2ts,
   _energyscore_ts2sts,
 ]

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -17,7 +17,7 @@ import Validation.RecoTrack.plotting.validation as validation
 import Validation.RecoTrack.plotting.html as html
 
 from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
-from Validation.HGCalValidation.PostProcessorHGCAL_cfi import tsToCP_linking, lcToCP_linking
+from Validation.HGCalValidation.PostProcessorHGCAL_cfi import lcToCP_linking, simDict, tsToCP_linking, tsToSTS_patternRec
 
 #To be able to spot any issues both in -z and +z a layer id was introduced
 #that spans from 0 to 103 for hgcal_v9 geometry. The mapping for hgcal_v9 is:
@@ -1561,7 +1561,7 @@ _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 #--------------------------------------------------------------------------------------------
 # MULTICLUSTERS
 #--------------------------------------------------------------------------------------------
-_common_score = {#"title": "Score CaloParticle to Tracksters",
+_common_score = {#"title": "Score CaloParticle/SimTrackster to Tracksters",
                  "stat": False,
                  "ymin": 0.1,
                  "ymax": 100000,
@@ -1575,49 +1575,71 @@ _common_score.update(_legend_common)
 _score_caloparticle_to_tracksters = PlotGroup("ScoreCaloParticlesToTracksters", [
         Plot("Score_caloparticle2trackster", **_common_score)
         ], ncols=1)
-
-_common_score = {#"title": "Score Trackster to CaloParticles",
-                 "stat": False,
-                 "ymin": 0.1,
-                 "ymax": 100000,
-                 "xmin": 0,
-                 "xmax": 1.0,
-                 "drawStyle": "hist",
-                 "lineWidth": 1,
-                 "ylog": True
-                }
-_common_score.update(_legend_common)
+_score_simtrackster_to_tracksters = PlotGroup("ScoreSimTrackstersToTracksters", [
+        Plot("Score_simtrackster2trackster", **_common_score)
+        ], ncols=1)
 _score_trackster_to_caloparticles = PlotGroup("ScoreTrackstersToCaloParticles", [
         Plot("Score_trackster2caloparticle", **_common_score)
         ], ncols=1)
+_score_trackster_to_simtracksters = PlotGroup("ScoreTrackstersToSimTracksters", [
+        Plot("Score_trackster2simtrackster", **_common_score)
+        ], ncols=1)
 
-_common_shared= {"title": "Shared Energy CaloParticle To Trackster ",
+_common_shared_Link= {"title": "Shared Energy CaloParticle To Trackster ",
                  "stat": False,
                  "legend": True,
                  "xmin": 0,
                  "xmax": 1.0,
                }
-_common_shared.update(_legend_common)
-_shared_plots = [ Plot("SharedEnergy_caloparticle2trackster", **_common_shared) ]
-_common_shared["xmin"] = -4.0
-_common_shared["xmax"] = 4.0
-_shared_plots.extend([Plot("SharedEnergy_caloparticle2trackster_vs_eta", xtitle="CaloParticle #eta", **_common_shared)])
-_shared_plots.extend([Plot("SharedEnergy_caloparticle2trackster_vs_phi", xtitle="CaloParticle #phi", **_common_shared)])
+_common_shared_Link.update(_legend_common)
+_shared_plots = [ Plot("SharedEnergy_caloparticle2trackster", **_common_shared_Link) ]
+_common_shared_Link["xmin"] = -4.0
+_common_shared_Link["xmax"] = 4.0
+_shared_plots.extend([Plot("SharedEnergy_caloparticle2trackster_vs_eta", xtitle="CaloParticle #eta", **_common_shared_Link)])
+_shared_plots.extend([Plot("SharedEnergy_caloparticle2trackster_vs_phi", xtitle="CaloParticle #phi", **_common_shared_Link)])
 _sharedEnergy_caloparticle_to_trackster = PlotGroup("SharedEnergy_CaloParticleToTrackster", _shared_plots, ncols=3)
 
-_common_shared= {"title": "Shared Energy Trackster To CaloParticle ",
+_common_shared_Link= {"title": "Shared Energy Trackster To CaloParticle ",
                  "stat": False,
                  "legend": True,
                  "xmin": 0,
                  "xmax": 1.0,
                 }
-_common_shared.update(_legend_common)
-_shared_plots2 = [Plot("SharedEnergy_trackster2caloparticle", **_common_shared)]
-_common_shared["xmin"] = -4.0
-_common_shared["xmax"] = 4.0
-_shared_plots2.extend([Plot("SharedEnergy_trackster2caloparticle_vs_eta", xtitle="Trackster #eta", **_common_shared)])
-_shared_plots2.extend([Plot("SharedEnergy_trackster2caloparticle_vs_phi", xtitle="Trackster #phi", **_common_shared)])
+_common_shared_Link.update(_legend_common)
+_shared_plots2 = [Plot("SharedEnergy_trackster2caloparticle", **_common_shared_Link)]
+_common_shared_Link["xmin"] = -4.0
+_common_shared_Link["xmax"] = 4.0
+_shared_plots2.extend([Plot("SharedEnergy_trackster2caloparticle_vs_eta", xtitle="Trackster #eta", **_common_shared_Link)])
+_shared_plots2.extend([Plot("SharedEnergy_trackster2caloparticle_vs_phi", xtitle="Trackster #phi", **_common_shared_Link)])
 _sharedEnergy_trackster_to_caloparticle = PlotGroup("SharedEnergy_TracksterToCaloParticle", _shared_plots2, ncols=3)
+
+_common_shared_PR= {"title": "Shared Energy SimTrackster To Trackster ",
+                 "stat": False,
+                 "legend": True,
+                 "xmin": 0,
+                 "xmax": 1.0,
+               }
+_common_shared_PR.update(_legend_common)
+_shared_plots = [ Plot("SharedEnergy_simtrackster2trackster", **_common_shared_PR) ]
+_common_shared_PR["xmin"] = -4.0
+_common_shared_PR["xmax"] = 4.0
+_shared_plots.extend([Plot("SharedEnergy_simtrackster2trackster_vs_eta", xtitle="SimTrackster #eta", **_common_shared_PR)])
+_shared_plots.extend([Plot("SharedEnergy_simtrackster2trackster_vs_phi", xtitle="SimTrackster #phi", **_common_shared_PR)])
+_sharedEnergy_simtrackster_to_trackster = PlotGroup("SharedEnergy_SimTracksterToTrackster", _shared_plots, ncols=3)
+
+_common_shared_PR= {"title": "Shared Energy Trackster To SimTrackster ",
+                 "stat": False,
+                 "legend": True,
+                 "xmin": 0,
+                 "xmax": 1.0,
+                }
+_common_shared_PR.update(_legend_common)
+_shared_plots2 = [Plot("SharedEnergy_trackster2simtrackster", **_common_shared_PR)]
+_common_shared_PR["xmin"] = -4.0
+_common_shared_PR["xmax"] = 4.0
+_shared_plots2.extend([Plot("SharedEnergy_trackster2simtrackster_vs_eta", xtitle="Trackster #eta", **_common_shared_PR)])
+_shared_plots2.extend([Plot("SharedEnergy_trackster2simtrackster_vs_phi", xtitle="Trackster #phi", **_common_shared_PR)])
+_sharedEnergy_trackster_to_simtrackster = PlotGroup("SharedEnergy_TracksterToSimTrackster", _shared_plots2, ncols=3)
 
 
 _common_assoc = {#"title": "Cell Association Table",
@@ -1634,43 +1656,54 @@ _cell_association_table = PlotGroup("cellAssociation_table", [
         Plot("cellAssociation_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_assoc) for i in range(0,maxlayerzm)
         ], ncols=8 )
 
+# Trackster plots
 _common_eff = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
-_effplots = [Plot("effic_eta", xtitle="", **_common_eff)]
-_effplots.extend([Plot("effic_phi", xtitle="", **_common_eff)])
-_effplots.extend([Plot("globalEfficiencies", xtitle="", **_common_eff)])
-_efficiencies = PlotGroup("Efficiencies", _effplots, ncols=3)
-
 _common_purity = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
-_purityplots = [Plot("purity_eta", xtitle="", **_common_purity)]
-_purityplots.extend([Plot("purity_phi", xtitle="", **_common_purity)])
-_purityplots.extend([Plot("globalEfficiencies", xtitle="", **_common_purity)])
-_purities = PlotGroup("Purities", _purityplots, ncols=3)
-
 _common_dup = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
-_dupplots = [Plot("duplicate_eta", xtitle="", **_common_dup)]
-_dupplots.extend([Plot("duplicate_phi", xtitle="", **_common_dup)])
-_dupplots.extend([Plot("globalEfficiencies", xtitle="", **_common_dup)])
-_duplicates = PlotGroup("Duplicates", _dupplots, ncols=3)
-
 _common_fake = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
-_fakeplots = [Plot("fake_eta", xtitle="", **_common_fake)]
-_fakeplots.extend([Plot("fake_phi", xtitle="", **_common_fake)])
-_fakeplots.extend([Plot("globalEfficiencies", xtitle="", **_common_fake)])
-_fakes = PlotGroup("FakeRate", _fakeplots, ncols=3)
-
 _common_merge = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
-_mergeplots = [Plot("merge_eta", xtitle="", **_common_merge)]
-_mergeplots.extend([Plot("merge_phi", xtitle="", **_common_merge)])
-_mergeplots.extend([Plot("globalEfficiencies", xtitle="", **_common_merge)])
-_merges = PlotGroup("MergeRate", _mergeplots, ncols=3)
+
+_efficiencies = []
+_purities = []
+_duplicates = []
+_fakes = []
+_merges = []
+for val in simDict:
+    _effplots = [Plot("effic_eta"+simDict[val], xtitle="", **_common_eff)]
+    _effplots.extend([Plot("effic_phi"+simDict[val], xtitle="", **_common_eff)])
+    _effplots.extend([Plot("globalEfficiencies", xtitle="", **_common_eff)])
+    _efficiencies.append(PlotGroup("Efficiencies"+simDict[val], _effplots, ncols=3))
+
+    _purityplots = [Plot("purity_eta"+simDict[val], xtitle="", **_common_purity)]
+    _purityplots.extend([Plot("purity_phi"+simDict[val], xtitle="", **_common_purity)])
+    _purityplots.extend([Plot("globalEfficiencies", xtitle="", **_common_purity)])
+    _purities.append(PlotGroup("Purities"+simDict[val], _purityplots, ncols=3))
+
+    _dupplots = [Plot("duplicate_eta"+simDict[val], xtitle="", **_common_dup)]
+    _dupplots.extend([Plot("duplicate_phi"+simDict[val], xtitle="", **_common_dup)])
+    _dupplots.extend([Plot("globalEfficiencies", xtitle="", **_common_dup)])
+    _duplicates.append(PlotGroup("Duplicates"+simDict[val], _dupplots, ncols=3))
+
+    _fakeplots = [Plot("fake_eta"+simDict[val], xtitle="", **_common_fake)]
+    _fakeplots.extend([Plot("fake_phi"+simDict[val], xtitle="", **_common_fake)])
+    _fakeplots.extend([Plot("globalEfficiencies", xtitle="", **_common_fake)])
+    _fakes.append(PlotGroup("FakeRate"+simDict[val], _fakeplots, ncols=3))
+
+    _mergeplots = [Plot("merge_eta"+simDict[val], xtitle="", **_common_merge)]
+    _mergeplots.extend([Plot("merge_phi"+simDict[val], xtitle="", **_common_merge)])
+    _mergeplots.extend([Plot("globalEfficiencies", xtitle="", **_common_merge)])
+    _merges.append(PlotGroup("MergeRate"+simDict[val], _mergeplots, ncols=3))
+
 
 _common_energy_score = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d")
 _common_energy_score["ymax"] = 1.
 _common_energy_score["xmax"] = 1.0
 _energyscore_cp2ts = PlotOnSideGroup("Energy_vs_Score_CaloParticlesToTracksters", Plot("Energy_vs_Score_caloparticle2trackster", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
+_energyscore_sts2ts = PlotOnSideGroup("Energy_vs_Score_SimTrackstersToTracksters", Plot("Energy_vs_Score_simtrackster2trackster", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
 _common_energy_score["ymax"] = 1.
 _common_energy_score["xmax"] = 1.0
 _energyscore_ts2cp = PlotOnSideGroup("Energy_vs_Score_TrackstersToCaloParticles", Plot("Energy_vs_Score_trackster2caloparticle", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
+_energyscore_ts2sts = PlotOnSideGroup("Energy_vs_Score_TrackstersToSimTracksters", Plot("Energy_vs_Score_trackster2simtrackster", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
 
 #Coming back to the usual box definition
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
@@ -2319,8 +2352,6 @@ def append_hgcalLayerClustersPlots(collection = hgcalValidator.label_layerCluste
                 purpose=PlotPurpose.Timing, page=layerClustersLabel, section=reg))
 
 #=================================================================================================
-def _hgcalsimClustersFolders(lastDirName):
-    return "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/" + hgcalValidator.label_SimClusters._InputTag__moduleLabel + "/"+lastDirName
 
 sc_clusterlevel = [
   # number of layer clusters per event in a) 120um, b) 200um, c) 300um, d) scint
@@ -2414,14 +2445,14 @@ hgcalSimClustersPlotter = Plotter()
 def append_hgcalSimClustersPlots(collection, name_collection):
   if collection == hgcalValidator.label_SimClustersLevel._InputTag__moduleLabel:
       hgcalSimClustersPlotter.append(collection, [
-                  _hgcalsimClustersFolders(collection)
+                  _hgcalFolders(hgcalValidator.label_SimClusters._InputTag__moduleLabel +"/"+ collection)
                   ], PlotFolder(
                   *sc_clusterlevel,
                   loopSubFolders=False,
                   purpose=PlotPurpose.Timing, page="SimClusters", section=name_collection))
   else:
       hgcalSimClustersPlotter.append(collection, [
-                  _hgcalsimClustersFolders(collection)
+                  _hgcalFolders(hgcalValidator.label_SimClusters._InputTag__moduleLabel +"/"+collection)
                   ], PlotFolder(
                   *sc_ticltracksters,
                   loopSubFolders=False,
@@ -2449,11 +2480,11 @@ _trackstersPlots = [
 ]
 
 _trackstersToCPLinkPlots = [
-  _efficiencies,
-  _purities,
-  _duplicates,
-  _fakes,
-  _merges,
+  _efficiencies[0],
+  _purities[0],
+  _duplicates[0],
+  _fakes[0],
+  _merges[0],
   _score_caloparticle_to_tracksters,
   _score_trackster_to_caloparticles,
   _sharedEnergy_caloparticle_to_trackster,
@@ -2462,23 +2493,44 @@ _trackstersToCPLinkPlots = [
   _energyscore_ts2cp,
 ]
 
+_trackstersToSTSPRPlots = [
+  _efficiencies[1],
+  _purities[1],
+  _duplicates[1],
+  _fakes[1],
+  _merges[1],
+  _score_simtrackster_to_tracksters,
+  _score_trackster_to_simtracksters,
+  _sharedEnergy_simtrackster_to_trackster,
+  _sharedEnergy_trackster_to_simtrackster,
+  _energyscore_sts2ts,
+  _energyscore_ts2sts,
+]
 hgcalTrackstersPlotter = Plotter()
 def append_hgcalTrackstersPlots(collection = 'ticlTrackstersMerge', name_collection = "TrackstersMerge"):
   # Appending generic plots for Tracksters
   hgcalTrackstersPlotter.append(collection, [
-              _hgcalFolders(collection)
+              _hgcalFolders(collection+ "/" + hgcalValidator.label_TS._InputTag__moduleLabel)
               ], PlotFolder(
               *_trackstersPlots,
               loopSubFolders=False,
               purpose=PlotPurpose.Timing, page="Tracksters", section=name_collection))
 
-  # Appending plots for Tracksters to CP linking
+  # Appending plots for Tracksters-CP linking
   hgcalTrackstersPlotter.append(collection, [
               _hgcalFolders(collection + "/" + tsToCP_linking)
               ], PlotFolder(
               *_trackstersToCPLinkPlots,
               loopSubFolders=False,
               purpose=PlotPurpose.Timing, page=tsToCP_linking.replace('TSToCP_','TICL-'), section=name_collection))
+
+  # Appending plots for Tracksters Pattern Recognition
+  hgcalTrackstersPlotter.append(collection, [
+              _hgcalFolders(collection + "/" + tsToSTS_patternRec)
+              ], PlotFolder(
+              *_trackstersToSTSPRPlots,
+              loopSubFolders=False,
+              purpose=PlotPurpose.Timing, page=tsToSTS_patternRec.replace('TSToSTS_','TICL-'), section=name_collection))
 
   #We append here two PlotFolder because we want the text to be in percent
   #and the number of events are different in zplus and zminus

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -14,7 +14,7 @@ import Validation.RecoTrack.plotting.plotting as plotting
 
 simClustersIters = [hgcalValidator.label_SimClustersLevel._InputTag__moduleLabel, "ticlSimTracksters"]
 trackstersIters = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMerge]
-trackstersIters.extend(["ticlSimTracksters"])
+trackstersIters.extend(["ticlSimTracksters", "ticlSimTracksters_fromCPs"])
 
 hitCalLabel = 'hitCalibration'
 hitValLabel = 'hitValidation'

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -5,7 +5,7 @@ import os
 import argparse
 from time import time
 
-from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabels, ticlIterLabelsMerge
+from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabelsMerge
 
 from Validation.RecoTrack.plotting.validation import SeparateValidation, SimpleValidation, SimpleSample
 from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1129,19 +1129,35 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
 
-  //back to all Tracksters
+  // Back to all Tracksters
+  // eta
   histograms.h_num_trackster_eta[i].push_back(
-      ibook.book1D("Num_Trackster_Eta" + val[i], "Num Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
+      ibook.book1D("Num_Trackster_Eta" + val[i], "Num Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
   histograms.h_numMerge_trackster_eta[i].push_back(ibook.book1D(
-      "NumMerge_Trackster_Eta" + val[i], "Num Merge Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
+      "NumMerge_Trackster_Eta" + val[i], "Num Merge Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
   histograms.h_denom_trackster_eta[i].push_back(
-      ibook.book1D("Denom_Trackster_Eta" + val[i], "Denom Trackster Eta per Trackster", nintEta_, minEta_, maxEta_));
+      ibook.book1D("Denom_Trackster_Eta" + val[i], "Denom Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
+  // phi
   histograms.h_num_trackster_phi[i].push_back(
-      ibook.book1D("Num_Trackster_Phi" + val[i], "Num Trackster Phi per Trackster ", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("Num_Trackster_Phi" + val[i], "Num Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_numMerge_trackster_phi[i].push_back(ibook.book1D(
-      "NumMerge_Trackster_Phi" + val[i], "Num Merge Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+      "NumMerge_Trackster_Phi" + val[i], "Num Merge Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_denom_trackster_phi[i].push_back(
-      ibook.book1D("Denom_Trackster_Phi" + val[i], "Denom Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("Denom_Trackster_Phi" + val[i], "Denom Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
+  // energy
+  histograms.h_num_trackster_en[i].push_back(
+      ibook.book1D("Num_Trackster_Energy" + val[i], "Num Trackster Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
+  histograms.h_numMerge_trackster_en[i].push_back(ibook.book1D(
+      "NumMerge_Trackster_Energy" + val[i], "Num Merge Trackster Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
+  histograms.h_denom_trackster_en[i].push_back(
+      ibook.book1D("Denom_Trackster_Energy" + val[i], "Denom Trackster Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
+  // pT
+  histograms.h_num_trackster_pt[i].push_back(
+      ibook.book1D("Num_Trackster_Pt" + val[i], "Num Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_numMerge_trackster_pt[i].push_back(ibook.book1D(
+      "NumMerge_Trackster_Pt" + val[i], "Num Merge Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_denom_trackster_pt[i].push_back(
+      ibook.book1D("Denom_Trackster_Pt" + val[i], "Denom Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
 
   histograms.h_sharedenergy_trackster2caloparticle[i].push_back(
       ibook.book1D("SharedEnergy_trackster2" + ref[i],
@@ -1195,22 +1211,42 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
 
+  // eta
   histograms.h_numEff_caloparticle_eta[i].push_back(ibook.book1D(
-      "NumEff_" + refT[i] + "_Eta", "Num Efficiency " + refT[i] + " Eta per Trackster", nintEta_, minEta_, maxEta_));
+      "NumEff_" + refT[i] + "_Eta", "Num Efficiency " + refT[i] + " Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
   histograms.h_num_caloparticle_eta[i].push_back(ibook.book1D(
-      "Num_" + refT[i] + "_Eta", "Num Purity " + refT[i] + " Eta per Trackster", nintEta_, minEta_, maxEta_));
+      "Num_" + refT[i] + "_Eta", "Num Purity " + refT[i] + " Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
   histograms.h_numDup_trackster_eta[i].push_back(
-      ibook.book1D("NumDup_Trackster_Eta" + val[i], "Num Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
+      ibook.book1D("NumDup_Trackster_Eta" + val[i], "Num Duplicate Trackster vs Eta;#eta", nintEta_, minEta_, maxEta_));
   histograms.h_denom_caloparticle_eta[i].push_back(
-      ibook.book1D("Denom_" + refT[i] + "_Eta", "Denom " + refT[i] + " Eta per Trackster", nintEta_, minEta_, maxEta_));
+      ibook.book1D("Denom_" + refT[i] + "_Eta", "Denom " + refT[i] + " Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
+  // phi
   histograms.h_numEff_caloparticle_phi[i].push_back(ibook.book1D(
-      "NumEff_" + refT[i] + "_Phi", "Num Efficiency " + refT[i] + " Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+      "NumEff_" + refT[i] + "_Phi", "Num Efficiency " + refT[i] + " Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_num_caloparticle_phi[i].push_back(ibook.book1D(
-      "Num_" + refT[i] + "_Phi", "Num Purity " + refT[i] + " Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+      "Num_" + refT[i] + "_Phi", "Num Purity " + refT[i] + " Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_numDup_trackster_phi[i].push_back(
-      ibook.book1D("NumDup_Trackster_Phi" + val[i], "Num Duplicate Trackster vs Phi", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("NumDup_Trackster_Phi" + val[i], "Num Duplicate Trackster vs Phi;#phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_denom_caloparticle_phi[i].push_back(
-      ibook.book1D("Denom_" + refT[i] + "_Phi", "Denom " + refT[i] + " Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("Denom_" + refT[i] + "_Phi", "Denom " + refT[i] + " Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
+  // energy
+  histograms.h_numEff_caloparticle_en[i].push_back(ibook.book1D(
+      "NumEff_" + refT[i] + "_Energy", "Num Efficiency " + refT[i] + " Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
+  histograms.h_num_caloparticle_en[i].push_back(ibook.book1D(
+      "Num_" + refT[i] + "_Energy", "Num Purity " + refT[i] + " Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
+  histograms.h_numDup_trackster_en[i].push_back(
+      ibook.book1D("NumDup_Trackster_Energy" + val[i], "Num Duplicate Trackster vs Energy;energy [GeV]", nintEne_, minEne_, maxEne_));
+  histograms.h_denom_caloparticle_en[i].push_back(
+      ibook.book1D("Denom_" + refT[i] + "_Energy", "Denom " + refT[i] + " Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
+  // pT
+  histograms.h_numEff_caloparticle_pt[i].push_back(ibook.book1D(
+      "NumEff_" + refT[i] + "_Pt", "Num Efficiency " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_num_caloparticle_pt[i].push_back(ibook.book1D(
+      "Num_" + refT[i] + "_Pt", "Num Purity " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_numDup_trackster_pt[i].push_back(
+      ibook.book1D("NumDup_Trackster_Pt" + val[i], "Num Duplicate Trackster vs p_{T};p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_denom_caloparticle_pt[i].push_back(
+      ibook.book1D("Denom_" + refT[i] + "_Pt", "Denom " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
 }
 
 void HGVHistoProducerAlgo::fill_info_histos(const Histograms& histograms, unsigned int layers) const {
@@ -2929,8 +2965,12 @@ else return false;
 
     const auto sts_eta = sts.barycenter().eta();
     const auto sts_phi = sts.barycenter().phi();
+    const auto sts_en = sts.raw_energy();
+    const auto sts_pt = sts.raw_pt();
     histograms.h_denom_caloparticle_eta[i][count]->Fill(sts_eta);
     histograms.h_denom_caloparticle_phi[i][count]->Fill(sts_phi);
+    histograms.h_denom_caloparticle_en[i][count]->Fill(sts_en);
+    histograms.h_denom_caloparticle_pt[i][count]->Fill(sts_pt);
 
     //Loop through related Tracksters here
     // In case the threshold to associate a CaloParticle to a Trackster is
@@ -2961,6 +3001,8 @@ else return false;
         cp_considered_efficient = true;
         histograms.h_numEff_caloparticle_eta[i][count]->Fill(sts_eta);
         histograms.h_numEff_caloparticle_phi[i][count]->Fill(sts_phi);
+        histograms.h_numEff_caloparticle_en[i][count]->Fill(sts_en);
+        histograms.h_numEff_caloparticle_pt[i][count]->Fill(sts_pt);
       }
 
       if (score3d_iSTS[tstId] < ScoreCutSTStoTSPurDup) {
@@ -2987,6 +3029,8 @@ else return false;
     if (assocDup > 0) {
       histograms.h_num_caloparticle_eta[i][count]->Fill(sts_eta);
       histograms.h_num_caloparticle_phi[i][count]->Fill(sts_phi);
+      histograms.h_num_caloparticle_en[i][count]->Fill(sts_en);
+      histograms.h_num_caloparticle_pt[i][count]->Fill(sts_pt);
       const auto bestTstId = std::distance(std::begin(score3d_iSTS), best);
       const auto tstRawEnergyFrac = tracksters[bestTstId].raw_energy() / SimEnergy;
       const auto tstSharedEnergyFrac = tstSharedEnergy[iSTS][bestTstId] / SimEnergy;
@@ -3007,22 +3051,31 @@ else return false;
   // reco-level, namely fake-rate an merge-rate. Should *not*
   // restrict only to the selected caloParaticles.
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
-    if (tracksters[tstId].vertices().empty())
+    const auto& trackster = tracksters[tstId];
+    if (trackster.vertices().empty())
       continue;
-    const auto iTS_eta = tracksters[tstId].barycenter().eta();
-    const auto iTS_phi = tracksters[tstId].barycenter().phi();
+    const auto iTS_eta = trackster.barycenter().eta();
+    const auto iTS_phi = trackster.barycenter().phi();
+    const auto iTS_en = trackster.raw_energy();
+    const auto iTS_pt = trackster.raw_pt();
     histograms.h_denom_trackster_eta[i][count]->Fill(iTS_eta);
     histograms.h_denom_trackster_phi[i][count]->Fill(iTS_phi);
+    histograms.h_denom_trackster_en[i][count]->Fill(iTS_en);
+    histograms.h_denom_trackster_pt[i][count]->Fill(iTS_pt);
 
     const auto assocDuplicate = tracksters_duplicate[tstId];
     if (assocDuplicate) {
       histograms.h_numDup_trackster_eta[i][count]->Fill(iTS_eta);
       histograms.h_numDup_trackster_phi[i][count]->Fill(iTS_phi);
+      histograms.h_numDup_trackster_en[i][count]->Fill(iTS_en);
+      histograms.h_numDup_trackster_pt[i][count]->Fill(iTS_pt);
     }
     const auto assocFakeMerge = tracksters_fakemerge[tstId];
     if (assocFakeMerge > 0) {
       histograms.h_num_trackster_eta[i][count]->Fill(iTS_eta);
       histograms.h_num_trackster_phi[i][count]->Fill(iTS_phi);
+      histograms.h_num_trackster_en[i][count]->Fill(iTS_en);
+      histograms.h_num_trackster_pt[i][count]->Fill(iTS_pt);
       const auto best = std::min_element(std::begin(stsInTrackster[tstId]),
                                    std::end(stsInTrackster[tstId]),
                                    [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
@@ -3035,13 +3088,15 @@ else return false;
         sharedeneCPallLayers += best_cp_linked.first;
       }
       histograms.h_sharedenergy_trackster2caloparticle_vs_eta[i][count]->Fill(
-          iTS_eta, sharedeneCPallLayers / tracksters[tstId].raw_energy());
+          iTS_eta, sharedeneCPallLayers / iTS_en);
       histograms.h_sharedenergy_trackster2caloparticle_vs_phi[i][count]->Fill(
-          iTS_phi, sharedeneCPallLayers / tracksters[tstId].raw_energy());
+          iTS_phi, sharedeneCPallLayers / iTS_en);
 
       if (assocFakeMerge >= 2) {
         histograms.h_numMerge_trackster_eta[i][count]->Fill(iTS_eta);
         histograms.h_numMerge_trackster_phi[i][count]->Fill(iTS_phi);
+        histograms.h_numMerge_trackster_en[i][count]->Fill(iTS_en);
+        histograms.h_numMerge_trackster_pt[i][count]->Fill(iTS_pt);
       }
     }
   } // End loop over Tracksters

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -2397,11 +2397,12 @@ return v.first == hitid; });
 
     // Loop through SimClusters
     for (const auto& simCluster : cP[cpId].simClusters()) {
+      auto iSim = simTSs[iSTS].seedIndex();
       if (simTSs[iSTS].seedID() != cPHandle_id) { // SimTrackster from SimCluster
-        if (simTSs[iSTS].seedIndex()  !=  (&(*simCluster) - &(sC[0])))
+        if (iSim  !=  (&(*simCluster) - &(sC[0])))
           continue;
-      }
-      const auto iSim = simTSs[iSTS].seedIndex();
+      } else
+        iSim = 0;
 
       for (const auto& it_haf : simCluster->hits_and_fractions()) {
         const auto hitid = (it_haf.first);
@@ -2584,6 +2585,9 @@ return v.first == hitid; });
 
           const auto iSTS = h.clusterId;
           const auto& simTS = simTSs[iSTS];
+          auto iSim = simTS.seedIndex();
+          if (simTSs[iSTS].seedID() == cPHandle_id) // SimTrackster from CaloParticle
+            iSim = 0;
 
           float lcFraction_s = 0;
           const auto lcId_s = getLCId(simTS.vertices(), layerClusters, rh_detid);
@@ -2604,9 +2608,9 @@ return v.first == hitid; });
           //Here cPOnLayer[caloparticle][layer] describe above is set.
           //Here for Tracksters with matched rechit the CP fraction times hit energy is added and saved .
           cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore[tstId].first += shared_fraction * hit->energy();
-          sCOnLayer[cpId][simTS.seedIndex()][layerId].layerClusterIdToEnergyAndScore[tstId].first += shared_fraction_lc * hit->energy();
+          sCOnLayer[cpId][iSim][layerId].layerClusterIdToEnergyAndScore[tstId].first += shared_fraction_lc * hit->energy();
           cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore[tstId].second = FLT_MAX;
-          sCOnLayer[cpId][simTS.seedIndex()][layerId].layerClusterIdToEnergyAndScore[tstId].second = FLT_MAX;
+          sCOnLayer[cpId][iSim][layerId].layerClusterIdToEnergyAndScore[tstId].second = FLT_MAX;
           //stsInTrackster[trackster][STSids]
           //Connects a Trackster with all related SimTracksters.
           stsInTrackster[tstId].emplace_back(iSTS, FLT_MAX);
@@ -2834,7 +2838,11 @@ else return false;
       if (std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
         continue;
 
-    auto& simOnLayer = (i == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][sts.seedIndex()];
+    auto iSim = sts.seedIndex();
+    if (sts.seedID() == cPHandle_id) // SimTrackster from CaloParticle
+      iSim = 0;
+
+    auto& simOnLayer = (i == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][iSim];
 
     // Keep the Trackster ids that are related to
     // SimTrackster under study for the final filling of the score

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -3322,7 +3322,6 @@ void HGVHistoProducerAlgo::fill_trackster_histos(
     std::vector<CaloParticle> const& cP,
     std::vector<size_t> const& cPIndices,
     std::vector<size_t> const& cPSelectedIndices,
-    //const enum validationType,
     std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
     unsigned int layers) const {
   //Each event to be treated as two events:

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -220,7 +220,7 @@ void HGVHistoProducerAlgo::bookCaloParticleHistos(DQMStore::IBooker& ibook,
       ibook.book2D("Eta vs Zorigin", "Eta vs Zorigin", nintEta_, minEta_, maxEta_, nintZpos_, minZpos_, maxZpos_);
 
   histograms.h_caloparticle_energy[pdgid] =
-      ibook.book1D("Energy", "Energy of CaloParticles", nintEne_, minEne_, maxEne_);
+      ibook.book1D("Energy", "Energy of CaloParticles; Energy [GeV]", nintEne_, minEne_, maxEne_);
   histograms.h_caloparticle_pt[pdgid] = ibook.book1D("Pt", "Pt of CaloParticles", nintPt_, minPt_, maxPt_);
   histograms.h_caloparticle_phi[pdgid] = ibook.book1D("Phi", "Phi of CaloParticles", nintPhi_, minPhi_, maxPhi_);
   histograms.h_caloparticle_selfenergy[pdgid] =
@@ -264,6 +264,12 @@ void HGVHistoProducerAlgo::bookCaloParticleHistos(DQMStore::IBooker& ibook,
                    110,
                    0.,
                    110.);
+  histograms.h_caloparticle_fractions[pdgid] =
+      ibook.book2D("HitFractions", "Hit fractions;Hit fraction;E_{hit}^{2} fraction",
+                   101, 0, 1.01, 100, 0, 1);
+  histograms.h_caloparticle_fractions_weight[pdgid] =
+      ibook.book2D("HitFractions_weighted", "Hit fractions weighted;Hit fraction;E_{hit}^{2} fraction",
+                   101, 0, 1.01, 100, 0, 1);
 
   histograms.h_caloparticle_firstlayer[pdgid] =
       ibook.book1D("First Layer", "First layer of the CaloParticles", 2 * layers, 0., (float)2 * layers);
@@ -992,7 +998,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
   histograms.h_clusternum_in_trackster_perlayer.push_back(std::move(clusternum_in_trackster_perlayer));
 
   histograms.h_tracksternum.push_back(
-      ibook.book1D("tottracksternum", "total number of Tracksters", nintTotNTSTs_, minTotNTSTs_, maxTotNTSTs_));
+      ibook.book1D("tottracksternum", "total number of Tracksters;# of Tracksters", nintTotNTSTs_, minTotNTSTs_, maxTotNTSTs_));
 
   histograms.h_conttracksternum.push_back(ibook.book1D(
       "conttracksternum", "number of Tracksters with 3 contiguous layers", nintTotNTSTs_, minTotNTSTs_, maxTotNTSTs_));
@@ -1004,14 +1010,14 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
                                                           maxTotNTSTs_));
 
   histograms.h_clusternum_in_trackster.push_back(ibook.book1D("clusternum_in_trackster",
-                                                              "total number of layer clusters in Trackster",
+                                                              "total number of layer clusters in Trackster;# of LayerClusters",
                                                               nintTotNClsinTSTs_,
                                                               minTotNClsinTSTs_,
                                                               maxTotNClsinTSTs_));
 
   histograms.h_clusternum_in_trackster_vs_layer.push_back(
       ibook.bookProfile("clusternum_in_trackster_vs_layer",
-                        "Profile of 2d layer clusters in Trackster vs layer number",
+                        "Profile of 2d layer clusters in Trackster vs layer number;layer number;<2D LayerClusters in Trackster>",
                         2 * layers,
                         0.,
                         2. * layers,
@@ -1019,7 +1025,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
                         maxTotNClsinTSTsperlayer_));
 
   histograms.h_multiplicityOfLCinTST.push_back(ibook.book2D("multiplicityOfLCinTST",
-                                                            "Multiplicity vs Layer cluster size in Tracksters",
+                                                            "Multiplicity vs Layer cluster size in Tracksters;LayerCluster multiplicity in Tracksters;Cluster size (n_{hits})",
                                                             nintMplofLCs_,
                                                             minMplofLCs_,
                                                             maxMplofLCs_,
@@ -1049,7 +1055,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
 
   histograms.h_multiplicityOfLCinTST_vs_layercluster_zminus.push_back(
       ibook.book2D("multiplicityOfLCinTST_vs_layercluster_zminus",
-                   "Multiplicity vs Layer number in z-",
+                   "Multiplicity vs Layer number in z-;LayerCluster multiplicity in Tracksters;layer number",
                    nintMplofLCs_,
                    minMplofLCs_,
                    maxMplofLCs_,
@@ -1059,7 +1065,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
 
   histograms.h_multiplicityOfLCinTST_vs_layercluster_zplus.push_back(
       ibook.book2D("multiplicityOfLCinTST_vs_layercluster_zplus",
-                   "Multiplicity vs Layer number in z+",
+                   "Multiplicity vs Layer number in z+;LayerCluster multiplicity in Tracksters;layer number",
                    nintMplofLCs_,
                    minMplofLCs_,
                    maxMplofLCs_,
@@ -1069,7 +1075,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
 
   histograms.h_multiplicityOfLCinTST_vs_layerclusterenergy.push_back(
       ibook.book2D("multiplicityOfLCinTST_vs_layerclusterenergy",
-                   "Multiplicity vs Layer cluster energy",
+                   "Multiplicity vs Layer cluster energy;LayerCluster multiplicity in Tracksters;Cluster energy [GeV]",
                    nintMplofLCs_,
                    minMplofLCs_,
                    maxMplofLCs_,
@@ -1077,42 +1083,66 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
                    minClEnepermultiplicity_,
                    maxClEnepermultiplicity_));
 
-  histograms.h_trackster_pt.push_back(ibook.book1D("trackster_pt", "Pt of the Trackster", nintPt_, minPt_, maxPt_));
+  histograms.h_trackster_pt.push_back(ibook.book1D("trackster_pt", "Pt of the Trackster;Trackster p_{T} [GeV]", nintPt_, minPt_, maxPt_));
   histograms.h_trackster_eta.push_back(
-      ibook.book1D("trackster_eta", "Eta of the Trackster", nintEta_, minEta_, maxEta_));
+      ibook.book1D("trackster_eta", "Eta of the Trackster;Trackster #eta", nintEta_, minEta_, maxEta_));
   histograms.h_trackster_phi.push_back(
-      ibook.book1D("trackster_phi", "Phi of the Trackster", nintPhi_, minPhi_, maxPhi_));
+      ibook.book1D("trackster_phi", "Phi of the Trackster;Trackster #phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_trackster_energy.push_back(
-      ibook.book1D("trackster_energy", "Energy of the Trackster", nintEne_, minEne_, maxEne_));
-  histograms.h_trackster_x.push_back(ibook.book1D("trackster_x", "X position of the Trackster", nintX_, minX_, maxX_));
-  histograms.h_trackster_y.push_back(ibook.book1D("trackster_y", "Y position of the Trackster", nintY_, minY_, maxY_));
-  histograms.h_trackster_z.push_back(ibook.book1D("trackster_z", "Z position of the Trackster", nintZ_, minZ_, maxZ_));
+      ibook.book1D("trackster_energy", "Energy of the Trackster;Trackster energy [GeV]", nintEne_, minEne_, maxEne_));
+  histograms.h_trackster_x.push_back(ibook.book1D("trackster_x", "X position of the Trackster;Trackster x", nintX_, minX_, maxX_));
+  histograms.h_trackster_y.push_back(ibook.book1D("trackster_y", "Y position of the Trackster;Trackster y", nintY_, minY_, maxY_));
+  histograms.h_trackster_z.push_back(ibook.book1D("trackster_z", "Z position of the Trackster;Trackster z", nintZ_, minZ_, maxZ_));
   histograms.h_trackster_firstlayer.push_back(
-      ibook.book1D("trackster_firstlayer", "First layer of the Trackster", 2 * layers, 0., (float)2 * layers));
+      ibook.book1D("trackster_firstlayer", "First layer of the Trackster;Trackster First Layer", 2 * layers, 0., (float)2 * layers));
   histograms.h_trackster_lastlayer.push_back(
-      ibook.book1D("trackster_lastlayer", "Last layer of the Trackster", 2 * layers, 0., (float)2 * layers));
+      ibook.book1D("trackster_lastlayer", "Last layer of the Trackster;Trackster Last Layer", 2 * layers, 0., (float)2 * layers));
   histograms.h_trackster_layersnum.push_back(
-      ibook.book1D("trackster_layersnum", "Number of layers of the Trackster", 2 * layers, 0., (float)2 * layers));
+      ibook.book1D("trackster_layersnum", "Number of layers of the Trackster;Trackster Number of Layers", 2 * layers, 0., (float)2 * layers));
 }
 
 void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Histograms& histograms, const int i) {
   const string ref[] = {"caloparticle", "simtrackster"};
   const string refT[] = {"CaloParticle", "SimTrackster"};
   const string val[] = {"_Link", "_PR"};
+  const string rtos = ";score Reco-to-Sim";
+  const string stor = ";score Sim-to-Reco";
+  const string shREnFr = ";shared Reco energy fraction";
+  const string shSEnFr = ";shared Sim energy fraction";
 
   histograms.h_score_trackster2caloparticle[i].push_back(
-      ibook.book1D("Score_trackster2" + ref[i], "Score of Trackster per best " + refT[i], nintScore_, minScore_, maxScore_));
-  histograms.h_scoreMerge_trackster2caloparticle[i].push_back(
-      ibook.book1D("ScoreMerge_trackster2" + ref[i], "Score of merged Trackster per " + refT[i], nintScore_, minScore_, maxScore_));
+      ibook.book1D("Score_trackster2" + ref[i], "Score of Trackster per " + refT[i]+rtos, nintScore_, minScore_, maxScore_));
+  histograms.h_score_trackster2bestCaloparticle[i].push_back(
+      ibook.book1D("ScoreFake_trackster2" + ref[i], "Score of Trackster per best " + refT[i]+rtos, nintScore_, minScore_, maxScore_));
+  histograms.h_score_trackster2bestCaloparticle2[i].push_back(
+      ibook.book1D("ScoreMerge_trackster2" + ref[i], "Score of Trackster per 2^{nd} best " + refT[i]+rtos, nintScore_, minScore_, maxScore_));
   histograms.h_score_caloparticle2trackster[i].push_back(ibook.book1D(
-      "Score_" + ref[i] + "2trackster", "Score of " + refT[i] + " per Trackster", nintScore_, minScore_, maxScore_));
+      "Score_" + ref[i] + "2trackster", "Score of " + refT[i] + " per Trackster"+stor, nintScore_, minScore_, maxScore_));
   histograms.h_scorePur_caloparticle2trackster[i].push_back(ibook.book1D(
-      "ScorePur_" + ref[i] + "2trackster", "Score of " + refT[i] + " per best Trackster", nintScore_, minScore_, maxScore_));
+      "ScorePur_" + ref[i] + "2trackster", "Score of " + refT[i] + " per best Trackster"+stor, nintScore_, minScore_, maxScore_));
   histograms.h_scoreDupl_caloparticle2trackster[i].push_back(ibook.book1D(
-      "ScoreDupl_" + ref[i] + "2trackster", "Score of " + refT[i] + " per first duplicate Trackster", nintScore_, minScore_, maxScore_));
+      "ScoreDupl_" + ref[i] + "2trackster", "Score of " + refT[i] + " per 2^{nd} best Trackster"+stor, nintScore_, minScore_, maxScore_));
   histograms.h_energy_vs_score_trackster2caloparticle[i].push_back(
-      ibook.book2D("Energy_vs_Score_trackster2" + ref[i],
-                   "Energy vs Score of Trackster per best " + refT[i],
+      ibook.book2D("Energy_vs_Score_trackster2" + refT[i],
+                   "Energy vs Score of Trackster per " + refT[i]+rtos+shREnFr,
+                   nintScore_,
+                   minScore_,
+                   maxScore_,
+                   nintSharedEneFrac_,
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_energy_vs_score_trackster2bestCaloparticle[i].push_back(
+      ibook.book2D("Energy_vs_Score_trackster2best" + refT[i],
+                   "Energy vs Score of Trackster per best " + refT[i]+rtos+shREnFr,
+                   nintScore_,
+                   minScore_,
+                   maxScore_,
+                   nintSharedEneFrac_,
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_energy_vs_score_trackster2bestCaloparticle2[i].push_back(
+      ibook.book2D("Energy_vs_Score_trackster2secBest" + refT[i],
+                   "Energy vs Score of Trackster per 2^{nd} best " + refT[i]+rtos+shREnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1120,8 +1150,26 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
   histograms.h_energy_vs_score_caloparticle2trackster[i].push_back(
-      ibook.book2D("Energy_vs_Score_" + ref[i] + "2trackster",
-                   "Energy vs Score of " + refT[i] + " per Trackster",
+      ibook.book2D("Energy_vs_Score_" + ref[i] + "2Trackster",
+                   "Energy vs Score of " + refT[i] + " per Trackster"+stor+shSEnFr,
+                   nintScore_,
+                   minScore_,
+                   maxScore_,
+                   nintSharedEneFrac_,
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_energy_vs_score_caloparticle2bestTrackster[i].push_back(
+      ibook.book2D("Energy_vs_Score_" + ref[i] + "2bestTrackster",
+                   "Energy vs Score of " + refT[i] + " per best Trackster"+stor+shSEnFr,
+                   nintScore_,
+                   minScore_,
+                   maxScore_,
+                   nintSharedEneFrac_,
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_energy_vs_score_caloparticle2bestTrackster2[i].push_back(
+      ibook.book2D("Energy_vs_Score_" + ref[i] + "2secBestTrackster",
+                   "Energy vs Score of " + refT[i] + " per 2^{nd} best Trackster"+stor+shSEnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1161,42 +1209,54 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
 
   histograms.h_sharedenergy_trackster2caloparticle[i].push_back(
       ibook.book1D("SharedEnergy_trackster2" + ref[i],
-                   "Shared Energy of Trackster per best " + refT[i],
+                   "Shared Energy of Trackster per " + refT[i]+shREnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_trackster2caloparticle_vs_eta[i].push_back(
+  histograms.h_sharedenergy_trackster2bestCaloparticle[i].push_back(
+      ibook.book1D("SharedEnergy_trackster2" + ref[i] + "_assoc",
+                   "Shared Energy of Trackster per best " + refT[i]+shREnFr,
+                   nintSharedEneFrac_,
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_trackster2bestCaloparticle_vs_eta[i].push_back(
       ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_assoc_vs_eta",
-                        "Shared Energy of Trackster vs #eta per best " + refT[i],
+                        "Shared Energy of Trackster vs #eta per best " + refT[i]+";Trackster #eta"+shREnFr,
                         nintEta_,
                         minEta_,
                         maxEta_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_trackster2caloparticle_vs_phi[i].push_back(
+  histograms.h_sharedenergy_trackster2bestCaloparticle_vs_phi[i].push_back(
       ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_assoc_vs_phi",
-                        "Shared Energy of Trackster vs #phi per best " + refT[i],
+                        "Shared Energy of Trackster vs #phi per best " + refT[i]+";Trackster #phi"+shREnFr,
                         nintPhi_,
                         minPhi_,
                         maxPhi_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_trackster2bestCaloparticle2[i].push_back(
+      ibook.book1D("SharedEnergy_trackster2" + ref[i] + "_assoc2",
+                   "Shared Energy of Trackster per 2^{nd} best " + refT[i]+shREnFr,
+                   nintSharedEneFrac_,
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
 
   histograms.h_sharedenergy_caloparticle2trackster[i].push_back(
       ibook.book1D("SharedEnergy_" + ref[i] + "2trackster",
-                   "Shared Energy of " + refT[i] + " per Trackster",
+                   "Shared Energy of " + refT[i] + " per Trackster"+shSEnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_caloparticle2trackster_assoc[i].push_back(
       ibook.book1D("SharedEnergy_" + ref[i] + "2trackster_assoc",
-                   "Shared Energy of " + refT[i] + " per best Trackster",
+                   "Shared Energy of " + refT[i] + " per best Trackster"+shSEnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[i].push_back(
       ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_assoc_vs_eta",
-                        "Shared Energy of " + refT[i] + " vs #eta per best Trackster",
+                        "Shared Energy of " + refT[i] + " vs #eta per best Trackster;"+refT[i]+" #eta"+shSEnFr,
                         nintEta_,
                         minEta_,
                         maxEta_,
@@ -1204,12 +1264,18 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                         maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[i].push_back(
       ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_assoc_vs_phi",
-                        "Shared Energy of " + refT[i] + " vs #phi per best Trackster",
+                        "Shared Energy of " + refT[i] + " vs #phi per best Trackster;"+refT[i]+" #phi"+shSEnFr,
                         nintPhi_,
                         minPhi_,
                         maxPhi_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_caloparticle2trackster_assoc2[i].push_back(
+      ibook.book1D("SharedEnergy_" + ref[i] + "2trackster_assoc2",
+                   "Shared Energy of " + refT[i] + " per 2^{nd} best Trackster;"+shSEnFr,
+                   nintSharedEneFrac_,
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
 
   // eta
   histograms.h_numEff_caloparticle_eta[i].push_back(ibook.book1D(
@@ -1301,13 +1367,15 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
     float energy = 0.;
     std::map<int, double> totenergy_layer;
 
+    float hitEnergyWeight_invSum = 0;
+    std::vector<std::pair<DetId, float>> haf_cp;
     for (const auto& sc : caloParticle.simClusters()) {
       LogDebug("HGCalValidator") << " This sim cluster has " << sc->hits_and_fractions().size() << " simHits and "
                                  << sc->energy() << " energy. " << std::endl;
       simHits += sc->hits_and_fractions().size();
       for (auto const& h_and_f : sc->hits_and_fractions()) {
         const auto hitDetId = h_and_f.first;
-        int layerId =
+        const int layerId =
             recHitTools_->getLayerWithOffset(hitDetId) + layers * ((recHitTools_->zside(hitDetId) + 1) >> 1) - 1;
         // set to 0 if matched RecHit not found
         int layerId_matched_min = 999;
@@ -1319,7 +1387,9 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
           simHits_matched++;
 
           const auto hitEn = itcheck->second->energy();
-          const auto hitEnFr = hitEn * h_and_f.second;
+          hitEnergyWeight_invSum += pow(hitEn, 2);
+          const auto hitFr = h_and_f.second;
+          const auto hitEnFr = hitEn * hitFr;
           energy += hitEnFr;
           histograms.h_caloparticle_nHits_matched_energy.at(pdgid)->Fill(hitEnFr);
           histograms.h_caloparticle_nHits_matched_energy_layer.at(pdgid)->Fill(layerId, hitEnFr);
@@ -1332,6 +1402,14 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
           if (caloParticle.simClusters().size() == 1)
             histograms.h_caloparticle_nHits_matched_energy_layer_1SimCl.at(pdgid)->Fill(layerId,
                                                                                         hitEnFr);
+
+          auto found = std::find_if(
+              std::begin(haf_cp), std::end(haf_cp), [&hitDetId](const std::pair<DetId, float>& v) { return v.first == hitDetId; });
+          if (found != haf_cp.end())
+            found->second += hitFr;
+          else
+            haf_cp.emplace_back(hitDetId, hitFr);
+
         } else {
           LogDebug("HGCalValidator") << "   matched to RecHit NOT found !" << std::endl;
         }
@@ -1342,7 +1420,9 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
         maxLayerId_matched = std::max(maxLayerId_matched, layerId_matched_max);
       }
       LogDebug("HGCalValidator") << std::endl;
-    }
+    } // End loop over SimClusters of CaloParticle
+    if (hitEnergyWeight_invSum) hitEnergyWeight_invSum = 1/hitEnergyWeight_invSum;
+
     histograms.h_caloparticle_firstlayer.at(pdgid)->Fill(minLayerId);
     histograms.h_caloparticle_lastlayer.at(pdgid)->Fill(maxLayerId);
     histograms.h_caloparticle_layersnum.at(pdgid)->Fill(int(maxLayerId - minLayerId));
@@ -1363,6 +1443,13 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
       sum_energy += i->second;
       histograms.h_caloparticle_sum_energy_layer.at(pdgid)->Fill(i->first, sum_energy / caloParticle.energy() * 100.);
       i++;
+    }
+
+    for (auto const& haf : haf_cp) {
+      const auto hitEn = hitMap.find(haf.first)->second->energy();
+      const auto weight = pow(hitEn, 2);
+      histograms.h_caloparticle_fractions.at(pdgid)->Fill(haf.second, weight * hitEnergyWeight_invSum);
+      histograms.h_caloparticle_fractions_weight.at(pdgid)->Fill(haf.second, weight * hitEnergyWeight_invSum, weight);
     }
   }
 }
@@ -2319,8 +2406,8 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
 
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInCluster>> detIdSimTSId_Map;
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInTrackster>> detIdToTracksterId_Map;
-  std::vector<int> tracksters_fakemerge(nTracksters, 0);
-  std::vector<int> tracksters_duplicate(nTracksters, 0);
+  std::vector<int> tracksters_FakeMerge(nTracksters, 0);
+  std::vector<int> tracksters_PurityDuplicate(nTracksters, 0);
 
   // This vector contains the ids of the SimTracksters contributing with at least one hit to the Trackster and the reconstruction error
   //stsInTrackster[trackster][STSids]
@@ -2408,7 +2495,9 @@ return v.first == hitid; });
         const auto lcId = getLCId(simTSs[iSTS].vertices(), layerClusters, hitid);
         //V9:maps the layers in -z: 0->51 and in +z: 52->103
         //V10:maps the layers in -z: 0->49 and in +z: 50->99
-        const auto hitLayerId = recHitTools_->getLayerWithOffset(hitid) + layers * ((recHitTools_->zside(hitid) + 1) >> 1) - 1;
+        const auto hitLayerId =
+            //recHitTools_->getLayerWithOffset(hitid) + layers * ((recHitTools_->zside(hitid) + 1) >> 1) - 1;
+            0;
         const auto itcheck = hitMap.find(hitid);
         //Checks whether the current hit belonging to sim cluster has a reconstructed hit.
         if ((i == 0  &&  itcheck != hitMap.end())  ||  (i == 1  &&  int(lcId) >= 0)) {
@@ -2550,14 +2639,23 @@ return v.first == hitid; });
       //here comparing with the calo particle map above the
       if (detIdToTracksterId_Map.find(rh_detid) == detIdToTracksterId_Map.end()) {
         detIdToTracksterId_Map[rh_detid] = std::vector<HGVHistoProducerAlgo::detIdInfoInTrackster>();
-      }
-      detIdToTracksterId_Map[rh_detid].emplace_back(
+        detIdToTracksterId_Map[rh_detid].emplace_back(
           HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, lcId_r, rhFraction});
+      } else {
+        auto findTSIt = std::find(detIdToTracksterId_Map[rh_detid].begin(),
+                                  detIdToTracksterId_Map[rh_detid].end(),
+                                  HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, 0, 0}); // only the first element is used for the matching (overloaded operator==)
+        if (findTSIt != detIdToTracksterId_Map[rh_detid].end()) {
+          if (i==0) findTSIt->fraction += rhFraction;
+        } else {
+          detIdToTracksterId_Map[rh_detid].emplace_back(
+            HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, lcId_r, rhFraction});
+        }
+      }
 
       // if the fraction is zero or the hit does not belong to any calo
       // particle, set the caloparticleId for the hit to -1 this will
       // contribute to the number of noise hits
-
       // MR Remove the case in which the fraction is 0, since this could be a
       // real hit that has been marked as halo.
       if (rhFraction == 0.) {
@@ -2574,8 +2672,9 @@ return v.first == hitid; });
       } else {
         // Since the hit is belonging to the layer cluster, it must be also in the rechits map
         const auto hitEn = hitMap.find(rh_detid)->second->energy();
-        const int layerId =
-          recHitTools_->getLayerWithOffset(rh_detid) + layers * ((recHitTools_->zside(rh_detid) + 1) >> 1) - 1;
+        const auto layerId =
+            //recHitTools_->getLayerWithOffset(rh_detid) + layers * ((recHitTools_->zside(rh_detid) + 1) >> 1) - 1;
+            0;
 
         auto maxCPEnergyInTS = 0.f;
         auto maxCPId = -1;
@@ -2750,13 +2849,12 @@ return v.first == hitid; });
                                             HGVHistoProducerAlgo::detIdInfoInCluster{stsPair.first, 0.f}); // only the first element is used for the matching (overloaded operator==)
           if (findSTSIt != detIdSimTSId_Map[elemId].end())
             cpFraction = findSTSIt->fraction;
-          else if (i==1) continue;
         }
         if (stsPair.second == FLT_MAX) {
           stsPair.second = 0.f;
         }
         stsPair.second +=
-            pow(min(rhFraction - cpFraction, rhFraction), 2) * hitEnergyWeight * invTracksterEnergyWeight;
+            min(pow(rhFraction - cpFraction, 2), pow(rhFraction, 2)) * hitEnergyWeight * invTracksterEnergyWeight;
       }
     } // end of loop through trackster rechits
 
@@ -2764,7 +2862,7 @@ return v.first == hitid; });
     if (stsInTrackster[tstId].empty())
       LogDebug("HGCalValidator") << "Trackster Id: " << tstId << "\tSimTrackster id: -1" << "\tscore: -1\n";
 
-    tracksters_fakemerge[tstId] = std::count_if(std::begin(stsInTrackster[tstId]),
+    tracksters_FakeMerge[tstId] = std::count_if(std::begin(stsInTrackster[tstId]),
                                                 std::end(stsInTrackster[tstId]),
                                                 [&, i, ScoreCutTStoSTSFakeMerge](const auto& obj) {
       if ((i == 1) && (tst.ticlIteration() == ticl::Trackster::SIM))
@@ -2776,40 +2874,52 @@ return v.first == hitid; });
     const auto score = std::min_element(std::begin(stsInTrackster[tstId]),
                                         std::end(stsInTrackster[tstId]),
                                         [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
-    const auto score2 = std::min_element(std::begin(stsInTrackster[tstId]),
-                                         std::end(stsInTrackster[tstId]),
-                                         [&score](const auto& obj1, const auto& obj2) { if (obj1.first != score->first) return obj1.second < obj2.second;
-else return false;
-});
-    for (const auto& stsPair : stsInTrackster[tstId]) {
+    float score2 = -1;
+    float sharedEneFrac2 = 0;
+    for (const auto stsPair : stsInTrackster[tstId]) {
       const auto iSTS = stsPair.first;
+      const auto iScore = stsPair.second;
       const auto cpId = getCPId(simTSs[iSTS], iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
       //if (std::find(cPIndices.begin(), cPIndices.end(), cpId) == cPIndices.end())
       //  continue;
-
-      const auto& simOnLayer = (i == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][simTSs[iSTS].seedIndex()];
+      auto iSim = simTSs[iSTS].seedIndex();
+      if (simTSs[iSTS].seedID() == cPHandle_id) // SimTrackster from CaloParticle
+        iSim = 0;
+      const auto& simOnLayer = (i == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][iSim];
 
       float sharedeneCPallLayers = 0.;
       for (unsigned int j = 0; j < layers * 2; ++j)
         sharedeneCPallLayers += simOnLayer[j].layerClusterIdToEnergyAndScore.count(tstId) ? simOnLayer[j].layerClusterIdToEnergyAndScore.at(tstId).first : 0;
+      if (tracksterEnergy == 0) continue;
       const auto sharedEneFrac = sharedeneCPallLayers / tracksterEnergy;
-      LogDebug("HGCalValidator") << "\nTrackster id: " << tstId << " (" << tst.vertices().size() << " vertice$
+      LogDebug("HGCalValidator") << "\nTrackster id: " << tstId << " (" << tst.vertices().size() << " vertices)" << "\tSimTrackster Id: " << iSTS << " (" << simTSs[iSTS].vertices().size() << " vertices)" << " (CP id: " << cpId << ")\tscore: " << iScore << "\tsharedeneCPallLayers: " << sharedeneCPallLayers << std::endl;
 
+      histograms.h_score_trackster2caloparticle[i][count]->Fill(iScore);
+      histograms.h_sharedenergy_trackster2caloparticle[i][count]->Fill(sharedEneFrac);
+      histograms.h_energy_vs_score_trackster2caloparticle[i][count]->Fill(iScore,
+                                                                          sharedEneFrac);
       if (iSTS == score->first) {
-        histograms.h_score_trackster2caloparticle[i][count]->Fill(score->second);
-        histograms.h_sharedenergy_trackster2caloparticle[i][count]->Fill(sharedEneFrac);
-        histograms.h_sharedenergy_trackster2caloparticle_vs_eta[i][count]->Fill(tst.barycenter().eta(),
+        histograms.h_score_trackster2bestCaloparticle[i][count]->Fill(iScore);
+        histograms.h_sharedenergy_trackster2bestCaloparticle[i][count]->Fill(sharedEneFrac);
+        histograms.h_sharedenergy_trackster2bestCaloparticle_vs_eta[i][count]->Fill(tst.barycenter().eta(),
+                                                                                    sharedEneFrac);
+        histograms.h_sharedenergy_trackster2bestCaloparticle_vs_phi[i][count]->Fill(tst.barycenter().phi(),
+                                                                                    sharedEneFrac);
+        histograms.h_energy_vs_score_trackster2bestCaloparticle[i][count]->Fill(iScore,
                                                                                 sharedEneFrac);
-        histograms.h_sharedenergy_trackster2caloparticle_vs_phi[i][count]->Fill(tst.barycenter().phi(),
-                                                                                sharedEneFrac);
-        histograms.h_energy_vs_score_trackster2caloparticle[i][count]->Fill(score->second,
-                                                                            sharedEneFrac);
       }
-      else if (iSTS == score2->first) {
-        histograms.h_scoreMerge_trackster2caloparticle[i][count]->Fill(score2->second);
+      else if (score2 < 0  ||  iScore < score2) {
+        score2 = iScore;
+        sharedEneFrac2 = sharedEneFrac;
       }
+    } // end of loop through SimTracksters associated to Trackster
+    if (score2 > -1) {
+      histograms.h_score_trackster2bestCaloparticle2[i][count]->Fill(score2);
+      histograms.h_sharedenergy_trackster2bestCaloparticle2[i][count]->Fill(sharedEneFrac2);
+      histograms.h_energy_vs_score_trackster2bestCaloparticle2[i][count]->Fill(score2,
+                                                                               sharedEneFrac2);
     }
-  }  //end of loop through Tracksters
+  } // end of loop through Tracksters
 
 
   std::unordered_map<unsigned int, std::vector<float>> score3d;
@@ -2830,15 +2940,13 @@ else return false;
   for (unsigned int iSTS = 0; iSTS < nSimTracksters; ++iSTS) {
     const auto& sts = simTSs[iSTS];
     const auto& cpId = getCPId(sts, iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
-    if (i == 0)
-      if (std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
-        continue;
+    if (i==0 && std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
+      continue;
 
+    const auto& hafLC = apply_LCMultiplicity(sts, layerClusters);
     float SimEnergy_LC = 0.f;
-    for (const auto& haf : apply_LCMultiplicity(sts, layerClusters)) {
+    for (const auto& haf : hafLC) {
       const auto lcId = getLCId(sts.vertices(), layerClusters, haf.first);
-      if (int(lcId) < 0) // For Pattern Recognition ignore non-clustered hits
-        continue;
       const auto iLC = std::find(sts.vertices().begin(), sts.vertices().end(), lcId);
       SimEnergy_LC += hitMap.at(haf.first)->energy() / sts.vertex_multiplicity(std::distance(std::begin(sts.vertices()), iLC));
     }
@@ -2850,12 +2958,12 @@ else return false;
 
     // Keep the Trackster ids that are related to
     // SimTrackster under study for the final filling of the score
-    std::vector<unsigned int> stsId_tstId_related;
+    std::set<unsigned int> stsId_tstId_related;
     auto& score3d_iSTS = score3d[iSTS];
 
     float SimEnergy = 0.f;
     float SimEnergyWeight = 0.f, hitsEnergyWeight = 0.f;
-    for (unsigned int layerId = 0; layerId < layers * 2; ++layerId) {
+    for (unsigned int layerId = 0; layerId < 1/*layers * 2*/; ++layerId) {
       const auto SimNumberOfHits = simOnLayer[layerId].hits_and_fractions.size();
       if (SimNumberOfHits == 0)
         continue;
@@ -2885,8 +2993,13 @@ else return false;
                                  << "\t" << std::setw(15) << maxEnergyTSperlayerinSim << "\t" << std::setw(20)
                                  << SimEnergyFractionInTSperlayer << "\n";
 
-      for (const auto& haf : simOnLayer[layerId].hits_and_fractions) {
+      for (const auto& haf : ((i==0) ? simOnLayer[layerId].hits_and_fractions : hafLC)) {
         const auto& hitDetId = haf.first;
+        const auto hitLayerId =
+            //recHitTools_->getLayerWithOffset(hitDetId) + layers * ((recHitTools_->zside(hitDetId) + 1) >> 1) - 1;
+            0;
+        if (i == 1  &&  layerId != hitLayerId)
+          continue;
         // Compute the correct normalization
         // Need to loop on the simOnLayer data structure since this is the
         // only one that has the compressed information for multiple usage
@@ -2894,11 +3007,6 @@ else return false;
         SimEnergyWeight += pow(haf.second * hitMap.at(hitDetId)->energy(), 2);
 
         const auto lcId = getLCId(sts.vertices(), layerClusters, hitDetId);
-        if (i == 1) { // For Pattern Recognition ignore non-clustered hits
-          if (int(lcId) < 0)
-            continue;
-        }
-
         float cpFraction = 0.f;
         if (i == 0) {
           cpFraction = haf.second;
@@ -2914,17 +3022,17 @@ else return false;
           hitWithNoTS = true;
         const HGCRecHit* hit = hitMap.find(hitDetId)->second;
         const auto hitEnergyWeight = pow(hit->energy(), 2);
+        hitsEnergyWeight += pow(cpFraction, 2) * hitEnergyWeight;
+
         for (auto& tsPair : simOnLayer[layerId].layerClusterIdToEnergyAndScore) {
           const auto tstId = tsPair.first;
-          if (std::find(std::begin(stsId_tstId_related), std::end(stsId_tstId_related), tstId) ==
-              std::end(stsId_tstId_related))
-            stsId_tstId_related.push_back(tstId);
+          stsId_tstId_related.insert(tstId);
 
           float tstFraction = 0.f;
           if (!hitWithNoTS) {
             const auto findTSIt = std::find(detIdToTracksterId_Map[hitDetId].begin(),
-                                             detIdToTracksterId_Map[hitDetId].end(),
-                                             HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, 0, 0.f}); // only the first element is used for the matching (overloaded operator==)
+                                            detIdToTracksterId_Map[hitDetId].end(),
+                                            HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, 0, 0.f}); // only the first element is used for the matching (overloaded operator==)
             if (findTSIt != detIdToTracksterId_Map[hitDetId].end()) {
               if (i == 0) {
                 tstFraction = findTSIt->fraction;
@@ -2936,13 +3044,12 @@ else return false;
               }
             }
           }
-          // Here do not divide as before by the layer cluster energy weight. Should sum first
+          // Here do not divide as before by the trackster energy weight. Should sum first
           // over all layers and divide with the total CP energy over all layers.
           if (tsPair.second.second == FLT_MAX) {
             tsPair.second.second = 0.f;
           }
-          tsPair.second.second += pow(min(tstFraction - cpFraction, cpFraction), 2) * hitEnergyWeight;
-          hitsEnergyWeight += pow(cpFraction, 2) * hitEnergyWeight;
+          tsPair.second.second += min(pow(tstFraction - cpFraction, 2), pow(cpFraction, 2)) * hitEnergyWeight;
 
           LogDebug("HGCalValidator") << "\nTracksterId:\t" << tstId
                                      << "\tSimTracksterId:\t" << iSTS
@@ -2989,7 +3096,7 @@ else return false;
     // one tracksters, leading to efficiencies >1. This boolean is used to
     // avoid "over counting".
     bool cp_considered_efficient = false;
-    int assocDup = 0;
+    bool cp_considered_pure = false;
     for (const auto tstId : stsId_tstId_related) {
       // Now time for the denominator
       score3d_iSTS[tstId] /= scoreDenom;
@@ -3003,10 +3110,9 @@ else return false;
                                  << "\tshared energy fraction: " << tstSharedEnergyFrac << "\n";
 
       histograms.h_score_caloparticle2trackster[i][count]->Fill(score3d_iSTS[tstId]);
-
       histograms.h_sharedenergy_caloparticle2trackster[i][count]->Fill(tstSharedEnergyFrac);
       histograms.h_energy_vs_score_caloparticle2trackster[i][count]->Fill(score3d_iSTS[tstId],
-                                                                       tstSharedEnergyFrac);
+                                                                          tstSharedEnergyFrac);
       // Fill the numerator for the efficiency calculation. The efficiency is computed by considering the energy shared between a Trackster and a _corresponding_ caloParticle. The threshold is configurable via python.
       if (!cp_considered_efficient && (tstSharedEnergyFrac >= minTSTSharedEneFracEfficiency_)) {
         cp_considered_efficient = true;
@@ -3020,40 +3126,42 @@ else return false;
         if ((i == 1) && (tracksters[tstId].ticlIteration() == ticl::Trackster::SIM))
           if (tracksters[tstId].vertices().size() != sts.vertices().size())
             continue;
-        assocDup++;
+
+        if (tracksters_PurityDuplicate[tstId] < 1) tracksters_PurityDuplicate[tstId]++; // for Purity
+        if (cp_considered_pure) tracksters_PurityDuplicate[tstId]++; // for Duplicate
+        cp_considered_pure = true;
       }
-      if (assocDup >= 2)
-        tracksters_duplicate[tstId] = 1;
     } // end of loop through Tracksters related to SimTrackster
 
-    if (score3d_iSTS.size() < 1)
-      continue ;
-
     const auto best = std::min_element(std::begin(score3d_iSTS), std::end(score3d_iSTS));
-    histograms.h_scorePur_caloparticle2trackster[i][count]->Fill(*best);
-    const auto best2 = std::min_element(std::begin(score3d_iSTS), std::end(score3d_iSTS),
-                                        [&best](const auto& obj1, const auto& obj2) { if (obj1 != *best) return obj1 < obj2;
-else return false;
-});
-    histograms.h_scoreDupl_caloparticle2trackster[i][count]->Fill(*best2);
-
-    if (assocDup > 0) {
-      histograms.h_num_caloparticle_eta[i][count]->Fill(sts_eta);
-      histograms.h_num_caloparticle_phi[i][count]->Fill(sts_phi);
-      histograms.h_num_caloparticle_en[i][count]->Fill(sts_en);
-      histograms.h_num_caloparticle_pt[i][count]->Fill(sts_pt);
+    if (best != score3d_iSTS.end()) {
       const auto bestTstId = std::distance(std::begin(score3d_iSTS), best);
-      const auto tstSharedEnergyFrac = tstSharedEnergy[iSTS][bestTstId] / energyDenom;
-
+      const auto bestTstSharedEnergyFrac = tstSharedEnergy[iSTS][bestTstId] / energyDenom;
+      histograms.h_scorePur_caloparticle2trackster[i][count]->Fill(*best);
+      histograms.h_sharedenergy_caloparticle2trackster_assoc[i][count]->Fill(bestTstSharedEnergyFrac);
       histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[i][count]->Fill(
-          sts_eta, tstSharedEnergyFrac);
+          sts_eta, bestTstSharedEnergyFrac);
       histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[i][count]->Fill(
-          sts_phi, tstSharedEnergyFrac);
-      histograms.h_sharedenergy_caloparticle2trackster_assoc[i][count]->Fill(tstSharedEnergyFrac);
+          sts_phi, bestTstSharedEnergyFrac);
+      histograms.h_energy_vs_score_caloparticle2bestTrackster[i][count]->Fill(*best,
+                                                                              bestTstSharedEnergyFrac);
       LogDebug("HGCalValidator") << count << " " << sts_eta << " "
                                  << sts_phi << " " << tracksters[bestTstId].raw_energy()
                                  << " " << sts.raw_energy() << " "
-                                 << tstSharedEnergyFrac << "\n";
+                                 << bestTstSharedEnergyFrac << "\n";
+
+      if (score3d_iSTS.size() > 1) {
+        auto best2 = (best == score3d_iSTS.begin()) ? std::next(best, 1) : score3d_iSTS.begin() ;
+        for (auto tstId = score3d_iSTS.begin(); tstId != score3d_iSTS.end()  &&  tstId != best; tstId++)
+          if (*tstId < *best2)
+            best2 = tstId;
+        const auto best2TstId = std::distance(std::begin(score3d_iSTS), best2);
+        const auto best2TstSharedEnergyFrac = tstSharedEnergy[iSTS][best2TstId] / energyDenom;
+        histograms.h_scoreDupl_caloparticle2trackster[i][count]->Fill(*best2);
+        histograms.h_sharedenergy_caloparticle2trackster_assoc2[i][count]->Fill(best2TstSharedEnergyFrac);
+        histograms.h_energy_vs_score_caloparticle2bestTrackster2[i][count]->Fill(*best2,
+                                                                                 best2TstSharedEnergyFrac);
+      }
     }
   }  // end of loop through SimTracksters
 
@@ -3073,22 +3181,27 @@ else return false;
     histograms.h_denom_trackster_en[i][count]->Fill(iTS_en);
     histograms.h_denom_trackster_pt[i][count]->Fill(iTS_pt);
 
-    const auto assocDuplicate = tracksters_duplicate[tstId];
-    if (assocDuplicate) {
-      histograms.h_numDup_trackster_eta[i][count]->Fill(iTS_eta);
-      histograms.h_numDup_trackster_phi[i][count]->Fill(iTS_phi);
-      histograms.h_numDup_trackster_en[i][count]->Fill(iTS_en);
-      histograms.h_numDup_trackster_pt[i][count]->Fill(iTS_pt);
+    if (tracksters_PurityDuplicate[tstId] > 0) {
+      histograms.h_num_caloparticle_eta[i][count]->Fill(iTS_eta);
+      histograms.h_num_caloparticle_phi[i][count]->Fill(iTS_phi);
+      histograms.h_num_caloparticle_en[i][count]->Fill(iTS_en);
+      histograms.h_num_caloparticle_pt[i][count]->Fill(iTS_pt);
+
+      if (tracksters_PurityDuplicate[tstId] > 1) {
+        histograms.h_numDup_trackster_eta[i][count]->Fill(iTS_eta);
+        histograms.h_numDup_trackster_phi[i][count]->Fill(iTS_phi);
+        histograms.h_numDup_trackster_en[i][count]->Fill(iTS_en);
+        histograms.h_numDup_trackster_pt[i][count]->Fill(iTS_pt);
+      }
     }
 
-    const auto assocFakeMerge = tracksters_fakemerge[tstId];
-    if (assocFakeMerge > 0) {
+    if (tracksters_FakeMerge[tstId] > 0) {
       histograms.h_num_trackster_eta[i][count]->Fill(iTS_eta);
       histograms.h_num_trackster_phi[i][count]->Fill(iTS_phi);
       histograms.h_num_trackster_en[i][count]->Fill(iTS_en);
       histograms.h_num_trackster_pt[i][count]->Fill(iTS_pt);
 
-      if (assocFakeMerge >= 2) {
+      if (tracksters_FakeMerge[tstId] > 1) {
         histograms.h_numMerge_trackster_eta[i][count]->Fill(iTS_eta);
         histograms.h_numMerge_trackster_phi[i][count]->Fill(iTS_phi);
         histograms.h_numMerge_trackster_en[i][count]->Fill(iTS_en);

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1751,9 +1751,9 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
     // This will store the fraction of the CaloParticle energy shared with the LayerCluster: e_shared/cp_energy
     std::unordered_map<unsigned, float> CPEnergyInLC;
 
-    for (unsigned int hitId = 0; hitId < numberOfHitsInLC; hitId++) {
-      const DetId rh_detid = hits_and_fractions[hitId].first;
-      const auto rhFraction = hits_and_fractions[hitId].second;
+    for (unsigned int iHit = 0; iHit < numberOfHitsInLC; iHit++) {
+      const DetId rh_detid = hits_and_fractions[iHit].first;
+      const auto rhFraction = hits_and_fractions[iHit].second;
 
       std::unordered_map<DetId, const HGCRecHit*>::const_iterator itcheck = hitMap.find(rh_detid);
       const HGCRecHit* hit = itcheck->second;
@@ -1772,10 +1772,10 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
       // MR Remove the case in which the fraction is 0, since this could be a
       // real hit that has been marked as halo.
       if (rhFraction == 0.) {
-        hitsToCaloParticleId[hitId] = -2;
+        hitsToCaloParticleId[iHit] = -2;
       }
       if (hit_find_in_CP == detIdToCaloParticleId_Map.end()) {
-        hitsToCaloParticleId[hitId] -= 1;
+        hitsToCaloParticleId[iHit] -= 1;
       } else {
         auto maxCPEnergyInLC = 0.f;
         auto maxCPId = -1;
@@ -1789,10 +1789,10 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
             maxCPId = iCP;
           }
         }
-        hitsToCaloParticleId[hitId] = maxCPId;
+        hitsToCaloParticleId[iHit] = maxCPId;
       }
       histograms.h_cellAssociation_perlayer.at(lcLayerId)->Fill(
-          hitsToCaloParticleId[hitId] > 0. ? 0. : hitsToCaloParticleId[hitId]);
+          hitsToCaloParticleId[iHit] > 0. ? 0. : hitsToCaloParticleId[iHit]);
     }  // End loop over hits on a LayerCluster
 
   }  // End of loop over LayerClusters
@@ -2676,24 +2676,24 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
     //layer cluster under study. If negative, there is no simhit from any CaloParticle related.
     //If positive, at least one CaloParticle has been found with matched simhit.
     //In more detail:
-    // 1. hitsToCaloParticleId[hitId] = -3
+    // 1. hitsToCaloParticleId[iHit] = -3
     //    TN:  These represent Halo Cells(N) that have not been
     //    assigned to any CaloParticle (hence the T).
-    // 2. hitsToCaloParticleId[hitId] = -2
+    // 2. hitsToCaloParticleId[iHit] = -2
     //    FN: There represent Halo Cells(N) that have been assigned
     //    to a CaloParticle (hence the F, since those should have not been marked as halo)
-    // 3. hitsToCaloParticleId[hitId] = -1
+    // 3. hitsToCaloParticleId[iHit] = -1
     //    FP: These represent Real Cells(P) that have not been
     //    assigned to any CaloParticle (hence the F, since these are fakes)
-    // 4. hitsToCaloParticleId[hitId] >= 0
+    // 4. hitsToCaloParticleId[iHit] >= 0
     //    TP There represent Real Cells(P) that have been assigned
     //    to a CaloParticle (hence the T)
     std::vector<int> hitsToCaloParticleId(numberOfHitsInTS);
 
     //Loop through the hits of the trackster under study
-    for (unsigned int hitId = 0; hitId < numberOfHitsInTS; hitId++) {
-      const auto rh_detid = tst_hitsAndFractions[hitId].first;
-      const auto rhFraction = tst_hitsAndFractions[hitId].second;
+    for (unsigned int iHit = 0; iHit < numberOfHitsInTS; iHit++) {
+      const auto rh_detid = tst_hitsAndFractions[iHit].first;
+      const auto rhFraction = tst_hitsAndFractions[iHit].second;
 
       const auto lcId_r = getLCId(tst.vertices(), layerClusters, rh_detid);
       const auto iLC_r = std::find(tst.vertices().begin(), tst.vertices().end(), lcId_r);
@@ -2731,7 +2731,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
       // MR Remove the case in which the fraction is 0, since this could be a
       // real hit that has been marked as halo.
       if (rhFraction == 0.) {
-        hitsToCaloParticleId[hitId] = -2;
+        hitsToCaloParticleId[iHit] = -2;
         numberOfHaloHitsInTS++;
       }
 
@@ -2740,7 +2740,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
       const auto recoFr = (i == 0) ? rhFraction : lcFraction_r;
       const auto& hit_find_in_STS = detIdSimTSId_Map.find(elemId);
       if (hit_find_in_STS == detIdSimTSId_Map.end()) {
-        hitsToCaloParticleId[hitId] -= 1;
+        hitsToCaloParticleId[iHit] -= 1;
       } else {
         // Since the hit is belonging to the layer cluster, it must be also in the rechits map
         const auto hitEn = hitMap.find(rh_detid)->second->energy();
@@ -2785,7 +2785,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
           }
         }
         //Keep in mind here maxCPId could be zero. So, below ask for negative not including zero to count noise.
-        hitsToCaloParticleId[hitId] = maxCPId;
+        hitsToCaloParticleId[iHit] = maxCPId;
       }
 
     }  //end of loop through rechits of the layer cluster.

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -2932,17 +2932,17 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
       LogDebug("HGCalValidator") << "Trackster Id: " << tstId << "\tSimTrackster id: -1"
                                  << "\tscore: -1\n";
 
-    tracksters_FakeMerge[tstId] = std::count_if(
-        std::begin(stsInTrackster[tstId]),
-        std::end(stsInTrackster[tstId]),
-        [&, i, ScoreCutTStoSTSFakeMerge](const auto& obj) { return obj.second < ScoreCutTStoSTSFakeMerge; });
+    tracksters_FakeMerge[tstId] =
+        std::count_if(std::begin(stsInTrackster[tstId]),
+                      std::end(stsInTrackster[tstId]),
+                      [ScoreCutTStoSTSFakeMerge](const auto& obj) { return obj.second < ScoreCutTStoSTSFakeMerge; });
 
     const auto score = std::min_element(std::begin(stsInTrackster[tstId]),
                                         std::end(stsInTrackster[tstId]),
                                         [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
     float score2 = -1;
     float sharedEneFrac2 = 0;
-    for (const auto stsPair : stsInTrackster[tstId]) {
+    for (const auto& stsPair : stsInTrackster[tstId]) {
       const auto iSTS = stsPair.first;
       const auto iScore = stsPair.second;
       const auto cpId = getCPId(simTSs[iSTS], iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -16,8 +16,8 @@ const double ScoreCutLCtoCP_ = 0.1;
 const double ScoreCutCPtoLC_ = 0.1;
 const double ScoreCutLCtoSC_ = 0.1;
 const double ScoreCutSCtoLC_ = 0.1;
-const double ScoreCutTStoCPFakeMerge_ = 0.6;
-const double ScoreCutCPtoTSEffDup_ = 0.2;
+const double ScoreCutTStoCPFakeMerge_[] = {0.6, 1.e-09}; //FLT_MIN
+const double ScoreCutCPtoTSEffDup_[] = {0.2, 1.e-10}; //FLT_MIN
 
 HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
     :  //parameters for eta
@@ -154,7 +154,7 @@ HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
       nintCellsEneDensperthick_(pset.getParameter<int>("nintCellsEneDensperthick")),
 
       //Parameters for the total number of Tracksters per event
-      //We always treet one event as two events, one in +z one in -z
+      // Always treat one event as two events, one in +z one in -z
       minTotNTSTs_(pset.getParameter<double>("minTotNTSTs")),
       maxTotNTSTs_(pset.getParameter<double>("maxTotNTSTs")),
       nintTotNTSTs_(pset.getParameter<int>("nintTotNTSTs")),
@@ -293,12 +293,12 @@ void HGVHistoProducerAlgo::bookSimClusterHistos(DQMStore::IBooker& ibook,
     while (istr1.size() < 2) {
       istr1.insert(0, "0");
     }
-    //We will make a mapping to the regural layer naming plus z- or z+ for convenience
+    // Make a mapping to the regural layer naming plus z- or z+ for convenience
     std::string istr2 = "";
-    //First with the -z endcap
+    // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else {  //Then for the +z
+    } else { // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     histograms.h_simclusternum_perlayer[ilayer] = ibook.book1D("totsimclusternum_layer_" + istr1,
@@ -390,12 +390,12 @@ void HGVHistoProducerAlgo::bookSimClusterAssociationHistos(DQMStore::IBooker& ib
     while (istr1.size() < 2) {
       istr1.insert(0, "0");
     }
-    //We will make a mapping to the regural layer naming plus z- or z+ for convenience
+    // Make a mapping to the regural layer naming plus z- or z+ for convenience
     std::string istr2 = "";
-    //First with the -z endcap
+    // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else {  //Then for the +z
+    } else { // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     //-------------------------------------------------------------------------------------------------------------------------
@@ -656,12 +656,12 @@ void HGVHistoProducerAlgo::bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibo
     while (istr1.size() < 2) {
       istr1.insert(0, "0");
     }
-    //We will make a mapping to the regural layer naming plus z- or z+ for convenience
+    // Make a mapping to the regural layer naming plus z- or z+ for convenience
     std::string istr2 = "";
-    //First with the -z endcap
+    // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else {  //Then for the +z
+    } else { // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     histograms.h_clusternum_perlayer[ilayer] = ibook.book1D("totclusternum_layer_" + istr1,
@@ -698,12 +698,12 @@ void HGVHistoProducerAlgo::bookClusterHistos_LCtoCP_association(DQMStore::IBooke
     while (istr1.size() < 2) {
       istr1.insert(0, "0");
     }
-    //We will make a mapping to the regural layer naming plus z- or z+ for convenience
+    // Make a mapping to the regural layer naming plus z- or z+ for convenience
     std::string istr2 = "";
-    //First with the -z endcap
+    // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else {  //Then for the +z
+    } else { // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     histograms.h_score_layercl2caloparticle_perlayer[ilayer] =
@@ -866,12 +866,12 @@ void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
     while (istr1.size() < 2) {
       istr1.insert(0, "0");
     }
-    //We will make a mapping to the regural layer naming plus z- or z+ for convenience
+    // Make a mapping to the regural layer naming plus z- or z+ for convenience
     std::string istr2 = "";
-    //First with the -z endcap
+    // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else {  //Then for the +z
+    } else { // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     histograms.h_cellAssociation_perlayer[ilayer] =
@@ -891,7 +891,7 @@ void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
                                                              maxCellsEneDensperthick_);
   }
   //----------------------------------------------------------------------------------------------------------------------------
-  //Not all combination exists but we should keep them all for cross checking reason.
+  //Not all combination exists but should keep them all for cross checking reason.
   for (std::vector<int>::iterator it = thicknesses.begin(); it != thicknesses.end(); ++it) {
     for (unsigned ilayer = 0; ilayer < 2 * layers; ++ilayer) {
       auto istr1 = std::to_string(*it);
@@ -899,12 +899,12 @@ void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
       while (istr2.size() < 2)
         istr2.insert(0, "0");
       auto istr = istr1 + "_" + istr2;
-      //We will make a mapping to the regural layer naming plus z- or z+ for convenience
+      // Make a mapping to the regural layer naming plus z- or z+ for convenience
       std::string istr3 = "";
-      //First with the -z endcap
+      // first with the -z endcap
       if (ilayer < layers) {
         istr3 = std::to_string(ilayer + 1) + " in z- ";
-      } else {  //Then for the +z
+      } else { // then for the +z
         istr3 = std::to_string(ilayer - (layers - 1)) + " in z+ ";
       }
       //---
@@ -973,12 +973,12 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
     while (istr1.size() < 2) {
       istr1.insert(0, "0");
     }
-    //We will make a mapping to the regural layer naming plus z- or z+ for convenience
+    // Make a mapping to the regural layer naming plus z- or z+ for convenience
     std::string istr2 = "";
-    //First with the -z endcap
+    // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else {  //Then for the +z
+    } else { // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
 
@@ -1208,10 +1208,10 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
 }
 
 void HGVHistoProducerAlgo::fill_info_histos(const Histograms& histograms, unsigned int layers) const {
-  //We will save some info straight from geometry to avoid mistakes from updates
+  // Save some info straight from geometry to avoid mistakes from updates
   //----------- TODO ----------------------------------------------------------
-  //For now values returned for 'lastLayerFHzp': '104', 'lastLayerFHzm': '52' are not the one expected.
-  //Will come back to this when there will be info in CMSSW to put in DQM file.
+  // For now values returned for 'lastLayerFHzp': '104', 'lastLayerFHzm': '52' are not the one expected.
+  // Will come back to this when there will be info in CMSSW to put in DQM file.
   histograms.lastLayerEEzm->Fill(recHitTools_->lastLayerEE());
   histograms.lastLayerFHzm->Fill(recHitTools_->lastLayerFH());
   histograms.maxlayerzm->Fill(layers);
@@ -1513,7 +1513,7 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInCluster>> detIdToLayerClusterId_Map;
 
   // The association has to be done in an all-vs-all fashion.
-  // For this reason we use the full set of CaloParticles, with the only filter on bx
+  // For this reason use the full set of CaloParticles, with the only filter on bx
   for (const auto& cpId : cPIndices) {
     for (const auto& simCluster : cP[cpId].simClusters()) {
       for (const auto& it_haf : simCluster->hits_and_fractions()) {
@@ -1588,12 +1588,13 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
         auto maxCPEnergyInLC = 0.f;
         auto maxCPId = -1;
         for (auto& h : hit_find_in_CP->second) {
-          CPEnergyInLC[h.clusterId] += h.fraction * hit->energy();
+          const auto iCP = h.clusterId;
+          CPEnergyInLC[iCP] += h.fraction * hit->energy();
           // Keep track of which CaloParticle contributed the most, in terms
           // of energy, to this specific LayerCluster.
-          if (CPEnergyInLC[h.clusterId] > maxCPEnergyInLC) {
-            maxCPEnergyInLC = CPEnergyInLC[h.clusterId];
-            maxCPId = h.clusterId;
+          if (CPEnergyInLC[iCP] > maxCPEnergyInLC) {
+            maxCPEnergyInLC = CPEnergyInLC[iCP];
+            maxCPId = iCP;
           }
         }
         hitsToCaloParticleId[hitId] = maxCPId;
@@ -1604,8 +1605,8 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
 
   }  // End of loop over LayerClusters
 
-  // Here we do fill the plots to compute the different metrics linked to
-  // reco-level, namely fake-rate an merge-rate. In this loop we should *not*
+  // Fill the plots to compute the different metrics linked to
+  // reco-level, namely fake-rate an merge-rate. In this loop should *not*
   // restrict only to the selected caloParaticles.
   for (unsigned int lcId = 0; lcId < nLayerClusters; ++lcId) {
     const auto firstHitDetId = (clusters[lcId].hitsAndFractions())[0].first;
@@ -1672,8 +1673,8 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
     }
   }  // End of loop over LayerClusters
 
-  // Here we do fill the plots to compute the different metrics linked to
-  // gen-level, namely efficiency and duplicate. In this loop we should restrict
+  // Here Fill the plots to compute the different metrics linked to
+  // gen-level, namely efficiency and duplicate. In this loop should restrict
   // only to the selected caloParaticles.
   for (const auto& cpId : cPSelectedIndices) {
     const edm::Ref<CaloParticleCollection> cpRef(caloParticleHandle, cpId);
@@ -1686,12 +1687,12 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
     for (const auto& simCluster : cP[cpId].simClusters()) {
       for (const auto& it_haf : simCluster->hits_and_fractions()) {
         const DetId hitid = (it_haf.first);
-        const auto cpLayerId =
+        const auto hitLayerId =
             recHitTools_->getLayerWithOffset(hitid) + layers * ((recHitTools_->zside(hitid) + 1) >> 1) - 1;
         std::unordered_map<DetId, const HGCRecHit*>::const_iterator itcheck = hitMap.find(hitid);
         if (itcheck != hitMap.end()) {
           const HGCRecHit* hit = itcheck->second;
-          cPEnergyOnLayer[cpLayerId] += it_haf.second * hit->energy();
+          cPEnergyOnLayer[hitLayerId] += it_haf.second * hit->energy();
         }
       }
     }
@@ -1767,8 +1768,8 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
     const hgcal::RecoToSimCollectionWithSimClusters& scsInLayerClusterMap,
     const hgcal::SimToRecoCollectionWithSimClusters& lcsInSimClusterMap) const {
 
-  // Here we do fill the plots to compute the different metrics linked to
-  // reco-level, namely fake-rate and merge-rate. In this loop we should *not*
+  // Here fill the plots to compute the different metrics linked to
+  // reco-level, namely fake-rate and merge-rate. In this loop should *not*
   // restrict only to the selected SimClusters.
   for (unsigned int lcId = 0; lcId < clusters.size(); ++lcId) {
     if (mask[lcId] != 0.) {
@@ -1778,7 +1779,7 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
     const auto firstHitDetId = (clusters[lcId].hitsAndFractions())[0].first;
     const auto lcLayerId =
         recHitTools_->getLayerWithOffset(firstHitDetId) + layers * ((recHitTools_->zside(firstHitDetId) + 1) >> 1) - 1;
-    //Although the ones below are already created in the LC to CP association, we will
+    //Although the ones below are already created in the LC to CP association, will
     //recreate them here since in the post processor it looks in a specific directory.
     histograms.h_denom_layercl_in_simcl_eta_perlayer[count].at(lcLayerId)->Fill(clusters[lcId].eta());
     histograms.h_denom_layercl_in_simcl_phi_perlayer[count].at(lcLayerId)->Fill(clusters[lcId].phi());
@@ -1847,8 +1848,8 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
     }
   }  // End of loop over LayerClusters
 
-  // Here we do fill the plots to compute the different metrics linked to
-  // gen-level, namely efficiency and duplicate. In this loop we should restrict
+  // Fill the plots to compute the different metrics linked to
+  // gen-level, namely efficiency and duplicate. In this loop should restrict
   // only to the selected SimClusters.
   for (const auto& scId : sCIndices) {
     const edm::Ref<SimClusterCollection> scRef(simClusterHandle, scId);
@@ -1990,7 +1991,7 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
   //for the longitudinal depth barycenter
   std::vector<double> ldbar(1000, 0.0);  //ldbar.clear(); ldbar.reserve(1000);
 
-  //We need to compare with the total amount of energy coming from CaloParticles
+  // Need to compare with the total amount of energy coming from CaloParticles
   double caloparteneplus = 0.;
   double caloparteneminus = 0.;
   for (const auto& cpId : cPIndices) {
@@ -2025,10 +2026,10 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
     double thickness = 0.;
     //The layer the cluster belongs to. As mentioned in the mapping above, it takes into account -z and +z.
     int layerid = 0;
-    //We will need another layer variable for the longitudinal material budget file reading.
-    //In this case we need no distinction between -z and +z.
+    // Need another layer variable for the longitudinal material budget file reading.
+    //In this case need no distinction between -z and +z.
     int lay = 0;
-    //We will need here to save the combination thick_lay
+    // Need to save the combination thick_lay
     std::string istr = "";
     //boolean to check for the layer that the cluster belong to. Maybe later will check all the layer hits.
     bool cluslay = true;
@@ -2196,11 +2197,10 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
 
   }  //end of loop through clusters of the event
 
-  //After the end of the event we can now fill with the results.
-  //First a couple of variables to keep the sum of the energy of all clusters
+  // First a couple of variables to keep the sum of the energy of all clusters
   double sumeneallcluspl = 0.;
   double sumeneallclusmi = 0.;
-  //And the longitudinal variable
+  // and the longitudinal variable
   double sumldbarpl = 0.;
   double sumldbarmi = 0.;
   //Per layer : Loop 0->103
@@ -2262,9 +2262,9 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
                                                        int count,
                                                        const ticl::TracksterCollection& tracksters,
                                                        const reco::CaloClusterCollection& layerClusters,
-                                                       const ticl::TracksterCollection& simTS,
+                                                       const ticl::TracksterCollection& simTSs,
                                                        const int i,
-                                                       const ticl::TracksterCollection& simTS_fromCP,
+                                                       const ticl::TracksterCollection& simTSs_fromCP,
                                                        const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
                                                        std::vector<SimCluster> const& sC,
                                                        const edm::ProductID& cPHandle_id,
@@ -2274,7 +2274,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
                                                        std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
                                                        unsigned int layers) const {
   const auto nTracksters = tracksters.size();
-  const auto nSimTracksters = simTS.size();
+  const auto nSimTracksters = simTSs.size();
 
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInCluster>> detIdSimTSId_Map;
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInTrackster>> detIdToTracksterId_Map;
@@ -2295,17 +2295,28 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
   //2. the hits and fractions of that calo particle i in layer j.
   //3. the layer clusters with matched rechit id.
   std::unordered_map<int, std::vector<caloParticleOnLayer>> cPOnLayer;
+  std::unordered_map<int, std::vector<std::vector<caloParticleOnLayer>>> sCOnLayer;
   //Consider CaloParticles coming from the hard scatterer, excluding the PU contribution.
   for (const auto cpIndex : cPIndices) {
     cPOnLayer[cpIndex].resize(layers * 2);
-    for (unsigned int j = 0; j < layers * 2; ++j) {
-      cPOnLayer[cpIndex][j].caloParticleId = cpIndex;
-      cPOnLayer[cpIndex][j].energy = 0.f;
-      cPOnLayer[cpIndex][j].hits_and_fractions.clear();
+    const auto nSC_inCP = cP[cpIndex].simClusters().size();
+    sCOnLayer[cpIndex].resize(nSC_inCP);
+    for (unsigned int iSC=0; iSC<nSC_inCP; iSC++) {
+      sCOnLayer[cpIndex][iSC].resize(layers * 2);
+      for (unsigned int j = 0; j < layers * 2; ++j) {
+        if (iSC == 0) {
+          cPOnLayer[cpIndex][j].caloParticleId = cpIndex;
+          cPOnLayer[cpIndex][j].energy = 0.f;
+          cPOnLayer[cpIndex][j].hits_and_fractions.clear();
+        }
+        sCOnLayer[cpIndex][iSC][j].caloParticleId = cpIndex;
+        sCOnLayer[cpIndex][iSC][j].energy = 0.f;
+        sCOnLayer[cpIndex][iSC][j].hits_and_fractions.clear();
+      }
     }
   }
 
-  auto getCPId = [](const ticl::Trackster& simTS, const unsigned int iSTS, const edm::ProductID& cPHandle_id, const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap, const ticl::TracksterCollection& simTS_fromCP){
+  auto getCPId = [](const ticl::Trackster& simTS, const unsigned int iSTS, const edm::ProductID& cPHandle_id, const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap, const ticl::TracksterCollection& simTSs_fromCP){
     unsigned int cpId = -1;
 
     const auto productID = simTS.seedID();
@@ -2317,31 +2328,44 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
         return std::find(std::begin(cpToScs.second), std::end(cpToScs.second), iSTS) != std::end(cpToScs.second);
       });
       if (findSimTSFromCP != std::end(cpToSc_SimTrackstersMap)) {
-        cpId = simTS_fromCP[findSimTSFromCP->first].seedIndex();
+        cpId = simTSs_fromCP[findSimTSFromCP->first].seedIndex();
       }
     }
 
     return cpId;
   };
 
+  auto getLCId = [](const std::vector<unsigned int>& tst_vertices, const reco::CaloClusterCollection& layerClusters, const DetId& hitid) {
+    unsigned int lcId = -1;
+    std::for_each(std::begin(tst_vertices), std::end(tst_vertices), [&](unsigned int idx) {
+      const auto& lc_haf = layerClusters[idx].hitsAndFractions();
+      const auto& hitFound = std::find_if(std::begin(lc_haf), std::end(lc_haf), [&hitid](const std::pair<DetId, float>& v) {
+return v.first == hitid; });
+      if (hitFound != lc_haf.end()) // not all hits may be clusterized
+        lcId = idx;
+    });
+    return lcId;
+  };
+
 
   for (unsigned int iSTS = 0; iSTS < nSimTracksters; ++iSTS) {
-    const auto cpId = getCPId(simTS[iSTS], iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
+    const auto cpId = getCPId(simTSs[iSTS], iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
     if (std::find(cPIndices.begin(), cPIndices.end(), cpId) == cPIndices.end())
       continue;
 
     // Loop through SimClusters
     for (const auto& simCluster : cP[cpId].simClusters()) {
-      if (simTS[iSTS].seedID() != cPHandle_id) { // SimTrackster from SimCluster
-        if (simTS[iSTS].seedIndex()  !=  (&(*simCluster) - &(sC[0])))
+      if (simTSs[iSTS].seedID() != cPHandle_id) { // SimTrackster from SimCluster
+        if (simTSs[iSTS].seedIndex()  !=  (&(*simCluster) - &(sC[0])))
           continue;
       }
+      const auto iSim = simTSs[iSTS].seedIndex();
 
       for (const auto& it_haf : simCluster->hits_and_fractions()) {
         const auto hitid = (it_haf.first);
         //V9:maps the layers in -z: 0->51 and in +z: 52->103
         //V10:maps the layers in -z: 0->49 and in +z: 50->99
-        const auto cpLayerId = recHitTools_->getLayerWithOffset(hitid) + layers * ((recHitTools_->zside(hitid) + 1) >> 1) - 1;
+        const auto hitLayerId = recHitTools_->getLayerWithOffset(hitid) + layers * ((recHitTools_->zside(hitid) + 1) >> 1) - 1;
         const auto itcheck = hitMap.find(hitid);
         //Checks whether the current hit belonging to sim cluster has a reconstructed hit.
         if (itcheck != hitMap.end()) {
@@ -2356,11 +2380,11 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
             detIdSimTSId_Map[hitid] = std::vector<HGVHistoProducerAlgo::detIdInfoInCluster>();
             detIdSimTSId_Map[hitid].emplace_back(HGVHistoProducerAlgo::detIdInfoInCluster{iSTS, it_haf.second});
           } else {
-            auto findHitIt = std::find(detIdSimTSId_Map[hitid].begin(),
+            auto findSTSIt = std::find(detIdSimTSId_Map[hitid].begin(),
                                        detIdSimTSId_Map[hitid].end(),
-                                       HGVHistoProducerAlgo::detIdInfoInCluster{iSTS, it_haf.second});
-            if (findHitIt != detIdSimTSId_Map[hitid].end()) {
-              findHitIt->fraction += it_haf.second;
+                                       HGVHistoProducerAlgo::detIdInfoInCluster{iSTS, 0}); // only the first element is used for the matching (overloaded operator==)
+            if (findSTSIt != detIdSimTSId_Map[hitid].end()) {
+              findSTSIt->fraction += it_haf.second;
             } else {
               detIdSimTSId_Map[hitid].emplace_back(HGVHistoProducerAlgo::detIdInfoInCluster{iSTS, it_haf.second});
             }
@@ -2369,21 +2393,36 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
           //Since the current hit from sim cluster has a reconstructed hit with the same detid,
           //fill the cPOnLayer[caloparticle][layer] object with energy (sum of all rechits energy times fraction
           //of the relevant simhit) and keep the hit (detid and fraction) that contributed.
-          cPOnLayer[cpId][cpLayerId].energy += it_haf.second * hit->energy();
-          // We need to compress the hits and fractions in order to have a
+          cPOnLayer[cpId][hitLayerId].energy += it_haf.second * hit->energy();
+
+          float lcFraction = 0;
+          const auto lcId = getLCId(simTSs[iSTS].vertices(), layerClusters, hitid);
+          if (int(lcId) >= 0) {
+            const auto iLC = std::find(simTSs[iSTS].vertices().begin(), simTSs[iSTS].vertices().end(), lcId);
+            lcFraction = 1.f / simTSs[iSTS].vertex_multiplicity(std::distance(std::begin(simTSs[iSTS].vertices()), iLC));
+          }
+          sCOnLayer[cpId][iSim][hitLayerId].energy += lcFraction * hit->energy();
+          // Need to compress the hits and fractions in order to have a
           // reasonable score between CP and LC. Imagine, for example, that a
           // CP has detID X used by 2 SimClusters with different fractions. If
           // a single LC uses X with fraction 1 and is compared to the 2
           // contributions separately, it will be assigned a score != 0, which
           // is wrong.
-          auto& haf = cPOnLayer[cpId][cpLayerId].hits_and_fractions;
+          auto& haf = cPOnLayer[cpId][hitLayerId].hits_and_fractions;
           auto found = std::find_if(
               std::begin(haf), std::end(haf), [&hitid](const std::pair<DetId, float>& v) { return v.first == hitid; });
-          if (found != haf.end()) {
+          if (found != haf.end())
             found->second += it_haf.second;
-          } else {
-            cPOnLayer[cpId][cpLayerId].hits_and_fractions.emplace_back(hitid, it_haf.second);
-          }
+          else
+            haf.emplace_back(hitid, it_haf.second);
+          // Same for sCOnLayer
+          auto& haf_sc = sCOnLayer[cpId][iSim][hitLayerId].hits_and_fractions;
+          auto found_sc = std::find_if(
+              std::begin(haf_sc), std::end(haf_sc), [&hitid](const std::pair<DetId, float>& v) { return v.first == hitid; });
+          if (found_sc != haf_sc.end())
+            found_sc->second += it_haf.second;
+          else
+            haf_sc.emplace_back(hitid, it_haf.second);
         }
       }  // end of loop through SimHits
     }    // end of loop through SimClusters
@@ -2395,7 +2434,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
     std::for_each(std::begin(trackster.vertices()), std::end(trackster.vertices()), [&](unsigned int idx) {
       const auto fraction = 1.f / trackster.vertex_multiplicity(lcInTst++);
       for (const auto& cell : layerClusters[idx].hitsAndFractions()) {
-        hits_and_fractions_norm.emplace_back(cell.first, cell.second * fraction);
+        hits_and_fractions_norm.emplace_back(cell.first, cell.second * fraction); // cell.second is the hit fraction in the layerCluster
       }
     });
     return hits_and_fractions_norm;
@@ -2403,7 +2442,8 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
 
   // Loop through Tracksters
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
-    if (tracksters[tstId].vertices().empty())
+    const auto& trackster = tracksters[tstId];
+    if (trackster.vertices().empty())
       continue;
 
     std::unordered_map<unsigned, float> CPEnergyInTS;
@@ -2423,7 +2463,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
     unsigned int numberOfNoiseHitsInTS = 0;
     unsigned int numberOfHaloHitsInTS = 0;
 
-    const auto tst_hitsAndFractions = apply_LCMultiplicity(tracksters[tstId], layerClusters);
+    const auto tst_hitsAndFractions = apply_LCMultiplicity(trackster, layerClusters);
     const auto numberOfHitsInTS = tst_hitsAndFractions.size();
 
     //hitsToCaloParticleId is a vector of ints, one for each rechit of the
@@ -2442,20 +2482,16 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
     // 4. hitsToCaloParticleId[hitId] >= 0
     //    TP There represent Real Cells(P) that have been assigned
     //    to a CaloParticle (hence the T)
-
     std::vector<int> hitsToCaloParticleId(numberOfHitsInTS);
-    //Det id of the first hit just to make the lcLayerId variable
-    //which maps the layers in -z: 0->51 and in +z: 52->103
 
     //Loop through the hits of the trackster under study
     for (unsigned int hitId = 0; hitId < numberOfHitsInTS; hitId++) {
       const auto rh_detid = tst_hitsAndFractions[hitId].first;
       const auto rhFraction = tst_hitsAndFractions[hitId].second;
 
-      const int lcLayerId =
-          recHitTools_->getLayerWithOffset(rh_detid) + layers * ((recHitTools_->zside(rh_detid) + 1) >> 1) - 1;
-      //Since the hit is belonging to the layer cluster, it must also be in the rechits map.
-      const HGCRecHit* hit = hitMap.find(rh_detid)->second;
+      const auto lcId_r = getLCId(trackster.vertices(), layerClusters, rh_detid);
+      const auto iLC_r = std::find(trackster.vertices().begin(), trackster.vertices().end(), lcId_r);
+      const auto lcFraction_r = 1.f / trackster.vertex_multiplicity(std::distance(std::begin(trackster.vertices()), iLC_r));
 
       //Make a map that will connect a detid (that belongs to a rechit of the layer cluster under study,
       //no need to save others) with:
@@ -2468,7 +2504,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
         detIdToTracksterId_Map[rh_detid] = std::vector<HGVHistoProducerAlgo::detIdInfoInTrackster>();
       }
       detIdToTracksterId_Map[rh_detid].emplace_back(
-          HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, tstId, rhFraction});
+          HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, lcId_r, rhFraction});
 
       // if the fraction is zero or the hit does not belong to any calo
       // particle, set the caloparticleId for the hit to -1 this will
@@ -2481,31 +2517,49 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
         numberOfHaloHitsInTS++;
       }
 
-      //Check whether the rechit of the trackster under study has a sim hit in the same cell.
-      const auto hit_find_in_STS = detIdSimTSId_Map.find(rh_detid);
+      // Check whether the RecHit of the trackster under study has a SimHit in the same cell
+      const auto& hit_find_in_STS = detIdSimTSId_Map.find(rh_detid);
       if (hit_find_in_STS == detIdSimTSId_Map.end()) {
         hitsToCaloParticleId[hitId] -= 1;
       } else {
+        // Since the hit is belonging to the layer cluster, it must be also in the rechits map
+        const HGCRecHit* hit = hitMap.find(rh_detid)->second;
+        const int layerId =
+          recHitTools_->getLayerWithOffset(rh_detid) + layers * ((recHitTools_->zside(rh_detid) + 1) >> 1) - 1;
+
         auto maxCPEnergyInTS = 0.f;
         auto maxCPId = -1;
         for (const auto& h : hit_find_in_STS->second) {
-          auto shared_fraction = std::min(rhFraction, h.fraction);
-          //We are in the case where there are calo particles with simhits connected via detid with the rechit under study
+          const auto shared_fraction = std::min(rhFraction, h.fraction);
+
+          const auto iSTS = h.clusterId;
+          const auto& simTS = simTSs[iSTS];
+
+          float lcFraction_s = 0;
+          const auto lcId_s = getLCId(simTS.vertices(), layerClusters, rh_detid);
+          if (int(lcId_s) >= 0) {
+            const auto iLC_s = std::find(simTS.vertices().begin(), simTS.vertices().end(), lcId_s);
+            lcFraction_s = 1.f / simTS.vertex_multiplicity(std::distance(std::begin(simTS.vertices()), iLC_s));
+          }
+          const auto shared_fraction_lc = std::min(lcFraction_r, lcFraction_s);
+          // SimTrackster with simHits connected via detid with the rechit under study
           //So, from all layers clusters, find the rechits that are connected with a calo particle and save/calculate the
           //energy of that calo particle as the sum over all rechits of the rechits energy weighted
           //by the caloparticle's fraction related to that rechit.
-          const auto cpId = getCPId(simTS[h.clusterId], h.clusterId, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
+          const auto cpId = getCPId(simTS, iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
           if (std::find(cPIndices.begin(), cPIndices.end(), cpId) == cPIndices.end())
             continue;
 
           CPEnergyInTS[cpId] += shared_fraction * hit->energy();
           //Here cPOnLayer[caloparticle][layer] describe above is set.
           //Here for Tracksters with matched rechit the CP fraction times hit energy is added and saved .
-          cPOnLayer[cpId][lcLayerId].layerClusterIdToEnergyAndScore[tstId].first += shared_fraction * hit->energy();
-          cPOnLayer[cpId][lcLayerId].layerClusterIdToEnergyAndScore[tstId].second = FLT_MAX;
+          cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore[tstId].first += shared_fraction * hit->energy();
+          sCOnLayer[cpId][simTS.seedIndex()][layerId].layerClusterIdToEnergyAndScore[tstId].first += shared_fraction_lc * hit->energy();
+          cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore[tstId].second = FLT_MAX;
+          sCOnLayer[cpId][simTS.seedIndex()][layerId].layerClusterIdToEnergyAndScore[tstId].second = FLT_MAX;
           //stsInTrackster[trackster][STSids]
           //Connects a Trackster with all related SimTracksters.
-          stsInTrackster[tstId].emplace_back(h.clusterId, FLT_MAX);
+          stsInTrackster[tstId].emplace_back(iSTS, FLT_MAX);
           //From all CaloParticles related to a layer cluster, it saves id and energy of the calo particle
           //that after simhit-rechit matching in layer has the maximum energy.
           if (shared_fraction > maxCPEnergyInTS) {
@@ -2553,8 +2607,8 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
         totalCPEnergyFromLayerCP = totalCPEnergyFromLayerCP + cPOnLayer[maxCPId_byEnergy][j].energy;
       }
       energyFractionOfCPinTS = maxEnergySharedTSandCP / totalCPEnergyFromLayerCP;
-      if (tracksters[tstId].raw_energy() > 0.f) {
-        energyFractionOfTSinCP = maxEnergySharedTSandCP / tracksters[tstId].raw_energy();
+      if (trackster.raw_energy() > 0.f) {
+        energyFractionOfTSinCP = maxEnergySharedTSandCP / trackster.raw_energy();
       }
     }
 
@@ -2571,7 +2625,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
                                << std::setw(25) << "energyFractionOfCPinTS\t"
                                << std::endl;
     LogDebug("HGCalValidator") << std::setw(12) << tstId << "\t"  //LogDebug("HGCalValidator")
-                               << std::setw(10) << tracksters[tstId].raw_energy() << "\t" << std::setw(5)
+                               << std::setw(10) << trackster.raw_energy() << "\t" << std::setw(5)
                                << numberOfHitsInTS << "\t" << std::setw(12) << numberOfNoiseHitsInTS << "\t"
                                << std::setw(22) << maxCPId_byNumberOfHits << "\t" << std::setw(8)
                                << maxCPNumberOfHitsInTS << "\t" << std::setw(16) << maxCPId_byEnergy << "\t"
@@ -2583,7 +2637,8 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
 
   // Loop through Tracksters
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
-    if (tracksters[tstId].vertices().empty())
+    const auto& trackster = tracksters[tstId];
+    if (trackster.vertices().empty())
       continue;
 
     // find the unique SimTrackster ids contributing to the Trackster
@@ -2592,10 +2647,10 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
     const auto last = std::unique(stsInTrackster[tstId].begin(), stsInTrackster[tstId].end());
     stsInTrackster[tstId].erase(last, stsInTrackster[tstId].end());
 
-    if (tracksters[tstId].raw_energy() == 0. && !stsInTrackster[tstId].empty()) {
+    if (trackster.raw_energy() == 0. && !stsInTrackster[tstId].empty()) {
       //Loop through all SimTracksters contributing to Trackster tstId
       for (auto& stsPair : stsInTrackster[tstId]) {
-        //In case of a Trackster with zero energy but related CaloParticles the score is set to 1.
+        // In case of a Trackster with zero energy but related SimTracksters the score is set to 1
         stsPair.second = 1.;
         LogDebug("HGCalValidator") << "Trackster Id:\t" << tstId << "\tSimTrackster id:\t" << stsPair.first
                                    << "\tscore\t" << stsPair.second << std::endl;
@@ -2604,7 +2659,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
       continue;
     }
 
-    const auto tst_hitsAndFractions = apply_LCMultiplicity(tracksters[tstId], layerClusters);
+    const auto tst_hitsAndFractions = apply_LCMultiplicity(trackster, layerClusters);
 
     // Compute the correct normalization
     float invTracksterEnergyWeight = 0.f;
@@ -2616,24 +2671,41 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
 
     for (const auto& haf : tst_hitsAndFractions) {
       const auto rh_detid = haf.first;
-      const auto rhFraction = haf.second;
-      bool hitWithNoSTS = false;
+      float rhFraction = 0.f;
+      if (i == 0) {
+        rhFraction = haf.second;
+      } else if (i == 1) {
+        const auto lcId = getLCId(trackster.vertices(), layerClusters, rh_detid);
+        const auto iLC = std::find(trackster.vertices().begin(), trackster.vertices().end(), lcId);
+        rhFraction = 1.f / trackster.vertex_multiplicity(std::distance(std::begin(trackster.vertices()), iLC));
+      }
 
+      bool hitWithNoSTS = false;
       if (detIdSimTSId_Map.find(rh_detid) == detIdSimTSId_Map.end())
         hitWithNoSTS = true;
       const HGCRecHit* hit = hitMap.find(rh_detid)->second;
       const auto hitEnergyWeight = pow(hit->energy(), 2);
 
       for (auto& stsPair : stsInTrackster[tstId]) {
+        const auto& simTS = simTSs[stsPair.first];
+
         float cpFraction = 0.f;
-        if (!hitWithNoSTS) {
-          const auto findHitIt = std::find(detIdSimTSId_Map[rh_detid].begin(),
+        if (i == 0) {
+          if (!hitWithNoSTS) {
+            const auto& findSTSIt = std::find(detIdSimTSId_Map[rh_detid].begin(),
                                      detIdSimTSId_Map[rh_detid].end(),
                                      HGVHistoProducerAlgo::detIdInfoInCluster{stsPair.first, 0.f}); // only the first element is used for the matching (overloaded operator==)
-          if (findHitIt != detIdSimTSId_Map[rh_detid].end()) {
-            cpFraction = findHitIt->fraction;
+            if (findSTSIt != detIdSimTSId_Map[rh_detid].end())
+              cpFraction = findSTSIt->fraction;
           }
+        } else if (i == 1) {
+          const auto lcId = getLCId(simTS.vertices(), layerClusters, rh_detid);
+          if (int(lcId) < 0) // For Pattern Recognition ignore non-clustered hits
+            continue;
+          const auto iLC = std::find(simTS.vertices().begin(), simTS.vertices().end(), lcId);
+          cpFraction = 1.f / simTS.vertex_multiplicity(std::distance(std::begin(simTS.vertices()), iLC));
         }
+
         if (stsPair.second == FLT_MAX) {
           stsPair.second = 0.f;
         }
@@ -2649,13 +2721,19 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
 
     tracksters_fakemerge[tstId] = std::count_if(std::begin(stsInTrackster[tstId]),
                                                 std::end(stsInTrackster[tstId]),
-                                                [](const auto& obj) { return obj.second < ScoreCutTStoCPFakeMerge_; });
+                                                [&, i](const auto& obj) {
+      if ((i == 1) && (trackster.vertices().size() != simTSs[obj.first].vertices().size()))
+        return false;
+      else
+        return obj.second < ScoreCutTStoCPFakeMerge_[i];
+    });
 
     const auto score = std::min_element(std::begin(stsInTrackster[tstId]),
                                         std::end(stsInTrackster[tstId]),
                                         [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
     for (const auto& stsPair : stsInTrackster[tstId]) {
-      const auto cpId = getCPId(simTS[stsPair.first], stsPair.first, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
+      const auto iSTS = stsPair.first;
+      const auto cpId = getCPId(simTSs[iSTS], iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
       //if (std::find(cPIndices.begin(), cPIndices.end(), cpId) == cPIndices.end())
       //  continue;
 
@@ -2666,13 +2744,13 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
         const auto& cp_linked = cPOnLayer[cpId][j].layerClusterIdToEnergyAndScore[tstId];
         sharedeneCPallLayers += cp_linked.first;
       }
-      LogDebug("HGCalValidator") << "sharedeneCPallLayers " << sharedeneCPallLayers << std::endl;
-      if (stsPair.first == score->first) {
+
+      if (iSTS == score->first) {
         histograms.h_score_trackster2caloparticle[i][count]->Fill(score->second);
         histograms.h_sharedenergy_trackster2caloparticle[i][count]->Fill(sharedeneCPallLayers /
-                                                                         tracksters[tstId].raw_energy());
+                                                                         trackster.raw_energy());
         histograms.h_energy_vs_score_trackster2caloparticle[i][count]->Fill(
-            score->second, sharedeneCPallLayers / tracksters[tstId].raw_energy());
+            score->second, sharedeneCPallLayers / trackster.raw_energy());
       }
     }
   }  //end of loop through Tracksters
@@ -2680,51 +2758,55 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
   std::unordered_map<unsigned int, std::vector<float>> score3d;
   std::unordered_map<unsigned int, std::vector<float>> tstSharedEnergy;
 
-  for (const auto cpIndex : cPIndices) {
-    score3d[cpIndex].resize(nTracksters);
-    tstSharedEnergy[cpIndex].resize(nTracksters);
+  for (unsigned int iSTS = 0; iSTS < nSimTracksters; ++iSTS) {
+    score3d[iSTS].resize(nTracksters);
+    tstSharedEnergy[iSTS].resize(nTracksters);
     for (unsigned int j = 0; j < nTracksters; ++j) {
-      score3d[cpIndex][j] = FLT_MAX;
-      tstSharedEnergy[cpIndex][j] = 0.f;
+      score3d[iSTS][j] = FLT_MAX;
+      tstSharedEnergy[iSTS][j] = 0.f;
     }
   }
 
-  auto is_assoc = [&](const auto& v) -> bool { return v < ScoreCutCPtoTSEffDup_; };
+  auto is_assoc = [i](const auto& v) -> bool { return v < ScoreCutCPtoTSEffDup_[i]; };
 
-  // Here we do fill the plots to compute the different metrics linked to
-  // gen-level, namely efficiency, purity and duplicate. In this loop we should restrict
+  // Fill the plots to compute the different metrics linked to
+  // gen-level, namely efficiency, purity and duplicate. In this loop should restrict
   // only to the selected caloParaticles.
   for (unsigned int iSTS = 0; iSTS < nSimTracksters; ++iSTS) {
-    const auto& cpId = getCPId(simTS[iSTS], iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
+    const auto& sts = simTSs[iSTS];
+    const auto& cpId = getCPId(sts, iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
     if (i == 0)
       if (std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
         continue;
 
-    //We need to keep the Tracksters ids that are related to
-    //CaloParticle under study for the final filling of the score.
-    std::vector<unsigned int> cpId_tstId_related;
-    cpId_tstId_related.clear();
+    auto& simOnLayer = (i == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][sts.seedIndex()];
 
-    float CPenergy = 0.f;
+    // Keep the Trackster ids that are related to
+    // SimTrackster under study for the final filling of the score
+    std::vector<unsigned int> stsId_tstId_related;
+    auto& score3d_iSTS = score3d[iSTS];
+
+    float SimEnergy = 0.f;
     for (unsigned int layerId = 0; layerId < layers * 2; ++layerId) {
-      const auto CPNumberOfHits = cPOnLayer[cpId][layerId].hits_and_fractions.size();
-      //Below gives the CP energy related to Trackster per layer.
-      CPenergy += cPOnLayer[cpId][layerId].energy;
-      if (CPNumberOfHits == 0)
+      const auto SimNumberOfHits = simOnLayer[layerId].hits_and_fractions.size();
+      // Below gives the Sim energy related to Trackster per layer
+      if (i == 0) SimEnergy += simOnLayer[layerId].energy;
+      else if (i == 1) SimEnergy += simOnLayer[layerId].energy;
+      if (SimNumberOfHits == 0)
         continue;
       int tstWithMaxEnergyInCP = -1;
       //This is the maximum energy related to Trackster per layer.
-      float maxEnergyTSperlayerinCP = 0.f;
-      float CPEnergyFractionInTSperlayer = 0.f;
+      float maxEnergyTSperlayerinSim = 0.f;
+      float SimEnergyFractionInTSperlayer = 0.f;
       //Remember and not confused by name. layerClusterIdToEnergyAndScore contains the Trackster id.
-      for (const auto& tst : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
-        if (tst.second.first > maxEnergyTSperlayerinCP) {
-          maxEnergyTSperlayerinCP = tst.second.first;
+      for (const auto& tst : simOnLayer[layerId].layerClusterIdToEnergyAndScore) {
+        if (tst.second.first > maxEnergyTSperlayerinSim) {
+          maxEnergyTSperlayerinSim = tst.second.first;
           tstWithMaxEnergyInCP = tst.first;
         }
       }
-      if (CPenergy > 0.f)
-        CPEnergyFractionInTSperlayer = maxEnergyTSperlayerinCP / CPenergy;
+      if (SimEnergy > 0.f)
+        SimEnergyFractionInTSperlayer = maxEnergyTSperlayerinSim / SimEnergy;
 
       LogDebug("HGCalValidator") << std::setw(8) << "LayerId:\t" << std::setw(12) << "caloparticle\t" << std::setw(15)
                                  << "cp total energy\t" << std::setw(15) << "cpEnergyOnLayer\t" << std::setw(14)
@@ -2732,85 +2814,108 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
                                  << "maxEnergyTSinCP\t" << std::setw(20) << "CPEnergyFractionInTS"
                                  << "\n";
       LogDebug("HGCalValidator") << std::setw(8) << layerId << "\t" << std::setw(12) << cpId << "\t" << std::setw(15)
-                                 << simTS[iSTS].raw_energy() << "\t" << std::setw(15) << CPenergy << "\t"
-                                 << std::setw(14) << CPNumberOfHits << "\t" << std::setw(18) << tstWithMaxEnergyInCP
-                                 << "\t" << std::setw(15) << maxEnergyTSperlayerinCP << "\t" << std::setw(20)
-                                 << CPEnergyFractionInTSperlayer << "\n";
+                                 << sts.raw_energy() << "\t" << std::setw(15) << SimEnergy << "\t"
+                                 << std::setw(14) << SimNumberOfHits << "\t" << std::setw(18) << tstWithMaxEnergyInCP
+                                 << "\t" << std::setw(15) << maxEnergyTSperlayerinSim << "\t" << std::setw(20)
+                                 << SimEnergyFractionInTSperlayer << "\n";
 
-      for (const auto& haf : cPOnLayer[cpId][layerId].hits_and_fractions) {
-        const auto& cp_hitDetId = haf.first;
-        const auto& cpFraction = haf.second;
+      for (const auto& haf : simOnLayer[layerId].hits_and_fractions) {
+        const auto& hitDetId = haf.first;
+        const auto lcId = getLCId(sts.vertices(), layerClusters, hitDetId);
+        if (i == 1) { // For Pattern Recognition ignore non-clustered hits
+          if (int(lcId) < 0)
+            continue;
+        }
+
+        float cpFraction = 0.f;
+        if (i == 0) {
+          cpFraction = haf.second;
+        } else if (i == 1) {
+          const auto iLC = std::find(sts.vertices().begin(), sts.vertices().end(), lcId);
+          cpFraction = 1.f / sts.vertex_multiplicity(std::distance(std::begin(sts.vertices()), iLC));
+        }
         if (cpFraction == 0.f)
           continue;  // hopefully this should never happen
 
         bool hitWithNoTS = false;
-        if (detIdToTracksterId_Map.find(cp_hitDetId) == detIdToTracksterId_Map.end())
+        if (detIdToTracksterId_Map.find(hitDetId) == detIdToTracksterId_Map.end())
           hitWithNoTS = true;
-        const HGCRecHit* hit = hitMap.find(cp_hitDetId)->second;
+        const HGCRecHit* hit = hitMap.find(hitDetId)->second;
         const auto hitEnergyWeight = pow(hit->energy(), 2);
-        for (auto& tsPair : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
+        for (auto& tsPair : simOnLayer[layerId].layerClusterIdToEnergyAndScore) {
           const auto tracksterId = tsPair.first;
-          if (std::find(std::begin(cpId_tstId_related), std::end(cpId_tstId_related), tracksterId) ==
-              std::end(cpId_tstId_related)) {
-            cpId_tstId_related.push_back(tracksterId);
+          if (std::find(std::begin(stsId_tstId_related), std::end(stsId_tstId_related), tracksterId) ==
+              std::end(stsId_tstId_related)) {
+            stsId_tstId_related.push_back(tracksterId);
           }
 
           float tstFraction = 0.f;
           if (!hitWithNoTS) {
-            const auto findHitIt = std::find(detIdToTracksterId_Map[cp_hitDetId].begin(),
-                                       detIdToTracksterId_Map[cp_hitDetId].end(),
-                                       HGVHistoProducerAlgo::detIdInfoInTrackster{tracksterId, 0, 0.f});
-            if (findHitIt != detIdToTracksterId_Map[cp_hitDetId].end())
-              tstFraction = findHitIt->fraction;
+            const auto findTSIt = std::find(detIdToTracksterId_Map[hitDetId].begin(),
+                                             detIdToTracksterId_Map[hitDetId].end(),
+                                             HGVHistoProducerAlgo::detIdInfoInTrackster{tracksterId, 0, 0.f}); // only the first element is used for the matching (overloaded operator==)
+            if (findTSIt != detIdToTracksterId_Map[hitDetId].end()) {
+              if (i == 0) {
+                tstFraction = findTSIt->fraction;
+              } else if (i == 1) {
+                const auto iLC = std::find(tracksters[tracksterId].vertices().begin(), tracksters[tracksterId].vertices().end(), findTSIt->clusterId);
+                if (iLC != tracksters[tracksterId].vertices().end()) {
+                  tstFraction = 1.f / tracksters[tracksterId].vertex_multiplicity(std::distance(std::begin(tracksters[tracksterId].vertices()), iLC));
+                }
+              }
+            }
           }
-          // Observe here that we do not divide as before by the layer cluster energy weight. We should sum first
+          // Here do not divide as before by the layer cluster energy weight. Should sum first
           // over all layers and divide with the total CP energy over all layers.
           if (tsPair.second.second == FLT_MAX) {
             tsPair.second.second = 0.f;
           }
-          tsPair.second.second += (tstFraction - cpFraction) * (tstFraction - cpFraction) * hitEnergyWeight;
-          LogDebug("HGCalValidator") << "TracksterId:\t" << tracksterId
+          tsPair.second.second += pow((tstFraction - cpFraction), 2) * hitEnergyWeight;
+
+          LogDebug("HGCalValidator") << "\nTracksterId:\t" << tracksterId
+                                     << "\tSimTracksterId:\t" << iSTS
                                      << "\tcpId:\t" << cpId
-                                     << "\tLayer: " << layerId << '\t' << "tstfraction,cpfraction:\t" << tstFraction
+                                     << "\tLayer: " << layerId << '\t' << "tstfraction, cpfraction:\t" << tstFraction
                                      << ", " << cpFraction
                                      << "\thitEnergyWeight:\t" << hitEnergyWeight
                                      << "\tadded delta:\t"
-                                     << (tstFraction - cpFraction) * (tstFraction - cpFraction) * hitEnergyWeight
-                                     << "\tcurrect score numerator:\t" << tsPair.second.second
-                                     << "\tshared Energy:\t" << tsPair.second.first << '\n';
+                                     << pow((tstFraction - cpFraction), 2) * hitEnergyWeight
+                                     << "\tcurrent Sim-score numerator:\t" << tsPair.second.second
+                                     << "\tshared Sim energy:\t" << tsPair.second.first << '\n';
         }
-      }  //end of loop through sim hits of current calo particle
+      } // end of loop through SimHits of current CaloParticle
 
-      if (cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore.empty())
-        LogDebug("HGCalValidator") << "CP Id: \t" << cpId << "\t TS id:\t-1 "
-                                   << "\t layer \t " << layerId << " Sub score in \t -1\n";
+      if (simOnLayer[layerId].layerClusterIdToEnergyAndScore.empty())
+        LogDebug("HGCalValidator") << "CP Id:\t" << cpId << "\tTS id:\t-1 "
+                                   << "\tlayer\t" << layerId << " Sub score in \t -1\n";
 
-      for (const auto& tsPair : cPOnLayer[cpId][layerId].layerClusterIdToEnergyAndScore) {
+      for (const auto& tsPair : simOnLayer[layerId].layerClusterIdToEnergyAndScore) {
+        const auto tracksterId = tsPair.first;
         // 3D score here without the denominator at this point
-        if (score3d[cpId][tsPair.first] == FLT_MAX) {
-          score3d[cpId][tsPair.first] = 0.f;
+        if (score3d_iSTS[tracksterId] == FLT_MAX) {
+          score3d_iSTS[tracksterId] = 0.f;
         }
-        score3d[cpId][tsPair.first] += tsPair.second.second;
-        tstSharedEnergy[cpId][tsPair.first] += tsPair.second.first;
+        score3d_iSTS[tracksterId] += tsPair.second.second;
+        tstSharedEnergy[iSTS][tracksterId] += tsPair.second.first;
       }
-    }  //end of loop through layers
+    } // end of loop through layers
 
     // Compute the correct normalization
-    // We need to loop on the cPOnLayer data structure since this is the
+    // Need to loop on the simOnLayer data structure since this is the
     // only one that has the compressed information for multiple usage
     // of the same DetId by different SimClusters by a single CaloParticle.
-    float invCPEnergyWeight = 0.f;
-    for (const auto& layer : cPOnLayer[cpId])
+    float invSimEnergyWeight = 0.f;
+    for (const auto& layer : simOnLayer)
       for (const auto& haf : layer.hits_and_fractions)
-        invCPEnergyWeight +=
+        invSimEnergyWeight +=
             pow(haf.second * hitMap.at(haf.first)->energy(), 2);
-    invCPEnergyWeight = 1.f / invCPEnergyWeight;
+    invSimEnergyWeight = 1.f / invSimEnergyWeight;
 
-    const auto iSTS_eta = simTS[iSTS].barycenter().eta();
-    const auto iSTS_phi = simTS[iSTS].barycenter().phi();
+    const auto sts_eta = sts.barycenter().eta();
+    const auto sts_phi = sts.barycenter().phi();
 
-    histograms.h_denom_caloparticle_eta[i][count]->Fill(iSTS_eta);
-    histograms.h_denom_caloparticle_phi[i][count]->Fill(iSTS_phi);
+    histograms.h_denom_caloparticle_eta[i][count]->Fill(sts_eta);
+    histograms.h_denom_caloparticle_phi[i][count]->Fill(sts_phi);
 
     //Loop through related Tracksters here
     // In case the threshold to associate a CaloParticle to a Trackster is
@@ -2818,62 +2923,63 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
     // one tracksters, leading to efficiencies >1. This boolean is used to
     // avoid "over counting".
     bool cp_considered_efficient = false;
-    for (const auto tstId : cpId_tstId_related) {
+    for (const auto tstId : stsId_tstId_related) {
       // Now time for the denominator
-      score3d[cpId][tstId] = score3d[cpId][tstId] * invCPEnergyWeight;
-      const auto tstSharedEnergyFrac = tstSharedEnergy[cpId][tstId] / CPenergy;
+      score3d_iSTS[tstId] *= invSimEnergyWeight;
+      const auto tstSharedEnergyFrac = tstSharedEnergy[iSTS][tstId] / SimEnergy;
 
-      LogDebug("HGCalValidator") << "CP Id: \t" << cpId << "\t TS id: \t" << tstId << "\t score \t"  //
-                                 << score3d[cpId][tstId]
-                                 << "\tinvCPEnergyWeight \t" << invCPEnergyWeight
-                                 << "\tTrackste energy: \t" << tracksters[tstId].raw_energy()
-                                 << "\tshared energy:\t" << tstSharedEnergy[cpId][tstId]
-                                 << "\tshared energy fraction:\t" << tstSharedEnergyFrac << "\n";
+      LogDebug("HGCalValidator") << "STS id: " << iSTS << "\t(CP id: " << cpId << ")\tTS id: " << tstId //
+                                 << "\nscore: " << score3d_iSTS[tstId]
+                                 << "\tinvSimEnergyWeight:\t" << invSimEnergyWeight
+                                 << "\tTrackste energy: " << tracksters[tstId].raw_energy()
+                                 << "\tshared energy: " << tstSharedEnergy[iSTS][tstId]
+                                 << "\tshared energy fraction: " << tstSharedEnergyFrac << "\n";
 
-      histograms.h_score_caloparticle2trackster[i][count]->Fill(score3d[cpId][tstId]);
+      histograms.h_score_caloparticle2trackster[i][count]->Fill(score3d_iSTS[tstId]);
 
       histograms.h_sharedenergy_caloparticle2trackster[i][count]->Fill(tstSharedEnergyFrac);
-      histograms.h_energy_vs_score_caloparticle2trackster[i][count]->Fill(score3d[cpId][tstId],
+      histograms.h_energy_vs_score_caloparticle2trackster[i][count]->Fill(score3d_iSTS[tstId],
                                                                        tstSharedEnergyFrac);
       // Fill the numerator for the efficiency calculation. The efficiency is computed by considering the energy shared between a Trackster and a _corresponding_ caloParticle. The threshold is configurable via python.
       if (!cp_considered_efficient && (tstSharedEnergyFrac >= minTSTSharedEneFracEfficiency_)) {
         cp_considered_efficient = true;
-        histograms.h_numEff_caloparticle_eta[i][count]->Fill(iSTS_eta);
-        histograms.h_numEff_caloparticle_phi[i][count]->Fill(iSTS_phi);
+        histograms.h_numEff_caloparticle_eta[i][count]->Fill(sts_eta);
+        histograms.h_numEff_caloparticle_phi[i][count]->Fill(sts_phi);
       }
-    }  //end of loop through Tracksters
+    } // end of loop through Tracksters related to SimTrackster
 
-    const auto assocDup = std::count_if(std::begin(score3d[cpId]), std::end(score3d[cpId]), is_assoc);
+    const auto assocDup = std::count_if(std::begin(score3d_iSTS), std::end(score3d_iSTS), is_assoc);
 
     if (assocDup > 0) {
-      histograms.h_num_caloparticle_eta[i][count]->Fill(iSTS_eta);
-      histograms.h_num_caloparticle_phi[i][count]->Fill(iSTS_phi);
-      const auto best = std::min_element(std::begin(score3d[cpId]), std::end(score3d[cpId]));
-      const auto bestTstId = std::distance(std::begin(score3d[cpId]), best);
-      const auto tstSharedEnergyFrac = tstSharedEnergy[cpId][bestTstId] / CPenergy;
+      histograms.h_num_caloparticle_eta[i][count]->Fill(sts_eta);
+      histograms.h_num_caloparticle_phi[i][count]->Fill(sts_phi);
+      const auto best = std::min_element(std::begin(score3d_iSTS), std::end(score3d_iSTS));
+      const auto bestTstId = std::distance(std::begin(score3d_iSTS), best);
+      const auto tstRawEnergyFrac = tracksters[bestTstId].raw_energy() / SimEnergy;
+      const auto tstSharedEnergyFrac = tstSharedEnergy[iSTS][bestTstId] / SimEnergy;
 
       histograms.h_sharedenergy_caloparticle2trackster_vs_eta[i][count]->Fill(
-          iSTS_eta, tracksters[bestTstId].raw_energy() / CPenergy);
+          sts_eta, tstRawEnergyFrac);
       histograms.h_sharedenergy_caloparticle2trackster_vs_phi[i][count]->Fill(
-          iSTS_phi, tracksters[bestTstId].raw_energy() / CPenergy);
-      LogDebug("HGCalValidator") << count << " " << iSTS_eta << " "
-                                 << iSTS_phi << " " << tracksters[bestTstId].raw_energy()
-                                 << " " << CPenergy << " " << (tracksters[bestTstId].raw_energy() / CPenergy) << " "
-                                 << tstSharedEnergyFrac << '\n';
+          sts_phi, tstRawEnergyFrac);
       histograms.h_sharedenergy_caloparticle2trackster_assoc[i][count]->Fill(tstSharedEnergyFrac);
+      LogDebug("HGCalValidator") << count << " " << sts_eta << " "
+                                 << sts_phi << " " << tracksters[bestTstId].raw_energy()
+                                 << " " << sts.raw_energy() << " " << tstRawEnergyFrac << " "
+                                 << tstSharedEnergyFrac << "\n";
 
       if (assocDup >= 2) {
-        auto match = std::find_if(std::begin(score3d[cpId]), std::end(score3d[cpId]), is_assoc);
-        while (match != score3d[cpId].end()) {
-          tracksters_duplicate[std::distance(std::begin(score3d[cpId]), match)] = 1;
-          match = std::find_if(std::next(match), std::end(score3d[cpId]), is_assoc);
+        auto match = std::find_if(std::begin(score3d_iSTS), std::end(score3d_iSTS), is_assoc);
+        while (match != score3d_iSTS.end()) {
+          tracksters_duplicate[std::distance(std::begin(score3d_iSTS), match)] = 1;
+          match = std::find_if(std::next(match), std::end(score3d_iSTS), is_assoc);
         }
       }
-    } // end loop through Tracksters related to CaloParticle
-  }  //end of loop through SimTracksters
+    }
+  }  // end of loop through SimTracksters
 
-  // Here we do fill the plots to compute the different metrics linked to
-  // reco-level, namely fake-rate an merge-rate. In this loop we should *not*
+  // Fill the plots to compute the different metrics linked to
+  // reco-level, namely fake-rate an merge-rate. Should *not*
   // restrict only to the selected caloParaticles.
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
     if (tracksters[tstId].vertices().empty())
@@ -2898,7 +3004,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
 
       //This is the shared energy taking the best caloparticle in each layer
       float sharedeneCPallLayers = 0.;
-      const auto cpId = getCPId(simTS[best->first], best->first, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
+      const auto cpId = getCPId(simTSs[best->first], best->first, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
       for (unsigned int j = 0; j < layers * 2; ++j) { // Loop through all layers
         auto const& best_cp_linked = cPOnLayer[cpId][j].layerClusterIdToEnergyAndScore[tstId];
         sharedeneCPallLayers += best_cp_linked.first;
@@ -2920,8 +3026,8 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
                                                  int count,
                                                  const ticl::TracksterCollection& tracksters,
                                                  const reco::CaloClusterCollection& layerClusters,
-                                                 const ticl::TracksterCollection& simTS,
-                                                 const ticl::TracksterCollection& simTS_fromCP,
+                                                 const ticl::TracksterCollection& simTSs,
+                                                 const ticl::TracksterCollection& simTSs_fromCP,
                                                  const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
                                                  std::vector<SimCluster> const& sC,
                                                  const edm::ProductID& cPHandle_id,
@@ -2942,7 +3048,7 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
   //For the number of Tracksters without 3 contiguous layers per event.
   int totNNotContTstZp = 0;  //+z
   int totNNotContTstZm = 0;  //-z
-  //We want to check below the score of cont and non cont Tracksters
+  // Check below the score of cont and non cont Tracksters
   std::vector<bool> contTracksters;
   contTracksters.clear();
 
@@ -3018,14 +3124,14 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
 
     // Looking for Tracksters with 3 contiguous layers per event.
     std::vector<int> trackster_layers_vec(trackster_layers.begin(), trackster_layers.end());
-    // Since we want to also check for non contiguous Tracksters
+    // Check also for non contiguous Tracksters
     bool contiTrackster = false;
-    //Observe that we start from 1 and go up to size - 1 element.
+    // Start from 1 and go up to size - 1 element.
     if (trackster_layers_vec.size() >= 3) {
       for (unsigned int iLayer = 1; iLayer < trackster_layers_vec.size() - 1; ++iLayer) {
         if ((trackster_layers_vec[iLayer - 1] + 1 == trackster_layers_vec[iLayer]) &&
             (trackster_layers_vec[iLayer + 1] - 1 == trackster_layers_vec[iLayer])) {
-          //So, this is a Trackster with 3 contiguous layers per event
+          // Trackster with 3 contiguous layers per event
           if (tracksterInZplus)
             totNContTstZp++;
           else if (tracksterInZminus)
@@ -3055,7 +3161,7 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
       //LogDebug("HGCalValidator") << "mlp %" << (100. * mlp)/ ((float) nLayerClusters) << std::endl;
       // histograms.h_multiplicityOfLCinTST[count]->Fill( mlp , multiplicity[tstId][lc] , 100. / (float) totalLcInTsts );
       histograms.h_multiplicityOfLCinTST[count]->Fill(mlp, multiplicity[tstId][lc]);
-      //When we will plot with the text option we want the entries to be the same
+      //When plotting with the text option we want the entries to be the same
       //as the % of the current cell over the whole number of layerClusters. For this we need an extra histo.
       histograms.h_multiplicity_numberOfEventsHistogram[count]->Fill(mlp);
       //For the cluster multiplicity vs layer
@@ -3100,9 +3206,9 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
                               count,
                               tracksters,
                               layerClusters,
-                              simTS_fromCP,
+                              simTSs_fromCP,
                               0,
-                              simTS_fromCP,
+                              simTSs_fromCP,
                               cpToSc_SimTrackstersMap,
                               sC,
                               cPHandle_id,
@@ -3116,9 +3222,9 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
                               count,
                               tracksters,
                               layerClusters,
-                              simTS,
+                              simTSs,
                               1,
-                              simTS_fromCP,
+                              simTSs_fromCP,
                               cpToSc_SimTrackstersMap,
                               sC,
                               cPHandle_id,

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1569,12 +1569,11 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
             auto findHitIt = std::find(detIdToCaloParticleId_Map[hitid].begin(),
                                        detIdToCaloParticleId_Map[hitid].end(),
                                        HGVHistoProducerAlgo::detIdInfoInCluster{cpId, 0.f}); // only the first element is used for the matching (overloaded operator==)
-            if (findHitIt != detIdToCaloParticleId_Map[hitid].end()) {
+            if (findHitIt != detIdToCaloParticleId_Map[hitid].end())
               findHitIt->fraction += it_haf.second;
-            } else {
+            else
               detIdToCaloParticleId_Map[hitid].emplace_back(
                   HGVHistoProducerAlgo::detIdInfoInCluster{cpId, it_haf.second});
-            }
           }
         }
       }
@@ -1665,9 +1664,8 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
     const auto lc_en = clusters[lcId].energy();
     const auto& cps = cpsIt->val;
     if (lc_en == 0. && !cps.empty()) {
-      for (const auto& cpPair : cps) {
+      for (const auto& cpPair : cps)
         histograms.h_score_layercl2caloparticle_perlayer.at(lcLayerId)->Fill(cpPair.second);
-      }
       continue;
     }
     for (const auto& cpPair : cps) {
@@ -2717,11 +2715,16 @@ return v.first == hitid; });
 
     // Compute the correct normalization
     float invTracksterEnergyWeight = 0.f;
-    float hitFr = 1;
     for (const auto& haf : tst_hitsAndFractions) {
-      if (i==0) hitFr = haf.second; // for Linking the hit fraction is accounted for
-      invTracksterEnergyWeight +=
-          pow(hitFr * hitMap.at(haf.first)->energy(), 2);
+      float hitFr =1;
+      if (i == 0) {
+        hitFr = haf.second;
+      } else if (i == 1) {
+        const auto lcId = getLCId(tst.vertices(), layerClusters, haf.first);
+        const auto iLC = std::find(tst.vertices().begin(), tst.vertices().end(), lcId);
+        hitFr = 1.f / tst.vertex_multiplicity(std::distance(std::begin(tst.vertices()), iLC));
+      }
+      invTracksterEnergyWeight += pow(hitFr * hitMap.at(haf.first)->energy(), 2);
     }
     if (invTracksterEnergyWeight) invTracksterEnergyWeight = 1.f / invTracksterEnergyWeight;
 
@@ -2766,7 +2769,7 @@ return v.first == hitid; });
           stsPair.second = 0.f;
         }
         stsPair.second +=
-            pow((rhFraction - cpFraction), 2) * hitEnergyWeight * invTracksterEnergyWeight;
+            pow(min(rhFraction - cpFraction, rhFraction), 2) * hitEnergyWeight * invTracksterEnergyWeight;
       }
     } // end of loop through trackster rechits
 
@@ -2933,8 +2936,8 @@ else return false;
           if (tsPair.second.second == FLT_MAX) {
             tsPair.second.second = 0.f;
           }
-          tsPair.second.second += pow((tstFraction - cpFraction), 2) * hitEnergyWeight;
-          invHitsEnergyWeight += hitEnergyWeight;
+          tsPair.second.second += pow(min(tstFraction - cpFraction, cpFraction), 2) * hitEnergyWeight;
+          invHitsEnergyWeight += pow(cpFraction, 2) * hitEnergyWeight;
 
           LogDebug("HGCalValidator") << "\nTracksterId:\t" << tstId
                                      << "\tSimTracksterId:\t" << iSTS
@@ -3289,7 +3292,6 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
       histograms.h_trackster_layersnum[count]->Fill((float)trackster_layers.size());
 
       histograms.h_trackster_pt[count]->Fill(tst.raw_pt());
-
       histograms.h_trackster_energy[count]->Fill(tst.raw_energy());
     }
 

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -16,8 +16,8 @@ const double ScoreCutLCtoCP_ = 0.1;
 const double ScoreCutCPtoLC_ = 0.1;
 const double ScoreCutLCtoSC_ = 0.1;
 const double ScoreCutSCtoLC_ = 0.1;
-const double ScoreCutTStoSTSFakeMerge_[] = {0.6, 1.e-09}; //FLT_MIN
-const double ScoreCutSTStoTSPurDup_[] = {0.2, 1.e-11}; //FLT_MIN
+const double ScoreCutTStoSTSFakeMerge_[] = {0.6, 1.e-09};  //FLT_MIN
+const double ScoreCutSTStoTSPurDup_[] = {0.2, 1.e-11};     //FLT_MIN
 
 HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
     :  //parameters for eta
@@ -265,11 +265,9 @@ void HGVHistoProducerAlgo::bookCaloParticleHistos(DQMStore::IBooker& ibook,
                    0.,
                    110.);
   histograms.h_caloparticle_fractions[pdgid] =
-      ibook.book2D("HitFractions", "Hit fractions;Hit fraction;E_{hit}^{2} fraction",
-                   101, 0, 1.01, 100, 0, 1);
-  histograms.h_caloparticle_fractions_weight[pdgid] =
-      ibook.book2D("HitFractions_weighted", "Hit fractions weighted;Hit fraction;E_{hit}^{2} fraction",
-                   101, 0, 1.01, 100, 0, 1);
+      ibook.book2D("HitFractions", "Hit fractions;Hit fraction;E_{hit}^{2} fraction", 101, 0, 1.01, 100, 0, 1);
+  histograms.h_caloparticle_fractions_weight[pdgid] = ibook.book2D(
+      "HitFractions_weighted", "Hit fractions weighted;Hit fraction;E_{hit}^{2} fraction", 101, 0, 1.01, 100, 0, 1);
 
   histograms.h_caloparticle_firstlayer[pdgid] =
       ibook.book1D("First Layer", "First layer of the CaloParticles", 2 * layers, 0., (float)2 * layers);
@@ -304,7 +302,7 @@ void HGVHistoProducerAlgo::bookSimClusterHistos(DQMStore::IBooker& ibook,
     // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else { // then for the +z
+    } else {  // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     histograms.h_simclusternum_perlayer[ilayer] = ibook.book1D("totsimclusternum_layer_" + istr1,
@@ -401,7 +399,7 @@ void HGVHistoProducerAlgo::bookSimClusterAssociationHistos(DQMStore::IBooker& ib
     // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else { // then for the +z
+    } else {  // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     //-------------------------------------------------------------------------------------------------------------------------
@@ -667,7 +665,7 @@ void HGVHistoProducerAlgo::bookClusterHistos_ClusterLevel(DQMStore::IBooker& ibo
     // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else { // then for the +z
+    } else {  // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     histograms.h_clusternum_perlayer[ilayer] = ibook.book1D("totclusternum_layer_" + istr1,
@@ -709,7 +707,7 @@ void HGVHistoProducerAlgo::bookClusterHistos_LCtoCP_association(DQMStore::IBooke
     // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else { // then for the +z
+    } else {  // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     histograms.h_score_layercl2caloparticle_perlayer[ilayer] =
@@ -877,7 +875,7 @@ void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
     // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else { // then for the +z
+    } else {  // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
     histograms.h_cellAssociation_perlayer[ilayer] =
@@ -910,7 +908,7 @@ void HGVHistoProducerAlgo::bookClusterHistos_CellLevel(DQMStore::IBooker& ibook,
       // first with the -z endcap
       if (ilayer < layers) {
         istr3 = std::to_string(ilayer + 1) + " in z- ";
-      } else { // then for the +z
+      } else {  // then for the +z
         istr3 = std::to_string(ilayer - (layers - 1)) + " in z+ ";
       }
       //---
@@ -984,7 +982,7 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
     // first with the -z endcap
     if (ilayer < layers) {
       istr2 = std::to_string(ilayer + 1) + " in z-";
-    } else { // then for the +z
+    } else {  // then for the +z
       istr2 = std::to_string(ilayer - (layers - 1)) + " in z+";
     }
 
@@ -997,8 +995,8 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
 
   histograms.h_clusternum_in_trackster_perlayer.push_back(std::move(clusternum_in_trackster_perlayer));
 
-  histograms.h_tracksternum.push_back(
-      ibook.book1D("tottracksternum", "total number of Tracksters;# of Tracksters", nintTotNTSTs_, minTotNTSTs_, maxTotNTSTs_));
+  histograms.h_tracksternum.push_back(ibook.book1D(
+      "tottracksternum", "total number of Tracksters;# of Tracksters", nintTotNTSTs_, minTotNTSTs_, maxTotNTSTs_));
 
   histograms.h_conttracksternum.push_back(ibook.book1D(
       "conttracksternum", "number of Tracksters with 3 contiguous layers", nintTotNTSTs_, minTotNTSTs_, maxTotNTSTs_));
@@ -1009,29 +1007,32 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
                                                           minTotNTSTs_,
                                                           maxTotNTSTs_));
 
-  histograms.h_clusternum_in_trackster.push_back(ibook.book1D("clusternum_in_trackster",
-                                                              "total number of layer clusters in Trackster;# of LayerClusters",
-                                                              nintTotNClsinTSTs_,
-                                                              minTotNClsinTSTs_,
-                                                              maxTotNClsinTSTs_));
+  histograms.h_clusternum_in_trackster.push_back(
+      ibook.book1D("clusternum_in_trackster",
+                   "total number of layer clusters in Trackster;# of LayerClusters",
+                   nintTotNClsinTSTs_,
+                   minTotNClsinTSTs_,
+                   maxTotNClsinTSTs_));
 
-  histograms.h_clusternum_in_trackster_vs_layer.push_back(
-      ibook.bookProfile("clusternum_in_trackster_vs_layer",
-                        "Profile of 2d layer clusters in Trackster vs layer number;layer number;<2D LayerClusters in Trackster>",
-                        2 * layers,
-                        0.,
-                        2. * layers,
-                        minTotNClsinTSTsperlayer_,
-                        maxTotNClsinTSTsperlayer_));
+  histograms.h_clusternum_in_trackster_vs_layer.push_back(ibook.bookProfile(
+      "clusternum_in_trackster_vs_layer",
+      "Profile of 2d layer clusters in Trackster vs layer number;layer number;<2D LayerClusters in Trackster>",
+      2 * layers,
+      0.,
+      2. * layers,
+      minTotNClsinTSTsperlayer_,
+      maxTotNClsinTSTsperlayer_));
 
-  histograms.h_multiplicityOfLCinTST.push_back(ibook.book2D("multiplicityOfLCinTST",
-                                                            "Multiplicity vs Layer cluster size in Tracksters;LayerCluster multiplicity in Tracksters;Cluster size (n_{hits})",
-                                                            nintMplofLCs_,
-                                                            minMplofLCs_,
-                                                            maxMplofLCs_,
-                                                            nintSizeCLsinTSTs_,
-                                                            minSizeCLsinTSTs_,
-                                                            maxSizeCLsinTSTs_));
+  histograms.h_multiplicityOfLCinTST.push_back(
+      ibook.book2D("multiplicityOfLCinTST",
+                   "Multiplicity vs Layer cluster size in Tracksters;LayerCluster multiplicity in Tracksters;Cluster "
+                   "size (n_{hits})",
+                   nintMplofLCs_,
+                   minMplofLCs_,
+                   maxMplofLCs_,
+                   nintSizeCLsinTSTs_,
+                   minSizeCLsinTSTs_,
+                   maxSizeCLsinTSTs_));
 
   histograms.h_multiplicity_numberOfEventsHistogram.push_back(ibook.book1D("multiplicity_numberOfEventsHistogram",
                                                                            "multiplicity numberOfEventsHistogram",
@@ -1083,48 +1084,77 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
                    minClEnepermultiplicity_,
                    maxClEnepermultiplicity_));
 
-  histograms.h_trackster_pt.push_back(ibook.book1D("trackster_pt", "Pt of the Trackster;Trackster p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_trackster_pt.push_back(
+      ibook.book1D("trackster_pt", "Pt of the Trackster;Trackster p_{T} [GeV]", nintPt_, minPt_, maxPt_));
   histograms.h_trackster_eta.push_back(
       ibook.book1D("trackster_eta", "Eta of the Trackster;Trackster #eta", nintEta_, minEta_, maxEta_));
   histograms.h_trackster_phi.push_back(
       ibook.book1D("trackster_phi", "Phi of the Trackster;Trackster #phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_trackster_energy.push_back(
       ibook.book1D("trackster_energy", "Energy of the Trackster;Trackster energy [GeV]", nintEne_, minEne_, maxEne_));
-  histograms.h_trackster_x.push_back(ibook.book1D("trackster_x", "X position of the Trackster;Trackster x", nintX_, minX_, maxX_));
-  histograms.h_trackster_y.push_back(ibook.book1D("trackster_y", "Y position of the Trackster;Trackster y", nintY_, minY_, maxY_));
-  histograms.h_trackster_z.push_back(ibook.book1D("trackster_z", "Z position of the Trackster;Trackster z", nintZ_, minZ_, maxZ_));
-  histograms.h_trackster_firstlayer.push_back(
-      ibook.book1D("trackster_firstlayer", "First layer of the Trackster;Trackster First Layer", 2 * layers, 0., (float)2 * layers));
-  histograms.h_trackster_lastlayer.push_back(
-      ibook.book1D("trackster_lastlayer", "Last layer of the Trackster;Trackster Last Layer", 2 * layers, 0., (float)2 * layers));
+  histograms.h_trackster_x.push_back(
+      ibook.book1D("trackster_x", "X position of the Trackster;Trackster x", nintX_, minX_, maxX_));
+  histograms.h_trackster_y.push_back(
+      ibook.book1D("trackster_y", "Y position of the Trackster;Trackster y", nintY_, minY_, maxY_));
+  histograms.h_trackster_z.push_back(
+      ibook.book1D("trackster_z", "Z position of the Trackster;Trackster z", nintZ_, minZ_, maxZ_));
+  histograms.h_trackster_firstlayer.push_back(ibook.book1D(
+      "trackster_firstlayer", "First layer of the Trackster;Trackster First Layer", 2 * layers, 0., (float)2 * layers));
+  histograms.h_trackster_lastlayer.push_back(ibook.book1D(
+      "trackster_lastlayer", "Last layer of the Trackster;Trackster Last Layer", 2 * layers, 0., (float)2 * layers));
   histograms.h_trackster_layersnum.push_back(
-      ibook.book1D("trackster_layersnum", "Number of layers of the Trackster;Trackster Number of Layers", 2 * layers, 0., (float)2 * layers));
+      ibook.book1D("trackster_layersnum",
+                   "Number of layers of the Trackster;Trackster Number of Layers",
+                   2 * layers,
+                   0.,
+                   (float)2 * layers));
 }
 
 void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Histograms& histograms, const int i) {
-  const string ref[] = {"caloparticle", "simtrackster"};
-  const string refT[] = {"CaloParticle", "SimTrackster"};
+  const string ref[] = {"caloparticle", "simtrackster", "simtrackster_fromCP"};
+  const string refT[] = {"CaloParticle", "SimTrackster", "SimTrackster_fromCP"};
+  // Must be in sync with labels in PostProcessorHGCAL_cfi.py
   const string val[] = {"_Link", "_PR"};
+  //const string val[] = {"_CP", "_PR", "_Link"};
   const string rtos = ";score Reco-to-Sim";
   const string stor = ";score Sim-to-Reco";
   const string shREnFr = ";shared Reco energy fraction";
   const string shSEnFr = ";shared Sim energy fraction";
 
-  histograms.h_score_trackster2caloparticle[i].push_back(
-      ibook.book1D("Score_trackster2" + ref[i], "Score of Trackster per " + refT[i]+rtos, nintScore_, minScore_, maxScore_));
+  histograms.h_score_trackster2caloparticle[i].push_back(ibook.book1D(
+      "Score_trackster2" + ref[i], "Score of Trackster per " + refT[i] + rtos, nintScore_, minScore_, maxScore_));
   histograms.h_score_trackster2bestCaloparticle[i].push_back(
-      ibook.book1D("ScoreFake_trackster2" + ref[i], "Score of Trackster per best " + refT[i]+rtos, nintScore_, minScore_, maxScore_));
+      ibook.book1D("ScoreFake_trackster2" + ref[i],
+                   "Score of Trackster per best " + refT[i] + rtos,
+                   nintScore_,
+                   minScore_,
+                   maxScore_));
   histograms.h_score_trackster2bestCaloparticle2[i].push_back(
-      ibook.book1D("ScoreMerge_trackster2" + ref[i], "Score of Trackster per 2^{nd} best " + refT[i]+rtos, nintScore_, minScore_, maxScore_));
-  histograms.h_score_caloparticle2trackster[i].push_back(ibook.book1D(
-      "Score_" + ref[i] + "2trackster", "Score of " + refT[i] + " per Trackster"+stor, nintScore_, minScore_, maxScore_));
-  histograms.h_scorePur_caloparticle2trackster[i].push_back(ibook.book1D(
-      "ScorePur_" + ref[i] + "2trackster", "Score of " + refT[i] + " per best Trackster"+stor, nintScore_, minScore_, maxScore_));
-  histograms.h_scoreDupl_caloparticle2trackster[i].push_back(ibook.book1D(
-      "ScoreDupl_" + ref[i] + "2trackster", "Score of " + refT[i] + " per 2^{nd} best Trackster"+stor, nintScore_, minScore_, maxScore_));
+      ibook.book1D("ScoreMerge_trackster2" + ref[i],
+                   "Score of Trackster per 2^{nd} best " + refT[i] + rtos,
+                   nintScore_,
+                   minScore_,
+                   maxScore_));
+  histograms.h_score_caloparticle2trackster[i].push_back(ibook.book1D("Score_" + ref[i] + "2trackster",
+                                                                      "Score of " + refT[i] + " per Trackster" + stor,
+                                                                      nintScore_,
+                                                                      minScore_,
+                                                                      maxScore_));
+  histograms.h_scorePur_caloparticle2trackster[i].push_back(
+      ibook.book1D("ScorePur_" + ref[i] + "2trackster",
+                   "Score of " + refT[i] + " per best Trackster" + stor,
+                   nintScore_,
+                   minScore_,
+                   maxScore_));
+  histograms.h_scoreDupl_caloparticle2trackster[i].push_back(
+      ibook.book1D("ScoreDupl_" + ref[i] + "2trackster",
+                   "Score of " + refT[i] + " per 2^{nd} best Trackster" + stor,
+                   nintScore_,
+                   minScore_,
+                   maxScore_));
   histograms.h_energy_vs_score_trackster2caloparticle[i].push_back(
       ibook.book2D("Energy_vs_Score_trackster2" + refT[i],
-                   "Energy vs Score of Trackster per " + refT[i]+rtos+shREnFr,
+                   "Energy vs Score of Trackster per " + refT[i] + rtos + shREnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1133,7 +1163,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                    maxTSTSharedEneFrac_));
   histograms.h_energy_vs_score_trackster2bestCaloparticle[i].push_back(
       ibook.book2D("Energy_vs_Score_trackster2best" + refT[i],
-                   "Energy vs Score of Trackster per best " + refT[i]+rtos+shREnFr,
+                   "Energy vs Score of Trackster per best " + refT[i] + rtos + shREnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1142,7 +1172,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                    maxTSTSharedEneFrac_));
   histograms.h_energy_vs_score_trackster2bestCaloparticle2[i].push_back(
       ibook.book2D("Energy_vs_Score_trackster2secBest" + refT[i],
-                   "Energy vs Score of Trackster per 2^{nd} best " + refT[i]+rtos+shREnFr,
+                   "Energy vs Score of Trackster per 2^{nd} best " + refT[i] + rtos + shREnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1151,7 +1181,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                    maxTSTSharedEneFrac_));
   histograms.h_energy_vs_score_caloparticle2trackster[i].push_back(
       ibook.book2D("Energy_vs_Score_" + ref[i] + "2Trackster",
-                   "Energy vs Score of " + refT[i] + " per Trackster"+stor+shSEnFr,
+                   "Energy vs Score of " + refT[i] + " per Trackster" + stor + shSEnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1160,7 +1190,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                    maxTSTSharedEneFrac_));
   histograms.h_energy_vs_score_caloparticle2bestTrackster[i].push_back(
       ibook.book2D("Energy_vs_Score_" + ref[i] + "2bestTrackster",
-                   "Energy vs Score of " + refT[i] + " per best Trackster"+stor+shSEnFr,
+                   "Energy vs Score of " + refT[i] + " per best Trackster" + stor + shSEnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1169,7 +1199,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                    maxTSTSharedEneFrac_));
   histograms.h_energy_vs_score_caloparticle2bestTrackster2[i].push_back(
       ibook.book2D("Energy_vs_Score_" + ref[i] + "2secBestTrackster",
-                   "Energy vs Score of " + refT[i] + " per 2^{nd} best Trackster"+stor+shSEnFr,
+                   "Energy vs Score of " + refT[i] + " per 2^{nd} best Trackster" + stor + shSEnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1183,45 +1213,51 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
       ibook.book1D("Num_Trackster_Eta" + val[i], "Num Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
   histograms.h_numMerge_trackster_eta[i].push_back(ibook.book1D(
       "NumMerge_Trackster_Eta" + val[i], "Num Merge Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
-  histograms.h_denom_trackster_eta[i].push_back(
-      ibook.book1D("Denom_Trackster_Eta" + val[i], "Denom Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
+  histograms.h_denom_trackster_eta[i].push_back(ibook.book1D(
+      "Denom_Trackster_Eta" + val[i], "Denom Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
   // phi
   histograms.h_num_trackster_phi[i].push_back(
       ibook.book1D("Num_Trackster_Phi" + val[i], "Num Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_numMerge_trackster_phi[i].push_back(ibook.book1D(
       "NumMerge_Trackster_Phi" + val[i], "Num Merge Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_denom_trackster_phi[i].push_back(
-      ibook.book1D("Denom_Trackster_Phi" + val[i], "Denom Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_denom_trackster_phi[i].push_back(ibook.book1D(
+      "Denom_Trackster_Phi" + val[i], "Denom Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
   // energy
-  histograms.h_num_trackster_en[i].push_back(
-      ibook.book1D("Num_Trackster_Energy" + val[i], "Num Trackster Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
-  histograms.h_numMerge_trackster_en[i].push_back(ibook.book1D(
-      "NumMerge_Trackster_Energy" + val[i], "Num Merge Trackster Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
-  histograms.h_denom_trackster_en[i].push_back(
-      ibook.book1D("Denom_Trackster_Energy" + val[i], "Denom Trackster Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
+  histograms.h_num_trackster_en[i].push_back(ibook.book1D(
+      "Num_Trackster_Energy" + val[i], "Num Trackster Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
+  histograms.h_numMerge_trackster_en[i].push_back(ibook.book1D("NumMerge_Trackster_Energy" + val[i],
+                                                               "Num Merge Trackster Energy per Trackster;energy [GeV]",
+                                                               nintEne_,
+                                                               minEne_,
+                                                               maxEne_));
+  histograms.h_denom_trackster_en[i].push_back(ibook.book1D("Denom_Trackster_Energy" + val[i],
+                                                            "Denom Trackster Energy per Trackster;energy [GeV]",
+                                                            nintEne_,
+                                                            minEne_,
+                                                            maxEne_));
   // pT
-  histograms.h_num_trackster_pt[i].push_back(
-      ibook.book1D("Num_Trackster_Pt" + val[i], "Num Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_num_trackster_pt[i].push_back(ibook.book1D(
+      "Num_Trackster_Pt" + val[i], "Num Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
   histograms.h_numMerge_trackster_pt[i].push_back(ibook.book1D(
       "NumMerge_Trackster_Pt" + val[i], "Num Merge Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
-  histograms.h_denom_trackster_pt[i].push_back(
-      ibook.book1D("Denom_Trackster_Pt" + val[i], "Denom Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_denom_trackster_pt[i].push_back(ibook.book1D(
+      "Denom_Trackster_Pt" + val[i], "Denom Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
 
   histograms.h_sharedenergy_trackster2caloparticle[i].push_back(
       ibook.book1D("SharedEnergy_trackster2" + ref[i],
-                   "Shared Energy of Trackster per " + refT[i]+shREnFr,
+                   "Shared Energy of Trackster per " + refT[i] + shREnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_trackster2bestCaloparticle[i].push_back(
       ibook.book1D("SharedEnergy_trackster2" + ref[i] + "_assoc",
-                   "Shared Energy of Trackster per best " + refT[i]+shREnFr,
+                   "Shared Energy of Trackster per best " + refT[i] + shREnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_trackster2bestCaloparticle_vs_eta[i].push_back(
       ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_assoc_vs_eta",
-                        "Shared Energy of Trackster vs #eta per best " + refT[i]+";Trackster #eta"+shREnFr,
+                        "Shared Energy of Trackster vs #eta per best " + refT[i] + ";Trackster #eta" + shREnFr,
                         nintEta_,
                         minEta_,
                         maxEta_,
@@ -1229,7 +1265,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                         maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_trackster2bestCaloparticle_vs_phi[i].push_back(
       ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_assoc_vs_phi",
-                        "Shared Energy of Trackster vs #phi per best " + refT[i]+";Trackster #phi"+shREnFr,
+                        "Shared Energy of Trackster vs #phi per best " + refT[i] + ";Trackster #phi" + shREnFr,
                         nintPhi_,
                         minPhi_,
                         maxPhi_,
@@ -1237,26 +1273,26 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                         maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_trackster2bestCaloparticle2[i].push_back(
       ibook.book1D("SharedEnergy_trackster2" + ref[i] + "_assoc2",
-                   "Shared Energy of Trackster per 2^{nd} best " + refT[i]+shREnFr,
+                   "Shared Energy of Trackster per 2^{nd} best " + refT[i] + shREnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
 
   histograms.h_sharedenergy_caloparticle2trackster[i].push_back(
       ibook.book1D("SharedEnergy_" + ref[i] + "2trackster",
-                   "Shared Energy of " + refT[i] + " per Trackster"+shSEnFr,
+                   "Shared Energy of " + refT[i] + " per Trackster" + shSEnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_caloparticle2trackster_assoc[i].push_back(
       ibook.book1D("SharedEnergy_" + ref[i] + "2trackster_assoc",
-                   "Shared Energy of " + refT[i] + " per best Trackster"+shSEnFr,
+                   "Shared Energy of " + refT[i] + " per best Trackster" + shSEnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[i].push_back(
       ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_assoc_vs_eta",
-                        "Shared Energy of " + refT[i] + " vs #eta per best Trackster;"+refT[i]+" #eta"+shSEnFr,
+                        "Shared Energy of " + refT[i] + " vs #eta per best Trackster;" + refT[i] + " #eta" + shSEnFr,
                         nintEta_,
                         minEta_,
                         maxEta_,
@@ -1264,7 +1300,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                         maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[i].push_back(
       ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_assoc_vs_phi",
-                        "Shared Energy of " + refT[i] + " vs #phi per best Trackster;"+refT[i]+" #phi"+shSEnFr,
+                        "Shared Energy of " + refT[i] + " vs #phi per best Trackster;" + refT[i] + " #phi" + shSEnFr,
                         nintPhi_,
                         minPhi_,
                         maxPhi_,
@@ -1272,47 +1308,71 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                         maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_caloparticle2trackster_assoc2[i].push_back(
       ibook.book1D("SharedEnergy_" + ref[i] + "2trackster_assoc2",
-                   "Shared Energy of " + refT[i] + " per 2^{nd} best Trackster;"+shSEnFr,
+                   "Shared Energy of " + refT[i] + " per 2^{nd} best Trackster;" + shSEnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
 
   // eta
-  histograms.h_numEff_caloparticle_eta[i].push_back(ibook.book1D(
-      "NumEff_" + refT[i] + "_Eta", "Num Efficiency " + refT[i] + " Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
+  histograms.h_numEff_caloparticle_eta[i].push_back(
+      ibook.book1D("NumEff_" + refT[i] + "_Eta",
+                   "Num Efficiency " + refT[i] + " Eta per Trackster;#eta",
+                   nintEta_,
+                   minEta_,
+                   maxEta_));
   histograms.h_num_caloparticle_eta[i].push_back(ibook.book1D(
       "Num_" + refT[i] + "_Eta", "Num Purity " + refT[i] + " Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
   histograms.h_numDup_trackster_eta[i].push_back(
       ibook.book1D("NumDup_Trackster_Eta" + val[i], "Num Duplicate Trackster vs Eta;#eta", nintEta_, minEta_, maxEta_));
-  histograms.h_denom_caloparticle_eta[i].push_back(
-      ibook.book1D("Denom_" + refT[i] + "_Eta", "Denom " + refT[i] + " Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
+  histograms.h_denom_caloparticle_eta[i].push_back(ibook.book1D(
+      "Denom_" + refT[i] + "_Eta", "Denom " + refT[i] + " Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
   // phi
-  histograms.h_numEff_caloparticle_phi[i].push_back(ibook.book1D(
-      "NumEff_" + refT[i] + "_Phi", "Num Efficiency " + refT[i] + " Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_numEff_caloparticle_phi[i].push_back(
+      ibook.book1D("NumEff_" + refT[i] + "_Phi",
+                   "Num Efficiency " + refT[i] + " Phi per Trackster;#phi",
+                   nintPhi_,
+                   minPhi_,
+                   maxPhi_));
   histograms.h_num_caloparticle_phi[i].push_back(ibook.book1D(
       "Num_" + refT[i] + "_Phi", "Num Purity " + refT[i] + " Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
   histograms.h_numDup_trackster_phi[i].push_back(
       ibook.book1D("NumDup_Trackster_Phi" + val[i], "Num Duplicate Trackster vs Phi;#phi", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_denom_caloparticle_phi[i].push_back(
-      ibook.book1D("Denom_" + refT[i] + "_Phi", "Denom " + refT[i] + " Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_denom_caloparticle_phi[i].push_back(ibook.book1D(
+      "Denom_" + refT[i] + "_Phi", "Denom " + refT[i] + " Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
   // energy
-  histograms.h_numEff_caloparticle_en[i].push_back(ibook.book1D(
-      "NumEff_" + refT[i] + "_Energy", "Num Efficiency " + refT[i] + " Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
-  histograms.h_num_caloparticle_en[i].push_back(ibook.book1D(
-      "Num_" + refT[i] + "_Energy", "Num Purity " + refT[i] + " Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
-  histograms.h_numDup_trackster_en[i].push_back(
-      ibook.book1D("NumDup_Trackster_Energy" + val[i], "Num Duplicate Trackster vs Energy;energy [GeV]", nintEne_, minEne_, maxEne_));
+  histograms.h_numEff_caloparticle_en[i].push_back(
+      ibook.book1D("NumEff_" + refT[i] + "_Energy",
+                   "Num Efficiency " + refT[i] + " Energy per Trackster;energy [GeV]",
+                   nintEne_,
+                   minEne_,
+                   maxEne_));
+  histograms.h_num_caloparticle_en[i].push_back(
+      ibook.book1D("Num_" + refT[i] + "_Energy",
+                   "Num Purity " + refT[i] + " Energy per Trackster;energy [GeV]",
+                   nintEne_,
+                   minEne_,
+                   maxEne_));
+  histograms.h_numDup_trackster_en[i].push_back(ibook.book1D(
+      "NumDup_Trackster_Energy" + val[i], "Num Duplicate Trackster vs Energy;energy [GeV]", nintEne_, minEne_, maxEne_));
   histograms.h_denom_caloparticle_en[i].push_back(
-      ibook.book1D("Denom_" + refT[i] + "_Energy", "Denom " + refT[i] + " Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
+      ibook.book1D("Denom_" + refT[i] + "_Energy",
+                   "Denom " + refT[i] + " Energy per Trackster;energy [GeV]",
+                   nintEne_,
+                   minEne_,
+                   maxEne_));
   // pT
-  histograms.h_numEff_caloparticle_pt[i].push_back(ibook.book1D(
-      "NumEff_" + refT[i] + "_Pt", "Num Efficiency " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_numEff_caloparticle_pt[i].push_back(
+      ibook.book1D("NumEff_" + refT[i] + "_Pt",
+                   "Num Efficiency " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]",
+                   nintPt_,
+                   minPt_,
+                   maxPt_));
   histograms.h_num_caloparticle_pt[i].push_back(ibook.book1D(
       "Num_" + refT[i] + "_Pt", "Num Purity " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
-  histograms.h_numDup_trackster_pt[i].push_back(
-      ibook.book1D("NumDup_Trackster_Pt" + val[i], "Num Duplicate Trackster vs p_{T};p_{T} [GeV]", nintPt_, minPt_, maxPt_));
-  histograms.h_denom_caloparticle_pt[i].push_back(
-      ibook.book1D("Denom_" + refT[i] + "_Pt", "Denom " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_numDup_trackster_pt[i].push_back(ibook.book1D(
+      "NumDup_Trackster_Pt" + val[i], "Num Duplicate Trackster vs p_{T};p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_denom_caloparticle_pt[i].push_back(ibook.book1D(
+      "Denom_" + refT[i] + "_Pt", "Denom " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
 }
 
 void HGVHistoProducerAlgo::fill_info_histos(const Histograms& histograms, unsigned int layers) const {
@@ -1400,11 +1460,11 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
             totenergy_layer.emplace(layerId, hitEn);
           }
           if (caloParticle.simClusters().size() == 1)
-            histograms.h_caloparticle_nHits_matched_energy_layer_1SimCl.at(pdgid)->Fill(layerId,
-                                                                                        hitEnFr);
+            histograms.h_caloparticle_nHits_matched_energy_layer_1SimCl.at(pdgid)->Fill(layerId, hitEnFr);
 
-          auto found = std::find_if(
-              std::begin(haf_cp), std::end(haf_cp), [&hitDetId](const std::pair<DetId, float>& v) { return v.first == hitDetId; });
+          auto found = std::find_if(std::begin(haf_cp),
+                                    std::end(haf_cp),
+                                    [&hitDetId](const std::pair<DetId, float>& v) { return v.first == hitDetId; });
           if (found != haf_cp.end())
             found->second += hitFr;
           else
@@ -1420,8 +1480,9 @@ void HGVHistoProducerAlgo::fill_caloparticle_histos(const Histograms& histograms
         maxLayerId_matched = std::max(maxLayerId_matched, layerId_matched_max);
       }
       LogDebug("HGCalValidator") << std::endl;
-    } // End loop over SimClusters of CaloParticle
-    if (hitEnergyWeight_invSum) hitEnergyWeight_invSum = 1/hitEnergyWeight_invSum;
+    }  // End loop over SimClusters of CaloParticle
+    if (hitEnergyWeight_invSum)
+      hitEnergyWeight_invSum = 1 / hitEnergyWeight_invSum;
 
     histograms.h_caloparticle_firstlayer.at(pdgid)->Fill(minLayerId);
     histograms.h_caloparticle_lastlayer.at(pdgid)->Fill(maxLayerId);
@@ -1654,9 +1715,11 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
             detIdToCaloParticleId_Map[hitid].emplace_back(
                 HGVHistoProducerAlgo::detIdInfoInCluster{cpId, it_haf.second});
           } else {
-            auto findHitIt = std::find(detIdToCaloParticleId_Map[hitid].begin(),
-                                       detIdToCaloParticleId_Map[hitid].end(),
-                                       HGVHistoProducerAlgo::detIdInfoInCluster{cpId, 0.f}); // only the first element is used for the matching (overloaded operator==)
+            auto findHitIt =
+                std::find(detIdToCaloParticleId_Map[hitid].begin(),
+                          detIdToCaloParticleId_Map[hitid].end(),
+                          HGVHistoProducerAlgo::detIdInfoInCluster{
+                              cpId, 0.f});  // only the first element is used for the matching (overloaded operator==)
             if (findHitIt != detIdToCaloParticleId_Map[hitid].end())
               findHitIt->fraction += it_haf.second;
             else
@@ -1769,10 +1832,10 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
       if (cp_linked ==
           cPOnLayerMap[cpPair.first].end())  // This should never happen by construction of the association maps
         continue;
-      histograms.h_sharedenergy_layercl2caloparticle_perlayer.at(lcLayerId)->Fill(
-          cp_linked->second.first / lc_en, lc_en);
-      histograms.h_energy_vs_score_layercl2caloparticle_perlayer.at(lcLayerId)->Fill(
-          cpPair.second, cp_linked->second.first / lc_en);
+      histograms.h_sharedenergy_layercl2caloparticle_perlayer.at(lcLayerId)->Fill(cp_linked->second.first / lc_en,
+                                                                                  lc_en);
+      histograms.h_energy_vs_score_layercl2caloparticle_perlayer.at(lcLayerId)->Fill(cpPair.second,
+                                                                                     cp_linked->second.first / lc_en);
     }
     const auto assoc =
         std::count_if(std::begin(cps), std::end(cps), [](const auto& obj) { return obj.second < ScoreCutLCtoCP_; });
@@ -1839,7 +1902,7 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
       auto getLCLayerId = [&](const unsigned int lcId) {
         const auto firstHitDetId = (clusters[lcId].hitsAndFractions())[0].first;
         const auto lcLayerId = recHitTools_->getLayerWithOffset(firstHitDetId) +
-                                       layers * ((recHitTools_->zside(firstHitDetId) + 1) >> 1) - 1;
+                               layers * ((recHitTools_->zside(firstHitDetId) + 1) >> 1) - 1;
         return lcLayerId;
       };
 
@@ -1895,7 +1958,6 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
     unsigned int layers,
     const hgcal::RecoToSimCollectionWithSimClusters& scsInLayerClusterMap,
     const hgcal::SimToRecoCollectionWithSimClusters& lcsInSimClusterMap) const {
-
   // Here fill the plots to compute the different metrics linked to
   // reco-level, namely fake-rate and merge-rate. In this loop should *not*
   // restrict only to the selected SimClusters.
@@ -1942,8 +2004,8 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
       if (sc_linked ==
           lcsInSimClusterMap[scPair.first].end())  // This should never happen by construction of the association maps
         continue;
-      histograms.h_sharedenergy_layercl2simcluster_perlayer[count].at(lcLayerId)->Fill(
-          sc_linked->second.first / lc_en, lc_en);
+      histograms.h_sharedenergy_layercl2simcluster_perlayer[count].at(lcLayerId)->Fill(sc_linked->second.first / lc_en,
+                                                                                       lc_en);
       histograms.h_energy_vs_score_layercl2simcluster_perlayer[count].at(lcLayerId)->Fill(
           scPair.second, sc_linked->second.first / lc_en);
     }
@@ -2386,21 +2448,22 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
   histograms.h_longdepthbarycentre_zminus[count]->Fill(sumldbarmi / sumeneallclusmi);
 }
 
-void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histograms,
-                                                       int count,
-                                                       const ticl::TracksterCollection& tracksters,
-                                                       const reco::CaloClusterCollection& layerClusters,
-                                                       const ticl::TracksterCollection& simTSs,
-                                                       const int i,
-                                                       const ticl::TracksterCollection& simTSs_fromCP,
-                                                       const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
-                                                       std::vector<SimCluster> const& sC,
-                                                       const edm::ProductID& cPHandle_id,
-                                                       std::vector<CaloParticle> const& cP,
-                                                       std::vector<size_t> const& cPIndices,
-                                                       std::vector<size_t> const& cPSelectedIndices,
-                                                       std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
-                                                       unsigned int layers) const {
+void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
+    const Histograms& histograms,
+    int count,
+    const ticl::TracksterCollection& tracksters,
+    const reco::CaloClusterCollection& layerClusters,
+    const ticl::TracksterCollection& simTSs,
+    const int i,
+    const ticl::TracksterCollection& simTSs_fromCP,
+    const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
+    std::vector<SimCluster> const& sC,
+    const edm::ProductID& cPHandle_id,
+    std::vector<CaloParticle> const& cP,
+    std::vector<size_t> const& cPIndices,
+    std::vector<size_t> const& cPSelectedIndices,
+    std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
+    unsigned int layers) const {
   const auto nTracksters = tracksters.size();
   const auto nSimTracksters = simTSs.size();
 
@@ -2432,24 +2495,30 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
     //const auto nSC_inCP = cP[cpIndex].simClusters().size();
     const auto nSC_inCP = sC.size();
     sCOnLayer[cpIndex].resize(nSC_inCP);
-    for (unsigned int iSC=0; iSC<nSC_inCP; iSC++) {
+    for (unsigned int iSC = 0; iSC < nSC_inCP; iSC++) {
       sCOnLayer[cpIndex][iSC].caloParticleId = cpIndex;
       sCOnLayer[cpIndex][iSC].energy = 0.f;
       sCOnLayer[cpIndex][iSC].hits_and_fractions.clear();
     }
   }
 
-  auto getCPId = [](const ticl::Trackster& simTS, const unsigned int iSTS, const edm::ProductID& cPHandle_id, const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap, const ticl::TracksterCollection& simTSs_fromCP){
+  auto getCPId = [](const ticl::Trackster& simTS,
+                    const unsigned int iSTS,
+                    const edm::ProductID& cPHandle_id,
+                    const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
+                    const ticl::TracksterCollection& simTSs_fromCP) {
     unsigned int cpId = -1;
 
     const auto productID = simTS.seedID();
     if (productID == cPHandle_id) {
       cpId = simTS.seedIndex();
-    } else { // SimTrackster from SimCluster
-      const auto findSimTSFromCP = std::find_if(std::begin(cpToSc_SimTrackstersMap), std::end(cpToSc_SimTrackstersMap),
-                                                           [&](const std::pair<unsigned int, std::vector<unsigned int>>& cpToScs) {
-        return std::find(std::begin(cpToScs.second), std::end(cpToScs.second), iSTS) != std::end(cpToScs.second);
-      });
+    } else {  // SimTrackster from SimCluster
+      const auto findSimTSFromCP = std::find_if(
+          std::begin(cpToSc_SimTrackstersMap),
+          std::end(cpToSc_SimTrackstersMap),
+          [&](const std::pair<unsigned int, std::vector<unsigned int>>& cpToScs) {
+            return std::find(std::begin(cpToScs.second), std::end(cpToScs.second), iSTS) != std::end(cpToScs.second);
+          });
       if (findSimTSFromCP != std::end(cpToSc_SimTrackstersMap)) {
         cpId = simTSs_fromCP[findSimTSFromCP->first].seedIndex();
       }
@@ -2458,13 +2527,16 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
     return cpId;
   };
 
-  auto getLCId = [](const std::vector<unsigned int>& tst_vertices, const reco::CaloClusterCollection& layerClusters, const DetId& hitid) {
+  auto getLCId = [](const std::vector<unsigned int>& tst_vertices,
+                    const reco::CaloClusterCollection& layerClusters,
+                    const DetId& hitid) {
     unsigned int lcId = -1;
     std::for_each(std::begin(tst_vertices), std::end(tst_vertices), [&](unsigned int idx) {
       const auto& lc_haf = layerClusters[idx].hitsAndFractions();
-      const auto& hitFound = std::find_if(std::begin(lc_haf), std::end(lc_haf), [&hitid](const std::pair<DetId, float>& v) {
-return v.first == hitid; });
-      if (hitFound != lc_haf.end()) // not all hits may be clusterized
+      const auto& hitFound = std::find_if(std::begin(lc_haf),
+                                          std::end(lc_haf),
+                                          [&hitid](const std::pair<DetId, float>& v) { return v.first == hitid; });
+      if (hitFound != lc_haf.end())  // not all hits may be clusterized
         lcId = idx;
     });
     return lcId;
@@ -2478,8 +2550,8 @@ return v.first == hitid; });
     // Loop through SimClusters
     for (const auto& simCluster : cP[cpId].simClusters()) {
       auto iSim = simTSs[iSTS].seedIndex();
-      if (simTSs[iSTS].seedID() != cPHandle_id) { // SimTrackster from SimCluster
-        if (iSim  !=  (&(*simCluster) - &(sC[0])))
+      if (simTSs[iSTS].seedID() != cPHandle_id) {  // SimTrackster from SimCluster
+        if (iSim != (&(*simCluster) - &(sC[0])))
           continue;
       } else
         iSim = 0;
@@ -2489,15 +2561,13 @@ return v.first == hitid; });
         const auto lcId = getLCId(simTSs[iSTS].vertices(), layerClusters, hitid);
         //V9:maps the layers in -z: 0->51 and in +z: 52->103
         //V10:maps the layers in -z: 0->49 and in +z: 50->99
-        //const auto hitLayerId =
-            //recHitTools_->getLayerWithOffset(hitid) + layers * ((recHitTools_->zside(hitid) + 1) >> 1) - 1;
-            //0;
         const auto itcheck = hitMap.find(hitid);
         //Checks whether the current hit belonging to sim cluster has a reconstructed hit.
-        if ((i == 0  &&  itcheck != hitMap.end())  ||  (i == 1  &&  int(lcId) >= 0)) {
+        if ((i == 0 && itcheck != hitMap.end()) || (i > 0 && int(lcId) >= 0)) {
           const auto elemId = (i == 0) ? hitid : lcId;
           const auto iLC = std::find(simTSs[iSTS].vertices().begin(), simTSs[iSTS].vertices().end(), lcId);
-          const auto lcFraction = 1.f / simTSs[iSTS].vertex_multiplicity(std::distance(std::begin(simTSs[iSTS].vertices()), iLC));
+          const auto lcFraction =
+              1.f / simTSs[iSTS].vertex_multiplicity(std::distance(std::begin(simTSs[iSTS].vertices()), iLC));
           const auto elemFr = (i == 0) ? it_haf.second : lcFraction;
           //Since the current hit from sim cluster has a reconstructed hit with the same detid,
           //make a map that will connect a detid with:
@@ -2510,11 +2580,14 @@ return v.first == hitid; });
             detIdSimTSId_Map[elemId] = std::vector<HGVHistoProducerAlgo::detIdInfoInCluster>();
             detIdSimTSId_Map[elemId].emplace_back(HGVHistoProducerAlgo::detIdInfoInCluster{iSTS, elemFr});
           } else {
-            auto findSTSIt = std::find(detIdSimTSId_Map[elemId].begin(),
-                                       detIdSimTSId_Map[elemId].end(),
-                                       HGVHistoProducerAlgo::detIdInfoInCluster{iSTS, 0}); // only the first element is used for the matching (overloaded operator==)
+            auto findSTSIt =
+                std::find(detIdSimTSId_Map[elemId].begin(),
+                          detIdSimTSId_Map[elemId].end(),
+                          HGVHistoProducerAlgo::detIdInfoInCluster{
+                              iSTS, 0});  // only the first element is used for the matching (overloaded operator==)
             if (findSTSIt != detIdSimTSId_Map[elemId].end()) {
-              if (i==0) findSTSIt->fraction += elemFr;
+              if (i == 0)
+                findSTSIt->fraction += elemFr;
             } else {
               detIdSimTSId_Map[elemId].emplace_back(HGVHistoProducerAlgo::detIdInfoInCluster{iSTS, elemFr});
             }
@@ -2540,8 +2613,9 @@ return v.first == hitid; });
             haf.emplace_back(hitid, it_haf.second);
           // Same for sCOnLayer
           auto& haf_sc = sCOnLayer[cpId][iSim].hits_and_fractions;
-          auto found_sc = std::find_if(
-              std::begin(haf_sc), std::end(haf_sc), [&hitid](const std::pair<DetId, float>& v) { return v.first == hitid; });
+          auto found_sc = std::find_if(std::begin(haf_sc),
+                                       std::end(haf_sc),
+                                       [&hitid](const std::pair<DetId, float>& v) { return v.first == hitid; });
           if (found_sc != haf_sc.end())
             found_sc->second += it_haf.second;
           else
@@ -2557,7 +2631,8 @@ return v.first == hitid; });
     std::for_each(std::begin(trackster.vertices()), std::end(trackster.vertices()), [&](unsigned int idx) {
       const auto fraction = 1.f / trackster.vertex_multiplicity(lcInTst++);
       for (const auto& cell : layerClusters[idx].hitsAndFractions()) {
-        hits_and_fractions_norm.emplace_back(cell.first, cell.second * fraction); // cell.second is the hit fraction in the layerCluster
+        hits_and_fractions_norm.emplace_back(
+            cell.first, cell.second * fraction);  // cell.second is the hit fraction in the layerCluster
       }
     });
     return hits_and_fractions_norm;
@@ -2569,7 +2644,7 @@ return v.first == hitid; });
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
     const auto& tst = tracksters[tstId];
     if (tstId == 0)
-      if ((i == 1) && (tst.ticlIteration() == ticl::Trackster::SIM)) {
+      if ((i > 0) && (tst.ticlIteration() == ticl::Trackster::SIM)) {
         ScoreCutSTStoTSPurDup = ScoreCutSTStoTSPurDup_[i];
         ScoreCutTStoSTSFakeMerge = ScoreCutTStoSTSFakeMerge_[i];
       }
@@ -2634,16 +2709,19 @@ return v.first == hitid; });
       if (detIdToTracksterId_Map.find(rh_detid) == detIdToTracksterId_Map.end()) {
         detIdToTracksterId_Map[rh_detid] = std::vector<HGVHistoProducerAlgo::detIdInfoInTrackster>();
         detIdToTracksterId_Map[rh_detid].emplace_back(
-          HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, lcId_r, rhFraction});
+            HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, lcId_r, rhFraction});
       } else {
-        auto findTSIt = std::find(detIdToTracksterId_Map[rh_detid].begin(),
-                                  detIdToTracksterId_Map[rh_detid].end(),
-                                  HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, 0, 0}); // only the first element is used for the matching (overloaded operator==)
+        auto findTSIt =
+            std::find(detIdToTracksterId_Map[rh_detid].begin(),
+                      detIdToTracksterId_Map[rh_detid].end(),
+                      HGVHistoProducerAlgo::detIdInfoInTrackster{
+                          tstId, 0, 0});  // only the first element is used for the matching (overloaded operator==)
         if (findTSIt != detIdToTracksterId_Map[rh_detid].end()) {
-          if (i==0) findTSIt->fraction += rhFraction;
+          if (i == 0)
+            findTSIt->fraction += rhFraction;
         } else {
           detIdToTracksterId_Map[rh_detid].emplace_back(
-            HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, lcId_r, rhFraction});
+              HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, lcId_r, rhFraction});
         }
       }
 
@@ -2659,7 +2737,7 @@ return v.first == hitid; });
 
       // Check whether the RecHit of the trackster under study has a SimHit in the same cell
       const auto elemId = (i == 0) ? rh_detid.rawId() : lcId_r;
-      const auto recoFr = (i==0) ? rhFraction : lcFraction_r;
+      const auto recoFr = (i == 0) ? rhFraction : lcFraction_r;
       const auto& hit_find_in_STS = detIdSimTSId_Map.find(elemId);
       if (hit_find_in_STS == detIdSimTSId_Map.end()) {
         hitsToCaloParticleId[hitId] -= 1;
@@ -2667,8 +2745,8 @@ return v.first == hitid; });
         // Since the hit is belonging to the layer cluster, it must be also in the rechits map
         const auto hitEn = hitMap.find(rh_detid)->second->energy();
         //const auto layerId =
-            //recHitTools_->getLayerWithOffset(rh_detid) + layers * ((recHitTools_->zside(rh_detid) + 1) >> 1) - 1;
-            //0;
+        //recHitTools_->getLayerWithOffset(rh_detid) + layers * ((recHitTools_->zside(rh_detid) + 1) >> 1) - 1;
+        //0;
 
         auto maxCPEnergyInTS = 0.f;
         auto maxCPId = -1;
@@ -2677,7 +2755,7 @@ return v.first == hitid; });
           const auto iSTS = h.clusterId;
           const auto& simTS = simTSs[iSTS];
           auto iSim = simTS.seedIndex();
-          if (simTSs[iSTS].seedID() == cPHandle_id) // SimTrackster from CaloParticle
+          if (simTSs[iSTS].seedID() == cPHandle_id)  // SimTrackster from CaloParticle
             iSim = 0;
 
           // SimTrackster with simHits connected via detid with the rechit under study
@@ -2742,7 +2820,7 @@ return v.first == hitid; });
     if (maxCPId_byEnergy >= 0) {
       //Loop through all layers
       //for (unsigned int j = 0; j < layers * 2; ++j) {
-        totalCPEnergyFromLayerCP += cPOnLayer[maxCPId_byEnergy].energy;
+      totalCPEnergyFromLayerCP += cPOnLayer[maxCPId_byEnergy].energy;
       //}
       energyFractionOfCPinTS = maxEnergySharedTSandCP / totalCPEnergyFromLayerCP;
       if (tst.raw_energy() > 0.f) {
@@ -2750,26 +2828,20 @@ return v.first == hitid; });
       }
     }
 
-    LogDebug("HGCalValidator") << std::setw(12) << "Trackster\t"
-                               << std::setw(10) << "energy\t"
-                               << std::setw(5) << "nhits\t"
-                               << std::setw(12) << "noise hits\t"
-                               << std::setw(22) << "maxCPId_byNumberOfHits\t"
-                               << std::setw(8) << "nhitsCP\t"
-                               << std::setw(16) << "maxCPId_byEnergy\t"
-                               << std::setw(23) << "maxEnergySharedTSandCP\t"
-                               << std::setw(22) << "totalCPEnergyFromAllLayerCP\t"
-                               << std::setw(22) << "energyFractionOfTSinCP\t"
-                               << std::setw(25) << "energyFractionOfCPinTS\t"
-                               << std::endl;
+    LogDebug("HGCalValidator") << std::setw(12) << "Trackster\t" << std::setw(10) << "energy\t" << std::setw(5)
+                               << "nhits\t" << std::setw(12) << "noise hits\t" << std::setw(22)
+                               << "maxCPId_byNumberOfHits\t" << std::setw(8) << "nhitsCP\t" << std::setw(16)
+                               << "maxCPId_byEnergy\t" << std::setw(23) << "maxEnergySharedTSandCP\t" << std::setw(22)
+                               << "totalCPEnergyFromAllLayerCP\t" << std::setw(22) << "energyFractionOfTSinCP\t"
+                               << std::setw(25) << "energyFractionOfCPinTS\t" << std::endl;
     LogDebug("HGCalValidator") << std::setw(12) << tstId << "\t"  //LogDebug("HGCalValidator")
-                               << std::setw(10) << tst.raw_energy() << "\t" << std::setw(5)
-                               << numberOfHitsInTS << "\t" << std::setw(12) << numberOfNoiseHitsInTS << "\t"
-                               << std::setw(22) << maxCPId_byNumberOfHits << "\t" << std::setw(8)
-                               << maxCPNumberOfHitsInTS << "\t" << std::setw(16) << maxCPId_byEnergy << "\t"
-                               << std::setw(23) << maxEnergySharedTSandCP << "\t" << std::setw(22)
-                               << totalCPEnergyFromLayerCP << "\t" << std::setw(22) << energyFractionOfTSinCP << "\t"
-                               << std::setw(25) << energyFractionOfCPinTS << std::endl;
+                               << std::setw(10) << tst.raw_energy() << "\t" << std::setw(5) << numberOfHitsInTS << "\t"
+                               << std::setw(12) << numberOfNoiseHitsInTS << "\t" << std::setw(22)
+                               << maxCPId_byNumberOfHits << "\t" << std::setw(8) << maxCPNumberOfHitsInTS << "\t"
+                               << std::setw(16) << maxCPId_byEnergy << "\t" << std::setw(23) << maxEnergySharedTSandCP
+                               << "\t" << std::setw(22) << totalCPEnergyFromLayerCP << "\t" << std::setw(22)
+                               << energyFractionOfTSinCP << "\t" << std::setw(25) << energyFractionOfCPinTS
+                               << std::endl;
 
   }  // end of loop through Tracksters
 
@@ -2805,7 +2877,7 @@ return v.first == hitid; });
       float hitFr = 0.f;
       if (i == 0) {
         hitFr = haf.second;
-      } else if (i == 1) {
+      } else {
         const auto lcId = getLCId(tst.vertices(), layerClusters, haf.first);
         const auto iLC = std::find(tst.vertices().begin(), tst.vertices().end(), lcId);
         hitFr = 1.f / tst.vertex_multiplicity(std::distance(std::begin(tst.vertices()), iLC));
@@ -2813,7 +2885,8 @@ return v.first == hitid; });
       tracksterEnergy += hitFr * hitMap.at(haf.first)->energy();
       invTracksterEnergyWeight += pow(hitFr * hitMap.at(haf.first)->energy(), 2);
     }
-    if (invTracksterEnergyWeight) invTracksterEnergyWeight = 1.f / invTracksterEnergyWeight;
+    if (invTracksterEnergyWeight)
+      invTracksterEnergyWeight = 1.f / invTracksterEnergyWeight;
 
     for (const auto& haf : tst_hitsAndFractions) {
       const auto rh_detid = haf.first;
@@ -2822,7 +2895,7 @@ return v.first == hitid; });
       if (i == 0) {
         elemId = rh_detid.rawId();
         rhFraction = haf.second;
-      } else if (i == 1) {
+      } else {
         const auto lcId = getLCId(tst.vertices(), layerClusters, rh_detid);
         elemId = lcId;
         const auto iLC = std::find(tst.vertices().begin(), tst.vertices().end(), lcId);
@@ -2838,9 +2911,11 @@ return v.first == hitid; });
       for (auto& stsPair : stsInTrackster[tstId]) {
         float cpFraction = 0.f;
         if (!hitWithNoSTS) {
-          const auto& findSTSIt = std::find(detIdSimTSId_Map[elemId].begin(),
-                                            detIdSimTSId_Map[elemId].end(),
-                                            HGVHistoProducerAlgo::detIdInfoInCluster{stsPair.first, 0.f}); // only the first element is used for the matching (overloaded operator==)
+          const auto& findSTSIt = std::find(
+              detIdSimTSId_Map[elemId].begin(),
+              detIdSimTSId_Map[elemId].end(),
+              HGVHistoProducerAlgo::detIdInfoInCluster{
+                  stsPair.first, 0.f});  // only the first element is used for the matching (overloaded operator==)
           if (findSTSIt != detIdSimTSId_Map[elemId].end())
             cpFraction = findSTSIt->fraction;
         }
@@ -2850,20 +2925,17 @@ return v.first == hitid; });
         stsPair.second +=
             min(pow(rhFraction - cpFraction, 2), pow(rhFraction, 2)) * hitEnergyWeight * invTracksterEnergyWeight;
       }
-    } // end of loop through trackster rechits
+    }  // end of loop through trackster rechits
 
     //In case of a Trackster with some energy but none related CaloParticles print some info.
     if (stsInTrackster[tstId].empty())
-      LogDebug("HGCalValidator") << "Trackster Id: " << tstId << "\tSimTrackster id: -1" << "\tscore: -1\n";
+      LogDebug("HGCalValidator") << "Trackster Id: " << tstId << "\tSimTrackster id: -1"
+                                 << "\tscore: -1\n";
 
-    tracksters_FakeMerge[tstId] = std::count_if(std::begin(stsInTrackster[tstId]),
-                                                std::end(stsInTrackster[tstId]),
-                                                [&, i, ScoreCutTStoSTSFakeMerge](const auto& obj) {
-      if ((i == 1) && (tst.ticlIteration() == ticl::Trackster::SIM))
-        if (tst.vertices().size() != simTSs[obj.first].vertices().size())
-          return false;
-      return obj.second < ScoreCutTStoSTSFakeMerge;
-    });
+    tracksters_FakeMerge[tstId] = std::count_if(
+        std::begin(stsInTrackster[tstId]),
+        std::end(stsInTrackster[tstId]),
+        [&, i, ScoreCutTStoSTSFakeMerge](const auto& obj) { return obj.second < ScoreCutTStoSTSFakeMerge; });
 
     const auto score = std::min_element(std::begin(stsInTrackster[tstId]),
                                         std::end(stsInTrackster[tstId]),
@@ -2877,21 +2949,27 @@ return v.first == hitid; });
       //if (std::find(cPIndices.begin(), cPIndices.end(), cpId) == cPIndices.end())
       //  continue;
       auto iSim = simTSs[iSTS].seedIndex();
-      if (simTSs[iSTS].seedID() == cPHandle_id) // SimTrackster from CaloParticle
+      if (simTSs[iSTS].seedID() == cPHandle_id)  // SimTrackster from CaloParticle
         iSim = 0;
       const auto& simOnLayer = (i == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][iSim];
 
       float sharedeneCPallLayers = 0.;
       //for (unsigned int j = 0; j < layers * 2; ++j)
-        sharedeneCPallLayers += simOnLayer.layerClusterIdToEnergyAndScore.count(tstId) ? simOnLayer.layerClusterIdToEnergyAndScore.at(tstId).first : 0;
-      if (tracksterEnergy == 0) continue;
+      sharedeneCPallLayers += simOnLayer.layerClusterIdToEnergyAndScore.count(tstId)
+                                  ? simOnLayer.layerClusterIdToEnergyAndScore.at(tstId).first
+                                  : 0;
+      if (tracksterEnergy == 0)
+        continue;
       const auto sharedEneFrac = sharedeneCPallLayers / tracksterEnergy;
-      LogDebug("HGCalValidator") << "\nTrackster id: " << tstId << " (" << tst.vertices().size() << " vertices)" << "\tSimTrackster Id: " << iSTS << " (" << simTSs[iSTS].vertices().size() << " vertices)" << " (CP id: " << cpId << ")\tscore: " << iScore << "\tsharedeneCPallLayers: " << sharedeneCPallLayers << std::endl;
+      LogDebug("HGCalValidator") << "\nTrackster id: " << tstId << " (" << tst.vertices().size() << " vertices)"
+                                 << "\tSimTrackster Id: " << iSTS << " (" << simTSs[iSTS].vertices().size()
+                                 << " vertices)"
+                                 << " (CP id: " << cpId << ")\tscore: " << iScore
+                                 << "\tsharedeneCPallLayers: " << sharedeneCPallLayers << std::endl;
 
       histograms.h_score_trackster2caloparticle[i][count]->Fill(iScore);
       histograms.h_sharedenergy_trackster2caloparticle[i][count]->Fill(sharedEneFrac);
-      histograms.h_energy_vs_score_trackster2caloparticle[i][count]->Fill(iScore,
-                                                                          sharedEneFrac);
+      histograms.h_energy_vs_score_trackster2caloparticle[i][count]->Fill(iScore, sharedEneFrac);
       if (iSTS == score->first) {
         histograms.h_score_trackster2bestCaloparticle[i][count]->Fill(iScore);
         histograms.h_sharedenergy_trackster2bestCaloparticle[i][count]->Fill(sharedEneFrac);
@@ -2899,22 +2977,18 @@ return v.first == hitid; });
                                                                                     sharedEneFrac);
         histograms.h_sharedenergy_trackster2bestCaloparticle_vs_phi[i][count]->Fill(tst.barycenter().phi(),
                                                                                     sharedEneFrac);
-        histograms.h_energy_vs_score_trackster2bestCaloparticle[i][count]->Fill(iScore,
-                                                                                sharedEneFrac);
-      }
-      else if (score2 < 0  ||  iScore < score2) {
+        histograms.h_energy_vs_score_trackster2bestCaloparticle[i][count]->Fill(iScore, sharedEneFrac);
+      } else if (score2 < 0 || iScore < score2) {
         score2 = iScore;
         sharedEneFrac2 = sharedEneFrac;
       }
-    } // end of loop through SimTracksters associated to Trackster
+    }  // end of loop through SimTracksters associated to Trackster
     if (score2 > -1) {
       histograms.h_score_trackster2bestCaloparticle2[i][count]->Fill(score2);
       histograms.h_sharedenergy_trackster2bestCaloparticle2[i][count]->Fill(sharedEneFrac2);
-      histograms.h_energy_vs_score_trackster2bestCaloparticle2[i][count]->Fill(score2,
-                                                                               sharedEneFrac2);
+      histograms.h_energy_vs_score_trackster2bestCaloparticle2[i][count]->Fill(score2, sharedEneFrac2);
     }
-  } // end of loop through Tracksters
-
+  }  // end of loop through Tracksters
 
   std::unordered_map<unsigned int, std::vector<float>> score3d;
   std::unordered_map<unsigned int, std::vector<float>> tstSharedEnergy;
@@ -2934,7 +3008,7 @@ return v.first == hitid; });
   for (unsigned int iSTS = 0; iSTS < nSimTracksters; ++iSTS) {
     const auto& sts = simTSs[iSTS];
     const auto& cpId = getCPId(sts, iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
-    if (i==0 && std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
+    if (i == 0 && std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
       continue;
 
     const auto& hafLC = apply_LCMultiplicity(sts, layerClusters);
@@ -2942,11 +3016,12 @@ return v.first == hitid; });
     for (const auto& haf : hafLC) {
       const auto lcId = getLCId(sts.vertices(), layerClusters, haf.first);
       const auto iLC = std::find(sts.vertices().begin(), sts.vertices().end(), lcId);
-      SimEnergy_LC += hitMap.at(haf.first)->energy() / sts.vertex_multiplicity(std::distance(std::begin(sts.vertices()), iLC));
+      SimEnergy_LC +=
+          hitMap.at(haf.first)->energy() / sts.vertex_multiplicity(std::distance(std::begin(sts.vertices()), iLC));
     }
 
     auto iSim = sts.seedIndex();
-    if (sts.seedID() == cPHandle_id) // SimTrackster from CaloParticle
+    if (sts.seedID() == cPHandle_id)  // SimTrackster from CaloParticle
       iSim = 0;
     auto& simOnLayer = (i == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][iSim];
 
@@ -2958,123 +3033,118 @@ return v.first == hitid; });
     float SimEnergy = 0.f;
     float SimEnergyWeight = 0.f, hitsEnergyWeight = 0.f;
     //for (unsigned int layerId = 0; layerId < 1/*layers * 2*/; ++layerId) {
-      const auto SimNumberOfHits = simOnLayer.hits_and_fractions.size();
-      if (SimNumberOfHits == 0)
-        continue;
-      SimEnergy += simOnLayer.energy;
-      int tstWithMaxEnergyInCP = -1;
-      //This is the maximum energy related to Trackster per layer.
-      float maxEnergyTSperlayerinSim = 0.f;
-      float SimEnergyFractionInTSperlayer = 0.f;
-      //Remember and not confused by name. layerClusterIdToEnergyAndScore contains the Trackster id.
-      for (const auto& tst : simOnLayer.layerClusterIdToEnergyAndScore) {
-        if (tst.second.first > maxEnergyTSperlayerinSim) {
-          maxEnergyTSperlayerinSim = tst.second.first;
-          tstWithMaxEnergyInCP = tst.first;
-        }
+    const auto SimNumberOfHits = simOnLayer.hits_and_fractions.size();
+    if (SimNumberOfHits == 0)
+      continue;
+    SimEnergy += simOnLayer.energy;
+    int tstWithMaxEnergyInCP = -1;
+    //This is the maximum energy related to Trackster per layer.
+    float maxEnergyTSperlayerinSim = 0.f;
+    float SimEnergyFractionInTSperlayer = 0.f;
+    //Remember and not confused by name. layerClusterIdToEnergyAndScore contains the Trackster id.
+    for (const auto& tst : simOnLayer.layerClusterIdToEnergyAndScore) {
+      if (tst.second.first > maxEnergyTSperlayerinSim) {
+        maxEnergyTSperlayerinSim = tst.second.first;
+        tstWithMaxEnergyInCP = tst.first;
       }
-      if (SimEnergy > 0.f)
-        SimEnergyFractionInTSperlayer = maxEnergyTSperlayerinSim / SimEnergy;
+    }
+    if (SimEnergy > 0.f)
+      SimEnergyFractionInTSperlayer = maxEnergyTSperlayerinSim / SimEnergy;
 
-      LogDebug("HGCalValidator") << std::setw(12) << "caloparticle\t" << std::setw(15)
-                                 << "cp total energy\t" << std::setw(15) << "cpEnergyOnLayer\t" << std::setw(14)
-                                 << "CPNhitsOnLayer\t" << std::setw(18) << "tstWithMaxEnergyInCP\t" << std::setw(15)
-                                 << "maxEnergyTSinCP\t" << std::setw(20) << "CPEnergyFractionInTS"
-                                 << "\n";
-      LogDebug("HGCalValidator") << std::setw(12) << cpId << "\t" << std::setw(15)
-                                 << sts.raw_energy() << "\t" << std::setw(15) << SimEnergy << "\t"
-                                 << std::setw(14) << SimNumberOfHits << "\t" << std::setw(18) << tstWithMaxEnergyInCP
-                                 << "\t" << std::setw(15) << maxEnergyTSperlayerinSim << "\t" << std::setw(20)
-                                 << SimEnergyFractionInTSperlayer << "\n";
+    LogDebug("HGCalValidator") << std::setw(12) << "caloparticle\t" << std::setw(15) << "cp total energy\t"
+                               << std::setw(15) << "cpEnergyOnLayer\t" << std::setw(14) << "CPNhitsOnLayer\t"
+                               << std::setw(18) << "tstWithMaxEnergyInCP\t" << std::setw(15) << "maxEnergyTSinCP\t"
+                               << std::setw(20) << "CPEnergyFractionInTS"
+                               << "\n";
+    LogDebug("HGCalValidator") << std::setw(12) << cpId << "\t" << std::setw(15) << sts.raw_energy() << "\t"
+                               << std::setw(15) << SimEnergy << "\t" << std::setw(14) << SimNumberOfHits << "\t"
+                               << std::setw(18) << tstWithMaxEnergyInCP << "\t" << std::setw(15)
+                               << maxEnergyTSperlayerinSim << "\t" << std::setw(20) << SimEnergyFractionInTSperlayer
+                               << "\n";
 
-      for (const auto& haf : ((i==0) ? simOnLayer.hits_and_fractions : hafLC)) {
-        const auto& hitDetId = haf.first;
-        //const auto hitLayerId =
-            //recHitTools_->getLayerWithOffset(hitDetId) + layers * ((recHitTools_->zside(hitDetId) + 1) >> 1) - 1;
-            //0;
-        //if (i > 0  &&  layerId != hitLayerId)
-          //continue;
-        // Compute the correct normalization
-        // Need to loop on the simOnLayer data structure since this is the
-        // only one that has the compressed information for multiple usage
-        // of the same DetId by different SimClusters by a single CaloParticle.
-        SimEnergyWeight += pow(haf.second * hitMap.at(hitDetId)->energy(), 2);
+    for (const auto& haf : ((i == 0) ? simOnLayer.hits_and_fractions : hafLC)) {
+      const auto& hitDetId = haf.first;
+      // Compute the correct normalization
+      // Need to loop on the simOnLayer data structure since this is the
+      // only one that has the compressed information for multiple usage
+      // of the same DetId by different SimClusters by a single CaloParticle.
+      SimEnergyWeight += pow(haf.second * hitMap.at(hitDetId)->energy(), 2);
 
-        const auto lcId = getLCId(sts.vertices(), layerClusters, hitDetId);
-        float cpFraction = 0.f;
-        if (i == 0) {
-          cpFraction = haf.second;
-        } else if (i == 1) {
-          const auto iLC = std::find(sts.vertices().begin(), sts.vertices().end(), lcId);
-          cpFraction = 1.f / sts.vertex_multiplicity(std::distance(std::begin(sts.vertices()), iLC));
-        }
-        if (cpFraction == 0.f)
-          continue;  // hopefully this should never happen
+      const auto lcId = getLCId(sts.vertices(), layerClusters, hitDetId);
+      float cpFraction = 0.f;
+      if (i == 0) {
+        cpFraction = haf.second;
+      } else {
+        const auto iLC = std::find(sts.vertices().begin(), sts.vertices().end(), lcId);
+        cpFraction = 1.f / sts.vertex_multiplicity(std::distance(std::begin(sts.vertices()), iLC));
+      }
+      if (cpFraction == 0.f)
+        continue;  // hopefully this should never happen
 
-        bool hitWithNoTS = false;
-        if (detIdToTracksterId_Map.find(hitDetId) == detIdToTracksterId_Map.end())
-          hitWithNoTS = true;
-        const HGCRecHit* hit = hitMap.find(hitDetId)->second;
-        const auto hitEnergyWeight = pow(hit->energy(), 2);
-        hitsEnergyWeight += pow(cpFraction, 2) * hitEnergyWeight;
+      bool hitWithNoTS = false;
+      if (detIdToTracksterId_Map.find(hitDetId) == detIdToTracksterId_Map.end())
+        hitWithNoTS = true;
+      const HGCRecHit* hit = hitMap.find(hitDetId)->second;
+      const auto hitEnergyWeight = pow(hit->energy(), 2);
+      hitsEnergyWeight += pow(cpFraction, 2) * hitEnergyWeight;
 
-        for (auto& tsPair : simOnLayer.layerClusterIdToEnergyAndScore) {
-          const auto tstId = tsPair.first;
-          stsId_tstId_related.insert(tstId);
+      for (auto& tsPair : simOnLayer.layerClusterIdToEnergyAndScore) {
+        const auto tstId = tsPair.first;
+        stsId_tstId_related.insert(tstId);
 
-          float tstFraction = 0.f;
-          if (!hitWithNoTS) {
-            const auto findTSIt = std::find(detIdToTracksterId_Map[hitDetId].begin(),
-                                            detIdToTracksterId_Map[hitDetId].end(),
-                                            HGVHistoProducerAlgo::detIdInfoInTrackster{tstId, 0, 0.f}); // only the first element is used for the matching (overloaded operator==)
-            if (findTSIt != detIdToTracksterId_Map[hitDetId].end()) {
-              if (i == 0) {
-                tstFraction = findTSIt->fraction;
-              } else if (i == 1) {
-                const auto iLC = std::find(tracksters[tstId].vertices().begin(), tracksters[tstId].vertices().end(), findTSIt->clusterId);
-                if (iLC != tracksters[tstId].vertices().end()) {
-                  tstFraction = 1.f / tracksters[tstId].vertex_multiplicity(std::distance(std::begin(tracksters[tstId].vertices()), iLC));
-                }
+        float tstFraction = 0.f;
+        if (!hitWithNoTS) {
+          const auto findTSIt =
+              std::find(detIdToTracksterId_Map[hitDetId].begin(),
+                        detIdToTracksterId_Map[hitDetId].end(),
+                        HGVHistoProducerAlgo::detIdInfoInTrackster{
+                            tstId, 0, 0.f});  // only the first element is used for the matching (overloaded operator==)
+          if (findTSIt != detIdToTracksterId_Map[hitDetId].end()) {
+            if (i == 0) {
+              tstFraction = findTSIt->fraction;
+            } else {
+              const auto iLC = std::find(
+                  tracksters[tstId].vertices().begin(), tracksters[tstId].vertices().end(), findTSIt->clusterId);
+              if (iLC != tracksters[tstId].vertices().end()) {
+                tstFraction = 1.f / tracksters[tstId].vertex_multiplicity(
+                                        std::distance(std::begin(tracksters[tstId].vertices()), iLC));
               }
             }
           }
-          // Here do not divide as before by the trackster energy weight. Should sum first
-          // over all layers and divide with the total CP energy over all layers.
-          if (tsPair.second.second == FLT_MAX) {
-            tsPair.second.second = 0.f;
-          }
-          tsPair.second.second += min(pow(tstFraction - cpFraction, 2), pow(cpFraction, 2)) * hitEnergyWeight;
-
-          LogDebug("HGCalValidator") << "\nTracksterId:\t" << tstId
-                                     << "\tSimTracksterId:\t" << iSTS
-                                     << "\tcpId:\t" << cpId
-                                     << "\ttstfraction, cpfraction:\t" << tstFraction
-                                     << ", " << cpFraction
-                                     << "\thitEnergyWeight:\t" << hitEnergyWeight
-                                     << "\tadded delta:\t"
-                                     << pow((tstFraction - cpFraction), 2) * hitEnergyWeight
-                                     << "\tcurrent Sim-score numerator:\t" << tsPair.second.second
-                                     << "\tshared Sim energy:\t" << tsPair.second.first << '\n';
         }
-      } // end of loop through SimCluster SimHits on current layer
-
-      if (simOnLayer.layerClusterIdToEnergyAndScore.empty())
-        LogDebug("HGCalValidator") << "CP Id:\t" << cpId << "\tTS id:\t-1"
-                                   << " Sub score in \t -1\n";
-
-      for (const auto& tsPair : simOnLayer.layerClusterIdToEnergyAndScore) {
-        const auto tstId = tsPair.first;
-        // 3D score here without the denominator at this point
-        if (score3d_iSTS[tstId] == FLT_MAX) {
-          score3d_iSTS[tstId] = 0.f;
+        // Here do not divide as before by the trackster energy weight. Should sum first
+        // over all layers and divide with the total CP energy over all layers.
+        if (tsPair.second.second == FLT_MAX) {
+          tsPair.second.second = 0.f;
         }
-        score3d_iSTS[tstId] += tsPair.second.second;
-        tstSharedEnergy[iSTS][tstId] += tsPair.second.first;
+        tsPair.second.second += min(pow(tstFraction - cpFraction, 2), pow(cpFraction, 2)) * hitEnergyWeight;
+
+        LogDebug("HGCalValidator") << "\nTracksterId:\t" << tstId << "\tSimTracksterId:\t" << iSTS << "\tcpId:\t"
+                                   << cpId << "\ttstfraction, cpfraction:\t" << tstFraction << ", " << cpFraction
+                                   << "\thitEnergyWeight:\t" << hitEnergyWeight << "\tadded delta:\t"
+                                   << pow((tstFraction - cpFraction), 2) * hitEnergyWeight
+                                   << "\tcurrent Sim-score numerator:\t" << tsPair.second.second
+                                   << "\tshared Sim energy:\t" << tsPair.second.first << '\n';
       }
+    }  // end of loop through SimCluster SimHits on current layer
+
+    if (simOnLayer.layerClusterIdToEnergyAndScore.empty())
+      LogDebug("HGCalValidator") << "CP Id:\t" << cpId << "\tTS id:\t-1"
+                                 << " Sub score in \t -1\n";
+
+    for (const auto& tsPair : simOnLayer.layerClusterIdToEnergyAndScore) {
+      const auto tstId = tsPair.first;
+      // 3D score here without the denominator at this point
+      if (score3d_iSTS[tstId] == FLT_MAX) {
+        score3d_iSTS[tstId] = 0.f;
+      }
+      score3d_iSTS[tstId] += tsPair.second.second;
+      tstSharedEnergy[iSTS][tstId] += tsPair.second.first;
+    }
     //} // end of loop through layers
 
-    const auto scoreDenom = (i==0) ? SimEnergyWeight : hitsEnergyWeight;
-    const auto energyDenom = (i==0) ? SimEnergy : SimEnergy_LC;
+    const auto scoreDenom = (i == 0) ? SimEnergyWeight : hitsEnergyWeight;
+    const auto energyDenom = (i == 0) ? SimEnergy : SimEnergy_LC;
 
     const auto sts_eta = sts.barycenter().eta();
     const auto sts_phi = sts.barycenter().phi();
@@ -3097,8 +3167,7 @@ return v.first == hitid; });
       score3d_iSTS[tstId] /= scoreDenom;
       const auto tstSharedEnergyFrac = tstSharedEnergy[iSTS][tstId] / energyDenom;
       LogDebug("HGCalValidator") << "STS id: " << iSTS << "\t(CP id: " << cpId << ")\tTS id: " << tstId
-                                 << "\nSimEnergy: " << energyDenom
-                                 << "\tSimEnergyWeight: " << SimEnergyWeight
+                                 << "\nSimEnergy: " << energyDenom << "\tSimEnergyWeight: " << SimEnergyWeight
                                  << "\tTrackste energy: " << tracksters[tstId].raw_energy()
                                  << "\nscore: " << score3d_iSTS[tstId]
                                  << "\tshared energy: " << tstSharedEnergy[iSTS][tstId]
@@ -3106,8 +3175,7 @@ return v.first == hitid; });
 
       histograms.h_score_caloparticle2trackster[i][count]->Fill(score3d_iSTS[tstId]);
       histograms.h_sharedenergy_caloparticle2trackster[i][count]->Fill(tstSharedEnergyFrac);
-      histograms.h_energy_vs_score_caloparticle2trackster[i][count]->Fill(score3d_iSTS[tstId],
-                                                                          tstSharedEnergyFrac);
+      histograms.h_energy_vs_score_caloparticle2trackster[i][count]->Fill(score3d_iSTS[tstId], tstSharedEnergyFrac);
       // Fill the numerator for the efficiency calculation. The efficiency is computed by considering the energy shared between a Trackster and a _corresponding_ caloParticle. The threshold is configurable via python.
       if (!cp_considered_efficient && (tstSharedEnergyFrac >= minTSTSharedEneFracEfficiency_)) {
         cp_considered_efficient = true;
@@ -3118,15 +3186,13 @@ return v.first == hitid; });
       }
 
       if (score3d_iSTS[tstId] < ScoreCutSTStoTSPurDup) {
-        if ((i == 1) && (tracksters[tstId].ticlIteration() == ticl::Trackster::SIM))
-          if (tracksters[tstId].vertices().size() != sts.vertices().size())
-            continue;
-
-        if (tracksters_PurityDuplicate[tstId] < 1) tracksters_PurityDuplicate[tstId]++; // for Purity
-        if (cp_considered_pure) tracksters_PurityDuplicate[tstId]++; // for Duplicate
+        if (tracksters_PurityDuplicate[tstId] < 1)
+          tracksters_PurityDuplicate[tstId]++;  // for Purity
+        if (cp_considered_pure)
+          tracksters_PurityDuplicate[tstId]++;  // for Duplicate
         cp_considered_pure = true;
       }
-    } // end of loop through Tracksters related to SimTrackster
+    }  // end of loop through Tracksters related to SimTrackster
 
     const auto best = std::min_element(std::begin(score3d_iSTS), std::end(score3d_iSTS));
     if (best != score3d_iSTS.end()) {
@@ -3134,28 +3200,23 @@ return v.first == hitid; });
       const auto bestTstSharedEnergyFrac = tstSharedEnergy[iSTS][bestTstId] / energyDenom;
       histograms.h_scorePur_caloparticle2trackster[i][count]->Fill(*best);
       histograms.h_sharedenergy_caloparticle2trackster_assoc[i][count]->Fill(bestTstSharedEnergyFrac);
-      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[i][count]->Fill(
-          sts_eta, bestTstSharedEnergyFrac);
-      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[i][count]->Fill(
-          sts_phi, bestTstSharedEnergyFrac);
-      histograms.h_energy_vs_score_caloparticle2bestTrackster[i][count]->Fill(*best,
-                                                                              bestTstSharedEnergyFrac);
-      LogDebug("HGCalValidator") << count << " " << sts_eta << " "
-                                 << sts_phi << " " << tracksters[bestTstId].raw_energy()
-                                 << " " << sts.raw_energy() << " "
+      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[i][count]->Fill(sts_eta, bestTstSharedEnergyFrac);
+      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[i][count]->Fill(sts_phi, bestTstSharedEnergyFrac);
+      histograms.h_energy_vs_score_caloparticle2bestTrackster[i][count]->Fill(*best, bestTstSharedEnergyFrac);
+      LogDebug("HGCalValidator") << count << " " << sts_eta << " " << sts_phi << " "
+                                 << tracksters[bestTstId].raw_energy() << " " << sts.raw_energy() << " "
                                  << bestTstSharedEnergyFrac << "\n";
 
       if (score3d_iSTS.size() > 1) {
-        auto best2 = (best == score3d_iSTS.begin()) ? std::next(best, 1) : score3d_iSTS.begin() ;
-        for (auto tstId = score3d_iSTS.begin(); tstId != score3d_iSTS.end()  &&  tstId != best; tstId++)
+        auto best2 = (best == score3d_iSTS.begin()) ? std::next(best, 1) : score3d_iSTS.begin();
+        for (auto tstId = score3d_iSTS.begin(); tstId != score3d_iSTS.end() && tstId != best; tstId++)
           if (*tstId < *best2)
             best2 = tstId;
         const auto best2TstId = std::distance(std::begin(score3d_iSTS), best2);
         const auto best2TstSharedEnergyFrac = tstSharedEnergy[iSTS][best2TstId] / energyDenom;
         histograms.h_scoreDupl_caloparticle2trackster[i][count]->Fill(*best2);
         histograms.h_sharedenergy_caloparticle2trackster_assoc2[i][count]->Fill(best2TstSharedEnergyFrac);
-        histograms.h_energy_vs_score_caloparticle2bestTrackster2[i][count]->Fill(*best2,
-                                                                                 best2TstSharedEnergyFrac);
+        histograms.h_energy_vs_score_caloparticle2bestTrackster2[i][count]->Fill(*best2, best2TstSharedEnergyFrac);
       }
     }
   }  // end of loop through SimTracksters
@@ -3203,23 +3264,24 @@ return v.first == hitid; });
         histograms.h_numMerge_trackster_pt[i][count]->Fill(iTS_pt);
       }
     }
-  } // End loop over Tracksters
+  }  // End loop over Tracksters
 }
 
-void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
-                                                 int count,
-                                                 const ticl::TracksterCollection& tracksters,
-                                                 const reco::CaloClusterCollection& layerClusters,
-                                                 const ticl::TracksterCollection& simTSs,
-                                                 const ticl::TracksterCollection& simTSs_fromCP,
-                                                 const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
-                                                 std::vector<SimCluster> const& sC,
-                                                 const edm::ProductID& cPHandle_id,
-                                                 std::vector<CaloParticle> const& cP,
-                                                 std::vector<size_t> const& cPIndices,
-                                                 std::vector<size_t> const& cPSelectedIndices,
-                                                 std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
-                                                 unsigned int layers) const {
+void HGVHistoProducerAlgo::fill_trackster_histos(
+    const Histograms& histograms,
+    int count,
+    const ticl::TracksterCollection& tracksters,
+    const reco::CaloClusterCollection& layerClusters,
+    const ticl::TracksterCollection& simTSs,
+    const ticl::TracksterCollection& simTSs_fromCP,
+    const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
+    std::vector<SimCluster> const& sC,
+    const edm::ProductID& cPHandle_id,
+    std::vector<CaloParticle> const& cP,
+    std::vector<size_t> const& cPIndices,
+    std::vector<size_t> const& cPSelectedIndices,
+    std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
+    unsigned int layers) const {
   //Each event to be treated as two events:
   //an event in +ve endcap, plus another event in -ve endcap.
 
@@ -3250,7 +3312,7 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
   // loop through Tracksters
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
     const auto& tst = tracksters[tstId];
-    if (tst.vertices().size() == 0)
+    if (tst.vertices().empty())
       continue;
 
     if (tst.barycenter().z() < 0.)
@@ -3283,7 +3345,7 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
       const auto firstHitDetId = hits_and_fractions[0].first;
       //The layer that the layer cluster belongs to
       const auto layerid = recHitTools_->getLayerWithOffset(firstHitDetId) +
-                    layers * ((recHitTools_->zside(firstHitDetId) + 1) >> 1) - 1;
+                           layers * ((recHitTools_->zside(firstHitDetId) + 1) >> 1) - 1;
       trackster_layers.insert(layerid);
       multiplicity_vs_layer[tstId].emplace_back(layerid);
 
@@ -3360,8 +3422,8 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
         histograms.h_multiplicity_zplus_numberOfEventsHistogram[count]->Fill(mlp);
       }
       //For the cluster multiplicity vs cluster energy
-      histograms.h_multiplicityOfLCinTST_vs_layerclusterenergy[count]->Fill(
-          mlp, layerClusters[tst.vertices(lc)].energy());
+      histograms.h_multiplicityOfLCinTST_vs_layerclusterenergy[count]->Fill(mlp,
+                                                                            layerClusters[tst.vertices(lc)].energy());
     }
 
     if (!trackster_layers.empty()) {
@@ -3385,7 +3447,7 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
   histograms.h_conttracksternum[count]->Fill(totNContTstZp + totNContTstZm);
   histograms.h_nonconttracksternum[count]->Fill(totNNotContTstZp + totNNotContTstZm);
 
-  // Linking
+  // CaloPaericle
   tracksters_to_SimTracksters(histograms,
                               count,
                               tracksters,

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -16,8 +16,8 @@ const double ScoreCutLCtoCP_ = 0.1;
 const double ScoreCutCPtoLC_ = 0.1;
 const double ScoreCutLCtoSC_ = 0.1;
 const double ScoreCutSCtoLC_ = 0.1;
-const double ScoreCutTStoSTSFakeMerge_[] = {0.6, 1.e-09};  //FLT_MIN
-const double ScoreCutSTStoTSPurDup_[] = {0.2, 1.e-11};     //FLT_MIN
+const double ScoreCutTStoSTSFakeMerge_[] = {0.6, FLT_MIN};  //1.e-09
+const double ScoreCutSTStoTSPurDup_[] = {0.2, FLT_MIN};     //1.e-11
 
 HGVHistoProducerAlgo::HGVHistoProducerAlgo(const edm::ParameterSet& pset)
     :  //parameters for eta

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1110,7 +1110,9 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
                    (float)2 * layers));
 }
 
-void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Histograms& histograms, const int i) {
+void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook,
+                                                  Histograms& histograms,
+                                                  const validationType valType) {
   const string ref[] = {"caloparticle", "simtrackster", "simtrackster_fromCP"};
   const string refT[] = {"CaloParticle", "SimTrackster", "SimTrackster_fromCP"};
   // Must be in sync with labels in PostProcessorHGCAL_cfi.py
@@ -1121,85 +1123,90 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
   const string shREnFr = ";shared Reco energy fraction";
   const string shSEnFr = ";shared Sim energy fraction";
 
-  histograms.h_score_trackster2caloparticle[i].push_back(ibook.book1D(
-      "Score_trackster2" + ref[i], "Score of Trackster per " + refT[i] + rtos, nintScore_, minScore_, maxScore_));
-  histograms.h_score_trackster2bestCaloparticle[i].push_back(
-      ibook.book1D("ScoreFake_trackster2" + ref[i],
-                   "Score of Trackster per best " + refT[i] + rtos,
+  histograms.h_score_trackster2caloparticle[valType].push_back(
+      ibook.book1D("Score_trackster2" + ref[valType],
+                   "Score of Trackster per " + refT[valType] + rtos,
                    nintScore_,
                    minScore_,
                    maxScore_));
-  histograms.h_score_trackster2bestCaloparticle2[i].push_back(
-      ibook.book1D("ScoreMerge_trackster2" + ref[i],
-                   "Score of Trackster per 2^{nd} best " + refT[i] + rtos,
+  histograms.h_score_trackster2bestCaloparticle[valType].push_back(
+      ibook.book1D("ScoreFake_trackster2" + ref[valType],
+                   "Score of Trackster per best " + refT[valType] + rtos,
                    nintScore_,
                    minScore_,
                    maxScore_));
-  histograms.h_score_caloparticle2trackster[i].push_back(ibook.book1D("Score_" + ref[i] + "2trackster",
-                                                                      "Score of " + refT[i] + " per Trackster" + stor,
-                                                                      nintScore_,
-                                                                      minScore_,
-                                                                      maxScore_));
-  histograms.h_scorePur_caloparticle2trackster[i].push_back(
-      ibook.book1D("ScorePur_" + ref[i] + "2trackster",
-                   "Score of " + refT[i] + " per best Trackster" + stor,
+  histograms.h_score_trackster2bestCaloparticle2[valType].push_back(
+      ibook.book1D("ScoreMerge_trackster2" + ref[valType],
+                   "Score of Trackster per 2^{nd} best " + refT[valType] + rtos,
                    nintScore_,
                    minScore_,
                    maxScore_));
-  histograms.h_scoreDupl_caloparticle2trackster[i].push_back(
-      ibook.book1D("ScoreDupl_" + ref[i] + "2trackster",
-                   "Score of " + refT[i] + " per 2^{nd} best Trackster" + stor,
+  histograms.h_score_caloparticle2trackster[valType].push_back(
+      ibook.book1D("Score_" + ref[valType] + "2trackster",
+                   "Score of " + refT[valType] + " per Trackster" + stor,
                    nintScore_,
                    minScore_,
                    maxScore_));
-  histograms.h_energy_vs_score_trackster2caloparticle[i].push_back(
-      ibook.book2D("Energy_vs_Score_trackster2" + refT[i],
-                   "Energy vs Score of Trackster per " + refT[i] + rtos + shREnFr,
+  histograms.h_scorePur_caloparticle2trackster[valType].push_back(
+      ibook.book1D("ScorePur_" + ref[valType] + "2trackster",
+                   "Score of " + refT[valType] + " per best Trackster" + stor,
+                   nintScore_,
+                   minScore_,
+                   maxScore_));
+  histograms.h_scoreDupl_caloparticle2trackster[valType].push_back(
+      ibook.book1D("ScoreDupl_" + ref[valType] + "2trackster",
+                   "Score of " + refT[valType] + " per 2^{nd} best Trackster" + stor,
+                   nintScore_,
+                   minScore_,
+                   maxScore_));
+  histograms.h_energy_vs_score_trackster2caloparticle[valType].push_back(
+      ibook.book2D("Energy_vs_Score_trackster2" + refT[valType],
+                   "Energy vs Score of Trackster per " + refT[valType] + rtos + shREnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_energy_vs_score_trackster2bestCaloparticle[i].push_back(
-      ibook.book2D("Energy_vs_Score_trackster2best" + refT[i],
-                   "Energy vs Score of Trackster per best " + refT[i] + rtos + shREnFr,
+  histograms.h_energy_vs_score_trackster2bestCaloparticle[valType].push_back(
+      ibook.book2D("Energy_vs_Score_trackster2best" + refT[valType],
+                   "Energy vs Score of Trackster per best " + refT[valType] + rtos + shREnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_energy_vs_score_trackster2bestCaloparticle2[i].push_back(
-      ibook.book2D("Energy_vs_Score_trackster2secBest" + refT[i],
-                   "Energy vs Score of Trackster per 2^{nd} best " + refT[i] + rtos + shREnFr,
+  histograms.h_energy_vs_score_trackster2bestCaloparticle2[valType].push_back(
+      ibook.book2D("Energy_vs_Score_trackster2secBest" + refT[valType],
+                   "Energy vs Score of Trackster per 2^{nd} best " + refT[valType] + rtos + shREnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_energy_vs_score_caloparticle2trackster[i].push_back(
-      ibook.book2D("Energy_vs_Score_" + ref[i] + "2Trackster",
-                   "Energy vs Score of " + refT[i] + " per Trackster" + stor + shSEnFr,
+  histograms.h_energy_vs_score_caloparticle2trackster[valType].push_back(
+      ibook.book2D("Energy_vs_Score_" + ref[valType] + "2Trackster",
+                   "Energy vs Score of " + refT[valType] + " per Trackster" + stor + shSEnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_energy_vs_score_caloparticle2bestTrackster[i].push_back(
-      ibook.book2D("Energy_vs_Score_" + ref[i] + "2bestTrackster",
-                   "Energy vs Score of " + refT[i] + " per best Trackster" + stor + shSEnFr,
+  histograms.h_energy_vs_score_caloparticle2bestTrackster[valType].push_back(
+      ibook.book2D("Energy_vs_Score_" + ref[valType] + "2bestTrackster",
+                   "Energy vs Score of " + refT[valType] + " per best Trackster" + stor + shSEnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_energy_vs_score_caloparticle2bestTrackster2[i].push_back(
-      ibook.book2D("Energy_vs_Score_" + ref[i] + "2secBestTrackster",
-                   "Energy vs Score of " + refT[i] + " per 2^{nd} best Trackster" + stor + shSEnFr,
+  histograms.h_energy_vs_score_caloparticle2bestTrackster2[valType].push_back(
+      ibook.book2D("Energy_vs_Score_" + ref[valType] + "2secBestTrackster",
+                   "Energy vs Score of " + refT[valType] + " per 2^{nd} best Trackster" + stor + shSEnFr,
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1209,170 +1216,211 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
 
   // Back to all Tracksters
   // eta
-  histograms.h_num_trackster_eta[i].push_back(
-      ibook.book1D("Num_Trackster_Eta" + val[i], "Num Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
-  histograms.h_numMerge_trackster_eta[i].push_back(ibook.book1D(
-      "NumMerge_Trackster_Eta" + val[i], "Num Merge Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
-  histograms.h_denom_trackster_eta[i].push_back(ibook.book1D(
-      "Denom_Trackster_Eta" + val[i], "Denom Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
+  histograms.h_num_trackster_eta[valType].push_back(ibook.book1D(
+      "Num_Trackster_Eta" + val[valType], "Num Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
+  histograms.h_numMerge_trackster_eta[valType].push_back(ibook.book1D("NumMerge_Trackster_Eta" + val[valType],
+                                                                      "Num Merge Trackster Eta per Trackster;#eta",
+                                                                      nintEta_,
+                                                                      minEta_,
+                                                                      maxEta_));
+  histograms.h_denom_trackster_eta[valType].push_back(ibook.book1D(
+      "Denom_Trackster_Eta" + val[valType], "Denom Trackster Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
   // phi
-  histograms.h_num_trackster_phi[i].push_back(
-      ibook.book1D("Num_Trackster_Phi" + val[i], "Num Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_numMerge_trackster_phi[i].push_back(ibook.book1D(
-      "NumMerge_Trackster_Phi" + val[i], "Num Merge Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_denom_trackster_phi[i].push_back(ibook.book1D(
-      "Denom_Trackster_Phi" + val[i], "Denom Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_num_trackster_phi[valType].push_back(ibook.book1D(
+      "Num_Trackster_Phi" + val[valType], "Num Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_numMerge_trackster_phi[valType].push_back(ibook.book1D("NumMerge_Trackster_Phi" + val[valType],
+                                                                      "Num Merge Trackster Phi per Trackster;#phi",
+                                                                      nintPhi_,
+                                                                      minPhi_,
+                                                                      maxPhi_));
+  histograms.h_denom_trackster_phi[valType].push_back(ibook.book1D(
+      "Denom_Trackster_Phi" + val[valType], "Denom Trackster Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
   // energy
-  histograms.h_num_trackster_en[i].push_back(ibook.book1D(
-      "Num_Trackster_Energy" + val[i], "Num Trackster Energy per Trackster;energy [GeV]", nintEne_, minEne_, maxEne_));
-  histograms.h_numMerge_trackster_en[i].push_back(ibook.book1D("NumMerge_Trackster_Energy" + val[i],
-                                                               "Num Merge Trackster Energy per Trackster;energy [GeV]",
-                                                               nintEne_,
-                                                               minEne_,
-                                                               maxEne_));
-  histograms.h_denom_trackster_en[i].push_back(ibook.book1D("Denom_Trackster_Energy" + val[i],
-                                                            "Denom Trackster Energy per Trackster;energy [GeV]",
-                                                            nintEne_,
-                                                            minEne_,
-                                                            maxEne_));
+  histograms.h_num_trackster_en[valType].push_back(ibook.book1D("Num_Trackster_Energy" + val[valType],
+                                                                "Num Trackster Energy per Trackster;energy [GeV]",
+                                                                nintEne_,
+                                                                minEne_,
+                                                                maxEne_));
+  histograms.h_numMerge_trackster_en[valType].push_back(
+      ibook.book1D("NumMerge_Trackster_Energy" + val[valType],
+                   "Num Merge Trackster Energy per Trackster;energy [GeV]",
+                   nintEne_,
+                   minEne_,
+                   maxEne_));
+  histograms.h_denom_trackster_en[valType].push_back(ibook.book1D("Denom_Trackster_Energy" + val[valType],
+                                                                  "Denom Trackster Energy per Trackster;energy [GeV]",
+                                                                  nintEne_,
+                                                                  minEne_,
+                                                                  maxEne_));
   // pT
-  histograms.h_num_trackster_pt[i].push_back(ibook.book1D(
-      "Num_Trackster_Pt" + val[i], "Num Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
-  histograms.h_numMerge_trackster_pt[i].push_back(ibook.book1D(
-      "NumMerge_Trackster_Pt" + val[i], "Num Merge Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
-  histograms.h_denom_trackster_pt[i].push_back(ibook.book1D(
-      "Denom_Trackster_Pt" + val[i], "Denom Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_num_trackster_pt[valType].push_back(ibook.book1D(
+      "Num_Trackster_Pt" + val[valType], "Num Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_numMerge_trackster_pt[valType].push_back(
+      ibook.book1D("NumMerge_Trackster_Pt" + val[valType],
+                   "Num Merge Trackster p_{T} per Trackster;p_{T} [GeV]",
+                   nintPt_,
+                   minPt_,
+                   maxPt_));
+  histograms.h_denom_trackster_pt[valType].push_back(ibook.book1D(
+      "Denom_Trackster_Pt" + val[valType], "Denom Trackster p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
 
-  histograms.h_sharedenergy_trackster2caloparticle[i].push_back(
-      ibook.book1D("SharedEnergy_trackster2" + ref[i],
-                   "Shared Energy of Trackster per " + refT[i] + shREnFr,
+  histograms.h_sharedenergy_trackster2caloparticle[valType].push_back(
+      ibook.book1D("SharedEnergy_trackster2" + ref[valType],
+                   "Shared Energy of Trackster per " + refT[valType] + shREnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_trackster2bestCaloparticle[i].push_back(
-      ibook.book1D("SharedEnergy_trackster2" + ref[i] + "_assoc",
-                   "Shared Energy of Trackster per best " + refT[i] + shREnFr,
+  histograms.h_sharedenergy_trackster2bestCaloparticle[valType].push_back(
+      ibook.book1D("SharedEnergy_trackster2" + ref[valType] + "_assoc",
+                   "Shared Energy of Trackster per best " + refT[valType] + shREnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_trackster2bestCaloparticle_vs_eta[i].push_back(
-      ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_assoc_vs_eta",
-                        "Shared Energy of Trackster vs #eta per best " + refT[i] + ";Trackster #eta" + shREnFr,
+  histograms.h_sharedenergy_trackster2bestCaloparticle_vs_eta[valType].push_back(
+      ibook.bookProfile("SharedEnergy_trackster2" + ref[valType] + "_assoc_vs_eta",
+                        "Shared Energy of Trackster vs #eta per best " + refT[valType] + ";Trackster #eta" + shREnFr,
                         nintEta_,
                         minEta_,
                         maxEta_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_trackster2bestCaloparticle_vs_phi[i].push_back(
-      ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_assoc_vs_phi",
-                        "Shared Energy of Trackster vs #phi per best " + refT[i] + ";Trackster #phi" + shREnFr,
+  histograms.h_sharedenergy_trackster2bestCaloparticle_vs_phi[valType].push_back(
+      ibook.bookProfile("SharedEnergy_trackster2" + ref[valType] + "_assoc_vs_phi",
+                        "Shared Energy of Trackster vs #phi per best " + refT[valType] + ";Trackster #phi" + shREnFr,
                         nintPhi_,
                         minPhi_,
                         maxPhi_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_trackster2bestCaloparticle2[i].push_back(
-      ibook.book1D("SharedEnergy_trackster2" + ref[i] + "_assoc2",
-                   "Shared Energy of Trackster per 2^{nd} best " + refT[i] + shREnFr,
+  histograms.h_sharedenergy_trackster2bestCaloparticle2[valType].push_back(
+      ibook.book1D("SharedEnergy_trackster2" + ref[valType] + "_assoc2",
+                   "Shared Energy of Trackster per 2^{nd} best " + refT[valType] + shREnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
 
-  histograms.h_sharedenergy_caloparticle2trackster[i].push_back(
-      ibook.book1D("SharedEnergy_" + ref[i] + "2trackster",
-                   "Shared Energy of " + refT[i] + " per Trackster" + shSEnFr,
+  histograms.h_sharedenergy_caloparticle2trackster[valType].push_back(
+      ibook.book1D("SharedEnergy_" + ref[valType] + "2trackster",
+                   "Shared Energy of " + refT[valType] + " per Trackster" + shSEnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster_assoc[i].push_back(
-      ibook.book1D("SharedEnergy_" + ref[i] + "2trackster_assoc",
-                   "Shared Energy of " + refT[i] + " per best Trackster" + shSEnFr,
+  histograms.h_sharedenergy_caloparticle2trackster_assoc[valType].push_back(
+      ibook.book1D("SharedEnergy_" + ref[valType] + "2trackster_assoc",
+                   "Shared Energy of " + refT[valType] + " per best Trackster" + shSEnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[i].push_back(
-      ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_assoc_vs_eta",
-                        "Shared Energy of " + refT[i] + " vs #eta per best Trackster;" + refT[i] + " #eta" + shSEnFr,
-                        nintEta_,
-                        minEta_,
-                        maxEta_,
-                        minTSTSharedEneFrac_,
-                        maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[i].push_back(
-      ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_assoc_vs_phi",
-                        "Shared Energy of " + refT[i] + " vs #phi per best Trackster;" + refT[i] + " #phi" + shSEnFr,
-                        nintPhi_,
-                        minPhi_,
-                        maxPhi_,
-                        minTSTSharedEneFrac_,
-                        maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster_assoc2[i].push_back(
-      ibook.book1D("SharedEnergy_" + ref[i] + "2trackster_assoc2",
-                   "Shared Energy of " + refT[i] + " per 2^{nd} best Trackster;" + shSEnFr,
+  histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[valType].push_back(ibook.bookProfile(
+      "SharedEnergy_" + ref[valType] + "2trackster_assoc_vs_eta",
+      "Shared Energy of " + refT[valType] + " vs #eta per best Trackster;" + refT[valType] + " #eta" + shSEnFr,
+      nintEta_,
+      minEta_,
+      maxEta_,
+      minTSTSharedEneFrac_,
+      maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[valType].push_back(ibook.bookProfile(
+      "SharedEnergy_" + ref[valType] + "2trackster_assoc_vs_phi",
+      "Shared Energy of " + refT[valType] + " vs #phi per best Trackster;" + refT[valType] + " #phi" + shSEnFr,
+      nintPhi_,
+      minPhi_,
+      maxPhi_,
+      minTSTSharedEneFrac_,
+      maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_caloparticle2trackster_assoc2[valType].push_back(
+      ibook.book1D("SharedEnergy_" + ref[valType] + "2trackster_assoc2",
+                   "Shared Energy of " + refT[valType] + " per 2^{nd} best Trackster;" + shSEnFr,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
 
   // eta
-  histograms.h_numEff_caloparticle_eta[i].push_back(
-      ibook.book1D("NumEff_" + refT[i] + "_Eta",
-                   "Num Efficiency " + refT[i] + " Eta per Trackster;#eta",
+  histograms.h_numEff_caloparticle_eta[valType].push_back(
+      ibook.book1D("NumEff_" + refT[valType] + "_Eta",
+                   "Num Efficiency " + refT[valType] + " Eta per Trackster;#eta",
                    nintEta_,
                    minEta_,
                    maxEta_));
-  histograms.h_num_caloparticle_eta[i].push_back(ibook.book1D(
-      "Num_" + refT[i] + "_Eta", "Num Purity " + refT[i] + " Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
-  histograms.h_numDup_trackster_eta[i].push_back(
-      ibook.book1D("NumDup_Trackster_Eta" + val[i], "Num Duplicate Trackster vs Eta;#eta", nintEta_, minEta_, maxEta_));
-  histograms.h_denom_caloparticle_eta[i].push_back(ibook.book1D(
-      "Denom_" + refT[i] + "_Eta", "Denom " + refT[i] + " Eta per Trackster;#eta", nintEta_, minEta_, maxEta_));
+  histograms.h_num_caloparticle_eta[valType].push_back(
+      ibook.book1D("Num_" + refT[valType] + "_Eta",
+                   "Num Purity " + refT[valType] + " Eta per Trackster;#eta",
+                   nintEta_,
+                   minEta_,
+                   maxEta_));
+  histograms.h_numDup_trackster_eta[valType].push_back(ibook.book1D(
+      "NumDup_Trackster_Eta" + val[valType], "Num Duplicate Trackster vs Eta;#eta", nintEta_, minEta_, maxEta_));
+  histograms.h_denom_caloparticle_eta[valType].push_back(
+      ibook.book1D("Denom_" + refT[valType] + "_Eta",
+                   "Denom " + refT[valType] + " Eta per Trackster;#eta",
+                   nintEta_,
+                   minEta_,
+                   maxEta_));
   // phi
-  histograms.h_numEff_caloparticle_phi[i].push_back(
-      ibook.book1D("NumEff_" + refT[i] + "_Phi",
-                   "Num Efficiency " + refT[i] + " Phi per Trackster;#phi",
+  histograms.h_numEff_caloparticle_phi[valType].push_back(
+      ibook.book1D("NumEff_" + refT[valType] + "_Phi",
+                   "Num Efficiency " + refT[valType] + " Phi per Trackster;#phi",
                    nintPhi_,
                    minPhi_,
                    maxPhi_));
-  histograms.h_num_caloparticle_phi[i].push_back(ibook.book1D(
-      "Num_" + refT[i] + "_Phi", "Num Purity " + refT[i] + " Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_numDup_trackster_phi[i].push_back(
-      ibook.book1D("NumDup_Trackster_Phi" + val[i], "Num Duplicate Trackster vs Phi;#phi", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_denom_caloparticle_phi[i].push_back(ibook.book1D(
-      "Denom_" + refT[i] + "_Phi", "Denom " + refT[i] + " Phi per Trackster;#phi", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_num_caloparticle_phi[valType].push_back(
+      ibook.book1D("Num_" + refT[valType] + "_Phi",
+                   "Num Purity " + refT[valType] + " Phi per Trackster;#phi",
+                   nintPhi_,
+                   minPhi_,
+                   maxPhi_));
+  histograms.h_numDup_trackster_phi[valType].push_back(ibook.book1D(
+      "NumDup_Trackster_Phi" + val[valType], "Num Duplicate Trackster vs Phi;#phi", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_denom_caloparticle_phi[valType].push_back(
+      ibook.book1D("Denom_" + refT[valType] + "_Phi",
+                   "Denom " + refT[valType] + " Phi per Trackster;#phi",
+                   nintPhi_,
+                   minPhi_,
+                   maxPhi_));
   // energy
-  histograms.h_numEff_caloparticle_en[i].push_back(
-      ibook.book1D("NumEff_" + refT[i] + "_Energy",
-                   "Num Efficiency " + refT[i] + " Energy per Trackster;energy [GeV]",
+  histograms.h_numEff_caloparticle_en[valType].push_back(
+      ibook.book1D("NumEff_" + refT[valType] + "_Energy",
+                   "Num Efficiency " + refT[valType] + " Energy per Trackster;energy [GeV]",
                    nintEne_,
                    minEne_,
                    maxEne_));
-  histograms.h_num_caloparticle_en[i].push_back(
-      ibook.book1D("Num_" + refT[i] + "_Energy",
-                   "Num Purity " + refT[i] + " Energy per Trackster;energy [GeV]",
+  histograms.h_num_caloparticle_en[valType].push_back(
+      ibook.book1D("Num_" + refT[valType] + "_Energy",
+                   "Num Purity " + refT[valType] + " Energy per Trackster;energy [GeV]",
                    nintEne_,
                    minEne_,
                    maxEne_));
-  histograms.h_numDup_trackster_en[i].push_back(ibook.book1D(
-      "NumDup_Trackster_Energy" + val[i], "Num Duplicate Trackster vs Energy;energy [GeV]", nintEne_, minEne_, maxEne_));
-  histograms.h_denom_caloparticle_en[i].push_back(
-      ibook.book1D("Denom_" + refT[i] + "_Energy",
-                   "Denom " + refT[i] + " Energy per Trackster;energy [GeV]",
+  histograms.h_numDup_trackster_en[valType].push_back(ibook.book1D("NumDup_Trackster_Energy" + val[valType],
+                                                                   "Num Duplicate Trackster vs Energy;energy [GeV]",
+                                                                   nintEne_,
+                                                                   minEne_,
+                                                                   maxEne_));
+  histograms.h_denom_caloparticle_en[valType].push_back(
+      ibook.book1D("Denom_" + refT[valType] + "_Energy",
+                   "Denom " + refT[valType] + " Energy per Trackster;energy [GeV]",
                    nintEne_,
                    minEne_,
                    maxEne_));
   // pT
-  histograms.h_numEff_caloparticle_pt[i].push_back(
-      ibook.book1D("NumEff_" + refT[i] + "_Pt",
-                   "Num Efficiency " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]",
+  histograms.h_numEff_caloparticle_pt[valType].push_back(
+      ibook.book1D("NumEff_" + refT[valType] + "_Pt",
+                   "Num Efficiency " + refT[valType] + " p_{T} per Trackster;p_{T} [GeV]",
                    nintPt_,
                    minPt_,
                    maxPt_));
-  histograms.h_num_caloparticle_pt[i].push_back(ibook.book1D(
-      "Num_" + refT[i] + "_Pt", "Num Purity " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
-  histograms.h_numDup_trackster_pt[i].push_back(ibook.book1D(
-      "NumDup_Trackster_Pt" + val[i], "Num Duplicate Trackster vs p_{T};p_{T} [GeV]", nintPt_, minPt_, maxPt_));
-  histograms.h_denom_caloparticle_pt[i].push_back(ibook.book1D(
-      "Denom_" + refT[i] + "_Pt", "Denom " + refT[i] + " p_{T} per Trackster;p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_num_caloparticle_pt[valType].push_back(
+      ibook.book1D("Num_" + refT[valType] + "_Pt",
+                   "Num Purity " + refT[valType] + " p_{T} per Trackster;p_{T} [GeV]",
+                   nintPt_,
+                   minPt_,
+                   maxPt_));
+  histograms.h_numDup_trackster_pt[valType].push_back(ibook.book1D(
+      "NumDup_Trackster_Pt" + val[valType], "Num Duplicate Trackster vs p_{T};p_{T} [GeV]", nintPt_, minPt_, maxPt_));
+  histograms.h_denom_caloparticle_pt[valType].push_back(
+      ibook.book1D("Denom_" + refT[valType] + "_Pt",
+                   "Denom " + refT[valType] + " p_{T} per Trackster;p_{T} [GeV]",
+                   nintPt_,
+                   minPt_,
+                   maxPt_));
 }
 
 void HGVHistoProducerAlgo::fill_info_histos(const Histograms& histograms, unsigned int layers) const {
@@ -1647,7 +1695,7 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simCluster_histos(const Hi
 
 void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simClusterAssociation_histos(
     const Histograms& histograms,
-    int count,
+    const int count,
     edm::Handle<reco::CaloClusterCollection> clusterHandle,
     const reco::CaloClusterCollection& clusters,
     edm::Handle<std::vector<SimCluster>> simClusterHandle,
@@ -1681,7 +1729,7 @@ void HGVHistoProducerAlgo::HGVHistoProducerAlgo::fill_simClusterAssociation_hist
 }
 
 void HGVHistoProducerAlgo::fill_cluster_histos(const Histograms& histograms,
-                                               int count,
+                                               const int count,
                                                const reco::CaloCluster& cluster) const {
   const auto eta = getEta(cluster.eta());
   histograms.h_cluster_eta[count]->Fill(eta);
@@ -1947,7 +1995,7 @@ void HGVHistoProducerAlgo::layerClusters_to_CaloParticles(const Histograms& hist
 
 void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
     const Histograms& histograms,
-    int count,
+    const int count,
     edm::Handle<reco::CaloClusterCollection> clusterHandle,
     const reco::CaloClusterCollection& clusters,
     edm::Handle<std::vector<SimCluster>> simClusterHandle,
@@ -2125,7 +2173,7 @@ void HGVHistoProducerAlgo::layerClusters_to_SimClusters(
 }
 
 void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histograms,
-                                                       int count,
+                                                       const int count,
                                                        edm::Handle<reco::CaloClusterCollection> clusterHandle,
                                                        const reco::CaloClusterCollection& clusters,
                                                        const Density& densities,
@@ -2450,11 +2498,11 @@ void HGVHistoProducerAlgo::fill_generic_cluster_histos(const Histograms& histogr
 
 void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
     const Histograms& histograms,
-    int count,
+    const int count,
     const ticl::TracksterCollection& tracksters,
     const reco::CaloClusterCollection& layerClusters,
     const ticl::TracksterCollection& simTSs,
-    const int i,
+    const validationType valType,
     const ticl::TracksterCollection& simTSs_fromCP,
     const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
     std::vector<SimCluster> const& sC,
@@ -2478,12 +2526,9 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
   std::vector<std::vector<std::pair<unsigned int, float>>> stsInTrackster;
   stsInTrackster.resize(nTracksters);
 
-  //cPOnLayer[caloparticle][layer]
-  //This defines a "calo particle on layer" concept. It is only filled in case
-  //that calo particle has a reconstructed hit related via detid. So, a cPOnLayer[i][j] connects a
-  //specific calo particle i in layer j with:
-  //1. the sum of all rechits energy times fraction of the relevant simhit in layer j related to that calo particle i.
-  //2. the hits and fractions of that calo particle i in layer j.
+  // cPOnLayer[caloparticle]:
+  //1. the sum of all rechits energy times fraction of the relevant simhit related to that calo particle.
+  //2. the hits and fractions of that calo particle.
   //3. the layer clusters with matched rechit id.
   std::unordered_map<int, caloParticleOnLayer> cPOnLayer;
   std::unordered_map<int, std::vector<caloParticleOnLayer>> sCOnLayer;
@@ -2492,7 +2537,6 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
     cPOnLayer[cpIndex].caloParticleId = cpIndex;
     cPOnLayer[cpIndex].energy = 0.f;
     cPOnLayer[cpIndex].hits_and_fractions.clear();
-    //const auto nSC_inCP = cP[cpIndex].simClusters().size();
     const auto nSC_inCP = sC.size();
     sCOnLayer[cpIndex].resize(nSC_inCP);
     for (unsigned int iSC = 0; iSC < nSC_inCP; iSC++) {
@@ -2563,12 +2607,12 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
         //V10:maps the layers in -z: 0->49 and in +z: 50->99
         const auto itcheck = hitMap.find(hitid);
         //Checks whether the current hit belonging to sim cluster has a reconstructed hit.
-        if ((i == 0 && itcheck != hitMap.end()) || (i > 0 && int(lcId) >= 0)) {
-          const auto elemId = (i == 0) ? hitid : lcId;
+        if ((valType == 0 && itcheck != hitMap.end()) || (valType > 0 && int(lcId) >= 0)) {
+          const auto elemId = (valType == 0) ? hitid : lcId;
           const auto iLC = std::find(simTSs[iSTS].vertices().begin(), simTSs[iSTS].vertices().end(), lcId);
           const auto lcFraction =
               1.f / simTSs[iSTS].vertex_multiplicity(std::distance(std::begin(simTSs[iSTS].vertices()), iLC));
-          const auto elemFr = (i == 0) ? it_haf.second : lcFraction;
+          const auto elemFr = (valType == 0) ? it_haf.second : lcFraction;
           //Since the current hit from sim cluster has a reconstructed hit with the same detid,
           //make a map that will connect a detid with:
           //1. the CaloParticles that have a SimCluster with sim hits in that cell via caloparticle id.
@@ -2586,7 +2630,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
                           HGVHistoProducerAlgo::detIdInfoInCluster{
                               iSTS, 0});  // only the first element is used for the matching (overloaded operator==)
             if (findSTSIt != detIdSimTSId_Map[elemId].end()) {
-              if (i == 0)
+              if (valType == 0)
                 findSTSIt->fraction += elemFr;
             } else {
               detIdSimTSId_Map[elemId].emplace_back(HGVHistoProducerAlgo::detIdInfoInCluster{iSTS, elemFr});
@@ -2644,9 +2688,9 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
   for (unsigned int tstId = 0; tstId < nTracksters; ++tstId) {
     const auto& tst = tracksters[tstId];
     if (tstId == 0)
-      if ((i > 0) && (tst.ticlIteration() == ticl::Trackster::SIM)) {
-        ScoreCutSTStoTSPurDup = ScoreCutSTStoTSPurDup_[i];
-        ScoreCutTStoSTSFakeMerge = ScoreCutTStoSTSFakeMerge_[i];
+      if ((valType > 0) && (tst.ticlIteration() == ticl::Trackster::SIM)) {
+        ScoreCutSTStoTSPurDup = ScoreCutSTStoTSPurDup_[valType];
+        ScoreCutTStoSTSFakeMerge = ScoreCutTStoSTSFakeMerge_[valType];
       }
 
     if (tst.vertices().empty())
@@ -2717,7 +2761,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
                       HGVHistoProducerAlgo::detIdInfoInTrackster{
                           tstId, 0, 0});  // only the first element is used for the matching (overloaded operator==)
         if (findTSIt != detIdToTracksterId_Map[rh_detid].end()) {
-          if (i == 0)
+          if (valType == 0)
             findTSIt->fraction += rhFraction;
         } else {
           detIdToTracksterId_Map[rh_detid].emplace_back(
@@ -2736,8 +2780,8 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
       }
 
       // Check whether the RecHit of the trackster under study has a SimHit in the same cell
-      const auto elemId = (i == 0) ? rh_detid.rawId() : lcId_r;
-      const auto recoFr = (i == 0) ? rhFraction : lcFraction_r;
+      const auto elemId = (valType == 0) ? rh_detid.rawId() : lcId_r;
+      const auto recoFr = (valType == 0) ? rhFraction : lcFraction_r;
       const auto& hit_find_in_STS = detIdSimTSId_Map.find(elemId);
       if (hit_find_in_STS == detIdSimTSId_Map.end()) {
         hitsToCaloParticleId[iHit] -= 1;
@@ -2818,10 +2862,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
     //The energy of the CaloParticle that found to have the maximum energy shared with the Trackster under study.
     float totalCPEnergyFromLayerCP = 0.f;
     if (maxCPId_byEnergy >= 0) {
-      //Loop through all layers
-      //for (unsigned int j = 0; j < layers * 2; ++j) {
       totalCPEnergyFromLayerCP += cPOnLayer[maxCPId_byEnergy].energy;
-      //}
       energyFractionOfCPinTS = maxEnergySharedTSandCP / totalCPEnergyFromLayerCP;
       if (tst.raw_energy() > 0.f) {
         energyFractionOfTSinCP = maxEnergySharedTSandCP / tst.raw_energy();
@@ -2864,7 +2905,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
         stsPair.second = 1.;
         LogDebug("HGCalValidator") << "Trackster Id:\t" << tstId << "\tSimTrackster id:\t" << stsPair.first
                                    << "\tscore\t" << stsPair.second << std::endl;
-        histograms.h_score_trackster2caloparticle[i][count]->Fill(stsPair.second);
+        histograms.h_score_trackster2caloparticle[valType][count]->Fill(stsPair.second);
       }
       continue;
     }
@@ -2875,7 +2916,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
     float tracksterEnergy = 0.f, invTracksterEnergyWeight = 0.f;
     for (const auto& haf : tst_hitsAndFractions) {
       float hitFr = 0.f;
-      if (i == 0) {
+      if (valType == 0) {
         hitFr = haf.second;
       } else {
         const auto lcId = getLCId(tst.vertices(), layerClusters, haf.first);
@@ -2892,7 +2933,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
       const auto rh_detid = haf.first;
       unsigned int elemId = 0;
       float rhFraction = 0.f;
-      if (i == 0) {
+      if (valType == 0) {
         elemId = rh_detid.rawId();
         rhFraction = haf.second;
       } else {
@@ -2946,15 +2987,12 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
       const auto iSTS = stsPair.first;
       const auto iScore = stsPair.second;
       const auto cpId = getCPId(simTSs[iSTS], iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
-      //if (std::find(cPIndices.begin(), cPIndices.end(), cpId) == cPIndices.end())
-      //  continue;
       auto iSim = simTSs[iSTS].seedIndex();
       if (simTSs[iSTS].seedID() == cPHandle_id)  // SimTrackster from CaloParticle
         iSim = 0;
-      const auto& simOnLayer = (i == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][iSim];
+      const auto& simOnLayer = (valType == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][iSim];
 
       float sharedeneCPallLayers = 0.;
-      //for (unsigned int j = 0; j < layers * 2; ++j)
       sharedeneCPallLayers += simOnLayer.layerClusterIdToEnergyAndScore.count(tstId)
                                   ? simOnLayer.layerClusterIdToEnergyAndScore.at(tstId).first
                                   : 0;
@@ -2967,26 +3005,26 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
                                  << " (CP id: " << cpId << ")\tscore: " << iScore
                                  << "\tsharedeneCPallLayers: " << sharedeneCPallLayers << std::endl;
 
-      histograms.h_score_trackster2caloparticle[i][count]->Fill(iScore);
-      histograms.h_sharedenergy_trackster2caloparticle[i][count]->Fill(sharedEneFrac);
-      histograms.h_energy_vs_score_trackster2caloparticle[i][count]->Fill(iScore, sharedEneFrac);
+      histograms.h_score_trackster2caloparticle[valType][count]->Fill(iScore);
+      histograms.h_sharedenergy_trackster2caloparticle[valType][count]->Fill(sharedEneFrac);
+      histograms.h_energy_vs_score_trackster2caloparticle[valType][count]->Fill(iScore, sharedEneFrac);
       if (iSTS == score->first) {
-        histograms.h_score_trackster2bestCaloparticle[i][count]->Fill(iScore);
-        histograms.h_sharedenergy_trackster2bestCaloparticle[i][count]->Fill(sharedEneFrac);
-        histograms.h_sharedenergy_trackster2bestCaloparticle_vs_eta[i][count]->Fill(tst.barycenter().eta(),
-                                                                                    sharedEneFrac);
-        histograms.h_sharedenergy_trackster2bestCaloparticle_vs_phi[i][count]->Fill(tst.barycenter().phi(),
-                                                                                    sharedEneFrac);
-        histograms.h_energy_vs_score_trackster2bestCaloparticle[i][count]->Fill(iScore, sharedEneFrac);
+        histograms.h_score_trackster2bestCaloparticle[valType][count]->Fill(iScore);
+        histograms.h_sharedenergy_trackster2bestCaloparticle[valType][count]->Fill(sharedEneFrac);
+        histograms.h_sharedenergy_trackster2bestCaloparticle_vs_eta[valType][count]->Fill(tst.barycenter().eta(),
+                                                                                          sharedEneFrac);
+        histograms.h_sharedenergy_trackster2bestCaloparticle_vs_phi[valType][count]->Fill(tst.barycenter().phi(),
+                                                                                          sharedEneFrac);
+        histograms.h_energy_vs_score_trackster2bestCaloparticle[valType][count]->Fill(iScore, sharedEneFrac);
       } else if (score2 < 0 || iScore < score2) {
         score2 = iScore;
         sharedEneFrac2 = sharedEneFrac;
       }
     }  // end of loop through SimTracksters associated to Trackster
     if (score2 > -1) {
-      histograms.h_score_trackster2bestCaloparticle2[i][count]->Fill(score2);
-      histograms.h_sharedenergy_trackster2bestCaloparticle2[i][count]->Fill(sharedEneFrac2);
-      histograms.h_energy_vs_score_trackster2bestCaloparticle2[i][count]->Fill(score2, sharedEneFrac2);
+      histograms.h_score_trackster2bestCaloparticle2[valType][count]->Fill(score2);
+      histograms.h_sharedenergy_trackster2bestCaloparticle2[valType][count]->Fill(sharedEneFrac2);
+      histograms.h_energy_vs_score_trackster2bestCaloparticle2[valType][count]->Fill(score2, sharedEneFrac2);
     }
   }  // end of loop through Tracksters
 
@@ -3008,7 +3046,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
   for (unsigned int iSTS = 0; iSTS < nSimTracksters; ++iSTS) {
     const auto& sts = simTSs[iSTS];
     const auto& cpId = getCPId(sts, iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTSs_fromCP);
-    if (i == 0 && std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
+    if (valType == 0 && std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
       continue;
 
     const auto& hafLC = apply_LCMultiplicity(sts, layerClusters);
@@ -3023,7 +3061,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
     auto iSim = sts.seedIndex();
     if (sts.seedID() == cPHandle_id)  // SimTrackster from CaloParticle
       iSim = 0;
-    auto& simOnLayer = (i == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][iSim];
+    auto& simOnLayer = (valType == 0) ? cPOnLayer[cpId] : sCOnLayer[cpId][iSim];
 
     // Keep the Trackster ids that are related to
     // SimTrackster under study for the final filling of the score
@@ -3062,7 +3100,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
                                << maxEnergyTSperlayerinSim << "\t" << std::setw(20) << SimEnergyFractionInTSperlayer
                                << "\n";
 
-    for (const auto& haf : ((i == 0) ? simOnLayer.hits_and_fractions : hafLC)) {
+    for (const auto& haf : ((valType == 0) ? simOnLayer.hits_and_fractions : hafLC)) {
       const auto& hitDetId = haf.first;
       // Compute the correct normalization
       // Need to loop on the simOnLayer data structure since this is the
@@ -3072,7 +3110,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
 
       const auto lcId = getLCId(sts.vertices(), layerClusters, hitDetId);
       float cpFraction = 0.f;
-      if (i == 0) {
+      if (valType == 0) {
         cpFraction = haf.second;
       } else {
         const auto iLC = std::find(sts.vertices().begin(), sts.vertices().end(), lcId);
@@ -3100,7 +3138,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
                         HGVHistoProducerAlgo::detIdInfoInTrackster{
                             tstId, 0, 0.f});  // only the first element is used for the matching (overloaded operator==)
           if (findTSIt != detIdToTracksterId_Map[hitDetId].end()) {
-            if (i == 0) {
+            if (valType == 0) {
               tstFraction = findTSIt->fraction;
             } else {
               const auto iLC = std::find(
@@ -3143,25 +3181,25 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
     }
     //} // end of loop through layers
 
-    const auto scoreDenom = (i == 0) ? SimEnergyWeight : hitsEnergyWeight;
-    const auto energyDenom = (i == 0) ? SimEnergy : SimEnergy_LC;
+    const auto scoreDenom = (valType == 0) ? SimEnergyWeight : hitsEnergyWeight;
+    const auto energyDenom = (valType == 0) ? SimEnergy : SimEnergy_LC;
 
     const auto sts_eta = sts.barycenter().eta();
     const auto sts_phi = sts.barycenter().phi();
     const auto sts_en = sts.raw_energy();
     const auto sts_pt = sts.raw_pt();
-    histograms.h_denom_caloparticle_eta[i][count]->Fill(sts_eta);
-    histograms.h_denom_caloparticle_phi[i][count]->Fill(sts_phi);
-    histograms.h_denom_caloparticle_en[i][count]->Fill(sts_en);
-    histograms.h_denom_caloparticle_pt[i][count]->Fill(sts_pt);
+    histograms.h_denom_caloparticle_eta[valType][count]->Fill(sts_eta);
+    histograms.h_denom_caloparticle_phi[valType][count]->Fill(sts_phi);
+    histograms.h_denom_caloparticle_en[valType][count]->Fill(sts_en);
+    histograms.h_denom_caloparticle_pt[valType][count]->Fill(sts_pt);
 
     //Loop through related Tracksters here
     // In case the threshold to associate a CaloParticle to a Trackster is
     // below 50%, there could be cases in which the CP is linked to more than
     // one tracksters, leading to efficiencies >1. This boolean is used to
     // avoid "over counting".
-    bool cp_considered_efficient = false;
-    bool cp_considered_pure = false;
+    bool sts_considered_efficient = false;
+    bool sts_considered_pure = false;
     for (const auto tstId : stsId_tstId_related) {
       // Now time for the denominator
       score3d_iSTS[tstId] /= scoreDenom;
@@ -3173,24 +3211,25 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
                                  << "\tshared energy: " << tstSharedEnergy[iSTS][tstId]
                                  << "\tshared energy fraction: " << tstSharedEnergyFrac << "\n";
 
-      histograms.h_score_caloparticle2trackster[i][count]->Fill(score3d_iSTS[tstId]);
-      histograms.h_sharedenergy_caloparticle2trackster[i][count]->Fill(tstSharedEnergyFrac);
-      histograms.h_energy_vs_score_caloparticle2trackster[i][count]->Fill(score3d_iSTS[tstId], tstSharedEnergyFrac);
+      histograms.h_score_caloparticle2trackster[valType][count]->Fill(score3d_iSTS[tstId]);
+      histograms.h_sharedenergy_caloparticle2trackster[valType][count]->Fill(tstSharedEnergyFrac);
+      histograms.h_energy_vs_score_caloparticle2trackster[valType][count]->Fill(score3d_iSTS[tstId],
+                                                                                tstSharedEnergyFrac);
       // Fill the numerator for the efficiency calculation. The efficiency is computed by considering the energy shared between a Trackster and a _corresponding_ caloParticle. The threshold is configurable via python.
-      if (!cp_considered_efficient && (tstSharedEnergyFrac >= minTSTSharedEneFracEfficiency_)) {
-        cp_considered_efficient = true;
-        histograms.h_numEff_caloparticle_eta[i][count]->Fill(sts_eta);
-        histograms.h_numEff_caloparticle_phi[i][count]->Fill(sts_phi);
-        histograms.h_numEff_caloparticle_en[i][count]->Fill(sts_en);
-        histograms.h_numEff_caloparticle_pt[i][count]->Fill(sts_pt);
+      if (!sts_considered_efficient && (tstSharedEnergyFrac >= minTSTSharedEneFracEfficiency_)) {
+        sts_considered_efficient = true;
+        histograms.h_numEff_caloparticle_eta[valType][count]->Fill(sts_eta);
+        histograms.h_numEff_caloparticle_phi[valType][count]->Fill(sts_phi);
+        histograms.h_numEff_caloparticle_en[valType][count]->Fill(sts_en);
+        histograms.h_numEff_caloparticle_pt[valType][count]->Fill(sts_pt);
       }
 
       if (score3d_iSTS[tstId] < ScoreCutSTStoTSPurDup) {
         if (tracksters_PurityDuplicate[tstId] < 1)
           tracksters_PurityDuplicate[tstId]++;  // for Purity
-        if (cp_considered_pure)
+        if (sts_considered_pure)
           tracksters_PurityDuplicate[tstId]++;  // for Duplicate
-        cp_considered_pure = true;
+        sts_considered_pure = true;
       }
     }  // end of loop through Tracksters related to SimTrackster
 
@@ -3198,11 +3237,13 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
     if (best != score3d_iSTS.end()) {
       const auto bestTstId = std::distance(std::begin(score3d_iSTS), best);
       const auto bestTstSharedEnergyFrac = tstSharedEnergy[iSTS][bestTstId] / energyDenom;
-      histograms.h_scorePur_caloparticle2trackster[i][count]->Fill(*best);
-      histograms.h_sharedenergy_caloparticle2trackster_assoc[i][count]->Fill(bestTstSharedEnergyFrac);
-      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[i][count]->Fill(sts_eta, bestTstSharedEnergyFrac);
-      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[i][count]->Fill(sts_phi, bestTstSharedEnergyFrac);
-      histograms.h_energy_vs_score_caloparticle2bestTrackster[i][count]->Fill(*best, bestTstSharedEnergyFrac);
+      histograms.h_scorePur_caloparticle2trackster[valType][count]->Fill(*best);
+      histograms.h_sharedenergy_caloparticle2trackster_assoc[valType][count]->Fill(bestTstSharedEnergyFrac);
+      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[valType][count]->Fill(sts_eta,
+                                                                                          bestTstSharedEnergyFrac);
+      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[valType][count]->Fill(sts_phi,
+                                                                                          bestTstSharedEnergyFrac);
+      histograms.h_energy_vs_score_caloparticle2bestTrackster[valType][count]->Fill(*best, bestTstSharedEnergyFrac);
       LogDebug("HGCalValidator") << count << " " << sts_eta << " " << sts_phi << " "
                                  << tracksters[bestTstId].raw_energy() << " " << sts.raw_energy() << " "
                                  << bestTstSharedEnergyFrac << "\n";
@@ -3214,9 +3255,10 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
             best2 = tstId;
         const auto best2TstId = std::distance(std::begin(score3d_iSTS), best2);
         const auto best2TstSharedEnergyFrac = tstSharedEnergy[iSTS][best2TstId] / energyDenom;
-        histograms.h_scoreDupl_caloparticle2trackster[i][count]->Fill(*best2);
-        histograms.h_sharedenergy_caloparticle2trackster_assoc2[i][count]->Fill(best2TstSharedEnergyFrac);
-        histograms.h_energy_vs_score_caloparticle2bestTrackster2[i][count]->Fill(*best2, best2TstSharedEnergyFrac);
+        histograms.h_scoreDupl_caloparticle2trackster[valType][count]->Fill(*best2);
+        histograms.h_sharedenergy_caloparticle2trackster_assoc2[valType][count]->Fill(best2TstSharedEnergyFrac);
+        histograms.h_energy_vs_score_caloparticle2bestTrackster2[valType][count]->Fill(*best2,
+                                                                                       best2TstSharedEnergyFrac);
       }
     }
   }  // end of loop through SimTracksters
@@ -3232,36 +3274,36 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
     const auto iTS_phi = tst.barycenter().phi();
     const auto iTS_en = tst.raw_energy();
     const auto iTS_pt = tst.raw_pt();
-    histograms.h_denom_trackster_eta[i][count]->Fill(iTS_eta);
-    histograms.h_denom_trackster_phi[i][count]->Fill(iTS_phi);
-    histograms.h_denom_trackster_en[i][count]->Fill(iTS_en);
-    histograms.h_denom_trackster_pt[i][count]->Fill(iTS_pt);
+    histograms.h_denom_trackster_eta[valType][count]->Fill(iTS_eta);
+    histograms.h_denom_trackster_phi[valType][count]->Fill(iTS_phi);
+    histograms.h_denom_trackster_en[valType][count]->Fill(iTS_en);
+    histograms.h_denom_trackster_pt[valType][count]->Fill(iTS_pt);
 
     if (tracksters_PurityDuplicate[tstId] > 0) {
-      histograms.h_num_caloparticle_eta[i][count]->Fill(iTS_eta);
-      histograms.h_num_caloparticle_phi[i][count]->Fill(iTS_phi);
-      histograms.h_num_caloparticle_en[i][count]->Fill(iTS_en);
-      histograms.h_num_caloparticle_pt[i][count]->Fill(iTS_pt);
+      histograms.h_num_caloparticle_eta[valType][count]->Fill(iTS_eta);
+      histograms.h_num_caloparticle_phi[valType][count]->Fill(iTS_phi);
+      histograms.h_num_caloparticle_en[valType][count]->Fill(iTS_en);
+      histograms.h_num_caloparticle_pt[valType][count]->Fill(iTS_pt);
 
       if (tracksters_PurityDuplicate[tstId] > 1) {
-        histograms.h_numDup_trackster_eta[i][count]->Fill(iTS_eta);
-        histograms.h_numDup_trackster_phi[i][count]->Fill(iTS_phi);
-        histograms.h_numDup_trackster_en[i][count]->Fill(iTS_en);
-        histograms.h_numDup_trackster_pt[i][count]->Fill(iTS_pt);
+        histograms.h_numDup_trackster_eta[valType][count]->Fill(iTS_eta);
+        histograms.h_numDup_trackster_phi[valType][count]->Fill(iTS_phi);
+        histograms.h_numDup_trackster_en[valType][count]->Fill(iTS_en);
+        histograms.h_numDup_trackster_pt[valType][count]->Fill(iTS_pt);
       }
     }
 
     if (tracksters_FakeMerge[tstId] > 0) {
-      histograms.h_num_trackster_eta[i][count]->Fill(iTS_eta);
-      histograms.h_num_trackster_phi[i][count]->Fill(iTS_phi);
-      histograms.h_num_trackster_en[i][count]->Fill(iTS_en);
-      histograms.h_num_trackster_pt[i][count]->Fill(iTS_pt);
+      histograms.h_num_trackster_eta[valType][count]->Fill(iTS_eta);
+      histograms.h_num_trackster_phi[valType][count]->Fill(iTS_phi);
+      histograms.h_num_trackster_en[valType][count]->Fill(iTS_en);
+      histograms.h_num_trackster_pt[valType][count]->Fill(iTS_pt);
 
       if (tracksters_FakeMerge[tstId] > 1) {
-        histograms.h_numMerge_trackster_eta[i][count]->Fill(iTS_eta);
-        histograms.h_numMerge_trackster_phi[i][count]->Fill(iTS_phi);
-        histograms.h_numMerge_trackster_en[i][count]->Fill(iTS_en);
-        histograms.h_numMerge_trackster_pt[i][count]->Fill(iTS_pt);
+        histograms.h_numMerge_trackster_eta[valType][count]->Fill(iTS_eta);
+        histograms.h_numMerge_trackster_phi[valType][count]->Fill(iTS_phi);
+        histograms.h_numMerge_trackster_en[valType][count]->Fill(iTS_en);
+        histograms.h_numMerge_trackster_pt[valType][count]->Fill(iTS_pt);
       }
     }
   }  // End loop over Tracksters
@@ -3269,7 +3311,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
 
 void HGVHistoProducerAlgo::fill_trackster_histos(
     const Histograms& histograms,
-    int count,
+    const int count,
     const ticl::TracksterCollection& tracksters,
     const reco::CaloClusterCollection& layerClusters,
     const ticl::TracksterCollection& simTSs,
@@ -3280,6 +3322,7 @@ void HGVHistoProducerAlgo::fill_trackster_histos(
     std::vector<CaloParticle> const& cP,
     std::vector<size_t> const& cPIndices,
     std::vector<size_t> const& cPSelectedIndices,
+    //const enum validationType,
     std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
     unsigned int layers) const {
   //Each event to be treated as two events:
@@ -3447,13 +3490,13 @@ void HGVHistoProducerAlgo::fill_trackster_histos(
   histograms.h_conttracksternum[count]->Fill(totNContTstZp + totNContTstZm);
   histograms.h_nonconttracksternum[count]->Fill(totNNotContTstZp + totNNotContTstZm);
 
-  // CaloPaericle
+  // CaloParticle
   tracksters_to_SimTracksters(histograms,
                               count,
                               tracksters,
                               layerClusters,
                               simTSs_fromCP,
-                              0,
+                              Linking,
                               simTSs_fromCP,
                               cpToSc_SimTrackstersMap,
                               sC,
@@ -3470,7 +3513,7 @@ void HGVHistoProducerAlgo::fill_trackster_histos(
                               tracksters,
                               layerClusters,
                               simTSs,
-                              1,
+                              PatternRecognition,
                               simTSs_fromCP,
                               cpToSc_SimTrackstersMap,
                               sC,

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1101,7 +1101,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
   const string val[] = {"_Link", "_PR"};
 
   histograms.h_score_trackster2caloparticle[i].push_back(
-      ibook.book1D("Score_trackster2" + ref[i], "Score of Trackster per " + refT[i], nintScore_, minScore_, maxScore_));
+      ibook.book1D("Score_trackster2" + ref[i], "Score of Trackster per best " + refT[i], nintScore_, minScore_, maxScore_));
   histograms.h_scoreMerge_trackster2caloparticle[i].push_back(
       ibook.book1D("ScoreMerge_trackster2" + ref[i], "Score of merged Trackster per " + refT[i], nintScore_, minScore_, maxScore_));
   histograms.h_score_caloparticle2trackster[i].push_back(ibook.book1D(
@@ -1112,7 +1112,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
       "ScoreDupl_" + ref[i] + "2trackster", "Score of " + refT[i] + " per first duplicate Trackster", nintScore_, minScore_, maxScore_));
   histograms.h_energy_vs_score_trackster2caloparticle[i].push_back(
       ibook.book2D("Energy_vs_Score_trackster2" + ref[i],
-                   "Energy vs Score of Trackster per " + refT[i],
+                   "Energy vs Score of Trackster per best " + refT[i],
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1161,12 +1161,12 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
 
   histograms.h_sharedenergy_trackster2caloparticle[i].push_back(
       ibook.book1D("SharedEnergy_trackster2" + ref[i],
-                   "Shared Energy of Trackster per " + refT[i] + " in each layer",
+                   "Shared Energy of Trackster per best " + refT[i] + " in each layer",
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_trackster2caloparticle_vs_eta[i].push_back(
-      ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_vs_eta",
+      ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_assoc_vs_eta",
                         "Shared Energy of Trackster vs #eta per best " + refT[i] + " in each layer",
                         nintEta_,
                         minEta_,
@@ -1174,7 +1174,7 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_trackster2caloparticle_vs_phi[i].push_back(
-      ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_vs_phi",
+      ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_assoc_vs_phi",
                         "Shared Energy of Trackster vs #phi per best " + refT[i] + " in each layer",
                         nintPhi_,
                         minPhi_,
@@ -1190,20 +1190,20 @@ void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Hist
                    maxTSTSharedEneFrac_));
   histograms.h_sharedenergy_caloparticle2trackster_assoc[i].push_back(
       ibook.book1D("SharedEnergy_" + ref[i] + "2trackster_assoc",
-                   "Shared Energy of Associated " + refT[i] + " per Trackster",
+                   "Shared Energy of " + refT[i] + " per best Trackster",
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster_vs_eta[i].push_back(
-      ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_vs_eta",
+  histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[i].push_back(
+      ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_assoc_vs_eta",
                         "Shared Energy of " + refT[i] + " vs #eta per best Trackster",
                         nintEta_,
                         minEta_,
                         maxEta_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster_vs_phi[i].push_back(
-      ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_vs_phi",
+  histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[i].push_back(
+      ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_assoc_vs_phi",
                         "Shared Energy of " + refT[i] + " vs #phi per best Trackster",
                         nintPhi_,
                         minPhi_,
@@ -3043,9 +3043,9 @@ else return false;
       const auto tstRawEnergyFrac = tracksters[bestTstId].raw_energy() / SimEnergy;
       const auto tstSharedEnergyFrac = tstSharedEnergy[iSTS][bestTstId] / SimEnergy;
 
-      histograms.h_sharedenergy_caloparticle2trackster_vs_eta[i][count]->Fill(
+      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_eta[i][count]->Fill(
           sts_eta, tstRawEnergyFrac);
-      histograms.h_sharedenergy_caloparticle2trackster_vs_phi[i][count]->Fill(
+      histograms.h_sharedenergy_caloparticle2trackster_assoc_vs_phi[i][count]->Fill(
           sts_phi, tstRawEnergyFrac);
       histograms.h_sharedenergy_caloparticle2trackster_assoc[i][count]->Fill(tstSharedEnergyFrac);
       LogDebug("HGCalValidator") << count << " " << sts_eta << " "

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -1095,23 +1095,27 @@ void HGVHistoProducerAlgo::bookTracksterHistos(DQMStore::IBooker& ibook, Histogr
       ibook.book1D("trackster_layersnum", "Number of layers of the Trackster", 2 * layers, 0., (float)2 * layers));
 }
 
-void HGVHistoProducerAlgo::bookTracksterCPLinkingHistos(DQMStore::IBooker& ibook, Histograms& histograms) {
-  histograms.h_score_trackster2caloparticle.push_back(ibook.book1D(
-      "Score_trackster2caloparticle", "Score of Trackster per CaloParticle", nintScore_, minScore_, maxScore_));
-  histograms.h_score_caloparticle2trackster.push_back(ibook.book1D(
-      "Score_caloparticle2trackster", "Score of CaloParticle per Trackster", nintScore_, minScore_, maxScore_));
-  histograms.h_energy_vs_score_trackster2caloparticle.push_back(
-      ibook.book2D("Energy_vs_Score_trackster2caloparticle",
-                   "Energy vs Score of Trackster per CaloParticle",
+void HGVHistoProducerAlgo::bookTracksterSTSHistos(DQMStore::IBooker& ibook, Histograms& histograms, const int i) {
+  const string ref[] = {"caloparticle", "simtrackster"};
+  const string refT[] = {"CaloParticle", "SimTrackster"};
+  const string val[] = {"_Link", "_PR"};
+
+  histograms.h_score_trackster2caloparticle[i].push_back(
+      ibook.book1D("Score_trackster2" + ref[i], "Score of Trackster per " + refT[i], nintScore_, minScore_, maxScore_));
+  histograms.h_score_caloparticle2trackster[i].push_back(ibook.book1D(
+      "Score_" + ref[i] + "2trackster", "Score of " + refT[i] + " per Trackster", nintScore_, minScore_, maxScore_));
+  histograms.h_energy_vs_score_trackster2caloparticle[i].push_back(
+      ibook.book2D("Energy_vs_Score_trackster2" + ref[i],
+                   "Energy vs Score of Trackster per " + refT[i],
                    nintScore_,
                    minScore_,
                    maxScore_,
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_energy_vs_score_caloparticle2trackster.push_back(
-      ibook.book2D("Energy_vs_Score_caloparticle2trackster",
-                   "Energy vs Score of CaloParticle per Trackster",
+  histograms.h_energy_vs_score_caloparticle2trackster[i].push_back(
+      ibook.book2D("Energy_vs_Score_" + ref[i] + "2trackster",
+                   "Energy vs Score of " + refT[i] + " per Trackster",
                    nintScore_,
                    minScore_,
                    maxScore_,
@@ -1120,86 +1124,87 @@ void HGVHistoProducerAlgo::bookTracksterCPLinkingHistos(DQMStore::IBooker& ibook
                    maxTSTSharedEneFrac_));
 
   //back to all Tracksters
-  histograms.h_num_trackster_eta.push_back(
-      ibook.book1D("Num_Trackster_Eta", "Num Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
-  histograms.h_numMerge_trackster_eta.push_back(
-      ibook.book1D("NumMerge_Trackster_Eta", "Num Merge Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
-  histograms.h_denom_trackster_eta.push_back(
-      ibook.book1D("Denom_Trackster_Eta", "Denom Trackster Eta per Trackster", nintEta_, minEta_, maxEta_));
-  histograms.h_num_trackster_phi.push_back(
-      ibook.book1D("Num_Trackster_Phi", "Num Trackster Phi per Trackster ", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_numMerge_trackster_phi.push_back(
-      ibook.book1D("NumMerge_Trackster_Phi", "Num Merge Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_denom_trackster_phi.push_back(
-      ibook.book1D("Denom_Trackster_Phi", "Denom Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_num_trackster_eta[i].push_back(
+      ibook.book1D("Num_Trackster_Eta" + val[i], "Num Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
+  histograms.h_numMerge_trackster_eta[i].push_back(ibook.book1D(
+      "NumMerge_Trackster_Eta" + val[i], "Num Merge Trackster Eta per Trackster ", nintEta_, minEta_, maxEta_));
+  histograms.h_denom_trackster_eta[i].push_back(
+      ibook.book1D("Denom_Trackster_Eta" + val[i], "Denom Trackster Eta per Trackster", nintEta_, minEta_, maxEta_));
+  histograms.h_num_trackster_phi[i].push_back(
+      ibook.book1D("Num_Trackster_Phi" + val[i], "Num Trackster Phi per Trackster ", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_numMerge_trackster_phi[i].push_back(ibook.book1D(
+      "NumMerge_Trackster_Phi" + val[i], "Num Merge Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_denom_trackster_phi[i].push_back(
+      ibook.book1D("Denom_Trackster_Phi" + val[i], "Denom Trackster Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
 
-  histograms.h_sharedenergy_trackster2caloparticle.push_back(
-      ibook.book1D("SharedEnergy_trackster2caloparticle",
-                   "Shared Energy of Trackster per Calo Particle in each layer",
+  histograms.h_sharedenergy_trackster2caloparticle[i].push_back(
+      ibook.book1D("SharedEnergy_trackster2" + ref[i],
+                   "Shared Energy of Trackster per " + refT[i] + " in each layer",
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_trackster2caloparticle_vs_eta.push_back(
-      ibook.bookProfile("SharedEnergy_trackster2caloparticle_vs_eta",
-                        "Shared Energy of Trackster vs #eta per best Calo Particle in each layer",
+  histograms.h_sharedenergy_trackster2caloparticle_vs_eta[i].push_back(
+      ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_vs_eta",
+                        "Shared Energy of Trackster vs #eta per best " + refT[i] + " in each layer",
                         nintEta_,
                         minEta_,
                         maxEta_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_trackster2caloparticle_vs_phi.push_back(
-      ibook.bookProfile("SharedEnergy_trackster2caloparticle_vs_phi",
-                        "Shared Energy of Trackster vs #phi per best Calo Particle in each layer",
+  histograms.h_sharedenergy_trackster2caloparticle_vs_phi[i].push_back(
+      ibook.bookProfile("SharedEnergy_trackster2" + ref[i] + "_vs_phi",
+                        "Shared Energy of Trackster vs #phi per best " + refT[i] + " in each layer",
                         nintPhi_,
                         minPhi_,
                         maxPhi_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
 
-  histograms.h_sharedenergy_caloparticle2trackster.push_back(ibook.book1D("SharedEnergy_caloparticle2trackster",
-                                                                          "Shared Energy of CaloParticle per Trackster",
-                                                                          nintSharedEneFrac_,
-                                                                          minTSTSharedEneFrac_,
-                                                                          maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster_assoc.push_back(
-      ibook.book1D("SharedEnergy_caloparticle2trackster_assoc",
-                   "Shared Energy of Associated CaloParticle per Trackster",
+  histograms.h_sharedenergy_caloparticle2trackster[i].push_back(
+      ibook.book1D("SharedEnergy_" + ref[i] + "2trackster",
+                   "Shared Energy of " + refT[i] + " per Trackster",
                    nintSharedEneFrac_,
                    minTSTSharedEneFrac_,
                    maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster_vs_eta.push_back(
-      ibook.bookProfile("SharedEnergy_caloparticle2trackster_vs_eta",
-                        "Shared Energy of CaloParticle vs #eta per best Trackster",
+  histograms.h_sharedenergy_caloparticle2trackster_assoc[i].push_back(
+      ibook.book1D("SharedEnergy_" + ref[i] + "2trackster_assoc",
+                   "Shared Energy of Associated " + refT[i] + " per Trackster",
+                   nintSharedEneFrac_,
+                   minTSTSharedEneFrac_,
+                   maxTSTSharedEneFrac_));
+  histograms.h_sharedenergy_caloparticle2trackster_vs_eta[i].push_back(
+      ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_vs_eta",
+                        "Shared Energy of " + refT[i] + " vs #eta per best Trackster",
                         nintEta_,
                         minEta_,
                         maxEta_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
-  histograms.h_sharedenergy_caloparticle2trackster_vs_phi.push_back(
-      ibook.bookProfile("SharedEnergy_caloparticle2trackster_vs_phi",
-                        "Shared Energy of CaloParticle vs #phi per best Trackster",
+  histograms.h_sharedenergy_caloparticle2trackster_vs_phi[i].push_back(
+      ibook.bookProfile("SharedEnergy_" + ref[i] + "2trackster_vs_phi",
+                        "Shared Energy of " + refT[i] + " vs #phi per best Trackster",
                         nintPhi_,
                         minPhi_,
                         maxPhi_,
                         minTSTSharedEneFrac_,
                         maxTSTSharedEneFrac_));
 
-  histograms.h_numEff_caloparticle_eta.push_back(ibook.book1D(
-      "NumEff_CaloParticle_Eta", "Num Efficiency CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
-  histograms.h_num_caloparticle_eta.push_back(
-      ibook.book1D("Num_CaloParticle_Eta", "Num Purity CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
-  histograms.h_numDup_trackster_eta.push_back(
-      ibook.book1D("NumDup_Trackster_Eta", "Num Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
-  histograms.h_denom_caloparticle_eta.push_back(
-      ibook.book1D("Denom_CaloParticle_Eta", "Denom CaloParticle Eta per Trackster", nintEta_, minEta_, maxEta_));
-  histograms.h_numEff_caloparticle_phi.push_back(ibook.book1D(
-      "NumEff_CaloParticle_Phi", "Num Efficiency CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_num_caloparticle_phi.push_back(
-      ibook.book1D("Num_CaloParticle_Phi", "Num Purity CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_numDup_trackster_phi.push_back(
-      ibook.book1D("NumDup_Trackster_Phi", "Num Duplicate Trackster vs Phi", nintPhi_, minPhi_, maxPhi_));
-  histograms.h_denom_caloparticle_phi.push_back(
-      ibook.book1D("Denom_CaloParticle_Phi", "Denom CaloParticle Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_numEff_caloparticle_eta[i].push_back(ibook.book1D(
+      "NumEff_" + refT[i] + "_Eta", "Num Efficiency " + refT[i] + " Eta per Trackster", nintEta_, minEta_, maxEta_));
+  histograms.h_num_caloparticle_eta[i].push_back(ibook.book1D(
+      "Num_" + refT[i] + "_Eta", "Num Purity " + refT[i] + " Eta per Trackster", nintEta_, minEta_, maxEta_));
+  histograms.h_numDup_trackster_eta[i].push_back(
+      ibook.book1D("NumDup_Trackster_Eta" + val[i], "Num Duplicate Trackster vs Eta", nintEta_, minEta_, maxEta_));
+  histograms.h_denom_caloparticle_eta[i].push_back(
+      ibook.book1D("Denom_" + refT[i] + "_Eta", "Denom " + refT[i] + " Eta per Trackster", nintEta_, minEta_, maxEta_));
+  histograms.h_numEff_caloparticle_phi[i].push_back(ibook.book1D(
+      "NumEff_" + refT[i] + "_Phi", "Num Efficiency " + refT[i] + " Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_num_caloparticle_phi[i].push_back(ibook.book1D(
+      "Num_" + refT[i] + "_Phi", "Num Purity " + refT[i] + " Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_numDup_trackster_phi[i].push_back(
+      ibook.book1D("NumDup_Trackster_Phi" + val[i], "Num Duplicate Trackster vs Phi", nintPhi_, minPhi_, maxPhi_));
+  histograms.h_denom_caloparticle_phi[i].push_back(
+      ibook.book1D("Denom_" + refT[i] + "_Phi", "Denom " + refT[i] + " Phi per Trackster", nintPhi_, minPhi_, maxPhi_));
 }
 
 void HGVHistoProducerAlgo::fill_info_histos(const Histograms& histograms, unsigned int layers) const {
@@ -2257,14 +2262,19 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
                                                        int count,
                                                        const ticl::TracksterCollection& tracksters,
                                                        const reco::CaloClusterCollection& layerClusters,
-                                                       const ticl::TracksterCollection& simTSFromCP,
+                                                       const ticl::TracksterCollection& simTS,
+                                                       const int i,
+                                                       const ticl::TracksterCollection& simTS_fromCP,
+                                                       const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
+                                                       std::vector<SimCluster> const& sC,
+                                                       const edm::ProductID& cPHandle_id,
                                                        std::vector<CaloParticle> const& cP,
                                                        std::vector<size_t> const& cPIndices,
                                                        std::vector<size_t> const& cPSelectedIndices,
                                                        std::unordered_map<DetId, const HGCRecHit*> const& hitMap,
                                                        unsigned int layers) const {
   const auto nTracksters = tracksters.size();
-  const auto nSimTracksters = simTSFromCP.size();
+  const auto nSimTracksters = simTS.size();
 
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInCluster>> detIdSimTSId_Map;
   std::unordered_map<DetId, std::vector<HGVHistoProducerAlgo::detIdInfoInTrackster>> detIdToTracksterId_Map;
@@ -2295,13 +2305,38 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
     }
   }
 
+  auto getCPId = [](const ticl::Trackster& simTS, const unsigned int iSTS, const edm::ProductID& cPHandle_id, const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap, const ticl::TracksterCollection& simTS_fromCP){
+    unsigned int cpId = -1;
+
+    const auto productID = simTS.seedID();
+    if (productID == cPHandle_id) {
+      cpId = simTS.seedIndex();
+    } else { // SimTrackster from SimCluster
+      const auto findSimTSFromCP = std::find_if(std::begin(cpToSc_SimTrackstersMap), std::end(cpToSc_SimTrackstersMap),
+                                                           [&](const std::pair<unsigned int, std::vector<unsigned int>>& cpToScs) {
+        return std::find(std::begin(cpToScs.second), std::end(cpToScs.second), iSTS) != std::end(cpToScs.second);
+      });
+      if (findSimTSFromCP != std::end(cpToSc_SimTrackstersMap)) {
+        cpId = simTS_fromCP[findSimTSFromCP->first].seedIndex();
+      }
+    }
+
+    return cpId;
+  };
+
+
   for (unsigned int iSTS = 0; iSTS < nSimTracksters; ++iSTS) {
-    const auto& cpId = simTSFromCP[iSTS].seedIndex();
+    const auto cpId = getCPId(simTS[iSTS], iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
     if (std::find(cPIndices.begin(), cPIndices.end(), cpId) == cPIndices.end())
       continue;
 
     // Loop through SimClusters
     for (const auto& simCluster : cP[cpId].simClusters()) {
+      if (simTS[iSTS].seedID() != cPHandle_id) { // SimTrackster from SimCluster
+        if (simTS[iSTS].seedIndex()  !=  (&(*simCluster) - &(sC[0])))
+          continue;
+      }
+
       for (const auto& it_haf : simCluster->hits_and_fractions()) {
         const auto hitid = (it_haf.first);
         //V9:maps the layers in -z: 0->51 and in +z: 52->103
@@ -2459,7 +2494,10 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
           //So, from all layers clusters, find the rechits that are connected with a calo particle and save/calculate the
           //energy of that calo particle as the sum over all rechits of the rechits energy weighted
           //by the caloparticle's fraction related to that rechit.
-          const auto cpId = simTSFromCP[h.clusterId].seedIndex();
+          const auto cpId = getCPId(simTS[h.clusterId], h.clusterId, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
+          if (std::find(cPIndices.begin(), cPIndices.end(), cpId) == cPIndices.end())
+            continue;
+
           CPEnergyInTS[cpId] += shared_fraction * hit->energy();
           //Here cPOnLayer[caloparticle][layer] describe above is set.
           //Here for Tracksters with matched rechit the CP fraction times hit energy is added and saved .
@@ -2559,9 +2597,9 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
       for (auto& stsPair : stsInTrackster[tstId]) {
         //In case of a Trackster with zero energy but related CaloParticles the score is set to 1.
         stsPair.second = 1.;
-        LogDebug("HGCalValidator") << "Trackster Id: \t" << tstId << "\t SimTrackster id: \t" << stsPair.first
-                                   << "\t score \t" << stsPair.second << std::endl;
-        histograms.h_score_trackster2caloparticle[count]->Fill(stsPair.second);
+        LogDebug("HGCalValidator") << "Trackster Id:\t" << tstId << "\tSimTrackster id:\t" << stsPair.first
+                                   << "\tscore\t" << stsPair.second << std::endl;
+        histograms.h_score_trackster2caloparticle[i][count]->Fill(stsPair.second);
       }
       continue;
     }
@@ -2617,7 +2655,10 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
                                         std::end(stsInTrackster[tstId]),
                                         [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
     for (const auto& stsPair : stsInTrackster[tstId]) {
-      const auto& cpId = simTSFromCP[stsPair.first].seedIndex();
+      const auto cpId = getCPId(simTS[stsPair.first], stsPair.first, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
+      //if (std::find(cPIndices.begin(), cPIndices.end(), cpId) == cPIndices.end())
+      //  continue;
+
       LogDebug("HGCalValidator") << "Trackster Id: \t" << tstId << "\t CP id: \t" << cpId << "\t score \t"
                                  << stsPair.second << std::endl;
       float sharedeneCPallLayers = 0.;
@@ -2627,10 +2668,10 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
       }
       LogDebug("HGCalValidator") << "sharedeneCPallLayers " << sharedeneCPallLayers << std::endl;
       if (stsPair.first == score->first) {
-        histograms.h_score_trackster2caloparticle[count]->Fill(score->second);
-        histograms.h_sharedenergy_trackster2caloparticle[count]->Fill(sharedeneCPallLayers /
-                                                                      tracksters[tstId].raw_energy());
-        histograms.h_energy_vs_score_trackster2caloparticle[count]->Fill(
+        histograms.h_score_trackster2caloparticle[i][count]->Fill(score->second);
+        histograms.h_sharedenergy_trackster2caloparticle[i][count]->Fill(sharedeneCPallLayers /
+                                                                         tracksters[tstId].raw_energy());
+        histograms.h_energy_vs_score_trackster2caloparticle[i][count]->Fill(
             score->second, sharedeneCPallLayers / tracksters[tstId].raw_energy());
       }
     }
@@ -2653,10 +2694,11 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
   // Here we do fill the plots to compute the different metrics linked to
   // gen-level, namely efficiency, purity and duplicate. In this loop we should restrict
   // only to the selected caloParaticles.
-  for (const auto& iSTS : simTSFromCP) {
-    const auto& cpId = iSTS.seedIndex();
-    if (std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
-      continue;
+  for (unsigned int iSTS = 0; iSTS < nSimTracksters; ++iSTS) {
+    const auto& cpId = getCPId(simTS[iSTS], iSTS, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
+    if (i == 0)
+      if (std::find(cPSelectedIndices.begin(), cPSelectedIndices.end(), cpId) == cPSelectedIndices.end())
+        continue;
 
     //We need to keep the Tracksters ids that are related to
     //CaloParticle under study for the final filling of the score.
@@ -2726,7 +2768,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
           if (tsPair.second.second == FLT_MAX) {
             tsPair.second.second = 0.f;
           }
-          tsPair.second.second += pow((tstFraction - cpFraction), 2) * hitEnergyWeight;
+          tsPair.second.second += (tstFraction - cpFraction) * (tstFraction - cpFraction) * hitEnergyWeight;
           LogDebug("HGCalValidator") << "TracksterId:\t" << tracksterId
                                      << "\tcpId:\t" << cpId
                                      << "\tLayer: " << layerId << '\t' << "tstfraction,cpfraction:\t" << tstFraction
@@ -2767,8 +2809,8 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
     const auto iSTS_eta = simTS[iSTS].barycenter().eta();
     const auto iSTS_phi = simTS[iSTS].barycenter().phi();
 
-    histograms.h_denom_caloparticle_eta[count]->Fill(iSTS_eta);
-    histograms.h_denom_caloparticle_phi[count]->Fill(iSTS_phi);
+    histograms.h_denom_caloparticle_eta[i][count]->Fill(iSTS_eta);
+    histograms.h_denom_caloparticle_phi[i][count]->Fill(iSTS_phi);
 
     //Loop through related Tracksters here
     // In case the threshold to associate a CaloParticle to a Trackster is
@@ -2788,37 +2830,37 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
                                  << "\tshared energy:\t" << tstSharedEnergy[cpId][tstId]
                                  << "\tshared energy fraction:\t" << tstSharedEnergyFrac << "\n";
 
-      histograms.h_score_caloparticle2trackster[count]->Fill(score3d[cpId][tstId]);
+      histograms.h_score_caloparticle2trackster[i][count]->Fill(score3d[cpId][tstId]);
 
-      histograms.h_sharedenergy_caloparticle2trackster[count]->Fill(tstSharedEnergyFrac);
-      histograms.h_energy_vs_score_caloparticle2trackster[count]->Fill(score3d[cpId][tstId],
+      histograms.h_sharedenergy_caloparticle2trackster[i][count]->Fill(tstSharedEnergyFrac);
+      histograms.h_energy_vs_score_caloparticle2trackster[i][count]->Fill(score3d[cpId][tstId],
                                                                        tstSharedEnergyFrac);
       // Fill the numerator for the efficiency calculation. The efficiency is computed by considering the energy shared between a Trackster and a _corresponding_ caloParticle. The threshold is configurable via python.
       if (!cp_considered_efficient && (tstSharedEnergyFrac >= minTSTSharedEneFracEfficiency_)) {
         cp_considered_efficient = true;
-        histograms.h_numEff_caloparticle_eta[count]->Fill(iSTS_eta);
-        histograms.h_numEff_caloparticle_phi[count]->Fill(iSTS_phi);
+        histograms.h_numEff_caloparticle_eta[i][count]->Fill(iSTS_eta);
+        histograms.h_numEff_caloparticle_phi[i][count]->Fill(iSTS_phi);
       }
     }  //end of loop through Tracksters
 
     const auto assocDup = std::count_if(std::begin(score3d[cpId]), std::end(score3d[cpId]), is_assoc);
 
     if (assocDup > 0) {
-      histograms.h_num_caloparticle_eta[count]->Fill(iSTS_eta);
-      histograms.h_num_caloparticle_phi[count]->Fill(iSTS_phi);
+      histograms.h_num_caloparticle_eta[i][count]->Fill(iSTS_eta);
+      histograms.h_num_caloparticle_phi[i][count]->Fill(iSTS_phi);
       const auto best = std::min_element(std::begin(score3d[cpId]), std::end(score3d[cpId]));
       const auto bestTstId = std::distance(std::begin(score3d[cpId]), best);
       const auto tstSharedEnergyFrac = tstSharedEnergy[cpId][bestTstId] / CPenergy;
 
-      histograms.h_sharedenergy_caloparticle2trackster_vs_eta[count]->Fill(
+      histograms.h_sharedenergy_caloparticle2trackster_vs_eta[i][count]->Fill(
           iSTS_eta, tracksters[bestTstId].raw_energy() / CPenergy);
-      histograms.h_sharedenergy_caloparticle2trackster_vs_phi[count]->Fill(
+      histograms.h_sharedenergy_caloparticle2trackster_vs_phi[i][count]->Fill(
           iSTS_phi, tracksters[bestTstId].raw_energy() / CPenergy);
       LogDebug("HGCalValidator") << count << " " << iSTS_eta << " "
                                  << iSTS_phi << " " << tracksters[bestTstId].raw_energy()
                                  << " " << CPenergy << " " << (tracksters[bestTstId].raw_energy() / CPenergy) << " "
                                  << tstSharedEnergyFrac << '\n';
-      histograms.h_sharedenergy_caloparticle2trackster_assoc[count]->Fill(tstSharedEnergyFrac);
+      histograms.h_sharedenergy_caloparticle2trackster_assoc[i][count]->Fill(tstSharedEnergyFrac);
 
       if (assocDup >= 2) {
         auto match = std::find_if(std::begin(score3d[cpId]), std::end(score3d[cpId]), is_assoc);
@@ -2838,37 +2880,37 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(const Histograms& histogr
       continue;
     const auto iTS_eta = tracksters[tstId].barycenter().eta();
     const auto iTS_phi = tracksters[tstId].barycenter().phi();
-    histograms.h_denom_trackster_eta[count]->Fill(iTS_eta);
-    histograms.h_denom_trackster_phi[count]->Fill(iTS_phi);
+    histograms.h_denom_trackster_eta[i][count]->Fill(iTS_eta);
+    histograms.h_denom_trackster_phi[i][count]->Fill(iTS_phi);
 
     const auto assocDuplicate = tracksters_duplicate[tstId];
     if (assocDuplicate) {
-      histograms.h_numDup_trackster_eta[count]->Fill(iTS_eta);
-      histograms.h_numDup_trackster_phi[count]->Fill(iTS_phi);
+      histograms.h_numDup_trackster_eta[i][count]->Fill(iTS_eta);
+      histograms.h_numDup_trackster_phi[i][count]->Fill(iTS_phi);
     }
     const auto assocFakeMerge = tracksters_fakemerge[tstId];
     if (assocFakeMerge > 0) {
-      histograms.h_num_trackster_eta[count]->Fill(iTS_eta);
-      histograms.h_num_trackster_phi[count]->Fill(iTS_phi);
+      histograms.h_num_trackster_eta[i][count]->Fill(iTS_eta);
+      histograms.h_num_trackster_phi[i][count]->Fill(iTS_phi);
       const auto best = std::min_element(std::begin(stsInTrackster[tstId]),
                                    std::end(stsInTrackster[tstId]),
                                    [](const auto& obj1, const auto& obj2) { return obj1.second < obj2.second; });
 
       //This is the shared energy taking the best caloparticle in each layer
       float sharedeneCPallLayers = 0.;
-      for (unsigned int j = 0; j < layers * 2; ++j) {// Loop through all layers
-        auto const& best_cp_linked =
-            cPOnLayer[simTSFromCP[best->first].seedIndex()][j].layerClusterIdToEnergyAndScore[tstId];
+      const auto cpId = getCPId(simTS[best->first], best->first, cPHandle_id, cpToSc_SimTrackstersMap, simTS_fromCP);
+      for (unsigned int j = 0; j < layers * 2; ++j) { // Loop through all layers
+        auto const& best_cp_linked = cPOnLayer[cpId][j].layerClusterIdToEnergyAndScore[tstId];
         sharedeneCPallLayers += best_cp_linked.first;
-      }  //end of loop through layers
-      histograms.h_sharedenergy_trackster2caloparticle_vs_eta[count]->Fill(
+      }
+      histograms.h_sharedenergy_trackster2caloparticle_vs_eta[i][count]->Fill(
           iTS_eta, sharedeneCPallLayers / tracksters[tstId].raw_energy());
-      histograms.h_sharedenergy_trackster2caloparticle_vs_phi[count]->Fill(
+      histograms.h_sharedenergy_trackster2caloparticle_vs_phi[i][count]->Fill(
           iTS_phi, sharedeneCPallLayers / tracksters[tstId].raw_energy());
 
       if (assocFakeMerge >= 2) {
-        histograms.h_numMerge_trackster_eta[count]->Fill(iTS_eta);
-        histograms.h_numMerge_trackster_phi[count]->Fill(iTS_phi);
+        histograms.h_numMerge_trackster_eta[i][count]->Fill(iTS_eta);
+        histograms.h_numMerge_trackster_phi[i][count]->Fill(iTS_phi);
       }
     }
   } // End loop over Tracksters
@@ -2878,7 +2920,11 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
                                                  int count,
                                                  const ticl::TracksterCollection& tracksters,
                                                  const reco::CaloClusterCollection& layerClusters,
-                                                 const ticl::TracksterCollection& simTSFromCP,
+                                                 const ticl::TracksterCollection& simTS,
+                                                 const ticl::TracksterCollection& simTS_fromCP,
+                                                 const std::map<unsigned int, std::vector<unsigned int>>& cpToSc_SimTrackstersMap,
+                                                 std::vector<SimCluster> const& sC,
+                                                 const edm::ProductID& cPHandle_id,
                                                  std::vector<CaloParticle> const& cP,
                                                  std::vector<size_t> const& cPIndices,
                                                  std::vector<size_t> const& cPSelectedIndices,
@@ -3049,8 +3095,38 @@ void HGVHistoProducerAlgo::fill_trackster_histos(const Histograms& histograms,
   histograms.h_conttracksternum[count]->Fill(totNContTstZp + totNContTstZm);
   histograms.h_nonconttracksternum[count]->Fill(totNNotContTstZp + totNNotContTstZm);
 
-  tracksters_to_SimTracksters(
-      histograms, count, tracksters, layerClusters, simTSFromCP, cP, cPIndices, cPSelectedIndices, hitMap, layers);
+  // Linking
+  tracksters_to_SimTracksters(histograms,
+                              count,
+                              tracksters,
+                              layerClusters,
+                              simTS_fromCP,
+                              0,
+                              simTS_fromCP,
+                              cpToSc_SimTrackstersMap,
+                              sC,
+                              cPHandle_id,
+                              cP,
+                              cPIndices,
+                              cPSelectedIndices,
+                              hitMap,
+                              layers);
+  // Pattern recognition
+  tracksters_to_SimTracksters(histograms,
+                              count,
+                              tracksters,
+                              layerClusters,
+                              simTS,
+                              1,
+                              simTS_fromCP,
+                              cpToSc_SimTrackstersMap,
+                              sC,
+                              cPHandle_id,
+                              cP,
+                              cPIndices,
+                              cPSelectedIndices,
+                              hitMap,
+                              layers);
 }
 
 double HGVHistoProducerAlgo::distance2(const double x1,

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2382,32 +2382,33 @@ class PlotGroup(object):
             if not plot.isEmpty():
                 plot.draw(pad, ratio, self._ratioFactor, nrows)
 
-        # Setup legend
-        canvas.cd()
-        if len(self._plots) <= 4:
-            lx1 = 0.2
-            lx2 = 0.9
-            ly1 = 0.48
-            ly2 = 0.53
-        else:
-            lx1 = 0.1
-            lx2 = 0.9
-            ly1 = 0.64
-            ly2 = 0.67
-        if self._legendDx is not None:
-            lx1 += self._legendDx
-            lx2 += self._legendDx
-        if self._legendDy is not None:
-            ly1 += self._legendDy
-            ly2 += self._legendDy
-        if self._legendDw is not None:
-            lx2 += self._legendDw
-        if self._legendDh is not None:
-            ly1 -= self._legendDh
-        plot = max(self._plots, key=lambda p: p.getNumberOfHistograms())
-        denomUnc = sum([p.drawRatioUncertainty() for p in self._plots]) > 0
-        legend = self._createLegend(plot, legendLabels, lx1, ly1, lx2, ly2,
-                                    denomUncertainty=(ratio and denomUnc))
+        if plot._legend:
+          # Setup legend
+          canvas.cd()
+          if len(self._plots) <= 4:
+              lx1 = 0.2
+              lx2 = 0.9
+              ly1 = 0.48
+              ly2 = 0.53
+          else:
+              lx1 = 0.1
+              lx2 = 0.9
+              ly1 = 0.64
+              ly2 = 0.67
+          if self._legendDx is not None:
+              lx1 += self._legendDx
+              lx2 += self._legendDx
+          if self._legendDy is not None:
+              ly1 += self._legendDy
+              ly2 += self._legendDy
+          if self._legendDw is not None:
+              lx2 += self._legendDw
+          if self._legendDh is not None:
+              ly1 -= self._legendDh
+          plot = max(self._plots, key=lambda p: p.getNumberOfHistograms())
+          denomUnc = sum([p.drawRatioUncertainty() for p in self._plots]) > 0
+          legend = self._createLegend(plot, legendLabels, lx1, ly1, lx2, ly2,
+                                      denomUncertainty=(ratio and denomUnc))
 
         return self._save(canvas, saveFormat, prefix=prefix, directory=directory)
 


### PR DESCRIPTION
#### PR description:

This PR introduces a Trackster validation against SimTracksters, labeled `PatternRecognition`.
The changes expected in the output are:
  - new histograms in the original validation folder (`TSToCP_linking`), 
  - a new validation folder (`TSToSTS_patternRecognition`) symmetric to the previous one,
  - a new validation folder (`Morphology`) containing the Tracksters histograms previously in the `linking` folder,
  - shrink of the score distributions due to a change in their definition.

A preliminary presentation can be found [here](https://indico.cern.ch/event/1097262/contributions/4616492/attachments/2348500/4008340/Metrics.pdf).

#### PR validation:

`runTheMatrix -l limited`