### PR TITLE
Fix accessing one-past-the-end element

### DIFF
--- a/HLTrigger/special/plugins/HLTLogMonitorFilter.cc
+++ b/HLTrigger/special/plugins/HLTLogMonitorFilter.cc
@@ -193,7 +193,7 @@ bool HLTLogMonitorFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
       auto& cat = getCategory(category);
       if (cat.id >= doneCache.size()) {
         //new categories were added so need to grow
-        doneCache.resize(cat.id);
+        doneCache.resize(cat.id + 1);
       }
       if (not doneCache[cat.id].done) {
         doneCache[cat.id].cachedValue = cat.accept();


### PR DESCRIPTION
#### PR description:

Fix writing to one-past-the-end element in `HLTLogMonitorFilter`.

#### PR validation:

Runing the unit tests in the ASAN IB no longer gives any errors.