### PR TITLE
Add HiGenEvent object to heavy-ion miniAOD event content

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -148,7 +148,6 @@ _pp_on_AA_extraCommands = [
     'keep *_hiEvtPlane_*_*',
     'keep *_hiEvtPlaneFlat_*_*',
     'keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*',
-    'keep edmGenHIEvent_heavyIon_*_*',
 ]
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
@@ -163,7 +162,7 @@ MicroEventContentMC.outputCommands += [
                                         # RUN
                                         'keep L1GtTriggerMenuLite_l1GtTriggerMenuLite__*'
                                       ]
-_pp_on_AA_MC_extraCommands = ['keep *_packedGenParticlesSignal_*_*']
+_pp_on_AA_MC_extraCommands = ['keep *_packedGenParticlesSignal_*_*','keep edmGenHIEvent_heavyIon_*_*']
 pp_on_AA.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + _pp_on_AA_MC_extraCommands)
 
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -148,6 +148,7 @@ _pp_on_AA_extraCommands = [
     'keep *_hiEvtPlane_*_*',
     'keep *_hiEvtPlaneFlat_*_*',
     'keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*',
+    'keep edmGenHIEvent_heavyIon_*_*',
 ]
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA


### PR DESCRIPTION
#### PR description:

The HIGenEvent object stores a few gen-level variables that are relevant for heavy ion collisions.  It's stored in AOD, we would like to keep it for miniAOD, too.  The size of the object is negligible 

#### PR validation:

Tested w/ wf 159

