### PR TITLE
use auto-generated configuration fragments in a few `RecoTracker` classes

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/interface/ClusterChargeCut.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ClusterChargeCut.h
@@ -8,19 +8,25 @@ inline float clusterChargeCut(const edm::ParameterSet& conf, const char* name = 
   return conf.getParameter<edm::ParameterSet>(name).getParameter<double>("value");
 }
 
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-inline edm::ParameterSetDescription getFilledConfigurationDescription4CCC() {
-  // HLTSiStripClusterChargeCutNone:    -1.0
-  // HLTSiStripClusterChargeCutTiny:   800.0
-  // HLTSiStripClusterChargeCutLoose: 1620.0
-  // HLTSiStripClusterChargeCutTight: 1945.0
+namespace CCC {
+  // SiStripClusterChargeCutNone:    -1.0
+  // SiStripClusterChargeCutTiny:   800.0
+  // SiStripClusterChargeCutLoose: 1620.0
+  // SiStripClusterChargeCutTight: 1945.0
 
+  enum OP { kNone = 0, kTiny = 1, kLoose = 2, kTight = 3 };
+  static constexpr std::array<float, 4> cuts = {{-1.0, 800.0, 1620.0, 1945.0}};
+}  // namespace CCC
+
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+inline edm::ParameterSetDescription getConfigurationDescription4CCC(const CCC::OP& op) {
   edm::ParameterSetDescription desc;
-  desc.add<double>("value", 1620.0);
+  desc.add<double>("value", CCC::cuts[op]);
   return desc;
 }
 
-inline edm::ParameterSetDescription getFilledConfigurationDescription4CCCNoDefault() {
+// this is needed to validate the configuration without explicitly setting a cut
+inline edm::ParameterSetDescription getConfigurationDescription4CCCNoDefault() {
   edm::ParameterSetDescription desc;
   desc.add<double>("value");
   return desc;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeHitFilterESProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeHitFilterESProducer.cc
@@ -97,16 +97,14 @@ ClusterShapeHitFilterESProducer::ReturnType ClusterShapeHitFilterESProducer::pro
 /*****************************************************************************/
 void ClusterShapeHitFilterESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("PixelShapeFile");
-  desc.add<std::string>("PixelShapeFileL1");
-  desc.add<std::string>("ComponentName");
+  desc.add<std::string>("PixelShapeFile", "RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase0.par");
+  desc.add<std::string>("PixelShapeFileL1", "RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase0.par");
+  desc.add<std::string>("ComponentName", "");
   desc.add<bool>("isPhase2", false);
   desc.add<bool>("doPixelShapeCut", true);
   desc.add<bool>("doStripShapeCut", true);
-
-  desc.add<edm::ParameterSetDescription>("clusterChargeCut", getFilledConfigurationDescription4CCCNoDefault());
-
-  descriptions.addDefault(desc);
+  desc.add<edm::ParameterSetDescription>("clusterChargeCut", getConfigurationDescription4CCC(CCC::kNone));
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(ClusterShapeHitFilterESProducer);

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeHitFilterESProducer_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeHitFilterESProducer_cfi.py
@@ -1,11 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-ClusterShapeHitFilterESProducer = cms.ESProducer("ClusterShapeHitFilterESProducer",
-                                                        ComponentName = cms.string('ClusterShapeHitFilter'),
-                                                        PixelShapeFile= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase0.par'),
-                                                        PixelShapeFileL1= cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase0.par'),
-                                                        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
-                                                        isPhase2 = cms.bool(False))
+from RecoPixelVertexing.PixelLowPtUtilities.clusterShapeHitFilterESProducer_cfi import clusterShapeHitFilterESProducer
+ClusterShapeHitFilterESProducer = clusterShapeHitFilterESProducer.clone(ComponentName = 'ClusterShapeHitFilter',
+                                                                        PixelShapeFile = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase0.par',
+                                                                        PixelShapeFileL1 = 'RecoPixelVertexing/PixelLowPtUtilities/data/pixelShapePhase0.par',
+                                                                        clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone')),
+                                                                        isPhase2 = False)
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(ClusterShapeHitFilterESProducer,

--- a/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -111,7 +111,7 @@ namespace {
     auto desc = chi2MeasurementEstimatorParams::getFilledConfigurationDescription();
     desc.add<std::string>("ComponentName", "Chi2Charge");
     desc.add<double>("pTChargeCutThreshold", -1.);
-    edm::ParameterSetDescription descCCC = getFilledConfigurationDescription4CCC();
+    edm::ParameterSetDescription descCCC = getConfigurationDescription4CCC(CCC::kLoose);
     desc.add<edm::ParameterSetDescription>("clusterChargeCut", descCCC);
     descriptions.add("Chi2ChargeMeasurementEstimatorDefault", desc);
   }

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -110,15 +110,13 @@ std::unique_ptr<TransientTrackingRecHitBuilder> TkTransientTrackingRecHitBuilder
 
 void TkTransientTrackingRecHitBuilderESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-
-  desc.add<std::string>("ComponentName");
-  desc.add<bool>("ComputeCoarseLocalPositionFromDisk");
-  desc.add<std::string>("StripCPE")->setComment("Using \"Fake\" disables use of StripCPE");
-  desc.add<std::string>("PixelCPE")->setComment("Using \"Fake\" disables use of PixelCPE");
-  desc.add<std::string>("Matcher")->setComment("Using \"Fake\" disables use of SiStripRecHitMatcher");
+  desc.add<std::string>("ComponentName", "Fake");
+  desc.add<bool>("ComputeCoarseLocalPositionFromDisk", false);
+  desc.add<std::string>("StripCPE", "Fake")->setComment("Using \"Fake\" disables use of StripCPE");
+  desc.add<std::string>("PixelCPE", "Fake")->setComment("Using \"Fake\" disables use of PixelCPE");
+  desc.add<std::string>("Matcher", "Fake")->setComment("Using \"Fake\" disables use of SiStripRecHitMatcher");
   desc.add<std::string>("Phase2StripCPE", "")->setComment("Using empty string disables use of Phase2StripCPE");
-
-  descriptions.addDefault(desc);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 DEFINE_FWK_EVENTSETUP_MODULE(TkTransientTrackingRecHitBuilderESProducer);

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithFake_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithFake_cfi.py
@@ -10,11 +10,10 @@ StripCPEfromFake = stripCPEESProducer.clone(
     ComponentType = 'FakeStripCPE'
 )
 
-TTRHBuilderFake = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
-    StripCPE = cms.string('FakeStripCPE'),
-    ComponentName = cms.string('Fake'),
-    PixelCPE = cms.string('FakePixelCPE'),
-    Matcher = cms.string('StandardMatcher'),
-    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
-)
+from RecoTracker.TransientTrackingRecHit.tkTransientTrackingRecHitBuilderESProducer_cfi import tkTransientTrackingRecHitBuilderESProducer
+TTRHBuilderFake = tkTransientTrackingRecHitBuilderESProducer.clone(StripCPE = 'FakeStripCPE',
+                                                                   ComponentName = 'Fake',
+                                                                   PixelCPE = 'FakePixelCPE',
+                                                                   Matcher = 'StandardMatcher',
+                                                                   ComputeCoarseLocalPositionFromDisk = False)
 

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -1,13 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
-    StripCPE = cms.string('StripCPEfromTrackAngle'),
-    Phase2StripCPE = cms.string(''),
-    ComponentName = cms.string('WithAngleAndTemplate'),
-    PixelCPE = cms.string('PixelCPETemplateReco'),
-    Matcher = cms.string('StandardMatcher'),
-    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
-)
+from RecoTracker.TransientTrackingRecHit.tkTransientTrackingRecHitBuilderESProducer_cfi import tkTransientTrackingRecHitBuilderESProducer
+TTRHBuilderAngleAndTemplate = tkTransientTrackingRecHitBuilderESProducer.clone(StripCPE = 'StripCPEfromTrackAngle',
+                                                                               Phase2StripCPE = '',
+                                                                               ComponentName = 'WithAngleAndTemplate',
+                                                                               PixelCPE = 'PixelCPETemplateReco',
+                                                                               Matcher = 'StandardMatcher',
+                                                                               ComputeCoarseLocalPositionFromDisk = False)
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilderWithoutRefit_cfi.py
@@ -1,13 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-ttrhbwor = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
-    StripCPE = cms.string('Fake'),
-    Phase2StripCPE = cms.string(''),
-    ComponentName = cms.string('WithoutRefit'),
-    PixelCPE = cms.string('Fake'),
-    Matcher = cms.string('Fake'),
-    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
-)
+from RecoTracker.TransientTrackingRecHit.tkTransientTrackingRecHitBuilderESProducer_cfi import tkTransientTrackingRecHitBuilderESProducer
+ttrhbwor =  tkTransientTrackingRecHitBuilderESProducer.clone(StripCPE = 'Fake',
+                                                             Phase2StripCPE = '',
+                                                             ComponentName = 'WithoutRefit',
+                                                             PixelCPE = 'Fake',
+                                                             Matcher = 'Fake',
+                                                             ComputeCoarseLocalPositionFromDisk = False)
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(ttrhbwor, 

--- a/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TransientTrackingRecHitBuilder_cfi.py
@@ -1,13 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-ttrhbwr = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
-    StripCPE = cms.string('StripCPEfromTrackAngle'),
-    Phase2StripCPE = cms.string(''),
-    ComponentName = cms.string('WithTrackAngle'),
-    PixelCPE = cms.string('PixelCPEGeneric'),
-    Matcher = cms.string('StandardMatcher'),
-    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
-)
+from RecoTracker.TransientTrackingRecHit.tkTransientTrackingRecHitBuilderESProducer_cfi import tkTransientTrackingRecHitBuilderESProducer
+ttrhbwr =  tkTransientTrackingRecHitBuilderESProducer.clone(StripCPE = 'StripCPEfromTrackAngle',
+                                                            Phase2StripCPE = '',
+                                                            ComponentName = 'WithTrackAngle',
+                                                            PixelCPE = 'PixelCPEGeneric',
+                                                            Matcher = 'StandardMatcher',
+                                                            ComputeCoarseLocalPositionFromDisk = False)
 
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(ttrhbwr, 

--- a/TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h
+++ b/TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h
@@ -17,7 +17,7 @@ public:
 
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
     iDesc.add<int>("maxCCCLostHits", 9999);
-    iDesc.add<edm::ParameterSetDescription>("minGoodStripCharge", getFilledConfigurationDescription4CCC());
+    iDesc.add<edm::ParameterSetDescription>("minGoodStripCharge", getConfigurationDescription4CCC(CCC::kLoose));
   }
 
   bool qualityFilter(const Trajectory& traj) const override { return TrajectoryFilter::qualityFilterIfNotContributing; }

--- a/TrackingTools/TrajectoryFiltering/src/MaxCCCLostHitsTrajectoryFilter.cc
+++ b/TrackingTools/TrajectoryFiltering/src/MaxCCCLostHitsTrajectoryFilter.cc
@@ -1,1 +1,0 @@
-#include "TrackingTools/TrajectoryFiltering/interface/MaxCCCLostHitsTrajectoryFilter.h"


### PR DESCRIPTION
#### PR description:

This is a technical follow-up to PR https://github.com/cms-sw/cmssw/pull/36983 and in particular to https://github.com/cms-sw/cmssw/pull/36983#issuecomment-1042956235.
As the title says the purpose is to use auto-generated configuration fragments in a few `RecoTracker` classes instead of direct implementations in the python code.
I profit of this PR to clean-up the `getFilledConfigurationDescription4CCC` method introduced in commit https://github.com/cms-sw/cmssw/pull/13164/commits/10e227ec316ed81902573484f1d41e48d8641957 to be versatile (e.g. serve all possible values of the CCC).

#### PR validation:

`cmssw` compiles after checking dependencies.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A


