### PR TITLE
small improvements to `HLTSumJetTag`

### DIFF
--- a/HLTrigger/btau/plugins/HLTSumJetTag.h
+++ b/HLTrigger/btau/plugins/HLTSumJetTag.h
@@ -7,31 +7,31 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "DataFormats/BTauReco/interface/JetTag.h"
-#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
-
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
-#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
 
 template <typename T>
 class HLTSumJetTag : public HLTFilter {
 public:
   explicit HLTSumJetTag(const edm::ParameterSet& config);
   ~HLTSumJetTag() override = default;
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   bool hltFilter(edm::Event& event,
                  const edm::EventSetup& setup,
                  trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
 
 private:
-  float findTagValueByMinDeltaR2(const T& jet, const reco::JetTagCollection& jetTags, float maxDeltaR2) const;
+  bool findTagValueByMinDeltaR2(float& jetTagValue,
+                                const T& jet,
+                                const reco::JetTagCollection& jetTags,
+                                float maxDeltaR2) const;
 
   const edm::InputTag m_Jets;     // input jet collection
   const edm::InputTag m_JetTags;  // input tag collection
-  const edm::EDGetTokenT<std::vector<T> > m_JetsToken;
+  const edm::EDGetTokenT<std::vector<T>> m_JetsToken;
   const edm::EDGetTokenT<reco::JetTagCollection> m_JetTagsToken;
   const double m_MinTag;       // min tag value
   const double m_MaxTag;       // max tag value
@@ -40,7 +40,7 @@ private:
   const bool m_UseMeanValue;   // consider mean of jet tags instead of their sum
   const bool m_MatchByDeltaR;  // find jet-tag value by Delta-R matching
   const bool m_MaxDeltaR;      // max Delta-R to assign jet-tag to a jet via Delta-R matching
-  const int m_TriggerType;
+  const int m_TriggerType;     // type of TriggerObject in TriggerFilterObjectWithRefs
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

This PR provides small improvements to the HLT filters introduced in https://github.com/cms-sw/cmssw/pull/36862 (cc: @rgerosa), including a follow-up to the review comments in https://github.com/cms-sw/cmssw/pull/36862#pullrequestreview-880947093.

One change is not merely technical; it concerns the case where `MatchByDeltaR == true`. In the original implementation, every jet is assigned a "jetTag" value, and, when there is no valid Delta-R match with a jet in the JetTag map, then the tagValue is set to an arbitrary -1000. In this PR, jets without a valid DR-match are instead skipped; for realistic cuts on "JetSumTag", the two approaches should be equivalent from a practical point of view, and I would suggest to use the one in this PR.

Since the relevant plugins are not run in any central wf, the PR tests are not expected to be sensitive to this PR.

#### PR validation:

I manually checked with the recipe provided in https://github.com/cms-data/RecoBTag-Combined/pull/47#issuecomment-1033521156 (plus some edits to the config file, using one instance of the plugin with `MatchByDeltaR=false` and one with `MatchByDeltaR=true`) that the results of the HLT filters, and corresponding trigger objects, are exactly the same for 100 MC events.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A