### PR TITLE
Updated Exceptions for SIM step

### DIFF
--- a/SimG4Core/Application/interface/ExceptionHandler.h
+++ b/SimG4Core/Application/interface/ExceptionHandler.h
@@ -18,7 +18,7 @@
 
 class ExceptionHandler : public G4VExceptionHandler {
 public:
-  explicit ExceptionHandler(double th);
+  explicit ExceptionHandler(double th, bool tr);
   ~ExceptionHandler() override;
 
   int operator==(const ExceptionHandler &right) const { return (this == &right); }
@@ -34,6 +34,7 @@ public:
 
 private:
   double m_eth;
+  bool m_trace;
 };
 
 #endif

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -21,8 +21,6 @@
 #include "SimG4Core/Application/interface/OscarMTMasterThread.h"
 #include "SimG4Core/Application/interface/RunManagerMT.h"
 #include "SimG4Core/Application/interface/RunManagerMTWorker.h"
-
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 #include "SimG4Core/Notification/interface/G4SimEvent.h"
 
 #include "SimG4Core/SensitiveDetector/interface/SensitiveTkDetector.h"
@@ -248,20 +246,12 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   auto& sCalo = m_runManagerWorker->sensCaloDetectors();
 
   std::unique_ptr<G4SimEvent> evt;
