### PR TITLE
L1 emulator for LLP displaced jet trigger (L1 6:1 LUT, L2 jet algo), L1TNtuples addition of jet hwQual

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Packer.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Packer.cc
@@ -107,9 +107,14 @@ namespace l1t {
 
             HcalTrigTowerDetId id(cEta, cPhi);
             const auto tp = hcalTPGs->find(id);
+
+            int fg_bits = 0;
+            for (int index = 0; index < 6; index++)
+              fg_bits += tp->SOI_fineGrain(index) << index;
+
             if (tp != hcalTPGs->end()) {
               ctp7Data.setET(cType, negativeEta, iEta, iPhi, tp->SOI_compressedEt());
-              ctp7Data.setFB(cType, negativeEta, iEta, iPhi, tp->SOI_fineGrain());
+              ctp7Data.setFB(cType, negativeEta, iEta, iPhi, fg_bits);
             }
           }
         }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/UCTCTP7RawData.h
@@ -200,7 +200,14 @@ public:
       if (((cEta - 1) % 2) == 1) {
         tower += 4;
       }
-      data |= (fb & 0x1) << tower;
+      if (cType == HBHE) {
+        int depth = fb & 0b1;
+        int prompt = (fb & 0b10) >> 1;
+        int delay1 = (fb & 0b100) >> 2;
+        int delay2 = (fb & 0b1000) >> 3;
+        data |= (depth | ((!prompt) & (delay1 | delay2))) << tower;  // bit[0] | (!bit[1] & (bit[2] | bit[3]))
+      } else
+        data |= (fb & 0x1) << tower;
     }
   }
 

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -224,7 +224,7 @@ void L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
             if (fg2)
               featureBits |= 0b10;
           }
