### PR TITLE
fix ge2/1 demonstrator in validation

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
@@ -40,7 +40,7 @@ void GEMGeometryBuilderFromCondDB::build(GEMGeometry& theGeometry, const RecoIde
         if (gemid.region() == 1 && gemid.station() == 2 && gemid.chamber() == 16) {
           const GEMDetId demoSuChId(1, 1, 2, 0, 16, 0);
           bool found = false;
-          for (auto & id : detids) {
+          for (auto& id : detids) {
             if (id.rawId() == demoSuChId.rawId()) {
               found = true;
               break;

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
@@ -34,6 +34,24 @@ void GEMGeometryBuilderFromCondDB::build(GEMGeometry& theGeometry, const RecoIde
       } else {
         GEMChamber* gch = buildChamber(rgeo, id, gemid);
         chambers.emplace(gemid.rawId(), gch);
+
+        // workaround for demonstrator geometry with no superchamber
+        const GEMDetId demoChId(1, 1, 2, 2, 16, 0);
+        if (gemid.region() == 1 && gemid.station() == 2 && gemid.chamber() == 16) {
+          const GEMDetId demoSuChId(1, 1, 2, 0, 16, 0);
+          bool found = false;
+          for (auto & id : detids) {
+            if (id.rawId() == demoSuChId.rawId()) {
+              found = true;
+              break;
+            }
+          }
+          if (!found) {
+            GEMSuperChamber* gsc = buildSuperChamber(rgeo, id, demoSuChId);
+            superChambers.emplace(demoSuChId.rawId(), gsc);
+            edm::LogWarning("Geometry") << "GE2/1 Demonstrator superchamber missing, adding by hand";
+          }
+        }
       }
     } else {
       GEMEtaPartition* gep = buildEtaPartition(rgeo, id, gemid);

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
@@ -34,23 +34,6 @@ void GEMGeometryBuilderFromCondDB::build(GEMGeometry& theGeometry, const RecoIde
       } else {
         GEMChamber* gch = buildChamber(rgeo, id, gemid);
         chambers.emplace(gemid.rawId(), gch);
-
-        // workaround for demonstrator geometry with no superchamber
-        if (gemid.region() == 1 && gemid.station() == 2 && gemid.chamber() == 16) {
-          const GEMDetId demoSuChId(1, 1, 2, 0, 16, 0);
-          bool found = false;
-          for (auto& id : detids) {
-            if (id.rawId() == demoSuChId.rawId()) {
-              found = true;
-              break;
-            }
-          }
-          if (!found) {
-            GEMSuperChamber* gsc = buildSuperChamber(rgeo, id, demoSuChId);
-            superChambers.emplace(demoSuChId.rawId(), gsc);
-            edm::LogWarning("Geometry") << "GE2/1 Demonstrator superchamber missing, adding by hand";
-          }
-        }
       }
     } else {
       GEMEtaPartition* gep = buildEtaPartition(rgeo, id, gemid);

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromCondDB.cc
@@ -36,7 +36,6 @@ void GEMGeometryBuilderFromCondDB::build(GEMGeometry& theGeometry, const RecoIde
         chambers.emplace(gemid.rawId(), gch);
 
         // workaround for demonstrator geometry with no superchamber
-        const GEMDetId demoChId(1, 1, 2, 2, 16, 0);
         if (gemid.region() == 1 && gemid.station() == 2 && gemid.chamber() == 16) {
           const GEMDetId demoSuChId(1, 1, 2, 0, 16, 0);
           bool found = false;

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -74,7 +74,7 @@ void GEMGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
     // back to chambers
     fvGE2.parent();
     fvGE2.parent();
-    doSuper = fvGE2.nextSibling();
+    doSuper = (nGE21 < 2 && fvGE2.nextSibling());
   }
   bool demonstratorGeometry = nGE21 == 1;
 

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -279,16 +279,12 @@ void GEMGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fv,
   // Check for the demonstrator geometry (only 1 chamber of GE2/1)
   auto start = fv.copyNos();
   int nGE21 = 0;
-  while (fv.firstChild()) {
+  while (nGE21 < 2 && fv.firstChild()) {
     const auto& history = fv.history();
     MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
     GEMDetId detId(gemNum.baseNumberToUnitNumber(num));
-    if (detId.station() == GEMDetId::minStationId0) {
-    } else {
-      if (fv.level() == levelChamb) {
-        if (detId.station() == 2)
-          nGE21++;
-      }
+    if (fv.level() == levelChamb && detId.station() == 2) {
+      nGE21++;
     }
   }
   bool demonstratorGeometry = nGE21 == 1;

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -58,7 +58,32 @@ void GEMGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
   MuonGeometryNumbering muonDDDNumbering(muonConstants);
   GEMNumberingScheme gemNumbering(muonConstants);
 
-  bool doSuper = fv.firstChild();
+  // Check for the demonstrator geometry (only 1 chamber of GE2/1)
+  DDFilteredView fvGE2{fv};
+  int nGE21 = 0;
+  bool doSuper = fvGE2.firstChild();
+  while (doSuper) {
+    // getting chamber id from eta partitions
+    fvGE2.firstChild();
+    fvGE2.firstChild();
+    int rawidCh = gemNumbering.baseNumberToUnitNumber(muonDDDNumbering.geoHistoryToBaseNumber(fvGE2.geoHistory()));
+    GEMDetId detIdCh = GEMDetId(rawidCh);
+    if (detIdCh.station() == 2)
+      nGE21++;
+
+    // back to chambers
+    fvGE2.parent();
+    fvGE2.parent();
+    doSuper = fvGE2.nextSibling();
+  }
+  bool demonstratorGeometry = nGE21 == 1;
+
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "
+                               << demonstratorGeometry;
+#endif
+
+  doSuper = fv.firstChild();
 
   LogDebug("GEMGeometryParsFromDD") << "doSuperChamber = " << doSuper;
   // loop over superchambers
@@ -75,7 +100,12 @@ void GEMGeometryParsFromDD::buildGeometry(DDFilteredView& fv,
     // currently there is no superchamber in the geometry
     // only 2 chambers are present separated by a gap.
     // making superchamber out of the first chamber layer including the gap between chambers
-    if (detIdCh.layer() == 1) {  // only make superChambers when doing layer 1
+
+    // In Run 3 we also have a single GE2/1 chamber at layer 2. We
+    // make sure the superchamber gets built but also we build on the
+    // first layer for the other stations so the superchamber is in
+    // the right position there.
+    if ((detIdCh.layer() == 1) || (detIdCh.layer() == 2 and detIdCh.station() == 2 and demonstratorGeometry)) {
       buildSuperChamber(fv, detIdCh, rgeo);
     }
     buildChamber(fv, detIdCh, rgeo);
@@ -246,6 +276,28 @@ void GEMGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fv,
   int theRingLevel = muonConstants.getValue("mg_ring") / theLevelPart;
   int theSectorLevel = muonConstants.getValue("mg_sector") / theLevelPart;
 
+  // Check for the demonstrator geometry (only 1 chamber of GE2/1)
+  auto start = fv.copyNos();
+  int nGE21 = 0;
+  while (fv.firstChild()) {
+    const auto& history = fv.history();
+    MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
+    GEMDetId detId(gemNum.baseNumberToUnitNumber(num));
+    if (detId.station() == GEMDetId::minStationId0) {
+    } else {
+      if (fv.level() == levelChamb) {
+        if (detId.station() == 2)
+          nGE21++;
+      }
+    }
+  }
+  bool demonstratorGeometry = nGE21 == 1;
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("Geometry") << "Found " << nGE21 << " GE2/1 chambers. Demonstrator geometry on? "
+                               << demonstratorGeometry;
+#endif
+
+  fv.goTo(start);
   while (fv.firstChild()) {
     const auto& history = fv.history();
     MuonBaseNumber num(mdddnum.geoHistoryToBaseNumber(history));
@@ -267,7 +319,7 @@ void GEMGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fv,
       }
     } else {
       if (fv.level() == levelChamb) {
-        if (detId.layer() == 1) {
+        if ((detId.layer() == 1) || (detId.layer() == 2 and detId.station() == 2 and demonstratorGeometry)) {
           buildSuperChamber(fv, detId, rgeo);
         }
         buildChamber(fv, detId, rgeo);

--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
@@ -75,21 +75,27 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
   TString eloss_xtitle = "Energy loss [eV]";
   TString eloss_ytitle = "Entries / 0.5 keV";
 
-  for (const auto& station : gem->regions()[0]->stations()) {
-    Int_t station_id = station->station();
-
-    auto eloss_mu_name = TString::Format("sim_eloss_muon_GE%d1", station_id);
-    auto eloss_mu_title = TString::Format("SimHit Energy Loss (Muon only) : GE%d1", station_id);
-
-    me_eloss_mu_[station_id] =
+  // Demonstrator chamber means we could have a missing station,
+  // process both regions to make sure we include it
+  for (const auto& region : gem->regions()) {
+    for (const auto& station : region->stations()) {
+      Int_t station_id = station->station();
+      if (me_eloss_mu_.find(station_id) != me_eloss_mu_.end())
+        continue;
+      
+      auto eloss_mu_name = TString::Format("sim_eloss_muon_GE%d1", station_id);
+      auto eloss_mu_title = TString::Format("SimHit Energy Loss (Muon only) : GE%d1", station_id);
+      
+      me_eloss_mu_[station_id] =
         booker.book1D(eloss_mu_name, eloss_mu_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
-
-    auto eloss_others_name = TString::Format("sim_eloss_others_GE%d1", station_id);
-    auto eloss_others_title = TString::Format("SimHit Energy Loss (Other Particles) : GE%d1", station_id);
-
-    me_eloss_others_[station_id] =
+      
+      auto eloss_others_name = TString::Format("sim_eloss_others_GE%d1", station_id);
+      auto eloss_others_title = TString::Format("SimHit Energy Loss (Other Particles) : GE%d1", station_id);
+      
+      me_eloss_others_[station_id] =
         booker.book1D(eloss_others_name, eloss_others_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
-  }  // station loop
+    }  // station loop
+  }    // region loop
 
   if (detail_plot_) {
     for (const auto& region : gem->regions()) {

--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
@@ -82,18 +82,18 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
       Int_t station_id = station->station();
       if (me_eloss_mu_.find(station_id) != me_eloss_mu_.end())
         continue;
-      
+
       auto eloss_mu_name = TString::Format("sim_eloss_muon_GE%d1", station_id);
       auto eloss_mu_title = TString::Format("SimHit Energy Loss (Muon only) : GE%d1", station_id);
-      
+
       me_eloss_mu_[station_id] =
-        booker.book1D(eloss_mu_name, eloss_mu_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
-      
+          booker.book1D(eloss_mu_name, eloss_mu_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
+
       auto eloss_others_name = TString::Format("sim_eloss_others_GE%d1", station_id);
       auto eloss_others_title = TString::Format("SimHit Energy Loss (Other Particles) : GE%d1", station_id);
-      
+
       me_eloss_others_[station_id] =
-        booker.book1D(eloss_others_name, eloss_others_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
+          booker.book1D(eloss_others_name, eloss_others_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
     }  // station loop
   }    // region loop
 


### PR DESCRIPTION
#### PR description:

Fix issues in #36826 caused by a missing the demonstrator superchamber in the db geometry. Also fix an issue in Validation/MuonGEMHits which might not build station 2 when it exists for the demonstrator.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Ran the PSet referenced in the issue, checked it ran the crashing event.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
