### PR TITLE
fix bug in NANOAOD Pileup_nTrueInt variable (int instead of float)

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
@@ -42,7 +42,7 @@ public:
   void fillNPUObjectTable(const std::vector<PileupSummaryInfo>& npuProd, nanoaod::FlatTable& out, double refpvz) const {
     // Get BX 0
     unsigned int bx0 = 0;
-    unsigned int nt = 0;
+    float nt = 0;
     unsigned int npu = 0;
 
     auto zbin = std::lower_bound(vz_.begin(), vz_.end() - 1, std::abs(refpvz));

--- a/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
@@ -87,7 +87,8 @@ public:
     out.addColumnValue<float>("nTrueInt",
                               nt,
                               "the true mean number of the poisson distribution for this event from which the number "
-                              "of interactions each bunch crossing has been sampled");
+                              "of interactions each bunch crossing has been sampled",
+                              10);
     out.addColumnValue<int>(
         "nPU",
         npu,


### PR DESCRIPTION
#### PR description:
Follow-up of thread "Pileup_nTrueInt in nanoAOD v9"
https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3811/1/1/1.html


#### PR validation:
Ran
runTheMatrix.py -l 1325.81 --sites ""
and in a second step adapted the input to a sample with flatPU distribution (runTheMatrix sample has integer true PU 35). Output is as expected:
```
root [6] Events->Scan("Pileup_nTrueInt")
************************
*    Row   * Pileup_nT *
************************
*        0 * 12.430791 *
*        1 * 9.1569194 *
*        2 * 18.460222 *
*        3 * 26.073337 *
*        4 * 10.425618 *
*        5 * 8.3619899 *
```

Whereas previous nanoAOD had integer values for Pileup_nTrueInt, e.g. (from the same dataset as used for the test above)
```
Attaching file root://xrootd-cms.infn.it//store/mc/RunIISummer19UL16NanoAODv2/QCD_Pt-15to7000_TuneCP5_Flat2018_13TeV_pythia8/NANOAODSIM/FlatPU0to70_106X_mcRun2_asymptotic_v15-v1/270000/05FEFA95-6CDF-1C47-B69F-9108AA3DE7EE.root as _file0...
(TFile *) 0x5edce70
root [1] Events->Scan("Pileup_nTrueInt")
************************
*    Row   * Pileup_nT *
************************
*        0 *        21 *
*        1 *        15 *
*        2 *        38 *
*        3 *         8 *
```

