### PR TITLE
Technical fixes for geometry DB payload creation

### DIFF
--- a/CondTools/Geometry/test/writehelpers/geometryExtended2021_writer.py
+++ b/CondTools/Geometry/test/writehelpers/geometryExtended2021_writer.py
@@ -10,7 +10,6 @@ process.load('CondCore.CondDB.CondDB_cfi')
 process.load('Configuration.Geometry.GeometryExtended2021_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
-process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
 process.load('Geometry.CaloEventSetup.CaloGeometryDBWriter_cfi')
 process.load('CondTools.Geometry.HcalParametersWriter_cff')
 

--- a/DetectorDescription/OfflineDBLoader/plugins/OutputDDToDDL.cc
+++ b/DetectorDescription/OfflineDBLoader/plugins/OutputDDToDDL.cc
@@ -91,7 +91,7 @@ OutputDDToDDL::OutputDDToDDL(const edm::ParameterSet& iConfig) : m_fname() {
            << std::endl;
   (*m_xos) << std::fixed << std::setprecision(18);
 
-  ddToken_ = esConsumes<DDCompactView, IdealGeometryRecord>();
+  ddToken_ = esConsumes<DDCompactView, IdealGeometryRecord, edm::Transition::BeginRun>();
 }
 
 OutputDDToDDL::~OutputDDToDDL() {

--- a/Geometry/CSCGeometry/test/stubs/CSCGeometryAnalyzer.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGeometryAnalyzer.cc
@@ -27,13 +27,14 @@ private:
   const int dashedLineWidth_;
   const std::string dashedLine_;
   const std::string myName_;
-  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> ddToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> ddToken_;
 };
 
 CSCGeometryAnalyzer::CSCGeometryAnalyzer(const edm::ParameterSet& iConfig)
-    : dashedLineWidth_(194), dashedLine_(std::string(dashedLineWidth_, '-')), myName_("CSCGeometryAnalyzer") {
-  ddToken_ = esConsumes<CSCGeometry, MuonGeometryRecord>();
-}
+    : dashedLineWidth_(194),
+      dashedLine_(std::string(dashedLineWidth_, '-')),
+      myName_("CSCGeometryAnalyzer"),
+      ddToken_(esConsumes<CSCGeometry, MuonGeometryRecord>()) {}
 
 CSCGeometryAnalyzer::~CSCGeometryAnalyzer() {}
 
@@ -45,7 +46,7 @@ void CSCGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
   std::cout << "start " << dashedLine_ << std::endl;
   std::cout << "pi = " << dPi << ", radToDeg = " << radToDeg << std::endl;
 
-  edm::ESTransientHandle<CSCGeometry> pDD = iSetup.getTransientHandle(ddToken_);
+  const edm::ESTransientHandle<CSCGeometry> pDD = iSetup.getTransientHandle(ddToken_);
   std::cout << " Geometry node for CSCGeom is  " << &(*pDD) << std::endl;
   std::cout << " I have " << pDD->detTypes().size() << " detTypes" << std::endl;
   std::cout << " I have " << pDD->detUnits().size() << " detUnits" << std::endl;

--- a/Geometry/CSCGeometry/test/stubs/CSCGeometryAnalyzer.cc
+++ b/Geometry/CSCGeometry/test/stubs/CSCGeometryAnalyzer.cc
@@ -27,10 +27,13 @@ private:
   const int dashedLineWidth_;
   const std::string dashedLine_;
   const std::string myName_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> ddToken_;
 };
 
 CSCGeometryAnalyzer::CSCGeometryAnalyzer(const edm::ParameterSet& iConfig)
-    : dashedLineWidth_(194), dashedLine_(std::string(dashedLineWidth_, '-')), myName_("CSCGeometryAnalyzer") {}
+    : dashedLineWidth_(194), dashedLine_(std::string(dashedLineWidth_, '-')), myName_("CSCGeometryAnalyzer") {
+  ddToken_ = esConsumes<CSCGeometry, MuonGeometryRecord>();
+}
 
 CSCGeometryAnalyzer::~CSCGeometryAnalyzer() {}
 
@@ -42,8 +45,7 @@ void CSCGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
   std::cout << "start " << dashedLine_ << std::endl;
   std::cout << "pi = " << dPi << ", radToDeg = " << radToDeg << std::endl;
 
-  edm::ESHandle<CSCGeometry> pDD;
-  iSetup.get<MuonGeometryRecord>().get(pDD);
+  edm::ESTransientHandle<CSCGeometry> pDD = iSetup.getTransientHandle(ddToken_);
   std::cout << " Geometry node for CSCGeom is  " << &(*pDD) << std::endl;
   std::cout << " I have " << pDD->detTypes().size() << " detTypes" << std::endl;
   std::cout << " I have " << pDD->detUnits().size() << " detUnits" << std::endl;

