### PR TITLE
add support for L1T-MuonShowers as trigger objects at HLT

### DIFF
--- a/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
+++ b/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
@@ -50,6 +50,7 @@ namespace trigger {
       size_type pftaus_;
       size_type pfmets_;
       size_type l1tmuon_;
+      size_type l1tmuonShower_;
       size_type l1tegamma_;
       size_type l1tjet_;
       size_type l1ttkmuon_;
@@ -82,6 +83,7 @@ namespace trigger {
             pftaus_(0),
             pfmets_(0),
             l1tmuon_(0),
+            l1tmuonShower_(0),
             l1tegamma_(0),
             l1tjet_(0),
             l1ttkmuon_(0),
@@ -113,6 +115,7 @@ namespace trigger {
                           size_type pftaus,
                           size_type pfmets,
                           size_type l1tmuon,
+                          size_type l1tmuonShower,
                           size_type l1tegamma,
                           size_type l1tjet,
                           size_type l1ttkmuon,
@@ -142,6 +145,7 @@ namespace trigger {
             pftaus_(pftaus),
             pfmets_(pfmets),
             l1tmuon_(l1tmuon),
+            l1tmuonShower_(l1tmuonShower),
             l1tegamma_(l1tegamma),
             l1tjet_(l1tjet),
             l1ttkmuon_(l1ttkmuon),
@@ -193,6 +197,7 @@ namespace trigger {
                               addObjects(tfowr.pftauIds(), tfowr.pftauRefs()),
                               addObjects(tfowr.pfmetIds(), tfowr.pfmetRefs()),
                               addObjects(tfowr.l1tmuonIds(), tfowr.l1tmuonRefs()),
+                              addObjects(tfowr.l1tmuonShowerIds(), tfowr.l1tmuonShowerRefs()),
                               addObjects(tfowr.l1tegammaIds(), tfowr.l1tegammaRefs()),
                               addObjects(tfowr.l1tjetIds(), tfowr.l1tjetRefs()),
                               addObjects(tfowr.l1ttkmuonIds(), tfowr.l1ttkmuonRefs()),
@@ -332,6 +337,11 @@ namespace trigger {
     std::pair<size_type, size_type> l1tmuonSlice(size_type filter) const {
       const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tmuon_);
       const size_type end(filterObjects_.at(filter).l1tmuon_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+    std::pair<size_type, size_type> l1tmuonShowerSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tmuonShower_);
+      const size_type end(filterObjects_.at(filter).l1tmuonShower_);
       return std::pair<size_type, size_type>(begin, end);
     }
     std::pair<size_type, size_type> l1tegammaSlice(size_type filter) const {
@@ -581,6 +591,17 @@ namespace trigger {
       const size_type begin(l1tmuonSlice(filter).first);
       const size_type end(l1tmuonSlice(filter).second);
       TriggerRefsCollections::getObjects(id, l1tmuon, begin, end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1tmuonShower& l1tmuonShower) const {
+      const size_type begin(l1tmuonShowerSlice(filter).first);
+      const size_type end(l1tmuonShowerSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1tmuonShower, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1tmuonShower& l1tmuonShower) const {
+      const size_type begin(l1tmuonShowerSlice(filter).first);
+      const size_type end(l1tmuonShowerSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1tmuonShower, begin, end);
     }
 
     void getObjects(size_type filter, Vids& ids, VRl1tegamma& l1tegamma) const {

--- a/DataFormats/HLTReco/interface/TriggerRefsCollections.h
+++ b/DataFormats/HLTReco/interface/TriggerRefsCollections.h
@@ -39,6 +39,7 @@
 #include "DataFormats/L1Trigger/interface/L1EtMissParticleFwd.h"  // deprecate
 
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
@@ -80,6 +81,7 @@ namespace trigger {
   typedef std::vector<l1extra::L1HFRingsRef> VRl1hfrings;        //deprecate
 
   typedef l1t::MuonVectorRef VRl1tmuon;
+  typedef l1t::MuonShowerVectorRef VRl1tmuonShower;
   typedef l1t::EGammaVectorRef VRl1tegamma;
   typedef l1t::JetVectorRef VRl1tjet;
   typedef l1t::TauVectorRef VRl1ttau;
@@ -132,6 +134,8 @@ namespace trigger {
 
     Vids l1tmuonIds_;
     VRl1tmuon l1tmuonRefs_;
+    Vids l1tmuonShowerIds_;
+    VRl1tmuonShower l1tmuonShowerRefs_;
     Vids l1tegammaIds_;
     VRl1tegamma l1tegammaRefs_;
     Vids l1tjetIds_;
@@ -198,6 +202,8 @@ namespace trigger {
 
           l1tmuonIds_(),
           l1tmuonRefs_(),
+          l1tmuonShowerIds_(),
+          l1tmuonShowerRefs_(),
           l1tegammaIds_(),
           l1tegammaRefs_(),
           l1tjetIds_(),
@@ -262,6 +268,8 @@ namespace trigger {
 
       std::swap(l1tmuonIds_, other.l1tmuonIds_);
       std::swap(l1tmuonRefs_, other.l1tmuonRefs_);
+      std::swap(l1tmuonShowerIds_, other.l1tmuonShowerIds_);
+      std::swap(l1tmuonShowerRefs_, other.l1tmuonShowerRefs_);
       std::swap(l1tegammaIds_, other.l1tegammaIds_);
       std::swap(l1tegammaRefs_, other.l1tegammaRefs_);
       std::swap(l1tjetIds_, other.l1tjetIds_);
@@ -352,6 +360,10 @@ namespace trigger {
     void addObject(int id, const l1t::MuonRef& ref) {
       l1tmuonIds_.push_back(id);
       l1tmuonRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::MuonShowerRef& ref) {
+      l1tmuonShowerIds_.push_back(id);
+      l1tmuonShowerRefs_.push_back(ref);
     }
     void addObject(int id, const l1t::EGammaRef& ref) {
       l1tegammaIds_.push_back(id);
@@ -491,6 +503,12 @@ namespace trigger {
       l1tmuonIds_.insert(l1tmuonIds_.end(), ids.begin(), ids.end());
       l1tmuonRefs_.insert(l1tmuonRefs_.end(), refs.begin(), refs.end());
       return l1tmuonIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1tmuonShower& refs) {
+      assert(ids.size() == refs.size());
+      l1tmuonShowerIds_.insert(l1tmuonShowerIds_.end(), ids.begin(), ids.end());
+      l1tmuonShowerRefs_.insert(l1tmuonShowerRefs_.end(), refs.begin(), refs.end());
+      return l1tmuonShowerIds_.size();
     }
     size_type addObjects(const Vids& ids, const VRl1tegamma& refs) {
       assert(ids.size() == refs.size());
@@ -1077,6 +1095,41 @@ namespace trigger {
       return;
     }
 
+    void getObjects(Vids& ids, VRl1tmuonShower& refs) const { getObjects(ids, refs, 0, l1tmuonShowerIds_.size()); }
+    void getObjects(Vids& ids, VRl1tmuonShower& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tmuonShowerIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1tmuonShowerIds_[i];
+        refs[j] = l1tmuonShowerRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1tmuonShower& refs) const { getObjects(id, refs, 0, l1tmuonShowerIds_.size()); }
+    void getObjects(int id, VRl1tmuonShower& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tmuonShowerIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tmuonShowerIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tmuonShowerIds_[i]) {
+          refs[j] = l1tmuonShowerRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
     void getObjects(Vids& ids, VRl1tegamma& refs) const { getObjects(ids, refs, 0, l1tegammaIds_.size()); }
     void getObjects(Vids& ids, VRl1tegamma& refs, size_type begin, size_type end) const {
       assert(begin <= end);
@@ -1636,6 +1689,10 @@ namespace trigger {
     size_type l1tmuonSize() const { return l1tmuonIds_.size(); }
     const Vids& l1tmuonIds() const { return l1tmuonIds_; }
     const VRl1tmuon& l1tmuonRefs() const { return l1tmuonRefs_; }
+
+    size_type l1tmuonShowerSize() const { return l1tmuonShowerIds_.size(); }
+    const Vids& l1tmuonShowerIds() const { return l1tmuonShowerIds_; }
+    const VRl1tmuonShower& l1tmuonShowerRefs() const { return l1tmuonShowerRefs_; }
 
     size_type l1tegammaSize() const { return l1tegammaIds_.size(); }
     const Vids& l1tegammaIds() const { return l1tegammaIds_; }

--- a/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+++ b/DataFormats/HLTReco/interface/TriggerTypeDefs.h
@@ -60,7 +60,7 @@ namespace trigger {
     TriggerL1AsymHt = -111,
     TriggerL1AsymEtHF = -112,
     TriggerL1AsymHtHF = -113,
-    /// This has all to be decided for Phase-2. Here is Thiago's proposal.
+    // Phase-2: This has all to be decided for Phase-2. Here is Thiago's proposal.
     TriggerL1TkMu = -114,
     TriggerL1TkEle = -115,
     TriggerL1PFJet = -116,
@@ -72,6 +72,8 @@ namespace trigger {
     TriggerL1PFMHT = -122,
     TriggerL1PFTrack = -123,
     TriggerL1Vertex = -124,
+    // Phase-1: MuonShower
+    TriggerL1MuShower = -125,  // stage2 (introduced in Run 3)
 
     /// HLT
     TriggerPhoton = +81,

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -42,13 +42,15 @@
    <version ClassVersion="10" checksum="2923979599"/>
   </class>
   <class name="trigger::TriggerObjectCollection"/>
-  <class name="trigger::TriggerRefsCollections" ClassVersion="15">
+  <class name="trigger::TriggerRefsCollections" ClassVersion="16">
+   <version ClassVersion="16" checksum="3574724031"/>
    <version ClassVersion="15" checksum="1920377523"/>
    <version ClassVersion="14" checksum="874193725"/>
    <version ClassVersion="13" checksum="3831523881"/>
    <version ClassVersion="12" checksum="4231679693"/>
   </class>
-  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="14">
+  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="15">
+   <version ClassVersion="15" checksum="2946786356"/>
    <version ClassVersion="14" checksum="4087045168"/>
    <version ClassVersion="13" checksum="2951644382"/>
    <version ClassVersion="12" checksum="2645314434"/>
@@ -64,14 +66,16 @@
    <version ClassVersion="11" checksum="3351458717"/>
    <version ClassVersion="10" checksum="1112210423"/>
   </class>
-  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="15">
+  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="16">
+   <version ClassVersion="16" checksum="752200108"/>
    <version ClassVersion="15" checksum="450435068"/>
    <version ClassVersion="14" checksum="1673531968"/>
    <version ClassVersion="13" checksum="1672519577"/>
    <version ClassVersion="12" checksum="2301242282"/>
   </class>
   <class name="std::vector<trigger::TriggerEventWithRefs::TriggerFilterObject>"/>
-  <class name="trigger::TriggerEventWithRefs" ClassVersion="14">
+  <class name="trigger::TriggerEventWithRefs" ClassVersion="15">
+   <version ClassVersion="15" checksum="3947606822"/>
    <version ClassVersion="14" checksum="2001321210"/>
    <version ClassVersion="13" checksum="1258968436"/>
    <version ClassVersion="12" checksum="3347721344"/>

--- a/HLTrigger/HLTcore/interface/HLTEventAnalyzerRAW.h
+++ b/HLTrigger/HLTcore/interface/HLTEventAnalyzerRAW.h
@@ -79,6 +79,19 @@ private:
   trigger::Vids l1hfringsIds_;
   trigger::VRl1hfrings l1hfringsRefs_;
 
+  trigger::Vids l1tmuonIds_;
+  trigger::VRl1tmuon l1tmuonRefs_;
+  trigger::Vids l1tmuonShowerIds_;
+  trigger::VRl1tmuonShower l1tmuonShowerRefs_;
+  trigger::Vids l1tegammaIds_;
+  trigger::VRl1tegamma l1tegammaRefs_;
+  trigger::Vids l1tjetIds_;
+  trigger::VRl1tjet l1tjetRefs_;
+  trigger::Vids l1ttauIds_;
+  trigger::VRl1ttau l1ttauRefs_;
+  trigger::Vids l1tetsumIds_;
+  trigger::VRl1tetsum l1tetsumRefs_;
+
   /* Phase-2 */
   trigger::Vids l1ttkmuIds_;
   trigger::VRl1ttkmuon l1ttkmuRefs_;

--- a/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
+++ b/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
@@ -205,6 +205,7 @@ private:
   edm::GetterOfProducts<reco::PFJetCollection> getPFJetCollection_;
   edm::GetterOfProducts<reco::PFTauCollection> getPFTauCollection_;
   edm::GetterOfProducts<l1t::MuonBxCollection> getL1TMuonParticleCollection_;
+  edm::GetterOfProducts<l1t::MuonShowerBxCollection> getL1TMuonShowerParticleCollection_;
   edm::GetterOfProducts<l1t::EGammaBxCollection> getL1TEGammaParticleCollection_;
   edm::GetterOfProducts<l1t::JetBxCollection> getL1TJetParticleCollection_;
   edm::GetterOfProducts<l1t::TauBxCollection> getL1TTauParticleCollection_;

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -23,11 +23,20 @@
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/METReco/interface/PFMET.h"
 #include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
-#include "DataFormats/L1Trigger/interface/L1HFRings.h"
-#include "DataFormats/L1Trigger/interface/L1EmParticle.h"
-#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
-#include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
-#include "DataFormats/L1Trigger/interface/L1EtMissParticle.h"
+
+#include "DataFormats/L1Trigger/interface/L1HFRings.h"         // deprecate
+#include "DataFormats/L1Trigger/interface/L1EmParticle.h"      // deprecate
+#include "DataFormats/L1Trigger/interface/L1JetParticle.h"     // deprecate
+#include "DataFormats/L1Trigger/interface/L1MuonParticle.h"    // deprecate
+#include "DataFormats/L1Trigger/interface/L1EtMissParticle.h"  // deprecate
+
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1Trigger/interface/Tau.h"
+#include "DataFormats/L1Trigger/interface/EtSum.h"
+
 #include "DataFormats/L1TCorrelator/interface/TkMuon.h"
 #include "DataFormats/L1TCorrelator/interface/TkElectron.h"
 #include "DataFormats/L1TCorrelator/interface/TkEm.h"
@@ -193,6 +202,7 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
   calometRefs_.clear();
   pixtrackIds_.clear();
   pixtrackRefs_.clear();
+
   l1emIds_.clear();
   l1emRefs_.clear();
   l1muonIds_.clear();
@@ -203,6 +213,20 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
   l1etmissRefs_.clear();
   l1hfringsIds_.clear();
   l1hfringsRefs_.clear();
+
+  l1tmuonIds_.clear();
+  l1tmuonRefs_.clear();
+  l1tmuonShowerIds_.clear();
+  l1tmuonShowerRefs_.clear();
+  l1tegammaIds_.clear();
+  l1tegammaRefs_.clear();
+  l1tjetIds_.clear();
+  l1tjetRefs_.clear();
+  l1ttauIds_.clear();
+  l1ttauRefs_.clear();
+  l1tetsumIds_.clear();
+  l1tetsumRefs_.clear();
+
   l1ttkmuIds_.clear();
   l1ttkmuRefs_.clear();
   l1ttkeleIds_.clear();
@@ -217,6 +241,7 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
   l1thpspftauRefs_.clear();
   l1tpftrackIds_.clear();
   l1tpftrackRefs_.clear();
+
   pfjetIds_.clear();
   pfjetRefs_.clear();
   pftauIds_.clear();
@@ -367,6 +392,67 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
                                              << l1hfringsRefs_[i]->hfBitCount(l1extra::L1HFRings::kRing1NegEta) << " "
                                              << l1hfringsRefs_[i]->hfBitCount(l1extra::L1HFRings::kRing2PosEta) << " "
                                              << l1hfringsRefs_[i]->hfBitCount(l1extra::L1HFRings::kRing2NegEta) << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1tmuonIds_, l1tmuonRefs_);
+      const unsigned int nL1TMuon(l1tmuonIds_.size());
+      if (nL1TMuon > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TMuon: " << nL1TMuon << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TMuon; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1tmuonIds_[i] << " " << l1tmuonRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1tmuonShowerIds_, l1tmuonShowerRefs_);
+      const unsigned int nL1TMuonShower(l1tmuonShowerIds_.size());
+      if (nL1TMuonShower > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW")
+            << "   L1TMuonShower: " << nL1TMuonShower << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TMuonShower; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1tmuonShowerIds_[i] << " " << l1tmuonShowerRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1tegammaIds_, l1tegammaRefs_);
+      const unsigned int nL1TEGamma(l1tegammaIds_.size());
+      if (nL1TEGamma > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TEGamma: " << nL1TEGamma << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TEGamma; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1tegammaIds_[i] << " " << l1tegammaRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1tjetIds_, l1tjetRefs_);
+      const unsigned int nL1TJet(l1tjetIds_.size());
+      if (nL1TJet > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TJet: " << nL1TJet << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TJet; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1tjetIds_[i] << " " << l1tjetRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1ttauIds_, l1ttauRefs_);
+      const unsigned int nL1TTau(l1ttauIds_.size());
+      if (nL1TTau > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TTau: " << nL1TTau << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TTau; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1ttauIds_[i] << " " << l1ttauRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1tetsumIds_, l1tetsumRefs_);
+      const unsigned int nL1TEtSum(l1tetsumIds_.size());
+      if (nL1TEtSum > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TEtSum: " << nL1TEtSum << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TEtSum; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1tetsumIds_[i] << " " << l1tetsumRefs_[i]->pt() << endl;
         }
       }
 

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
@@ -141,6 +141,10 @@ void TriggerSummaryAnalyzerRAW::analyze(edm::StreamID, const edm::Event& iEvent,
       if (nL1TMuon > 0)
         LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TMuon: " << nL1TMuon;
 
+      const unsigned int nL1TMuonShower(handle->l1tmuonShowerSlice(iFO).second - handle->l1tmuonShowerSlice(iFO).first);
+      if (nL1TMuonShower > 0)
+        LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TMuonShower: " << nL1TMuonShower;
+
       const unsigned int nL1TEGamma(handle->l1tegammaSlice(iFO).second - handle->l1tegammaSlice(iFO).first);
       if (nL1TEGamma > 0)
         LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TEGamma: " << nL1TEGamma;
@@ -189,27 +193,28 @@ void TriggerSummaryAnalyzerRAW::analyze(edm::StreamID, const edm::Event& iEvent,
       LogVerbatim("TriggerSummaryAnalyzerRAW") << endl;
     }
     LogVerbatim("TriggerSummaryAnalyzerRAW") << "Elements in linearised collections of Refs: " << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Photons:    " << handle->photonSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Electrons:  " << handle->electronSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Muons:      " << handle->muonSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Jets:       " << handle->jetSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Composites: " << handle->compositeSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  BaseMETs:   " << handle->basemetSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  CaloMETs:   " << handle->calometSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Pixtracks:  " << handle->pixtrackSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1EM:       " << handle->l1emSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1Muon:     " << handle->l1muonSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1Jet:      " << handle->l1jetSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1EtMiss:   " << handle->l1etmissSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1HfRings:  " << handle->l1hfringsSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  PFJets:     " << handle->pfjetSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  PFTaus:     " << handle->pftauSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  PFMETs:     " << handle->pfmetSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TMuon:    " << handle->l1tmuonSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TEGamma:  " << handle->l1tegammaSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TJet:     " << handle->l1tjetSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TTau:     " << handle->l1ttauSize() << endl;
-    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TEtSum:   " << handle->l1tetsumSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Photons:       " << handle->photonSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Electrons:     " << handle->electronSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Muons:         " << handle->muonSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Jets:          " << handle->jetSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Composites:    " << handle->compositeSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  BaseMETs:      " << handle->basemetSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  CaloMETs:      " << handle->calometSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  Pixtracks:     " << handle->pixtrackSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1EM:          " << handle->l1emSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1Muon:        " << handle->l1muonSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1Jet:         " << handle->l1jetSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1EtMiss:      " << handle->l1etmissSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1HfRings:     " << handle->l1hfringsSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  PFJets:        " << handle->pfjetSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  PFTaus:        " << handle->pftauSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  PFMETs:        " << handle->pfmetSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TMuon:       " << handle->l1tmuonSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TMuonShower: " << handle->l1tmuonShowerSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TEGamma:     " << handle->l1tegammaSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TJet:        " << handle->l1tjetSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TTau:        " << handle->l1ttauSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TEtSum:      " << handle->l1tetsumSize() << endl;
     /* Phase-2 */
     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TTkMuon:    " << handle->l1ttkmuonSize() << endl;
     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TTkEle:     " << handle->l1ttkeleSize() << endl;

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -42,6 +42,7 @@
 #include "DataFormats/L1Trigger/interface/L1EtMissParticle.h"
 
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
@@ -140,6 +141,7 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
   getL1EtMissParticleCollection_ = edm::GetterOfProducts<l1extra::L1EtMissParticleCollection>(productMatch, this);
   getL1HFRingsCollection_ = edm::GetterOfProducts<l1extra::L1HFRingsCollection>(productMatch, this);
   getL1TMuonParticleCollection_ = edm::GetterOfProducts<l1t::MuonBxCollection>(productMatch, this);
+  getL1TMuonShowerParticleCollection_ = edm::GetterOfProducts<l1t::MuonShowerBxCollection>(productMatch, this);
   getL1TEGammaParticleCollection_ = edm::GetterOfProducts<l1t::EGammaBxCollection>(productMatch, this);
   getL1TJetParticleCollection_ = edm::GetterOfProducts<l1t::JetBxCollection>(productMatch, this);
   getL1TTauParticleCollection_ = edm::GetterOfProducts<l1t::TauBxCollection>(productMatch, this);
@@ -173,6 +175,7 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
     getL1EtMissParticleCollection_(bd);
     getL1HFRingsCollection_(bd);
     getL1TMuonParticleCollection_(bd);
+    getL1TMuonShowerParticleCollection_(bd);
     getL1TEGammaParticleCollection_(bd);
     getL1TJetParticleCollection_(bd);
     getL1TTauParticleCollection_(bd);
@@ -349,6 +352,8 @@ void TriggerSummaryProducerAOD::produce(edm::StreamID, edm::Event& iEvent, const
       toc, offset, tags, keys, iEvent, getL1HFRingsCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<MuonBxCollection>(
       toc, offset, tags, keys, iEvent, getL1TMuonParticleCollection_, collectionTagsEvent);
+  fillTriggerObjectCollections<MuonShowerBxCollection>(
+      toc, offset, tags, keys, iEvent, getL1TMuonShowerParticleCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<EGammaBxCollection>(
       toc, offset, tags, keys, iEvent, getL1TEGammaParticleCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<JetBxCollection>(
@@ -425,6 +430,8 @@ void TriggerSummaryProducerAOD::produce(edm::StreamID, edm::Event& iEvent, const
           iEvent, filterTag, fobs[ifob]->l1hfringsIds(), fobs[ifob]->l1hfringsRefs(), offset, keys, ids);
       fillFilterObjectMembers(
           iEvent, filterTag, fobs[ifob]->l1tmuonIds(), fobs[ifob]->l1tmuonRefs(), offset, keys, ids);
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1tmuonShowerIds(), fobs[ifob]->l1tmuonShowerRefs(), offset, keys, ids);
       fillFilterObjectMembers(
           iEvent, filterTag, fobs[ifob]->l1tegammaIds(), fobs[ifob]->l1tegammaRefs(), offset, keys, ids);
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->l1tjetIds(), fobs[ifob]->l1tjetRefs(), offset, keys, ids);

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
@@ -78,7 +78,7 @@ void TriggerSummaryProducerRAW::produce(edm::StreamID, edm::Event& iEvent, const
     const string& process(fobs[ifob].provenance()->processName());
     const InputTag tag(label, instance, process);
     LogTrace("TriggerSummaryProducerRaw")
-        << ifob << " " << tag << endl
+        << ifob << " " << tag << "\n"
         << " Sizes: "
         << " 1/" << fobs[ifob]->photonSize() << " 2/" << fobs[ifob]->electronSize() << " 3/" << fobs[ifob]->muonSize()
         << " 4/" << fobs[ifob]->jetSize() << " 5/" << fobs[ifob]->compositeSize() << " 6/" << fobs[ifob]->basemetSize()
@@ -91,27 +91,30 @@ void TriggerSummaryProducerRAW::produce(edm::StreamID, edm::Event& iEvent, const
         << " K/" << fobs[ifob]->l1tjetSize() << " L/" << fobs[ifob]->l1ttauSize() << " M/" << fobs[ifob]->l1tetsumSize()
         << " N/" << fobs[ifob]->l1ttkmuonSize() << " O/" << fobs[ifob]->l1ttkeleSize() << " P/"
         << fobs[ifob]->l1ttkemSize() << " Q/" << fobs[ifob]->l1tpfjetSize() << " R/" << fobs[ifob]->l1tpftauSize()
-        << " S/" << fobs[ifob]->l1thpspftauSize() << " T/" << fobs[ifob]->l1tpftrackSize() << endl;
+        << " S/" << fobs[ifob]->l1thpspftauSize() << " T/" << fobs[ifob]->l1tpftrackSize() << " U/"
+        << fobs[ifob]->l1tmuonShowerSize();
     LogTrace("TriggerSummaryProducerRaw")
         << "TriggerSummaryProducerRaw::addFilterObjects(   )"
         << "\n fobs[ifob]->l1tmuonIds().size() = " << fobs[ifob]->l1tmuonIds().size()
-        << "\n fobs[ifob]->l1tmuonRefs().size() = " << fobs[ifob]->l1tmuonRefs().size() << endl;
+        << "\n fobs[ifob]->l1tmuonRefs().size() = " << fobs[ifob]->l1tmuonRefs().size();
     LogTrace("TriggerSummaryProducerRaw")
         << "TriggerSummaryProducerRaw::addFilterObjects(   )"
         << "\n fobs[ifob]->l1tegammaIds().size() = " << fobs[ifob]->l1tegammaIds().size()
-        << "\n fobs[ifob]->l1tegammaRefs().size() = " << fobs[ifob]->l1tegammaRefs().size() << endl;
-    LogTrace("TriggerSummaryProducerRaw")
-        << "TriggerSummaryProducerRaw::addFilterObjects(   )"
-        << "\n fobs[ifob]->l1tjetIds().size() = " << fobs[ifob]->l1tjetIds().size()
-        << "\n fobs[ifob]->l1tjetRefs().size() = " << fobs[ifob]->l1tjetRefs().size() << endl;
-    LogTrace("TriggerSummaryProducerRaw")
-        << "TriggerSummaryProducerRaw::addFilterObjects(   )"
-        << "\n fobs[ifob]->l1ttauIds().size() = " << fobs[ifob]->l1ttauIds().size()
-        << "\n fobs[ifob]->l1ttauRefs().size() = " << fobs[ifob]->l1ttauRefs().size() << endl;
+        << "\n fobs[ifob]->l1tegammaRefs().size() = " << fobs[ifob]->l1tegammaRefs().size();
+    LogTrace("TriggerSummaryProducerRaw") << "TriggerSummaryProducerRaw::addFilterObjects(   )"
+                                          << "\n fobs[ifob]->l1tjetIds().size() = " << fobs[ifob]->l1tjetIds().size()
+                                          << "\n fobs[ifob]->l1tjetRefs().size() = " << fobs[ifob]->l1tjetRefs().size();
+    LogTrace("TriggerSummaryProducerRaw") << "TriggerSummaryProducerRaw::addFilterObjects(   )"
+                                          << "\n fobs[ifob]->l1ttauIds().size() = " << fobs[ifob]->l1ttauIds().size()
+                                          << "\n fobs[ifob]->l1ttauRefs().size() = " << fobs[ifob]->l1ttauRefs().size();
     LogTrace("TriggerSummaryProducerRaw")
         << "TriggerSummaryProducerRaw::addFilterObjects(   )"
         << "\n fobs[ifob]->l1tetsumIds().size() = " << fobs[ifob]->l1tetsumIds().size()
-        << "\n fobs[ifob]->l1tetsumRefs().size() = " << fobs[ifob]->l1tetsumRefs().size() << endl;
+        << "\n fobs[ifob]->l1tetsumRefs().size() = " << fobs[ifob]->l1tetsumRefs().size();
+    LogTrace("TriggerSummaryProducerRaw")
+        << "TriggerSummaryProducerRaw::addFilterObjects(   )"
+        << "\n fobs[ifob]->l1tmuonShowerIds().size() = " << fobs[ifob]->l1tmuonShowerIds().size()
+        << "\n fobs[ifob]->l1tmuonShowerRefs().size() = " << fobs[ifob]->l1tmuonShowerRefs().size();
     product.addFilterObject(tag, *fobs[ifob]);
   }
 

--- a/HLTrigger/HLTfilters/plugins/HLTL1TSeed.h
+++ b/HLTrigger/HLTfilters/plugins/HLTL1TSeed.h
@@ -110,6 +110,11 @@ private:
   edm::InputTag m_l1MuonTag;
   edm::EDGetTokenT<l1t::MuonBxCollection> m_l1MuonToken;
 
+  /// Meta InputTag for L1 Muon collection
+  edm::InputTag m_l1MuonShowerCollectionsTag;
+  edm::InputTag m_l1MuonShowerTag;
+  edm::EDGetTokenT<l1t::MuonShowerBxCollection> m_l1MuonShowerToken;
+
   /// Meta InputTag for L1 Egamma collection
   edm::InputTag m_l1EGammaCollectionsTag;
   edm::InputTag m_l1EGammaTag;


### PR DESCRIPTION
#### PR description:

This PR adds support for the Run-3 "MuonShower" L1T objects (introduced in https://github.com/cms-sw/cmssw/pull/33446 and https://github.com/cms-sw/cmssw/pull/36018) in the DataFormats, producers and analysers used by HLT to write and read trigger objects.

Beyond the L1T MuonShowers use case, the update of `HLTEventAnalyzerRAW` also adds support for other L1T objects that were previously not considered in that plugin (following the ordering in `TriggerRefsCollections`).

#### PR validation:

 - Validated with a user recipe (provided by @kakwok, see description of https://github.com/cms-sw/cmssw/pull/36929) using new L1T seeds based on L1T-MuonShowers.

 - `addOnTests.py` passed.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A