### PR TITLE
Remove Phase-0 SiStrip records dependency from Phase-2 workflows

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -76,7 +76,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '123X_mcRun4_realistic_v4'
+    'phase2_realistic'             : '123X_mcRun4_realistic_noSiStrip_v3'
 }
 
 aliases = {

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -35,9 +35,10 @@ run3_common.toReplaceWith(DigiToRawTask, DigiToRawTask.copyAndExclude([castorRaw
 from Configuration.Eras.Modifier_hcalSkipPacker_cff import hcalSkipPacker
 hcalSkipPacker.toReplaceWith(DigiToRawTask, DigiToRawTask.copyAndExclude([hcalRawDataTask]))
 
-# Remove siPixelRawData until we have phase1 pixel digis
+# Remove siPixelRawData until we have phase2 pixel digis
+# No Strip detector in Phase-2 Tracker
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase2_tracker.toReplaceWith(DigiToRawTask, DigiToRawTask.copyAndExclude([siPixelRawData])) # FIXME
+phase2_tracker.toReplaceWith(DigiToRawTask, DigiToRawTask.copyAndExclude([siPixelRawData,SiStripDigiToRaw])) # FIXME
 
 # GEM settings
 _gem_DigiToRawTask = DigiToRawTask.copy()

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -87,9 +87,9 @@ from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([castorDigis]))
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-# Remove siPixelDigis until we have Phase 2 pixel digis
-phase2_tracker.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([siPixelDigis])) # FIXME
-
+# Remove siPixelDigis until we have phase2 pixel digis
+# No Strips in the Phase-2 tracker
+phase2_tracker.toReplaceWith(RawToDigiTask, RawToDigiTask.copyAndExclude([siPixelDigis,siStripDigis])) # FIXME
 
 # add CTPPS 2016 raw-to-digi modules
 from Configuration.Eras.Modifier_ctpps_cff import ctpps

--- a/EventFilter/RawDataCollector/python/rawDataCollector_cfi.py
+++ b/EventFilter/RawDataCollector/python/rawDataCollector_cfi.py
@@ -38,3 +38,7 @@ run3_GEM.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.
 # For Run2 it is needed to include the general ctpps era ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
 ctpps_2021.toModify(rawDataCollector.RawCollectionList, func = lambda  list: list.extend([cms.InputTag("ctppsTotemRawData"),cms.InputTag("ctppsPixelRawData")]) )
+
+# Phase-2 Tracker
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.remove(cms.InputTag("SiStripDigiToRaw")) )

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeHitFilterESProducer_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeHitFilterESProducer_cfi.py
@@ -4,16 +4,18 @@ ClusterShapeHitFilterESProducer = cms.ESProducer("ClusterShapeHitFilterESProduce
                                                         ComponentName = cms.string('ClusterShapeHitFilter'),
                                                         PixelShapeFile= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase0.par'),
                                                         PixelShapeFileL1= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase0.par'),
-                                                        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
-                                                        )
+                                                        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+                                                        isPhase2 = cms.bool(False))
+
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(ClusterShapeHitFilterESProducer,
     PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase1_noL1.par',
     PixelShapeFileL1 = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase1_loose.par',
 )
+
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(ClusterShapeHitFilterESProducer,
-    isPhase2 = cms.bool(True),                    
+    isPhase2 = True,
     PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/ITShapePhase2_all.par',
     PixelShapeFileL1 = 'RecoPixelVertexing/PixelLowPtUtilities/data/ITShapePhase2_all.par',
 )

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeHitFilterESProducer_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeHitFilterESProducer_cfi.py
@@ -13,6 +13,7 @@ phase1Pixel.toModify(ClusterShapeHitFilterESProducer,
 )
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(ClusterShapeHitFilterESProducer,
+    isPhase2 = cms.bool(True),                    
     PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/ITShapePhase2_all.par',
     PixelShapeFileL1 = 'RecoPixelVertexing/PixelLowPtUtilities/data/ITShapePhase2_all.par',
 )

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeHitFilter.cc
@@ -205,7 +205,10 @@ pair<float, float> ClusterShapeHitFilter::getDrift(const PixelGeomDetUnit* pixel
 float ClusterShapeHitFilter::getDrift(const StripGeomDetUnit* stripDet) const {
   LocalVector lBfield = (stripDet->surface()).toLocal(theMagneticField->inTesla(stripDet->surface().position()));
 
-  double theTanLorentzAnglePerTesla = theSiStripLorentzAngle->getLorentzAngle(stripDet->geographicalId().rawId());
+  double theTanLorentzAnglePerTesla = 0.0;
+  if (theSiStripLorentzAngle) {
+    theTanLorentzAnglePerTesla = theSiStripLorentzAngle->getLorentzAngle(stripDet->geographicalId().rawId());
+  }
 
   float dir = theTanLorentzAnglePerTesla * lBfield.y();
 

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -147,7 +147,6 @@ MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterS
   }
 
   pixelCPEToken_ = c.consumes(edm::ESInputTag("", p.getParameter<std::string>("PixelCPE")));
-  stripCPEToken_ = c.consumes(edm::ESInputTag("", p.getParameter<std::string>("StripCPE")));
   hitMatcherToken_ = c.consumes(edm::ESInputTag("", p.getParameter<std::string>("HitMatcher")));
   trackerTopologyToken_ = c.consumes();
   trackerGeomToken_ = c.consumes();
@@ -158,6 +157,8 @@ MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterS
   if (not phase2.empty()) {
     usePhase2_ = true;
     phase2TrackerCPEToken_ = c.consumes(edm::ESInputTag("", phase2));
+  } else {
+    stripCPEToken_ = c.consumes(edm::ESInputTag("", p.getParameter<std::string>("StripCPE")));
   }
 }
 
