### PR TITLE
Run3-alca215 Provide possibility of using ECAL RecHit thresholds used by particle flow group in Hcal Calibration code

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalIsotrkProducer.cc
@@ -331,28 +331,23 @@ AlCaHcalIsotrkProducer::AlCaHcalIsotrkProducer(edm::ParameterSet const& iConfig,
   tok_resp_ = esConsumes<HcalRespCorrs, HcalRespCorrsRcd>();
   tok_ecalPFRecHitThresholds_ = esConsumes<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd>();
 
-  edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n"
-                                   << "\t minPt " << selectionParameter_.minPt << "\t theTrackQuality "
-                                   << theTrackQuality_ << "\t minQuality " << selectionParameter_.minQuality
-                                   << "\t maxDxyPV " << selectionParameter_.maxDxyPV << "\t maxDzPV "
-                                   << selectionParameter_.maxDzPV << "\t maxChi2 " << selectionParameter_.maxChi2
-                                   << "\t maxDpOverP " << selectionParameter_.maxDpOverP << "\t minOuterHit "
-                                   << selectionParameter_.minOuterHit << "\t minLayerCrossed "
-                                   << selectionParameter_.minLayerCrossed << "\t maxInMiss "
-                                   << selectionParameter_.maxInMiss << "\t maxOutMiss "
-                                   << selectionParameter_.maxOutMiss << "\t a_coneR " << a_coneR_ << ":" << a_coneR1_
-                                   << ":" << a_coneR2_ << "\t a_charIsoR " << a_charIsoR_ << "\t a_mipR " << a_mipR_
-                                   << "\t a_mipR2 " << a_mipR2_ << "\t a_mipR3 " << a_mipR3_ << "\t a_mipR4 "
-                                   << a_mipR4_ << "\t a_mipR5 " << a_mipR5_ << "\n pTrackMin_ " << pTrackMin_
-                                   << "\t eEcalMax_ " << eEcalMax_ << "\t maxRestrictionP_ " << maxRestrictionP_
-                                   << "\t slopeRestrictionP_ " << slopeRestrictionP_ << "\t eIsolateStrong_ "
-                                   << eIsolate1_ << "\t eIsolateSoft_ " << eIsolate2_ << "\t hcalScale_ " << hcalScale_
-                                   << "\n\t momentumLow_ " << pTrackLow_ << "\t momentumHigh_ " << pTrackHigh_
-                                   << "\n\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigger_ " << useL1Trigger_
-                                   << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ " << collapseDepth_
-                                   << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_
-                                   << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":"
-                                   << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_;
+  edm::LogVerbatim("HcalIsoTrack")
+      << "Parameters read from config file \n"
+      << "\t minPt " << selectionParameter_.minPt << "\t theTrackQuality " << theTrackQuality_ << "\t minQuality "
+      << selectionParameter_.minQuality << "\t maxDxyPV " << selectionParameter_.maxDxyPV << "\t maxDzPV "
+      << selectionParameter_.maxDzPV << "\t maxChi2 " << selectionParameter_.maxChi2 << "\t maxDpOverP "
+      << selectionParameter_.maxDpOverP << "\t minOuterHit " << selectionParameter_.minOuterHit << "\t minLayerCrossed "
+      << selectionParameter_.minLayerCrossed << "\t maxInMiss " << selectionParameter_.maxInMiss << "\t maxOutMiss "
+      << selectionParameter_.maxOutMiss << "\t a_coneR " << a_coneR_ << ":" << a_coneR1_ << ":" << a_coneR2_
+      << "\t a_charIsoR " << a_charIsoR_ << "\t a_mipR " << a_mipR_ << "\t a_mipR2 " << a_mipR2_ << "\t a_mipR3 "
+      << a_mipR3_ << "\t a_mipR4 " << a_mipR4_ << "\t a_mipR5 " << a_mipR5_ << "\n pTrackMin_ " << pTrackMin_
+      << "\t eEcalMax_ " << eEcalMax_ << "\t maxRestrictionP_ " << maxRestrictionP_ << "\t slopeRestrictionP_ "
+      << slopeRestrictionP_ << "\t eIsolateStrong_ " << eIsolate1_ << "\t eIsolateSoft_ " << eIsolate2_
+      << "\t hcalScale_ " << hcalScale_ << "\n\t momentumLow_ " << pTrackLow_ << "\t momentumHigh_ " << pTrackHigh_
+      << "\n\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigger_ " << useL1Trigger_ << "\t unCorrect_     "
+      << unCorrect_ << "\t collapseDepth_ " << collapseDepth_ << "\t L1TrigName_    " << l1TrigName_
+      << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":"
+      << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_;
   edm::LogVerbatim("HcalIsoTrack") << "Process " << processName_ << " L1Filter:" << l1Filter_
                                    << " L2Filter:" << l2Filter_ << " L3Filter:" << l3Filter_ << " and "
                                    << debEvents_.size() << " events to be debugged";
@@ -1277,9 +1272,9 @@ double AlCaHcalIsotrkProducer::eThreshold(const DetId& id, const CaloGeometry* g
     if (id.subdetId() != EcalBarrel) {
       eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
       if (eThr < hitEthrEELo_)
-	eThr = hitEthrEELo_;
+        eThr = hitEthrEELo_;
       else if (eThr > hitEthrEEHi_)
-	eThr = hitEthrEEHi_;
+        eThr = hitEthrEEHi_;
     }
   }
   return eThr;

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
@@ -222,9 +222,10 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
                                    << slopeRestrictionP_ << "\t eIsolate_ " << eIsolate_ << "\n"
                                    << "\t Precale factor " << preScale_ << "\t in momentum range " << pTrackLow_ << ":"
                                    << pTrackHigh_ << " and prescale factor " << preScaleH_ << " for p > " << pTrackH_
-                                   << " Threshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_
-                                   << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":"
-                                   << hitEthrEEHi_ << " and " << debEvents_.size() << " events to be debugged";
+                                   << " Threshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_
+                                   << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":"
+                                   << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_ << " and "
+                                   << debEvents_.size() << " events to be debugged";
 
   for (unsigned int k = 0; k < trigNames_.size(); ++k)
     edm::LogVerbatim("HcalIsoTrack") << "Trigger[" << k << "] " << trigNames_[k];
@@ -247,7 +248,7 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
                                      << " Luminosity " << iEvent.luminosityBlock() << " Bunch "
                                      << iEvent.bunchCrossing();
 #endif
-  
+
   // get Ecal Thresholds
   eThresholds_ = &iSetup.getData(tok_ecalPFRecHitThresholds_);
 
@@ -400,19 +401,19 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
           double eMipDR(0);
           for (unsigned int k = 0; k < eIds.size(); ++k) {
             double eThr(hitEthrEB_);
-	    if (usePFThresh_) {
-	      eThr = static_cast<double>((*eThresholds_)[eIds[k]]);
-	    } else {
-	      const GlobalPoint& pos = geo->getPosition(eIds[k]);
-	      double eta = std::abs(pos.eta());
-	      if (eIds[k].subdetId() != EcalBarrel) {
-		eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
-		if (eThr < hitEthrEELo_)
-		  eThr = hitEthrEELo_;
-		else if (eThr > hitEthrEEHi_)
-		  eThr = hitEthrEEHi_;
-	      }
-	    }
+            if (usePFThresh_) {
+              eThr = static_cast<double>((*eThresholds_)[eIds[k]]);
+            } else {
+              const GlobalPoint& pos = geo->getPosition(eIds[k]);
+              double eta = std::abs(pos.eta());
+              if (eIds[k].subdetId() != EcalBarrel) {
+                eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
+                if (eThr < hitEthrEELo_)
+                  eThr = hitEthrEELo_;
+                else if (eThr > hitEthrEEHi_)
+                  eThr = hitEthrEEHi_;
+              }
+            }
             if (eHit[k] > eThr)
               eMipDR += eHit[k];
           }

--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaIsoTracksFilter.cc
@@ -17,6 +17,9 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Common/interface/TriggerNames.h"
 
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+
 #include "DataFormats/Common/interface/Handle.h"
 //Tracks
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -101,6 +104,7 @@ private:
   const int preScale_, preScaleH_;
   const std::string theTrackQuality_;
   const std::vector<int> debEvents_;
+  const bool usePFThresh_;
   spr::trackSelectionParameters selectionParameter_;
   double a_charIsoR_;
   unsigned int nRun_, nAll_, nGood_, nRange_, nHigh_;
@@ -114,6 +118,9 @@ private:
   edm::EDGetTokenT<HBHERecHitCollection> tok_hbhe_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> tok_geom_;
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> tok_magField_;
+  edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> tok_ecalPFRecHitThresholds_;
+
+  const EcalPFRecHitThresholds* eThresholds_;
 };
 
 //
