### PR TITLE
[12.2.X] Improvements on SiPixelLorentzAngle PCL workflow: layer-dependent cluster size cut and output maps

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -30,6 +30,7 @@ public:
   MonitorMap h_drift_depth_;
   MonitorMap h_mean_;
 
+  // track monitoring
   dqm::reco::MonitorElement* h_tracks_;
   dqm::reco::MonitorElement* h_trackEta_;
   dqm::reco::MonitorElement* h_trackPhi_;
@@ -47,6 +48,7 @@ public:
 
   // ouput LA maps
   std::vector<dqm::reco::MonitorElement*> h2_byLayerLA_;
+  std::vector<dqm::reco::MonitorElement*> h2_byLayerDiff_;
 };
 
 #endif

--- a/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
+++ b/CalibTracker/SiPixelLorentzAngle/interface/SiPixelLorentzAngleCalibrationStruct.h
@@ -12,6 +12,7 @@ public:
 
   int nlay;
   std::vector<int> nModules_;
+  std::vector<int> nLadders_;
   std::vector<std::string> BPixnewmodulename_;
   std::vector<unsigned int> BPixnewDetIds_;
   std::vector<int> BPixnewModule_;
@@ -43,6 +44,9 @@ public:
   dqm::reco::MonitorElement* h_bySectLA_;
   dqm::reco::MonitorElement* h_bySectDeltaLA_;
   dqm::reco::MonitorElement* h_bySectChi2_;
+
+  // ouput LA maps
+  std::vector<dqm::reco::MonitorElement*> h2_byLayerLA_;
 };
 
 #endif

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -361,6 +361,17 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
                                                     hists.nLadders_[i],
                                                     0.5,
                                                     hists.nLadders_[i] + 0.5));
+
+    repName = "h2_byLayerDiff_%i";
+    repText = "BPix Layer %i #Delta#mu_{H}/#mu_{H};module number;ladder number;#Delta#mu_{H}/#mu_{H} [%%]";
+    hists.h2_byLayerDiff_.emplace_back(iBooker.book2D(fmt::sprintf(repName, i + 1),
+                                                      fmt::sprintf(repText, i + 1),
+                                                      hists.nModules_[i],
+                                                      0.5,
+                                                      hists.nModules_[i] + 0.5,
+                                                      hists.nLadders_[i],
+                                                      0.5,
+                                                      hists.nLadders_[i] + 0.5));
   }
 
   // clang-format off
@@ -494,6 +505,10 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
       const auto& ladder = theTrackerTopology->pxbLadder(id);
       const auto& module = theTrackerTopology->pxbModule(id);
       hists.h2_byLayerLA_[layer - 1]->setBinContent(module, ladder, value);
+
+      float deltaMuHoverMuH =
+          (currentLorentzAngle->getLorentzAngle(id) - value) / currentLorentzAngle->getLorentzAngle(id);
+      hists.h2_byLayerDiff_[layer - 1]->setBinContent(module, ladder, deltaMuHoverMuH * 100.f);
     }
   }
 

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -85,12 +85,13 @@ public:
 
 private:
   void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override;
   void findMean(MonitorElement* h_drift_depth_adc_slice_, int i, int i_ring);
   SiPixelLAHarvest::fitResults fitAndStore(std::shared_ptr<SiPixelLorentzAngle> theLA, int i_idx, int i_lay, int i_mod);
 
   // es tokens
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomEsToken_;
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoEsToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoEsTokenBR_, topoEsTokenER_;
   edm::ESGetToken<SiPixelLorentzAngle, SiPixelLorentzAngleRcd> siPixelLAEsToken_;
   edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
 
@@ -105,12 +106,14 @@ private:
   SiPixelLorentzAngleCalibrationHistograms hists;
   const SiPixelLorentzAngle* currentLorentzAngle;
   const MagneticField* magField;
+  std::unique_ptr<TrackerTopology> theTrackerTopology;
 };
 
 //------------------------------------------------------------------------------
 SiPixelLorentzAnglePCLHarvester::SiPixelLorentzAnglePCLHarvester(const edm::ParameterSet& iConfig)
     : geomEsToken_(esConsumes<edm::Transition::BeginRun>()),
-      topoEsToken_(esConsumes<edm::Transition::BeginRun>()),
+      topoEsTokenBR_(esConsumes<edm::Transition::BeginRun>()),
+      topoEsTokenER_(esConsumes<edm::Transition::EndRun>()),
       siPixelLAEsToken_(esConsumes<edm::Transition::BeginRun>()),
       magneticFieldToken_(esConsumes<edm::Transition::BeginRun>()),
       newmodulelist_(iConfig.getParameter<std::vector<std::string>>("newmodulelist")),
