### PR TITLE
Fix printed text in Payload Inspector plots for DropBoxMetaData

### DIFF
--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -470,14 +470,14 @@ namespace DBoxMetadataHelper {
         }
       }
 
-      // Second, check if there are records in targe which are not in reference
+      // Second, check if there are records in target which are not in reference
       for (const auto& tar : tar_records) {
         if (std::find(ref_records.begin(), ref_records.end(), tar) == ref_records.end()) {
           y -= pitch;
           y_x1.push_back(y);
           s_x1.push_back(tar);
           y_x2.push_back(y);
-          s_x2.push_back("#bf{Only in reference, not in target.}");
+          s_x2.push_back("#bf{Only in target, not in reference.}");
           y_line.push_back(y - (pitch / 2.));
         }
       }

--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -80,31 +80,30 @@ namespace DBoxMetadataHelper {
 
     void printMetaDatas() {
       for (const auto& [key, val] : m_Map) {
-        edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << key << "\n\n" << std::endl;
-        edm::LogPrint("DropBoxMetadataPIHelper") << "prep: " << cleanJson(val.getPrepMetaData()) << "\n" << std::endl;
-        edm::LogPrint("DropBoxMetadataPIHelper") << "prod: " << cleanJson(val.getProdMetaData()) << "\n" << std::endl;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << key;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "prep: " << cleanJson(val.getPrepMetaData());
+        edm::LogPrint("DropBoxMetadataPIHelper") << "prod: " << cleanJson(val.getProdMetaData());
         // check, since it's optional
         if (val.hasMultiMetaData()) {
-          edm::LogPrint("DropBoxMetadataPIHelper") << "multi: " << cleanJson(val.getMultiMetaData()) << "\n"
-                                                   << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << "multi: " << cleanJson(val.getMultiMetaData());
         }
+        edm::LogPrint("DropBoxMetadataPIHelper") << "\n";
       }
     }
 
     void printOneKey(const DBoxMetadataHelper::RecordMetaDataInfo& oneKey) {
-      edm::LogPrint("DropBoxMetadataPIHelper") << "prep: " << cleanJson(oneKey.getPrepMetaData()) << std::endl;
-      edm::LogPrint("DropBoxMetadataPIHelper") << "prod: " << cleanJson(oneKey.getProdMetaData()) << std::endl;
+      edm::LogPrint("DropBoxMetadataPIHelper") << "prep: " << cleanJson(oneKey.getPrepMetaData());
+      edm::LogPrint("DropBoxMetadataPIHelper") << "prod: " << cleanJson(oneKey.getProdMetaData());
       // check, since it's optional
       if (oneKey.hasMultiMetaData()) {
-        edm::LogPrint("DropBoxMetadataPIHelper") << "multi: " << cleanJson(oneKey.getMultiMetaData()) << std::endl;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "multi: " << cleanJson(oneKey.getMultiMetaData());
       }
-      edm::LogPrint("DropBoxMetadataPIHelper") << "\n" << std::endl;
+      edm::LogPrint("DropBoxMetadataPIHelper") << "\n";
     }
 
     void printDiffWithMetadata(const DBoxMetadataHelper::recordMap& theRefMap) {
       edm::LogPrint("DropBoxMetadataPIHelper")
-          << "Target has: " << m_Map.size() << " records, reference has: " << theRefMap.size() << " records"
-          << std::endl;
+          << "Target has: " << m_Map.size() << " records, reference has: " << theRefMap.size() << " records";
 
       const auto& ref_records = DBoxMetadataHelper::getAllRecords(theRefMap);
       const auto& tar_records = DBoxMetadataHelper::getAllRecords(m_Map);
@@ -114,32 +113,26 @@ namespace DBoxMetadataHelper {
 
       // do first the common parts
       for (const auto& key : common) {
-        edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << key << "\n" << std::endl;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << key;
         const auto& val = m_Map.at(key);
         const auto& refval = theRefMap.at(key);
 
         if ((val.getPrepMetaData()).compare(refval.getPrepMetaData()) != 0) {
-          edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in prep metadata!" << std::endl;
-          edm::LogPrint("DropBoxMetadataPIHelper")
-              << " in target   : " << cleanJson(val.getPrepMetaData()) << std::endl;
-          edm::LogPrint("DropBoxMetadataPIHelper")
-              << " in reference: " << cleanJson(refval.getPrepMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in prep metadata!";
+          edm::LogPrint("DropBoxMetadataPIHelper") << " in target   : " << cleanJson(val.getPrepMetaData());
+          edm::LogPrint("DropBoxMetadataPIHelper") << " in reference: " << cleanJson(refval.getPrepMetaData());
         }
         if ((val.getProdMetaData()).compare(refval.getProdMetaData()) != 0) {
-          edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in prod metadata!" << std::endl;
-          edm::LogPrint("DropBoxMetadataPIHelper")
-              << " in target   : " << cleanJson(val.getProdMetaData()) << std::endl;
-          edm::LogPrint("DropBoxMetadataPIHelper")
-              << " in reference: " << cleanJson(refval.getProdMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in prod metadata!";
+          edm::LogPrint("DropBoxMetadataPIHelper") << " in target   : " << cleanJson(val.getProdMetaData());
+          edm::LogPrint("DropBoxMetadataPIHelper") << " in reference: " << cleanJson(refval.getProdMetaData());
         }
         if ((val.getMultiMetaData()).compare(refval.getMultiMetaData()) != 0) {
-          edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in multi metadata!" << std::endl;
-          edm::LogPrint("DropBoxMetadataPIHelper")
-              << " in target   : " << cleanJson(val.getMultiMetaData()) << std::endl;
-          edm::LogPrint("DropBoxMetadataPIHelper")
-              << " in reference: " << cleanJson(refval.getMultiMetaData()) << std::endl;
+          edm::LogPrint("DropBoxMetadataPIHelper") << "found difference in multi metadata!";
+          edm::LogPrint("DropBoxMetadataPIHelper") << " in target   : " << cleanJson(val.getMultiMetaData());
+          edm::LogPrint("DropBoxMetadataPIHelper") << " in reference: " << cleanJson(refval.getMultiMetaData());
         }
-        edm::LogPrint("DropBoxMetadataPIHelper") << "\n" << std::endl;
+        edm::LogPrint("DropBoxMetadataPIHelper") << "\n";
       }
 
       // if interesction is not the union check for extra differences
@@ -149,7 +142,7 @@ namespace DBoxMetadataHelper {
           for (const auto& ref : ref_records) {
             if (std::find(tar_records.begin(), tar_records.end(), ref) == tar_records.end()) {
               const auto& refval = theRefMap.at(ref);
-              edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << ref << " not present in target! \n" << std::endl;
+              edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << ref << " not present in target!";
               printOneKey(refval);
             }
           }
@@ -159,8 +152,7 @@ namespace DBoxMetadataHelper {
           for (const auto& tar : tar_records) {
             if (std::find(ref_records.begin(), ref_records.end(), tar) == ref_records.end()) {
               const auto& tarval = m_Map.at(tar);
-              edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << tar << " not present in reference! \n"
-                                                       << std::endl;
+              edm::LogPrint("DropBoxMetadataPIHelper") << "key: " << tar << " not present in reference!";
               printOneKey(tarval);
             }
           }


### PR DESCRIPTION
#### PR description:

As a continuation to PRs #36520 and #36927, this PR corrects the text printed in case a record exists in target but not in reference. 

#### PR validation:

The correct behaviour is illustrated at the end of the attached plot, a comparison of first and last payloads of DropBoxMetadata_v5.1_express.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
![DropBoxMetadata_Compare](https://user-images.githubusercontent.com/51359/154969689-55fa9189-671c-4014-a575-a7064625ba32.png)

attn: @mmusich 

