### PR TITLE
Try a second time if pop fails in ReusableObjectHolder

### DIFF
--- a/FWCore/Utilities/interface/ReusableObjectHolder.h
+++ b/FWCore/Utilities/interface/ReusableObjectHolder.h
@@ -113,7 +113,12 @@ namespace edm {
       if (m_availableQueue.try_pop(item)) {
         return wrapCustomDeleter(std::move(item));
       } else {
-        return std::shared_ptr<T>{};
+        //try a second time as try_pop can have a false failure
+        if (m_availableQueue.try_pop(item)) {
+          return wrapCustomDeleter(std::move(item));
+        } else {
+          return std::shared_ptr<T>{};
+        }
       }
     }
 
@@ -124,7 +129,12 @@ namespace edm {
       if (m_availableQueue.try_pop(item)) {
         return wrapCustomDeleter(std::move(item));
       } else {
-        return wrapCustomDeleter(makeUnique(iMakeFunc()));
+        //try a second time as try_pop can have a false failure
+        if (m_availableQueue.try_pop(item)) {
+          return wrapCustomDeleter(std::move(item));
+        } else {
+          return wrapCustomDeleter(makeUnique(iMakeFunc()));
+        }
       }
     }
 


### PR DESCRIPTION
#### PR description:

Experience has shown that for some builds, tbb::concurrent_queue try_pop appears to falsely fail. Adding a second attempt to try to decrease that frequency.

#### PR validation:

Code compiles and the related unit test passes.