### PR TITLE
Fix Phase 2 ECAL digis gain id bit mask

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalConstants.h
+++ b/DataFormats/EcalDigi/interface/EcalConstants.h
@@ -1,31 +1,37 @@
 //Namespaces for Phase1 and Phase2
-#ifndef CondFormats_EcalObject_EcalConstants_h
-#define CondFormats_EcalObject_EcalConstants_h
+#ifndef DataFormats_EcalDigi_EcalConstants_h
+#define DataFormats_EcalDigi_EcalConstants_h
 
 class ecalPh2 {
 public:
-  static constexpr double Samp_Period = 6.25;
-  static constexpr unsigned int NGAINS = 2;
-  static constexpr float gains[NGAINS] = {10., 1.};
-  static constexpr unsigned int gainId1 = 1;
-  static constexpr unsigned int gainId10 = 0;
-  static constexpr unsigned int sampleSize = 16;
-  static constexpr unsigned int NBITS = 12;                 // number of available bits
-  static constexpr unsigned int MAXADC = (1 << NBITS) - 1;  // 2^12 -1,  adc max range
-  static constexpr unsigned int kEBChannels = 61200;
-  static constexpr double maxEneEB = 2000.;
-  static constexpr unsigned int kNOffsets = 2000;
-  static constexpr unsigned int kAdcMask = 0xFFF;
-  static constexpr unsigned int kGainIdMask = 0x3;
-
-};  // namespace ecalPh2
+  static constexpr double Samp_Period = 6.25;               // ADC sampling period in ns
+  static constexpr unsigned int NGAINS = 2;                 // Number of CATIA gains
+  static constexpr float gains[NGAINS] = {10., 1.};         // CATIA gain values
+  static constexpr unsigned int gainId1 = 1;                // Position of gain 1 in gains array
+  static constexpr unsigned int gainId10 = 0;               // Position of gain 10 in gains array
+  static constexpr unsigned int sampleSize = 16;            // Number of samples per event
+  static constexpr unsigned int NBITS = 12;                 // Number of available bits
+  static constexpr unsigned int MAXADC = (1 << NBITS) - 1;  // 2^NBITS - 1,  ADC max range
+  static constexpr unsigned int kEBChannels = 61200;        // Number of channels in the barrel
+  static constexpr double maxEneEB = 2000.;                 // Max attainable energy in the barrel in GeV
+                                                            // ~(MAXADC * 10(gain) * 0.05 GeV(LSB at gain 10))
+  static constexpr unsigned int kNOffsets = 2000;           // Number of time offsets generated for APD pulse shape
+                                                            // simulation and reused for every kNOffsets^th channel
+  static constexpr unsigned int kAdcMask = 0xFFF;           // ADC sample mask for unpacking
+  static constexpr unsigned int kGainIdMask = 0x1;          // Gain id mask for unpacking
+};
 
 class ecalPh1 {
 public:
-  static constexpr double Samp_Period = 25.;
-  static constexpr unsigned int NGAINS = 4;
-  static constexpr float gains[NGAINS] = {0., 12., 6., 1.};
-  static constexpr unsigned int sampleSize = 10;
-  static constexpr unsigned int kNOffsets = 2000;
-};  // namespace ecalPh1
+  static constexpr double Samp_Period = 25.;                 // ADC sampling period in ns
+  static constexpr unsigned int NGAINS = 4;                  // Number of MGPA gains including a zero gain that
+                                                             // could be encoded in the gain id mask
+  static constexpr float gains[NGAINS] = {0., 12., 6., 1.};  // MGPA gain values including a zero gain
+  static constexpr unsigned int sampleSize = 10;             // Number of samples per event
+  static constexpr unsigned int NBITS = 12;                  // Number of available bits
+  static constexpr unsigned int kNOffsets = 2000;            // Number of time offsets generated for APD pulse shape
+                                                             // simulation and reused for every kNOffsets^th channel
+  static constexpr unsigned int kAdcMask = 0xFFF;            // ADC sample mask for unpacking
+  static constexpr unsigned int kGainIdMask = 0x3;           // Gain id mask for unpacking
+};
 #endif

--- a/DataFormats/EcalDigi/interface/EcalMGPASample.h
+++ b/DataFormats/EcalDigi/interface/EcalMGPASample.h
@@ -1,21 +1,24 @@
-#ifndef DIGIECAL_ECALMGPASAMPLE_H
-#define DIGIECAL_ECALMGPASAMPLE_H
+#ifndef DataFormats_EcalDigi_EcalMGPASample_h
+#define DataFormats_EcalDigi_EcalMGPASample_h
 
 #include <iosfwd>
 #include <cstdint>
+#include "DataFormats/EcalDigi/interface/EcalConstants.h"
 
 namespace ecalMGPA {
   typedef uint16_t sample_type;
 
   /// get the ADC sample (12 bits)
-  constexpr int adc(sample_type sample) { return sample & 0xFFF; }
+  constexpr int adc(sample_type sample) { return sample & ecalPh1::kAdcMask; }
   /// get the gainId (2 bits)
-  constexpr int gainId(sample_type sample) { return (sample >> 12) & 0x3; }
-  constexpr sample_type pack(int adc, int gainId) { return (adc & 0xFFF) | ((gainId & 0x3) << 12); }
+  constexpr int gainId(sample_type sample) { return (sample >> ecalPh1::NBITS) & ecalPh1::kGainIdMask; }
+  constexpr sample_type pack(int adc, int gainId) {
+    return (adc & ecalPh1::kAdcMask) | ((gainId & ecalPh1::kGainIdMask) << ecalPh1::NBITS);
+  }
 }  // namespace ecalMGPA
 
 /** \class EcalMGPASample
- *  Simple container packer/unpacker for a single sample from teh MGPA electronics
+ *  Simple container packer/unpacker for a single sample from the MGPA electronics
  *
  *
  */
@@ -28,9 +31,9 @@ public:
   /// get the raw word
   uint16_t raw() const { return theSample; }
   /// get the ADC sample (12 bits)
-  int adc() const { return theSample & 0xFFF; }
+  int adc() const { return theSample & ecalPh1::kAdcMask; }
   /// get the gainId (2 bits)
-  int gainId() const { return (theSample >> 12) & 0x3; }
+  int gainId() const { return (theSample >> ecalPh1::NBITS) & ecalPh1::kGainIdMask; }
   /// for streaming
   uint16_t operator()() const { return theSample; }
   operator uint16_t() const { return theSample; }


### PR DESCRIPTION
#### PR description:

This fixes the Phase 2 ECAL digis gain id bit mask by setting it to use one bit instead of two.
In addition, ADC and gain id masks for the Phase 1 MGPA sample are introduced similar to the existing Phase 2 ones and the constants are documented. No output changes are expected.

#### PR validation:

Passes limited matrix tests.