### PR TITLE
Fix to remove object order dependence and update test cfg files

### DIFF
--- a/DQM/Physics/src/ExoticaDQM.cc
+++ b/DQM/Physics/src/ExoticaDQM.cc
@@ -531,7 +531,7 @@ void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     }
     if (muon_->pt() > dimuon_Muon1_pt_cut_)
       dimuon_countMuon_++;
-    if (muon_->pt() > dimuon_Muon1_pt_cut_)
+    if (muon_->pt() > monomuon_Muon_pt_cut_)
       monomuon_countMuon_++;
   }
 
@@ -593,7 +593,7 @@ void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     }
     if (electron_->pt() > dielectron_Electron1_pt_cut_)
       dielectron_countElectron_++;
-    if (electron_->pt() > dielectron_Electron1_pt_cut_)
+    if (electron_->pt() > monoelectron_Electron_pt_cut_)
       monoelectron_countElectron_++;
   }
 
@@ -635,10 +635,9 @@ void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       PhotonTrkSumPtSolidConeDR03[1] = photon_->trkSumPtSolidConeDR03();
       PhotonE1x5E5x5[1] = photon_->e1x5() / photon_->e5x5();
       PhotonE2x5E5x5[1] = photon_->e2x5() / photon_->e5x5();
-
-      if (photon_->pt() > dielectron_Electron1_pt_cut_)
-        diphoton_countPhoton_++;
     }
+    if (photon_->pt() > diphoton_Photon1_pt_cut_)
+      diphoton_countPhoton_++;
   }
 
   //

--- a/DQM/Physics/src/ExoticaDQM.cc
+++ b/DQM/Physics/src/ExoticaDQM.cc
@@ -520,6 +520,13 @@ void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         MuonEta[0] = muon_->eta();
         MuonPhi[0] = muon_->phi();
         MuonCharge[0] = muon_->charge();
+      } else if (muon_->pt() > MuonPt[1] && muon_->pt() < MuonPt[0]) {
+        MuonPt[1] = muon_->pt();
+        MuonPx[1] = muon_->px();
+        MuonPy[1] = muon_->py();
+        MuonEta[1] = muon_->eta();
+        MuonPhi[1] = muon_->phi();
+        MuonCharge[1] = muon_->charge();
       }
     }
     if (muon_->pt() > dimuon_Muon1_pt_cut_)
@@ -576,6 +583,13 @@ void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       ElectronEta[0] = electron_->eta();
       ElectronPhi[0] = electron_->phi();
       ElectronCharge[0] = electron_->charge();
+    } else if (electron_->pt() > ElectronPt[1] && electron_->pt() < ElectronPt[0]) {
+      ElectronPt[1] = electron_->pt();
+      ElectronPx[1] = electron_->px();
+      ElectronPy[1] = electron_->py();
+      ElectronEta[1] = electron_->eta();
+      ElectronPhi[1] = electron_->phi();
+      ElectronCharge[1] = electron_->charge();
     }
     if (electron_->pt() > dielectron_Electron1_pt_cut_)
       dielectron_countElectron_++;
@@ -598,7 +612,6 @@ void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       PhotonTrkSumPtSolidConeDR03[1] = PhotonTrkSumPtSolidConeDR03[0];
       PhotonE1x5E5x5[1] = PhotonE1x5E5x5[0];
       PhotonE2x5E5x5[1] = PhotonE2x5E5x5[0];
-
       PhotonEnergy[0] = photon_->energy();
       PhotonPt[0] = photon_->pt();
       PhotonEt[0] = photon_->et();
@@ -610,6 +623,18 @@ void ExoticaDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       PhotonTrkSumPtSolidConeDR03[0] = photon_->trkSumPtSolidConeDR03();
       PhotonE1x5E5x5[0] = photon_->e1x5() / photon_->e5x5();
       PhotonE2x5E5x5[0] = photon_->e2x5() / photon_->e5x5();
