### PR TITLE
DAQ: write throttling in output modules (12_3_X)

### DIFF
--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/RunForOutput.h"
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 
 #include "FWCore/Concurrency/interface/SerialTaskQueue.h"
 
@@ -56,6 +57,7 @@ namespace evf {
     }
 
     void doOutputEventAsync(std::unique_ptr<EventMsgBuilder> msg, edm::WaitingTaskHolder iHolder) {
+      throttledCheck();
       auto group = iHolder.group();
       writeQueue_.push(*group, [holder = std::move(iHolder), msg = msg.release(), this]() {
         try {
@@ -66,6 +68,18 @@ namespace evf {
           tmp.doneWaiting(std::current_exception());
         }
       });
+    }
+
+    inline void throttledCheck() {
+      unsigned int counter = 0;
+      while (edm::Service<evf::EvFDaqDirector>()->inputThrottled()) {
+        if (edm::shutdown_flag.load(std::memory_order_relaxed))
+          break;
+        if (!(counter % 100))
+          edm::LogWarning("FedRawDataInputSource") << "Input throttled detected, writing is paused...";
+        usleep(100000);
+        counter++;
+      }
     }
 
     uint32 get_adler32() const { return stream_writer_events_->adler32(); }

--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -136,7 +136,7 @@ process.streamB = cms.OutputModule("EvFOutputModule",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
 )
 
-process.streamC = cms.OutputModule("ShmStreamConsumer",
+process.streamC = cms.OutputModule("GlobalEvFOutputModule",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
 )
 

--- a/EventFilter/Utilities/test/unittest_FU.py
+++ b/EventFilter/Utilities/test/unittest_FU.py
@@ -145,7 +145,7 @@ process.streamB = cms.OutputModule("EvFOutputModule",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
 )
 
-process.streamC = cms.OutputModule("ShmStreamConsumer",
+process.streamC = cms.OutputModule("GlobalEvFOutputModule",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p2' ))
 )
 


### PR DESCRIPTION
#### PR description:
- More aggresive throtting in case a marker is present in local ramdisk.
Provides more fine-grained throttling avoiding chance to reach "no disk space" errors induced by latency in applying the throttling.
- updated unit tests to use new global evf output module and remove test for the deprecated one.

#### PR validation:

Patch was tested in the global HLT syste (EvFOutputModule).
Also part of the unit test which runs automatically as part of cmsbuild tests. Running it manually, the test passes.