### PR TITLE
ECAL Phase 2 Development WF 28234.61 fix

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -213,7 +213,6 @@ RECOEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 RECOEventContent.outputCommands.extend(EITopPAGEventContent.outputCommands)
 
 from Configuration.Eras.Modifier_ctpps_cff import ctpps
-from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
@@ -623,10 +622,6 @@ from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
         'keep *_*_GEMStripDigiSimLink_*',
         'keep *_*_ME0DigiSimLink_*',
         'keep *_*_ME0StripDigiSimLink_*'])
-
-phase2_ecal_devel.toModify(FEVTDEBUGHLTEventContent,
-    outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
-        'keep *_ecal*_*_*'])
 #
 #
 # RECOSIMDEBUG Data Tier definition

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -213,6 +213,7 @@ RECOEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 RECOEventContent.outputCommands.extend(EITopPAGEventContent.outputCommands)
 
 from Configuration.Eras.Modifier_ctpps_cff import ctpps
+from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
@@ -622,6 +623,10 @@ from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
         'keep *_*_GEMStripDigiSimLink_*',
         'keep *_*_ME0DigiSimLink_*',
         'keep *_*_ME0StripDigiSimLink_*'])
+
+phase2_ecal_devel.toModify(FEVTDEBUGHLTEventContent,
+    outputCommands = FEVTDEBUGHLTEventContent.outputCommands+[
+        'keep *_ecal*_*_*'])
 #
 #
 # RECOSIMDEBUG Data Tier definition

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -852,7 +852,13 @@ class UpgradeWorkflow_ecalDevel(UpgradeWorkflow):
         # temporarily remove trigger & downstream steps
         mods = {'--era': stepDict[step][k]['--era']+',phase2_ecal_devel'}
         if 'Digi' in step:
