### PR TITLE
[12_2_X] Include PF HLT Calibration and new EGM Regression in mcRun3 and mcRun4 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,19 +64,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '122X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '122X_mcRun3_2021_design_v5',
+    'phase1_2021_design'           : '122X_mcRun3_2021_design_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v5',
+    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v5',
+    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v5',
+    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v5',
+    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v5',
+    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '122X_mcRun4_realistic_v4'
+    'phase2_realistic'             : '122X_mcRun4_realistic_v5'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
Backport of #36710. 
Adds to the MC Run3 and Run4 GTs:
- PF calibration HLT tag as requested in https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4572.html
- New EGM Regression as requested in https://cms-talk.web.cern.ch/t/mc-update-of-new-egm-regression-conditions/4637

The PF tag is:
`PFCalibration_120X_mcRun3_2021_hlt`

For EGM the 24 tags are:
`electron_eb_ecalTrk_1To500_0p2To2_mean_Run3_120X_V1`
`electron_ee_ecalTrk_1To500_0p2To2_mean_Run3_120X_V1`
`electron_eb_ecalTrk_1To500_0p0002To0p5_sigma_Run3_120X_V1`
`electron_ee_ecalTrk_1To500_0p0002To0p5_sigma_Run3_120X_V1`
`photon_eb_ecalOnly_5To500_0p2To2_mean_Run3_120X_V1`
`photon_ee_ecalOnly_5To500_0p2To2_mean_Run3_120X_V1`
`photon_eb_ecalOnly_5To500_0p0002To0p5_sigma_Run3_120X_V1`
`photon_ee_ecalOnly_5To500_0p0002To0p5_sigma_Run3_120X_V1`
`electron_eb_ecalOnly_1To500_0p2To2_mean_Run3_120X_V1`
`electron_ee_ecalOnly_1To500_0p2To2_mean_Run3_120X_V1`
`electron_eb_ecalOnly_1To500_0p0002To0p5_sigma_Run3_120X_V1`
`electron_ee_ecalOnly_1To500_0p0002To0p5_sigma_Run3_120X_V1`
`pfscecal_EBCorrection_offline_v2_Run3_120X_V1`
`pfscecal_EECorrection_offline_v2_Run3_120X_V1`
`pfscecal_EBUncertainty_offline_v2_Run3_120X_V1`
`pfscecal_EEUncertainty_offline_v2_Run3_120X_V1`
`GEDelectron_EBCorrection_120X_EGM_v1`
`GEDelectron_EBUncertainty_120X_EGM_v1`
`GEDelectron_EECorrection_120X_EGM_v1`
`GEDelectron_EEUncertainty_120X_EGM_v1`
`GEDphoton_EBCorrection_120X_EGM_v1`
`GEDphoton_EBUncertainty_120X_EGM_v1`
`GEDphoton_EECorrection_120X_EGM_v1`
`GEDphoton_EEUncertainty_120X_EGM_v1`


The difference in GTs is here:
**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_design_v5/122X_mcRun3_2021_design_v6

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_realistic_v5/122X_mcRun3_2021_realistic_v6

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021cosmics_realistic_deco_v5/122X_mcRun3_2021cosmics_realistic_deco_v6

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_realistic_HI_v5/122X_mcRun3_2021_realistic_HI_v6

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2023_realistic_v5/122X_mcRun3_2023_realistic_v6

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2024_realistic_v5/122X_mcRun3_2024_realistic_v6

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun4_realistic_v4/122X_mcRun4_realistic_v5

#### PR validation:
Validated with:
- `runTheMatrix.py -l  12034.0,7.23,12834.0 --ibeos -j 15`
- `runTheMatrix.py --what upgrade -l 34606.0 --command='--conditions auto:phase2_realistic'` (for PhaseII GT)

#### Backport:
Backport of #36710