### PR TITLE
Added LZ4 as a compression option in RootOutputModule

### DIFF
--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -463,7 +463,7 @@ namespace edm {
     desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
     desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
         ->setComment(
-            "Algorithm used to compress data in the ROOT output file, allowed values are ZLIB, LZMA, and ZSTD");
+            "Algorithm used to compress data in the ROOT output file, allowed values are ZLIB, LZMA, LZ4, and ZSTD");
     desc.addUntracked<int>("basketSize", 16384)->setComment("Default ROOT basket size in output file.");
     desc.addUntracked<int>("eventAuxiliaryBasketSize", 16384)
         ->setComment("Default ROOT basket size in output file for EventAuxiliary branch.");

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -129,10 +129,12 @@ namespace edm {
       filePtr_->SetCompressionAlgorithm(ROOT::kLZMA);
     } else if (om_->compressionAlgorithm() == std::string("ZSTD")) {
       filePtr_->SetCompressionAlgorithm(ROOT::kZSTD);
+    } else if (om_->compressionAlgorithm() == std::string("LZ4")) {
+      filePtr_->SetCompressionAlgorithm(ROOT::kLZ4);
     } else {
       throw Exception(errors::Configuration)
           << "PoolOutputModule configured with unknown compression algorithm '" << om_->compressionAlgorithm() << "'\n"
-          << "Allowed compression algorithms are ZLIB, LZMA, and ZSTD\n";
+          << "Allowed compression algorithms are ZLIB, LZMA, LZ4, and ZSTD\n";
     }
     if (-1 != om->eventAutoFlushSize()) {
       eventTree_.setAutoFlush(-1 * om->eventAutoFlushSize());


### PR DESCRIPTION
#### PR description:

LZ4 was added to ROOT a while ago.

#### PR validation:

Code compiles. Nothing in CMSSW uses that compression option.