### PR TITLE
Include PPS timing-hptdc tag, HCal trigger primitive tag and update HI GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,23 +24,23 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   : '123X_mcRun2_pA_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '123X_dataRun2_v1',
+    'run2_data'                    : '123X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '123X_dataRun2_HEfail_v1',
+    'run2_data_HEfail'             : '123X_dataRun2_HEfail_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '123X_dataRun2_relval_v1',
+    'run2_data_relval'             : '123X_dataRun2_relval_v2',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '123X_dataRun3_HLT_v3',
+    'run3_hlt'                     : '123X_dataRun3_HLT_v4',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v1',
+    'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '123X_dataRun3_Express_v2',
+    'run3_data_express'            : '123X_dataRun3_Express_v3',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '123X_dataRun3_Prompt_v2',
+    'run3_data_prompt'             : '123X_dataRun3_Prompt_v3',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '123X_dataRun3_v1',
+    'run3_data'                    : '123X_dataRun3_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -64,19 +64,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v6',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v6',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v6',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v6',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v6',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v6',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v7',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '123X_mcRun4_realistic_noSiStrip_v3'
+    'phase2_realistic'             : '123X_mcRun4_realistic_v5'
 }
 
 aliases = {

--- a/RecoPPS/Local/python/ctppsDiamondLocalReconstruction_cff.py
+++ b/RecoPPS/Local/python/ctppsDiamondLocalReconstruction_cff.py
@@ -1,13 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-# Temporary customization of GT - to be removed once the tag is included in the GTs
-from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import GlobalTag
-GlobalTag.toGet.append(
-  cms.PSet(record = cms.string('PPSTimingCalibrationLUTRcd'),
-           tag = cms.string('PPSDiamondTimingCalibrationLUT_test')
-  )
-)
-
 # reco hit production
 from RecoPPS.Local.ctppsDiamondRecHits_cfi import ctppsDiamondRecHits
 


### PR DESCRIPTION
#### PR description:
resolves https://github.com/cms-AlCaDB/AlCaTools/issues/54

This PR addresses several points:

- Adds the PPS tag, `PPSDiamondTimingCalibrationLUT_test`, to the data GTs. It addresses issue https://github.com/cms-AlCaDB/AlCaTools/issues/54 and removes the hardcoded access to the tag from PPS configuration file.

- Adds the HCAL tag, `HcalTPChannelParameters_2022_v1.1_mc`, in the mcRun3 Queues, as requested in https://cms-talk.web.cern.ch/t/mc-new-hcal-run3-mc-condition/6801

- Updates the mcRun3_realistic HI Queue according to the corresponding 122X GT, used in the [HIN 2022 MC campaign](https://its.cern.ch/jira/browse/PDMVMCPROD-52)

- Adds back the `AlCaRecoTriggerBits_MuonDQM_v2_mc` that had been mistakenly removed from the Queues.

- Adds new Muon alignment in dataRun2 Queue

-  `PFCalibration_v10_mc` tag has been replaced by `PFCalibration_express_prompt_v1` in the Run3 Express and Prompt Queues. The new tag has the same payload and the correct synchronization.

- Renames the Phase2 GT.

FYI, @ChrisMisan , @vavati

GT diffs are below.

**run2_data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun2_v2/123X_dataRun2_v1

**run2_data_HEfail**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun2_HEfail_v2/123X_dataRun2_HEfail_v1

**run2_data_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun2_relval_v2/123X_dataRun2_relval_v1

**run2_data_promptlike_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun2_PromptLike_HI_v2/123X_dataRun2_PromptLike_HI_v1

**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_HLT_v4/123X_dataRun3_HLT_v3

**run2_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun2_HLT_relval_v2/123X_dataRun2_HLT_relval_v1

**run3_data_express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_Express_v3/123X_dataRun3_Express_v2

**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_Prompt_v3/123X_dataRun3_Prompt_v2

**run3_data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_v2/123X_dataRun3_v1

**phase1_2021_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_design_v7/123X_mcRun3_2021_design_v6

**phase1_2021_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_realistic_v7/123X_mcRun3_2021_realistic_v6

**phase1_2021_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021cosmics_realistic_deco_v7/123X_mcRun3_2021cosmics_realistic_deco_v6

**phase1_2021_realistic_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_realistic_HI_v7/123X_mcRun3_2021_realistic_HI_v6

**phase1_2023_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2023_realistic_v7/123X_mcRun3_2023_realistic_v6

**phase1_2024_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2024_realistic_v7/123X_mcRun3_2024_realistic_v6

**phase2_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun4_realistic_v5/123X_mcRun4_realistic_noSiStrip_v3


#### PR validation:

`runTheMatrix.py -l 136.793,136.874,12034.0,7.23,159.0,12834.0,136.8642,136.7952,140.56 --ibeos -j8`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

not a backport
