### PR TITLE
Rotated wafer geometry for 12 placement index

### DIFF
--- a/Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcal.xml
+++ b/Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcal.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection label="hgcal.xml" eval="true">
+  <Constant name="WaferSize"             value="166.4408*mm"/>
+  <Constant name="WaferThickness"        value="0.30*mm"/>
+  <Constant name="WaferThicknessFine"    value="0.30*mm"/>
+  <Constant name="WaferThicknessCoarse1" value="0.20*mm"/>
+  <Constant name="WaferThicknessCoarse2" value="0.30*mm"/>
+  <Constant name="SensorSeparation"      value="1.00*mm"/>
+  <Constant name="ModuleThicknessEE"     value="9.325*mm"/>
+  <Constant name="ModuleThicknessHE"     value="8.70*mm"/>
+  <Constant name="CellThicknessFine"     value="0.12*mm"/>
+  <Constant name="CellThicknessCoarse1"  value="0.20*mm"/>
+  <Constant name="CellThicknessCoarse2"  value="0.30*mm"/>
+  <Constant name="NumberOfCellsFine"     value="12"/>
+  <Constant name="NumberOfCellsCoarse"   value="8"/>
+  <Constant name="LayerRotation"         value="30*deg"/>
+</ConstantsSection>
+
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcalpos.xml
+++ b/Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcalpos.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<PosPartSection label="hgcalpos.xml">
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer00Fine"/>
+    <Translation x="0.0*cm" y="-120.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer01Fine"/>
+    <Translation x="0.0*cm" y="-100.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer02Fine"/>
+    <Translation x="0.0*cm" y="-80.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer03Fine"/>
+    <Translation x="0.0*cm" y="-60.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer04Fine"/>
+    <Translation x="0.0*cm" y="-40.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer05Fine"/>
+    <Translation x="0.0*cm" y="-20.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer06Fine"/>
+    <Translation x="0.0*cm" y="0.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer07Fine"/>
+    <Translation x="0.0*cm" y="20.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer08Fine"/>
+    <Translation x="0.0*cm" y="40.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer09Fine"/>
+    <Translation x="0.0*cm" y="60.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer10Fine"/>
+    <Translation x="0.0*cm" y="80.0*cm" z="0*cm"/>
+  </PosPart>
+  <PosPart copyNumber="1">
+    <rParent name="cms:CMSE"/>
+    <rChild name="hgcalwafer:HGCalEEWafer11Fine"/>
+    <Translation x="0.0*cm" y="100.0*cm" z="0*cm"/>
+  </PosPart>
+</PosPartSection>
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcalwafer.xml
+++ b/Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcalwafer.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection label="hgcalwafer.xml" eval="true">
+  <Constant name="ModuleThicknessEE"     value="[hgcal:ModuleThicknessEE]"/>
+  <Constant name="ModuleThicknessHE"     value="[hgcal:ModuleThicknessHE]"/>
+  <Constant name="WaferSize"             value="[hgcal:WaferSize]"/>
+  <Constant name="WaferThickness"        value="[hgcal:WaferThickness]"/>
+  <Constant name="WaferThicknessFine"    value="[hgcal:WaferThicknessFine]"/>
+  <Constant name="WaferThicknessCoarse1" value="[hgcal:WaferThicknessCoarse1]"/>
+  <Constant name="WaferThicknessCoarse2" value="[hgcal:WaferThicknessCoarse2]"/>
+  <Constant name="SensorSeparation"      value="[hgcal:SensorSeparation]"/>
+  <Constant name="CellThicknessFine"     value="[hgcal:CellThicknessFine]"/>
+  <Constant name="CellThicknessCoarse1"  value="[hgcal:CellThicknessCoarse1]"/>
+  <Constant name="CellThicknessCoarse2"  value="[hgcal:CellThicknessCoarse2]"/>
+  <Constant name="NumberOfCellsFine"     value="[hgcal:NumberOfCellsFine]"/>
+  <Constant name="NumberOfCellsCoarse"   value="[hgcal:NumberOfCellsCoarse]"/>
+</ConstantsSection>
+
+<PosPartSection label="hgcalwafer.xml" eval="true">
+  <Algorithm name="hgcal:DDHGCalWaferFR">
+    <rParent name="hgcalwafer:HGCalEEWafer"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <String name="WaferTag" value="Fine"/>
+    <Vector name="WaferOrinet" type="numeric" nEntries="6">
+      0, 1, 2, 3, 4, 5 </Vector>
+    <Vector name="WaferFace" type="numeric" nEntries="6"> 
+      0, 0, 0, 0, 0, 0 </Vector>
+    <Vector name="WaferPlacementIndex" type="string" nEntries="6"> 
+      06, 07, 08, 09, 10, 11 </Vector>  
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap, HGCalEEMotherBoard, 
+      HGCalEEConnector, HGCalEEPCB, HGCalEEEpoxy,
+      HGCalEEEpoxyT, HGCalEEKapton, HGCalEESensitive,
+      HGCalEEBasePlate</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      0, 1, 2, 3, 4, 7, 5, 6, 5, 8 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsFine]"/>
+    <Numeric name="CellType"         value="0"/>
+    <Vector name="CellOffset" type="numeric" nEntries="4"> 
+      0, 1, 13, 19 </Vector>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull0Fine,   hgcalcell:HGCalEECellCorner01Fine, 
+      hgcalcell:HGCalEECellCorner02Fine,hgcalcell:HGCalEECellCorner03Fine,
+      hgcalcell:HGCalEECellCorner04Fine,hgcalcell:HGCalEECellCorner05Fine,
+      hgcalcell:HGCalEECellCorner06Fine,hgcalcell:HGCalEECellCorner07Fine,
+      hgcalcell:HGCalEECellCorner08Fine,hgcalcell:HGCalEECellCorner09Fine,
+      hgcalcell:HGCalEECellCorner10Fine,hgcalcell:HGCalEECellCorner11Fine,
+      hgcalcell:HGCalEECellCorner12Fine,hgcalcell:HGCalEECellTrunc01Fine,
+      hgcalcell:HGCalEECellTrunc02Fine, hgcalcell:HGCalEECellTrunc03Fine,
+      hgcalcell:HGCalEECellTrunc04Fine, hgcalcell:HGCalEECellTrunc05Fine,
+      hgcalcell:HGCalEECellTrunc06Fine, hgcalcell:HGCalEECellExten01Fine,
+      hgcalcell:HGCalEECellExten02Fine, hgcalcell:HGCalEECellExten03Fine,
+      hgcalcell:HGCalEECellExten04Fine, hgcalcell:HGCalEECellExten05Fine, 
+      hgcalcell:HGCalEECellExten06Fine</Vector>
+  </Algorithm>
+  <Algorithm name="hgcal:DDHGCalWaferFR">
+    <rParent name="hgcalwafer:HGCalEEWafer"/>
+    <String name="ModuleMaterial"    value="materials:Air"/>
+    <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
+    <Numeric name="WaferSize"        value="[WaferSize]"/>
+    <Numeric name="SensorSeparation" value="[SensorSeparation]"/>
+    <Numeric name="WaferThickness"   value="[WaferThicknessFine]"/>
+    <String name="WaferTag" value="Fine"/>
+    <Vector name="WaferOrinet" type="numeric" nEntries="6">
+      0, 1, 2, 3, 4, 5 </Vector>
+    <Vector name="WaferFace" type="numeric" nEntries="6"> 
+      1, 1, 1, 1, 1, 1 </Vector>
+    <Vector name="WaferPlacementIndex" type="string" nEntries="6"> 
+      00, 01, 02, 03, 04, 05 </Vector>  
+    <Vector name="LayerNames" type="string" nEntries="9">
+      HGCalEEAirGap, HGCalEEMotherBoard, 
+      HGCalEEConnector, HGCalEEPCB, HGCalEEEpoxy,
+      HGCalEEEpoxyT, HGCalEEKapton, HGCalEESensitive,
+      HGCalEEBasePlate</Vector>
+    <Vector name="LayerMaterials" type="string" nEntries="9">
+      materials:Air, hgcalMaterial:HGC_G10-FR4, hgcalMaterial:HGC_EEConnector,
+      hgcalMaterial:HGC_G10-FR4, materials:Epoxy, materials:Epoxy, 
+      materials:Kapton, materials:Silicon, hgcalMaterial:WCu</Vector>
+    <Vector name="LayerThickness" type="numeric" nEntries="9">
+      0.225*mm, 1.60*mm, 3.73*mm, 1.60*mm, 0.075*mm, 0.065*mm, 0.265*mm, 
+      [WaferThickness], 1.40*mm </Vector>
+    <Vector name="LayerTypes" type="numeric" nEntries="9"> 
+      0, 0, 0, 0, 0, 0, 0, 1, 0 </Vector>
+    <Vector name="Layers" type="numeric" nEntries="10"> 
+      8, 5, 6, 5, 7, 4, 3, 2, 1, 0 </Vector>
+    <Numeric name="NCells"           value="[NumberOfCellsFine]"/>
+    <Numeric name="CellType"         value="0"/>
+    <Vector name="CellOffset" type="numeric" nEntries="4"> 
+      0, 1, 13, 19 </Vector>
+    <Vector name="CellNames" type="string" nEntries="25">
+      hgcalcell:HGCalEECellFull1Fine,   hgcalcell:HGCalEECellCorner21Fine, 
+      hgcalcell:HGCalEECellCorner22Fine,hgcalcell:HGCalEECellCorner23Fine,
+      hgcalcell:HGCalEECellCorner24Fine,hgcalcell:HGCalEECellCorner25Fine,
+      hgcalcell:HGCalEECellCorner26Fine,hgcalcell:HGCalEECellCorner27Fine,
+      hgcalcell:HGCalEECellCorner28Fine,hgcalcell:HGCalEECellCorner29Fine,
+      hgcalcell:HGCalEECellCorner30Fine,hgcalcell:HGCalEECellCorner31Fine,
+      hgcalcell:HGCalEECellCorner32Fine,hgcalcell:HGCalEECellTrunc21Fine,
+      hgcalcell:HGCalEECellTrunc22Fine, hgcalcell:HGCalEECellTrunc23Fine,
+      hgcalcell:HGCalEECellTrunc24Fine, hgcalcell:HGCalEECellTrunc25Fine,
+      hgcalcell:HGCalEECellTrunc26Fine, hgcalcell:HGCalEECellExten21Fine,
+      hgcalcell:HGCalEECellExten22Fine, hgcalcell:HGCalEECellExten23Fine,
+      hgcalcell:HGCalEECellExten24Fine, hgcalcell:HGCalEECellExten25Fine, 
+      hgcalcell:HGCalEECellExten26Fine</Vector>
+  </Algorithm>
+  </PosPartSection>
+</DDDefinition>

