### PR TITLE
MTD reconstruction: speed up TrackExtenderWithMTD

### DIFF
--- a/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
+++ b/Configuration/StandardSequences/python/earlyDeleteSettings_cff.py
@@ -6,6 +6,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.Configuration.customiseEarlyDeleteForSeeding import customiseEarlyDeleteForSeeding
 from RecoTracker.Configuration.customiseEarlyDeleteForMkFit import customiseEarlyDeleteForMkFit
+from RecoTracker.Configuration.customiseEarlyDeleteForCKF import customiseEarlyDeleteForCKF
 from CommonTools.ParticleFlow.Isolation.customiseEarlyDeleteForCandIsoDeposits import customiseEarlyDeleteForCandIsoDeposits
 
 def _hasInputTagModuleLabel(process, pset, psetModLabel, moduleLabels, result):
@@ -45,6 +46,7 @@ def customiseEarlyDelete(process):
 
     products = customiseEarlyDeleteForSeeding(process, products)
     products = customiseEarlyDeleteForMkFit(process, products)
+    products = customiseEarlyDeleteForCKF(process, products)
 
     products = customiseEarlyDeleteForCandIsoDeposits(process, products)
 

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -25,6 +25,7 @@
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
@@ -446,7 +447,7 @@ public:
     return RefitDirection::undetermined;
   }
 
