### PR TITLE
[ASAN] Fix unit tests for asan IBs

### DIFF
--- a/CommonTools/Utils/test/BuildFile.xml
+++ b/CommonTools/Utils/test/BuildFile.xml
@@ -15,6 +15,9 @@
 </bin>
 
 <bin name="testExpressionEvaluator" file="testExpressionEvaluator.cc,testRunner.cpp">
+  <ifrelease name="_ASAN_">
+    <flags NO_TEST_PREFIX="1"/>
+  </ifrelease>
   <use name="Geometry/CommonDetUnit"/>
   <use name="DataFormats/TrackReco"/>
   <use name="DataFormats/TrackerRecHit2D"/>
@@ -29,6 +32,9 @@
 </bin>
 
 <bin file="ExpressionEvaluatorUnitTest.cpp">
+  <ifrelease name="_ASAN_">
+    <flags NO_TEST_PREFIX="1"/>
+  </ifrelease>
   <flags CXXFLAGS="-fopenmp"/>
   <use name="CommonTools/Utils"/>
 </bin>

--- a/CondCore/Utilities/test/BuildFile.xml
+++ b/CondCore/Utilities/test/BuildFile.xml
@@ -1,6 +1,3 @@
-<ifrelease name="_ASAN_">
-  <flags NO_TEST_PREFIX="1"/>
-</ifrelease>
 <use name="CondCore/CondDB"/>
 <use name="CondCore/Utilities"/>
 <use name="CondFormats/Common"/>

--- a/HeterogeneousCore/SonicTriton/test/BuildFile.xml
+++ b/HeterogeneousCore/SonicTriton/test/BuildFile.xml
@@ -1,10 +1,11 @@
-<environment>
-  <test name="TestHeterogeneousCoreSonicTritonProducerCPU" command="${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/unittest.sh ${LOCALTOP} CPU"/>
-  <test name="TestHeterogeneousCoreSonicTritonProducerGPU" command="${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/unittest.sh ${LOCALTOP} GPU"/>
-  <library file="*.cc" name="testHeterogenousCoreSonicTriton">
-    <flags EDM_PLUGIN="1"/>
-    <use name="FWCore/ParameterSet"/>
-    <use name="FWCore/Framework"/>
-    <use name="HeterogeneousCore/SonicTriton"/>
-  </library>
-</environment>
+<ifrelease name="_ASAN_|_UBSAN_">
+  <flags NO_TEST_PREFIX="1"/>
+</ifrelease>
+<test name="TestHeterogeneousCoreSonicTritonProducerCPU" command="${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/unittest.sh ${LOCALTOP} CPU"/>
+<test name="TestHeterogeneousCoreSonicTritonProducerGPU" command="${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/unittest.sh ${LOCALTOP} GPU"/>
+<library file="*.cc" name="testHeterogenousCoreSonicTriton">
+  <flags EDM_PLUGIN="1"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Framework"/>
+  <use name="HeterogeneousCore/SonicTriton"/>
+</library>


### PR DESCRIPTION
These changes should fix the unit tests failing in ASAN IBs
- Changes in CommonTools/Utils/test/BuildFile.xml should fix the two unit tests which try to build a shared library but LD_PRELOAD=libasan.so causes the compilation to fail.
- Change in CondCore/Utilities/test/BuildFile.xml was added by https://github.com/cms-sw/cmssw/pull/36365 as frontier client had issues with libasan. That issue has been fixed by https://github.com/cms-externals/frontier_client/pull/2 
- the libasan.so ( or /cvmfs in general ) is not available under the singularity container started by unit tests in HeterogeneousCore/SonicTriton/test/BuildFile.xml  . This change instruct scram to not set LD_PRELOAD for these unit tests