### PR TITLE
Sonic interface simplifications

### DIFF
--- a/HeterogeneousCore/SonicCore/README.md
+++ b/HeterogeneousCore/SonicCore/README.md
@@ -15,7 +15,7 @@ To implement a concrete derived producer class, the following skeleton can be us
 class MyProducer : public SonicEDProducer<Client>
 {
 public:
-  explicit MyProducer(edm::ParameterSet const& cfg) : SonicEDProducer<Client>(cfg, "MyProducer") {
+  explicit MyProducer(edm::ParameterSet const& cfg) : SonicEDProducer<Client>(cfg) {
     //do any necessary operations
   }
   void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {

--- a/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
@@ -17,8 +17,8 @@ public:
   //typedef to simplify usage
   typedef typename Client::Input Input;
   //constructor
-  SonicAcquirer(edm::ParameterSet const& cfg, const std::string& debugName = "", bool verbose = true)
-      : clientPset_(cfg.getParameterSet("Client")), debugName_(debugName), verbose_(verbose) {}
+  SonicAcquirer(edm::ParameterSet const& cfg, bool verbose = true)
+      : clientPset_(cfg.getParameterSet("Client")), debugName_(cfg.getParameter<std::string>("@module_label")), verbose_(verbose) {}
   //destructor
   ~SonicAcquirer() override = default;
 

--- a/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
@@ -17,8 +17,8 @@ public:
   //typedef to simplify usage
   typedef typename Client::Input Input;
   //constructor
-  SonicAcquirer(edm::ParameterSet const& cfg, bool verbose = true)
-      : clientPset_(cfg.getParameterSet("Client")), debugName_(cfg.getParameter<std::string>("@module_label")), verbose_(verbose) {}
+  SonicAcquirer(edm::ParameterSet const& cfg)
+      : clientPset_(cfg.getParameterSet("Client")), debugName_(cfg.getParameter<std::string>("@module_label")), verbose_(clientPset_.getUntrackedParameter<bool>("verbose")) {}
   //destructor
   ~SonicAcquirer() override = default;
 

--- a/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
@@ -18,7 +18,9 @@ public:
   typedef typename Client::Input Input;
   //constructor
   SonicAcquirer(edm::ParameterSet const& cfg)
-      : clientPset_(cfg.getParameterSet("Client")), debugName_(cfg.getParameter<std::string>("@module_label")), verbose_(clientPset_.getUntrackedParameter<bool>("verbose")) {}
+      : clientPset_(cfg.getParameterSet("Client")),
+        debugName_(cfg.getParameter<std::string>("@module_label")),
+        verbose_(clientPset_.getUntrackedParameter<bool>("verbose")) {}
   //destructor
   ~SonicAcquirer() override = default;
 

--- a/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
@@ -52,6 +52,7 @@ protected:
 
   //members
   SonicMode mode_;
+  bool verbose_;
   std::unique_ptr<SonicDispatcher> dispatcher_;
   unsigned allowedTries_, tries_;
   std::optional<edm::WaitingTaskWithArenaHolder> holder_;

--- a/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
@@ -16,8 +16,8 @@ public:
   //typedef to simplify usage
   typedef typename Client::Output Output;
   //constructor
-  SonicEDFilter(edm::ParameterSet const& cfg, bool verbose = true)
-      : SonicAcquirer<Client, edm::stream::EDFilter<edm::ExternalWork, Capabilities...>>(cfg, verbose) {}
+  SonicEDFilter(edm::ParameterSet const& cfg)
+      : SonicAcquirer<Client, edm::stream::EDFilter<edm::ExternalWork, Capabilities...>>(cfg) {}
   //destructor
   ~SonicEDFilter() override = default;
 

--- a/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
@@ -16,8 +16,8 @@ public:
   //typedef to simplify usage
   typedef typename Client::Output Output;
   //constructor
-  SonicEDFilter(edm::ParameterSet const& cfg, const std::string& debugName, bool verbose = true)
-      : SonicAcquirer<Client, edm::stream::EDFilter<edm::ExternalWork, Capabilities...>>(cfg, debugName, verbose) {}
+  SonicEDFilter(edm::ParameterSet const& cfg, bool verbose = true)
+      : SonicAcquirer<Client, edm::stream::EDFilter<edm::ExternalWork, Capabilities...>>(cfg, verbose) {}
   //destructor
   ~SonicEDFilter() override = default;
 

--- a/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
@@ -16,8 +16,8 @@ public:
   //typedef to simplify usage
   typedef typename Client::Output Output;
   //constructor
-  SonicEDProducer(edm::ParameterSet const& cfg, const std::string& debugName, bool verbose = true)
-      : SonicAcquirer<Client, edm::stream::EDProducer<edm::ExternalWork, Capabilities...>>(cfg, debugName, verbose) {}
+  SonicEDProducer(edm::ParameterSet const& cfg, bool verbose = true)
+      : SonicAcquirer<Client, edm::stream::EDProducer<edm::ExternalWork, Capabilities...>>(cfg, verbose) {}
   //destructor
   ~SonicEDProducer() override = default;
 

--- a/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
@@ -16,8 +16,8 @@ public:
   //typedef to simplify usage
   typedef typename Client::Output Output;
   //constructor
-  SonicEDProducer(edm::ParameterSet const& cfg, bool verbose = true)
-      : SonicAcquirer<Client, edm::stream::EDProducer<edm::ExternalWork, Capabilities...>>(cfg, verbose) {}
+  SonicEDProducer(edm::ParameterSet const& cfg)
+      : SonicAcquirer<Client, edm::stream::EDProducer<edm::ExternalWork, Capabilities...>>(cfg) {}
   //destructor
   ~SonicEDProducer() override = default;
 

--- a/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
@@ -22,7 +22,9 @@ public:
   typedef typename Client::Output Output;
   //constructor
   SonicOneEDAnalyzer(edm::ParameterSet const& cfg, bool verbose = true)
-      : clientPset_(cfg.getParameterSet("Client")), debugName_(cfg.getParameter<std::string>("@module_label")), verbose_(clientPset_.getUntrackedParameter<bool>("verbose")) {
+      : clientPset_(cfg.getParameterSet("Client")),
+        debugName_(cfg.getParameter<std::string>("@module_label")),
+        verbose_(clientPset_.getUntrackedParameter<bool>("verbose")) {
     //ExternalWork is not compatible with one modules, so Sync mode is enforced
     if (clientPset_.getParameter<std::string>("mode") != "Sync") {
       edm::LogWarning("ResetClientMode") << "Resetting client mode to Sync for SonicOneEDAnalyzer";

--- a/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
@@ -22,7 +22,7 @@ public:
   typedef typename Client::Output Output;
   //constructor
   SonicOneEDAnalyzer(edm::ParameterSet const& cfg, bool verbose = true)
-      : clientPset_(cfg.getParameterSet("Client")), debugName_(cfg.getParameter<std::string>("@module_label")), verbose_(verbose) {
+      : clientPset_(cfg.getParameterSet("Client")), debugName_(cfg.getParameter<std::string>("@module_label")), verbose_(clientPset_.getUntrackedParameter<bool>("verbose")) {
     //ExternalWork is not compatible with one modules, so Sync mode is enforced
     if (clientPset_.getParameter<std::string>("mode") != "Sync") {
       edm::LogWarning("ResetClientMode") << "Resetting client mode to Sync for SonicOneEDAnalyzer";

--- a/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
@@ -21,8 +21,8 @@ public:
   typedef typename Client::Input Input;
   typedef typename Client::Output Output;
   //constructor
-  SonicOneEDAnalyzer(edm::ParameterSet const& cfg, const std::string& debugName, bool verbose = true)
-      : clientPset_(cfg.getParameterSet("Client")), debugName_(debugName), verbose_(verbose) {
+  SonicOneEDAnalyzer(edm::ParameterSet const& cfg, bool verbose = true)
+      : clientPset_(cfg.getParameterSet("Client")), debugName_(cfg.getParameter<std::string>("@module_label")), verbose_(verbose) {
     //ExternalWork is not compatible with one modules, so Sync mode is enforced
     if (clientPset_.getParameter<std::string>("mode") != "Sync") {
       edm::LogWarning("ResetClientMode") << "Resetting client mode to Sync for SonicOneEDAnalyzer";

--- a/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
@@ -76,4 +76,5 @@ void SonicClientBase::fillBasePSetDescription(edm::ParameterSetDescription& desc
                edm::allowedValues<std::string>("Sync", "Async", "PseudoAsync"));
   if (allowRetry)
     desc.addUntracked<unsigned>("allowedTries", 0);
+  desc.addUntracked<bool>("verbose", false);
 }

--- a/HeterogeneousCore/SonicCore/test/SonicDummyFilter.cc
+++ b/HeterogeneousCore/SonicCore/test/SonicDummyFilter.cc
@@ -10,7 +10,7 @@ namespace sonictest {
   class SonicDummyFilter : public SonicEDFilter<DummyClient> {
   public:
     explicit SonicDummyFilter(edm::ParameterSet const& cfg)
-        : SonicEDFilter<DummyClient>(cfg, "SonicDummyFilter"), input_(cfg.getParameter<int>("input")) {
+        : SonicEDFilter<DummyClient>(cfg), input_(cfg.getParameter<int>("input")) {
       putToken_ = produces<edmtest::IntProduct>();
     }
 

--- a/HeterogeneousCore/SonicCore/test/SonicDummyOneAnalyzer.cc
+++ b/HeterogeneousCore/SonicCore/test/SonicDummyOneAnalyzer.cc
@@ -12,7 +12,7 @@ namespace sonictest {
   class SonicDummyOneAnalyzer : public SonicOneEDAnalyzer<DummyClient> {
   public:
     explicit SonicDummyOneAnalyzer(edm::ParameterSet const& cfg)
-        : SonicOneEDAnalyzer<DummyClient>(cfg, "SonicDummyOneAnalyzer"),
+        : SonicOneEDAnalyzer<DummyClient>(cfg),
           input_(cfg.getParameter<int>("input")),
           expected_(cfg.getParameter<int>("expected")) {}
 

--- a/HeterogeneousCore/SonicCore/test/SonicDummyProducer.cc
+++ b/HeterogeneousCore/SonicCore/test/SonicDummyProducer.cc
@@ -10,7 +10,7 @@ namespace sonictest {
   class SonicDummyProducer : public SonicEDProducer<DummyClient> {
   public:
     explicit SonicDummyProducer(edm::ParameterSet const& cfg)
-        : SonicEDProducer<DummyClient>(cfg, "SonicDummyProducer"), input_(cfg.getParameter<int>("input")) {
+        : SonicEDProducer<DummyClient>(cfg), input_(cfg.getParameter<int>("input")) {
       putToken_ = produces<edmtest::IntProduct>();
     }
 

--- a/HeterogeneousCore/SonicTriton/interface/TritonEDFilter.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonEDFilter.h
@@ -13,8 +13,7 @@ template <typename G, typename... Capabilities>
 class TritonEDFilterT : public SonicEDFilter<TritonClient, edm::GlobalCache<G>, Capabilities...> {
 public:
   TritonEDFilterT(edm::ParameterSet const& cfg)
-      : SonicEDFilter<TritonClient, edm::GlobalCache<G>, Capabilities...>(
-            cfg, cfg.getParameterSet("Client").getUntrackedParameter<bool>("verbose")) {}
+      : SonicEDFilter<TritonClient, edm::GlobalCache<G>, Capabilities...>(cfg) {}
 
   //use this function to avoid calling TritonService functions Nstreams times
   static std::unique_ptr<G> initializeGlobalCache(edm::ParameterSet const& pset) {

--- a/HeterogeneousCore/SonicTriton/interface/TritonEDFilter.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonEDFilter.h
@@ -12,9 +12,9 @@
 template <typename G, typename... Capabilities>
 class TritonEDFilterT : public SonicEDFilter<TritonClient, edm::GlobalCache<G>, Capabilities...> {
 public:
-  TritonEDFilterT(edm::ParameterSet const& cfg, const std::string& debugName)
+  TritonEDFilterT(edm::ParameterSet const& cfg)
       : SonicEDFilter<TritonClient, edm::GlobalCache<G>, Capabilities...>(
-            cfg, debugName, cfg.getParameterSet("Client").getUntrackedParameter<bool>("verbose")) {}
+            cfg, cfg.getParameterSet("Client").getUntrackedParameter<bool>("verbose")) {}
 
   //use this function to avoid calling TritonService functions Nstreams times
   static std::unique_ptr<G> initializeGlobalCache(edm::ParameterSet const& pset) {

--- a/HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h
@@ -12,9 +12,9 @@
 template <typename G, typename... Capabilities>
 class TritonEDProducerT : public SonicEDProducer<TritonClient, edm::GlobalCache<G>, Capabilities...> {
 public:
-  TritonEDProducerT(edm::ParameterSet const& cfg, const std::string& debugName)
+  TritonEDProducerT(edm::ParameterSet const& cfg)
       : SonicEDProducer<TritonClient, edm::GlobalCache<G>, Capabilities...>(
-            cfg, debugName, cfg.getParameterSet("Client").getUntrackedParameter<bool>("verbose")) {}
+            cfg, cfg.getParameterSet("Client").getUntrackedParameter<bool>("verbose")) {}
 
   //use this function to avoid calling TritonService functions Nstreams times
   static std::unique_ptr<G> initializeGlobalCache(edm::ParameterSet const& pset) {

--- a/HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h
@@ -13,8 +13,7 @@ template <typename G, typename... Capabilities>
 class TritonEDProducerT : public SonicEDProducer<TritonClient, edm::GlobalCache<G>, Capabilities...> {
 public:
   TritonEDProducerT(edm::ParameterSet const& cfg)
-      : SonicEDProducer<TritonClient, edm::GlobalCache<G>, Capabilities...>(
-            cfg, cfg.getParameterSet("Client").getUntrackedParameter<bool>("verbose")) {}
+      : SonicEDProducer<TritonClient, edm::GlobalCache<G>, Capabilities...>(cfg) {}
 
   //use this function to avoid calling TritonService functions Nstreams times
   static std::unique_ptr<G> initializeGlobalCache(edm::ParameterSet const& pset) {

--- a/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
@@ -12,9 +12,9 @@
 template <typename... Capabilities>
 class TritonOneEDAnalyzer : public SonicOneEDAnalyzer<TritonClient, Capabilities...> {
 public:
-  TritonOneEDAnalyzer(edm::ParameterSet const& cfg, const std::string& debugName)
+  TritonOneEDAnalyzer(edm::ParameterSet const& cfg)
       : SonicOneEDAnalyzer<TritonClient, Capabilities...>(
-            cfg, debugName, cfg.getParameterSet("Client").getUntrackedParameter<bool>("verbose")) {
+            cfg, cfg.getParameterSet("Client").getUntrackedParameter<bool>("verbose")) {
     edm::Service<TritonService> ts;
     const auto& clientPset = cfg.getParameterSet("Client");
     ts->addModel(clientPset.getParameter<std::string>("modelName"),

--- a/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
@@ -13,12 +13,10 @@ template <typename... Capabilities>
 class TritonOneEDAnalyzer : public SonicOneEDAnalyzer<TritonClient, Capabilities...> {
 public:
   TritonOneEDAnalyzer(edm::ParameterSet const& cfg)
-      : SonicOneEDAnalyzer<TritonClient, Capabilities...>(
-            cfg, cfg.getParameterSet("Client").getUntrackedParameter<bool>("verbose")) {
+      : SonicOneEDAnalyzer<TritonClient, Capabilities...>(cfg) {
     edm::Service<TritonService> ts;
-    const auto& clientPset = cfg.getParameterSet("Client");
-    ts->addModel(clientPset.getParameter<std::string>("modelName"),
-                 clientPset.getParameter<edm::FileInPath>("modelConfigPath").fullPath());
+    ts->addModel(this->clientPset_.template getParameter<std::string>("modelName"),
+                 this->clientPset_.template getParameter<edm::FileInPath>("modelConfigPath").fullPath());
   }
 };
 

--- a/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
@@ -12,8 +12,7 @@
 template <typename... Capabilities>
 class TritonOneEDAnalyzer : public SonicOneEDAnalyzer<TritonClient, Capabilities...> {
 public:
-  TritonOneEDAnalyzer(edm::ParameterSet const& cfg)
-      : SonicOneEDAnalyzer<TritonClient, Capabilities...>(cfg) {
+  TritonOneEDAnalyzer(edm::ParameterSet const& cfg) : SonicOneEDAnalyzer<TritonClient, Capabilities...>(cfg) {
     edm::Service<TritonService> ts;
     ts->addModel(this->clientPset_.template getParameter<std::string>("modelName"),
                  this->clientPset_.template getParameter<edm::FileInPath>("modelConfigPath").fullPath());

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -412,7 +412,6 @@ void TritonClient::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
   //server parameters should not affect the physics results
   descClient.addUntracked<std::string>("preferredServer", "");
   descClient.addUntracked<unsigned>("timeout");
-  descClient.addUntracked<bool>("verbose", false);
   descClient.addUntracked<bool>("useSharedMemory", true);
   descClient.addUntracked<std::string>("compression", "");
   descClient.addUntracked<std::vector<std::string>>("outputs", {});

--- a/HeterogeneousCore/SonicTriton/test/TritonGraphModules.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonGraphModules.cc
@@ -92,7 +92,7 @@ private:
 class TritonGraphProducer : public TritonEDProducer<> {
 public:
   explicit TritonGraphProducer(edm::ParameterSet const& cfg)
-      : TritonEDProducer<>(cfg, "TritonGraphProducer"), helper_(cfg) {}
+      : TritonEDProducer<>(cfg), helper_(cfg) {}
   void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
     helper_.makeInput(iEvent, iInput);
   }
@@ -120,7 +120,7 @@ DEFINE_FWK_MODULE(TritonGraphProducer);
 
 class TritonGraphFilter : public TritonEDFilter<> {
 public:
-  explicit TritonGraphFilter(edm::ParameterSet const& cfg) : TritonEDFilter<>(cfg, "TritonGraphFilter"), helper_(cfg) {}
+  explicit TritonGraphFilter(edm::ParameterSet const& cfg) : TritonEDFilter<>(cfg), helper_(cfg) {}
   void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
     helper_.makeInput(iEvent, iInput);
   }
@@ -150,7 +150,7 @@ DEFINE_FWK_MODULE(TritonGraphFilter);
 class TritonGraphAnalyzer : public TritonOneEDAnalyzer<> {
 public:
   explicit TritonGraphAnalyzer(edm::ParameterSet const& cfg)
-      : TritonOneEDAnalyzer<>(cfg, "TritonGraphAnalyzer"), helper_(cfg) {}
+      : TritonOneEDAnalyzer<>(cfg), helper_(cfg) {}
   void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
     helper_.makeInput(iEvent, iInput);
   }

--- a/HeterogeneousCore/SonicTriton/test/TritonGraphModules.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonGraphModules.cc
@@ -91,8 +91,7 @@ private:
 
 class TritonGraphProducer : public TritonEDProducer<> {
 public:
-  explicit TritonGraphProducer(edm::ParameterSet const& cfg)
-      : TritonEDProducer<>(cfg), helper_(cfg) {}
+  explicit TritonGraphProducer(edm::ParameterSet const& cfg) : TritonEDProducer<>(cfg), helper_(cfg) {}
   void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
     helper_.makeInput(iEvent, iInput);
   }
@@ -149,8 +148,7 @@ DEFINE_FWK_MODULE(TritonGraphFilter);
 
 class TritonGraphAnalyzer : public TritonOneEDAnalyzer<> {
 public:
-  explicit TritonGraphAnalyzer(edm::ParameterSet const& cfg)
-      : TritonOneEDAnalyzer<>(cfg), helper_(cfg) {}
+  explicit TritonGraphAnalyzer(edm::ParameterSet const& cfg) : TritonOneEDAnalyzer<>(cfg), helper_(cfg) {}
   void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override {
     helper_.makeInput(iEvent, iInput);
   }

--- a/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonImageProducer.cc
@@ -16,7 +16,7 @@
 class TritonImageProducer : public TritonEDProducer<> {
 public:
   explicit TritonImageProducer(edm::ParameterSet const& cfg)
-      : TritonEDProducer<>(cfg, "TritonImageProducer"),
+      : TritonEDProducer<>(cfg),
         batchSize_(cfg.getParameter<int>("batchSize")),
         topN_(cfg.getParameter<unsigned>("topN")) {
     //load score list

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -161,6 +161,7 @@ for im,module in enumerate(options.modules):
         )
         processModule2 = getattr(process, _module2)
         process.p += processModule2
+        keepMsgs.extend([_module2,_module2+':TritonClient'])
 
 process.load('FWCore/MessageService/MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 500

--- a/RecoEcal/EgammaClusterProducers/src/SCEnergyCorrectorDRNProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/SCEnergyCorrectorDRNProducer.cc
@@ -57,7 +57,7 @@ private:
 };
 
 SCEnergyCorrectorDRNProducer::SCEnergyCorrectorDRNProducer(const edm::ParameterSet& iConfig)
-    : TritonEDProducer<>(iConfig, "SCEnergyCorrectorDRNProducer"),
+    : TritonEDProducer<>(iConfig),
       energyCorrector_(iConfig.getParameterSet("correctorCfg"), consumesCollector()),
       inputSCToken_(consumes<reco::SuperClusterCollection>(iConfig.getParameter<edm::InputTag>("inputSCs"))) {
   produces<reco::SuperClusterCollection>();


### PR DESCRIPTION
#### PR description:

* Use Python module name from framework for debugging messages
* Include `verbose` parameter in base client
  * I previously avoided this in case someone wanted to implement a less trivial verbosity scheme (e.g. with different levels). But there hasn't been interest in this, and in any case, it can be done just by overriding the module and client `verbose_` flags.

#### PR validation:

Unit tests run successfully.