### PR TITLE
MTD geometry: update tests to scenario D88, update DDFilteredView::parameters() accordingly

### DIFF
--- a/Geometry/MTDCommonData/test/testMTDGeometry.py
+++ b/Geometry/MTDCommonData/test/testMTDGeometry.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
-process = cms.Process("MTDGeometryTest",Phase2C11I13M9,dd4hep)
+process = cms.Process("MTDGeometryTest",Phase2C17I13M9,dd4hep)
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(
@@ -47,10 +47,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     )
 )
 
-process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('Geometry/MTDCommonData/data/dd4hep/cms-mtdD76-geometry.xml'),
-                                            appendToDataLabel = cms.string('')
-                                            )
+process.load('Configuration.Geometry.GeometryDD4hep_cff')
+process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D88.xml")
 
 process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
                                                      appendToDataLabel = cms.string('')

--- a/Geometry/MTDCommonData/test/testMTDinDD4hep.py
+++ b/Geometry/MTDCommonData/test/testMTDinDD4hep.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
-process = cms.Process("CompareGeometryTest",Phase2C11I13M9,dd4hep)
+process = cms.Process("CompareGeometryTest",Phase2C17I13M9,dd4hep)
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(
@@ -50,10 +50,8 @@ process.MessageLogger.files.mtdCommonDataDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('Geometry/MTDCommonData/data/dd4hep/cms-mtdD76-geometry.xml'),
-                                            appendToDataLabel = cms.string('')
-)
+process.load('Configuration.Geometry.GeometryDD4hep_cff')
+process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D88.xml")
 
 process.DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
                                                      appendToDataLabel = cms.string('')

--- a/Geometry/MTDCommonData/test/testMTDinDDD.py
+++ b/Geometry/MTDCommonData/test/testMTDinDDD.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 
-process = cms.Process("CompareGeometryTest",Phase2C11I13M9)
+process = cms.Process("CompareGeometryTest",Phase2C17I13M9)
 
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(
@@ -49,7 +49,7 @@ process.MessageLogger.files.mtdCommonDataDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load('Configuration.Geometry.GeometryExtended2026D76_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
 
 process.testBTL = cms.EDAnalyzer("TestMTDIdealGeometry",
                                ddTopNodeName = cms.untracked.string('BarrelTimingLayer'),

--- a/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/dd4hep_mtd_cfg.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
-process = cms.Process("GeometryTest",Phase2C11I13M9,dd4hep)
+process = cms.Process("GeometryTest",Phase2C17I13M9,dd4hep)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -50,10 +50,8 @@ process.MessageLogger.files.mtdGeometryDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('Geometry/MTDCommonData/data/dd4hep/cms-mtdD76-geometry.xml'),
-                                            appendToDataLabel = cms.string('')
-)
+process.load('Configuration.Geometry.GeometryDD4hep_cff')
+process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D88.xml")
 
 process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
                                                  appendToDataLabel = cms.string('')

--- a/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDGeometryBuilder/test/mtd_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 
-process = cms.Process("GeometryTest",Phase2C11I13M9)
+process = cms.Process("GeometryTest",Phase2C17I13M9)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -46,7 +46,7 @@ process.MessageLogger.files.mtdGeometryDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryExtended2026D76_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
 

--- a/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/dd4hep_mtd_cfg.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
-process = cms.Process("GeometryTest",Phase2C11I13M9,dd4hep)
+process = cms.Process("GeometryTest",Phase2C17I13M9,dd4hep)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -47,10 +47,8 @@ process.MessageLogger.files.mtdNumberingDD4hep = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                            confGeomXMLFiles = cms.FileInPath('Geometry/MTDCommonData/data/dd4hep/cms-mtdD76-geometry.xml'),
-                                            appendToDataLabel = cms.string('')
-)
+process.load('Configuration.Geometry.GeometryDD4hep_cff')
+process.DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D88.xml")
 
 process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
                                                  appendToDataLabel = cms.string('')

--- a/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
+++ b/Geometry/MTDNumberingBuilder/test/mtd_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 
-process = cms.Process("GeometryTest",Phase2C11I13M9)
+process = cms.Process("GeometryTest",Phase2C17I13M9)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -46,7 +46,7 @@ process.MessageLogger.files.mtdNumberingDDD = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO')
 )
 
-process.load("Configuration.Geometry.GeometryExtended2026D76_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
 

--- a/RecoMTD/DetLayers/test/mtd_cfg.py
+++ b/RecoMTD/DetLayers/test/mtd_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
 
-process = cms.Process("GeometryTest",Phase2C11I13M9)
+process = cms.Process("GeometryTest",Phase2C17I13M9)
 
 process.source = cms.Source("EmptySource")
 
@@ -48,7 +48,7 @@ process.MessageLogger.files.mtdDetLayerGeometry = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO'))
 
 # Choose Tracker Geometry
-process.load("Configuration.Geometry.GeometryExtended2026D76_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D88_cff")
 
 process.load("Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff")
 


### PR DESCRIPTION
#### PR description:

This PR addresses the issue https://github.com/cms-sw/cmssw/issues/36837#issuecomment-1038860482 reported at the simulation meeting https://indico.cern.ch/event/1127757/contributions/4733494/attachments/2389568/4085879/20220211-Phase2SWPlan.pdf slide 12 by @srimanob . 

All the MTD standalone geometry tests are moved to the latest D88 scenario, and in order to cope with boolean solids, the ```DetectorDescription/DDCMS``` package is update in the ```DDFilteredView::parameters()``` method, to accomodate also polycones as possible components of a boolean solid.

The unit tests need the appropriate reference https://github.com/cms-data/Geometry-TestReference/pull/10 to correctly run.

#### PR validation:

MTD geometry unit tests run smoothly and provide the expected geometry dump (as in scenario D77 with only a z shift in ETL sensors position). 