-            mods['-s'] = 'DIGI:pdigi_valid'
+            mods['-s'] = 'DIGI:pdigi_valid,DIGI2RAW'
+        elif 'Reco' in step:
+            mods['-s'] = 'RAW2DIGI,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly'
+            mods['--datatier'] = 'GEN-SIM-RECO,DQMIO'
+            mods['--eventcontent'] = 'FEVTDEBUGHLT,DQM'
+        elif 'HARVEST' in step:
+            mods['-s'] = 'HARVESTING:@ecalOnlyValidation+@ecal'
         stepDict[stepName][k] = merge([mods, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
         return fragment=="TTbar_14TeV" and '2026' in key

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -57,4 +57,4 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toReplaceWith(DigiToRawTask, DigiToRawTask.copyAndExclude([siPixelRawData,SiStripDigiToRaw,castorRawData,ctppsRawData]))
 
 from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
-phase2_ecal_devel.toReplaceWith(DigiToRawTask, DigiToRawTask.copyAndExclude([esDigiToRaw]))
+phase2_ecal_devel.toReplaceWith(DigiToRawTask, DigiToRawTask.copyAndExclude([L1TDigiToRawTask, ecalPacker, esDigiToRaw, cscpacker]))

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -232,7 +232,6 @@ reconstruction_ecalOnlyTask = cms.Task(
 reconstruction_ecalOnly = cms.Sequence(reconstruction_ecalOnlyTask)
 
 from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
-phase2_ecal_devel.toReplaceWith(ecalRecHitNoTPTask, ecalRecHitNoTPTask.copyAndExclude([ecalPreshowerRecHit]))
 phase2_ecal_devel.toReplaceWith(reconstruction_ecalOnlyTask, reconstruction_ecalOnlyTask.copyAndExclude([pfClusteringPSTask, pfClusteringECALTask, particleFlowSuperClusterECALOnly]))
 
 reconstruction_hcalOnlyTask = cms.Task(

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -231,6 +231,10 @@ reconstruction_ecalOnlyTask = cms.Task(
 )
 reconstruction_ecalOnly = cms.Sequence(reconstruction_ecalOnlyTask)
 
+from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
+phase2_ecal_devel.toReplaceWith(ecalRecHitNoTPTask, ecalRecHitNoTPTask.copyAndExclude([ecalPreshowerRecHit]))
+phase2_ecal_devel.toReplaceWith(reconstruction_ecalOnlyTask, reconstruction_ecalOnlyTask.copyAndExclude([pfClusteringPSTask, pfClusteringECALTask, particleFlowSuperClusterECALOnly]))
+
 reconstruction_hcalOnlyTask = cms.Task(
     bunchSpacingProducer,
     offlineBeamSpot,

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -46,6 +46,9 @@ DQMOfflineEcal = cms.Sequence(
     ecal_dqm_source_offline +
     es_dqm_source_offline )
 
+from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
+phase2_ecal_devel.toReplaceWith(DQMOfflineEcalOnly, DQMOfflineEcalOnly.copyAndExclude([es_dqm_source_offline]))
+
 #offline version of the online DQM: used in validation/certification
 DQMOfflineHcal = cms.Sequence( hcalOfflineSourceSequence )
 

--- a/RecoLocalCalo/Configuration/python/ecalLocalRecoSequence_cff.py
+++ b/RecoLocalCalo/Configuration/python/ecalLocalRecoSequence_cff.py
@@ -48,6 +48,10 @@ from RecoLocalCalo.EcalRecProducers.ecalDetailedTimeRecHit_cfi import *
 _phase2_timing_ecalRecHitTask = cms.Task( ecalRecHitTask.copy() , ecalDetailedTimeRecHit )
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toReplaceWith( ecalRecHitTask, _phase2_timing_ecalRecHitTask )
+from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
+from RecoLocalCalo.EcalRecProducers.ecalUncalibRecHitPhase2_cff import *
+phase2_ecal_devel.toReplaceWith(ecalUncalibRecHitTask, ecalUncalibRecHitPhase2Task)
+phase2_ecal_devel.toReplaceWith(ecalRecHitNoTPTask, ecalRecHitNoTPTask.copyAndExclude([ecalPreshowerRecHit]))
 
 # FastSim modifications
 _fastSim_ecalRecHitTask = ecalRecHitTask.copyAndExclude([ecalCompactTrigPrim,ecalTPSkim])

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
@@ -6,12 +6,9 @@
  **/
 #include "RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalCleaningAlgo.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
@@ -25,20 +22,17 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 EcalRecHitProducer::EcalRecHitProducer(const edm::ParameterSet& ps)
-    : ebRechitCollection_(ps.getParameter<std::string>("EBrechitCollection")),
-      eeRechitCollection_(ps.getParameter<std::string>("EErechitCollection")),
-      doEB_(ps.getParameter<edm::InputTag>("EBuncalibRecHitCollection").label() != "none"),
-      doEE_(ps.getParameter<edm::InputTag>("EEuncalibRecHitCollection").label() != "none"),
+    : doEB_(!ps.getParameter<edm::InputTag>("EBuncalibRecHitCollection").label().empty()),
+      doEE_(!ps.getParameter<edm::InputTag>("EEuncalibRecHitCollection").label().empty()),
       recoverEBIsolatedChannels_(ps.getParameter<bool>("recoverEBIsolatedChannels")),
       recoverEEIsolatedChannels_(ps.getParameter<bool>("recoverEEIsolatedChannels")),
       recoverEBVFE_(ps.getParameter<bool>("recoverEBVFE")),
       recoverEEVFE_(ps.getParameter<bool>("recoverEEVFE")),
       recoverEBFE_(ps.getParameter<bool>("recoverEBFE")),
       recoverEEFE_(ps.getParameter<bool>("recoverEEFE")),
-      killDeadChannels_(ps.getParameter<bool>("killDeadChannels")) {
-  produces<EBRecHitCollection>(ebRechitCollection_);
-  produces<EERecHitCollection>(eeRechitCollection_);
-
+      killDeadChannels_(ps.getParameter<bool>("killDeadChannels")),
+      ebRecHitToken_(produces<EBRecHitCollection>(ps.getParameter<std::string>("EBrechitCollection"))),
+      eeRecHitToken_(produces<EERecHitCollection>(ps.getParameter<std::string>("EErechitCollection"))) {
   if (doEB_) {
     ebUncalibRecHitToken_ =
         consumes<EBUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("EBuncalibRecHitCollection"));
@@ -87,26 +81,6 @@ EcalRecHitProducer::~EcalRecHitProducer() = default;
 void EcalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   using namespace edm;
 
-  Handle<EBUncalibratedRecHitCollection> pEBUncalibRecHits;
-  Handle<EEUncalibratedRecHitCollection> pEEUncalibRecHits;
-
-  const EBUncalibratedRecHitCollection* ebUncalibRecHits = nullptr;
-  const EEUncalibratedRecHitCollection* eeUncalibRecHits = nullptr;
-
-  // get the barrel uncalib rechit collection
-
-  if (doEB_) {
-    evt.getByToken(ebUncalibRecHitToken_, pEBUncalibRecHits);
-    ebUncalibRecHits = pEBUncalibRecHits.product();
-    LogDebug("EcalRecHitDebug") << "total # EB uncalibrated rechits: " << ebUncalibRecHits->size();
-  }
-
-  if (doEE_) {
-    evt.getByToken(eeUncalibRecHitToken_, pEEUncalibRecHits);
-    eeUncalibRecHits = pEEUncalibRecHits.product();  // get a ptr to the product
-    LogDebug("EcalRecHitDebug") << "total # EE uncalibrated rechits: " << eeUncalibRecHits->size();
-  }
-
   // collection of rechits to put in the event
   auto ebRecHits = std::make_unique<EBRecHitCollection>();
   auto eeRecHits = std::make_unique<EERecHitCollection>();
@@ -118,19 +92,25 @@ void EcalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
     workerRecover_->set(es);
   }
 
-  if (ebUncalibRecHits) {
+  // Make EB rechits
+  if (doEB_) {
+    const auto& ebUncalibRecHits = evt.get(ebUncalibRecHitToken_);
+    LogDebug("EcalRecHitDebug") << "total # EB uncalibrated rechits: " << ebUncalibRecHits.size();
+
     // loop over uncalibrated rechits to make calibrated ones
-    for (EBUncalibratedRecHitCollection::const_iterator it = ebUncalibRecHits->begin(); it != ebUncalibRecHits->end();
-         ++it) {
-      worker_->run(evt, *it, *ebRecHits);
+    for (const auto& uncalibRecHit : ebUncalibRecHits) {
+      worker_->run(evt, uncalibRecHit, *ebRecHits);
     }
   }
 
-  if (eeUncalibRecHits) {
+  // Make EE rechits
+  if (doEE_) {
+    const auto& eeUncalibRecHits = evt.get(eeUncalibRecHitToken_);
+    LogDebug("EcalRecHitDebug") << "total # EE uncalibrated rechits: " << eeUncalibRecHits.size();
+
     // loop over uncalibrated rechits to make calibrated ones
-    for (EEUncalibratedRecHitCollection::const_iterator it = eeUncalibRecHits->begin(); it != eeUncalibRecHits->end();
-         ++it) {
-      worker_->run(evt, *it, *eeRecHits);
+    for (const auto& uncalibRecHit : eeUncalibRecHits) {
+      worker_->run(evt, uncalibRecHit, *eeRecHits);
     }
   }
 
@@ -139,114 +119,91 @@ void EcalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   eeRecHits->sort();
 
   if (recoverEBIsolatedChannels_ || recoverEBFE_ || killDeadChannels_) {
-    edm::Handle<std::set<EBDetId>> pEBDetId;
-    const std::set<EBDetId>* detIds = nullptr;
-    evt.getByToken(ebDetIdToBeRecoveredToken_, pEBDetId);
-    detIds = pEBDetId.product();
+    const auto& detIds = evt.get(ebDetIdToBeRecoveredToken_);
+    const auto& chStatus = es.getData(ecalChannelStatusToken_);
 
-    if (detIds) {
-      edm::ESHandle<EcalChannelStatus> chStatus = es.getHandle(ecalChannelStatusToken_);
-      for (std::set<EBDetId>::const_iterator it = detIds->begin(); it != detIds->end(); ++it) {
-        // get channel status map to treat dead VFE separately
-        EcalChannelStatusMap::const_iterator chit = chStatus->find(*it);
-        EcalChannelStatusCode chStatusCode;
-        if (chit != chStatus->end()) {
-          chStatusCode = *chit;
-        } else {
-          edm::LogError("EcalRecHitProducerError") << "No channel status found for xtal " << (*it).rawId()
-                                                   << "! something wrong with EcalChannelStatus in your DB? ";
-        }
-        EcalUncalibratedRecHit urh;
-        if (chStatusCode.getStatusCode() == EcalChannelStatusCode::kDeadVFE) {  // dead VFE (from DB info)
-          // uses the EcalUncalibratedRecHit to pass the DetId info
-          urh = EcalUncalibratedRecHit(*it, 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EB_VFE);
-          if (recoverEBVFE_ || killDeadChannels_)
-            workerRecover_->run(evt, urh, *ebRecHits);
-        } else {
-          // uses the EcalUncalibratedRecHit to pass the DetId info
-          urh = EcalUncalibratedRecHit(*it, 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EB_single);
-          if (recoverEBIsolatedChannels_ || killDeadChannels_)
-            workerRecover_->run(evt, urh, *ebRecHits);
-        }
+    for (const auto& detId : detIds) {
+      // get channel status map to treat dead VFE separately
+      EcalChannelStatusMap::const_iterator chit = chStatus.find(detId);
+      EcalChannelStatusCode chStatusCode;
+      if (chit != chStatus.end()) {
+        chStatusCode = *chit;
+      } else {
+        edm::LogError("EcalRecHitProducerError") << "No channel status found for xtal " << detId.rawId()
+                                                 << "! something wrong with EcalChannelStatus in your DB? ";
+      }
+      EcalUncalibratedRecHit urh;
+      if (chStatusCode.getStatusCode() == EcalChannelStatusCode::kDeadVFE) {  // dead VFE (from DB info)
+        // uses the EcalUncalibratedRecHit to pass the DetId info
+        urh = EcalUncalibratedRecHit(detId, 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EB_VFE);
+        if (recoverEBVFE_ || killDeadChannels_)
+          workerRecover_->run(evt, urh, *ebRecHits);
+      } else {
+        // uses the EcalUncalibratedRecHit to pass the DetId info
+        urh = EcalUncalibratedRecHit(detId, 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EB_single);
+        if (recoverEBIsolatedChannels_ || killDeadChannels_)
+          workerRecover_->run(evt, urh, *ebRecHits);
       }
     }
   }
 
   if (recoverEEIsolatedChannels_ || recoverEEVFE_ || killDeadChannels_) {
-    edm::Handle<std::set<EEDetId>> pEEDetId;
-    const std::set<EEDetId>* detIds = nullptr;
+    const auto& detIds = evt.get(eeDetIdToBeRecoveredToken_);
+    const auto& chStatus = es.getData(ecalChannelStatusToken_);
 
-    evt.getByToken(eeDetIdToBeRecoveredToken_, pEEDetId);
-    detIds = pEEDetId.product();
-
-    if (detIds) {
-      edm::ESHandle<EcalChannelStatus> chStatus = es.getHandle(ecalChannelStatusToken_);
-      for (std::set<EEDetId>::const_iterator it = detIds->begin(); it != detIds->end(); ++it) {
-        // get channel status map to treat dead VFE separately
-        EcalChannelStatusMap::const_iterator chit = chStatus->find(*it);
-        EcalChannelStatusCode chStatusCode;
-        if (chit != chStatus->end()) {
-          chStatusCode = *chit;
-        } else {
-          edm::LogError("EcalRecHitProducerError") << "No channel status found for xtal " << (*it).rawId()
-                                                   << "! something wrong with EcalChannelStatus in your DB? ";
-        }
-        EcalUncalibratedRecHit urh;
-        if (chStatusCode.getStatusCode() == EcalChannelStatusCode::kDeadVFE) {  // dead VFE (from DB info)
-          // uses the EcalUncalibratedRecHit to pass the DetId info
-          urh = EcalUncalibratedRecHit(*it, 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EE_VFE);
-          if (recoverEEVFE_ || killDeadChannels_)
-            workerRecover_->run(evt, urh, *eeRecHits);
-        } else {
-          // uses the EcalUncalibratedRecHit to pass the DetId info
-          urh = EcalUncalibratedRecHit(*it, 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EE_single);
-          if (recoverEEIsolatedChannels_ || killDeadChannels_)
-            workerRecover_->run(evt, urh, *eeRecHits);
-        }
+    for (const auto& detId : detIds) {
+      // get channel status map to treat dead VFE separately
+      EcalChannelStatusMap::const_iterator chit = chStatus.find(detId);
+      EcalChannelStatusCode chStatusCode;
+      if (chit != chStatus.end()) {
+        chStatusCode = *chit;
+      } else {
+        edm::LogError("EcalRecHitProducerError") << "No channel status found for xtal " << detId.rawId()
+                                                 << "! something wrong with EcalChannelStatus in your DB? ";
+      }
+      EcalUncalibratedRecHit urh;
+      if (chStatusCode.getStatusCode() == EcalChannelStatusCode::kDeadVFE) {  // dead VFE (from DB info)
+        // uses the EcalUncalibratedRecHit to pass the DetId info
+        urh = EcalUncalibratedRecHit(detId, 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EE_VFE);
+        if (recoverEEVFE_ || killDeadChannels_)
+          workerRecover_->run(evt, urh, *eeRecHits);
+      } else {
+        // uses the EcalUncalibratedRecHit to pass the DetId info
+        urh = EcalUncalibratedRecHit(detId, 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EE_single);
+        if (recoverEEIsolatedChannels_ || killDeadChannels_)
+          workerRecover_->run(evt, urh, *eeRecHits);
       }
     }
   }
 
   if (recoverEBFE_ || killDeadChannels_) {
-    edm::Handle<std::set<EcalTrigTowerDetId>> pEBFEId;
-    const std::set<EcalTrigTowerDetId>* ttIds = nullptr;
+    const auto& ttIds = evt.get(ebFEToBeRecoveredToken_);
 
-    evt.getByToken(ebFEToBeRecoveredToken_, pEBFEId);
-    ttIds = pEBFEId.product();
-
-    if (ttIds) {
-      for (std::set<EcalTrigTowerDetId>::const_iterator it = ttIds->begin(); it != ttIds->end(); ++it) {
-        // uses the EcalUncalibratedRecHit to pass the DetId info
-        int ieta = (((*it).ietaAbs() - 1) * 5 + 1) * (*it).zside();  // from EcalTrigTowerConstituentsMap
-        int iphi = (((*it).iphi() - 1) * 5 + 11) % 360;              // from EcalTrigTowerConstituentsMap
-        if (iphi <= 0)
-          iphi += 360;  // from EcalTrigTowerConstituentsMap
-        EcalUncalibratedRecHit urh(
-            EBDetId(ieta, iphi, EBDetId::ETAPHIMODE), 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EB_FE);
-        workerRecover_->run(evt, urh, *ebRecHits);
-      }
+    for (const auto& ttId : ttIds) {
+      // uses the EcalUncalibratedRecHit to pass the DetId info
+      int ieta = ((ttId.ietaAbs() - 1) * 5 + 1) * ttId.zside();  // from EcalTrigTowerConstituentsMap
+      int iphi = ((ttId.iphi() - 1) * 5 + 11) % 360;             // from EcalTrigTowerConstituentsMap
+      if (iphi <= 0)
+        iphi += 360;  // from EcalTrigTowerConstituentsMap
+      EcalUncalibratedRecHit urh(
+          EBDetId(ieta, iphi, EBDetId::ETAPHIMODE), 0, 0, 0, 0, EcalRecHitWorkerBaseClass::EB_FE);
+      workerRecover_->run(evt, urh, *ebRecHits);
     }
   }
 
   if (recoverEEFE_ || killDeadChannels_) {
-    edm::Handle<std::set<EcalScDetId>> pEEFEId;
-    const std::set<EcalScDetId>* scIds = nullptr;
+    const auto& scIds = evt.get(eeFEToBeRecoveredToken_);
 
-    evt.getByToken(eeFEToBeRecoveredToken_, pEEFEId);
-    scIds = pEEFEId.product();
-
-    if (scIds) {
-      for (std::set<EcalScDetId>::const_iterator it = scIds->begin(); it != scIds->end(); ++it) {
-        // uses the EcalUncalibratedRecHit to pass the DetId info
-        if (EEDetId::validDetId(((*it).ix() - 1) * 5 + 1, ((*it).iy() - 1) * 5 + 1, (*it).zside())) {
-          EcalUncalibratedRecHit urh(EEDetId(((*it).ix() - 1) * 5 + 1, ((*it).iy() - 1) * 5 + 1, (*it).zside()),
-                                     0,
-                                     0,
-                                     0,
-                                     0,
-                                     EcalRecHitWorkerBaseClass::EE_FE);
-          workerRecover_->run(evt, urh, *eeRecHits);
-        }
+    for (const auto& scId : scIds) {
+      // uses the EcalUncalibratedRecHit to pass the DetId info
+      if (EEDetId::validDetId((scId.ix() - 1) * 5 + 1, (scId.iy() - 1) * 5 + 1, scId.zside())) {
+        EcalUncalibratedRecHit urh(EEDetId((scId.ix() - 1) * 5 + 1, (scId.iy() - 1) * 5 + 1, scId.zside()),
+                                   0,
+                                   0,
+                                   0,
+                                   0,
+                                   EcalRecHitWorkerBaseClass::EE_FE);
+        workerRecover_->run(evt, urh, *eeRecHits);
       }
     }
   }
@@ -262,12 +219,12 @@ void EcalRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
     cleaningAlgo_->setFlags(*eeRecHits);
   }
 
-  // put the collection of recunstructed hits in the event
+  // put the collection of reconstructed hits in the event
   LogInfo("EcalRecHitInfo") << "total # EB calibrated rechits: " << ebRecHits->size();
   LogInfo("EcalRecHitInfo") << "total # EE calibrated rechits: " << eeRecHits->size();
 
-  evt.put(std::move(ebRecHits), ebRechitCollection_);
-  evt.put(std::move(eeRecHits), eeRechitCollection_);
+  evt.put(ebRecHitToken_, std::move(ebRecHits));
+  evt.put(eeRecHitToken_, std::move(eeRecHits));
 }
 
 void EcalRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.cc
@@ -24,19 +24,18 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-EcalRecHitProducer::EcalRecHitProducer(const edm::ParameterSet& ps) :
-  ebRechitCollection_(ps.getParameter<std::string>("EBrechitCollection")),
-  eeRechitCollection_(ps.getParameter<std::string>("EErechitCollection")),
-  doEB_(ps.getParameter<edm::InputTag>("EBuncalibRecHitCollection").label() != "none"),
-  doEE_(ps.getParameter<edm::InputTag>("EEuncalibRecHitCollection").label() != "none"),
-  recoverEBIsolatedChannels_(ps.getParameter<bool>("recoverEBIsolatedChannels")),
-  recoverEEIsolatedChannels_(ps.getParameter<bool>("recoverEEIsolatedChannels")),
-  recoverEBVFE_(ps.getParameter<bool>("recoverEBVFE")),
-  recoverEEVFE_(ps.getParameter<bool>("recoverEEVFE")),
-  recoverEBFE_(ps.getParameter<bool>("recoverEBFE")),
-  recoverEEFE_(ps.getParameter<bool>("recoverEEFE")),
-  killDeadChannels_(ps.getParameter<bool>("killDeadChannels"))
-{
+EcalRecHitProducer::EcalRecHitProducer(const edm::ParameterSet& ps)
+    : ebRechitCollection_(ps.getParameter<std::string>("EBrechitCollection")),
+      eeRechitCollection_(ps.getParameter<std::string>("EErechitCollection")),
+      doEB_(ps.getParameter<edm::InputTag>("EBuncalibRecHitCollection").label() != "none"),
+      doEE_(ps.getParameter<edm::InputTag>("EEuncalibRecHitCollection").label() != "none"),
+      recoverEBIsolatedChannels_(ps.getParameter<bool>("recoverEBIsolatedChannels")),
+      recoverEEIsolatedChannels_(ps.getParameter<bool>("recoverEEIsolatedChannels")),
+      recoverEBVFE_(ps.getParameter<bool>("recoverEBVFE")),
+      recoverEEVFE_(ps.getParameter<bool>("recoverEEVFE")),
+      recoverEBFE_(ps.getParameter<bool>("recoverEBFE")),
+      recoverEEFE_(ps.getParameter<bool>("recoverEEFE")),
+      killDeadChannels_(ps.getParameter<bool>("killDeadChannels")) {
   produces<EBRecHitCollection>(ebRechitCollection_);
   produces<EERecHitCollection>(eeRechitCollection_);
 
@@ -49,7 +48,8 @@ EcalRecHitProducer::EcalRecHitProducer(const edm::ParameterSet& ps) :
     }
 
     if (recoverEBFE_ || killDeadChannels_) {
-      ebFEToBeRecoveredToken_ = consumes<std::set<EcalTrigTowerDetId>>(ps.getParameter<edm::InputTag>("ebFEToBeRecovered"));
+      ebFEToBeRecoveredToken_ =
+          consumes<std::set<EcalTrigTowerDetId>>(ps.getParameter<edm::InputTag>("ebFEToBeRecovered"));
     }
   }
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
@@ -33,16 +33,18 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  std::string ebRechitCollection_;  // secondary name to be given to EB collection of hits
-  std::string eeRechitCollection_;  // secondary name to be given to EE collection of hits
+  const std::string ebRechitCollection_;  // secondary name to be given to EB collection of hits
+  const std::string eeRechitCollection_;  // secondary name to be given to EE collection of hits
 
-  bool recoverEBIsolatedChannels_;
-  bool recoverEEIsolatedChannels_;
-  bool recoverEBVFE_;
-  bool recoverEEVFE_;
-  bool recoverEBFE_;
-  bool recoverEEFE_;
-  bool killDeadChannels_;
+  const bool doEB_; // consume and use the EB uncalibrated RecHits. An EB collection is produced even if this is false
+  const bool doEE_; // consume and use the EE uncalibrated RecHits. An EE collection is produced even if this is false
+  const bool recoverEBIsolatedChannels_;
+  const bool recoverEEIsolatedChannels_;
+  const bool recoverEBVFE_;
+  const bool recoverEEVFE_;
+  const bool recoverEBFE_;
+  const bool recoverEEFE_;
+  const bool killDeadChannels_;
 
   std::unique_ptr<EcalRecHitWorkerBaseClass> worker_;
   std::unique_ptr<EcalRecHitWorkerBaseClass> workerRecover_;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
@@ -36,8 +36,8 @@ private:
   const std::string ebRechitCollection_;  // secondary name to be given to EB collection of hits
   const std::string eeRechitCollection_;  // secondary name to be given to EE collection of hits
 
-  const bool doEB_; // consume and use the EB uncalibrated RecHits. An EB collection is produced even if this is false
-  const bool doEE_; // consume and use the EE uncalibrated RecHits. An EE collection is produced even if this is false
+  const bool doEB_;  // consume and use the EB uncalibrated RecHits. An EB collection is produced even if this is false
+  const bool doEE_;  // consume and use the EE uncalibrated RecHits. An EE collection is produced even if this is false
   const bool recoverEBIsolatedChannels_;
   const bool recoverEEIsolatedChannels_;
   const bool recoverEBVFE_;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecHitProducer.h
@@ -14,7 +14,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 
-//#include "RecoLocalCalo/EcalRecAlgos/interface/EcalRecHitAbsAlgo.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "RecoLocalCalo/EcalRecProducers/interface/EcalRecHitWorkerBaseClass.h"
@@ -33,9 +32,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  const std::string ebRechitCollection_;  // secondary name to be given to EB collection of hits
-  const std::string eeRechitCollection_;  // secondary name to be given to EE collection of hits
-
   const bool doEB_;  // consume and use the EB uncalibrated RecHits. An EB collection is produced even if this is false
   const bool doEE_;  // consume and use the EE uncalibrated RecHits. An EE collection is produced even if this is false
   const bool recoverEBIsolatedChannels_;
@@ -58,6 +54,8 @@ private:
   edm::EDGetTokenT<std::set<EcalTrigTowerDetId> > ebFEToBeRecoveredToken_;
   edm::EDGetTokenT<std::set<EcalScDetId> > eeFEToBeRecoveredToken_;
   edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> ecalChannelStatusToken_;
+  const edm::EDPutTokenT<EBRecHitCollection> ebRecHitToken_;
+  const edm::EDPutTokenT<EERecHitCollection> eeRecHitToken_;
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
@@ -98,12 +98,12 @@ fastSim.toModify(ecalRecHit,
 # Phase 2 modifications
 from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
 phase2_ecal_devel.toModify(ecalRecHit,
-    EBuncalibRecHitCollection = cms.InputTag("ecalUncalibRecHitPhase2", "EcalUncalibRecHitsEB"),
-    EEuncalibRecHitCollection = cms.InputTag(""),  # No EE input since there is no ECAL endcap in Phase 2
-    killDeadChannels = cms.bool(False),
-    recoverEBFE = cms.bool(False),
-    recoverEEFE = cms.bool(False),
-    recoverEBIsolatedChannels = cms.bool(False),
-    recoverEEIsolatedChannels = cms.bool(False)
+    EBuncalibRecHitCollection = "ecalUncalibRecHitPhase2:EcalUncalibRecHitsEB",
+    EEuncalibRecHitCollection = "",  # No EE input since there is no ECAL endcap in Phase 2
+    killDeadChannels = False,
+    recoverEBFE = False,
+    recoverEEFE = False,
+    recoverEBIsolatedChannels = False,
+    recoverEEIsolatedChannels = False
 )
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
@@ -93,4 +93,17 @@ fastSim.toModify(ecalRecHit,
                  recoverEBFE = False,
                  recoverEEFE = False,
                  recoverEBIsolatedChannels = False
-                  )
+                )
+
+# Phase 2 modifications
+from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
+phase2_ecal_devel.toModify(ecalRecHit,
+    EBuncalibRecHitCollection = cms.InputTag("ecalUncalibRecHitPhase2", "EcalUncalibRecHitsEB"),
+    EEuncalibRecHitCollection = cms.InputTag("none"),
+    killDeadChannels = cms.bool(False),
+    recoverEBFE = cms.bool(False),
+    recoverEEFE = cms.bool(False),
+    recoverEBIsolatedChannels = cms.bool(False),
+    recoverEEIsolatedChannels = cms.bool(False)
+)
+

--- a/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalRecHit_cfi.py
@@ -99,7 +99,7 @@ fastSim.toModify(ecalRecHit,
 from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
 phase2_ecal_devel.toModify(ecalRecHit,
     EBuncalibRecHitCollection = cms.InputTag("ecalUncalibRecHitPhase2", "EcalUncalibRecHitsEB"),
-    EEuncalibRecHitCollection = cms.InputTag("none"),
+    EEuncalibRecHitCollection = cms.InputTag(""),  # No EE input since there is no ECAL endcap in Phase 2
     killDeadChannels = cms.bool(False),
     recoverEBFE = cms.bool(False),
     recoverEEFE = cms.bool(False),

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -44,6 +44,9 @@ from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
 run2_common.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
 
+from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
+phase2_ecal_devel.toModify(SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_ecal*_*_*') )
+
 from Configuration.Eras.Modifier_phase2_hcal_cff import phase2_hcal
 phase2_hcal.toModify(SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_DMHcalDigis_*_*') )
 

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -172,6 +172,8 @@ globalValidationECALOnly = cms.Sequence(
     + ecalRecHitsValidationSequence
     + pfClusterCaloOnlyValidationSequence
 )
+from Configuration.Eras.Modifier_phase2_ecal_devel_cff import phase2_ecal_devel
+phase2_ecal_devel.toReplaceWith(ecalRecHitsValidationSequence, ecalRecHitsValidationSequencePhase2)
 
 # HCAL local reconstruction
 globalPrevalidationHCAL = cms.Sequence()


### PR DESCRIPTION
#### PR description:

The Phase 2 ECAL development WF 28234.61 currently fails at the reco step. This PR fixes this by removing unnecessary non-ECAL development related tasks and making sure that all inputs for step3 and step4 are available.
It also runs the Phase 2 weights based uncalibrated RecHits producer introduced in #34505, the first ECAL Phase 2 reco algorithm. Small changes to the EcalRecHitProducer were necessary to allow it to run only on barrel uncalibrated RecHits as it will be for Phase 2.

#### PR validation:

Passes the standard limited matrix tests and also 28234.61.
