### PR TITLE
Updated GEMGeometryBuilder to allow GE2/1 demonstrator to be built - Alternative Method

### DIFF
--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -53,12 +53,14 @@ int GEMDQMBase::loadChambers() {
     for (int l = 0; l < n_lay; l++) {
       Bool_t bExist = false;
       for (const auto& ch : gemChambers_) {
-        if (ch.id() == sch->chamber(l + 1)->id()) {
+        if (sch->chamber(l + 1) and ch.id() == sch->chamber(l + 1)->id()) {
           bExist = true;
           break;
         }
       }
       if (bExist)
+        continue;
+      if (not sch->chamber(l + 1))
         continue;
       gemChambers_.push_back(*sch->chamber(l + 1));
     }

--- a/Geometry/GEMGeometry/test/testGE0Geometry_cfg.py
+++ b/Geometry/GEMGeometry/test/testGE0Geometry_cfg.py
@@ -4,6 +4,7 @@ process = cms.Process("Demo")
 
 process.load('GeometryExtended2026GE0Test_cff')
 process.load('GeometryExtended2026GE0TestReco_cff')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -162,7 +162,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
 
   std::vector<GEMSuperChamber*> vsuperChambers;
   vsuperChambers.reserve(superChambers.size());
-  for (auto & [k, v] : superChambers) {
+  for (auto& [k, v] : superChambers) {
     GEMSuperChamber* gemSuperChamber = buildSuperChamber(*v, k);
     vsuperChambers.push_back(gemSuperChamber);
   }

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -70,7 +70,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
   ;
 #endif
   // loop over superchambers
-  std::map<GEMDetId, GEMSuperChamber*> superChambers;
+  std::map<GEMDetId, DDFilteredView::nav_type> superChambers;
   std::map<GEMDetId, GEMDetId> seen;
   while (doSuper) {
     // getting chamber id from eta partitions
@@ -104,10 +104,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     if ((seen.find(detIdCh.superChamberId()) == seen.end()) ||
         detIdCh.layer() < seen[detIdCh.superChamberId()].layer()) {
       seen[detIdCh.superChamberId()] = detIdCh.chamberId();
-      if (superChambers.find(detIdCh.superChamberId()) != superChambers.end())
-        delete superChambers[detIdCh.superChamberId()];
-      GEMSuperChamber* gemSuperChamber = buildSuperChamber(fv, detIdCh);
-      superChambers[detIdCh.superChamberId()] = gemSuperChamber;
+      superChambers[detIdCh.superChamberId()] = fv.navPos();
     }
     GEMChamber* gemChamber = ((detIdCh.station() == GEMDetId::minStationId0) ? nullptr : buildChamber(fv, detIdCh));
 
@@ -165,8 +162,11 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
 
   std::vector<GEMSuperChamber*> vsuperChambers;
   vsuperChambers.reserve(superChambers.size());
-  for (auto [k, v] : superChambers)
-    vsuperChambers.push_back(v);
+  for (auto [k, v] : superChambers) {
+    fv.goTo(v);
+    GEMSuperChamber* gemSuperChamber = buildSuperChamber(fv, k);
+    vsuperChambers.push_back(gemSuperChamber);
+  }
 
   buildRegions(theGeometry, vsuperChambers);
 }

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -76,9 +76,10 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
   }
   bool demonstratorGeometry = (nGE21 == 1) ? true : false;
 
-  #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? " << demonstratorGeometry;
-  #endif
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "
+                               << demonstratorGeometry;
+#endif
 
   // Asking only for the MuonGEM's
   DDSpecificsMatchesValueFilter filter{DDValue(attribute, value, 0.0)};
@@ -127,8 +128,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     // the superchamber gets built but also we build on the first
     // layer for the other stations so the superchamber is in the
     // right position there.
-    if ((detIdCh.layer() == 1) ||
-        (detIdCh.layer() == 2 and detIdCh.station() == 2 and demonstratorGeometry)) {
+    if ((detIdCh.layer() == 1) || (detIdCh.layer() == 2 and detIdCh.station() == 2 and demonstratorGeometry)) {
       GEMSuperChamber* gemSuperChamber = buildSuperChamber(fv, detIdCh);
       superChambers.push_back(gemSuperChamber);
     }
@@ -370,9 +370,10 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
   }
 
   bool demonstratorGeometry = (nGE21 == 1) ? true : false;
-  #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? " << demonstratorGeometry;
-  #endif
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "
+                               << demonstratorGeometry;
+#endif
 
   const cms::DDFilter filter(attribute, value);
   cms::DDFilteredView fv(*cview, filter);
@@ -412,8 +413,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
       }
     } else {
       if (fv.level() == levelChamb) {
-        if ((detId.layer() == 1) ||
-            (detId.layer() == 2 and detId.station() == 2 and demonstratorGeometry)) {
+        if ((detId.layer() == 1) || (detId.layer() == 2 and detId.station() == 2 and demonstratorGeometry)) {
           GEMSuperChamber* gemSuperChamber = buildSuperChamber(fv, detId);
           superChambers.emplace_back(gemSuperChamber);
         }

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -373,8 +373,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
         // For Run3 we have a demonstrator GE2/1 superchamber with
         // only the 2nd layer, so we make sure all superchambers are
         // built on the lowest layer present in the geometry
-        if ((seen.find(detId.superChamberId()) == seen.end()) ||
-            detId.layer() < seen[detId.superChamberId()].layer()) {
+        if ((seen.find(detId.superChamberId()) == seen.end()) || detId.layer() < seen[detId.superChamberId()].layer()) {
           seen[detId.superChamberId()] = detId.chamberId();
           superChambers[detId.superChamberId()] = fv.navPos();
         }

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -70,7 +70,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
   ;
 #endif
   // loop over superchambers
-  std::map<GEMDetId, DDFilteredView::nav_type> superChambers;
+  std::map<GEMDetId, std::unique_ptr<DDFilteredView>> superChambers;
   std::map<GEMDetId, GEMDetId> seen;
   while (doSuper) {
     // getting chamber id from eta partitions
@@ -104,7 +104,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     if ((seen.find(detIdCh.superChamberId()) == seen.end()) ||
         detIdCh.layer() < seen[detIdCh.superChamberId()].layer()) {
       seen[detIdCh.superChamberId()] = detIdCh.chamberId();
-      superChambers[detIdCh.superChamberId()] = fv.navPos();
+      superChambers[detIdCh.superChamberId()] = std::make_unique<DDFilteredView>(fv);
     }
     GEMChamber* gemChamber = ((detIdCh.station() == GEMDetId::minStationId0) ? nullptr : buildChamber(fv, detIdCh));
 
@@ -162,9 +162,8 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
 
   std::vector<GEMSuperChamber*> vsuperChambers;
   vsuperChambers.reserve(superChambers.size());
-  for (auto [k, v] : superChambers) {
-    fv.goTo(v);
-    GEMSuperChamber* gemSuperChamber = buildSuperChamber(fv, k);
+  for (auto & [k, v] : superChambers) {
+    GEMSuperChamber* gemSuperChamber = buildSuperChamber(*v, k);
     vsuperChambers.push_back(gemSuperChamber);
   }
 

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -96,7 +96,8 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     // currently there is no superchamber in the geometry
     // only 2 chambers are present separated by a gap.
     // making superchamber out of the first chamber layer including the gap between chambers
-    if (seen.find(detIdCh.superChamberId()) == seen.end()) {  // only make a superchamber when the first chamber of the sc is seen
+    if (seen.find(detIdCh.superChamberId()) ==
+        seen.end()) {  // only make a superchamber when the first chamber of the sc is seen
       seen.insert(detIdCh.superChamberId());
       GEMSuperChamber* gemSuperChamber = buildSuperChamber(fv, detIdCh);
       superChambers.push_back(gemSuperChamber);

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -70,8 +70,8 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
   ;
 #endif
   // loop over superchambers
-  std::map<GEMDetId,GEMSuperChamber*> superChambers;
-  std::map<GEMDetId,GEMDetId> seen;
+  std::map<GEMDetId, GEMSuperChamber*> superChambers;
+  std::map<GEMDetId, GEMDetId> seen;
   while (doSuper) {
     // getting chamber id from eta partitions
     fv.firstChild();
@@ -163,8 +163,8 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     }
   }
 
-  std::vector<GEMSuperChamber*> vsuperChambers;
-  for (auto [k,v] : superChambers)
+  std::vector<GEMSuperChamber*> vsuperChambers(superChambers.size());
+  for (auto [k, v] : superChambers)
     vsuperChambers.push_back(v);
 
   buildRegions(theGeometry, vsuperChambers);

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -6,6 +6,8 @@
               Sergio Lo Meo (sergio.lo.meo@cern.ch) following what Ianna Osburne made for DTs (DD4hep migration)
               Updated by Sunanda Banerjee (Fermilab) to make it working for dd4hep
               Updated:  7 August 2020 
+              Updated by Ian J. Watson (ian.james.watson@cern.ch) to allow GE2/1 demonstrator to be built
+              Updated: 7 December 2021
 */
 #include "Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
@@ -69,6 +71,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
 #endif
   // loop over superchambers
   std::vector<GEMSuperChamber*> superChambers;
+  int last_chamber_id = -999;
   while (doSuper) {
     // getting chamber id from eta partitions
     fv.firstChild();
@@ -93,7 +96,8 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     // currently there is no superchamber in the geometry
     // only 2 chambers are present separated by a gap.
     // making superchamber out of the first chamber layer including the gap between chambers
-    if (detIdCh.layer() == 1) {  // only make superChambers when doing layer 1
+    if (last_chamber_id != detIdCh.chamber()) { // only make a superchamber when the first chamber of the sc is seen
+      last_chamber_id = detIdCh.chamber();
       GEMSuperChamber* gemSuperChamber = buildSuperChamber(fv, detIdCh);
       superChambers.push_back(gemSuperChamber);
     }

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -71,7 +71,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
 #endif
   // loop over superchambers
   std::vector<GEMSuperChamber*> superChambers;
-  int last_chamber_id = -999;
+  std::set<GEMDetId> seen;
   while (doSuper) {
     // getting chamber id from eta partitions
     fv.firstChild();
@@ -96,8 +96,8 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     // currently there is no superchamber in the geometry
     // only 2 chambers are present separated by a gap.
     // making superchamber out of the first chamber layer including the gap between chambers
-    if (last_chamber_id != detIdCh.chamber()) {  // only make a superchamber when the first chamber of the sc is seen
-      last_chamber_id = detIdCh.chamber();
+    if (seen.find(detIdCh.superChamberId()) == seen.end()) {  // only make a superchamber when the first chamber of the sc is seen
+      seen.insert(detIdCh.superChamberId());
       GEMSuperChamber* gemSuperChamber = buildSuperChamber(fv, detIdCh);
       superChambers.push_back(gemSuperChamber);
     }

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -96,7 +96,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     // currently there is no superchamber in the geometry
     // only 2 chambers are present separated by a gap.
     // making superchamber out of the first chamber layer including the gap between chambers
-    if (last_chamber_id != detIdCh.chamber()) { // only make a superchamber when the first chamber of the sc is seen
+    if (last_chamber_id != detIdCh.chamber()) {  // only make a superchamber when the first chamber of the sc is seen
       last_chamber_id = detIdCh.chamber();
       GEMSuperChamber* gemSuperChamber = buildSuperChamber(fv, detIdCh);
       superChambers.push_back(gemSuperChamber);

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -163,7 +163,8 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     }
   }
 
-  std::vector<GEMSuperChamber*> vsuperChambers(superChambers.size());
+  std::vector<GEMSuperChamber*> vsuperChambers;
+  vsuperChambers.reserve(superChambers.size());
   for (auto [k, v] : superChambers)
     vsuperChambers.push_back(v);
 

--- a/Geometry/GEMGeometryBuilder/test/GEMGeometryDump.cc
+++ b/Geometry/GEMGeometryBuilder/test/GEMGeometryDump.cc
@@ -65,14 +65,16 @@ void GEMGeometryDump::analyze(const edm::Event& event, const edm::EventSetup& ev
 
         for (unsigned int k4 = 0; k4 < superChambers.size(); ++k4) {
           auto pos = superChambers[k4]->position();
-          edm::LogVerbatim("GEMGeometry") << "\nSuperChamber " << k4 << ":" << superChambers[k4]->id() << " with "
-                                          << superChambers[k4]->nChambers() << " chambers. Position: " << pos.x() << " " << pos.y() << " " << pos.z();
+          edm::LogVerbatim("GEMGeometry")
+              << "\nSuperChamber " << k4 << ":" << superChambers[k4]->id() << " with " << superChambers[k4]->nChambers()
+              << " chambers. Position: " << pos.x() << " " << pos.y() << " " << pos.z();
           auto const& chambers = superChambers[k4]->chambers();
 
           for (unsigned int k5 = 0; k5 < chambers.size(); ++k5) {
             auto pos = chambers[k5]->position();
-            edm::LogVerbatim("GEMGeometry") << "\nChamber " << k5 << ":" << chambers[k5]->id() << " with "
-                                            << chambers[k5]->nEtaPartitions() << " etaPartitions. Position: " << pos.x() << " " << pos.y() << " " << pos.z();
+            edm::LogVerbatim("GEMGeometry")
+                << "\nChamber " << k5 << ":" << chambers[k5]->id() << " with " << chambers[k5]->nEtaPartitions()
+                << " etaPartitions. Position: " << pos.x() << " " << pos.y() << " " << pos.z();
             auto const& etaPartitions = chambers[k5]->etaPartitions();
 
             for (unsigned int k6 = 0; k6 < etaPartitions.size(); ++k6) {
@@ -80,7 +82,9 @@ void GEMGeometryDump::analyze(const edm::Event& event, const edm::EventSetup& ev
               edm::LogVerbatim("GEMGeometry")
                   << "\nEtaPartition " << k6 << ":" << etaPartitions[k6]->id() << etaPartitions[k6]->type().name()
                   << " with " << etaPartitions[k6]->nstrips() << " strips of pitch " << etaPartitions[k6]->pitch()
-                  << " and " << etaPartitions[k6]->npads() << " pads of pitch " << etaPartitions[k6]->padPitch() << ". Position: " << pos.x() << " " << pos.y() << " " << pos.z();;
+                  << " and " << etaPartitions[k6]->npads() << " pads of pitch " << etaPartitions[k6]->padPitch()
+                  << ". Position: " << pos.x() << " " << pos.y() << " " << pos.z();
+              ;
               if (verbose_) {
                 for (int k = 0; k < etaPartitions[k6]->nstrips(); ++k)
                   edm::LogVerbatim("GEMGeometry") << "Strip[" << k << "] " << etaPartitions[k6]->centreOfStrip(k);

--- a/Geometry/GEMGeometryBuilder/test/GEMGeometryDump.cc
+++ b/Geometry/GEMGeometryBuilder/test/GEMGeometryDump.cc
@@ -64,20 +64,23 @@ void GEMGeometryDump::analyze(const edm::Event& event, const edm::EventSetup& ev
         auto const& superChambers = rings[k3]->superChambers();
 
         for (unsigned int k4 = 0; k4 < superChambers.size(); ++k4) {
+          auto pos = superChambers[k4]->position();
           edm::LogVerbatim("GEMGeometry") << "\nSuperChamber " << k4 << ":" << superChambers[k4]->id() << " with "
-                                          << superChambers[k4]->nChambers() << " chambers";
+                                          << superChambers[k4]->nChambers() << " chambers. Position: " << pos.x() << " " << pos.y() << " " << pos.z();
           auto const& chambers = superChambers[k4]->chambers();
 
           for (unsigned int k5 = 0; k5 < chambers.size(); ++k5) {
+            auto pos = chambers[k5]->position();
             edm::LogVerbatim("GEMGeometry") << "\nChamber " << k5 << ":" << chambers[k5]->id() << " with "
-                                            << chambers[k5]->nEtaPartitions() << " etaPartitions";
+                                            << chambers[k5]->nEtaPartitions() << " etaPartitions. Position: " << pos.x() << " " << pos.y() << " " << pos.z();
             auto const& etaPartitions = chambers[k5]->etaPartitions();
 
             for (unsigned int k6 = 0; k6 < etaPartitions.size(); ++k6) {
+              auto pos = chambers[k5]->position();
               edm::LogVerbatim("GEMGeometry")
                   << "\nEtaPartition " << k6 << ":" << etaPartitions[k6]->id() << etaPartitions[k6]->type().name()
                   << " with " << etaPartitions[k6]->nstrips() << " strips of pitch " << etaPartitions[k6]->pitch()
-                  << " and " << etaPartitions[k6]->npads() << " pads of pitch " << etaPartitions[k6]->padPitch();
+                  << " and " << etaPartitions[k6]->npads() << " pads of pitch " << etaPartitions[k6]->padPitch() << ". Position: " << pos.x() << " " << pos.y() << " " << pos.z();;
               if (verbose_) {
                 for (int k = 0; k < etaPartitions[k6]->nstrips(); ++k)
                   edm::LogVerbatim("GEMGeometry") << "Strip[" << k << "] " << etaPartitions[k6]->centreOfStrip(k);

--- a/Geometry/GEMGeometryBuilder/test/python/dumpGEMGeometryDDD_cfg.py
+++ b/Geometry/GEMGeometryBuilder/test/python/dumpGEMGeometryDDD_cfg.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('DUMP')
 
-process.load('Configuration.Geometry.GeometryExtended2021_cff')
+process.load('Geometry.MuonCommonData.testExtendedGeometry2021XML_cfi')
+#process.load('Configuration.Geometry.GeometryExtended2021_cff')
 #process.load('Geometry.MuonCommonData.testGE0XML_cfi')
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")

--- a/Geometry/GEMGeometryBuilder/test/python/dumpGEMGeometryDDD_cfg.py
+++ b/Geometry/GEMGeometryBuilder/test/python/dumpGEMGeometryDDD_cfg.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('DUMP')
 
-#process.load('Configuration.Geometry.GeometryExtended2021_cff')
-process.load('Geometry.MuonCommonData.testGE0XML_cfi')
+process.load('Configuration.Geometry.GeometryExtended2021_cff')
+#process.load('Geometry.MuonCommonData.testGE0XML_cfi')
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load("Geometry.GEMGeometryBuilder.gemGeometry_cff")


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

To be able to build the GE2/1 demonstrator into the GEMGeometry, need to change a check which creates the superchamber. 
In this case, we do an initial scan of the geometry and check if only 1 GE2/1 chamber exists, and if so, set a flag which tells the superchamber builder to build off layer 2 for GE2/1 (since only a single layer 2 chamber is present in the demonstrator).

This is an alternative to #36482, only one of these two PRs should be added.

@cvuosalo Do you think this approach is better than the previous?

#### PR validation:

I have checked the geometry builder with a run3 DDD geometry and a phase2 geometry, and they build correctly. Would need to test with Sunanda's changes also.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
