### PR TITLE
Properly propate exception from DelayedReader

### DIFF
--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -69,7 +69,8 @@ namespace edm {
     void fillEventPrincipal(EventAuxiliary const& aux,
                             ProcessHistory const* processHistory,
                             EventSelectionIDVector eventSelectionIDs,
-                            BranchListIndexes branchListIndexes);
+                            BranchListIndexes branchListIndexes,
+                            DelayedReader* reader = nullptr);
     //provRetriever is changed via a call to ProductProvenanceRetriever::deepSwap
     void fillEventPrincipal(EventAuxiliary const& aux,
                             ProcessHistory const* processHistory,

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -94,7 +94,8 @@ namespace edm {
   void EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
                                           ProcessHistory const* processHistory,
                                           EventSelectionIDVector eventSelectionIDs,
-                                          BranchListIndexes branchListIndexes) {
+                                          BranchListIndexes branchListIndexes,
+                                          DelayedReader* reader) {
     eventSelectionIDs_ = std::move(eventSelectionIDs);
 
     if (wasBranchListIndexesChangedFromInput(branchListIndexes)) {
@@ -104,7 +105,7 @@ namespace edm {
       }
       updateBranchListIndexes(std::move(branchListIndexes));
     }
-    commonFillEventPrincipal(aux, processHistory, nullptr);
+    commonFillEventPrincipal(aux, processHistory, reader);
   }
 
   void EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -158,6 +158,16 @@ namespace edm {
     }
   }
 
+  namespace {
+    cms::Exception& extendException(cms::Exception& e, BranchDescription const& bd, ModuleCallingContext const* mcc) {
+      e.addContext(std::string("While reading from source ") + bd.className() + " " + bd.moduleLabel() + " '" +
+                   bd.productInstanceName() + "' " + bd.processName());
+      if (mcc) {
+        edm::exceptionContext(e, *mcc);
+      }
+      return e;
+    }
+  }  // namespace
   ProductResolverBase::Resolution DelayedReaderInputProductResolver::resolveProduct_(
       Principal const& principal, bool, SharedResourcesAcquirer*, ModuleCallingContext const* mcc) const {
     return resolveProductImpl<true>([this, &principal, mcc]() {
@@ -183,8 +193,15 @@ namespace edm {
           guard = std::unique_lock<std::recursive_mutex>(*sr);
         }
         if (not productResolved()) {
-          //another thread could have beaten us here
-          setProduct(reader->getProduct(branchDescription().branchID(), &principal, mcc));
+          try {
+            //another thread could have beaten us here
+            setProduct(reader->getProduct(branchDescription().branchID(), &principal, mcc));
+          } catch (cms::Exception& e) {
+            throw extendException(e, branchDescription(), mcc);
+          } catch (std::exception const& e) {
+            auto newExcept = edm::Exception(errors::StdException) << e.what();
+            throw extendException(newExcept, branchDescription(), mcc);
+          }
         }
       }
     });
@@ -278,8 +295,15 @@ namespace edm {
                 guard = std::unique_lock<std::recursive_mutex>(*sr);
               }
               if (not productResolved()) {
-                //another thread could have finished this while we were waiting
-                setProduct(reader->getProduct(branchDescription().branchID(), &principal, mcc));
+                try {
+                  //another thread could have finished this while we were waiting
+                  setProduct(reader->getProduct(branchDescription().branchID(), &principal, mcc));
+                } catch (cms::Exception& e) {
+                  throw extendException(e, branchDescription(), mcc);
+                } catch (std::exception const& e) {
+                  auto newExcept = edm::Exception(errors::StdException) << e.what();
+                  throw extendException(newExcept, branchDescription(), mcc);
+                }
               }
             }
           });

--- a/FWCore/Framework/test/stubs/ToyModules.cc
+++ b/FWCore/Framework/test/stubs/ToyModules.cc
@@ -12,6 +12,7 @@ Toy EDProducers and EDProducts for testing purposes only.
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -361,11 +362,47 @@ namespace edmtest {
     e.put(std::make_unique<Prodigal>(parent->value));
   }
 
