### PR TITLE
MTD validation: update cluster histograms

### DIFF
--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -461,7 +461,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
       else {
-        meUnmatchedCluEnergy_->Fill(cluster.energy());
+        meUnmatchedCluEnergy_->Fill(std::log10(cluster.energy()));
       }
 
     }  // cluster loop
@@ -717,7 +717,7 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
     meCluYLocalErr_ = ibook.book1D("BtlCluYLocalErr", "BTL cluster Y local error;sigmaY_{RECO,loc} [cm]", 30, 0., 0.9);
   }
   meUnmatchedCluEnergy_ =
-      ibook.book1D("BtlUnmatchedCluEnergy", "BTL unmatched cluster energy;E_{RECO} [MeV]", 100, 0, 20);
+      ibook.book1D("BtlUnmatchedCluEnergy", "BTL unmatched cluster log10(energy);log10(E_{RECO} [MeV])", 5, -3, 2);
 
   // --- UncalibratedRecHits histograms
 

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -152,9 +152,7 @@ private:
   MonitorElement* meCluXLocalErr_;
   MonitorElement* meCluYLocalErr_;
 
-  MonitorElement* meUnmatchedCluEta_;
   MonitorElement* meUnmatchedCluEnergy_;
-  MonitorElement* meUnmatchedCluTime_;
 
   // --- UncalibratedRecHits histograms
 
@@ -464,8 +462,6 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
       else {
         meUnmatchedCluEnergy_->Fill(cluster.energy());
-        meUnmatchedCluTime_->Fill(cluster.time());
-        meUnmatchedCluEta_->Fill(global_point.eta());
       }
 
     }  // cluster loop
@@ -720,10 +716,8 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
     meCluXLocalErr_ = ibook.book1D("BtlCluXLocalErr", "BTL cluster X local error;sigmaX_{RECO,loc} [cm]", 30, 0., 3.);
     meCluYLocalErr_ = ibook.book1D("BtlCluYLocalErr", "BTL cluster Y local error;sigmaY_{RECO,loc} [cm]", 30, 0., 0.9);
   }
-  meUnmatchedCluTime_ = ibook.book1D("BtlUnmatchedCluTime", "BTL unmatched cluster time ToA;ToA [ns]", 250, 0, 25);
   meUnmatchedCluEnergy_ =
       ibook.book1D("BtlUnmatchedCluEnergy", "BTL unmatched cluster energy;E_{RECO} [MeV]", 100, 0, 20);
-  meUnmatchedCluEta_ = ibook.book1D("BtlUnmatchedCluEta", "BTL unmatched cluster #eta;#eta_{RECO}", 100, -1.55, 1.55);
 
   // --- UncalibratedRecHits histograms
 

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -141,11 +141,11 @@ private:
   MonitorElement* meCluTPullvsEta_;
   MonitorElement* meCluRhoRes_;
   MonitorElement* meCluPhiRes_;
-  MonitorElement* meCluXRes_;
-  MonitorElement* meCluYRes_;
+  MonitorElement* meCluLocalXRes_;
+  MonitorElement* meCluLocalYRes_;
   MonitorElement* meCluZRes_;
-  MonitorElement* meCluXPull_;
-  MonitorElement* meCluYPull_;
+  MonitorElement* meCluLocalXPull_;
+  MonitorElement* meCluLocalYPull_;
   MonitorElement* meCluZPull_;
   MonitorElement* meCluYXLocal_;
   MonitorElement* meCluYXLocalSim_;
@@ -431,18 +431,18 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         meCluRhoRes_->Fill(rho_res);
         meCluPhiRes_->Fill(phi_res);
 
-        float x_res = global_point.x() - cluGlobalPosSIM.x();
-        float y_res = global_point.y() - cluGlobalPosSIM.y();
+        float xlocal_res = local_point.x() - cluLocalPosSIM.x();
+        float ylocal_res = local_point.y() - cluLocalPosSIM.y();
         float z_res = global_point.z() - cluGlobalPosSIM.z();
 
