### PR TITLE
Turn off GE2/1 unpacking (demonstrator chamber) in run 3

### DIFF
--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -7,8 +7,6 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
-# from DataFormats/FEDRawData/interface/FEDNumbering.h
-MINGE21FEDID = 1469
-MAXGEMFEDID = 1478
-run3_GEM.toModify(muonGEMDigis, useDBEMap = True, fedIdEnd=MINGE21FEDID-1)
-phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True, fedIdEnd=MAXGEMFEDID)
+# Note that by default we don't unpack the GE2/1 demonstrator digis in run3
+run3_GEM.toModify(muonGEMDigis, useDBEMap = True, ge21Off = True)
+phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True, ge21Off = False)

--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -7,5 +7,8 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
-run3_GEM.toModify(muonGEMDigis, useDBEMap = True)
-phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True)
+# from DataFormats/FEDRawData/interface/FEDNumbering.h
+MINGE21FEDID = 1469
+MAXGEMFEDID = 1478
+run3_GEM.toModify(muonGEMDigis, useDBEMap = True, fedIdEnd=MINGE21FEDID-1)
+phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True, fedIdEnd=MAXGEMFEDID)


### PR DESCRIPTION
#### PR description:

By default, we want to turn off hits from the GEM GE2/1 demonstrator chamber, so that they aren't propagated which could e.g. adversely affect the muon reconstruction. This PR does that by restricting the range of FED Ids considered by the GEM unpacker in run3 to not include GE2/1, so that digis from the GE2/1 demonstrator will not be produced by default, but are easily switched on for GEM DPG internal tests.

@jshlee 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Checked that run3 workflows still produces GE1/1 hits.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
