### PR TITLE
fixes for replace/remove with `FinalPath` [`12_2_X`]

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -2719,10 +2719,10 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             self.assertRaises(TypeError,FinalPath,p.es)
 
             t = FinalPath()
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.FinalPath()\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.FinalPath()\n')
 
             t = FinalPath(p.a)
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.FinalPath(process.a)\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.FinalPath(process.a)\n')
 
             self.assertRaises(TypeError, FinalPath, Task())
             self.assertRaises(TypeError, FinalPath, p.a, Task())
@@ -2730,6 +2730,11 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             p.prod = EDProducer("prodName")
             p.t1 = Task(p.prod)
             self.assertRaises(TypeError, FinalPath, p.a, p.t1, Task(), p.t1)
+            
+            p.t = FinalPath(p.a)
+            p.a = OutputModule("ReplacedOutputModule")
+            self.assertEqual(p.t.dumpPython(PrintOptions()), 'cms.FinalPath(process.a)\n')
+            
         def testCloneSequence(self):
             p = Process("test")
             a = EDAnalyzer("MyAnalyzer")

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -450,8 +450,9 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
         self.visit(v)
         if v.didReplace():
             self._seq = v.result(self)[0]
-            self._tasks.clear()
-            self.associate(*v.result(self)[1])
+            if v.result(self)[1]:
+              self._tasks.clear()
+              self.associate(*v.result(self)[1])
         return v.didReplace()
     def _replaceIfHeldDirectly(self,original,replacement):
         """Only replaces an 'original' with 'replacement' if 'original' is directly held.
@@ -495,8 +496,9 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
         self.visit(v)
         if v.didRemove():
             self._seq = v.result(self)[0]
-            self._tasks.clear()
-            self.associate(*v.result(self)[1])
+            if v.result(self)[1]:
+              self._tasks.clear()
+              self.associate(*v.result(self)[1])
         return v.didRemove()
     def resolve(self, processDict,keepIfCannotResolve=False):
         if self._seq is not None:
@@ -2103,6 +2105,13 @@ if __name__=="__main__":
             t3 = Task(m5)
             t2.replace(m2,t3)
             self.assertTrue(t2.dumpPython() == "cms.Task(process.m1, process.m3, process.m5)\n")
+            
+            fp = FinalPath()
+            fp.replace(m1,m2)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath()\n")
+            fp = FinalPath(m1)
+            fp.replace(m1,m2)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath(process.m2)\n")
 
         def testReplaceIfHeldDirectly(self):
             m1 = DummyModule("m1")
@@ -2330,6 +2339,12 @@ if __name__=="__main__":
             self.assertTrue(t3.dumpPython() == "cms.Task(process.m2)\n")
             t3.remove(m2)
             self.assertTrue(t3.dumpPython() == "cms.Task()\n")
+            fp = FinalPath(m1+m2)
+            fp.remove(m1)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath(process.m2)\n")
+            fp = FinalPath(m1)
+            fp.remove(m1)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath()\n")
 
         def testCopyAndExclude(self):
             a = DummyModule("a")


### PR DESCRIPTION
backport of #36937
backport of #37022

#### PR description:

This PR backports two fixes to the python API of `FinalPath` (all credit to @Dr15Jones for these fixes).

The case for the backport is that #36969 (and related updates in `ConfDB`) has introduced the use of `FinalPath` in some of the HLT utilities in `12_2_X`.

For technical details, please see the original PRs.

Merely technical. No changes expected.

#### PR validation:

Updated unit tests pass.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#36937 #37022