### PR TITLE
Backport to 12_2_X: ECAL TPG Parameter Builder changes for double weights

### DIFF
--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBApp.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBApp.cc
@@ -1,4 +1,5 @@
 #include "CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBApp.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <vector>
 #include <ctime>
@@ -14,11 +15,11 @@ EcalTPGDBApp::EcalTPGDBApp(string sid, string user, string pass) : EcalCondDBInt
 int EcalTPGDBApp::writeToConfDB_TPGPedestals(const map<EcalLogicID, FEConfigPedDat>& pedset, int iovId, string tag) {
   int result = 0;
 
-  cout << "*****************************************" << endl;
-  cout << "******** Inserting Peds in conf-OMDS*****" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "******** Inserting Peds in conf-OMDS*****";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
 
-  cout << "creating fe record " << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "creating fe record ";
   FEConfigPedInfo fe_ped_info;
   fe_ped_info.setIOVId(iovId);
   fe_ped_info.setConfigTag(tag);
@@ -26,10 +27,10 @@ int EcalTPGDBApp::writeToConfDB_TPGPedestals(const map<EcalLogicID, FEConfigPedD
   result = fe_ped_info.getID();
 
   // Insert the dataset, identifying by iov
-  cout << "*********about to insert peds *********" << endl;
-  cout << " map size = " << pedset.size() << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*********about to insert peds *********";
+  edm::LogVerbatim("ECALTPGDBApp") << " map size = " << pedset.size();
   insertDataArraySet(&pedset, &fe_ped_info);
-  cout << "*********Done peds            *********" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*********Done peds            *********";
 
   return result;
 }
@@ -40,11 +41,11 @@ int EcalTPGDBApp::writeToConfDB_TPGLinearCoef(const map<EcalLogicID, FEConfigLin
                                               string tag) {
   int result = 0;
 
-  cout << "*********************************************" << endl;
-  cout << "**Inserting Linarization coeff in conf-OMDS**" << endl;
-  cout << "*********************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*********************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "**Inserting Linarization coeff in conf-OMDS**";
+  edm::LogVerbatim("ECALTPGDBApp") << "*********************************************";
 
-  cout << "creating fe record " << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "creating fe record ";
   FEConfigLinInfo fe_lin_info;
   fe_lin_info.setIOVId(iovId);
   fe_lin_info.setConfigTag(tag);
@@ -52,11 +53,11 @@ int EcalTPGDBApp::writeToConfDB_TPGLinearCoef(const map<EcalLogicID, FEConfigLin
   result = fe_lin_info.getID();
 
   // Insert the dataset, identifying by iov
-  cout << "*********about to insert linearization coeff *********" << endl;
-  cout << " map size = " << linset.size() << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*********about to insert linearization coeff *********";
+  edm::LogVerbatim("ECALTPGDBApp") << " map size = " << linset.size();
   insertDataArraySet(&linset, &fe_lin_info);
   insertDataArraySet(&linparamset, &fe_lin_info);
-  cout << "*********Done lineraization coeff            *********" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*********Done lineraization coeff            *********";
 
   return result;
 }
@@ -78,11 +79,11 @@ int EcalTPGDBApp::writeToConfDB_TPGMain(int ped,
                                         int ver) {
   int result = 0;
 
-  cout << "*********************************************" << endl;
-  cout << "**Inserting Main FE table in conf-OMDS     **" << endl;
-  cout << "*********************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*********************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "**Inserting Main FE table in conf-OMDS     **";
+  edm::LogVerbatim("ECALTPGDBApp") << "*********************************************";
 
-  cout << "creating fe record " << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "creating fe record ";
 
   FEConfigMainInfo fe_main;
   fe_main.setPedId(ped);
@@ -104,7 +105,7 @@ int EcalTPGDBApp::writeToConfDB_TPGMain(int ped,
   insertConfigSet(&fe_main);
   result = fe_main.getId();
 
-  cout << "*********Done Main           *********" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*********Done Main           *********";
 
   return result;
 }
@@ -116,9 +117,9 @@ void EcalTPGDBApp::readFromConfDB_TPGPedestals(int iconf_req) {
 
   // FC alternatively a config set can be retrieved by the tag and version
 
-  cout << "*****************************************" << endl;
-  cout << "test readinf fe_ped with id=" << iconf_req << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "test readinf fe_ped with id=" << iconf_req;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
 
   FEConfigPedInfo fe_ped_info;
   fe_ped_info.setId(iconf_req);
@@ -142,15 +143,15 @@ void EcalTPGDBApp::readFromConfDB_TPGPedestals(int iconf_req) {
     rd_ped.getPedMeanG1();
   }
 
-  cout << "*****************************************" << endl;
-  cout << "test read done" << iconf_req << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "test read done" << iconf_req;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
 }
 
 int EcalTPGDBApp::readFromCondDB_Pedestals(map<EcalLogicID, MonPedestalsDat>& dataset, int runNb) {
   int iovId = 0;
 
-  cout << "Retrieving run list from DB from run nb ... " << runNb << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "Retrieving run list from DB from run nb ... " << runNb;
   RunTag my_runtag;
   LocationDef my_locdef;
   RunTypeDef my_rundef;
@@ -171,25 +172,25 @@ int EcalTPGDBApp::readFromCondDB_Pedestals(map<EcalLogicID, MonPedestalsDat>& da
   mon_list.setMonRunTag(montag);
   mon_list.setRunTag(my_runtag);
 
-  std::cout << "we are in read ped from condDB and runNb is " << runNb << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "we are in read ped from condDB and runNb is " << runNb;
 
   mon_list = fetchMonRunListLastNRuns(my_runtag, montag, runNb, 10);
 
-  std::cout << "we are in read ped from condDB" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "we are in read ped from condDB";
 
   std::vector<MonRunIOV> mon_run_vec = mon_list.getRuns();
-  cout << "number of ped runs is : " << mon_run_vec.size() << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "number of ped runs is : " << mon_run_vec.size();
   int mon_runs = mon_run_vec.size();
   //int sm_num = 0;
 
   if (mon_runs > 0) {
     for (int ii = 0; ii < (int)mon_run_vec.size(); ii++)
-      cout << "here is the run number: " << mon_run_vec[ii].getRunIOV().getRunNumber() << endl;
+      edm::LogVerbatim("ECALTPGDBApp") << "here is the run number: " << mon_run_vec[ii].getRunIOV().getRunNumber();
 
     // for the first run of the list we retrieve the pedestals
     int run = 0;
-    cout << " retrieve the data for a given run" << endl;
-    cout << "here is the run number: " << mon_run_vec[run].getRunIOV().getRunNumber() << endl;
+    edm::LogVerbatim("ECALTPGDBApp") << " retrieve the data for a given run";
+    edm::LogVerbatim("ECALTPGDBApp") << "here is the run number: " << mon_run_vec[run].getRunIOV().getRunNumber();
     iovId = mon_run_vec[run].getID();
 
     fetchDataSet(&dataset, &mon_run_vec[run]);
@@ -198,9 +199,9 @@ int EcalTPGDBApp::readFromCondDB_Pedestals(map<EcalLogicID, MonPedestalsDat>& da
 }
 
 int EcalTPGDBApp::writeToConfDB_TPGSliding(const map<EcalLogicID, FEConfigSlidingDat>& sliset, int iovId, string tag) {
-  cout << "*****************************************" << endl;
-  cout << "************Inserting SLIDING************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Inserting SLIDING************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   int result = 0;
 
   FEConfigSlidingInfo fe_info;
@@ -216,9 +217,9 @@ int EcalTPGDBApp::writeToConfDB_TPGSliding(const map<EcalLogicID, FEConfigSlidin
 
   result = fe_info.getId();
 
-  cout << "*****************************************" << endl;
-  cout << "************SLI done*********************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************SLI done*********************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   return result;
 }
 
@@ -227,9 +228,9 @@ int EcalTPGDBApp::writeToConfDB_TPGLUT(const map<EcalLogicID, FEConfigLUTGroupDa
                                        const map<EcalLogicID, FEConfigLUTParamDat>& lutparamset,
                                        int iovId,
                                        string tag) {
-  cout << "*****************************************" << endl;
-  cout << "************Inserting LUT************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Inserting LUT************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   int result = 0;
 
   FEConfigLUTInfo fe_lut_info;
@@ -249,9 +250,9 @@ int EcalTPGDBApp::writeToConfDB_TPGLUT(const map<EcalLogicID, FEConfigLUTGroupDa
 
   result = fe_lut_info.getId();
 
-  cout << "*****************************************" << endl;
-  cout << "************LUT done*********************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************LUT done*********************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   return result;
 }
 
@@ -259,14 +260,14 @@ int EcalTPGDBApp::writeToConfDB_TPGWeight(const map<EcalLogicID, FEConfigWeightG
                                           const map<EcalLogicID, FEConfigWeightDat>& lutset,
                                           int ngr,
                                           string tag) {
-  cout << "*****************************************" << endl;
-  cout << "************Inserting weights************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Inserting weights************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
 
   int result = 0;
 
   FEConfigWeightInfo fe_wei_info;
-  fe_wei_info.setNumberOfGroups(ngr);  // this eventually refers to some other table
+  fe_wei_info.setNumberOfGroups(ngr);
   fe_wei_info.setConfigTag(tag);
   insertConfigSet(&fe_wei_info);
 
@@ -280,9 +281,9 @@ int EcalTPGDBApp::writeToConfDB_TPGWeight(const map<EcalLogicID, FEConfigWeightG
 
   result = fe_wei_info.getId();
 
-  cout << "*****************************************" << endl;
-  cout << "************WEIGHT done******************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************WEIGHT done******************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   return result;
 }
 
@@ -291,14 +292,14 @@ int EcalTPGDBApp::writeToConfDB_TPGWeight_doubleWeights(const map<EcalLogicID, F
                                                         const map<EcalLogicID, FEConfigOddWeightModeDat>& tpmode,
                                                         int ngr,
                                                         string tag) {
-  cout << "*****************************************" << endl;
-  cout << "************Inserting odd weights************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Inserting odd weights************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
 
   int result = 0;
 
   FEConfigOddWeightInfo fe_wei_info;
-  fe_wei_info.setNumberOfGroups(ngr);  // this eventually refers to some other table
+  fe_wei_info.setNumberOfGroups(ngr);
   fe_wei_info.setConfigTag(tag);
   insertConfigSet(&fe_wei_info);
 
@@ -314,9 +315,9 @@ int EcalTPGDBApp::writeToConfDB_TPGWeight_doubleWeights(const map<EcalLogicID, F
 
   result = fe_wei_info.getId();
 
-  cout << "*****************************************" << endl;
-  cout << "************ODD WEIGHT + TPmode done******************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************ODD WEIGHT + TPmode done******************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   return result;
 }
 
@@ -327,9 +328,9 @@ int EcalTPGDBApp::writeToConfDB_TPGFgr(const map<EcalLogicID, FEConfigFgrGroupDa
                                        const map<EcalLogicID, FEConfigFgrEEStripDat>& dataset4,
                                        int iovId,
                                        string tag) {
-  cout << "*****************************************" << endl;
-  cout << "************Inserting Fgr************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Inserting Fgr************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   int result = 0;
 
   FEConfigFgrInfo fe_fgr_info;
@@ -353,16 +354,16 @@ int EcalTPGDBApp::writeToConfDB_TPGFgr(const map<EcalLogicID, FEConfigFgrGroupDa
 
   result = fe_fgr_info.getId();
 
-  cout << "*****************************************" << endl;
-  cout << "************Fgr done*********************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Fgr done*********************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   return result;
 }
 
 int EcalTPGDBApp::writeToConfDB_Spike(const map<EcalLogicID, FEConfigSpikeDat>& spikegroupset, string tag) {
-  cout << "*****************************************" << endl;
-  cout << "************Inserting Spike************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Inserting Spike************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   int result = 0;
 
   FEConfigSpikeInfo fe_spike_info;
@@ -377,16 +378,16 @@ int EcalTPGDBApp::writeToConfDB_Spike(const map<EcalLogicID, FEConfigSpikeDat>& 
 
   result = fe_spike_info.getId();
 
-  cout << "*****************************************" << endl;
-  cout << "************Spike done*******************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Spike done*******************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   return result;
 }
 
 int EcalTPGDBApp::writeToConfDB_Delay(const map<EcalLogicID, FEConfigTimingDat>& timegroupset, string tag) {
-  cout << "*****************************************" << endl;
-  cout << "************Inserting Delays************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Inserting Delays************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   int result = 0;
 
   FEConfigTimingInfo fe_time_info;
@@ -401,28 +402,26 @@ int EcalTPGDBApp::writeToConfDB_Delay(const map<EcalLogicID, FEConfigTimingDat>&
 
   result = fe_time_info.getId();
 
-  cout << "*****************************************" << endl;
-  cout << "************Delays done******************" << endl;
-  cout << "*****************************************" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
+  edm::LogVerbatim("ECALTPGDBApp") << "************Delays done******************";
+  edm::LogVerbatim("ECALTPGDBApp") << "*****************************************";
   return result;
 }
 
 void EcalTPGDBApp::printTag(const RunTag* tag) const {
-  cout << endl;
-  cout << "=============RunTag:" << endl;
-  cout << "GeneralTag:         " << tag->getGeneralTag() << endl;
-  cout << "Location:           " << tag->getLocationDef().getLocation() << endl;
-  cout << "Run Type:           " << tag->getRunTypeDef().getRunType() << endl;
-  cout << "====================" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "=============RunTag:";
+  edm::LogVerbatim("ECALTPGDBApp") << "GeneralTag:         " << tag->getGeneralTag();
+  edm::LogVerbatim("ECALTPGDBApp") << "Location:           " << tag->getLocationDef().getLocation();
+  edm::LogVerbatim("ECALTPGDBApp") << "Run Type:           " << tag->getRunTypeDef().getRunType();
+  edm::LogVerbatim("ECALTPGDBApp") << "====================";
 }
 
 void EcalTPGDBApp::printIOV(const RunIOV* iov) const {
-  cout << endl;
-  cout << "=============RunIOV:" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "=============RunIOV:";
   RunTag tag = iov->getRunTag();
   printTag(&tag);
-  cout << "Run Number:         " << iov->getRunNumber() << endl;
-  cout << "Run Start:          " << iov->getRunStart().str() << endl;
-  cout << "Run End:            " << iov->getRunEnd().str() << endl;
-  cout << "====================" << endl;
+  edm::LogVerbatim("ECALTPGDBApp") << "Run Number:         " << iov->getRunNumber();
+  edm::LogVerbatim("ECALTPGDBApp") << "Run Start:          " << iov->getRunStart().str();
+  edm::LogVerbatim("ECALTPGDBApp") << "Run End:            " << iov->getRunEnd().str();
+  edm::LogVerbatim("ECALTPGDBApp") << "====================";
 }

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBApp.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBApp.cc
@@ -67,11 +67,13 @@ int EcalTPGDBApp::writeToConfDB_TPGMain(int ped,
                                         int fgr,
                                         int sli,
                                         int wei,
+                                        int wei2,
                                         int spi,
                                         int tim,
                                         int bxt,
                                         int btt,
                                         int bst,
+                                        int cok,
                                         string tag,
                                         int ver) {
   int result = 0;
@@ -89,11 +91,13 @@ int EcalTPGDBApp::writeToConfDB_TPGMain(int ped,
   fe_main.setFgrId(fgr);
   fe_main.setSliId(sli);
   fe_main.setWeiId(wei);
+  fe_main.setWei2Id(wei2);
   fe_main.setSpiId(spi);
   fe_main.setTimId(tim);
   fe_main.setBxtId(bxt);
   fe_main.setBttId(btt);
   fe_main.setBstId(bst);
+  fe_main.setCokeId(cok);
   fe_main.setConfigTag(tag);
   fe_main.setVersion(ver);
 
@@ -262,7 +266,7 @@ int EcalTPGDBApp::writeToConfDB_TPGWeight(const map<EcalLogicID, FEConfigWeightG
   int result = 0;
 
   FEConfigWeightInfo fe_wei_info;
-  fe_wei_info.setNumberOfGroups(5);  // this eventually refers to some other table
+  fe_wei_info.setNumberOfGroups(ngr);  // this eventually refers to some other table
   fe_wei_info.setConfigTag(tag);
   insertConfigSet(&fe_wei_info);
 
@@ -278,6 +282,40 @@ int EcalTPGDBApp::writeToConfDB_TPGWeight(const map<EcalLogicID, FEConfigWeightG
 
   cout << "*****************************************" << endl;
   cout << "************WEIGHT done******************" << endl;
+  cout << "*****************************************" << endl;
+  return result;
+}
+
+int EcalTPGDBApp::writeToConfDB_TPGWeight_doubleWeights(const map<EcalLogicID, FEConfigOddWeightGroupDat>& lutgroupset,
+                                                        const map<EcalLogicID, FEConfigOddWeightDat>& lutset,
+                                                        const map<EcalLogicID, FEConfigOddWeightModeDat>& tpmode,
+                                                        int ngr,
+                                                        string tag) {
+  cout << "*****************************************" << endl;
+  cout << "************Inserting odd weights************" << endl;
+  cout << "*****************************************" << endl;
+
+  int result = 0;
+
+  FEConfigOddWeightInfo fe_wei_info;
+  fe_wei_info.setNumberOfGroups(ngr);  // this eventually refers to some other table
+  fe_wei_info.setConfigTag(tag);
+  insertConfigSet(&fe_wei_info);
+
+  //  Tm tdb = fe_lut_info.getDBTime();
+  //tdb.dumpTm();
+
+  // Insert the dataset
+  insertDataArraySet(&lutgroupset, &fe_wei_info);
+  // Insert the dataset
+  insertDataArraySet(&lutset, &fe_wei_info);
+  // Insert the Tpmode
+  insertDataSet(&tpmode, &fe_wei_info);
+
+  result = fe_wei_info.getId();
+
+  cout << "*****************************************" << endl;
+  cout << "************ODD WEIGHT + TPmode done******************" << endl;
   cout << "*****************************************" << endl;
   return result;
 }

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBApp.h
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGDBApp.h
@@ -38,6 +38,11 @@ public:
                               const std::map<EcalLogicID, FEConfigWeightDat>& lutdat,
                               int iovId,
                               std::string tag);
+  int writeToConfDB_TPGWeight_doubleWeights(const std::map<EcalLogicID, FEConfigOddWeightGroupDat>& lutgroupset,
+                                            const std::map<EcalLogicID, FEConfigOddWeightDat>& lutset,
+                                            const std::map<EcalLogicID, FEConfigOddWeightModeDat>& tpmode,
+                                            int ngr,
+                                            std::string tag);
   int writeToConfDB_TPGFgr(const std::map<EcalLogicID, FEConfigFgrGroupDat>& lutgroup,
                            const std::map<EcalLogicID, FEConfigFgrDat>& lutdat,
                            const std::map<EcalLogicID, FEConfigFgrParamDat>& fgrparamset,
@@ -59,11 +64,13 @@ public:
                             int fgr,
                             int sli,
                             int wei,
+                            int wei2,
                             int spi,
                             int tim,
                             int bxt,
                             int btt,
                             int bst,
+                            int cok,
                             std::string tag,
                             int ver);
 

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.cc
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.cc
@@ -988,7 +988,8 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
                  << " stripInTower = " << stripInTower << " xtalInStrip = " << xtalInStrip << " CCUid = " << CCUid
                  << " VFEid = " << VFEid << " xtalInVFE = " << xtalInVFE << " xtalWithinCCUid = " << xtalWithinCCUid
                  << " ieta = " << id.ieta() << " iphi = " << id.iphi() << " xtalhashedId = " << id.hashedIndex()
-                 << " xtalNb = " << id.ic() << " ietaTT = " << towid.ieta() << " iphiTT = " << towid.iphi() << endl;
+                 << " xtalNb = " << id.ic() << " ietaTT = " << towid.ieta() << " iphiTT = " << towid.iphi()
+                 << std::endl;
 
     int TCCch = towerInTCC;
     int SLBslot = int((towerInTCC - 1) / 8.) + 1;
@@ -1056,8 +1057,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
                                      << ", mult too large! forced to mult=255, shift=0\n";
             lin.mult_[i] = 255;
             lin.shift_[i] = 0;
-          }
-          if (mult < 128) {
+          } else if (mult < 128) {
             edm::LogError("TopInfo") << "ByEtaSlice: unable to compute the parameters for SM=" << id.ism()
                                      << " xt=" << id.ic() << " " << dec << id.rawId() << " gainId=" << i
                                      << ", mult too small! forced to mult=128, shift=15\n";
@@ -1202,8 +1202,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
                                      << ", EB, gainId=" << i << ", mult too large! forced to mult=255, shift=0\n";
             lin.mult_[i] = 255;
             lin.shift_[i] = 0;
-          }
-          if (mult < 128) {
+          } else if (mult < 128) {
             edm::LogError("TopInfo") << "unable to compute the parameters for " << dec << id.rawId()
                                      << ", EB, gainId=" << i << ", mult too small! forced to mult=128, shift=15\n";
             lin.mult_[i] = 128;
@@ -1324,8 +1323,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
 
     // Creating the stripMap for EE
     bool foundStripLogic = false;
-    for (int ich = 0; ich < (int)my_StripEcalLogicId1_EE.size(); ich++) {
-      EcalLogicID stripLogicId = my_StripEcalLogicId1_EE[ich];
+    for (EcalLogicID& stripLogicId : my_StripEcalLogicId1_EE) {
       if (stripLogicId.getID1() == 600 + dccNb && stripLogicId.getID2() == CCUid && stripLogicId.getID3() == VFEid) {
         stripMapEE[stripLogicId.getLogicID()] = elId.rawId() & 0xfffffff8;
         foundStripLogic = true;
@@ -1333,8 +1331,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
       }
     }
     if (!foundStripLogic) {
-      for (int ich = 0; ich < (int)my_StripEcalLogicId2_EE.size(); ich++) {
-        EcalLogicID stripLogicId = my_StripEcalLogicId2_EE[ich];
+      for (EcalLogicID& stripLogicId : my_StripEcalLogicId2_EE) {
         if (stripLogicId.getID1() == 600 + dccNb && stripLogicId.getID2() == CCUid && stripLogicId.getID3() == VFEid) {
           stripMapEE[stripLogicId.getLogicID()] = elId.rawId() & 0xfffffff8;
           foundStripLogic = true;
@@ -1351,7 +1348,8 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
                  << " stripInTower = " << stripInTower << " xtalInStrip = " << xtalInStrip << " CCUid = " << CCUid
                  << " VFEid = " << VFEid << " xtalInVFE = " << xtalInVFE << " xtalWithinCCUid = " << xtalWithinCCUid
                  << " ix = " << id.ix() << " iy = " << id.iy() << " xtalhashedId = " << id.hashedIndex()
-                 << " xtalNb = " << id.isc() << " ietaTT = " << towid.ieta() << " iphiTT = " << towid.iphi() << endl;
+                 << " xtalNb = " << id.isc() << " ietaTT = " << towid.ieta() << " iphiTT = " << towid.iphi()
+                 << std::endl;
 
     int TCCch = stripInTower;
     int SLBslot, SLBch;
@@ -1437,8 +1435,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
                                      << ", mult too large! forced to mult=255, shift=0\n";
             lin.mult_[i] = 255;
             lin.shift_[i] = 0;
-          }
-          if (mult < 128) {
+          } else if (mult < 128) {
             edm::LogError("TopInfo") << "ByEtaSlice: unable to compute the parameters for Quadrant=" << id.iquadrant()
                                      << " xt=" << id.ic() << " " << dec << id.rawId() << " gainId=" << i
                                      << ", mult too small! forced to mult=128, shift=15\n";
@@ -1587,8 +1584,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
                                      << ", EE, gainId=" << i << ", mult too large! forced to mult=255, shift=0\n";
             lin.mult_[i] = 255;
             lin.shift_[i] = 0;
-          }
-          if (mult < 128) {
+          } else if (mult < 128) {
             edm::LogError("TopInfo") << "unable to compute the parameters for " << dec << id.rawId()
                                      << ", EE, gainId=" << i << ", mult too small! forced to mult=128, shift=15\n";
             lin.mult_[i] = 128;
@@ -1686,14 +1682,14 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
   // Evgueni interface
   ////////////////////
   std::ofstream evgueni("TPG_hardcoded.hh", std::ios::out);
-  evgueni << "void getLinParamTPG_hardcoded(int fed, int ccu, int xtal," << endl;
-  evgueni << "                        int & mult12, int & shift12, int & base12," << endl;
-  evgueni << "                        int & mult6, int & shift6, int & base6," << endl;
-  evgueni << "                        int & mult1, int & shift1, int & base1)" << endl;
-  evgueni << "{" << endl;
+  evgueni << "void getLinParamTPG_hardcoded(int fed, int ccu, int xtal," << std::endl;
+  evgueni << "                        int & mult12, int & shift12, int & base12," << std::endl;
+  evgueni << "                        int & mult6, int & shift6, int & base6," << std::endl;
+  evgueni << "                        int & mult1, int & shift1, int & base1)" << std::endl;
+  evgueni << "{" << std::endl;
   evgueni << "  mult12 = 0 ; shift12 = 0 ; base12 = 0 ; mult6 = 0 ; shift6 = 0 ; base6 = 0 ; mult1 = 0 ; shift1 = 0 ; "
              "base1 = 0 ;"
-          << endl;
+          << std::endl;
   map<vector<int>, linStruc>::const_iterator itLinMap;
   for (itLinMap = linMap.begin(); itLinMap != linMap.end(); itLinMap++) {
     vector<int> xtalInCCU = itLinMap->first;
@@ -1704,9 +1700,9 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
             << " ; base6 = " << itLinMap->second.pedestal_[1] << " ; ";
     evgueni << "  mult1 = " << itLinMap->second.mult_[2] << " ; shift1 = " << itLinMap->second.shift_[2]
             << " ; base1 = " << itLinMap->second.pedestal_[2] << " ; ";
-    evgueni << "  return ;}" << endl;
+    evgueni << "  return ;}" << std::endl;
   }
-  evgueni << "}" << endl;
+  evgueni << "}" << std::endl;
   evgueni.close();
 
   /////////////////////////////
@@ -1728,17 +1724,17 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     map<EcalLogicID, FEConfigWeightGroupDat> dataset;
 
     for (int igrp = 0; igrp < NWEIGROUPS; igrp++) {
-      if (weights[igrp].size() == 5) {
+      if (weights[igrp].size() == EcalTPGParamBuilder::NWEIGHTS) {
         if (writeToFiles_) {
           (*out_file_) << std::endl;
-          (*out_file_) << "WEIGHT " << dec << igrp << endl;
-          for (unsigned int sample = 0; sample < 5; sample++)
+          (*out_file_) << "WEIGHT " << dec << igrp << std::endl;
+          for (unsigned int sample = 0; sample < EcalTPGParamBuilder::NWEIGHTS; sample++)
             (*out_file_) << "0x" << hex << weights[igrp][sample] << " ";
           (*out_file_) << std::endl;
           (*out_file_) << std::endl;
         }
         if (writeToDB_) {
-          ss << "going to write the weights for groupe:" << igrp << "\n";
+          ss << "going to write the weights for group:" << igrp << "\n";
           FEConfigWeightGroupDat gut;
           gut.setWeightGroupId(igrp);
           //PP WARNING: weights order is reverted when stored in the DB
@@ -1766,22 +1762,22 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     }
 
     // EE loop
-    for (int ich = 0; ich < (int)my_StripEcalLogicId1_EE.size(); ich++) {
+    for (EcalLogicID& stripLogicId : my_StripEcalLogicId1_EE) {
       FEConfigWeightDat wut;
       int igroup = 1;  // this group is for EE
-      weights_map_even[stripMapEE[my_StripEcalLogicId1_EE[ich].getLogicID()]] = 1;
+      weights_map_even[stripMapEE[stripLogicId.getLogicID()]] = 1;
       wut.setWeightGroupId(igroup);
       // Fill the dataset
-      dataset2[my_StripEcalLogicId1_EE[ich]] = wut;
+      dataset2[stripLogicId] = wut;
     }
     // EE loop 2 (we had to split the ids of EE in 2 vectors to avoid crash!)
-    for (int ich = 0; ich < (int)my_StripEcalLogicId2_EE.size(); ich++) {
+    for (EcalLogicID& stripLogicId : my_StripEcalLogicId2_EE) {
       FEConfigWeightDat wut;
       int igroup = 1;  // this group is for EE
-      weights_map_even[stripMapEE[my_StripEcalLogicId2_EE[ich].getLogicID()]] = 1;
+      weights_map_even[stripMapEE[stripLogicId.getLogicID()]] = 1;
       wut.setWeightGroupId(igroup);
       // Fill the dataset
-      dataset2[my_StripEcalLogicId2_EE[ich]] = wut;
+      dataset2[stripLogicId] = wut;
     }
 
     if (writeToDB_) {
@@ -1828,17 +1824,17 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     map<EcalLogicID, FEConfigWeightGroupDat> dataset_even;
 
     for (int igrp = 0; igrp < nweigroups_even; igrp++) {
-      if (weights_even[igrp].size() == 5) {
+      if (weights_even[igrp].size() == EcalTPGParamBuilder::NWEIGHTS) {
         if (writeToFiles_) {
           (*out_file_) << std::endl;
-          (*out_file_) << "WEIGHT " << dec << igrp << endl;
-          for (unsigned int sample = 0; sample < 5; sample++)
+          (*out_file_) << "WEIGHT " << dec << igrp << std::endl;
+          for (unsigned int sample = 0; sample < EcalTPGParamBuilder::NWEIGHTS; sample++)
             (*out_file_) << "0x" << hex << weights_even[igrp][sample] << " ";
           (*out_file_) << std::endl;
           (*out_file_) << std::endl;
         }
         if (writeToDB_) {
-          ss << "going to write the weights for groupe:" << igrp << "\n";
+          ss << "going to write the weights for group:" << igrp << "\n";
           FEConfigWeightGroupDat gut;
           gut.setWeightGroupId(igrp);
           //PP WARNING: weights order is reverted when stored in the DB
@@ -1865,20 +1861,20 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
         dataset_even_idmap[my_StripEcalLogicId[ich]] = wut;
       }
       // EE loop
-      for (int ich = 0; ich < (int)my_StripEcalLogicId1_EE.size(); ich++) {
+      for (EcalLogicID& stripLogicId : my_StripEcalLogicId1_EE) {
         FEConfigWeightDat wut;
-        int igroup = weights_map_even[stripMapEE[my_StripEcalLogicId1_EE[ich].getLogicID()]];
+        int igroup = weights_map_even[stripMapEE[stripLogicId.getLogicID()]];
         wut.setWeightGroupId(igroup);
         // Fill the dataset
-        dataset_even_idmap[my_StripEcalLogicId1_EE[ich]] = wut;
+        dataset_even_idmap[stripLogicId] = wut;
       }
       // EE loop 2 (we had to split the ids of EE in 2 vectors to avoid crash!)
-      for (int ich = 0; ich < (int)my_StripEcalLogicId2_EE.size(); ich++) {
+      for (EcalLogicID& stripLogicId : my_StripEcalLogicId2_EE) {
         FEConfigWeightDat wut;
-        int igroup = weights_map_even[stripMapEE[my_StripEcalLogicId2_EE[ich].getLogicID()]];  // this group is for EE
+        int igroup = weights_map_even[stripMapEE[stripLogicId.getLogicID()]];  // this group is for EE
         wut.setWeightGroupId(igroup);
         // Fill the dataset
-        dataset_even_idmap[my_StripEcalLogicId2_EE[ich]] = wut;
+        dataset_even_idmap[stripLogicId] = wut;
       }
       // Insert the datasets
       ostringstream wtag;
@@ -1924,17 +1920,17 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     map<EcalLogicID, FEConfigOddWeightGroupDat> dataset_odd;
 
     for (int igrp = 0; igrp < nweigroups_odd; igrp++) {
-      if (weights_odd[igrp].size() == 5) {
+      if (weights_odd[igrp].size() == EcalTPGParamBuilder::NWEIGHTS) {
         if (writeToFiles_) {
           (*out_file_) << std::endl;
-          (*out_file_) << "WEIGHT_ODD " << dec << igrp << endl;
-          for (unsigned int sample = 0; sample < 5; sample++)
+          (*out_file_) << "WEIGHT_ODD " << dec << igrp << std::endl;
+          for (unsigned int sample = 0; sample < EcalTPGParamBuilder::NWEIGHTS; sample++)
             (*out_file_) << "0x" << hex << weights_odd[igrp][sample] << " ";
           (*out_file_) << std::endl;
           (*out_file_) << std::endl;
         }
         if (writeToDB_) {
-          ss << "going to write the weights for groupe:" << igrp << "\n";
+          ss << "going to write the weights for group:" << igrp << "\n";
           FEConfigOddWeightGroupDat gut;
           gut.setWeightGroupId(igrp);
           //PP WARNING: weights order is reverted when stored in the DB
@@ -1953,25 +1949,25 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     // TP MODE configuration
     if (writeToFiles_) {
       (*out_file_) << std::endl;
-      (*out_file_) << "TP_MODE " << endl;
-      (*out_file_) << TPmode_EnableEBOddFilter_ << endl;
-      (*out_file_) << TPmode_EnableEEOddFilter_ << endl;
-      (*out_file_) << TPmode_EnableEBOddPeakFinder_ << endl;
-      (*out_file_) << TPmode_EnableEEOddPeakFinder_ << endl;
-      (*out_file_) << TPmode_DisableEBEvenPeakFinder_ << endl;
-      (*out_file_) << TPmode_DisableEEEvenPeakFinder_ << endl;
-      (*out_file_) << TPmode_FenixEBStripOutput_ << endl;
-      (*out_file_) << TPmode_FenixEEStripOutput_ << endl;
-      (*out_file_) << TPmode_FenixEBStripInfobit2_ << endl;
-      (*out_file_) << TPmode_FenixEEStripInfobit2_ << endl;
-      (*out_file_) << TPmode_FenixEBTcpOutput_ << endl;
-      (*out_file_) << TPmode_FenixEBTcpInfobit1_ << endl;
-      (*out_file_) << TPmode_FenixEETcpOutput_ << endl;
-      (*out_file_) << TPmode_FenixEETcpInfobit1_ << endl;
-      (*out_file_) << 0 << endl;  // FenixPar15-18 are placeholder parameters for future use
-      (*out_file_) << 0 << endl;
-      (*out_file_) << 0 << endl;
-      (*out_file_) << 0 << endl;
+      (*out_file_) << "TP_MODE " << std::endl;
+      (*out_file_) << TPmode_EnableEBOddFilter_ << std::endl;
+      (*out_file_) << TPmode_EnableEEOddFilter_ << std::endl;
+      (*out_file_) << TPmode_EnableEBOddPeakFinder_ << std::endl;
+      (*out_file_) << TPmode_EnableEEOddPeakFinder_ << std::endl;
+      (*out_file_) << TPmode_DisableEBEvenPeakFinder_ << std::endl;
+      (*out_file_) << TPmode_DisableEEEvenPeakFinder_ << std::endl;
+      (*out_file_) << TPmode_FenixEBStripOutput_ << std::endl;
+      (*out_file_) << TPmode_FenixEEStripOutput_ << std::endl;
+      (*out_file_) << TPmode_FenixEBStripInfobit2_ << std::endl;
+      (*out_file_) << TPmode_FenixEEStripInfobit2_ << std::endl;
+      (*out_file_) << TPmode_FenixEBTcpOutput_ << std::endl;
+      (*out_file_) << TPmode_FenixEBTcpInfobit1_ << std::endl;
+      (*out_file_) << TPmode_FenixEETcpOutput_ << std::endl;
+      (*out_file_) << TPmode_FenixEETcpInfobit1_ << std::endl;
+      (*out_file_) << 0 << std::endl;  // FenixPar15-18 are placeholder parameters for future use
+      (*out_file_) << 0 << std::endl;
+      (*out_file_) << 0 << std::endl;
+      (*out_file_) << 0 << std::endl;
       (*out_file_) << std::endl;
     }
 
@@ -1987,20 +1983,20 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
         dataset_odd_idmap[my_StripEcalLogicId[ich]] = wut;
       }
       // EE loop
-      for (int ich = 0; ich < (int)my_StripEcalLogicId1_EE.size(); ich++) {
+      for (auto& stripLogicId : my_StripEcalLogicId1_EE) {
         FEConfigOddWeightDat wut;
-        int igroup = weights_map_odd[stripMapEE[my_StripEcalLogicId1_EE[ich].getLogicID()]];
+        int igroup = weights_map_odd[stripMapEE[stripLogicId.getLogicID()]];
         wut.setWeightGroupId(igroup);
         // Fill the dataset
-        dataset_odd_idmap[my_StripEcalLogicId1_EE[ich]] = wut;
+        dataset_odd_idmap[stripLogicId] = wut;
       }
       // EE loop 2 (we had to split the ids of EE in 2 vectors to avoid crash!)
-      for (int ich = 0; ich < (int)my_StripEcalLogicId2_EE.size(); ich++) {
+      for (auto& stripLogicId : my_StripEcalLogicId2_EE) {
         FEConfigOddWeightDat wut;
-        int igroup = weights_map_odd[stripMapEE[my_StripEcalLogicId2_EE[ich].getLogicID()]];  // this group is for EE
+        int igroup = weights_map_odd[stripMapEE[stripLogicId.getLogicID()]];  // this group is for EE
         wut.setWeightGroupId(igroup);
         // Fill the dataset
-        dataset_odd_idmap[my_StripEcalLogicId2_EE[ich]] = wut;
+        dataset_odd_idmap[stripLogicId] = wut;
       }
       // TP mode on DB
       map<EcalLogicID, FEConfigOddWeightModeDat> dataset_tpmode;
@@ -2037,16 +2033,16 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     // wei2_conf_id=1 and save a blank TP mode and blank Odd weight group
     if (writeToFiles_) {
       // single set of ODD weights ==0 is written to the txt file
-      (*out_file_) << "WEIGHT_ODD " << dec << 0 << endl;
-      for (unsigned int sample = 0; sample < 5; sample++)
+      (*out_file_) << "WEIGHT_ODD " << dec << 0 << std::endl;
+      for (unsigned int sample = 0; sample < EcalTPGParamBuilder::NWEIGHTS; sample++)
         (*out_file_) << "0x0"
                      << " ";
       (*out_file_) << std::endl << std::endl;
 
       // Default TP mode with Run2 config == all parameters to 0
-      (*out_file_) << "TP_MODE " << endl;
+      (*out_file_) << "TP_MODE " << std::endl;
       for (int m = 0; m < 18; m++)
-        (*out_file_) << 0 << endl;
+        (*out_file_) << 0 << std::endl;
       (*out_file_) << std::endl;
     }
     wei2_conf_id_ = 1;  // special value that is interpreted by online DAQ code as Run2 configuration
@@ -2097,19 +2093,17 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
 
     // now we store in the DB the correspondence btw channels and groups
     map<EcalLogicID, FEConfigFgrDat> dataset2;
-    // in this case I decide in a stupid way which channel belongs to which group
-    for (int ich = 0; ich < (int)my_TTEcalLogicId.size(); ich++) {
+    for (auto& id : my_TTEcalLogicId) {
       FEConfigFgrDat wut;
       int igroup = 0;
       wut.setFgrGroupId(igroup);
       // Fill the dataset
       // the logic ids are ordered by SM (1,...36) and TT (1,...68)
-      // you have to calculate the right index here
-      dataset2[my_TTEcalLogicId[ich]] = wut;
+      dataset2[id] = wut;
     }
 
     // endcap loop
-    for (int ich = 0; ich < (int)my_RTEcalLogicId_EE.size(); ich++) {
+    for (auto& id : my_RTEcalLogicId_EE) {
       //	std::cout << " endcap FGR " << std::endl;
       FEConfigFgrDat wut;
       int igroup = 0;
@@ -2117,32 +2111,32 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
       // Fill the dataset
       // the logic ids are ordered by .... ?
       // you have to calculate the right index here
-      dataset2[my_RTEcalLogicId_EE[ich]] = wut;
+      dataset2[id] = wut;
     }
 
     // endcap TT loop for the FEfgr EE Tower
     map<EcalLogicID, FEConfigFgrEETowerDat> dataset3;
-    for (int ich = 0; ich < (int)my_TTEcalLogicId_EE.size(); ich++) {
+    for (auto& id : my_TTEcalLogicId_EE) {
       FEConfigFgrEETowerDat fgreett;
       fgreett.setLutValue(lut_tower);
-      dataset3[my_TTEcalLogicId_EE[ich]] = fgreett;
+      dataset3[id] = fgreett;
     }
 
     // endcap strip loop for the FEfgr EE strip
     // and barrel strip loop for the spike parameters (same structure than EE FGr)
     map<EcalLogicID, FEConfigFgrEEStripDat> dataset4;
-    for (int ich = 0; ich < (int)my_StripEcalLogicId1_EE.size(); ich++) {
+    for (auto& id : my_StripEcalLogicId1_EE) {
       FEConfigFgrEEStripDat zut;
       zut.setThreshold(threshold);
       zut.setLutFgr(lut_strip);
-      dataset4[my_StripEcalLogicId1_EE[ich]] = zut;
+      dataset4[id] = zut;
     }
-    for (int ich = 0; ich < (int)my_StripEcalLogicId2_EE.size(); ich++) {
+    for (auto& id : my_StripEcalLogicId2_EE) {
       FEConfigFgrEEStripDat zut;
       zut.setThreshold(threshold);
       zut.setLutFgr(lut_strip);
       // Fill the dataset
-      dataset4[my_StripEcalLogicId2_EE[ich]] = zut;
+      dataset4[id] = zut;
     }
     for (int ich = 0; ich < (int)my_StripEcalLogicId.size(); ich++) {
       // EB
@@ -2175,10 +2169,10 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
 
     //modif-alex 21/01/11
     map<EcalLogicID, FEConfigSpikeDat> datasetspike;  //loob EB TT
-    for (int ich = 0; ich < (int)my_TTEcalLogicId.size(); ich++) {
+    for (auto& id : my_TTEcalLogicId) {
       FEConfigSpikeDat spiketh;
       spiketh.setSpikeThreshold(SFGVB_SpikeKillingThreshold_);
-      datasetspike[my_TTEcalLogicId[ich]] = spiketh;
+      datasetspike[id] = spiketh;
     }  //loop EB TT towers
 
     //modif-alex 21/01/11
@@ -2198,8 +2192,8 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
       FEConfigTimingDat delay;
 
       EcalLogicID logiciddelay = my_TTEcalLogicId_EB_by_TCC[ich];
-      int id1_tcc = my_TTEcalLogicId_EB_by_TCC[ich].getID1();  // the TCC
-      int id2_tt = my_TTEcalLogicId_EB_by_TCC[ich].getID2();   // the tower
+      int id1_tcc = logiciddelay.getID1();  // the TCC
+      int id2_tt = logiciddelay.getID2();   // the tower
       std::map<int, vector<int>>::const_iterator ittEB = delays_EB_.find(id1_tcc);
       std::vector<int> TimingDelaysEB = ittEB->second;
 
@@ -2241,7 +2235,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
 
       //delay.setTimingPar1(1);
       //delay.setTimingPar2(2);
-      datasetdelay[my_TTEcalLogicId_EB_by_TCC[ich]] = delay;
+      datasetdelay[logiciddelay] = delay;
     }  //loop EB TT towers
 
     //DELAYS EE
@@ -2249,14 +2243,11 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     int tccin = 1;
     for (int ich = 0; ich < (int)my_StripEcalLogicId_EE_strips_by_TCC.size(); ich++) {
       FEConfigTimingDat delay;
-      //int id1_strip=my_StripEcalLogicId_EE_strips_by_TCC[ich].getID1(); // the TCC
-      //int id2_strip=my_StripEcalLogicId_EE_strips_by_TCC[ich].getID2(); // the Tower
-      //int id3_strip=my_StripEcalLogicId_EE_strips_by_TCC[ich].getID3(); // the strip
 
       EcalLogicID logiciddelay = my_StripEcalLogicId_EE_strips_by_TCC[ich];
-      int id1_tcc = my_StripEcalLogicId_EE_strips_by_TCC[ich].getID1();  // the TCC
-      int id2_tt = my_StripEcalLogicId_EE_strips_by_TCC[ich].getID2();   // the tower
-      int id3_st = my_StripEcalLogicId_EE_strips_by_TCC[ich].getID3();   // the strip
+      int id1_tcc = logiciddelay.getID1();  // the TCC
+      int id2_tt = logiciddelay.getID2();   // the tower
+      int id3_st = logiciddelay.getID3();   // the strip
 
       //reset strip counter
       if (id1_tcc != tccin) {
@@ -2306,7 +2297,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
 
       //delay.setTimingPar1(1);
       //delay.setTimingPar2(2);
-      datasetdelay[my_StripEcalLogicId_EE_strips_by_TCC[ich]] = delay;
+      datasetdelay[logiciddelay] = delay;
       stripindex++;
     }  //loop EE strip towers
 
@@ -2324,32 +2315,24 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     ss << "going to write the sliding "
        << "\n";
     map<EcalLogicID, FEConfigSlidingDat> dataset;
-    // in this case I decide in a stupid way which channel belongs to which group
-    for (int ich = 0; ich < (int)my_StripEcalLogicId.size(); ich++) {
+    for (auto& id : my_StripEcalLogicId) {
       FEConfigSlidingDat wut;
       wut.setSliding(sliding_);
       // Fill the dataset
       // the logic ids are ordered by SM (1,...36) , TT (1,...68) and strip (1..5)
-      // you have to calculate the right index here
-      dataset[my_StripEcalLogicId[ich]] = wut;
+      dataset[id] = wut;
     }
 
     // endcap loop
-    for (int ich = 0; ich < (int)my_StripEcalLogicId1_EE.size(); ich++) {
+    for (auto& id : my_StripEcalLogicId1_EE) {
       FEConfigSlidingDat wut;
       wut.setSliding(sliding_);
-      // Fill the dataset
-      // the logic ids are ordered by fed tower strip
-      // you have to calculate the right index here
-      dataset[my_StripEcalLogicId1_EE[ich]] = wut;
+      dataset[id] = wut;
     }
-    for (int ich = 0; ich < (int)my_StripEcalLogicId2_EE.size(); ich++) {
+    for (auto& id : my_StripEcalLogicId2_EE) {
       FEConfigSlidingDat wut;
       wut.setSliding(sliding_);
-      // Fill the dataset
-      // the logic ids are ordered by ... ?
-      // you have to calculate the right index here
-      dataset[my_StripEcalLogicId2_EE[ich]] = wut;
+      dataset[id] = wut;
     }
 
     // Insert the dataset
@@ -2375,8 +2358,8 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     (*out_file_) << std::endl;
     (*out_file_) << "LUT 0" << std::endl;
     for (int i = 0; i < 1024; i++)
-      (*out_file_) << "0x" << hex << lut_EB[i] << endl;
-    (*out_file_) << endl;
+      (*out_file_) << "0x" << hex << lut_EB[i] << std::endl;
+    (*out_file_) << std::endl;
   }
 
   // endcap
@@ -2390,8 +2373,8 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     (*out_file_) << std::endl;
     (*out_file_) << "LUT 1" << std::endl;
     for (int i = 0; i < 1024; i++)
-      (*out_file_) << "0x" << hex << lut_EE[i] << endl;
-    (*out_file_) << endl;
+      (*out_file_) << "0x" << hex << lut_EE[i] << std::endl;
+    (*out_file_) << std::endl;
   }
 
   if (writeToDB_) {
@@ -2426,23 +2409,23 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
     // now we store in the DB the correspondence btw channels and LUT groups
     map<EcalLogicID, FEConfigLUTDat> dataset2;
     // in this case I decide in a stupid way which channel belongs to which group
-    for (int ich = 0; ich < (int)my_TTEcalLogicId.size(); ich++) {
+    for (auto& id : my_TTEcalLogicId) {
       FEConfigLUTDat lut;
       int igroup = 0;
       lut.setLUTGroupId(igroup);
       // calculate the right TT - in the vector they are ordered by SM and by TT
       // Fill the dataset
-      dataset2[my_TTEcalLogicId[ich]] = lut;
+      dataset2[id] = lut;
     }
 
     // endcap loop
-    for (int ich = 0; ich < (int)my_TTEcalLogicId_EE.size(); ich++) {
+    for (auto& id : my_TTEcalLogicId_EE) {
       FEConfigLUTDat lut;
       int igroup = 1;
       lut.setLUTGroupId(igroup);
       // calculate the right TT
       // Fill the dataset
-      dataset2[my_TTEcalLogicId_EE[ich]] = lut;
+      dataset2[id] = lut;
     }
 
     // Insert the dataset
@@ -2489,7 +2472,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
   if (writeToFiles_) {
     (*out_file_) << std::endl;
     for (itList = stripListEB.begin(); itList != stripListEB.end(); itList++) {
-      (*out_file_) << "STRIP_EB " << dec << (*itList) << endl;
+      (*out_file_) << "STRIP_EB " << dec << (*itList) << std::endl;
       (*out_file_) << hex << "0x" << sliding_ << std::endl;
       (*out_file_) << hex << "0x" << weights_map_even[(*itList)] << " ";
       if (weight_useDoubleWeights_)
@@ -2507,7 +2490,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
   if (writeToFiles_) {
     (*out_file_) << std::endl;
     for (itList = stripListEE.begin(); itList != stripListEE.end(); itList++) {
-      (*out_file_) << "STRIP_EE " << dec << (*itList) << endl;
+      (*out_file_) << "STRIP_EE " << dec << (*itList) << std::endl;
       (*out_file_) << hex << "0x" << sliding_ << std::endl;
       (*out_file_) << hex << "0x" << weights_map_even[(*itList)] << " ";
       if (weight_useDoubleWeights_)
@@ -2531,7 +2514,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
   if (writeToFiles_) {
     (*out_file_) << std::endl;
     for (itList = towerListEB.begin(); itList != towerListEB.end(); itList++) {
-      (*out_file_) << "TOWER_EB " << dec << (*itList) << endl;
+      (*out_file_) << "TOWER_EB " << dec << (*itList) << std::endl;
       (*out_file_) << " 0\n 0\n";
       (*out_file_) << " " << SFGVB_SpikeKillingThreshold_ << std::endl;  //modif-alex
     }
@@ -2544,7 +2527,7 @@ void EcalTPGParamBuilder::analyze(const edm::Event& evt, const edm::EventSetup& 
   if (writeToFiles_) {
     (*out_file_) << std::endl;
     for (itList = towerListEE.begin(); itList != towerListEE.end(); itList++) {
-      (*out_file_) << "TOWER_EE " << dec << (*itList) << endl;
+      (*out_file_) << "TOWER_EE " << dec << (*itList) << std::endl;
       if (newLUT)
         (*out_file_) << " 1\n";
       else
@@ -2731,24 +2714,24 @@ void EcalTPGParamBuilder::create_header() {
 
   (*out_file_) << "COMMENT =================================" << std::endl;
   (*out_file_) << "COMMENT           TP mode" << std::endl;
-  (*out_file_) << "COMMENT EnableEBOddFilter" << endl;
-  (*out_file_) << "COMMENT EnableEEOddFilter" << endl;
-  (*out_file_) << "COMMENT EnableEBOddPeakFinder" << endl;
-  (*out_file_) << "COMMENT EnableEEOddPeakFinder" << endl;
-  (*out_file_) << "COMMENT DisableEBEvenPeakFinder" << endl;
-  (*out_file_) << "COMMENT DisableEEEvenPeakFinder" << endl;
-  (*out_file_) << "COMMENT FenixEBStripOutput" << endl;
-  (*out_file_) << "COMMENT FenixEEStripOutput" << endl;
-  (*out_file_) << "COMMENT FenixEBStripInfobit2" << endl;
-  (*out_file_) << "COMMENT FenixEEStripInfobit2" << endl;
-  (*out_file_) << "COMMENT EBFenixTcpOutput" << endl;
-  (*out_file_) << "COMMENT EBFenixTcpInfobit1" << endl;
-  (*out_file_) << "COMMENT EEFenixTcpOutput" << endl;
-  (*out_file_) << "COMMENT EEFenixTcpInfobit1" << endl;
-  (*out_file_) << "COMMENT FenixPar15" << endl;
-  (*out_file_) << "COMMENT FenixPar16" << endl;
-  (*out_file_) << "COMMENT FenixPar17" << endl;
-  (*out_file_) << "COMMENT FenixPar18" << endl;
+  (*out_file_) << "COMMENT EnableEBOddFilter" << std::endl;
+  (*out_file_) << "COMMENT EnableEEOddFilter" << std::endl;
+  (*out_file_) << "COMMENT EnableEBOddPeakFinder" << std::endl;
+  (*out_file_) << "COMMENT EnableEEOddPeakFinder" << std::endl;
+  (*out_file_) << "COMMENT DisableEBEvenPeakFinder" << std::endl;
+  (*out_file_) << "COMMENT DisableEEEvenPeakFinder" << std::endl;
+  (*out_file_) << "COMMENT FenixEBStripOutput" << std::endl;
+  (*out_file_) << "COMMENT FenixEEStripOutput" << std::endl;
+  (*out_file_) << "COMMENT FenixEBStripInfobit2" << std::endl;
+  (*out_file_) << "COMMENT FenixEEStripInfobit2" << std::endl;
+  (*out_file_) << "COMMENT EBFenixTcpOutput" << std::endl;
+  (*out_file_) << "COMMENT EBFenixTcpInfobit1" << std::endl;
+  (*out_file_) << "COMMENT EEFenixTcpOutput" << std::endl;
+  (*out_file_) << "COMMENT EEFenixTcpInfobit1" << std::endl;
+  (*out_file_) << "COMMENT FenixPar15" << std::endl;
+  (*out_file_) << "COMMENT FenixPar16" << std::endl;
+  (*out_file_) << "COMMENT FenixPar17" << std::endl;
+  (*out_file_) << "COMMENT FenixPar18" << std::endl;
   (*out_file_) << "COMMENT =================================" << std::endl;
   (*out_file_) << "COMMENT" << std::endl;
 

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.h
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.h
@@ -134,6 +134,7 @@ private:
   std::string weight_even_weightGroupFile_;
   std::string weight_odd_idMapFile_;
   std::string weight_odd_weightGroupFile_;
+  static constexpr uint NWEIGHTS = 5;  // It can be up to 6, but in Run 1,2,3 only 5 weights have been used
 
   bool weight_useDoubleWeights_;
   bool TPmode_EnableEBOddFilter_;

--- a/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.h
+++ b/CalibCalorimetry/EcalTPGTools/plugins/EcalTPGParamBuilder.h
@@ -100,7 +100,7 @@ private:
   void computeFineGrainEBParameters(uint& lowRatio, uint& highRatio, uint& lowThreshold, uint& highThreshold, uint& lut);
   void computeFineGrainEEParameters(uint& threshold, uint& lut_strip, uint& lut_tower);
   int getEtaSlice(int tccId, int towerInTCC);
-  bool realignBaseline(linStruc& lin, float forceBase12);
+  bool realignBaseline(linStruc& lin, float forceBase12, int cmsswid);
   int getGCTRegionPhi(int ttphi);
   int getGCTRegionEta(int tteta);
   std::string getDet(int tcc);
@@ -129,6 +129,28 @@ private:
   unsigned int sampleMax_;
   double weight_timeShift_;
   bool weight_unbias_recovery_;
+  bool weight_even_computeFromShape_;
+  std::string weight_even_idMapFile_;
+  std::string weight_even_weightGroupFile_;
+  std::string weight_odd_idMapFile_;
+  std::string weight_odd_weightGroupFile_;
+
+  bool weight_useDoubleWeights_;
+  bool TPmode_EnableEBOddFilter_;
+  bool TPmode_EnableEEOddFilter_;
+  bool TPmode_EnableEBOddPeakFinder_;
+  bool TPmode_EnableEEOddPeakFinder_;
+  bool TPmode_DisableEBEvenPeakFinder_;
+  bool TPmode_DisableEEEvenPeakFinder_;
+  unsigned int TPmode_FenixEBStripOutput_;
+  unsigned int TPmode_FenixEEStripOutput_;
+  unsigned int TPmode_FenixEBStripInfobit2_;
+  unsigned int TPmode_FenixEEStripInfobit2_;
+  unsigned int TPmode_FenixEBTcpOutput_;
+  unsigned int TPmode_FenixEBTcpInfobit1_;
+  unsigned int TPmode_FenixEETcpOutput_;
+  unsigned int TPmode_FenixEETcpInfobit1_;
+
   unsigned int nSample_;
   unsigned int complement2_;
   std::string LUT_option_;
@@ -181,17 +203,20 @@ private:
   int fgr_conf_id_;
   int sli_conf_id_;
   int wei_conf_id_;
+  int wei2_conf_id_;
   int spi_conf_id_;  //modif-alex 21/01.11
   int del_conf_id_;  //modif-alex 21/01.11
   int bxt_conf_id_;
   int btt_conf_id_;
   int bst_conf_id_;
+  int coke_conf_id_;
   std::string tag_;
   int version_;
   int m_write_ped;
   int m_write_lin;
   int m_write_lut;
   int m_write_wei;
+  int m_write_wei2;
   int m_write_fgr;
   int m_write_sli;
   int m_write_spi;  //modif-alex 21/01/11

--- a/CalibCalorimetry/EcalTPGTools/test/fillOfflineTPGDBfromFile_beamv7.py
+++ b/CalibCalorimetry/EcalTPGTools/test/fillOfflineTPGDBfromFile_beamv7.py
@@ -1,0 +1,192 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.MessageLogger = cms.Service("MessageLogger",
+    debugModules = cms.untracked.vstring('*'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    destinations = cms.untracked.vstring('cout')
+)
+
+process.source = cms.Source("EmptyIOVSource",
+    lastValue = cms.uint64(1),
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+process.load("SimCalorimetry.EcalTrigPrimProducers.ecalTrigPrimESProducer_cff")
+process.tpparams12 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGPhysicsConstRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+process.EcalTrigPrimESProducer.DatabaseFile = 'TPG_beamv7.txt.gz'
+
+from CondCore.CondDB.CondDB_cfi import CondDB
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+     CondDB.clone(connect = cms.string("sqlite_file:TPG_beamv7.db")),
+     timetype = cms.untracked.string("runnumber"),
+     toPut = cms.VPSet(cms.PSet(
+        record = cms.string('EcalTPGPedestalsRcd'),
+        tag = cms.string('EcalTPGPedestals_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGLinearizationConstRcd'),
+            tag = cms.string('EcalTPGLinearizationConst_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGSlidingWindowRcd'),
+            tag = cms.string('EcalTPGSlidingWindow_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGFineGrainEBIdMapRcd'),
+            tag = cms.string('EcalTPGFineGrainEBIdMap_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGFineGrainStripEERcd'),
+            tag = cms.string('EcalTPGFineGrainStripEE_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGFineGrainTowerEERcd'),
+            tag = cms.string('EcalTPGFineGrainTowerEE_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGLutIdMapRcd'),
+            tag = cms.string('EcalTPGLutIdMap_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGWeightIdMapRcd'),
+            tag = cms.string('EcalTPGWeightIdMap_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGWeightGroupRcd'),
+            tag = cms.string('EcalTPGWeightGroup_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGOddWeightIdMapRcd'),
+            tag = cms.string('EcalTPGOddWeightIdMap_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGOddWeightGroupRcd'),
+            tag = cms.string('EcalTPGOddWeightGroup_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGTPModeRcd'),
+            tag = cms.string('EcalTPGTPMode_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGLutGroupRcd'),
+            tag = cms.string('EcalTPGLutGroup_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGFineGrainEBGroupRcd'),
+            tag = cms.string('EcalTPGFineGrainEBGroup_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGPhysicsConstRcd'),
+            tag = cms.string('EcalTPGPhysicsConst_beamv7')
+        ),
+	cms.PSet(
+            record = cms.string('EcalTPGSpikeRcd'),
+            tag = cms.string('EcalTPGSpike_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGCrystalStatusRcd'),
+            tag = cms.string('EcalTPGCrystalStatus_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGTowerStatusRcd'),
+            tag = cms.string('EcalTPGTowerStatus_beamv7')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGStripStatusRcd'),
+            tag = cms.string('EcalTPGStripStatus_beamv7')
+        ))
+)
+
+process.dbCopy = cms.EDAnalyzer("EcalTPGDBCopy",
+    timetype = cms.string('runnumber'),
+    toCopy = cms.VPSet(cms.PSet(
+        record = cms.string('EcalTPGPedestalsRcd'),
+        container = cms.string('EcalTPGPedestals')
+    ),
+        cms.PSet(
+            record = cms.string('EcalTPGLinearizationConstRcd'),
+            container = cms.string('EcalTPGLinearizationConst')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGSlidingWindowRcd'),
+            container = cms.string('EcalTPGSlidingWindow')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGFineGrainEBIdMapRcd'),
+            container = cms.string('EcalTPGFineGrainEBIdMap')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGFineGrainStripEERcd'),
+            container = cms.string('EcalTPGFineGrainStripEE')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGFineGrainTowerEERcd'),
+            container = cms.string('EcalTPGFineGrainTowerEE')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGLutIdMapRcd'),
+            container = cms.string('EcalTPGLutIdMap')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGWeightIdMapRcd'),
+            container = cms.string('EcalTPGWeightIdMap')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGWeightGroupRcd'),
+            container = cms.string('EcalTPGWeightGroup')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGOddWeightIdMapRcd'),
+            container = cms.string('EcalTPGOddWeightIdMap')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGOddWeightGroupRcd'),
+            container = cms.string('EcalTPGOddWeightGroup')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGTPModeRcd'),
+            container = cms.string('EcalTPGTPMode')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGLutGroupRcd'),
+            container = cms.string('EcalTPGLutGroup')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGFineGrainEBGroupRcd'),
+            container = cms.string('EcalTPGFineGrainEBGroup')
+        ),
+        cms.PSet(
+            record = cms.string('EcalTPGPhysicsConstRcd'),
+            container = cms.string('EcalTPGPhysicsConst')
+        ),
+	cms.PSet(
+            record = cms.string('EcalTPGSpikeRcd'),
+            container = cms.string('EcalTPGSpike')
+        ),
+	cms.PSet(
+            record = cms.string('EcalTPGCrystalStatusRcd'),
+            container = cms.string('EcalTPGCrystalStatus')
+        ),
+	cms.PSet(
+            record = cms.string('EcalTPGTowerStatusRcd'),
+            container = cms.string('EcalTPGTowerStatus')
+        ),
+	cms.PSet(
+            record = cms.string('EcalTPGStripStatusRcd'),
+            container = cms.string('EcalTPGStripStatus')
+        ))
+)
+
+process.p = cms.Path(process.dbCopy)

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv7.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv7.py
@@ -1,16 +1,32 @@
 import FWCore.ParameterSet.Config as cms
 import CondTools.Ecal.db_credentials as auth
+import FWCore.ParameterSet.VarParsing as VarParsing
 
 process = cms.Process("ProdTPGParam")
+options = VarParsing.VarParsing('tpg')
+
+options.register ('writeToDB',
+                  0, # default value
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.int,         
+                  "Write conditions to DB")
+options.register ('outFile',
+                  'TPG_beamv7_trans_rrrrrr_spikekill_2021.txt', 
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.string,         
+                  "Output file")
+options.register ('transparency',
+                  'TRANSPARENCY_2018/hourly_rrrrrr', 
+                  VarParsing.VarParsing.multiplicity.singleton, 
+                  VarParsing.VarParsing.varType.string,         
+                  "Transparency conditions file")
+
+options.parseArguments()
 
 # Calo geometry service model
-process.load("Geometry.CaloEventSetup.CaloGeometry_cfi")
-process.load("Geometry.CaloEventSetup.EcalTrigTowerConstituents_cfi")
-process.load("Geometry.HcalCommonData.hcalDDConstants_cff")
-process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 # ecal mapping
-process.load("Geometry.EcalMapping.EcalMapping_cfi")
 process.eegeom = cms.ESSource("EmptyESSource",
     recordName = cms.string('EcalMappingRcd'),
     iovIsRunNotTime = cms.bool(True),
@@ -85,7 +101,7 @@ db_service,db_user,db_pwd = auth.get_db_credentials( db_reader_account )
 process.TPGParamProducer = cms.EDAnalyzer("EcalTPGParamBuilder",
 
     #### inputs/ouputs control ####
-    writeToDB  = cms.bool(yyyyyy),
+    writeToDB  = cms.bool(options.writeToDB),
     allowDBEE  = cms.bool(True),
 
 #    DBsid   = cms.string('cms_omds_lb'), ## real DB on P5
@@ -108,7 +124,7 @@ process.TPGParamProducer = cms.EDAnalyzer("EcalTPGParamBuilder",
     TPGWriteBst = cms.uint32(0),
 
     writeToFiles = cms.bool(True),
-    outFile = cms.string('TPG_beamv7_trans_rrrrrr_spikekill_2021.txt'),
+    outFile = cms.string(options.outFile),
 
    #### TPG config tag and version (if not given it will be automatically given ) ####
     TPGtag = cms.string('BEAMV7_TEST'),
@@ -161,7 +177,7 @@ process.TPGParamProducer = cms.EDAnalyzer("EcalTPGParamBuilder",
     timing_phases_EE = cms.string('Phases_EE.txt'), # TCC phase setting for EE / strip
 
     useTransparencyCorr = cms.bool(True),   ## true if you want to correct TPG for transparency change in EE
-    transparency_corrections = cms.string('TRANSPARENCY_2018/hourly_rrrrrr'), # transparency corr to be used to compute linearizer parameters 1/crystal
+    transparency_corrections = cms.string(options.transparency), # transparency corr to be used to compute linearizer parameters 1/crystal
 
     SFGVB_Threshold = cms.uint32(16),             ## (adc) SFGVB threshold in FE
     SFGVB_lut = cms.uint32(0xfffefee8),           ## SFGVB LUT in FE

--- a/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv7.py
+++ b/CalibCalorimetry/EcalTPGTools/test/produceTPGParameters_beamv7.py
@@ -1,0 +1,197 @@
+import FWCore.ParameterSet.Config as cms
+import CondTools.Ecal.db_credentials as auth
+
+process = cms.Process("ProdTPGParam")
+
+# Calo geometry service model
+process.load("Geometry.CaloEventSetup.CaloGeometry_cfi")
+process.load("Geometry.CaloEventSetup.EcalTrigTowerConstituents_cfi")
+process.load("Geometry.HcalCommonData.hcalDDConstants_cff")
+process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
+
+# ecal mapping
+process.load("Geometry.EcalMapping.EcalMapping_cfi")
+process.eegeom = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalMappingRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+# Get hardcoded conditions the same used for standard digitization before CMSSW_3_1_x
+## process.load("CalibCalorimetry.EcalTrivialCondModules.EcalTrivialCondRetriever_cfi")
+# or Get DB parameters
+# process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load("CondCore.CondDB.CondDB_cfi")
+
+process.CondDB.connect = 'frontier://FrontierProd/CMS_CONDITIONS'
+process.CondDB.DBParameters.authenticationPath = '/nfshome0/popcondev/conddb' ###P5 stuff
+
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+                                          process.CondDB,
+                                          timetype = cms.untracked.string('runnumber'),
+                                          toGet = cms.VPSet(
+              cms.PSet(
+            record = cms.string('EcalPedestalsRcd'),
+                    #tag = cms.string('EcalPedestals_v5_online')
+                    #tag = cms.string('EcalPedestals_2009runs_hlt') ### obviously diff w.r.t previous
+                    tag = cms.string('EcalPedestals_hlt'), ### modif-alex 22/02/2011
+                 ),
+              cms.PSet(
+            record = cms.string('EcalADCToGeVConstantRcd'),
+                    #tag = cms.string('EcalADCToGeVConstant_EBg50_EEnoB_new')
+                    #tag = cms.string('EcalADCToGeVConstant_2009runs_express') ### the 2 ADCtoGEV in EB and EE are diff w.r.t previous
+                    tag = cms.string('EcalADCToGeVConstant_V1_hlt')
+                 ),
+              cms.PSet(
+            record = cms.string('EcalIntercalibConstantsRcd'),
+                    #tag = cms.string('EcalIntercalibConstants_EBg50_EEnoB_new')
+                    #tag = cms.string('EcalIntercalibConstants_2009runs_express') ### differs from previous
+                    tag = cms.string('EcalIntercalibConstants_V1_hlt')
+                 ),
+              cms.PSet(
+            record = cms.string('EcalGainRatiosRcd'),
+                    #tag = cms.string('EcalGainRatios_TestPulse_online')
+                    tag = cms.string('EcalGainRatios_TestPulse_express') ### no diff w.r.t previous
+                 ),
+              cms.PSet(
+                record = cms.string('EcalMappingElectronicsRcd'),
+                    tag = cms.string('EcalMappingElectronics_EEMap_v1_mc')
+                 ),
+              cms.PSet(
+                record = cms.string('EcalLaserAlphasRcd'),
+                tag = cms.string('EcalLaserAlphas_EB_sic1_btcp152_EE_sic1_btcp116')
+              )
+               )
+             )
+
+
+#########################
+process.source = cms.Source("EmptySource",
+       ##firstRun = cms.untracked.uint32(100000000) ### need to use latest run to pick-up update values from DB
+       firstRun = cms.untracked.uint32(161310)
+)
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+db_reader_account = 'CMS_ECAL_CONF'
+db_service,db_user,db_pwd = auth.get_db_credentials( db_reader_account )
+
+
+##process.TPGParamProducer = cms.EDFilter("EcalTPGParamBuilder",
+process.TPGParamProducer = cms.EDAnalyzer("EcalTPGParamBuilder",
+
+    #### inputs/ouputs control ####
+    writeToDB  = cms.bool(yyyyyy),
+    allowDBEE  = cms.bool(True),
+
+#    DBsid   = cms.string('cms_omds_lb'), ## real DB on P5
+    DBuser = cms.string(db_user),
+    DBpass = cms.string(db_pwd),
+    DBsid  = cms.string(db_service),
+    DBport  = cms.uint32(10121),
+
+    TPGWritePed = cms.uint32(1), # can be 1=load ped from offline DB  0=use previous ped NN=use ped from ped_conf_id=NN
+    TPGWriteLin = cms.uint32(1),
+    TPGWriteSli = cms.uint32(1),
+    TPGWriteWei = cms.uint32(1),
+    TPGWriteWei2 = cms.uint32(1), # odd weights
+    TPGWriteLut = cms.uint32(1),
+    TPGWriteFgr = cms.uint32(1),
+    TPGWriteSpi = cms.uint32(1),
+    TPGWriteDel = cms.uint32(1),
+    TPGWriteBxt = cms.uint32(0), # these can be 0=use same as existing number for this tag or NN=use badxt from bxt_conf_id=NN
+    TPGWriteBtt = cms.uint32(0),
+    TPGWriteBst = cms.uint32(0),
+
+    writeToFiles = cms.bool(True),
+    outFile = cms.string('TPG_beamv7_trans_rrrrrr_spikekill_2021.txt'),
+
+   #### TPG config tag and version (if not given it will be automatically given ) ####
+    TPGtag = cms.string('BEAMV7_TEST'),
+    TPGversion = cms.uint32(1),
+
+   #### TPG calculation parameters ####
+    useTransverseEnergy = cms.bool(True),    ## true when TPG computes transverse energy, false for energy
+    Et_sat_EB = cms.double(128.0),            ## Saturation value (in GeV) of the TPG before the compressed-LUT (rem: with 35.84 the TPG_LSB = crystal_LSB)
+    Et_sat_EE = cms.double(128.0),            ## Saturation value (in GeV) of the TPG before the compressed-LUT (rem: with 35.84 the TPG_LSB = crystal_LSB)
+
+    sliding = cms.uint32(0),                 ## Parameter used for the FE data format, should'nt be changed
+
+    weight_timeShift = cms.double(0.),       ## weights are computed shifting the timing of the shape by this amount in ns: val>0 => shape shifted to the right
+    weight_sampleMax = cms.uint32(3),        ## position of the maximum among the 5 samples used by the TPG amplitude filter
+    weight_unbias_recovery = cms.bool(True), ## true if weights after int conversion are forced to have sum=0. Pb, in that case it can't have sum f*w = 1
+
+    weight_even_computeFromShape = cms.bool(True),   ## If False do not compute the even weights but read them from files
+    weight_even_idMapFile = cms.string('EcalTPGIdMap_2018_PU50_S2.txt'),
+    weight_even_weightGroupFile = cms.string('EcalTPGWeightGroup_2018_PU50_S2.txt'),
+    weight_odd_idMapFile = cms.string('EcalTPGIdMap_odd.txt'),
+    weight_odd_weightGroupFile = cms.string('EcalTPGWeightGroup_odd.txt'),
+
+    weight_useDoubleWeights =  cms.bool(False),  # If True the double weights configuration is created, if False the wei2_id is set to 1, the Run2 default (special meaning for the DAQ)
+    TPmode_EnableEBOddFilter = cms.bool(False), # TPmode configs are used only is weight_useDoubleWeights is True
+    TPmode_EnableEEOddFilter = cms.bool(False),
+    TPmode_EnableEBOddPeakFinder = cms.bool(False),
+    TPmode_EnableEEOddPeakFinder = cms.bool(False),
+    TPmode_DisableEBEvenPeakFinder = cms.bool(False),
+    TPmode_DisableEEEvenPeakFinder = cms.bool(False),
+    TPmode_FenixEBStripOutput      = cms.uint32(0),
+    TPmode_FenixEEStripOutput      = cms.uint32(0),
+    TPmode_FenixEBStripInfobit2    = cms.uint32(0),
+    TPmode_FenixEEStripInfobit2    = cms.uint32(0),
+    TPmode_FenixEBTcpOutput        = cms.uint32(0),
+    TPmode_FenixEBTcpInfobit1      = cms.uint32(0),
+    TPmode_FenixEETcpOutput        = cms.uint32(0),
+    TPmode_FenixEETcpInfobit1      = cms.uint32(0),
+
+    forcedPedestalValue = cms.int32(-3),     ## use this value instead of getting it from DB or MC
+                                             ## -1: means use value from DB or MC.
+                                              ## -2: ped12 = 0 used to cope with FENIX bug
+                                             ## -3: used with sFGVB: baseline subtracted is pedestal-offset*sin(theta)/G with G=mult*2^-(shift+2)
+    pedestal_offset =  cms.uint32(150),      ## pedestal offset used with option forcedPedestalValue = -3
+
+    useInterCalibration = cms.bool(True),    ## use or not values from DB. If not, 1 is assumed
+
+    timing_delays_EB = cms.string('Delays_EB.txt'), # timing delays for latency EB / TT
+    timing_delays_EE = cms.string('Delays_EE.txt'), # timing delays for latency EE / strip
+    timing_phases_EB = cms.string('Phases_EB.txt'), # TCC phase setting for EB / TT
+    timing_phases_EE = cms.string('Phases_EE.txt'), # TCC phase setting for EE / strip
+
+    useTransparencyCorr = cms.bool(True),   ## true if you want to correct TPG for transparency change in EE
+    transparency_corrections = cms.string('TRANSPARENCY_2018/hourly_rrrrrr'), # transparency corr to be used to compute linearizer parameters 1/crystal
+
+    SFGVB_Threshold = cms.uint32(16),             ## (adc) SFGVB threshold in FE
+    SFGVB_lut = cms.uint32(0xfffefee8),           ## SFGVB LUT in FE
+    SFGVB_SpikeKillingThreshold = cms.int32(16),  ## (GeV) Spike killing threshold applied in TPG ET in TCC (-1 no killing)
+
+    forceEtaSlice = cms.bool(False),         ## when true, same linearization coeff for all crystals belonging to a given eta slice (tower)
+
+    LUT_option = cms.string('Linear'),       ## compressed LUT option can be: "Identity", "Linear", "EcalResolution"
+    LUT_threshold_EB = cms.double(0.50),    ## All Trigger Primitives <= threshold (in GeV) will be set to 0
+    LUT_threshold_EE = cms.double(0.50),    ## All Trigger Primitives <= threshold (in GeV) will be set to 0
+    LUT_stochastic_EB = cms.double(0.03),    ## Stochastic term of the ECAL-EB ET resolution (used only if LUT_option="EcalResolution")
+    LUT_noise_EB = cms.double(0.2),          ## noise term (GeV) of the ECAL-EB ET resolution (used only if LUT_option="EcalResolution")
+    LUT_constant_EB = cms.double(0.005),     ## constant term of the ECAL-EB ET resolution (used only if LUT_option="EcalResolution")
+    LUT_stochastic_EE = cms.double(0.03),    ## Stochastic term of the ECAL-EE ET resolution (used only if LUT_option="EcalResolution")
+    LUT_noise_EE = cms.double(0.2),          ## noise term (GeV) of the ECAL-EE ET resolution (used only if LUT_option="EcalResolution")
+    LUT_constant_EE = cms.double(0.005),     ## constant term of the ECAL-EE ET resolution (used only if LUT_option="EcalResolution")
+
+    TTF_lowThreshold_EB = cms.double(2),   ## EB Trigger Tower Flag low threshold in GeV
+    TTF_highThreshold_EB = cms.double(4),  ## EB Trigger Tower Flag high threshold in GeV
+    TTF_lowThreshold_EE = cms.double(2),   ## EE Trigger Tower Flag low threshold in GeV
+    TTF_highThreshold_EE = cms.double(4),  ## EE Trigger Tower Flag high threshold in GeV
+
+    FG_lowThreshold_EB = cms.double(3.9),      ## EB Fine Grain Et low threshold in GeV
+    FG_highThreshold_EB = cms.double(3.9),     ## EB Fine Grain Et high threshold in GeV
+    FG_lowRatio_EB = cms.double(0.9),          ## EB Fine Grain low-ratio
+    FG_highRatio_EB = cms.double(0.9),         ## EB Fine Grain high-ratio
+    FG_lut_EB = cms.uint32(0x08),              ## EB Fine Grain Look-up table. Put something != 0 if you really know what you do!
+    FG_Threshold_EE = cms.double(18.75),       ## EE Fine threshold in GeV
+    FG_lut_strip_EE = cms.uint32(0xfffefee8),  ## EE Fine Grain strip Look-up table
+    FG_lut_tower_EE = cms.uint32(0)            ## EE Fine Grain tower Look-up table
+)
+
+process.p = cms.Path(process.TPGParamProducer)

--- a/OnlineDB/EcalCondDB/sql/trigger_add_doubleweights.sql
+++ b/OnlineDB/EcalCondDB/sql/trigger_add_doubleweights.sql
@@ -1,0 +1,166 @@
+-- SQL script used to add the double weights key in the ConfDB
+
+alter table fe_config_main drop constraint fe_config_main_pk ;
+
+ALTER TABLE FE_CONFIG_MAIN drop CONSTRAINT FE_CONFIG_L2_UNIQUE_uk ;
+
+ALTER TABLE FE_CONFIG_MAIN drop CONSTRAINT FE_CONFIG_MAIN_to_PED_fk ;
+ALTER TABLE FE_CONFIG_MAIN drop CONSTRAINT FE_CONFIG_MAIN_to_lin_fk ;
+ALTER TABLE FE_CONFIG_MAIN drop CONSTRAINT FE_CONFIG_MAIN_to_lut_fk ;
+ALTER TABLE FE_CONFIG_MAIN drop CONSTRAINT FE_CONFIG_MAIN_to_fgr_fk ;
+ALTER TABLE FE_CONFIG_MAIN drop CONSTRAINT FE_CONFIG_MAIN_to_sli_fk ;
+ALTER TABLE FE_CONFIG_MAIN drop CONSTRAINT FE_CONFIG_MAIN_to_WEIGHT_fk ;
+ALTER TABLE FE_CONFIG_MAIN drop CONSTRAINT FE_CONFIG_MAIN_to_spi_fk ;
+ALTER TABLE FE_CONFIG_MAIN drop CONSTRAINT FE_CONFIG_MAIN_to_tim_fk ;
+
+
+alter table fe_config_main rename to old_fe_config_main3;
+
+
+CREATE TABLE FE_CONFIG_MAIN (
+conf_id NUMBER NOT NULL,                                                               
+ped_conf_id NUMBER NOT NULL,                                                          
+lin_conf_id NUMBER NOT NULL,                                                       
+lut_conf_id NUMBER NOT NULL,                                                      
+fgr_conf_id NUMBER NOT NULL,                                                
+sli_conf_id NUMBER NOT NULL,                                            
+wei_conf_id NUMBER NOT NULL,                                      
+spi_conf_id NUMBER DEFAULT 0 NOT NULL, 
+tim_conf_id NUMBER DEFAULT 0 NOT NULL,                                         
+bxt_conf_id NUMBER NOT NULL,                                      
+btt_conf_id NUMBER NOT NULL,                                      
+bst_conf_id NUMBER DEFAULT 0 NOT NULL,                                   
+tag         VARCHAR2(100),                                                 
+version NUMBER  NOT NULL,                                                     
+description VARCHAR2(200)  ,                                                                    
+db_timestamp            TIMESTAMP DEFAULT SYSTIMESTAMP NOT NULL,
+coke_conf_id NUMBER DEFAULT 0 NOT NULL
+wei2_conf_id NUMBER DEFAULT 1 NOT NULL
+);
+
+
+insert into fe_config_main (conf_id, ped_conf_id ,lin_conf_id, 
+lut_conf_id, fgr_conf_id, sli_conf_id, wei_conf_id, spi_conf_id, tim_conf_id, bxt_conf_id, 
+btt_conf_id, bst_conf_id, tag, version, description, db_timestamp,coke_conf_id ) (select conf_id, ped_conf_id ,lin_conf_id, 
+lut_conf_id, fgr_conf_id, sli_conf_id, wei_conf_id, spi_conf_id, tim_conf_id, bxt_conf_id, 
+btt_conf_id, bst_conf_id, tag, version, description, db_timestamp,coke_conf_id from old_fe_config_main3 ) ;
+
+-- drop table old_fe_config_main3;
+
+
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_PK PRIMARY KEY (CONF_ID);
+
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_L2_UNIQUE_uk UNIQUE (tag,version);
+
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_to_PED_fk FOREIGN KEY (ped_conf_id) REFERENCES FE_CONFIG_PED_INFO (ped_conf_id);
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_to_lin_fk FOREIGN KEY (lin_conf_id) REFERENCES FE_CONFIG_LIN_INFO (lin_conf_id);
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_to_lut_fk FOREIGN KEY (lut_conf_id) REFERENCES FE_CONFIG_LUT_INFO (lut_conf_id);
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_to_fgr_fk FOREIGN KEY (fgr_conf_id) REFERENCES FE_CONFIG_fgr_INFO (fgr_conf_id);
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_to_sli_fk FOREIGN KEY (sli_conf_id) REFERENCES FE_CONFIG_sliding_INFO (sli_conf_id);
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_to_WEIGHT_fk FOREIGN KEY (wei_conf_id) REFERENCES FE_CONFIG_WEIGHT_INFO (wei_conf_id);
+
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_to_spi_fk FOREIGN KEY (spi_conf_id) REFERENCES FE_CONFIG_spike_INFO (spi_conf_id);
+ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_to_tim_fk FOREIGN KEY (tim_conf_id) REFERENCES FE_CONFIG_time_INFO (tim_conf_id);
+--  ALTER TABLE FE_CONFIG_MAIN ADD CONSTRAINT FE_CONFIG_MAIN_to_cok_fk FOREIGN KEY (coke_conf_id) REFERENCES FE_CONFIG_coke_INFO (coke_conf_id);
+
+
+CREATE OR REPLACE TRIGGER fe_config_main_auto3_ver_tg
+  BEFORE INSERT ON FE_CONFIG_MAIN
+  FOR EACH ROW
+    begin
+  select test_update_tag_and_version('FE_CONFIG_MAIN', :new.tag, :new.version) into :new.version from dual;
+end;
+/
+SHOW ERRORS;
+
+
+
+CREATE TABLE FE_CONFIG_WEIGHT2_INFO (
+ wei2_conf_id NUMBER(10) NOT NULL,
+ number_of_groups NUMBER(10) , -- (the number of groups of weights)
+ db_timestamp  TIMESTAMP DEFAULT SYSTIMESTAMP NOT NULL,
+ TAG VARCHAR2(100)
+);
+ALTER TABLE FE_CONFIG_WEIGHT2_INFO ADD CONSTRAINT  FE_CONFIG_WEIGHT2_INFO_PK PRIMARY KEY (wei2_conf_id);
+
+insert into FE_CONFIG_WEIGHT2_INFO (wei2_conf_id, number_of_groups, TAG) values (1,0, 'NoOddWeights' ) ;
+
+
+create table FE_WEIGHT2_PER_GROUP_DAT(
+ wei2_conf_id number not null,
+ group_id number(10) not null,
+ W0 NUMBER,
+ W1 NUMBER,
+ W2 NUMBER,
+ W3 NUMBER,
+ W4 NUMBER,
+ W5 NUMBER
+ );
+
+ALTER TABLE FE_WEIGHT2_PER_GROUP_DAT ADD CONSTRAINT FE_WEIGHT2_PER_GROUP_pk PRIMARY KEY (wei2_conf_id , group_id);
+ALTER TABLE FE_WEIGHT2_PER_GROUP_DAT ADD CONSTRAINT FE_WEIGHT2_PER_GROUP_fk foreign KEY (wei2_conf_id) REFERENCES FE_CONFIG_WEIGHT2_INFO (wei2_conf_id);
+
+insert into FE_CONFIG_WEIGHT2_PER_GROUP (1,0,0,0,0,0,0,0);
+insert into FE_CONFIG_WEIGHT2_PER_GROUP (1,1,0,0,0,0,0,0);
+
+
+CREATE TABLE FE_CONFIG_WEIGHT2_DAT (
+ wei2_conf_id NUMBER NOT NULL,
+ logic_id NUMBER(10) not null, -- ( of the strip)
+ group_id number(10) not null);
+
+ALTER TABLE FE_CONFIG_WEIGHT2_DAT ADD CONSTRAINT FE_CONFIG_WEIGHT2_fk  FOREIGN KEY (wei2_conf_id) REFERENCES FE_CONFIG_WEIGHT2_INFO (wei2_conf_id);
+ALTER TABLE FE_CONFIG_WEIGHT2_DAT ADD CONSTRAINT FE_CONFIG_WEIGHT2_fk2  FOREIGN KEY (wei2_conf_id, group_id) 
+REFERENCES FE_WEIGHT2_PER_GROUP_DAT (wei2_conf_id, group_id);
+
+insert into FE_CONFIG_WEIGHT2_DAT (wei2_conf_id,logic_id,group_id) (select 1,logic_id,group_id from FE_CONFIG_WEIGHT_DAT where wei_conf_id=480);
+
+
+create table FE_WEIGHT2_MODE_DAT(
+ wei2_conf_id number not null,
+ EnableEBOddFilter number DEFAULT 0 NOT NULL,
+ EnableEEOddFilter number DEFAULT 0 NOT NULL,
+ EnableEBOddPeakFinder number DEFAULT 0 NOT NULL,
+ EnableEEOddPeakFinder number DEFAULT 0 NOT NULL,
+ DisableEBEvenPeakFinder number DEFAULT 0 NOT NULL,
+ FenixEBStripOutput number DEFAULT 0 NOT NULL,
+ FenixEEStripOutput number DEFAULT 0 NOT NULL,
+ FenixEBStripInfobit2 number DEFAULT 0 NOT NULL,
+ FenixEEStripInfobit2 number DEFAULT 0 NOT NULL,
+ EBFenixTcpOutput number DEFAULT 0 NOT NULL,
+ EBFenixTcpInfobit1 number DEFAULT 0 NOT NULL,
+ FenixPar12  number DEFAULT 0 NOT NULL,
+ FenixPar13  number DEFAULT 0 NOT NULL,
+ FenixPar14  number DEFAULT 0 NOT NULL,
+ FenixPar15  number DEFAULT 0 NOT NULL
+ );
+
+ALTER TABLE FE_WEIGHT2_MODE_DAT ADD CONSTRAINT FE_WEIGHT2_MODE_pk PRIMARY KEY (wei2_conf_id);
+ALTER TABLE FE_WEIGHT2_MODE_DAT ADD CONSTRAINT FE_WEIGHT2_MODE_fk foreign KEY (wei2_conf_id) REFERENCES FE_CONFIG_WEIGHT2_INFO (wei2_conf_id);
+
+INSERT into FE_WEIGHT2_MODE_DAT(wei2_conf_id) values (1); 
+
+
+
+CREATE SEQUENCE FE_CONFIG_WEIGHT2GROUP_SQ INCREMENT BY 1 START WITH 1;
+select FE_CONFIG_WEIGHT2GROUP_SQ.NextVal from DUAL; 
+
+-- this selects the first number that we have already used
+
+/*
+ *  the id is auto-incremented at each time you insert in the table 
+ *  no need to bother about inserting conf_id
+ */
+
+CREATE trigger FE_CONFIG_WEI2_TRG
+before insert on FE_CONFIG_WEIGHT2_INFO
+for each row
+begin
+select FE_CONFIG_WEIGHT2GROUP_SQ.NextVal into :new.wei2_conf_id from dual;
+end;
+/
+
+
+
+
+

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.cc
@@ -399,7 +399,7 @@ void EcalTrigPrimESProducer::parseTextFile() {
       gis >> std::dec >> id;
 
       if (flagPrint_) {
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
       }
 
       paramF.clear();
@@ -411,7 +411,7 @@ void EcalTrigPrimESProducer::parseTextFile() {
         gis >> std::dec >> dataF;
         paramF.push_back(dataF);
 
-        // std::cout<<", "<<std::dec<<dataF ;
+        // edm::LogVerbatim("EcalTrigPrimESProducer")<<", "<<std::dec<<dataF ;
         if (flagPrint_) {
           //---------------------------------
           if (i < 3) {
@@ -438,18 +438,18 @@ void EcalTrigPrimESProducer::parseTextFile() {
       }
 
       if (flagPrint_) {
-        std::cout << "" << st1 << std::endl;
-        std::cout << "" << st2 << std::endl;
-        std::cout << "" << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << "" << st1;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << "" << st2;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << "";
       }
 
-      // std::cout<<std::endl ;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<std::endl ;
       mapPhys_[id] = paramF;
     }
 
     if (dataCard == "CRYSTAL") {
       gis >> std::dec >> id;
-      // std::cout<<dataCard<<" "<<std::dec<<id;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<dataCard<<" "<<std::dec<<id;
       std::string st3;
       std::string st4;
       std::string st5;
@@ -457,20 +457,20 @@ void EcalTrigPrimESProducer::parseTextFile() {
       if (flagPrint_) {
         // Print this comment only one time
         if (k == 0)
-          std::cout << "COMMENT ====== barrel crystals ====== " << std::endl;
+          edm::LogVerbatim("EcalTrigPrimESProducer") << "COMMENT ====== barrel crystals ====== ";
 
         if (k == 61200)
-          std::cout << "COMMENT ====== endcap crystals ====== " << std::endl;
+          edm::LogVerbatim("EcalTrigPrimESProducer") << "COMMENT ====== endcap crystals ====== ";
 
         k = k + 1;
 
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
       }
 
       param.clear();
       for (int i = 0; i < 9; i++) {
         gis >> std::hex >> data;
-        // std::cout<<", "<<std::hex<<data ;
+        // edm::LogVerbatim("EcalTrigPrimESProducer")<<", "<<std::hex<<data ;
         param.push_back(data);
 
         if (flagPrint_) {
@@ -508,12 +508,12 @@ void EcalTrigPrimESProducer::parseTextFile() {
       }  // end for
 
       if (flagPrint_) {
-        std::cout << " " << st3 << std::endl;
-        std::cout << " " << st4 << std::endl;
-        std::cout << " " << st5 << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << " " << st3;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << " " << st4;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << " " << st5;
       }
 
-      // std::cout<<std::endl ;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<std::endl ;
       mapXtal_[id] = param;
     }
 
@@ -523,19 +523,19 @@ void EcalTrigPrimESProducer::parseTextFile() {
       std::string st1;
 
       if (flagPrint_)
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
 
       param.clear();
       for (int i = 0; i < NBstripparams[0]; i++) {
         gis >> std::hex >> data;
-        // std::cout << " data = " << data << std::endl;
+        // edm::LogVerbatim("EcalTrigPrimESProducer") << " data = " << data;
         param.push_back(data);
 
         if (flagPrint_) {
           if (i == 0) {
-            std::cout << "0x" << std::hex << data << std::endl;
+            edm::LogVerbatim("EcalTrigPrimESProducer") << "0x" << std::hex << data;
           } else if (i >= 1 && i < 3) {
-            std::cout << "" << std::dec << data << std::endl;
+            edm::LogVerbatim("EcalTrigPrimESProducer") << "" << std::dec << data;
           } else if (i > 2) {
             std::ostringstream oss;
             if (i == 3) {
@@ -547,13 +547,13 @@ void EcalTrigPrimESProducer::parseTextFile() {
               oss << " 0x" << std::hex << data;
               std::string result5 = oss.str();
               st1.append(result5);
-              std::cout << "" << st1 << std::endl;
+              edm::LogVerbatim("EcalTrigPrimESProducer") << "" << st1;
             }
           }
         }
       }
 
-      // std::cout<<std::endl ;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<std::endl ;
       mapStrip_[0][id] = param;
     }
 
@@ -563,7 +563,7 @@ void EcalTrigPrimESProducer::parseTextFile() {
       std::string st6;
 
       if (flagPrint_) {
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
       }
 
       param.clear();
@@ -573,9 +573,9 @@ void EcalTrigPrimESProducer::parseTextFile() {
 
         if (flagPrint_) {
           if (i == 0) {
-            std::cout << "0x" << std::hex << data << std::endl;
+            edm::LogVerbatim("EcalTrigPrimESProducer") << "0x" << std::hex << data;
           } else if (i >= 1 && i < 3) {
-            std::cout << " " << std::hex << data << std::endl;
+            edm::LogVerbatim("EcalTrigPrimESProducer") << " " << std::hex << data;
           } else if (i > 2) {
             std::ostringstream oss;
             if (i == 3) {
@@ -588,13 +588,13 @@ void EcalTrigPrimESProducer::parseTextFile() {
               std::string result5 = oss.str();
 
               st6.append(result5);
-              std::cout << "" << st6 << std::endl;
+              edm::LogVerbatim("EcalTrigPrimESProducer") << "" << st6;
             }
           }
         }
       }
 
-      // std::cout<<std::endl ;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<std::endl ;
       mapStrip_[1][id] = param;
     }
 
@@ -602,7 +602,7 @@ void EcalTrigPrimESProducer::parseTextFile() {
       gis >> std::dec >> id;
 
       if (flagPrint_)
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
 
       param.clear();
       for (int i = 0; i < 2; i++) {
@@ -611,14 +611,14 @@ void EcalTrigPrimESProducer::parseTextFile() {
 
         if (flagPrint_) {
           if (i == 1) {
-            std::cout << "0x" << std::dec << data << std::endl;
+            edm::LogVerbatim("EcalTrigPrimESProducer") << "0x" << std::dec << data;
           } else {
-            std::cout << " " << std::dec << data << std::endl;
+            edm::LogVerbatim("EcalTrigPrimESProducer") << " " << std::dec << data;
           }
         }
       }
 
-      // std::cout<<std::endl ;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<std::endl ;
       mapTower_[1][id] = param;
     }
 
@@ -626,30 +626,27 @@ void EcalTrigPrimESProducer::parseTextFile() {
       gis >> std::dec >> id;
 
       if (flagPrint_)
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
 
       param.clear();
       for (int i = 0; i < 3; i++) {
         gis >> std::dec >> data;
 
         if (flagPrint_) {
-          std::cout << " " << std::dec << data << std::endl;
+          edm::LogVerbatim("EcalTrigPrimESProducer") << " " << std::dec << data;
         }
 
         param.push_back(data);
       }
 
-      // std::cout<<std::endl ;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<std::endl ;
       mapTower_[0][id] = param;
     }
 
     if (dataCard == "WEIGHT") {
-      if (flagPrint_)
-        std::cout << std::endl;
-
       gis >> std::hex >> id;
       if (flagPrint_) {
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
       }
 
       param.clear();
@@ -671,21 +668,17 @@ void EcalTrigPrimESProducer::parseTextFile() {
       }
 
       if (flagPrint_) {
-        std::cout << st6 << std::endl;
-        std::cout << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << st6;
       }
 
-      // std::cout<<std::endl ;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<std::endl ;
       mapWeight_[id] = param;
     }
 
     if (dataCard == "WEIGHT_ODD") {
-      if (flagPrint_)
-        std::cout << std::endl;
-
       gis >> std::hex >> id;
       if (flagPrint_) {
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
       }
 
       param.clear();
@@ -707,21 +700,17 @@ void EcalTrigPrimESProducer::parseTextFile() {
       }
 
       if (flagPrint_) {
-        std::cout << st6 << std::endl;
-        std::cout << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << st6;
       }
 
-      // std::cout<<std::endl ;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<std::endl ;
       mapWeight_odd_[id] = param;
     }
 
     if (dataCard == "FG") {
-      if (flagPrint_)
-        std::cout << std::endl;
-
       gis >> std::hex >> id;
       if (flagPrint_)
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
 
       param.clear();
       std::string st7;
@@ -743,8 +732,7 @@ void EcalTrigPrimESProducer::parseTextFile() {
       }
 
       if (flagPrint_) {
-        std::cout << st7 << std::endl;
-        std::cout << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << st7;
       }
 
       mapFg_[id] = param;
@@ -754,7 +742,7 @@ void EcalTrigPrimESProducer::parseTextFile() {
       gis >> std::hex >> id;
 
       if (flagPrint_)
-        std::cout << dataCard << " " << std::dec << id << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << std::dec << id;
 
       param.clear();
       for (int i = 0; i < 1024; i++) {
@@ -762,22 +750,14 @@ void EcalTrigPrimESProducer::parseTextFile() {
         param.push_back(data);
 
         if (flagPrint_) {
-          std::cout << "0x" << std::hex << data << std::endl;
+          edm::LogVerbatim("EcalTrigPrimESProducer") << "0x" << std::hex << data;
         }
-      }
-
-      if (flagPrint_) {
-        std::cout << std::endl;
-        std::cout << std::endl;
       }
 
       mapLut_[id] = param;
     }
 
     if (dataCard == "TP_MODE") {
-      if (flagPrint_)
-        std::cout << std::endl;
-
       param.clear();
 
       std::string st8;
@@ -796,11 +776,10 @@ void EcalTrigPrimESProducer::parseTextFile() {
       }
 
       if (flagPrint_) {
-        std::cout << dataCard << " " << st8 << std::endl;
-        std::cout << std::endl;
+        edm::LogVerbatim("EcalTrigPrimESProducer") << dataCard << " " << st8;
       }
 
-      // std::cout<<std::endl ;
+      // edm::LogVerbatim("EcalTrigPrimESProducer")<<std::endl ;
       tpMode_ = param;
     }
   }

--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimESProducer.h
@@ -24,6 +24,9 @@
 #include "CondFormats/DataRecord/interface/EcalTPGTowerStatusRcd.h"
 #include "CondFormats/DataRecord/interface/EcalTPGWeightGroupRcd.h"
 #include "CondFormats/DataRecord/interface/EcalTPGWeightIdMapRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGOddWeightGroupRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGOddWeightIdMapRcd.h"
+#include "CondFormats/DataRecord/interface/EcalTPGTPModeRcd.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGCrystalStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGFineGrainEBGroup.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGFineGrainEBIdMap.h"
@@ -40,6 +43,9 @@
 #include "CondFormats/EcalObjects/interface/EcalTPGTowerStatus.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightGroup.h"
 #include "CondFormats/EcalObjects/interface/EcalTPGWeightIdMap.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGOddWeightGroup.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGOddWeightIdMap.h"
+#include "CondFormats/EcalObjects/interface/EcalTPGTPMode.h"
 
 #include "zlib.h"
 
@@ -61,6 +67,9 @@ public:
   std::unique_ptr<EcalTPGLutIdMap> produceLUT(const EcalTPGLutIdMapRcd &);
   std::unique_ptr<EcalTPGWeightIdMap> produceWeight(const EcalTPGWeightIdMapRcd &);
   std::unique_ptr<EcalTPGWeightGroup> produceWeightGroup(const EcalTPGWeightGroupRcd &);
+  std::unique_ptr<EcalTPGOddWeightIdMap> produceOddWeight(const EcalTPGOddWeightIdMapRcd &);
+  std::unique_ptr<EcalTPGOddWeightGroup> produceOddWeightGroup(const EcalTPGOddWeightGroupRcd &);
+  std::unique_ptr<EcalTPGTPMode> produceTPMode(const EcalTPGTPModeRcd &);
   std::unique_ptr<EcalTPGLutGroup> produceLutGroup(const EcalTPGLutGroupRcd &);
   std::unique_ptr<EcalTPGFineGrainEBGroup> produceFineGrainEBGroup(const EcalTPGFineGrainEBGroupRcd &);
   std::unique_ptr<EcalTPGPhysicsConst> producePhysicsConst(const EcalTPGPhysicsConstRcd &);
@@ -80,9 +89,11 @@ private:
   std::map<uint32_t, std::vector<uint32_t>> mapStrip_[2];
   std::map<uint32_t, std::vector<uint32_t>> mapTower_[2];
   std::map<uint32_t, std::vector<uint32_t>> mapWeight_;
+  std::map<uint32_t, std::vector<uint32_t>> mapWeight_odd_;
   std::map<uint32_t, std::vector<uint32_t>> mapFg_;
   std::map<uint32_t, std::vector<uint32_t>> mapLut_;
   std::map<uint32_t, std::vector<float>> mapPhys_;
+  std::vector<uint32_t> tpMode_;
 
   //   typedef voidp gzFile;
   //   bool getNextString(gzFile &gzf);

--- a/SimCalorimetry/EcalTrigPrimProducers/python/ecalTrigPrimESProducer_cff.py
+++ b/SimCalorimetry/EcalTrigPrimProducers/python/ecalTrigPrimESProducer_cff.py
@@ -102,3 +102,20 @@ tpparams16 = cms.ESSource("EmptyESSource",
     firstValid = cms.vuint32(1)
 )
 
+tpparams17 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGOddWeightIdMapRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+tpparams18 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGOddWeightGroupRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+tpparams19 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGTPModeRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)

--- a/SimCalorimetry/EcalTrigPrimProducers/python/ecalTrigPrimESProducer_craft_cff.py
+++ b/SimCalorimetry/EcalTrigPrimProducers/python/ecalTrigPrimESProducer_craft_cff.py
@@ -101,3 +101,22 @@ tpparams16 = cms.ESSource("EmptyESSource",
     iovIsRunNotTime = cms.bool(True),
     firstValid = cms.vuint32(1)
 )
+
+
+tpparams17 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGOddWeightIdMapRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+tpparams18 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGOddWeightGroupRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+tpparams19 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGTPModeRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)

--- a/SimCalorimetry/EcalTrigPrimProducers/python/ecalTrigPrimESProducer_mc_cff.py
+++ b/SimCalorimetry/EcalTrigPrimProducers/python/ecalTrigPrimESProducer_mc_cff.py
@@ -96,3 +96,20 @@ tpparams15 = cms.ESSource("EmptyESSource",
     firstValid = cms.vuint32(1)
 )
 
+tpparams17 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGOddWeightIdMapRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+tpparams18 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGOddWeightGroupRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+tpparams19 = cms.ESSource("EmptyESSource",
+    recordName = cms.string('EcalTPGTPModeRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)


### PR DESCRIPTION
This is a backport of PR #36446 needed to propagate the changes to the CMSSW version currently available for tests in P5. 

## PR description:

The ECALTPGParamBuilder code computes the parameters for the ECAL Trigger Primitives (TP) configuration, including pedestals, weights and transparency calibrations.
This PR introduces the necessary changes to include the double weights configuration in the configuration scripts.
Moreover the code has been revised to include some additional cross-checks for problematic crystals. The weights configuration can be now read from files and not only computed from the pulse shapes.

The necessary OnlineDB, CondDB and trigger emulator changes for the double weights mechanism have been already included in previous PRs : #33220, #33349, #33748

## PR validation:

The full chain of ECAL TP configuration has been tested during the extended MWGR in November. The BEAMV7 key has been created in the OnlineDB by the configuration script and tested in global run.
A description of the double weight mechanism and related DB classes has been given at the Alca meeting and can be found here: https://indico.cern.ch/event/1020767/#16-new-ecal-tpg-db-classes-for