--- a/Geometry/GEMGeometry/test/testGEMGeometryFromDB_cfg.py
+++ b/Geometry/GEMGeometry/test/testGEMGeometryFromDB_cfg.py
@@ -4,12 +4,25 @@ from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process("Demo",eras.run3_GEM)
 
-process.load('Configuration.Geometry.GeometryExtended2021_cff')
-process.load('Configuration.Geometry.GeometryExtended2021Reco_cff')
+
+
+process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.XMLFromDBSource.label = cms.string('Extended')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2021', '')
+
+from Configuration.AlCa.autoCond import autoCond
+process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
+
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
+
 process.source = cms.Source("EmptySource")
 
 process.test = cms.EDAnalyzer("GEMGeometryAnalyzer")

--- a/Geometry/GEMGeometry/test/testGEMGeometryFromLocalDB_cfg.py
+++ b/Geometry/GEMGeometry/test/testGEMGeometryFromLocalDB_cfg.py
@@ -1,0 +1,82 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+
+process = cms.Process("Demo",eras.run3_GEM)
+
+
+
+process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('CondCore.CondDB.CondDB_cfi')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.XMLFromDBSource.label = cms.string('Extended')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2021', '')
+
+from Configuration.AlCa.autoCond import autoCond
+process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource") 
+
+process.source = cms.Source("EmptySource")
+
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.CondDB.timetype = cms.untracked.string('runnumber')
+process.CondDB.connect = cms.string('sqlite_file:myfile.db')
+process.PoolDBESSourceGeometry = cms.ESSource("PoolDBESSource",
+                                          process.CondDB,
+                                          toGet = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'),tag = cms.string('XMLFILE_Geometry_TagXX_Extended2021_mc')),
+                                          cms.PSet(record = cms.string('IdealGeometryRecord'),tag = cms.string('TKRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('PEcalBarrelRcd'),   tag = cms.string('EBRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('PEcalEndcapRcd'),   tag = cms.string('EERECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('PEcalPreshowerRcd'),tag = cms.string('EPRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('PHcalRcd'),         tag = cms.string('HCALRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('PCaloTowerRcd'),    tag = cms.string('CTRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('PZdcRcd'),          tag = cms.string('ZDCRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('PCastorRcd'),       tag = cms.string('CASTORRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('CSCRecoGeometryRcd'),tag = cms.string('CSCRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('CSCRecoDigiParametersRcd'),tag = cms.string('CSCRECODIGI_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('DTRecoGeometryRcd'),tag = cms.string('DTRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('RPCRecoGeometryRcd'),tag = cms.string('RPCRECO_Geometry_TagXX')),
+                                          cms.PSet(record = cms.string('GEMRecoGeometryRcd'),tag = cms.string('GEMRECO_Geometry_TagXX'))
+                                          )
+                                        )
+process.es_prefer_geometry = cms.ESPrefer( "PoolDBESSource", "PoolDBESSourceGeometry" )
+
+
+process.test = cms.EDAnalyzer("GEMGeometryAnalyzer")
+
+process.p = cms.Path(process.test)
+
+### TO ACTIVATE LogTrace NEED TO COMPILE IT WITH:
+### -----------------------------------------------------------
+### --> scram b -j8 USER_CXXFLAGS="-DEDM_ML_DEBUG"
+### Make sure that you first cleaned your CMSSW version:
+### --> scram b clean
+### before issuing the scram command above
+###############################################################
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+# 
+# 
+process.MessageLogger.debugModules = cms.untracked.vstring("*")
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.files.junk = dict()
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("DEBUG"),
+    default = cms.untracked.PSet( limit = cms.untracked.int32(0) ),
+    FwkReport = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
+    # GEMGeometryBuilderFromDDD   = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
+    # GEMNumberingScheme            = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
+)


### PR DESCRIPTION
This PR is a collection of fixes and enhancements to support geometry DB payload creation. The changes are as follows.

`CondTools/Geometry/test/writehelpers/geometryExtended2021_writer.py` -- remove improper DD4hep dependence from this DDD script.

`DetectorDescription/OfflineDBLoader/plugins/OutputDDToDDL.cc` -- fix to prevent run-time error related to Event Setup.

`Geometry/CSCGeometry/test/stubs/CSCGeometryAnalyzer.cc` -- ES Get Token migration to allow CSC geometry test to run in 12_3.

`Geometry/GEMGeometry/test/testGEMGeometry_cfg.py`
`Geometry/GEMGeometry/test/testGEMGeometryFromDB_cfg.py`
`Geometry/GEMGeometry/test/testGEMGeometryFromLocalDB_cfg.py` -- scripts to help compare GEM reco geometry in XML, DB, and a local DB.

None of the files in this PR are used by any workflow.  They are only used for expert tools.

#### PR validation:

DDD DB payloads were created succesfully to verify the changes in this PR. Also, the test scripts were run, and they produce reasonable output.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

A backport to 12_2 would promote consistency but it is not strictly necessary. I can manually copy these changes to a 12_2 working directory if it turns out I need them.