### PR TITLE
[MkFit] Fix uninitialized MkFinder::m_prop_config in backward-fit.

### DIFF
--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -583,6 +583,8 @@ namespace mkfit {
 
           ++rng;
         }  // end of loop over candidates in a tbb chunk
+
+        mkfndr->release();
       });  // end parallel_for over candidates in a region
     });    // end of parallel_for_each over regions
   }
@@ -878,6 +880,7 @@ namespace mkfit {
           }
 
         }  // end of layer loop
+        mkfndr->release();
 
         // final sorting
         for (int iseed = start_seed; iseed < end_seed; ++iseed) {
@@ -920,6 +923,7 @@ namespace mkfit {
         // loop over layers
         find_tracks_in_layers(*cloner, mkfndr.get(), iteration_dir, seeds.begin(), seeds.end(), region);
 
+        mkfndr->release();
         cloner->release();
       });
     });
@@ -1283,9 +1287,9 @@ namespace mkfit {
     EventOfCombCandidates &eoccs = m_event_of_comb_cands;
     const SteeringParams &st_par = m_job->steering_params(region);
     const PropagationConfig &prop_config = PropagationConfig::get_default();
+    mkfndr->setup_bkfit(prop_config);
 
     int step = NN;
-
     for (int icand = start_cand; icand < end_cand; icand += step) {
       int end = std::min(icand + NN, end_cand);
 
@@ -1357,6 +1361,7 @@ namespace mkfit {
       }
 #endif
     }
+    mkfndr->release();
   }
 
 }  // end namespace mkfit

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -44,9 +44,7 @@ namespace mkfit {
     m_iteration_hit_mask = ihm;
   }
 
-  void MkFinder::setup_bkfit(const PropagationConfig &pc) {
-    m_prop_config = &pc;
-  }
+  void MkFinder::setup_bkfit(const PropagationConfig &pc) { m_prop_config = &pc; }
 
   void MkFinder::release() {
     m_prop_config = nullptr;

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -44,6 +44,10 @@ namespace mkfit {
     m_iteration_hit_mask = ihm;
   }
 
+  void MkFinder::setup_bkfit(const PropagationConfig &pc) {
+    m_prop_config = &pc;
+  }
+
   void MkFinder::release() {
     m_prop_config = nullptr;
     m_iteration_params = nullptr;

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -44,6 +44,7 @@ namespace mkfit {
                const IterationParams &ip,
                const IterationLayerConfig &ilc,
                const std::vector<bool> *ihm);
+    void setup_bkfit(const PropagationConfig &pc);
     void release();
 
     //----------------------------------------------------------------------------


### PR DESCRIPTION
- Introduce new MkFinder::setup_bkfit() function needed to setup
  local configuration pointers for backward-fit and use this
  in MkBuilder bk-fit steering function.
- Consistenly call MkFinder::release() from track finding steering
  code to re-initialize MkFinder configuration pointers to nullptr.
  This was effectively masking the issue of the missing setup call.

This addresses #37017

