### PR TITLE
ele/ph mass fix

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1067,7 +1067,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
   // Will be overwritten later in the case of the regression
   ele.setCorrectedEcalEnergyError(egamma::ecalClusterEnergyUncertaintyElectronSpecific(*(ele.superCluster())));
   ele.setP4(GsfElectron::P4_FROM_SUPER_CLUSTER, momentum, 0, true);
-  ele.setMass(0.00050);
+  ele.setMass(0.0);
 
   //====================================================
   // brems fractions

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1067,6 +1067,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
   // Will be overwritten later in the case of the regression
   ele.setCorrectedEcalEnergyError(egamma::ecalClusterEnergyUncertaintyElectronSpecific(*(ele.superCluster())));
   ele.setP4(GsfElectron::P4_FROM_SUPER_CLUSTER, momentum, 0, true);
+  ele.setMass(0.00050);
 
   //====================================================
   // brems fractions

--- a/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
@@ -194,5 +194,6 @@ void RegressionHelper::applyCombinationRegression(reco::GsfElectron& ele) const 
                                         combinedMomentum);
 
     ele.setP4(reco::GsfElectron::P4_COMBINATION, newMomentum, combinedMomentumError, true);
+    ele.setMass(0.00050);
   }
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
@@ -194,6 +194,6 @@ void RegressionHelper::applyCombinationRegression(reco::GsfElectron& ele) const 
                                         combinedMomentum);
 
     ele.setP4(reco::GsfElectron::P4_COMBINATION, newMomentum, combinedMomentumError, true);
-    ele.setMass(0.00050);
+    ele.setMass(0.0);
   }
 }

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -946,25 +946,25 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
       if (candidateP4type_ == "fromEcalEnergy") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::ecal_photons));
         newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
-        newCandidate.setMass(0);
+        newCandidate.setMass(0.0);
       } else if (candidateP4type_ == "fromRegression1") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::regression1));
         newCandidate.setCandidateP4type(reco::Photon::regression1);
-        newCandidate.setMass(0);
+        newCandidate.setMass(0.0);
       } else if (candidateP4type_ == "fromRegression2") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
         newCandidate.setCandidateP4type(reco::Photon::regression2);
-        newCandidate.setMass(0);
+        newCandidate.setMass(0.0);
       } else if (candidateP4type_ == "fromRefinedSCRegression") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
         newCandidate.setCandidateP4type(reco::Photon::regression2);
-        newCandidate.setMass(0);
+        newCandidate.setMass(0.0);
       }
     } else {
       math::XYZVector gamma_momentum = direction.unit() * scRef->energy();
       math::XYZTLorentzVectorD p4(gamma_momentum.x(), gamma_momentum.y(), gamma_momentum.z(), scRef->energy());
       newCandidate.setP4(p4);
-      newCandidate.setMass(0);
+      newCandidate.setMass(0.0);
       newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
       // Make it an EE photon
       reco::Photon::FiducialFlags fiducialFlags;
@@ -1089,19 +1089,19 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     if (candidateP4type_ == "fromEcalEnergy") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::ecal_photons));
       newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
-      newCandidate.setMass(0);
+      newCandidate.setMass(0.0);
     } else if (candidateP4type_ == "fromRegression1") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::regression1));
       newCandidate.setCandidateP4type(reco::Photon::regression1);
-      newCandidate.setMass(0);
+      newCandidate.setMass(0.0);
     } else if (candidateP4type_ == "fromRegression2") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
       newCandidate.setCandidateP4type(reco::Photon::regression2);
-      newCandidate.setMass(0);
+      newCandidate.setMass(0.0);
     } else if (candidateP4type_ == "fromRefinedSCRegression") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
       newCandidate.setCandidateP4type(reco::Photon::regression2);
-      newCandidate.setMass(0);
+      newCandidate.setMass(0.0);
     }
 
     outputPhotonCollection.push_back(newCandidate);

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -946,20 +946,25 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
       if (candidateP4type_ == "fromEcalEnergy") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::ecal_photons));
         newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
+        newCandidate.setMass(0);
       } else if (candidateP4type_ == "fromRegression1") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::regression1));
         newCandidate.setCandidateP4type(reco::Photon::regression1);
+        newCandidate.setMass(0);
       } else if (candidateP4type_ == "fromRegression2") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
         newCandidate.setCandidateP4type(reco::Photon::regression2);
+        newCandidate.setMass(0);
       } else if (candidateP4type_ == "fromRefinedSCRegression") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
         newCandidate.setCandidateP4type(reco::Photon::regression2);
+        newCandidate.setMass(0);
       }
     } else {
       math::XYZVector gamma_momentum = direction.unit() * scRef->energy();
       math::XYZTLorentzVectorD p4(gamma_momentum.x(), gamma_momentum.y(), gamma_momentum.z(), scRef->energy());
       newCandidate.setP4(p4);
+      newCandidate.setMass(0);
       newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
       // Make it an EE photon
       reco::Photon::FiducialFlags fiducialFlags;
@@ -1084,15 +1089,19 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     if (candidateP4type_ == "fromEcalEnergy") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::ecal_photons));
       newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
+      newCandidate.setMass(0);
     } else if (candidateP4type_ == "fromRegression1") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::regression1));
       newCandidate.setCandidateP4type(reco::Photon::regression1);
+      newCandidate.setMass(0);
     } else if (candidateP4type_ == "fromRegression2") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
       newCandidate.setCandidateP4type(reco::Photon::regression2);
+      newCandidate.setMass(0);
     } else if (candidateP4type_ == "fromRefinedSCRegression") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
       newCandidate.setCandidateP4type(reco::Photon::regression2);
+      newCandidate.setMass(0);
     }
 
     outputPhotonCollection.push_back(newCandidate);


### PR DESCRIPTION
#### PR description:

Hello,
The electron and photon mass are not saved properly and nanoAOD users reported that many times. It is not related to nanoAOD. The problem is available in miniAOD too.
You can check the printout here
http://dalfonso.web.cern.ch/dalfonso/NANO/massDump.txt

I checked and found that the problem is not from the EGamma code but from TLorentzVector root class. I found that the TLorentz vector is set via pxpypzE for all object candidates. It seems fine but when I tested locally for a particle with pxpypzE=(1,1,1,sqrt(3)) I did not get the mass==0. You can easily reproduce it 
root -l
root [1] typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > XYZTLorentzVectorD
root [2] XYZTLorentzVectorD newP4(1,1,1,sqrt(3));
root [3] newP4.M()
(double) -2.1073424e-08

It is because of the precision problem in TLorentz vector and it is recommended to use PxPyPzM to have correct masses for low mass objects.
https://root.cern.ch/doc/master/classROOT_1_1Math_1_1PxPyPzM4D.html 

So I set the electron and photon masses by hand to 0.0005 and 0 GeV , respectively.

#### PR validation:

I generated electron and photon up to reco level using fastsim cmsDriver command and checked the photon and electron mass before and after this fix. Wrong mass values before the fix are corrected after the fix.


please let me know if you have any question.
Thanks ,
Reza
