### PR TITLE
Update of binning in L1T Shower comparison DQM

### DIFF
--- a/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
@@ -19,30 +19,30 @@ void L1TdeCSCTPGShower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Ru
 
   // 2D summary plots
   lctShowerDataNomSummary_denom_ =
-      iBooker.book2D("lct_cscshower_data_nom_summary_denom", "Data LCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+      iBooker.book2D("lct_cscshower_data_nom_summary_denom", "Data LCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   lctShowerDataNomSummary_num_ = iBooker.book2D(
-      "lct_cscshower_data_nom_summary_num", "Data LCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+      "lct_cscshower_data_nom_summary_num", "Data LCT Nominal Shower Emul Matched", 36, 1, 37, 18, 0, 18);
   alctShowerDataNomSummary_denom_ = iBooker.book2D(
-      "alct_cscshower_data_nom_summary_denom", "Data ALCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+      "alct_cscshower_data_nom_summary_denom", "Data ALCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   alctShowerDataNomSummary_num_ = iBooker.book2D(
-      "alct_cscshower_data_nom_summary_num", "Data ALCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+      "alct_cscshower_data_nom_summary_num", "Data ALCT Nominal Shower Emul Matched", 36, 1, 37, 18, 0, 18);
   clctShowerDataNomSummary_denom_ = iBooker.book2D(
-      "clct_cscshower_data_nom_summary_denom", "Data CLCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+      "clct_cscshower_data_nom_summary_denom", "Data CLCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   clctShowerDataNomSummary_num_ = iBooker.book2D(
-      "clct_cscshower_data_nom_summary_num", "Data CLCT Nominal Only Shower Emul Matched", 36, 1, 37, 18, 0, 18);
+      "clct_cscshower_data_nom_summary_num", "Data CLCT Nominal Shower Emul Matched", 36, 1, 37, 18, 0, 18);
 
   lctShowerEmulNomSummary_denom_ =
-      iBooker.book2D("lct_cscshower_emul_nom_summary_denom", "Emul LCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+      iBooker.book2D("lct_cscshower_emul_nom_summary_denom", "Emul LCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   lctShowerEmulNomSummary_num_ = iBooker.book2D(
-      "lct_cscshower_emul_nom_summary_num", "Emul LCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+      "lct_cscshower_emul_nom_summary_num", "Emul LCT Nominal Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
   alctShowerEmulNomSummary_denom_ = iBooker.book2D(
-      "alct_cscshower_emul_nom_summary_denom", "Emul ALCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+      "alct_cscshower_emul_nom_summary_denom", "Emul ALCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   alctShowerEmulNomSummary_num_ = iBooker.book2D(
-      "alct_cscshower_emul_nom_summary_num", "Emul ALCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+      "alct_cscshower_emul_nom_summary_num", "Emul ALCT Nominal Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
   clctShowerEmulNomSummary_denom_ = iBooker.book2D(
-      "clct_cscshower_emul_nom_summary_denom", "Emul CLCT Nominal Only Shower All", 36, 1, 37, 18, 0, 18);
+      "clct_cscshower_emul_nom_summary_denom", "Emul CLCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   clctShowerEmulNomSummary_num_ = iBooker.book2D(
-      "clct_cscshower_emul_nom_summary_num", "Emul CLCT Nominal Only Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
+      "clct_cscshower_emul_nom_summary_num", "Emul CLCT Nominal Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
 
   lctShowerDataTightSummary_denom_ =
       iBooker.book2D("lct_cscshower_data_tight_summary_denom", "Data LCT Tight Shower All", 36, 1, 37, 18, 0, 18);
@@ -264,13 +264,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     alctShowerDataTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     alctShowerDataTightSummary_denom_->Fill(chamber, sr);
-                } else {
-                  if (chamber20) {
-                    alctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                    alctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                  } else
-                    alctShowerDataNomSummary_denom_->Fill(chamber, sr);
                 }
+                if (chamber20) {
+                  alctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  alctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                } else
+                  alctShowerDataNomSummary_denom_->Fill(chamber, sr);
                 // check for least one matching ALCT
                 for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++) {
                   if (ealct->isValid() and areSameShowers(*dalct, *ealct)) {
@@ -280,13 +279,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                         alctShowerDataTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                       } else
                         alctShowerDataTightSummary_num_->Fill(chamber, sr);
-                    } else {
-                      if (chamber20) {
-                        alctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                        alctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
-                      } else
-                        alctShowerDataNomSummary_num_->Fill(chamber, sr);
                     }
+                    if (chamber20) {
+                      alctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      alctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    } else
+                      alctShowerDataNomSummary_num_->Fill(chamber, sr);
                   }
                 }
               }
@@ -301,13 +299,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     alctShowerEmulTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     alctShowerEmulTightSummary_denom_->Fill(chamber, sr);
-                } else {
-                  if (chamber20) {
-                    alctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                    alctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                  } else
-                    alctShowerEmulNomSummary_denom_->Fill(chamber, sr);
                 }
+                if (chamber20) {
+                  alctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  alctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                } else
+                  alctShowerEmulNomSummary_denom_->Fill(chamber, sr);
                 // check for least one matching ALCT
                 for (auto dalct = range_dataALCT.first; dalct != range_dataALCT.second; dalct++) {
                   if (areSameShowers(*dalct, *ealct))
@@ -322,13 +319,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                       alctShowerEmulTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                     } else
                       alctShowerEmulTightSummary_num_->Fill(chamber, sr);
-                  } else {
-                    if (chamber20) {
-                      alctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                      alctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
-                    } else
-                      alctShowerEmulNomSummary_num_->Fill(chamber, sr);
                   }
+                  if (chamber20) {
+                    alctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                    alctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    alctShowerEmulNomSummary_num_->Fill(chamber, sr);
                 }
               }
             }  // End of for (auto ealct = range_emulALCT.first; ealct != range_emulALCT.second; ealct++)
