### PR TITLE
Fix crash when reporting an unrunnable schedule

### DIFF
--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -363,6 +363,18 @@ namespace edm {
     std::vector<ModuleStatus> statusOfModules(largestIndex + 1);
     for (auto const& nameID : pathStatusInserterModuleLabelToModuleID) {
       statusOfModules[nameID.second].onPath_ = true;
+      unsigned int pathIndex;
+      auto const& paths = iPnC.paths();
+      auto itFound = std::find(paths.begin(), paths.end(), nameID.first);
+      if (itFound != paths.end()) {
+        pathIndex = itFound - paths.begin();
+      } else {
+        auto const& endPaths = iPnC.endPaths();
+        itFound = std::find(endPaths.begin(), endPaths.end(), nameID.first);
+        assert(itFound != endPaths.end());
+        pathIndex = itFound - endPaths.begin() + iPnC.paths().size();
+      }
+      statusOfModules[nameID.second].pathsOn_.push_back(pathIndex);
     }
     if (kTriggerResultsIndex != kInvalidIndex) {
       statusOfModules[kTriggerResultsIndex] = std::move(triggerResultsStatus);

--- a/FWCore/Framework/test/checkForModuleDependencyCorrectness_t.cppunit.cc
+++ b/FWCore/Framework/test/checkForModuleDependencyCorrectness_t.cppunit.cc
@@ -267,6 +267,14 @@ void test_checkForModuleDependencyCorrectness::onePathHasCycleTest() {
       CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
     }
   }
+  {
+    ModuleDependsOnMap md = {{"A", {"p"}}};
+    {
+      PathToModules paths = {{"p", {"A"}}};
+
+      CPPUNIT_ASSERT_THROW(testCase(md, paths), cms::Exception);
+    }
+  }
 }
 
 void test_checkForModuleDependencyCorrectness::twoPathsNoCycleTest() {


### PR DESCRIPTION
#### PR description:

The PathStatusInserter needed to have its path name added.

#### PR validation:

Code compiles and new unit test passes.

fixes #36726