### PR TITLE
Update Scouting Run3 format

### DIFF
--- a/DataFormats/Scouting/interface/Run3ScoutingParticle.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingParticle.h
@@ -1,17 +1,65 @@
-#ifndef DataFormats_Run3ScoutingParticle_h
-#define DataFormats_Run3ScoutingParticle_h
+#ifndef DataFormats_Scouting_Run3ScoutingParticle_h
+#define DataFormats_Scouting_Run3ScoutingParticle_h
 
 #include <vector>
+#include <cstdint>
 
 //class for holding PF candidate information, for use in data scouting
 //IMPORTANT: the content of this class should be changed only in backwards compatible ways!
 class Run3ScoutingParticle {
 public:
   //constructor with values for all data fields
-  Run3ScoutingParticle(float pt, float eta, float phi, float m, int pdgId, int vertex)
-      : pt_(pt), eta_(eta), phi_(phi), m_(m), pdgId_(pdgId), vertex_(vertex) {}
-  //default constructor
-  Run3ScoutingParticle() : pt_(0), eta_(0), phi_(0), m_(0), pdgId_(0), vertex_(-1) {}
+  Run3ScoutingParticle(float pt,
+                       float eta,
+                       float phi,
+                       float m,
+                       int pdgId,
+                       int vertex,
+                       float normchi2,
+                       float dz,
+                       float dxy,
+                       float dzsig,
+                       float dxysig,
+                       uint8_t lostInnerHits,
+                       uint8_t quality,
+                       float trk_pt,
+                       float trk_eta,
+                       float trk_phi)
+      : pt_(pt),
+        eta_(eta),
+        phi_(phi),
+        m_(m),
+        pdgId_(pdgId),
+        vertex_(vertex),
+        normchi2_(normchi2),
+        dz_(dz),
+        dxy_(dxy),
+        dzsig_(dzsig),
+        dxysig_(dxysig),
+        lostInnerHits_(lostInnerHits),
+        quality_(quality),
+        trk_pt_(trk_pt),
+        trk_eta_(trk_eta),
+        trk_phi_(trk_phi) {}
+
+  // default constractor
+  Run3ScoutingParticle()
+      : pt_(0),
+        eta_(0),
+        phi_(0),
+        m_(0),
+        pdgId_(0),
+        vertex_(-1),
+        normchi2_(0),
+        dz_(0),
+        dxy_(0),
+        dzsig_(0),
+        dxysig_(0),
+        lostInnerHits_(0),
+        quality_(0),
+        trk_pt_(0),
+        trk_eta_(0),
+        trk_phi_(0) {}
 
   //accessor functions
   float pt() const { return pt_; }
@@ -20,6 +68,16 @@ public:
   float m() const { return m_; }
   int pdgId() const { return pdgId_; }
   int vertex() const { return vertex_; }
+  float normchi2() const { return normchi2_; }
+  float dz() const { return dz_; }
+  float dxy() const { return dxy_; }
+  float dzsig() const { return dzsig_; }
+  float dxysig() const { return dxysig_; }
+  uint8_t lostInnerHits() const { return lostInnerHits_; }
+  uint8_t quality() const { return quality_; }
+  float trk_pt() const { return trk_pt_; }
+  float trk_eta() const { return trk_eta_; }
+  float trk_phi() const { return trk_phi_; }
 
 private:
   float pt_;
@@ -28,8 +86,18 @@ private:
   float m_;
   int pdgId_;
   int vertex_;
+  float normchi2_;
+  float dz_;
+  float dxy_;
+  float dzsig_;
+  float dxysig_;
+  uint8_t lostInnerHits_;
+  uint8_t quality_;
+  float trk_pt_;
+  float trk_eta_;
+  float trk_phi_;
 };
 
 typedef std::vector<Run3ScoutingParticle> Run3ScoutingParticleCollection;
 
