### PR TITLE
Run3-gex116A Remove some unused include to help compilation warnings in Sim packages

### DIFF
--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -4,7 +4,6 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESWatcher.h"

--- a/SimCalorimetry/EcalZeroSuppressionAlgos/interface/EcalZeroSuppressor.h
+++ b/SimCalorimetry/EcalZeroSuppressionAlgos/interface/EcalZeroSuppressor.h
@@ -8,7 +8,6 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/SimCalorimetry/EcalZeroSuppressionAlgos/interface/TrivialAmplitudeAlgo.h
+++ b/SimCalorimetry/EcalZeroSuppressionAlgos/interface/TrivialAmplitudeAlgo.h
@@ -10,7 +10,6 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/SimRomanPot/SimFP420/plugins/DigitizerFP420.cc
+++ b/SimRomanPot/SimFP420/plugins/DigitizerFP420.cc
@@ -11,7 +11,6 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"


### PR DESCRIPTION
#### PR description:

Remove some unused include to help compilation warnings in Sim packages

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special