### PR TITLE
Set receiveMuShower =true for uGT

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -495,7 +495,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
   //
   bool receiveMu = true;
-  bool receiveMuShower = false;
+  bool receiveMuShower = true;
   bool receiveEG = true;
   bool receiveTau = true;
   bool receiveJet = true;


### PR DESCRIPTION
#### PR description:

Follow up of https://github.com/cms-sw/cmssw/pull/36877, to enable global muon shower object unpacking at uGT.  

`receiveMuShower` is an local variable to switch on unpacking global hadronic showers, the era dependent behaviour is controlled by the `useMuonShowers` parameter of the producer [[here](useMuonShowers)] and the snippet [here](https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py#L37-L39). 


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Tested with `L1Repack::FullMC` on Run 3 signal MC and HLT menu with signal paths:
```
cmsDriver.py  l1Ntuple  --python_filename mc.py  -s L1REPACK:FullMC,RAW2DIGI  --mc -n -1\
--conditions auto:phase1_2021_realistic --era Run3 --no_output\
 --customise=L1Trigger/L1TNtuples/customiseL1Ntuple.L1NtupleRAWEMU\
  --customise=L1Trigger/Configuration/customiseUtils.L1TGlobalMenuXML\
 --filein /store/mc/Run3Summer21DRPremix/HTo2LongLivedTo4b_MH-1000_MFF-450_CTau-100000mm_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v6-v2/2550000/e28c777d-10fd-4100-b230-c42b0160ad8a.root
```

```
hltGetConfiguration /users/kakwok/CSCCluster_12_3_X_signalsPath/V2\
 --mc --full --unprescale --globaltag auto:phase1_2021_realistic\
 --setup /dev/CMSSW_12_3_0/HLT/V21\
 --process MYHLT --output minimal\
 --l1Xml L1Menu_Collisions2022_v0_1_2.xml --l1-emulator FullMC\
 --input root://xrootd-cms.infn.it///store/mc/Run3Summer21DRPremix/HTo2LongLivedTo4b_MH-1000_MFF-450_CTau-100000mm_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW/120X_mcRun3_2021_realistic_v6-v2/2550000/e28c777d-10fd-4100-b230-c42b0160ad8a.root >& hlt_FullMC_MC_new2.py
```
<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->
