### PR TITLE
patch-around immintrin.h for non-x86 case in MkFit

### DIFF
--- a/RecoTracker/MkFitCore/src/Matriplex/MatriplexCommon.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/MatriplexCommon.h
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #define _mm_malloc(a, b) aligned_alloc(b, a)
 #define _mm_free(p) free(p)
-#define _mm_prefetch(a,b)  __builtin_prefetch(a)
+#define _mm_prefetch(a, b) __builtin_prefetch(a)
 #endif
 
 #if defined(MPLEX_USE_INTRINSICS)

--- a/RecoTracker/MkFitCore/src/Matriplex/MatriplexCommon.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/MatriplexCommon.h
@@ -10,7 +10,14 @@
 // Intrinsics -- preamble
 //==============================================================================
 
+#if defined(__x86_64__)
 #include "immintrin.h"
+#else
+#include <stdlib.h>
+#define _mm_malloc(a, b) aligned_alloc(b, a)
+#define _mm_free(p) free(p)
+#define _mm_prefetch(a,b)  __builtin_prefetch(a)
+#endif
 
 #if defined(MPLEX_USE_INTRINSICS)
 // This seems unnecessary: __AVX__ is usually defined for all higher ISA extensions


### PR DESCRIPTION
following https://github.com/cms-sw/cmssw/pull/36546#issuecomment-1047004188
