### PR TITLE
[122X] Move ecal_dqm_sourceclient and hlt_dqm_sourceclient to Run-3 era

### DIFF
--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from EventFilter.Utilities.tcdsRawToDigi_cfi import * # To monitor LHC status, e.g. to mask trigger primitives quality alarm during Cosmics
 import sys
 
-process = cms.Process("process")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("process", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-
 import sys
-from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HECollapse_2018
-process = cms.Process("DQM", run2_HECollapse_2018)
+
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("DQM", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:


### PR DESCRIPTION
#### PR description:

See https://github.com/cms-sw/cmssw/pull/36946

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/36946