### PR TITLE
PPS RecHit nonlinearities compensation for diamond-hptdc

### DIFF
--- a/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -22,12 +22,13 @@
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
 
 #include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
+#include "CondFormats/PPSObjects/interface/PPSTimingCalibrationLUT.h"
 
 class CTPPSDiamondRecHitProducerAlgorithm {
 public:
   CTPPSDiamondRecHitProducerAlgorithm(const edm::ParameterSet& conf);
 
-  void setCalibration(const PPSTimingCalibration&);
+  void setCalibration(const PPSTimingCalibration&, const PPSTimingCalibrationLUT&);
   void build(const CTPPSGeometry&, const edm::DetSetVector<CTPPSDiamondDigi>&, edm::DetSetVector<CTPPSDiamondRecHit>&);
 
 private:
@@ -37,6 +38,7 @@ private:
   /// Switch on/off the timing calibration
   bool apply_calib_;
   PPSTimingCalibration calib_;
+  PPSTimingCalibrationLUT calibLUT_;
   std::unique_ptr<reco::FormulaEvaluator> calib_fct_;
 };
 

--- a/RecoPPS/Local/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSDiamondRecHitProducer.cc
@@ -62,8 +62,7 @@ CTPPSDiamondRecHitProducer::CTPPSDiamondRecHitProducer(const edm::ParameterSet& 
   if (applyCalib_) {
     timingCalibrationToken_ = esConsumes<PPSTimingCalibration, PPSTimingCalibrationRcd>(
         edm::ESInputTag(iConfig.getParameter<std::string>("timingCalibrationTag")));
-    timingCalibrationLUTToken_ = esConsumes<PPSTimingCalibrationLUT, PPSTimingCalibrationLUTRcd>(
-        edm::ESInputTag(iConfig.getParameter<std::string>("timingCalibrationLUTTag")));
+    timingCalibrationLUTToken_ = esConsumes<PPSTimingCalibrationLUT, PPSTimingCalibrationLUTRcd>();
   }
   produces<edm::DetSetVector<CTPPSDiamondRecHit> >();
 }
@@ -98,8 +97,6 @@ void CTPPSDiamondRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions
       ->setComment("input digis collection to retrieve");
   desc.add<std::string>("timingCalibrationTag", "GlobalTag:PPSDiamondTimingCalibration")
       ->setComment("input tag for timing calibrations retrieval");
-  desc.add<std::string>("timingCalibrationLUTTag", "GlobalTag:PPSDiamondTimingCalibrationLUT")
-      ->setComment("input tag for LUT timing calibrations retrieval");
   desc.add<double>("timeSliceNs", 25.0 / 1024.0)
       ->setComment("conversion constant between HPTDC timing bin size and nanoseconds");
   desc.add<bool>("applyCalibration", true)->setComment("switch on/off the timing calibration");

--- a/RecoPPS/Local/python/ctppsDiamondLocalReconstruction_cff.py
+++ b/RecoPPS/Local/python/ctppsDiamondLocalReconstruction_cff.py
@@ -1,5 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
+# Temporary customization of GT - to be removed once the tag is included in the GTs
+from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import GlobalTag
+GlobalTag.toGet.append(
+  cms.PSet(record = cms.string('PPSTimingCalibrationLUTRcd'),
+           tag = cms.string('PPSDiamondTimingCalibrationLUT_test')
+  )
+)
+
 # reco hit production
 from RecoPPS.Local.ctppsDiamondRecHits_cfi import ctppsDiamondRecHits
 

--- a/RecoPPS/Local/python/ctppsDiamondLocalReconstruction_cff.py
+++ b/RecoPPS/Local/python/ctppsDiamondLocalReconstruction_cff.py
@@ -6,6 +6,11 @@ from RecoPPS.Local.ctppsDiamondRecHits_cfi import ctppsDiamondRecHits
 # local track fitting
 from RecoPPS.Local.ctppsDiamondLocalTracks_cfi import ctppsDiamondLocalTracks
 
