### PR TITLE
Fixed static analyzer warnings in SimG4Core/Notification and clean-up Alignment/LaserAlignmentSimulation

### DIFF
--- a/Alignment/LaserAlignmentSimulation/src/LaserOpticalPhysicsList.cc
+++ b/Alignment/LaserAlignmentSimulation/src/LaserOpticalPhysicsList.cc
@@ -93,7 +93,6 @@ void LaserOpticalPhysicsList::ConstructProcess() {
   pManager->AddDiscreteProcess(theBoundaryProcess);
   pManager->AddDiscreteProcess(theWLSProcess);
 
-  theScintProcess->SetScintillationYieldFactor(1.);
   theScintProcess->SetTrackSecondariesFirst(true);
 
   G4ParticleTable *table = G4ParticleTable::GetParticleTable();

--- a/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
+++ b/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
@@ -3,16 +3,19 @@
 
 const GenParticleInfo &GenParticleInfoExtractor::operator()(const G4PrimaryParticle *p) const {
   G4VUserPrimaryParticleInformation *up = p->GetUserInformation();
-  if (up == nullptr)
+  GenParticleInfo *gpi = dynamic_cast<GenParticleInfo *>(up);
+  if (up == nullptr) {
     G4Exception("SimG4Core/Notification",
                 "mc001",
                 FatalException,
                 "GenParticleInfoExtractor: G4PrimaryParticle has no user information");
-  GenParticleInfo *gpi = dynamic_cast<GenParticleInfo *>(up);
-  if (gpi == nullptr)
-    G4Exception("SimG4Core/Notification",
-                "mc001",
-                FatalException,
-                "GenParticleInfoExtractor: user information in G4PrimaryParticle is not of GenParticleInfo type");
+  } else {
+    GenParticleInfo *gpi = dynamic_cast<GenParticleInfo *>(up);
+    if (gpi == nullptr)
+      G4Exception("SimG4Core/Notification",
+		  "mc001",
+		  FatalException,
+		  "GenParticleInfoExtractor: user information in G4PrimaryParticle is not of GenParticleInfo type");
+  }
   return *gpi;
 }

--- a/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
+++ b/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
@@ -9,13 +9,11 @@ const GenParticleInfo &GenParticleInfoExtractor::operator()(const G4PrimaryParti
                 "mc001",
                 FatalException,
                 "GenParticleInfoExtractor: G4PrimaryParticle has no user information");
-  } else {
-    GenParticleInfo *gpi = dynamic_cast<GenParticleInfo *>(up);
-    if (gpi == nullptr)
-      G4Exception("SimG4Core/Notification",
-                  "mc001",
-                  FatalException,
-                  "GenParticleInfoExtractor: user information in G4PrimaryParticle is not of GenParticleInfo type");
+  } else if (gpi == nullptr) {
+    G4Exception("SimG4Core/Notification",
+                "mc001",
+                FatalException,
+                "GenParticleInfoExtractor: user information in G4PrimaryParticle is not of GenParticleInfo type");
   }
   return *gpi;
 }

--- a/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
+++ b/SimG4Core/Notification/src/GenParticleInfoExtractor.cc
@@ -13,9 +13,9 @@ const GenParticleInfo &GenParticleInfoExtractor::operator()(const G4PrimaryParti
     GenParticleInfo *gpi = dynamic_cast<GenParticleInfo *>(up);
     if (gpi == nullptr)
       G4Exception("SimG4Core/Notification",
-		  "mc001",
-		  FatalException,
-		  "GenParticleInfoExtractor: user information in G4PrimaryParticle is not of GenParticleInfo type");
+                  "mc001",
+                  FatalException,
+                  "GenParticleInfoExtractor: user information in G4PrimaryParticle is not of GenParticleInfo type");
   }
   return *gpi;
 }

--- a/SimG4Core/Notification/src/NewTrackAction.cc
+++ b/SimG4Core/Notification/src/NewTrackAction.cc
@@ -6,8 +6,6 @@
 
 #include "G4Track.hh"
 
-//#define DebugLog
-
 NewTrackAction::NewTrackAction() {}
 
 void NewTrackAction::primary(const G4Track *aTrack) const { primary(const_cast<G4Track *>(aTrack)); }