@@ -345,13 +341,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     clctShowerDataTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     clctShowerDataTightSummary_denom_->Fill(chamber, sr);
-                } else {
-                  if (chamber20) {
-                    clctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                    clctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                  } else
-                    clctShowerDataNomSummary_denom_->Fill(chamber, sr);
                 }
+                if (chamber20) {
+                  clctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  clctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                } else
+                  clctShowerDataNomSummary_denom_->Fill(chamber, sr);
                 // check for least one matching CLCT
                 for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++) {
                   if (eclct->isValid() and areSameShowers(*dclct, *eclct)) {
@@ -361,13 +356,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                         clctShowerDataTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                       } else
                         clctShowerDataTightSummary_num_->Fill(chamber, sr);
-                    } else {
-                      if (chamber20) {
-                        clctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                        clctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
-                      } else
-                        clctShowerDataNomSummary_num_->Fill(chamber, sr);
                     }
+                    if (chamber20) {
+                      clctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      clctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    } else
+                      clctShowerDataNomSummary_num_->Fill(chamber, sr);
                   }
                 }
               }
@@ -382,13 +376,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     clctShowerEmulTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     clctShowerEmulTightSummary_denom_->Fill(chamber, sr);
-                } else {
-                  if (chamber20) {
-                    clctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                    clctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                  } else
-                    clctShowerEmulNomSummary_denom_->Fill(chamber, sr);
                 }
+                if (chamber20) {
+                  clctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  clctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                } else
+                  clctShowerEmulNomSummary_denom_->Fill(chamber, sr);
                 // check for least one matching CLCT
                 for (auto dclct = range_dataCLCT.first; dclct != range_dataCLCT.second; dclct++) {
                   if (areSameShowers(*dclct, *eclct))
@@ -403,13 +396,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                       clctShowerEmulTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                     } else
                       clctShowerEmulTightSummary_num_->Fill(chamber, sr);
-                  } else {
-                    if (chamber20) {
-                      clctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                      clctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
-                    } else
-                      clctShowerEmulNomSummary_num_->Fill(chamber, sr);
                   }
+                  if (chamber20) {
+                    clctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                    clctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    clctShowerEmulNomSummary_num_->Fill(chamber, sr);
                 }
               }
             }  // End of for (auto eclct = range_emulCLCT.first; eclct != range_emulCLCT.second; eclct++)
@@ -426,13 +418,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     lctShowerDataTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     lctShowerDataTightSummary_denom_->Fill(chamber, sr);
-                } else {
-                  if (chamber20) {
-                    lctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                    lctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                  } else
-                    lctShowerDataNomSummary_denom_->Fill(chamber, sr);
                 }
+                if (chamber20) {
+                  lctShowerDataNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  lctShowerDataNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                } else
+                  lctShowerDataNomSummary_denom_->Fill(chamber, sr);
                 // check for least one matching LCT
                 for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {
                   if (elct->isValid() and areSameShowers(*dlct, *elct)) {
@@ -442,13 +433,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                         lctShowerDataTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                       } else
                         lctShowerDataTightSummary_num_->Fill(chamber, sr);
-                    } else {
-                      if (chamber20) {
-                        lctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                        lctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
-                      } else
-                        lctShowerDataNomSummary_num_->Fill(chamber, sr);
                     }
