### PR TITLE
remove unused legacy headers in RPC

### DIFF
--- a/CalibMuon/RPCCalibration/interface/RPCCalibSetUp.h
+++ b/CalibMuon/RPCCalibration/interface/RPCCalibSetUp.h
@@ -1,7 +1,6 @@
 #ifndef RPCCalibSetUp_h
 #define RPCCalibSetUp_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/CalibMuon/RPCCalibration/src/RPCCalibSetUp.cc
+++ b/CalibMuon/RPCCalibration/src/RPCCalibSetUp.cc
@@ -1,7 +1,6 @@
 #include "CalibMuon/RPCCalibration/interface/RPCCalibSetUp.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/CalibMuon/RPCCalibration/src/RPCFakeCalibration.cc
+++ b/CalibMuon/RPCCalibration/src/RPCFakeCalibration.cc
@@ -4,7 +4,6 @@
 #include "CondFormats/RPCObjects/interface/RPCStripNoises.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/CondTools/RPC/interface/RPCDBSimSetUp.h
+++ b/CondTools/RPC/interface/RPCDBSimSetUp.h
@@ -1,7 +1,6 @@
 #ifndef RPCDBSimSetUp_h
 #define RPCDBSimSetUp_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

Remove the unused legacy EDModule headers in the RPC packages. This is part of the deprecated EDModule migration campaign.

#### PR validation:

Code compiles and local run tests passed.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backport foreseen.
