### PR TITLE
CLUE3D Bug Fixes

### DIFF
--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -32,3 +32,24 @@ TICL_FEVT = cms.PSet(
       )
     )
 TICL_FEVT.outputCommands.extend(TICL_RECO.outputCommands)
+
+def customiseHGCalOnlyEventContent(process):
+    def cleanOutputAndSet(outputModule, ticl_outputCommads):
+        outputModule.outputCommands = ['drop *_*_*_*']
+        outputModule.outputCommands.extend(ticl_outputCommads)
+        outputModule.outputCommands.extend(['keep *_HGCalRecHit_*_*',
+                                            'keep *_hgcalLayerClusters_*_*',
+                                            'keep CaloParticles_mix_*_*',
+                                            'keep SimClusters_mix_*_*',
+                                            'keep recoTracks_generalTracks_*_*',
+                                            'keep recoTrackExtras_generalTracks_*_*',
+                                            'keep SimTracks_g4SimHits_*_*',
+                                            'keep SimVertexs_g4SimHits_*_*',
+                                            ])
+
+    if hasattr(process, 'FEVTDEBUGEventContent'):
+        cleanOutputAndSet(process.FEVTDEBUGEventContent, TICL_FEVT.outputCommands)
+    if hasattr(process, 'FEVTDEBUGHLToutput'):
+        cleanOutputAndSet(process.FEVTDEBUGHLToutput, TICL_FEVT.outputCommands)
+
+    return process

--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -45,6 +45,8 @@ def customiseHGCalOnlyEventContent(process):
                                             'keep recoTrackExtras_generalTracks_*_*',
                                             'keep SimTracks_g4SimHits_*_*',
                                             'keep SimVertexs_g4SimHits_*_*',
