### PR TITLE
Update of some L1T producers for L1TNtuples (legacy modules), of the L1TExtCondProducer, and of the L1MenuViewer 

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
@@ -137,7 +137,7 @@ void L1TExtCondProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   }
 
   bool TriggerRulePrefireVetoBit(false);
-  if (makeTriggerRulePrefireVetoBit_) {
+  if (iEvent.isRealData() && makeTriggerRulePrefireVetoBit_) {
     // code taken from Nick Smith's EventFilter/L1TRawToDigi/plugins/TriggerRulePrefireVetoFilter.cc
 
     edm::Handle<TCDSRecord> tcdsRecordH;

--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
@@ -7,10 +7,8 @@
 /// \author: D. Puigh OSU
 ///
 
-// system include files
-
-// user include files
-
+// System include files
+// User include files
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -30,11 +28,8 @@
 #include <FWCore/ParameterSet/interface/ConfigurationDescriptions.h>
 #include <FWCore/ParameterSet/interface/ParameterSetDescription.h>
 
-//#include <vector>
 #include "DataFormats/L1Trigger/interface/BXVector.h"
-
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
-
 #include "DataFormats/TCDS/interface/TCDSRecord.h"
 
 using namespace std;
@@ -42,7 +37,7 @@ using namespace edm;
 using namespace l1t;
 
 //
-// class declaration
+// Class declaration
 //
 
 class L1TExtCondProducer : public stream::EDProducer<> {
@@ -55,7 +50,7 @@ public:
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  // ----------member data ---------------------------
+  // ---------- Member data ---------------------------
   // unsigned long long m_paramsCacheId; // Cache-ID from current parameters, to check if needs to be updated.
   //std::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
   //std::shared_ptr<const FirmwareVersion> m_fwv;
@@ -82,7 +77,7 @@ private:
 };
 
 //
-// constructors and destructor
+// Constructors and destructor
 //
 L1TExtCondProducer::L1TExtCondProducer(const ParameterSet& iConfig)
     : bxFirst_(iConfig.getParameter<int>("bxFirst")),
@@ -97,12 +92,13 @@ L1TExtCondProducer::L1TExtCondProducer(const ParameterSet& iConfig)
 
   m_triggerRulePrefireVetoBit = GlobalExtBlk::maxExternalConditions - 1;
 
+  // Note that the tcdsRecord input tag should be used as InputTag("unpackTcds","tcdsRecord") only for data
   if (!(tcdsInputTag_ == edm::InputTag(""))) {
     tcdsRecordToken_ = consumes<TCDSRecord>(tcdsInputTag_);
     makeTriggerRulePrefireVetoBit_ = true;
   }
 
-  // register what you produce
+  // Register what you produce
   produces<GlobalExtBlkBxCollection>();
 
   // Initialize parameters
@@ -112,14 +108,14 @@ L1TExtCondProducer::L1TExtCondProducer(const ParameterSet& iConfig)
 L1TExtCondProducer::~L1TExtCondProducer() {}
 
 //
-// member functions
+// Member functions
 //
 
 // ------------ method called to produce the data ------------
 void L1TExtCondProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   LogDebug("L1TExtCondProducer") << "L1TExtCondProducer::produce function called...\n";
 
-  // get / update the trigger menu from the EventSetup
+  // Get / update the trigger menu from the EventSetup
   // local cache & check on cacheIdentifier
   unsigned long long l1GtMenuCacheID = iSetup.get<L1TUtmTriggerMenuRcd>().cacheIdentifier();
 
@@ -137,9 +133,9 @@ void L1TExtCondProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   }
 
   bool TriggerRulePrefireVetoBit(false);
+  // The following list of checks on the tcdsRecord is relevant only for data;
+  // code taken from Nick Smith's EventFilter/L1TRawToDigi/plugins/TriggerRulePrefireVetoFilter.cc
   if (iEvent.isRealData() && makeTriggerRulePrefireVetoBit_) {
-    // code taken from Nick Smith's EventFilter/L1TRawToDigi/plugins/TriggerRulePrefireVetoFilter.cc
-
     edm::Handle<TCDSRecord> tcdsRecordH;
     iEvent.getByToken(tcdsRecordToken_, tcdsRecordH);
     const auto& tcdsRecord = *tcdsRecordH.product();
@@ -151,9 +147,10 @@ void L1TExtCondProducer::produce(Event& iEvent, const EventSetup& iSetup) {
       eventHistory.push_back(thisEvent - ((l1a.getBXID() - 1) + l1a.getOrbitNr() * 3564ull));
     }
 
-    // should be 16 according to TCDSRecord.h, we only care about the last 4
+    // It should be 16 according to TCDSRecord.h, we only care about the last 4
     if (eventHistory.size() < 4) {
-      edm::LogError("L1TExtCondProducer") << "Unexpectedly small L1A history from TCDSRecord";
+      throw cms::Exception("L1TExtCondProducer")
+          << "Unexpectedly small L1A history from TCDSRecord: (size = " << eventHistory.size() << " < 4)";
     }
 
     // No more than 1 L1A in 3 BX
@@ -191,7 +188,7 @@ void L1TExtCondProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   // Setup vectors
   GlobalExtBlk extCond_bx;
 
-  //outputs
+  // Outputs
   std::unique_ptr<GlobalExtBlkBxCollection> extCond(new GlobalExtBlkBxCollection(0, bxFirst_, bxLast_));
 
   bool foundBptxAND = (m_extBitMap.find("BPTX_plus_AND_minus.v0") != m_extBitMap.end());
@@ -209,7 +206,7 @@ void L1TExtCondProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   if (setBptxOR_ && foundBptxOR)
     extCond_bx.setExternalDecision(m_extBitMap["BPTX_plus_OR_minus.v0"], true);
 
-  //check for updated Bptx names as well
+  // Check for updated Bptx names as well
   foundBptxAND = (m_extBitMap.find("ZeroBias_BPTX_AND_VME") != m_extBitMap.end());
   foundBptxPlus = (m_extBitMap.find("BPTX_B1_VME") != m_extBitMap.end());
   foundBptxMinus = (m_extBitMap.find("BPTX_B2_VME") != m_extBitMap.end());
@@ -225,7 +222,7 @@ void L1TExtCondProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   if (setBptxOR_ && foundBptxOR)
     extCond_bx.setExternalDecision(m_extBitMap["BPTX_OR_VME"], true);
 
-  // set the bit for the TriggerRulePrefireVeto if true
+  // Set the bit for the TriggerRulePrefireVeto if true
   if (TriggerRulePrefireVetoBit)
     extCond_bx.setExternalDecision(m_triggerRulePrefireVetoBit, true);
 
@@ -237,7 +234,7 @@ void L1TExtCondProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   iEvent.put(std::move(extCond));
 }
 
-// ------------ method fills 'descriptions' with the allowed parameters for the module ------------
+// ------------ Method fills 'descriptions' with the allowed parameters for the module ------------
 void L1TExtCondProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {
   // simGtExtFakeProd
   edm::ParameterSetDescription desc;
@@ -251,5 +248,5 @@ void L1TExtCondProducer::fillDescriptions(ConfigurationDescriptions& description
   descriptions.add("simGtExtFakeProd", desc);
 }
 
-//define this as a plug-in
+// Define this as a plug-in
 DEFINE_FWK_MODULE(L1TExtCondProducer);

--- a/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TExtCondProducer.cc
@@ -32,6 +32,8 @@
 #include "DataFormats/L1TGlobal/interface/GlobalExtBlk.h"
 #include "DataFormats/TCDS/interface/TCDSRecord.h"
 
+#include <vector>
+
 using namespace std;
 using namespace edm;
 using namespace l1t;

--- a/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
+++ b/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
@@ -39,7 +39,7 @@ for arg in argv:
     else:
         globals()[k] = v
 
-neventsPerJob = nevents/njob
+neventsPerJob = int(nevents/njob)
 skip = job * neventsPerJob
 
 if skip>4:
@@ -79,15 +79,11 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),
     fileNames = cms.untracked.vstring(
-        "/store/mc/RunIISummer19UL18RECO/GluGluToContinToZZTo4mu_13TeV_MCFM701_pythia8/AODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/110000/664BBEBB-93A9-5B40-AD9C-DE835A79B712.root",
-        #"/store/mc/RunIISummer20UL18RECO/BuToTau_To3Mu_MuFilter_TuneCP5_13TeV-pythia8-evtgen/AODSIM/106X_upgrade2018_realistic_v11_L1v1-v1/20000/00901296-D966-DF40-AA25-5F7A959B79CA.root",
-        #"/store/mc/RunIISummer20UL18RECO/DsToTau_To3Mu_MuFilter_TuneCP5_13TeV-pythia8-evtgen/AODSIM/106X_upgrade2018_realistic_v11_L1v1-v1/00000/0003B7FD-6C1E-BF4C-8DA9-BA8A27AF0290.root",
-        #"/store/mc/RunIISummer19UL18RECO/ZZ_TuneCP5_13TeV-pythia8/AODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/280000/04530FC4-E54D-D34A-950E-9F300321E037.root",
-        #"/store/mc/RunIIFall15DR76/TT_TuneCUETP8M1_13TeV-powheg-pythia8/AODSIM/25nsFlat10to25TSG_76X_mcRun2_asymptotic_v11_ext3-v1/20000/F03B8956-5D87-E511-8AE9-002590D0AFFC.root",
-        #"/store/mc/RunIISummer19UL18HLT/TTTo2L2Nu_mtop178p5_TuneCP5_13TeV-powheg-pythia8/GEN-SIM-RAW/102X_upgrade2018_realistic_v15-v2/280000/00429618-85B5-124F-9C16-0C9F07A39E73.root+"
-        #"/store/mc/PhaseIFall16DR/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/GEN-SIM-RAW/FlatPU28to62HcalNZSRAW_81X_upgrade2017_realistic_v26-v1/110000/444C2036-84FC-E611-A86D-02163E01433C.root",
-        #"/store/mc/RunIISpring16DR80/TT_TuneCUETP8M1_13TeV-powheg-pythia8/GEN-SIM-RAW/FlatPU20to70HcalNZSRAW_withHLT_80X_mcRun2_asymptotic_v14_ext3-v1/50000/D6D4CAF2-AD65-E611-9642-001EC94BA169.root",
-        #"/store/relval/CMSSW_7_6_0_pre7/RelValTTbar_13/GEN-SIM/76X_mcRun2_asymptotic_v9_realBS-v1/00000/0A812333-427C-E511-A80A-0025905964A2.root",
+        # TTbar CMSSW_12X samples
+        "/store/relval/CMSSW_12_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/122X_mcRun3_2021_realistic_v5-v1/2580000/04b2f8e0-57d6-449c-aa9f-a416c9926f31.root",
+        "/store/relval/CMSSW_12_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/122X_mcRun3_2021_realistic_v5-v1/2580000/12bfbbc7-60fe-44c9-8f04-daa8c7b61406.root",
+        "/store/relval/CMSSW_12_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/122X_mcRun3_2021_realistic_v5-v1/2580000/198e5a8c-8f06-4688-ae0d-5cc51b1eef46.root",
+        "/store/relval/CMSSW_12_3_0_pre2/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/122X_mcRun3_2021_realistic_v5-v1/2580000/2e6c92bb-4997-4232-8475-04a668d8d163.root",
 	),
     skipEvents = cms.untracked.uint32(skip)
     )