-        meCluXRes_->Fill(x_res);
-        meCluYRes_->Fill(y_res);
         meCluZRes_->Fill(z_res);
 
         if (LocalPosDebug_) {
           if (matchClu && comp != nullptr) {
-            meCluXPull_->Fill(x_res / std::sqrt(comp->globalPositionError().cxx()));
-            meCluYPull_->Fill(y_res / std::sqrt(comp->globalPositionError().cyy()));
+            meCluLocalXRes_->Fill(xlocal_res);
+            meCluLocalYRes_->Fill(ylocal_res);
+            meCluLocalXPull_->Fill(xlocal_res / std::sqrt(comp->localPositionError().xx()));
+            meCluLocalYPull_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
             meCluZPull_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
             meCluXLocalErr_->Fill(std::sqrt(comp->localPositionError().xx()));
             meCluYLocalErr_->Fill(std::sqrt(comp->localPositionError().yy()));
@@ -690,12 +690,16 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("BtlCluRhoRes", "BTL cluster #rho resolution;#rho_{RECO}-#rho_{SIM} [cm]", 100, -0.5, 0.5);
   meCluPhiRes_ =
       ibook.book1D("BtlCluPhiRes", "BTL cluster #phi resolution;#phi_{RECO}-#phi_{SIM} [rad]", 100, -0.03, 0.03);
-  meCluXRes_ = ibook.book1D("BtlCluXRes", "BTL cluster X resolution;X_{RECO}-X_{SIM} [cm]", 100, -3.1, 3.1);
-  meCluYRes_ = ibook.book1D("BtlCluYRes", "BTL cluster Y resolution;Y_{RECO}-Y_{SIM} [cm]", 100, -3.1, 3.1);
   meCluZRes_ = ibook.book1D("BtlCluZRes", "BTL cluster Z resolution;Z_{RECO}-Z_{SIM} [cm]", 100, -0.2, 0.2);
   if (LocalPosDebug_) {
-    meCluXPull_ = ibook.book1D("BtlCluXPull", "BTL cluster X pull;X_{RECO}-X_{SIM}/sigmaX_[RECO]", 100, -5., 5.);
-    meCluYPull_ = ibook.book1D("BtlCluYPull", "BTL cluster Y pull;Y_{RECO}-Y_{SIM}/sigmaY_[RECO]", 100, -5., 5.);
+    meCluLocalXRes_ =
+        ibook.book1D("BtlCluLocalXRes", "BTL cluster local X resolution;X_{RECO}-X_{SIM} [cm]", 100, -3.1, 3.1);
+    meCluLocalYRes_ =
+        ibook.book1D("BtlCluLocalYRes", "BTL cluster local Y resolution;Y_{RECO}-Y_{SIM} [cm]", 100, -3.1, 3.1);
+    meCluLocalXPull_ =
+        ibook.book1D("BtlCluLocalXPull", "BTL cluster local X pull;X_{RECO}-X_{SIM}/sigmaX_[RECO]", 100, -5., 5.);
+    meCluLocalYPull_ =
+        ibook.book1D("BtlCluLocalYPull", "BTL cluster local Y pull;Y_{RECO}-Y_{SIM}/sigmaY_[RECO]", 100, -5., 5.);
     meCluZPull_ = ibook.book1D("BtlCluZPull", "BTL cluster Z pull;Z_{RECO}-Z_{SIM}/sigmaZ_[RECO]", 100, -5., 5.);
     meCluYXLocal_ = ibook.book2D("BtlCluYXLocal",
                                  "BTL cluster local Y vs X;X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -129,9 +129,13 @@ private:
   MonitorElement* meCluEta_;
   MonitorElement* meCluHits_;
   MonitorElement* meCluZvsPhi_;
+  MonitorElement* meCluEnergyvsEta_;
+  MonitorElement* meCluHitsvsEta_;
 
   MonitorElement* meCluTimeRes_;
   MonitorElement* meCluEnergyRes_;
+  MonitorElement* meCluTResvsE_;
+  MonitorElement* meCluTResvsEta_;
   MonitorElement* meCluTPullvsE_;
   MonitorElement* meCluTPullvsEta_;
   MonitorElement* meCluRhoRes_;
@@ -447,6 +451,12 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
           meCluYXLocalSim_->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
         }
 
+        meCluEnergyvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), cluster.energy());
+        meCluHitsvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), cluster.size());
+
+        meCluTResvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), time_res);
+        meCluTResvsE_->Fill(cluEneSIM, time_res);
+
         meCluTPullvsEta_->Fill(std::abs(cluGlobalPosSIM.eta()), time_res / cluster.timeError());
         meCluTPullvsE_->Fill(cluEneSIM, time_res / cluster.timeError());
 
