### PR TITLE
Add option in IgProfService to dump profiles at {pre,post}ModuleEvent

### DIFF
--- a/IgTools/IgProf/plugins/IgProfService.cc
+++ b/IgTools/IgProf/plugins/IgProfService.cc
@@ -58,6 +58,13 @@ IgProfService::IgProfService(ParameterSet const &ps, ActivityRegistry &iRegistry
   atPreEvent_ = ps.getUntrackedParameter<std::string>("reportToFileAtPreEvent", atPreEvent_);
   atPostEvent_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostEvent", atPostEvent_);
 
+  modules_ = ps.getUntrackedParameter<std::vector<std::string>>("reportModules", modules_);
+  moduleTypes_ = ps.getUntrackedParameter<std::vector<std::string>>("reportModuleTypes", moduleTypes_);
+  std::sort(modules_.begin(), modules_.end());
+  std::sort(moduleTypes_.begin(), moduleTypes_.end());
+  atPreModuleEvent_ = ps.getUntrackedParameter<std::string>("reportToFileAtPreModuleEvent", atPreModuleEvent_);
+  atPostModuleEvent_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostModuleEvent", atPostModuleEvent_);
+
   atPostEndLumi_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostEndLumi", atPostEndLumi_);
   atPostEndRun_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostEndRun", atPostEndRun_);
   atPostEndJob_ = ps.getUntrackedParameter<std::string>("reportToFileAtPostEndJob", atPostEndJob_);
@@ -72,6 +79,11 @@ IgProfService::IgProfService(ParameterSet const &ps, ActivityRegistry &iRegistry
 
   iRegistry.watchPreEvent(this, &IgProfService::preEvent);
   iRegistry.watchPostEvent(this, &IgProfService::postEvent);
+
+  if (not modules_.empty() or not moduleTypes_.empty()) {
+    iRegistry.watchPreModuleEvent(this, &IgProfService::preModuleEvent);
+    iRegistry.watchPostModuleEvent(this, &IgProfService::postModuleEvent);
+  }
 
   iRegistry.watchPostGlobalEndLumi(this, &IgProfService::postEndLumi);
   iRegistry.watchPostGlobalEndRun(this, &IgProfService::postEndRun);
@@ -106,9 +118,39 @@ void IgProfService::postEvent(StreamContext const &iStream) {
     makeDump(atPostEvent_);
 }
 
-void IgProfService::postEndLumi(GlobalContext const &) { makeDump(atPostEndLumi_); }
+void IgProfService::preModuleEvent(StreamContext const &iStream, ModuleCallingContext const &mcc) {
+  nevent_ = iStream.eventID().event();
+  if ((prescale_ > 0) && (nrecord_ >= mineventrecord_) && (((nrecord_ - mineventrecord_) % prescale_) == 0)) {
+    auto const &moduleLabel = mcc.moduleDescription()->moduleLabel();
+    auto const &moduleType = mcc.moduleDescription()->moduleName();
+    if (std::binary_search(modules_.begin(), modules_.end(), moduleLabel) or
+        std::binary_search(moduleTypes_.begin(), moduleTypes_.end(), moduleType)) {
+      makeDump(atPreModuleEvent_, moduleLabel);
+    }
+  }
+}
 
-void IgProfService::postEndRun(GlobalContext const &) { makeDump(atPostEndRun_); }
+void IgProfService::postModuleEvent(StreamContext const &iStream, ModuleCallingContext const &mcc) {
+  nevent_ = iStream.eventID().event();
+  if ((prescale_ > 0) && (nrecord_ >= mineventrecord_) && (((nrecord_ - mineventrecord_) % prescale_) == 0)) {
+    auto const &moduleLabel = mcc.moduleDescription()->moduleLabel();
+    auto const &moduleType = mcc.moduleDescription()->moduleName();
+    if (std::binary_search(modules_.begin(), modules_.end(), moduleLabel) or
+        std::binary_search(moduleTypes_.begin(), moduleTypes_.end(), moduleType)) {
+      makeDump(atPostModuleEvent_, moduleLabel);
+    }
+  }
+}
+
+void IgProfService::postEndLumi(GlobalContext const &gc) {
+  nlumi_ = gc.luminosityBlockID().luminosityBlock();
+  makeDump(atPostEndLumi_);
+}
+
+void IgProfService::postEndRun(GlobalContext const &gc) {
+  nrun_ = gc.luminosityBlockID().run();
+  makeDump(atPostEndRun_);
+}
 
 void IgProfService::postEndJob() { makeDump(atPostEndJob_); }
 
@@ -122,7 +164,7 @@ void IgProfService::postCloseFile(std::string const &) {
   makeDump(atPostCloseFile_);
 }
 
-void IgProfService::makeDump(const std::string &format) {
+void IgProfService::makeDump(const std::string &format, std::string_view moduleLabel) {
   if (!dump_ || format.empty())
     return;
 
@@ -133,6 +175,7 @@ void IgProfService::makeDump(const std::string &format) {
   final = replaceU64(final, "%L", nlumi_);
   final = replace(final, "%F", nfileopened_);
   final = replace(final, "%C", nfileclosed_);
+  final = replace(final, "%M", moduleLabel);
   dump_(final.c_str());
 }
 
@@ -159,6 +202,18 @@ std::string IgProfService::replaceU64(const std::string &s, const char *pat, uns
     int n = sprintf(buf, "%llu", val);
     result.replace(pos, patlen, buf);
     pos = pos - patlen + n;
+  }
+
+  return result;
+}
+
+std::string IgProfService::replace(const std::string &s, const char *pat, std::string_view val) {
+  size_t pos = 0;
+  size_t patlen = strlen(pat);
+  std::string result = s;
+  while ((pos = result.find(pat, pos)) != std::string::npos) {
+    result.replace(pos, patlen, val.data());
+    pos = pos - patlen + val.size();
   }
 
   return result;

--- a/IgTools/IgProf/plugins/IgProfService.h
+++ b/IgTools/IgProf/plugins/IgProfService.h
@@ -30,6 +30,9 @@ namespace edm {
       void preEvent(StreamContext const &sc);
       void postEvent(StreamContext const &sc);
 
+      void preModuleEvent(StreamContext const &sc, ModuleCallingContext const &mcc);
+      void postModuleEvent(StreamContext const &sc, ModuleCallingContext const &mcc);
+
       void postEndLumi(GlobalContext const &gc);
 
       void postEndRun(GlobalContext const &gc);
@@ -43,9 +46,10 @@ namespace edm {
       inline bool isProcessWideService(IgProfService const *) { return true; }
 
     private:
-      void makeDump(const std::string &format);
+      void makeDump(const std::string &format, std::string_view moduleLabel = "");
       static std::string replace(const std::string &s, const char *pat, int val);
       static std::string replaceU64(const std::string &s, const char *pat, unsigned long long val);
+      static std::string replace(const std::string &s, const char *pat, std::string_view val);
 
       void (*dump_)(const char *);
 
@@ -55,6 +59,11 @@ namespace edm {
 
       std::string atPreEvent_;
       std::string atPostEvent_;
+
+      std::vector<std::string> modules_;
+      std::vector<std::string> moduleTypes_;
+      std::string atPreModuleEvent_;
+      std::string atPostModuleEvent_;
 
       std::string atPostEndLumi_;
       std::string atPostEndRun_;


### PR DESCRIPTION
#### PR description:

This PR adds an option to dump IgProf profiles at {pre,post}ModuleEvent signals. The behavior can be configured with  `reportModules` (`vstring` for module labels) and `reportModuleTypes` (vstring for module C++ types) parameters: if the current module has either the label in `reportModules` or type in `reportModuleTypes`, the profile is dumped. The profile file names can be set with `reportToFileAt{Pre,Post}ModuleEvent (string for file name pattern) parameters. A new pattern `%M` is added for the module name.

#### PR validation:

