### PR TITLE
[122X] Update Run-3 data and MC GTs with several updates

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,7 +32,7 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '122X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '122X_dataRun3_HLT_v3',
+    'run3_hlt'                     : '122X_dataRun3_HLT_v4',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '122X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run3 data relvals (express GT)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -70,7 +70,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
     'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v9',
+    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2024

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,13 +32,13 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '122X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '122X_dataRun3_HLT_v1',
+    'run3_hlt'                     : '122X_dataRun3_HLT_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '122X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '122X_dataRun3_Express_v1',
+    'run3_data_express'            : '122X_dataRun3_Express_v3',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '122X_dataRun3_Prompt_v1',
+    'run3_data_prompt'             : '122X_dataRun3_Prompt_v3',
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '122X_dataRun3_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
@@ -64,19 +64,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '122X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '122X_mcRun3_2021_design_v8',
+    'phase1_2021_design'           : '122X_mcRun3_2021_design_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v8',
+    'phase1_2021_realistic'        : '122X_mcRun3_2021_realistic_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v8',
+    'phase1_2021_cosmics'          : '122X_mcRun3_2021cosmics_realistic_deco_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v8',
+    'phase1_2021_realistic_hi'     : '122X_mcRun3_2021_realistic_HI_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v8',
+    'phase1_2023_realistic'        : '122X_mcRun3_2023_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v8',
+    'phase1_2024_realistic'        : '122X_mcRun3_2024_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '122X_mcRun4_realistic_v5'
+    'phase2_realistic'             : '122X_mcRun4_realistic_v9'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Please see https://github.com/cms-sw/cmssw/pull/36940

The new GTs and their diffs are
  * ~122X_dataRun3_HLT_v3~
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_HLT_v1/122X_dataRun3_HLT_v3
  * 122X_dataRun3_HLT_v4 (replaces v3 by adding back the L1TCaloGeom)
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_HLT_v1/122X_dataRun3_HLT_v4
 * 122X_dataRun3_Express_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_Express_v1/122X_dataRun3_Express_v3
 * 122X_dataRun3_Prompt_v3
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_dataRun3_Prompt_v1/122X_dataRun3_Prompt_v3
 * 122X_mcRun3_2021_design_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_design_v8/122X_mcRun3_2021_design_v9
 * 122X_mcRun3_2021_realistic_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_realistic_v8/122X_mcRun3_2021_realistic_v9
 * 122X_mcRun3_2021cosmics_realistic_deco_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021cosmics_realistic_deco_v8/122X_mcRun3_2021cosmics_realistic_deco_v9
 * ~122X_mcRun3_2021_realistic_HI_v9~
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_realistic_HI_v8/122X_mcRun3_2021_realistic_HI_v9
 * 122X_mcRun3_2021_realistic_HI_v10 (this was needed to be in line with `122X_mcRun3_2021_realistic_v9`)
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2021_realistic_HI_v8/122X_mcRun3_2021_realistic_HI_v10
 * 122X_mcRun3_2023_realistic_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2023_realistic_v8/122X_mcRun3_2023_realistic_v9
 * 122X_mcRun3_2024_realistic_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun3_2024_realistic_v8/122X_mcRun3_2024_realistic_v9
 * 122X_mcRun4_realistic_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/122X_mcRun4_realistic_v5/122X_mcRun4_realistic_v9


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/36940