### PR TITLE
Update final Run3 MC geometry (reprise)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,17 +64,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v3',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v3',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v3',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v3',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v3',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v3',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '123X_mcRun4_realistic_v3'
 }

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -38,8 +38,8 @@ def autoCondDDD(autoCond):
     CSCRECODIGI_Geometry_ddd    =  ','.join( ['CSCRECODIGI_Geometry_112YV2'            , "CSCRecoDigiParametersRcd"      , connectionString, ""        , "2021-09-28 12:00:00.000"] )
     CSCRECO_Geometry_ddd        =  ','.join( ['CSCRECO_Geometry_112YV2'                , "CSCRecoGeometryRcd"            , connectionString, ""        , "2021-09-28 12:00:00.000"] )
     DTRECO_Geometry_ddd         =  ','.join( ['DTRECO_Geometry_112YV2'                 , "DTRecoGeometryRcd"             , connectionString, ""        , "2021-09-28 12:00:00.000"] )
-    GEMRECO_Geometry_ddd        =  ','.join( ['GEMRECO_Geometry_113YV4'                , "GEMRecoGeometryRcd"            , connectionString, ""        , "2021-09-28 12:00:00.000"] )
-    XMLFILE_Geometry_ddd        =  ','.join( ['XMLFILE_Geometry_121YV1_Extended2021_mc', "GeometryFileRcd"               , connectionString, "Extended", "2021-09-28 12:00:00.000"] )
+    GEMRECO_Geometry_ddd        =  ','.join( ['GEMRECO_Geometry_123YV1'                , "GEMRecoGeometryRcd"            , connectionString, ""        , "2022-01-21 12:00:00.000"] )
+    XMLFILE_Geometry_ddd        =  ','.join( ['XMLFILE_Geometry_123YV1_Extended2021_mc', "GeometryFileRcd"               , connectionString, "Extended", "2022-01-21 12:00:00.000"] )
     HCALParameters_Geometry_ddd =  ','.join( ['HCALParameters_Geometry_112YV2'         , "HcalParametersRcd"             , connectionString, ""        , "2021-09-28 12:00:00.000"] )
     TKRECO_Geometry_ddd         =  ','.join( ['TKRECO_Geometry_120YV2'                 , "IdealGeometryRecord"           , connectionString, ""        , "2021-09-28 12:00:00.000"] )
     CTRECO_Geometry_ddd         =  ','.join( ['CTRECO_Geometry_112YV2'                 , "PCaloTowerRcd"                 , connectionString, ""        , "2021-09-28 12:00:00.000"] )
@@ -49,7 +49,7 @@ def autoCondDDD(autoCond):
     HCALRECO_Geometry_ddd       =  ','.join( ['HCALRECO_Geometry_112YV2'               , "PHcalRcd"                      , connectionString, ""        , "2021-09-28 12:00:00.000"] )
     TKParameters_Geometry_ddd   =  ','.join( ['TKParameters_Geometry_112YV2'           , "PTrackerParametersRcd"         , connectionString, ""        , "2021-09-28 12:00:00.000"] )
     ZDCRECO_Geometry_ddd        =  ','.join( ['ZDCRECO_Geometry_112YV2'                , "PZdcRcd"                       , connectionString, ""        , "2021-09-28 12:00:00.000"] )
-    RPCRECO_Geometry_ddd        =  ','.join( ['RPCRECO_Geometry_112YV2'                , "RPCRecoGeometryRcd"            , connectionString, ""        , "2021-09-28 12:00:00.000"] )
+    RPCRECO_Geometry_ddd        =  ','.join( ['RPCRECO_Geometry_123YV1'                , "RPCRecoGeometryRcd"            , connectionString, ""        , "2022-01-21 12:00:00.000"] )
     PPSRECO_Geometry_ddd        =  ','.join( ['PPSRECO_Geometry_121YV2_2021_mc'        , "VeryForwardIdealGeometryRecord", connectionString, ""        , "2021-12-02 12:00:00.000"] )
 
     for key,val in autoCond.items():


### PR DESCRIPTION
#### PR description:
This is a (cleaner) reprise of #36764.
This PR updates the MC Run3 GTs to include the final geometry:
 - BRIL geometry updated to match actual P5 detectors
 - GEM and RPC demonstrator modules are added

For more details see: https://cms-talk.web.cern.ch/t/gt-mc-small-run-3-geometry-revision-for-12-3-0-pre4/4930

The added DD4HEP tags are:
`XMLFILE_Geometry_123DD4hepV1_Extended2021_mc`, label `Extended`
`XMLFILE_Geometry_123DD4hepV1_Extended2021ZeroMaterial_mc`, label `ZeroMaterial`
`XMLFILE_Geometry_123DD4hepV1_Extended2021FlatMinus05Percent_mc`, label `FlatMinus05Percent`
`XMLFILE_Geometry_123DD4hepV1_Extended2021FlatMinus10Percent_mc`, label `FlatMinus10Percent`
`XMLFILE_Geometry_123DD4hepV1_Extended2021FlatPlus05Percent_mc`, label `FlatPlus05Percent`
`XMLFILE_Geometry_123DD4hepV1_Extended2021FlatPlus10Percent_mc`, label `FlatPlus10Percent`
`GEMRECO_Geometry_123DD4hepV1`
`RPCRECO_Geometry_123DD4hepV1`

At the same time the following DDD tags are updated as well in the `autoCondDDD` modifier:
`XMLFILE_Geometry_123YV1_Extended2021_mc`
`GEMRECO_Geometry_123YV1`
`RPCRECO_Geometry_123YV1`

The difference in the GTs is:
**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_design_v3/123X_mcRun3_2021_design_v4

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_v3/123X_mcRun3_2021_realistic_v4

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021cosmics_realistic_deco_v3/123X_mcRun3_2021cosmics_realistic_deco_v4

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_HI_v3/123X_mcRun3_2021_realistic_HI_v4

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2023_realistic_v3/123X_mcRun3_2023_realistic_v4

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2024_realistic_v3/123X_mcRun3_2024_realistic_v4


#### PR validation:
Validated with
`runTheMatrix.py -l 12034.0,11634.0,7.23,312.0,12434.0,12834.0,11634.911,11634.914 --ibeos -j 15`

#### Backport
Not a backport. Will be backported to 12_2_X if everything goes fine with validation in 12_3_0_pre4.

FYI @cms-sw/geometry-l2 