@@ -128,7 +131,7 @@ SiPixelLorentzAnglePCLHarvester::SiPixelLorentzAnglePCLHarvester(const edm::Para
 void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   // geometry
   const TrackerGeometry* geom = &iSetup.getData(geomEsToken_);
-  const TrackerTopology* tTopo = &iSetup.getData(topoEsToken_);
+  const TrackerTopology* tTopo = &iSetup.getData(topoEsTokenBR_);
 
   magField = &iSetup.getData(magneticFieldToken_);
   currentLorentzAngle = &iSetup.getData(siPixelLAEsToken_);
@@ -136,8 +139,10 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
   PixelTopologyMap map = PixelTopologyMap(geom, tTopo);
   hists.nlay = geom->numberOfLayers(PixelSubdetector::PixelBarrel);
   hists.nModules_.resize(hists.nlay);
+  hists.nLadders_.resize(hists.nlay);
   for (int i = 0; i < hists.nlay; i++) {
     hists.nModules_[i] = map.getPXBModules(i + 1);
+    hists.nLadders_[i] = map.getPXBLadders(i + 1);
   }
 
   // list of modules already filled, then return (we already entered here)
@@ -206,6 +211,13 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
     };
   }
   LogDebug("SiPixelLorentzAnglePCLHarvester") << "Stored a total of " << count << " detIds.";
+}
+
+//------------------------------------------------------------------------------
+void SiPixelLorentzAnglePCLHarvester::endRun(edm::Run const& run, edm::EventSetup const& isetup) {
+  if (!theTrackerTopology) {
+    theTrackerTopology = std::make_unique<TrackerTopology>(isetup.getData(topoEsTokenER_));
+  }
 }
 
 //------------------------------------------------------------------------------
@@ -335,6 +347,22 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     hists.h_bySectChi2_->setBinLabel(bin, binName);
   }
 
+  // this will be booked in the Harvesting folder
+  iBooker.setCurrentFolder(fmt::format("{}Harvesting/LorentzAngleMaps", dqmDir_));
+  for (int i = 0; i < hists.nlay; i++) {
+    std::string repName = "h2_byLayerLA_%i";
+    std::string repText = "BPix Layer %i tan#theta_{LA}/B;module number;ladder number;tan#theta_{LA}/B [1/T]";
+
+    hists.h2_byLayerLA_.emplace_back(iBooker.book2D(fmt::sprintf(repName, i + 1),
+                                                    fmt::sprintf(repText, i + 1),
+                                                    hists.nModules_[i],
+                                                    0.5,
+                                                    hists.nModules_[i] + 0.5,
+                                                    hists.nLadders_[i],
+                                                    0.5,
+                                                    hists.nLadders_[i] + 0.5));
+  }
+
   // clang-format off
   edm::LogPrint("LorentzAngle") << "module" << "\t" << "layer" << "\t"
                                 << "offset" << "\t" << "e0" << "\t"
@@ -448,7 +476,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     float fPixLorentzAnglePerTesla_ = currentLorentzAngle->getLorentzAngle(id);
     if (!LorentzAngle->putLorentzAngle(id, fPixLorentzAnglePerTesla_)) {
       edm::LogError("SiPixelLorentzAnglePCLHarvester")
-          << "[SiPixelLorentzAnglePCLHarvester::dqmEndRun] filling rest of payload: detid already exists";
+          << "[SiPixelLorentzAnglePCLHarvester::dqmEndJob] filling rest of payload: detid already exists";
     }
   }
 
@@ -456,6 +484,17 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
     float deltaMuHoverMuH = (currentLorentzAngle->getLorentzAngle(id) - LorentzAngle->getLorentzAngle(id)) /
                             currentLorentzAngle->getLorentzAngle(id);
     h_diffLA->Fill(deltaMuHoverMuH);
+  }
+
+  // fill the 2D output Lorentz Angle maps
+  for (const auto& [id, value] : LorentzAngle->getLorentzAngles()) {
+    DetId ID = DetId(id);
+    if (ID.subdetId() == PixelSubdetector::PixelBarrel) {
+      const auto& layer = theTrackerTopology->pxbLayer(id);
+      const auto& ladder = theTrackerTopology->pxbLadder(id);
+      const auto& module = theTrackerTopology->pxbModule(id);
+      hists.h2_byLayerLA_[layer - 1]->setBinContent(module, ladder, value);
+    }
   }
 
   // fill the DB object record

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -314,7 +314,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
 
   // book histogram of differences
   MonitorElement* h_diffLA = iBooker.book1D(
-      "h_diffLA", "difference in #mu_{H}; #Delta #mu_{H}/#mu_{H} (old-new)/old [%];n. modules", 100, -3., 3.);
+      "h_diffLA", "difference in #mu_{H}; #Delta #mu_{H}/#mu_{H} (old-new)/old [%];n. modules", 100, -150, 150);
 
   // retrieve the number of bins from the other monitoring histogram
   const auto& maxSect = hists.h_bySectOccupancy_->getNbinsX();
