### PR TITLE
Skim for EXO Disappearing Tracks

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -4,14 +4,8 @@ from Configuration.EventContent.EventContent_cff import AODSIMEventContent
 EXODisappTrkSkimContent = AODSIMEventContent.clone()
 
 EXODisappTrkSkimContent.outputCommands.append('drop *')
-#EXODisappTrkSkimContent.outputCommands.append('keep *_ecalRecHit_EcalRecHitsEB_*')
-#EXODisappTrkSkimContent.outputCommands.append('keep *_ecalRecHit_EcalRecHitsEE_*')
-#EXODisappTrkSkimContent.outputCommands.append('keep *_hbhereco_*_*')
 EXODisappTrkSkimContent.outputCommands.append('keep *_reducedHcalRecHits_*_*')
 EXODisappTrkSkimContent.outputCommands.append('keep *_reducedEcalRecHits*_*_*')
-#EXODisappTrkSkimContent.outputCommands.append('keep *_dedxHitInfo_*_*')
-#EXODisappTrkSkimContent.outputCommands.append('keep *_dedx*Harmonic2_*_*')
-#EXODisappTrkSkimContent.outputCommands.append('keep *_generalTracks_*_*')
 
 import copy
 from HLTrigger.HLTfilters.hltHighLevel_cfi import *
@@ -20,49 +14,7 @@ hltDisappTrk = copy.deepcopy(hltHighLevel)
 hltDisappTrk.throw = cms.bool(False)
 
 hltDisappTrk.HLTPaths = [
-
-    #2017 and 2018
-    #MET
-
     #"HLT_MET105_IsoTrk50_v*",
-    #"HLT_PFMET120_PFMHT120_IDTight_v*",
-    #"HLT_PFMET130_PFMHT130_IDTight_v*",
-    #"HLT_PFMET140_PFMHT140_IDTight_v*", 
-    #"HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*", 
-    #"HLT_PFMETNoMu130_PFMHTNoMu130_IDTight_v*",
-    #"HLT_PFMETNoMu140_PFMHTNoMu140_IDTight_v*",
-    #"HLT_PFMET250_HBHECleaned_v*",
-    #"HLT_PFMET300_HBHECleaned_v*", 
-    #"HLT_PFMETTypePne140_PFMHT140_IDTight_v*",
-    #"HLT_PFMET200_HBHE_BeamHaloCleaned_v*",
-    #"HLT_PFMetTypeOne200_HBHE_BEAMHaloCleaned_v*",
-    #EGamma
-    #"HLT_Ele35_WPTight_Gsf_v*", 
-    #"HLT_Ele32_WPTight_Gsf_v*", 
-    #SingleMuon
-    #"HLT_IsoMu27_v*", 
-    #"HLT_IsoMu24_v*", 
-    #Tau
-    #"HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v*",
-
-    #2016
-    #"HLT_Photon175_v*",
-    #"HLT_DoublePhoton60_v*",
-    #"HLT_PFMET300_v*",
-    #"HLT_PFMET170_HBHE_BeamHaloCleaned_v*",
-    #2017 and 2018
-    #"HLT_Photon200_v*",
-    #"HLT_Photon300_NoHE_v*",
-    #"HLT_DoublePhoton70_v*",
-    #"HLT_PFMET140_PFMHT140_IDTight_v*",
-    #"HLT_PFMET250_HBHECleaned_v*",
-    #"HLT_PFMET300_HBHECleaned_v*",
-
-    #test
-    #"HLT_Mu20_Mu10_v*",
-    #"HLT_Random_v*",
-    #"HLT_ZeroBias_v*,"
-    #"MC_CaloMHT_v*",
     "MC_PFMET_v17"
 ]
 

--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -72,7 +72,7 @@ hltDisappTrk.andOr = True
 disappTrkSelection=cms.EDFilter("TrackSelector", 
     src = cms.InputTag("generalTracks"),
     cut = cms.string('pt > 25 && abs(eta()) < 2.1'),
-    filter = cms.bool(False)
+    filter = cms.bool(True)
 )
 
 # disappTrk skim sequence

