### PR TITLE
change signed int shifts to unsigned

### DIFF
--- a/CondFormats/L1TObjects/src/LUT.cc
+++ b/CondFormats/L1TObjects/src/LUT.cc
@@ -79,8 +79,8 @@ int l1t::LUT::readHeader_(std::istream& stream) {
       std::string version;      //currently not doing anything with this
       std::string headerField;  //currently not doing anything with this
       if (lineStream >> headerField >> version >> nrBitsAddress_ >> nrBitsData_) {
-        addressMask_ = nrBitsAddress_ != 32 ? (0x1 << nrBitsAddress_) - 1 : ~0x0;
-        dataMask_ = (0x1 << nrBitsData_) - 1;
+        addressMask_ = nrBitsAddress_ != 32 ? (0x1U << nrBitsAddress_) - 1 : ~0x0;
+        dataMask_ = (0x1U << nrBitsData_) - 1;
         stream.seekg(startPos);
         return SUCCESS;
       }


### PR DESCRIPTION
#### PR description:

CondFormats/L1TObjects/src/LUT.cc has a couple of shifts, found by UBSAN, that overflow a signed int.  This PR changes these to unsigned int shifts (it's pretty clear from the code that this was the intent).

#### PR validation:

Prior to this PR, several workflows log UBSAN errors of the form:
```
CMSSW_12_3_UBSAN_X_2022-02-04-1100/src/CondFormats/L1TObjects/src/LUT.cc:83:42: runtime error: signed integer overflow: -2147483648 - 1 cannot be represented in type 'int'
```
With this PR, those runtime errors are fixed.