@@ -483,7 +483,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   for (const auto& id : newLADets) {
     float deltaMuHoverMuH = (currentLorentzAngle->getLorentzAngle(id) - LorentzAngle->getLorentzAngle(id)) /
                             currentLorentzAngle->getLorentzAngle(id);
-    h_diffLA->Fill(deltaMuHoverMuH);
+    h_diffLA->Fill(deltaMuHoverMuH * 100.f);
   }
 
   // fill the 2D output Lorentz Angle maps

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -174,8 +174,7 @@ private:
   // parameters from config file
   double ptmin_;
   double normChi2Max_;
-  int clustSizeYMin_;
-  int clustSizeYMinL4_;
+  std::vector<int> clustSizeYMin_;
   int clustSizeXMax_;
   double residualMax_;
   double clustChargeMaxPerLength_;
@@ -207,8 +206,7 @@ SiPixelLorentzAnglePCLWorker::SiPixelLorentzAnglePCLWorker(const edm::ParameterS
       newmodulelist_(iConfig.getParameter<std::vector<std::string>>("newmodulelist")),
       ptmin_(iConfig.getParameter<double>("ptMin")),
       normChi2Max_(iConfig.getParameter<double>("normChi2Max")),
-      clustSizeYMin_(iConfig.getParameter<int>("clustSizeYMin")),
-      clustSizeYMinL4_(iConfig.getParameter<int>("clustSizeYMinL4")),
+      clustSizeYMin_(iConfig.getParameter<std::vector<int>>("clustSizeYMin")),
       clustSizeXMax_(iConfig.getParameter<int>("clustSizeXMax")),
       residualMax_(iConfig.getParameter<double>("residualMax")),
       clustChargeMaxPerLength_(iConfig.getParameter<double>("clustChargeMaxPerLength")),
@@ -443,7 +441,7 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
           // get qScale_ = templ.qscale() and  templ.r_qMeas_qTrue();
           float cotalpha = trackdirection.x() / trackdirection.z();
           float cotbeta = trackdirection.y() / trackdirection.z();
-          float cotbeta_min = clustSizeYMin_ * ypitch_ / width_;
+          float cotbeta_min = clustSizeYMin_[layer_ - 1] * ypitch_ / width_;
           if (fabs(cotbeta) <= cotbeta_min)
             continue;
           double drdz = sqrt(1. + cotalpha * cotalpha + cotbeta * cotbeta);
@@ -504,7 +502,7 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
           double ylim1 = trackhitCorrY_ - width_ * cotbeta / 2.;
           double ylim2 = trackhitCorrY_ + width_ * cotbeta / 2.;
 
-          int clustSizeY_cut = layer_ < 4 ? clustSizeYMin_ : clustSizeYMinL4_;
+          int clustSizeY_cut = clustSizeYMin_[layer_ - 1];
 
           if (!large_pix && (chi2_ / ndof_) < normChi2Max_ && cluster->sizeY() >= clustSizeY_cut &&
               residualsq < residualMax_ * residualMax_ && cluster->charge() < clusterCharge_cut &&
@@ -867,8 +865,8 @@ void SiPixelLorentzAnglePCLWorker::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<edm::InputTag>("src", edm::InputTag("TrackRefitter"))->setComment("input track collections");
   desc.add<double>("ptMin", 3.)->setComment("minimum pt on tracks");
   desc.add<double>("normChi2Max", 2.)->setComment("maximum reduced chi squared");
-  desc.add<int>("clustSizeYMin", 4)->setComment("minimum cluster size on Y axis for Layer 1-3");
-  desc.add<int>("clustSizeYMinL4", 3)->setComment("minimum cluster size on Y axis for Layer 4");
+  desc.add<std::vector<int>>("clustSizeYMin", {4, 4, 3, 2})
+      ->setComment("minimum cluster size on Y axis for all Barrel Layers");
   desc.add<int>("clustSizeXMax", 5)->setComment("maximum cluster size on X axis");
   desc.add<double>("residualMax", 0.005)->setComment("maximum residual");
   desc.add<double>("clustChargeMaxPerLength", 50000)

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -42,6 +42,7 @@ namespace SiPixelPI {
   static const unsigned int phase0size = 1440;
   static const unsigned int phase1size = 1856;
   static const unsigned int phase2size = 3892;
+  static const unsigned int mismatched = 9999;
 
   //============================================================================
   // struct to store info useful to construct topology based on the detid list
@@ -789,7 +790,11 @@ namespace SiPixelPI {
     t2.SetTextSize(0.1);
     t2.SetTextAngle(45);
     t2.SetTextColor(kRed);
-    t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+    if (size != SiPixelPI::mismatched) {
+      t2.DrawLatexNDC(0.6, 0.50, Form("%s  NOT SUPPORTED!", phase.c_str()));
+    } else {
+      t2.DrawLatexNDC(0.6, 0.50, "MISMATCHED PAYLOAD SIZE!");
+    }
   }
 
   /*--------------------------------------------------------------------*/

--- a/DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h
@@ -76,7 +76,7 @@ public:
 
   void resetOption(const char* option);
   void createTrackerBaseMap();
-  void printTrackerMap(TCanvas& canvas);
+  void printTrackerMap(TCanvas& canvas, const float topMargin = 0.02);
   bool fillTrackerMap(unsigned int id, double value);
 
 protected:

--- a/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
+++ b/DQM/TrackerRemapper/src/Phase1PixelSummaryMap.cc
@@ -81,10 +81,10 @@ void Phase1PixelSummaryMap::createTrackerBaseMap() {
 }
 
 //============================================================================
-void Phase1PixelSummaryMap::printTrackerMap(TCanvas& canvas) {
+void Phase1PixelSummaryMap::printTrackerMap(TCanvas& canvas, const float topMargin) {
   //canvas = TCanvas("c1","c1",plotWidth,plotHeight);
   canvas.cd();
-  canvas.SetTopMargin(0.02);
+  canvas.SetTopMargin(topMargin);
   canvas.SetBottomMargin(0.02);
   canvas.SetLeftMargin(0.02);
   canvas.SetRightMargin(0.14);
@@ -122,7 +122,7 @@ void Phase1PixelSummaryMap::printTrackerMap(TCanvas& canvas) {
   txt.SetTextAngle(0);
 
   //# draw new-style title
-  txt.SetTextSize(0.05);
+  txt.SetTextSize((topMargin == 0.02) ? 0.05 : 0.03);
   txt.DrawLatex(0.5, 0.95, (fmt::sprintf("Pixel Tracker Map: %s", m_title)).c_str());
   txt.SetTextSize(0.03);
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/36853

#### PR description:

This PR collects a series of improvements coming from the commissioning of the `SiPixelLorentzAngle` PCL workflow being commissioned at https://github.com/dmwm/T0/pull/4635 and builds on top of PRs https://github.com/cms-sw/cmssw/pull/36565 and https://github.com/cms-sw/cmssw/pull/36538:
   * adds output LorentzAngle maps to `SiPixelLorentzAnglePCLHarvester` (507cc26ea7754b73e6b042448b12dccd26a6aa08 and 246ef92d560d819a86fa48569172c41d1f673cdd)
   * layer-dependent cluster y-size cut in `SiPixelLorentzAnglePCLWorker` (2e02258d16a7c77bf141147278f984f8ec5625eb)
   * add `SiPixelLorentzAngleFullMapCompare` to Pixel Payload Inspector (dbb5a2d42f86bf5b75374592359128b0dafacd88), triggers also DQM signature

#### PR validation:

Privately run 

```console
 cmsDriver.py testReAlCa -s ALCA:PromptCalibProdSiPixelLorentzAngle --conditions 121X_dataRun3_Express_TIER0_REPLAY_Run2_v1 --scenario pp --data --era Run2_2018 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 100000 --dasquery='file dataset=/StreamExpress/Tier0_REPLAY_2021-SiPixelCalSingleMuon-Express-v1/ALCARECO' --customise_commands='process.ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle.TriggerResultsTag = cms.InputTag ( "TriggerResults","","HLT" ) ; process.ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle.HLTPaths = ["*"]' --nThreads=4 
```

followed by:

```console
 cmsDriver.py stepHarvest -s ALCAHARVEST:SiPixelLA --conditions 121X_dataRun3_Express_TIER0_REPLAY_Run2_v1 --scenario pp --data --era Run2_2018 --filein file:PromptCalibProdSiPixelLorentzAngle.root -n -1
```

For what concerns the PI update (dbb5a2d42f86bf5b75374592359128b0dafacd88), here's an example of plot obtainable (using the results of the Tier-0 replay):

![badaa251-0920-4125-a57a-99d80cf368f4](https://user-images.githubusercontent.com/5082376/152005875-9653685b-9e34-4135-adfa-9251cefdd1b4.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Verbatim backport of #36853