@@ -634,10 +644,30 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meCluHits_ = ibook.book1D("BtlCluHitNumber", "BTL hits per cluster; Cluster size", 10, 0, 10);
   meCluZvsPhi_ = ibook.book2D(
       "BtlOccupancy", "BTL cluster Z vs #phi;Z_{RECO} [cm]; #phi_{RECO} [rad]", 144, -260., 260., 50, -3.2, 3.2);
+  meCluEnergyvsEta_ = ibook.bookProfile(
+      "BtlCluEnergyVsEta", "BTL cluster energy vs #eta; |#eta_{RECO}|; E_{RECO} [cm]", 30, 0., 1.55, 0., 20., "S");
+  meCluHitsvsEta_ = ibook.bookProfile(
+      "BtlCluHitsVsEta", "BTL hits per cluster vs #eta; |#eta_{RECO}|;Cluster size", 30, 0., 1.55, 0., 10., "S");
 
   meCluTimeRes_ = ibook.book1D("BtlCluTimeRes", "BTL cluster time resolution;T_{RECO}-T_{SIM} [ns]", 100, -0.5, 0.5);
   meCluEnergyRes_ =
       ibook.book1D("BtlCluEnergyRes", "BTL cluster energy resolution;E_{RECO}-E_{SIM} [MeV]", 100, -0.5, 0.5);
