### PR TITLE
keep relvals input file order

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -113,9 +113,11 @@ def filesFromList(fileName,s=None):
         elif (line.find(".root")!=-1):
             entry=line.replace("\n","")
             prim.append(entry)
-    # remove any duplicates
-    prim = sorted(list(set(prim)))
-    sec = sorted(list(set(sec)))
+    # remove any duplicates but keep the order
+    file_seen = set()
+    prim = [f for f in prim if not (f in file_seen or file_seen.add(f))]
+    file_seen = set()
+    sec = [f for f in sec if not (f in file_seen or file_seen.add(f))]
     if s:
         if not hasattr(s,"fileNames"):
             s.fileNames=cms.untracked.vstring(prim)


### PR DESCRIPTION
For IBs and PR tests bot orders the input files in a way that the files which are available in ibeos cache comes first. The PR https://github.com/cms-sw/cmssw/pull/29454 changes this order. The new implementation removes the duplicates but keep the original order of input file. The implementation also speed up the code a bit e.g. for 
```
dasgoclient -query="file dataset=/Neutrino_E-10_gun/RunIISummer17PrePremix-PUAutumn18_102X_upgrade2018_realistic_v15-v1/GEN-SIM-DIGI-RAW"
``` 
with over 300K files `sorted(list(set(prim)))` takes `0.68s` while this changes only takes `0.1s`