### PR TITLE
Add muon shower plots to uGMT online DQM

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -3,6 +3,8 @@
 
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 #include "L1Trigger/L1TMuon/interface/MicroGMTConfiguration.h"
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -27,14 +29,17 @@ protected:
 private:
   l1t::tftype getTfOrigin(const int tfMuonIndex);
 
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtBMTFToken;
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtOMTFToken;
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtEMTFToken;
-  edm::EDGetTokenT<l1t::MuonBxCollection> ugmtMuonToken;
-  std::string monitorDir;
-  bool emul;
-  bool verbose;
+  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtBMTFToken_;
+  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtOMTFToken_;
+  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtEMTFToken_;
+  edm::EDGetTokenT<l1t::MuonBxCollection> ugmtMuonToken_;
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> ugmtEMTFShowerToken_;
+  edm::EDGetTokenT<l1t::MuonShowerBxCollection> ugmtMuonShowerToken_;
+  std::string monitorDir_;
+  bool emul_;
+  bool verbose_;
   bool displacedQuantities_;
+  bool hadronicShowers_;
 
   const float etaScale_;
   const float phiScale_;
@@ -93,6 +98,10 @@ private:
   MonitorElement* ugmtEMTFMuMuDEta;
   MonitorElement* ugmtEMTFMuMuDPhi;
   MonitorElement* ugmtEMTFMuMuDR;
+
+  MonitorElement* ugmtEMTFShowerTypeOccupancyPerSector;
+  MonitorElement* ugmtEMTFShowerTypeOccupancyPerBx;
+  MonitorElement* ugmtEMTFShowerSectorOccupancyPerBx;
 
   MonitorElement* ugmtBOMTFposMuMuDEta;
   MonitorElement* ugmtBOMTFposMuMuDPhi;
@@ -161,6 +170,9 @@ private:
   MonitorElement* ugmtMuonBXvshwIso;
   MonitorElement* ugmtMuonChargevsLink;
 
+  // Output shower plots
+  MonitorElement* ugmtMuonShowerTypeOccupancyPerBx;
+
   // muon correlations
   MonitorElement* ugmtMuMuInvMass;
   MonitorElement* ugmtMuMuInvMassAtVtx;
@@ -200,6 +212,9 @@ private:
   MonitorElement* ugmtMuMuDEtaEneg;
   MonitorElement* ugmtMuMuDPhiEneg;
   MonitorElement* ugmtMuMuDREneg;
+
+  static constexpr unsigned IDX_TIGHT_SHOWER{2};
+  static constexpr unsigned IDX_NOMINAL_SHOWER{1};
 };
 
 #endif

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -7,13 +7,16 @@ l1tStage2uGMT = DQMEDAnalyzer(
     bmtfProducer = cms.InputTag("gmtStage2Digis", "BMTF"),
     omtfProducer = cms.InputTag("gmtStage2Digis", "OMTF"),
     emtfProducer = cms.InputTag("gmtStage2Digis", "EMTF"),
+    emtfShowerProducer = cms.InputTag("gmtStage2Digis", "EMTF"),
     muonProducer = cms.InputTag("gmtStage2Digis", "Muon"),
+    muonShowerProducer = cms.InputTag("gmtStage2Digis", "MuonShower"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT"),
     emulator = cms.untracked.bool(False),
     verbose = cms.untracked.bool(False),
-    displacedQuantities = cms.untracked.bool(False)
+    displacedQuantities = cms.untracked.bool(False),
+    hadronicShowers = cms.untracked.bool(False)
 )
 
 ## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tStage2uGMT, displacedQuantities = cms.untracked.bool(True))
+stage2L1Trigger_2021.toModify(l1tStage2uGMT, displacedQuantities = cms.untracked.bool(True), hadronicShowers = cms.untracked.bool(True))


### PR DESCRIPTION
#### PR description:

This PR adds DQM plots for the new hadronic showers at the uGMT input and output. They are gated behind flags only set true for the Run3 era.

#### PR validation:

Used a private RAW file to check if the plots appear in the DQM. Also checked that they aren't created when not run under the Run3 era.
