### PR TITLE
RepeatingCachedRootSource now supports Refs

### DIFF
--- a/IOPool/Input/test/PrePoolInputTest_cfg.py
+++ b/IOPool/Input/test/PrePoolInputTest_cfg.py
@@ -13,12 +13,15 @@ for a in sys.argv:
     if ".py" in a:
         foundpy = True
 
+useOtherThing = False
+if len(argv) > 6:
+  if argv[6] == "useOtherThing":
+    useOtherThing = True
+
 process = cms.Process("TESTPROD")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(int(argv[1]))
-)
+process.maxEvents.input = int(argv[1])
 
 process.Thing = cms.EDProducer("ThingProducer")
 
@@ -34,6 +37,9 @@ process.source = cms.Source("EmptySource",
 )
 
 process.p = cms.Path(process.Thing)
+if useOtherThing:
+  process.OtherThing = cms.EDProducer("OtherThingProducer")
+  process.p = cms.Path(process.Thing + process.OtherThing)
 process.ep = cms.EndPath(process.output)
 
 

--- a/IOPool/Input/test/testRepeatingCachedRootSource.sh
+++ b/IOPool/Input/test/testRepeatingCachedRootSource.sh
@@ -2,6 +2,6 @@
 # Pass in name and status
 function die { echo $1: status $2 ;  exit $2; }
 
-cmsRun -j PoolInputRepeatingSourceTest_jobreport.xml ${LOCALTOP}/src/IOPool/Input/test/PrePoolInputTest_cfg.py PoolInputRepeatingSource.root 11 561 7 6 3 || die 'Failure using PrePoolInputTest_cfg.py' $?
+cmsRun -j PoolInputRepeatingSourceTest_jobreport.xml ${LOCALTOP}/src/IOPool/Input/test/PrePoolInputTest_cfg.py PoolInputRepeatingSource.root 11 561 7 6 3 useOtherThing || die 'Failure using PrePoolInputTest_cfg.py' $?
 
 cmsRun ${LOCALTOP}/src/IOPool/Input/test/test_repeating_cfg.py || die 'Failed cmsRun test_repeating_cfg.py' $?

--- a/IOPool/Input/test/test_repeating_cfg.py
+++ b/IOPool/Input/test/test_repeating_cfg.py
@@ -5,8 +5,8 @@ process.source = cms.Source("RepeatingCachedRootSource", fileName = cms.untracke
 
 process.maxEvents.input = 10000
 
-process.OtherThing = cms.EDProducer("OtherThingProducer")
+process.checker = cms.EDAnalyzer("OtherThingAnalyzer")
 #process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 
-process.p = cms.Path(process.OtherThing)
+process.p = cms.Path(process.checker)
 #process.o = cms.EndPath(process.dump)


### PR DESCRIPTION
#### PR description:

- Added the necessary infrastructure to support Ref like classes when doing a delayed read from RepeatingCachedRootSource.
- Extended the unit test to read and check Refs.

#### PR validation:

Code compiles and framework unit tests pass.