-#endif
+#endif  // DataFormats_Scouting_Run3ScoutingParticle_h

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -33,8 +33,9 @@
   <class name="Run3ScoutingPFJet" ClassVersion="3">
       <version ClassVersion="3" checksum="3819751468"/>
   </class>
-  <class name="Run3ScoutingParticle" ClassVersion="3">
+  <class name="Run3ScoutingParticle" ClassVersion="4">
       <version ClassVersion="3" checksum="1672617274"/>
+      <version ClassVersion="4" checksum="1541586682"/>
   </class>
   <class name="Run3ScoutingVertex" ClassVersion="3">
       <version ClassVersion="3" checksum="316446070"/>

--- a/HLTrigger/JetMET/plugins/BuildFile.xml
+++ b/HLTrigger/JetMET/plugins/BuildFile.xml
@@ -20,5 +20,6 @@
   <use name="TrackingTools/TransientTrack"/>
   <use name="HLTrigger/HLTcore"/>
   <use name="HLTrigger/JetMET"/>
+  <use name="RecoBTag/FeatureTools"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
@@ -60,38 +60,39 @@ private:
   const edm::EDGetTokenT<reco::PFMETCollection> metCollection_;
   const edm::EDGetTokenT<double> rho_;
 
-  const double pfJetPtCut;
-  const double pfJetEtaCut;
-  const double pfCandidatePtCut;
-  const double pfCandidateEtaCut;
-  const int mantissaPrecision;
+  const double pfJetPtCut_;
+  const double pfJetEtaCut_;
+  const double pfCandidatePtCut_;
+  const double pfCandidateEtaCut_;
+  const int mantissaPrecision_;
 
-  const bool doJetTags;
-  const bool doCandidates;
-  const bool doMet;
+  const bool doJetTags_;
+  const bool doCandidates_;
+  const bool doMet_;
   const bool doTrackRelVars_;
+  const bool doCandIndsForJets_;
 };
 
 //
 // constructors and destructor
 //
 HLTScoutingPFProducer::HLTScoutingPFProducer(const edm::ParameterSet &iConfig)