@@ -180,12 +181,15 @@ std::unique_ptr<MeasurementTracker> MeasurementTrackerESProducer::produce(const 
   }
 
   const ClusterParameterEstimator<Phase2TrackerCluster1D> *ptr_phase2TrackerCPE = nullptr;
+  const StripClusterParameterEstimator *ptr_SiStripTrackerCPE = nullptr;
   if (usePhase2_) {
     ptr_phase2TrackerCPE = &iRecord.get(phase2TrackerCPEToken_);
+  } else {
+    ptr_SiStripTrackerCPE = &iRecord.get(stripCPEToken_);
   }
   return std::make_unique<MeasurementTrackerImpl>(badStripCuts_,
                                                   &iRecord.get(pixelCPEToken_),
-                                                  &iRecord.get(stripCPEToken_),
+                                                  ptr_SiStripTrackerCPE,
                                                   &iRecord.get(hitMatcherToken_),
                                                   &iRecord.get(trackerTopologyToken_),
                                                   &iRecord.get(trackerGeomToken_),

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
@@ -5,7 +5,14 @@ from RecoTracker.MeasurementDet._MeasurementTrackerESProducer_default_cfi import
 MeasurementTracker = _MeasurementTrackerESProducer_default.clone()
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toModify(MeasurementTracker, Phase2StripCPE = 'Phase2StripCPE')
+trackingPhase2PU140.toModify(MeasurementTracker, 
+                             Phase2StripCPE = cms.string('Phase2StripCPE'),
+                             #StripCPE = cms.string(''),
+                             UseStripModuleQualityDB = cms.bool(False),
+                             UseStripAPVFiberQualityDB = cms.bool(False),
+                             MaskBadAPVFibers = cms.bool(False),
+                             UseStripStripQualityDB = cms.bool(False),
+                             )
 
 from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
 phase2_brickedPixels.toModify(MeasurementTracker, PixelCPE = cms.string('PixelCPEGenericForBricked'))

--- a/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
+++ b/RecoTracker/MeasurementDet/python/MeasurementTrackerESProducer_cfi.py
@@ -6,14 +6,13 @@ MeasurementTracker = _MeasurementTrackerESProducer_default.clone()
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(MeasurementTracker, 
-                             Phase2StripCPE = cms.string('Phase2StripCPE'),
-                             #StripCPE = cms.string(''),
-                             UseStripModuleQualityDB = cms.bool(False),
-                             UseStripAPVFiberQualityDB = cms.bool(False),
-                             MaskBadAPVFibers = cms.bool(False),
-                             UseStripStripQualityDB = cms.bool(False),
-                             )
+                             Phase2StripCPE = 'Phase2StripCPE',
+                             #StripCPE = '',
+                             UseStripModuleQualityDB = False,
+                             UseStripAPVFiberQualityDB = False,
+                             MaskBadAPVFibers = False,
+                             UseStripStripQualityDB = False)
 
 from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
