### PR TITLE
MTD geometry: fix ETL description in scenario D88

### DIFF
--- a/Geometry/MTDCommonData/data/etl/v7/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v7/etl.xml
@@ -222,6 +222,7 @@
             <rSolid name="Notch_int"/>
             <Translation x="[BackSupportPlate_thickness]" y="0.*mm" z="-[BackSupportPlate_thickness]"/>
     </SubtractionSolid>
+    <Box name="SubBox2" dz="2*[BackSupportPlate_thickness]" dx="0.5*[Notch_bl2]" dy="0.5*[NotchSubbox_width]"/>
     <SubtractionSolid name="Notch_left">
             <rSolid name="Notch_whole"/>
             <rSolid name="SubBox2"/>
@@ -232,7 +233,6 @@
             <rSolid name="SubBox2"/>
             <Translation x="[BackSupportPlate_thickness]+0.5*([Notch_bl2]-[Notch_bl1])" y="0.5*[NotchSubbox_width]" z="0.5*[Notch_thickness]"/>
     </SubtractionSolid>
-    <Box name="SubBox2" dz="2*[BackSupportPlate_thickness]" dx="0.5*[Notch_bl2]" dy="0.5*[NotchSubbox_width]"/>
     <UnionSolid name="BackSupportPlate_3">
             <rSolid name="BackSupportPlate_2"/>
             <rSolid name="Notch_left"/>
@@ -263,8 +263,8 @@
         <ZSection z="[BackSupportPlate_Z3]" rMin="[BackSupportPlate_R5]" rMax="[ServiceExtVolume_R3]"/>
         <ZSection z="[BackSupportPlate_Z4]" rMin="[BackSupportPlate_R5]" rMax="[ServiceExtVolume_R4]"/>
     </Polycone>
-    <Tubs name="InnerCylinder" rMin="[ETLrmin]" rMax="[InnerCylinder_Rmax]" dz="0.5*([BackSupportPlate_Z2]-[ETLzmin])" startPhi="0*deg" deltaPhi="360*deg"/>
-    <Tubs name="InnerBrackets" rMin="[InnerCylinder_Rmax]" rMax="[Disc_Rmin]" dz="0.5*([BackSupportPlate_Z2]-[ETLzmin])" startPhi="0*deg" deltaPhi="360*deg"/>
+    <!-- <Tubs name="InnerCylinder" rMin="[ETLrmin]" rMax="[InnerCylinder_Rmax]" dz="0.5*([BackSupportPlate_Z2]-[ETLzmin])" startPhi="0*deg" deltaPhi="360*deg"/> -->
+    <!-- <Tubs name="InnerBrackets" rMin="[InnerCylinder_Rmax]" rMax="[Disc_Rmin]" dz="0.5*([BackSupportPlate_Z2]-[ETLzmin])" startPhi="0*deg" deltaPhi="360*deg"/> -->
     
     <!-- FRONT: face closest to IP, BACK: furthest from IP -->
     <Tubs name="DiscSector_Front" rMin="[Disc_Rmin]" rMax="[Disc_Rmax]" dz="0.5*[Active_Disc_thickness]" startPhi="-90*deg" deltaPhi="180*deg"/> <!-- half-disc on front face -->
@@ -354,15 +354,15 @@
       <rSolid name="etl:ServicesExtVolume2"/>
       <rMaterial name="mtdMaterial:ETLServicesVolume"/>
     </LogicalPart>
-    <LogicalPart name="InnerCylinder" category="unspecified">
-      <rSolid name="etl:InnerCylinder"/>
-      <rMaterial name="materials:Borosilicate_Glass"/>
-    </LogicalPart>
-    <LogicalPart name="InnerBrackets" category="unspecified">
-      <rSolid name="etl:InnerBrackets"/>
-      <rMaterial name="materials:Aluminium"/>
-    </LogicalPart>
-    
+    <!-- <LogicalPart name="InnerCylinder" category="unspecified"> -->
+      <!-- <rSolid name="etl:InnerCylinder"/> -->
+      <!-- <rMaterial name="materials:Borosilicate_Glass"/> -->
+    <!-- </LogicalPart> -->
+    <!-- <LogicalPart name="InnerBrackets" category="unspecified"> -->
+      <!-- <rSolid name="etl:InnerBrackets"/> -->
+      <!-- <rMaterial name="materials:Aluminium"/> -->
+    <!-- </LogicalPart> -->
+
     <!-- Cables sectors -->
     <LogicalPart name="Cables1" category="unspecified">
       <rSolid name="etl:Cables1"/>
@@ -620,16 +620,16 @@
         <rChild name="etl:ServicesExtVolume2"/>
         <Translation x="0.*mm" y="0.*mm" z="0.*mm" />
     </PosPart>
-    <!-- <PosPart copyNumber="1">
-        <rParent name="etl:EndcapTimingLayer"/>
-        <rChild name="etl:InnerCylinder"/>
-        <Translation x="0.*mm" y="0.*mm" z="[InnerCylinder_center]" />
-    </PosPart>
-    <PosPart copyNumber="1">
-        <rParent name="etl:EndcapTimingLayer"/>
-        <rChild name="etl:InnerBrackets"/>
-        <Translation x="0.*mm" y="0.*mm" z="[InnerCylinder_center]" />
-    </PosPart> -->
+     <!-- <PosPart copyNumber="1"> -->
+        <!-- <rParent name="etl:EndcapTimingLayer"/> -->
+        <!-- <rChild name="etl:InnerCylinder"/> -->
+        <!-- <Translation x="0.*mm" y="0.*mm" z="[InnerCylinder_center]" /> -->
+    <!-- </PosPart> -->
+    <!-- <PosPart copyNumber="1"> -->
+        <!-- <rParent name="etl:EndcapTimingLayer"/> -->
+        <!-- <rChild name="etl:InnerBrackets"/> -->
+        <!-- <Translation x="0.*mm" y="0.*mm" z="[InnerCylinder_center]" /> -->
+    <!-- </PosPart> -->
     
     <!-- Children volumes Cables -->
     <PosPart copyNumber="1">


### PR DESCRIPTION
#### PR description:

This PR addresses issue #36829 . The ETL geometry description in scenario D88 is fixed to prevent crashes in DD4hep due to incorrect order of volume declaration and declaration of unused volumes.

#### PR validation:

The geometry tests in ```Geometry/MTDCommonData``` run for both DDD and DD4hep in scenario D88, providing equal output.