### PR TITLE
A few possible bug fixes in the L1T code

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerInputs.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerInputs.cc
@@ -287,7 +287,6 @@ namespace l1t {
         blocks.push_back(Block(block_id, payload));
 
         if (link % 2 != 0) {
-          moreBXphi = false;
           moreBXeta = false;
         }
 

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2EtSumAlgorithmImpPP.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2EtSumAlgorithmImpPP.cc
@@ -111,9 +111,6 @@ void l1t::Stage1Layer2EtSumAlgorithmImpPP::processEvent(const std::vector<l1t::C
   // Although we calculated it with regions, there is some benefit to interpolation.
   unsigned int iPhiET = 4 * L1CaloRegionDetId::N_PHI * physicalPhi / (2 * 3.1415927);
 
-  double physicalPhiHT = atan2(sumHy, sumHx) + 3.1415927;
-  unsigned int iPhiHT = L1CaloRegionDetId::N_PHI * (physicalPhiHT) / (2 * 3.1415927);
-
   const ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > etLorentz(0, 0, 0, 0);
 
   // Set quality (i.e. overflow) bits appropriately
@@ -137,7 +134,7 @@ void l1t::Stage1Layer2EtSumAlgorithmImpPP::processEvent(const std::vector<l1t::C
   // MHT=rank;
 
   uint16_t MHToHT = MHToverHT(MHT, sumHT);
-  iPhiHT = dijet_phi;
+  unsigned int iPhiHT = (unsigned int)dijet_phi;
 
   l1t::EtSum etMiss(*&etLorentz, EtSum::EtSumType::kMissingEt, MET, 0, iPhiET, METqual);
   l1t::EtSum htMiss(*&etLorentz, EtSum::EtSumType::kMissingHt, MHToHT & 0x7f, 0, iPhiHT, MHTqual);

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -668,7 +668,7 @@ void l1t::Stage2Layer2JetAlgorithmFirmwareImp1::calibrate(std::vector<l1t::Jet>&
       }
 
       double ptPhys = jet->hwPt() * params_->jetLsb();
-      double correction = params[7];
+      double correction;
 
       if (ptPhys < params[8])
         correction = params[7];

--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2TauAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2TauAlgorithmFirmwareImp1.cc
@@ -8,7 +8,6 @@
 #include "L1Trigger/L1TCalorimeter/interface/Stage2Layer2TauAlgorithmFirmware.h"
 
 #include "L1Trigger/L1TCalorimeter/interface/CaloTools.h"
-#include "L1Trigger/L1TCalorimeter/interface/CaloStage2Nav.h"
 #include "L1Trigger/L1TCalorimeter/interface/BitonicSort.h"
 #include "L1Trigger/L1TCalorimeter/interface/AccumulatingSort.h"
 
@@ -172,9 +171,9 @@ void l1t::Stage2Layer2TauAlgorithmFirmwareImp1::merging(const std::vector<l1t::C
         if ((secClusters.at(isNeigh4 - sites.begin()))->hwPt() == (secClusters.at(isNeigh6 - sites.begin()))->hwPt()) {
           // same E --> take 1
           if (mainCluster.hwEta() > 0)
-            secMaxN = secClusters.at(isNeigh4 - sites.begin()).get();
+            secMaxS = secClusters.at(isNeigh4 - sites.begin()).get();
           else
-            secMaxN = secClusters.at(isNeigh6 - sites.begin()).get();
+            secMaxS = secClusters.at(isNeigh6 - sites.begin()).get();
         }
 
         else {


### PR DESCRIPTION
#### PR description:

Looking at the Static Analyzer reports, a few possible inaccuracies, or even bugs, jumped to my eyes.
Instead of making a github issue, I chose to implement here the possible fixes, which should be carefully inspected by the L1T software experts: perhaps the fix is correct, perhaps the bug is there but the "most obvious" fix is not the correct one.

Namely, the adjustment proposed on which I am requesting feedback are the following:

- In [BMTFPackerInputs.cc](https://github.com/cms-sw/cmssw/compare/master...perrotta:aFewSmallFixesForL1T?expand=1#diff-af8c55fc4359daa3c3dffec6b7c74487fd773f4f5cf0d2887864c370a9448156) the variable `moreBXphi` is defined inside the loop body, and therefore it does not make sense to update it at the end of the loop. The obvious fix is to remove the update, but a possible alternative could be that the intention was to define that variable outside the loop, as it is the case for `moreBXeta`.
- In [Stage1Layer2EtSumAlgorithmImpPP.cc](https://github.com/cms-sw/cmssw/compare/master...perrotta:aFewSmallFixesForL1T?expand=1#diff-d9fac429cdc0d49f8340cdfe08c1eda5e42beba4e88145dc1b7d0242909874b1) the first definition of `iPhiHT` was never used, and the obvious fix is to simply remove it; unless there was some other need that was foreseen for it and that remained forgotten in the code
- In [Stage2Layer2JetAlgorithmFirmwareImp1.cc](https://github.com/cms-sw/cmssw/compare/master...perrotta:aFewSmallFixesForL1T?expand=1#diff-1ac8e3e3e21a7e7dc8505bb4c66c6f43787db5d0f3f13918dd34d7dcaa0d5184) the double initialization is quite obvious, and I don't even propose alternatives
- The one in [Stage2Layer2TauAlgorithmFirmwareImp1.cc](https://github.com/cms-sw/cmssw/compare/master...perrotta:aFewSmallFixesForL1T?expand=1#diff-521c704a5bde7b6fa632aec13f910ba9e8fd8c7beeb40129d935ddcc420284e0) is instead more tricky. The different if-steered options in that section of the code were all intended to define `secMaxS`, but I found two places were `secMaxN` (supposedly already defined in the previous lines) was overwritten instead. I had the impression that this was a mistake, and that's why I am proposing a possible fix here: but this is only based on an assumption of mine, and I was not able to investigate deep in the code to verify it.

While the first three updates listed above fully reproduce the previous behaviour of the code, only simplifying it, the last one does apply some change: I would therefore ask for a particular attention to it.

Of course, you can take this PR as a possible suggestion for a more complete fix and update to the code: I will close it, in that case, once all the issues listed here have been addressed.
`
#### PR validation:

It builds successfully