### PR TITLE
bug fix to allow modules on FinalPath to be reassigned

### DIFF
--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -656,8 +656,9 @@ class FinalPath(_ModuleSequenceType):
         super(FinalPath,self).__init__(*arg,**argv)
     def _placeImpl(self,name,proc):
         proc._placeFinalPath(name,self)
-    def associate(self,task):
-      raise TypeError("FinalPath does not allow associations with Tasks")
+    def associate(self,task=None):
+        if(task!=None):
+            raise TypeError("FinalPath does not allow associations with Tasks")
 
 class Sequence(_ModuleSequenceType,_Sequenceable):
     def __init__(self,*arg,**argv):


### PR DESCRIPTION
#### PR description:

Currently you cant reassign a module on a FinalPath

```python
import FWCore.ParameterSet.Config as cms

process = cms.Process("HLT")
process.dqmOutput = cms.OutputModule("DQMRootOutputModule",
    fileName = cms.untracked.string("DQMIO.root")
)


process.DQMOutput = cms.FinalPath( process.dqmOutput )

process.dqmOutput = cms.OutputModule("DQMRootOutputModule",
                                         fileName = cms.untracked.string("DQMIO.root")
)
```
will fail with
```
Traceback (most recent call last):
  File "/home/sharper/CMSSW/test/CMSSW_12_3_X_2022-02-10-1100/src/test.py", line 11, in <module>
    process.dqmOutput = cms.OutputModule("DQMRootOutputModule",
  File "/cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_3_X_2022-02-10-1100/python/FWCore/ParameterSet/Config.py", line 463, in __setattr__
    self._replaceInSequences(name, newValue)
  File "/cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_3_X_2022-02-10-1100/python/FWCore/ParameterSet/Config.py", line 1110, in _replaceInSequences
    sequenceable.replace(old,new)
  File "/cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_3_X_2022-02-10-1100/python/FWCore/ParameterSet/SequenceTypes.py", line 454, in replace
    self.associate(*v.result(self)[1])
TypeError: associate() missing 1 required positional argument: 'task'
```

This fix (which FW experts probably have a better solution and if so please go ahead with that) solve that issue by making the function handle no input correctly and therefore this assigment to work

#### PR validation:

the above python snippet works and runTheMatrix works except for das errors (which I had a lot of...)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
