### PR TITLE
Remove unnecessary edm ParameterSet existAs or exist in RecoMuon/{L2MuonProducer}

### DIFF
--- a/RecoMuon/L2MuonProducer/plugins/L2MuonProducer.cc
+++ b/RecoMuon/L2MuonProducer/plugins/L2MuonProducer.cc
@@ -91,9 +91,7 @@ L2MuonProducer::L2MuonProducer(const edm::ParameterSet& parameterSet) {
   // instantiate the concrete trajectory builder in the Track Finder
 
   edm::ConsumesCollector iC = consumesCollector();
-  string typeOfBuilder = parameterSet.existsAs<string>("MuonTrajectoryBuilder")
-                             ? parameterSet.getParameter<string>("MuonTrajectoryBuilder")
-                             : "StandAloneMuonTrajectoryBuilder";
+  string typeOfBuilder = parameterSet.getParameter<string>("MuonTrajectoryBuilder");
   if (typeOfBuilder == "StandAloneMuonTrajectoryBuilder" || typeOfBuilder.empty())
     trajectoryBuilder =
         std::make_unique<StandAloneMuonTrajectoryBuilder>(trajectoryBuilderParameters, theService.get(), iC);


### PR DESCRIPTION
#### PR description: 
Optimization of the module configurations: Improve maintainability by cleaning up the unnecessary "Function edm::ParameterSet::exists() or edm::ParameterSet::existsAs<>() " in the module configuration in C++ code.

This check is automatically available in the static analyzer*. (Bug: CMS code rules)
*[https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_12_3_X_2022-01-18-2300/slc7_amd64_gcc10/llvm-analysis/](https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_12_3_X_2022-01-18-2300/slc7_amd64_gcc10/llvm-analysis/)

In this PR, 1 file was changed.  
RecoMuon/L2MuonProducer/plugins/L2MuonProducer.cc

MuonTrajectoryBuilder is already exist in the default cfipython file**
** [cfipython/RecoMuon/L2MuonProducer/L2MuonProducer_cfi.py](https://cmssdt.cern.ch/lxr/source/cfipython/RecoMuon/L2MuonProducer/L2MuonProducer_cfi.py )
L105  MuonTrajectoryBuilder = cms.string('Exhaustive'),

#### PR validation:
Tested in CMSSW_12_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).