-  try {
-    auto token = edm::ServiceRegistry::instance().presentToken();
-    m_handoff.runAndWait([this, &e, &es, &evt, token, engine]() {
+  auto token = edm::ServiceRegistry::instance().presentToken();
+  m_handoff.runAndWait([this, &e, &es, &evt, token, engine]() {
       edm::ServiceRegistry::Operate guard{token};
       StaticRandomEngineSetUnset random(engine);
       evt = m_runManagerWorker->produce(e, es, globalCache()->runManagerMaster());
     });
-  } catch (const SimG4Exception& simg4ex) {
-    edm::LogWarning("SimG4CoreApplication") << "SimG4Exception caght! " << simg4ex.what();
-
-    throw edm::Exception(edm::errors::EventCorruption)
-        << "SimG4CoreApplication exception in generation of event " << e.id() << " in stream " << e.streamID() << " \n"
-        << simg4ex.what();
-  }
 
   std::unique_ptr<edm::SimTrackContainer> p1(new edm::SimTrackContainer);
   std::unique_ptr<edm::SimVertexContainer> p2(new edm::SimVertexContainer);
@@ -283,7 +273,6 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   }
   for (auto& calo : sCalo) {
     const std::vector<std::string>& v = calo->getNames();
-
     for (auto& name : v) {
       std::unique_ptr<edm::PCaloHitContainer> product(new edm::PCaloHitContainer);
       calo->fillHits(*product, name);

--- a/SimG4Core/Application/plugins/OscarMTProducer.cc
+++ b/SimG4Core/Application/plugins/OscarMTProducer.cc
@@ -248,10 +248,10 @@ void OscarMTProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   std::unique_ptr<G4SimEvent> evt;
   auto token = edm::ServiceRegistry::instance().presentToken();
   m_handoff.runAndWait([this, &e, &es, &evt, token, engine]() {
-      edm::ServiceRegistry::Operate guard{token};
-      StaticRandomEngineSetUnset random(engine);
-      evt = m_runManagerWorker->produce(e, es, globalCache()->runManagerMaster());
-    });
+    edm::ServiceRegistry::Operate guard{token};
+    StaticRandomEngineSetUnset random(engine);
+    evt = m_runManagerWorker->produce(e, es, globalCache()->runManagerMaster());
+  });
 
   std::unique_ptr<edm::SimTrackContainer> p1(new edm::SimTrackContainer);
   std::unique_ptr<edm::SimVertexContainer> p2(new edm::SimVertexContainer);

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -86,6 +86,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     RestorePhysicsTables = cms.untracked.bool(False),
     UseParametrisedEMPhysics = cms.untracked.bool(True),
     ThresholdForGeometryExceptions = cms.double(0.01),   ## in GeV
+    TraceExceptions = cms.bool(False),
     CheckGeometry = cms.untracked.bool(False),
     OnlySDs = cms.vstring('ZdcSensitiveDetector', 'TotemT2ScintSensitiveDetector', 'TotemSensitiveDetector', 'RomanPotSensitiveDetector', 'PLTSensitiveDetector', 'MuonSensitiveDetector', 'MtdSensitiveDetector', 'BCM1FSensitiveDetector', 'EcalSensitiveDetector', 'CTPPSSensitiveDetector', 'BSCSensitiveDetector', 'CTPPSDiamondSensitiveDetector', 'FP420SensitiveDetector', 'BHMSensitiveDetector', 'CastorSensitiveDetector', 'CaloTrkProcessing', 'HcalSensitiveDetector', 'TkAccumulatingSensitiveDetector'),
     G4CheckOverlap = cms.untracked.PSet(

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -42,8 +42,8 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
     if (nullptr != vol) {
       message << "\n   PhysicalVolume: " << vol->GetName() << ";";
       const G4LogicalVolume* lv = vol->GetLogicalVolume();
-      if(nullptr != lv) {
-	message << " material: " << lv->GetMaterial()->GetName();
+      if (nullptr != lv) {
+        message << " material: " << lv->GetMaterial()->GetName();
       }
     }
     message << "\n   stepNumber=" << track->GetCurrentStepNumber()
@@ -71,8 +71,7 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
     case FatalErrorInArgument:
     case RunMustBeAborted:
     case EventMustBeAborted:
-      edm::LogWarning("SimG4CoreApplication")
-          << es_banner << message.str() << ee_banner;
+      edm::LogWarning("SimG4CoreApplication") << es_banner << message.str() << ee_banner;
       throw cms::Exception("Geant4 fatal exception");
       res = m_trace;
       break;

--- a/SimG4Core/Application/src/ExceptionHandler.cc
+++ b/SimG4Core/Application/src/ExceptionHandler.cc
@@ -1,7 +1,7 @@
 #include "SimG4Core/Application/interface/ExceptionHandler.h"
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include "G4EventManager.hh"
 #include "G4TrackingManager.hh"
@@ -9,7 +9,7 @@
 #include "globals.hh"
 #include <sstream>
 
-ExceptionHandler::ExceptionHandler(double th) : m_eth(th) {}
+ExceptionHandler::ExceptionHandler(double th, bool tr) : m_eth(th), m_trace(tr) {}
 
 ExceptionHandler::~ExceptionHandler() {}
 
@@ -40,7 +40,11 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
             << "\n   position(mm): " << track->GetPosition() << "; direction: " << track->GetMomentumDirection();
     const G4VPhysicalVolume* vol = track->GetVolume();
     if (nullptr != vol) {
-      message << "\n   PhysicalVolume: " << vol->GetName() << "; material: " << track->GetMaterial()->GetName();
+      message << "\n   PhysicalVolume: " << vol->GetName() << ";";
+      const G4LogicalVolume* lv = vol->GetLogicalVolume();
+      if(nullptr != lv) {
+	message << " material: " << lv->GetMaterial()->GetName();
+      }
     }
     message << "\n   stepNumber=" << track->GetCurrentStepNumber()
             << "; stepLength(mm)=" << track->GetStepLength() / CLHEP::mm << "; weight=" << track->GetWeight();
@@ -49,22 +53,28 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
       message << "; creatorProcess: " << proc->GetProcessName() << "; modelID=" << track->GetCreatorModelID();
     }
   }
-  message << "\n";
+  message << " \n";
 
   G4ExceptionSeverity localSeverity = severity;
-  G4String code = G4String(*exceptionCode);
+  std::stringstream mescode;
+  mescode << exceptionCode << "\n";
+  G4String code;
+  mescode >> code;
+
   if (ekin < m_eth && code == "GeomNav0003") {
     localSeverity = JustWarning;
   }
 
-  std::stringstream ss;
+  bool res = false;
   switch (localSeverity) {
     case FatalException:
     case FatalErrorInArgument:
     case RunMustBeAborted:
     case EventMustBeAborted:
-      ss << es_banner << message.str() << ee_banner;
-      throw SimG4Exception(ss.str());
+      edm::LogWarning("SimG4CoreApplication")
+          << es_banner << message.str() << ee_banner;
+      throw cms::Exception("Geant4 fatal exception");
+      res = m_trace;
       break;
 
     case JustWarning:
@@ -72,5 +82,5 @@ bool ExceptionHandler::Notify(const char* exceptionOrigin,
           << ws_banner << message.str() << "*** This is just a warning message. ***" << we_banner;
       break;
   }
-  return false;
+  return res;
 }

--- a/SimG4Core/Application/src/OscarMTMasterThread.cc
+++ b/SimG4Core/Application/src/OscarMTMasterThread.cc
@@ -1,7 +1,7 @@
 #include <memory>
 
 #include "SimG4Core/Application/interface/OscarMTMasterThread.h"
-#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "SimG4Core/Application/interface/RunManagerMT.h"
@@ -66,11 +66,11 @@ OscarMTMasterThread::OscarMTMasterThread(const edm::ParameterSet& iConfig)
       } else if (m_masterThreadState == ThreadState::Destruct) {
         edm::LogVerbatim("OscarMTMasterThread") << "Master thread: Breaking out of state loop";
         if (isG4Alive)
-          throw edm::Exception(edm::errors::LogicError) << "OscarMTMasterThread: Geant4 is still alive, master thread "
-                                                           "state must be set to EndRun before Destruct";
+          throw cms::Exception("LogicError") << "OscarMTMasterThread: Geant4 is still alive, master thread "
+                                             << "state must be set to EndRun before Destruct";
         break;
       } else {
-        throw edm::Exception(edm::errors::LogicError)
+        throw cms::Exception("LogicError")
             << "OscarMTMasterThread: Illegal master thread state " << static_cast<int>(m_masterThreadState);
       }
     }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -18,11 +18,11 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 #include "SimG4Core/Notification/interface/G4SimEvent.h"
 #include "SimG4Core/Notification/interface/SimActivityRegistry.h"
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
 #include "SimG4Core/Notification/interface/CMSSteppingVerbose.h"
 #include "SimG4Core/Watcher/interface/SimWatcherFactory.h"
