### PR TITLE
Change to `SiStripCluster` DataFormat: use `auto` for return types

### DIFF
--- a/DataFormats/SiStripCluster/interface/SiStripCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripCluster.h
@@ -40,13 +40,6 @@ public:
     amplitudes_.insert(amplitudes_.end(), begin, end);
   }
 
-  /** The number of the first strip in the cluster.
-   *  The high bit of firstStrip_ indicates whether the cluster is a candidate for being merged.
-   */
-  uint16_t firstStrip() const { return firstStrip_ & stripIndexMask; }
-
-  uint16_t endStrip() const { return firstStrip() + size(); }
-
   /** The amplitudes of the strips forming the cluster.
    *  The amplitudes are on consecutive strips; if a strip is missing
    *  the amplitude is set to zero.
@@ -58,14 +51,20 @@ public:
    *  You can find the special meanings of values { 0, 254, 255} in section 3.4.1 of
    *  http://www.te.rl.ac.uk/esdg/cms-fed/firmware/Documents/FE_FPGA_Technical_Description.pdf
    */
-  uint8_t const* begin() const { return amplitudes_.data(); }
-  uint8_t const* end() const { return begin() + size(); }
-  uint8_t size() const { return amplitudes_.size(); }
-  uint8_t operator[](int i) const { return *(begin() + i); }
-  bool empty() const { return 0 == size(); }
+  auto size() const { return amplitudes_.size(); }
+  auto const* begin() const { return amplitudes_.data(); }
+  auto const* end() const { return begin() + size(); }
+  auto operator[](int i) const { return *(begin() + i); }
+  bool empty() const { return amplitudes_.empty(); }
   bool full() const { return false; }
 
   SiStripCluster const& amplitudes() const { return *this; }
+
+  /** The number of the first strip in the cluster.
+   *  The high bit of firstStrip_ indicates whether the cluster is a candidate for being merged.
+   */
+  uint16_t firstStrip() const { return firstStrip_ & stripIndexMask; }
+  uint16_t endStrip() const { return firstStrip() + size(); }
 
   /** The barycenter of the cluster, not corrected for Lorentz shift;
    *  should not be used as position estimate for tracking.


### PR DESCRIPTION
resolves #36336
resolves #35489

#### PR description:

Follow up on #35489, based on suggestion at https://github.com/cms-sw/cmssw/issues/36336#issuecomment-1017505414.
   * 527187e5b333a2ba15892a2a6db5672ab2c72514 :  Change to `SiStripCluster` DF, use `auto` for return types;

#### PR validation:

`cmssw` compiles.