### PR TITLE
 get rid of `CMSDEPRECATED_X` warnings from `TrackPropagation`

### DIFF
--- a/TrackPropagation/RungeKutta/test/RKTest.cc
+++ b/TrackPropagation/RungeKutta/test/RKTest.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -39,21 +39,20 @@ public:
 
 using namespace std;
 
-class RKTest : public edm::EDAnalyzer {
+class RKTest : public edm::one::EDAnalyzer<> {
 public:
-  RKTest(const edm::ParameterSet& pset) {}
+  RKTest(const edm::ParameterSet& pset) : magFieldToken(esConsumes()) {}
 
-  ~RKTest() {}
+  ~RKTest() = default;
 
   virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) {
     using namespace edm;
-    ESHandle<MagneticField> magfield;
-    setup.get<IdealMagneticFieldRecord>().get(magfield);
-
+    const ESHandle<MagneticField> magfield = setup.getHandle(magFieldToken);
     propagateInCentralVolume(&(*magfield));
   }
 
 private:
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken;
   typedef TrajectoryStateOnSurface TSOS;
 
   void propagateInCentralVolume(const MagneticField* field) const;


### PR DESCRIPTION
#### PR description:

Trivial PR, title says it all.
Part of the migration in #36404.
Went systematically through all of the `CMSDEPRECATED_`X warnings in the subsystems  ` TrackPropagation` from `CMSSW_12_3_CMSDEPRECATED_X_2022-01-17-2300` and removed deprecated API calls.
Profited to modernize the code.

#### PR validation:

`cmssw` compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A