+  meCluTResvsE_ = ibook.bookProfile("BtlCluTResvsE",
+                                    "BTL cluster time resolution vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM}) [ns]",
+                                    20,
+                                    0.,
+                                    20.,
+                                    -0.5,
+                                    0.5,
+                                    "S");
+  meCluTResvsEta_ = ibook.bookProfile("BtlCluTResvsEta",
+                                      "BTL cluster time resolution vs #eta;|#eta_{RECO}|;(T_{RECO}-T_{SIM}) [ns]",
+                                      30,
+                                      0,
+                                      1.55,
+                                      -0.5,
+                                      0.5,
+                                      "S");
   meCluTPullvsE_ = ibook.bookProfile("BtlCluTPullvsE",
                                      "BTL cluster time pull vs E;E_{SIM} [MeV];(T_{RECO}-T_{SIM})/#sigma_{T_{RECO}}",
                                      20,

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -63,6 +63,7 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   bool isSameCluster(const FTLCluster&, const FTLCluster&);
+
   // ------------ member data ------------
 
   const std::string folder_;
@@ -430,21 +431,21 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         meCluRhoRes_->Fill(rho_res);
         meCluPhiRes_->Fill(phi_res);
 
+        float x_res = global_point.x() - cluGlobalPosSIM.x();
+        float y_res = global_point.y() - cluGlobalPosSIM.y();
+        float z_res = global_point.z() - cluGlobalPosSIM.z();
+
+        meCluXRes_->Fill(x_res);
+        meCluYRes_->Fill(y_res);
+        meCluZRes_->Fill(z_res);
+
         if (LocalPosDebug_) {
-          float x_res = global_point.x() - cluGlobalPosSIM.x();
-          float y_res = global_point.y() - cluGlobalPosSIM.y();
-          float z_res = global_point.z() - cluGlobalPosSIM.z();
-
-          meCluXRes_->Fill(x_res);
-          meCluYRes_->Fill(y_res);
-          meCluZRes_->Fill(z_res);
-
           if (matchClu && comp != nullptr) {
-            meCluXPull_->Fill(x_res / comp->globalPositionError().cxx());
-            meCluYPull_->Fill(y_res / comp->globalPositionError().cyy());
-            meCluZPull_->Fill(z_res / comp->globalPositionError().czz());
-            meCluXLocalErr_->Fill(comp->localPositionError().xx());
-            meCluYLocalErr_->Fill(comp->localPositionError().yy());
+            meCluXPull_->Fill(x_res / std::sqrt(comp->globalPositionError().cxx()));
+            meCluYPull_->Fill(y_res / std::sqrt(comp->globalPositionError().cyy()));
+            meCluZPull_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
+            meCluXLocalErr_->Fill(std::sqrt(comp->localPositionError().xx()));
+            meCluYLocalErr_->Fill(std::sqrt(comp->localPositionError().yy()));
           }
 
           meCluYXLocal_->Fill(local_point.x(), local_point.y());
@@ -689,10 +690,10 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("BtlCluRhoRes", "BTL cluster #rho resolution;#rho_{RECO}-#rho_{SIM} [cm]", 100, -0.5, 0.5);
   meCluPhiRes_ =
       ibook.book1D("BtlCluPhiRes", "BTL cluster #phi resolution;#phi_{RECO}-#phi_{SIM} [rad]", 100, -0.03, 0.03);
+  meCluXRes_ = ibook.book1D("BtlCluXRes", "BTL cluster X resolution;X_{RECO}-X_{SIM} [cm]", 100, -3.1, 3.1);
+  meCluYRes_ = ibook.book1D("BtlCluYRes", "BTL cluster Y resolution;Y_{RECO}-Y_{SIM} [cm]", 100, -3.1, 3.1);
+  meCluZRes_ = ibook.book1D("BtlCluZRes", "BTL cluster Z resolution;Z_{RECO}-Z_{SIM} [cm]", 100, -0.2, 0.2);
   if (LocalPosDebug_) {
-    meCluXRes_ = ibook.book1D("BtlCluXRes", "BTL cluster X resolution;X_{RECO}-X_{SIM} [cm]", 100, -3.1, 3.1);
-    meCluYRes_ = ibook.book1D("BtlCluYRes", "BTL cluster Y resolution;Y_{RECO}-Y_{SIM} [cm]", 100, -3.1, 3.1);
-    meCluZRes_ = ibook.book1D("BtlCluZRes", "BTL cluster Z resolution;Z_{RECO}-Z_{SIM} [cm]", 100, -0.2, 0.2);
     meCluXPull_ = ibook.book1D("BtlCluXPull", "BTL cluster X pull;X_{RECO}-X_{SIM}/sigmaX_[RECO]", 100, -5., 5.);
     meCluYPull_ = ibook.book1D("BtlCluYPull", "BTL cluster Y pull;Y_{RECO}-Y_{SIM}/sigmaY_[RECO]", 100, -5., 5.);
     meCluZPull_ = ibook.book1D("BtlCluZPull", "BTL cluster Z pull;Z_{RECO}-Z_{SIM}/sigmaZ_[RECO]", 100, -5., 5.);
@@ -712,10 +713,8 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                     200,
                                     -2.8,
                                     2.8);
-    meCluXLocalErr_ =
-        ibook.book1D("BtlCluXLocalErr", "BTL cluster X local error;sigmaX_{RECO,loc} [cm]", 100, -3.1, 3.1);
-    meCluYLocalErr_ =
-        ibook.book1D("BtlCluYLocalErr", "BTL cluster Y local error;sigmaY_{RECO,loc} [cm]", 100, -3.1, 3.1);
+    meCluXLocalErr_ = ibook.book1D("BtlCluXLocalErr", "BTL cluster X local error;sigmaX_{RECO,loc} [cm]", 30, 0., 3.);
+    meCluYLocalErr_ = ibook.book1D("BtlCluYLocalErr", "BTL cluster Y local error;sigmaY_{RECO,loc} [cm]", 30, 0., 0.9);
   }
   meUnmatchedCluTime_ = ibook.book1D("BtlUnmatchedCluTime", "BTL unmatched cluster time ToA;ToA [ns]", 250, 0, 25);
   meUnmatchedCluEnergy_ =

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -131,9 +131,7 @@ private:
   MonitorElement* meCluXLocalErr_[2];
   MonitorElement* meCluYLocalErr_[2];
 
-  MonitorElement* meUnmatchedCluEta_[2];
   MonitorElement* meUnmatchedCluEnergy_[2];
-  MonitorElement* meUnmatchedCluTime_[2];
 
   // --- UncalibratedRecHits histograms
 
@@ -509,8 +507,6 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
       else {
         meUnmatchedCluEnergy_[iside]->Fill(cluster.energy());
-        meUnmatchedCluTime_[iside]->Fill(cluster.time());
-        meUnmatchedCluEta_[iside]->Fill(std::abs(global_point.eta()));
       }
 
     }  // cluster loop
