### PR TITLE
Fix incorrect hadronic shower packing and enable global shower unpacking for both uGMT and uGT

### DIFF
--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -54,13 +54,15 @@ namespace l1t {
       The 2 loose showers case would be mapped onto musOutOfTime0 and musOutOfTime1 later during Run-3
     */
 
-    void setMus0(const bool bit) { mus0_ = bit; }
-    void setMus1(const bool bit) { mus1_ = bit; }
+    void setOneNominalInTime(const bool bit) { oneNominalInTime_ = bit; }
+    void setOneTightInTime(const bool bit) { oneTightInTime_ = bit; }
+    void setMus0(const bool bit) { oneNominalInTime_ = bit; }
+    void setMus1(const bool bit) { oneTightInTime_ = bit; }
     void setMusOutOfTime0(const bool bit) { musOutOfTime0_ = bit; }
     void setMusOutOfTime1(const bool bit) { musOutOfTime1_ = bit; }
 
-    bool mus0() const { return mus0_; }
-    bool mus1() const { return mus1_; }
+    bool mus0() const { return oneNominalInTime_; }
+    bool mus1() const { return oneTightInTime_; }
     bool musOutOfTime0() const { return musOutOfTime0_; }
     bool musOutOfTime1() const { return musOutOfTime1_; }
 
@@ -69,8 +71,8 @@ namespace l1t {
 
     // useful members for trigger performance studies
     // needed at startup Run-3
-    bool isOneNominalInTime() const { return mus0_; }
-    bool isOneTightInTime() const { return mus1_; }
+    bool isOneNominalInTime() const { return oneNominalInTime_; }
+    bool isOneTightInTime() const { return oneTightInTime_; }
     // to be developed during Run-3
     bool isTwoLooseInTime() const { return false; }
     // these options require more study
@@ -84,8 +86,8 @@ namespace l1t {
   private:
     // Run-3 definitions as provided in DN-20-033
     // in time and out-of-time qualities. only 2 bits each.
-    bool mus0_;
-    bool mus1_;
+    bool oneNominalInTime_;
+    bool oneTightInTime_;
     bool musOutOfTime0_;
     bool musOutOfTime1_;
   };

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -9,16 +9,18 @@ l1t::MuonShower::MuonShower(bool oneNominalInTime,
     : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
       // in this object it makes more sense to the different shower types to
       // the 4 bits, so that the object easily interfaces with the uGT emulator
-      mus0_(oneNominalInTime),
-      mus1_(oneTightInTime),
+      oneNominalInTime_(oneNominalInTime),
+      oneTightInTime_(oneTightInTime),
       musOutOfTime0_(false),
       musOutOfTime1_(false) {}
 
 l1t::MuonShower::~MuonShower() {}
 
-bool l1t::MuonShower::isValid() const { return mus0_ or mus1_ or musOutOfTime0_ or musOutOfTime1_; }
+bool l1t::MuonShower::isValid() const {
+  return oneNominalInTime_ or oneTightInTime_ or musOutOfTime0_ or musOutOfTime1_;
+}
 
 bool l1t::MuonShower::operator==(const l1t::MuonShower& rhs) const {
-  return (mus0_ == rhs.mus0() and mus1_ == rhs.mus1() and musOutOfTime0_ == rhs.musOutOfTime0() and
-          musOutOfTime1_ == rhs.musOutOfTime1());
+  return (oneNominalInTime_ == rhs.isOneNominalInTime() and oneTightInTime_ == rhs.isOneTightInTime() and
+          musOutOfTime0_ == rhs.musOutOfTime0() and musOutOfTime1_ == rhs.musOutOfTime1());
 }

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -103,7 +103,8 @@
   <class name="l1t::MuonVectorRef"/>
   <class name="edm::Wrapper<l1t::MuonVectorRef>"/>
 
-  <class name="l1t::MuonShower" ClassVersion="11">
+  <class name="l1t::MuonShower" ClassVersion="12">
+   <version ClassVersion="12" checksum="2452991184"/>
    <version ClassVersion="11" checksum="3610959089"/>
    <version ClassVersion="10" checksum="3869296059"/>
   </class>

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.cc
@@ -6,13 +6,14 @@ namespace l1t {
   namespace stage2 {
     GTCollections::~GTCollections() {
       event_.put(std::move(muons_[0]), "Muon");
+      event_.put(std::move(muonShowers_[0]), "MuonShower");
       event_.put(std::move(egammas_[0]), "EGamma");
       event_.put(std::move(etsums_[0]), "EtSum");
       event_.put(std::move(jets_[0]), "Jet");
       event_.put(std::move(taus_[0]), "Tau");
-
       for (int i = 1; i < 6; ++i) {
         event_.put(std::move(muons_[i]), "Muon" + std::to_string(i + 1));
+        event_.put(std::move(muonShowers_[i]), "MuonShower" + std::to_string(i + 1));
         event_.put(std::move(egammas_[i]), "EGamma" + std::to_string(i + 1));
         event_.put(std::move(etsums_[i]), "EtSum" + std::to_string(i + 1));
         event_.put(std::move(jets_[i]), "Jet" + std::to_string(i + 1));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
@@ -20,6 +20,8 @@ namespace l1t {
       GTCollections(edm::Event& e)
           : L1TObjectCollections(e), algBlk_(new GlobalAlgBlkBxCollection()), extBlk_(new GlobalExtBlkBxCollection()) {
         std::generate(muons_.begin(), muons_.end(), [] { return std::make_unique<MuonBxCollection>(); });
+        std::generate(
+            muonShowers_.begin(), muonShowers_.end(), [] { return std::make_unique<MuonShowerBxCollection>(); });
         std::generate(egammas_.begin(), egammas_.end(), [] { return std::make_unique<EGammaBxCollection>(); });
         std::generate(etsums_.begin(), etsums_.end(), [] { return std::make_unique<EtSumBxCollection>(); });
         std::generate(jets_.begin(), jets_.end(), [] { return std::make_unique<JetBxCollection>(); });
@@ -29,6 +31,9 @@ namespace l1t {
       ~GTCollections() override;
 
       inline MuonBxCollection* getMuons(const unsigned int copy) override { return muons_[copy].get(); };
+      inline MuonShowerBxCollection* getMuonShowers(const unsigned int copy) override {
+        return muonShowers_[copy].get();
+      };
       inline EGammaBxCollection* getEGammas(const unsigned int copy) override { return egammas_[copy].get(); };
       inline EtSumBxCollection* getEtSums(const unsigned int copy) override { return etsums_[copy].get(); };
       inline JetBxCollection* getJets(const unsigned int copy) override { return jets_[copy].get(); };
@@ -39,6 +44,7 @@ namespace l1t {
 
     private:
       std::array<std::unique_ptr<MuonBxCollection>, 6> muons_;
+      std::array<std::unique_ptr<MuonShowerBxCollection>, 6> muonShowers_;
       std::array<std::unique_ptr<EGammaBxCollection>, 6> egammas_;
       std::array<std::unique_ptr<EtSumBxCollection>, 6> etsums_;
       std::array<std::unique_ptr<JetBxCollection>, 6> jets_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
@@ -21,6 +21,7 @@ namespace l1t {
       desc.addOptional<edm::InputTag>("GtInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("ExtInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("MuonInputTag")->setComment("for stage2");
+      desc.addOptional<edm::InputTag>("ShowerInputTag")->setComment("for Run3");
       desc.addOptional<edm::InputTag>("EGammaInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("JetInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("TauInputTag")->setComment("for stage2");
@@ -50,6 +51,7 @@ namespace l1t {
 
     void GTSetup::registerProducts(edm::ProducesCollector prod) {
       prod.produces<MuonBxCollection>("Muon");
+      prod.produces<MuonShowerBxCollection>("MuonShower");
       prod.produces<EGammaBxCollection>("EGamma");
       prod.produces<EtSumBxCollection>("EtSum");
       prod.produces<JetBxCollection>("Jet");
@@ -58,6 +60,7 @@ namespace l1t {
       prod.produces<GlobalExtBlkBxCollection>();
       for (int i = 2; i < 7; ++i) {  // Collections from boards 2-6
         prod.produces<MuonBxCollection>("Muon" + std::to_string(i));
+        prod.produces<MuonShowerBxCollection>("MuonShower" + std::to_string(i));
         prod.produces<EGammaBxCollection>("EGamma" + std::to_string(i));
         prod.produces<EtSumBxCollection>("EtSum" + std::to_string(i));
         prod.produces<JetBxCollection>("Jet" + std::to_string(i));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTTokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTTokens.cc
@@ -14,10 +14,12 @@ namespace l1t {
       auto tautag = cfg.getParameter<edm::InputTag>("TauInputTag");
       auto etsumtag = cfg.getParameter<edm::InputTag>("EtSumInputTag");
       auto muontag = cfg.getParameter<edm::InputTag>("MuonInputTag");
+      auto muonshowertag = cfg.getParameter<edm::InputTag>("ShowerInputLabel");
 
       //cout << "DEBUG:  GmtInputTag" <<  muontag << "\n";
 
       muonToken_ = cc.consumes<MuonBxCollection>(muontag);
+      muonShowerToken_ = cc.consumes<MuonShowerBxCollection>(muonshowertag);
       egammaToken_ = cc.consumes<EGammaBxCollection>(egammatag);
       etSumToken_ = cc.consumes<EtSumBxCollection>(etsumtag);
       jetToken_ = cc.consumes<JetBxCollection>(jettag);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
@@ -9,7 +9,7 @@ namespace l1t {
       GMTOutputObjectMap gmtObjMap;
       std::pair<int, int> muonBx = getMuons(gmtObjMap, event, static_cast<const CommonTokens*>(toks)->getMuonToken());
       std::pair<int, int> muonShowerBx{0, 0};
-      if (fedId_ == 1402 && fwId_ >= 0x7000000) {
+      if ((fedId_ == 1402 && fwId_ >= 0x7000000) || (fedId_ == 1404 && fwId_ >= 0x00010f01)) {
         muonShowerBx = getMuonShowers(gmtObjMap, event, static_cast<const CommonTokens*>(toks)->getMuonShowerToken());
       }
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -71,7 +71,7 @@ namespace l1t {
         // Output links are odd and input links are even.
         int link_offset{0};  // This is correct for the uGT unpacker
         if (fed_ == 1402) {  // For uGMT we have to adjust the block/link ID
-          --link_offset;
+          link_offset = 1;
         }
         unsigned linkID{(blockID - link_offset) / 2};
 
@@ -82,6 +82,7 @@ namespace l1t {
         MuonShower shower;
         if (!muonShowerCollection_->isEmpty(bx)) {
           shower = muonShowerCollection_->at(bx, 0);
+          muonShowerCollection_->erase(bx, 0);
         }
         if (linkID == 0) {  // OneNominal shower
           shower.setOneNominalInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -8,7 +8,7 @@
 
 namespace l1t {
   namespace stage2 {
-    MuonUnpacker::MuonUnpacker() : res_(nullptr), muonCopy_(0) {}
+    MuonUnpacker::MuonUnpacker() : muonCollection_(nullptr), muonShowerCollection_(nullptr), muonCopy_(0) {}
 
     bool MuonUnpacker::unpack(const Block& block, UnpackerCollections* coll) {
       LogDebug("L1T") << "Block ID  = " << block.header().getID() << " size = " << block.header().getSize();
@@ -33,8 +33,12 @@ namespace l1t {
       getBXRange(nBX, firstBX, lastBX);
 
       // Set the muon collection and the BX range
-      res_ = static_cast<L1TObjectCollections*>(coll)->getMuons(muonCopy_);
-      res_->setBXRange(firstBX, lastBX);
+      muonCollection_ = static_cast<L1TObjectCollections*>(coll)->getMuons(muonCopy_);
+      muonCollection_->setBXRange(firstBX, lastBX);
+      // Set the muon shower collection and the BX range
+      muonShowerCollection_ = static_cast<L1TObjectCollections*>(coll)->getMuonShowers(muonCopy_);
+      muonShowerCollection_->setBXRange(firstBX, lastBX);
+
       LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;
 
       // Get the BX blocks and unpack them
@@ -48,15 +52,47 @@ namespace l1t {
               << " in BX header is outside of the BX range [" << firstBX << "," << lastBX
               << "] defined in the block header.";
         }
-        unpackBx(bx, bxBlock.payload());
+        unpackBx(bx, bxBlock.payload(), block.header().getID());
       }
       return true;
     }
 
-    void MuonUnpacker::unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int startIdx) {
+    void MuonUnpacker::unpackBx(int bx,
+                                const std::vector<uint32_t>& payload,
+                                unsigned int blockID,
+                                unsigned int startIdx) {
       unsigned int i = startIdx + 2;  // Only words 2-5 are "standard" muon words.
       // Check if there are enough words left in the payload
       if (startIdx + nWords_ <= payload.size()) {
+        // Unpacking showers.
+        // The shower from uGMT is transmitted via four links, each link
+        // carrying on of the bits of the shower. We therefore have to
+        // determine which link we're looking at and act accordingly.
+        // Output links are odd and input links are even.
+        int link_offset{0};  // This is correct for the uGT unpacker
+        if (fed_ == 1402) {  // For uGMT we have to adjust the block/link ID
+          --link_offset;
+        }
+        unsigned linkID{(blockID - link_offset) / 2};
+
+        // Try to get the shower for this BX and if it doesn't exist create an
+        // empty one and push it in.
+        // Note: We can't just create it for the first linkID, because in
+        // prinicple there could be a case where that is removed by the ZS.
+        MuonShower shower;
+        if (!muonShowerCollection_->isEmpty(bx)) {
+          shower = muonShowerCollection_->at(bx, 0);
+        }
+        if (linkID == 0) {  // OneNominal shower
+          shower.setOneNominalInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));
+        } else if (linkID == 1) {  // OneTight shower
+          shower.setOneTightInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));
+        }
+
+        if (shower.isValid()) {
+          muonShowerCollection_->push_back(bx, shower);
+        }
+
         for (unsigned nWord = 2; nWord < nWords_; nWord += 2) {  // Only words 2-5 are "standard" muon words.
           uint32_t raw_data_spare = payload[startIdx + 1];
           uint32_t raw_data_00_31 = payload[i++];
@@ -78,7 +114,7 @@ namespace l1t {
                           << " iso " << mu.hwIso() << " qual " << mu.hwQual() << " charge " << mu.hwCharge()
                           << " charge valid " << mu.hwChargeValid();
 
-          res_->push_back(bx, mu);
+          muonCollection_->push_back(bx, mu);
         }
       } else {
         edm::LogWarning("L1T") << "Only " << payload.size() - i << " 32 bit words in this BX but " << nWords_

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
@@ -24,11 +24,12 @@ namespace l1t {
       static constexpr unsigned nWords_ = 6;  // every link transmits 6 words (3 muons) per bx
       static constexpr unsigned bxzs_enable_shift_ = 1;
 
-      MuonBxCollection* res_;
+      MuonBxCollection* muonCollection_;
+      MuonShowerBxCollection* muonShowerCollection_;
       int fed_;
       unsigned int muonCopy_;
 
-      void unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int startIdx = 0);
+      void unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int blockID, unsigned int startIdx = 0);
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
@@ -7,6 +7,7 @@ gtStage2Raw = cms.EDProducer(
     GtInputTag = cms.InputTag("simGtStage2Digis"),
     ExtInputTag = cms.InputTag("simGtExtFakeStage2Digis"),
     MuonInputTag   = cms.InputTag("simGmtStage2Digis"),
+    ShowerInputLabel = cms.InputTag("simGmtShowerDigis"),
     EGammaInputTag = cms.InputTag("simCaloStage2Digis"),
     TauInputTag    = cms.InputTag("simCaloStage2Digis"),
     JetInputTag    = cms.InputTag("simCaloStage2Digis"),
@@ -31,4 +32,4 @@ stage2L1Trigger_2018.toModify(gtStage2Raw, FWId = cms.uint32(0x10F2)) # FW w/ ne
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x1130)) # FW w/ displaced muon info.
+stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x10f01)) # FW w/ displaced muon info and hadronic showers.

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -18,6 +18,7 @@ namespace l1t {
                          int muInBx);
     static void fillMuon(Muon& mu, uint32_t raw_data_spare, uint64_t dataword, int fed, unsigned int fw, int muInBx);
     static void fillIntermediateMuon(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63, unsigned int fw);
+    static bool showerFired(uint32_t shower_word, int fedId, unsigned int fwId);
     static void generatePackedMuonDataWords(const Muon& mu,
                                             uint32_t& raw_data_spare,
                                             uint32_t& raw_data_00_31,

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -52,8 +52,8 @@ namespace l1t {
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;
     static constexpr unsigned emtfShowerMask_ = 0x1;
-    static constexpr unsigned emtfShowerInTimeFrame_ = 0;
-    static constexpr unsigned emtfShowerOOTFrame_ = 2;
+    static constexpr unsigned emtfShowerInTimeFrame_ = 1;
+    static constexpr unsigned emtfShowerOOTFrame_ = 3;
     static constexpr unsigned emtfShowerOneNominalShift_ = 18;
     static constexpr unsigned emtfShowerOneTightShift_ = 19;
 

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -51,7 +51,7 @@ namespace l1t {
     static constexpr unsigned emtfPtUnconstrainedShift_ = 20;
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;
-    static constexpr unsigned emtfShowerMask_ = 0x3;
+    static constexpr unsigned emtfShowerMask_ = 0x1;
     static constexpr unsigned emtfShowerInTimeFrame_ = 0;
     static constexpr unsigned emtfShowerOOTFrame_ = 2;
     static constexpr unsigned emtfShowerOneNominalShift_ = 18;

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -263,17 +263,20 @@ void l1t::MuonRawDigiTranslator::generate64bitDataWord(
   dataword = (((uint64_t)msw) << 32) + lsw;
 }
 
+bool l1t::MuonRawDigiTranslator::showerFired(uint32_t shower_word, int fedId, unsigned int fwId) {
+  if ((fedId == 1402 && fwId >= 0x7000000) || (fedId == 1404 && fwId >= 0x00010f01)) {
+    return ((shower_word >> showerShift_) & 1) == 1;
+  }
+  return false;
+}
+
 std::array<uint32_t, 4> l1t::MuonRawDigiTranslator::getPackedShowerDataWords(const MuonShower& shower,
                                                                              const int fedId,
                                                                              const unsigned int fwId) {
   std::array<uint32_t, 4> res{};
-  if (fedId == 1402 && fwId < 0x7000000) {
-    return res;
-  } else {
+  if ((fedId == 1402 && fwId >= 0x7000000) || (fedId == 1404 && fwId >= 0x00010f01)) {
     res.at(0) = shower.isOneNominalInTime() ? (1 << showerShift_) : 0;
-    res.at(1) = shower.isOneNominalOutOfTime() ? (1 << showerShift_) : 0;
-    res.at(2) = shower.isTwoLooseInTime() ? (1 << showerShift_) : 0;
-    res.at(3) = shower.isTwoLooseOutOfTime() ? (1 << showerShift_) : 0;
+    res.at(1) = shower.isOneTightInTime() ? (1 << showerShift_) : 0;
   }
   return res;
 }

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -127,7 +127,7 @@ bool l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonShower(
     muShower.setOneTightInTime(((bxPayload[emtfShowerInTimeFrame_] >> emtfShowerOneTightShift_) & 1) == 1);
     muShower.setOneTightOutOfTime(((bxPayload[emtfShowerOOTFrame_] >> emtfShowerOneTightShift_) & 1) == 1);
 
-    return true;
+    return muShower.isValid();
   } else {
     return false;
   }

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -134,7 +134,7 @@ bool l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonShower(
 void l1t::RegionalMuonRawDigiTranslator::generatePackedShowerPayload(const RegionalMuonShower& shower,
                                                                      std::array<uint32_t, 6>& payload,
                                                                      const bool useEmtfShowers) {
-  if (!useEmtfShowers) {
+  if (!useEmtfShowers || !shower.isValid()) {
     return;
   }
   // First we check whether we're going to overwrite something in the payload.

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -76,12 +76,13 @@ void l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonCand(RegionalMuonCand& 
     mu.setTrackSubAddress(RegionalMuonCand::kME3Ch, (rawTrackAddress >> emtfTrAddrMe3ChShift_) & emtfTrAddrMe3ChMask_);
     mu.setTrackSubAddress(RegionalMuonCand::kME4Seg, (rawTrackAddress >> emtfTrAddrMe4SegShift_) & 0x1);
     mu.setTrackSubAddress(RegionalMuonCand::kME4Ch, (rawTrackAddress >> emtfTrAddrMe4ChShift_) & emtfTrAddrMe4ChMask_);
-    mu.setTrackSubAddress(RegionalMuonCand::kTrkNum,
-                          (rawTrackAddress >> emtfTrAddrTrkNumShift_) & emtfTrAddrTrkNumMask_);
-    mu.setTrackSubAddress(RegionalMuonCand::kBX, (rawTrackAddress >> emtfTrAddrBxShift_) & emtfTrAddrBxMask_);
     if (useEmtfDisplacementInfo) {  // In Run-3 we receive displaced muon information from EMTF
       mu.setHwPtUnconstrained((raw_data_32_63 >> emtfPtUnconstrainedShift_) & ptUnconstrainedMask_);
       mu.setHwDXY((raw_data_32_63 >> emtfDxyShift_) & dxyMask_);
+    } else {
+      mu.setTrackSubAddress(RegionalMuonCand::kTrkNum,
+                            (rawTrackAddress >> emtfTrAddrTrkNumShift_) & emtfTrAddrTrkNumMask_);
+      mu.setTrackSubAddress(RegionalMuonCand::kBX, (rawTrackAddress >> emtfTrAddrBxShift_) & emtfTrAddrBxMask_);
     }
   } else if (tf == omtf_neg || tf == omtf_pos) {
     mu.setTrackSubAddress(RegionalMuonCand::kLayers,
@@ -142,7 +143,8 @@ void l1t::RegionalMuonRawDigiTranslator::generatePackedShowerPayload(const Regio
       (((payload.at(emtfShowerOOTFrame_) >> emtfShowerOneNominalShift_) & emtfShowerMask_) != 0) ||
       (((payload.at(emtfShowerOOTFrame_) >> emtfShowerOneTightShift_) & emtfShowerMask_) != 0)) {
     edm::LogError("L1T") << "Check constants for RegionalMuonShower fields! It looks like we're in danger of "
-                            "overwriting muon data in the packer!";
+                            "overwriting muon data in the packer! InTimeFrame is "
+                         << payload.at(emtfShowerInTimeFrame_) << ", OOTFrame is " << payload.at(emtfShowerOOTFrame_);
     return;
   }
   payload.at(emtfShowerInTimeFrame_) |= (shower.isOneNominalInTime() & 1) << emtfShowerOneNominalShift_ |
@@ -234,9 +236,7 @@ int l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(const RegionalMuon
                    (mu.trackSubAddress(RegionalMuonCand::kME3Seg) & 0x1) << emtfTrAddrMe3SegShift_ |
                    (mu.trackSubAddress(RegionalMuonCand::kME3Ch) & emtfTrAddrMe3ChMask_) << emtfTrAddrMe3ChShift_ |
                    (mu.trackSubAddress(RegionalMuonCand::kME4Seg) & 0x1) << emtfTrAddrMe4SegShift_ |
-                   (mu.trackSubAddress(RegionalMuonCand::kME4Ch) & emtfTrAddrMe4ChMask_) << emtfTrAddrMe4ChShift_ |
-                   (mu.trackSubAddress(RegionalMuonCand::kTrkNum) & emtfTrAddrTrkNumMask_) << emtfTrAddrTrkNumShift_ |
-                   (mu.trackSubAddress(RegionalMuonCand::kBX) & emtfTrAddrBxMask_) << emtfTrAddrBxShift_;
+                   (mu.trackSubAddress(RegionalMuonCand::kME4Ch) & emtfTrAddrMe4ChMask_) << emtfTrAddrMe4ChShift_;
 
     } else {
       edm::LogWarning("L1T") << "EMTF muon track address map contains " << mu.trackAddress().size()

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -79,6 +79,8 @@ void l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonCand(RegionalMuonCand& 
     if (useEmtfDisplacementInfo) {  // In Run-3 we receive displaced muon information from EMTF
       mu.setHwPtUnconstrained((raw_data_32_63 >> emtfPtUnconstrainedShift_) & ptUnconstrainedMask_);
       mu.setHwDXY((raw_data_32_63 >> emtfDxyShift_) & dxyMask_);
+      mu.setTrackSubAddress(RegionalMuonCand::kTrkNum, 0);
+      mu.setTrackSubAddress(RegionalMuonCand::kBX, 0);
     } else {
       mu.setTrackSubAddress(RegionalMuonCand::kTrkNum,
                             (rawTrackAddress >> emtfTrAddrTrkNumShift_) & emtfTrAddrTrkNumMask_);

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -137,8 +137,10 @@ void l1t::RegionalMuonRawDigiTranslator::generatePackedShowerPayload(const Regio
     return;
   }
   // First we check whether we're going to overwrite something in the payload.
-  if (((payload.at(emtfShowerInTimeFrame_) & emtfShowerMask_) != 0) ||
-      ((payload.at(emtfShowerOOTFrame_) & emtfShowerMask_) != 0)) {
+  if ((((payload.at(emtfShowerInTimeFrame_) >> emtfShowerOneNominalShift_) & emtfShowerMask_) != 0) ||
+      (((payload.at(emtfShowerInTimeFrame_) >> emtfShowerOneTightShift_) & emtfShowerMask_) != 0) ||
+      (((payload.at(emtfShowerOOTFrame_) >> emtfShowerOneNominalShift_) & emtfShowerMask_) != 0) ||
+      (((payload.at(emtfShowerOOTFrame_) >> emtfShowerOneTightShift_) & emtfShowerMask_) != 0)) {
     edm::LogError("L1T") << "Check constants for RegionalMuonShower fields! It looks like we're in danger of "
                             "overwriting muon data in the packer!";
     return;


### PR DESCRIPTION
#### PR description:

This PR groups a few fixes (please let me know if I should split it into one PR per fix):
- A check to make sure that we weren't overwriting muon information with the shower bits was watching the wrong bitfield.
- We were also off by one in selecting the correct payload word for the regional muon showers.
- Run-2 debug information from EMTF was still being written to the fields now foreseen for hadronic showers and displaced info. We now only do this for Run-2 data and for Run-3 set those data to zero to avoid a crash in the ntuplizers.
- Unpacking of global hadronic showers (i.e. the uGMT output) has been enabled both for uGMT and the uGT input unpacker/

Two mostly aesthetic fixes:
- We now only pack and unpack regional showers when they are actually filled (i.e. valid).
- The `MuonShower` data format was made a bit more descriptive:
  -  The private members storing the bits that are already defined for Run-3 have been named descriptively.
  - Accessors for those members have been added.

#### PR validation:

Ran on sample with hadronic showers[1] and confirmed that they appear at the output of the uGMT both in the EDM file and L1TNtuple.


[1] `cmsDriver.py  l1Ntuple  --python_filename mc.py  -s L1REPACK:FullMC,RAW2DIGI  --mc -n -1 --conditions auto:phase1_2021_realistic --era Run3 --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU  
--customise=L1Trigger/Configuration/customiseUtils.L1TGlobalMenuXML --filein /store/mc/Run3Summer21DRPremix/HTo2LongLivedTo4b_MH-1000_MFF-450_CTau-100000mm_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v6
-v2/2550000/e28c777d-10fd-4100-b230-c42b0160ad8a.root`