### PR TITLE
Add muon shower comparison plots

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2MuonShowerComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonShowerComp.h
@@ -1,0 +1,57 @@
+#ifndef DQM_L1TMonitor_L1TStage2MuonShowerComp_h
+#define DQM_L1TMonitor_L1TStage2MuonShowerComp_h
+
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+class L1TStage2MuonShowerComp : public DQMEDAnalyzer {
+public:
+  L1TStage2MuonShowerComp(const edm::ParameterSet& ps);
+  ~L1TStage2MuonShowerComp() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  enum variables { BXRANGEGOOD = 1, BXRANGEBAD, NSHOWERGOOD, NSHOWERBAD, SHOWERALL, SHOWERGOOD, NOMINALBAD, TIGHTBAD };
+  enum ratioVariables { RBXRANGE = 1, RNSHOWER, RSHOWER, RNOMINAL, RTIGHT };
+  int numSummaryBins_{TIGHTBAD};
+  int numErrBins_{RTIGHT};
+  bool incBin_[RTIGHT + 1];
+
+  edm::EDGetTokenT<l1t::MuonShowerBxCollection> showerToken1_;
+  edm::EDGetTokenT<l1t::MuonShowerBxCollection> showerToken2_;
+  std::string monitorDir_;
+  std::string showerColl1Title_;
+  std::string showerColl2Title_;
+  std::string summaryTitle_;
+  std::vector<int> ignoreBin_;
+  bool verbose_;
+
+  MonitorElement* summary_;
+  MonitorElement* errorSummaryNum_;
+  MonitorElement* errorSummaryDen_;
+
+  MonitorElement* showerColl1BxRange_;
+  MonitorElement* showerColl1nShowers_;
+  MonitorElement* showerColl1ShowerTypeVsBX_;
+
+  MonitorElement* showerColl2BxRange_;
+  MonitorElement* showerColl2nShowers_;
+  MonitorElement* showerColl2ShowerTypeVsBX_;
+
+  static constexpr unsigned IDX_TIGHT_SHOWER{2};
+  static constexpr unsigned IDX_NOMINAL_SHOWER{1};
+};
+
+#endif

--- a/DQM/L1TMonitor/interface/L1TStage2RegionalMuonShowerComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2RegionalMuonShowerComp.h
@@ -1,0 +1,62 @@
+#ifndef DQM_L1TMonitor_L1TStage2RegionalMuonShowerComp_h
+#define DQM_L1TMonitor_L1TStage2RegionalMuonShowerComp_h
+
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+class L1TStage2RegionalMuonShowerComp : public DQMEDAnalyzer {
+public:
+  L1TStage2RegionalMuonShowerComp(const edm::ParameterSet& ps);
+  ~L1TStage2RegionalMuonShowerComp() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  enum variables { BXRANGEGOOD = 1, BXRANGEBAD, NSHOWERGOOD, NSHOWERBAD, SHOWERALL, SHOWERGOOD, NOMINALBAD, TIGHTBAD };
+  enum ratioVariables { RBXRANGE = 1, RNSHOWER, RSHOWER, RNOMINAL, RTIGHT };
+  enum tfs { EMTFNEGBIN = 1, EMTFPOSBIN };
+  int numSummaryBins_{TIGHTBAD};
+  int numErrBins_{RTIGHT};
+  bool incBin_[RTIGHT + 1];
+
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> showerToken1_;
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> showerToken2_;
+  std::string monitorDir_;
+  std::string showerColl1Title_;
+  std::string showerColl2Title_;
+  std::string summaryTitle_;
+  std::vector<int> ignoreBin_;
+  bool verbose_;
+
+  MonitorElement* summary_;
+  MonitorElement* errorSummaryNum_;
+  MonitorElement* errorSummaryDen_;
+
+  MonitorElement* showerColl1BxRange_;
+  MonitorElement* showerColl1nShowers_;
+  MonitorElement* showerColl1ShowerTypeVsProcessor_;
+  MonitorElement* showerColl1ShowerTypeVsBX_;
+  MonitorElement* showerColl1ProcessorVsBX_;
+
+  MonitorElement* showerColl2BxRange_;
+  MonitorElement* showerColl2nShowers_;
+  MonitorElement* showerColl2ShowerTypeVsProcessor_;
+  MonitorElement* showerColl2ShowerTypeVsBX_;
+  MonitorElement* showerColl2ProcessorVsBX_;
+
+  static constexpr unsigned IDX_TIGHT_SHOWER{2};
+  static constexpr unsigned IDX_NOMINAL_SHOWER{1};
+};
+
+#endif

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -45,6 +45,9 @@ DEFINE_FWK_MODULE(L1TStage2MuonComp);
 #include "DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h"
 DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComp);
 
+#include "DQM/L1TMonitor/interface/L1TStage2RegionalMuonShowerComp.h"
+DEFINE_FWK_MODULE(L1TStage2RegionalMuonShowerComp);
+
 #include "DQM/L1TMonitor/interface/L1TStage2uGT.h"
 DEFINE_FWK_MODULE(L1TStage2uGT);
 

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -42,6 +42,9 @@ DEFINE_FWK_MODULE(L1TStage2uGMTMuon);
 #include "DQM/L1TMonitor/interface/L1TStage2MuonComp.h"
 DEFINE_FWK_MODULE(L1TStage2MuonComp);
 
+#include "DQM/L1TMonitor/interface/L1TStage2MuonShowerComp.h"
+DEFINE_FWK_MODULE(L1TStage2MuonShowerComp);
+
 #include "DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h"
 DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComp);
 

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -94,6 +94,11 @@ valGmtStage2Digis = simGmtStage2Digis.clone(
     triggerTowerInput = "valGmtCaloSumDigis:TriggerTowerSums"
 )
 
+# uGMT shower
+valGmtShowerDigis = simGmtShowerDigis.clone(
+    showerInput = "gmtStage2Digis:EMTF"
+)
+
 # uGT
 from L1Trigger.L1TGlobal.simGtStage2Digis_cfi import simGtStage2Digis
 from L1Trigger.L1TGlobal.simGtExtFakeProd_cfi import simGtExtFakeProd
@@ -131,7 +136,7 @@ _run3_Stage2L1HardwareValidation = Stage2L1HardwareValidation.copy()
 run3_GEM.toReplaceWith( Stage2L1HardwareValidation, cms.Sequence( valMuonGEMPadDigis + valMuonGEMPadDigiClusters + _run3_Stage2L1HardwareValidation) )
 
 _run3Shower_Stage2L1HardwareValidation = Stage2L1HardwareValidation.copy()