@@ -19,18 +17,18 @@ void NewTrackAction::secondary(const G4Track *aSecondary, const G4Track &mother,
 }
 
 void NewTrackAction::secondary(G4Track *aSecondary, const G4Track &mother, int flag) const {
-  if (aSecondary->GetParentID() != mother.GetTrackID())
+  if (aSecondary->GetParentID() != mother.GetTrackID()) {
     G4Exception("SimG4Core/Notification",
                 "mc001",
                 FatalException,
                 "NewTrackAction: secondary parent ID does not match mother id");
-  TrackInformationExtractor extractor;
-  const TrackInformation &motherInfo(extractor(mother));
-  addUserInfoToSecondary(aSecondary, motherInfo, flag);
-#ifdef DebugLog
-  LogDebug("SimTrackManager") << "NewTrackAction: Add track " << aSecondary->GetTrackID() << " from mother "
-                              << mother.GetTrackID();
-#endif
+  } else {
+    TrackInformationExtractor extractor;
+    const TrackInformation &motherInfo(extractor(mother));
+    addUserInfoToSecondary(aSecondary, motherInfo, flag);
+    LogDebug("SimTrackManager") << "NewTrackAction: Add track " << aSecondary->GetTrackID() << " from mother "
+                                << mother.GetTrackID();
+  }
 }
 
 void NewTrackAction::addUserInfoToPrimary(G4Track *aTrack) const {
@@ -44,13 +42,11 @@ void NewTrackAction::addUserInfoToPrimary(G4Track *aTrack) const {
 }
 
 void NewTrackAction::addUserInfoToSecondary(G4Track *aTrack, const TrackInformation &motherInfo, int flag) const {
-  // ralf.ulrich@kit.edu: it is more efficient to use the constructor to copy all data and modify later only when needed
-
   TrackInformation *trkInfo = new TrackInformation();
-  //  LogDebug("SimG4CoreApplication") << "NewTrackAction called for "
-  //				   << aTrack->GetTrackID()
-  //				   << " mother " << motherInfo.isPrimary()
-  //				   << " flag " << flag;
+  LogDebug("SimG4CoreApplication") << "NewTrackAction called for "
+  				   << aTrack->GetTrackID()
+  				   << " mother " << motherInfo.isPrimary()
+  				   << " flag " << flag;
 
   // Take care of cascade decays
   if (flag == 1) {

--- a/SimG4Core/Notification/src/NewTrackAction.cc
+++ b/SimG4Core/Notification/src/NewTrackAction.cc
@@ -43,10 +43,8 @@ void NewTrackAction::addUserInfoToPrimary(G4Track *aTrack) const {
 
 void NewTrackAction::addUserInfoToSecondary(G4Track *aTrack, const TrackInformation &motherInfo, int flag) const {
   TrackInformation *trkInfo = new TrackInformation();
-  LogDebug("SimG4CoreApplication") << "NewTrackAction called for "
-  				   << aTrack->GetTrackID()
-  				   << " mother " << motherInfo.isPrimary()
-  				   << " flag " << flag;
+  LogDebug("SimG4CoreApplication") << "NewTrackAction called for " << aTrack->GetTrackID() << " mother "
+                                   << motherInfo.isPrimary() << " flag " << flag;
 
   // Take care of cascade decays
   if (flag == 1) {

--- a/SimG4Core/Notification/src/TrackInformationExtractor.cc
+++ b/SimG4Core/Notification/src/TrackInformationExtractor.cc
@@ -7,9 +7,8 @@ const TrackInformation &TrackInformationExtractor::operator()(const G4Track &gtk
   const TrackInformation *tkInfo = dynamic_cast<const TrackInformation *>(gui);
   if (gui == nullptr) {
     missing(gtk);
-  } else {
-    if (tkInfo == nullptr)
-      wrongType();
+  } else if (tkInfo == nullptr) {
+    wrongType();
   }
   return *tkInfo;
 }
@@ -19,9 +18,8 @@ TrackInformation &TrackInformationExtractor::operator()(G4Track &gtk) const {
   TrackInformation *tkInfo = dynamic_cast<TrackInformation *>(gui);
   if (gui == nullptr) {
     missing(gtk);
-  } else {
-    if (tkInfo == nullptr)
-      wrongType();
+  } else if (tkInfo == nullptr) {
+    wrongType();
   }
   return *tkInfo;
 }

--- a/SimG4Core/Notification/src/TrackInformationExtractor.cc
+++ b/SimG4Core/Notification/src/TrackInformationExtractor.cc
@@ -4,21 +4,25 @@
 
 const TrackInformation &TrackInformationExtractor::operator()(const G4Track &gtk) const {
   G4VUserTrackInformation *gui = gtk.GetUserInformation();
-  if (gui == nullptr)
-    missing(gtk);
   const TrackInformation *tkInfo = dynamic_cast<const TrackInformation *>(gui);
-  if (tkInfo == nullptr)
-    wrongType();
+  if (gui == nullptr) {
+    missing(gtk);
+  } else {
+    if (tkInfo == nullptr)
+      wrongType();
+  }
   return *tkInfo;
 }
 
 TrackInformation &TrackInformationExtractor::operator()(G4Track &gtk) const {
   G4VUserTrackInformation *gui = gtk.GetUserInformation();
-  if (gui == nullptr)
-    missing(gtk);
   TrackInformation *tkInfo = dynamic_cast<TrackInformation *>(gui);
-  if (tkInfo == nullptr)
-    wrongType();
+  if (gui == nullptr) {
+    missing(gtk);
+  } else {
+    if (tkInfo == nullptr)
+      wrongType();
+  }
   return *tkInfo;
 }
 


### PR DESCRIPTION
#### PR description:
This PR only fixing static analyzer warnings in SimG4Core/Notification and fix the compilation problem for the new Geant4 11.0 in Alignment/LaserAlignmentSimulation. The last fix is expected to work both for Geant4 10.7 (current CMS default) and for Geant4 11.0. 

Should not affect results.

#### PR validation:
private

#### if this PR is a backport please specify the original PR and why you need to backport that PR: NO
