### PR TITLE
MTD validation : update modules' names

### DIFF
--- a/Validation/Configuration/python/mtdSimValid_cff.py
+++ b/Validation/Configuration/python/mtdSimValid_cff.py
@@ -1,16 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
 # MTD validation sequences
-from Validation.MtdValidation.btlSimHits_cfi import btlSimHits 
-from Validation.MtdValidation.btlDigiHits_cfi import btlDigiHits 
-from Validation.MtdValidation.btlLocalReco_cfi import btlLocalReco
-from Validation.MtdValidation.etlLocalReco_cfi import etlLocalReco
-from Validation.MtdValidation.etlSimHits_cfi import etlSimHits
-from Validation.MtdValidation.etlDigiHits_cfi import etlDigiHits
-from Validation.MtdValidation.mtdTracks_cfi import mtdTracks
-from Validation.MtdValidation.vertices4D_cfi import vertices4D
+from Validation.MtdValidation.btlSimHitsValid_cfi import btlSimHitsValid
+from Validation.MtdValidation.btlDigiHitsValid_cfi import btlDigiHitsValid
+from Validation.MtdValidation.btlLocalRecoValid_cfi import btlLocalRecoValid
+from Validation.MtdValidation.etlLocalRecoValid_cfi import etlLocalRecoValid
+from Validation.MtdValidation.etlSimHitsValid_cfi import etlSimHitsValid
+from Validation.MtdValidation.etlDigiHitsValid_cfi import etlDigiHitsValid
+from Validation.MtdValidation.mtdTracksValid_cfi import mtdTracksValid
+from Validation.MtdValidation.vertices4DValid_cfi import vertices4DValid
 
-mtdSimValid  = cms.Sequence(btlSimHits  + etlSimHits )
-mtdDigiValid = cms.Sequence(btlDigiHits + etlDigiHits)
-mtdRecoValid = cms.Sequence(btlLocalReco  + etlLocalReco + mtdTracks + vertices4D)
+mtdSimValid  = cms.Sequence(btlSimHitsValid  + etlSimHitsValid )
+mtdDigiValid = cms.Sequence(btlDigiHitsValid + etlDigiHitsValid)
+mtdRecoValid = cms.Sequence(btlLocalRecoValid  + etlLocalRecoValid + mtdTracksValid + vertices4DValid)
 

--- a/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
@@ -294,7 +294,7 @@ void BtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "FTLBarrel"));
   desc.add<bool>("LocalPositionDebug", false);
 
-  descriptions.add("btlDigiHitsDefault", desc);
+  descriptions.add("btlDigiHitsDefaultValid", desc);
 }
 
 DEFINE_FWK_MODULE(BtlDigiHitsValidation);

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -680,7 +680,7 @@ void BtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<bool>("UncalibRecHitsPlots", false);
   desc.add<double>("HitMinimumAmplitude", 30.);  // [pC]
 
-  descriptions.add("btlLocalReco", desc);
+  descriptions.add("btlLocalRecoValid", desc);
 }
 
 DEFINE_FWK_MODULE(BtlLocalRecoValidation);

--- a/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlSimHitsValidation.cc
@@ -272,7 +272,7 @@ void BtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsBarrel"));
   desc.add<double>("hitMinimumEnergy", 1.);  // [MeV]
 
-  descriptions.add("btlSimHits", desc);
+  descriptions.add("btlSimHitsValid", desc);
 }
 
 DEFINE_FWK_MODULE(BtlSimHitsValidation);

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -521,7 +521,7 @@ void EtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "FTLEndcap"));
   desc.add<bool>("LocalPositionDebug", false);
 
-  descriptions.add("etlDigiHitsDefault", desc);
+  descriptions.add("etlDigiHitsDefaultValid", desc);
 }
 
 DEFINE_FWK_MODULE(EtlDigiHitsValidation);

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -1035,7 +1035,7 @@ void EtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<bool>("UncalibRecHitsPlots", false);
   desc.add<double>("HitMinimumAmplitude", 0.33);  // [MIP]
 
-  descriptions.add("etlLocalReco", desc);
+  descriptions.add("etlLocalRecoValid", desc);
 }
 
 DEFINE_FWK_MODULE(EtlLocalRecoValidation);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -551,7 +551,7 @@ void EtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<double>("hitMinimumEnergy1Dis", 0.1);    // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
 
-  descriptions.add("etlSimHits", desc);
+  descriptions.add("etlSimHitsValid", desc);
 }
 
 DEFINE_FWK_MODULE(EtlSimHitsValidation);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -503,7 +503,7 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<double>("trackMinimumEta", 1.5);
   desc.add<double>("trackMaximumEta", 3.2);
 
-  descriptions.add("mtdTracks", desc);
+  descriptions.add("mtdTracksValid", desc);
 }
 
 const bool MtdTracksValidation::mvaGenSel(const HepMC::GenParticle& gp, const float& charge) {

--- a/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
+++ b/Validation/MtdValidation/plugins/Primary4DVertexValidation.cc
@@ -1477,7 +1477,7 @@ void Primary4DVertexValidation::fillDescriptions(edm::ConfigurationDescriptions&
   lDP.push_back(0.);
   lDP.push_back(42.5);
   desc.add<std::vector<double>>("lineDensityPar", lDP);
-  descriptions.add("vertices4D", desc);
+  descriptions.add("vertices4DValid", desc);
 }
 
 const bool Primary4DVertexValidation::mvaTPSel(const TrackingParticle& tp) {

--- a/Validation/MtdValidation/python/btlDigiHitsValid_cfi.py
+++ b/Validation/MtdValidation/python/btlDigiHitsValid_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from Validation.MtdValidation.btlDigiHitsDefaultValid_cfi import btlDigiHitsDefaultValid as _btlDigiHitsDefaultValid
+btlDigiHitsValid = _btlDigiHitsDefaultValid.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(btlDigiHitsValid, inputTag = "mixData:FTLBarrel")

--- a/Validation/MtdValidation/python/btlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/btlDigiHits_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Validation.MtdValidation.btlDigiHitsDefault_cfi import btlDigiHitsDefault as _btlDigiHitsDefault
-btlDigiHits = _btlDigiHitsDefault.clone()
+btlDigiHitsValid = _btlDigiHitsDefaultValid.clone()
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(btlDigiHits, inputTag = "mixData:FTLBarrel")

--- a/Validation/MtdValidation/python/btlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/btlDigiHits_cfi.py
@@ -1,6 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-from Validation.MtdValidation.btlDigiHitsDefault_cfi import btlDigiHitsDefault as _btlDigiHitsDefault
-btlDigiHitsValid = _btlDigiHitsDefaultValid.clone()
-
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(btlDigiHits, inputTag = "mixData:FTLBarrel")

--- a/Validation/MtdValidation/python/etlDigiHitsValid_cfi.py
+++ b/Validation/MtdValidation/python/etlDigiHitsValid_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from Validation.MtdValidation.etlDigiHitsDefaultValid_cfi import etlDigiHitsDefaultValid as _etlDigiHitsDefaultValid
+etlDigiHitsValid = _etlDigiHitsDefaultValid.clone()
+
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+premix_stage2.toModify(etlDigiHitsValid, inputTag = "mixData:FTLEndcap")

--- a/Validation/MtdValidation/python/etlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/etlDigiHits_cfi.py
@@ -1,6 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-from Validation.MtdValidation.etlDigiHitsDefault_cfi import etlDigiHitsDefault as _etlDigiHitsDefault
-etlDigiHitsValid = _etlDigiHitsDefaultValid.clone()
-
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-premix_stage2.toModify(etlDigiHits, inputTag = "mixData:FTLEndcap")

--- a/Validation/MtdValidation/python/etlDigiHits_cfi.py
+++ b/Validation/MtdValidation/python/etlDigiHits_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from Validation.MtdValidation.etlDigiHitsDefault_cfi import etlDigiHitsDefault as _etlDigiHitsDefault
-etlDigiHits = _etlDigiHitsDefault.clone()
+etlDigiHitsValid = _etlDigiHitsDefaultValid.clone()
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(etlDigiHits, inputTag = "mixData:FTLEndcap")

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -27,29 +27,29 @@ process.mix.digitizers = cms.PSet()
 for a in process.aliases: delattr(process, a)
 
 # --- BTL Validation
-process.load("Validation.MtdValidation.btlSimHits_cfi")
-process.load("Validation.MtdValidation.btlDigiHits_cfi")
-process.load("Validation.MtdValidation.btlLocalReco_cfi")
-btlValidation = cms.Sequence(process.btlSimHits + process.btlDigiHits + process.btlLocalReco)
+process.load("Validation.MtdValidation.btlSimHitsValid_cfi")
+process.load("Validation.MtdValidation.btlDigiHitsValid_cfi")
+process.load("Validation.MtdValidation.btlLocalRecoValid_cfi")
+btlValidation = cms.Sequence(process.btlSimHitsValid + process.btlDigiHitsValid + process.btlLocalRecoValid)
 
 # --- ETL Validation
-process.load("Validation.MtdValidation.etlSimHits_cfi")
-process.load("Validation.MtdValidation.etlDigiHits_cfi")
-process.load("Validation.MtdValidation.etlLocalReco_cfi")
-etlValidation = cms.Sequence(process.etlSimHits + process.etlDigiHits + process.etlLocalReco)
+process.load("Validation.MtdValidation.etlSimHitsValid_cfi")
+process.load("Validation.MtdValidation.etlDigiHitsValid_cfi")
+process.load("Validation.MtdValidation.etlLocalRecoValid_cfi")
+etlValidation = cms.Sequence(process.etlSimHitsValid + process.etlDigiHitsValid + process.etlLocalRecoValid)
 
 # --- Global Validation
-process.load("Validation.MtdValidation.mtdTracks_cfi")
+process.load("Validation.MtdValidation.mtdTracksValid_cfi")
 
 process.btlDigiHits.LocalPositionDebug = True
 process.etlDigiHits.LocalPositionDebug = True
 process.btlLocalReco.LocalPositionDebug = True
 process.etlLocalReco.LocalPositionDebug = True
 
-process.load("Validation.MtdValidation.vertices4D_cfi")
+process.load("Validation.MtdValidation.vertices4DValid_cfi")
 
 process.DQMStore = cms.Service("DQMStore")
 
 process.load("DQMServices.FileIO.DQMFileSaverOnline_cfi")
 
-process.p = cms.Path( process.mix + btlValidation + etlValidation + process.mtdTracks + process.vertices4D + process.dqmSaver)
+process.p = cms.Path( process.mix + btlValidation + etlValidation + process.mtdTracksValid + process.vertices4DValid + process.dqmSaver)


### PR DESCRIPTION
#### PR description:

The name of MTD validation modules is updated by adding the suffix "Valid" to allow them to be better identified within the stack of executed plugins.

#### PR validation:

Test workflow 35007.0 runs succesfully.