### PR TITLE
Add hgcalv16 modifier and corresponding era

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C17I13M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C17I13M9_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.Eras.Modifier_phase2_hgcalV12_cff import phase2_hgcalV12
+from Configuration.Eras.Modifier_phase2_hgcalV16_cff import phase2_hgcalV16
+
+Phase2C17I13M9 = cms.ModifierChain(Phase2C11I13M9.copyAndExclude([phase2_hgcalV12]),phase2_hgcalV16)

--- a/Configuration/Eras/python/Modifier_phase2_hgcalV16_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_hgcalV16_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is for HGCal V16 geometry-specific changes for sim, reco, etc.
+
+phase2_hgcalV16 =  cms.Modifier()
+

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -1144,7 +1144,7 @@ caloDict = {
             'from Geometry.EcalMapping.EcalMapping_cfi import *',
             'from Geometry.EcalMapping.EcalMappingRecord_cfi import *',
         ],
-        "era" : "phase2_ecal, phase2_hcal, phase2_hgcal, hcalHardcodeConditions, phase2_hgcalV10, phase2_hgcalV11, phase2_hgcalV12, phase2_hfnose",
+        "era" : "phase2_ecal, phase2_hcal, phase2_hgcal, hcalHardcodeConditions, phase2_hgcalV10, phase2_hgcalV11, phase2_hgcalV16, phase2_hfnose",
     },
 
 }

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1564,7 +1564,7 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D86',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T21',
-        'Era' : 'Phase2C11I13M9',
+        'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D87' : {
@@ -1578,7 +1578,7 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D88',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T21',
-        'Era' : 'Phase2C11I13M9',
+        'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D89' : {

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -56,7 +56,8 @@ class Eras (object):
                  'Phase2C11I13T23M9',
                  'Phase2C11I13T25M9',
                  'Phase2C11I13T26M9',
-                 'Phase2C11I13T27M9'
+                 'Phase2C11I13T27M9',
+                 'Phase2C17I13M9'
         ]
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',


### PR DESCRIPTION
#### PR description:
This PR is to add a new modifier for HGCAL V16, and the corresponding era. Currently, HGCal V16 (C17) is used in D86 and D88. It needs new RecHits calibration, introduced in https://github.com/cms-sw/cmssw/pull/36728. We need to split the modifier/era of D86 and D88 from C11, in order to keep D77 (default now) working as before.

#### PR validation:
This PR itself should do nothing. To see the effect of new RecHit calibration, it should be triggerred the test with https://github.com/cms-sw/cmssw/pull/36728

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No need of backporting.