--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Configuration.EventContent.EventContent_cff import AODSIMEventContent
 EXODisappTrkSkimContent = AODSIMEventContent.clone()
-
 EXODisappTrkSkimContent.outputCommands.append('drop *')
 EXODisappTrkSkimContent.outputCommands.append('keep *_reducedHcalRecHits_*_*')
 EXODisappTrkSkimContent.outputCommands.append('keep *_reducedEcalRecHits*_*_*')

--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -1,0 +1,81 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.EventContent.EventContent_cff import AODSIMEventContent
+EXODisappTrkSkimContent = AODSIMEventContent.clone()
+
+EXODisappTrkSkimContent.outputCommands.append('drop *')
+#EXODisappTrkSkimContent.outputCommands.append('keep *_ecalRecHit_EcalRecHitsEB_*')
+#EXODisappTrkSkimContent.outputCommands.append('keep *_ecalRecHit_EcalRecHitsEE_*')
+#EXODisappTrkSkimContent.outputCommands.append('keep *_hbhereco_*_*')
+EXODisappTrkSkimContent.outputCommands.append('keep *_reducedHcalRecHits_*_*')
+EXODisappTrkSkimContent.outputCommands.append('keep *_reducedEcalRecHits*_*_*')
+#EXODisappTrkSkimContent.outputCommands.append('keep *_dedxHitInfo_*_*')
+#EXODisappTrkSkimContent.outputCommands.append('keep *_dedx*Harmonic2_*_*')
+#EXODisappTrkSkimContent.outputCommands.append('keep *_generalTracks_*_*')
+
+import copy
+from HLTrigger.HLTfilters.hltHighLevel_cfi import *
+
+hltDisappTrk = copy.deepcopy(hltHighLevel)
+hltDisappTrk.throw = cms.bool(False)
+
+hltDisappTrk.HLTPaths = [
+
+    #2017 and 2018
+    #MET
+
+    #"HLT_MET105_IsoTrk50_v*",
+    #"HLT_PFMET120_PFMHT120_IDTight_v*",
+    #"HLT_PFMET130_PFMHT130_IDTight_v*",
+    #"HLT_PFMET140_PFMHT140_IDTight_v*", 
+    #"HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*", 
+    #"HLT_PFMETNoMu130_PFMHTNoMu130_IDTight_v*",
+    #"HLT_PFMETNoMu140_PFMHTNoMu140_IDTight_v*",
+    #"HLT_PFMET250_HBHECleaned_v*",
+    #"HLT_PFMET300_HBHECleaned_v*", 
+    #"HLT_PFMETTypePne140_PFMHT140_IDTight_v*",
+    #"HLT_PFMET200_HBHE_BeamHaloCleaned_v*",
+    #"HLT_PFMetTypeOne200_HBHE_BEAMHaloCleaned_v*",
+    #EGamma
+    #"HLT_Ele35_WPTight_Gsf_v*", 
+    #"HLT_Ele32_WPTight_Gsf_v*", 
+    #SingleMuon
+    #"HLT_IsoMu27_v*", 
+    #"HLT_IsoMu24_v*", 
+    #Tau
+    #"HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_v*",
+
+    #2016
+    #"HLT_Photon175_v*",
+    #"HLT_DoublePhoton60_v*",
+    #"HLT_PFMET300_v*",
+    #"HLT_PFMET170_HBHE_BeamHaloCleaned_v*",
+    #2017 and 2018
+    #"HLT_Photon200_v*",
+    #"HLT_Photon300_NoHE_v*",
+    #"HLT_DoublePhoton70_v*",
+    #"HLT_PFMET140_PFMHT140_IDTight_v*",
+    #"HLT_PFMET250_HBHECleaned_v*",
+    #"HLT_PFMET300_HBHECleaned_v*",
+
+    #test
+    #"HLT_Mu20_Mu10_v*",
+    #"HLT_Random_v*",
+    #"HLT_ZeroBias_v*,"
+    #"MC_CaloMHT_v*",
+    "MC_PFMET_v17"
+]
+
+hltDisappTrk.throw = False
+hltDisappTrk.andOr = True
+
+disappTrkSelection=cms.EDFilter("TrackSelector", 
+    src = cms.InputTag("generalTracks"),
+    cut = cms.string('pt > 25 && abs(eta()) < 2.1'),
+    filter = cms.bool(False)
+)
+
+# disappTrk skim sequence
+EXODisappTrkSkimSequence = cms.Sequence(
+    hltDisappTrk * disappTrkSelection
+    )

