### PR TITLE
removed unneeded `#include` in `ZVertexHeterogeneous.h`

### DIFF
--- a/CUDADataFormats/Vertex/interface/ZVertexHeterogeneous.h
+++ b/CUDADataFormats/Vertex/interface/ZVertexHeterogeneous.h
@@ -3,7 +3,6 @@
 
 #include "CUDADataFormats/Vertex/interface/ZVertexSoA.h"
 #include "CUDADataFormats/Common/interface/HeterogeneousSoA.h"
-#include "CUDADataFormats/Track/interface/PixelTrackHeterogeneous.h"
 
 using ZVertexHeterogeneous = HeterogeneousSoA<ZVertexSoA>;
 #ifndef __CUDACC__

--- a/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
@@ -42,6 +42,7 @@
 
 <bin file="phase1PixelTopology_t.cu">
   <use name="HeterogeneousCore/CUDAUtilities"/>
+  <use name="Geometry/CommonTopologies"/>
   <use name="cuda"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
 </bin>

--- a/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
@@ -42,7 +42,7 @@
 
 <bin file="phase1PixelTopology_t.cu">
   <use name="HeterogeneousCore/CUDAUtilities"/>
-  <use name="Geometry/CommonTopologies"/>
+  <use name="Geometry/CommonTopologies" source_only="1"/>
   <use name="cuda"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
 </bin>

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="CUDADataFormats/Vertex"/>
+<use name="CUDADataFormats/Track"/>
 <use name="CommonTools/Clustering1D"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/GeometryCommonDetAlgo"/>

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.h
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "CUDADataFormats/Vertex/interface/ZVertexHeterogeneous.h"
+#include "CUDADataFormats/Track/interface/PixelTrackHeterogeneous.h"
 
 namespace gpuVertexFinder {
 


### PR DESCRIPTION
#### PR description:

While trying to understand a failure in the testing of an unrelated PR (see https://github.com/cms-data/RecoBTag-Combined/pull/46#issuecomment-1027272509), I noticed that one `#include` statement in `ZVertexHeterogeneous.h` could be removed (the included header file is from `CUDADataFormats/Track`, and the latter package is not called in `CUDADataFormats/Vertex/BuildFile.xml`). This would require a related update in `RecoPixelVertexing/PixelVertexFinding`.

While doing this, I also encountered a missing dependency in the `test/BuildFile.xml` of one Geometry package.

#### PR validation:

`scram` builds.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A