### PR TITLE
Phase2-TB66 Add selection of SD's for HGCal TB application

### DIFF
--- a/Configuration/Eras/python/Modifier_hgcaltb_cff.py
+++ b/Configuration/Eras/python/Modifier_hgcaltb_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+hgcaltb =  cms.Modifier()

--- a/Geometry/HGCalCommonData/data/TB160/16Module/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB160/16Module/hgcalCons.xml
@@ -161,6 +161,7 @@
     <Parameter name="GroupingZOut"   value="-1"/>
     <Parameter name="GroupingZOut"   value="16"/>
     <Parameter name="GroupingZOut"   value="16"/>
+    <Parameter name="LayerOffset"    value="0"/>
   </SpecPar>
 </SpecParSection>
 

--- a/Geometry/HGCalCommonData/data/TB160/4Module/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB160/4Module/hgcalCons.xml
@@ -53,6 +53,7 @@
     <Parameter name="GroupingZOut"   value="-1"/>
     <Parameter name="GroupingZOut"   value="4"/>
     <Parameter name="GroupingZOut"   value="4"/>
+    <Parameter name="LayerOffset"    value="0"/>
   </SpecPar>
 </SpecParSection>
 

--- a/Geometry/HGCalCommonData/data/TB160/hgcalCons.xml
+++ b/Geometry/HGCalCommonData/data/TB160/hgcalCons.xml
@@ -270,6 +270,7 @@
     <Parameter name="GroupingZOut"   value="28"/>
     <Parameter name="GroupingZOut"   value="28"/>
     <Parameter name="LayerOffset"    value="0"/>