-    : pfJetCollection_(consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("pfJetCollection"))),
-      pfJetTagCollection_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("pfJetTagCollection"))),
-      pfCandidateCollection_(
-          consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandidateCollection"))),
-      vertexCollection_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"))),
-      metCollection_(consumes<reco::PFMETCollection>(iConfig.getParameter<edm::InputTag>("metCollection"))),
-      rho_(consumes<double>(iConfig.getParameter<edm::InputTag>("rho"))),
-      pfJetPtCut(iConfig.getParameter<double>("pfJetPtCut")),
-      pfJetEtaCut(iConfig.getParameter<double>("pfJetEtaCut")),
-      pfCandidatePtCut(iConfig.getParameter<double>("pfCandidatePtCut")),
-      pfCandidateEtaCut(iConfig.getParameter<double>("pfCandidateEtaCut")),
-      mantissaPrecision(iConfig.getParameter<int>("mantissaPrecision")),
-      doJetTags(iConfig.getParameter<bool>("doJetTags")),
-      doCandidates(iConfig.getParameter<bool>("doCandidates")),
-      doMet(iConfig.getParameter<bool>("doMet")),
-      doTrackRelVars_(iConfig.getParameter<bool>("doTrackRelVars")) {
+    : pfJetCollection_(consumes(iConfig.getParameter<edm::InputTag>("pfJetCollection"))),
+      pfJetTagCollection_(consumes(iConfig.getParameter<edm::InputTag>("pfJetTagCollection"))),
+      pfCandidateCollection_(consumes(iConfig.getParameter<edm::InputTag>("pfCandidateCollection"))),
+      vertexCollection_(consumes(iConfig.getParameter<edm::InputTag>("vertexCollection"))),
+      metCollection_(consumes(iConfig.getParameter<edm::InputTag>("metCollection"))),
+      rho_(consumes(iConfig.getParameter<edm::InputTag>("rho"))),
+      pfJetPtCut_(iConfig.getParameter<double>("pfJetPtCut")),
+      pfJetEtaCut_(iConfig.getParameter<double>("pfJetEtaCut")),
+      pfCandidatePtCut_(iConfig.getParameter<double>("pfCandidatePtCut")),
+      pfCandidateEtaCut_(iConfig.getParameter<double>("pfCandidateEtaCut")),
+      mantissaPrecision_(iConfig.getParameter<int>("mantissaPrecision")),
+      doJetTags_(iConfig.getParameter<bool>("doJetTags")),
+      doCandidates_(iConfig.getParameter<bool>("doCandidates")),
+      doMet_(iConfig.getParameter<bool>("doMet")),
+      doTrackRelVars_(iConfig.getParameter<bool>("doTrackRelVars")),
+      doCandIndsForJets_(iConfig.getParameter<bool>("doCandIndsForJets")) {
   //register products
   produces<Run3ScoutingPFJetCollection>();
   produces<Run3ScoutingParticleCollection>();
@@ -108,17 +109,17 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
 
   //get vertices
   Handle<reco::VertexCollection> vertexCollection;
-  std::unique_ptr<Run3ScoutingVertexCollection> outVertices(new Run3ScoutingVertexCollection());
+  auto outVertices = std::make_unique<Run3ScoutingVertexCollection>();
   if (iEvent.getByToken(vertexCollection_, vertexCollection)) {
-    for (auto &vtx : *vertexCollection) {
-      outVertices->emplace_back(vtx.x(),
-                                vtx.y(),
-                                vtx.z(),
-                                vtx.zError(),
-                                vtx.xError(),
-                                vtx.yError(),
+    for (auto const &vtx : *vertexCollection) {
+      outVertices->emplace_back(MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.x(), mantissaPrecision_),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.y(), mantissaPrecision_),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.z(), mantissaPrecision_),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.zError(), mantissaPrecision_),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.xError(), mantissaPrecision_),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.yError(), mantissaPrecision_),
                                 vtx.tracksSize(),
-                                vtx.chi2(),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.chi2(), mantissaPrecision_),
                                 vtx.ndof(),
                                 vtx.isValid());
     }
@@ -126,30 +127,30 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
 
   //get rho
   Handle<double> rho;
-  std::unique_ptr<double> outRho(new double(-999));
+  auto outRho = std::make_unique<double>(-999);
   if (iEvent.getByToken(rho_, rho)) {
-    outRho = std::make_unique<double>(*rho);
+    *outRho = *rho;
   }
 
   //get MET
   Handle<reco::PFMETCollection> metCollection;
