### PR TITLE
ECAL - Remove unneeded legacy ED module headers

### DIFF
--- a/Calibration/EcalCalibAlgos/interface/Pi0FixedMassWindowCalibration.h
+++ b/Calibration/EcalCalibAlgos/interface/Pi0FixedMassWindowCalibration.h
@@ -14,20 +14,15 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "CondFormats/EcalObjects/interface/EcalIntercalibConstants.h"
 #include "CondFormats/DataRecord/interface/EcalIntercalibConstantsRcd.h"
-#include "DataFormats/DetId/interface/DetId.h"
 
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
-#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
-#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
@@ -42,13 +37,6 @@
 #include "RecoEcal/EgammaCoreTools/interface/ClusterShapeAlgo.h"
 
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
-
-#include "TFile.h"
-#include "TTree.h"
-#include "TH1F.h"
-#include "TF1.h"
-#include "TGraph.h"
-#include "TCanvas.h"
 
 class Pi0FixedMassWindowCalibration : public edm::ESProducerLooper {
 public:
@@ -139,9 +127,6 @@ private:
   const edm::EDGetTokenT<EcalRecHitCollection> recHitToken_;
   const edm::ESGetToken<EcalIntercalibConstants, EcalIntercalibConstantsRcd> intercalibConstantsToken_;
   const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
-
-  // root tree
-  TFile* theFile;
 
   bool isfirstcall_;
 };

--- a/CondTools/Ecal/interface/EcalGetLaserData.h
+++ b/CondTools/Ecal/interface/EcalGetLaserData.h
@@ -1,5 +1,5 @@
-#ifndef ECALGETLASERDATA_H
-#define ECALGETLASERDATA_H
+#ifndef CondTools_Ecal_EcalGetLaserData_h
+#define CondTools_Ecal_EcalGetLaserData_h
 
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"

--- a/CondTools/Ecal/src/EcalGetLaserData.cc
+++ b/CondTools/Ecal/src/EcalGetLaserData.cc
@@ -20,10 +20,8 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -31,14 +29,11 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 
-#include "CondCore/CondDB/interface/Exception.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
 #include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatios.h"
 #include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalLaserAPDPNRatiosRef.h"
 #include "CondFormats/DataRecord/interface/EcalLaserAPDPNRatiosRefRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalLaserAlphas.h"
 #include "CondFormats/DataRecord/interface/EcalLaserAlphasRcd.h"
 
 #include "OnlineDB/EcalCondDB/interface/all_monitoring_types.h"
@@ -47,8 +42,6 @@
 
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
-
-#include "DataFormats/Common/interface/Handle.h"
 
 #include "CondTools/Ecal/interface/EcalGetLaserData.h"
 


### PR DESCRIPTION
#### PR description:

The PR removes unused headers from ECAL alca modules. In particular the ones for legacy ED modules. The migration to thread same module types has been done earlier already but the legacy headers were left in the code.

#### PR validation:

Code compiles.