### PR TITLE
bug fix for hltIntegration tests when using a setup menu : 12_3_X

### DIFF
--- a/HLTrigger/Configuration/scripts/hltIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltIntegrationTests
@@ -332,7 +332,7 @@ if [ "$SETUP" ]; then
   #we use $MENU not $SETUP here as we force the same DB / converter as the main menu
   #this is the hltGetConfiguration behaviour and would be confusing if you had to 
   #specify converter/db on the setup menu on hltIntegration tests but not on hltGetConfiguration
-  read SETUP_Vx SETUP_DB SETUP <<< $(parse_HLT_menu "$MENU")
+  read SETUP_Vx SETUP_DB CFG <<< $(parse_HLT_menu "$MENU")
 
   hltConfigFromDB --$SETUP_Vx --$SETUP_DB $HLTLISTPATHPROXY --cff --configName "$SETUP" --nopaths --services -FUShmDQMOutputService,-PrescaleService,-EvFDaqDirector,-FastMonitoringService > setup_cff.py
   sed -i -e's/process = cms.Process(.*)/&\nprocess.load("setup_cff")/' hlt.py $(for TRIGGER in $TRIGGERS; do echo "$TRIGGER".py; done)

--- a/HLTrigger/Configuration/scripts/hltIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltIntegrationTests
@@ -332,7 +332,7 @@ if [ "$SETUP" ]; then
   #we use $MENU not $SETUP here as we force the same DB / converter as the main menu
   #this is the hltGetConfiguration behaviour and would be confusing if you had to 
   #specify converter/db on the setup menu on hltIntegration tests but not on hltGetConfiguration
-  read SETUP_Vx SETUP_DB CFG <<< $(parse_HLT_menu "$MENU")
+  read SETUP_Vx SETUP_DB _ <<< $(parse_HLT_menu "$MENU")
 
   hltConfigFromDB --$SETUP_Vx --$SETUP_DB $HLTLISTPATHPROXY --cff --configName "$SETUP" --nopaths --services -FUShmDQMOutputService,-PrescaleService,-EvFDaqDirector,-FastMonitoringService > setup_cff.py
   sed -i -e's/process = cms.Process(.*)/&\nprocess.load("setup_cff")/' hlt.py $(for TRIGGER in $TRIGGERS; do echo "$TRIGGER".py; done)


### PR DESCRIPTION
#### PR description:

There was a bug in the hltIntegration tests where the setup menu was overridden with the main menu when trying to determine the database and converter parameters. Thanks to AR Sahasransu for reporting. 


#### PR validation:

the following command now completes successfully

```
hltIntegrationTests /users/asahasra/Run3HLTv1LLP/HLT_Mu20NoFiltersNoVtxDisplaced_Photon20CaloCustomTightId --setup /dev/CMSSW_12_3_0/GRun/V15 -i file:/eos/cms/store/data/Run2018D/EphemeralHLTPhysics1/RAW/v1/000/323/775/00000/0244D183-F28D-2741-9DBF-1638BEDC734E.root -x "--globaltag auto:run3_hlt --customise HLTrigger/Configuration/customizeHLTforCMSSW.customiseFor2018Input"
```