@@ -1056,18 +1052,10 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
     meCluYLocalErr_[1] =
         ibook.book1D("EtlCluYLocalErrPos", "ETL cluster Y local error (+Z);sigmaY_{RECO,loc} [cm]", 50, 0., 0.2);
   }
-  meUnmatchedCluTime_[0] =
-      ibook.book1D("EtlUnmatchedCluTimeNeg", "ETL unmatched cluster time ToA (-Z);ToA [ns]", 250, 0, 25);
-  meUnmatchedCluTime_[1] =
-      ibook.book1D("EtlUnmatchedCluTimePos", "ETL unmatched cluster time ToA (+Z);ToA [ns]", 250, 0, 25);
   meUnmatchedCluEnergy_[0] =
       ibook.book1D("EtlUnmatchedCluEnergyNeg", "ETL unmatched cluster energy (-Z);E_{RECO} [MeV]", 100, 0, 20);
   meUnmatchedCluEnergy_[1] =
       ibook.book1D("EtlUnmatchedCluEnergyPos", "ETL unmatched cluster energy (+Z);E_{RECO} [MeV]", 100, 0, 20);
-  meUnmatchedCluEta_[0] =
-      ibook.book1D("EtlUnmatchedCluEtaNeg", "ETL unmatched cluster |#eta| (-Z);#eta_{RECO}", 100, 1.55, 3.1);
-  meUnmatchedCluEta_[1] =
-      ibook.book1D("EtlUnmatchedCluEtaPos", "ETL unmatched cluster |#eta| (+Z);#eta_{RECO}", 100, 1.55, 3.1);
 
   // --- UncalibratedRecHits histograms
 

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -506,7 +506,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
       else {
-        meUnmatchedCluEnergy_[iside]->Fill(cluster.energy());
+        meUnmatchedCluEnergy_[iside]->Fill(std::log10(cluster.energy()));
       }
 
     }  // cluster loop
@@ -1052,10 +1052,10 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
     meCluYLocalErr_[1] =
         ibook.book1D("EtlCluYLocalErrPos", "ETL cluster Y local error (+Z);sigmaY_{RECO,loc} [cm]", 50, 0., 0.2);
   }
-  meUnmatchedCluEnergy_[0] =
-      ibook.book1D("EtlUnmatchedCluEnergyNeg", "ETL unmatched cluster energy (-Z);E_{RECO} [MeV]", 100, 0, 20);
-  meUnmatchedCluEnergy_[1] =
-      ibook.book1D("EtlUnmatchedCluEnergyPos", "ETL unmatched cluster energy (+Z);E_{RECO} [MeV]", 100, 0, 20);
+  meUnmatchedCluEnergy_[0] = ibook.book1D(
+      "EtlUnmatchedCluEnergyNeg", "ETL unmatched cluster log10(energy) (-Z);log10(E_{RECO} [MeV])", 5, -3, 2);
+  meUnmatchedCluEnergy_[1] = ibook.book1D(
+      "EtlUnmatchedCluEnergyPos", "ETL unmatched cluster log10(energy) (+Z);log10(E_{RECO} [MeV])", 5, -3, 2);
 
   // --- UncalibratedRecHits histograms
 

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -26,6 +26,7 @@
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
 #include "DataFormats/FTLRecHit/interface/FTLRecHitCollections.h"
 #include "DataFormats/FTLRecHit/interface/FTLClusterCollections.h"
+#include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
 
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
@@ -58,6 +59,8 @@ private:
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
+  bool isSameCluster(const FTLCluster&, const FTLCluster&);
+
   // ------------ member data ------------
 
   const std::string folder_;
@@ -71,6 +74,7 @@ private:
   edm::EDGetTokenT<FTLUncalibratedRecHitCollection> etlUncalibRecHitsToken_;
   edm::EDGetTokenT<CrossingFrame<PSimHit> > etlSimHitsToken_;
   edm::EDGetTokenT<FTLClusterCollection> etlRecCluToken_;
+  edm::EDGetTokenT<MTDTrackingDetSetVector> mtdTrackingHitToken_;
 
   edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> mtdgeoToken_;
   edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
@@ -120,8 +124,17 @@ private:
   MonitorElement* meCluXRes_[2];
   MonitorElement* meCluYRes_[2];
   MonitorElement* meCluZRes_[2];
