### PR TITLE
Improved Payload Inspector plots for `DropBoxMetaData`

### DIFF
--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -363,7 +363,7 @@ namespace DBoxMetadataHelper {
       y_x2.push_back(y);
       //      s_x2.push_back("#scale[1.2]{tags (target/ref): " + tagName + "/" + theRefTag
       //		     + " in IOVs: " + IOVsinceDisplay + "/" + theRefIOV + "}");
-      s_x2.push_back("#scale[1.2]{Target tag / IOV    :" + tagName + " / " + IOVsinceDisplay + "}");
+      s_x2.push_back("#scale[1.2]{Target tag / IOV :" + tagName + " / " + IOVsinceDisplay + "}");
 
       y -= pitch;
       y_x1.push_back(y);
@@ -409,7 +409,7 @@ namespace DBoxMetadataHelper {
         std::string tmpRef = "";
 
         toAppend = "PREP/tar: ";
-        output.push_back(toAppend);
+        output.push_back("#color[3]{" + toAppend + "}");
         toAppend.clear();
         for (unsigned int iPath = 0; iPath < tarPathsPrep.size(); ++iPath) {
           std::string thisString = tarPathsPrep[iPath];
@@ -421,7 +421,7 @@ namespace DBoxMetadataHelper {
               toAppend += thisString;
             } else {
               // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
-              output.push_back(toAppend);
+              output.push_back("#color[3]{" + toAppend + "}");
               tmpTar += toAppend;
               toAppend.clear();
               toAppend += thisString;
@@ -429,13 +429,13 @@ namespace DBoxMetadataHelper {
           }
           // if it's the last, dump it
           if (iPath == tarPathsPrep.size() - 1) {
-            output.push_back(toAppend);
+            output.push_back("#color[3]{" + toAppend + "}");
             tmpTar += toAppend;
           }
         }
 
         toAppend = "PREP/ref: ";
-        output.push_back(toAppend);
+        output.push_back("#color[2]{" + toAppend + "}");
         toAppend.clear();
         for (unsigned int iPath = 0; iPath < refPathsPrep.size(); ++iPath) {
           std::string thisString = refPathsPrep[iPath];
@@ -447,7 +447,7 @@ namespace DBoxMetadataHelper {
               toAppend += thisString;
             } else {
               // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
-              output.push_back(toAppend);
+              output.push_back("#color[2]{" + toAppend + "}");
               tmpRef += toAppend;
               toAppend.clear();
               toAppend += thisString;
@@ -455,7 +455,7 @@ namespace DBoxMetadataHelper {
           }
           // if it's the last, dump it
           if (iPath == refPathsPrep.size() - 1) {
-            output.push_back(toAppend);
+            output.push_back("#color[2]{" + toAppend + "}");
             tmpRef += toAppend;
           }
         }
@@ -469,7 +469,7 @@ namespace DBoxMetadataHelper {
         tmpRef = "";
 
         toAppend = "PROD/tar: ";
-        output.push_back(toAppend);
+        output.push_back("#color[3]{" + toAppend + "}");
         toAppend.clear();
         for (unsigned int iPath = 0; iPath < tarPathsProd.size(); ++iPath) {
           std::string thisString = tarPathsProd[iPath];
@@ -481,7 +481,7 @@ namespace DBoxMetadataHelper {
               toAppend += thisString;
             } else {
               // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
-              output.push_back(toAppend);
+              output.push_back("#color[3]{" + toAppend + "}");
               tmpTar += toAppend;
               toAppend.clear();
               toAppend += thisString;
@@ -489,13 +489,13 @@ namespace DBoxMetadataHelper {
           }
           // if it's the last, dump it
           if (iPath == tarPathsProd.size() - 1) {
-            output.push_back(toAppend);
+            output.push_back("#color[3]{" + toAppend + "}");
             tmpTar += toAppend;
           }
         }
 
         toAppend = "PROD/ref: ";
-        output.push_back(toAppend);
+        output.push_back("#color[2]{" + toAppend + "}");
         toAppend.clear();
         for (unsigned int iPath = 0; iPath < refPathsProd.size(); ++iPath) {
           std::string thisString = refPathsProd[iPath];
@@ -507,7 +507,7 @@ namespace DBoxMetadataHelper {
               toAppend += thisString;
             } else {
               // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
-              output.push_back(toAppend);
+              output.push_back("#color[2]{" + toAppend + "}");
               tmpRef += toAppend;
               toAppend.clear();
               toAppend += thisString;
@@ -515,7 +515,7 @@ namespace DBoxMetadataHelper {
           }
           // if it's the last, dump it
           if (iPath == refPathsProd.size() - 1) {
-            output.push_back(toAppend);
+            output.push_back("#color[2]{" + toAppend + "}");
             tmpRef += toAppend;
           }
         }
@@ -529,7 +529,7 @@ namespace DBoxMetadataHelper {
         // print either "identical" or contents of tags
         if (refAndTarIdentical) {
           y_x2.push_back(y);
-          s_x2.push_back("identical");
+          s_x2.push_back("#color[4]{identical}");
         } else {
           for (unsigned int br = 0; br < output.size(); br++) {
             y_x2.push_back(y);
@@ -541,7 +541,6 @@ namespace DBoxMetadataHelper {
               y -= pitch;
           }
         }
-
         y_line.push_back(y - (pitch / 2.));
       }
 
@@ -690,7 +689,6 @@ namespace DBoxMetadataHelper {
             previousPos++;  // remove space
         }
       }
-
       return result;
     }
   };

--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -189,14 +189,15 @@ namespace DBoxMetadataHelper {
   class DBMetaDataPlotDisplay {
   public:
     DBMetaDataPlotDisplay(DBoxMetadataHelper::recordMap theMap, std::string theTag, std::string theIOV)
-        : m_Map(theMap), tagName(theTag), IOVsinceDisplay(theIOV) {}
+        : m_Map(theMap), m_tagName(theTag), m_IOVsinceDisplay(theIOV) {}
     ~DBMetaDataPlotDisplay() = default;
 
-    void setImageFileName(std::string theFileName) {
-      imageFileName_ = theFileName;
+    void setImageFileName(const std::string& theFileName) {
+      m_imageFileName = theFileName;
       return;
     }
 
+    //___________________________________________________________________
     void plotMetaDatas() {
       unsigned int mapsize = m_Map.size();
       float pitch = 1. / (mapsize * 1.1);
@@ -215,7 +216,7 @@ namespace DBoxMetadataHelper {
       y_x1.push_back(y);
       s_x1.push_back("#scale[1.2]{Key}");
       y_x2.push_back(y);
-      s_x2.push_back("#scale[1.2]{tag: " + tagName + " in IOV: " + IOVsinceDisplay + "}");
+      s_x2.push_back("#scale[1.2]{tag: " + m_tagName + " in IOV: " + m_IOVsinceDisplay + "}");
 
       y -= pitch / 2.;
       y_line.push_back(y);
@@ -330,11 +331,12 @@ namespace DBoxMetadataHelper {
       }
 
       std::string fileName("DropBoxMetadata_Display.png");
-      if (!imageFileName_.empty())
-        fileName = imageFileName_;
+      if (!m_imageFileName.empty())
+        fileName = m_imageFileName;
       canvas.SaveAs(fileName.c_str());
     }
 
+    //___________________________________________________________________
     void plotDiffWithMetadata(const DBoxMetadataHelper::recordMap& theRefMap,
                               std::string theRefTag,
                               std::string theRefIOV) {
@@ -361,9 +363,7 @@ namespace DBoxMetadataHelper {
       y_x1.push_back(y);
       s_x1.push_back("#scale[1.2]{Key}");
       y_x2.push_back(y);
-      //      s_x2.push_back("#scale[1.2]{tags (target/ref): " + tagName + "/" + theRefTag
-      //		     + " in IOVs: " + IOVsinceDisplay + "/" + theRefIOV + "}");
-      s_x2.push_back("#scale[1.2]{Target tag / IOV :" + tagName + " / " + IOVsinceDisplay + "}");
+      s_x2.push_back("#scale[1.2]{Target tag / IOV :" + m_tagName + " / " + m_IOVsinceDisplay + "}");
 
       y -= pitch;
       y_x1.push_back(y);
@@ -417,7 +417,7 @@ namespace DBoxMetadataHelper {
           output.clear();
         }
 
-	// determine the size after having filled the prep- metadata
+        // determine the size after having filled the prep- metadata
         size_t lenAfterPrep = output.size();
 
         // clear the tmps
@@ -517,17 +517,18 @@ namespace DBoxMetadataHelper {
       }
 
       std::string fileName("DropBoxMetadata_Compare.png");
-      if (!imageFileName_.empty())
-        fileName = imageFileName_;
+      if (!m_imageFileName.empty())
+        fileName = m_imageFileName;
       canvas.SaveAs(fileName.c_str());
     }
 
   private:
-    DBoxMetadataHelper::recordMap m_Map;
-    std::string tagName;
-    std::string IOVsinceDisplay;
-    std::string imageFileName_;
+    DBoxMetadataHelper::recordMap m_Map;  //!< map of the record / metadata associations
+    std::string m_tagName;                //!< tag name
+    std::string m_IOVsinceDisplay;        //!< iov since
+    std::string m_imageFileName;          //!< image file name
 
+    //___________________________________________________________________
     std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
       size_t start_pos = 0;
       while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
@@ -537,11 +538,13 @@ namespace DBoxMetadataHelper {
       return str;
     }
 
+    //___________________________________________________________________
     std::string cleanJson(std::string str) {
       std::string out = replaceAll(str, std::string("&quot;"), std::string("'"));
       return out;
     }
 
+    //___________________________________________________________________
     void eraseAllSubStr(std::string& s, const std::string& toErase) {
       size_t pos = std::string::npos;
       // Search for the substring in string in a loop until nothing is found
@@ -552,6 +555,7 @@ namespace DBoxMetadataHelper {
       return;
     }
 
+    //___________________________________________________________________
     void cleanPrepString(std::string& myString) {
       eraseAllSubStr(myString, "&quot;");
       eraseAllSubStr(myString, "destinationDatabase: oracle://cms_orcoff_prep/CMS_CONDITIONS, ");
@@ -564,6 +568,7 @@ namespace DBoxMetadataHelper {
       return;
     }
 
+    //___________________________________________________________________
     void cleanProdString(std::string& myString) {
       eraseAllSubStr(myString, "&quot;");
       eraseAllSubStr(myString, "destinationDatabase: oracle://cms_orcon_prod/CMS_CONDITIONS, ");
@@ -576,6 +581,7 @@ namespace DBoxMetadataHelper {
       return;
     }
 
+    //___________________________________________________________________
     std::vector<std::string> decompose(const std::string& s) const {
       // decompose 's' into its parts that are separated by 'delimeter_'
       // (similar as in
@@ -603,12 +609,13 @@ namespace DBoxMetadataHelper {
       return result;
     }
 
+    //___________________________________________________________________
     void prepareLine(const std::vector<std::string>& thePaths,
                      std::vector<std::string>& output,
                      std::string& tmp,
                      const std::string& header) {
-      const int color = (header.find("tar") == std::string::npos) ? 2 : 3;
-      const int colWidth = 80;
+      const int color = (header.find("tar") == std::string::npos) ? 2 /*kRed*/ : 3 /*kGreen*/;
+      const int colWidth = 80;  // maximum width of column
 
       std::string toAppend = "";
       toAppend = header;
@@ -616,7 +623,6 @@ namespace DBoxMetadataHelper {
       toAppend.clear();
       for (unsigned int iPath = 0; iPath < thePaths.size(); ++iPath) {
         std::string thisString = thePaths[iPath];
-
         // if the line to be added has less than colWidth chars append to current
         if (thisString.find("userText") == std::string::npos) {
           // if the line to be added has less than colWidth chars append to current
@@ -630,7 +636,6 @@ namespace DBoxMetadataHelper {
             toAppend += thisString;
           }
         }
-        // if it's the last, dump it
         if (iPath == thePaths.size() - 1) {
           output.push_back("#color[" + std::to_string(color) + "]{" + toAppend + "}");
           tmp += toAppend;

--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -411,8 +411,14 @@ namespace DBoxMetadataHelper {
         // check if printouts are identical for PREP
         eraseAllSubStr(tmpTar, "PREP/tar: ");
         eraseAllSubStr(tmpRef, "PREP/ref: ");
-        if (tmpTar != tmpRef)
+        if (tmpTar != tmpRef) {
           refAndTarIdentical = false;
+        } else {
+          output.clear();
+        }
+
+	// determine the size after having filled the prep- metadata
+        size_t lenAfterPrep = output.size();
 
         // clear the tmps
         tmpTar = "";
@@ -424,8 +430,12 @@ namespace DBoxMetadataHelper {
         // check if printouts are identical for PROD
         eraseAllSubStr(tmpTar, "PROD/tar: ");
         eraseAllSubStr(tmpRef, "PROD/ref: ");
-        if (tmpTar != tmpRef)
+        if (tmpTar != tmpRef) {
           refAndTarIdentical = false;
+        } else {
+          // remove everything after the prep one
+          output.erase(output.end() - lenAfterPrep, output.end());
+        }
 
         // print either "identical" or contents of tags
         if (refAndTarIdentical) {
@@ -455,7 +465,7 @@ namespace DBoxMetadataHelper {
           y_x1.push_back(y);
           s_x1.push_back(ref);
           y_x2.push_back(y);
-          s_x2.push_back("Only in reference, not in target.");
+          s_x2.push_back("#bf{Only in reference, not in target.}");
           y_line.push_back(y - (pitch / 2.));
         }
       }
@@ -467,7 +477,7 @@ namespace DBoxMetadataHelper {
           y_x1.push_back(y);
           s_x1.push_back(tar);
           y_x2.push_back(y);
-          s_x2.push_back("Only in reference, not in target. ");
+          s_x2.push_back("#bf{Only in reference, not in target.}");
           y_line.push_back(y - (pitch / 2.));
         }
       }

--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -384,7 +384,6 @@ namespace DBoxMetadataHelper {
         s_x1.push_back(key);
 
         std::vector<std::string> output;
-        std::string toAppend = "";
 
         std::string tarPrepMetaData = val.getPrepMetaData();
         std::string tarProdMetaData = val.getProdMetaData();
@@ -402,123 +401,25 @@ namespace DBoxMetadataHelper {
         const std::vector<std::string> tarPathsProd = decompose(tarProdMetaData);
         const std::vector<std::string> refPathsProd = decompose(refProdMetaData);
 
-        const int colWidth = 80;
-
         bool refAndTarIdentical = true;
         std::string tmpTar = "";
         std::string tmpRef = "";
 
-        toAppend = "PREP/tar: ";
-        output.push_back("#color[3]{" + toAppend + "}");
-        toAppend.clear();
-        for (unsigned int iPath = 0; iPath < tarPathsPrep.size(); ++iPath) {
-          std::string thisString = tarPathsPrep[iPath];
-
-          // if the line to be added has less than colWidth chars append to current
-          if (thisString.find("userText") == std::string::npos) {
-            // if the line to be added has less than colWidth chars append to current
-            if ((toAppend + thisString).length() < colWidth) {
-              toAppend += thisString;
-            } else {
-              // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
-              output.push_back("#color[3]{" + toAppend + "}");
-              tmpTar += toAppend;
-              toAppend.clear();
-              toAppend += thisString;
-            }
-          }
-          // if it's the last, dump it
-          if (iPath == tarPathsPrep.size() - 1) {
-            output.push_back("#color[3]{" + toAppend + "}");
-            tmpTar += toAppend;
-          }
-        }
-
-        toAppend = "PREP/ref: ";
-        output.push_back("#color[2]{" + toAppend + "}");
-        toAppend.clear();
-        for (unsigned int iPath = 0; iPath < refPathsPrep.size(); ++iPath) {
-          std::string thisString = refPathsPrep[iPath];
-
-          // if the line to be added has less than colWidth chars append to current
-          if (thisString.find("userText") == std::string::npos) {
-            // if the line to be added has less than colWidth chars append to current
-            if ((toAppend + thisString).length() < colWidth) {
-              toAppend += thisString;
-            } else {
-              // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
-              output.push_back("#color[2]{" + toAppend + "}");
-              tmpRef += toAppend;
-              toAppend.clear();
-              toAppend += thisString;
-            }
-          }
-          // if it's the last, dump it
-          if (iPath == refPathsPrep.size() - 1) {
-            output.push_back("#color[2]{" + toAppend + "}");
-            tmpRef += toAppend;
-          }
-        }
+        prepareLine(tarPathsPrep, output, tmpTar, "PREP/tar");
+        prepareLine(refPathsPrep, output, tmpRef, "PREP/ref");
 
         // check if printouts are identical for PREP
         eraseAllSubStr(tmpTar, "PREP/tar: ");
         eraseAllSubStr(tmpRef, "PREP/ref: ");
         if (tmpTar != tmpRef)
           refAndTarIdentical = false;
+
+        // clear the tmps
         tmpTar = "";
         tmpRef = "";
 
-        toAppend = "PROD/tar: ";
-        output.push_back("#color[3]{" + toAppend + "}");
-        toAppend.clear();
-        for (unsigned int iPath = 0; iPath < tarPathsProd.size(); ++iPath) {
-          std::string thisString = tarPathsProd[iPath];
-
-          // if the line to be added has less than colWidth chars append to current
-          if (thisString.find("userText") == std::string::npos) {
-            // if the line to be added has less than colWidth chars append to current
-            if ((toAppend + thisString).length() < colWidth) {
-              toAppend += thisString;
-            } else {
-              // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
-              output.push_back("#color[3]{" + toAppend + "}");
-              tmpTar += toAppend;
-              toAppend.clear();
-              toAppend += thisString;
-            }
-          }
-          // if it's the last, dump it
-          if (iPath == tarPathsProd.size() - 1) {
-            output.push_back("#color[3]{" + toAppend + "}");
-            tmpTar += toAppend;
-          }
-        }
-
-        toAppend = "PROD/ref: ";
-        output.push_back("#color[2]{" + toAppend + "}");
-        toAppend.clear();
-        for (unsigned int iPath = 0; iPath < refPathsProd.size(); ++iPath) {
-          std::string thisString = refPathsProd[iPath];
-
-          // if the line to be added has less than colWidth chars append to current
-          if (thisString.find("userText") == std::string::npos) {
-            // if the line to be added has less than colWidth chars append to current
-            if ((toAppend + thisString).length() < colWidth) {
-              toAppend += thisString;
-            } else {
-              // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
-              output.push_back("#color[2]{" + toAppend + "}");
-              tmpRef += toAppend;
-              toAppend.clear();
-              toAppend += thisString;
-            }
-          }
-          // if it's the last, dump it
-          if (iPath == refPathsProd.size() - 1) {
-            output.push_back("#color[2]{" + toAppend + "}");
-            tmpRef += toAppend;
-          }
-        }
+        prepareLine(tarPathsProd, output, tmpTar, "PROD/tar");
+        prepareLine(refPathsProd, output, tmpRef, "PROD/ref");
 
         // check if printouts are identical for PROD
         eraseAllSubStr(tmpTar, "PROD/tar: ");
@@ -690,6 +591,41 @@ namespace DBoxMetadataHelper {
         }
       }
       return result;
+    }
+
+    void prepareLine(const std::vector<std::string>& thePaths,
+                     std::vector<std::string>& output,
+                     std::string& tmp,
+                     const std::string& header) {
+      const int color = (header.find("tar") == std::string::npos) ? 2 : 3;
+      const int colWidth = 80;
+
+      std::string toAppend = "";
+      toAppend = header;
+      output.push_back("#color[" + std::to_string(color) + "]{" + toAppend + "}");
+      toAppend.clear();
+      for (unsigned int iPath = 0; iPath < thePaths.size(); ++iPath) {
+        std::string thisString = thePaths[iPath];
+
+        // if the line to be added has less than colWidth chars append to current
+        if (thisString.find("userText") == std::string::npos) {
+          // if the line to be added has less than colWidth chars append to current
+          if ((toAppend + thisString).length() < colWidth) {
+            toAppend += thisString;
+          } else {
+            // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
+            output.push_back("#color[" + std::to_string(color) + "]{" + toAppend + "}");
+            tmp += toAppend;
+            toAppend.clear();
+            toAppend += thisString;
+          }
+        }
+        // if it's the last, dump it
+        if (iPath == thePaths.size() - 1) {
+          output.push_back("#color[" + std::to_string(color) + "]{" + toAppend + "}");
+          tmp += toAppend;
+        }
+      }
     }
   };
 }  // namespace DBoxMetadataHelper

--- a/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
+++ b/CondCore/PhysicsToolsPlugins/plugins/DropBoxMetadata_PayloadInspector.cc
@@ -112,8 +112,6 @@ namespace {
 
       return true;
     }
-
-  private:
   };
 
   /************************************************
@@ -186,8 +184,6 @@ namespace {
 
       return true;
     }
-
-  private:
   };
 
   using DropBoxMetadata_Compare = DropBoxMetadata_CompareBase<MULTI_IOV, 1>;


### PR DESCRIPTION
#### PR description:

Inspired by PR https://github.com/cms-sw/cmssw/pull/36927, I propose few miscellaneous improvements:
   * 6f2db252565790a7e3b6538a0ddb091cda65e628: introduces coloring to the display / compare tables
   * ef889b49bf1c24fa50db291e69d4a66cff650a8f:  simplifies code to avoid repetition
   * f616b9665ddf5aedcc625e1f517b214a0244bde7: don't display identical prep or prod metadatas if they're identical, addressing https://github.com/cms-sw/cmssw/pull/36927#issuecomment-1035464935
   * 286fc7290be9727bc3f31d655e1e79690529fda1 introduces some more code clean-up and improves naming to follow cmssw coding rules

#### PR validation:

Run the script in the test folder `CondCore/PhysicsToolsPlugins/test/test_DropBoxMetadata_PayloadInspector.sh`and got the following plots:

| vanilla  | this branch |
| ------------- | ------------- |
| ![DropBoxMetadata_Compare](https://user-images.githubusercontent.com/5082376/153596913-aef4c206-c189-4727-ac75-3e1ca1fe7c5c.png) |  ![DropBoxMetadata_Compare](https://user-images.githubusercontent.com/5082376/153604097-674f80a6-73e2-4e86-ab1b-381a205a2dfd.png) |
| ![DropBoxMetadata_CompareTwoTags](https://user-images.githubusercontent.com/5082376/153604136-f8d7b494-e295-4ee4-ab7b-829f3fc10800.png) |  ![DropBoxMetadata_CompareTwoTags](https://user-images.githubusercontent.com/5082376/153605428-83ceb9b3-2112-4449-84c7-a4788e8f6ce6.png) |

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

attn: @tlampen 
