### PR TITLE
create `cfi` files for `JetConstituentSelector<>` plugins

### DIFF
--- a/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
@@ -44,16 +44,10 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    desc.add<edm::InputTag>("src")->setComment("InputTag used for retrieving jets in event.");
-    desc.add<std::string>("cut")->setComment(
-        "Cut used by which to select jets.  For example:\n"
-        "  \"pt > 100.0 && abs(rapidity()) < 2.4\".");
-
-    // addDefault must be used here instead of add unless this function is specialized
-    // for different sets of template parameter types. Each specialization would need
-    // a different module label. Otherwise the generated cfi filenames will conflict
-    // for the different plugins.
-    descriptions.addDefault(desc);
+    desc.add<edm::InputTag>("src", edm::InputTag(""))->setComment("InputTag used for retrieving jets in event.");
+    desc.add<std::string>("cut", "")->setComment(
+        "Cut used by which to select jets. For example:\n  \"pt > 100.0 && abs(rapidity()) < 2.4\".");
+    descriptions.addWithDefaultLabel(desc);
   }
 
   // Default initialization is for edm::FwdPtr. Specialization (below) is for edm::Ptr.


### PR DESCRIPTION
#### PR description:

This PR is technical. It enables the creation of default `cfi` files for all instances of the plugin template `JetConstituentSelector`.

This is expected to have no consequences for any existing workflow.

The reason to enable the creation of the said `cfi` files is that an external tool used by HLT (i.e. `ConfDB`) relies on the existence of `cfi` files to know the default configuration of CMSSW plugins.

Thanks to @rgerosa for reporting the issue.

Merely technical. No changes expected.

#### PR validation:

The new `cfi` files are created as expected.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A