### PR TITLE
migrate `RawDataConverter` away from deprecated `EDAnalyzer` API

### DIFF
--- a/Alignment/LaserAlignment/plugins/RawDataConverter.cc
+++ b/Alignment/LaserAlignment/plugins/RawDataConverter.cc
@@ -1,15 +1,12 @@
-#include <FWCore/Framework/interface/MakerMacros.h>
-
-#include <DataFormats/Common/interface/DetSetVector.h>
-
-#include <DataFormats/SiStripCommon/interface/SiStripEventSummary.h>
-#include <DataFormats/SiStripDigi/interface/SiStripDigi.h>
-#include <DataFormats/SiStripDigi/interface/SiStripRawDigi.h>
-#include <DataFormats/SiStripDigi/interface/SiStripProcessedRawDigi.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/EventSetupRecord.h>
-
-#include <Alignment/LaserAlignment/interface/LASGlobalLoop.h>
+#include "Alignment/LaserAlignment/interface/LASGlobalLoop.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiStripCommon/interface/SiStripEventSummary.h"
+#include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
+#include "DataFormats/SiStripDigi/interface/SiStripProcessedRawDigi.h"
+#include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "TFile.h"
 #include "TTree.h"
@@ -40,11 +37,6 @@ RawDataConverter::RawDataConverter(const edm::ParameterSet& iConfig)
   theDigiModuleLabels = iConfig.getParameter<std::vector<std::string> >("DigiModuleLabels");
   theProductInstanceLabels = iConfig.getParameter<std::vector<std::string> >("ProductInstanceLabels");
 }
-
-///
-///
-///
-RawDataConverter::~RawDataConverter() {}
 
 ///
 ///

--- a/Alignment/LaserAlignment/plugins/RawDataConverter.h
+++ b/Alignment/LaserAlignment/plugins/RawDataConverter.h
@@ -1,24 +1,25 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "Alignment/LaserAlignment/interface/LASGlobalData.h"
-#include <DataFormats/Common/interface/DetSetVector.h>
-#include <FWCore/Framework/interface/Event.h>
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Alignment/LaserAlignment/interface/LASGlobalLoop.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // Forward declarations
 class TFile;
 class TTree;
 
-class RawDataConverter : public edm::EDAnalyzer {
+class RawDataConverter : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   explicit RawDataConverter(const edm::ParameterSet&);
-  ~RawDataConverter() override;
+  ~RawDataConverter() override = default;
 
 private:
   enum DigiType { ZeroSuppressed, VirginRaw, ProcessedRaw, Unknown };
   void beginJob() override;
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override{};
   void endJob() override;
 
   void fillDetectorId(void);


### PR DESCRIPTION
#### PR description:

Title says it all, part of the migrations in https://github.com/cms-sw/cmssw/issues/31061 and https://github.com/cms-sw/cmssw/issues/36404, missed in https://github.com/cms-sw/cmssw/pull/36962. In partial response of [this spreadsheet](https://docs.google.com/spreadsheets/d/18hTA-VwyNAQcclQM-vgXFJRqxPegDLJC4sZqAQAAuAk/edit#gid=0).

#### PR validation:

`cmssw` compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
