### PR TITLE
Support arbitrary path names in the TriggerResultsFilter in HLTPathStatus mode [12.2.x]

### DIFF
--- a/HLTrigger/HLTcore/interface/TriggerExpressionConstant.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionConstant.h
@@ -13,8 +13,6 @@ namespace triggerExpression {
 
     bool operator()(const Data& data) const override { return m_value; }
 
-    void init(const Data& data) override {}
-
     void dump(std::ostream& out) const override { out << (m_value ? "TRUE" : "FALSE"); }
 
   private:

--- a/HLTrigger/HLTcore/interface/TriggerExpressionData.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionData.h
@@ -75,7 +75,7 @@ namespace triggerExpression {
           m_hltUpdated(false),
           // event values
           m_eventNumber() {
-      if (not m_hltResultsTag.label().empty() && not m_usePathStatus)
+      if (not m_hltResultsTag.label().empty() and not m_usePathStatus)
         m_hltResultsToken = iC.consumes<edm::TriggerResults>(m_hltResultsTag);
       if (not m_l1tResultsTag.label().empty())
         m_l1tResultsToken = iC.consumes<GlobalAlgBlkBxCollection>(m_l1tResultsTag);
@@ -112,7 +112,7 @@ namespace triggerExpression {
           m_hltUpdated(false),
           // event values
           m_eventNumber() {
-      if (not m_hltResultsTag.label().empty() && not m_usePathStatus)
+      if (not m_hltResultsTag.label().empty() and not m_usePathStatus)
         m_hltResultsToken = iC.consumes<edm::TriggerResults>(m_hltResultsTag);
       if (not m_l1tResultsTag.label().empty())
         m_l1tResultsToken = iC.consumes<GlobalAlgBlkBxCollection>(m_l1tResultsTag);

--- a/HLTrigger/HLTcore/interface/TriggerExpressionEvaluator.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionEvaluator.h
@@ -2,6 +2,8 @@
 #define HLTrigger_HLTfilters_TriggerExpressionEvaluator_h
 
 #include <iostream>
+#include <string>
+#include <vector>
 
 namespace triggerExpression {
 
@@ -9,19 +11,22 @@ namespace triggerExpression {
 
   class Evaluator {
   public:
-    Evaluator() {}
+    Evaluator() = default;
 
-    // pure virtual, need a concrete implementation
+    // check if the data satisfies the logical expression
     virtual bool operator()(const Data& data) const = 0;
 
-    // virtual function, do nothing unless overridden
+    // (re)initialise the logical expression
     virtual void init(const Data& data) {}
 
-    // pure virtual, need a concrete implementation
+    // list CMSSW path patterns associated to the logical expression
+    virtual std::vector<std::string> patterns() const { return {}; }
+
+    // dump the logical expression to the output stream
     virtual void dump(std::ostream& out) const = 0;
 
     // virtual destructor
-    virtual ~Evaluator() {}
+    virtual ~Evaluator() = default;
   };
 
   inline std::ostream& operator<<(std::ostream& out, const Evaluator& eval) {

--- a/HLTrigger/HLTcore/interface/TriggerExpressionOperators.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionOperators.h
@@ -14,6 +14,9 @@ namespace triggerExpression {
     // initialize the depending modules
     void init(const Data& data) override { m_arg->init(data); }
 
+    // return the patterns from the depending modules
+    std::vector<std::string> patterns() const override { return m_arg->patterns(); }
+
   protected:
     std::unique_ptr<Evaluator> m_arg;
   };
@@ -27,6 +30,15 @@ namespace triggerExpression {
     void init(const Data& data) override {
       m_arg1->init(data);
       m_arg2->init(data);
+    }
+
+    // return the patterns from the depending modules
+    std::vector<std::string> patterns() const override {
+      std::vector<std::string> patterns = m_arg1->patterns();
+      auto patterns2 = m_arg2->patterns();
+      patterns.insert(
+          patterns.end(), std::make_move_iterator(patterns2.begin()), std::make_move_iterator(patterns2.end()));
+      return patterns;
     }
 
   protected:

--- a/HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h
@@ -16,6 +16,8 @@ namespace triggerExpression {
 
     void init(const Data& data) override;
 
+    std::vector<std::string> patterns() const override { return std::vector<std::string>{m_pattern}; }
+
     void dump(std::ostream& out) const override;
 
   private:

--- a/HLTrigger/HLTcore/src/TriggerExpressionData.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionData.cc
@@ -12,10 +12,8 @@
 namespace triggerExpression {
 
   void Data::setPathStatusToken(edm::BranchDescription const& branch, edm::ConsumesCollector&& iC) {
-    if (branch.branchType() == edm::InEvent && branch.className() == "edm::HLTPathStatus" &&
-        branch.moduleLabel().rfind("HLT_", 0) == 0)
-      m_pathStatusTokens[branch.moduleLabel()] = iC.consumes<edm::HLTPathStatus>(
-          edm::InputTag(branch.moduleLabel(), branch.productInstanceName(), branch.processName()));
+    m_pathStatusTokens[branch.moduleLabel()] = iC.consumes<edm::HLTPathStatus>(
+        edm::InputTag(branch.moduleLabel(), branch.productInstanceName(), branch.processName()));
   }
 
   bool Data::setEvent(const edm::Event& event, const edm::EventSetup& setup) {

--- a/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.h
+++ b/HLTrigger/HLTfilters/plugins/TriggerResultsFilter.h
@@ -14,11 +14,12 @@
  *
  */
 
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -39,7 +40,7 @@ namespace triggerExpression {
 class TriggerResultsFilter : public edm::stream::EDFilter<> {
 public:
   explicit TriggerResultsFilter(const edm::ParameterSet &);
-  ~TriggerResultsFilter() override;
+  ~TriggerResultsFilter() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
   bool filter(edm::Event &, const edm::EventSetup &) override;
 
@@ -49,7 +50,7 @@ private:
   void parse(const std::vector<std::string> &expressions);
 
   /// evaluator for the trigger condition
-  triggerExpression::Evaluator *m_expression;
+  std::unique_ptr<triggerExpression::Evaluator> m_expression;
 
   /// cache some data from the Event for faster access by the m_expression
   triggerExpression::Data m_eventCache;

--- a/HLTrigger/HLTfilters/test/BuildFile.xml
+++ b/HLTrigger/HLTfilters/test/BuildFile.xml
@@ -1,0 +1,5 @@
+<!-- test the TriggerResultsFilter reading the CMSSW results from the TriggerResults object of a previous process -->
+<test name="triggerResultsFilter_by_TriggerResults" command="cmsRun ${LOCALTOP}/src/HLTrigger/HLTfilters/test/triggerResultsFilter_producer.py; cmsRun ${LOCALTOP}/src/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py"/>
+
+<!-- test the TriggerResultsFilter reading the CMSSW results from the HLTPathStatus objects of the current process -->
+<test name="triggerResultsFilter_by_PathStatus" command="cmsRun ${LOCALTOP}/src/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py"/>

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_PathStatus.py
@@ -1,0 +1,212 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('HLT')
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+# define the Prescaler service, and set the scale factors
+process.PrescaleService = cms.Service('PrescaleService',
+    prescaleTable = cms.VPSet(
+        cms.PSet(
+            pathName  = cms.string('Path_1'),
+            prescales = cms.vuint32( 2 )
+        ),
+        cms.PSet(
+            pathName  = cms.string('Path_2'),
+            prescales = cms.vuint32( 3 )
+        ),
+        cms.PSet(
+            pathName  = cms.string('Path_3'),
+            prescales = cms.vuint32( 5 )
+        )
+    ),
+    lvl1Labels = cms.vstring('any'),
+    lvl1DefaultLabel = cms.string('any')
+)    
+
+# load conditions from the global tag
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+# define an empty source, and ask for 100 events
+process.source = cms.Source('EmptySource')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000)
+)
+
+# define 3 prescalers, one per path
+process.scale_1 = cms.EDFilter('HLTPrescaler')
+process.scale_2 = cms.EDFilter('HLTPrescaler')
+process.scale_3 = cms.EDFilter('HLTPrescaler')
+process.fail    = cms.EDFilter('HLTBool', result = cms.bool(False))
+process.success = cms.EDFilter('HLTBool', result = cms.bool(True))
+
+process.Path_1  = cms.Path(process.scale_1)
+process.Path_2  = cms.Path(process.scale_2)
+process.Path_3  = cms.Path(process.scale_3)
+process.AlwaysTrue    = cms.Path(process.success)
+process.AlwaysFalse   = cms.Path(process.fail)
+process.L1_Path = cms.Path(process.success)
+
+# define the TriggerResultsFilters based on the status of the previous paths
+from HLTrigger.HLTfilters.triggerResultsFilter_cfi import triggerResultsFilter as _triggerResultsFilter
+triggerResultsFilter = _triggerResultsFilter.clone( usePathStatus = True )
+
+# accept if 'Path_1' succeeds
+process.filter_1 = triggerResultsFilter.clone(
+    triggerConditions =  ( 'Path_1', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if 'Path_2' succeeds
+process.filter_2 = triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_2', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if 'Path_3' succeeds
+process.filter_3 = triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_3', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if any path succeeds (explicit OR)
+process.filter_any_or = triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_1', 'Path_2', 'Path_3' ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if 'Path_1' succeeds, prescaled by 2
+process.filter_1_pre = triggerResultsFilter.clone(
+    triggerConditions =  ( '(Path_1) / 15', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if 'Path_2' succeeds, prescaled by 10
+process.filter_2_pre = triggerResultsFilter.clone(
+    triggerConditions = ( '(Path_2 / 10)', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if any path succeeds, with different prescales (explicit OR, prescaled)
+process.filter_any_pre = triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_1 / 15', 'Path_2 / 10', 'Path_3 / 6', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if any path succeeds (wildcard, '*')
+process.filter_any_star = triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_*', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if any path succeeds (wildcard, '?')
+process.filter_any_question = triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_?', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if any path succeeds (double wildcard, '*_?')
+process.filter_any_starquestion = triggerResultsFilter.clone(
+    triggerConditions = ( '*_?', ),
+    l1tResults = '',
+    throw = False
+)
+
+# accept if all path succeed (explicit AND)
+process.filter_all_explicit = triggerResultsFilter.clone(
+    triggerConditions = ( 'Path_1 AND Path_2 AND Path_3', ),
+    l1tResults = '',
+    throw = False
+)
+
+# wrong path name (explicit)
+process.filter_wrong_name = triggerResultsFilter.clone(
+    triggerConditions = ( 'Wrong', ),
+    l1tResults = '',
+    throw = False
+)
+
+# wrong path name (wildcard)
+process.filter_wrong_pattern = triggerResultsFilter.clone(
+    triggerConditions = ( '*_Wrong', ),
+    l1tResults = '',
+    throw = False
+)
+
+# empty path list
+process.filter_empty_pattern = triggerResultsFilter.clone(
+    triggerConditions = ( ),
+    l1tResults = '',
+    throw = False
+)
+
+# L1-like path name
+process.filter_l1path_pattern = triggerResultsFilter.clone(
+    triggerConditions = ( 'L1_Path', ),
+    l1tResults = '',
+    throw = False
+)
+
+# real L1 trigger
+process.filter_l1singlemuopen_pattern = triggerResultsFilter.clone(
+    triggerConditions = ( 'L1_SingleMuOpen', ),
+    l1tResults = '',
+    throw = False
+)
+
+# TRUE
+process.filter_true_pattern = triggerResultsFilter.clone(
+    triggerConditions = ( 'TRUE', ),
+    l1tResults = '',
+    throw = False
+)
+
+# FALSE
+process.filter_false_pattern = triggerResultsFilter.clone(
+    triggerConditions = ( 'FALSE', ),
+    l1tResults = '',
+    throw = False
+)
+
+
+process.Check_1 = cms.Path( process.filter_1 )
+process.Check_2 = cms.Path( process.filter_2 )
+process.Check_3 = cms.Path( process.filter_3 )
+
+process.Check_All_Explicit = cms.Path( process.filter_all_explicit )
+
+process.Check_Any_Or   = cms.Path( process.filter_any_or )
+process.Check_Any_Star = cms.Path( process.filter_any_star )
+
+process.Check_1_Pre    = cms.Path( process.filter_1_pre )
+process.Check_2_Pre    = cms.Path( process.filter_2_pre )
+process.Check_Any_Pre  = cms.Path( process.filter_any_pre ) 
+
+process.Check_Any_Question        = cms.Path( process.filter_any_question )
+process.Check_Any_StarQuestion    = cms.Path( process.filter_any_starquestion )
+process.Check_Wrong_Name          = cms.Path( process.filter_wrong_name )
+process.Check_Wrong_Pattern       = cms.Path( process.filter_wrong_pattern )
+process.Check_Not_Wrong_Pattern   = cms.Path( ~ process.filter_wrong_pattern )
+process.Check_Empty_Pattern       = cms.Path( process.filter_empty_pattern )
+process.Check_L1Path_Pattern      = cms.Path( process.filter_l1path_pattern )
+process.Check_L1Singlemuopen_Pattern = cms.Path( process.filter_l1singlemuopen_pattern )
+process.Check_True_Pattern        = cms.Path( process.filter_true_pattern )
+process.Check_False_Pattern       = cms.Path( process.filter_false_pattern )
+
+# define an EndPath to analyze all other path results
+process.hltTrigReport = cms.EDAnalyzer( 'HLTrigReport',
+    HLTriggerResults = cms.InputTag( 'TriggerResults', '', 'HLT' )
+)
+process.HLTAnalyzerEndpath = cms.EndPath( process.hltTrigReport )

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_by_TriggerResults.py
@@ -23,66 +23,66 @@ process.source = cms.Source('PoolSource',
     fileNames = cms.untracked.vstring('file:trigger.root')
 )
 
-import HLTrigger.HLTfilters.triggerResultsFilter_cfi as hlt
+from HLTrigger.HLTfilters.triggerResultsFilter_cfi import triggerResultsFilter
 
 # accept if 'Path_1' succeeds
-process.filter_1 = hlt.triggerResultsFilter.clone(
+process.filter_1 = triggerResultsFilter.clone(
     triggerConditions =  ( 'Path_1', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if 'Path_2' succeeds
-process.filter_2 = hlt.triggerResultsFilter.clone(
+process.filter_2 = triggerResultsFilter.clone(
     triggerConditions = ( 'Path_2', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if 'Path_3' succeeds
-process.filter_3 = hlt.triggerResultsFilter.clone(
+process.filter_3 = triggerResultsFilter.clone(
     triggerConditions = ( 'Path_3', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if any path succeeds (explicit OR)
-process.filter_any_or = hlt.triggerResultsFilter.clone(
+process.filter_any_or = triggerResultsFilter.clone(
     triggerConditions = ( 'Path_1', 'Path_2', 'Path_3' ),
     l1tResults = '',
     throw = False
     )
 
 # accept if 'Path_1' succeeds, prescaled by 2
-process.filter_1_pre = hlt.triggerResultsFilter.clone(
+process.filter_1_pre = triggerResultsFilter.clone(
     triggerConditions =  ( '(Path_1) / 15', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if 'Path_2' succeeds, prescaled by 10
-process.filter_2_pre = hlt.triggerResultsFilter.clone(
+process.filter_2_pre = triggerResultsFilter.clone(
     triggerConditions = ( '(Path_2 / 10)', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if any path succeeds, with different prescales (explicit OR, prescaled)
-process.filter_any_pre = hlt.triggerResultsFilter.clone(
+process.filter_any_pre = triggerResultsFilter.clone(
     triggerConditions = ( 'Path_1 / 15', 'Path_2 / 10', 'Path_3 / 6', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if any path succeeds (wildcard, '*')
-process.filter_any_star = hlt.triggerResultsFilter.clone(
+process.filter_any_star = triggerResultsFilter.clone(
     triggerConditions = ( '*', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if any path succeeds (wildcard, twice '*')
-process.filter_any_doublestar = hlt.triggerResultsFilter.clone(
+process.filter_any_doublestar = triggerResultsFilter.clone(
     triggerConditions = ( '*_*', ),
     l1tResults = '',
     throw = False
@@ -90,63 +90,63 @@ process.filter_any_doublestar = hlt.triggerResultsFilter.clone(
 
 
 # accept if any path succeeds (wildcard, '?')
-process.filter_any_question = hlt.triggerResultsFilter.clone(
+process.filter_any_question = triggerResultsFilter.clone(
     triggerConditions = ( 'Path_?', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if all path succeed (explicit AND)
-process.filter_all_explicit = hlt.triggerResultsFilter.clone(
+process.filter_all_explicit = triggerResultsFilter.clone(
     triggerConditions = ( 'Path_1 AND Path_2 AND Path_3', ),
     l1tResults = '',
     throw = False
 )
 
 # wrong path name (explicit)
-process.filter_wrong_name = hlt.triggerResultsFilter.clone(
+process.filter_wrong_name = triggerResultsFilter.clone(
     triggerConditions = ( 'Wrong', ),
     l1tResults = '',
     throw = False
 )
 
 # wrong path name (wildcard)
-process.filter_wrong_pattern = hlt.triggerResultsFilter.clone(
+process.filter_wrong_pattern = triggerResultsFilter.clone(
     triggerConditions = ( '*_Wrong', ),
     l1tResults = '',
     throw = False
 )
 
 # empty path list
-process.filter_empty_pattern = hlt.triggerResultsFilter.clone(
+process.filter_empty_pattern = triggerResultsFilter.clone(
     triggerConditions = ( ),
     l1tResults = '',
     throw = False
 )
 
 # L1-like path name
-process.filter_l1path_pattern = hlt.triggerResultsFilter.clone(
+process.filter_l1path_pattern = triggerResultsFilter.clone(
     triggerConditions = ( 'L1_Path', ),
     l1tResults = '',
     throw = False
 )
 
 # real L1 trigger
-process.filter_l1singlemuopen_pattern = hlt.triggerResultsFilter.clone(
+process.filter_l1singlemuopen_pattern = triggerResultsFilter.clone(
     triggerConditions = ( 'L1_SingleMuOpen', ),
     l1tResults = '',
     throw = False
 )
 
 # TRUE
-process.filter_true_pattern = hlt.triggerResultsFilter.clone(
+process.filter_true_pattern = triggerResultsFilter.clone(
     triggerConditions = ( 'TRUE', ),
     l1tResults = '',
     throw = False
 )
 
 # FALSE
-process.filter_false_pattern = hlt.triggerResultsFilter.clone(
+process.filter_false_pattern = triggerResultsFilter.clone(
     triggerConditions = ( 'FALSE', ),
     l1tResults = '',
     throw = False


### PR DESCRIPTION
#### PR description:

Support arbitrary path names in the TriggerResultsFilter in HLTPathStatus mode

Other changes:
  - clean up and modernise the module
  - add a new unit test for the HLTPathStatus mode

#### PR validation:

The new unit tests should run.

#### Backport status

This PR is a backport to 12.2.x of #36732 .