### PR TITLE
Update GEM reco geometry for Run3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,17 +64,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v4',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v4',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v4',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v4',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v4',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v4',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '123X_mcRun4_realistic_v3'
 }

--- a/Configuration/AlCa/python/autoCondModifiers.py
+++ b/Configuration/AlCa/python/autoCondModifiers.py
@@ -38,7 +38,7 @@ def autoCondDDD(autoCond):
     CSCRECODIGI_Geometry_ddd    =  ','.join( ['CSCRECODIGI_Geometry_112YV2'            , "CSCRecoDigiParametersRcd"      , connectionString, ""        , "2021-09-28 12:00:00.000"] )
     CSCRECO_Geometry_ddd        =  ','.join( ['CSCRECO_Geometry_112YV2'                , "CSCRecoGeometryRcd"            , connectionString, ""        , "2021-09-28 12:00:00.000"] )
     DTRECO_Geometry_ddd         =  ','.join( ['DTRECO_Geometry_112YV2'                 , "DTRecoGeometryRcd"             , connectionString, ""        , "2021-09-28 12:00:00.000"] )
-    GEMRECO_Geometry_ddd        =  ','.join( ['GEMRECO_Geometry_123YV1'                , "GEMRecoGeometryRcd"            , connectionString, ""        , "2022-01-21 12:00:00.000"] )
+    GEMRECO_Geometry_ddd        =  ','.join( ['GEMRECO_Geometry_123YV2'                , "GEMRecoGeometryRcd"            , connectionString, ""        , "2022-02-02 12:00:00.000"] )
     XMLFILE_Geometry_ddd        =  ','.join( ['XMLFILE_Geometry_123YV1_Extended2021_mc', "GeometryFileRcd"               , connectionString, "Extended", "2022-01-21 12:00:00.000"] )
     HCALParameters_Geometry_ddd =  ','.join( ['HCALParameters_Geometry_112YV2'         , "HcalParametersRcd"             , connectionString, ""        , "2021-09-28 12:00:00.000"] )
     TKRECO_Geometry_ddd         =  ','.join( ['TKRECO_Geometry_120YV2'                 , "IdealGeometryRecord"           , connectionString, ""        , "2021-09-28 12:00:00.000"] )


### PR DESCRIPTION
#### PR description:
This PR updates the GEM reco geometry in Run3 MC GTs. 
More details are available in
 - DD4HEP: https://cms-talk.web.cern.ch/t/gt-mc-updated-gem-reco-geometry-for-12-3-run-3-testing/5376
 - DDD   : https://cms-talk.web.cern.ch/t/re-gt-mc-updated-gem-reco-geometry-for-12-3-run-3-testing/5377/5

The updated DD4HEP tag is:
`GEMRECO_Geometry_123DD4hepV2`

At the same time the following DDD tag is updated as well in the `autoCondDDD`:
`GEMRECO_Geometry_123YV2`


The difference in the GTs is:

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_design_v4/123X_mcRun3_2021_design_v5

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_v4/123X_mcRun3_2021_realistic_v5

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021cosmics_realistic_deco_v4/123X_mcRun3_2021cosmics_realistic_deco_v5

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_HI_v4/123X_mcRun3_2021_realistic_HI_v5

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2023_realistic_v4/123X_mcRun3_2023_realistic_v5

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2024_realistic_v4/123X_mcRun3_2024_realistic_v5


#### PR validation:
Validated with:
`runTheMatrix.py -l 12034.0,11634.0,7.23,312.0,12434.0,12834.0,11634.911,11634.914 --ibeos -j 15`

#### Backport:
This is not a backport but will be backported in #36785

resolves https://github.com/cms-sw/cmssw/issues/36826