### PR TITLE
Updated the PPS PCL workers to support the new AlCaRecoProducer

### DIFF
--- a/CalibPPS/AlignmentGlobal/plugins/PPSAlignmentWorker.cc
+++ b/CalibPPS/AlignmentGlobal/plugins/PPSAlignmentWorker.cc
@@ -88,17 +88,17 @@ private:
   };
 
   // ------------ member data ------------
-  edm::ESGetToken<PPSAlignmentConfiguration, PPSAlignmentConfigurationRcd> esTokenBookHistograms_;
-  edm::ESGetToken<PPSAlignmentConfiguration, PPSAlignmentConfigurationRcd> esTokenAnalyze_;
+  const edm::ESGetToken<PPSAlignmentConfiguration, PPSAlignmentConfigurationRcd> esTokenBookHistograms_;
+  const edm::ESGetToken<PPSAlignmentConfiguration, PPSAlignmentConfigurationRcd> esTokenAnalyze_;
 
-  std::vector<edm::InputTag> tracksTags_;
+  const std::vector<edm::InputTag> tracksTags_;
   std::vector<edm::EDGetTokenT<CTPPSLocalTrackLiteCollection>> tracksTokens_;
 
   SectorData sectorData45_;
   SectorData sectorData56_;
 
-  std::string dqmDir_;
-  bool debug_;
+  const std::string dqmDir_;
+  const bool debug_;
 };
 
 // -------------------------------- DQMEDAnalyzer methods --------------------------------

--- a/CalibPPS/AlignmentGlobal/plugins/PPSAlignmentWorker.cc
+++ b/CalibPPS/AlignmentGlobal/plugins/PPSAlignmentWorker.cc
@@ -91,7 +91,8 @@ private:
   edm::ESGetToken<PPSAlignmentConfiguration, PPSAlignmentConfigurationRcd> esTokenBookHistograms_;
   edm::ESGetToken<PPSAlignmentConfiguration, PPSAlignmentConfigurationRcd> esTokenAnalyze_;
 
-  edm::EDGetTokenT<CTPPSLocalTrackLiteCollection> tracksToken_;
+  std::vector<edm::InputTag> tracksTags_;
+  std::vector<edm::EDGetTokenT<CTPPSLocalTrackLiteCollection>> tracksTokens_;
 
   SectorData sectorData45_;
   SectorData sectorData56_;
@@ -108,16 +109,23 @@ PPSAlignmentWorker::PPSAlignmentWorker(const edm::ParameterSet& iConfig)
               edm::ESInputTag("", iConfig.getParameter<std::string>("label")))),
       esTokenAnalyze_(esConsumes<PPSAlignmentConfiguration, PPSAlignmentConfigurationRcd>(
           edm::ESInputTag("", iConfig.getParameter<std::string>("label")))),
