### PR TITLE
Fix for smeared MET calculation and its uncertainties.

### DIFF
--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -342,9 +342,9 @@ void MET::setUncShift(double px, double py, double sumEt, METUncertainty shift, 
     //changing reference to only get the uncertainty shift and not the smeared one
     // which is performed independently
     shift = (MET::METUncertainty)(METUncertainty::METUncertaintySize + shift + 1);
-    const PackedMETUncertainty &ref = uncertainties_[METUncertainty::NoShift];
+    const PackedMETUncertainty &ref = corrections_[METCorrectionType::Smear];
     uncertainties_[shift].set(
-        px + ref.dpx() - this->px(), py + ref.dpy() - this->py(), sumEt + ref.dsumEt() - this->sumEt());
+        px - ref.dpx() - this->px(), py - ref.dpy() - this->py(), sumEt - ref.dsumEt() - this->sumEt());
   } else
     uncertainties_[shift].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
 }

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -61,6 +61,16 @@ namespace PFJetMETcorrInputProducer_namespace {
     reco::Candidate::LorentzVector operator()(const T& jet) const { return jet.p4(); }
   };
 
+  // functor to retrieve additional scales of jets
+  // general template just returns 1 because only pat::Jet keeps track of the scales
+  // specialized template for pat::Jet returns combined factor of additional scales
+  template <typename T>
+  class AdditionalScalesT {
+  public:
+    AdditionalScalesT() {}
+    float operator()(const T& jet) const { return 1.0; }
+  };
+
 }  // namespace PFJetMETcorrInputProducer_namespace
 
 template <typename T, typename Textractor>
@@ -196,6 +206,9 @@ private:
         corrJetP4 = jetCorrExtractor_(jet, jetCorrLabel_.label(), jetCorrEtaMax_, &rawJetP4);
       else
         corrJetP4 = jetCorrExtractor_(jet, jetCorr.product(), jetCorrEtaMax_, &rawJetP4);
+      // retrieve additional jet energy scales in case of pat::Jets (done via specialized template defined for pat::Jets) and apply them
+      const static PFJetMETcorrInputProducer_namespace::AdditionalScalesT<T> additionalScales{};
+      corrJetP4 *= additionalScales(jet);
 
       if (corrJetP4.pt() > type1JetPtThreshold_) {
         reco::Candidate::LorentzVector rawJetP4offsetCorr = rawJetP4;

--- a/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
@@ -22,9 +22,24 @@ namespace PFJetMETcorrInputProducer_namespace {
     RawJetExtractorT() {}
     reco::Candidate::LorentzVector operator()(const pat::Jet& jet) const {
       if (jet.jecSetsAvailable())
-        return jet.correctedP4("Uncorrected");
+        return jet.correctedP4(0);
       else
         return jet.p4();
+    }
+  };
+
+  // template specialization for pat::Jets
+  // retrieve combined factor of additional scales applied to the jets
+  // otherwise just return 1
+  template <>
+  class AdditionalScalesT<pat::Jet> {
+  public:
+    AdditionalScalesT() {}
+    float operator()(const pat::Jet& jet) const {
+      if (jet.jecSetsAvailable()) {
+        return jet.jecFactor("Uncorrected") / jet.jecFactor(0);
+      } else
+        return 1.0;
     }
   };
 }  // namespace PFJetMETcorrInputProducer_namespace


### PR DESCRIPTION
This PR is in reference to an older PR (https://github.com/cms-sw/cmssw/pull/36165).
It basically does the same thing, however with a lot less new lines of code.

**PR description:**

This pull request fixes the incorrect calculation of the nominal smeared missing transverse energy (MET). The underyling problem is the application of the JER correction factors. These factors are applied in PhysicsTools/PatUtils/interface/SmearedJetProducerT.h but later not considered when reverting to the uncorrected jets in JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h.
This results in the problem that the JER correction factors in the smeared MET calculation effectively cancels and therefore the smeared MET is basically the same as the regular type1-corrected MET. After the changes shown below, the nominal smeared MET distributions from MiniAOD are similar to the ones obtained from NanoAOD.

Finally, there is also a mistake when saving the JERup and JERdown varied smearedMET. The different contributions of the nominal smeared MET correction and the JERup and JERdown variations are not separated correctly from one another. After the changes shown below, the varied smeared MET distributions from MiniAOD are similar to the ones obtained from NanoAOD.

This pull request includes the following:

DataFormats/PatCandidates/src/MET.cc
- to get the corrections/deltas for the JER variations of the smeared MET, the calculation now takes the up/down-varied smeared MET (px,py,...) and subtracts the contributions from the nominal smeared MET corrections (ref.dpx(),ref.dpy(),...) as well as the nominal type1-corrected MET (this->px(),this->py(),...)
- the previous implementation is a mystery to me

 JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
- add a template class/functor (AdditionalScalesT) to retrieve additional scales (JER correction factors)
- in generic implementation it only applies 1 as a factor therefore doing nothing
- in case of pat::Jet, see below

 PhysicsTools/PatUtils/plugins/PATPFJetMETcorrInputProducer.cc
- edit pat::Jet template specialization of the already existing RawJetExtractor class to revert all possibly applied correction factors
- pat::Jet template specialization of AdditionalScalesT, which retrieves all previously applied jet scales

**PR validation:**

- runTheMatrix.py -l limited -i all' worked besides some workflows which had CMSDAS errors despite a working certificate
- 'scram b runtest' worked
