### PR TITLE
Fix KF Track Parameter Digitization

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Track.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Track.h
@@ -56,11 +56,11 @@ namespace trklet {
 
     double phi0(Settings const& settings) const;
 
-    double eta(Settings const& settings) const { return asinh(ipars_.t() * settings.ktpars()); }
-    double tanL(Settings const& settings) const { return ipars_.t() * settings.ktpars(); }
-    double z0(Settings const& settings) const { return ipars_.z0() * settings.kz0pars(); }
-    double rinv(Settings const& settings) const { return ipars_.rinv() * settings.krinvpars(); }
-    double d0(Settings const& settings) const { return ipars_.d0() * settings.kd0pars(); }
+    double eta(Settings const& settings) const { return (asinh(ipars_.t() + 0.5) * settings.ktpars()); }
+    double tanL(Settings const& settings) const { return (ipars_.t() + 0.5) * settings.ktpars(); }
+    double z0(Settings const& settings) const { return (ipars_.z0() + 0.5) * settings.kz0pars(); }
+    double rinv(Settings const& settings) const { return (ipars_.rinv() + 0.5) * settings.krinvpars(); }
+    double d0(Settings const& settings) const { return (ipars_.d0() + 0.5) * settings.kd0pars(); }
     double chisq() const { return chisqrphi_ + chisqrz_; }
 
     double chisqrphi() const { return chisqrphi_; }

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -212,11 +212,11 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
     double phi0fit = reco::reduceRange(phi0 - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
     double rinvfit = 0.01 * settings_.c() * settings_.bfield() * qoverpt;
 
-    int irinvfit = rinvfit / settings_.krinvpars();
-    int iphi0fit = phi0fit / settings_.kphi0pars();
-    int itanlfit = trk.tanLambda() / settings_.ktpars();
-    int iz0fit = trk.z0() / settings_.kz0pars();
-    int id0fit = d0 / settings_.kd0pars();
+    int irinvfit = floor(rinvfit / settings_.krinvpars());
+    int iphi0fit = floor(phi0fit / settings_.kphi0pars());
+    int itanlfit = floor(trk.tanLambda() / settings_.ktpars());
+    int iz0fit = floor(trk.z0() / settings_.kz0pars());
+    int id0fit = floor(d0 / settings_.kd0pars());
     int ichi2rphifit = chi2rphi / 16;
     int ichi2rzfit = trk.chi2rz() / 16;
 


### PR DESCRIPTION
Fixes to the KF Track Parameter Digitization to remove the problem of assigning too many parameters to 0. Now implementing the digitization as: 

int ix = floor(x / k)

and undigitizing as: 

float x = (ix+0.5)*k;