+    <Parameter name="LayerOffset"    value="0"/>
   </SpecPar>
 </SpecParSection>
 

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN170_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN170_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -95,10 +96,6 @@ process.VtxSmeared.MinY = -7.5
 process.VtxSmeared.MaxY =  7.5
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 		HGCPassive = cms.PSet(
                     LVNames = cms.vstring('HGCalEE','HGCalHE','HGCalAH', 'HGCalBeam', 'CMSE'),

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1DD4hep_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1DD4hep_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM',dd4hep)
+process = cms.Process('SIM',dd4hep,hgcaltb)
 
 # import of standard configurations
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -95,10 +96,6 @@ process.VtxSmeared.MinY                 = -7.5
 process.VtxSmeared.MaxY                 =  7.5
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
 process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("SimG4CMS/HGCalTestBeam/data/dd4hep/HGCalTB181Oct1.xml")
 
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1PC1mm_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1PC1mm_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -95,10 +96,6 @@ process.VtxSmeared.MinY                 = -7.5
 process.VtxSmeared.MaxY                 =  7.5
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
         HGCPassive = cms.PSet(
                 LVNames = cms.vstring('HGCalEE','HGCalHE','HGCalAH', 'HGCalBeam', 'CMSE'),

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -94,10 +95,6 @@ process.VtxSmeared.MinY                 = -7.5
 process.VtxSmeared.MaxY                 =  7.5
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 		HGCPassive = cms.PSet(
                     LVNames = cms.vstring('HGCalEE','HGCalHE','HGCalAH', 'HGCalBeam', 'CMSE'),

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1el100_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct1el100_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -96,10 +97,7 @@ process.VtxSmeared.MeanZ  = 0
 process.VtxSmeared.SigmaZ = 0
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
+
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 		HGCPassive = cms.PSet(
                      LVNames = cms.vstring('HGCalEE','HGCalHE','HGCalAH', 'HGCalBeam', 'CMSE'),

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct2_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct2_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -94,10 +95,6 @@ process.VtxSmeared.MinY                 = -7.5
 process.VtxSmeared.MaxY                 =  7.5
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 		HGCPassive = cms.PSet(
                     LVNames = cms.vstring('HGCalEE','HGCalHE','HGCalAH', 'HGCalBeam', 'CMSE'),

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct3_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct3_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -94,10 +95,6 @@ process.VtxSmeared.MinY                 = -7.5
 process.VtxSmeared.MaxY                 =  7.5
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 		HGCPassive = cms.PSet(
                     LVNames = cms.vstring('HGCalEE','HGCalHE','HGCalAH', 'HGCalBeam', 'CMSE'),

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct4_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181Oct4_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -94,10 +95,6 @@ process.VtxSmeared.MinY                 = -7.5
 process.VtxSmeared.MaxY                 =  7.5
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
 process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 		HGCPassive = cms.PSet(
                     LVNames = cms.vstring('HGCalEE','HGCalHE','HGCalAH', 'HGCalBeam', 'CMSE'),

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBCERN181_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load("FWCore.MessageService.MessageLogger_cfi")
@@ -75,10 +76,6 @@ process.VtxSmeared.MinY = -7.5
 process.VtxSmeared.MaxY =  7.5
 process.g4SimHits.HGCSD.RejectMouseBite = True
 process.g4SimHits.HGCSD.RotatedWafer    = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
 
 # Path and EndPath definitions
 process.generation_step = cms.Path(process.pgen)

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBGenSimCERN_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBGenSimCERN_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -101,9 +102,6 @@ process.VtxSmeared.MinY = -7.5
 process.VtxSmeared.MaxY =  7.5
 process.HGCalTBAnalyzer.doDigis = False
 process.HGCalTBAnalyzer.doRecHits = False
-process.g4SimHits.OnlySDs = ['HGCSensitiveDetector',
-                             'HcalTB06BeamDetector',
-                             'HGCalTB1601SensitiveDetector']
 process.g4SimHits.HGCSD.Detectors = 1
 process.g4SimHits.HGCSD.UseDetector = 1
 

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBGenSimMBNew_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBGenSimMBNew_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2_cff import Phase2
-process = cms.Process('SIM',Phase2)
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
+process = cms.Process('SIM',Phase2,hgcaltb)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -97,10 +98,6 @@ process.VtxSmeared.MaxY =  0
 process.HGCalTBAnalyzer.doDigis = False
 process.HGCalTBAnalyzer.doRecHits = False
 process.g4SimHits.StackingAction.TrackNeutrino = True
-process.g4SimHits.OnlySDs = ['AHcalSensitiveDetector',
-                             'HGCSensitiveDetector',
-                             'HGCalTB1601SensitiveDetector',
-                             'HcalTB06BeamDetector']
 
 # Path and EndPath definitions
 process.generation_step = cms.Path(process.pgen)

--- a/SimG4CMS/HGCalTestBeam/test/HGCalTBTimingGenSim_cfg.py
+++ b/SimG4CMS/HGCalTestBeam/test/HGCalTBTimingGenSim_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
 
-process = cms.Process('SIM')
+process = cms.Process('SIM', hgcaltb)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -22,7 +23,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('SimG4CMS.HGCalTestBeam.HGCalTimingAnalyzer_cfi')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+        input = cms.untracked.int32(10)
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
@@ -102,8 +103,7 @@ process.VtxSmeared.MinY = -7.5
 process.VtxSmeared.MaxY =  7.5
 process.g4SimHits.HGCSD.StoreAllG4Hits = True
 process.HGCalTimingAnalyzer.GroupHits = False
-process.g4SimHits.OnlySDs = ['HGCSensitiveDetector',
-                             'HcalTB06BeamDetector']
+
 process.g4SimHits.HGCSD.Detectors = 1
 process.g4SimHits.HGCSD.UseDetector = 1
 

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -682,3 +682,8 @@ phase2_common.toModify(g4SimHits,
                        MuonSD = dict( 
                        HaveDemoChambers = False ) 
 )
+
+from Configuration.Eras.Modifier_hgcaltb_cff import hgcaltb
+hgcaltb.toModify(g4SimHits,
+                 OnlySDs = ['AHcalSensitiveDetector', 'HGCSensitiveDetector', 'HGCalTB1601SensitiveDetector', 'HcalTB06BeamDetector']
+)


### PR DESCRIPTION
#### PR description:

Add selection of SD's for HGCal TB application. Selection of SD's to be checked depend on application. For test beam applications, many of the standard SD's need not be initialized. This PR takes care of that for TBH2 and TBHGCal applications

#### PR validation:

Use test workflows in SimG4CMS/HGCalTestBeam/test

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special