### PR TITLE
rename `dqmEnv` in `ALCARECOPPSDiamondSampicTimingCalibHarvester_cff`

### DIFF
--- a/CalibPPS/TimingCalibration/python/ALCARECOPPSDiamondSampicTimingCalibHarvester_cff.py
+++ b/CalibPPS/TimingCalibration/python/ALCARECOPPSDiamondSampicTimingCalibHarvester_cff.py
@@ -7,13 +7,13 @@ from CalibPPS.TimingCalibration.PPSDiamondSampicTimingCalibrationPCLHarvester_cf
 DQMStore = cms.Service("DQMStore")
 
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
-dqmEnv = DQMEDHarvester('DQMHarvestingMetadata',
-                              subSystemFolder=cms.untracked.string('AlCaReco/PPSDiamondSampicTimingCalibrationPCL/AlignedChannels'))
+dqmEnvPPSTimingSampicCalibration = DQMEDHarvester('DQMHarvestingMetadata',
+                                                  subSystemFolder=cms.untracked.string('AlCaReco/PPSDiamondSampicTimingCalibrationPCL/AlignedChannels'))
                    
 EDMtoMEConvertPPSTimingSampicCalibration = EDMtoMEConverter.clone()
 EDMtoMEConvertPPSTimingSampicCalibration.lumiInputTag = cms.InputTag("EDMtoMEConvertPPSTimingSampicCalibration", "MEtoEDMConverterLumi")
 EDMtoMEConvertPPSTimingSampicCalibration.runInputTag = cms.InputTag("EDMtoMEConvertPPSTimingSampicCalibration", "MEtoEDMConverterRun")
            
 ALCAHARVESTPPSDiamondSampicTimingCalibration = cms.Sequence(EDMtoMEConvertPPSTimingSampicCalibration +
-						PPSDiamondSampicTimingCalibrationPCLHarvester +
-						dqmEnv)
+                                                            PPSDiamondSampicTimingCalibrationPCLHarvester +
+                                                            dqmEnvPPSTimingSampicCalibration)


### PR DESCRIPTION
#### PR description:

Trivial renaming of `dqmEnv` to `dqmEnvPPSTimingSampicCalibration`.
Otherwise using [this configuration file ](https://github.com/mmusich/cmssw/blob/G2Gains_newFit_12_3_X/CalibTracker/SiStripChannelGain/test/Gains_CT_step2.py) I get python configuration errors:

```console
----- Begin Fatal Exception 18-Jan-2022 15:52:58 CET-----------------------
An exception of category 'ConfigFileReadError' occurred while
   [0] Processing the python configuration file named Gains_CT_step2.py
Exception Message:
 unknown python problem occurred.
ValueError: Trying to override definition of dqmEnv while it is used by the sequence ALCAHARVESTPPSDiamondSampicTimingCalibration
 new object defined in: /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw-patch/CMSSW_12_3_X_2022-01-17-2300/python/DQMServices/Components/DQMEventInfo_cfi.py
 existing object defined in: /tmp/musich/CMSSW_12_3_X_2022-01-17-2300/python/CalibPPS/TimingCalibration/ALCARECOPPSDiamondSampicTimingCalibHarvester_cff.py

At:
  /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw-patch/CMSSW_12_3_X_2022-01-17-2300/python/FWCore/ParameterSet/Config.py(478): __setattr__
  /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw-patch/CMSSW_12_3_X_2022-01-17-2300/python/FWCore/ParameterSet/Config.py(737): extend
  /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw-patch/CMSSW_12_3_X_2022-01-17-2300/python/FWCore/ParameterSet/Config.py(714): load
  Gains_CT_step2.py(53): <module>

----- End Fatal Exception -------------------------------------------------
```

#### PR validation:

With this patch the executable above runs.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
