### PR TITLE
[DQM] Fix for DQM merging exception due to duplicated labels 12_2_X

### DIFF
--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -373,7 +373,7 @@ void DTDataIntegrityTask::bookHistosROS(DQMStore::IBooker& ibooker, const int wh
       if (link > 18 && link < 22)
         sector = 14;
       else if (link == 22 || link == 23)
-        rob = rob - 1;
+        rob = rob - 3;
     }
 
     //Sector 11 exceptions
@@ -474,7 +474,7 @@ void DTDataIntegrityTask::bookHistosROS(DQMStore::IBooker& ibooker, const int wh
       if (link > 18 && link < 22)
         sector = 14;
       else if (link == 22 || link == 23)
-        rob = rob - 1;
+        rob = rob - 3;
     }
 
     //Sector 11 exceptions


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/36778

This PR fixes the crash in DQM merging due to duplicated lables reported on:
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2328/1/1/1/1/1.html