### PR TITLE
Update to L1 prescale code following move to fractional prescales

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -145,6 +145,17 @@ def customiseFor2018Input(process):
     return process
 
 
+
+def customiseFor37046(process):
+    """ Customisation to remove the PrescaleCSVFile parameter from the ParametersetDescription of the L1TGlobalProducer
+     in PR 37046 (https://github.com/cms-sw/cmssw/pull/37046)
+    """
+    for prod in producers_by_type(process, 'L1TGlobalProducer'):
+        if hasattr(prod, 'PrescaleCSVFile'):
+            delattr(prod, 'PrescaleCSVFile')
+    return process
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -154,5 +165,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    process = customiseFor37046(process)
 
     return process

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescalesVetosFractESProducer.cc
@@ -1,0 +1,392 @@
+///
+/// \class L1TGlobalPrescalesVetosFractESProducer
+///
+/// Description: Produces L1T Trigger Menu Condition Format
+///
+/// Implementation:
+///    Dummy producer for L1T uGT Trigger Menu
+///
+
+// system include files
+#include <memory>
+#include <iostream>
+#include <fstream>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+
+#include "tmEventSetup/tmEventSetup.hh"
+#include "tmEventSetup/esTriggerMenu.hh"
+#include "tmEventSetup/esAlgorithm.hh"
+#include "tmEventSetup/esCondition.hh"
+#include "tmEventSetup/esObject.hh"
+#include "tmEventSetup/esCut.hh"
+#include "tmEventSetup/esScale.hh"
+#include "tmGrammar/Algorithm.hh"
+
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include "L1Trigger/L1TGlobal/interface/PrescalesVetosFractHelper.h"
+
+#include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetosFract.h"
+#include "CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosFractRcd.h"
+
+#include "L1Trigger/L1TCommon/interface/XmlConfigParser.h"
+#include "L1Trigger/L1TCommon/interface/TriggerSystem.h"
+#include "L1Trigger/L1TCommon/interface/Parameter.h"
+
+using namespace std;
+using namespace edm;
+using namespace l1t;
+//
+// class declaration
+//
+
+class L1TGlobalPrescalesVetosFractESProducer : public edm::ESProducer {
+public:
+  L1TGlobalPrescalesVetosFractESProducer(const edm::ParameterSet&);
+  ~L1TGlobalPrescalesVetosFractESProducer() override;
+
+  using ReturnType = std::unique_ptr<L1TGlobalPrescalesVetosFract>;
+
+  ReturnType produce(const L1TGlobalPrescalesVetosFractRcd&);
+
+private:
+  PrescalesVetosFractHelper data_;
+
+  unsigned int m_numberPhysTriggers;
+  int m_verbosity;
+  int m_bx_mask_default;
+
+  std::vector<std::vector<double> > m_initialPrescaleFactorsAlgoTrig;
+  std::vector<unsigned int> m_initialTriggerMaskAlgoTrig;
+  std::vector<int> m_initialTriggerMaskVetoAlgoTrig;
+  std::map<int, std::vector<int> > m_initialTriggerAlgoBxMaskAlgoTrig;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+L1TGlobalPrescalesVetosFractESProducer::L1TGlobalPrescalesVetosFractESProducer(const edm::ParameterSet& conf)
+    : data_(new L1TGlobalPrescalesVetosFract()) {
+  //the following line is needed to tell the framework what
+  // data is being produced
+  setWhatProduced(this);
+  //setWhatProduced(this, conf.getParameter<std::string>("label"));
+
+  m_numberPhysTriggers = 512;
+
+  // directory in /data/Luminosity for the trigger menu
+  std::string menuDir = conf.getParameter<std::string>("TriggerMenuLuminosity");
+  //std::string menuDir = "startup";
+
+  m_verbosity = conf.getParameter<int>("Verbosity");
+  m_bx_mask_default = conf.getParameter<int>("AlgoBxMaskDefault");
+
+  // XML files
+  std::string prescalesFileName = conf.getParameter<std::string>("PrescaleXMLFile");
+  std::string algobxmaskFileName = conf.getParameter<std::string>("AlgoBxMaskXMLFile");
+  std::string finormaskFileName = conf.getParameter<std::string>("FinOrMaskXMLFile");
+  std::string vetomaskFileName = conf.getParameter<std::string>("VetoMaskXMLFile");
+
+  // Full path
+  edm::FileInPath f1_prescale("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + prescalesFileName);
+  std::string m_prescaleFile = f1_prescale.fullPath();
+
+  edm::FileInPath f1_mask_algobx("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + algobxmaskFileName);
+  std::string m_algobxmaskFile = f1_mask_algobx.fullPath();
+
+  edm::FileInPath f1_mask_finor("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + finormaskFileName);
+  std::string m_finormaskFile = f1_mask_finor.fullPath();
+
+  edm::FileInPath f1_mask_veto("L1Trigger/L1TGlobal/data/Luminosity/" + menuDir + "/" + vetomaskFileName);
+  std::string m_vetomaskFile = f1_mask_veto.fullPath();
+
+  // XML payloads
+  std::string xmlPayload_prescale;
+  std::string xmlPayload_mask_algobx;
+  std::string xmlPayload_mask_finor;
+  std::string xmlPayload_mask_veto;
+
+  std::vector<std::vector<double> > prescales;
+  std::vector<unsigned int> triggerMasks;
+  std::vector<int> triggerVetoMasks;
+  std::map<int, std::vector<int> > triggerAlgoBxMaskAlgoTrig;
+
+  // Prescales
+  std::ifstream input_prescale;
+  input_prescale.open(m_prescaleFile);
+  if (not m_prescaleFile.empty() and not input_prescale) {
+    edm::LogError("L1TGlobalPrescalesVetosFractESProducer")
+        << "\nCould not find prescale file: " << m_prescaleFile
+        << "\nDeafulting to a single prescale column, with all prescales set to 1 (unprescaled)";
+
+    const int inputDefaultPrescale = 1;
+    // by default, fill a single prescale column
+    prescales.push_back(std::vector<double>(m_numberPhysTriggers, inputDefaultPrescale));
+  } else {
+    while (!input_prescale.eof()) {
+      string tmp;
+      getline(input_prescale, tmp, '\n');
+      xmlPayload_prescale.append(tmp);
+    }
+
+    l1t::XmlConfigParser xmlReader_prescale;
+    l1t::TriggerSystem ts_prescale;
+    ts_prescale.addProcessor("uGtProcessor", "uGtProcessor", "-1", "-1");
+
+    // run the parser
+    xmlReader_prescale.readDOMFromString(xmlPayload_prescale);  // initialize it
+    xmlReader_prescale.readRootElement(ts_prescale, "uGT");     // extract all of the relevant context
+    ts_prescale.setConfigured();
+
+    const std::map<std::string, l1t::Parameter>& settings_prescale = ts_prescale.getParameters("uGtProcessor");
+    std::map<std::string, unsigned int> prescaleColumns = settings_prescale.at("prescales").getColumnIndices();
+
+    unsigned int numColumns_prescale = prescaleColumns.size();
+
+    int NumPrescaleSets = numColumns_prescale - 1;
+    ///  there may be "missing" rows/bits in the xml description meaning that triggers are not unused, so go for max
+    std::vector<unsigned int> algoBits =
+        settings_prescale.at("prescales").getTableColumn<unsigned int>("algo/prescale-index");
+    int NumAlgos_prescale = *std::max_element(algoBits.begin(), algoBits.end()) + 1;
+
+    if (NumPrescaleSets > 0) {
+      // Fill default prescale set
+      for (int iSet = 0; iSet < NumPrescaleSets; iSet++) {
+        prescales.push_back(std::vector<double>());
+        for (int iBit = 0; iBit < NumAlgos_prescale; ++iBit) {
+          int inputDefaultPrescale = 0;  // only prescales that are set in the block below are used
+          prescales[iSet].push_back(inputDefaultPrescale);
+        }
+      }
+
+      for (auto& col : prescaleColumns) {
+        if (col.second < 1)
+          continue;  // we don't care for the algorithms' indicies in 0th column
+        int iSet = col.second - 1;
+        std::vector<double> prescalesForSet =
+            settings_prescale.at("prescales").getTableColumn<double>(col.first.c_str());
+        for (unsigned int row = 0; row < prescalesForSet.size(); row++) {
+          double prescale = prescalesForSet[row];
+          unsigned int algoBit = algoBits[row];
+          prescales[iSet][algoBit] = prescale;
+        }
+      }
+    }
+  }
+  input_prescale.close();
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // finor mask
+  // set all masks to 1 (unmasked) by default
+  triggerMasks.insert(triggerMasks.end(), m_numberPhysTriggers, 1);
+
+  std::ifstream input_mask_finor;
+  input_mask_finor.open(m_finormaskFile);
+  if (not m_finormaskFile.empty() and not input_mask_finor) {
+    edm::LogError("L1TGlobalPrescalesVetosFractESProducer")
+        << "\nCould not find finor mask file: " << m_finormaskFile
+        << "\nDeafulting the finor mask for all triggers to 1 (unmasked)";
+  } else {
+    while (!input_mask_finor.eof()) {
+      string tmp;
+      getline(input_mask_finor, tmp, '\n');
+      xmlPayload_mask_finor.append(tmp);
+    }
+
+    l1t::XmlConfigParser xmlReader_mask_finor;
+    l1t::TriggerSystem ts_mask_finor;
+    ts_mask_finor.addProcessor("uGtProcessor", "uGtProcessor", "-1", "-1");
+
+    // run the parser
+    xmlReader_mask_finor.readDOMFromString(xmlPayload_mask_finor);  // initialize it
+    xmlReader_mask_finor.readRootElement(ts_mask_finor, "uGT");     // extract all of the relevant context
+    ts_mask_finor.setConfigured();
+
+    const std::map<std::string, l1t::Parameter>& settings_mask_finor = ts_mask_finor.getParameters("uGtProcessor");
+
+    std::vector<unsigned int> algo_mask_finor =
+        settings_mask_finor.at("finorMask").getTableColumn<unsigned int>("algo");
+    std::vector<unsigned int> mask_mask_finor =
+        settings_mask_finor.at("finorMask").getTableColumn<unsigned int>("mask");
+
+    for (unsigned int row = 0; row < algo_mask_finor.size(); row++) {
+      unsigned int algoBit = algo_mask_finor[row];
+      unsigned int mask = mask_mask_finor[row];
+      if (algoBit < m_numberPhysTriggers)
+        triggerMasks[algoBit] = mask;
+    }
+  }
+  input_mask_finor.close();
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // veto mask
+  // Setting veto mask to default 0 (no veto)
+  for (unsigned int iAlg = 0; iAlg < m_numberPhysTriggers; iAlg++)
+    triggerVetoMasks.push_back(0);
+
+  std::ifstream input_mask_veto;
+  input_mask_veto.open(m_vetomaskFile);
+  if (not m_vetomaskFile.empty() and not input_mask_veto) {
+    edm::LogError("L1TGlobalPrescalesVetosFractESProducer")
+        << "\nCould not find veto mask file: " << m_vetomaskFile
+        << "\nDeafulting the veto mask for all triggers to 1 (unmasked)";
+  } else {
+    while (!input_mask_veto.eof()) {
+      string tmp;
+      getline(input_mask_veto, tmp, '\n');
+      xmlPayload_mask_veto.append(tmp);
+    }
+
+    l1t::XmlConfigParser xmlReader_mask_veto;
+    l1t::TriggerSystem ts_mask_veto;
+    ts_mask_veto.addProcessor("uGtProcessor", "uGtProcessor", "-1", "-1");
+
+    // run the parser
+    xmlReader_mask_veto.readDOMFromString(xmlPayload_mask_veto);  // initialize it
+    xmlReader_mask_veto.readRootElement(ts_mask_veto, "uGT");     // extract all of the relevant context
+    ts_mask_veto.setConfigured();
+
+    const std::map<std::string, l1t::Parameter>& settings_mask_veto = ts_mask_veto.getParameters("uGtProcessor");
+    std::vector<unsigned int> algo_mask_veto = settings_mask_veto.at("vetoMask").getTableColumn<unsigned int>("algo");
+    std::vector<unsigned int> veto_mask_veto = settings_mask_veto.at("vetoMask").getTableColumn<unsigned int>("veto");
+
+    for (unsigned int row = 0; row < algo_mask_veto.size(); row++) {
+      unsigned int algoBit = algo_mask_veto[row];
+      unsigned int veto = veto_mask_veto[row];
+      if (algoBit < m_numberPhysTriggers)
+        triggerVetoMasks[algoBit] = int(veto);
+    }
+  }
+  input_mask_veto.close();
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // Algo bx mask
+  std::ifstream input_mask_algobx;
+  input_mask_algobx.open(m_algobxmaskFile);
+  if (not m_algobxmaskFile.empty() and not input_mask_algobx) {
+    edm::LogError("L1TGlobalPrescalesVetosFractESProducer")
+        << "\nCould not find bx mask file: " << m_algobxmaskFile << "\nNot filling the bx mask map";
+  } else {
+    while (!input_mask_algobx.eof()) {
+      string tmp;
+      getline(input_mask_algobx, tmp, '\n');
+      xmlPayload_mask_algobx.append(tmp);
+    }
+
+    l1t::XmlConfigParser xmlReader_mask_algobx;
+    l1t::TriggerSystem ts_mask_algobx;
+    ts_mask_algobx.addProcessor("uGtProcessor", "uGtProcessor", "-1", "-1");
+
+    // run the parser
+    xmlReader_mask_algobx.readDOMFromString(xmlPayload_mask_algobx);  // initialize it
+    xmlReader_mask_algobx.readRootElement(ts_mask_algobx, "uGT");     // extract all of the relevant context
+    ts_mask_algobx.setConfigured();
+
+    const std::map<std::string, l1t::Parameter>& settings_mask_algobx = ts_mask_algobx.getParameters("uGtProcessor");
+    std::map<std::string, unsigned int> mask_algobx_columns =
+        settings_mask_algobx.at("algorithmBxMask").getColumnIndices();
+    std::vector<unsigned int> bunches =
+        settings_mask_algobx.at("algorithmBxMask").getTableColumn<unsigned int>("bx/algo");
+
+    unsigned int numCol_mask_algobx = mask_algobx_columns.size();
+
+    int NumAlgoBitsInMask = numCol_mask_algobx - 1;
+    for (int iBit = 0; iBit < NumAlgoBitsInMask; iBit++) {
+      std::vector<unsigned int> algo =
+          settings_mask_algobx.at("algorithmBxMask").getTableColumn<unsigned int>(std::to_string(iBit).c_str());
+      for (unsigned int bx = 0; bx < bunches.size(); bx++) {
+        if (algo[bx] != unsigned(m_bx_mask_default))
+          triggerAlgoBxMaskAlgoTrig[bunches[bx]].push_back(iBit);
+      }
+    }
+  }
+  input_mask_algobx.close();
+
+  // Set prescales to zero if masked
+  for (auto& prescale : prescales) {
+    for (unsigned int iBit = 0; iBit < prescale.size(); iBit++) {
+      // Add protection in case prescale table larger than trigger mask size
+      if (iBit >= triggerMasks.size()) {
+        edm::LogWarning("L1TGlobal") << "\nWarning: algoBit in prescale table >= triggerMasks.size() "
+                                     << "\nWarning: no information on masking bit or not, setting as unmasked "
+                                     << std::endl;
+      } else {
+        prescale[iBit] *= triggerMasks[iBit];
+      }
+    }
+  }
+
+  m_initialPrescaleFactorsAlgoTrig = prescales;
+  m_initialTriggerMaskAlgoTrig = triggerMasks;
+  m_initialTriggerMaskVetoAlgoTrig = triggerVetoMasks;
+  m_initialTriggerAlgoBxMaskAlgoTrig = triggerAlgoBxMaskAlgoTrig;
+}
+
+L1TGlobalPrescalesVetosFractESProducer::~L1TGlobalPrescalesVetosFractESProducer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+L1TGlobalPrescalesVetosFractESProducer::ReturnType L1TGlobalPrescalesVetosFractESProducer::produce(
+    const L1TGlobalPrescalesVetosFractRcd& iRecord) {
+  // configure the helper class parameters via its set funtions, e.g.:
+  data_.setBxMaskDefault(m_bx_mask_default);
+  data_.setPrescaleFactorTable(m_initialPrescaleFactorsAlgoTrig);
+  data_.setTriggerMaskVeto(m_initialTriggerMaskVetoAlgoTrig);
+  data_.setTriggerAlgoBxMask(m_initialTriggerAlgoBxMaskAlgoTrig);
+
+  if (m_verbosity) {
+    LogDebug("L1TGlobal") << " ====> Prescales table <=== " << std::endl;
+    for (unsigned int ix = 0; ix < m_initialPrescaleFactorsAlgoTrig.size(); ix++) {
+      LogDebug("L1TGlobal") << " Prescale set = " << ix << std::endl;
+      for (unsigned int iy = 0; iy < m_initialPrescaleFactorsAlgoTrig[ix].size(); iy++) {
+        LogDebug("L1TGlobal") << "\t Algo " << iy << ": " << m_initialPrescaleFactorsAlgoTrig[ix][iy] << std::endl;
+      }
+    }
+
+    LogDebug("L1TGlobal") << " ====> Trigger mask veto <=== " << std::endl;
+    for (unsigned int ix = 0; ix < m_initialTriggerMaskVetoAlgoTrig.size(); ix++) {
+      LogDebug("L1TGlobal") << "\t Algo " << ix << ": " << m_initialTriggerMaskVetoAlgoTrig[ix] << std::endl;
+    }
+
+    LogDebug("L1TGlobal") << " ====> Algo bx mask <=== " << std::endl;
+    if (m_initialTriggerAlgoBxMaskAlgoTrig.empty())
+      LogDebug("L1TGlobal") << "\t(empty map)" << std::endl;
+    for (auto& it : m_initialTriggerAlgoBxMaskAlgoTrig) {
+      LogDebug("L1TGlobal") << " bx = " << it.first << " : iAlg =";
+      std::vector<int> masked = it.second;
+      for (int& iAlg : masked) {
+        LogDebug("L1TGlobal") << " " << iAlg;
+      }
+      LogDebug("L1TGlobal") << " " << std::endl;
+    }
+  }
+
+  // Return copy so that we don't give away our owned pointer to framework
+  return std::make_unique<L1TGlobalPrescalesVetosFract>(*data_.getWriteInstance());
+}
+
+//define this as a plug-in
+DEFINE_FWK_EVENTSETUP_MODULE(L1TGlobalPrescalesVetosFractESProducer);

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -81,7 +81,6 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.addUntracked<int>("Verbosity", 0);
   desc.addUntracked<bool>("PrintL1Menu", false);
   desc.add<std::string>("TriggerMenuLuminosity", "startup");
-  desc.add<std::string>("PrescaleCSVFile", "prescale_L1TGlobal.csv");
   descriptions.add("L1TGlobalProducer", desc);
 }
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -98,9 +98,6 @@ private:
   const std::vector<std::vector<double>>* m_prescaleFactorsAlgoTrig;
   std::vector<std::vector<double>> m_initialPrescaleFactorsAlgoTrig;
 
-  /// CSV file for prescales
-  std::string m_prescalesFile;
-
   uint m_currentLumi;
 
   /// trigger masks & veto masks

--- a/L1Trigger/L1TGlobal/python/PrescalesVetosFract_cff.py
+++ b/L1Trigger/L1TGlobal/python/PrescalesVetosFract_cff.py
@@ -1,0 +1,24 @@
+#
+# WARNING: This file is in the L1T configuration critical path.
+#
+# All changes must be explicitly discussed with the L1T offline coordinator.
+#
+import FWCore.ParameterSet.Config as cms
+
+L1TGlobalPrescalesVetosFractRcdSource = cms.ESSource("EmptyESSource",
+    recordName = cms.string('L1TGlobalPrescalesVetosFractRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+
+L1TGlobalPrescalesVetosFract = cms.ESProducer("L1TGlobalPrescalesVetosFractESProducer",
+    TriggerMenuLuminosity = cms.string('startup'),
+    Verbosity = cms.int32(0),
+    AlgoBxMaskDefault = cms.int32(1),
+    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_v11.xml'),
+    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_V1.xml'),
+    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_v17.xml'),
+    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_v1.xml'),
+
+)

--- a/L1Trigger/L1TGlobal/python/hackConditions_cff.py
+++ b/L1Trigger/L1TGlobal/python/hackConditions_cff.py
@@ -31,5 +31,6 @@ def _load(process, fs):
 modifyL1TGlobalHackConditions_stage2 = stage2L1Trigger.makeProcessModifier(lambda p: _load(p, [
     "L1Trigger.L1TGlobal.GlobalParameters_cff",
     "L1Trigger.L1TGlobal.PrescalesVetos_cff",
+    "L1Trigger.L1TGlobal.PrescalesVetosFract_cff",
 #   "L1Trigger.L1TGlobal.TriggerMenu_cff"
 ]))

--- a/L1Trigger/L1TGlobal/test/l1tGlobalEmulation_FromDigi.py
+++ b/L1Trigger/L1TGlobal/test/l1tGlobalEmulation_FromDigi.py
@@ -105,7 +105,6 @@ process.es_prefer_l1GtParameters = cms.ESPrefer('l1t::TriggerMenuXmlProducer','T
 process.load('L1Trigger.L1TGlobal.simGlobalStage2Digis_cff')
 process.simGlobalStage2Digis.caloInputTag = cms.InputTag("gtStage2Digis","GT")
 process.simGlobalStage2Digis.GmtInputTag = cms.InputTag("gtStage2Digis","GT")
-process.simGlobalStage2Digis.PrescaleCSVFile = cms.string('prescale_L1TGlobal.csv')
 process.simGlobalStage2Digis.PrescaleSet = cms.uint32(1)
 process.simGlobalStage2Digis.Verbosity = cms.untracked.int32(0)
 

--- a/L1Trigger/L1TGlobal/test/l1tGlobalEmulation_FromRAW.py
+++ b/L1Trigger/L1TGlobal/test/l1tGlobalEmulation_FromRAW.py
@@ -202,7 +202,6 @@ process.load('L1Trigger.L1TGlobal.simGlobalStage2Digis_cff')
 process.simGlobalStage2Digis.caloInputTag = cms.InputTag("gtStage2Digis","GT")
 process.simGlobalStage2Digis.GmtInputTag = cms.InputTag("gtStage2Digis","GT")
 process.simGlobalStage2Digis.extInputTag = cms.InputTag("gtStage2Digis","GT")
-process.simGlobalStage2Digis.PrescaleCSVFile = cms.string('prescale_L1TGlobal.csv')
 process.simGlobalStage2Digis.PrescaleSet = cms.uint32(1)
 process.simGlobalStage2Digis.Verbosity = cms.untracked.int32(0)
 

--- a/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
+++ b/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
@@ -230,7 +230,6 @@ process.simGtExtFakeProd.setBptxOR    = cms.bool(True)
 
 ## Run the Stage 2 uGT emulator
 process.load('L1Trigger.L1TGlobal.simGtStage2Digis_cfi')
-process.simGtStage2Digis.PrescaleCSVFile = cms.string('prescale_L1TGlobal.csv')
 process.simGtStage2Digis.PrescaleSet = cms.uint32(1)
 process.simGtStage2Digis.ExtInputTag = cms.InputTag("simGtExtFakeProd")
 process.simGtStage2Digis.MuonInputTag = cms.InputTag("gtInput")


### PR DESCRIPTION
#### PR description:

(looks like I messed up with the push force on the previous PR https://github.com/cms-sw/cmssw/pull/37040/ so just restarting from scratch) 

This PR adds a new EventSetup producer producing L1TGlobalPrescalesVetosFractRcd (the L1 prescale table), a record similar to the previous L1TGlobalPrescalesVetosRcd which is not in use anymore.

This producer is used to overwrite the prescale table (with the help of two dedicated config files) and this update is rather urgently needed for trigger studies at L1 and HLT.

We also take this opportunity to drop from L1TGlobalProducer an unused (and quite confusing) parameter supposed to provide a prescale table in CSV format which is actually not used.

#### PR validation:
Tested with wf 11834.0 which includes DIGI/L1/DIGI2RAW/HLT steps.
The use of the producer was tested and allowed to modify L1 prescales as expected.
 

 