+from CalibPPS.ESProducers.ppsTimingCalibrationLUTESSource_cfi import ppsTimingCalibrationLUTESSource
+
+ppsTimingCalibrationLUTESSource.calibrationFile = cms.FileInPath('RecoPPS/Local/data/LUT_cal_test.json')
+ctppsDiamondRecHits.timingCalibrationLUTTag=cms.string('ppsTimingCalibrationLUTESSource:')
+
 ctppsDiamondLocalReconstructionTask = cms.Task(
     ctppsDiamondRecHits,
     ctppsDiamondLocalTracks

--- a/RecoPPS/Local/python/ctppsDiamondLocalReconstruction_cff.py
+++ b/RecoPPS/Local/python/ctppsDiamondLocalReconstruction_cff.py
@@ -6,11 +6,6 @@ from RecoPPS.Local.ctppsDiamondRecHits_cfi import ctppsDiamondRecHits
 # local track fitting
 from RecoPPS.Local.ctppsDiamondLocalTracks_cfi import ctppsDiamondLocalTracks
 
-from CalibPPS.ESProducers.ppsTimingCalibrationLUTESSource_cfi import ppsTimingCalibrationLUTESSource
-
-ppsTimingCalibrationLUTESSource.calibrationFile = cms.FileInPath('RecoPPS/Local/data/LUT_cal_test.json')
-ctppsDiamondRecHits.timingCalibrationLUTTag=cms.string('ppsTimingCalibrationLUTESSource:')
-
 ctppsDiamondLocalReconstructionTask = cms.Task(
     ctppsDiamondRecHits,
     ctppsDiamondLocalTracks

--- a/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -7,7 +7,6 @@
 ****************************************************************************/
 
 #include <memory>
-#include <numeric>
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h"
 
@@ -62,7 +61,6 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
     const double ch_t_offset = (apply_calib_) ? calib_.timeOffset(sector, station, plane, channel) : 0.;
     const double ch_t_precis = (apply_calib_) ? calib_.timePrecision(sector, station, plane, channel) : 0.;
 
-    //edm::LogWarning("RECO ")<< sector<<" "<<station<<" "<<plane<<" "<<channel;
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert(detid);
 
     for (const auto& digi : vec) {
@@ -87,7 +85,6 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
 
       // calibrated time of arrival
       const double t0 = (t_lead % 1024) * ts_to_ns_ + LUT[t_lead % 1024] - ch_t_twc;
-      //edm::LogWarning("t0 ")<<"t0 "<<LUT[t_lead % 1024];
       rec_hits.emplace_back(
           // spatial information
           x_pos,

--- a/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -47,13 +47,13 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
 
     const int sector = detid.arm(), station = detid.station(), plane = detid.plane(), channel = detid.channel();
     //LUT calibration
-    std::vector<double> LUT;
+    std::vector<double> lut;
     if (apply_calib_) {
-      LUT = calibLUT_.bins(sector, station, plane, channel);
-      if (LUT.size() != 1024)
-        LUT = std::vector<double>(1024, 0.0);
+      lut = calibLUT_.bins(sector, station, plane, channel);
+      if (lut.size() != 1024)
+        lut = std::vector<double>(1024, 0.0);
     } else
-      LUT = std::vector<double>(1024, 0.0);
+      lut = std::vector<double>(1024, 0.0);
 
     // retrieve the timing calibration part for this channel
     const auto& ch_params = (apply_calib_) ? calib_.parameters(sector, station, plane, channel) : std::vector<double>{};
@@ -84,7 +84,7 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
           (t_lead != 0) ? (t_lead - ch_t_offset / ts_to_ns_) / 1024 : CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
 
       // calibrated time of arrival
-      const double t0 = (t_lead % 1024) * ts_to_ns_ + LUT[t_lead % 1024] - ch_t_twc;
+      const double t0 = (t_lead % 1024) * ts_to_ns_ + lut[t_lead % 1024] - ch_t_twc;
       rec_hits.emplace_back(
           // spatial information
           x_pos,

--- a/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -7,7 +7,7 @@
 ****************************************************************************/
 
 #include <memory>
-
+#include <numeric>
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "RecoPPS/Local/interface/CTPPSDiamondRecHitProducerAlgorithm.h"
 
@@ -17,8 +17,10 @@ CTPPSDiamondRecHitProducerAlgorithm::CTPPSDiamondRecHitProducerAlgorithm(const e
     : ts_to_ns_(iConfig.getParameter<double>("timeSliceNs")),
       apply_calib_(iConfig.getParameter<bool>("applyCalibration")) {}
 
-void CTPPSDiamondRecHitProducerAlgorithm::setCalibration(const PPSTimingCalibration& calib) {
+void CTPPSDiamondRecHitProducerAlgorithm::setCalibration(const PPSTimingCalibration& calib,
+                                                         const PPSTimingCalibrationLUT& calibLUT) {
   calib_ = calib;
+  calibLUT_ = calibLUT;
   calib_fct_ = std::make_unique<reco::FormulaEvaluator>(calib_.formula());
 }
 
@@ -44,13 +46,23 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
     const float y_width = 2.0 * diamondDimensions.yHalfWidth;
     const float z_width = 2.0 * diamondDimensions.zHalfWidth;
 
-    // retrieve the timing calibration part for this channel
     const int sector = detid.arm(), station = detid.station(), plane = detid.plane(), channel = detid.channel();
+    //LUT calibration
+    std::vector<double> LUT;
+    if (apply_calib_) {
+      LUT = calibLUT_.bins(sector, station, plane, channel);
+      if (LUT.size() != 1024)
+        LUT = std::vector<double>(1024, 0.0);
+    } else
+      LUT = std::vector<double>(1024, 0.0);
+
+    // retrieve the timing calibration part for this channel
     const auto& ch_params = (apply_calib_) ? calib_.parameters(sector, station, plane, channel) : std::vector<double>{};
     // default values for offset + time precision if calibration object not found
     const double ch_t_offset = (apply_calib_) ? calib_.timeOffset(sector, station, plane, channel) : 0.;
     const double ch_t_precis = (apply_calib_) ? calib_.timePrecision(sector, station, plane, channel) : 0.;
 
+    //edm::LogWarning("RECO ")<< sector<<" "<<station<<" "<<plane<<" "<<channel;
     edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert(detid);
 
     for (const auto& digi : vec) {
@@ -74,8 +86,8 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
           (t_lead != 0) ? (t_lead - ch_t_offset / ts_to_ns_) / 1024 : CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
 
       // calibrated time of arrival
-      const double t0 = (t_lead % 1024) * ts_to_ns_ - ch_t_twc;
-
+      const double t0 = (t_lead % 1024) * ts_to_ns_ + LUT[t_lead % 1024] - ch_t_twc;
+      //edm::LogWarning("t0 ")<<"t0 "<<LUT[t_lead % 1024];
       rec_hits.emplace_back(
           // spatial information
           x_pos,


### PR DESCRIPTION
#### PR description:
This is the second part of the nonlinearities calibration. The first part implemented the calibration record https://github.com/cms-sw/cmssw/pull/36537 and this PR introduces changes to the RecHitProducer, which allow for the callibration to be correctly applied. For more information, please refer to: https://indico.cern.ch/event/1100184/contributions/4635498/attachments/2359270/4026918/VBORSHCH_PPS_general_06122021.pdf

#### PR Validation:
PR was validated with candidateGT 123X_dataRun3_Prompt_Candidate_2022_01_18_15_41_02