### PR TITLE
Avoid storing empty DetSet containers in the pixel digi collection

### DIFF
--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -210,9 +210,14 @@ void PixelDataFormatter::interpretRawData(
       }
     }
 
-    GlobalPixel global = rocp->toGlobal(*local);  // global pixel coordinate (in module)
-    (*detDigis).data.emplace_back(global.row, global.col, adc);
-    LogTrace("") << (*detDigis).data.back();
+    if (detDigis) {
+      GlobalPixel global = rocp->toGlobal(*local);  // global pixel coordinate (in module)
+      (*detDigis).data.emplace_back(global.row, global.col, adc);
+      LogTrace("") << (*detDigis).data.back();
+    } else {
+      LogError("NullPointerException") << "@SUB=PixelDataFormatter::interpretRawData"
+                                       << "DetSet pointer not set. This is not supposed to happen.";
+    }
   }
 }
 

--- a/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
+++ b/EventFilter/SiPixelRawToDigi/src/PixelDataFormatter.cc
@@ -111,6 +111,8 @@ void PixelDataFormatter::interpretRawData(
   int link = -1;
   int roc = -1;
   int layer = 0;
+  unsigned int rawId = 0;
+  unsigned int nrawId = 0;
   PixelROC const* rocp = nullptr;
   bool skipROC = false;
   edm::DetSet<PixelDigi>* detDigis = nullptr;
@@ -147,7 +149,7 @@ void PixelDataFormatter::interpretRawData(
         skipROC = true;
         continue;
       }
-      auto rawId = rocp->rawId();
+      rawId = rocp->rawId();
       bool barrel = PixelModuleName::isBarrel(rawId);
       if (barrel)
         layer = PixelROC::bpixLayerPhase1(rawId);
@@ -163,10 +165,6 @@ void PixelDataFormatter::interpretRawData(
       skipROC = modulesToUnpack_ && (modulesToUnpack_->find(rawId) == modulesToUnpack_->end());
       if (skipROC)
         continue;
-
-      detDigis = &digis.find_or_insert(rawId);
-      if ((*detDigis).empty())
-        (*detDigis).data.reserve(32);  // avoid the first relocations
     }
 
     // skip is roc to be skipped ot invalid
@@ -202,6 +200,14 @@ void PixelDataFormatter::interpretRawData(
         continue;
       }
       local = std::make_unique<LocalPixel>(localDP);  // local pixel coordinate
+    }
+
+    if (nrawId != rawId) {
+      nrawId = rawId;
+      detDigis = &digis.find_or_insert(rawId);
+      if ((*detDigis).empty()) {
+        (*detDigis).data.reserve(32);  // avoid the first relocations
+      }
     }
 
     GlobalPixel global = rocp->toGlobal(*local);  // global pixel coordinate (in module)


### PR DESCRIPTION
#### PR description:

This PR addresses the issue with excessive LogWarning printouts in the pixel clusterizer reported in https://github.com/cms-sw/cmssw/pull/36326#issuecomment-984417751. This PR is an alternative to https://github.com/cms-sw/cmssw/pull/36968 and tries to fix the problem at the source, in the RawToDigi code. This is a technical fix so no impact on physics is expected.

#### PR validation:

The code compiles and was tested to successfully run with the MinimumBias workflow 139.001.

@tsusa @mmusich