-      tracksToken_(consumes<CTPPSLocalTrackLiteCollection>(iConfig.getParameter<edm::InputTag>("tagTracks"))),
+      tracksTags_(iConfig.getParameter<std::vector<edm::InputTag>>("tracksTags")),
       dqmDir_(iConfig.getParameter<std::string>("dqm_dir")),
       debug_(iConfig.getParameter<bool>("debug")) {
   edm::LogInfo("PPSAlignmentWorker").log([&](auto& li) {
     li << "parameters:\n";
     li << "* label: " << iConfig.getParameter<std::string>("label") << "\n";
-    li << "* tagTracks: " << iConfig.getParameter<edm::InputTag>("tagTracks") << "\n";
+    li << "* tracksTags:\n";
+    for (auto& tag : tracksTags_) {
+      li << "    " << tag << ",\n";
+    }
     li << "* dqm_dir: " << dqmDir_ << "\n";
     li << "* debug: " << std::boolalpha << debug_;
   });
+
+  for (auto& tag : tracksTags_) {
+    tracksTokens_.emplace_back(consumes<CTPPSLocalTrackLiteCollection>(tag));
+  }
 }
 
 void PPSAlignmentWorker::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&, edm::EventSetup const& iSetup) {
@@ -128,7 +136,20 @@ void PPSAlignmentWorker::bookHistograms(DQMStore::IBooker& iBooker, edm::Run con
 }
 
 void PPSAlignmentWorker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  const auto& tracks = iEvent.get(tracksToken_);
+  CTPPSLocalTrackLiteCollection tracks;
+  bool foundProduct = false;
+
+  for (unsigned int i = 0; i < tracksTokens_.size(); i++) {
+    if (auto handle = iEvent.getHandle(tracksTokens_[i])) {
+      tracks = *handle;
+      foundProduct = true;
+      edm::LogInfo("PPSAlignmentWorker") << "Found a product with " << tracksTags_[i];
+      break;
+    }
+  }
+  if (!foundProduct) {
+    throw edm::Exception(edm::errors::ProductNotFound) << "Could not find a product with any of the selected labels.";
+  }
 
   const auto& cfg = iSetup.getData(esTokenAnalyze_);
 
@@ -140,7 +161,7 @@ void PPSAlignmentWorker::fillDescriptions(edm::ConfigurationDescriptions& descri
   edm::ParameterSetDescription desc;
 
   desc.add<std::string>("label", "");
-  desc.add<edm::InputTag>("tagTracks", edm::InputTag("ctppsLocalTrackLiteProducer"));
+  desc.add<std::vector<edm::InputTag>>("tracksTags", {edm::InputTag("ctppsLocalTrackLiteProducer")});
   desc.add<std::string>("dqm_dir", "AlCaReco/PPSAlignment");
   desc.add<bool>("debug", false);
 

--- a/CalibPPS/AlignmentGlobal/python/ALCARECOPromptCalibProdPPSAlignment_cff.py
+++ b/CalibPPS/AlignmentGlobal/python/ALCARECOPromptCalibProdPPSAlignment_cff.py
@@ -1,6 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
-from CalibPPS.AlignmentGlobal.ppsAlignmentWorker_cfi import ppsAlignmentWorker
+from CalibPPS.AlignmentGlobal.ppsAlignmentWorker_cfi import ppsAlignmentWorker as ppsAlignmentWorker_
+
+ppsAlignmentWorker = ppsAlignmentWorker_.clone()
+ppsAlignmentWorker.tracksTags = cms.VInputTag(
+    cms.InputTag("ctppsLocalTrackLiteProducer"),
+    cms.InputTag("ctppsLocalTrackLiteProducerAlCaRecoProducer")
+)
 
 MEtoEDMConvertPPSAlignment = cms.EDProducer('MEtoEDMConverter',
     Name=cms.untracked.string('MEtoEDMConverter'),

--- a/CalibPPS/TimingCalibration/plugins/PPSDiamondSampicTimingCalibrationPCLWorker.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSDiamondSampicTimingCalibrationPCLWorker.cc
@@ -69,14 +69,14 @@ private:
                         edm::Handle<T>& handle) const;
 
   // ------------ member data ------------
-  std::vector<edm::InputTag> digiTags_;
-  std::vector<edm::InputTag> RecHitTags_;
+  const std::vector<edm::InputTag> digiTags_;
+  const std::vector<edm::InputTag> RecHitTags_;
 
   std::vector<edm::EDGetTokenT<edm::DetSetVector<TotemTimingDigi>>> totemTimingDigiTokens_;
   std::vector<edm::EDGetTokenT<edm::DetSetVector<TotemTimingRecHit>>> totemTimingRecHitTokens_;
 
-  edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> geomEsToken_;
-  std::string folder_;
+  const edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> geomEsToken_;
+  const std::string folder_;
 };
 
 //------------------------------------------------------------------------------

--- a/CalibPPS/TimingCalibration/plugins/PPSDiamondSampicTimingCalibrationPCLWorker.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSDiamondSampicTimingCalibrationPCLWorker.cc
@@ -61,10 +61,12 @@ private:
   void dqmAnalyze(edm::Event const&,
                   edm::EventSetup const&,
                   Histograms_PPSDiamondSampicTimingCalibrationPCLWorker const&) const override;
-  
-  template<typename T>
-  bool searchForProduct(edm::Event const& iEvent, const std::vector<edm::EDGetTokenT<T>>& tokens, 
-                        const std::vector<edm::InputTag>& tags, edm::Handle<T>& handle) const;
+
+  template <typename T>
+  bool searchForProduct(edm::Event const& iEvent,
+                        const std::vector<edm::EDGetTokenT<T>>& tokens,
+                        const std::vector<edm::InputTag>& tags,
+                        edm::Handle<T>& handle) const;
 
   // ------------ member data ------------
   std::vector<edm::InputTag> digiTags_;
@@ -84,13 +86,10 @@ PPSDiamondSampicTimingCalibrationPCLWorker::PPSDiamondSampicTimingCalibrationPCL
       RecHitTags_(iConfig.getParameter<std::vector<edm::InputTag>>("totemTimingRecHitTags")),
       geomEsToken_(esConsumes<edm::Transition::BeginRun>()),
       folder_(iConfig.getParameter<std::string>("folder")) {
-
-      for (auto& tag : digiTags_)
-        totemTimingDigiTokens_.push_back(consumes<edm::DetSetVector<TotemTimingDigi>>(tag));
-      for (auto& tag : RecHitTags_)
-        totemTimingRecHitTokens_.push_back(consumes<edm::DetSetVector<TotemTimingRecHit>>(tag));
-
-
+  for (auto& tag : digiTags_)
+    totemTimingDigiTokens_.push_back(consumes<edm::DetSetVector<TotemTimingDigi>>(tag));
+  for (auto& tag : RecHitTags_)
+    totemTimingRecHitTokens_.push_back(consumes<edm::DetSetVector<TotemTimingRecHit>>(tag));
 }
 
 PPSDiamondSampicTimingCalibrationPCLWorker::~PPSDiamondSampicTimingCalibrationPCLWorker() {}
@@ -101,7 +100,6 @@ void PPSDiamondSampicTimingCalibrationPCLWorker::dqmAnalyze(
     edm::Event const& iEvent,
     edm::EventSetup const& iSetup,
     Histograms_PPSDiamondSampicTimingCalibrationPCLWorker const& histos) const {
-
   edm::Handle<edm::DetSetVector<TotemTimingDigi>> timingDigi;
   edm::Handle<edm::DetSetVector<TotemTimingRecHit>> timingRecHit;
 
@@ -170,23 +168,24 @@ void PPSDiamondSampicTimingCalibrationPCLWorker::fillDescriptions(edm::Configura
 
 //------------------------------------------------------------------------------
 
-template<typename T>
-bool PPSDiamondSampicTimingCalibrationPCLWorker::searchForProduct(edm::Event const& iEvent, const std::vector<edm::EDGetTokenT<T>>& tokens, 
-                                                                  const std::vector<edm::InputTag>& tags, edm::Handle<T>& handle) const{
+template <typename T>
+bool PPSDiamondSampicTimingCalibrationPCLWorker::searchForProduct(edm::Event const& iEvent,
+                                                                  const std::vector<edm::EDGetTokenT<T>>& tokens,
+                                                                  const std::vector<edm::InputTag>& tags,
+                                                                  edm::Handle<T>& handle) const {
   bool foundProduct = false;
   for (unsigned int i = 0; i < tokens.size(); i++)
     if (auto h = iEvent.getHandle(tokens[i])) {
-      handle=h;
+      handle = h;
       foundProduct = true;
       edm::LogInfo("searchForProduct") << "Found a product with " << tags[i];
       break;
     }
-  
+
   if (!foundProduct)
     throw edm::Exception(edm::errors::ProductNotFound) << "Could not find a product with any of the selected labels.";
 
   return foundProduct;
-  
 }
 
 DEFINE_FWK_MODULE(PPSDiamondSampicTimingCalibrationPCLWorker);

--- a/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLWorker.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLWorker.cc
@@ -41,9 +41,11 @@ private:
                       const edm::EventSetup&,
                       TimingCalibrationHistograms&) const override;
 
-  template<typename T>
-  bool searchForProduct(edm::Event const& iEvent, const std::vector<edm::EDGetTokenT<T>>& tokens, 
-                    const std::vector<edm::InputTag>& tags, edm::Handle<T>& handle) const;
+  template <typename T>
+  bool searchForProduct(edm::Event const& iEvent,
+                        const std::vector<edm::EDGetTokenT<T>>& tokens,
+                        const std::vector<edm::InputTag>& tags,
+                        edm::Handle<T>& handle) const;
 
   std::vector<edm::InputTag> RecHitTags_;
   std::vector<edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondRecHit>>> diamondRecHitTokens_;
@@ -58,11 +60,8 @@ PPSTimingCalibrationPCLWorker::PPSTimingCalibrationPCLWorker(const edm::Paramete
     : RecHitTags_(iConfig.getParameter<std::vector<edm::InputTag>>("diamondRecHitTags")),
       geomEsToken_(esConsumes<edm::Transition::BeginRun>()),
       dqmDir_(iConfig.getParameter<std::string>("dqmDir")) {
-
-
-
-      for (auto& tag : RecHitTags_)
-        diamondRecHitTokens_.push_back(consumes<edm::DetSetVector<CTPPSDiamondRecHit>>(tag));
+  for (auto& tag : RecHitTags_)
+    diamondRecHitTokens_.push_back(consumes<edm::DetSetVector<CTPPSDiamondRecHit>>(tag));
 }
 
 //------------------------------------------------------------------------------
@@ -95,7 +94,6 @@ void PPSTimingCalibrationPCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
 void PPSTimingCalibrationPCLWorker::dqmAnalyze(const edm::Event& iEvent,
                                                const edm::EventSetup& iSetup,
                                                const TimingCalibrationHistograms& iHists) const {
-
   edm::Handle<edm::DetSetVector<CTPPSDiamondRecHit>> dsv_rechits;
   // then extract the rechits information for later processing
   searchForProduct(iEvent, diamondRecHitTokens_, RecHitTags_, dsv_rechits);
@@ -135,23 +133,24 @@ void PPSTimingCalibrationPCLWorker::fillDescriptions(edm::ConfigurationDescripti
   descriptions.addWithDefaultLabel(desc);
 }
 
-template<typename T>
-bool PPSTimingCalibrationPCLWorker::searchForProduct(edm::Event const& iEvent, const std::vector<edm::EDGetTokenT<T>>& tokens, 
-                                                                  const std::vector<edm::InputTag>& tags, edm::Handle<T>& handle) const{
+template <typename T>
+bool PPSTimingCalibrationPCLWorker::searchForProduct(edm::Event const& iEvent,
+                                                     const std::vector<edm::EDGetTokenT<T>>& tokens,
+                                                     const std::vector<edm::InputTag>& tags,
+                                                     edm::Handle<T>& handle) const {
   bool foundProduct = false;
   for (unsigned int i = 0; i < tokens.size(); i++)
     if (auto h = iEvent.getHandle(tokens[i])) {
-      handle=h;
+      handle = h;
       foundProduct = true;
       edm::LogInfo("searchForProduct") << "Found a product with " << tags[i];
       break;
     }
-  
+
   if (!foundProduct)
     throw edm::Exception(edm::errors::ProductNotFound) << "Could not find a product with any of the selected labels.";
 
   return foundProduct;
-  
 }
 
 DEFINE_FWK_MODULE(PPSTimingCalibrationPCLWorker);

--- a/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLWorker.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLWorker.cc
@@ -47,9 +47,9 @@ private:
                         const std::vector<edm::InputTag>& tags,
                         edm::Handle<T>& handle) const;
 
-  std::vector<edm::InputTag> RecHitTags_;
+  const std::vector<edm::InputTag> RecHitTags_;
   std::vector<edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondRecHit>>> diamondRecHitTokens_;
-  edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> geomEsToken_;
+  const edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> geomEsToken_;
 
   const std::string dqmDir_;
 };

--- a/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLWorker.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLWorker.cc
@@ -41,7 +41,12 @@ private:
                       const edm::EventSetup&,
                       TimingCalibrationHistograms&) const override;
 
-  edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondRecHit>> diamondRecHitToken_;
+  template<typename T>
+  bool searchForProduct(edm::Event const& iEvent, const std::vector<edm::EDGetTokenT<T>>& tokens, 
+                    const std::vector<edm::InputTag>& tags, edm::Handle<T>& handle) const;
+
+  std::vector<edm::InputTag> RecHitTags_;
+  std::vector<edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondRecHit>>> diamondRecHitTokens_;
   edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> geomEsToken_;
 
   const std::string dqmDir_;
@@ -50,10 +55,15 @@ private:
 //------------------------------------------------------------------------------
 
 PPSTimingCalibrationPCLWorker::PPSTimingCalibrationPCLWorker(const edm::ParameterSet& iConfig)
-    : diamondRecHitToken_(
-          consumes<edm::DetSetVector<CTPPSDiamondRecHit>>(iConfig.getParameter<edm::InputTag>("diamondRecHitTag"))),
+    : RecHitTags_(iConfig.getParameter<std::vector<edm::InputTag>>("diamondRecHitTags")),
       geomEsToken_(esConsumes<edm::Transition::BeginRun>()),
-      dqmDir_(iConfig.getParameter<std::string>("dqmDir")) {}
+      dqmDir_(iConfig.getParameter<std::string>("dqmDir")) {
+
+
+
+      for (auto& tag : RecHitTags_)
+        diamondRecHitTokens_.push_back(consumes<edm::DetSetVector<CTPPSDiamondRecHit>>(tag));
+}
 
 //------------------------------------------------------------------------------
 
@@ -85,9 +95,11 @@ void PPSTimingCalibrationPCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
 void PPSTimingCalibrationPCLWorker::dqmAnalyze(const edm::Event& iEvent,
                                                const edm::EventSetup& iSetup,
                                                const TimingCalibrationHistograms& iHists) const {
-  // then extract the rechits information for later processing
+
   edm::Handle<edm::DetSetVector<CTPPSDiamondRecHit>> dsv_rechits;
-  iEvent.getByToken(diamondRecHitToken_, dsv_rechits);
+  // then extract the rechits information for later processing
+  searchForProduct(iEvent, diamondRecHitTokens_, RecHitTags_, dsv_rechits);
+
   // ensure timing detectors rechits are found in the event content
   if (dsv_rechits->empty()) {
     edm::LogWarning("PPSTimingCalibrationPCLWorker:dqmAnalyze") << "No rechits retrieved from the event content.";
@@ -115,12 +127,31 @@ void PPSTimingCalibrationPCLWorker::dqmAnalyze(const edm::Event& iEvent,
 
 void PPSTimingCalibrationPCLWorker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("diamondRecHitTag", edm::InputTag("ctppsDiamondUncalibRecHits"))
+  desc.add<std::vector<edm::InputTag>>("diamondRecHitTags", {edm::InputTag("ctppsDiamondRecHits")})
       ->setComment("input tag for the PPS diamond detectors rechits");
   desc.add<std::string>("dqmDir", "AlCaReco/PPSTimingCalibrationPCL")
       ->setComment("output path for the various DQM plots");
 
   descriptions.addWithDefaultLabel(desc);
+}
+
+template<typename T>
+bool PPSTimingCalibrationPCLWorker::searchForProduct(edm::Event const& iEvent, const std::vector<edm::EDGetTokenT<T>>& tokens, 
+                                                                  const std::vector<edm::InputTag>& tags, edm::Handle<T>& handle) const{
+  bool foundProduct = false;
+  for (unsigned int i = 0; i < tokens.size(); i++)
+    if (auto h = iEvent.getHandle(tokens[i])) {
+      handle=h;
+      foundProduct = true;
+      edm::LogInfo("searchForProduct") << "Found a product with " << tags[i];
+      break;
+    }
+  
+  if (!foundProduct)
+    throw edm::Exception(edm::errors::ProductNotFound) << "Could not find a product with any of the selected labels.";
+
+  return foundProduct;
+  
 }
 
 DEFINE_FWK_MODULE(PPSTimingCalibrationPCLWorker);

--- a/CalibPPS/TimingCalibration/python/ALCARECOPPSCalTrackBasedSel_Output_cff.py
+++ b/CalibPPS/TimingCalibration/python/ALCARECOPPSCalTrackBasedSel_Output_cff.py
@@ -7,7 +7,9 @@ OutALCARECOPPSCalTrackBasedSel_noDrop = cms.PSet(
     outputCommands = cms.untracked.vstring(
         'keep *_ALCARECOPPSCalTrackBasedSel_*_*',
         'keep *_ctppsDiamondRawToDigi_*_*',
+        'keep *_ctppsDiamondRecHits_*_*',
         'keep *_totemTimingRawToDigi_*_*',
+        'keep *_totemTimingRecHits_*_*',
         'keep *_ctppsLocalTrackLiteProducer_*_*'
     )
 )

--- a/CalibPPS/TimingCalibration/python/ALCARECOPromptCalibProdPPSDiamondSampicTimingCalib_cff.py
+++ b/CalibPPS/TimingCalibration/python/ALCARECOPromptCalibProdPPSDiamondSampicTimingCalib_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoPPS.Configuration.recoCTPPS_cff import diamondSampicLocalReconstructionTask
 from CalibPPS.TimingCalibration.PPSDiamondSampicTimingCalibrationPCLWorker_cfi import PPSDiamondSampicTimingCalibrationPCLWorker
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
@@ -10,9 +9,14 @@ MEtoEDMConvertPPSDiamondSampicTimingCalib = cms.EDProducer('MEtoEDMConverter',
     Frequency = cms.untracked.int32(50),
     MEPathToSave = cms.untracked.string('AlCaReco/PPSDiamondSampicTimingCalibrationPCL')
 )
+    
+PPSDiamondSampicTimingCalibrationPCLWorker.totemTimingDigiTags=cms.VInputTag(cms.InputTag("totemTimingRawToDigiAlCaRecoProducer","TotemTiming"),
+                                         			  cms.InputTag("totemTimingRawToDigi","TotemTiming"))
+                                         			  
+PPSDiamondSampicTimingCalibrationPCLWorker.totemTimingRecHitTags=cms.VInputTag(cms.InputTag("totemTimingRecHitsAlCaRecoProducer"),
+                                                  		    cms.InputTag("totemTimingRecHits"))
 
 taskALCARECOPromptCalibProdPPSDiamondSampicTimingCalib = cms.Task(
-    diamondSampicLocalReconstructionTask,
     PPSDiamondSampicTimingCalibrationPCLWorker,
     MEtoEDMConvertPPSDiamondSampicTimingCalib
 )

--- a/CalibPPS/TimingCalibration/python/ALCARECOPromptCalibProdPPSTimingCalib_cff.py
+++ b/CalibPPS/TimingCalibration/python/ALCARECOPromptCalibProdPPSTimingCalib_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoPPS.Configuration.recoCTPPS_cff import ctppsDiamondRecHits as _ctppsDiamondRecHits
 from CalibPPS.TimingCalibration.ppsTimingCalibrationPCLWorker_cfi import ppsTimingCalibrationPCLWorker
 
 MEtoEDMConvertPPSTimingCalib = cms.EDProducer('MEtoEDMConverter',
@@ -11,18 +10,10 @@ MEtoEDMConvertPPSTimingCalib = cms.EDProducer('MEtoEDMConverter',
     deleteAfterCopy = cms.untracked.bool(True),
 )
 
-# calibrated rechits/tracks
-ctppsDiamondUncalibRecHits = _ctppsDiamondRecHits.clone(
-    applyCalibration = False
-)
-# this task will be updated to include tracking based on the last
-# calibration values to extract per-channel timing precision estimation
-recoDiamondUncalibLocalReconstructionTask = cms.Task(
-    ctppsDiamondUncalibRecHits,
-)
+ppsTimingCalibrationPCLWorker.diamondRecHitTags=cms.VInputTag(cms.InputTag("ctppsDiamondRecHitsAlCaRecoProducer"),
+                                         			  cms.InputTag("ctppsDiamondRecHits"))
 
 taskALCARECOPromptCalibProdPPSTimingCalib = cms.Task(
-    recoDiamondUncalibLocalReconstructionTask,
     ppsTimingCalibrationPCLWorker,
     MEtoEDMConvertPPSTimingCalib
 )


### PR DESCRIPTION
#### PR description:

This PR modifies the way the PCL workers (alignment, timing, sampic timing) handle consuming input products. Single InputTags have been replaced with vectors of InputTags so that the workers could work both with the old producer and with the new producer introduced in https://github.com/cms-sw/cmssw/pull/36273.

By default, the behaviour of the workers is unchanged - the vectors contain only one element. The PCL configs modify these vectors to contain the InputTags required by the new producer as well.

In the case of the timing PCLs, the re-reconstruction of the recHits was dropped, and the old producer was modified to supply the recHits directly. It shouldn't cause any change in terms of the produced results.

#### PR validation:

- no changes in the relvals (1041, 1042)
- no changes in the results of some local tests
- The multi-InputTag policy works as expected - the PCL workers accept the files produced by the old producer and the files produced by the new producer.