+  class IntProductFilter : public edm::global::EDFilter<> {
+  public:
+    explicit IntProductFilter(edm::ParameterSet const& p)
+        : token_(consumes(p.getParameter<edm::InputTag>("label"))),
+          threshold_(p.getParameter<int>("threshold")),
+          shouldProduce_(p.getParameter<bool>("shouldProduce")) {
+      if (shouldProduce_) {
+        putToken_ = produces<edmtest::IntProduct>();
+      }
+    }
+
+    bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
+      auto const& product = iEvent.get(token_);
+      if (product.value < threshold_) {
+        return false;
+      }
+      iEvent.emplace(putToken_, product);
+      return true;
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("label");
+      desc.add<int>("threshold", 0);
+      desc.add<bool>("shouldProduce", false);
+      descriptions.addDefault(desc);
+    }
+
+  private:
+    const edm::EDGetTokenT<edmtest::IntProduct> token_;
+    edm::EDPutTokenT<edmtest::IntProduct> putToken_;
+    int threshold_;
+    const bool shouldProduce_;
+  };
+
 }  // namespace edmtest
 
 using edmtest::AVSimpleProducer;
 using edmtest::DSTVProducer;
 using edmtest::DSVProducer;
+using edmtest::IntProductFilter;
 using edmtest::OVSimpleProducer;
 using edmtest::ProdigalProducer;
 using edmtest::SCSimpleProducer;
@@ -377,3 +414,4 @@ DEFINE_FWK_MODULE(AVSimpleProducer);
 DEFINE_FWK_MODULE(DSVProducer);
 DEFINE_FWK_MODULE(DSTVProducer);
 DEFINE_FWK_MODULE(ProdigalProducer);
+DEFINE_FWK_MODULE(IntProductFilter);

--- a/FWCore/Framework/test/stubs/ToyModules.cc
+++ b/FWCore/Framework/test/stubs/ToyModules.cc
@@ -393,7 +393,7 @@ namespace edmtest {
   private:
     const edm::EDGetTokenT<edmtest::IntProduct> token_;
     edm::EDPutTokenT<edmtest::IntProduct> putToken_;
-    int threshold_;
+    const int threshold_;
     const bool shouldProduce_;
   };
 

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -446,6 +446,8 @@
 
   <test name="TestFWCoreIntegrationEDLooperESProcuer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testEDLooperESProducer_cfg.py"/>
 
+  <test name="TestFWCoreIntegrationDelayedReaderTest" command="delayedreader_throw_test.sh"/>
+
   <test name="TestIntegrationProcessBlock1" command="run_TestProcessBlock.sh 1"/>
   <test name="TestIntegrationProcessBlock2" command="run_TestProcessBlock.sh 2"/>
   <test name="TestIntegrationProcessBlock3" command="run_TestProcessBlock.sh 3"/>

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -221,7 +221,7 @@
     <use name="FWCore/ParameterSet"/>
   </library>
 
-  <library file="ThrowingSource.cc" name="ThrowingSource">
+  <library file="ThrowingSource.cc, DelayedReaderThrowingSource.cc" name="ThrowingSource">
     <flags EDM_PLUGIN="1"/>
     <use name="FWCore/Framework"/>
     <use name="FWCore/ParameterSet"/>

