### PR TITLE
DAQ - fixing streamer count of HLT paths with the GlobalEvFOutputModule (12_3_X)

### DIFF
--- a/EventFilter/Utilities/interface/EvFOutputModule.h
+++ b/EventFilter/Utilities/interface/EvFOutputModule.h
@@ -48,7 +48,8 @@ namespace evf {
   public:
     EvFOutputJSONWriter(edm::ParameterSet const& ps,
                         edm::SelectedProducts const* selections,
-                        std::string const& streamLabel);
+                        std::string const& streamLabel,
+                        std::string const& moduleLabel);
 
     edm::StreamerOutputModuleCommon streamerCommon_;
 

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -290,14 +290,14 @@ namespace evf {
   }
 
   std::unique_ptr<edm::StreamerOutputModuleCommon> GlobalEvFOutputModule::beginStream(edm::StreamID) const {
-    return std::make_unique<edm::StreamerOutputModuleCommon>(ps_, &keptProducts()[edm::InEvent]);
+    return std::make_unique<edm::StreamerOutputModuleCommon>(ps_, &keptProducts()[edm::InEvent], description().moduleLabel());
   }
 
   std::shared_ptr<GlobalEvFOutputJSONDef> GlobalEvFOutputModule::globalBeginRun(edm::RunForOutput const& run) const {
     //create run Cache holding JSON file writer and variables
     auto jsonDef = std::make_unique<GlobalEvFOutputJSONDef>();
 
-    edm::StreamerOutputModuleCommon streamerCommon(ps_, &keptProducts()[edm::InEvent]);
+    edm::StreamerOutputModuleCommon streamerCommon(ps_, &keptProducts()[edm::InEvent], description().moduleLabel());
 
     //output INI file (non-const). This doesn't require globalBeginRun to be finished
     const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(streamLabel_);

--- a/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
+++ b/EventFilter/Utilities/plugins/GlobalEvFOutputModule.cc
@@ -290,7 +290,8 @@ namespace evf {
   }
 
   std::unique_ptr<edm::StreamerOutputModuleCommon> GlobalEvFOutputModule::beginStream(edm::StreamID) const {
-    return std::make_unique<edm::StreamerOutputModuleCommon>(ps_, &keptProducts()[edm::InEvent], description().moduleLabel());
+    return std::make_unique<edm::StreamerOutputModuleCommon>(
+        ps_, &keptProducts()[edm::InEvent], description().moduleLabel());
   }
 
   std::shared_ptr<GlobalEvFOutputJSONDef> GlobalEvFOutputModule::globalBeginRun(edm::RunForOutput const& run) const {

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -149,7 +149,8 @@ namespace evf {
 
   void EvFOutputModule::beginRun(edm::RunForOutput const& run) {
     //create run Cache holding JSON file writer and variables
-    jsonWriter_ = std::make_unique<EvFOutputJSONWriter>(ps_, &keptProducts()[edm::InEvent], streamLabel_, description().moduleLabel());
+    jsonWriter_ = std::make_unique<EvFOutputJSONWriter>(
+        ps_, &keptProducts()[edm::InEvent], streamLabel_, description().moduleLabel());
 
     //output INI file (non-const). This doesn't require globalBeginRun to be finished
     const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(streamLabel_);

--- a/EventFilter/Utilities/src/EvFOutputModule.cc
+++ b/EventFilter/Utilities/src/EvFOutputModule.cc
@@ -26,8 +26,9 @@ namespace evf {
 
   EvFOutputJSONWriter::EvFOutputJSONWriter(edm::ParameterSet const& ps,
                                            edm::SelectedProducts const* selections,
-                                           std::string const& streamLabel)
-      : streamerCommon_(ps, selections),
+                                           std::string const& streamLabel,
+                                           std::string const& moduleLabel)
+      : streamerCommon_(ps, selections, moduleLabel),
         processed_(0),
         accepted_(0),
         errorEvents_(0),
@@ -148,7 +149,7 @@ namespace evf {
 
   void EvFOutputModule::beginRun(edm::RunForOutput const& run) {
     //create run Cache holding JSON file writer and variables
-    jsonWriter_ = std::make_unique<EvFOutputJSONWriter>(ps_, &keptProducts()[edm::InEvent], streamLabel_);
+    jsonWriter_ = std::make_unique<EvFOutputJSONWriter>(ps_, &keptProducts()[edm::InEvent], streamLabel_, description().moduleLabel());
 
     //output INI file (non-const). This doesn't require globalBeginRun to be finished
     const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(streamLabel_);

--- a/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
@@ -20,7 +20,7 @@ namespace edm {
 
   class StreamerOutputModuleCommon {
   public:
-    explicit StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections);
+    explicit StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections, std::string const& moduleLabel);
     ~StreamerOutputModuleCommon();
     static void fillDescription(ParameterSetDescription& desc);
 

--- a/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleCommon.h
@@ -20,7 +20,9 @@ namespace edm {
 
   class StreamerOutputModuleCommon {
   public:
-    explicit StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections, std::string const& moduleLabel);
+    explicit StreamerOutputModuleCommon(ParameterSet const& ps,
+                                        SelectedProducts const* selections,
+                                        std::string const& moduleLabel);
     ~StreamerOutputModuleCommon();
     static void fillDescription(ParameterSetDescription& desc);
 

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -16,7 +16,7 @@ namespace edm {
   StreamerOutputModuleBase::StreamerOutputModuleBase(ParameterSet const& ps)
       : one::OutputModuleBase::OutputModuleBase(ps),
         one::OutputModule<one::WatchRuns, one::WatchLuminosityBlocks>(ps),
-        StreamerOutputModuleCommon(ps, &keptProducts()[InEvent]),
+        StreamerOutputModuleCommon(ps, &keptProducts()[InEvent], description().moduleLabel()),
         trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
         psetToken_(
             consumes<SendJobHeader::ParameterSetMap, edm::InRun>(ps.getUntrackedParameter<edm::InputTag>("psetMap"))) {}

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -23,7 +23,7 @@
 #include <zlib.h>
 
 namespace edm {
-  StreamerOutputModuleCommon::StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections)
+  StreamerOutputModuleCommon::StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections, std::string const& moduleLabel)
       :
 
         serializer_(selections),
@@ -84,6 +84,16 @@ namespace edm {
     // 25-Jan-2008, KAB - pull out the trigger selection request
     // which we need for the INIT message
     hltTriggerSelections_ = EventSelector::getEventSelectionVString(ps);
+
+    Strings const& hltTriggerNames = edm::getAllTriggerNames();
+    hltsize_ = hltTriggerNames.size();
+
+    //Checksum of the module label
+    uLong crc = crc32(0L, Z_NULL, 0);
+    Bytef const* buf = (Bytef const*)(moduleLabel.data());
+    crc = crc32(crc, buf, moduleLabel.length());
+    outputModuleId_ = static_cast<uint32>(crc);
+
   }
 
   StreamerOutputModuleCommon::~StreamerOutputModuleCommon() {}
@@ -120,8 +130,6 @@ namespace edm {
     //  cms::MD5Result r1 = dig.digest();
     //  std::string hexy = r1.toString();
     //  std::cout << "HEX Representation of Process PSetID: " << hexy << std::endl;
-    Strings const& hltTriggerNames = edm::getAllTriggerNames();
-    hltsize_ = hltTriggerNames.size();
 
     //L1 stays dummy as of today
     Strings l1_names;  //3
@@ -129,11 +137,7 @@ namespace edm {
     l1_names.push_back("t10");
     l1_names.push_back("t2");
 
-    //Setting the process name to HLT
-    uLong crc = crc32(0L, Z_NULL, 0);
-    Bytef const* buf = (Bytef const*)(moduleLabel.data());
-    crc = crc32(crc, buf, moduleLabel.length());
-    outputModuleId_ = static_cast<uint32>(crc);
+    Strings const& hltTriggerNames = edm::getAllTriggerNames();
 
     auto init_message = std::make_unique<InitMsgBuilder>(&sbuf.header_buf_[0],
                                                          sbuf.header_buf_.size(),

--- a/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleCommon.cc
@@ -23,7 +23,9 @@
 #include <zlib.h>
 
 namespace edm {
-  StreamerOutputModuleCommon::StreamerOutputModuleCommon(ParameterSet const& ps, SelectedProducts const* selections, std::string const& moduleLabel)
+  StreamerOutputModuleCommon::StreamerOutputModuleCommon(ParameterSet const& ps,
+                                                         SelectedProducts const* selections,
+                                                         std::string const& moduleLabel)
       :
 
         serializer_(selections),
@@ -93,7 +95,6 @@ namespace edm {
     Bytef const* buf = (Bytef const*)(moduleLabel.data());
     crc = crc32(crc, buf, moduleLabel.length());
     outputModuleId_ = static_cast<uint32>(crc);
-
   }
 
   StreamerOutputModuleCommon::~StreamerOutputModuleCommon() {}


### PR DESCRIPTION

#### PR description:

Calculating trigger names and module ID in constructor so that it is
available both for for serializeRegistry and serializing event with the
GlobalEvFOutputMOdule

Resolves #37029

#### PR validation:

Tested with a scripted test:
/afs/cern.ch/user/s/smorovic/public/test_outputmodule (see also #37029)
The test passes with this patch.
The test will also be integrated into the existing unit test (pending work planned for another PR).
