### PR TITLE
Adding PPSCalTrackBasedSel AlCa Reco to autoAlca.py

### DIFF
--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -35,7 +35,7 @@ AlCaRecoMatrix = {"AlCaLumiPixels" : "AlCaPCCZeroBias+AlCaPCCRandom",
                   "DoubleMuParked" : "MuAlCalIsolatedMu+MuAlOverlaps+TkAlZMuMu",
                   "MuOniaParked" : "TkAlJpsiMuMu+TkAlUpsilonMuMu",
                   "DoubleElectron" : "EcalCalZElectron+EcalUncalZElectron+HcalCalIsoTrkFilter",
-                  "StreamExpress" : "SiStripCalZeroBias+TkAlMinBias+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+Hotline+LumiPixelsMinBias+SiPixelCalZeroBias+SiPixelCalSingleMuon",
+                  "StreamExpress" : "SiStripCalZeroBias+TkAlMinBias+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+Hotline+LumiPixelsMinBias+SiPixelCalZeroBias+SiPixelCalSingleMuon+PPSCalTrackBasedSel",
                   "StreamExpressHI" : "SiStripCalZeroBias+TkAlMinBiasHI+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+SiPixelCalZeroBias"
                   }
 


### PR DESCRIPTION
#### PR description:

This PR adds PPSCalTrackBasedSel AlCa Reco to `autoAlca.py` as requested by @malbouis 
We believe this is needed for successful Trie0 replay

This work is part of ongoing campaign to have PPS included in Tier0 replay, see i.e. https://github.com/cms-AlCaDB/AlCaTools/issues/53

#### PR validation:

We are not aware of any method to test this PR. Most probably running Tier0 replay may reveal some problems.