### PR TITLE
Fix for l1Event in the L1EventTreeProducer

### DIFF
--- a/L1Trigger/L1TNtuples/plugins/L1EventTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1EventTreeProducer.cc
@@ -83,7 +83,7 @@ L1EventTreeProducer::L1EventTreeProducer(const edm::ParameterSet& iConfig)
   bool useAvgVtx = iConfig.getUntrackedParameter<bool>("useAvgVtx", true);
   double maxAllowedWeight = iConfig.getUntrackedParameter<double>("maxAllowedWeight", -1);
 
-  std::make_unique<L1Analysis::L1AnalysisEvent>(
+  l1Event = std::make_unique<L1Analysis::L1AnalysisEvent>(
       puMCFile, puMCHist, puDataFile, puDataHist, useAvgVtx, maxAllowedWeight, consumesCollector());
   l1EventData = l1Event->getData();
 


### PR DESCRIPTION
#### PR description:
Fix of the usage of the l1Event in the recently updated L1EventTreeProducer that was creating a crash when running the cmsDriver command. (My mistake, sorry!)
Reference PR: https://github.com/cms-sw/cmssw/pull/36839.

#### PR validation:
Basic tests performed successfully starting from CMSSW_12_3_X_2022-02-03-1100. 
From CMSSW_12_3_X_2022-02-03-1100/src:
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests
> scram build code-checks
> scram build code-format
> runTheMatrix.py -l limited -i all --ibeos