@@ -214,7 +210,7 @@ process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
 
 process.load("L1Trigger.L1TGlobal.TriggerMenu_cff")
 
-xmlMenu="L1Menu_test_mass_3_body_reduced_v2.xml"
+xmlMenu="L1Menu_Collisions2022_v0_1_2.xml"
 process.TriggerMenu.L1TriggerMenuFile = cms.string(xmlMenu)
 process.ESPreferL1TXML = cms.ESPrefer("L1TUtmTriggerMenuESProducer","TriggerMenu")
 

--- a/L1Trigger/L1TNtuples/plugins/L1EventTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1EventTreeProducer.cc
@@ -49,7 +49,7 @@ Implementation:
 class L1EventTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1EventTreeProducer(const edm::ParameterSet&);
-  ~L1EventTreeProducer() override = default; 
+  ~L1EventTreeProducer() override = default;
 
 private:
   void beginJob(void) override;
@@ -71,9 +71,8 @@ private:
   const edm::EDGetTokenT<edm::TriggerResults> hltSource_;
 };
 
-L1EventTreeProducer::L1EventTreeProducer(const edm::ParameterSet& iConfig) :
-  hltSource_(consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("hltSource"))){
-
+L1EventTreeProducer::L1EventTreeProducer(const edm::ParameterSet& iConfig)
+    : hltSource_(consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("hltSource"))) {
   std::string puMCFile = iConfig.getUntrackedParameter<std::string>("puMCFile", "");
   std::string puMCHist = iConfig.getUntrackedParameter<std::string>("puMCHist", "pileup");
   std::string puDataFile = iConfig.getUntrackedParameter<std::string>("puDataFile", "");
@@ -84,7 +83,8 @@ L1EventTreeProducer::L1EventTreeProducer(const edm::ParameterSet& iConfig) :
   bool useAvgVtx = iConfig.getUntrackedParameter<bool>("useAvgVtx", true);
   double maxAllowedWeight = iConfig.getUntrackedParameter<double>("maxAllowedWeight", -1);
 
-  std::make_unique<L1Analysis::L1AnalysisEvent>(puMCFile, puMCHist, puDataFile, puDataHist, useAvgVtx, maxAllowedWeight, consumesCollector());
+  std::make_unique<L1Analysis::L1AnalysisEvent>(
+      puMCFile, puMCHist, puDataFile, puDataHist, useAvgVtx, maxAllowedWeight, consumesCollector());
   l1EventData = l1Event->getData();
 
   // set up output

--- a/L1Trigger/L1TNtuples/plugins/L1EventTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1EventTreeProducer.cc
@@ -22,7 +22,7 @@ Implementation:
 
 // framework
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -46,10 +46,10 @@ Implementation:
 // class declaration
 //
 
-class L1EventTreeProducer : public edm::EDAnalyzer {
+class L1EventTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1EventTreeProducer(const edm::ParameterSet&);
-  ~L1EventTreeProducer() override;
+  ~L1EventTreeProducer() override = default; 
 
 private:
   void beginJob(void) override;
@@ -57,7 +57,7 @@ private:
   void endJob() override;
 
 public:
-  L1Analysis::L1AnalysisEvent* l1Event;
+  std::unique_ptr<L1Analysis::L1AnalysisEvent> l1Event;
   L1Analysis::L1AnalysisEventDataFormat* l1EventData;
 
 private:
@@ -67,36 +67,29 @@ private:
   // tree
   TTree* tree_;
 
-  edm::EDGetTokenT<edm::TriggerResults> hltSource_;
-
   // EDM input tags
-  //edm::EDGetTokenT<l1t::EGammaBxCollection> egToken_;
+  const edm::EDGetTokenT<edm::TriggerResults> hltSource_;
 };
 
-L1EventTreeProducer::L1EventTreeProducer(const edm::ParameterSet& iConfig) {
-  hltSource_ = consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("hltSource"));
+L1EventTreeProducer::L1EventTreeProducer(const edm::ParameterSet& iConfig) :
+  hltSource_(consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("hltSource"))){
 
   std::string puMCFile = iConfig.getUntrackedParameter<std::string>("puMCFile", "");
   std::string puMCHist = iConfig.getUntrackedParameter<std::string>("puMCHist", "pileup");
   std::string puDataFile = iConfig.getUntrackedParameter<std::string>("puDataFile", "");
   std::string puDataHist = iConfig.getUntrackedParameter<std::string>("puDataHist", "pileup");
 
+  usesResource(TFileService::kSharedResource);
+
   bool useAvgVtx = iConfig.getUntrackedParameter<bool>("useAvgVtx", true);
   double maxAllowedWeight = iConfig.getUntrackedParameter<double>("maxAllowedWeight", -1);
 
-  l1Event = new L1Analysis::L1AnalysisEvent(
-      puMCFile, puMCHist, puDataFile, puDataHist, useAvgVtx, maxAllowedWeight, consumesCollector());
+  std::make_unique<L1Analysis::L1AnalysisEvent>(puMCFile, puMCHist, puDataFile, puDataHist, useAvgVtx, maxAllowedWeight, consumesCollector());
   l1EventData = l1Event->getData();
 
   // set up output
   tree_ = fs_->make<TTree>("L1EventTree", "L1EventTree");
   tree_->Branch("Event", "L1Analysis::L1AnalysisEventDataFormat", &l1EventData, 32000, 3);
-}
-
-L1EventTreeProducer::~L1EventTreeProducer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-  delete l1Event;
 }
 
 //

