### PR TITLE
Fix GEM Offline DQM for GE2/1 Demonstrator (backport of #36883, 12_2_X)

### DIFF
--- a/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
+++ b/DQMOffline/Muon/interface/GEMEfficiencyAnalyzer.h
@@ -61,6 +61,7 @@ private:
 
   inline bool isInsideOut(const reco::Track &);
 
+  bool skipGEMStation(const int);
   std::vector<GEMLayerData> buildGEMLayers(const edm::ESHandle<GEMGeometry> &);
   const reco::Track *getTrack(const reco::Muon &);
   std::pair<TrajectoryStateOnSurface, DetId> getStartingState(const reco::TransientTrack &,
@@ -97,6 +98,9 @@ private:
   int eta_nbins_;
   double eta_low_;
   double eta_up_;
+  bool monitor_ge11_;
+  bool monitor_ge21_;
+  bool monitor_ge0_;
 
   // data mebers derived from parameters
   MuonServiceProxy *muon_service_;

--- a/DQMOffline/Muon/python/gemEfficiencyAnalyzerCosmics_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyAnalyzerCosmics_cfi.py
@@ -6,23 +6,29 @@ from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 
 gemEfficiencyAnalyzerCosmics = _gemEfficiencyAnalyzerCosmicsDefault.clone(
     ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
-    muonTag = cms.InputTag('muons'),
-    name = cms.untracked.string('Cosmic 2-Leg STA Muon'),
-    folder = cms.untracked.string('GEM/Efficiency/type1'),
+    muonTag = 'muons',
+    name = 'Cosmic 2-Leg STA Muon',
+    folder = 'GEM/Efficiency/type1',
 )
 
 gemEfficiencyAnalyzerCosmicsOneLeg = _gemEfficiencyAnalyzerCosmicsDefault.clone(
     ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
-    muonTag = cms.InputTag('muons1Leg'),
-    name = cms.untracked.string('Cosmic 1-Leg STA Muon'),
-    folder = cms.untracked.string('GEM/Efficiency/type2'),
+    muonTag = 'muons1Leg',
+    name = 'Cosmic 1-Leg STA Muon',
+    folder = 'GEM/Efficiency/type2',
 )
 
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 phase2_GEM.toModify(gemEfficiencyAnalyzerCosmics,
-    etaNbins=cms.untracked.int32(15),
-    etaUp=cms.untracked.double(3.0))
+    etaNbins = 15,
+    etaUp = 3.0,
+    monitorGE21 = True,
+    monitorGE0 = True,
+)
 
 phase2_GEM.toModify(gemEfficiencyAnalyzerCosmicsOneLeg,
-    etaNbins=cms.untracked.int32(15),
-    etaUp=cms.untracked.double(3.0))
+    etaNbins = 15,
+    etaUp = 3.0,
+    monitorGE21 = True,
+    monitorGE0 = True,
+)

