### PR TITLE
added VersionedSelector dict mapping to PhysicsTools/SelectorUtils

### DIFF
--- a/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
+++ b/Utilities/ReleaseScripts/scripts/duplicateReflexLibrarySearch.py
@@ -31,6 +31,7 @@ typedefsDict = \
 #Ordered List to search for matched packages
 equivDict = \
      [
+         {'SelectorUtils': ['VersionedSelector']},
          {'Associations': ['TTTrackTruthPair', 'edm::Wrapper.+edm::AssociationMap.+TrackingParticle']},
          {'TrajectoryState'         : ['TrajectoryStateOnSurface']},
          {'TrackTriggerAssociation' : ['(TTClusterAssociationMap|TTStubAssociationMap|TTTrackAssociationMap|TrackingParticle).*Phase2TrackerDigi',


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/pull/35953 has moved `VersionedSelector` related dictionaries under `PhysicsTools/SelectorUtils` as this is the package which defines `VersionedSelector<T>`. This change fixes the dictionary/package mapping for `VersionedSelector`