### PR TITLE
Fix of the L1MenuWriter needed for the X2O procedure + update of the L1UpgradeTfMuonShowerTreeProducer

### DIFF
--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonShowerTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonShowerTreeProducer.cc
@@ -23,10 +23,10 @@
 // class declaration
 //
 
-class L1UpgradeTfMuonShowerTreeProducer : public edm::one::EDAnalyzer<> {
+class L1UpgradeTfMuonShowerTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1UpgradeTfMuonShowerTreeProducer(const edm::ParameterSet&);
-  ~L1UpgradeTfMuonShowerTreeProducer() override;
+  ~L1UpgradeTfMuonShowerTreeProducer() override = default;
 
 private:
   void beginJob(void) override;
@@ -58,13 +58,13 @@ L1UpgradeTfMuonShowerTreeProducer::L1UpgradeTfMuonShowerTreeProducer(const edm::
 
   l1UpgradeEmtfData = l1UpgradeEmtf.getData();
 
+  usesResource(TFileService::kSharedResource);
+
   // set up output
   tree_ = fs_->make<TTree>("L1UpgradeTfMuonShowerTree", "L1UpgradeTfMuonShowerTree");
   tree_->Branch(
       "L1UpgradeEmtfMuonShower", "L1Analysis::L1AnalysisL1UpgradeTfMuonShowerDataFormat", &l1UpgradeEmtfData, 32000, 3);
 }
-
-L1UpgradeTfMuonShowerTreeProducer::~L1UpgradeTfMuonShowerTreeProducer() {}
 
 //
 // member functions

--- a/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonShowerTreeProducer.cc
+++ b/L1Trigger/L1TNtuples/plugins/L1UpgradeTfMuonShowerTreeProducer.cc
@@ -23,10 +23,10 @@
 // class declaration
 //
 
-class L1UpgradeTfMuonShowerTreeProducer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+class L1UpgradeTfMuonShowerTreeProducer : public edm::one::EDAnalyzer<> {
 public:
   explicit L1UpgradeTfMuonShowerTreeProducer(const edm::ParameterSet&);
-  ~L1UpgradeTfMuonShowerTreeProducer() override = default;
+  ~L1UpgradeTfMuonShowerTreeProducer() override;
 
 private:
   void beginJob(void) override;
@@ -58,13 +58,13 @@ L1UpgradeTfMuonShowerTreeProducer::L1UpgradeTfMuonShowerTreeProducer(const edm::
 
   l1UpgradeEmtfData = l1UpgradeEmtf.getData();
 
-  usesResource(TFileService::kSharedResource);
-
   // set up output
   tree_ = fs_->make<TTree>("L1UpgradeTfMuonShowerTree", "L1UpgradeTfMuonShowerTree");
   tree_->Branch(
       "L1UpgradeEmtfMuonShower", "L1Analysis::L1AnalysisL1UpgradeTfMuonShowerDataFormat", &l1UpgradeEmtfData, 32000, 3);
 }
+
+L1UpgradeTfMuonShowerTreeProducer::~L1UpgradeTfMuonShowerTreeProducer() {}
 
 //
 // member functions

--- a/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,25 +16,31 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-class L1MenuWriter : public edm::EDAnalyzer {
+class L1MenuWriter : public edm::one::EDAnalyzer<> {
 private:
   bool isO2Opayload;
 
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+  const edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> l1GtMenuToken_;
+  const edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuO2ORcd> l1GtMenuO2OToken_;
 
-  explicit L1MenuWriter(const edm::ParameterSet& pset) : edm::EDAnalyzer() {
+  explicit L1MenuWriter(const edm::ParameterSet& pset)
+      : edm::one::EDAnalyzer<>(),
+        l1GtMenuToken_(esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>()),
+        l1GtMenuO2OToken_(esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuO2ORcd>()) {
     isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload", false);
   }
-  ~L1MenuWriter(void) override {}
+  ~L1MenuWriter(void) override = default;
 };
 
 void L1MenuWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TUtmTriggerMenu> handle1;
+
   if (isO2Opayload)
-    evSetup.get<L1TUtmTriggerMenuO2ORcd>().get(handle1);
+    handle1 = evSetup.getHandle(l1GtMenuO2OToken_);
   else
-    evSetup.get<L1TUtmTriggerMenuRcd>().get(handle1);
+    handle1 = evSetup.getHandle(l1GtMenuToken_);
 
   std::shared_ptr<L1TUtmTriggerMenu> ptr1(new L1TUtmTriggerMenu(*(handle1.product())));
 

--- a/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1MenuWriter.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,31 +16,25 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-class L1MenuWriter : public edm::one::EDAnalyzer<> {
+class L1MenuWriter : public edm::EDAnalyzer {
 private:
   bool isO2Opayload;
 
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  const edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> l1GtMenuToken_;
-  const edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuO2ORcd> l1GtMenuO2OToken_;
 
-  explicit L1MenuWriter(const edm::ParameterSet& pset)
-      : edm::one::EDAnalyzer<>(),
-        l1GtMenuToken_(esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>()),
-        l1GtMenuO2OToken_(esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuO2ORcd>()) {
+  explicit L1MenuWriter(const edm::ParameterSet& pset) : edm::EDAnalyzer() {
     isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload", false);
   }
-  ~L1MenuWriter(void) override = default;
+  ~L1MenuWriter(void) override {}
 };
 
 void L1MenuWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TUtmTriggerMenu> handle1;
-
   if (isO2Opayload)
-    handle1 = evSetup.getHandle(l1GtMenuO2OToken_);
+    evSetup.get<L1TUtmTriggerMenuO2ORcd>().get(handle1);
   else
-    handle1 = evSetup.getHandle(l1GtMenuToken_);
+    evSetup.get<L1TUtmTriggerMenuRcd>().get(handle1);
 
   std::shared_ptr<L1TUtmTriggerMenu> ptr1(new L1TUtmTriggerMenu(*(handle1.product())));
 


### PR DESCRIPTION
#### PR description:
This PR includes the update of two files:
- the L1MenuWriter that it is called when running the dumpMenu.py script to manually upload a new tag to condDB via X2O procedure. It was crashing because of an exception MustUseESGetToken;
- the L1UpgradeTfMuonShowerTreeProducer, previously updated for the deprecated usage of EDAnalyzer, was missing the corresponding updates to the destructor and to the usage of the SharedResources.

#### PR validation:
Basic tests performed successfully starting from CMSSW_12_3_0_pre4. 
From CMSSW_12_3_0_pre4/src:
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests
> scram build code-checks
> scram build code-format
> runTheMatrix.py -l limited -i all --ibeos