--- a/FWCore/Integration/test/DelayedReaderThrowingSource.cc
+++ b/FWCore/Integration/test/DelayedReaderThrowingSource.cc
@@ -1,0 +1,134 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/InputSourceMacros.h"
+#include "FWCore/Framework/interface/InputSourceDescription.h"
+#include "FWCore/Framework/interface/DelayedReader.h"
+#include "FWCore/Framework/interface/SharedResourcesRegistry.h"
+#include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Sources/interface/IDGeneratorSourceBase.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+
+#include "FWCore/Utilities/interface/GetPassID.h"
+
+namespace edm {
+  namespace {
+    class ThrowingDelayedReader : public DelayedReader {
+    public:
+      ThrowingDelayedReader(
+          signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadSource,
+          signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadSource)
+          : preEventReadFromSourceSignal_(preEventReadSource), postEventReadFromSourceSignal_(postEventReadSource) {}
+
+      signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal()
+          const final {
+        return preEventReadFromSourceSignal_;
+      }
+      signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal()
+          const final {
+        return postEventReadFromSourceSignal_;
+      }
+
+    private:
+      std::shared_ptr<WrapperBase> getProduct_(BranchID const& k, EDProductGetter const* ep) final {
+        throw cms::Exception("TEST");
+      }
+      void mergeReaders_(DelayedReader*) final{};
+      void reset_() final{};
+
+      signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal_ =
+          nullptr;
+      signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal_ =
+          nullptr;
+    };
+  }  // namespace
+
+  class DelayedReaderThrowingSource : public IDGeneratorSourceBase<InputSource> {
+  public:
+    explicit DelayedReaderThrowingSource(ParameterSet const&, InputSourceDescription const&);
+    ~DelayedReaderThrowingSource() override;
+    static void fillDescriptions(ConfigurationDescriptions& descriptions);
+
+  private:
+    bool setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::EventAuxiliary::ExperimentType&) override;
+    void readEvent_(edm::EventPrincipal&) override;
+
+    std::pair<SharedResourcesAcquirer*, std::recursive_mutex*> resourceSharedWithDelayedReader_() override {
+      return std::make_pair(resourceSharedWithDelayedReaderPtr_.get(), mutexSharedWithDelayedReader_.get());
+    }
+
+    ThrowingDelayedReader delayedReader_;
+    ProcessHistoryID historyID_;
+
+    std::unique_ptr<SharedResourcesAcquirer>
+        resourceSharedWithDelayedReaderPtr_;  // We do not use propagate_const because the acquirer is itself mutable.
+    std::shared_ptr<std::recursive_mutex> mutexSharedWithDelayedReader_;
+  };
+
+  DelayedReaderThrowingSource::DelayedReaderThrowingSource(ParameterSet const& pset, InputSourceDescription const& desc)
+      : IDGeneratorSourceBase<InputSource>(pset, desc, false),
+        delayedReader_(&preEventReadFromSourceSignal_, &postEventReadFromSourceSignal_) {
+    auto resources = SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader();
+    resourceSharedWithDelayedReaderPtr_ = std::make_unique<SharedResourcesAcquirer>(std::move(resources.first));
+    mutexSharedWithDelayedReader_ = resources.second;
+
+    ParameterSet dummy;
+    dummy.registerIt();
+    auto twd = TypeWithDict::byTypeInfo(typeid(edmtest::IntProduct));
+
+    std::vector<BranchDescription> branches;
+    for (auto const& label : pset.getUntrackedParameter<std::vector<std::string>>("labels")) {
+      branches.push_back(BranchDescription(InEvent,
+                                           label,        //module label
+                                           "INPUTTEST",  //can't be the present process name
+                                           twd.userClassName(),
+                                           twd.friendlyClassName(),
+                                           "",  //product instance name
+                                           "",  //module name which isn't set for items not produced
+                                           dummy.id(),
+                                           twd,
+                                           false  //not produced
+                                           ));
+      branches.back().setOnDemand(true);  //says we use delayed reader
+    }
+    productRegistry()->updateFromInput(branches);
+
+    ProcessHistory ph;
+    ph.emplace_back("INPUTTEST", dummy.id(), PROJECT_VERSION, getPassID());
+    processHistoryRegistry().registerProcessHistory(ph);
+    historyID_ = ph.id();
+
+    BranchIDLists bilists(1);
+    for (auto const& branch : branches) {
+      bilists[0].emplace_back(branch.branchID().id());
+    }
+    branchIDListHelper()->updateFromInput(bilists);
+  }
+
+  DelayedReaderThrowingSource::~DelayedReaderThrowingSource() {}
+
+  bool DelayedReaderThrowingSource::setRunAndEventInfo(EventID&, TimeValue_t&, edm::EventAuxiliary::ExperimentType&) {
+    return true;
+  }
+
+  void DelayedReaderThrowingSource::readEvent_(edm::EventPrincipal& e) {
+    BranchListIndexes indexes(1, static_cast<unsigned short>(0));
+    branchIDListHelper()->fixBranchListIndexes(indexes);
+    doReadEventWithDelayedReader(e, historyID_, EventSelectionIDVector(), std::move(indexes), &delayedReader_);
+  }
+
+  void DelayedReaderThrowingSource::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    ParameterSetDescription desc;
+    desc.setComment("Throws an exception when the DelayedReader is used.");
+    IDGeneratorSourceBase<InputSource>::fillDescription(desc);
+    desc.addUntracked<std::vector<std::string>>("labels", {{"test"}});
+    descriptions.add("source", desc);
+  }
+}  // namespace edm
+
+using edm::DelayedReaderThrowingSource;
+DEFINE_FWK_INPUT_SOURCE(DelayedReaderThrowingSource);

