### PR TITLE
Fix of a check on the geometry in the RPCConeBuilder

### DIFF
--- a/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
+++ b/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
@@ -121,7 +121,7 @@ void RPCConeBuilder::buildCones(RPCGeometry const* rpcGeom,
     it.second.fillWithVirtualStrips();
   }
 
-  // Xcheck, if rings are symettrical
+  // Xcheck, if rings are symmetrical
   for (auto& it : ringsMap) {
     int key = it.first;
     int sign = key / 100 - (key / 1000) * 10;
@@ -132,11 +132,17 @@ void RPCConeBuilder::buildCones(RPCGeometry const* rpcGeom,
       key -= 100;
     }
 
+    // Check if the geometry has a complete ring:
+    // in the case of demo chambers, the ring is not filled because only 2 sectors are added,
+    // so this check fails.
+    // Below part commented as a temporary solution as agreed with the L1 RPC team.
+    /*
     if (key != 2000) {  // Hey 2100 has no counterring
       if (it.second.size() != ringsMap[key].size()) {
         throw cms::Exception("RPCInternal") << " Size differs for ring " << key << " +- 100 \n";
       }
     }
+    */
   }
   buildConnections(l1RPCConeDefinition, ringsMap);
 }

--- a/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
+++ b/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
@@ -137,7 +137,7 @@ void RPCConeBuilder::buildCones(RPCGeometry const* rpcGeom,
     // Check if the geometry has a complete ring:
     // note that in the case of demo chambers, the ring is not filled because only 2 sectors are added.
     // (3014 and 4014 lack counter-rings)
-    if (key != 2000 && key != 3014 && key != 4014) {  // Hey 2100 has no countering
+    if (key != 2000 && key != 3014 && key != 4014) {  // Key 2100 has no counter-ring
       if (it.second.size() != ringsMap[key].size()) {
         throw cms::Exception("RPCInternal") << " Size differs for ring " << key << " +- 100 \n";
       }

--- a/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
+++ b/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
@@ -5,7 +5,9 @@
 //
 /**\class RPCConeBuilder RPCConeBuilder.h L1Trigger/RPCTriggerConfig/src/RPCConeBuilder.cc
 
- Description: <one line class summary>
+ Description: The RPCConeBuilder class is the emulator of the Run 1 RPC PAC Trigger. 
+              It is not used in the L1 Trigger decision since 2016.
+	      It might be needed just for the re-emulation of the Run 1 data.
 
  Implementation:
      <Notes on implementation>
@@ -133,16 +135,13 @@ void RPCConeBuilder::buildCones(RPCGeometry const* rpcGeom,
     }
 
     // Check if the geometry has a complete ring:
-    // in the case of demo chambers, the ring is not filled because only 2 sectors are added,
-    // so this check fails.
-    // Below part commented as a temporary solution as agreed with the L1 RPC team.
-    /*
-    if (key != 2000) {  // Hey 2100 has no counterring
+    // note that in the case of demo chambers, the ring is not filled because only 2 sectors are added.
+    // (3014 and 4014 lack counter-rings)
+    if (key != 2000 && key != 3014 && key != 4014) {  // Hey 2100 has no countering
       if (it.second.size() != ringsMap[key].size()) {
         throw cms::Exception("RPCInternal") << " Size differs for ring " << key << " +- 100 \n";
       }
     }
-    */
   }
   buildConnections(l1RPCConeDefinition, ringsMap);
 }


### PR DESCRIPTION
#### PR description:
Temporary fix of an issue encountered while testing the new CMSSW_12_3_0_pre4 release to run the L1 emulation. 
All details about the issue can be found in this [GitHub issue](https://github.com/cms-sw/cmssw/issues/36786).
Some follow-up is needed with L1 RPC people who agreed for now with the proposed solution of removing the problematic check on the geometry. It is supposed to check if the geometry has a complete ring, however in the case of demo chambers only two sectors are added and the ring is not filled, so that the check fails.

#### PR validation:
Basic tests performed successfully starting from CMSSW_12_3_0_pre4. 
From CMSSW_12_3_0_pre4/src:
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests
> scram build code-checks
> scram build code-format
> runTheMatrix.py -l limited -i all --ibeos