### PR TITLE
Fixes in the RPC clusterization in the L1Trigger/L1TMuonOverlapPhase1

### DIFF
--- a/L1Trigger/L1TMuonOverlapPhase1/interface/MuonStub.h
+++ b/L1Trigger/L1TMuonOverlapPhase1/interface/MuonStub.h
@@ -22,6 +22,7 @@ public:
     DT_PHI_ETA,
     DT_HIT,
     RPC,
+    RPC_DROPPED,  //to mark that all clusters were dropped because there are more than 2 clusters or at least one too big cluster
     CSC_PHI,
     CSC_ETA,
     CSC_PHI_ETA,
@@ -61,7 +62,7 @@ public:
 typedef std::vector<MuonStub> MuonStubs1D;
 typedef std::vector<MuonStubs1D> MuonStubs2D;
 
-typedef std::shared_ptr<const MuonStub> MuonStubPtr;
+typedef std::shared_ptr<MuonStub> MuonStubPtr;
 typedef std::vector<MuonStubPtr> MuonStubPtrs1D;
 typedef std::vector<MuonStubPtrs1D> MuonStubPtrs2D;
 

--- a/L1Trigger/L1TMuonOverlapPhase1/src/AngleConverterBase.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/AngleConverterBase.cc
@@ -235,7 +235,7 @@ EtaValue AngleConverterBase::getGlobalEtaDt(const DTChamberId& detId) const {
 
   EtaValue etaValue = {
       config->etaToHwEta(chamberMiddleGP.eta()),
-      config->etaToHwEta(abs(chamberMiddleGP.eta() - chambNeighMiddleGP.eta())) / 2,
+      config->etaToHwEta(fabs(chamberMiddleGP.eta() - chambNeighMiddleGP.eta())) / 2,
       0,  //quality
       0,  //bx
       0   //timin

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFProcessor.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFProcessor.cc
@@ -386,6 +386,7 @@ std::vector<l1t::RegionalMuonCand> OMTFProcessor<GoldenPatternType>::run(
   //uncomment if you want to check execution time of each method
   //boost::timer::auto_cpu_timer t("%ws wall, %us user in getProcessorCandidates\n");
 
+  //input is shared_ptr because the observers may need them after the run() method execution is finished
   std::shared_ptr<OMTFinput> input = std::make_shared<OMTFinput>(this->myOmtfConfig);
   inputMaker->buildInputForProcessor(input->getMuonStubs(), iProcessor, mtfType, bx, bx);
 

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFinputMaker.cc
@@ -177,7 +177,33 @@ void RpcDigiToStubsConverterOmtf::addRPCstub(MuonStubPtrs2D& muonStubsInLayers,
   stub.logicLayer = iLayer;
   stub.detId = rawid;
 
-  OMTFinputMaker::addStub(config, muonStubsInLayers, iLayer, iInput, stub);
+  //This is very simple filtering of the clusters
+  //Till Nov 2021: unfortunately performance of the firmware cannot be easily emulated from digi
+  //(in principle would required raws, because in the firmware the clusterizaton is based on the 8-bit strip partitions)
+  //The FW from from Nov 2021 solved this problem - option dropAllClustersIfMoreThanMax:
+  //if any cluster is dropped in one barrel roll or endcap chamber - all are dropped for this roll/chamber.
+  //Beside better data-to-emulator agreement it provides better eff for high pt muons
+  if (config->getRpcDropAllClustersIfMoreThanMax()) {
+    //two clusters were already added, so as we have the next one, we mark as dropped the one that was added before
+    if (muonStubsInLayers[iLayer][iInput + 1]) {
+      //if iInput+1 is not null, iInput is not null as well
+      muonStubsInLayers[iLayer][iInput]->type = MuonStub::RPC_DROPPED;
+      muonStubsInLayers[iLayer][iInput + 1]->type = MuonStub::RPC_DROPPED;
+    } else if (cluster.size() > config->getRpcMaxClusterSize()) {
+      //marking as dropped the one that was added before on the iInput
+      if (muonStubsInLayers[iLayer][iInput])
+        muonStubsInLayers[iLayer][iInput]->type = MuonStub::RPC_DROPPED;
+      else {
+        //no stub was added at this input already, so adding a stub and marking it as dropped
+        muonStubsInLayers.at(iLayer).at(iInput) = std::make_shared<MuonStub>(stub);
+        muonStubsInLayers[iLayer][iInput]->type = MuonStub::RPC_DROPPED;
+      }
+    } else
+      OMTFinputMaker::addStub(config, muonStubsInLayers, iLayer, iInput, stub);
+  } else {
+    if (cluster.size() <= config->getRpcMaxClusterSize())
+      OMTFinputMaker::addStub(config, muonStubsInLayers, iLayer, iInput, stub);
+  }
 
   std::ostringstream str;
   str << " RPC halfDigi "
@@ -431,5 +457,5 @@ void OMTFinputMaker::addStub(const OMTFConfiguration* config,
     return;
   //in this implementation only two first stubs are added for a given iInput
 
-  muonStubsInLayers.at(iLayer).at(iInput) = std::make_shared<const MuonStub>(stub);
+  muonStubsInLayers.at(iLayer).at(iInput) = std::make_shared<MuonStub>(stub);
 }

--- a/L1Trigger/L1TMuonOverlapPhase1/src/RpcClusterization.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/RpcClusterization.cc
@@ -16,53 +16,71 @@ RpcClusterization::~RpcClusterization() {}
 std::vector<RpcCluster> RpcClusterization::getClusters(const RPCDetId& roll, std::vector<RPCDigi>& digis) const {
   std::vector<RpcCluster> allClusters;
 
-  std::sort(digis.begin(), digis.end(), [](const RPCDigi& a, const RPCDigi& b) { return a.strip() < b.strip(); });
+  if (!dropAllClustersIfMoreThanMax) {
+    //with the 2018 firmware the agreement is better with this sort
+    std::sort(digis.begin(), digis.end(), [](const RPCDigi& a, const RPCDigi& b) { return a.strip() < b.strip(); });
+  } else {
+    //with the fixed RPC clusterization (Nov 2021 firmware) the data to emulator agreement is better if this reverse is used here,
+    //with the 2018 firmware the agreement is worse with this reverse,
+    std::reverse(digis.begin(), digis.end());
+  }
 
   typedef std::pair<unsigned int, unsigned int> Cluster;
 
-  for (auto& digi : digis) {
-    if (allClusters.empty()) {
-      allClusters.emplace_back(digi.strip(), digi.strip());
-      allClusters.back().bx = digi.bx();
-      allClusters.back().timing = convertTiming(digi.time());
-    } else if (digi.strip() - allClusters.back().lastStrip == 1) {
-      allClusters.back().lastStrip = digi.strip();
-      //TODO update bx and timing in some smart way
-    } else if (digi.strip() - allClusters.back().lastStrip > 1) {
-      allClusters.emplace_back(digi.strip(), digi.strip());
-      allClusters.back().bx = digi.bx();
-      allClusters.back().timing = convertTiming(digi.time());
+  //This implementation of clusterization emulation gives the cluster in the same order as the order of digis,
+  //and the order of unpacked digis should be the same as the order of the LB channels on which the clustrization
+  //in the firmware is performed.
+  //This cluster order plays role in some rare cases for the OMTF algorithm
+  //when two hits has the same abs(minDistPhi), and then the phi of the resulting candidate
+  //depends on the order of these hits.
+  for (unsigned int iDigi = 0; iDigi < digis.size(); iDigi++) {
+    //edm::LogVerbatim("l1tOmtfEventPrint")<< __FUNCTION__ << ":" << __LINE__<<" "<<roll<<" iDigi "<<iDigi<<" digi "<<digis[iDigi];
+
+    //removing duplicated digis
+    //the digis might be duplicated, because the same data might be received by two OMTF boards (as the same link goes to two neighboring boards)
+    //and the unpacker is not cleaning them
+    bool duplicatedDigi = false;
+    for (unsigned int iDigi2 = 0; iDigi2 < iDigi; iDigi2++) {
+      if (digis[iDigi].strip() == digis[iDigi2].strip()) {
+        duplicatedDigi = true;
+        //edm::LogVerbatim("l1tOmtfEventPrint")<<"duplicatedDigi";
+        break;
+      }
+    }
+
+    if (duplicatedDigi)
+      continue;
+
+    bool addNewCluster = true;
+
+    for (auto& cluster : allClusters) {
+      if (digis[iDigi].strip() - cluster.lastStrip == 1) {
+        cluster.lastStrip = digis[iDigi].strip();
+        addNewCluster = false;
+      } else if (digis[iDigi].strip() - cluster.firstStrip == -1) {
+        cluster.firstStrip = digis[iDigi].strip();
+        addNewCluster = false;
+      } else if (digis[iDigi].strip() >= cluster.firstStrip && digis[iDigi].strip() <= cluster.lastStrip) {
+        addNewCluster = false;
+      }
+    }
+
+    if (addNewCluster) {
+      allClusters.emplace_back(digis[iDigi].strip(), digis[iDigi].strip());
+      allClusters.back().bx = digis[iDigi].bx();
+      allClusters.back().timing = convertTiming(digis[iDigi].time());
     }
   }
 
-  std::vector<RpcCluster> filteredClusters;
+  /* Debug only
+  if(allClusters.size())
+	  edm::LogVerbatim("l1tOmtfEventPrint")<< __FUNCTION__ <<" "<<roll<<" allClusters.size() "<<allClusters.size();
+  for (auto& cluster : allClusters)
+	  edm::LogVerbatim("l1tOmtfEventPrint")
+        << __FUNCTION__ << " cluster: firstStrip " << cluster.firstStrip
+        << " lastStrip " << cluster.lastStrip << " halfStrip " << cluster.halfStrip() << std::endl;*/
 
-  if (dropAllClustersIfMoreThanMax)
-    if (allClusters.size() > maxClusterCnt)
-      return filteredClusters;
-
-  //debug printout only
-  if (allClusters.size() > maxClusterCnt) {
-    LogTrace("l1tOmtfEventPrint") << __FUNCTION__ << ":" << __LINE__ << " allClusters.size() >= maxClusterCnt "
-                                  << std::endl;
-    for (auto& cluster : allClusters)
-      edm::LogVerbatim("l1tOmtfEventPrint")
-          << __FUNCTION__ << ":" << __LINE__ << " roll " << roll << " cluster: firstStrip " << cluster.firstStrip
-          << " lastStrip " << cluster.lastStrip << " halfStrip " << cluster.halfStrip() << std::endl;
-  }
-
-  //TODO this is very simple filtering of the cluster,
-  //unfortunately the in firmware it is more complicated and cannot be easily emulated from digi
-  //(in principle would required raws, because in the firmware the clusterizaton is based on the 8-bit strip partitions
-  for (auto& cluster : allClusters) {
-    if (cluster.size() <= maxClusterSize)
-      filteredClusters.emplace_back(cluster);
-
-    if (filteredClusters.size() >= maxClusterCnt)
-      break;
-  }
-
-  return filteredClusters;
+  return allClusters;
 }
 
 int RpcClusterization::convertTiming(double timing) const {

--- a/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/write_sqlite.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/test/expert/omtf/write_sqlite.py
@@ -15,11 +15,8 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB,
     timetype = cms.untracked.string('runnumber'),
     toPut = cms.VPSet(cms.PSet(
-                      record = cms.string('L1TMTFOverlapParamsRcd'),
-                      tag = cms.string('params')),
-                      cms.PSet(
-                      record = cms.string('L1TMTFOverlapParamsRcd'),
-                      tag = cms.string('patterns'))
+                      record = cms.string('L1TMuonOverlapParamsRcd'),
+                      tag = cms.string('params'))
     )
 )
 


### PR DESCRIPTION
#### PR description:
Implementation of the RPC clusterization that should be in agreement with the updated OMTF firmware from November 2021. In the emulator, if the option dropAllClustersIfMoreThanMax is used, then if any cluster is dropped in a given barrel roll or endcap chamber (because it is bigger than RpcMaxClusterSize or there is more than 2 of them) - all clusters are dropped for this roll/chamber. Besides the better data-to-emulator agreement it provides better efficiency for high pt muons. The OMTF emulator should be backward compatible with the run2 data.

- what changes are expected in the output if any:
better data-to-emulator agreement for OMTF muon trigger for the data with the OMTF firmware from Nov 2021 ([https://its.cern.ch/jira/browse/CMSLITOPS-272](https://its.cern.ch/jira/browse/CMSLITOPS-272)) ,
no significant changes in the data-to-emulator agreement for the run2 data.

- what other PRs or externals it depends upon if any 
None

#### PR validation:
scram b runtests - OK
runTheMatrix.py -l limited -i all --ibeos - OK
The DQM was run locally in order to check the plots for showing the OMTF data-to-emulator agreement. Results:
- November 2021 test run (MWGR) 347053 - RPC noise only, 76661 OMTF muon candidates checked, no mismatches
- collision run 325117 (2018D, ZeroBias sample): mismatch ratio 0.01 - similar as in the previous version of the OMTF emulator,

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
It is not a backport