--- a/Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcalwafer.xml
+++ b/Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcalwafer.xml
@@ -18,7 +18,7 @@
 </ConstantsSection>
 
 <PosPartSection label="hgcalwafer.xml" eval="true">
-  <Algorithm name="hgcal:DDHGCalWaferFR">
+  <Algorithm name="hgcal:DDHGCalWaferFullRotated">
     <rParent name="hgcalwafer:HGCalEEWafer"/>
     <String name="ModuleMaterial"    value="materials:Air"/>
     <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>
@@ -67,7 +67,7 @@
       hgcalcell:HGCalEECellExten04Fine, hgcalcell:HGCalEECellExten05Fine, 
       hgcalcell:HGCalEECellExten06Fine</Vector>
   </Algorithm>
-  <Algorithm name="hgcal:DDHGCalWaferFR">
+  <Algorithm name="hgcal:DDHGCalWaferFullRotated">
     <rParent name="hgcalwafer:HGCalEEWafer"/>
     <String name="ModuleMaterial"    value="materials:Air"/>
     <Numeric name="ModuleThickness"  value="[ModuleThicknessEE]"/>

--- a/Geometry/HGCalCommonData/plugins/DDHGCalWaferFR.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalWaferFR.cc
@@ -1,0 +1,237 @@
+///////////////////////////////////////////////////////////////////////////////
+// File: DDHGCalWaferFR.cc
+// Description: Geometry factory class for a full silicon Wafer
+// Created by Sunanda Banerjee, Pruthvi Suryadevara, Indranil Das
+///////////////////////////////////////////////////////////////////////////////
+#include "DetectorDescription/Core/interface/DDAlgorithm.h"
+#include "DetectorDescription/Core/interface/DDAlgorithmFactory.h"
+#include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
+#include "DetectorDescription/Core/interface/DDLogicalPart.h"
+#include "DetectorDescription/Core/interface/DDMaterial.h"
+#include "DetectorDescription/Core/interface/DDSolid.h"
+#include "DetectorDescription/Core/interface/DDSplit.h"
+#include "DetectorDescription/Core/interface/DDTypes.h"
+#include "DetectorDescription/Core/interface/DDutils.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
+#include "Geometry/HGCalCommonData/interface/HGCalCell.h"
+
+#include <string>
+#include <vector>
+#include <sstream>
+
+//#define EDM_ML_DEBUG
+
+class DDHGCalWaferFR : public DDAlgorithm {
+public:
+  // Constructor and Destructor
+  DDHGCalWaferFR();
+  ~DDHGCalWaferFR() override;
+
+  void initialize(const DDNumericArguments& nArgs,
+                  const DDVectorArguments& vArgs,
+                  const DDMapArguments& mArgs,
+                  const DDStringArguments& sArgs,
+                  const DDStringVectorArguments& vsArgs) override;
+  void execute(DDCompactView& cpv) override;
+
+private:
+  std::string material_;                 // Material name for module with gap
+  std::string waferTag_;                 // Tag for type pf wafer
+  double thick_;                         // Module thickness
+  double waferSize_;                     // Wafer size
+  double waferSepar_;                    // Sensor separation
+  double waferThick_;                    // Wafer thickness
+  std::vector<std::string> layerNames_;  // Names of the layers
+  std::vector<std::string> materials_;   // Materials of the layers
+  std::vector<std::string> tag_;         // Tag of placement index
+  std::vector<double> layerThick_;       // Thickness of layers
+  std::vector<int> layerType_;           // Layer types
+  std::vector<int> copyNumber_;          // Initial copy numbers
+  std::vector<int> layers_;              // Number of layers in a section
+  std::vector<int> orient_;              // Orientation of wafer
+  std::vector<int> face_;                // Front or back of cooling layer
+  int nCells_;                           // Half number of cells along u-v axis
+  int cellType_;                         // Cell Type (0,1,2: Fine, Course 2/3)
+  std::vector<int> cellOffset_;          // Offset of cells of each type
+  std::vector<std::string> cellNames_;   // Name of the cells
+  std::string nameSpace_;                // Namespace to be used
+};
+
+DDHGCalWaferFR::DDHGCalWaferFR() {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: Creating an instance";
+#endif
+}
+
+DDHGCalWaferFR::~DDHGCalWaferFR() {}
+
+void DDHGCalWaferFR::initialize(const DDNumericArguments& nArgs,
+                               const DDVectorArguments& vArgs,
+                               const DDMapArguments&,
+                               const DDStringArguments& sArgs,
+                               const DDStringVectorArguments& vsArgs) {
+  material_ = sArgs["ModuleMaterial"];
+  thick_ = nArgs["ModuleThickness"];
+  waferSize_ = nArgs["WaferSize"];
+  waferSepar_ = nArgs["SensorSeparation"];
+  waferThick_ = nArgs["WaferThickness"];
+  waferTag_ = sArgs["WaferTag"];
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: Module " << parent().name() << " made of " << material_ << " T "
+                                << thick_ << " Wafer 2r " << waferSize_ << " Half Separation " << waferSepar_ << " T "
+                                << waferThick_;
+#endif
+  orient_ = dbl_to_int(vArgs["WaferOrinet"]);
+  face_ = dbl_to_int(vArgs["WaferFace"]);
+  tag_ = vsArgs["WaferPlacementIndex"];
+  layerNames_ = vsArgs["LayerNames"];
+  materials_ = vsArgs["LayerMaterials"];
+  layerThick_ = vArgs["LayerThickness"];
+  layerType_ = dbl_to_int(vArgs["LayerTypes"]);
+  copyNumber_.resize(materials_.size(), 1);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << layerNames_.size() << " types of volumes";
+  for (unsigned int i = 0; i < layerNames_.size(); ++i)
+    edm::LogVerbatim("HGCalGeom") << "Volume [" << i << "] " << layerNames_[i] << " of thickness " << layerThick_[i]
+                                  << " filled with " << materials_[i] << " type " << layerType_[i];
+#endif
+  layers_ = dbl_to_int(vArgs["Layers"]);
+#ifdef EDM_ML_DEBUG
+  std::ostringstream st1;
+  for (unsigned int i = 0; i < layers_.size(); ++i)
+    st1 << " [" << i << "] " << layers_[i];
+  edm::LogVerbatim("HGCalGeom") << "There are " << layers_.size() << " blocks" << st1.str();
+#endif
+  nCells_ = (int)(nArgs["NCells"]);
+  cellType_ = (int)(nArgs["CellType"]);
+  cellNames_ = vsArgs["CellNames"];
+  cellOffset_ = dbl_to_int(vArgs["CellOffset"]);
+  nameSpace_ = DDCurrentNamespace::ns();
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: Cells/Wafer " << nCells_ << " Cell Type " << cellType_
+                                << " NameSpace " << nameSpace_ << " # of cells " << cellNames_.size();
+  std::ostringstream st2;
+  for (unsigned int i = 0; i < cellOffset_.size(); ++i)
+    st2 << " [" << i << "] " << cellOffset_[i];
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << cellOffset_.size() << " types of cells with offsets " << st2.str();
+  for (unsigned int k = 0; k < cellNames_.size(); ++k)
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: Cell[" << k << "] " << cellNames_[k];
+#endif
+}
+
+void DDHGCalWaferFR::execute(DDCompactView& cpv) {
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "==>> Executing DDHGCalWaferF...";
+#endif
+
+  static constexpr double tol = 0.00001;
+  static const double sqrt3 = std::sqrt(3.0);
+  double rM = 0.5 * waferSize_;
+  double RM2 = rM / sqrt3;
+  double r2 = 0.5 * waferSize_;
+  double R2 = r2 / sqrt3;
+  const int nFine(nCells_), nCoarse(nCells_);
+  HGCalCell wafer(waferSize_, nFine, nCoarse);
+  for (unsigned int k = 0; k<tag_.size(); ++k){
+  // First the mother
+  std::vector<double> xM = {rM, 0, -rM, -rM, 0, rM};
+  std::vector<double> yM = {RM2, 2 * RM2, RM2, -RM2, -2 * RM2, -RM2};
+  std::vector<double> zw = {-0.5 * thick_, 0.5 * thick_};
+  std::vector<double> zx(2, 0), zy(2, 0), scale(2, 1.0);
+  std::string parentName = parent().name().name();
+  parentName = parentName + tag_[k] + waferTag_;
+  DDSolid solid = DDSolidFactory::extrudedpolygon(parentName, xM, yM, zw, zx, zy, scale);
+  DDName matName(DDSplit(material_).first, DDSplit(material_).second);
+  DDMaterial matter(matName);
+  DDLogicalPart glogM = DDLogicalPart(solid.ddname(), matter, solid);
+#ifdef EDM_ML_DEBUG
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << solid.name() << " extruded polygon made of " << matName
+                                << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0] << ":" << scale[0]
+                                << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1] << ":" << scale[1]
+                                << " and " << xM.size() << " edges";
+  for (unsigned int kk = 0; kk < xM.size(); ++kk)
+    edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << xM[kk] << ":" << yM[kk];
+#endif
+
+  // Then the layers
+  std::vector<double> xL = {r2, 0, -r2, -r2, 0, r2};
+  std::vector<double> yL = {R2, 2 * R2, R2, -R2, -2 * R2, -R2};
+  std::vector<DDLogicalPart> glogs(materials_.size());
+  for (unsigned int ii = 0; ii<copyNumber_.size();ii++){
+    copyNumber_[ii] = 1;
+  }
+  double zi(-0.5 * thick_), thickTot(0.0);
+  for (unsigned int l = 0; l < layers_.size(); l++) {
+    unsigned int i = layers_[l];
+    if (copyNumber_[i] == 1) {
+      if (layerType_[i] > 0) {
+        zw[0] = -0.5 * waferThick_;
+        zw[1] = 0.5 * waferThick_;
+      } else {
+        zw[0] = -0.5 * layerThick_[i];
+        zw[1] = 0.5 * layerThick_[i];
+      }
+      std::string layerName = layerNames_[i] + tag_[k] + waferTag_;
+      solid = DDSolidFactory::extrudedpolygon(layerName, xL, yL, zw, zx, zy, scale);
+      DDName matN(DDSplit(materials_[i]).first, DDSplit(materials_[i]).second);
+      DDMaterial matter(matN);
+      glogs[i] = DDLogicalPart(solid.ddname(), matter, solid);
+      
+#ifdef EDM_ML_DEBUG
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << solid.name() << " extruded polygon made of " << matN
+                                    << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0] << ":" << scale[0]
+                                    << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1] << ":" << scale[1]
+                                    << " and " << xL.size() << " edges";
+      for (unsigned int kk = 0; kk < xL.size(); ++kk)
+        edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << xL[kk] << ":" << yL[kk];
+#endif
+    }
+    DDTranslation tran0(0, 0, (zi + 0.5 * layerThick_[i]));
+    DDRotation rot;
+    cpv.position(glogs[i], glogM, copyNumber_[i], tran0, rot);
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << glogs[i].name() << " number " << copyNumber_[i]
+                                  << " positioned in " << glogM.name() << " at " << tran0 << " with no rotation";
+#endif
+    ++copyNumber_[i];
+    zi += layerThick_[i];
+    thickTot += layerThick_[i];
+    if (layerType_[i] > 0) {
+      //int n2 = nCells_ / 2;
+      for (int u = 0; u < 2 * nCells_; ++u) {
+        for (int v = 0; v < 2 * nCells_; ++v) {
+          if (((v - u) < nCells_) && ((u - v) <= nCells_)) {
+            int placeIndex_ = wafer.HGCalCellPlacementIndex(1, face_[k], orient_[k]);
+            std::pair<double, double> xy1 = wafer.HGCalCellUV2XY1(u, v, placeIndex_, cellType_);
+            double yp = xy1.second;
+            double xp = xy1.first;
+            int cell(0);
+            std::pair<int, int> cell1 = wafer.HGCalCellUV2Cell(u, v, placeIndex_, cellType_);
+            cell = cell1.first + cellOffset_[cell1.second];
+            DDTranslation tran(xp, yp, 0);
+            int copy = HGCalTypes::packCellTypeUV(cellType_, u, v);
+            cpv.position(DDName(cellNames_[cell]), glogs[i], copy, tran, rot);
+#ifdef EDM_ML_DEBUG
+            edm::LogVerbatim("HGCalGeom")
+                << "DDHGCalWaferF: " << cellNames_[cell] << " number " << copy << " positioned in " << glogs[i].name()
+                << " at " << tran << " with no rotation";
+#endif
+          }
+        }
+      }
+    }
+  }
+  if (std::abs(thickTot - thick_) >= tol) {
+    if (thickTot > thick_) {
+      edm::LogError("HGCalGeom") << "Thickness of the partition " << thick_ << " is smaller than " << thickTot
+                                 << ": thickness of all its components **** ERROR ****";
+    } else {
+      edm::LogWarning("HGCalGeom") << "Thickness of the partition " << thick_ << " does not match with " << thickTot
+                                   << " of the components";
+    }
+  }
+}}
+
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHGCalWaferFR, "hgcal:DDHGCalWaferFR");

