### PR TITLE
Fix to allow G4 simulation of the long-lived susy-tau (1000015) decay products

### DIFF
--- a/SimG4Core/Generators/src/Generator.cc
+++ b/SimG4Core/Generators/src/Generator.cc
@@ -473,7 +473,8 @@ void Generator::particleAssignDaughters(G4PrimaryParticle *g4p, HepMC::GenPartic
     if (verbose > 2)
       LogDebug("SimG4CoreGenerator") << "Assigning a " << (*vpdec)->pdg_id() << " as daughter of a " << vp->pdg_id();
 
-    if ((*vpdec)->status() == 2 && (*vpdec)->end_vertex() != nullptr) {
+    if (((*vpdec)->status() == 2 || ((*vpdec)->status() == 23 && std::abs(vp->pdg_id()) == 1000015)) &&
+        (*vpdec)->end_vertex() != nullptr) {
       double x2 = (*vpdec)->end_vertex()->position().x();
       double y2 = (*vpdec)->end_vertex()->position().y();
       double z2 = (*vpdec)->end_vertex()->position().z();


### PR DESCRIPTION
#### PR description:

The issue is described under the following link: https://github.com/cms-sw/cmssw/issues/36706
And related to the following dicussion: https://hypernews.cern.ch/HyperNews/CMS/get/simDevelopment/1997/1/1/1.html

In the corresponding PR we add fix in order to prevent the duplication of the decay products of the long-lived charged stau (1000015), the gen particles are generated by the Pythia:
![sta_status23](https://user-images.githubusercontent.com/31743376/150530196-700d5e36-ef9c-47d9-a934-a8faaf98e940.jpg)
In order to add the whole decay chain of stau using the following function without chain break https://github.com/cms-sw/cmssw/blob/df76a09aa010097fbc0a2356e6933ddd01070a3a/SimG4Core/Generators/src/Generator.cc#L396 we need to prevent iterations from stopping at the particle with intermediate status=23 which highlighted on the picture above.

The check of the mother pdgId == 1000015 is added to apply the fix only specifically for stau MC.

#### PR validation:

- the basic style tests specified on the following page are performed http://cms-sw.github.io/PRWorkflow.html
- runTheMatrix tests results: 
[runTheMatrix.log](https://github.com/cms-sw/cmssw/files/7914142/runTheMatrix.log)

- the visual inspection shows that after corresponding fix, SimTracks are not duplicated
**before the fix**
![Screenshot from 2022-01-21 13-19-43](https://user-images.githubusercontent.com/31743376/150530304-6b48ac6e-1444-4f0a-8256-51182687b957.png)
**after the fix**
![Screenshot from 2022-01-21 13-20-00](https://user-images.githubusercontent.com/31743376/150530326-11fbc3c1-ce4c-48a3-b32f-1015a5a23355.png)