+  MonitorElement* meCluXPull_[2];
+  MonitorElement* meCluYPull_[2];
+  MonitorElement* meCluZPull_[2];
   MonitorElement* meCluYXLocal_[2];
   MonitorElement* meCluYXLocalSim_[2];
+  MonitorElement* meCluXLocalErr_[2];
+  MonitorElement* meCluYLocalErr_[2];
+
+  MonitorElement* meUnmatchedCluEta_[2];
+  MonitorElement* meUnmatchedCluEnergy_[2];
+  MonitorElement* meUnmatchedCluTime_[2];
 
   // --- UncalibratedRecHits histograms
 
@@ -137,6 +150,11 @@ private:
   MonitorElement* meTimeResEta_[2][nBinsEta_];
 };
 
+bool EtlLocalRecoValidation::isSameCluster(const FTLCluster& clu1, const FTLCluster& clu2) {
+  return clu1.id() == clu2.id() && clu1.size() == clu2.size() && clu1.x() == clu2.x() && clu1.y() == clu2.y() &&
+         clu1.time() == clu2.time();
+}
+
 // ------------ constructor and destructor --------------
 EtlLocalRecoValidation::EtlLocalRecoValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
@@ -151,6 +169,7 @@ EtlLocalRecoValidation::EtlLocalRecoValidation(const edm::ParameterSet& iConfig)
         consumes<FTLUncalibratedRecHitCollection>(iConfig.getParameter<edm::InputTag>("uncalibRecHitsTag"));
   etlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("simHitsTag"));
   etlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTag"));
+  mtdTrackingHitToken_ = consumes<MTDTrackingDetSetVector>(iConfig.getParameter<edm::InputTag>("trkHitTag"));
 
   mtdgeoToken_ = esConsumes<MTDGeometry, MTDDigiGeometryRecord>();
   mtdtopoToken_ = esConsumes<MTDTopology, MTDTopologyRcd>();
@@ -182,6 +201,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   auto etlRecHitsHandle = makeValid(iEvent.getHandle(etlRecHitsToken_));
   auto etlSimHitsHandle = makeValid(iEvent.getHandle(etlSimHitsToken_));
   auto etlRecCluHandle = makeValid(iEvent.getHandle(etlRecCluToken_));
+  auto mtdTrkHitHandle = makeValid(iEvent.getHandle(mtdTrackingHitToken_));
   MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());
 
   // --- Loop over the ETL SIM hits
@@ -437,10 +457,25 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       }  // ihit loop
 
-      // --- Fill the cluster resolution histograms
-      if (cluTimeSIM > 0. && cluEneSIM > 0.) {
-        int iside = (cluId.zside() == -1 ? 0 : 1);
+      // Find the MTDTrackingRecHit corresponding to the cluster
+      MTDTrackingRecHit* comp(nullptr);
+      bool matchClu = false;
+      const auto& trkHits = (*mtdTrkHitHandle)[detIdObject];
+      for (const auto& trkHit : trkHits) {
+        if (isSameCluster(trkHit.mtdCluster(), cluster)) {
+          comp = trkHit.clone();
+          matchClu = true;
+          break;
+        }
+      }
+      if (!matchClu) {
+        edm::LogWarning("BtlLocalRecoValidation")
+            << "No valid TrackingRecHit corresponding to cluster, detId = " << detIdObject.rawId();
+      }
 
+      // --- Fill the cluster resolution histograms
+      int iside = (cluId.zside() == -1 ? 0 : 1);
+      if (cluTimeSIM > 0. && cluEneSIM > 0.) {
         cluTimeSIM /= cluEneSIM;
 
         Local3DPoint cluLocalPosSIM(cluLocXSIM / cluEneSIM, cluLocYSIM / cluEneSIM, cluLocZSIM / cluEneSIM);
@@ -462,11 +497,23 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         meCluTPullvsE_[iside]->Fill(cluEneSIM, time_res / cluster.timeError());
 
         if (LocalPosDebug_) {
+          if (matchClu && comp != nullptr) {
+            meCluXPull_[iside]->Fill(x_res / std::sqrt(comp->globalPositionError().cxx()));
+            meCluYPull_[iside]->Fill(y_res / std::sqrt(comp->globalPositionError().cyy()));
+            meCluZPull_[iside]->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
+            meCluXLocalErr_[iside]->Fill(std::sqrt(comp->localPositionError().xx()));
+            meCluYLocalErr_[iside]->Fill(std::sqrt(comp->localPositionError().yy()));
+          }
           meCluYXLocal_[iside]->Fill(local_point.x(), local_point.y());
           meCluYXLocalSim_[iside]->Fill(cluLocalPosSIM.x(), cluLocalPosSIM.y());
         }
 
       }  // if ( cluTimeSIM > 0. &&  cluEneSIM > 0. )
+      else {
+        meUnmatchedCluEnergy_[iside]->Fill(cluster.energy());
+        meUnmatchedCluTime_[iside]->Fill(cluster.time());
+        meUnmatchedCluEta_[iside]->Fill(std::abs(global_point.eta()));
+      }
 
     }  // cluster loop
 
