### PR TITLE
Fix of the L1CaloTowerTreeProducer and L1uGTTreeProducer to avoid an exception MustUseESGetToken

### DIFF
--- a/L1Trigger/L1TNtuples/README.md
+++ b/L1Trigger/L1TNtuples/README.md
@@ -1,6 +1,9 @@
 L1Ntuples
 =========
 
-Tool to build L1 DPG ntuples used in LHC run 1  
+Tool to build Level 1 Trigger DPG ntuples used for L1T developments, performance studies, and rate estimation.
 
-Ducumentation Twiki Page: https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1TriggerDPGNtupleProduction
+The general description of the L1 ntuples as used in LHC Run 1 can be found ([here](https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1TriggerDPGNtupleProduction)).
+The documentation about the recipe to produces L1 ntuples is kept up-to-date in this [Twiki Page](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TStage2Instructions).
+Instructions and tools to prepare these ntuples are also available in the [L1MenuTools repository](https://github.com/cms-l1-dpg/L1MenuTools/tree/master/L1Ntuples).
+

--- a/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
@@ -22,7 +22,7 @@ Implementation:
 
 // framework
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -59,10 +59,10 @@ Implementation:
 // class declaration
 //
 
-class L1CaloTowerTreeProducer : public edm::EDAnalyzer {
+class L1CaloTowerTreeProducer : public edm::one::EDAnalyzer<> {
 public:
   explicit L1CaloTowerTreeProducer(const edm::ParameterSet&);
-  ~L1CaloTowerTreeProducer() override;
+  ~L1CaloTowerTreeProducer() override = default;
 
 private:
   void beginJob(void) override;
@@ -75,10 +75,17 @@ public:
   L1Analysis::L1AnalysisL1CaloClusterDataFormat* l1CaloClusterData_;
 
 private:
-  double ecalLSB_;
-  unsigned maxCaloTP_;
-  unsigned maxL1Tower_;
-  unsigned maxL1Cluster_;
+  const double ecalLSB_;
+  const unsigned maxCaloTP_;
+  const unsigned maxL1Tower_;
+  const unsigned maxL1Cluster_;
+
+  // EDM input tags
+  const edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalToken_;
+  const edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalToken_;
+  const edm::EDGetTokenT<l1t::CaloTowerBxCollection> l1TowerToken_;
+  const edm::ESGetToken<CaloTPGTranscoder, CaloTPGRecord> decoderToken_;
+  edm::EDGetTokenT<l1t::CaloClusterBxCollection> l1ClusterToken_;
 
   // output file
   edm::Service<TFileService> fs_;
@@ -86,21 +93,19 @@ private:
   // tree
   TTree* tree_;
 
-  // EDM input tags
-  edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalToken_;
-  edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalToken_;
-  edm::EDGetTokenT<l1t::CaloTowerBxCollection> l1TowerToken_;
-  edm::EDGetTokenT<l1t::CaloClusterBxCollection> l1ClusterToken_;
-  edm::ESGetToken<CaloTPGTranscoder, CaloTPGRecord> decoderToken_;
-
   bool storeCaloClusters_;
 };
 
-L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfig) {
-  ecalToken_ = consumes<EcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("ecalToken"));
-  hcalToken_ = consumes<HcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("hcalToken"));
-  l1TowerToken_ = consumes<l1t::CaloTowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("l1TowerToken"));
-  decoderToken_ = esConsumes<CaloTPGTranscoder, CaloTPGRecord>();
+L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfig) :
+  ecalLSB_(iConfig.getUntrackedParameter<double>("ecalLSB", 0.5)),
+  maxCaloTP_(iConfig.getUntrackedParameter<unsigned int>("maxCaloTP", 5760)),
+  maxL1Tower_(iConfig.getUntrackedParameter<unsigned int>("maxL1Tower", 5760)),
+  maxL1Cluster_(iConfig.getUntrackedParameter<unsigned int>("maxL1Cluster", 5760)),
+  ecalToken_(consumes<EcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("ecalToken"))),
+  hcalToken_(consumes<HcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("hcalToken"))),
+  l1TowerToken_(consumes<l1t::CaloTowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("l1TowerToken"))),
+  decoderToken_(esConsumes<CaloTPGTranscoder, CaloTPGRecord>())
+{
 
   edm::InputTag clusterTag = iConfig.getUntrackedParameter<edm::InputTag>("l1ClusterToken");
   storeCaloClusters_ = true;
@@ -110,10 +115,6 @@ L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfi
   if (clusterTag.instance() != std::string(""))
     l1ClusterToken_ = consumes<l1t::CaloClusterBxCollection>(clusterTag);
 
-  ecalLSB_ = iConfig.getUntrackedParameter<double>("ecalLSB", 0.5);
-  maxCaloTP_ = iConfig.getUntrackedParameter<unsigned int>("maxCaloTP", 5760);
-  maxL1Tower_ = iConfig.getUntrackedParameter<unsigned int>("maxL1Tower", 5760);
-  maxL1Cluster_ = iConfig.getUntrackedParameter<unsigned int>("maxL1Cluster", 5760);
 
   // set up output
   tree_ = fs_->make<TTree>("L1CaloTowerTree", "L1CaloTowerTree");
@@ -126,11 +127,6 @@ L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfi
   caloTPData_ = new L1Analysis::L1AnalysisCaloTPDataFormat();
   l1CaloTowerData_ = new L1Analysis::L1AnalysisL1CaloTowerDataFormat();
   l1CaloClusterData_ = new L1Analysis::L1AnalysisL1CaloClusterDataFormat();
-}
-
-L1CaloTowerTreeProducer::~L1CaloTowerTreeProducer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -212,7 +208,6 @@ void L1CaloTowerTreeProducer::analyze(const edm::Event& iEvent, const edm::Event
   l1CaloTowerData_->Reset();
 
   edm::Handle<l1t::CaloTowerBxCollection> l1Towers;
-
   iEvent.getByToken(l1TowerToken_, l1Towers);
 
   if (l1Towers.isValid()) {
@@ -246,7 +241,6 @@ void L1CaloTowerTreeProducer::analyze(const edm::Event& iEvent, const edm::Event
     l1CaloClusterData_->Reset();
 
     edm::Handle<l1t::CaloClusterBxCollection> l1Clusters;
-
     if (!l1ClusterToken_.isUninitialized())
       iEvent.getByToken(l1ClusterToken_, l1Clusters);
 

--- a/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
@@ -91,7 +91,7 @@ private:
   edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalToken_;
   edm::EDGetTokenT<l1t::CaloTowerBxCollection> l1TowerToken_;
   edm::EDGetTokenT<l1t::CaloClusterBxCollection> l1ClusterToken_;
-  edm::ESGetToken<CaloTPGTranscoder, CaloTPGRecord> decoderToken_; 
+  edm::ESGetToken<CaloTPGTranscoder, CaloTPGRecord> decoderToken_;
 
   bool storeCaloClusters_;
 };
@@ -100,7 +100,7 @@ L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfi
   ecalToken_ = consumes<EcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("ecalToken"));
   hcalToken_ = consumes<HcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("hcalToken"));
   l1TowerToken_ = consumes<l1t::CaloTowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("l1TowerToken"));
