### PR TITLE
Unify bin-edge handling in JetResolutionObject and JetCorrectorParameters

### DIFF
--- a/CondFormats/JetMETObjects/interface/JetResolutionObject.h
+++ b/CondFormats/JetMETObjects/interface/JetResolutionObject.h
@@ -128,7 +128,7 @@ namespace JME {
         this->max = max;
       }
 
-      bool is_inside(float value) const { return (value >= min) && (value <= max); }
+      bool is_inside(float value) const { return (value >= min) && (value < max); }
 
       COND_SERIALIZABLE;
     };


### PR DESCRIPTION
#### PR description:

This PR is similar in spirit to https://github.com/cms-sw/cmssw/pull/34382 which fixed a bug in the non-linear lookup version of JetCorrectorParameters. 
Here, the issue is that the current implementation of JetResolutionObject includes both the lower and upper bin edge when iterating through the records. This is inconsistent with both the JetCorrectorParameters and the correctionlib implementation and can be considered a bug from my point of view.

#### PR validation:

I have included a validation of JetResolutionObject+JetCorrectorParameters against correctionlib in the context of providing JSON-format files, cf. https://github.com/kirschen/JECDatabase/blob/master/scripts/JERC2JSON/testJERCJSON.py

There are inconsistent results of the CMSSW/correctionlib evaluation at all bin edges before applying this fix, but full consistency afterward.
@tankit @juska @laurenhay 