### PR TITLE
Make some L1Trigger config static pointers thread safe

### DIFF
--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
@@ -25,6 +25,7 @@
 //---------------
 
 #include <vector>
+#include <memory>
 
 //----------------------
 // Base Class Headers --
@@ -99,7 +100,7 @@ public:
   int numberOfTracks(int bx);
 
   /// return configuration
-  static L1MuDTTFConfig* config() { return m_config; }
+  static L1MuDTTFConfig* config() { return m_config.get(); }
 
   std::vector<L1MuDTTrackCand>& getcache0() { return _cache0; }
 
@@ -121,7 +122,7 @@ private:
   L1MuDTMuonSorter* m_ms;                    ///< DT Muon Sorter
   edm::EDGetTokenT<L1MuDTChambPhContainer> m_DTDigiToken;
 
-  static L1MuDTTFConfig* m_config;  ///< Track Finder configuration
+  static std::shared_ptr<L1MuDTTFConfig> m_config;  ///< Track Finder configuration
 };
 
 #endif

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
@@ -53,8 +53,11 @@ using namespace std;
 
 L1MuDTTrackFinder::L1MuDTTrackFinder(const edm::ParameterSet& ps, edm::ConsumesCollector&& iC) {
   // set configuration parameters
-  if (m_config == nullptr)
-    m_config = new L1MuDTTFConfig(ps);
+  if (not m_config) {
+    auto temp = std::make_shared<L1MuDTTFConfig>(ps);
+    std::shared_ptr<L1MuDTTFConfig> empty;
+    std::atomic_compare_exchange_strong(&m_config, &empty, temp);
+  }
 
   if (m_config->Debug(1))
     cout << endl;
@@ -96,10 +99,6 @@ L1MuDTTrackFinder::~L1MuDTTrackFinder() {
   m_wsvec.clear();
 
   delete m_ms;
-
-  if (m_config)
-    delete m_config;
-  m_config = nullptr;
 }
 
 //--------------
@@ -322,4 +321,4 @@ int L1MuDTTrackFinder::numberOfTracks(int bx) {
 
 // static data members
 
-L1MuDTTFConfig* L1MuDTTrackFinder::m_config = nullptr;
+std::shared_ptr<L1MuDTTFConfig> L1MuDTTrackFinder::m_config;

--- a/L1Trigger/GlobalMuonTrigger/interface/L1MuGlobalMuonTrigger.h
+++ b/L1Trigger/GlobalMuonTrigger/interface/L1MuGlobalMuonTrigger.h
@@ -17,6 +17,8 @@
 // C++ Headers --
 //---------------
 
+#include <memory>
+
 //----------------------
 // Base Class Headers --
 //----------------------
@@ -98,7 +100,7 @@ public:
   L1MuGMTReadoutRecord* currentReadoutRecord() const { return m_ReadoutRingbuffer.back(); };
 
   /// for debug: return the debug block (in order to fill it)
-  L1MuGMTDebugBlock* DebugBlockForFill() const { return m_db; };
+  L1MuGMTDebugBlock* DebugBlockForFill() const { return m_db.get(); };
 
 private:
   L1MuGMTPSB* m_PSB;
@@ -114,9 +116,9 @@ private:
   bool m_writeLUTsAndRegs;
   bool m_sendMipIso;
 
-  static L1MuGMTConfig* m_config;
+  static std::shared_ptr<L1MuGMTConfig> m_config;
 
-  static L1MuGMTDebugBlock* m_db;
+  static std::shared_ptr<L1MuGMTDebugBlock> m_db;
 
   unsigned long long m_L1MuGMTScalesCacheID;
   unsigned long long m_L1MuTriggerScalesCacheID;

--- a/L1Trigger/L1TMuonBarrel/interface/L1MuBMTrackFinder.h
+++ b/L1Trigger/L1TMuonBarrel/interface/L1MuBMTrackFinder.h
@@ -27,6 +27,8 @@
 
 #include <vector>
 #include <iostream>
+#include <memory>
+
 //----------------------
 // Base Class Headers --
 //----------------------
@@ -114,7 +116,7 @@ public:
   int numberOfTracks(int bx);
 
   /// return configuration
-  static const L1MuBMTFConfig* config() { return m_config; }
+  static const L1MuBMTFConfig* config() { return m_config.get(); }
 
   l1t::RegionalMuonCandBxCollection& getcache() { return _cache; }
   l1t::RegionalMuonCandBxCollection& getcache0() { return _cache0; }
@@ -141,7 +143,7 @@ private:
   std::vector<L1MuBMWedgeSorter*> m_wsvec;   ///< Wedge Sorters
   L1MuBMMuonSorter* m_ms;                    ///< BM Muon Sorter
 
-  static L1MuBMTFConfig* m_config;  ///< Track Finder configuration
+  static std::shared_ptr<L1MuBMTFConfig> m_config;  ///< Track Finder configuration
 
   edm::EDGetTokenT<L1MuDTChambPhContainer> m_DTDigiToken;
   edm::ESGetToken<L1TMuonBarrelParams, L1TMuonBarrelParamsRcd> m_mbParamsToken;

--- a/L1Trigger/L1TMuonBarrel/src/L1MuBMTrackFinder.cc
+++ b/L1Trigger/L1TMuonBarrel/src/L1MuBMTrackFinder.cc
@@ -60,8 +60,11 @@ using namespace std;
 L1MuBMTrackFinder::L1MuBMTrackFinder(const edm::ParameterSet& ps, edm::ConsumesCollector&& iC)
     : _cache0(144, -9, 8), _cache(36, -9, 8) {
   // set configuration parameters
-  if (m_config == nullptr)
-    m_config = new L1MuBMTFConfig(ps);
+  if (not m_config) {
+    auto temp = std::make_shared<L1MuBMTFConfig>(ps);
+    std::shared_ptr<L1MuBMTFConfig> empty;
+    std::atomic_compare_exchange_strong(&m_config, &empty, temp);
+  }
 
   if (L1MuBMTFConfig::Debug(1))
     cout << endl;
@@ -101,10 +104,6 @@ L1MuBMTrackFinder::~L1MuBMTrackFinder() {
   m_wsvec.clear();
 
   delete m_ms;
-
-  if (m_config)
-    delete m_config;
-  m_config = nullptr;
 }
 
 //--------------
@@ -528,4 +527,4 @@ int L1MuBMTrackFinder::setAdd(int ust, int rel_add) {
 
 // static data members
 
-L1MuBMTFConfig* L1MuBMTrackFinder::m_config = nullptr;
+std::shared_ptr<L1MuBMTFConfig> L1MuBMTrackFinder::m_config;


### PR DESCRIPTION
#### PR description:

UBSAN IBs identified some thread-unsafe initialization and destruction of static pointers used for config and debug information.  These produced runtime errors like:
```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/e79955c4ee35855e71c28ad84fd140dd/opt/cmssw/slc7_amd64_gcc11/cms/cmssw/CMSSW_12_3_UBSAN_X_2022-02-11-1100/src/L1Trigger/L1TMuonBarrel/src/L1MuBMTrackFinder.cc:162:26: runtime error: member call on null pointer of type 'struct L1MuBMTFConfig'
```
followed by segmentation violations.  This PR replaces the thread-unsafe initialization and destruction of the static pointers with thread-safe manipulations of `std::shared_ptr`.

#### PR validation:

Ran WF 139.002 in CMSSW_12_3_UBSAN_X_2022-02-11-1100 and verified that no null pointer derefs were seen and no new errors appeared.  Purely technical fix, should have no impact on performance.