### PR TITLE
fix era to be compliant with underlying D91 geometry

### DIFF
--- a/Configuration/Geometry/README.md
+++ b/Configuration/Geometry/README.md
@@ -68,7 +68,7 @@ Tracker:
 * T27: Phase2 tilted tracker. Outer Tracker (v8.0.0): same as T24/T21. Inner Tracker (v8.0.0): Based on (v7.0.2) (T25), but with bricked pixels in the central rod of TBPX L2 and in the central 3 rods of TBPX L3+4. All pixels in TFPX and TEPX are bricked. Compatible with DD4hep library.
 * T28: Phase2 tilted tracker. Outer Tracker (v8.0.0): same as T24/T21. Inner Tracker (v8.0.2): Based on (v7.0.2) (T25), but with bricked pixels in the central rod of TBPX L2+L3 and in the central 3 rods of TBPX L4, as well as in TFPX disks 5-8 and in TEPX. The other barrel pixels, and those in TFPX disks 1-4, are 25x100 mum planar. Compatible with DD4hep library.
 * T29: Phase2 tilted tracker. Outer Tracker (v8.0.0): same as T24/T21. Inner Tracker (v8.0.3): Based on (v7.0.2) (T25), but with bricked pixels in the central rod of TBPX L2+L3 and in the central 3 rods of TBPX L4, and with 50x50 mum pixels in TFPX and TEPX. Compatible with DD4hep library.
-
+* T30: Phase2 titled tracker. Exploratory geometry *only to be used in D91 for now*. Outer Tracker (v8.0.1): based on v8.0.0 with updated TB2S spacing. Inner Tracker (v6.4.0): based on v6.1.5 but TFPX with more realistic module positions.
 
 Calorimeters:
 * C9: HGCal (v11 post TDR HGCal Geometry w/ corner centering for HE part) + Phase2 HCAL and EB + Tracker cables (used in 2026D49)
@@ -132,3 +132,4 @@ Several detector combinations have been generated:
 * D88 = T24+C17+M10+I15+O9+F6
 * D89 = T28+C14+M9+I13+O7+F8
 * D90 = T29+C14+M9+I13+O7+F8
+* D91 = T30+C17+M10+I15+O9+F6

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1607,7 +1607,7 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D91',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T30',
-        'Era' : 'Phase2C11I13M9',
+        'Era' : 'Phase2C17I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
 }


### PR DESCRIPTION
#### PR description:

Addresses comment at https://github.com/cms-sw/cmssw/pull/36660#discussion_r803730616, in order to comply with the description of the geometry at:

https://github.com/cms-sw/cmssw/blob/09bb0b76d6c22947de05c50a46c8ae254c504b97/Configuration/Geometry/python/dict2026Geometry.py#L1750

#### PR validation:

none

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
