### PR TITLE
[DDD] Fix building of DDD GEM reco geometry DB payload

### DIFF
--- a/Geometry/GEMGeometryBuilder/interface/GEMGeometryParsFromDD.h
+++ b/Geometry/GEMGeometryBuilder/interface/GEMGeometryParsFromDD.h
@@ -38,7 +38,10 @@ public:
 
 private:
   // DD
-  void buildGeometry(DDFilteredView& fview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
+  void buildGeometry(DDFilteredView& fview,
+                     DDFilteredView& fview2,
+                     const MuonGeometryConstants& muonConstants,
+                     RecoIdealGeometry& rgeo);
   void buildSuperChamber(DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo);
   void buildChamber(DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo);
   void buildEtaPartition(DDFilteredView& fv, GEMDetId detId, RecoIdealGeometry& rgeo);


### PR DESCRIPTION
PR #36835 fixed the building of the GEM reco geometry for DD4hep, but it caused a problem for building the DDD GEM reco geometry DB payload. Technically, an unreliable `DDFilteredView` copy constructor had been used, which caused the original `DDFilteredView` to be changed when the copy was altered. The solution is to create a separate, identical `DDFilteredView` that can be iterated through without altering the original.

Note that this PR only affects the manual process of creating the DDD GEM reco geometry DB payload, which is done by an expert. This code is never used in any workflow.

#### PR validation:

A correct DDD GEM reco geometry DB payload was created successfully with this PR, whereas previously the creation program crashed.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

For completeness and consistency, this PR could be backported to 12_2, but it is not strictly necessary. There shouldn't be a need to create geometry DB payloads in 12_2, since the latest 12_3 tags are the ones that should be used with 12_2_1.