+                    if (chamber20) {
+                      lctShowerDataNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                      lctShowerDataNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                    } else
+                      lctShowerDataNomSummary_num_->Fill(chamber, sr);
                   }
                 }
               }
@@ -463,13 +453,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                     lctShowerEmulTightSummary_denom_->Fill(chamber * 2, sr, 0.5);
                   } else
                     lctShowerEmulTightSummary_denom_->Fill(chamber, sr);
-                } else {
-                  if (chamber20) {
-                    lctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
-                    lctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
-                  } else
-                    lctShowerEmulNomSummary_denom_->Fill(chamber, sr);
                 }
+                if (chamber20) {
+                  lctShowerEmulNomSummary_denom_->Fill(chamber * 2 - 1, sr, 0.5);
+                  lctShowerEmulNomSummary_denom_->Fill(chamber * 2, sr, 0.5);
+                } else
+                  lctShowerEmulNomSummary_denom_->Fill(chamber, sr);
                 // check for least one matching LCT
                 for (auto dlct = range_dataLCT.first; dlct != range_dataLCT.second; dlct++) {
                   if (areSameShowers(*dlct, *elct))
@@ -484,13 +473,12 @@ void L1TdeCSCTPGShower::analyze(const edm::Event& e, const edm::EventSetup& c) {
                       lctShowerEmulTightSummary_num_->Fill(chamber * 2, sr, 0.5);
                     } else
                       lctShowerEmulTightSummary_num_->Fill(chamber, sr);
-                  } else {
-                    if (chamber20) {
-                      lctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
-                      lctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
-                    } else
-                      lctShowerEmulNomSummary_num_->Fill(chamber, sr);
                   }
+                  if (chamber20) {
+                    lctShowerEmulNomSummary_num_->Fill(chamber * 2 - 1, sr, 0.5);
+                    lctShowerEmulNomSummary_num_->Fill(chamber * 2, sr, 0.5);
+                  } else
+                    lctShowerEmulNomSummary_num_->Fill(chamber, sr);
                 }
               }
             }  // End of for (auto elct = range_emulLCT.first; elct != range_emulLCT.second; elct++) {

--- a/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPGShower.cc
@@ -22,12 +22,12 @@ void L1TdeCSCTPGShower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Ru
       iBooker.book2D("lct_cscshower_data_nom_summary_denom", "Data LCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   lctShowerDataNomSummary_num_ = iBooker.book2D(
       "lct_cscshower_data_nom_summary_num", "Data LCT Nominal Shower Emul Matched", 36, 1, 37, 18, 0, 18);