-  reco::Track buildTrack(const reco::Track&,
+  reco::Track buildTrack(const reco::TrackRef&,
                          const Trajectory&,
                          const Trajectory&,
                          const reco::BeamSpot&,
@@ -483,6 +484,7 @@ private:
   edm::EDPutToken assocOrigTrkToken_;
 
   edm::EDGetTokenT<InputCollection> tracksToken_;
+  edm::EDGetTokenT<TrajTrackAssociationCollection> trajTrackAToken_;
   edm::EDGetTokenT<MTDTrackingDetSetVector> hitsToken_;
   edm::EDGetTokenT<reco::BeamSpot> bsToken_;
   edm::EDGetTokenT<GlobalPoint> genVtxPositionToken_;
@@ -521,6 +523,7 @@ private:
 template <class TrackCollection>
 TrackExtenderWithMTDT<TrackCollection>::TrackExtenderWithMTDT(const ParameterSet& iConfig)
     : tracksToken_(consumes<InputCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
+      trajTrackAToken_(consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trjtrkAssSrc"))),
       hitsToken_(consumes<MTDTrackingDetSetVector>(iConfig.getParameter<edm::InputTag>("hitsSrc"))),
       bsToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotSrc"))),
       updateTraj_(iConfig.getParameter<bool>("updateTrackTrajectory")),
@@ -586,6 +589,7 @@ template <class TrackCollection>
 void TrackExtenderWithMTDT<TrackCollection>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc, transDesc;
   desc.add<edm::InputTag>("tracksSrc", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("trjtrkAssSrc", edm::InputTag("generalTracks"));
   desc.add<edm::InputTag>("hitsSrc", edm::InputTag("mtdTrackingRecHits"));
   desc.add<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot"));
   desc.add<edm::InputTag>("genVtxPositionSrc", edm::InputTag("genParticles:xyz0"));
@@ -682,7 +686,9 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   std::vector<int> assocOrigTrkRaw;
 
   auto const tracksH = ev.getHandle(tracksToken_);
-  const auto& tracks = *tracksH;
+
+  auto const trjtrkH = ev.getHandle(trajTrackAToken_);
+  const auto& trjtrks = *trjtrkH;
 
   //MTD hits DetSet
   const auto& hits = ev.get(hitsToken_);
@@ -716,38 +722,41 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
   std::vector<unsigned> track_indices;
   unsigned itrack = 0;
 
-  for (const auto& track : tracks) {
+  for (const auto& trjtrk : trjtrks) {
+    const Trajectory& trajs = *trjtrk.key;
+    const reco::TrackRef& track = trjtrk.val;
+
     float trackVtxTime = 0.f;
     if (useVertex_) {
       float dz;
       if (useSimVertex_)
-        dz = std::abs(track.dz(math::XYZPoint(*genPV)));
+        dz = std::abs(track->dz(math::XYZPoint(*genPV)));
       else
-        dz = std::abs(track.dz(pv->position()));
+        dz = std::abs(track->dz(pv->position()));
 
       if (dz < dzCut_)
         trackVtxTime = vtxTime;
     }
 
     reco::TransientTrack ttrack(track, magfield.product(), gtg_);
-    const auto& trajs = theTransformer->transform(track);
     auto thits = theTransformer->getTransientRecHits(ttrack);
     TransientTrackingRecHit::ConstRecHitContainer mtdthits;
     MTDHitMatchingInfo mBTL, mETL;
-    if (!trajs.empty()) {
+
+    if (trajs.isValid()) {
       // get the outermost trajectory point on the track
       TrajectoryStateOnSurface tsos = builder_->build(track).outermostMeasurementState();
       TrajectoryStateClosestToBeamLine tscbl;
-      bool tscbl_status = getTrajectoryStateClosestToBeamLine(trajs.front(), bs, prop, tscbl);
+      bool tscbl_status = getTrajectoryStateClosestToBeamLine(trajs, bs, prop, tscbl);
 
       if (tscbl_status) {
         float pmag2 = tscbl.trackStateAtPCA().momentum().mag2();
         float pathlength0;
         TrackSegments trs0;
-        trackPathLength(trajs.front(), tscbl, prop, pathlength0, trs0);
+        trackPathLength(trajs, tscbl, prop, pathlength0, trs0);
 
         const auto& btlhits = tryBTLLayers(tsos,
-                                           trajs.front(),
+                                           trajs,
                                            pmag2,
                                            pathlength0,
                                            trs0,
@@ -764,7 +773,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         // in the future this should include an intermediate refit before propagating to the ETL
         // for now it is ok
         const auto& etlhits = tryETLLayers(tsos,
-                                           trajs.front(),
+                                           trajs,
                                            pmag2,
                                            pathlength0,
                                            trs0,
@@ -778,7 +787,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
                                            mETL);
         mtdthits.insert(mtdthits.end(), etlhits.begin(), etlhits.end());
       }
-    }  //!trajs.empty()
+    }
 
     auto ordering = checkRecHitsOrdering(thits);
     if (ordering == RefitDirection::insideOut) {
@@ -789,16 +798,17 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
       thits.swap(mtdthits);
     }
 
-    const auto& trajwithmtd = mtdthits.empty() ? trajs : theTransformer->transform(ttrack, thits);
+    const auto& trajwithmtd =
+        mtdthits.empty() ? std::vector<Trajectory>(1, trajs) : theTransformer->transform(ttrack, thits);
     float pMap = 0.f, betaMap = 0.f, t0Map = 0.f, sigmat0Map = -1.f, pathLengthMap = -1.f, tmtdMap = 0.f,
           sigmatmtdMap = -1.f, tofpiMap = 0.f, tofkMap = 0.f, tofpMap = 0.f;
     int iMap = -1;
 
     for (const auto& trj : trajwithmtd) {
-      const auto& thetrj = (updateTraj_ ? trj : trajs.front());
+      const auto& thetrj = (updateTraj_ ? trj : trajs);
       float pathLength = 0.f, tmtd = 0.f, sigmatmtd = -1.f, tofpi = 0.f, tofk = 0.f, tofp = 0.f;
-      LogTrace("TrackExtenderWithMTD") << "Refit track " << itrack << " p/pT = " << track.p() << " " << track.pt()
-                                       << " eta = " << track.eta();
+      LogTrace("TrackExtenderWithMTD") << "Refit track " << itrack << " p/pT = " << track->p() << " " << track->pt()
+                                       << " eta = " << track->eta();
       reco::Track result = buildTrack(track,
                                       thetrj,
                                       trj,
@@ -845,7 +855,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
         tofkMap = tofk;
         tofpMap = tofp;
         reco::TrackExtraRef extraRef(extrasRefProd, extras->size() - 1);
-        backtrack.setExtra((updateExtra_ ? extraRef : track.extra()));
+        backtrack.setExtra((updateExtra_ ? extraRef : track->extra()));
         for (unsigned ihit = hitsstart; ihit < hitsend; ++ihit) {
           backtrack.appendHitPattern((*outhits)[ihit], ttopo);
         }
@@ -1110,7 +1120,7 @@ void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* il
 //below is unfortunately ripped from other places but
 //since track producer doesn't know about MTD we have to do this
 template <class TrackCollection>
-reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track& orig,
+reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::TrackRef& orig,
                                                                const Trajectory& traj,
                                                                const Trajectory& trajWithMtd,
                                                                const reco::BeamSpot& bs,
@@ -1151,7 +1161,7 @@ reco::Track TrackExtenderWithMTDT<TrackCollection>::buildTrack(const reco::Track
                        mom,
                        tscbl.trackStateAtPCA().charge(),
                        tscbl.trackStateAtPCA().curvilinearError(),
-                       orig.algo(),
+                       orig->algo(),
                        reco::TrackBase::undefQuality,
                        t0,
                        betaOut,

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -687,8 +687,7 @@ void TrackExtenderWithMTDT<TrackCollection>::produce(edm::Event& ev, const edm::
 
   auto const tracksH = ev.getHandle(tracksToken_);
 
-  auto const trjtrkH = ev.getHandle(trajTrackAToken_);
-  const auto& trjtrks = *trjtrkH;
+  const auto& trjtrks = ev.get(trajTrackAToken_);
 
   //MTD hits DetSet
   const auto& hits = ev.get(hitsToken_);

--- a/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
+++ b/RecoMTD/TrackExtender/plugins/TrackExtenderWithMTD.cc
@@ -1074,11 +1074,14 @@ void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* il
   else
     find_hits(0, false);
 
+  float spaceChi2Cut = ilay->isBarrel() ? btlChi2Cut_ : etlChi2Cut_;
+  float timeChi2Cut = ilay->isBarrel() ? btlTimeChi2Cut_ : etlTimeChi2Cut_;
+
   //just take the first hit because the hits are sorted on their matching quality
   if (!hitsInLayer.empty()) {
     //check hits to pass minimum quality matching requirements
     auto const& firstHit = *hitsInLayer.begin();
-    if (firstHit.estChi2 < etlChi2Cut_ && firstHit.timeChi2 < etlTimeChi2Cut_) {
+    if (firstHit.estChi2 < spaceChi2Cut && firstHit.timeChi2 < timeChi2Cut) {
       hitMatched = true;
       output.push_back(hitbuilder_->build(firstHit.hit));
       if (firstHit < bestHit)
@@ -1092,8 +1095,8 @@ void TrackExtenderWithMTDT<TrackCollection>::fillMatchingHits(const DetLayer* il
     find_hits(0, false);
     if (!hitsInLayer.empty()) {
       auto const& firstHit = *hitsInLayer.begin();
-      if (firstHit.timeChi2 < etlTimeChi2Cut_) {
-        if (firstHit.estChi2 < etlChi2Cut_) {
+      if (firstHit.timeChi2 < timeChi2Cut) {
+        if (firstHit.estChi2 < spaceChi2Cut) {
           hitMatched = true;
           output.push_back(hitbuilder_->build(firstHit.hit));
           if (firstHit < bestHit)

--- a/RecoTracker/Configuration/python/customiseEarlyDeleteForCKF.py
+++ b/RecoTracker/Configuration/python/customiseEarlyDeleteForCKF.py
@@ -10,15 +10,47 @@ def customiseEarlyDeleteForCKF(process, products):
     def _branchName(productType, moduleLabel, instanceLabel=""):
         return "%s_%s_%s_%s" % (productType, moduleLabel, instanceLabel, process.name_())
 
+    trajectoryLabels = []
+    trackListMergers = []
+    def _addProduct(name):
+        products[name].append(_branchName("Trajectorys", name))
+        products[name].append(_branchName("TrajectorysToOnerecoTracksAssociation", name))
+        trajectoryLabels.append(name)
+
     for name, module in process.producers_().items():
-        cppType = module._TypedParameterizable__type
+        cppType = module.type_()
         if cppType == "TrackProducer":
             if module.TrajectoryInEvent:
-                products[name].append(_branchName("Trajectorys", name))
-                products[name].append(_branchName("TrajectorysToOnerecoTracksAssociation", name))
+                _addProduct(name)
         elif cppType == "DuplicateListMerger":
             if module.copyTrajectories:
-                products[name].append(_branchName("Trajectorys", name))
-                products[name].append(_branchName("TrajectorysToOnerecoTracksAssociation", name))
+                _addProduct(name)
+        elif cppType == "TrackListMerger":
+            trackListMergers.append(module)
+
+    # TrackListMerger copies Trajectory collections silently, so we
+    # add its Trajectory products only if we know from above the input
+    # has Trajectory collections. Note that this property is transitive.
+    def _containsTrajectory(vinputtag):
+        for t in vinputtag:
+            t2 = t
+            if not isinstance(t, cms.VInputTag):
+                t2 = cms.InputTag(t)
+            for label in trajectoryLabels:
+                if t2.getModuleLabel() == label:
+                    return True
+        return False
+
+    changed = True
+    while changed:
+        changed = False
+        noTrajectoryYet = []
+        for tlm in trackListMergers:
+            if _containsTrajectory(tlm.TrackProducers):
+                _addProduct(tlm.label())
+                changed = True
+            else:
+                noTrajectoryYet.append(tlm)
+        trackListMergers = noTrajectoryYet
 
     return products

--- a/RecoTracker/Configuration/python/customiseEarlyDeleteForCKF.py
+++ b/RecoTracker/Configuration/python/customiseEarlyDeleteForCKF.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+import collections
+
+def customiseEarlyDeleteForCKF(process, products):
+
+    if "trackExtenderWithMTD" not in process.producerNames():
+        return products
+
+    def _branchName(productType, moduleLabel, instanceLabel=""):
+        return "%s_%s_%s_%s" % (productType, moduleLabel, instanceLabel, process.name_())
+
+    for name, module in process.producers_().items():
+        cppType = module._TypedParameterizable__type
+        if cppType == "TrackProducer":
+            if module.TrajectoryInEvent:
+                products[name].append(_branchName("Trajectorys", name))
+                products[name].append(_branchName("TrajectorysToOnerecoTracksAssociation", name))
+        elif cppType == "DuplicateListMerger":
+            if module.copyTrajectories:
+                products[name].append(_branchName("Trajectorys", name))
+                products[name].append(_branchName("TrajectorysToOnerecoTracksAssociation", name))
+
+    return products

--- a/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
+++ b/RecoTracker/FinalTrackSelectors/python/MergeTrackCollections_cff.py
@@ -74,3 +74,7 @@ conversionStepTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.track
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False),
 )
+
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify(mergedDuplicateTracks, TrajectoryInEvent = True)
+phase2_timing_layer.toModify(generalTracks, copyTrajectories = True)

--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -231,6 +231,9 @@ detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
 )
 fastSim.toModify(detachedQuadStepTracks,TTRHBuilder = 'WithoutRefit')
 
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify(detachedQuadStepTracks, TrajectoryInEvent = True)
+
 # TRACK SELECTION AND QUALITY FLAG SETTING.
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierDetached_cfi import *
 detachedQuadStep = TrackMVAClassifierDetached.clone(

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -274,6 +274,9 @@ highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProdu
 )
 fastSim.toModify(highPtTripletStepTracks,TTRHBuilder = 'WithoutRefit')
 
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify(highPtTripletStepTracks, TrajectoryInEvent = True)
+
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 highPtTripletStep = TrackMVAClassifierPrompt.clone(

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -275,6 +275,9 @@ initialStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.cl
 )
 fastSim.toModify(initialStepTracks, TTRHBuilder = 'WithoutRefit')
 
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify(initialStepTracks, TrajectoryInEvent = True)
+
 #vertices
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import offlinePrimaryVertices as _offlinePrimaryVertices
 firstStepPrimaryVerticesUnsorted = _offlinePrimaryVertices.clone(

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -221,6 +221,8 @@ lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.
 )
 fastSim.toModify(lowPtQuadStepTracks,TTRHBuilder = 'WithoutRefit')
 
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify(lowPtQuadStepTracks, TrajectoryInEvent = True)
 
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -288,6 +288,9 @@ lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
 )
 fastSim.toModify(lowPtTripletStepTracks, TTRHBuilder = 'WithoutRefit')
 
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify(lowPtTripletStepTracks, TrajectoryInEvent = True)
+
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 lowPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
     ComponentName       = 'lowPtTripletStepTrajectoryCleanerBySharedHits',

--- a/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MuonSeededStep_cff.py
@@ -248,6 +248,11 @@ muonSeededStepCoreTask = cms.Task(
 muonSeededStepCore = cms.Sequence(muonSeededStepCoreTask)
 #Phase2 : just muon Seed InOut is used in this moment
 #trackingPhase2PU140.toReplaceWith(muonSeededStepCore, muonSeededStepCoreInOut)
+
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify(muonSeededTracksInOut, TrajectoryInEvent = True)
+phase2_timing_layer.toModify(muonSeededTracksOutIn, TrajectoryInEvent = True)
+
 muonSeededStepExtraInOutTask = cms.Task(
     muonSeededTracksInOutClassifier
 )

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -361,6 +361,9 @@ pixelPairStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.
 )
 fastSim.toModify(pixelPairStepTracks, TTRHBuilder = 'WithoutRefit')
 
+from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer
+phase2_timing_layer.toModify(pixelPairStepTracks, TrajectoryInEvent = True)
+
 # Final selection
 from RecoTracker.FinalTrackSelectors.TrackMVAClassifierPrompt_cfi import *
 pixelPairStep =  TrackMVAClassifierPrompt.clone(


### PR DESCRIPTION
#### PR description:

This PR proposes an update of ```TrackExtenderWithMTD``` following the presentation at the TRK POG meeting https://indico.cern.ch/event/1108413/contributions/4662751/attachments/2373693/4054455/TRK_MTD_20220117.pdf and the following discussion. 

About 1/3 of the time used by this module is taken by retrieving the ```Trajectory``` for a given general track using the ```TrackTransformer```, see https://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/CMSSW_12_2_0_pre3/34834.21/step3/cpu_endjob/92 . This can be avoided by reusing the ```Trajectory``` optionally stored in a transient form into the event by the iterative tracking, an option by default disabled. 
Of course this comes at some cost in memory usage, which should be balanced with the CPU gain benefit.

The activation of the flags to save the trajectories in the event if made only for the selection of modules entering into the definition of the ```generalTracks``` output, which at present constitutes the input of the ```TrackExtenderWithMTD```

#### PR validation:

Tests have been done using the benchmark workflow 34834.21 (D76 scenario TTbar with PU, prod-like), using a home-made MinBias pile-up sample of 10k events. A simple memory and CPU profiling (single stream mode) on 100 events shows a gain in CPU:

```
TimeReport> Time report complete in 5809.45 seconds
 Time Summary: 
 - Min event:   34.1598
 - Max event:   83.5143
 - Avg event:   55.9624
 - Total loop:  5753.35
 - Total init:  55.8676
 - Total job:   5809.45
 - EventSetup Lock: 0
 - EventSetup Get:  0
 Event Throughput: 0.0173812 ev/s
 CPU Summary: 
 - Total loop:     5633.37
 - Total init:     30.6902
 - Total extra:    0
 - Total children: 0.184089
 - Total job:      5664.15
 Processing Summary: 
 - Number of Events:  100
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1
```

vs previous

```
TimeReport> Time report complete in 6020.16 seconds
 Time Summary: 
 - Min event:   32.6102
 - Max event:   85.8682
 - Avg event:   57.9717
 - Total loop:  5935.13
 - Total init:  84.8239
 - Total job:   6020.16
 - EventSetup Lock: 0
 - EventSetup Get:  0
 Event Throughput: 0.0168488 ev/s
 CPU Summary: 
 - Total loop:     5861.23
 - Total init:     34.564
 - Total extra:    0
 - Total children: 0.168424
 - Total job:      5895.85
 Processing Summary: 
 - Number of Events:  100
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1
```

with similar CPU load in both tests, and an extra memory load quantified in about 5%:

```
MemoryReport> Peak virtual size 6426.03 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 5458.03 deltaVsize = 0 rss = 3278.55 delta = 0
[2] run: 1 lumi: 1 event: 2  vsize = 5970.03 deltaVsize = 512 rss = 3375.28 delta = 96.7305
[7] run: 1 lumi: 1 event: 7  vsize = 6426.03 deltaVsize = 456 rss = 3375.51 delta = 0.234375
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[9] run: 1 lumi: 1 event: 9  vsize = 6426.03 deltaVsize = 0 rss = 3393.05 delta = 17.5352
[8] run: 1 lumi: 1 event: 8  vsize = 6426.03 deltaVsize = 0 rss = 3178.45 delta = -197.059
[7] run: 1 lumi: 1 event: 7  vsize = 6426.03 deltaVsize = 456 rss = 3375.51 delta = 0.234375
```

vs previous

```
MemoryReport> Peak virtual size 6418.28 Mbytes
 Key events increasing vsize: 
[1] run: 1 lumi: 1 event: 1  vsize = 5458.28 deltaVsize = 0 rss = 3093.7 delta = 0
[7] run: 1 lumi: 1 event: 7  vsize = 5906.28 deltaVsize = 448 rss = 3178.19 delta = 84.4922
[19] run: 1 lumi: 1 event: 19  vsize = 6418.28 deltaVsize = 512 rss = 3202.4 delta = 24.207
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[21] run: 1 lumi: 1 event: 21  vsize = 6418.28 deltaVsize = 0 rss = 2888.15 delta = -314.25
[20] run: 1 lumi: 1 event: 20  vsize = 6418.28 deltaVsize = 0 rss = 3077.96 delta = -124.441
[19] run: 1 lumi: 1 event: 19  vsize = 6418.28 deltaVsize = 512 rss = 3202.4 delta = 24.207
```

An igprof PERF_TICKS profiling on 10 events shows the expected variation in the internal module CPU use, with the modue weighting now for 2.2% of the total CPU (vs more than 3% previously):

```
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
            2.2  .........     119.17 / 4'386.72     edm::stream::EDProducerAdaptorBase::doEvent(edm::EventTransitionInfo const&, edm::ActivityRegistry*, edm::ModuleCallingContext const*) [16]
[118]       2.2     119.17       1.68 / 117.49     TrackExtenderWithMTDT<std::vector<reco::Track, std::allocator<reco::Track> > >::produce(edm::Event&, edm::EventSetup const&)
            0.8  .........      44.98 / 59.01        TrackTransformer::transform(reco::TransientTrack const&, std::vector<std::shared_ptr<TrackingRecHit const>, std::allocator<std::shared_ptr<TrackingRecHit const> > >&) const [187]
            0.5  .........      29.13 / 29.13        TrackExtenderWithMTDT<std::vector<reco::Track, std::allocator<reco::Track> > >::tryETLLayers(TrajectoryStateOnSurface const&, Trajectory const&, float, float, (anonymous namespace)::TrackSegments const&, edmNew::DetSetVector<MTDTrackingRecHit> const&, MTDDetLayerGeometry const*, MagneticField const*, Propagator const*, reco::BeamSpot const&, float, bool, (anonymous namespace)::MTDHitMatchingInfo&) const [clone .constprop.0] [344]
            0.3  .........      15.16 / 15.16        TrackExtenderWithMTDT<std::vector<reco::Track, std::allocator<reco::Track> > >::buildTrack(reco::Track const&, Trajectory const&, Trajectory const&, reco::BeamSpot const&, MagneticField const*, Propagator const*, bool, float&, float&, float&, float&, float&, float&) const [926]
            0.2  .........       9.94 / 15.63        (anonymous namespace)::trackPathLength(Trajectory const&, TrajectoryStateClosestToBeamLine const&, Propagator const*, float&, (anonymous namespace)::TrackSegments&) [833]
            0.1  .........       7.55 / 16.30        (anonymous namespace)::getTrajectoryStateClosestToBeamLine(Trajectory const&, reco::BeamSpot const&, Propagator const*, TrajectoryStateClosestToBeamLine&) [676]
            0.0  .........       2.27 / 31.25        TrackExtenderWithMTDT<std::vector<reco::Track, std::allocator<reco::Track> > >::fillMatchingHits(DetLayer const*, TrajectoryStateOnSurface const&, Trajectory const&, float, float, (anonymous namespace)::TrackSegments const&, edmNew::DetSetVector<MTDTrackingRecHit> const&, Propagator const*, reco::BeamSpot const&, float const&, bool, std::vector<std::shared_ptr<TrackingRecHit const>, std::allocator<std::shared_ptr<TrackingRecHit const> > >&, (anonymous namespace)::MTDHitMatchingInfo&) const [325]
            0.0  .........       1.91 / 2.11         TrackTransformer::getTransientRecHits(reco::TransientTrack const&) const [2341]
            0.0  .........       0.90 / 58.40        std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() [190]
            0.0  .........       0.88 / 0.91         Traj2TrackHits::operator()(Trajectory const&, edm::OwnVector<TrackingRecHit, edm::ClonePolicy<TrackingRecHit> >&, std::vector<LocalTrajectoryParameters, std::allocator<LocalTrajectoryParameters> >&, std::vector<unsigned char, std::allocator<unsigned char> >&) const [3214]
            0.0  .........       0.54 / 0.54         TrackExtenderWithMTDT<std::vector<reco::Track, std::allocator<reco::Track> > >::buildTrackExtra(Trajectory const&) const [3891]
            0.0  .........       0.52 / 1.04         edm::AssociationMap<edm::OneToOne<std::vector<Trajectory, std::allocator<Trajectory> >, std::vector<reco::Track, std::allocator<reco::Track> >, unsigned short> >::get(unsigned long) const [3050]
            0.0  .........       0.49 / 0.49         void std::vector<reco::TrackExtra, std::allocator<reco::TrackExtra> >::_M_realloc_insert<reco::TrackExtra>(__gnu_cxx::__normal_iterator<reco::TrackExtra*, std::vector<reco::TrackExtra, std::allocator<reco::TrackExtra> > >, reco::TrackExtra&&) [4043]
            0.0  .........       0.40 / 0.95         reco::HitPattern::appendHit(TrackingRecHit const&, TrackerTopology const&) [3147]
            0.0  .........       0.33 / 5.01         reco::TransientTrack::TransientTrack(edm::Ref<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track, edm::refhelper::FindUsingAdvance<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track> > const&, MagneticField const*, edm::ESHandle<GlobalTrackingGeometry> const&) [1721]
            0.0  .........       0.33 / 0.34         non-virtual thunk to reco::TrackTransientTrack::outermostMeasurementState() const [4570]
            0.0  .........       0.30 / 0.30         std::vector<std::shared_ptr<TrackingRecHit const>, std::allocator<std::shared_ptr<TrackingRecHit const> > >::~vector() [4781]
            0.0  .........       0.28 / 114.60       operator delete(void*, unsigned long) [121]
            0.0  .........       0.27 / 0.27         edm::refitem::GetRefPtrImpl<std::vector<Trajectory, std::allocator<Trajectory> >, Trajectory, edm::refhelper::FindUsingAdvance<std::vector<Trajectory, std::allocator<Trajectory> >, Trajectory>, unsigned int>::getRefPtr_(edm::RefCore const&, unsigned int) [4916]
            0.0  .........       0.26 / 2.39         TransientTrackBuilder::build(edm::Ref<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track, edm::refhelper::FindUsingAdvance<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track> > const&) const [2248]
(...)
```

The DQM histogram comparison shows a very moderate difference in the output of MTD tracks and vertices tests, and 4D vertices. Since the code should just replace the ```Trajectory``` from the original track fit with its reconstruction from the ```TrackTransformer``` I would conclude that some possible small difference might be expected there. In any case the overall behaviour of the code looks very well consistent between the two versions, even though not strictly identical.