### PR TITLE
Add the detector ids to the scouting electron and photon collection for Run 3

### DIFF
--- a/DataFormats/Scouting/interface/Run3ScoutingElectron.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingElectron.h
@@ -2,6 +2,7 @@
 #define DataFormats_Run3ScoutingElectron_h
 
 #include <vector>
+#include <cstdint>
 
 // Class for holding electron information, for use in data scouting
 // IMPORTANT: the content of this class should be changed only in backwards compatible ways!
@@ -27,8 +28,9 @@ public:
                        float r9,
                        float sMin,
                        float sMaj,
-                       unsigned int seedId,
+                       uint32_t seedId,
                        std::vector<float> energyMatrix,
+                       std::vector<uint32_t> detIds,
                        std::vector<float> timingMatrix)
       : pt_(pt),
         eta_(eta),
@@ -51,6 +53,7 @@ public:
         sMaj_(sMaj),
         seedId_(seedId),
         energyMatrix_(std::move(energyMatrix)),
+        detIds_(std::move(detIds)),
         timingMatrix_(std::move(timingMatrix)) {}
   //default constructor
   Run3ScoutingElectron()
@@ -95,8 +98,9 @@ public:
   float r9() const { return r9_; }
   float sMin() const { return sMin_; }
   float sMaj() const { return sMaj_; }
-  unsigned int seedId() const { return seedId_; }
+  uint32_t seedId() const { return seedId_; }
   std::vector<float> const& energyMatrix() const { return energyMatrix_; }
+  std::vector<uint32_t> const& detIds() const { return detIds_; }
   std::vector<float> const& timingMatrix() const { return timingMatrix_; }
 
 private:
@@ -119,8 +123,9 @@ private:
   float r9_;
   float sMin_;
   float sMaj_;
-  unsigned int seedId_;
+  uint32_t seedId_;
   std::vector<float> energyMatrix_;
+  std::vector<uint32_t> detIds_;
   std::vector<float> timingMatrix_;
 };
 

--- a/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingPhoton.h
@@ -2,6 +2,7 @@
 #define DataFormats_Run3ScoutingPhoton_h
 
 #include <vector>
+#include <cstdint>
 
 // Class for holding photon information, for use in data scouting
 // IMPORTANT: the content of this class should be changed only in backwards compatible ways!
@@ -20,8 +21,9 @@ public:
                      float r9,
                      float sMin,
                      float sMaj,
-                     unsigned int seedId,
+                     uint32_t seedId,
                      std::vector<float> energyMatrix,
+                     std::vector<uint32_t> detIds,
                      std::vector<float> timingMatrix)
       : pt_(pt),
         eta_(eta),
@@ -37,6 +39,7 @@ public:
         sMaj_(sMaj),
         seedId_(seedId),
         energyMatrix_(std::move(energyMatrix)),
+        detIds_(std::move(detIds)),
         timingMatrix_(std::move(timingMatrix)) {}
   //default constructor
   Run3ScoutingPhoton()
@@ -69,8 +72,9 @@ public:
   float r9() const { return r9_; }
   float sMin() const { return sMin_; }
   float sMaj() const { return sMaj_; }
-  float seedId() const { return seedId_; }
+  uint32_t seedId() const { return seedId_; }
   std::vector<float> const& energyMatrix() const { return energyMatrix_; }
+  std::vector<uint32_t> const& detIds() const { return detIds_; }
   std::vector<float> const& timingMatrix() const { return timingMatrix_; }
 
 private:
@@ -86,8 +90,9 @@ private:
   float r9_;
   float sMin_;
   float sMaj_;
-  unsigned int seedId_;
+  uint32_t seedId_;
   std::vector<float> energyMatrix_;
+  std::vector<uint32_t> detIds_;
   std::vector<float> timingMatrix_;
 };
 

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -39,14 +39,16 @@
   <class name="Run3ScoutingVertex" ClassVersion="3">
       <version ClassVersion="3" checksum="316446070"/>
   </class>
-  <class name="Run3ScoutingElectron" ClassVersion="3">
+  <class name="Run3ScoutingElectron" ClassVersion="4">
       <version ClassVersion="3" checksum="1086011373"/>
+      <version ClassVersion="4" checksum="1250202632"/>
   </class>
   <class name="Run3ScoutingMuon" ClassVersion="3">
       <version ClassVersion="3" checksum="3882497397"/>
   </class>
-  <class name="Run3ScoutingPhoton" ClassVersion="3">
+  <class name="Run3ScoutingPhoton" ClassVersion="4">
       <version ClassVersion="3" checksum="1683146807"/>
+      <version ClassVersion="4" checksum="1725280278"/>
   </class>
   <class name="Run3ScoutingTrack" ClassVersion="3">
       <version ClassVersion="3" checksum="3352318277"/>


### PR DESCRIPTION
#### PR description:

The Run 3 Scouting collection for electrons and photons will now have the ECal detector ids corresponding to the energy deposit and time stored earlier. This is done by adding a similar-sized vector of unsigned int datatype. The conversion from CMS datatype DetId to unsigned int is implicit. 

#### PR validation:

This implementation has been cross-checked to correctly store all relevant information. The implicit conversion from DetId to unsigned int has also been verified. I re-ran the scouting path on a small set of events to ensure that there is no error in implementation and that the output that is of interest is stored.

The coding recommendations at http://cms-sw.github.io/cms_coding_rules.html were followed.
The basic test procedure was also successful. 
