### PR TITLE
SiPixelClusterizer: No digis to clusterize warning into error

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -130,9 +130,11 @@ void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
   typename T::const_iterator begin = input.begin();
   typename T::const_iterator end = input.end();
 
-  // Do not bother for empty detectors
-  if (begin == end)
-    edm::LogWarning("clusterizeDetUnit()") << "No digis to clusterize";
+  // this should never happen and the raw2digi does not create empty detsets
+  if (begin == end) {
+    edm::LogError("PixelThresholdClusterizer") << "@SUB=PixelThresholdClusterizer::clusterizeDetUnitT()"
+                                               << " No digis to clusterize";
+  }
 
   //  Set up the clusterization on this DetId.
   if (!setup(pixDet))

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizerForBricked.cc
@@ -49,9 +49,12 @@ void PixelThresholdClusterizerForBricked::clusterizeDetUnitT(const T& input,
 
   edm::LogInfo("PixelThresholdClusterizerForBricked::clusterizeDetUnitT()");
 
-  // Do not bother for empty detectors
-  if (begin == end)
-    edm::LogWarning("clusterizeDetUnit()") << "No digis to clusterize";
+  // this should never happen and the raw2digi does not create empty detsets
+  if (begin == end) {
+    edm::LogError("PixelThresholdClusterizerForBricked")
+        << "@SUB=PixelThresholdClusterizerForBricked::clusterizeDetUnitT()"
+        << " No digis to clusterize";
+  }
 
   //  Set up the clusterization on this DetId.
   if (!setup(pixDet))


### PR DESCRIPTION
#### PR description:

See discussion at https://github.com/cms-sw/cmssw/pull/36326#issuecomment-984417751 and https://github.com/cms-sw/cmssw/pull/37035#issuecomment-1056774527.
In PR #37035, the logic of the pixel raw2digi was changed in order to avoid producing empty `DetSet`s in the Pixel digi `DetSerVector`. This usually happened when a given `DetId` only contained invalid pixels (0,0) and no other valid pixel. These were anyway discarded later on, leading to the creation of empty `DetSet`s.
Now after https://github.com/cms-sw/cmssw/pull/37035 will be merged, empty `DetSet`s should never happen and thus the message is transformed into an error.

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
