### PR TITLE
[ROOT6] Fix needed for root master to explicitly pass RooCmdArg

### DIFF
--- a/PhysicsTools/Utilities/src/SideBandSubtraction.cc
+++ b/PhysicsTools/Utilities/src/SideBandSubtraction.cc
@@ -412,7 +412,7 @@ int SideBandSubtract::doGlobalFit() {
     cout << "Beginning SideBand Subtraction\n";
 
   if (ModelPDF != nullptr && Data != nullptr && SeparationVariable != nullptr) {
-    fit_result = ModelPDF->fitTo(*Data, "r");
+    fit_result = ModelPDF->fitTo(*Data, RooCmdArg("r", 0));
   } else {
     cerr << "ERROR: doGobalFit, no ModelPDF, SeparationVariable or Data specified\n";
     return -1;


### PR DESCRIPTION
This is needed for ROOT master branch based IBs (CMSSW_12_3_ROOT6_X). Root change  https://github.com/root-project/root/commit/b553d387ee141fc46c72ecfc9e12d57e97c2895b#diff-6534a03c2b46be206e3b5193cdad1ae96349308681da35a5b5cc54183aedcee3 was done e to make the implicit construction of `RooCmdArg` from just  a string impossible .  The change here explicitly use `RooCmdArg("r", 0)` to fix the ROOT6 build issue ( https://github.com/cms-sw/cmsdist/pull/7601#issuecomment-1030084728 )