### PR TITLE
Clean DQMOffline/MuonDPG/BuildFile.xml and remove UBSAN comments

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="RecoLocalTracker/SiStripClusterizer"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="DataFormats/DetId"/>
-<use name="DataFormats/Scalers"/> <!--Needed for typeinfo for LumiScalers for UBSAN builds-->
+<use name="DataFormats/Scalers"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/TrackingRecHit"/>
 <use name="DataFormats/TrackReco"/>

--- a/DQM/TrackerRemapper/BuildFile.xml
+++ b/DQM/TrackerRemapper/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="rootgraphics"/>
 <use name="rootmath"/>
 <use name="roothistmatrix"/>
-<use name="roothistpainter"/> <!--Needed for typeinfo for TPaletteAxis in UBSAN builds-->
+<use name="roothistpainter"/> <!--Needed for TPaletteAxis and other classes for drawing histograms-->
 <export>
   <lib name="1"/>
 </export>

--- a/DQMOffline/MuonDPG/BuildFile.xml
+++ b/DQMOffline/MuonDPG/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="FWCore/Framework"/>
 <use name="DQMServices/Core"/>
-<use name="DataFormats/Scalers"/> <!--Needed for typeinfo for LumiScalers for UBSAN builds-->
 <use name="HLTrigger/HLTcore"/>
 <use name="boost"/>
 <use name="rootgraphics"/>

--- a/Geometry/MTDNumberingBuilder/BuildFile.xml
+++ b/Geometry/MTDNumberingBuilder/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/GeometrySurface"/>
 <use name="DetectorDescription/Core"/>
 <use name="Geometry/TrackerNumberingBuilder"/>
-<use name="Geometry/CommonDetUnit"/> <!--Needed for typeinfo for GeomDet in UBSAN builds-->
+<use name="Geometry/CommonDetUnit"/>
 <use name="DataFormats/ForwardDetId"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
#### PR description:

**Note: this should be tested like `please test for CMSSW_12_3_UBSAN_X` (see https://github.com/cms-sw/cmssw/pull/36834#issuecomment-1025138264)**

At a few places, there are comments in Build files that a given
dependency is "needed for UBSAN builds". I'd argue that this these
comments are confusing an should be removed: if a package has a
dependency it's because headers from that dependency are included, so no
need to argue with the UBSAN builds.

Both in the `CalibTracker/SiStripHitEfficiency`  and
`DQM/TrackerRemapper` BuildFiles, the packages indeed include headers
from `DataFormats/Scalers`, so arguing with UBSAN builds is completely
redundant.

A good example for why these comments are confusing was the BuildFile in
`DQMOffline/MuonDPG` that package doesn't actually depend on
`DataFormats/Scalers` as far as I can tell, but because the BuildFile
was copy-pasted from `DQM/TrackerRemapper` it included the comment about
UBSAN builds which was not even applicable. That's why I didn't clean
that BuildFile in #36834, but instead make this separate commit to
elaborate the arguments.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.