-  decoderToken_ = esConsumes<CaloTPGTranscoder, CaloTPGRecord>(); 
+  decoderToken_ = esConsumes<CaloTPGTranscoder, CaloTPGRecord>();
 
   edm::InputTag clusterTag = iConfig.getUntrackedParameter<edm::InputTag>("l1ClusterToken");
   storeCaloClusters_ = true;
@@ -142,8 +142,8 @@ void L1CaloTowerTreeProducer::analyze(const edm::Event& iEvent, const edm::Event
   // do calo towers
   caloTPData_->Reset();
 
-  edm::ESHandle<CaloTPGTranscoder> decoder;  
-  decoder = iSetup.getHandle(decoderToken_); 
+  edm::ESHandle<CaloTPGTranscoder> decoder;
+  decoder = iSetup.getHandle(decoderToken_);
 
   edm::Handle<EcalTrigPrimDigiCollection> ecalTPs;
   edm::Handle<HcalTrigPrimDigiCollection> hcalTPs;

--- a/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
@@ -91,6 +91,7 @@ private:
   edm::EDGetTokenT<HcalTrigPrimDigiCollection> hcalToken_;
   edm::EDGetTokenT<l1t::CaloTowerBxCollection> l1TowerToken_;
   edm::EDGetTokenT<l1t::CaloClusterBxCollection> l1ClusterToken_;
+  edm::ESGetToken<CaloTPGTranscoder, CaloTPGRecord> decoderToken_; 
 
   bool storeCaloClusters_;
 };
