### PR TITLE
Migrate legacy EDModules DataFormats/L1TrackTrigger

### DIFF
--- a/DataFormats/L1TrackTrigger/test/TestDataFormatsTTTrackTrackWord.cc
+++ b/DataFormats/L1TrackTrigger/test/TestDataFormatsTTTrackTrackWord.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -9,7 +9,7 @@
 #include <memory>
 
 namespace trackwordtest {
-  class TTTrackTrackWordDummyOneAnalyzer : public edm::EDAnalyzer {
+  class TTTrackTrackWordDummyOneAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit TTTrackTrackWordDummyOneAnalyzer(const edm::ParameterSet&) {}
     ~TTTrackTrackWordDummyOneAnalyzer() {}


### PR DESCRIPTION
#### PR description:
Technical PR following the issue https://github.com/cms-sw/cmssw/issues/36404 to migrate legacy EDModules to thread-efficient alternatives.

#### PR validation:
`scram b` runs.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport and no need of backport.
