### PR TITLE
fixing removal of modules from `FinalPath`

### DIFF
--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -496,8 +496,9 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
         self.visit(v)
         if v.didRemove():
             self._seq = v.result(self)[0]
-            self._tasks.clear()
-            self.associate(*v.result(self)[1])
+            if v.result(self)[1]:
+              self._tasks.clear()
+              self.associate(*v.result(self)[1])
         return v.didRemove()
     def resolve(self, processDict,keepIfCannotResolve=False):
         if self._seq is not None:
@@ -2338,6 +2339,12 @@ if __name__=="__main__":
             self.assertTrue(t3.dumpPython() == "cms.Task(process.m2)\n")
             t3.remove(m2)
             self.assertTrue(t3.dumpPython() == "cms.Task()\n")
+            fp = FinalPath(m1+m2)
+            fp.remove(m1)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath(process.m2)\n")
+            fp = FinalPath(m1)
+            fp.remove(m1)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath()\n")
 
         def testCopyAndExclude(self):
             a = DummyModule("a")


### PR DESCRIPTION
#### PR description:

This PR follows #36932 and #36937, and concerns the removal of a module from a `FinalPath`.

It looks like said removal does not work correctly in `12_3_0_pre5`, as [1] returns [2] (the issue was reported by @sanuvarghese from TSG).

The implementation in this PR is basically a copy-paste of the solution provided by @Dr15Jones in #36937.

The PR is mainly a way to point out the issue. I'm happy to close it if it's incorrect/incomplete, of if experts prefer to take care of the implementation of this fix.

FYI: @Martin-Grunewald @Sam-Harper @silviodonato

[1] Example borrowed from #36932
```py
import FWCore.ParameterSet.Config as cms

process = cms.Process("HLT")

process.dqmOutput = cms.OutputModule("DQMRootOutputModule",
    fileName = cms.untracked.string("DQMIO.root")
)

process.DQMOutput = cms.FinalPath( process.dqmOutput )

process.DQMOutput.remove(process.dqmOutput)
```

[2]
```sh
Traceback (most recent call last):
  File "tmp.py", line 11, in <module>
    process.DQMOutput.remove(process.dqmOutput)
  File "/cvmfs/cms.cern.ch/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_3_0_pre5/python/FWCore/ParameterSet/SequenceTypes.py", line 500, in remove
    self.associate(*v.result(self)[1])
TypeError: associate() missing 1 required positional argument: 'task'
```

#### PR validation:

The example in [1] works, and unit tests of `FWCore/ParameterSet` pass.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A