### PR TITLE
Gem turn off demo unpacker - 12_2_X backport of #36769

### DIFF
--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -7,8 +7,6 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
-# from DataFormats/FEDRawData/interface/FEDNumbering.h
-MINGE21FEDID = 1469
-MAXGEMFEDID = 1478
-run3_GEM.toModify(muonGEMDigis, useDBEMap = True, fedIdEnd=MINGE21FEDID-1)
-phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True, fedIdEnd=MAXGEMFEDID)
+# Note that by default we don't unpack the GE2/1 demonstrator digis in run3
+run3_GEM.toModify(muonGEMDigis, useDBEMap = True, ge21Off = True)
+phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True, ge21Off = False)

--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -7,5 +7,8 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
-run3_GEM.toModify(muonGEMDigis, useDBEMap = True)
-phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True)
+# from DataFormats/FEDRawData/interface/FEDNumbering.h
+MINGE21FEDID = 1469
+MAXGEMFEDID = 1478
+run3_GEM.toModify(muonGEMDigis, useDBEMap = True, fedIdEnd=MINGE21FEDID-1)
+phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True, fedIdEnd=MAXGEMFEDID)


### PR DESCRIPTION
#### PR description:

Backport of #36769 - turns off the GE2/1 demonstrator in the unpacker, so that upstream physics objects aren't affected by the demonstrator.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
To make sure that GE2/1 hits aren't used in run3 reconstruction. I was going through the backports for the demonstrator geometry and saw this wasn't included in the other big changesets.

<!-- Please replace this text with any link to  -->