--- a/DQMOffline/Muon/python/gemEfficiencyAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyAnalyzer_cfi.py
@@ -27,30 +27,34 @@ gemOfflineDQMStaMuons = cms.EDFilter("MuonSelector",
 
 gemEfficiencyAnalyzerTightGlb = _gemEfficiencyAnalyzerDefault.clone(
     ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
-    folder = cms.untracked.string('GEM/Efficiency/type1'),
-    muonTag = cms.InputTag('gemOfflineDQMTightGlbMuons'),
-    name = cms.untracked.string('Tight GLB Muon'),
-    useGlobalMuon = cms.untracked.bool(True),
+    folder = 'GEM/Efficiency/type1',
+    muonTag = 'gemOfflineDQMTightGlbMuons',
+    name = 'Tight GLB Muon',
+    useGlobalMuon = True,
 )
 
 gemEfficiencyAnalyzerSta = _gemEfficiencyAnalyzerDefault.clone(
     ServiceParameters = MuonServiceProxy.ServiceParameters.clone(),
     muonTag = cms.InputTag("gemOfflineDQMStaMuons"),
-    folder = cms.untracked.string('GEM/Efficiency/type2'),
-    name = cms.untracked.string('STA Muon'),
-    useGlobalMuon = cms.untracked.bool(False),
+    folder = 'GEM/Efficiency/type2',
+    name = 'STA Muon',
+    useGlobalMuon = False,
 )
 
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
-phase2_GEM.toModify(
-    gemEfficiencyAnalyzerTightGlb,
-    etaNbins=cms.untracked.int32(15),
-    etaUp=cms.untracked.double(3.0))
+phase2_GEM.toModify(gemEfficiencyAnalyzerTightGlb,
+    etaNbins = 15,
+    etaUp = 3.0,
+    monitorGE21 = True,
+    monitorGE0 = True,
+)
 
-phase2_GEM.toModify(
-    gemEfficiencyAnalyzerSta,
-    etaNbins=cms.untracked.int32(15),
-    etaUp=cms.untracked.double(3.0))
+phase2_GEM.toModify(gemEfficiencyAnalyzerSta,
+    etaNbins = 15,
+    etaUp = 3.0,
+    monitorGE21 = True,
+    monitorGE0 = True,
+)
 
 gemEfficiencyAnalyzerTightGlbSeq = cms.Sequence(
     cms.ignore(gemOfflineDQMTightGlbMuons) *

--- a/DQMOffline/Muon/python/gemEfficiencyHarvesterCosmics_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyHarvesterCosmics_cfi.py
@@ -6,9 +6,9 @@ from DQMOffline.Muon.gemEfficiencyAnalyzerCosmics_cfi import gemEfficiencyAnalyz
 from DQMOffline.Muon.gemEfficiencyAnalyzerCosmics_cfi import gemEfficiencyAnalyzerCosmicsOneLeg as _gemEfficiencyAnalyzerCosmicsOneLeg
 
 gemEfficiencyHarvesterCosmics = _gemEfficiencyHarvesterDefault.clone(
-    folder = cms.untracked.string(_gemEfficiencyAnalyzerCosmics.folder.value()),
+    folder = _gemEfficiencyAnalyzerCosmics.folder.value(),
 )
 
 gemEfficiencyHarvesterCosmicsOneLeg = _gemEfficiencyHarvesterDefault.clone(
-    folder = cms.untracked.string(_gemEfficiencyAnalyzerCosmicsOneLeg.folder.value()),
+    folder = _gemEfficiencyAnalyzerCosmicsOneLeg.folder.value(),
 )

--- a/DQMOffline/Muon/python/gemEfficiencyHarvester_cfi.py
+++ b/DQMOffline/Muon/python/gemEfficiencyHarvester_cfi.py
@@ -6,9 +6,9 @@ from DQMOffline.Muon.gemEfficiencyAnalyzer_cfi import gemEfficiencyAnalyzerTight
 from DQMOffline.Muon.gemEfficiencyAnalyzer_cfi import gemEfficiencyAnalyzerSta as _gemEfficiencyAnalyzerSta
 
 gemEfficiencyHarvesterTightGlb = _gemEfficiencyHarvesterDefault.clone(
-    folder = cms.untracked.string(_gemEfficiencyAnalyzerTightGlb.folder.value())
+    folder = _gemEfficiencyAnalyzerTightGlb.folder.value()
 )
 
 gemEfficiencyHarvesterSta = _gemEfficiencyHarvesterDefault.clone(
-    folder = cms.untracked.string(_gemEfficiencyAnalyzerSta.folder.value())
+    folder = _gemEfficiencyAnalyzerSta.folder.value()
 )


### PR DESCRIPTION
#### PR description:
Backport of #36883. This PR fixes MonitorElement: WARNING:setBinLabel caused by GEM offline DQM not handling the new GEM geometry with GE2/1 demonstrator. See https://github.com/cms-sw/cmssw/pull/36860#issuecomment-1028028804.

#### PR validation:
This PR is tested with 11634.911.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This PR is a backport of #36883. 