### PR TITLE
CTPPS: corrections to dLyds optical function perturbation

### DIFF
--- a/Validation/CTPPS/plugins/CTPPSModifiedOpticalFunctionsESSource.cc
+++ b/Validation/CTPPS/plugins/CTPPSModifiedOpticalFunctionsESSource.cc
@@ -171,7 +171,7 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSModifiedOptic
       }
 
       if (scenario_ == "Lpy") {
-        const double a = 0.42, b = 0.015;  // dimensionless
+        const double a = 2.66, b = 0.015;  // dimensionless
         const double de_Lp_y = factor_ * (a * xi + b) * Lp_y;
         Lp_y += de_Lp_y;
         L_y_N -= de_Lp_y * de_z / 2.;
@@ -188,6 +188,9 @@ std::shared_ptr<LHCInterpolatedOpticalFunctionsSetCollection> CTPPSModifiedOptic
 
       of_N.m_fcn_values[LHCOpticalFunctionsSet::eLpx][i] = Lp_x;
       of_F.m_fcn_values[LHCOpticalFunctionsSet::eLpx][i] = Lp_x;
+
+      of_N.m_fcn_values[LHCOpticalFunctionsSet::eLy][i] = L_y_N;
+      of_F.m_fcn_values[LHCOpticalFunctionsSet::eLy][i] = L_y_F;
 
       of_N.m_fcn_values[LHCOpticalFunctionsSet::eLpy][i] = Lp_y;
       of_F.m_fcn_values[LHCOpticalFunctionsSet::eLpy][i] = Lp_y;


### PR DESCRIPTION
After line 191 two lines were added to save the perturbation result of lines 177 and 178 to an array; otherwise the result remains ineffective for case "Lpy". For "Lpx" it was already correct. The correction was suggested by J. Kaspar.

At line 174 the slope parameter "a" has been update to 2.66 instead of 0.42. The simple calculation is

             a = delta(dLy/ds) / delta(xi) = (0.24) / (0.14 - 0.05 ) = 2.66 

the change of the uncertainty band with xi (the 0.24 means 24 percent xi change from 5 to 14 % xi) . These values / results can be found on page 8 bottom panel of this PPS General meeting presentation:

https://indico.cern.ch/event/1100184/contributions/4635625/attachments/2359698/4027802/optics_uncertainty_PPS_GM_F_Nemes_v2.pdf

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