@@ -99,6 +100,7 @@ L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfi
   ecalToken_ = consumes<EcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("ecalToken"));
   hcalToken_ = consumes<HcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("hcalToken"));
   l1TowerToken_ = consumes<l1t::CaloTowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("l1TowerToken"));
+  decoderToken_ = esConsumes<CaloTPGTranscoder, CaloTPGRecord>(); 
 
   edm::InputTag clusterTag = iConfig.getUntrackedParameter<edm::InputTag>("l1ClusterToken");
   storeCaloClusters_ = true;
@@ -140,8 +142,8 @@ void L1CaloTowerTreeProducer::analyze(const edm::Event& iEvent, const edm::Event
   // do calo towers
   caloTPData_->Reset();
 
-  edm::ESHandle<CaloTPGTranscoder> decoder;
-  iSetup.get<CaloTPGRecord>().get(decoder);
+  edm::ESHandle<CaloTPGTranscoder> decoder;  
+  decoder = iSetup.getHandle(decoderToken_); 
 
   edm::Handle<EcalTrigPrimDigiCollection> ecalTPs;
   edm::Handle<HcalTrigPrimDigiCollection> hcalTPs;

--- a/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
@@ -96,17 +96,15 @@ private:
   bool storeCaloClusters_;
 };
 
-L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfig) :
-  ecalLSB_(iConfig.getUntrackedParameter<double>("ecalLSB", 0.5)),
-  maxCaloTP_(iConfig.getUntrackedParameter<unsigned int>("maxCaloTP", 5760)),
-  maxL1Tower_(iConfig.getUntrackedParameter<unsigned int>("maxL1Tower", 5760)),
-  maxL1Cluster_(iConfig.getUntrackedParameter<unsigned int>("maxL1Cluster", 5760)),
-  ecalToken_(consumes<EcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("ecalToken"))),
-  hcalToken_(consumes<HcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("hcalToken"))),
-  l1TowerToken_(consumes<l1t::CaloTowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("l1TowerToken"))),
-  decoderToken_(esConsumes<CaloTPGTranscoder, CaloTPGRecord>())
-{
-
+L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfig)
+    : ecalLSB_(iConfig.getUntrackedParameter<double>("ecalLSB", 0.5)),
+      maxCaloTP_(iConfig.getUntrackedParameter<unsigned int>("maxCaloTP", 5760)),
+      maxL1Tower_(iConfig.getUntrackedParameter<unsigned int>("maxL1Tower", 5760)),
+      maxL1Cluster_(iConfig.getUntrackedParameter<unsigned int>("maxL1Cluster", 5760)),
+      ecalToken_(consumes<EcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("ecalToken"))),
+      hcalToken_(consumes<HcalTrigPrimDigiCollection>(iConfig.getUntrackedParameter<edm::InputTag>("hcalToken"))),
+      l1TowerToken_(consumes<l1t::CaloTowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("l1TowerToken"))),
+      decoderToken_(esConsumes<CaloTPGTranscoder, CaloTPGRecord>()) {
   edm::InputTag clusterTag = iConfig.getUntrackedParameter<edm::InputTag>("l1ClusterToken");
   storeCaloClusters_ = true;
   if (clusterTag.label() == std::string("") or clusterTag.label() == std::string("none"))
@@ -114,7 +112,6 @@ L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfi
 
   if (clusterTag.instance() != std::string(""))
     l1ClusterToken_ = consumes<l1t::CaloClusterBxCollection>(clusterTag);
-
 
   // set up output
   tree_ = fs_->make<TTree>("L1CaloTowerTree", "L1CaloTowerTree");

--- a/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
@@ -85,9 +85,7 @@ void L1uGTTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
   }
 
   edm::Handle<GlobalAlgBlkBxCollection> ugt;
-
   event.getByToken(ugtToken_, ugt);
-
   if (ugt.isValid()) {
     results_ = &ugt->at(0, 0);
   }

--- a/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
@@ -51,7 +51,6 @@ private:
 
   // L1 uGT menu
   unsigned long long cache_id_;
-  
 };
 
 L1uGTTreeProducer::L1uGTTreeProducer(edm::ParameterSet const &config)
@@ -62,7 +61,7 @@ L1uGTTreeProducer::L1uGTTreeProducer(edm::ParameterSet const &config)
   // set up the TTree and its branches
   tree_ = fs_->make<TTree>("L1uGTTree", "L1uGTTree");
   tree_->Branch("L1uGT", "GlobalAlgBlk", &results_, 32000, 3);
