### PR TITLE
add process modifier to enable x-talk in Phase-2 InnerTracker pixels

### DIFF
--- a/Configuration/ProcessModifiers/python/enableXTalkInPhase2Pixel_cff.py
+++ b/Configuration/ProcessModifiers/python/enableXTalkInPhase2Pixel_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+# This modifier is to enable X-talk in IT pixels in Phase-2 workflows
+enableXTalkInPhase2Pixel =  cms.Modifier()

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -250,4 +250,19 @@ _premixStage1ModifyDict = dict(
         AddThresholdSmearing = False,
     ),
 )
+
 premix_stage1.toModify(phase2TrackerDigitizer, **_premixStage1ModifyDict)
+
+from Configuration.ProcessModifiers.enableXTalkInPhase2Pixel_cff import enableXTalkInPhase2Pixel
+_enableXTalkInPhase2PixelModifyDict = dict( 
+    PixelDigitizerAlgorithm = dict(
+        AddXTalk = True, 
+        Odd_row_interchannelCoupling_next_row = 0.00,
+        Even_row_interchannelCoupling_next_row = 0.06
+        )
+)
+
+enableXTalkInPhase2Pixel.toModify(phase2TrackerDigitizer, **_enableXTalkInPhase2PixelModifyDict)
+
+
+


### PR DESCRIPTION
#### PR description:

This PR concerns the phase-2 upgrade.
This PR introduces a process modifier to activate cross-talk in the phase-2 Inner Tracker 25x100 um planar pixels.
For the time being, the process modifier  is meant to be used only as a command line option of cmsDriver.py for requesting  RelVals to study the impact of cross-talk. 
Workflows in upgradeWorkflowComponents.py are not affected by this process modifier.
As no mitigation of cross-talk is currently implemented in the local reco of phase-2 Inner Tracker,  we plan to request RelVals up to the DIGI step.

#### PR validation:

- Checked runTheMatrix workflows run without errors 
- Checked  running w/f 36200.0  without and with the "--procModifier enableXTalkInPhase2Pixel" option that the distribution of DIGI in the InnerTracker changes as expected

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport

@suchandradutta @AndreasAlbert 