### PR TITLE
[MiniAOD] Lower AK4 Puppi jets pT cut for Run 3

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -439,7 +439,7 @@ def miniAOD_customizeCommon(process):
     
         process.patJetsPuppi.jetChargeSource = cms.InputTag("patJetPuppiCharge")
     
-        process.selectedPatJetsPuppi.cut = cms.string("pt > 15")
+        process.selectedPatJetsPuppi.cut = cms.string("pt > 10")
     
         from PhysicsTools.PatAlgos.slimming.applyDeepBtagging_cff import applyDeepBtagging
         applyDeepBtagging( process )
@@ -457,6 +457,8 @@ def miniAOD_customizeCommon(process):
     (~pp_on_AA).toModify(process, _add_jetsPuppi)
 
     pp_on_AA.toModify(process, func = lambda p: addToProcessAndTask('slimmedJetsPuppi', _dummyPatJets.clone(), p, task))
+
+    (_run2_miniAOD_ANY | pA_2016).toModify(process.selectedPatJetsPuppi, cut = "pt > 15")
 
     # Embed pixelClusterTagInfos in slimmedJets
     process.patJets.addTagInfos = True

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -118,7 +118,7 @@ def miniAOD_customizeCommon(process):
     process.patOOTPhotons.photonSource = cms.InputTag("reducedEgamma","reducedOOTPhotons")
     process.patOOTPhotons.electronSource = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
     #
-    process.selectedPatJets.cut = cms.string("pt > 10")
+    process.selectedPatJets.cut = cms.string("pt > 15")
     process.selectedPatMuons.cut = cms.string("pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose')))")
     
     from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -440,6 +440,7 @@ def miniAOD_customizeCommon(process):
         process.patJetsPuppi.jetChargeSource = cms.InputTag("patJetPuppiCharge")
     
         process.selectedPatJetsPuppi.cut = cms.string("pt > 10")
+        (_run2_miniAOD_ANY | pA_2016).toModify(process.selectedPatJetsPuppi, cut = "pt > 15")
     
         from PhysicsTools.PatAlgos.slimming.applyDeepBtagging_cff import applyDeepBtagging
         applyDeepBtagging( process )
@@ -457,8 +458,6 @@ def miniAOD_customizeCommon(process):
     (~pp_on_AA).toModify(process, _add_jetsPuppi)
 
     pp_on_AA.toModify(process, func = lambda p: addToProcessAndTask('slimmedJetsPuppi', _dummyPatJets.clone(), p, task))
-
-    (_run2_miniAOD_ANY | pA_2016).toModify(process.selectedPatJetsPuppi, cut = "pt > 15")
 
     # Embed pixelClusterTagInfos in slimmedJets
     process.patJets.addTagInfos = True

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -440,7 +440,6 @@ def miniAOD_customizeCommon(process):
         process.patJetsPuppi.jetChargeSource = cms.InputTag("patJetPuppiCharge")
     
         process.selectedPatJetsPuppi.cut = cms.string("pt > 10")
-        (_run2_miniAOD_ANY | pA_2016).toModify(process.selectedPatJetsPuppi, cut = "pt > 15")
     
         from PhysicsTools.PatAlgos.slimming.applyDeepBtagging_cff import applyDeepBtagging
         applyDeepBtagging( process )

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -118,7 +118,7 @@ def miniAOD_customizeCommon(process):
     process.patOOTPhotons.photonSource = cms.InputTag("reducedEgamma","reducedOOTPhotons")
     process.patOOTPhotons.electronSource = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
     #
-    process.selectedPatJets.cut = cms.string("pt > 15")
+    process.selectedPatJets.cut = cms.string("pt > 10")
     process.selectedPatMuons.cut = cms.string("pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose')))")
     
     from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon


### PR DESCRIPTION
This PR lowers the pT cut on AK4 Puppi jets (`slimmedJetsPuppi`) from 15 GeV to 10 GeV in Run 3 MiniAODs, same pT cut value as AK4 CHS jets (`slimmedJets`). 
- Event size increases by about 0.37%. The size comparison tests were performed with 5000 events from a UL18 TTJets AODSIM file.

#### PR validation:

passes the usual runTheMatrix test: `runTheMatrix.py -l limited -i all --ibeos`