-phase2_brickedPixels.toModify(MeasurementTracker, PixelCPE = cms.string('PixelCPEGenericForBricked'))
+phase2_brickedPixels.toModify(MeasurementTracker, PixelCPE = 'PixelCPEGenericForBricked')
 

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -76,7 +76,7 @@ TkTransientTrackingRecHitBuilderESProducer::TkTransientTrackingRecHitBuilderESPr
 std::unique_ptr<TransientTrackingRecHitBuilder> TkTransientTrackingRecHitBuilderESProducer::produce(
     const TransientRecHitRecord& iRecord) {
   const StripClusterParameterEstimator* sp = nullptr;
-  if (spToken_) {
+  if (spToken_ && !p2OTToken_) {  // no strips in Phase-2
     sp = &iRecord.get(*spToken_);
   }
 

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
     StripCPE = cms.string('StripCPEfromTrackAngle'),
+    Phase2StripCPE = cms.string(''),
     ComponentName = cms.string('WithAngleAndTemplate'),
     PixelCPE = cms.string('PixelCPETemplateReco'),
     Matcher = cms.string('StandardMatcher'),
@@ -10,10 +11,8 @@ TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderES
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, 
-                             Phase2StripCPE = cms.string('Phase2StripCPE'),
-                             StripCPE = cms.string('FakeStripCPE')
-                             )
-
+                             Phase2StripCPE = 'Phase2StripCPE',
+                             StripCPE = 'FakeStripCPE')
 
 # uncomment these two lines to turn on Cluster Repair CPE
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -9,7 +9,11 @@ TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderES
 )
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.string('Phase2StripCPE'))
+trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, 
+                             Phase2StripCPE = cms.string('Phase2StripCPE'),
+                             StripCPE = cms.string('FakeStripCPE')
+                             )
+
 
 # uncomment these two lines to turn on Cluster Repair CPE
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
@@ -9,5 +9,8 @@ ttrhbwor = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
 )
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toModify(ttrhbwor, Phase2StripCPE = cms.string('Phase2StripCPE'))
+trackingPhase2PU140.toModify(ttrhbwor, 
+                             Phase2StripCPE = cms.string('Phase2StripCPE'),
+                             StripCPE = cms.string('FakeStripCPE')
+                             )
 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 ttrhbwor = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
     StripCPE = cms.string('Fake'),
+    Phase2StripCPE = cms.string(''),
     ComponentName = cms.string('WithoutRefit'),
     PixelCPE = cms.string('Fake'),
     Matcher = cms.string('Fake'),
@@ -10,7 +11,6 @@ ttrhbwor = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(ttrhbwor, 
-                             Phase2StripCPE = cms.string('Phase2StripCPE'),
-                             StripCPE = cms.string('FakeStripCPE')
-                             )
+                             Phase2StripCPE = 'Phase2StripCPE',
+                             StripCPE = 'FakeStripCPE')
 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 ttrhbwr = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
     StripCPE = cms.string('StripCPEfromTrackAngle'),
+    Phase2StripCPE = cms.string(''),
     ComponentName = cms.string('WithTrackAngle'),
     PixelCPE = cms.string('PixelCPEGeneric'),
     Matcher = cms.string('StandardMatcher'),
@@ -10,10 +11,9 @@ ttrhbwr = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(ttrhbwr, 
-                             Phase2StripCPE = cms.string('Phase2StripCPE'),
-                             StripCPE = cms.string('FakeStripCPE')
-                             )
+                             Phase2StripCPE = 'Phase2StripCPE',
+                             StripCPE = 'FakeStripCPE')
 
 from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
-phase2_brickedPixels.toModify(ttrhbwr, PixelCPE = cms.string('PixelCPEGenericForBricked'))
+phase2_brickedPixels.toModify(ttrhbwr, PixelCPE = 'PixelCPEGenericForBricked')
 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
@@ -9,7 +9,10 @@ ttrhbwr = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
 )
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
-trackingPhase2PU140.toModify(ttrhbwr, Phase2StripCPE = cms.string('Phase2StripCPE'))
+trackingPhase2PU140.toModify(ttrhbwr, 
+                             Phase2StripCPE = cms.string('Phase2StripCPE'),
+                             StripCPE = cms.string('FakeStripCPE')
+                             )
 
 from Configuration.Eras.Modifier_phase2_brickedPixels_cff import phase2_brickedPixels
 phase2_brickedPixels.toModify(ttrhbwr, PixelCPE = cms.string('PixelCPEGenericForBricked'))

--- a/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_PreMix_cfi.py
@@ -66,6 +66,7 @@ from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(simSiPixelDigis, mix = _pixelCommon + [cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))])
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(simSiStripDigis,  mix = None)
 phase2_tracker.toModify(simAPVsaturation, mixData = None)
 
 # no castor,pixel,strip digis in fastsim

--- a/SimGeneral/MixingModule/python/aliases_cfi.py
+++ b/SimGeneral/MixingModule/python/aliases_cfi.py
@@ -101,6 +101,10 @@ from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(simSiPixelDigis, mix = _pixelCommon + [cms.PSet(type = cms.string('PixelFEDChanneledmNewDetSetVector'))])
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(simSiStripDigis, mix = None)
+phase2_tracker.toModify(simAPVsaturation, mix = None)
+
 # no castor,pixel,strip digis in fastsim
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 fastSim.toModify(simCastorDigis, mix = None)

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -101,6 +101,10 @@ premix_stage2.toModify(theDigitizers,
     )
 )
 