-  std::unique_ptr<double> outMetPt(new double(-999));
-  std::unique_ptr<double> outMetPhi(new double(-999));
-  if (doMet && iEvent.getByToken(metCollection_, metCollection)) {
+  auto outMetPt = std::make_unique<double>(-999);
+  auto outMetPhi = std::make_unique<double>(-999);
+  if (doMet_ && iEvent.getByToken(metCollection_, metCollection)) {
     outMetPt = std::make_unique<double>(metCollection->front().pt());
     outMetPhi = std::make_unique<double>(metCollection->front().phi());
   }
 
   //get PF candidates
   Handle<reco::PFCandidateCollection> pfCandidateCollection;
-  std::unique_ptr<Run3ScoutingParticleCollection> outPFCandidates(new Run3ScoutingParticleCollection());
-  if (doCandidates && iEvent.getByToken(pfCandidateCollection_, pfCandidateCollection)) {
-    for (auto &cand : *pfCandidateCollection) {
-      if (cand.pt() > pfCandidatePtCut && std::abs(cand.eta()) < pfCandidateEtaCut) {
+  auto outPFCandidates = std::make_unique<Run3ScoutingParticleCollection>();
+  if (doCandidates_ && iEvent.getByToken(pfCandidateCollection_, pfCandidateCollection)) {
+    for (auto const &cand : *pfCandidateCollection) {
+      if (cand.pt() > pfCandidatePtCut_ && std::abs(cand.eta()) < pfCandidateEtaCut_) {
         int vertex_index = -1;
         int index_counter = 0;
         double dr2 = 0.0001;
-        for (auto &vtx : *outVertices) {
+        for (auto const &vtx : *outVertices) {
           double tmp_dr2 = pow(vtx.x() - cand.vx(), 2) + pow(vtx.y() - cand.vy(), 2) + pow(vtx.z() - cand.vz(), 2);
           if (tmp_dr2 < dr2) {
             dr2 = tmp_dr2;
@@ -164,33 +165,33 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
         if (doTrackRelVars_) {
           const auto *trk = cand.bestTrack();
           if (trk != nullptr) {
-            normchi2 = MiniFloatConverter::reduceMantissaToNbitsRounding(trk->normalizedChi2(), mantissaPrecision);
+            normchi2 = MiniFloatConverter::reduceMantissaToNbitsRounding(trk->normalizedChi2(), mantissaPrecision_);
             lostInnerHits = btagbtvdeep::lost_inner_hits_from_pfcand(cand);
             quality = btagbtvdeep::quality_from_pfcand(cand);
-            trk_pt = MiniFloatConverter::reduceMantissaToNbitsRounding(trk->pt(), mantissaPrecision);
-            trk_eta = MiniFloatConverter::reduceMantissaToNbitsRounding(trk->eta(), mantissaPrecision);
-            trk_phi = MiniFloatConverter::reduceMantissaToNbitsRounding(trk->phi(), mantissaPrecision);
+            trk_pt = MiniFloatConverter::reduceMantissaToNbitsRounding(trk->pt(), mantissaPrecision_);
+            trk_eta = MiniFloatConverter::reduceMantissaToNbitsRounding(trk->eta(), mantissaPrecision_);
+            trk_phi = MiniFloatConverter::reduceMantissaToNbitsRounding(trk->phi(), mantissaPrecision_);
 
             if (not vertexCollection->empty()) {
               const reco::Vertex &pv = (*vertexCollection)[0];
 
               dz = trk->dz(pv.position());
-              dzError = MiniFloatConverter::reduceMantissaToNbitsRounding(dz / trk->dzError(), mantissaPrecision);
-              dz = MiniFloatConverter::reduceMantissaToNbitsRounding(dz, mantissaPrecision);
+              dzError = MiniFloatConverter::reduceMantissaToNbitsRounding(dz / trk->dzError(), mantissaPrecision_);
+              dz = MiniFloatConverter::reduceMantissaToNbitsRounding(dz, mantissaPrecision_);
 
               dxy = trk->dxy(pv.position());
-              dxyError = MiniFloatConverter::reduceMantissaToNbitsRounding(dxy / trk->dxyError(), mantissaPrecision);
-              dxy = MiniFloatConverter::reduceMantissaToNbitsRounding(dxy, mantissaPrecision);
+              dxyError = MiniFloatConverter::reduceMantissaToNbitsRounding(dxy / trk->dxyError(), mantissaPrecision_);
+              dxy = MiniFloatConverter::reduceMantissaToNbitsRounding(dxy, mantissaPrecision_);
             }
           } else {
-            normchi2 = MiniFloatConverter::reduceMantissaToNbitsRounding(999, mantissaPrecision);
+            normchi2 = MiniFloatConverter::reduceMantissaToNbitsRounding(999, mantissaPrecision_);
           }
         }
         outPFCandidates->emplace_back(
-            MiniFloatConverter::reduceMantissaToNbitsRounding(cand.pt(), mantissaPrecision),
-            MiniFloatConverter::reduceMantissaToNbitsRounding(cand.eta(), mantissaPrecision),
-            MiniFloatConverter::reduceMantissaToNbitsRounding(cand.phi(), mantissaPrecision),
-            MiniFloatConverter::reduceMantissaToNbitsRounding(cand.mass(), mantissaPrecision),
+            MiniFloatConverter::reduceMantissaToNbitsRounding(cand.pt(), mantissaPrecision_),
+            MiniFloatConverter::reduceMantissaToNbitsRounding(cand.eta(), mantissaPrecision_),
+            MiniFloatConverter::reduceMantissaToNbitsRounding(cand.phi(), mantissaPrecision_),
+            MiniFloatConverter::reduceMantissaToNbitsRounding(cand.mass(), mantissaPrecision_),
             cand.pdgId(),
             vertex_index,
             normchi2,
@@ -209,23 +210,23 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
 
   //get PF jets
   Handle<reco::PFJetCollection> pfJetCollection;
-  std::unique_ptr<Run3ScoutingPFJetCollection> outPFJets(new Run3ScoutingPFJetCollection());
+  auto outPFJets = std::make_unique<Run3ScoutingPFJetCollection>();
   if (iEvent.getByToken(pfJetCollection_, pfJetCollection)) {
     //get PF jet tags
     Handle<reco::JetTagCollection> pfJetTagCollection;
     bool haveJetTags = false;
-    if (doJetTags && iEvent.getByToken(pfJetTagCollection_, pfJetTagCollection)) {
+    if (doJetTags_ && iEvent.getByToken(pfJetTagCollection_, pfJetTagCollection)) {
       haveJetTags = true;
     }
 
-    for (auto &jet : *pfJetCollection) {
-      if (jet.pt() < pfJetPtCut || std::abs(jet.eta()) > pfJetEtaCut)
+    for (auto const &jet : *pfJetCollection) {
+      if (jet.pt() < pfJetPtCut_ || std::abs(jet.eta()) > pfJetEtaCut_)
         continue;
       //find the jet tag corresponding to the jet
       float tagValue = -20;
       float minDR2 = 0.01;
       if (haveJetTags) {
-        for (auto &tag : *pfJetTagCollection) {
+        for (auto const &tag : *pfJetTagCollection) {
           float dR2 = reco::deltaR2(jet, *(tag.first));
           if (dR2 < minDR2) {
             minDR2 = dR2;
@@ -235,19 +236,19 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
       }
       //get the PF constituents of the jet
       std::vector<int> candIndices;
-      if (doCandidates) {
-        for (auto &cand : jet.getPFConstituents()) {
+      if (doCandidates_ && doCandIndsForJets_) {
+        for (auto const &cand : jet.getPFConstituents()) {
           if (not(cand.isNonnull() and cand.isAvailable())) {
             throw cms::Exception("HLTScoutingPFProducer")
                 << "invalid reference to reco::PFCandidate from reco::PFJet::getPFConstituents()";
           }
-          if (cand->pt() > pfCandidatePtCut && std::abs(cand->eta()) < pfCandidateEtaCut) {
+          if (cand->pt() > pfCandidatePtCut_ && std::abs(cand->eta()) < pfCandidateEtaCut_) {
             //search for the candidate in the collection
             float minDR2 = 0.0001;
             int matchIndex = -1;
             int outIndex = 0;
             for (auto &outCand : *outPFCandidates) {
-              float dR2 = pow(cand->eta() - outCand.eta(), 2) + pow(cand->phi() - outCand.phi(), 2);
+              auto const dR2 = reco::deltaR2(*cand, outCand);
               if (dR2 < minDR2) {
                 minDR2 = dR2;
                 matchIndex = outIndex;
@@ -261,29 +262,30 @@ void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event &iEvent, edm::
           }
         }
       }
-      outPFJets->emplace_back(jet.pt(),
-                              jet.eta(),
-                              jet.phi(),
-                              jet.mass(),
-                              jet.jetArea(),
-                              jet.chargedHadronEnergy(),
-                              jet.neutralHadronEnergy(),
-                              jet.photonEnergy(),
-                              jet.electronEnergy(),
-                              jet.muonEnergy(),
-                              jet.HFHadronEnergy(),
-                              jet.HFEMEnergy(),
-                              jet.chargedHadronMultiplicity(),
-                              jet.neutralHadronMultiplicity(),
-                              jet.photonMultiplicity(),
-                              jet.electronMultiplicity(),
-                              jet.muonMultiplicity(),
-                              jet.HFHadronMultiplicity(),
-                              jet.HFEMMultiplicity(),
-                              jet.hoEnergy(),
-                              tagValue,
-                              0.0,
-                              candIndices);
+      outPFJets->emplace_back(
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.pt(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.eta(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.phi(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.mass(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.jetArea(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.chargedHadronEnergy(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.neutralHadronEnergy(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.photonEnergy(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.electronEnergy(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.muonEnergy(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.HFHadronEnergy(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.HFEMEnergy(), mantissaPrecision_),
+          jet.chargedHadronMultiplicity(),
+          jet.neutralHadronMultiplicity(),
+          jet.photonMultiplicity(),
+          jet.electronMultiplicity(),
+          jet.muonMultiplicity(),
+          jet.HFHadronMultiplicity(),
+          jet.HFEMMultiplicity(),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(jet.hoEnergy(), mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(tagValue, mantissaPrecision_),
+          MiniFloatConverter::reduceMantissaToNbitsRounding(0.0, mantissaPrecision_),
+          candIndices);
     }
   }
 
@@ -312,8 +314,9 @@ void HLTScoutingPFProducer::fillDescriptions(edm::ConfigurationDescriptions &des
   desc.add<bool>("doJetTags", true);
   desc.add<bool>("doCandidates", true);
   desc.add<bool>("doMet", true);
-  descriptions.add("hltScoutingPFProducer", desc);
   desc.add<bool>("doTrackRelVars", true);
+  desc.add<bool>("doCandIndsForJets", false);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 // declare this class as a framework plugin

--- a/HLTrigger/JetMET/plugins/HLTScoutingPrimaryVertexProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPrimaryVertexProducer.cc
@@ -17,6 +17,8 @@
 #include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
+#include "DataFormats/Math/interface/libminifloat.h"
+
 class HLTScoutingPrimaryVertexProducer : public edm::global::EDProducer<> {
 public:
   explicit HLTScoutingPrimaryVertexProducer(const edm::ParameterSet&);
@@ -53,14 +55,14 @@ void HLTScoutingPrimaryVertexProducer::produce(edm::StreamID sid,
 
   if (iEvent.getByToken(vertexCollection_, vertexCollection)) {
     for (auto& vtx : *vertexCollection) {
-      outVertices->emplace_back(vtx.x(),
-                                vtx.y(),
-                                vtx.z(),
-                                vtx.zError(),
-                                vtx.xError(),
-                                vtx.yError(),
+      outVertices->emplace_back(MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.x(), 10),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.y(), 10),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.z(), 10),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.zError(), 10),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.xError(), 10),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.yError(), 10),
                                 vtx.tracksSize(),
-                                vtx.chi2(),
+                                MiniFloatConverter::reduceMantissaToNbitsRounding(vtx.chi2(), 10),
                                 vtx.ndof(),
                                 vtx.isValid());
     }


### PR DESCRIPTION
#### PR description:

- Several features of the PF Candidate `bestTrack()` has been added to the class Run3ScoutingParticle. The included variables are necessary to run b-tagging with ParticleNet, and has also been identified as helpful for additional analyses groups.
- A couple of changes to HLTScoutingPFProducer.cc to bring the overall scouting data size down. These include:
   - Reduced precision of vertex and jet quantities.
   - Configurable option (`doCandIndsForJets`) which dictates if the output should contain the indices of the PF constituents of the jet.
- Reduced precision of the vertex  quantities in the primary vertex producer.
- Pt cut (default value of 0.3) for tracks in the track producer.

#### PR validation:

I ran `scram b runtests` as well as runTheMatrix. On lxplus runTheMatrix came back with 9 fails but all due to `DAS_ERROR`.
