### PR TITLE
Run3-gex112Y Make the default creation of Simhits for Demo chambers to be true as required by the respective DPG's

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -329,8 +329,8 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         EnergyThresholdForPersistency = cms.double(1.0),
         PrintHits = cms.bool(False),
         AllMuonsPersistent = cms.bool(True),
-        UseDemoHitRPC = cms.bool(False),
-        UseDemoHitGEM = cms.bool(False),
+        UseDemoHitRPC = cms.bool(True),
+        UseDemoHitGEM = cms.bool(True),
         HaveDemoChambers = cms.bool(True)
     ),
     CaloSD = cms.PSet(


### PR DESCRIPTION
#### PR description:

Make the default creation of Simhits for Demo chambers to be true as required by the respective DPG's

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special