--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -7,7 +7,7 @@ EXODisappTrkSkimContent.outputCommands.append('keep *_reducedHcalRecHits_*_*')
 EXODisappTrkSkimContent.outputCommands.append('keep *_reducedEcalRecHits*_*_*')
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi as _hltHighLevel
-hltDisappTrk = _hltHighLevel.clone(
+hltDisappTrk = _hltHighLevel.hltHighLevel.clone(
    throw = False,
    andOr = True,
    HLTPaths = [

--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -7,19 +7,15 @@ EXODisappTrkSkimContent.outputCommands.append('drop *')
 EXODisappTrkSkimContent.outputCommands.append('keep *_reducedHcalRecHits_*_*')
 EXODisappTrkSkimContent.outputCommands.append('keep *_reducedEcalRecHits*_*_*')
 
-import copy
-from HLTrigger.HLTfilters.hltHighLevel_cfi import *
-
-hltDisappTrk = copy.deepcopy(hltHighLevel)
-hltDisappTrk.throw = cms.bool(False)
-
-hltDisappTrk.HLTPaths = [
-    #"HLT_MET105_IsoTrk50_v*",
-    "MC_PFMET_v17"
-]
-
-hltDisappTrk.throw = False
-hltDisappTrk.andOr = True
+import HLTrigger.HLTfilters.hltHighLevel_cfi as _hltHighLevel
+hltDisappTrk = _hltHighLevel.clone(
+   throw = False,
+   andOr = True,
+   HLTPaths = [
+      #"HLT_MET105_IsoTrk50_v*",
+      "MC_PFMET_v17"
+   ]
+)
 
 disappTrkSelection=cms.EDFilter("TrackSelector", 
     src = cms.InputTag("generalTracks"),

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -257,6 +257,17 @@ SKIMStreamEXODisplacedJet = cms.FilteredStream(
     paths = (EXODisplacedJetPath),
     content = skimRawAODContent.outputCommands,
     selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('AOD')
+    )
+
+from Configuration.Skimming.PDWG_EXODisappTrk_cff import *
+EXODisappTrkPath = cms.Path(EXODisappTrkSkimSequence)
+SKIMStreamEXODisappTrk = cms.FilteredStream(
+    responsible = 'PDWG', 
+    name = 'EXODisappTrk', 
+    paths = (EXODisappTrkPath),
+    content = EXODisappTrkSkimContent.outputCommands, 
+    selectEvents = cms.untracked.PSet(), 
     dataTier = cms.untracked.string('USER')
     )
 

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -257,7 +257,7 @@ SKIMStreamEXODisplacedJet = cms.FilteredStream(
     paths = (EXODisplacedJetPath),
     content = skimRawAODContent.outputCommands,
     selectEvents = cms.untracked.PSet(),
-    dataTier = cms.untracked.string('AOD')
+    dataTier = cms.untracked.string('USER')
     )
 
 from Configuration.Skimming.PDWG_EXODisappTrk_cff import *
@@ -268,7 +268,7 @@ SKIMStreamEXODisappTrk = cms.FilteredStream(
     paths = (EXODisappTrkPath),
     content = EXODisappTrkSkimContent.outputCommands, 
     selectEvents = cms.untracked.PSet(), 
-    dataTier = cms.untracked.string('USER')
+    dataTier = cms.untracked.string('AOD')
     )
 
 #####################

--- a/Configuration/Skimming/test/test_DisTrk_cfg.py
+++ b/Configuration/Skimming/test/test_DisTrk_cfg.py
@@ -1,0 +1,149 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: step1 --filein root://cmsxrootd.fnal.gov//store/mc/Run3Summer21DRPremix/DYToLL_M-4To50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v6-v2/80000/03b302a8-8389-406d-945a-16c2f16f065f.root --fileout file:step1_RECO.root --mc --eventcontent AODSIM --runUnscheduled --datatier AODSIM --conditions 120X_mcRun3_2021_realistic_v6 --step RAW2DIGI,L1Reco,RECO,RECOSIM --nThreads 4 --geometry DB:Extended --era Run3 --python_filename test_DisTrksV2_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 100
+import FWCore.ParameterSet.Config as cms
+from Configuration.Skimming.PDWG_EXODisappTrk_cff import *
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('RECO',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.Skims_cff')
+process.load('Configuration.StandardSequences.RecoSim_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('root://cmsxrootd.fnal.gov//store/mc/Run3Summer21DRPremix/DYToLL_M-4To50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v6-v2/80000/03b302a8-8389-406d-945a-16c2f16f065f.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step1 nevts:100'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.AODSIMoutput = cms.OutputModule("PoolOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(4),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('AODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(31457280),
+    fileName = cms.untracked.string('file:step1_RECO.root'),
+    outputCommands = process.AODSIMEventContent.outputCommands
+)
+
+# Additional output definition
+process.SKIMStreamEXODisappTrk = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('EXODisappTrkPath')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('AODSIM'),
+        filterName = cms.untracked.string('EXODisappTrk')
+        #filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('EXODisappTrk.root'),
+    outputCommands = process.EXODisappTrkSkimContent.outputCommands
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '120X_mcRun3_2021_realistic_v6', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.recosim_step = cms.Path(process.recosim)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.AODSIMoutput_step = cms.EndPath(process.AODSIMoutput)
+process.SKIMStreamEXODisappTrkOutPath = cms.EndPath(process.SKIMStreamEXODisappTrk)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.EXODisappTrkPath,process.recosim_step,process.endjob_step,process.AODSIMoutput_step,process.SKIMStreamEXODisappTrkOutPath)
+# Additional output definition
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads = 4
+process.options.numberOfStreams = 0
+process.options.numberOfConcurrentLuminosityBlocks = 0
+process.options.eventSetup.numberOfConcurrentIOVs = 1
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.Utils
+from Configuration.DataProcessing.Utils import addMonitoring 
+
+#call to customisation function addMonitoring imported from Configuration.DataProcessing.Utils
+process = addMonitoring(process)
+
+# End of customisation functions
+
+
+# Customisation from command line
+
+#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule
+from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+process = customiseLogErrorHarvesterUsingOutputCommands(process)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
#### PR description:
This PR adds a RECO level skim for use by the disappearing tracks search (EXO-19-010). The skim saves the AOD collections:

EcalRecHitsSorted_reducedEcalRecHitsEE__RECO
EcalRecHitsSorted_reducedEcalRecHitsEB__RECO
EcalRecHitsSorted_reducedEcalRecHitsES__RECO
HBHERecHitsSorted_reducedHcalRecHits_hbhereco_RECO
HFRecHitsSorted_reducedHcalRecHits_hfreco_RECO
HORecHitsSorted_reducedHcalRecHits_horeco_RECO

The skim then cuts on general tracks, requiring there be a general track with pt> 25GeV and with |eta| < 2.1.

Testing with one file from the "DYToLL_M-4To50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v6-v2" dataset (807 events) the AOD file size of the skim is 2.5mb while the unskimmed AOD file is 7.9mb.

#### PR validation:

Ran with CMSSW_12_0_3_patch2 and used config file for testing "test_DisTrk_cfg.py". Config file is included in PR.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

