### PR TITLE
Add D88 wfs to the short matrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -38,7 +38,7 @@ numWFIB.extend([37434.0]) #2026D83
 numWFIB.extend([37834.0]) #2026D84
 numWFIB.extend([38234.0]) #2026D85
 numWFIB.extend([38634.0]) #2026D86
-numWFIB.extend([39034.0]) #2026D87 
+numWFIB.extend([39034.0]) #2026D87
 numWFIB.extend([39434.0,39434.5,39434.501,39434.502]) #2026D88, pixelTrackingOnly, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
 numWFIB.extend([39634.99,39634.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([39434.21,39634.21,39634.9921]) #2026D88 prodlike, prodlike PU, prodlike premix stage1+stage2

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -45,5 +45,10 @@ numWFIB.extend([39434.21,39634.21,39634.9921]) #2026D88 prodlike, prodlike PU, p
 numWFIB.extend([39834.0]) #2026D89
 numWFIB.extend([40234.0]) #2026D90
 
+#additional sample for short matrix
+#CloseByPGun
+numWFIB.extend([39496.0]) #CE_E_Front_120um D88
+numWFIB.extend([39500.0]) #CE_H_Coarse_Scint D88
+
 for numWF in numWFIB:
     workflows[numWF] = _upgrade_workflows[numWF]

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -39,7 +39,7 @@ numWFIB.extend([37834.0]) #2026D84
 numWFIB.extend([38234.0]) #2026D85
 numWFIB.extend([38634.0]) #2026D86
 numWFIB.extend([39034.0]) #2026D87
-numWFIB.extend([39434.0,39434.5,39434.501,39434.502,39434.911,39434.912]) #2026D88, pixelTrackingOnly, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU, DD4hep XML, DD4hep DB (not available yet, for future test)
+numWFIB.extend([39434.0,39434.5,39434.501,39434.502,39434.911]) #2026D88, pixelTrackingOnly, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU, DD4hep XML
 numWFIB.extend([39634.99,39634.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([39434.21,39634.21,39634.9921]) #2026D88 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([39834.0]) #2026D89

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -39,7 +39,7 @@ numWFIB.extend([37834.0]) #2026D84
 numWFIB.extend([38234.0]) #2026D85
 numWFIB.extend([38634.0]) #2026D86
 numWFIB.extend([39034.0]) #2026D87
-numWFIB.extend([39434.0,39434.5,39434.501,39434.502]) #2026D88, pixelTrackingOnly, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
+numWFIB.extend([39434.0,39434.5,39434.501,39434.502,39434.911,39434.912]) #2026D88, pixelTrackingOnly, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU, DD4hep XML, DD4hep DB (not available yet, for future test)
 numWFIB.extend([39634.99,39634.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([39434.21,39634.21,39634.9921]) #2026D88 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([39834.0]) #2026D89

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -38,8 +38,10 @@ numWFIB.extend([37434.0]) #2026D83
 numWFIB.extend([37834.0]) #2026D84
 numWFIB.extend([38234.0]) #2026D85
 numWFIB.extend([38634.0]) #2026D86
-numWFIB.extend([39034.0]) #2026D87
+numWFIB.extend([39034.0]) #2026D87 
 numWFIB.extend([39434.0,39434.5,39434.501,39434.502]) #2026D88, pixelTrackingOnly, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
+numWFIB.extend([39634.99,39634.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
+numWFIB.extend([39434.21,39634.21,39634.9921]) #2026D88 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([39834.0]) #2026D89
 numWFIB.extend([40234.0]) #2026D90
 

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3464,7 +3464,7 @@ defaultDataSets['2024']='CMSSW_12_0_0_pre4-120X_mcRun3_2024_realistic_v2-v'
 defaultDataSets['2026D49']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D49noPU-v'
 defaultDataSets['2026D76']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D76noPU-v'
 defaultDataSets['2026D77']='CMSSW_12_1_0_pre2-113X_mcRun4_realistic_v7_2026D77noPU-v'
-defaultDataSets['2026D88']='CMSSW_12_2_0_pre3-122X_mcRun4_realistic_v4_2026D88noPU-v1'
+#defaultDataSets['2026D88']='CMSSW_12_2_0_pre3-122X_mcRun4_realistic_v4_2026D88noPU-v1'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3464,6 +3464,7 @@ defaultDataSets['2024']='CMSSW_12_0_0_pre4-120X_mcRun3_2024_realistic_v2-v'
 defaultDataSets['2026D49']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D49noPU-v'
 defaultDataSets['2026D76']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D76noPU-v'
 defaultDataSets['2026D77']='CMSSW_12_1_0_pre2-113X_mcRun4_realistic_v7_2026D77noPU-v'
+defaultDataSets['2026D88']='CMSSW_12_2_0_pre3-122X_mcRun4_realistic_v4_2026D88noPU-v1'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
                      28234.0, #2026D60 (exercise HF nose)
                      35034.0, #2026D77 ttbar (2021 new baseline)
                      35234.999, #2026D77 ttbar premixing stage1+stage2, PU50
-                     #38634.0, #2026D86 ttbar
+                     38634.0, #2026D86 ttbar
                      39434.0, #2026D88 ttbar
                      39634.0, #2026D88 ttbar premixing stage1+stage2, PU50
                      25202.0, #2016 ttbar UP15 PU

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -97,7 +97,9 @@ if __name__ == '__main__':
                      28234.0, #2026D60 (exercise HF nose)
                      35034.0, #2026D77 ttbar (2021 new baseline)
                      35234.999, #2026D77 ttbar premixing stage1+stage2, PU50
-                     38634.0, #2026D86 ttbar
+                     #38634.0, #2026D86 ttbar
+                     39434.0, #2026D88 ttbar
+                     39634.0, #2026D88 ttbar premixing stage1+stage2, PU50
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix
                      ],

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
                      35234.999, #2026D77 ttbar premixing stage1+stage2, PU50
                      38634.0, #2026D86 ttbar
                      39434.0, #2026D88 ttbar
-                     39634.0, #2026D88 ttbar premixing stage1+stage2, PU50
+                     39634.999, #2026D88 ttbar premixing stage1+stage2, PU50
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix
                      ],

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -97,9 +97,11 @@ if __name__ == '__main__':
                      28234.0, #2026D60 (exercise HF nose)
                      35034.0, #2026D77 ttbar (2021 new baseline)
                      35234.999, #2026D77 ttbar premixing stage1+stage2, PU50
-                     38634.0, #2026D86 ttbar
+                     38634.0, #2026D86 ttbar (to be removed when migration to D88 is complete)
                      39434.0, #2026D88 ttbar
-                     39634.999, #2026D88 ttbar premixing stage1+stage2, PU50
+                     #39634.999, #2026D88 ttbar premixing stage1+stage2, PU50 (to disable when PU is available)
+                     39496.0, #CE_E_Front_120um D88
+                     39500.0, #CE_H_Coarse_Scint D88 
                      25202.0, #2016 ttbar UP15 PU
                      250202.181, #2018 ttbar stage1 + stage2 premix
                      ],


### PR DESCRIPTION
#### PR description:
As foreseen on move relvals to D88 in 12_3_0_pre5, this PR adds D88 workflows to the short matrix. We then can remove D86 and D77 in the later PR after migration to D88 is complete.

In addition, two workflows (39496.0,39500.0) of CloseByPGun are added to the short matrix as discussed in https://github.com/cms-sw/cmssw/issues/36832

#### PR validation:

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backport
