### PR TITLE
PPS fix to comply to EDModule rules

### DIFF
--- a/CondTools/CTPPS/src/WriteCTPPSPixelAnalysisMask.cc
+++ b/CondTools/CTPPS/src/WriteCTPPSPixelAnalysisMask.cc
@@ -15,7 +15,6 @@
 #include "CondCore/CondDB/interface/Time.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"

--- a/CondTools/CTPPS/src/WriteCTPPSPixelDAQMapping.cc
+++ b/CondTools/CTPPS/src/WriteCTPPSPixelDAQMapping.cc
@@ -15,7 +15,6 @@
 #include "CondCore/CondDB/interface/Time.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"


### PR DESCRIPTION
#### PR description:

Fix in two PPS files to comply to EDModule rules.
Removed inclusion of unneeded deprecated EDProducer headers.

#### PR validation:

It compiles and works/