--- a/L1Trigger/L1TNtuples/plugins/L1HOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1HOTreeProducer.cc
@@ -9,7 +9,7 @@
 
 // framework
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -30,10 +30,10 @@
 // class declaration
 //
 
-class L1HOTreeProducer : public edm::EDAnalyzer {
+class L1HOTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1HOTreeProducer(const edm::ParameterSet&);
-  ~L1HOTreeProducer() override;
+  ~L1HOTreeProducer() override = default;
 
 private:
   void beginJob(void) override;
@@ -52,21 +52,21 @@ private:
   TTree* tree_;
 
   // EDM input tags
-  edm::EDGetTokenT<edm::SortedCollection<HODataFrame>> hoDataFrameToken_;
+  const edm::EDGetTokenT<edm::SortedCollection<HODataFrame>> hoDataFrameToken_;
 };
 
-L1HOTreeProducer::L1HOTreeProducer(const edm::ParameterSet& iConfig) {
-  hoDataFrameToken_ =
-      consumes<edm::SortedCollection<HODataFrame>>(iConfig.getUntrackedParameter<edm::InputTag>("hoDataFrameToken"));
+L1HOTreeProducer::L1HOTreeProducer(const edm::ParameterSet& iConfig): 
+  hoDataFrameToken_(consumes<edm::SortedCollection<HODataFrame>>(iConfig.getUntrackedParameter<edm::InputTag>("hoDataFrameToken"))) {
+  //hoDataFrameToken_ =
+  //    consumes<edm::SortedCollection<HODataFrame>>(iConfig.getUntrackedParameter<edm::InputTag>("hoDataFrameToken"));
 
   l1HOData = l1HO.getData();
+  usesResource(TFileService::kSharedResource);
 
   // set up output
   tree_ = fs_->make<TTree>("L1HOTree", "L1HOTree");
   tree_->Branch("L1HO", "L1Analysis::L1AnalysisL1HODataFormat", &l1HOData, 32000, 3);
 }
-
-L1HOTreeProducer::~L1HOTreeProducer() {}
 
 //
 // member functions

--- a/L1Trigger/L1TNtuples/plugins/L1HOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1HOTreeProducer.cc
@@ -58,9 +58,6 @@ private:
 L1HOTreeProducer::L1HOTreeProducer(const edm::ParameterSet& iConfig)
     : hoDataFrameToken_(consumes<edm::SortedCollection<HODataFrame>>(
           iConfig.getUntrackedParameter<edm::InputTag>("hoDataFrameToken"))) {
-  //hoDataFrameToken_ =
-  //    consumes<edm::SortedCollection<HODataFrame>>(iConfig.getUntrackedParameter<edm::InputTag>("hoDataFrameToken"));
-
   l1HOData = l1HO.getData();
   usesResource(TFileService::kSharedResource);
 

--- a/L1Trigger/L1TNtuples/plugins/L1HOTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1HOTreeProducer.cc
@@ -55,8 +55,9 @@ private:
   const edm::EDGetTokenT<edm::SortedCollection<HODataFrame>> hoDataFrameToken_;
 };
 
-L1HOTreeProducer::L1HOTreeProducer(const edm::ParameterSet& iConfig): 
-  hoDataFrameToken_(consumes<edm::SortedCollection<HODataFrame>>(iConfig.getUntrackedParameter<edm::InputTag>("hoDataFrameToken"))) {
+L1HOTreeProducer::L1HOTreeProducer(const edm::ParameterSet& iConfig)
+    : hoDataFrameToken_(consumes<edm::SortedCollection<HODataFrame>>(
+          iConfig.getUntrackedParameter<edm::InputTag>("hoDataFrameToken"))) {
   //hoDataFrameToken_ =
   //    consumes<edm::SortedCollection<HODataFrame>>(iConfig.getUntrackedParameter<edm::InputTag>("hoDataFrameToken"));
 

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
@@ -95,14 +95,20 @@ private:
   unsigned getAlgoFwVersion();
 };
 
-L1UpgradeTfMuonTreeProducer::L1UpgradeTfMuonTreeProducer(const edm::ParameterSet& iConfig) :
-  fedToken_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("feds"))),
-  bmtfMuonToken_(consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfMuonToken"))),
-  bmtf2MuonToken_(consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("bmtf2MuonToken"))),
-  omtfMuonToken_(consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("omtfMuonToken"))),
-  emtfMuonToken_(consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("emtfMuonToken"))),
-  bmtfPhInputToken_(consumes<L1MuDTChambPhContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputPhMuonToken"))),
-  bmtfThInputToken_(consumes<L1MuDTChambThContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputThMuonToken"))) {
+L1UpgradeTfMuonTreeProducer::L1UpgradeTfMuonTreeProducer(const edm::ParameterSet& iConfig)
+    : fedToken_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("feds"))),
+      bmtfMuonToken_(
+          consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfMuonToken"))),
+      bmtf2MuonToken_(
+          consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("bmtf2MuonToken"))),
+      omtfMuonToken_(
+          consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("omtfMuonToken"))),
+      emtfMuonToken_(
+          consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("emtfMuonToken"))),
+      bmtfPhInputToken_(
+          consumes<L1MuDTChambPhContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputPhMuonToken"))),
+      bmtfThInputToken_(
+          consumes<L1MuDTChambThContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputThMuonToken"))) {
   isEMU_ = iConfig.getParameter<bool>("isEMU");
   /*
   fedToken_ = consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("feds"));

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
@@ -20,7 +20,7 @@ Implementation:
 
 // framework
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -47,10 +47,10 @@ Implementation:
 // class declaration
 //
 
-class L1UpgradeTfMuonTreeProducer : public edm::EDAnalyzer {
+class L1UpgradeTfMuonTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1UpgradeTfMuonTreeProducer(const edm::ParameterSet&);
-  ~L1UpgradeTfMuonTreeProducer() override;
+  ~L1UpgradeTfMuonTreeProducer() override = default;
 
 private:
   void beginJob(void) override;
@@ -80,14 +80,14 @@ private:
   TTree* tree_;
 
   // EDM input tags
-  edm::EDGetTokenT<FEDRawDataCollection> fedToken_;
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> bmtfMuonToken_;
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> bmtf2MuonToken_;
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> omtfMuonToken_;
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> emtfMuonToken_;
+  const edm::EDGetTokenT<FEDRawDataCollection> fedToken_;
+  const edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> bmtfMuonToken_;
+  const edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> bmtf2MuonToken_;
+  const edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> omtfMuonToken_;
+  const edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> emtfMuonToken_;
 
-  edm::EDGetTokenT<L1MuDTChambPhContainer> bmtfPhInputToken_;
-  edm::EDGetTokenT<L1MuDTChambThContainer> bmtfThInputToken_;
+  const edm::EDGetTokenT<L1MuDTChambPhContainer> bmtfPhInputToken_;
+  const edm::EDGetTokenT<L1MuDTChambThContainer> bmtfThInputToken_;
 
   // EDM handles
   edm::Handle<FEDRawDataCollection> feds_;
@@ -95,8 +95,16 @@ private:
   unsigned getAlgoFwVersion();
 };
 
-L1UpgradeTfMuonTreeProducer::L1UpgradeTfMuonTreeProducer(const edm::ParameterSet& iConfig) {
+L1UpgradeTfMuonTreeProducer::L1UpgradeTfMuonTreeProducer(const edm::ParameterSet& iConfig) :
+  fedToken_(consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("feds"))),
+  bmtfMuonToken_(consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfMuonToken"))),
+  bmtf2MuonToken_(consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("bmtf2MuonToken"))),
+  omtfMuonToken_(consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("omtfMuonToken"))),
+  emtfMuonToken_(consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("emtfMuonToken"))),
+  bmtfPhInputToken_(consumes<L1MuDTChambPhContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputPhMuonToken"))),
+  bmtfThInputToken_(consumes<L1MuDTChambThContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputThMuonToken"))) {
   isEMU_ = iConfig.getParameter<bool>("isEMU");
+  /*
   fedToken_ = consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("feds"));
   bmtfMuonToken_ =
       consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfMuonToken"));
@@ -110,7 +118,7 @@ L1UpgradeTfMuonTreeProducer::L1UpgradeTfMuonTreeProducer(const edm::ParameterSet
       consumes<L1MuDTChambPhContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputPhMuonToken"));
   bmtfThInputToken_ =
       consumes<L1MuDTChambThContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputThMuonToken"));
-
+  */
   maxL1UpgradeTfMuon_ = iConfig.getParameter<unsigned int>("maxL1UpgradeTfMuon");
 
   l1UpgradeBmtfData = l1UpgradeBmtf.getData();
@@ -118,6 +126,8 @@ L1UpgradeTfMuonTreeProducer::L1UpgradeTfMuonTreeProducer(const edm::ParameterSet
   l1UpgradeOmtfData = l1UpgradeOmtf.getData();
   l1UpgradeEmtfData = l1UpgradeEmtf.getData();
   l1UpgradeBmtfInputsData = l1UpgradeBmtfInputs.getData();
+
+  usesResource(TFileService::kSharedResource);
 
   // set up output
   tree_ = fs_->make<TTree>("L1UpgradeTfMuonTree", "L1UpgradeTfMuonTree");
@@ -129,8 +139,6 @@ L1UpgradeTfMuonTreeProducer::L1UpgradeTfMuonTreeProducer(const edm::ParameterSet
   tree_->Branch(
       "L1UpgradeBmtfInputs", "L1Analysis::L1AnalysisBMTFInputsDataFormat", &l1UpgradeBmtfInputsData, 32000, 3);
 }
-
-L1UpgradeTfMuonTreeProducer::~L1UpgradeTfMuonTreeProducer() {}
 
 //
 // member functions

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonTreeProducer.cc
@@ -110,21 +110,6 @@ L1UpgradeTfMuonTreeProducer::L1UpgradeTfMuonTreeProducer(const edm::ParameterSet
       bmtfThInputToken_(
           consumes<L1MuDTChambThContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputThMuonToken"))) {
   isEMU_ = iConfig.getParameter<bool>("isEMU");
-  /*
-  fedToken_ = consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("feds"));
-  bmtfMuonToken_ =
-      consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfMuonToken"));
-  bmtf2MuonToken_ =
-      consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("bmtf2MuonToken"));
-  omtfMuonToken_ =
-      consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("omtfMuonToken"));
-  emtfMuonToken_ =
-      consumes<l1t::RegionalMuonCandBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("emtfMuonToken"));
-  bmtfPhInputToken_ =
-      consumes<L1MuDTChambPhContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputPhMuonToken"));
-  bmtfThInputToken_ =
-      consumes<L1MuDTChambThContainer>(iConfig.getUntrackedParameter<edm::InputTag>("bmtfInputThMuonToken"));
-  */
   maxL1UpgradeTfMuon_ = iConfig.getParameter<unsigned int>("maxL1UpgradeTfMuon");
 
   l1UpgradeBmtfData = l1UpgradeBmtf.getData();

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTreeProducer.cc
@@ -22,7 +22,7 @@ Implementation:
 
 // framework
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -47,10 +47,10 @@ Implementation:
 // class declaration
 //
 
-class L1UpgradeTreeProducer : public edm::EDAnalyzer {
+class L1UpgradeTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1UpgradeTreeProducer(const edm::ParameterSet&);
-  ~L1UpgradeTreeProducer() override;
+  ~L1UpgradeTreeProducer() override = default;
 
 private:
   void beginJob(void) override;
@@ -71,23 +71,20 @@ private:
   TTree* tree_;
 
   // EDM input tags
-  edm::EDGetTokenT<l1t::EGammaBxCollection> egToken_;
+  const edm::EDGetTokenT<l1t::EGammaBxCollection> egToken_;
+  const edm::EDGetTokenT<l1t::JetBxCollection> jetToken_;
+  const edm::EDGetTokenT<l1t::EtSumBxCollection> sumToken_;
+  const edm::EDGetTokenT<l1t::MuonBxCollection> muonToken_;
+  const edm::EDGetTokenT<l1t::MuonShowerBxCollection> muonShowerToken_;
   std::vector<edm::EDGetTokenT<l1t::TauBxCollection>> tauTokens_;
-  edm::EDGetTokenT<l1t::JetBxCollection> jetToken_;
-  edm::EDGetTokenT<l1t::EtSumBxCollection> sumToken_;
-  edm::EDGetTokenT<l1t::MuonBxCollection> muonToken_;
-  edm::EDGetTokenT<l1t::MuonShowerBxCollection> muonShowerToken_;
 };
 
-L1UpgradeTreeProducer::L1UpgradeTreeProducer(const edm::ParameterSet& iConfig) {
-  egToken_ = consumes<l1t::EGammaBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("egToken"));
-  //tauToken_ = consumes<l1t::TauBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("tauToken"));
-  jetToken_ = consumes<l1t::JetBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("jetToken"));
-  sumToken_ = consumes<l1t::EtSumBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("sumToken"));
-  muonToken_ = consumes<l1t::MuonBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonToken"));
-  muonShowerToken_ =
-      consumes<l1t::MuonShowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonShowerToken"));
-
+L1UpgradeTreeProducer::L1UpgradeTreeProducer(const edm::ParameterSet& iConfig) :
+  egToken_(consumes<l1t::EGammaBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("egToken"))),
+  jetToken_(consumes<l1t::JetBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("jetToken"))),
+  sumToken_(consumes<l1t::EtSumBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("sumToken"))),
+  muonToken_(consumes<l1t::MuonBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonToken"))),
+  muonShowerToken_(consumes<l1t::MuonShowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonShowerToken"))) {
   const auto& taus = iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("tauTokens");
   for (const auto& tau : taus) {
     tauTokens_.push_back(consumes<l1t::TauBxCollection>(tau));
@@ -98,14 +95,11 @@ L1UpgradeTreeProducer::L1UpgradeTreeProducer(const edm::ParameterSet& iConfig) {
   l1Upgrade = new L1Analysis::L1AnalysisL1Upgrade();
   l1UpgradeData = l1Upgrade->getData();
 
+  usesResource(TFileService::kSharedResource);
+
   // set up output
   tree_ = fs_->make<TTree>("L1UpgradeTree", "L1UpgradeTree");
   tree_->Branch("L1Upgrade", "L1Analysis::L1AnalysisL1UpgradeDataFormat", &l1UpgradeData, 32000, 3);
-}
-
-L1UpgradeTreeProducer::~L1UpgradeTreeProducer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTreeProducer.cc
@@ -79,12 +79,13 @@ private:
   std::vector<edm::EDGetTokenT<l1t::TauBxCollection>> tauTokens_;
 };
 
-L1UpgradeTreeProducer::L1UpgradeTreeProducer(const edm::ParameterSet& iConfig) :
-  egToken_(consumes<l1t::EGammaBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("egToken"))),
-  jetToken_(consumes<l1t::JetBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("jetToken"))),
-  sumToken_(consumes<l1t::EtSumBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("sumToken"))),
-  muonToken_(consumes<l1t::MuonBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonToken"))),
-  muonShowerToken_(consumes<l1t::MuonShowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonShowerToken"))) {
+L1UpgradeTreeProducer::L1UpgradeTreeProducer(const edm::ParameterSet& iConfig)
+    : egToken_(consumes<l1t::EGammaBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("egToken"))),
+      jetToken_(consumes<l1t::JetBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("jetToken"))),
+      sumToken_(consumes<l1t::EtSumBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("sumToken"))),
+      muonToken_(consumes<l1t::MuonBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonToken"))),
+      muonShowerToken_(
+          consumes<l1t::MuonShowerBxCollection>(iConfig.getUntrackedParameter<edm::InputTag>("muonShowerToken"))) {
   const auto& taus = iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("tauTokens");
   for (const auto& tau : taus) {
     tauTokens_.push_back(consumes<l1t::TauBxCollection>(tau));

--- a/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -16,15 +16,15 @@
 
 using namespace std;
 
-class L1MenuViewer : public edm::EDAnalyzer {
+class L1MenuViewer : public edm::one::EDAnalyzer<> {
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> l1GtMenuToken_;
 
-  explicit L1MenuViewer(const edm::ParameterSet&) : edm::EDAnalyzer() {
+  explicit L1MenuViewer(const edm::ParameterSet&) : edm::one::EDAnalyzer<>() {
     l1GtMenuToken_ = esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>();
   }
-  ~L1MenuViewer(void) override {}
+  ~L1MenuViewer(void) override = default;
 };
 
 void L1MenuViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {

--- a/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
@@ -8,6 +8,8 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
@@ -15,20 +17,22 @@
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondCore/CondDB/interface/Session.h"
 
-#include <iostream>
 using namespace std;
 
 class L1MenuViewer : public edm::EDAnalyzer {
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+  edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> l1GtMenuToken_;
 
-  explicit L1MenuViewer(const edm::ParameterSet&) : edm::EDAnalyzer() {}
+  explicit L1MenuViewer(const edm::ParameterSet&) : edm::EDAnalyzer() {
+    l1GtMenuToken_ = esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>();
+  }
   ~L1MenuViewer(void) override {}
 };
 
 void L1MenuViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TUtmTriggerMenu> handle1;
-  evSetup.get<L1TUtmTriggerMenuRcd>().get(handle1);
+  handle1 = evSetup.getHandle(l1GtMenuToken_);
   std::shared_ptr<L1TUtmTriggerMenu> ptr1(new L1TUtmTriggerMenu(*(handle1.product())));
 
   cout << "L1TUtmTriggerMenu: " << endl;

--- a/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"

--- a/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
@@ -4,12 +4,8 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Utilities/interface/ESGetToken.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
@@ -31,28 +27,26 @@ public:
 };
 
 void L1MenuViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1TUtmTriggerMenu> handle1;
-  handle1 = evSetup.getHandle(l1GtMenuToken_);
-  std::shared_ptr<L1TUtmTriggerMenu> ptr1(new L1TUtmTriggerMenu(*(handle1.product())));
+  auto const& l1GtMenu = evSetup.getData(l1GtMenuToken_);
 
   cout << "L1TUtmTriggerMenu: " << endl;
-  cout << " name: " << ptr1->getName() << endl;
-  cout << " version: " << ptr1->getVersion() << endl;
-  cout << " date/time: " << ptr1->getDatetime() << endl;
-  cout << " UUID: " << ptr1->getFirmwareUuid() << endl;
-  cout << " Scales: " << ptr1->getScaleSetName() << endl;
-  cout << " modules: " << ptr1->getNmodules() << endl;
+  cout << " name: " << l1GtMenu.getName() << endl;
+  cout << " version: " << l1GtMenu.getVersion() << endl;
+  cout << " date/time: " << l1GtMenu.getDatetime() << endl;
+  cout << " UUID: " << l1GtMenu.getFirmwareUuid() << endl;
+  cout << " Scales: " << l1GtMenu.getScaleSetName() << endl;
+  cout << " modules: " << l1GtMenu.getNmodules() << endl;
 
-  cout << " Algorithms[" << ptr1->getAlgorithmMap().size() << "]: " << endl;
-  for (const auto& a : ptr1->getAlgorithmMap())
+  cout << " Algorithms[" << l1GtMenu.getAlgorithmMap().size() << "]: " << endl;
+  for (const auto& a : l1GtMenu.getAlgorithmMap())
     cout << "  " << a.first << endl;
 
-  cout << " Conditions[" << ptr1->getConditionMap().size() << "]: " << endl;
-  for (const auto& a : ptr1->getConditionMap())
+  cout << " Conditions[" << l1GtMenu.getConditionMap().size() << "]: " << endl;
+  for (const auto& a : l1GtMenu.getConditionMap())
     cout << "  " << a.first << endl;
 
-  cout << " Conditions[" << ptr1->getScaleMap().size() << "]: " << endl;
-  for (const auto& a : ptr1->getScaleMap())
+  cout << " Conditions[" << l1GtMenu.getScaleMap().size() << "]: " << endl;
+  for (const auto& a : l1GtMenu.getScaleMap())
     cout << "  " << a.first << endl;
 }
 

--- a/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuViewer.cc
@@ -19,11 +19,10 @@ using namespace std;
 class L1MenuViewer : public edm::one::EDAnalyzer<> {
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> l1GtMenuToken_;
+  const edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> l1GtMenuToken_;
 
-  explicit L1MenuViewer(const edm::ParameterSet&) : edm::one::EDAnalyzer<>() {
-    l1GtMenuToken_ = esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>();
-  }
+  explicit L1MenuViewer(const edm::ParameterSet&)
+      : edm::one::EDAnalyzer<>(), l1GtMenuToken_(esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>()) {}
   ~L1MenuViewer(void) override = default;
 };
 


### PR DESCRIPTION
#### PR description:
This PR includes some updates related to the L1 trigger emulation:  
  - Updates of some producers used to produce L1TNtuples that were causing warnings because they were legacy modules: 
 L1UpgradeTfMuonTreeProducer, L1UpgradeTreeProducer, L1HOTreeProducer, L1EventTreeProducer.
  - Update of the L1TExtCondProducer, where a problem related to the usage of the hltGetConfiguration command for MC (uGT only, not FullMC) occured. The issue is related to the configuration file [SimL1EmulatorRepack_uGT_cff](https://github.com/cms-sw/cmssw/blob/master/Configuration/StandardSequences/python/SimL1EmulatorRepack_uGT_cff.py#L25-L27), where _simGtExtFakeStage2Digis.tcdsRecordLabel_ is modified both for data and MC. However, the label _InputTag("unpackTcds","tcdsRecord")_ for MC implies some checks in the L1ExtCondProducer that are failing. After some investigation, it seems that this tcdsRecordLabel and related input tag should be used as InputTag("unpackTcds","tcdsRecord") only for data. The implemented fix allows to consider all different scenarios in a proper way: FullMC (InputTag empty --> no checks), Full (InputTag ("unpackTcds","tcdsRecord") and real data), uGT data (InputTag  ("unpackTcds","tcdsRecord") and real data), uGT MC (InputTag  ("unpackTcds","tcdsRecord") BUT not real data --> checks skipped).
  - Fix of the L1MenuViewer to avoid an exception MustUseESGetToken.
  - Update of the script use to produce test vectors including example files produced with CMSSW_12X and a small fix needed for the migration to Python3.

#### PR validation:
Basic tests performed successfully starting from CMSSW_12_3_X_2022-01-26-1100. 
From CMSSW_12_3_X_2022-01-26-1100/src:
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests
> scram build code-checks
> scram build code-format
> runTheMatrix.py -l limited -i all --ibeos


