### PR TITLE
Handle all exception types in Path::workerFinished

### DIFF
--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -262,6 +262,10 @@ namespace edm {
         std::rethrow_exception(*iException);
       } catch (cms::Exception& oldEx) {
         pEx = std::unique_ptr<cms::Exception>(oldEx.clone());
+      } catch (std::exception const& oldEx) {
+        pEx = std::make_unique<edm::Exception>(errors::StdException);
+      } catch (...) {
+        pEx = std::make_unique<edm::Exception>(errors::Unknown);
       }
       // Caught exception is propagated via WaitingTaskList
       CMS_SA_ALLOW try {


### PR DESCRIPTION

#### PR description:

An exception leaking from this routine will cause premature ending of the Event before all tasks have a chance to finish.

This was the true origin of the cmsRun related problem seen in #36697.

#### PR validation:

Code compiles.