### PR TITLE
Add lumi and run SimpleFlatTableProducer interfaces

### DIFF
--- a/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
+++ b/PhysicsTools/NanoAOD/interface/SimpleFlatTableProducer.h
@@ -397,8 +397,6 @@ protected:
   typedef FuncVariable<StringObjectFunction<T>, int> IntVar;
   typedef FuncVariable<StringObjectFunction<T>, float> FloatVar;
   typedef FuncVariable<StringObjectFunction<T>, uint8_t> UInt8Var;
-  // typedef FuncVariable<StringObjectFunction<T>, uint16_t> UInt16Var;
-  // typedef FuncVariable<StringObjectFunction<T>, uint32_t> UInt32Var;
   typedef FuncVariable<StringCutObjectSelector<T>, bool> BoolVar;
   std::vector<std::unique_ptr<Variable>> vars_;
 };


### PR DESCRIPTION
#### PR description:

- Add a general interface for NanoAOD's SimpleFlatTableProducer to dump collections in Lumi and Run trees.
- The interface is copied from the Event tree equivalent producers

#### PR validation:
- I tested a custom workflow (for ECAL calibration) using [these producers](https://gitlab.cern.ch/spigazzi/PhiSym/-/blob/dev_alcanano/EcalCalibAlgos/plugins/PhiSymFlatTableProducers.cc). 
- The produced tables are correctly dumped by both the NANOAOD and NANOAODEDM output modules.

The test workflow mentioned above will be part of a separate PR, we are investigating the possibility to run it as part of an ALCARECO. 
