### PR TITLE
Electron and photon masses are set to zero

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1067,6 +1067,7 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
   // Will be overwritten later in the case of the regression
   ele.setCorrectedEcalEnergyError(egamma::ecalClusterEnergyUncertaintyElectronSpecific(*(ele.superCluster())));
   ele.setP4(GsfElectron::P4_FROM_SUPER_CLUSTER, momentum, 0, true);
+  ele.setMass(0.0);
 
   //====================================================
   // brems fractions

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1235,3 +1235,5 @@ void GsfElectronAlgo::setPixelMatchInfomation(reco::GsfElectron& ele) const {
   ele.setPixelMatchDRz1(dRz1);
   ele.setPixelMatchDRz2(dRz2);
 }
+
+

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1235,5 +1235,3 @@ void GsfElectronAlgo::setPixelMatchInfomation(reco::GsfElectron& ele) const {
   ele.setPixelMatchDRz1(dRz1);
   ele.setPixelMatchDRz2(dRz2);
 }
-
-

--- a/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
@@ -194,5 +194,6 @@ void RegressionHelper::applyCombinationRegression(reco::GsfElectron& ele) const 
                                         combinedMomentum);
 
     ele.setP4(reco::GsfElectron::P4_COMBINATION, newMomentum, combinedMomentumError, true);
+    ele.setMass(0.0);
   }
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
@@ -197,5 +197,3 @@ void RegressionHelper::applyCombinationRegression(reco::GsfElectron& ele) const 
     ele.setMass(0.0);
   }
 }
-
-

--- a/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
@@ -197,3 +197,5 @@ void RegressionHelper::applyCombinationRegression(reco::GsfElectron& ele) const 
     ele.setMass(0.0);
   }
 }
+
+

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -1106,5 +1106,3 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     outputPhotonCollection.push_back(newCandidate);
   }
 }
-
-

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -946,19 +946,23 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
       if (candidateP4type_ == "fromEcalEnergy") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::ecal_photons));
         newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
+        newCandidate.setMass(0.0);
       } else if (candidateP4type_ == "fromRegression1") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::regression1));
         newCandidate.setCandidateP4type(reco::Photon::regression1);
+        newCandidate.setMass(0.0);
       } else if (candidateP4type_ == "fromRegression2") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
         newCandidate.setCandidateP4type(reco::Photon::regression2);
+        newCandidate.setMass(0.0);
       } else if (candidateP4type_ == "fromRefinedSCRegression") {
         newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
         newCandidate.setCandidateP4type(reco::Photon::regression2);
+        newCandidate.setMass(0.0);
       }
     } else {
       math::XYZVector gamma_momentum = direction.unit() * scRef->energy();
-      math::XYZTLorentzVectorD p4(gamma_momentum.x(), gamma_momentum.y(), gamma_momentum.z(), scRef->energy());
+      math::PtEtaPhiMLorentzVector p4(gamma_momentum.rho(), gamma_momentum.eta(), gamma_momentum.phi(), 0.0);
       newCandidate.setP4(p4);
       newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
       // Make it an EE photon
@@ -1084,15 +1088,19 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     if (candidateP4type_ == "fromEcalEnergy") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::ecal_photons));
       newCandidate.setCandidateP4type(reco::Photon::ecal_photons);
+      newCandidate.setMass(0.0);
     } else if (candidateP4type_ == "fromRegression1") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::regression1));
       newCandidate.setCandidateP4type(reco::Photon::regression1);
+      newCandidate.setMass(0.0);
     } else if (candidateP4type_ == "fromRegression2") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
       newCandidate.setCandidateP4type(reco::Photon::regression2);
+      newCandidate.setMass(0.0);
     } else if (candidateP4type_ == "fromRefinedSCRegression") {
       newCandidate.setP4(newCandidate.p4(reco::Photon::regression2));
       newCandidate.setCandidateP4type(reco::Photon::regression2);
+      newCandidate.setMass(0.0);
     }
 
     outputPhotonCollection.push_back(newCandidate);

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -1106,3 +1106,5 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     outputPhotonCollection.push_back(newCandidate);
   }
 }
+
+


### PR DESCRIPTION
Hello,
The electron and photon mass are not saved properly and nanoAOD users reported that many times. It is not related to nanoAOD. The problem is available in miniAOD too.
You can check the printout here
root [6] Events->Scan("Photon_mass:Electron_mass:Muon_mass:Tau_mass")
***********************************************************************
*    Row   * Instance * Photon_ma * Electron_ * Muon_mass *  Tau_mass *
***********************************************************************
*        0 *        0 * 1.348e-06 *           *           * 0.9638671 *
*        1 *        0 *         0 *           * 0.1057128 * 0.1395263 *
*        2 *        0 * 4.768e-07 *           *           * 0.3725585 *
*        2 *        1 * -2.23e-07 *           *           *           *
*        3 *        0 * 1.192e-07 *           * 0.1057128 * 0.1395263 *
*        3 *        1 * 2.919e-07 *           *           *           *
*        4 *        0 * -2.69e-06 *           *           *           *
*        4 *        1 *         0 *           *           *           *
*        5 *        0 * 6.742e-07 * 0.0024929 *           *           *
*        6 *        0 *           * -0.004924 * 0.1057128 * 0.1395263 *
*        6 *        1 *           * 0.0061264 * 0.1057128 * 0.1395263 *
*        7 *        0 * 6.421e-07 * 0.0085830 *           * 0.1395263 *
*        7 *        1 * 1.907e-06 * -0.018432 *           *           *
*        7 *        2 * 1.348e-06 *           *           *           *
*        8 *        0 *         0 * -0.020462 *           * 1.0068359 *

I checked and found that the problem is not from the EGamma code but from TLorentzVector root class. I found that the TLorentz vector is set via pxpypzE for all object candidates. It seems fine but when I tested locally for a particle with pxpypzE=(1,1,1,sqrt(3)) I did not get the mass==0. You can easily reproduce it
root -l
root [1] typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D > XYZTLorentzVectorD
root [2] XYZTLorentzVectorD newP4(1,1,1,sqrt(3));
root [3] newP4.M()
(double) -2.1073424e-08

It is because of the precision problem in TLorentz vector and it is recommended to use PxPyPzM to have correct masses for low mass objects.
https://root.cern.ch/doc/master/classROOT_1_1Math_1_1PxPyPzM4D.html

So I set the electron and photon masses by hand to 0 GeV , respectively.

Thanks,
Reza