@@ -85,7 +85,7 @@ namespace {
       std::unique_ptr<SimWatcherMakerBase> maker(
           SimWatcherFactory::get()->create(watcher.getParameter<std::string>("type")));
       if (maker == nullptr) {
-        throw edm::Exception(edm::errors::Configuration)
+        throw cms::Exception("Configuration")
             << "RunManagerMTWorker::createWatchers: "
             << "Unable to find the requested Watcher " << watcher.getParameter<std::string>("type");
       } else {
@@ -94,7 +94,7 @@ namespace {
         maker->make(watcher, *(iReg), watcherTemp, producerTemp);
         if (nullptr != watcherTemp) {
           if (!watcherTemp->isMT() && 0 < threadID) {
-            throw edm::Exception(edm::errors::Configuration)
+            throw cms::Exception("Configuration")
                 << "RunManagerMTWorker::createWatchers: "
                 << "Unable to use Watcher " << watcher.getParameter<std::string>("type") << " if number of threads > 1";
           } else {
@@ -230,7 +230,7 @@ void RunManagerMTWorker::initializeTLS() {
   if (otherRegistry) {
     m_tls->registry->connect(*otherRegistry);
     if (thisID > 0) {
-      throw edm::Exception(edm::errors::Configuration)
+      throw cms::Exception("Configuration")
           << "RunManagerMTWorker::initializeTLS : "
           << "SimActivityRegistry service (i.e. visualization) is not supported for more than 1 thread. "
           << " \n If this use case is needed, RunManagerMTWorker has to be updated.";
@@ -265,7 +265,7 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
     m_UIsession =
         new CustomUIsessionToFile(m_pCustomUIsession.getUntrackedParameter<std::string>("ThreadFile", ""), thisID);
   } else {
-    throw edm::Exception(edm::errors::Configuration)
+    throw cms::Exception("Configuration")
         << "RunManagerMTWorker::initializeG4: Invalid value of CustomUIsession.Type '" << uitype
         << "', valid are MessageLogger, MessageLoggerThreadPrefix, FilePerThread";
   }
@@ -282,7 +282,8 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
 
   // Define G4 exception handler
   double th = m_p.getParameter<double>("ThresholdForGeometryExceptions") * CLHEP::GeV;
-  G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler(th));
+  bool tr = m_p.getParameter<bool>("TraceExceptions");
+  G4StateManager::GetStateManager()->SetExceptionHandler(new ExceptionHandler(th, tr));
 
   // Set the geometry for the worker, share from master
   auto worldPV = runManagerMaster->world().GetWorldVolume();
@@ -346,7 +347,7 @@ void RunManagerMTWorker::initializeG4(RunManagerMT* runManagerMaster, const edm:
   m_tls->kernel->InitializePhysics();
 
   if (!m_tls->kernel->RunInitialization()) {
-    throw edm::Exception(edm::errors::Configuration)
+    throw cms::Exception("Configuration")
         << "RunManagerMTWorker::InitializeG4: Geant4 kernel initialization failed in thread " << thisID;
   }
   //tell all interesting parties that we are beginning the job
@@ -506,9 +507,9 @@ std::unique_ptr<G4SimEvent> RunManagerMTWorker::produce(const edm::Event& inpevt
                                                         genVertex->t() / CLHEP::second));
   }
   if (m_tls->currentEvent->GetNumberOfPrimaryVertex() == 0) {
-    std::stringstream ss;
-    ss << "RunManagerMTWorker::produce: event " << inpevt.id().event() << " with no G4PrimaryVertices \n";
-    throw SimG4Exception(ss.str());
+    throw cms::Exception("EventCorruption")
+        << "RunManagerMTWorker::produce: event " << inpevt.id().event() << " with no G4PrimaryVertices"
+        << " StreamID=" << inpevt.streamID() << " threadIndex=" << getThreadIndex();
 
   } else {
     edm::LogVerbatim("SimG4CoreApplication")
@@ -527,7 +528,6 @@ std::unique_ptr<G4SimEvent> RunManagerMTWorker::produce(const edm::Event& inpevt
     sd->reset();
   }
   edm::LogVerbatim("SimG4CoreApplication") << "RunManagerMTWorker::produce: ended Event " << inpevt.id().event();
-
   m_simEvent = nullptr;
   return simEvent;
 }

--- a/SimG4Core/Notification/interface/TrackInformationExtractor.h
+++ b/SimG4Core/Notification/interface/TrackInformationExtractor.h
@@ -2,7 +2,6 @@
 #define SimG4Core_TrackInformationExtractor_H
 
 #include "SimG4Core/Notification/interface/TrackInformation.h"
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 
 class G4Track;
 
@@ -31,10 +30,8 @@ public:
   TrackInformation& operator()(G4Track* gtk) const { return operator()(*gtk); }
 
 private:
-  void missing(const G4Track& gtk) const {
-    throw SimG4Exception("TrackInformationExtractor: G4Track has no TrackInformation");
-  }
-  void wrongType() const { throw SimG4Exception("User information in G4Track is not of TrackInformation type"); }
+  void missing(const G4Track& gtk) const;
+  void wrongType() const;
 };
 
 #endif

--- a/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
+++ b/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
@@ -1,14 +1,14 @@
 #include "SimG4Core/Notification/interface/GenParticleInfoExtractor.h"
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
-
 #include "G4PrimaryParticle.hh"
 
 const GenParticleInfo &GenParticleInfoExtractor::operator()(const G4PrimaryParticle *p) const {
   G4VUserPrimaryParticleInformation *up = p->GetUserInformation();
   if (up == nullptr)
-    throw SimG4Exception("GenParticleInfoExtractor: G4PrimaryParticle has no user information");
+    G4Exception("SimG4Core/Notification", "mc001", FatalException, 
+                "GenParticleInfoExtractor: G4PrimaryParticle has no user information");
   GenParticleInfo *gpi = dynamic_cast<GenParticleInfo *>(up);
   if (gpi == nullptr)
-    throw SimG4Exception("User information in G4PrimaryParticle is not of GenParticleInfo type");
+    G4Exception("SimG4Core/Notification", "mc001", FatalException, 
+                "GenParticleInfoExtractor: user information in G4PrimaryParticle is not of GenParticleInfo type");
   return *gpi;
 }

--- a/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
+++ b/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
@@ -4,11 +4,15 @@
 const GenParticleInfo &GenParticleInfoExtractor::operator()(const G4PrimaryParticle *p) const {
   G4VUserPrimaryParticleInformation *up = p->GetUserInformation();
   if (up == nullptr)
-    G4Exception("SimG4Core/Notification", "mc001", FatalException, 
+    G4Exception("SimG4Core/Notification",
+                "mc001",
+                FatalException,
                 "GenParticleInfoExtractor: G4PrimaryParticle has no user information");
   GenParticleInfo *gpi = dynamic_cast<GenParticleInfo *>(up);
   if (gpi == nullptr)
-    G4Exception("SimG4Core/Notification", "mc001", FatalException, 
+    G4Exception("SimG4Core/Notification",
+                "mc001",
+                FatalException,
                 "GenParticleInfoExtractor: user information in G4PrimaryParticle is not of GenParticleInfo type");
   return *gpi;
 }

--- a/SimG4Core/Notification/src/NewTrackAction.cc
+++ b/SimG4Core/Notification/src/NewTrackAction.cc
@@ -1,6 +1,5 @@
 #include "SimG4Core/Notification/interface/NewTrackAction.h"
 #include "SimG4Core/Notification/interface/TrackInformation.h"
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 #include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -21,7 +20,8 @@ void NewTrackAction::secondary(const G4Track *aSecondary, const G4Track &mother,
 
 void NewTrackAction::secondary(G4Track *aSecondary, const G4Track &mother, int flag) const {
   if (aSecondary->GetParentID() != mother.GetTrackID())
-    throw SimG4Exception("NewTrackAction: secondary parent ID does not match mother id");
+    G4Exception("SimG4Core/Notification", "mc001", FatalException,
+                "NewTrackAction: secondary parent ID does not match mother id");
   TrackInformationExtractor extractor;
   const TrackInformation &motherInfo(extractor(mother));
   addUserInfoToSecondary(aSecondary, motherInfo, flag);

--- a/SimG4Core/Notification/src/NewTrackAction.cc
+++ b/SimG4Core/Notification/src/NewTrackAction.cc
@@ -20,7 +20,9 @@ void NewTrackAction::secondary(const G4Track *aSecondary, const G4Track &mother,
 
 void NewTrackAction::secondary(G4Track *aSecondary, const G4Track &mother, int flag) const {
   if (aSecondary->GetParentID() != mother.GetTrackID())
-    G4Exception("SimG4Core/Notification", "mc001", FatalException,
+    G4Exception("SimG4Core/Notification",
+                "mc001",
+                FatalException,
                 "NewTrackAction: secondary parent ID does not match mother id");
   TrackInformationExtractor extractor;
   const TrackInformation &motherInfo(extractor(mother));

--- a/SimG4Core/Notification/src/TrackInformationExtractor.cc
+++ b/SimG4Core/Notification/src/TrackInformationExtractor.cc
@@ -22,12 +22,12 @@ TrackInformation &TrackInformationExtractor::operator()(G4Track &gtk) const {
   return *tkInfo;
 }
 
-void TrackInformationExtractor::missing(const G4Track&) const {
-  G4Exception("SimG4Core/Notification", "mc001", FatalException,
-              "TrackInformationExtractor: G4Track has no TrackInformation");
+void TrackInformationExtractor::missing(const G4Track &) const {
+  G4Exception(
+      "SimG4Core/Notification", "mc001", FatalException, "TrackInformationExtractor: G4Track has no TrackInformation");
 }
 
-void TrackInformationExtractor::wrongType() const { 
-  G4Exception("SimG4Core/Notification", "mc001", FatalException,
-	      "User information in G4Track is not of TrackInformation type");
+void TrackInformationExtractor::wrongType() const {
+  G4Exception(
+      "SimG4Core/Notification", "mc001", FatalException, "User information in G4Track is not of TrackInformation type");
 }

--- a/SimG4Core/Notification/src/TrackInformationExtractor.cc
+++ b/SimG4Core/Notification/src/TrackInformationExtractor.cc
@@ -21,3 +21,13 @@ TrackInformation &TrackInformationExtractor::operator()(G4Track &gtk) const {
     wrongType();
   return *tkInfo;
 }
+
+void TrackInformationExtractor::missing(const G4Track&) const {
+  G4Exception("SimG4Core/Notification", "mc001", FatalException,
+              "TrackInformationExtractor: G4Track has no TrackInformation");
+}
+
+void TrackInformationExtractor::wrongType() const { 
+  G4Exception("SimG4Core/Notification", "mc001", FatalException,
+	      "User information in G4Track is not of TrackInformation type");
+}

--- a/SimG4Core/Notification/src/TrackWithHistory.cc
+++ b/SimG4Core/Notification/src/TrackWithHistory.cc
@@ -1,7 +1,6 @@
 #include "SimG4Core/Notification/interface/TrackWithHistory.h"
 #include "SimG4Core/Notification/interface/G4TrackToParticleID.h"
 #include "SimG4Core/Notification/interface/TrackInformationExtractor.h"
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 #include "SimG4Core/Notification/interface/GenParticleInfoExtractor.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -73,8 +72,8 @@ void TrackWithHistory::checkAtEnd(const G4Track* gt) {
                                         << "\nAt end:          " << vmomdir;
     ok = false;
   }
-  if (!ok)
-    throw SimG4Exception("TrackWithHistory::checkAtEnd failed");
+
+  if (!ok) G4Exception("TrackWithHistory::checkAtEnd()", "mc001", FatalException, "check at track end failed");
 }
 
 int TrackWithHistory::extractGenID(const G4Track* gt) const {

--- a/SimG4Core/Notification/src/TrackWithHistory.cc
+++ b/SimG4Core/Notification/src/TrackWithHistory.cc
@@ -73,7 +73,8 @@ void TrackWithHistory::checkAtEnd(const G4Track* gt) {
     ok = false;
   }
 
-  if (!ok) G4Exception("TrackWithHistory::checkAtEnd()", "mc001", FatalException, "check at track end failed");
+  if (!ok)
+    G4Exception("TrackWithHistory::checkAtEnd()", "mc001", FatalException, "check at track end failed");
 }
 
 int TrackWithHistory::extractGenID(const G4Track* gt) const {

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -1,6 +1,5 @@
 #include "SimG4Core/SensitiveDetector/interface/SensitiveDetector.h"
 
-#include "SimG4Core/Notification/interface/SimG4Exception.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -91,10 +90,12 @@ Local3DPoint SensitiveDetector::LocalPostStepPosition(const G4Step* step) const 
 
 TrackInformation* SensitiveDetector::cmsTrackInformation(const G4Track* aTrack) {
   TrackInformation* info = (TrackInformation*)(aTrack->GetUserInformation());
-  if (!info) {
-    edm::LogWarning("SensitiveDetector") << " no TrackInformation available for trackID= " << aTrack->GetTrackID();
-    throw SimG4Exception("SimG4CoreSensitiveDetector: cannot handle hits for " + GetName());
-  }
+  if (nullptr == info) {
+    edm::LogWarning("SensitiveDetector") 
+        << " no TrackInformation available for trackID= " << aTrack->GetTrackID() << " inside SD " << GetName();
+    G4Exception("SensitiveDetector::cmsTrackInformation()", "sd01",
+                  FatalException, "cannot handle hits without trackinfo");
+  } 
   return info;
 }
 
@@ -104,15 +105,16 @@ void SensitiveDetector::setNames(const std::vector<std::string>& hnames) {
 }
 
 void SensitiveDetector::NaNTrap(const G4Step* aStep) const {
-  const G4Track* CurrentTrk = aStep->GetTrack();
-  const G4ThreeVector& CurrentPos = CurrentTrk->GetPosition();
-  double xyz = CurrentPos.x() + CurrentPos.y() + CurrentPos.z();
-  const G4ThreeVector& CurrentMom = CurrentTrk->GetMomentum();
-  xyz += CurrentMom.x() + CurrentMom.y() + CurrentMom.z();
+  const G4Track* currentTrk = aStep->GetTrack();
+  const G4ThreeVector& currentPos = currentTrk->GetPosition();
+  double xyz = currentPos.x() + currentPos.y() + currentPos.z();
+  const G4ThreeVector& currentMom = currentTrk->GetMomentum();
+  xyz += currentMom.x() + currentMom.y() + currentMom.z();
 
   if (edm::isNotFinite(xyz)) {
     const G4VPhysicalVolume* pCurrentVol = aStep->GetPreStepPoint()->GetPhysicalVolume();
-    const G4String& NameOfVol = pCurrentVol->GetName();
-    throw SimG4Exception("SimG4CoreSensitiveDetector: Corrupted Event - NaN detected in volume " + NameOfVol);
+    edm::LogWarning("SensitiveDetector") 
+      << "NaN detected for trackID= " << currentTrk->GetTrackID() << " inside " << pCurrentVol->GetName();
+    G4Exception("SensitiveDetector::NaNTrap()", "sd01", FatalException, "corrupted event or step");
   }
 }

--- a/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
+++ b/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc
@@ -91,11 +91,11 @@ Local3DPoint SensitiveDetector::LocalPostStepPosition(const G4Step* step) const 
 TrackInformation* SensitiveDetector::cmsTrackInformation(const G4Track* aTrack) {
   TrackInformation* info = (TrackInformation*)(aTrack->GetUserInformation());
   if (nullptr == info) {
-    edm::LogWarning("SensitiveDetector") 
-        << " no TrackInformation available for trackID= " << aTrack->GetTrackID() << " inside SD " << GetName();
-    G4Exception("SensitiveDetector::cmsTrackInformation()", "sd01",
-                  FatalException, "cannot handle hits without trackinfo");
-  } 
+    edm::LogWarning("SensitiveDetector") << " no TrackInformation available for trackID= " << aTrack->GetTrackID()
+                                         << " inside SD " << GetName();
+    G4Exception(
+        "SensitiveDetector::cmsTrackInformation()", "sd01", FatalException, "cannot handle hits without trackinfo");
+  }
   return info;
 }
 
@@ -113,8 +113,8 @@ void SensitiveDetector::NaNTrap(const G4Step* aStep) const {
 
   if (edm::isNotFinite(xyz)) {
     const G4VPhysicalVolume* pCurrentVol = aStep->GetPreStepPoint()->GetPhysicalVolume();
-    edm::LogWarning("SensitiveDetector") 
-      << "NaN detected for trackID= " << currentTrk->GetTrackID() << " inside " << pCurrentVol->GetName();
+    edm::LogWarning("SensitiveDetector") << "NaN detected for trackID= " << currentTrk->GetTrackID() << " inside "
+                                         << pCurrentVol->GetName();
     G4Exception("SensitiveDetector::NaNTrap()", "sd01", FatalException, "corrupted event or step");
   }
 }


### PR DESCRIPTION
#### PR description:
In this PR unification of Exception scheme for SIM step is provided. During initialization cms::Exception is used. In run time G4Exception instead. G4Exception is customized by ExceptionHandler provided in CMSSW, which is using cms::Exception. For debug purpose a user may enable Geant4 trace if g4SimHits variable Trace=True.

This PR should not change results successful WFs but may be useful for debugging of SIM problems.



#### PR validation:
private

#### if this PR is a backport please specify the original PR and why you need to backport that PR: NO
