### PR TITLE
Add energy units to CMSUnits.h

### DIFF
--- a/DataFormats/Math/interface/CMSUnits.h
+++ b/DataFormats/Math/interface/CMSUnits.h
@@ -38,13 +38,13 @@ namespace cms_units {
     constexpr double operator"" _TeV(long double energy) { return energy * 1.e3_GeV; }
 
     // Add these conversion functions to this namespace for convenience
-    using angle_units::operators::convertCmToMm;
-    using angle_units::operators::convertMmToCm;
-    using angle_units::operators::convertMm3ToM3;
     using angle_units::operators::convertCm2ToMm2;
+    using angle_units::operators::convertCmToMm;
     using angle_units::operators::convertGeVToKeV;
     using angle_units::operators::convertGeVToMeV;
     using angle_units::operators::convertMeVToGeV;
+    using angle_units::operators::convertMm3ToM3;
+    using angle_units::operators::convertMmToCm;
 
   }  // namespace operators
 }  // namespace cms_units

--- a/DataFormats/Math/interface/CMSUnits.h
+++ b/DataFormats/Math/interface/CMSUnits.h
@@ -31,6 +31,21 @@ namespace cms_units {
     constexpr double operator"" _mm(unsigned long long int length) { return length * 0.1; }
     constexpr double operator"" _cm(unsigned long long int length) { return length * 1; }
 
+    // Energy
+    constexpr double operator"" _GeV(long double energy) { return energy * 1.; }
+    constexpr double operator"" _eV(long double energy) { return energy * 1.e-9_GeV; }
+    constexpr double operator"" _MeV(long double energy) { return energy * 1.e-3_GeV; }
+    constexpr double operator"" _TeV(long double energy) { return energy * 1.e3_GeV; }
+
+    // Add these conversion functions to this namespace for convenience
+    using angle_units::operators::convertCmToMm;
+    using angle_units::operators::convertMmToCm;
+    using angle_units::operators::convertMm3ToM3;
+    using angle_units::operators::convertCm2ToMm2;
+    using angle_units::operators::convertGeVToKeV;
+    using angle_units::operators::convertGeVToMeV;
+    using angle_units::operators::convertMeVToGeV;
+
   }  // namespace operators
 }  // namespace cms_units
 

--- a/DataFormats/Math/interface/GeantUnits.h
+++ b/DataFormats/Math/interface/GeantUnits.h
@@ -59,41 +59,14 @@ namespace geant_units {
     constexpr double operator"" _g_per_cm3(long double density) { return density * 1._g / 1._cm3; }
     constexpr double operator"" _g_per_mole(long double mass) { return mass * 1._g / 1._mole; }
 
-    template <class NumType>
-    inline constexpr NumType convertMmToCm(NumType millimeters)  // Millimeters -> centimeters
-    {
-      return (millimeters / 10.);
-    }
-
-    template <class NumType>
-    inline constexpr NumType convertCmToMm(NumType centimeters)  // Centimeters -> Milliimeters
-    {
-      return (centimeters * 10.);
-    }
-
-    template <class NumType>
-    inline constexpr NumType convertCm2ToMm2(NumType centimeters)  // Centimeters^2 -> Milliimeters^2
-    {
-      return (centimeters * 100.);
-    }
-
-    template <class NumType>
-    inline constexpr NumType convertMm3ToM3(NumType mm3)  // Cubic millimeters -> cubic meters
-    {
-      return (mm3 / 1.e9);
-    }
-
-    template <class NumType>
-    inline constexpr NumType convertMeVToGeV(NumType mev)  // MeV -> GeV
-    {
-      return (mev * 0.001);
-    }
-
-    template <class NumType>
-    inline constexpr NumType convertGeVToMeV(NumType gev)  // GeV -> MeV
-    {
-      return (gev * 1000.);
-    }
+    // Add these conversion functions to this namespace for convenience
+    using angle_units::operators::convertCmToMm;
+    using angle_units::operators::convertMmToCm;
+    using angle_units::operators::convertCm2ToMm2;
+    using angle_units::operators::convertMm3ToM3;
+    using angle_units::operators::convertGeVToKeV;
+    using angle_units::operators::convertGeVToMeV;
+    using angle_units::operators::convertMeVToGeV;
 
     // Convert Geant units to desired units
     template <class NumType>

--- a/DataFormats/Math/interface/GeantUnits.h
+++ b/DataFormats/Math/interface/GeantUnits.h
@@ -60,13 +60,13 @@ namespace geant_units {
     constexpr double operator"" _g_per_mole(long double mass) { return mass * 1._g / 1._mole; }
 
     // Add these conversion functions to this namespace for convenience
-    using angle_units::operators::convertCmToMm;
-    using angle_units::operators::convertMmToCm;
     using angle_units::operators::convertCm2ToMm2;
-    using angle_units::operators::convertMm3ToM3;
+    using angle_units::operators::convertCmToMm;
     using angle_units::operators::convertGeVToKeV;
     using angle_units::operators::convertGeVToMeV;
     using angle_units::operators::convertMeVToGeV;
+    using angle_units::operators::convertMm3ToM3;
+    using angle_units::operators::convertMmToCm;
 
     // Convert Geant units to desired units
     template <class NumType>

--- a/DataFormats/Math/interface/angle_units.h
+++ b/DataFormats/Math/interface/angle_units.h
@@ -37,6 +37,51 @@ namespace angle_units {
              std::fabs(x - y) < std::numeric_limits<NumType>::min();
     }
 
+    // Unit conversion functions. They are not related to angles, but it is convenient to define them here
+    // to avoid code duplication.
+
+    template <class NumType>
+    inline constexpr NumType convertMmToCm(NumType millimeters)  // Millimeters -> centimeters
+    {
+      return (millimeters / 10.);
+    }
+
+    template <class NumType>
+    inline constexpr NumType convertCmToMm(NumType centimeters)  // Centimeters -> Milliimeters
+    {
+      return (centimeters * 10.);
+    }
+
+    template <class NumType>
+    inline constexpr NumType convertCm2ToMm2(NumType centimeters)  // Centimeters^2 -> Milliimeters^2
+    {
+      return (centimeters * 100.);
+    }
+
+    template <class NumType>
+    inline constexpr NumType convertMm3ToM3(NumType mm3)  // Cubic millimeters -> cubic meters
+    {
+      return (mm3 / 1.e9);
+    }
+
+    template <class NumType>
+    inline constexpr NumType convertMeVToGeV(NumType mev)  // MeV -> GeV
+    {
+      return (mev * 0.001);
+    }
+
+    template <class NumType>
+    inline constexpr NumType convertGeVToMeV(NumType gev)  // GeV -> MeV
+    {
+      return (gev * 1000.);
+    }
+
+    template <class NumType>
+    inline constexpr NumType convertGeVToKeV(NumType gev)  // GeV -> keV
+    {
+      return (gev * 1.e6);
+    }
+
   }  // namespace operators
 }  // namespace angle_units
 


### PR DESCRIPTION
`DataFormats/Math/interface/GeantUnits.h` contains energy units, but `DataFormats/Math/interface/CMSUnits.h` didn't have them. For consistency, the units _eV, _MeV, _GeV, and _TeV are added to `CMSUnits.h`, along with enegy conversion functions. The definitions of the conversion functions were moved to `DataFormats/Math/interface/angle_units.h` to avoid code duplication. `angle_units.h` is not an ideal location for energy and length conversion functions, but such simple functions don't really justify the creation of a new header file to hold them.

This PR resolves issue #29750.

#### PR validation:

The new units were added to a test program, and it successfully compiled.

No backport is needed.