### PR TITLE
Add SV variables to BTV OfflineDQM

### DIFF
--- a/DQMOffline/RecoB/interface/FlavourHistorgrams.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams.h
@@ -640,7 +640,7 @@ void FlavourHistograms<T>::fillVariable(const int& flavour, const T& var, const 
   if (!mcPlots_ || (theBaseNameDescription == "Jet Multiplicity" && flavour == -1))
     return;
 
-  switch (flavour) {
+  switch (std::abs(flavour)) {
     case 1:
       if (mcPlots_ > 2) {
         theHisto_d->Fill(var, w);

--- a/DQMOffline/RecoB/plugins/BuildFile.xml
+++ b/DQMOffline/RecoB/plugins/BuildFile.xml
@@ -14,7 +14,7 @@
 <use name="FWCore/Utilities"/>
 <use name="JetMETCorrections/JetCorrector"/>
 <use name="SimDataFormats/GeneratorProducts"/>
-<library file="BTagPerformanceAnalyzerOnData.cc PrimaryVertexMonitor.cc BTagPerformanceHarvester.cc MiniAODTaggerAnalyzer.cc MiniAODTaggerHarvester.cc" name="DQMOfflineRecoBPlugins">
+<library file="BTagPerformanceAnalyzerOnData.cc PrimaryVertexMonitor.cc BTagPerformanceHarvester.cc MiniAODTaggerAnalyzer.cc MiniAODTaggerHarvester.cc MiniAODSVAnalyzer.cc" name="DQMOfflineRecoBPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.cc
+++ b/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.cc
@@ -16,7 +16,7 @@ void MiniAODSVAnalyzer::bookHistograms(DQMStore::IBooker& ibook, edm::Run const&
   ibook.setCurrentFolder("Btag/SV");
 
   n_sv_ = ibook.book1D("n_sv", "number of SV in jet", 5, 0, 5);
-  n_sv_->setAxisTitle("number of SV");
+  n_sv_->setAxisTitle("number of SV in jet");
 
   sv_mass_ = ibook.book1D("sv_mass", "SV mass", 30, 0., 6.);
   sv_mass_->setAxisTitle("SV mass");
@@ -25,15 +25,15 @@ void MiniAODSVAnalyzer::bookHistograms(DQMStore::IBooker& ibook, edm::Run const&
   sv_pt_->setAxisTitle("SV pt");
 
   sv_ntracks_ = ibook.book1D("sv_ntracks", "SV number of daugthers", 10, 0, 10);
-  sv_ntracks_->setAxisTitle("SV tracks");
+  sv_ntracks_->setAxisTitle("number of tracks at SV");
 
   sv_chi2norm_ = ibook.book1D("sv_chi2norm", "normalized Chi2 of vertex", 30, 0, 15);
-  sv_chi2norm_->setAxisTitle("normalized Chi2");
+  sv_chi2norm_->setAxisTitle("normalized Chi2 of SV");
 
   sv_chi2prob_ = ibook.book1D("sv_chi2prob", "Chi2 probability of vertex", 20, 0., 1.);
-  sv_chi2prob_->setAxisTitle("Chi2 probability");
+  sv_chi2prob_->setAxisTitle("Chi2 probability of SV");
 
-  sv_ptrel_ = ibook.book1D("sv_ptrel_", "SV jet transverse momentum ratio", 25, 0., 1.);
+  sv_ptrel_ = ibook.book1D("sv_ptrel", "SV jet transverse momentum ratio", 25, 0., 1.);
   sv_ptrel_->setAxisTitle("pt(SV)/pt(jet)");
 
   sv_energyratio_ = ibook.book1D("sv_energyratio", "SV jet energy ratio", 25, 0., 1.);
@@ -69,7 +69,7 @@ void MiniAODSVAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
       // loop secondary vertices
       for (unsigned int i = 0; i < taginfo->nVertices(); i++) {
-        const reco::VertexCompositePtrCandidate sv = taginfo->secondaryVertex(i);
+        const reco::VertexCompositePtrCandidate& sv = taginfo->secondaryVertex(i);
 
         sv_mass_->Fill(sv.mass());
         sv_pt_->Fill(sv.pt());

--- a/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.cc
+++ b/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.cc
@@ -5,8 +5,8 @@
 MiniAODSVAnalyzer::MiniAODSVAnalyzer(const edm::ParameterSet& pSet)
     : jetToken_(consumes<std::vector<pat::Jet>>(pSet.getParameter<edm::InputTag>("JetTag"))),
       svTagInfo_(pSet.getParameter<std::string>("svTagInfo")),
-      jetPtMin_(pSet.getParameter<double>("JetptMin")),
-      etaMax_(pSet.getParameter<double>("EtaMax"))
+      ptMin_(pSet.getParameter<double>("ptMin")),
+      etaMax_(pSet.getParameter<double>("etaMax"))
 
 {}
 
@@ -62,7 +62,7 @@ void MiniAODSVAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
   // Loop over the pat::Jets
   for (std::vector<pat::Jet>::const_iterator jet = jetCollection->begin(); jet != jetCollection->end(); ++jet) {
     // jet selection
-    if (jet->hasTagInfo(svTagInfo_) && jet->pt() > jetPtMin_ && std::abs(jet->eta()) < etaMax_) {
+    if (jet->hasTagInfo(svTagInfo_) && jet->pt() > ptMin_ && std::abs(jet->eta()) < etaMax_) {
       const reco::CandSecondaryVertexTagInfo* taginfo =
           static_cast<const reco::CandSecondaryVertexTagInfo*>(jet->tagInfo(svTagInfo_));
       n_sv_->Fill(taginfo->nVertices());

--- a/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.cc
+++ b/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.cc
@@ -1,0 +1,94 @@
+#include "DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Event.h"
+
+MiniAODSVAnalyzer::MiniAODSVAnalyzer(const edm::ParameterSet& pSet)
+    : jetToken_(consumes<std::vector<pat::Jet>>(pSet.getParameter<edm::InputTag>("JetTag"))),
+      svTagInfo_(pSet.getParameter<std::string>("svTagInfo")),
+      jetPtMin_(pSet.getParameter<double>("JetptMin")),
+      etaMax_(pSet.getParameter<double>("EtaMax"))
+
+{}
+
+MiniAODSVAnalyzer::~MiniAODSVAnalyzer() {}
+
+void MiniAODSVAnalyzer::bookHistograms(DQMStore::IBooker& ibook, edm::Run const& run, edm::EventSetup const& es) {
+  ibook.setCurrentFolder("Btag/SV");
+
+  n_sv_ = ibook.book1D("n_sv", "number of SV in jet", 5, 0, 5);
+  n_sv_->setAxisTitle("number of SV");
+
+  sv_mass_ = ibook.book1D("sv_mass", "SV mass", 30, 0., 6.);
+  sv_mass_->setAxisTitle("SV mass");
+
+  sv_pt_ = ibook.book1D("sv_pt", "SV transverse momentum", 40, 0., 120.);
+  sv_pt_->setAxisTitle("SV pt");
+
+  sv_ntracks_ = ibook.book1D("sv_ntracks", "SV number of daugthers", 10, 0, 10);
+  sv_ntracks_->setAxisTitle("SV tracks");
+
+  sv_chi2norm_ = ibook.book1D("sv_chi2norm", "normalized Chi2 of vertex", 30, 0, 15);
+  sv_chi2norm_->setAxisTitle("normalized Chi2");
+
+  sv_chi2prob_ = ibook.book1D("sv_chi2prob", "Chi2 probability of vertex", 20, 0., 1.);
+  sv_chi2prob_->setAxisTitle("Chi2 probability");
+
+  sv_ptrel_ = ibook.book1D("sv_ptrel_", "SV jet transverse momentum ratio", 25, 0., 1.);
+  sv_ptrel_->setAxisTitle("pt(SV)/pt(jet)");
+
+  sv_energyratio_ = ibook.book1D("sv_energyratio", "SV jet energy ratio", 25, 0., 1.);
+  sv_energyratio_->setAxisTitle("E(SV)/E(jet)");
+
+  sv_deltaR_ = ibook.book1D("sv_deltaR", "SV jet deltaR", 40, 0., 0.4);
+  sv_deltaR_->setAxisTitle("deltaR(jet, SV)");
+
+  sv_dxy_ = ibook.book1D("sv_dxy", "2D flight distance", 40, 0., 8.);
+  sv_dxy_->setAxisTitle("dxy");
+
+  sv_dxysig_ = ibook.book1D("sv_dxysig", "2D flight distance significance", 25, 0., 250.);
+  sv_dxysig_->setAxisTitle("dxy significance");
+
+  sv_d3d_ = ibook.book1D("sv_d3d", "3D flight distance", 40, 0., 8.);
+  sv_d3d_->setAxisTitle("d3d");
+
+  sv_d3dsig_ = ibook.book1D("sv_d3dsig", "3D flight distance significance", 25, 0., 250.);
+  sv_d3dsig_->setAxisTitle("d3d significance");
+}
+
+void MiniAODSVAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<std::vector<pat::Jet>> jetCollection;
+  iEvent.getByToken(jetToken_, jetCollection);
+
+  // Loop over the pat::Jets
+  for (std::vector<pat::Jet>::const_iterator jet = jetCollection->begin(); jet != jetCollection->end(); ++jet) {
+    // jet selection
+    if (jet->hasTagInfo(svTagInfo_) && jet->pt() > jetPtMin_ && std::abs(jet->eta()) < etaMax_) {
+      const reco::CandSecondaryVertexTagInfo* taginfo =
+          static_cast<const reco::CandSecondaryVertexTagInfo*>(jet->tagInfo(svTagInfo_));
+      n_sv_->Fill(taginfo->nVertices());
+
+      // loop secondary vertices
+      for (unsigned int i = 0; i < taginfo->nVertices(); i++) {
+        const reco::VertexCompositePtrCandidate sv = taginfo->secondaryVertex(i);
+
+        sv_mass_->Fill(sv.mass());
+        sv_pt_->Fill(sv.pt());
+        sv_ntracks_->Fill(sv.numberOfDaughters());
+        sv_chi2norm_->Fill(sv.vertexNormalizedChi2());
+        sv_chi2prob_->Fill(ChiSquaredProbability(sv.vertexChi2(), sv.vertexNdof()));
+
+        sv_ptrel_->Fill(sv.pt() / jet->pt());
+        sv_energyratio_->Fill(sv.energy() / jet->energy());
+        sv_deltaR_->Fill(reco::deltaR(sv, jet->momentum()));
+
+        sv_dxy_->Fill(taginfo->flightDistance(i, 2).value());
+        sv_dxysig_->Fill(taginfo->flightDistance(i, 2).significance());
+        sv_d3d_->Fill(taginfo->flightDistance(i, 3).value());
+        sv_d3dsig_->Fill(taginfo->flightDistance(i, 3).significance());
+      }
+    }
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(MiniAODSVAnalyzer);

--- a/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.h
+++ b/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.h
@@ -25,7 +25,7 @@ private:
 
   const edm::EDGetTokenT<std::vector<pat::Jet> > jetToken_;
   const std::string svTagInfo_;
-  const double jetPtMin_;
+  const double ptMin_;
   const double etaMax_;
 
   MonitorElement* n_sv_;

--- a/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.h
+++ b/DQMOffline/RecoB/plugins/MiniAODSVAnalyzer.h
@@ -1,0 +1,50 @@
+#ifndef MiniAODSVAnalyzer_H
+#define MiniAODSVAnalyzer_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+
+/** \class MiniAODSVAnalyzer
+ *
+ *  Secondary Vertex Analyzer to run on MiniAOD
+ *
+ */
+
+class MiniAODSVAnalyzer : public DQMEDAnalyzer {
+public:
+  explicit MiniAODSVAnalyzer(const edm::ParameterSet& pSet);
+  ~MiniAODSVAnalyzer() override;
+
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+private:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+
+  const edm::EDGetTokenT<std::vector<pat::Jet> > jetToken_;
+  const std::string svTagInfo_;
+  const double jetPtMin_;
+  const double etaMax_;
+
+  MonitorElement* n_sv_;
+
+  MonitorElement* sv_mass_;
+  MonitorElement* sv_pt_;
+  MonitorElement* sv_ntracks_;
+  MonitorElement* sv_chi2norm_;
+  MonitorElement* sv_chi2prob_;
+
+  // relation to jet
+  MonitorElement* sv_ptrel_;
+  MonitorElement* sv_energyratio_;
+  MonitorElement* sv_deltaR_;
+
+  MonitorElement* sv_dxy_;
+  MonitorElement* sv_dxysig_;
+  MonitorElement* sv_d3d_;
+  MonitorElement* sv_d3dsig_;
+};
+
+#endif

--- a/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
+++ b/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
@@ -114,3 +114,13 @@ addSequences(bTagMiniValidationSource,
              regions={'Global': Etaregions['Global']}, # only for global Eta range
              globalPSet=bTagMiniValidationGlobal,
              label='bTagDeepCSVValidation')
+
+
+
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+from Configuration.ProcessModifiers.miniAOD_skip_trackExtras_cff import miniAOD_skip_trackExtras
+from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
+
+_mAOD = (pp_on_AA | miniAOD_skip_trackExtras | run2_miniAOD_94XFall17)
+_mAOD.toReplaceWith(bTagMiniDQMSource, bTagMiniDQMSource.copyAndExclude([bTagSVDQM, patJetsSVInfoTask]))
+_mAOD.toReplaceWith(bTagMiniValidationSource, bTagMiniValidationSource.copyAndExclude([bTagSVDQM, patJetsSVInfoTask]))

--- a/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
+++ b/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
@@ -20,8 +20,8 @@ patJetsSVInfoTask = cms.Task(patJetsSVInfo)
 bTagSVDQM = DQMEDAnalyzer('MiniAODSVAnalyzer',
                           cms.PSet(JetTag = cms.InputTag('patJetsSVInfo'),
                                    svTagInfo = cms.string('pfSecondaryVertex'),
-                                   JetptMin = cms.double(30.),
-                                   EtaMax = cms.double(2.5),
+                                   ptMin = cms.double(30.),
+                                   etaMax = cms.double(2.5),
                                    )
                           )
 

--- a/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
+++ b/DQMOffline/RecoB/python/bTagMiniDQM_cff.py
@@ -5,6 +5,26 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 from DQMOffline.RecoB.bTagMiniDQMDeepFlavour import *
 from DQMOffline.RecoB.bTagMiniDQMDeepCSV import *
 
+from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import patJets
+
+
+
+# add jets with pfSecondaryVertexTagInfos
+patJetsSVInfo = patJets.clone(
+    tagInfoSources = cms.VInputTag('pfSecondaryVertexTagInfos'),
+    addTagInfos = True
+)
+patJetsSVInfoTask = cms.Task(patJetsSVInfo)
+
+
+bTagSVDQM = DQMEDAnalyzer('MiniAODSVAnalyzer',
+                          cms.PSet(JetTag = cms.InputTag('patJetsSVInfo'),
+                                   svTagInfo = cms.string('pfSecondaryVertex'),
+                                   JetptMin = cms.double(30.),
+                                   EtaMax = cms.double(2.5),
+                                   )
+                          )
+
 
 bTagMiniDQMGlobal = cms.PSet(
     JetTag = cms.InputTag('slimmedJets'),
@@ -52,7 +72,7 @@ def addSequences(Analyzer, Harvester, discriminators, regions, globalPSet, label
 
 
 
-bTagMiniDQMSource = cms.Sequence()
+bTagMiniDQMSource = cms.Sequence(bTagSVDQM, patJetsSVInfoTask)
 bTagMiniDQMHarvesting = cms.Sequence()
 
 addSequences(bTagMiniDQMSource,
@@ -77,7 +97,7 @@ bTagMiniValidationGlobal = bTagMiniDQMGlobal.clone(
     MClevel = 1 # produce flavour plots for b, c ,light (dusg)
 )
 
-bTagMiniValidationSource = cms.Sequence()
+bTagMiniValidationSource = cms.Sequence(bTagSVDQM, patJetsSVInfoTask)
 bTagMiniValidationHarvesting = cms.Sequence()
 
 


### PR DESCRIPTION
#### PR description:
- add secondary vertex variables to @miniAODDQM (removed with deprecated module in #34156)
- fix discriminator distributions to match with pre-#35985 distributions


Addition of SV variables presented in the [Btag WG Meeting](https://indico.cern.ch/event/1112381/#18-update-on-dqm-developments).

#### PR validation:
`runTheMatrix.py -l 12034.0`, used for validation plots to verify the fix of discriminator distributions.

`runTheMatrix.py -l limited -i all`