+    } else if (photon_->pt() > PhotonPt[1] && photon_->pt() < PhotonPt[0]) {
+      PhotonEnergy[1] = photon_->energy();
+      PhotonPt[1] = photon_->pt();
+      PhotonEt[1] = photon_->et();
+      PhotonEta[1] = photon_->eta();
+      PhotonEtaSc[1] = photon_->caloPosition().eta();
+      PhotonPhi[1] = photon_->phi();
+      PhotonHoverE[1] = photon_->hadronicOverEm();
+      PhotonSigmaIetaIeta[1] = photon_->sigmaIetaIeta();
+      PhotonTrkSumPtSolidConeDR03[1] = photon_->trkSumPtSolidConeDR03();
+      PhotonE1x5E5x5[1] = photon_->e1x5() / photon_->e5x5();
+      PhotonE2x5E5x5[1] = photon_->e2x5() / photon_->e5x5();
 
       if (photon_->pt() > dielectron_Electron1_pt_cut_)
         diphoton_countPhoton_++;

--- a/DQM/Physics/test/ExoticaDQM_cfg.py
+++ b/DQM/Physics/test/ExoticaDQM_cfg.py
@@ -1,31 +1,92 @@
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+
+## VarParsing object
+
+options = VarParsing('analysis')
+
+options.register('globaltag', '122X_mcRun3_2021_realistic_v1', VarParsing.multiplicity.singleton, VarParsing.varType.string, 'Set Global Tag')
+options.register('name', 'TEST', VarParsing.multiplicity.singleton, VarParsing.varType.string, 'Set process name')
+
+options.parseArguments()
+
+
+## Process
+
 process = cms.Process("ExoticaDQM")
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.GlobalTag.globaltag = cms.string("80X_mcRun2_asymptotic_v13")
+process.GlobalTag.globaltag = cms.string(options.globaltag)
 
 process.load("DQM.Physics.ExoticaDQM_cfi")
 process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 
-process.dqmSaver.workflow = cms.untracked.string('/Physics/Exotica/TEST')
+
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+
+process.DQMStore.verbose = cms.untracked.int32(2)
+process.dqmSaver.workflow = cms.untracked.string('/Physics/Exotica/WprimeENu')
+process.dqmSaver.convention = cms.untracked.string('RelVal')
+
+
+## output
+#Needed to the the plots locally
+
+process.output = cms.OutputModule("PoolOutputModule",
+  fileName       = cms.untracked.string('EXOTICA_DQM_' + options.name + '.root'),
+  outputCommands = cms.untracked.vstring(
+    'drop *_*_*_*',
+    'keep *_*_*_ExoticaDQM'
+    ),
+  splitLevel     = cms.untracked.int32(0),
+  dataset = cms.untracked.PSet(
+    dataTier   = cms.untracked.string(''),
+    filterName = cms.untracked.string('')
+  )
+)
+
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
 
+
+
 process.source = cms.Source(
     "PoolSource",
     fileNames = cms.untracked.vstring(
-       #'/store/relval/CMSSW_8_0_1/JetHT/GEN-SIM-RECO/80X_dataRun2_relval_v3_rereco_RelVal_jetHT2015DReReco-v1/10000/FA5A1EA3-73ED-E511-9B51-0025905B8582.root',
-       #'/store/data/Run2011A/MinimumBias/RAW/v1/000/165/121/0699429A-B37F-E011-A57A-0019B9F72D71.root',
-       '/store/relval/CMSSW_8_1_0_pre12/RelValDisplacedSUSY_stopToBottom_M_300_1000mm_13/GEN-SIM-RECO/81X_mcRun2_asymptotic_v8-v1/00000/BE4178D3-9A86-E611-8B45-0CC47A7C3450.root',
-       #'/store/relval/CMSSW_8_0_1/RelValTTbar_13/GEN-SIM-DIGI-RECO/80X_mcRun2_asymptotic_v6_FastSim-v1/10000/0402D6BF-BAE4-E511-B293-00248C55CC7F.root',
+'/store/relval/CMSSW_12_2_0_pre2/RelValZprimeToEE_M-6000_TuneCP5_14TeV-pythia8/GEN-SIM-RECO/122X_mcRun3_2021_realistic_v1_TkmkFitHighStat-v1/2580000/1e0694f9-fbf3-4bd0-8eef-3ec39232e5ad.root'
     )
 )
 
 process.load('JetMETCorrections.Configuration.JetCorrectors_cff')
 
-process.p = cms.Path( process.ExoticaDQM + process.dqmSaver)
-#process.p = cms.Path( process.dqmAk4PFCHSL1FastL2L3CorrectorChain + process.ExoticaDQM + process.dqmSaver)
+
+## path definitions
+process.p      = cms.Path(
+    process.ExoticaDQM
+
+)
+
+process.endjob = cms.Path(
+    process.endOfProcess
+)
+
+process.fanout = cms.EndPath(
+    process.output
+)
+
+
+## schedule definition
+process.schedule = cms.Schedule(
+    process.p,
+    process.endjob,
+    process.fanout
+)
+                          
+
+

--- a/DQM/Physics/test/ExoticaDQM_cfg.py
+++ b/DQM/Physics/test/ExoticaDQM_cfg.py
@@ -28,9 +28,8 @@ process.load("DQMServices.Components.DQMEnvironment_cfi")
 process.load('DQMOffline.Configuration.DQMOffline_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-process.DQMStore.verbose = cms.untracked.int32(2)
-process.dqmSaver.workflow = cms.untracked.string('/Physics/Exotica/WprimeENu')
-process.dqmSaver.convention = cms.untracked.string('RelVal')
+process.dqmSaver.workflow   = '/Physics/Exotica/WprimeENu'
+process.dqmSaver.convention = 'RelVal'
 
 
 ## output

--- a/DQM/Physics/test/ExoticaDQM_harvesting_cfg.py
+++ b/DQM/Physics/test/ExoticaDQM_harvesting_cfg.py
@@ -45,10 +45,10 @@ process.options = cms.untracked.PSet(
 #process.DQMStore.collateHistograms        = True
 process.EDMtoMEConverter.convertOnEndLumi = True
 process.EDMtoMEConverter.convertOnEndRun  = True
-process.dqmSaver.saveByRun      = cms.untracked.int32( -1)
-process.dqmSaver.saveAtJobEnd   = cms.untracked.bool(True)
-process.dqmSaver.forceRunNumber = cms.untracked.int32(  1)
-process.dqmSaver.workflow       = cms.untracked.string('/Physics/Exotica/' + options.name) ## adapt appropriately
+process.dqmSaver.saveByRun      = -1
+process.dqmSaver.saveAtJobEnd   = True
+process.dqmSaver.forceRunNumber = 1
+process.dqmSaver.workflow       = '/Physics/Exotica/' + options.name ## adapt appropriately
 
 
 ## path definitions

--- a/DQM/Physics/test/ExoticaDQM_harvesting_cfg.py
+++ b/DQM/Physics/test/ExoticaDQM_harvesting_cfg.py
@@ -1,0 +1,63 @@
+import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+
+## VarParsing object
+
+options = VarParsing('python')
+
+options.register('globaltag', '121X_mcRun3_2021_realistic_v15', VarParsing.multiplicity.singleton, VarParsing.varType.string, 'Set Global Tag')
+options.register('name', 'TEST', VarParsing.multiplicity.singleton, VarParsing.varType.string, 'Set process name')
+
+options.parseArguments()
+
+
+## Process
+
+process = cms.Process('HARVESTING')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Harvesting_cff')
+process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+## global tag
+process.GlobalTag.globaltag = cms.string(options.globaltag)
+
+## input file 
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(options.inputFiles),
+    processingMode = cms.untracked.string('RunsAndLumis')
+)
+
+## number of events
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+## output options
+process.options = cms.untracked.PSet(
+    Rethrow  = cms.untracked.vstring('ProductNotFound'),
+    fileMode = cms.untracked.string('FULLMERGE')
+)
+
+## DQMStore and output configuration
+#process.DQMStore.collateHistograms        = True
+process.EDMtoMEConverter.convertOnEndLumi = True
+process.EDMtoMEConverter.convertOnEndRun  = True
+process.dqmSaver.saveByRun      = cms.untracked.int32( -1)
+process.dqmSaver.saveAtJobEnd   = cms.untracked.bool(True)
+process.dqmSaver.forceRunNumber = cms.untracked.int32(  1)
+process.dqmSaver.workflow       = cms.untracked.string('/Physics/Exotica/' + options.name) ## adapt appropriately
+
+
+## path definitions
+process.edmtome = cms.Path(
+    process.EDMtoME
+)
+process.dqmsave = cms.Path(
+    process.DQMSaver
+)
+
+## schedule definition
+process.schedule = cms.Schedule(process.edmtome,process.dqmsave)


### PR DESCRIPTION
#### PR description:

This PR includes:

- A modification that fixes the routine to select the electrons, muons and photons that are counted in the DQM histograms. Currently, the code to select the object with highest pt assumes that these objects are ordered in ascending pt. This doesn't hold for all the validation samples and could result in order-dependent validations or reduction of statistics i.e. some high pt objects do not fill the histograms because they are placed in the "wrong" position. The addition of an "else if" statement allows to consider all these objects. 
This fix will have a positive impact in **DiMuon**,  **DiElectron**,  and **DiPhoton** categories where at least two muons/electrons/photons are required. 

- A change in the test cfg files to run the EXO code. The old **ExoticaDQM_cfg.py** is modified to run the processing step only, and a new **ExoticaDQM_harvesting_cfg.py** file is added to run the harvesting step separately. This was done because the old  ExoticaDQM_cfg.py test file wasn't filling the histograms.

#### PR validation:

The code has run over specific RelVal samples to check the output DQM histograms. The full set of monitoring objects can be found [here](https://fernance.web.cern.ch/fernance/ExoticaDQM-validation/PR-fixOrder_CMSSW_12_2_0_pre2/), but these are the most representative plots:

- [DiMuons plots with RelValZprimeToMuMu](https://fernance.web.cern.ch/fernance/ExoticaDQM-validation/PR-fixOrder_CMSSW_12_2_0_pre2/RelValZprimeToMuMu/DiMuons/)
- [DiElectrons plots with RelValZprimeToEE](https://fernance.web.cern.ch/fernance/ExoticaDQM-validation/PR-fixOrder_CMSSW_12_2_0_pre2/RelValZprimeToEE/DiElectrons/)
- [DiPhotons plots with RelValQCD_FlatPt_15_3000](https://fernance.web.cern.ch/fernance/ExoticaDQM-validation/PR-fixOrder_CMSSW_12_2_0_pre2/RelValQCD_FlatPt_15_3000/DiPhotons/)

_(These RelVal samples are the standard ones used to validate **CMSSW_12_2_0_pre2**, where this fix is made)_

The new config files **ExoticaDQM_cfg.py** and **ExoticaDQM_harvesting_cfg.py** were used to obtain these plots.

Apart from that, all dependencies were checked out, it had a clean build, all unit tests succeed and I run a battery of successful tests with:
`runTheMatrix.py -l limited -i all --ibeos`
`(42 41 40 30 18 4 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 failed)`