--- a/FWCore/Integration/test/DelayedReaderThrowingSource.cc
+++ b/FWCore/Integration/test/DelayedReaderThrowingSource.cc
@@ -50,7 +50,6 @@ namespace edm {
   class DelayedReaderThrowingSource : public IDGeneratorSourceBase<InputSource> {
   public:
     explicit DelayedReaderThrowingSource(ParameterSet const&, InputSourceDescription const&);
-    ~DelayedReaderThrowingSource() override;
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
@@ -108,8 +107,6 @@ namespace edm {
     }
     branchIDListHelper()->updateFromInput(bilists);
   }
-
-  DelayedReaderThrowingSource::~DelayedReaderThrowingSource() {}
 
   bool DelayedReaderThrowingSource::setRunAndEventInfo(EventID&, TimeValue_t&, edm::EventAuxiliary::ExperimentType&) {
     return true;

--- a/FWCore/Integration/test/delayedreader_throw_cfg.py
+++ b/FWCore/Integration/test/delayedreader_throw_cfg.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("DelayedReaderThrowingSource", labels = cms.untracked.vstring("test", "test2", "test3"))
+
+process.getter = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("test","","INPUTTEST")))
+process.onPath = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("test2", "", "INPUTTEST"), cms.InputTag("getter", "other")))
+process.f1 = cms.EDFilter("IntProductFilter", label = cms.InputTag("onPath"), shouldProduce = cms.bool(True))
+process.f2 = cms.EDFilter("IntProductFilter", label = cms.InputTag("onPath"), shouldProduce = cms.bool(True))
+process.inFront = cms.EDFilter("IntProductFilter", label = cms.InputTag("test3"))
+
+process.p1 = cms.Path(process.inFront+process.onPath+process.f1+process.f2)
+process.p3 = cms.Path(process.onPath+process.f1, cms.Task(process.getter))
+
+process.p2 = cms.Path(process.onPath+process.f2)
+
+
+#process.dump = cms.EDAnalyzer("EventContentAnalyzer")
+#process.p = cms.Path(process.dump)
+
+process.out = cms.OutputModule("AsciiOutputModule")
+process.e = cms.EndPath(process.out, cms.Task(process.getter))
+
+process.maxEvents.input = 1
+
+#process.add_(cms.Service("Tracer"))

--- a/FWCore/Integration/test/delayedreader_throw_test.sh
+++ b/FWCore/Integration/test/delayedreader_throw_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -x
+LOCAL_TEST_DIR=${CMSSW_BASE}/src/FWCore/Integration/test
+LOCAL_TMP_DIR=${CMSSW_BASE}/tmp/${SCRAM_ARCH}
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+cmsRun ${LOCAL_TEST_DIR}/delayedreader_throw_cfg.py && die "cmsRun ${test}delayedreader_throw_cfg.py did not fail" 1
+
+popd
+exit 0

--- a/FWCore/Sources/interface/IDGeneratorSourceBase.h
+++ b/FWCore/Sources/interface/IDGeneratorSourceBase.h
@@ -51,6 +51,20 @@ namespace edm {
       BASE::resetEventCached();
     }
 
+    void doReadEventWithDelayedReader(EventPrincipal& eventPrincipal,
+                                      ProcessHistoryID const& historyID,
+                                      EventSelectionIDVector eventSelectionIDs,
+                                      BranchListIndexes branchListIndexes,
+                                      DelayedReader* reader) {
+      assert(BASE::eventCached() || BASE::processingMode() != BASE::RunsLumisAndEvents);
+      EventAuxiliary aux(eventID_, BASE::processGUID(), Timestamp(presentTime_), isRealData_, eType_);
+      aux.setProcessHistoryID(historyID);
+      auto history = BASE::processHistoryRegistry().getMapped(aux.processHistoryID());
+      eventPrincipal.fillEventPrincipal(
+          aux, history, std::move(eventSelectionIDs), std::move(branchListIndexes), reader);
+      BASE::resetEventCached();
+    }
+
   private:
     typename BASE::ItemType getNextItemType() final;
     virtual void initialize(EventID& id, TimeValue_t& time, TimeValue_t& interval);


### PR DESCRIPTION
#### PR description:

- Catch exception from DelayedReader and
   - convert it to cms::Exception
   - add calling context
- Add  unit test for exceptions thrown from DelayedReader

This problem was uncovered in the ROOT 6_26 IB.

fixes #36697

#### PR validation:

Code compiles. New unit test passes. Problem with cmsRun not properly shutting down in #36697 was also fixed.