@@ -962,6 +1009,18 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meCluZRes_[1] =
       ibook.book1D("EtlCluZResZpos", "ETL cluster Z resolution (+Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
   if (LocalPosDebug_) {
+    meCluXPull_[0] =
+        ibook.book1D("EtlCluXPullZneg", "ETL cluster X pull (-Z);X_{RECO}-X_{SIM}/sigmaX_[RECO] [cm]", 100, -5., 5.);
+    meCluXPull_[1] =
+        ibook.book1D("EtlCluXPullZpos", "ETL cluster X pull (+Z);X_{RECO}-X_{SIM}/sigmaX_[RECO] [cm]", 100, -5., 5.);
+    meCluYPull_[0] =
+        ibook.book1D("EtlCluYPullZneg", "ETL cluster Y pull (-Z);Y_{RECO}-Y_{SIM}/sigmaY_[RECO] [cm]", 100, -5., 5.);
+    meCluYPull_[1] =
+        ibook.book1D("EtlCluYPullZpos", "ETL cluster Y pull (+Z);Y_{RECO}-Y_{SIM}/sigmaY_[RECO] [cm]", 100, -5., 5.);
+    meCluZPull_[0] =
+        ibook.book1D("EtlCluZPullZneg", "ETL cluster Z pull (-Z);Z_{RECO}-Z_{SIM}/sigmaZ_[RECO] [cm]", 100, -5., 5.);
+    meCluZPull_[1] =
+        ibook.book1D("EtlCluZPullZpos", "ETL cluster Z pull (+Z);Z_{RECO}-Z_{SIM}/sigmaZ_[RECO] [cm]", 100, -5., 5.);
     meCluYXLocal_[0] = ibook.book2D("EtlCluYXLocalZneg",
                                     "ETL cluster local Y vs X (-Z);X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
                                     100,
@@ -994,7 +1053,27 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                        200,
                                        -1.1,
                                        1.1);
+    meCluXLocalErr_[0] =
+        ibook.book1D("EtlCluXLocalErrNeg", "ETL cluster X local error (-Z);sigmaX_{RECO,loc} [cm]", 50, 0., 0.2);
+    meCluXLocalErr_[1] =
+        ibook.book1D("EtlCluXLocalErrPos", "ETL cluster X local error (+Z);sigmaX_{RECO,loc} [cm]", 50, 0., 0.2);
+    meCluYLocalErr_[0] =
+        ibook.book1D("EtlCluYLocalErrNeg", "ETL cluster Y local error (-Z);sigmaY_{RECO,loc} [cm]", 50., 0., 0.2);
+    meCluYLocalErr_[1] =
+        ibook.book1D("EtlCluYLocalErrPos", "ETL cluster Y local error (+Z);sigmaY_{RECO,loc} [cm]", 50, 0., 0.2);
   }
+  meUnmatchedCluTime_[0] =
+      ibook.book1D("EtlUnmatchedCluTimeNeg", "ETL unmatched cluster time ToA (-Z);ToA [ns]", 250, 0, 25);
+  meUnmatchedCluTime_[1] =
+      ibook.book1D("EtlUnmatchedCluTimePos", "ETL unmatched cluster time ToA (+Z);ToA [ns]", 250, 0, 25);
+  meUnmatchedCluEnergy_[0] =
+      ibook.book1D("EtlUnmatchedCluEnergyNeg", "ETL unmatched cluster energy (-Z);E_{RECO} [MeV]", 100, 0, 20);
+  meUnmatchedCluEnergy_[1] =
+      ibook.book1D("EtlUnmatchedCluEnergyPos", "ETL unmatched cluster energy (+Z);E_{RECO} [MeV]", 100, 0, 20);
+  meUnmatchedCluEta_[0] =
+      ibook.book1D("EtlUnmatchedCluEtaNeg", "ETL unmatched cluster |#eta| (-Z);#eta_{RECO}", 100, 1.55, 3.1);
+  meUnmatchedCluEta_[1] =
+      ibook.book1D("EtlUnmatchedCluEtaPos", "ETL unmatched cluster |#eta| (+Z);#eta_{RECO}", 100, 1.55, 3.1);
 
   // --- UncalibratedRecHits histograms
 
@@ -1029,6 +1108,7 @@ void EtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<edm::InputTag>("uncalibRecHitsTag", edm::InputTag("mtdUncalibratedRecHits", "FTLEndcap"));
   desc.add<edm::InputTag>("simHitsTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));
   desc.add<edm::InputTag>("recCluTag", edm::InputTag("mtdClusters", "FTLEndcap"));
+  desc.add<edm::InputTag>("trkHitTag", edm::InputTag("mtdTrackingRecHits"));
   desc.add<double>("hitMinimumEnergy1Dis", 1.);     // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
   desc.add<bool>("LocalPositionDebug", false);

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -126,7 +126,6 @@ private:
   MonitorElement* meCluZRes_[2];
   MonitorElement* meCluXPull_[2];
   MonitorElement* meCluYPull_[2];
-  MonitorElement* meCluZPull_[2];
   MonitorElement* meCluYXLocal_[2];
   MonitorElement* meCluYXLocalSim_[2];
   MonitorElement* meCluXLocalErr_[2];
@@ -500,7 +499,6 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
           if (matchClu && comp != nullptr) {
             meCluXPull_[iside]->Fill(x_res / std::sqrt(comp->globalPositionError().cxx()));
             meCluYPull_[iside]->Fill(y_res / std::sqrt(comp->globalPositionError().cyy()));
-            meCluZPull_[iside]->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
             meCluXLocalErr_[iside]->Fill(std::sqrt(comp->localPositionError().xx()));
             meCluYLocalErr_[iside]->Fill(std::sqrt(comp->localPositionError().yy()));
           }
@@ -1017,10 +1015,6 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
         ibook.book1D("EtlCluYPullZneg", "ETL cluster Y pull (-Z);Y_{RECO}-Y_{SIM}/sigmaY_[RECO] [cm]", 100, -5., 5.);
     meCluYPull_[1] =
         ibook.book1D("EtlCluYPullZpos", "ETL cluster Y pull (+Z);Y_{RECO}-Y_{SIM}/sigmaY_[RECO] [cm]", 100, -5., 5.);
-    meCluZPull_[0] =
-        ibook.book1D("EtlCluZPullZneg", "ETL cluster Z pull (-Z);Z_{RECO}-Z_{SIM}/sigmaZ_[RECO] [cm]", 100, -5., 5.);
-    meCluZPull_[1] =
-        ibook.book1D("EtlCluZPullZpos", "ETL cluster Z pull (+Z);Z_{RECO}-Z_{SIM}/sigmaZ_[RECO] [cm]", 100, -5., 5.);
     meCluYXLocal_[0] = ibook.book2D("EtlCluYXLocalZneg",
                                     "ETL cluster local Y vs X (-Z);X^{local}_{RECO} [cm];Y^{local}_{RECO} [cm]",
                                     100,


### PR DESCRIPTION
#### PR description:

Addition of histograms for better monitoring of cluster characteristics and position.

#### PR validation:

On workflow 35034.0 the observed ```dqmMemoryStat``` memory increase in normal conditions (without activating flag for dedicated studies) is of about 3 kB:

```
71c71
< 1136.00 KiB      MTD/ETL
---
> 1135.12 KiB      MTD/ETL
123c123
< 243.73 KiB       MTD/BTL
---
> 241.82 KiB       MTD/BTL
411c411
< Total bytes: 413140.61 KiB
---
> Total bytes: 413137.82 KiB
```