-run3_GEM.toReplaceWith( Stage2L1HardwareValidation, cms.Sequence(_run3Shower_Stage2L1HardwareValidation + valEmtfStage2Showers) )
+run3_GEM.toReplaceWith( Stage2L1HardwareValidation, cms.Sequence(_run3Shower_Stage2L1HardwareValidation + valEmtfStage2Showers + valGmtShowerDigis) )
 
 Stage2L1HardwareValidationForValidationEvents = cms.Sequence(
     valCaloStage2Layer2Digis

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -112,9 +112,10 @@ l1tStage2uGMTZeroSuppFatEvts.monitorDir = cms.untracked.string("L1T/L1TStage2uGM
 
 # List of bins to ignore
 ignoreBins = {
-    'Bmtf' : [1],
-    'Omtf' : [1],
-    'Emtf' : [1]
+    'Bmtf'        : [1],
+    'Omtf'        : [1],
+    'Emtf'        : [1],
+    'EmtfShowers' : [1]
     }
 
 # compares the unpacked BMTF output regional muon collection with the unpacked uGMT input regional muon collection from BMTF
@@ -165,6 +166,21 @@ l1tStage2EmtfOutVsuGMTIn = DQMEDAnalyzer(
 
 ## Era: Run3_2021; Displaced muons from EMTF used in uGMT from Run-3
 stage2L1Trigger_2021.toModify(l1tStage2EmtfOutVsuGMTIn, hasDisplacementInfo = cms.untracked.bool(True))
+
+# TODO: Run this module only for Run3!
+# compares the unpacked EMTF output regional muon shower collection with the unpacked uGMT input regional muon shower collection from EMTF
+# only muons that do not match are filled in the histograms
+l1tStage2EmtfOutVsuGMTInShowers = DQMEDAnalyzer(
+    "L1TStage2RegionalMuonShowerComp",
+    regionalMuonShowerCollection1 = cms.InputTag("emtfStage2Digis"),
+    regionalMuonShowerCollection2 = cms.InputTag("gmtStage2Digis", "EMTF"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/EMTFoutput_vs_uGMTinput/Muon Showers"),
+    regionalMuonShowerCollection1Title = cms.untracked.string("EMTF output data"),
+    regionalMuonShowerCollection2Title = cms.untracked.string("uGMT input data from EMTF"),
+    summaryTitle = cms.untracked.string("Summary of comparison between EMTF output showers and uGMT input showers from EMTF"),
+    ignoreBin = cms.untracked.vint32(ignoreBins['EmtfShowers']),
+    verbose = cms.untracked.bool(False),
+)
 
 # The five modules below compare the primary unpacked uGMT muon collection to goes to uGT board 0
 # to the unpacked uGMT muon collections that are sent to uGT boards 1 to 5.
@@ -221,6 +237,7 @@ l1tStage2uGMTOnlineDQMSeq = cms.Sequence(
     l1tStage2BmtfOutVsuGMTIn +
     l1tStage2OmtfOutVsuGMTIn +
     l1tStage2EmtfOutVsuGMTIn
+    # l1tStage2EmtfOutVsuGMTInShowers  # TODO: Once the EMTF shower unpacker becomes available we can enable this module.
 )
 
 l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -167,7 +167,6 @@ l1tStage2EmtfOutVsuGMTIn = DQMEDAnalyzer(
 ## Era: Run3_2021; Displaced muons from EMTF used in uGMT from Run-3
 stage2L1Trigger_2021.toModify(l1tStage2EmtfOutVsuGMTIn, hasDisplacementInfo = cms.untracked.bool(True))
 
-# TODO: Run this module only for Run3!
 # compares the unpacked EMTF output regional muon shower collection with the unpacked uGMT input regional muon shower collection from EMTF
 # only muons that do not match are filled in the histograms
 l1tStage2EmtfOutVsuGMTInShowers = DQMEDAnalyzer(
@@ -273,7 +272,6 @@ l1tStage2uGMTOnlineDQMSeq = cms.Sequence(
     l1tStage2BmtfOutVsuGMTIn +
     l1tStage2OmtfOutVsuGMTIn +
     l1tStage2EmtfOutVsuGMTIn
-    # l1tStage2EmtfOutVsuGMTInShowers  # TODO: Once the EMTF shower unpacker becomes available we can enable this module.
 )
 
 l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(
@@ -282,10 +280,23 @@ l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMTMuonVsuGMTMuonCopy2 +
     l1tStage2uGMTMuonVsuGMTMuonCopy3 +
     l1tStage2uGMTMuonVsuGMTMuonCopy4 +
-    l1tStage2uGMTMuonVsuGMTMuonCopy5 +
+    l1tStage2uGMTMuonVsuGMTMuonCopy5
+)
+
+
+## Era: Run3_2021; Hadronic showers from EMTF used in uGMT from Run-3
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+
+## TODO: To be enabled once we have unpacked EMTF showers
+# _run3_l1tStage2uGMTOnlineDQMSeq = cms.Sequence(l1tStage2uGMTOnlineDQMSeq.copy() + l1tStage2EmtfOutVsuGMTInShowers)
+# stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTOnlineDQMSeq, _run3_l1tStage2uGMTOnlineDQMSeq)
+
+_run3_l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(l1tStage2uGMTValidationEventOnlineDQMSeq.copy() +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy2 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy3 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy4 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy5
 )
+stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTValidationEventOnlineDQMSeq, _run3_l1tStage2uGMTValidationEventOnlineDQMSeq)
+

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -225,6 +225,42 @@ l1tStage2uGMTMuonVsuGMTMuonCopy5 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
     muonCollection2Title = "uGMT muons copy 5",
     summaryTitle = "Summary of comparison between uGMT muons and uGMT muon copy 5"
 )
+
+l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1= DQMEDAnalyzer("L1TStage2MuonShowerComp",
+    muonShowerCollection1 = cms.InputTag("gmtStage2Digis", "MuonShower"),
+    muonShowerCollection2 = cms.InputTag("gmtStage2Digis", "MuonShowerCopy1"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/uGMTMuonShowerCopies/uGMTMuonShowerCopy1"),
+    muonShowerCollection1Title = cms.untracked.string("uGMT muon showers"),
+    muonShowerCollection2Title = cms.untracked.string("uGMT muon showers copy 1"),
+    summaryTitle = cms.untracked.string("Summary of comparison between uGMT showers and uGMT shower copy 1"),
+    verbose = cms.untracked.bool(False)
+)
+
+l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy2 = l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1.clone(
+    muonShowerCollection2 = "gmtStage2Digis:MuonShowerCopy2",
+    monitorDir = "L1T/L1TStage2uGMT/uGMTMuonShowerCopies/uGMTMuonShowerCopy2",
+    muonShowerCollection2Title = "uGMT muon showers copy 2",
+    summaryTitle = "Summary of comparison between uGMT showers and uGMT shower copy 2"
+)
+l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy3 = l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1.clone(
+    muonShowerCollection2 = "gmtStage2Digis:MuonShowerCopy3",
+    monitorDir = "L1T/L1TStage2uGMT/uGMTMuonShowerCopies/uGMTMuonShowerCopy3",
+    muonShowerCollection2Title = "uGMT muon showers copy 3",
+    summaryTitle = "Summary of comparison between uGMT showers and uGMT shower copy 3"
+)
+l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy4 = l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1.clone(
+    muonShowerCollection2 = "gmtStage2Digis:MuonShowerCopy4",
+    monitorDir = "L1T/L1TStage2uGMT/uGMTMuonShowerCopies/uGMTMuonShowerCopy4",
+    muonShowerCollection2Title = "uGMT muon showers copy 4",
+    summaryTitle = "Summary of comparison between uGMT showers and uGMT shower copy 4"
+)
+l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy5 = l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1.clone(
+    muonShowerCollection2 = "gmtStage2Digis:MuonShowerCopy5",
+    monitorDir = "L1T/L1TStage2uGMT/uGMTMuonShowerCopies/uGMTMuonShowerCopy5",
+    muonShowerCollection2Title = "uGMT muon showers copy 5",
+    summaryTitle = "Summary of comparison between uGMT showers and uGMT shower copy 5"
+)
+
 # sequences
 l1tStage2uGMTOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMT +
@@ -246,5 +282,10 @@ l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMTMuonVsuGMTMuonCopy2 +
     l1tStage2uGMTMuonVsuGMTMuonCopy3 +
     l1tStage2uGMTMuonVsuGMTMuonCopy4 +
-    l1tStage2uGMTMuonVsuGMTMuonCopy5
+    l1tStage2uGMTMuonVsuGMTMuonCopy5 +
+    l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1 +
+    l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy2 +
+    l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy3 +
+    l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy4 +
+    l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy5
 )

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -155,10 +155,13 @@ l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMTIntermediateEMTFNegEmul +
     l1tStage2uGMTIntermediateEMTFPosEmul +
     l1tdeStage2uGMT +
-    l1tdeStage2uGMTShowers +
     l1tdeStage2uGMTIntermediateBMTF +
     l1tdeStage2uGMTIntermediateOMTFNeg +
     l1tdeStage2uGMTIntermediateOMTFPos +
     l1tdeStage2uGMTIntermediateEMTFNeg +
     l1tdeStage2uGMTIntermediateEMTFPos
 )
+
+_run3_l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(l1tStage2uGMTEmulatorOnlineDQMSeq.copy() + l1tdeStage2uGMTShowers)
+stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTEmulatorOnlineDQMSeq, _run3_l1tStage2uGMTEmulatorOnlineDQMSeq)
+

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # input modules
 unpackerModule = "gmtStage2Digis"
 emulatorModule = "valGmtStage2Digis"
+showerEmulatorModule = "valGmtShowerDigis"
 
 # directories
 ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
@@ -90,6 +91,20 @@ l1tdeStage2uGMT = DQMEDAnalyzer(
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
 stage2L1Trigger_2021.toModify(l1tdeStage2uGMT, displacedQuantities = cms.untracked.bool(True))
 
+# compares the unpacked uGMT muon shower collection to the emulated uGMT muon shower collection
+# only showers that do not match are filled in the histograms
+l1tdeStage2uGMTShowers = DQMEDAnalyzer(
+    "L1TStage2MuonShowerComp",
+    muonShowerCollection1 = cms.InputTag(unpackerModule, "MuonShower"),
+    muonShowerCollection2 = cms.InputTag(showerEmulatorModule),
+    monitorDir = cms.untracked.string(ugmtEmuDqmDir+"/data_vs_emulator_comparison/Muon showers"),
+    muonShowerCollection1Title = cms.untracked.string("uGMT data"),
+    muonShowerCollection2Title = cms.untracked.string("uGMT emulator"),
+    summaryTitle = cms.untracked.string("Summary of comparison between uGMT showers and uGMT emulator showers"),
+    verbose = cms.untracked.bool(False),
+    ignoreBin = cms.untracked.vint32(),
+)
+
 # compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection
 # only muons that do not match are filled in the histograms
 l1tdeStage2uGMTIntermediateBMTF = l1tdeStage2uGMT.clone(
@@ -140,6 +155,7 @@ l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMTIntermediateEMTFNegEmul +
     l1tStage2uGMTIntermediateEMTFPosEmul +
     l1tdeStage2uGMT +
+    l1tdeStage2uGMTShowers +
     l1tdeStage2uGMTIntermediateBMTF +
     l1tdeStage2uGMTIntermediateOMTFNeg +
     l1tdeStage2uGMTIntermediateOMTFPos +

--- a/DQM/L1TMonitor/src/L1TStage2MuonShowerComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonShowerComp.cc
@@ -1,0 +1,256 @@
+#include "DQM/L1TMonitor/interface/L1TStage2MuonShowerComp.h"
+
+L1TStage2MuonShowerComp::L1TStage2MuonShowerComp(const edm::ParameterSet& ps)
+    : showerToken1_(consumes<l1t::MuonShowerBxCollection>(ps.getParameter<edm::InputTag>("muonShowerCollection1"))),
+      showerToken2_(consumes<l1t::MuonShowerBxCollection>(ps.getParameter<edm::InputTag>("muonShowerCollection2"))),
+      monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")),
+      showerColl1Title_(ps.getUntrackedParameter<std::string>("muonShowerCollection1Title")),
+      showerColl2Title_(ps.getUntrackedParameter<std::string>("muonShowerCollection2Title")),
+      summaryTitle_(ps.getUntrackedParameter<std::string>("summaryTitle")),
+      ignoreBin_(ps.getUntrackedParameter<std::vector<int>>("ignoreBin")),
+      verbose_(ps.getUntrackedParameter<bool>("verbose")) {
+  // First include all bins
+  for (int i = 1; i <= numErrBins_; i++) {
+    incBin_[i] = true;
+  }
+  // Then check the list of bins to ignore
+  for (const auto& i : ignoreBin_) {
+    if (i > 0 && i <= numErrBins_) {
+      incBin_[i] = false;
+    }
+  }
+}
+
+L1TStage2MuonShowerComp::~L1TStage2MuonShowerComp() {}
+
+void L1TStage2MuonShowerComp::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("muonShowerCollection1")->setComment("L1T Muon Shower collection 1");
+  desc.add<edm::InputTag>("muonShowerCollection2")->setComment("L1T Muon Shower collection 2");
+  desc.addUntracked<std::string>("monitorDir", "")
+      ->setComment("Target directory in the DQM file. Will be created if not existing.");
+  desc.addUntracked<std::string>("muonShowerCollection1Title", "Muon Shower collection 1")
+      ->setComment("Histogram title for first collection.");
+  desc.addUntracked<std::string>("muonShowerCollection2Title", "Muon Shower collection 2")
+      ->setComment("Histogram title for second collection.");
+  desc.addUntracked<std::string>("summaryTitle", "Summary")->setComment("Title of summary histogram.");
+  desc.addUntracked<std::vector<int>>("ignoreBin", std::vector<int>())->setComment("List of bins to ignore");
+  desc.addUntracked<bool>("verbose", false);
+  descriptions.add("l1tStage2MuonShowerComp", desc);
+}
+
+void L1TStage2MuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
+  // Subsystem Monitoring and Muon Shower Output
+  ibooker.setCurrentFolder(monitorDir_);
+
+  summary_ = ibooker.book1D("summary",
+                            summaryTitle_.c_str(),
+                            numSummaryBins_,
+                            1,
+                            numSummaryBins_ + 1);  // range to match bin numbering
+  summary_->setBinLabel(BXRANGEGOOD, "BX range match", 1);
+  summary_->setBinLabel(BXRANGEBAD, "BX range mismatch", 1);
+  summary_->setBinLabel(NSHOWERGOOD, "shower collection size match", 1);
+  summary_->setBinLabel(NSHOWERBAD, "shower collection size mismatch", 1);
+  summary_->setBinLabel(SHOWERALL, "# showers", 1);
+  summary_->setBinLabel(SHOWERGOOD, "# matching showers", 1);
+  summary_->setBinLabel(NOMINALBAD, "nominal shower mismatch", 1);
+  summary_->setBinLabel(TIGHTBAD, "tight shower mismatch", 1);
+
+  errorSummaryNum_ = ibooker.book1D("errorSummaryNum",
+                                    summaryTitle_.c_str(),
+                                    numErrBins_,
+                                    1,
+                                    numErrBins_ + 1);  // range to match bin numbering
+  errorSummaryNum_->setBinLabel(RBXRANGE, "BX range mismatch", 1);
+  errorSummaryNum_->setBinLabel(RNSHOWER, "shower collection size mismatch", 1);
+  errorSummaryNum_->setBinLabel(RSHOWER, "mismatching showers", 1);
+  errorSummaryNum_->setBinLabel(RNOMINAL, "nominal shower mismatch", 1);
+  errorSummaryNum_->setBinLabel(RTIGHT, "tight shower mismatch", 1);
+
+  // Change the label for those bins that will be ignored
+  for (int i = 1; i <= errorSummaryNum_->getNbinsX(); i++) {
+    if (incBin_[i] == false) {
+      errorSummaryNum_->setBinLabel(i, "Ignored", 1);
+    }
+  }
+  // Setting canExtend to false is needed to get the correct behaviour when running multithreaded.
+  // Otherwise, when merging the histgrams of the threads, TH1::Merge sums bins that have the same label in one bin.
+  // This needs to come after the calls to setBinLabel.
+  errorSummaryNum_->getTH1F()->GetXaxis()->SetCanExtend(false);
+
+  errorSummaryDen_ = ibooker.book1D(
+      "errorSummaryDen", "denominators", numErrBins_, 1, numErrBins_ + 1);  // range to match bin numbering
+  errorSummaryDen_->setBinLabel(RBXRANGE, "# events", 1);
+  errorSummaryDen_->setBinLabel(RNSHOWER, "# shower collections", 1);
+  for (int i = RSHOWER; i <= errorSummaryDen_->getNbinsX(); ++i) {
+    errorSummaryDen_->setBinLabel(i, "# showers", 1);
+  }
+  // Needed for correct histogram summing in multithreaded running.
+  errorSummaryDen_->getTH1F()->GetXaxis()->SetCanExtend(false);
+
+  showerColl1BxRange_ =
+      ibooker.book1D("showerBxRangeColl1", (showerColl1Title_ + " mismatching BX range").c_str(), 11, -5.5, 5.5);
+  showerColl1BxRange_->setAxisTitle("BX range", 1);
+  showerColl1nShowers_ =
+      ibooker.book1D("nShowerColl1", (showerColl1Title_ + " mismatching shower multiplicity").c_str(), 37, -0.5, 36.5);
+  showerColl1nShowers_->setAxisTitle("Shower multiplicity", 1);
+  showerColl1ShowerTypeVsBX_ = ibooker.book2D("showerColl1ShowerTypeVsBX",
+                                              showerColl1Title_ + " mismatching shower type occupancy per BX",
+                                              7,
+                                              -3.5,
+                                              3.5,
+                                              2,
+                                              1,
+                                              3);
+  showerColl1ShowerTypeVsBX_->setAxisTitle("BX", 1);
+  showerColl1ShowerTypeVsBX_->setAxisTitle("Shower type", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+
+  showerColl2BxRange_ =
+      ibooker.book1D("showerBxRangeColl2", (showerColl2Title_ + " mismatching BX range").c_str(), 11, -5.5, 5.5);
+  showerColl2BxRange_->setAxisTitle("BX range", 1);
+  showerColl2nShowers_ =
+      ibooker.book1D("nShowerColl2", (showerColl2Title_ + " mismatching shower multiplicity").c_str(), 37, -0.5, 36.5);
+  showerColl2nShowers_->setAxisTitle("Shower multiplicity", 1);
+  showerColl2ShowerTypeVsBX_ = ibooker.book2D("showerColl2ShowerTypeVsBX",
+                                              showerColl2Title_ + " mismatching shower type occupancy per BX",
+                                              7,
+                                              -3.5,
+                                              3.5,
+                                              2,
+                                              1,
+                                              3);
+  showerColl2ShowerTypeVsBX_->setAxisTitle("BX", 1);
+  showerColl2ShowerTypeVsBX_->setAxisTitle("Shower type", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+}
+
+void L1TStage2MuonShowerComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  if (verbose_) {
+    edm::LogInfo("L1TStage2MuonShowerComp") << "L1TStage2MuonShowerComp: analyze..." << std::endl;
+  }
+
+  edm::Handle<l1t::MuonShowerBxCollection> showerBxColl1;
+  edm::Handle<l1t::MuonShowerBxCollection> showerBxColl2;
+  e.getByToken(showerToken1_, showerBxColl1);
+  e.getByToken(showerToken2_, showerBxColl2);
+
+  errorSummaryDen_->Fill(RBXRANGE);
+  int bxRange1 = showerBxColl1->getLastBX() - showerBxColl1->getFirstBX() + 1;
+  int bxRange2 = showerBxColl2->getLastBX() - showerBxColl2->getFirstBX() + 1;
+  if (bxRange1 != bxRange2) {
+    summary_->Fill(BXRANGEBAD);
+    if (incBin_[RBXRANGE])
+      errorSummaryNum_->Fill(RBXRANGE);
+    int bx;
+    for (bx = showerBxColl1->getFirstBX(); bx <= showerBxColl1->getLastBX(); ++bx) {
+      showerColl1BxRange_->Fill(bx);
+    }
+    for (bx = showerBxColl2->getFirstBX(); bx <= showerBxColl2->getLastBX(); ++bx) {
+      showerColl2BxRange_->Fill(bx);
+    }
+  } else {
+    summary_->Fill(BXRANGEGOOD);
+  }
+
+  for (int iBx = showerBxColl1->getFirstBX(); iBx <= showerBxColl1->getLastBX(); ++iBx) {
+    // don't analyse if this BX does not exist in the second collection
+    if (iBx < showerBxColl2->getFirstBX() || iBx > showerBxColl2->getLastBX()) {
+      continue;
+    }
+
+    l1t::MuonShowerBxCollection::const_iterator showerIt1;
+    l1t::MuonShowerBxCollection::const_iterator showerIt2;
+
+    errorSummaryDen_->Fill(RNSHOWER);
+    // check number of showers
+    if (showerBxColl1->size(iBx) != showerBxColl2->size(iBx)) {
+      summary_->Fill(NSHOWERBAD);
+      if (incBin_[RNSHOWER]) {
+        errorSummaryNum_->Fill(RNSHOWER);
+      }
+      showerColl1nShowers_->Fill(showerBxColl1->size(iBx));
+      showerColl2nShowers_->Fill(showerBxColl2->size(iBx));
+
+      if (showerBxColl1->size(iBx) > showerBxColl2->size(iBx)) {
+        showerIt1 = showerBxColl1->begin(iBx) + showerBxColl2->size(iBx);
+        for (; showerIt1 != showerBxColl1->end(iBx); ++showerIt1) {
+          if (showerIt1->isOneNominalInTime()) {
+            showerColl1ShowerTypeVsBX_->Fill(IDX_NOMINAL_SHOWER, iBx);
+          }
+          if (showerIt1->isOneTightInTime()) {
+            showerColl1ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+          }
+        }
+      } else {
+        showerIt2 = showerBxColl2->begin(iBx) + showerBxColl1->size(iBx);
+        for (; showerIt2 != showerBxColl2->end(iBx); ++showerIt2) {
+          if (showerIt2->isOneNominalInTime()) {
+            showerColl2ShowerTypeVsBX_->Fill(IDX_NOMINAL_SHOWER, iBx);
+          }
+          if (showerIt2->isOneTightInTime()) {
+            showerColl2ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+          }
+        }
+      }
+    } else {
+      summary_->Fill(NSHOWERGOOD);
+    }
+
+    showerIt1 = showerBxColl1->begin(iBx);
+    showerIt2 = showerBxColl2->begin(iBx);
+    while (showerIt1 != showerBxColl1->end(iBx) && showerIt2 != showerBxColl2->end(iBx)) {
+      summary_->Fill(SHOWERALL);
+      for (int i = RSHOWER; i <= numErrBins_; ++i) {
+        errorSummaryDen_->Fill(i);
+      }
+
+      bool showerMismatch = false;     // All shower mismatches
+      bool showerSelMismatch = false;  // Muon mismatches excluding ignored bins
+      if (showerIt1->isOneNominalInTime() != showerIt2->isOneNominalInTime()) {
+        showerMismatch = true;
+        summary_->Fill(NOMINALBAD);
+        if (incBin_[RNOMINAL]) {
+          showerSelMismatch = true;
+          errorSummaryNum_->Fill(RNOMINAL);
+        }
+      }
+      if (showerIt1->isOneTightInTime() != showerIt2->isOneTightInTime()) {
+        showerMismatch = true;
+        summary_->Fill(TIGHTBAD);
+        if (incBin_[RTIGHT]) {
+          showerSelMismatch = true;
+          errorSummaryNum_->Fill(RTIGHT);
+        }
+      }
+
+      if (incBin_[RSHOWER] && showerSelMismatch) {
+        errorSummaryNum_->Fill(RSHOWER);
+      }
+
+      if (showerMismatch) {
+        if (showerIt1->isOneNominalInTime()) {
+          showerColl1ShowerTypeVsBX_->Fill(IDX_NOMINAL_SHOWER, iBx);
+        }
+        if (showerIt1->isOneTightInTime()) {
+          showerColl1ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+        }
+
+        if (showerIt2->isOneNominalInTime()) {
+          showerColl2ShowerTypeVsBX_->Fill(IDX_NOMINAL_SHOWER, iBx);
+        }
+        if (showerIt2->isOneTightInTime()) {
+          showerColl2ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+        }
+      } else {
+        summary_->Fill(SHOWERGOOD);
+      }
+
+      ++showerIt1;
+      ++showerIt2;
+    }
+  }
+}

--- a/DQM/L1TMonitor/src/L1TStage2RegionalMuonShowerComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2RegionalMuonShowerComp.cc
@@ -1,0 +1,385 @@
+#include "DQM/L1TMonitor/interface/L1TStage2RegionalMuonShowerComp.h"
+
+L1TStage2RegionalMuonShowerComp::L1TStage2RegionalMuonShowerComp(const edm::ParameterSet& ps)
+    : showerToken1_(consumes<l1t::RegionalMuonShowerBxCollection>(
+          ps.getParameter<edm::InputTag>("regionalMuonShowerCollection1"))),
+      showerToken2_(consumes<l1t::RegionalMuonShowerBxCollection>(
+          ps.getParameter<edm::InputTag>("regionalMuonShowerCollection2"))),
+      monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")),
+      showerColl1Title_(ps.getUntrackedParameter<std::string>("regionalMuonShowerCollection1Title")),
+      showerColl2Title_(ps.getUntrackedParameter<std::string>("regionalMuonShowerCollection2Title")),
+      summaryTitle_(ps.getUntrackedParameter<std::string>("summaryTitle")),
+      ignoreBin_(ps.getUntrackedParameter<std::vector<int>>("ignoreBin")),
+      verbose_(ps.getUntrackedParameter<bool>("verbose")) {
+  // First include all bins
+  for (int i = 1; i <= numErrBins_; i++) {
+    incBin_[i] = true;
+  }
+  // Then check the list of bins to ignore
+  for (const auto& i : ignoreBin_) {
+    if (i > 0 && i <= numErrBins_) {
+      incBin_[i] = false;
+    }
+  }
+}
+
+L1TStage2RegionalMuonShowerComp::~L1TStage2RegionalMuonShowerComp() {}
+
+void L1TStage2RegionalMuonShowerComp::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("regionalMuonShowerCollection1")->setComment("L1T RegionalMuonShower collection 1");
+  desc.add<edm::InputTag>("regionalMuonShowerCollection2")->setComment("L1T RegionalMuonShower collection 2");
+  desc.addUntracked<std::string>("monitorDir", "")
+      ->setComment("Target directory in the DQM file. Will be created if not existing.");
+  desc.addUntracked<std::string>("regionalMuonShowerCollection1Title", "Regional muon shower collection 1")
+      ->setComment("Histogram title for first collection.");
+  desc.addUntracked<std::string>("regionalMuonShowerCollection2Title", "Regional muon shower collection 2")
+      ->setComment("Histogram title for second collection.");
+  desc.addUntracked<std::string>("summaryTitle", "Summary")->setComment("Title of summary histogram.");
+  desc.addUntracked<std::vector<int>>("ignoreBin", std::vector<int>())->setComment("List of bins to ignore");
+  desc.addUntracked<bool>("verbose", false);
+  descriptions.add("L1TStage2RegionalMuonShowerComp", desc);
+}
+
+void L1TStage2RegionalMuonShowerComp::bookHistograms(DQMStore::IBooker& ibooker,
+                                                     const edm::Run&,
+                                                     const edm::EventSetup&) {
+  // Subsystem Monitoring and Muon Shower Output
+  ibooker.setCurrentFolder(monitorDir_);
+
+  summary_ = ibooker.book1D("summary",
+                            summaryTitle_.c_str(),
+                            numSummaryBins_,
+                            1,
+                            numSummaryBins_ + 1);  // range to match bin numbering
+  summary_->setBinLabel(BXRANGEGOOD, "BX range match", 1);
+  summary_->setBinLabel(BXRANGEBAD, "BX range mismatch", 1);
+  summary_->setBinLabel(NSHOWERGOOD, "shower collection size match", 1);
+  summary_->setBinLabel(NSHOWERBAD, "shower collection size mismatch", 1);
+  summary_->setBinLabel(SHOWERALL, "# showers", 1);
+  summary_->setBinLabel(SHOWERGOOD, "# matching showers", 1);
+  summary_->setBinLabel(NOMINALBAD, "nominal shower mismatch", 1);
+  summary_->setBinLabel(TIGHTBAD, "tight shower mismatch", 1);
+
+  errorSummaryNum_ = ibooker.book1D("errorSummaryNum",
+                                    summaryTitle_.c_str(),
+                                    numErrBins_,
+                                    1,
+                                    numErrBins_ + 1);  // range to match bin numbering
+  errorSummaryNum_->setBinLabel(RBXRANGE, "BX range mismatch", 1);
+  errorSummaryNum_->setBinLabel(RNSHOWER, "shower collection size mismatch", 1);
+  errorSummaryNum_->setBinLabel(RSHOWER, "mismatching showers", 1);
+  errorSummaryNum_->setBinLabel(RNOMINAL, "nominal shower mismatch", 1);
+  errorSummaryNum_->setBinLabel(RTIGHT, "tight shower mismatch", 1);
+
+  // Change the label for those bins that will be ignored
+  for (int i = 1; i <= errorSummaryNum_->getNbinsX(); i++) {
+    if (incBin_[i] == false) {
+      errorSummaryNum_->setBinLabel(i, "Ignored", 1);
+    }
+  }
+  // Setting canExtend to false is needed to get the correct behaviour when running multithreaded.
+  // Otherwise, when merging the histgrams of the threads, TH1::Merge sums bins that have the same label in one bin.
+  // This needs to come after the calls to setBinLabel.
+  errorSummaryNum_->getTH1F()->GetXaxis()->SetCanExtend(false);
+
+  errorSummaryDen_ = ibooker.book1D(
+      "errorSummaryDen", "denominators", numErrBins_, 1, numErrBins_ + 1);  // range to match bin numbering
+  errorSummaryDen_->setBinLabel(RBXRANGE, "# events", 1);
+  errorSummaryDen_->setBinLabel(RNSHOWER, "# shower collections", 1);
+  for (int i = RSHOWER; i <= errorSummaryDen_->getNbinsX(); ++i) {
+    errorSummaryDen_->setBinLabel(i, "# showers", 1);
+  }
+  // Needed for correct histogram summing in multithreaded running.
+  errorSummaryDen_->getTH1F()->GetXaxis()->SetCanExtend(false);
+
+  showerColl1BxRange_ =
+      ibooker.book1D("showerBxRangeColl1", (showerColl1Title_ + " mismatching BX range").c_str(), 11, -5.5, 5.5);
+  showerColl1BxRange_->setAxisTitle("BX range", 1);
+  showerColl1nShowers_ =
+      ibooker.book1D("nShowerColl1", (showerColl1Title_ + " mismatching shower multiplicity").c_str(), 37, -0.5, 36.5);
+  showerColl1nShowers_->setAxisTitle("Shower multiplicity", 1);
+  showerColl1ShowerTypeVsProcessor_ =
+      ibooker.book2D("showerColl1ShowerTypeVsProcessor",
+                     showerColl1Title_ + " mismatching shower type occupancy per sector",
+                     12,
+                     1,
+                     13,
+                     2,
+                     1,
+                     3);
+  showerColl1ShowerTypeVsProcessor_->setAxisTitle("Processor", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(12, "+6", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(11, "+5", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(10, "+4", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(9, "+3", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(8, "+2", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(7, "+1", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(6, "-6", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(5, "-5", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(4, "-4", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(3, "-3", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(2, "-2", 1);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(1, "-1", 1);
+  showerColl1ShowerTypeVsProcessor_->setAxisTitle("Shower type", 2);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
+  showerColl1ShowerTypeVsProcessor_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl1ShowerTypeVsBX_ = ibooker.book2D("showerColl1ShowerTypeVsBX",
+                                              showerColl1Title_ + " mismatching shower type occupancy per BX",
+                                              7,
+                                              -3.5,
+                                              3.5,
+                                              2,
+                                              1,
+                                              3);
+  showerColl1ShowerTypeVsBX_->setAxisTitle("BX", 1);
+  showerColl1ShowerTypeVsBX_->setAxisTitle("Shower type", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
+  showerColl1ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl1ProcessorVsBX_ = ibooker.book2D("showerColl1ProcessorVsBX",
+                                             showerColl1Title_ + " mismatching shower BX occupancy per sector",
+                                             7,
+                                             -3.5,
+                                             3.5,
+                                             12,
+                                             1,
+                                             13);
+  showerColl1ProcessorVsBX_->setAxisTitle("BX", 1);
+  showerColl1ProcessorVsBX_->setAxisTitle("Processor", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(12, "+6", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(11, "+5", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(10, "+4", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(9, "+3", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(8, "+2", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(7, "+1", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(6, "-6", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(5, "-5", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(4, "-4", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(3, "-3", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(2, "-2", 2);
+  showerColl1ProcessorVsBX_->setBinLabel(1, "-1", 2);
+
+  showerColl2BxRange_ =
+      ibooker.book1D("showerBxRangeColl2", (showerColl2Title_ + " mismatching BX range").c_str(), 11, -5.5, 5.5);
+  showerColl2BxRange_->setAxisTitle("BX range", 1);
+  showerColl2nShowers_ =
+      ibooker.book1D("nShowerColl2", (showerColl2Title_ + " mismatching shower multiplicity").c_str(), 37, -0.5, 36.5);
+  showerColl2nShowers_->setAxisTitle("Shower multiplicity", 1);
+  showerColl2ShowerTypeVsProcessor_ =
+      ibooker.book2D("showerColl2ShowerTypeVsProcessor",
+                     showerColl2Title_ + " mismatching shower type occupancy per sector",
+                     12,
+                     1,
+                     13,
+                     2,
+                     1,
+                     3);
+  showerColl2ShowerTypeVsProcessor_->setAxisTitle("Processor", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(12, "+6", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(11, "+5", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(10, "+4", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(9, "+3", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(8, "+2", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(7, "+1", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(6, "-6", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(5, "-5", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(4, "-4", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(3, "-3", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(2, "-2", 1);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(1, "-1", 1);
+  showerColl2ShowerTypeVsProcessor_->setAxisTitle("Shower type", 2);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
+  showerColl2ShowerTypeVsProcessor_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl2ShowerTypeVsBX_ = ibooker.book2D("showerColl2ShowerTypeVsBX",
+                                              showerColl2Title_ + " mismatching shower type occupancy per BX",
+                                              7,
+                                              -3.5,
+                                              3.5,
+                                              2,
+                                              1,
+                                              3);
+  showerColl2ShowerTypeVsBX_->setAxisTitle("BX", 1);
+  showerColl2ShowerTypeVsBX_->setAxisTitle("Shower type", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
+  showerColl2ShowerTypeVsBX_->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+  showerColl2ProcessorVsBX_ = ibooker.book2D("showerColl2ProcessorVsBX",
+                                             showerColl2Title_ + " mismatching shower BX occupancy per sector",
+                                             7,
+                                             -3.5,
+                                             3.5,
+                                             12,
+                                             1,
+                                             13);
+  showerColl2ProcessorVsBX_->setAxisTitle("BX", 1);
+  showerColl2ProcessorVsBX_->setAxisTitle("Processor", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(12, "+6", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(11, "+5", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(10, "+4", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(9, "+3", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(8, "+2", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(7, "+1", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(6, "-6", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(5, "-5", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(4, "-4", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(3, "-3", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(2, "-2", 2);
+  showerColl2ProcessorVsBX_->setBinLabel(1, "-1", 2);
+}
+
+void L1TStage2RegionalMuonShowerComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  if (verbose_) {
+    edm::LogInfo("L1TStage2RegionalMuonShowerComp") << "L1TStage2RegionalMuonShowerComp: analyze..." << std::endl;
+  }
+
+  edm::Handle<l1t::RegionalMuonShowerBxCollection> showerBxColl1;
+  edm::Handle<l1t::RegionalMuonShowerBxCollection> showerBxColl2;
+  e.getByToken(showerToken1_, showerBxColl1);
+  e.getByToken(showerToken2_, showerBxColl2);
+
+  errorSummaryDen_->Fill(RBXRANGE);
+  int bxRange1 = showerBxColl1->getLastBX() - showerBxColl1->getFirstBX() + 1;
+  int bxRange2 = showerBxColl2->getLastBX() - showerBxColl2->getFirstBX() + 1;
+  if (bxRange1 != bxRange2) {
+    summary_->Fill(BXRANGEBAD);
+    if (incBin_[RBXRANGE])
+      errorSummaryNum_->Fill(RBXRANGE);
+    int bx;
+    for (bx = showerBxColl1->getFirstBX(); bx <= showerBxColl1->getLastBX(); ++bx) {
+      showerColl1BxRange_->Fill(bx);
+    }
+    for (bx = showerBxColl2->getFirstBX(); bx <= showerBxColl2->getLastBX(); ++bx) {
+      showerColl2BxRange_->Fill(bx);
+    }
+  } else {
+    summary_->Fill(BXRANGEGOOD);
+  }
+
+  for (int iBx = showerBxColl1->getFirstBX(); iBx <= showerBxColl1->getLastBX(); ++iBx) {
+    // don't analyse if this BX does not exist in the second collection
+    if (iBx < showerBxColl2->getFirstBX() || iBx > showerBxColl2->getLastBX())
+      continue;
+
+    l1t::RegionalMuonShowerBxCollection::const_iterator showerIt1;
+    l1t::RegionalMuonShowerBxCollection::const_iterator showerIt2;
+
+    errorSummaryDen_->Fill(RNSHOWER);
+
+    // check number of showers
+    if (showerBxColl1->size(iBx) != showerBxColl2->size(iBx)) {
+      summary_->Fill(NSHOWERBAD);
+      if (incBin_[RNSHOWER])
+        errorSummaryNum_->Fill(RNSHOWER);
+      showerColl1nShowers_->Fill(showerBxColl1->size(iBx));
+      showerColl2nShowers_->Fill(showerBxColl2->size(iBx));
+
+      if (showerBxColl1->size(iBx) > showerBxColl2->size(iBx)) {
+        showerIt1 = showerBxColl1->begin(iBx) + showerBxColl2->size(iBx);
+        for (; showerIt1 != showerBxColl1->end(iBx); ++showerIt1) {
+          if (showerIt1->isOneNominalInTime()) {
+            showerColl1ShowerTypeVsProcessor_->Fill(
+                IDX_NOMINAL_SHOWER,
+                showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+            showerColl1ShowerTypeVsBX_->Fill(IDX_NOMINAL_SHOWER, iBx);
+          }
+          if (showerIt1->isOneTightInTime()) {
+            showerColl1ShowerTypeVsProcessor_->Fill(
+                IDX_TIGHT_SHOWER,
+                showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+            showerColl1ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+          }
+          showerColl1ProcessorVsBX_->Fill(
+              showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0), iBx);
+        }
+      } else {
+        showerIt2 = showerBxColl2->begin(iBx) + showerBxColl1->size(iBx);
+        for (; showerIt2 != showerBxColl2->end(iBx); ++showerIt2) {
+          if (showerIt2->isOneNominalInTime()) {
+            showerColl2ShowerTypeVsProcessor_->Fill(
+                IDX_NOMINAL_SHOWER,
+                showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+            showerColl2ShowerTypeVsBX_->Fill(IDX_NOMINAL_SHOWER, iBx);
+          }
+          if (showerIt2->isOneTightInTime()) {
+            showerColl2ShowerTypeVsProcessor_->Fill(
+                IDX_TIGHT_SHOWER,
+                showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+            showerColl2ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+          }
+          showerColl2ProcessorVsBX_->Fill(
+              showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0), iBx);
+        }
+      }
+    } else {
+      summary_->Fill(NSHOWERGOOD);
+    }
+
+    showerIt1 = showerBxColl1->begin(iBx);
+    showerIt2 = showerBxColl2->begin(iBx);
+    while (showerIt1 != showerBxColl1->end(iBx) && showerIt2 != showerBxColl2->end(iBx)) {
+      summary_->Fill(SHOWERALL);
+      for (int i = RSHOWER; i <= errorSummaryDen_->getNbinsX(); ++i) {
+        errorSummaryDen_->Fill(i);
+      }
+
+      bool showerMismatch = false;     // All shower mismatches
+      bool showerSelMismatch = false;  // Shower mismatches excluding ignored bins
+      if (showerIt1->isOneNominalInTime() != showerIt2->isOneNominalInTime()) {
+        showerMismatch = true;
+        summary_->Fill(NOMINALBAD);
+        if (incBin_[RNOMINAL]) {
+          showerSelMismatch = true;
+          errorSummaryNum_->Fill(RNOMINAL);
+        }
+      }
+      if (showerIt1->isOneTightInTime() != showerIt2->isOneTightInTime()) {
+        showerMismatch = true;
+        summary_->Fill(TIGHTBAD);
+        if (incBin_[RTIGHT]) {
+          showerSelMismatch = true;
+          errorSummaryNum_->Fill(RTIGHT);
+        }
+      }
+      if (incBin_[RSHOWER] && showerSelMismatch) {
+        errorSummaryNum_->Fill(RSHOWER);
+      }
+
+      if (showerMismatch) {
+        if (showerIt1->isOneNominalInTime()) {
+          showerColl1ShowerTypeVsProcessor_->Fill(
+              IDX_NOMINAL_SHOWER,
+              showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+          showerColl1ShowerTypeVsBX_->Fill(IDX_NOMINAL_SHOWER, iBx);
+        }
+        if (showerIt1->isOneTightInTime()) {
+          showerColl1ShowerTypeVsProcessor_->Fill(
+              IDX_TIGHT_SHOWER,
+              showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+          showerColl1ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+        }
+        showerColl1ProcessorVsBX_->Fill(
+            showerIt1->processor() + 1 + (showerIt1->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0), iBx);
+
+        if (showerIt2->isOneNominalInTime()) {
+          showerColl2ShowerTypeVsProcessor_->Fill(
+              IDX_NOMINAL_SHOWER,
+              showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+          showerColl2ShowerTypeVsBX_->Fill(IDX_NOMINAL_SHOWER, iBx);
+        }
+        if (showerIt2->isOneTightInTime()) {
+          showerColl2ShowerTypeVsProcessor_->Fill(
+              IDX_TIGHT_SHOWER,
+              showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+          showerColl2ShowerTypeVsBX_->Fill(IDX_TIGHT_SHOWER, iBx);
+        }
+        showerColl2ProcessorVsBX_->Fill(
+            showerIt2->processor() + 1 + (showerIt2->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0), iBx);
+
+      } else {
+        summary_->Fill(SHOWERGOOD);
+      }
+
+      ++showerIt1;
+      ++showerIt2;
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

This PR adds comparison plots for hadronic showers between
* the EMTF outputs and the uGMT inputs (currently deactivated until EMTF has an unpacker for its output showers)
* the uGMT emulated and unpacked outputs
* the six copies of uGMT outputs

#### PR validation:

Ran the emulator workflow on a private raw file containing showers without issues. This doesn't test the full functionality as we don't have muon shower copies outside of a global run and currently there are no unpacked showers from EMTF, however no crashes etc. were observed so I think this could go in for further validation at P5 and once we have EMTF unpackers.

attn: @vukasinmilosevic 