--- a/Geometry/HGCalCommonData/plugins/DDHGCalWaferFullRotated.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalWaferFullRotated.cc
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// File: DDHGCalWaferFR.cc
+// File: DDHGCalWaferFullRotated.cc
 // Description: Geometry factory class for a full silicon Wafer
 // Created by Sunanda Banerjee, Pruthvi Suryadevara, Indranil Das
 ///////////////////////////////////////////////////////////////////////////////
@@ -23,11 +23,11 @@
 
 //#define EDM_ML_DEBUG
 
-class DDHGCalWaferFR : public DDAlgorithm {
+class DDHGCalWaferFullRotated : public DDAlgorithm {
 public:
   // Constructor and Destructor
-  DDHGCalWaferFR();
-  ~DDHGCalWaferFR() override;
+  DDHGCalWaferFullRotated();
+  ~DDHGCalWaferFullRotated() override;
 
   void initialize(const DDNumericArguments& nArgs,
                   const DDVectorArguments& vArgs,
@@ -59,15 +59,15 @@ private:
   std::string nameSpace_;                // Namespace to be used
 };
 
-DDHGCalWaferFR::DDHGCalWaferFR() {
+DDHGCalWaferFullRotated::DDHGCalWaferFullRotated() {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: Creating an instance";
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: Creating an instance";
 #endif
 }
 
-DDHGCalWaferFR::~DDHGCalWaferFR() {}
+DDHGCalWaferFullRotated::~DDHGCalWaferFullRotated() {}
 
-void DDHGCalWaferFR::initialize(const DDNumericArguments& nArgs,
+void DDHGCalWaferFullRotated::initialize(const DDNumericArguments& nArgs,
                                 const DDVectorArguments& vArgs,
                                 const DDMapArguments&,
                                 const DDStringArguments& sArgs,
@@ -79,7 +79,7 @@ void DDHGCalWaferFR::initialize(const DDNumericArguments& nArgs,
   waferThick_ = nArgs["WaferThickness"];
   waferTag_ = sArgs["WaferTag"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: Module " << parent().name() << " made of " << material_ << " T "
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: Module " << parent().name() << " made of " << material_ << " T "
                                 << thick_ << " Wafer 2r " << waferSize_ << " Half Separation " << waferSepar_ << " T "
                                 << waferThick_;
 #endif
@@ -92,7 +92,7 @@ void DDHGCalWaferFR::initialize(const DDNumericArguments& nArgs,
   layerType_ = dbl_to_int(vArgs["LayerTypes"]);
   copyNumber_.resize(materials_.size(), 1);
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << layerNames_.size() << " types of volumes";
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << layerNames_.size() << " types of volumes";
   for (unsigned int i = 0; i < layerNames_.size(); ++i)
     edm::LogVerbatim("HGCalGeom") << "Volume [" << i << "] " << layerNames_[i] << " of thickness " << layerThick_[i]
                                   << " filled with " << materials_[i] << " type " << layerType_[i];
@@ -110,21 +110,21 @@ void DDHGCalWaferFR::initialize(const DDNumericArguments& nArgs,
   cellOffset_ = dbl_to_int(vArgs["CellOffset"]);
   nameSpace_ = DDCurrentNamespace::ns();
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: Cells/Wafer " << nCells_ << " Cell Type " << cellType_
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: Cells/Wafer " << nCells_ << " Cell Type " << cellType_
                                 << " NameSpace " << nameSpace_ << " # of cells " << cellNames_.size();
   std::ostringstream st2;
   for (unsigned int i = 0; i < cellOffset_.size(); ++i)
     st2 << " [" << i << "] " << cellOffset_[i];
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << cellOffset_.size() << " types of cells with offsets "
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << cellOffset_.size() << " types of cells with offsets "
                                 << st2.str();
   for (unsigned int k = 0; k < cellNames_.size(); ++k)
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: Cell[" << k << "] " << cellNames_[k];
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: Cell[" << k << "] " << cellNames_[k];
 #endif
 }
 
-void DDHGCalWaferFR::execute(DDCompactView& cpv) {
+void DDHGCalWaferFullRotated::execute(DDCompactView& cpv) {
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "==>> Executing DDHGCalWaferF...";
+  edm::LogVerbatim("HGCalGeom") << "==>> Executing DDHGCalWaferFullRotated...";
 #endif
 
   static constexpr double tol = 0.00001;
@@ -148,7 +148,7 @@ void DDHGCalWaferFR::execute(DDCompactView& cpv) {
     DDMaterial matter(matName);
     DDLogicalPart glogM = DDLogicalPart(solid.ddname(), matter, solid);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << solid.name() << " extruded polygon made of " << matName
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << solid.name() << " extruded polygon made of " << matName
                                   << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0] << ":" << scale[0]
                                   << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1] << ":" << scale[1]
                                   << " and " << xM.size() << " edges";
@@ -181,7 +181,7 @@ void DDHGCalWaferFR::execute(DDCompactView& cpv) {
         glogs[i] = DDLogicalPart(solid.ddname(), matter, solid);
 
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << solid.name() << " extruded polygon made of " << matN
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << solid.name() << " extruded polygon made of " << matN
                                       << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0] << ":" << scale[0]
                                       << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1] << ":" << scale[1]
                                       << " and " << xL.size() << " edges";
@@ -193,7 +193,7 @@ void DDHGCalWaferFR::execute(DDCompactView& cpv) {
       DDRotation rot;
       cpv.position(glogs[i], glogM, copyNumber_[i], tran0, rot);
 #ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferF: " << glogs[i].name() << " number " << copyNumber_[i]
+      edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << glogs[i].name() << " number " << copyNumber_[i]
                                     << " positioned in " << glogM.name() << " at " << tran0 << " with no rotation";
 #endif
       ++copyNumber_[i];
@@ -216,7 +216,7 @@ void DDHGCalWaferFR::execute(DDCompactView& cpv) {
               cpv.position(DDName(cellNames_[cell]), glogs[i], copy, tran, rot);
 #ifdef EDM_ML_DEBUG
               edm::LogVerbatim("HGCalGeom")
-                  << "DDHGCalWaferF: " << cellNames_[cell] << " number " << copy << " positioned in " << glogs[i].name()
+                  << "DDHGCalWaferFullRotated: " << cellNames_[cell] << " number " << copy << " positioned in " << glogs[i].name()
                   << " at " << tran << " with no rotation";
 #endif
             }
@@ -236,4 +236,4 @@ void DDHGCalWaferFR::execute(DDCompactView& cpv) {
   }
 }
 
-DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHGCalWaferFR, "hgcal:DDHGCalWaferFR");
+DEFINE_EDM_PLUGIN(DDAlgorithmFactory, DDHGCalWaferFullRotated, "hgcal:DDHGCalWaferFullRotated");

--- a/Geometry/HGCalCommonData/plugins/DDHGCalWaferFullRotated.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalWaferFullRotated.cc
@@ -68,10 +68,10 @@ DDHGCalWaferFullRotated::DDHGCalWaferFullRotated() {
 DDHGCalWaferFullRotated::~DDHGCalWaferFullRotated() {}
 
 void DDHGCalWaferFullRotated::initialize(const DDNumericArguments& nArgs,
-                                const DDVectorArguments& vArgs,
-                                const DDMapArguments&,
-                                const DDStringArguments& sArgs,
-                                const DDStringVectorArguments& vsArgs) {
+                                         const DDVectorArguments& vArgs,
+                                         const DDMapArguments&,
+                                         const DDStringArguments& sArgs,
+                                         const DDStringVectorArguments& vsArgs) {
   material_ = sArgs["ModuleMaterial"];
   thick_ = nArgs["ModuleThickness"];
   waferSize_ = nArgs["WaferSize"];
@@ -79,9 +79,9 @@ void DDHGCalWaferFullRotated::initialize(const DDNumericArguments& nArgs,
   waferThick_ = nArgs["WaferThickness"];
   waferTag_ = sArgs["WaferTag"];
 #ifdef EDM_ML_DEBUG
-  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: Module " << parent().name() << " made of " << material_ << " T "
-                                << thick_ << " Wafer 2r " << waferSize_ << " Half Separation " << waferSepar_ << " T "
-                                << waferThick_;
+  edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: Module " << parent().name() << " made of " << material_
+                                << " T " << thick_ << " Wafer 2r " << waferSize_ << " Half Separation " << waferSepar_
+                                << " T " << waferThick_;
 #endif
   orient_ = dbl_to_int(vArgs["WaferOrinet"]);
   face_ = dbl_to_int(vArgs["WaferFace"]);
@@ -148,10 +148,10 @@ void DDHGCalWaferFullRotated::execute(DDCompactView& cpv) {
     DDMaterial matter(matName);
     DDLogicalPart glogM = DDLogicalPart(solid.ddname(), matter, solid);
 #ifdef EDM_ML_DEBUG
-    edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << solid.name() << " extruded polygon made of " << matName
-                                  << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0] << ":" << scale[0]
-                                  << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1] << ":" << scale[1]
-                                  << " and " << xM.size() << " edges";
+    edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << solid.name() << " extruded polygon made of "
+                                  << matName << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0] << ":"
+                                  << scale[0] << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1] << ":"
+                                  << scale[1] << " and " << xM.size() << " edges";
     for (unsigned int kk = 0; kk < xM.size(); ++kk)
       edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << xM[kk] << ":" << yM[kk];
 #endif
@@ -181,10 +181,10 @@ void DDHGCalWaferFullRotated::execute(DDCompactView& cpv) {
         glogs[i] = DDLogicalPart(solid.ddname(), matter, solid);
 
 #ifdef EDM_ML_DEBUG
-        edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << solid.name() << " extruded polygon made of " << matN
-                                      << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0] << ":" << scale[0]
-                                      << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1] << ":" << scale[1]
-                                      << " and " << xL.size() << " edges";
+        edm::LogVerbatim("HGCalGeom") << "DDHGCalWaferFullRotated: " << solid.name() << " extruded polygon made of "
+                                      << matN << " z|x|y|s (0) " << zw[0] << ":" << zx[0] << ":" << zy[0] << ":"
+                                      << scale[0] << " z|x|y|s (1) " << zw[1] << ":" << zx[1] << ":" << zy[1] << ":"
+                                      << scale[1] << " and " << xL.size() << " edges";
         for (unsigned int kk = 0; kk < xL.size(); ++kk)
           edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << xL[kk] << ":" << yL[kk];
 #endif
@@ -216,8 +216,8 @@ void DDHGCalWaferFullRotated::execute(DDCompactView& cpv) {
               cpv.position(DDName(cellNames_[cell]), glogs[i], copy, tran, rot);
 #ifdef EDM_ML_DEBUG
               edm::LogVerbatim("HGCalGeom")
-                  << "DDHGCalWaferFullRotated: " << cellNames_[cell] << " number " << copy << " positioned in " << glogs[i].name()
-                  << " at " << tran << " with no rotation";
+                  << "DDHGCalWaferFullRotated: " << cellNames_[cell] << " number " << copy << " positioned in "
+                  << glogs[i].name() << " at " << tran << " with no rotation";
 #endif
             }
           }

--- a/Geometry/HGCalCommonData/python/testHGCalWaferFRXML_cfi.py
+++ b/Geometry/HGCalCommonData/python/testHGCalWaferFRXML_cfi.py
@@ -5,10 +5,10 @@ XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
         'Geometry/CMSCommonData/data/rotations.xml',
         'Geometry/HGCalCommonData/test/cms.xml',
         'Geometry/HGCalCommonData/data/hgcalMaterial/v2/hgcalMaterial.xml',
-        'Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcal.xml',
+        'Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcal.xml',
         'Geometry/HGCalCommonData/data/hgcalcell/v17/hgcalcell.xml',
-        'Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcalwafer.xml',
-        'Geometry/HGCalCommonData/data/hgcalwafer/v17/hgcalpos.xml'),
+        'Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcalwafer.xml',
+        'Geometry/HGCalCommonData/data/hgcalwafer/v17f/hgcalpos.xml'),
     rootNodeName = cms.string('cms:OCMS')
 )
 


### PR DESCRIPTION
 PR description:

- There will no changes in the output.
- It depends on PR https://github.com/cms-sw/cmssw/pull/36723.
- This is related with the development of a new geometry version v17 for HGCAL as discussed in the summary section of "Rotation of full Si modules" at https://indico.cern.ch/event/1122240/

 PR validation:

- Use runTheMatrix test workflows 'runTheMatrix.py -l limited -i all --ibeos'
- Specific cfg's in Geometry/HGCalCommonData/test/python/dumpHGCalWaferDDDR_cfi.py to dump geometry view using fireworks

if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing