### PR TITLE
L1T: remove l1ExtraParticles from stage 2 reco

### DIFF
--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -232,3 +232,6 @@ hltExoticaValidator = DQMEDAnalyzer(
     DSTMuons         = DSTMuonsPSet,
     TracklessJets    = TracklessJetsPSet
 )
+
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(hltExoticaValidator, METplusTrack = dict(l1METLabel = None))

--- a/L1Trigger/Configuration/python/L1TReco_cff.py
+++ b/L1Trigger/Configuration/python/L1TReco_cff.py
@@ -52,12 +52,12 @@ stage1L1Trigger.toReplaceWith(L1Reco_L1Extra_L1GtRecord,cms.Sequence())
 stage1L1Trigger.toReplaceWith(L1Reco, cms.Sequence(l1extraParticles))
 
 #
-# Stage-2 Trigger:  fow now, reco Stage-1 as before:
+# Stage-2 Trigger:
 #
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 stage2L1Trigger.toReplaceWith(L1Reco_L1Extra,cms.Sequence())
 stage2L1Trigger.toReplaceWith(L1Reco_L1Extra_L1GtRecord,cms.Sequence())
-stage2L1Trigger.toReplaceWith(L1Reco, cms.Sequence(l1extraParticles))
+stage2L1Trigger.toReplaceWith(L1Reco, cms.Sequence())
 
 #
 # l1L1GtObjectMap does not work properly with fastsim


### PR DESCRIPTION
Fix addressing #36806 https://github.com/cms-sw/cmssw/issues/36806

Removes l1ExtraParticles from Stage 2 L1T reconstruction, which should not be included for Stage 2 (only Stage 1).

Tested with:

runTheMatrix.py --what standard -l 138.4 --command "--conditions 123X_dataRun3_Prompt_dd4hep_Candidate_2022_02_07_15_17_27 -n 1000" -t 8

No longer see error:
"No "L1CaloGeometryRecord" record found in the EventSetup."
since the l1ExtraParticles producer that asks for this record is no longer called in the Stage 2 L1T reco.
