### PR TITLE
Deleted non-consumed modules do not keep early-deleted data products alive

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -331,6 +331,8 @@ namespace edm {
     std::vector<std::shared_ptr<LuminosityBlockProcessingStatus>> streamLumiStatus_;
     std::atomic<unsigned int> streamLumiActive_{0};  //works as guard for streamLumiStatus
 
+    std::vector<std::string> branchesToDeleteEarly_;
+
     std::vector<SubProcess> subProcesses_;
     edm::propagate_const<std::unique_ptr<HistoryAppender>> historyAppender_;
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -277,6 +277,8 @@ namespace edm {
     /// Deletes module with label iLabel
     void deleteModule(std::string const& iLabel, ActivityRegistry* areg);
 
+    void initializeEarlyDelete(std::vector<std::string> const& branchesToDeleteEarly, edm::ProductRegistry const& preg);
+
     /// returns the collection of pointers to workers
     AllWorkers const& allWorkers() const;
 

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -175,7 +175,6 @@ namespace edm {
                    ExceptionToActionTable const& actions,
                    std::shared_ptr<ActivityRegistry> areg,
                    std::shared_ptr<ProcessConfiguration> processConfiguration,
-                   bool allowEarlyDelete,
                    StreamID streamID,
                    ProcessContext const* processContext);
 
@@ -246,6 +245,10 @@ namespace edm {
     /// Delete the module with label iLabel
     void deleteModule(std::string const& iLabel);
 
+    void initializeEarlyDelete(ModuleRegistry& modReg,
+                               std::vector<std::string> const& branchesToDeleteEarly,
+                               edm::ProductRegistry const& preg);
+
     /// returns the collection of pointers to workers
     AllWorkers const& allWorkers() const { return workerManager_.allWorkers(); }
 
@@ -312,10 +315,6 @@ namespace edm {
     void addToAllWorkers(Worker* w);
 
     void resetEarlyDelete();
-    void initializeEarlyDelete(ModuleRegistry& modReg,
-                               edm::ParameterSet const& opts,
-                               edm::ProductRegistry const& preg,
-                               bool allowEarlyDelete);
 
     TrigResConstPtr results() const { return get_underlying_safe(results_); }
     TrigResPtr& results() { return get_underlying_safe(results_); }

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -722,7 +722,6 @@ namespace edm {
                                                                                actions,
                                                                                areg,
                                                                                processConfiguration,
-                                                                               !hasSubprocesses,
                                                                                StreamID{i},
                                                                                processContext));
     }
@@ -1429,6 +1428,13 @@ namespace edm {
       stream->deleteModule(iLabel);
     }
     moduleRegistry_->deleteModule(iLabel, areg->preModuleDestructionSignal_, areg->postModuleDestructionSignal_);
+  }
+
+  void Schedule::initializeEarlyDelete(std::vector<std::string> const& branchesToDeleteEarly,
+                                       edm::ProductRegistry const& preg) {
+    for (auto& stream : streamSchedules_) {
+      stream->initializeEarlyDelete(*moduleRegistry(), branchesToDeleteEarly, preg);
+    }
   }
 
   std::vector<ModuleDescription const*> Schedule::getAllModuleDescriptions() const {

--- a/FWCore/Framework/test/test_deleteEarly.sh
+++ b/FWCore/Framework/test/test_deleteEarly.sh
@@ -11,6 +11,7 @@ F5=${LOCAL_TEST_DIR}/test_multiPathMultiModuleEarlyDelete_cfg.py
 F6=${LOCAL_TEST_DIR}/test_subProcessDeleteEarly_cfg.py
 F7=${LOCAL_TEST_DIR}/test_consumeAfterEarlyDeleteTask_cfg.py
 F8=${LOCAL_TEST_DIR}/test_consumeAfterEarlyDeletePath_cfg.py
+F9=${LOCAL_TEST_DIR}/test_nonConsumedModuleEarlyDelete_cfg.py
 
 (cmsRun $F1 ) || die "Failure using $F1" $?
 (cmsRun $F2 ) || die "Failure using $F2" $?
@@ -20,5 +21,6 @@ F8=${LOCAL_TEST_DIR}/test_consumeAfterEarlyDeletePath_cfg.py
 (cmsRun $F6 ) || die "Failure using $F6" $?
 (cmsRun $F7 ) || die "Failure using $F7" $?
 (cmsRun $F8 ) || die "Failure using $F8" $?
+(cmsRun $F9 ) || die "Failure using $F9" $?
 
 

--- a/FWCore/Framework/test/test_nonConsumedModuleEarlyDelete_cfg.py
+++ b/FWCore/Framework/test/test_nonConsumedModuleEarlyDelete_cfg.py
@@ -1,0 +1,64 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(3))
+
+process.options = cms.untracked.PSet(
+    canDeleteEarly = cms.untracked.vstring(
+        "edmtestDeleteEarly_maker1__TEST",
+        "edmtestDeleteEarly_maker2__TEST",
+        "edmtestDeleteEarly_maker3__TEST"
+    )
+)
+
+
+process.maker1 = cms.EDProducer("DeleteEarlyProducer")
+process.maker2 = cms.EDProducer("DeleteEarlyProducer")
+process.maker3 = cms.EDProducer("DeleteEarlyProducer") # this module should get deleted
+
+# These 3 modules should get deleted
+process.otherProducer1 = cms.EDProducer("IntProducer",
+    ivalue = cms.int32(1),
+    mightGet = cms.untracked.vstring("edmtestDeleteEarly_maker1__TEST")
+)
+process.otherProducer2 = cms.EDProducer("IntProducer",
+    ivalue = cms.int32(2),
+    mightGet = cms.untracked.vstring("edmtestDeleteEarly_maker2__TEST")
+)
+process.otherProducer3 = cms.EDProducer("IntProducer",
+    ivalue = cms.int32(3),
+    mightGet = cms.untracked.vstring(
+        "edmtestDeleteEarly_maker2__TEST",
+        "edmtestDeleteEarly_maker3__TEST"
+    )
+)
+
+process.reader1 = cms.EDAnalyzer("DeleteEarlyReader",
+    tag = cms.untracked.InputTag("maker1"),
+    mightGet = cms.untracked.vstring(
+        "edmtestDeleteEarly_maker1__TEST",
+    )
+)
+process.reader2 = cms.EDAnalyzer("DeleteEarlyReader",
+    tag = cms.untracked.InputTag("maker2"),
+    mightGet = cms.untracked.vstring(
+        "edmtestDeleteEarly_maker2__TEST",
+    )
+)
+
+process.tester = cms.EDAnalyzer("DeleteEarlyCheckDeleteAnalyzer",
+    expectedValues = cms.untracked.vuint32(4,8,12)
+)
+
+process.t = cms.Task(
+    process.maker1,
+    process.maker2,
+    process.maker3,
+    process.otherProducer1,
+    process.otherProducer2,
+    process.otherProducer3,
+)
+process.p = cms.Path(process.reader1+process.reader2+process.tester, process.t)


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/cmssw/issues/36863. The effect is achieved by moving the call to `initializeEarlyDelete()` from the constructor of `StreamSchedule` to right after the non-consumed unscheduled have been deleted.

#### PR validation:

Framework unit tests pass