### PR TITLE
Update Run-3 data and MC GTs with several updates

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,13 +32,13 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '123X_dataRun3_HLT_v1',
+    'run3_hlt'                     : '123X_dataRun3_HLT_v2',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '123X_dataRun3_Express_v1',
+    'run3_data_express'            : '123X_dataRun3_Express_v2',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '123X_dataRun3_Prompt_v1',
+    'run3_data_prompt'             : '123X_dataRun3_Prompt_v2',
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '123X_dataRun3_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -64,19 +64,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v5',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v5',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v5',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v5',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v5',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v5',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '123X_mcRun4_realistic_v3'
+    'phase2_realistic'             : '123X_mcRun4_realistic_v4'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Update Run-3 data and MC GTs with several updates

Data changes:
 * Include DD4hep geometry payloads
 * Remove old L1T tag (https://github.com/cms-sw/cmssw/pull/36916)
 * Remove old Castor tag (https://github.com/cms-sw/cmssw/pull/36814)
 * Include PF HLT calibration tag as requested in https://cms-talk.web.cern.ch/t/gt-pf-calibration-hlt-tag-for-run-3/3963/17, 
 * Include JEC tags as requested in: https://cms-talk.web.cern.ch/t/gt-full-track-validation-of-jec-tag-for-run3/5141

MC changes
 * Adding empty CSC bad chamber map, requested in https://cms-talk.web.cern.ch/t/gt-mc-update-to-csc-bad-chambers-for-run-3-simulation/5617/
 * Adding new HcalTPChannelParameters, requested in https://cms-talk.web.cern.ch/t/mc-new-run3-mc-condition-hcaltpchannelparameters-2022-v1-0-mc/6138/2
 * Adding new EGM Regression conditions, requested in https://cms-talk.web.cern.ch/t/mc-update-of-new-egm-regression-conditions/4637/6

The new GTs and their diffs
 * 123X_dataRun3_HLT_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_HLT_v1/123X_dataRun3_HLT_v2
 * 123X_dataRun3_Express_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_Express_v1/123X_dataRun3_Express_v2
 * 123X_dataRun3_Prompt_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_Prompt_v1/123X_dataRun3_Prompt_v2
 * 123X_mcRun3_2021_design_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_design_v5/123X_mcRun3_2021_design_v6
 * 123X_mcRun3_2021_realistic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_v5/123X_mcRun3_2021_realistic_v6
 * 123X_mcRun3_2021cosmics_realistic_deco_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021cosmics_realistic_deco_v5/123X_mcRun3_2021cosmics_realistic_deco_v6
 * 123X_mcRun3_2021_realistic_HI_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_HI_v5/123X_mcRun3_2021_realistic_HI_v6
 * 123X_mcRun3_2023_realistic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2023_realistic_v5/123X_mcRun3_2023_realistic_v6
 * 123X_mcRun3_2024_realistic_v6
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2024_realistic_v5/123X_mcRun3_2024_realistic_v6
 * 123X_mcRun4_realistic_v4
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun4_realistic_v3/123X_mcRun4_realistic_v4

#### PR validation:
Wfs 12034.0,11634.0,7.23,159.0,12434.0,12834.0


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

We'll need a backport to 12_2_X

Resolves https://github.com/cms-sw/cmssw/issues/36886