+                                            'keep *_layerClusterSimClusterAssociationProducer_*_*',
+                                            'keep *_layerClusterCaloParticleAssociationProducer_*_*',
                                             ])
 
     if hasattr(process, 'FEVTDEBUGEventContent'):

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.cc
@@ -50,9 +50,9 @@ template <typename TILES>
 void PatternRecognitionbyCLUE3D<TILES>::dumpTiles(const TILES &tiles) const {
   constexpr int nEtaBin = TILES::constants_type_t::nEtaBins;
   constexpr int nPhiBin = TILES::constants_type_t::nPhiBins;
-  auto lastLayerPerSide = (unsigned int)(rhtools_.lastLayer(false));
-  unsigned int maxLayer = 2 * lastLayerPerSide - 1;
-  for (unsigned int layer = 0; layer <= maxLayer; layer++) {
+  auto lastLayerPerSide = static_cast<int>(rhtools_.lastLayer(false));
+  int maxLayer = 2 * lastLayerPerSide - 1;
+  for (int layer = 0; layer <= maxLayer; layer++) {
     for (int ieta = 0; ieta < nEtaBin; ieta++) {
       auto offset = ieta * nPhiBin;
       for (int phi = 0; phi < nPhiBin; phi++) {
@@ -216,13 +216,13 @@ void PatternRecognitionbyCLUE3D<TILES>::makeTracksters(
     clusters_[layer].followers.resize(clusters_[layer].x.size());
   }
 
-  auto lastLayerPerSide = (unsigned int)(rhtools_.lastLayer(false));
-  unsigned int maxLayer = 2 * lastLayerPerSide - 1;
+  auto lastLayerPerSide = static_cast<int>(rhtools_.lastLayer(false));
+  int maxLayer = 2 * lastLayerPerSide - 1;
   std::vector<int> numberOfClustersPerLayer(maxLayer, 0);
-  for (unsigned int i = 0; i <= maxLayer; i++) {
+  for (int i = 0; i <= maxLayer; i++) {
     calculateLocalDensity(input.tiles, i, layerIdx2layerandSoa);
   }
-  for (unsigned int i = 0; i <= maxLayer; i++) {
+  for (int i = 0; i <= maxLayer; i++) {
     calculateDistanceToHigher(input.tiles, i, layerIdx2layerandSoa);
   }
 
@@ -437,7 +437,7 @@ void PatternRecognitionbyCLUE3D<TILES>::energyRegressionAndID(const std::vector<
 
 template <typename TILES>
 void PatternRecognitionbyCLUE3D<TILES>::calculateLocalDensity(
-    const TILES &tiles, const unsigned int layerId, const std::vector<std::pair<int, int>> &layerIdx2layerandSoa) {
+    const TILES &tiles, const int layerId, const std::vector<std::pair<int, int>> &layerIdx2layerandSoa) {
   constexpr int nEtaBin = TILES::constants_type_t::nEtaBins;
   constexpr int nPhiBin = TILES::constants_type_t::nPhiBins;
   auto &clustersOnLayer = clusters_[layerId];
@@ -454,17 +454,17 @@ void PatternRecognitionbyCLUE3D<TILES>::calculateLocalDensity(
 
   for (unsigned int i = 0; i < numberOfClusters; i++) {
     // We need to partition the two sides of the HGCAL detector
-    auto lastLayerPerSide = static_cast<unsigned int>(rhtools_.lastLayer(false)) - 1;
-    unsigned int minLayer = 0;
-    unsigned int maxLayer = 2 * lastLayerPerSide - 1;
+    auto lastLayerPerSide = static_cast<int>(rhtools_.lastLayer(false));
+    int minLayer = 0;
+    int maxLayer = 2 * lastLayerPerSide - 1;
     if (layerId < lastLayerPerSide) {
       minLayer = std::max(layerId - densitySiblingLayers_, minLayer);
       maxLayer = std::min(layerId + densitySiblingLayers_, lastLayerPerSide - 1);
     } else {
-      minLayer = std::max(layerId - densitySiblingLayers_, lastLayerPerSide + 1);
+      minLayer = std::max(layerId - densitySiblingLayers_, lastLayerPerSide);
       maxLayer = std::min(layerId + densitySiblingLayers_, maxLayer);
     }
-    for (unsigned int currentLayer = minLayer; currentLayer <= maxLayer; currentLayer++) {
+    for (int currentLayer = minLayer; currentLayer <= maxLayer; currentLayer++) {
       if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Advanced) {
         edm::LogVerbatim("PatternRecogntionbyCLUE3D") << "RefLayer: " << layerId << " SoaIDX: " << i;
         edm::LogVerbatim("PatternRecogntionbyCLUE3D") << "NextLayer: " << currentLayer;
@@ -474,8 +474,8 @@ void PatternRecognitionbyCLUE3D<TILES>::calculateLocalDensity(
       if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Advanced) {
         edm::LogVerbatim("PatternRecogntionbyCLUE3D") << "onSameLayer: " << onSameLayer;
       }
-      int etaWindow = onSameLayer ? 2 : 1;
-      int phiWindow = onSameLayer ? 2 : 1;
+      const int etaWindow = 2;
+      const int phiWindow = 2;
       int etaBinMin = std::max(tileOnLayer.etaBin(clustersOnLayer.eta[i]) - etaWindow, 0);
       int etaBinMax = std::min(tileOnLayer.etaBin(clustersOnLayer.eta[i]) + etaWindow, nEtaBin);
       int phiBinMin = tileOnLayer.phiBin(clustersOnLayer.phi[i]) - phiWindow;
@@ -556,7 +556,7 @@ void PatternRecognitionbyCLUE3D<TILES>::calculateLocalDensity(
 
 template <typename TILES>
 void PatternRecognitionbyCLUE3D<TILES>::calculateDistanceToHigher(
-    const TILES &tiles, const unsigned int layerId, const std::vector<std::pair<int, int>> &layerIdx2layerandSoa) {
+    const TILES &tiles, const int layerId, const std::vector<std::pair<int, int>> &layerIdx2layerandSoa) {
   constexpr int nEtaBin = TILES::constants_type_t::nEtaBins;
   constexpr int nPhiBin = TILES::constants_type_t::nPhiBins;
   auto &clustersOnLayer = clusters_[layerId];
@@ -570,9 +570,9 @@ void PatternRecognitionbyCLUE3D<TILES>::calculateDistanceToHigher(
           << tiles[layerId].etaBin(clustersOnLayer.phi[i]);
     }
     // We need to partition the two sides of the HGCAL detector
-    auto lastLayerPerSide = static_cast<unsigned int>(rhtools_.lastLayer(false));
-    unsigned int minLayer = 0;
-    unsigned int maxLayer = 2 * lastLayerPerSide - 1;
+    auto lastLayerPerSide = static_cast<int>(rhtools_.lastLayer(false));
+    int minLayer = 0;
+    int maxLayer = 2 * lastLayerPerSide - 1;
     if (layerId < lastLayerPerSide) {
       minLayer = std::max(layerId - densitySiblingLayers_, minLayer);
       maxLayer = std::min(layerId + densitySiblingLayers_, lastLayerPerSide - 1);
@@ -583,10 +583,10 @@ void PatternRecognitionbyCLUE3D<TILES>::calculateDistanceToHigher(
     float maxDelta = std::numeric_limits<float>::max();
     float i_delta = maxDelta;
     std::pair<int, int> i_nearestHigher(-1, -1);
-    for (unsigned int currentLayer = minLayer; currentLayer <= maxLayer; currentLayer++) {
+    for (int currentLayer = minLayer; currentLayer <= maxLayer; currentLayer++) {
       const auto &tileOnLayer = tiles[currentLayer];
-      int etaWindow = 2;
-      int phiWindow = 2;
+      int etaWindow = 3;
+      int phiWindow = 3;
       int etaBinMin = std::max(tileOnLayer.etaBin(clustersOnLayer.eta[i]) - etaWindow, 0);
       int etaBinMax = std::min(tileOnLayer.etaBin(clustersOnLayer.eta[i]) + etaWindow, nEtaBin);
       int phiBinMin = tileOnLayer.phiBin(clustersOnLayer.phi[i]) - phiWindow;
@@ -626,10 +626,10 @@ void PatternRecognitionbyCLUE3D<TILES>::calculateDistanceToHigher(
               // update i_nearestHigher
               i_nearestHigher = layerandSoa;
             }
-          }
-        }
-      }
-    }
+          }  // End of loop on clusters
+        }    // End of loop on phi bins
+      }      // End of loop on eta bins
+    }        // End of loop on layers
 
     bool foundNearestHigherInEtaPhiCylinder = (i_delta != maxDelta);
     if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Advanced) {
@@ -646,7 +646,7 @@ void PatternRecognitionbyCLUE3D<TILES>::calculateDistanceToHigher(
       clustersOnLayer.delta[i] = maxDelta;
       clustersOnLayer.nearestHigher[i] = {-1, -1};
     }
-  }
+  }  // End of loop on clusters
 }
 
 template <typename TILES>
@@ -681,7 +681,8 @@ int PatternRecognitionbyCLUE3D<TILES>::findAndAssignTracksters(
               << "Found follower on Layer " << layer << " SOAidx: " << i << " attached to cluster on layer: " << lyrIdx
               << " SOAidx: " << soaIdx;
         }
-        clusters_[lyrIdx].followers[soaIdx].emplace_back(layer, i);
+        if (lyrIdx >= 0)
+          clusters_[lyrIdx].followers[soaIdx].emplace_back(layer, i);
       } else {
         if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Advanced) {
           edm::LogVerbatim("PatternRecogntionbyCLUE3D")
@@ -718,7 +719,7 @@ void PatternRecognitionbyCLUE3D<TILES>::fillPSetDescription(edm::ParameterSetDes
   iDesc.add<bool>("densityOnSameLayer", false);
   iDesc.add<double>("criticalEtaPhiDistance", 0.035);
   iDesc.add<double>("outlierMultiplier", 2);
-  iDesc.add<int>("minNumLayerCluster", 5)->setComment("Not Inclusive");
+  iDesc.add<int>("minNumLayerCluster", 2)->setComment("Not Inclusive");
   iDesc.add<std::string>("eid_input_name", "input");
   iDesc.add<std::string>("eid_output_name_energy", "output/regressed_energy");
   iDesc.add<std::string>("eid_output_name_id", "output/id_probabilities");

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCLUE3D.h
@@ -82,8 +82,8 @@ namespace ticl {
         c.shrink_to_fit();
       }
     }
-    void calculateLocalDensity(const TILES&, const unsigned int layerId, const std::vector<std::pair<int, int>>&);
-    void calculateDistanceToHigher(const TILES&, const unsigned int layerId, const std::vector<std::pair<int, int>>&);
+    void calculateLocalDensity(const TILES&, const int layerId, const std::vector<std::pair<int, int>>&);
+    void calculateDistanceToHigher(const TILES&, const int layerId, const std::vector<std::pair<int, int>>&);
     int findAndAssignTracksters(const TILES&, const std::vector<std::pair<int, int>>&);
     void dumpClusters(const std::vector<std::pair<int, int>>& layerIdx2layerandSoa, const int) const;
     void dumpTracksters(const std::vector<std::pair<int, int>>& layerIdx2layerandSoa,


### PR DESCRIPTION
#### PR description:

Fix bug related to unsigned int subtraction. Also, add a customize
python function to allow to save in output only the data-products that
are needed to run the HGCAL (local) reconstruction from. Finally,
increase the search window in eta to 2, for all eta values.



#### PR validation:

Tested using `runTheMatrix` workflows with `clue3D` enabled.
