### PR TITLE
Phase2-gex114 Remove duplicate declaration of the constants in Geometry/MTDCommonData

### DIFF
--- a/Geometry/MTDCommonData/data/etl/v6/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v6/etl.xml
@@ -17,7 +17,6 @@
     <Constant name="FrontModerator_thickness" value="20*mm"/>
     <Constant name="BackSupportPlatecenter" value="3061.5*mm"/>
     <Constant name="BackSupportPlate_thickness" value="5*mm"/>
-    <Constant name="Active_Disc_thickness" value="8*mm"/>
     <Constant name="Disc_Rmin" value="300*mm"/>
     <Constant name="Disc_Rmax" value="1190*mm"/>
     <Constant name="PatchPanel_Rmin" value="1125*mm"/>
@@ -90,7 +89,6 @@
     <Constant name="LGAD_Substrate_translation_z" value="0.025*mm"/>
     <Constant name="PowerBoard_translation_z" value="1*mm"/>
     <Constant name="servicesServiceHybrid_translation_z" value="-2*mm"/>
-    <Constant name="SensorModule_translation_z" value="0.21*mm"/>
     <Constant name="ServiceHybrid_translation_z" value="1.*mm"/>
     <Constant name="xoffset_servicehybrid" value="1*mm"/>
 

--- a/Geometry/MTDCommonData/data/etl/v7/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v7/etl.xml
@@ -25,7 +25,6 @@
     <Constant name="PatchPanel_Cables_FrontModcenter" value="3048.5*mm"/>
     <Constant name="PatchPanel_Cables_thickness" value="21*mm"/>
     <Constant name="FrontModerator_thickness" value="20*mm"/>
-    <Constant name="Active_Disc_thickness" value="8*mm"/>
     <Constant name="BackSupportPlate_thickness" value="5*mm"/>
     <!-- <Constant name="Disc_Rmin" value="315*mm"/> --> <!-- correct value, but not compatible with current modules placement -->
     <Constant name="Disc_Rmin" value="300*mm"/>
@@ -126,7 +125,6 @@
     <Constant name="LGAD_Substrate_translation_z" value="0.025*mm"/>
     <Constant name="PowerBoard_translation_z" value="1*mm"/>
     <Constant name="servicesServiceHybrid_translation_z" value="-2*mm"/>
-    <Constant name="SensorModule_translation_z" value="0.21*mm"/>
     <Constant name="ServiceHybrid_translation_z" value="1.*mm"/>
     <Constant name="xoffset_servicehybrid" value="1*mm"/>
 


### PR DESCRIPTION
#### PR description:

Remove duplicate declaration of the constants in Geometry/MTDCommonData

#### PR validation:

Use runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special