### PR TITLE
Add back L1CaloGeometry tag to HLT GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -32,7 +32,7 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '123X_dataRun3_HLT_v2',
+    'run3_hlt'                     : '123X_dataRun3_HLT_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v1',
     # GlobalTag for Run3 data relvals (express GT)


### PR DESCRIPTION
#### PR description:
This PR adds back the `L1CaloGeometry_CRAFT09_hlt` tag to the HLT GT, as this was causing a crash first reported in https://github.com/cms-sw/cmssw/pull/36940#issuecomment-1038745243 and later discussed in https://github.com/cms-sw/cmssw/pull/36940#issuecomment-1038805021 and #36806.

Since HLT experts are still in the process of investigating how to modify the producer that consumes this tag, we decided to add it back so it can be included in 12_3_0_pre5 and fix the IBs for now.

GT diff:
**Run 3 data HLT**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_HLT_v2/123X_dataRun3_HLT_v3

#### PR validation:
Validated with:
`runTheMatrix.py -l 139.004 -j 8 --ibeos`

#### Backport:
Already backported in #36948

