### PR TITLE
Clean up redundant edm ParameterSet existAs or exist in RecoTracker/{TkSeedGenerator}

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -64,8 +64,7 @@ MultiHitGeneratorFromChi2::MultiHitGeneratorFromChi2(const edm::ParameterSet& cf
       maxChi2(cfg.getParameter<double>("maxChi2")),
       refitHits(cfg.getParameter<bool>("refitHits")),
       filterName_(cfg.getParameter<std::string>("ClusterShapeHitFilterName")),
-      builderName_(cfg.existsAs<std::string>("TTRHBuilder") ? cfg.getParameter<std::string>("TTRHBuilder")
-                                                            : std::string("WithTrackAngle")),
+      builderName_(cfg.getParameter<std::string>("TTRHBuilder")),
       useSimpleMF_(false),
       mfName_("") {
   if (useFixedPreFiltering)


### PR DESCRIPTION
#### PR description:  
(Technical PR) Optimization of the module configurations: Improve maintainability by cleaning up redundant cases of edm::ParameterSet calls to `existAs` or `exist` for tracked parameters, where redundancy is based on the value being already defined by `fillDescriptions`.
#### Motivation: 
values of tracked parameters should be properly defined in the configuration and be visible in the process configuration provenance; code that checks for the existence of a parameter and sets a hardcoded default would bypass the configuration provenance registration and should be avoided. In general, default parameter values should be provided via `fillDescriptions`, as detailed in [SWGuideConfigValidation](https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideConfigurationValidationAndHelp). Redundant calls to `existAs` or `exist` can be **cleaned up**.

As follow the previous [PR36746](https://github.com/cms-sw/cmssw/pull/36746),

The list of all calls of `existAs` or `exist` are automatically available in the Static Analyzer report. (Bug: CMS code rules)
It is accessible from IB page. https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/
For this task consider only modules or tools used by the modules that define `fillDescriptions`.


In this PR, 1 file was changed.  
RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc


[MultiHitGeneratorFromChi2.cc L67](https://github.com/jeongeun/cmssw/blob/442a21fb568e6c2f2bf4c394afa2e02d65555638/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc#L67) : "TTRHBuilder" parameter value is provided in a `fillDescription` in [L127](https://github.com/jeongeun/cmssw/blob/442a21fb568e6c2f2bf4c394afa2e02d65555638/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc#L127)

#### PR validation:
Tested in CMSSW_12_3_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).