-          if (absCaloEta <= 29)
+          else
             featureBits |= (fg | ((!fg2) & (fg3 | fg4)));  // depth | (!prompt & (delay1 | delay2))
           if (!layer1->setHCALData(t, featureBits, et)) {
             LOG_ERROR << "caloEta = " << caloEta << "; caloPhi =" << caloPhi << std::endl;

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -221,10 +221,9 @@ void L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
             if (fg)
               featureBits |= 0b01;
             // fg2 should only be set for HF
-            if (absCaloEta > 29 && fg2)
+            if (fg2)
               featureBits |= 0b10;
-          }
-          if (absCaloEta <= 29)
+          } else
             featureBits |= (fg | ((!fg2) & (fg3 | fg4)));  // depth | (!prompt & (delay1 | delay2))
           if (!layer1->setHCALData(t, featureBits, et)) {
             LOG_ERROR << "caloEta = " << caloEta << "; caloPhi =" << caloPhi << std::endl;

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -209,16 +209,24 @@ void L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       } else if (absCaloEta <= 41) {
         int caloPhi = hcalTp.id().iphi();
         int et = hcalTp.SOI_compressedEt();
-        bool fg = hcalTp.t0().fineGrain(0);
-        bool fg2 = hcalTp.t0().fineGrain(1);
+        bool fg = hcalTp.t0().fineGrain(0);   // depth
+        bool fg2 = hcalTp.t0().fineGrain(1);  // prompt
+        bool fg3 = hcalTp.t0().fineGrain(2);  // delay 1
+        bool fg4 = hcalTp.t0().fineGrain(3);  // delay 2
+        bool fg5 = hcalTp.t0().fineGrain(4);  // MIP
+        bool fg6 = hcalTp.t0().fineGrain(5);  // MIP
         if (caloPhi <= 72) {
           UCTTowerIndex t = UCTTowerIndex(caloEta, caloPhi);
           uint32_t featureBits = 0;
-          if (fg)
-            featureBits |= 0b01;
-          // fg2 should only be set for HF
-          if (absCaloEta > 29 && fg2)
-            featureBits |= 0b10;
+          if (absCaloEta > 29) {
+            if (fg)
+              featureBits |= 0b01;
+            // fg2 should only be set for HF
+            if (absCaloEta > 29 && fg2)
+              featureBits |= 0b10;
+          }
+          if (absCaloEta <= 29)
+            featureBits |= (fg | ((!fg2) & (fg3 | fg4)));  // depth | (!prompt & (delay1 | delay2))
           if (!layer1->setHCALData(t, featureBits, et)) {
             LOG_ERROR << "caloEta = " << caloEta << "; caloPhi =" << caloPhi << std::endl;
             LOG_ERROR << "UCT: Failed loading an HCAL tower" << std::endl;

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -213,8 +213,7 @@ void L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         bool fg2 = hcalTp.t0().fineGrain(1);  // prompt
         bool fg3 = hcalTp.t0().fineGrain(2);  // delay 1
         bool fg4 = hcalTp.t0().fineGrain(3);  // delay 2
-        bool fg5 = hcalTp.t0().fineGrain(4);  // MIP
-        bool fg6 = hcalTp.t0().fineGrain(5);  // MIP
+        // note that hcalTp.t0().fineGrain(4) and hcalTp.t0().fineGrain(5) are the reserved MIP bits (not used for LLP logic)
         if (caloPhi <= 72) {
           UCTTowerIndex t = UCTTowerIndex(caloEta, caloPhi);
           uint32_t featureBits = 0;

--- a/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
+++ b/L1Trigger/L1TCaloLayer1/plugins/L1TCaloLayer1.cc
@@ -221,7 +221,7 @@ void L1TCaloLayer1::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
             if (fg)
               featureBits |= 0b01;
             // fg2 should only be set for HF
-            if (absCaloEta > 29 && fg2)
+            if (fg2)
               featureBits |= 0b10;
           }
           if (absCaloEta <= 29)

--- a/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
+++ b/L1Trigger/L1TNtuples/interface/L1AnalysisL1UpgradeDataFormat.h
@@ -92,6 +92,7 @@ namespace L1Analysis {
       jetIEt.clear();
       jetIEta.clear();
       jetIPhi.clear();
+      jetHwQual.clear();
       jetBx.clear();
       jetTowerIPhi.clear();
       jetTowerIEta.clear();
@@ -184,6 +185,7 @@ namespace L1Analysis {
     std::vector<short int> jetIEt;
     std::vector<short int> jetIEta;
     std::vector<short int> jetIPhi;
+    std::vector<short int> jetHwQual;
     std::vector<short int> jetBx;
     std::vector<short int> jetTowerIPhi;
     std::vector<short int> jetTowerIEta;

--- a/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
+++ b/L1Trigger/L1TNtuples/src/L1AnalysisL1Upgrade.cc
@@ -73,6 +73,7 @@ void L1Analysis::L1AnalysisL1Upgrade::SetJet(const edm::Handle<l1t::JetBxCollect
         l1upgrade_.jetIEt.push_back(it->hwPt());
         l1upgrade_.jetIEta.push_back(it->hwEta());
         l1upgrade_.jetIPhi.push_back(it->hwPhi());
+        l1upgrade_.jetHwQual.push_back(it->hwQual());
         l1upgrade_.jetBx.push_back(ibx);
         l1upgrade_.jetRawEt.push_back(it->rawEt());
         l1upgrade_.jetSeedEt.push_back(it->seedEt());

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
@@ -92,7 +92,7 @@ std::bitset<6> HcalFinegrainBit::compute(const HcalFinegrainBit::TowerTDC& tower
           1;  // deep layers, 3+. If bit13 = 1, energy in deep layers. Require ADC > 0 to ensure valid hit in cell
   }
 
-  // very delayed (100000), slightly delayed (010000), prompt (001000), 2 reserved bits (000110), depth flag (000001)
+  // very delayed (001000), slightly delayed (000100), prompt (000010), depth flag (000001), 2 reserved bits (110000)
   if (DeepEnergy > 0 && EarlyEnergy == 0)
     result[0] = true;  // 000001
   else


### PR DESCRIPTION
#### PR description:

This PR implements the L1 emulator of the LLP displaced jet trigger algorithm. Calo L1 takes the 6 fine grain bits from the HCAL uHTR (PRs [#34600](https://github.com/cms-sw/cmssw/pull/34600) and [#35599](https://github.com/cms-sw/cmssw/pull/35599)) and uses a 6:1 LUT to set a single bit of tower hwQual based on the logical OR of the timing and depth information. The Calo L2 jet algorithm flags a jet as delayed if there are >= 2 flagged towers within the 9x9 jet region. This is saved in the LSB of jet.hwQual, 1 if jet is flagged as containing an LLP, 0 otherwise. L1 and L2 firmware updates have been completed. 

The uGT emulator follows, and is implemented in recent PR [#36868](https://github.com/cms-sw/cmssw/pull/36858). L1 Menu Tools is in the process of being updated to include the displaced jet bit, in PR [#74](https://github.com/cms-l1-dpg/L1MenuTools/pull/74).

The L1 seed JIRA ticket, including slides detailing the testing of the L1 emulator and links to relevant presentations, is [here](https://its.cern.ch/jira/browse/CMSLITDPG-963). Slides 2-10 focus on the L1 emulator implementation and validation tests. 

The emulator implementation has been presented at [L1 Trigger CMS Week](https://indico.cern.ch/event/1072305/contributions/4513777/attachments/2308783/3928427/HCAL_L1TCMSweek_14Sept.pdf) and to the [HCAL Trigger](https://indico.cern.ch/event/1069597/contributions/4497838/attachments/2299267/3914153/HCALtrigger_27August.pdf) group.

Additionally, the L1TNtuples are updated to store the jet hwQual information (in `L1AnalysisL1Upgrade.cc` and `L1AnalysisL1UpgradeDataFormat.h`). Tested by myself and @elfontan.

A single comment in `HcalFinegrainBit.cc` is updated to reflect the correct assignment of the 6 fine grain bits from the uHTR. 

#### PR validation:

Passed runTheMatrix.py tests. Tested in CMSSW_12_3_X_2022-02-08-1100.