### PR TITLE
Fix ge2/1 demonstrator in validation - backport

### DIFF
--- a/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
+++ b/Validation/MuonGEMHits/plugins/GEMSimHitValidation.cc
@@ -75,21 +75,27 @@ void GEMSimHitValidation::bookHistograms(DQMStore::IBooker& booker, edm::Run con
   TString eloss_xtitle = "Energy loss [eV]";
   TString eloss_ytitle = "Entries / 0.5 keV";
 
-  for (const auto& station : gem->regions()[0]->stations()) {
-    Int_t station_id = station->station();
+  // Demonstrator chamber means we could have a missing station,
+  // process both regions to make sure we include it
+  for (const auto& region : gem->regions()) {
+    for (const auto& station : region->stations()) {
+      Int_t station_id = station->station();
+      if (me_eloss_mu_.find(station_id) != me_eloss_mu_.end())
+        continue;
 
-    auto eloss_mu_name = TString::Format("sim_eloss_muon_GE%d1", station_id);
-    auto eloss_mu_title = TString::Format("SimHit Energy Loss (Muon only) : GE%d1", station_id);
+      auto eloss_mu_name = TString::Format("sim_eloss_muon_GE%d1", station_id);
+      auto eloss_mu_title = TString::Format("SimHit Energy Loss (Muon only) : GE%d1", station_id);
 
-    me_eloss_mu_[station_id] =
-        booker.book1D(eloss_mu_name, eloss_mu_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
+      me_eloss_mu_[station_id] =
+          booker.book1D(eloss_mu_name, eloss_mu_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
 
-    auto eloss_others_name = TString::Format("sim_eloss_others_GE%d1", station_id);
-    auto eloss_others_title = TString::Format("SimHit Energy Loss (Other Particles) : GE%d1", station_id);
+      auto eloss_others_name = TString::Format("sim_eloss_others_GE%d1", station_id);
+      auto eloss_others_title = TString::Format("SimHit Energy Loss (Other Particles) : GE%d1", station_id);
 
-    me_eloss_others_[station_id] =
-        booker.book1D(eloss_others_name, eloss_others_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
-  }  // station loop
+      me_eloss_others_[station_id] =
+          booker.book1D(eloss_others_name, eloss_others_title + ";" + eloss_xtitle + ";" + eloss_ytitle, 20, 0.0, 10.0);
+    }  // station loop
+  }    // region loop
 
   if (detail_plot_) {
     for (const auto& region : gem->regions()) {


### PR DESCRIPTION
#### PR description:

Backport of PR #36835, this only includes the changes to the Validation/MuonGEMHits code to create the histograms correctly when the demonstrator GEM is included as PR #36870 should contain the code necessary for the geometry builder.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

If the demonstrator geometry will be used in 12_2 as #36870 indicates this will be necessary to avoid crashes.

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
