### PR TITLE
Add forgotten SharedResources for TFileService in L1Trigger/L1TNtuples

### DIFF
--- a/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1CaloTowerTreeProducer.cc
@@ -59,7 +59,7 @@ Implementation:
 // class declaration
 //
 
-class L1CaloTowerTreeProducer : public edm::one::EDAnalyzer<> {
+class L1CaloTowerTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1CaloTowerTreeProducer(const edm::ParameterSet&);
   ~L1CaloTowerTreeProducer() override = default;
@@ -112,6 +112,8 @@ L1CaloTowerTreeProducer::L1CaloTowerTreeProducer(const edm::ParameterSet& iConfi
 
   if (clusterTag.instance() != std::string(""))
     l1ClusterToken_ = consumes<l1t::CaloClusterBxCollection>(clusterTag);
+
+  usesResource(TFileService::kSharedResource);
 
   // set up output
   tree_ = fs_->make<TTree>("L1CaloTowerTree", "L1CaloTowerTree");

--- a/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1uGTTreeProducer.cc
@@ -25,7 +25,7 @@
 // class declaration
 //
 
-class L1uGTTreeProducer : public edm::one::EDAnalyzer<> {
+class L1uGTTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1uGTTreeProducer(edm::ParameterSet const &);
   ~L1uGTTreeProducer() override = default;
@@ -59,6 +59,7 @@ L1uGTTreeProducer::L1uGTTreeProducer(edm::ParameterSet const &config)
       ugtToken_(consumes<GlobalAlgBlkBxCollection>(config.getParameter<edm::InputTag>("ugtToken"))),
       l1GtMenuToken_(esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>()),
       cache_id_(0) {
+  usesResource(TFileService::kSharedResource);
   // set up the TTree and its branches
   tree_ = fs_->make<TTree>("L1uGTTree", "L1uGTTree");
   tree_->Branch("L1uGT", "GlobalAlgBlk", &results_, 32000, 3);


### PR DESCRIPTION
#### PR description:

Follow up of #36756. As pointed out by @Dr15Jones , the SharedResources for the TFileService were forgotten while porting to the one::EDAnalyzer there. This PR simply adds them in the two files touched by that PR

It has to be remembered when migrating the remaing files in that package (@elfontan )

#### PR validation:

It builds