+from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+phase2_tracker.toModify(theDigitizers,
+                        strip = None)
+
 theDigitizersValid = cms.PSet(theDigitizers)
 theDigitizers.mergedtruth.select.signalOnlyTP = True
 


### PR DESCRIPTION
#### PR description:

The main goal of this PR is loose the dependency on the Phase-0 SiStrip records supplied via GlobalTag in the Phase-2 workflows.
The change of Global Tag (without the SiStrip records) is performed in commit 4706cd44a4835f4b9b760a5845ee48412b8b1377. 
The difference of GlobalTag is available here: https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun4_realistic_v4/123X_mcRun4_realistic_noSiStrip_v3:

```
$ conddb diff 123X_mcRun4_realistic_v4 123X_mcRun4_realistic_noSiStrip_v3
[2022-02-16 15:57:04,575] INFO: Connecting to pro [frontier://PromptProd/cms_conditions]
Record                         Label            pro::123X_mcRun4_realistic_v4 Tag                    pro::123X_mcRun4_realistic_noSiStrip_v3 Tag   
-----------------------------  ---------------  ---------------------------------------------------  -------------------------------------------   
SiStripApvGain2Rcd             -                SiStripApvGain_FromParticles_DecoMode_v6_mc          -                                             
SiStripApvGainRcd              -                SiStripApvGain_RealisticMC_v2_mc                     -                                             
SiStripApvGainSimRcd           -                SiStripApvGain_RealisticMCSim_v3_mc                  -                                             
SiStripBackPlaneCorrectionRcd  deconvolution    SiStripBackPlaneCorrection_deco_Ideal_v1_mc          -                                             
SiStripBackPlaneCorrectionRcd  peak             SiStripBackPlaneCorrection_peak_Ideal_v1_mc          -                                             
SiStripBadChannelRcd           -                SiStripBadComponents_realisticMC_for2018_v0_mc       -                                             
SiStripBadFiberRcd             -                SiStripBadFiber_Ideal_31X_v2                         -                                             
SiStripBadModuleRcd            -                SiStripBadModule_Ideal_31X_v2                        -                                             
SiStripBadStripRcd             -                SiStripBadStrip_Ideal_31X_v1                         -                                             
SiStripClusterThresholdRcd     -                SiStripClusterThreshold_Standard_31X_v2              -                                             
SiStripConfObjectRcd           -                SiStripShiftAndCrosstalk_Ideal_v1_mc                 -                                             
SiStripConfObjectRcd           apvphaseoffsets  SiStripAPVPhaseOffsets_v1_mc                         -                                             
SiStripDeDxElectron_3D_Rcd     -                SiStripDeDxElectron_3D_30X                           -                                             
SiStripDeDxKaon_3D_Rcd         -                SiStripDeDxKaon_3D_30X                               -                                             
SiStripDeDxMip_3D_Rcd          -                SiStripDeDxMip3D_v04_mc                              -                                             
SiStripDeDxPion_3D_Rcd         -                SiStripDeDxPion_3D_30X                               -                                             
SiStripDeDxProton_3D_Rcd       -                SiStripDeDxProton_3D_30X                             -                                             
SiStripDetVOffRcd              -                SiStripDetVOff_Ideal_31X_v2                          -                                             
SiStripFedCablingRcd           -                SiStripFedCabling_Ideal_31X_v2                       -                                             
SiStripLatencyRcd              -                SiStripLatency_MC_31X_v1                             -                                             
SiStripLorentzAngleRcd         deconvolution    SiStripLorentzAngleDeco_StartUp_31X_v2               -                                             
SiStripLorentzAngleSimRcd      -                SiStripLorentzAngle_IdealSim_31X_v2                  -                                             
SiStripNoisesRcd               -                SiStripNoise_DecoMode_TickCorr_Minus15C_Fixed_v1_mc  -                                             
SiStripPedestalsRcd            -                SiStripPedestals_Ideal_31X_v2                        -                                             
SiStripThresholdRcd            -                SiStripThreshold_Ideal_31X_v2                        -                                             
```
The rest are changes necessary in the configuration / code in order to loose the entanglement with phase-0 SiStrip conditions when running the whole Phase-2 chain (digitization, digi2raw, raw2digi, reconstruction) and is done in commit 4706cd44a4835f4b9b760a5845ee48412b8b1377.

#### PR validation:

It passes limited matrix tests `runTheMatrix.py -l limited --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
