### PR TITLE
Removed unused member data in TriggerOutputBranches

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TriggerOutputBranches.h
+++ b/PhysicsTools/NanoAOD/plugins/TriggerOutputBranches.h
@@ -30,7 +30,6 @@ private:
 
   edm::EDGetToken m_token;
   std::string m_baseName;
-  bool m_singleton;
   UInt_t m_counter;
   struct NamedBranchPtr {
     std::string name, title;


### PR DESCRIPTION
#### PR description:

This should fix an UBSAN warning.

#### PR validation:

Code compiles.