-  alctShowerDataNomSummary_denom_ = iBooker.book2D(
-      "alct_cscshower_data_nom_summary_denom", "Data ALCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerDataNomSummary_denom_ =
+      iBooker.book2D("alct_cscshower_data_nom_summary_denom", "Data ALCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   alctShowerDataNomSummary_num_ = iBooker.book2D(
       "alct_cscshower_data_nom_summary_num", "Data ALCT Nominal Shower Emul Matched", 36, 1, 37, 18, 0, 18);
-  clctShowerDataNomSummary_denom_ = iBooker.book2D(
-      "clct_cscshower_data_nom_summary_denom", "Data CLCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerDataNomSummary_denom_ =
+      iBooker.book2D("clct_cscshower_data_nom_summary_denom", "Data CLCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   clctShowerDataNomSummary_num_ = iBooker.book2D(
       "clct_cscshower_data_nom_summary_num", "Data CLCT Nominal Shower Emul Matched", 36, 1, 37, 18, 0, 18);
 
@@ -35,12 +35,12 @@ void L1TdeCSCTPGShower::bookHistograms(DQMStore::IBooker& iBooker, const edm::Ru
       iBooker.book2D("lct_cscshower_emul_nom_summary_denom", "Emul LCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   lctShowerEmulNomSummary_num_ = iBooker.book2D(
       "lct_cscshower_emul_nom_summary_num", "Emul LCT Nominal Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
-  alctShowerEmulNomSummary_denom_ = iBooker.book2D(
-      "alct_cscshower_emul_nom_summary_denom", "Emul ALCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
+  alctShowerEmulNomSummary_denom_ =
+      iBooker.book2D("alct_cscshower_emul_nom_summary_denom", "Emul ALCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   alctShowerEmulNomSummary_num_ = iBooker.book2D(
       "alct_cscshower_emul_nom_summary_num", "Emul ALCT Nominal Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
-  clctShowerEmulNomSummary_denom_ = iBooker.book2D(
-      "clct_cscshower_emul_nom_summary_denom", "Emul CLCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
+  clctShowerEmulNomSummary_denom_ =
+      iBooker.book2D("clct_cscshower_emul_nom_summary_denom", "Emul CLCT Nominal Shower All", 36, 1, 37, 18, 0, 18);
   clctShowerEmulNomSummary_num_ = iBooker.book2D(
       "clct_cscshower_emul_nom_summary_num", "Emul CLCT Nominal Shower Not Matched to Data", 36, 1, 37, 18, 0, 18);
 

--- a/DQM/L1TMonitor/src/L1TdeStage2RegionalShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2RegionalShower.cc
@@ -68,14 +68,16 @@ void L1TdeStage2RegionalShower::analyze(const edm::Event& e, const edm::EventSet
       if (dSh->isOneTightInTime())
         emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1,
                                            (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
-      emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+      emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1,
+                                         (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
         if (eSh->isValid() and eSh->isOneNominalInTime() and dSh->processor() == eSh->processor() and
             dSh->trackFinderType() == eSh->trackFinderType() and *dSh == *eSh) {
           if (dSh->isOneTightInTime())
             emtfShowerDataSummary_num_->Fill(dSh->processor() + 1,
                                              (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
-          emtfShowerDataSummary_num_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+          emtfShowerDataSummary_num_->Fill(dSh->processor() + 1,
+                                           (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
         }
       }
     }
@@ -87,7 +89,8 @@ void L1TdeStage2RegionalShower::analyze(const edm::Event& e, const edm::EventSet
       if (eSh->isOneTightInTime())
         emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1,
                                            (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
-      emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+      emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1,
+                                         (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
         if (dSh->isValid() and dSh->isOneNominalInTime() and eSh->processor() == dSh->processor() and
             eSh->trackFinderType() == dSh->trackFinderType() and *dSh == *eSh)
@@ -97,7 +100,8 @@ void L1TdeStage2RegionalShower::analyze(const edm::Event& e, const edm::EventSet
         if (eSh->isOneTightInTime())
           emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1,
                                            (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
-        emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+        emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1,
+                                         (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       }
     }
   }

--- a/DQM/L1TMonitor/src/L1TdeStage2RegionalShower.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2RegionalShower.cc
@@ -68,18 +68,14 @@ void L1TdeStage2RegionalShower::analyze(const edm::Event& e, const edm::EventSet
       if (dSh->isOneTightInTime())
         emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1,
                                            (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
-      else
-        emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1,
-                                           (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+      emtfShowerDataSummary_denom_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       for (auto eSh = emulShowers->begin(); eSh != emulShowers->end(); ++eSh) {
         if (eSh->isValid() and eSh->isOneNominalInTime() and dSh->processor() == eSh->processor() and
             dSh->trackFinderType() == eSh->trackFinderType() and *dSh == *eSh) {
           if (dSh->isOneTightInTime())
             emtfShowerDataSummary_num_->Fill(dSh->processor() + 1,
                                              (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
-          else
-            emtfShowerDataSummary_num_->Fill(dSh->processor() + 1,
-                                             (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+          emtfShowerDataSummary_num_->Fill(dSh->processor() + 1, (dSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
         }
       }
     }
@@ -91,9 +87,7 @@ void L1TdeStage2RegionalShower::analyze(const edm::Event& e, const edm::EventSet
       if (eSh->isOneTightInTime())
         emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1,
                                            (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
-      else
-        emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1,
-                                           (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+      emtfShowerEmulSummary_denom_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       for (auto dSh = dataShowers->begin(); dSh != dataShowers->end(); ++dSh) {
         if (dSh->isValid() and dSh->isOneNominalInTime() and eSh->processor() == dSh->processor() and
             eSh->trackFinderType() == dSh->trackFinderType() and *dSh == *eSh)
@@ -103,9 +97,7 @@ void L1TdeStage2RegionalShower::analyze(const edm::Event& e, const edm::EventSet
         if (eSh->isOneTightInTime())
           emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1,
                                            (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 3.5 : 0.5);
-        else
-          emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1,
-                                           (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
+        emtfShowerEmulSummary_num_->Fill(eSh->processor() + 1, (eSh->trackFinderType() == l1t::tftype::emtf_pos) ? 2.5 : 1.5);
       }
     }
   }


### PR DESCRIPTION
#### PR description:

This is a minor update in the binning of the L1T shower comparison DQM plots:
The bins for nominal showers were filled with nominal NOT tight showers. Now they are changed to nominal OR tight showers.

#### PR validation:

Tests with a Higgs to LLP to 4b sample, all plots look good (at [link](https://xzuo.web.cern.ch/ShowerDQM/data_vs_emul/new/)). 

Passed unit tests and matrix tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
