### PR TITLE
Run3-sim108X Backport #36899 to use the modifier run3_geomOld to use GT's with old geometry versions

### DIFF
--- a/Configuration/Eras/python/Era_Run3_oldGeom_cff.py
+++ b/Configuration/Eras/python/Era_Run3_oldGeom_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Modifier_run3_geomOld_cff import run3_geomOld
+
+Run3_oldGeom = cms.ModifierChain(Run3, run3_geomOld)

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -38,6 +38,7 @@ class Eras (object):
                  'Run3_pp_on_PbPb',
                  'Run3_dd4hep',
                  'Run3_DDD',
+                 'Run3_oldGeom',
                  'Phase2',
                  'Phase2C9',
                  'Phase2C10',


### PR DESCRIPTION
#### PR description:

Backport #36899 to use the modifier run3_geomOld to use GT's with old geometry versions

#### PR validation:

The PR #36899 is tested using cmsDriver.py command. This PR however can be tested only with #36872 or all the PR's for back porting new geometry are integrated 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport PR #36899 