@@ -158,6 +165,7 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
       preScaleH_(iConfig.getParameter<int>("preScaleHigh")),
       theTrackQuality_(iConfig.getParameter<std::string>("trackQuality")),
       debEvents_(iConfig.getParameter<std::vector<int>>("debugEvents")),
+      usePFThresh_(iConfig.getParameter<bool>("usePFThreshold")),
       nRun_(0),
       nAll_(0),
       nGood_(0),
@@ -197,6 +205,7 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
 
   tok_geom_ = esConsumes<CaloGeometry, CaloGeometryRecord>();
   tok_magField_ = esConsumes<MagneticField, IdealMagneticFieldRecord>();
+  tok_ecalPFRecHitThresholds_ = esConsumes<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd>();
 
   edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n"
                                    << "\t minPt " << selectionParameter_.minPt << "\t theTrackQuality "
@@ -213,7 +222,7 @@ AlCaIsoTracksFilter::AlCaIsoTracksFilter(const edm::ParameterSet& iConfig, const
                                    << slopeRestrictionP_ << "\t eIsolate_ " << eIsolate_ << "\n"
                                    << "\t Precale factor " << preScale_ << "\t in momentum range " << pTrackLow_ << ":"
                                    << pTrackHigh_ << " and prescale factor " << preScaleH_ << " for p > " << pTrackH_
-                                   << " Threshold for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_
+                                   << " Threshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_
                                    << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":"
                                    << hitEthrEEHi_ << " and " << debEvents_.size() << " events to be debugged";
 
@@ -238,6 +247,9 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
                                      << " Luminosity " << iEvent.luminosityBlock() << " Bunch "
                                      << iEvent.bunchCrossing();
 #endif
+  
+  // get Ecal Thresholds
+  eThresholds_ = &iSetup.getData(tok_ecalPFRecHitThresholds_);
 
   //Step1: Find if the event passes one of the chosen triggers
   bool triggerSatisfied(false);
@@ -387,16 +399,20 @@ bool AlCaIsoTracksFilter::filter(edm::Event& iEvent, edm::EventSetup const& iSet
                               eHit);
           double eMipDR(0);
           for (unsigned int k = 0; k < eIds.size(); ++k) {
-            const GlobalPoint& pos = geo->getPosition(eIds[k]);
-            double eta = std::abs(pos.eta());
             double eThr(hitEthrEB_);
-            if (eIds[k].subdetId() != EcalBarrel) {
-              eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
-              if (eThr < hitEthrEELo_)
-                eThr = hitEthrEELo_;
-              else if (eThr > hitEthrEEHi_)
-                eThr = hitEthrEEHi_;
-            }
+	    if (usePFThresh_) {
+	      eThr = static_cast<double>((*eThresholds_)[eIds[k]]);
+	    } else {
+	      const GlobalPoint& pos = geo->getPosition(eIds[k]);
+	      double eta = std::abs(pos.eta());
+	      if (eIds[k].subdetId() != EcalBarrel) {
+		eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
+		if (eThr < hitEthrEELo_)
+		  eThr = hitEthrEELo_;
+		else if (eThr > hitEthrEEHi_)
+		  eThr = hitEthrEEHi_;
+	      }
+	    }
             if (eHit[k] > eThr)
               eMipDR += eHit[k];
           }
@@ -532,6 +548,7 @@ void AlCaIsoTracksFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<int>("preScaleHigh", 1);
   std::vector<int> events;
   desc.add<std::vector<int>>("debugEvents", events);
+  desc.add<bool>("usePFThreshold", true);
   descriptions.add("alcaIsoTracksFilter", desc);
 }
 

--- a/Calibration/HcalAlCaRecoProducers/python/alcaHcalIsotrkProducer_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcaHcalIsotrkProducer_cff.py
@@ -14,9 +14,9 @@ run2_ECAL_2017.toModify(alcaHcalIsotrkProducer,
   EEHitEnergyThresholdHigh= 10.0
 )
 
-from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+from Configuration.Eras.Modifier_run2_ECAL_2018_cff import run2_ECAL_2018
 
-run2_HCAL_2018.toModify(alcaHcalIsotrkProducer,
+run2_ECAL_2018.toModify(alcaHcalIsotrkProducer,
   EBHitEnergyThreshold    = 0.10,
   EEHitEnergyThreshold0   = -41.0664,
   EEHitEnergyThreshold1   = 68.795,

--- a/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/alcaIsoTracksFilter_cff.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from Calibration.HcalAlCaRecoProducers.alcaIsoTracksFilter_cfi import *
 
-from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
+from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
 
-run2_HCAL_2017.toModify(alcaIsoTracksFilter,
+run2_ECAL_2017.toModify(alcaIsoTracksFilter,
   EBHitEnergyThreshold    = cms.double(0.18),
   EEHitEnergyThreshold0   = cms.double(-206.074),
   EEHitEnergyThreshold1   = cms.double(357.671),
@@ -14,9 +14,9 @@ run2_HCAL_2017.toModify(alcaIsoTracksFilter,
   EEHitEnergyThresholdHigh= cms.double(10.0),
 )
 
-from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+from Configuration.Eras.Modifier_run2_ECAL_2018_cff import run2_ECAL_2018
 
-run2_HCAL_2018.toModify(alcaIsoTracksFilter,
+run2_ECAL_2018.toModify(alcaIsoTracksFilter,
   EBHitEnergyThreshold    = cms.double(0.10),
   EEHitEnergyThreshold0   = cms.double(-41.0664),
   EEHitEnergyThreshold1   = cms.double(68.795),

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
@@ -15,6 +15,9 @@
 #include "TLorentzVector.h"
 #include "TInterpreter.h"
 
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
@@ -157,9 +160,12 @@ private:
   const std::vector<int> oldID_, newDepth_;
   const bool hep17_;
   const std::vector<int> debEvents_;
+  const bool usePFThresh_;
   unsigned int nRun_, nLow_, nHigh_;
   double a_charIsoR_, a_coneR1_, a_coneR2_;
   const HcalDDDRecConstants* hdc_;
+  const EcalPFRecHitThresholds* eThresholds_;
+
   std::vector<double> etabins_, phibins_;
   std::vector<int> oldDet_, oldEta_, oldDepth_;
   double etadist_, phidist_, etahalfdist_, phihalfdist_;
@@ -185,6 +191,7 @@ private:
   edm::ESGetToken<CaloTopology, CaloTopologyRecord> tok_caloTopology_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_htopo_;
   edm::ESGetToken<HcalRespCorrs, HcalRespCorrsRcd> tok_resp_;
+  edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> tok_ecalPFRecHitThresholds_;
 
   TTree *tree, *tree2;
   unsigned int t_RunNo, t_EventNo;
@@ -262,6 +269,7 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       newDepth_(iConfig.getUntrackedParameter<std::vector<int>>("newDepth")),
       hep17_(iConfig.getUntrackedParameter<bool>("hep17")),
       debEvents_(iConfig.getParameter<std::vector<int>>("debugEvents")),
+      usePFThresh_(iConfig.getParameter<bool>("usePFThreshold")),
       nRun_(0),
       nLow_(0),
       nHigh_(0),
@@ -346,6 +354,7 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
   tok_caloTopology_ = esConsumes<CaloTopology, CaloTopologyRecord>();
   tok_htopo_ = esConsumes<HcalTopology, HcalRecNumberingRecord>();
   tok_resp_ = esConsumes<HcalRespCorrs, HcalRespCorrsRcd>();
+  tok_ecalPFRecHitThresholds_ = esConsumes<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd>();
 
   edm::LogVerbatim("HcalIsoTrack")
       << "Parameters read from config file \n"
@@ -363,7 +372,7 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       << "\t momentumHigh_ " << pTrackHigh_ << "\t prescaleHigh_ " << prescaleHigh_ << "\n\t useRaw_ " << useRaw_
       << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_ << "\t dataType_      "
       << dataType_ << "\t mode_          " << mode_ << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ "
-      << collapseDepth_ << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold for EB " << hitEthrEB_ << " EE "
+      << collapseDepth_ << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE "
       << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":"
       << hitEthrEEHi_ << " and " << debEvents_.size() << " events to be debugged";
   edm::LogVerbatim("HcalIsoTrack") << "Process " << processName_ << " L1Filter:" << l1Filter_
@@ -414,11 +423,14 @@ void HcalIsoTrkAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const
   const MagneticField* bField = &iSetup.getData(tok_bFieldH_);
   const EcalChannelStatus* theEcalChStatus = &iSetup.getData(tok_ecalChStatus_);
   const EcalSeverityLevelAlgo* theEcalSevlv = &iSetup.getData(tok_sevlv_);
+  eThresholds_ = &iSetup.getData(tok_ecalPFRecHitThresholds_);
 
-  // get handles to calogeometry and calotopology
+  // get calogeometry and calotopology
   const CaloGeometry* geo = &iSetup.getData(tok_geom_);
   const CaloTopology* caloTopology = &iSetup.getData(tok_caloTopology_);
   const HcalTopology* theHBHETopology = &iSetup.getData(tok_htopo_);
+
+  // get Hcal response corrections
   const HcalRespCorrs* respCorrs = &iSetup.getData(tok_resp_);
 
   //=== genParticle information
@@ -931,7 +943,8 @@ void HcalIsoTrkAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.addUntracked<bool>("hep17", false);
   std::vector<int> events;
   desc.add<std::vector<int>>("debugEvents", events);
-  descriptions.add("HcalIsoTrkAnalyzer", desc);
+  desc.add<bool>("usePFThreshold", true);
+  descriptions.add("hcalIsoTrkAnalyzer", desc);
 }
 
 std::array<int, 3> HcalIsoTrkAnalyzer::fillTree(std::vector<math::XYZTLorentzVector>& vecL1,
@@ -1372,15 +1385,19 @@ double HcalIsoTrkAnalyzer::rhoh(const edm::Handle<CaloTowerCollection>& tower) {
 }
 
 double HcalIsoTrkAnalyzer::eThreshold(const DetId& id, const CaloGeometry* geo) const {
-  const GlobalPoint& pos = geo->getPosition(id);
-  double eta = std::abs(pos.eta());
   double eThr(hitEthrEB_);
-  if (id.subdetId() != EcalBarrel) {
-    eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
-    if (eThr < hitEthrEELo_)
-      eThr = hitEthrEELo_;
-    else if (eThr > hitEthrEEHi_)
-      eThr = hitEthrEEHi_;
+  if (usePFThresh_) {
+    eThr = static_cast<double>((*eThresholds_)[id]);
+  } else {
+    const GlobalPoint& pos = geo->getPosition(id);
+    double eta = std::abs(pos.eta());
+    if (id.subdetId() != EcalBarrel) {
+      eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
+      if (eThr < hitEthrEELo_)
+	eThr = hitEthrEELo_;
+      else if (eThr > hitEthrEEHi_)
+	eThr = hitEthrEEHi_;
+    }
   }
   return eThr;
 }

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkAnalyzer.cc
@@ -372,9 +372,10 @@ HcalIsoTrkAnalyzer::HcalIsoTrkAnalyzer(const edm::ParameterSet& iConfig)
       << "\t momentumHigh_ " << pTrackHigh_ << "\t prescaleHigh_ " << prescaleHigh_ << "\n\t useRaw_ " << useRaw_
       << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_ << "\t dataType_      "
       << dataType_ << "\t mode_          " << mode_ << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ "
-      << collapseDepth_ << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE "
-      << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":"
-      << hitEthrEEHi_ << " and " << debEvents_.size() << " events to be debugged";
+      << collapseDepth_ << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_
+      << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":"
+      << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_ << " and " << debEvents_.size()
+      << " events to be debugged";
   edm::LogVerbatim("HcalIsoTrack") << "Process " << processName_ << " L1Filter:" << l1Filter_
                                    << " L2Filter:" << l2Filter_ << " L3Filter:" << l3Filter_;
   for (unsigned int k = 0; k < trigNames_.size(); ++k) {
@@ -1394,9 +1395,9 @@ double HcalIsoTrkAnalyzer::eThreshold(const DetId& id, const CaloGeometry* geo) 
     if (id.subdetId() != EcalBarrel) {
       eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
       if (eThr < hitEthrEELo_)
-	eThr = hitEthrEELo_;
+        eThr = hitEthrEELo_;
       else if (eThr > hitEthrEEHi_)
-	eThr = hitEthrEEHi_;
+        eThr = hitEthrEEHi_;
     }
   }
   return eThr;

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
@@ -338,9 +338,10 @@ HcalIsoTrkSimAnalyzer::HcalIsoTrkSimAnalyzer(const edm::ParameterSet& iConfig)
                                    << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_
                                    << "\t dataType_      " << dataType_ << "\t mode_          " << mode_
                                    << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ " << collapseDepth_
-                                   << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_
-                                   << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":"
-                                   << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_;
+                                   << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_
+                                   << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_
+                                   << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":"
+                                   << hitEthrEEHi_;
   edm::LogVerbatim("HcalIsoTrack") << "Process " << processName_ << " L1Filter:" << l1Filter_
                                    << " L2Filter:" << l2Filter_ << " L3Filter:" << l3Filter_;
   for (unsigned int k = 0; k < trigNames_.size(); ++k) {
@@ -1264,9 +1265,9 @@ double HcalIsoTrkSimAnalyzer::eThreshold(const DetId& id, const CaloGeometry* ge
     if (id.subdetId() != EcalBarrel) {
       eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
       if (eThr < hitEthrEELo_)
-	eThr = hitEthrEELo_;
+        eThr = hitEthrEELo_;
       else if (eThr > hitEthrEEHi_)
-	eThr = hitEthrEEHi_;
+        eThr = hitEthrEEHi_;
     }
   }
   return eThr;

--- a/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/plugins/HcalIsoTrkSimAnalyzer.cc
@@ -15,6 +15,9 @@
 #include "TLorentzVector.h"
 #include "TInterpreter.h"
 
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
@@ -143,9 +146,12 @@ private:
   const std::string labelEE_, labelHBHE_, labelTower_, l1TrigName_;
   const std::vector<int> oldID_, newDepth_;
   const bool hep17_;
+  const bool usePFThresh_;
   unsigned int nRun_, nLow_, nHigh_;
   double a_charIsoR_, a_coneR1_, a_coneR2_;
   const HcalDDDRecConstants* hdc_;
+  const EcalPFRecHitThresholds* eThresholds_;
+
   std::vector<double> etabins_, phibins_;
   std::vector<int> oldDet_, oldEta_, oldDepth_;
   double etadist_, phidist_, etahalfdist_, phihalfdist_;
@@ -170,6 +176,7 @@ private:
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_htopo_;
   edm::ESGetToken<HcalRespCorrs, HcalRespCorrsRcd> tok_resp_;
   edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> tok_pdt_;
+  edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> tok_ecalPFRecHitThresholds_;
 
   TTree *tree, *tree2;
   unsigned int t_RunNo, t_EventNo;
@@ -245,6 +252,7 @@ HcalIsoTrkSimAnalyzer::HcalIsoTrkSimAnalyzer(const edm::ParameterSet& iConfig)
       oldID_(iConfig.getUntrackedParameter<std::vector<int> >("oldID")),
       newDepth_(iConfig.getUntrackedParameter<std::vector<int> >("newDepth")),
       hep17_(iConfig.getUntrackedParameter<bool>("hep17")),
+      usePFThresh_(iConfig.getParameter<bool>("usePFThreshold")),
       nRun_(0),
       nLow_(0),
       nHigh_(0),
@@ -314,6 +322,7 @@ HcalIsoTrkSimAnalyzer::HcalIsoTrkSimAnalyzer(const edm::ParameterSet& iConfig)
   tok_htopo_ = esConsumes<HcalTopology, HcalRecNumberingRecord>();
   tok_resp_ = esConsumes<HcalRespCorrs, HcalRespCorrsRcd>();
   tok_pdt_ = esConsumes<HepPDT::ParticleDataTable, PDTRecord>();
+  tok_ecalPFRecHitThresholds_ = esConsumes<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd>();
 
   edm::LogVerbatim("HcalIsoTrack") << "Parameters read from config file \n"
                                    << "\t minPt " << ptMin_ << "\t etaMax " << etaMax_ << "\t a_coneR " << a_coneR_
@@ -329,7 +338,7 @@ HcalIsoTrkSimAnalyzer::HcalIsoTrkSimAnalyzer(const edm::ParameterSet& iConfig)
                                    << "\t ignoreTrigger_ " << ignoreTrigger_ << "\n\t useL1Trigegr_ " << useL1Trigger_
                                    << "\t dataType_      " << dataType_ << "\t mode_          " << mode_
                                    << "\t unCorrect_     " << unCorrect_ << "\t collapseDepth_ " << collapseDepth_
-                                   << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold for EB " << hitEthrEB_
+                                   << "\t L1TrigName_    " << l1TrigName_ << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_
                                    << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":"
                                    << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_;
   edm::LogVerbatim("HcalIsoTrack") << "Process " << processName_ << " L1Filter:" << l1Filter_
@@ -376,13 +385,18 @@ void HcalIsoTrkSimAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup co
   const EcalChannelStatus* theEcalChStatus = &iSetup.getData(tok_ecalChStatus_);
   const EcalSeverityLevelAlgo* theEcalSevlv = &iSetup.getData(tok_sevlv_);
 
-  // get handles to calogeometry and calotopology
+  // get calogeometry and calotopology
   const CaloGeometry* geo = &iSetup.getData(tok_geom_);
   const CaloTopology* caloTopology = &iSetup.getData(tok_caloTopology_);
   const HcalTopology* theHBHETopology = &iSetup.getData(tok_htopo_);
+
+  // get response correction
   const HcalRespCorrs* resp = &iSetup.getData(tok_resp_);
   HcalRespCorrs* respCorrs = new HcalRespCorrs(*resp);
   respCorrs->setTopo(theHBHETopology);
+
+  // get ECAL thresholds
+  eThresholds_ = &iSetup.getData(tok_ecalPFRecHitThresholds_);
 
   // get particle data table
   const HepPDT::ParticleDataTable* pdt = &iSetup.getData(tok_pdt_);
@@ -848,6 +862,7 @@ void HcalIsoTrkSimAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.addUntracked<std::vector<int> >("oldID", dummy);
   desc.addUntracked<std::vector<int> >("newDepth", dummy);
   desc.addUntracked<bool>("hep17", false);
+  desc.add<bool>("usePFThreshold", true);
   descriptions.add("hcalIsoTrkSimAnalyzer", desc);
 }
 
@@ -1240,15 +1255,19 @@ double HcalIsoTrkSimAnalyzer::rhoh(const edm::Handle<CaloTowerCollection>& tower
 }
 
 double HcalIsoTrkSimAnalyzer::eThreshold(const DetId& id, const CaloGeometry* geo) const {
-  const GlobalPoint& pos = geo->getPosition(id);
-  double eta = std::abs(pos.eta());
   double eThr(hitEthrEB_);
-  if (id.subdetId() != EcalBarrel) {
-    eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
-    if (eThr < hitEthrEELo_)
-      eThr = hitEthrEELo_;
-    else if (eThr > hitEthrEEHi_)
-      eThr = hitEthrEEHi_;
+  if (usePFThresh_) {
+    eThr = static_cast<double>((*eThresholds_)[id]);
+  } else {
+    const GlobalPoint& pos = geo->getPosition(id);
+    double eta = std::abs(pos.eta());
+    if (id.subdetId() != EcalBarrel) {
+      eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
+      if (eThr < hitEthrEELo_)
+	eThr = hitEthrEELo_;
+      else if (eThr > hitEthrEEHi_)
+	eThr = hitEthrEEHi_;
+    }
   }
   return eThr;
 }

--- a/Calibration/HcalCalibAlgos/python/hcalIsoTrackStudy_cff.py
+++ b/Calibration/HcalCalibAlgos/python/hcalIsoTrackStudy_cff.py
@@ -14,9 +14,9 @@ run2_ECAL_2017.toModify(hcalIsoTrackStudy,
   EEHitEnergyThresholdHigh= cms.double(10.0),
 )
 
-from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+from Configuration.Eras.Modifier_run2_ECAL_2018_cff import run2_ECAL_2018
 
-run2_HCAL_2018.toModify(hcalIsoTrackStudy,
+run2_ECAL_2018.toModify(hcalIsoTrackStudy,
   EBHitEnergyThreshold    = cms.double(0.10),
   EEHitEnergyThreshold0   = cms.double(-41.0664),
   EEHitEnergyThreshold1   = cms.double(68.795),

--- a/Calibration/HcalCalibAlgos/python/hcalIsoTrkAnalyzer_cff.py
+++ b/Calibration/HcalCalibAlgos/python/hcalIsoTrkAnalyzer_cff.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-from Calibration.HcalCalibAlgos.HcalIsoTrkAnalyzer_cfi import *
+from Calibration.HcalCalibAlgos.hcalIsoTrkAnalyzer_cfi import *
 
 from Configuration.Eras.Modifier_run2_ECAL_2017_cff import run2_ECAL_2017
 
-run2_ECAL_2017.toModify(HcalIsoTrkAnalyzer,
+run2_ECAL_2017.toModify(hcalIsoTrkAnalyzer,
   EBHitEnergyThreshold    = cms.double(0.18),
   EEHitEnergyThreshold0   = cms.double(-206.074),
   EEHitEnergyThreshold1   = cms.double(357.671),
@@ -14,9 +14,9 @@ run2_ECAL_2017.toModify(HcalIsoTrkAnalyzer,
   EEHitEnergyThresholdHigh= cms.double(10.0),
 )
 
-from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+from Configuration.Eras.Modifier_run2_ECAL_2018_cff import run2_ECAL_2018
 
-run2_HCAL_2018.toModify(HcalIsoTrkAnalyzer,
+run2_ECAL_2018.toModify(hcalIsoTrkAnalyzer,
   EBHitEnergyThreshold    = cms.double(0.10),
   EEHitEnergyThreshold0   = cms.double(-41.0664),
   EEHitEnergyThreshold1   = cms.double(68.795),

--- a/Calibration/HcalCalibAlgos/python/hcalTestThreshold_cff.py
+++ b/Calibration/HcalCalibAlgos/python/hcalTestThreshold_cff.py
@@ -14,9 +14,9 @@ run2_ECAL_2017.toModify(hcalTestThreshold,
   EEHitEnergyThresholdHigh= 10.0,
 )
 
-from Configuration.Eras.Modifier_run2_HCAL_2018_cff import run2_HCAL_2018
+from Configuration.Eras.Modifier_run2_ECAL_2018_cff import run2_ECAL_2018
 
-run2_HCAL_2018.toModify(hcalTestThreshold,
+run2_ECAL_2018.toModify(hcalTestThreshold,
   EBHitEnergyThreshold    = 0.10,
   EEHitEnergyThreshold0   = -41.0664,
   EEHitEnergyThreshold1   = 68.795,

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrackAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrackAnalysis.cc
@@ -157,9 +157,9 @@ HcalIsoTrackAnalysis::HcalIsoTrackAnalysis(const edm::ParameterSet& iConfig)
                                    << "\t a_mipR " << a_mipR_ << "\n\t momentumLow_ " << pTrackLow_
                                    << "\t momentumHigh_ " << pTrackHigh_ << "\t useRaw_ " << useRaw_
                                    << "\t dataType_      " << dataType_ << "\t etaLimit " << etaMin_ << ":" << etaMax_
-                                   << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_ << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_
-                                   << ":" << hitEthrEE2_ << ":" << hitEthrEE3_ << ":" << hitEthrEELo_ << ":"
-                                   << hitEthrEEHi_;
+                                   << "\nThreshold flag used " << usePFThresh_ << " value for EB " << hitEthrEB_
+                                   << " EE " << hitEthrEE0_ << ":" << hitEthrEE1_ << ":" << hitEthrEE2_ << ":"
+                                   << hitEthrEE3_ << ":" << hitEthrEELo_ << ":" << hitEthrEEHi_;
 
   tok_bFieldH_ = esConsumes<MagneticField, IdealMagneticFieldRecord>();
   tok_geom_ = esConsumes<CaloGeometry, CaloGeometryRecord>();
@@ -269,20 +269,20 @@ void HcalIsoTrackAnalysis::analyze(edm::Event const& iEvent, edm::EventSetup con
                                         eHit);
         double eEcal(0);
         for (unsigned int k = 0; k < eIds.size(); ++k) {
-	  double eThr(hitEthrEB_);
-	  if (usePFThresh_) {
-	    eThr = static_cast<double>((*eThresholds_)[eIds[k]]);
-	  } else {
-	    const GlobalPoint& pos = geo->getPosition(eIds[k]);
-	    double eta = std::abs(pos.eta());
-	    if (eIds[k].subdetId() != EcalBarrel) {
-	      eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
-	      if (eThr < hitEthrEELo_)
-		eThr = hitEthrEELo_;
-	      else if (eThr > hitEthrEEHi_)
-		eThr = hitEthrEEHi_;
-	    }
-	  }
+          double eThr(hitEthrEB_);
+          if (usePFThresh_) {
+            eThr = static_cast<double>((*eThresholds_)[eIds[k]]);
+          } else {
+            const GlobalPoint& pos = geo->getPosition(eIds[k]);
+            double eta = std::abs(pos.eta());
+            if (eIds[k].subdetId() != EcalBarrel) {
+              eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
+              if (eThr < hitEthrEELo_)
+                eThr = hitEthrEELo_;
+              else if (eThr > hitEthrEEHi_)
+                eThr = hitEthrEEHi_;
+            }
+          }
           if (eHit[k] > eThr)
             eEcal += eHit[k];
         }

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
@@ -1474,9 +1474,9 @@ double HcalIsoTrackStudy::eThreshold(const DetId& id, double eta) const {
     if (id.subdetId() != EcalBarrel) {
       eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
       if (eThr < hitEthrEELo_)
-	eThr = hitEthrEELo_;
+        eThr = hitEthrEELo_;
       else if (eThr > hitEthrEEHi_)
-	eThr = hitEthrEEHi_;
+        eThr = hitEthrEEHi_;
     }
   }
   return eThr;

--- a/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
+++ b/Calibration/HcalCalibAlgos/test/HcalIsoTrackStudy.cc
@@ -26,6 +26,8 @@
 
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 #include "CondFormats/DataRecord/interface/HcalRespCorrsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalPFRecHitThresholdsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalPFRecHitThresholds.h"
 #include "CondFormats/HcalObjects/interface/HcalRespCorrs.h"
 
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
@@ -167,9 +169,11 @@ private:
   const int matrixECAL_, matrixHCAL_;
   const double mapR_;
   const bool get2Ddist_;
+  const bool usePFThresh_;
   unsigned int nRun_, nLow_, nHigh_;
   double a_charIsoR_, a_coneR1_, a_coneR2_;
   const HcalDDDRecConstants* hdc_;
+  const EcalPFRecHitThresholds* eThresholds_;
   std::vector<double> etabins_, phibins_;
   double etadist_, phidist_, etahalfdist_, phihalfdist_;
   edm::EDGetTokenT<trigger::TriggerEvent> tok_trigEvt_;
@@ -193,6 +197,7 @@ private:
   edm::ESGetToken<CaloTopology, CaloTopologyRecord> tok_caloTopology_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_htopo_;
   edm::ESGetToken<HcalRespCorrs, HcalRespCorrsRcd> tok_resp_;
+  edm::ESGetToken<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd> tok_ecalPFRecHitThresholds_;
 
   TTree *tree, *tree2;
   unsigned int t_RunNo, t_EventNo;
@@ -267,6 +272,7 @@ HcalIsoTrackStudy::HcalIsoTrackStudy(const edm::ParameterSet& iConfig)
       matrixHCAL_(iConfig.getUntrackedParameter<int>("matrixHCAL", 3)),
       mapR_(iConfig.getUntrackedParameter<double>("mapRadius", 34.98)),
       get2Ddist_(iConfig.getUntrackedParameter<bool>("get2Ddist", false)),
+      usePFThresh_(iConfig.getParameter<bool>("usePFThreshold")),
       nRun_(0),
       nLow_(0),
       nHigh_(0),
@@ -368,6 +374,7 @@ HcalIsoTrackStudy::HcalIsoTrackStudy(const edm::ParameterSet& iConfig)
   tok_caloTopology_ = esConsumes<CaloTopology, CaloTopologyRecord>();
   tok_htopo_ = esConsumes<HcalTopology, HcalRecNumberingRecord>();
   tok_resp_ = esConsumes<HcalRespCorrs, HcalRespCorrsRcd>();
+  tok_ecalPFRecHitThresholds_ = esConsumes<EcalPFRecHitThresholds, EcalPFRecHitThresholdsRcd>();
 
   for (int i = 0; i < 10; i++)
     phibins_.push_back(-M_PI + 0.1 * (2 * i + 1) * M_PI);
@@ -408,6 +415,9 @@ void HcalIsoTrackStudy::analyze(edm::Event const& iEvent, edm::EventSetup const&
   const CaloTopology* caloTopology = &iSetup.getData(tok_caloTopology_);
   const HcalTopology* theHBHETopology = &iSetup.getData(tok_htopo_);
   const HcalRespCorrs* respCorrs = &iSetup.getData(tok_resp_);
+
+  // get ECAL thresholds
+  eThresholds_ = &iSetup.getData(tok_ecalPFRecHitThresholds_);
 
   //=== genParticle information
   edm::Handle<reco::GenParticleCollection> genParticles;
@@ -915,6 +925,7 @@ void HcalIsoTrackStudy::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.addUntracked<int>("matrixHCAL", 3);
   desc.addUntracked<double>("mapRadius", 34.98);
   desc.addUntracked<bool>("get2Ddist", false);
+  desc.add<bool>("usePFThreshold", true);
   descriptions.add("hcalIsoTrackStudy", desc);
 }
 
@@ -1457,12 +1468,16 @@ void HcalIsoTrackStudy::TrackMap(unsigned int trkIndex,
 
 double HcalIsoTrackStudy::eThreshold(const DetId& id, double eta) const {
   double eThr(hitEthrEB_);
-  if (id.subdetId() != EcalBarrel) {
-    eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
-    if (eThr < hitEthrEELo_)
-      eThr = hitEthrEELo_;
-    else if (eThr > hitEthrEEHi_)
-      eThr = hitEthrEEHi_;
+  if (usePFThresh_) {
+    eThr = static_cast<double>((*eThresholds_)[id]);
+  } else {
+    if (id.subdetId() != EcalBarrel) {
+      eThr = (((eta * hitEthrEE3_ + hitEthrEE2_) * eta + hitEthrEE1_) * eta + hitEthrEE0_);
+      if (eThr < hitEthrEELo_)
+	eThr = hitEthrEELo_;
+      else if (eThr > hitEthrEEHi_)
+	eThr = hitEthrEEHi_;
+    }
   }
   return eThr;
 }

--- a/Calibration/HcalCalibAlgos/test/python/isoTrackAlCaAnalysis_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/isoTrackAlCaAnalysis_cfg.py
@@ -27,11 +27,11 @@ process.towerMakerAll.hfInput = cms.InputTag("none")
 process.towerMakerAll.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEE"))
 process.towerMakerAll.AllowMissingInputs = True
 
-process.load('Calibration.HcalCalibAlgos.HcalIsoTrkAnalyzer_cff')
-process.HcalIsoTrkAnalyzer.triggers = []
-process.HcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
-process.HcalIsoTrkAnalyzer.ignoreTriggers = True
-process.HcalIsoTrkAnalyzer.debugEvents = [640818633, 640797426, 641251898,
+process.load('Calibration.HcalCalibAlgos.hcalIsoTrkAnalyzer_cff')
+process.hcalIsoTrkAnalyzer.triggers = []
+process.hcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
+process.hcalIsoTrkAnalyzer.ignoreTriggers = True
+process.hcalIsoTrkAnalyzer.debugEvents = [640818633, 640797426, 641251898,
                                           641261804, 641172007, 641031809]
 
 process.source = cms.Source("PoolSource", 
@@ -44,5 +44,5 @@ process.TFileService = cms.Service("TFileService",
    fileName = cms.string('output_oldalca.root')
 )
 
-process.p = cms.Path(process.HcalIsoTrkAnalyzer)
+process.p = cms.Path(process.hcalIsoTrkAnalyzer)
 

--- a/Calibration/HcalCalibAlgos/test/python/isoTrackAlCaRecoAnalysis_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/isoTrackAlCaRecoAnalysis_cfg.py
@@ -26,13 +26,13 @@ process.towerMakerAll.hfInput = cms.InputTag("none")
 process.towerMakerAll.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEE"))
 process.towerMakerAll.AllowMissingInputs = True
 
-process.load('Calibration.HcalCalibAlgos.HcalIsoTrkAnalyzer_cff')
-process.HcalIsoTrkAnalyzer.triggers = []
-process.HcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
-process.HcalIsoTrkAnalyzer.ignoreTriggers = True
-#process.HcalIsoTrkAnalyzer.processName  = 'HLTNew1'
-#process.HcalIsoTrkAnalyzer.producerName = 'ALCAISOTRACK'
-#process.HcalIsoTrkAnalyzer.moduleName   = 'IsoProd'
+process.load('Calibration.HcalCalibAlgos.hcalIsoTrkAnalyzer_cff')
+process.hcalIsoTrkAnalyzer.triggers = []
+process.hcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
+process.hcalIsoTrkAnalyzer.ignoreTriggers = True
+#process.hcalIsoTrkAnalyzer.processName  = 'HLTNew1'
+#process.hcalIsoTrkAnalyzer.producerName = 'ALCAISOTRACK'
+#process.hcalIsoTrkAnalyzer.moduleName   = 'IsoProd'
 
 process.source = cms.Source("PoolSource", 
                             fileNames = cms.untracked.vstring(
@@ -47,5 +47,5 @@ process.TFileService = cms.Service("TFileService",
    fileName = cms.string('output_alca.root')
 )
 
-process.p = cms.Path(process.HcalIsoTrkAnalyzer)
+process.p = cms.Path(process.hcalIsoTrkAnalyzer)
 

--- a/Calibration/HcalCalibAlgos/test/python/isoTrackNoHLTAnalysis_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/isoTrackNoHLTAnalysis_cfg.py
@@ -26,10 +26,10 @@ process.towerMakerAll.hfInput = cms.InputTag("none")
 process.towerMakerAll.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEE"))
 process.towerMakerAll.AllowMissingInputs = True
 
-process.load('Calibration.HcalCalibAlgos.HcalIsoTrkAnalyzer_cff')
-process.HcalIsoTrkAnalyzer.triggers = []
-process.HcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
-process.HcalIsoTrkAnalyzer.ignoreTriggers = True
+process.load('Calibration.HcalCalibAlgos.hcalIsoTrkAnalyzer_cff')
+process.hcalIsoTrkAnalyzer.triggers = []
+process.hcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
+process.hcalIsoTrkAnalyzer.ignoreTriggers = True
 
 process.source = cms.Source("PoolSource", 
                             fileNames = cms.untracked.vstring(
@@ -44,5 +44,5 @@ process.TFileService = cms.Service("TFileService",
    fileName = cms.string('output_alca.root')
 )
 
-process.p = cms.Path(process.HcalIsoTrkAnalyzer)
+process.p = cms.Path(process.hcalIsoTrkAnalyzer)
 

--- a/Calibration/HcalCalibAlgos/test/python/isoTrackRecoAnalysis_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/isoTrackRecoAnalysis_cfg.py
@@ -26,7 +26,7 @@ process.towerMakerAll.hfInput = cms.InputTag("none")
 process.towerMakerAll.ecalInputs = cms.VInputTag(cms.InputTag("ecalRecHit","EcalRecHitsEB"), cms.InputTag("ecalRecHit","EcalRecHitsEE"))
 process.towerMakerAll.AllowMissingInputs = True
 
-process.load('Calibration.HcalCalibAlgos.HcalIsoTrkAnalyzer_cff')
+process.load('Calibration.HcalCalibAlgos.hcalIsoTrkAnalyzer_cff')
 process.source = cms.Source("PoolSource", 
                             fileNames = cms.untracked.vstring(
        'file:/eos/cms/store/group/dpg_hcal/comm_hcal/ISOTRACK/MinBias_AlcaReco_2017D_IsotrkFilter.root',
@@ -39,19 +39,18 @@ process.TFileService = cms.Service("TFileService",
    fileName = cms.string('output.root')
 )
 
-process.HcalIsoTrkAnalyzer.triggers = []
-process.HcalIsoTrkAnalyzer.oldID = [21701, 21603]
-process.HcalIsoTrkAnalyzer.newDepth = [2, 4]
-process.HcalIsoTrkAnalyzer.hep17 = True
-process.HcalIsoTrkAnalyzer.dataType = 0 # 0 for jetHT else 1
-process.HcalIsoTrkAnalyzer.maximumEcalEnergy = 2.0 # set MIP cut  
-process.HcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
-process.HcalIsoTrkAnalyzer.unCorrect = True
+process.hcalIsoTrkAnalyzer.triggers = []
+process.hcalIsoTrkAnalyzer.oldID = [21701, 21603]
+process.hcalIsoTrkAnalyzer.newDepth = [2, 4]
+process.hcalIsoTrkAnalyzer.hep17 = True
+process.hcalIsoTrkAnalyzer.dataType = 0 # 0 for jetHT else 1
+process.hcalIsoTrkAnalyzer.maximumEcalEnergy = 2.0 # set MIP cut  
+process.hcalIsoTrkAnalyzer.useRaw = 0   # 1 for Raw
+process.hcalIsoTrkAnalyzer.unCorrect = True
+process.hcalIsoTrkAnalyzer.EEHitEnergyThreshold1 = 0.00 # default 0.30
+process.hcalIsoTrkAnalyzer.EEHitEnergyThreshold2 = 0.00 # coeff. of linear term
+process.hcalIsoTrkAnalyzer.EEHitEnergyThreshold3 = 0.00 # coeff. of quad term
+process.hcalIsoTrkAnalyzer.EEHitEnergyThresholdLow = 0.00 # minimum def 0.30
 
-process.HcalIsoTrkAnalyzer.EEHitEnergyThreshold1 = 0.00 # default 0.30
-process.HcalIsoTrkAnalyzer.EEHitEnergyThreshold2 = 0.00 # coeff. of linear term
-process.HcalIsoTrkAnalyzer.EEHitEnergyThreshold3 = 0.00 # coeff. of quad term
-process.HcalIsoTrkAnalyzer.EEHitEnergyThresholdLow = 0.00 # minimum def 0.30
-
-process.p = cms.Path(process.HcalIsoTrkAnalyzer)
+process.p = cms.Path(process.hcalIsoTrkAnalyzer)
 

--- a/Configuration/Eras/python/Modifier_run2_ECAL_2018_cff.py
+++ b/Configuration/Eras/python/Modifier_run2_ECAL_2018_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run2_ECAL_2018 =  cms.Modifier()


### PR DESCRIPTION
#### PR description:

Provide possibility of using ECAL RecHit thresholds used by particle flow group in Hcal Calibration code. Also introduce a new modifier for ECAL_2018

#### PR validation:

Use the runTheMatrix test workflows and workflows in the test areas of Calibration/HcalAlCaRecoProducers and Calibration/HcalCalibAlgos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special