### PR TITLE
Turn off warnings for missing chamber in GEM GE2/1 demonstrator geometry

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.cc
@@ -186,7 +186,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     }
   }
 
-  buildRegions(theGeometry, superChambers);
+  buildRegions(theGeometry, superChambers, demonstratorGeometry);
 }
 
 GEMSuperChamber* GEMGeometryBuilder::buildSuperChamber(DDFilteredView& fv, GEMDetId detId) const {
@@ -437,7 +437,7 @@ void GEMGeometryBuilder::build(GEMGeometry& theGeometry,
     theGeometry.add(gemChamber);
   }
 
-  buildRegions(theGeometry, superChambers);
+  buildRegions(theGeometry, superChambers, demonstratorGeometry);
 }
 
 GEMSuperChamber* GEMGeometryBuilder::buildSuperChamber(cms::DDFilteredView& fv, GEMDetId detId) const {
@@ -555,7 +555,9 @@ GEMGeometryBuilder::RCPBoundPlane GEMGeometryBuilder::boundPlane(const cms::DDFi
   return RCPBoundPlane(new BoundPlane(posResult, rotResult, bounds));
 }
 
-void GEMGeometryBuilder::buildRegions(GEMGeometry& theGeometry, const std::vector<GEMSuperChamber*>& superChambers) {
+void GEMGeometryBuilder::buildRegions(GEMGeometry& theGeometry,
+                                      const std::vector<GEMSuperChamber*>& superChambers,
+                                      bool demonstratorGeometry) {
   // construct the regions, stations and rings.
   for (int re = -1; re <= 1; re = re + 2) {
     GEMRegion* region = new GEMRegion(re);
@@ -582,7 +584,11 @@ void GEMGeometryBuilder::buildRegions(GEMGeometry& theGeometry, const std::vecto
             GEMDetId chId(detId.region(), detId.ring(), detId.station(), la, detId.chamber(), 0);
             auto chamber = theGeometry.chamber(chId);
             if (!chamber) {
-              edm::LogWarning("GEMGeometryBuilder") << "Missing chamber " << chId;
+              // this particular layer 1 chamber *should* be missing in the demonstrator geometry (we only have layer 2)
+              if (!demonstratorGeometry or
+                  not(chId.region() == 1 and chId.station() == 2 and chId.chamber() == 16 and chId.layer() == 1)) {
+                edm::LogWarning("GEMGeometryBuilder") << "Missing chamber " << chId;
+              }
             } else {
               superChamber->add(chamber);
             }

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.h
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilder.h
@@ -66,7 +66,7 @@ private:
   GEMEtaPartition* buildEtaPartition(cms::DDFilteredView& fv, GEMDetId detId) const;
 
   // Common
-  void buildRegions(GEMGeometry&, const std::vector<GEMSuperChamber*>&);
+  void buildRegions(GEMGeometry&, const std::vector<GEMSuperChamber*>&, bool demonstratorGeometry);
 
   static constexpr double k_ScaleFromDD4hep = (1.0 / dd4hep::cm);
 };


### PR DESCRIPTION
#### PR description:

There are currently warnings about missing layer 1 of the superchamber corresponding to the demonstrator GEM, which in fact doesn't exist in the real geometry. This PR turns the warnings off.

@cvuosalo @civanch @bsunanda 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Ran run3 and phase2 GEMGeometry/test GEM geometry builder files, and checked the only reported difference is the missing warning.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
