### PR TITLE
Allow DD4hep in D86 and D88

### DIFF
--- a/Configuration/StandardSequences/python/GeometryConf.py
+++ b/Configuration/StandardSequences/python/GeometryConf.py
@@ -65,8 +65,10 @@ GeometryConf={
     'Extended2026D84' : 'Extended2026D84,Extended2026D84Reco',
     'Extended2026D85' : 'Extended2026D85,Extended2026D85Reco',
     'Extended2026D86' : 'Extended2026D86,Extended2026D86Reco',
+    'DD4hepExtended2026D86' : 'DD4hepExtended2026D86,DD4hepExtended2026D86Reco',
     'Extended2026D87' : 'Extended2026D87,Extended2026D87Reco',
     'Extended2026D88' : 'Extended2026D88,Extended2026D88Reco',
+    'DD4hepExtended2026D88' : 'DD4hepExtended2026D88,DD4hepExtended2026D88Reco',
     'Extended2026D89' : 'Extended2026D89,Extended2026D89Reco',
     'Extended2026D90' : 'Extended2026D90,Extended2026D90Reco',
     }


### PR DESCRIPTION
#### PR description:
This PR is to allow to run DD4hep in D86 and D88. As mentioned in 
https://github.com/cms-sw/cmssw/issues/36849
we missed the proper config of DD4hep.

#### PR validation:
`runTheMatrix.py --what upgrade -l 38634.911 -t 8 --wm init`
gives the proper config that load
`process.load('Configuration.Geometry.GeometryDD4hepExtended2026D88Reco_cff')`
instead of
`process.load('Configuration.StandardSequences.GeometryRecoDB_cff')`

We can't trigger the DD4hep wf test in Phase-2 yet. This PR is just to allow us to run GEN-SIM properly.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
None