-  l1GtMenuToken_ = esConsumes<L1TUtmTriggerMenu,L1TUtmTriggerMenuRcd>();
+  l1GtMenuToken_ = esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>();
 }
 
 L1uGTTreeProducer::~L1uGTTreeProducer() {
@@ -79,7 +78,7 @@ void L1uGTTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
   unsigned long long id = setup.get<L1TUtmTriggerMenuRcd>().cacheIdentifier();
   if (id != cache_id_) {
     cache_id_ = id;
-    edm::ESHandle<L1TUtmTriggerMenu> menu; 
+    edm::ESHandle<L1TUtmTriggerMenu> menu;
     menu = setup.getHandle(l1GtMenuToken_);
 
     for (auto const &keyval : menu->getAlgorithmMap()) {

--- a/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
@@ -47,7 +47,7 @@ private:
 
   // EDM input tokens
   const edm::EDGetTokenT<GlobalAlgBlkBxCollection> ugt_token_;
-  edm::ESGetToken<L1TUtmTriggerMenu,L1TUtmTriggerMenuRcd> menuToken_; 
+  edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> l1GtMenuToken_;
 
   // L1 uGT menu
   unsigned long long cache_id_;
@@ -62,7 +62,7 @@ L1uGTTreeProducer::L1uGTTreeProducer(edm::ParameterSet const &config)
   // set up the TTree and its branches
   tree_ = fs_->make<TTree>("L1uGTTree", "L1uGTTree");
   tree_->Branch("L1uGT", "GlobalAlgBlk", &results_, 32000, 3);
-  menuToken_ = esConsumes<L1TUtmTriggerMenu,L1TUtmTriggerMenuRcd>();
+  l1GtMenuToken_ = esConsumes<L1TUtmTriggerMenu,L1TUtmTriggerMenuRcd>();
 }
 
 L1uGTTreeProducer::~L1uGTTreeProducer() {
@@ -80,7 +80,7 @@ void L1uGTTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
   if (id != cache_id_) {
     cache_id_ = id;
     edm::ESHandle<L1TUtmTriggerMenu> menu; 
-    menu = setup.getHandle(menuToken_);
+    menu = setup.getHandle(l1GtMenuToken_);
 
     for (auto const &keyval : menu->getAlgorithmMap()) {
       std::string const &name = keyval.second.getName();

--- a/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
@@ -47,9 +47,11 @@ private:
 
   // EDM input tokens
   const edm::EDGetTokenT<GlobalAlgBlkBxCollection> ugt_token_;
+  edm::ESGetToken<L1TUtmTriggerMenu,L1TUtmTriggerMenuRcd> menuToken_; 
 
   // L1 uGT menu
   unsigned long long cache_id_;
+  
 };
 
 L1uGTTreeProducer::L1uGTTreeProducer(edm::ParameterSet const &config)
@@ -60,6 +62,7 @@ L1uGTTreeProducer::L1uGTTreeProducer(edm::ParameterSet const &config)
   // set up the TTree and its branches
   tree_ = fs_->make<TTree>("L1uGTTree", "L1uGTTree");
   tree_->Branch("L1uGT", "GlobalAlgBlk", &results_, 32000, 3);
+  menuToken_ = esConsumes<L1TUtmTriggerMenu,L1TUtmTriggerMenuRcd>();
 }
 
 L1uGTTreeProducer::~L1uGTTreeProducer() {
@@ -76,8 +79,8 @@ void L1uGTTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
   unsigned long long id = setup.get<L1TUtmTriggerMenuRcd>().cacheIdentifier();
   if (id != cache_id_) {
     cache_id_ = id;
-    edm::ESHandle<L1TUtmTriggerMenu> menu;
-    setup.get<L1TUtmTriggerMenuRcd>().get(menu);
+    edm::ESHandle<L1TUtmTriggerMenu> menu; 
+    menu = setup.getHandle(menuToken_);
 
     for (auto const &keyval : menu->getAlgorithmMap()) {
       std::string const &name = keyval.second.getName();

--- a/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
@@ -85,7 +85,9 @@ void L1uGTTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
   }
 
   edm::Handle<GlobalAlgBlkBxCollection> ugt;
+
   event.getByToken(ugtToken_, ugt);
+
   if (ugt.isValid()) {
     results_ = &ugt->at(0, 0);
   }

--- a/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
@@ -12,7 +12,7 @@
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -25,10 +25,10 @@
 // class declaration
 //
 
-class L1uGTTreeProducer : public edm::EDAnalyzer {
+class L1uGTTreeProducer : public edm::one::EDAnalyzer<> {
 public:
   explicit L1uGTTreeProducer(edm::ParameterSet const &);
-  ~L1uGTTreeProducer() override;
+  ~L1uGTTreeProducer() override = default;
 
 private:
   void beginJob() override;
@@ -46,8 +46,8 @@ private:
   TTree *tree_;
 
   // EDM input tokens
-  const edm::EDGetTokenT<GlobalAlgBlkBxCollection> ugt_token_;
-  edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> l1GtMenuToken_;
+  const edm::EDGetTokenT<GlobalAlgBlkBxCollection> ugtToken_;
+  const edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> l1GtMenuToken_;
 
   // L1 uGT menu
   unsigned long long cache_id_;
@@ -56,17 +56,12 @@ private:
 L1uGTTreeProducer::L1uGTTreeProducer(edm::ParameterSet const &config)
     : results_(nullptr),
       tree_(nullptr),
-      ugt_token_(consumes<GlobalAlgBlkBxCollection>(config.getParameter<edm::InputTag>("ugtToken"))),
+      ugtToken_(consumes<GlobalAlgBlkBxCollection>(config.getParameter<edm::InputTag>("ugtToken"))),
+      l1GtMenuToken_(esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>()),
       cache_id_(0) {
   // set up the TTree and its branches
   tree_ = fs_->make<TTree>("L1uGTTree", "L1uGTTree");
   tree_->Branch("L1uGT", "GlobalAlgBlk", &results_, 32000, 3);
-  l1GtMenuToken_ = esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>();
-}
-
-L1uGTTreeProducer::~L1uGTTreeProducer() {
-  //if (tree_) { delete tree_; tree_ = NULL; }
-  //if (results_) { delete results_; results_ = NULL; }  // It seems TTree owns this pointer...
 }
 
 //
@@ -90,9 +85,7 @@ void L1uGTTreeProducer::analyze(edm::Event const &event, edm::EventSetup const &
   }
 
   edm::Handle<GlobalAlgBlkBxCollection> ugt;
-
-  event.getByToken(ugt_token_, ugt);
-
+  event.getByToken(ugtToken_, ugt);
   if (ugt.isValid()) {
     results_ = &ugt->at(0, 0);
   }


### PR DESCRIPTION
#### PR description:
The PR is needed to prevent the L1 Trigger emulation to crash when running in CMSSW_12_3_X using the cmsDriver command. 

#### PR validation:
Basic tests performed successfully starting from CMSSW_12_3_0_pre3. 
From CMSSW_12_3_0_pre3/src:
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests
> runTheMatrix.py -l limited -i all --ibeos

Checks that the following cmsDriver commands (for MC and data) are running properly:

_MC_:
- cmsDriver.py  l1Ntuple  --python_filename mc.py  -s L1REPACK:uGT,RAW2DIGI  --mc -n -1 --conditions auto:phase1_2021_realistic --era Run3 --no_output --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU  --customise=L1Trigger/Configuration/customiseUtils.L1TGlobalMenuXML --filein /store/relval/CMSSW_12_0_1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v7-v2/10000/b67e121b-b29f-4eb0-8628-b3aa1cb76720.root
- cmsDriver.py  l1Ntuple  --python_filename mc.py  -s L1REPACK:FullMC,RAW2DIGI  --mc -n -1 --conditions auto:phase1_2021_realistic --era Run3 --no_output --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU  --customise=L1Trigger/Configuration/customiseUtils.L1TGlobalMenuXML --filein /store/relval/CMSSW_12_0_1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v7-v2/10000/b67e121b-b29f-4eb0-8628-b3aa1cb76720.root

_Data_:
- cmsDriver.py l1Ntuple -s L1REPACK:uGT,RAW2DIGI  --python_filename=data.py -n -1 --no_output --era=Run2_2018 --data --conditions=120X_dataRun2_v2 --customise=L1Trigger/Configuration/customiseReEmul.L1TReEmulFromRAW --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU --customise=L1Trigger/Configuration/customiseUtils.L1TGlobalMenuXML --filein=root://xrootd-cms.infn.it//store/data/Run2018D/EphemeralZeroBias8/RAW/v1/000/320/497/00000/04E0297E-C893-E811-B0AA-FA163EADBE2E.root