### PR TITLE
more `esConsumes` in `RecoPixelVertexing`

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/test/HitTripletProducer.cc
+++ b/RecoPixelVertexing/PixelTriplets/test/HitTripletProducer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -20,7 +20,7 @@
 #include "TH1D.h"
 #include "TFile.h"
 
-class HitTripletProducer : public edm::EDAnalyzer {
+class HitTripletProducer : public edm::one::EDAnalyzer<> {
 public:
   explicit HitTripletProducer(const edm::ParameterSet& conf);
   ~HitTripletProducer();


### PR DESCRIPTION
#### PR description:

Part of the migrations in #31061 and #36404.
Removed some `CMSDEPRECATED_X` warnings in the `RecoPixelVertexing` subsystem from `CMSSW_12_3_CMSDEPRECATED_X_2022-01-21-2300`.

#### PR validation:

`cmssw` compiles. 
Run successfully: `runTheMatrix.py -l limited --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
