### PR TITLE
modernise and template HLT plugin for matching of two Jet collections

### DIFF
--- a/HLTrigger/JetMET/interface/HLTPFJetsMatchedToFilteredJetsProducer.h
+++ b/HLTrigger/JetMET/interface/HLTPFJetsMatchedToFilteredJetsProducer.h
@@ -1,0 +1,96 @@
+#ifndef HLTrigger_JetMET_HLTPFJetsMatchedToFilteredJetsProducer_h
+#define HLTrigger_JetMET_HLTPFJetsMatchedToFilteredJetsProducer_h
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <vector>
+#include <memory>
+#include <utility>
+
+template <typename TriggerJetsRefType>
+class HLTPFJetsMatchedToFilteredJetsProducer : public edm::global::EDProducer<> {
+public:
+  explicit HLTPFJetsMatchedToFilteredJetsProducer(edm::ParameterSet const& iConfig);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void produce(edm::StreamID streamID, edm::Event& iEvent, edm::EventSetup const& iSetup) const override;
+
+private:
+  // collection of reco::*Jets (using edm::View<reco::Candidate> to be able to read different types of reco::*Jet collections without templating explicitly)
+  edm::EDGetTokenT<edm::View<reco::Candidate>> const recoCandsToken_;
+  // collection of TriggerFilterObjectWithRefs containing TriggerObjects holding refs to Jets stored by an HLTFilter
+  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> const triggerJetsToken_;
+  // TriggerType of Jets produced by previous HLTFilter
+  int const triggerJetsType_;
+  // maximum Delta-R and Delta-R^2 distances between matched jets
+  double const maxDeltaR_, maxDeltaR2_;
+};
+
+template <typename TriggerJetsRefType>
+HLTPFJetsMatchedToFilteredJetsProducer<TriggerJetsRefType>::HLTPFJetsMatchedToFilteredJetsProducer(
+    edm::ParameterSet const& iConfig)
+    : recoCandsToken_(consumes(iConfig.getParameter<edm::InputTag>("src"))),
+      triggerJetsToken_(consumes(iConfig.getParameter<edm::InputTag>("triggerJetsFilter"))),
+      triggerJetsType_(iConfig.getParameter<int>("triggerJetsType")),
+      maxDeltaR_(iConfig.getParameter<double>("maxDeltaR")),
+      maxDeltaR2_(maxDeltaR_ * maxDeltaR_) {
+  if (maxDeltaR_ <= 0.) {
+    throw cms::Exception("HLTPFJetsMatchedToFilteredJetsProducerConfiguration")
+        << "invalid value for parameter \"DeltaR\" (must be > 0): " << maxDeltaR_;
+  }
+
+  produces<reco::PFJetCollection>();
+}
+
+template <typename TriggerJetsRefType>
+void HLTPFJetsMatchedToFilteredJetsProducer<TriggerJetsRefType>::fillDescriptions(
+    edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("hltPFJets"));
+  desc.add<edm::InputTag>("triggerJetsFilter", edm::InputTag("hltSingleJet240Regional"));
+  desc.add<int>("triggerJetsType", trigger::TriggerJet);
+  desc.add<double>("maxDeltaR", 0.5);
+  descriptions.addWithDefaultLabel(desc);
+}
+
+template <typename TriggerJetsRefType>
+void HLTPFJetsMatchedToFilteredJetsProducer<TriggerJetsRefType>::produce(edm::StreamID streamID,
+                                                                         edm::Event& iEvent,
+                                                                         edm::EventSetup const&) const {
+  auto const& recoCands = iEvent.get(recoCandsToken_);
+
+  std::vector<TriggerJetsRefType> triggerJetsRefVec;
+  auto const& triggerJets = iEvent.get(triggerJetsToken_);
+  triggerJets.getObjects(triggerJetsType_, triggerJetsRefVec);
+
+  math::XYZPoint const pvtxPoint(0., 0., 0.);
+  reco::PFJet::Specific const pfJetSpec;
+
+  auto outPFJets = std::make_unique<reco::PFJetCollection>();
+  outPFJets->reserve(recoCands.size());
+
+  for (auto const& iJetRef : triggerJetsRefVec) {
+    for (auto const& jRecoCand : recoCands) {
+      auto const dR2 = reco::deltaR2(jRecoCand.p4(), iJetRef->p4());
+      if (dR2 < maxDeltaR2_) {
+        outPFJets->emplace_back(jRecoCand.p4(), pvtxPoint, pfJetSpec);
+        break;
+      }
+    }
+  }
+
+  iEvent.put(std::move(outPFJets));
+}
+
+#endif

--- a/HLTrigger/JetMET/plugins/SealModule.cc
+++ b/HLTrigger/JetMET/plugins/SealModule.cc
@@ -96,6 +96,8 @@
 //
 #include "HLTrigger/JetMET/interface/HLTExclDiJetFilter.h"
 #include "HLTrigger/JetMET/src/HLTExclDiJetFilter.cc"
+//
+#include "HLTrigger/JetMET/interface/HLTPFJetsMatchedToFilteredJetsProducer.h"
 
 using namespace reco;
 using namespace trigger;
@@ -248,3 +250,9 @@ DEFINE_FWK_MODULE(HLTFatPFJetMassFilter);
 
 DEFINE_FWK_MODULE(HLTExclDiCaloJetFilter);
 DEFINE_FWK_MODULE(HLTExclDiPFJetFilter);
+
+typedef HLTPFJetsMatchedToFilteredJetsProducer<reco::CaloJetRef> HLTPFJetsMatchedToFilteredCaloJetsProducer;
+DEFINE_FWK_MODULE(HLTPFJetsMatchedToFilteredCaloJetsProducer);
+
+typedef HLTPFJetsMatchedToFilteredJetsProducer<reco::PFJetRef> HLTPFJetsMatchedToFilteredPFJetsProducer;
+DEFINE_FWK_MODULE(HLTPFJetsMatchedToFilteredPFJetsProducer);


### PR DESCRIPTION
#### PR description:

~~This PR modernises the HLT plugin `PFJetsMatchedToFilteredCaloJetsProducer`, and converts it to a plugin template in order to support not only the type `reco::CaloJetRef`, but also `reco::PFJetRef`. Small optimisations are also applied (e.g. using delta-R^2 instead of delta-R).~~

This PR introduces a new plugin template which offers a modernised version of the HLT plugin `PFJetsMatchedToFilteredCaloJetsProducer`, and allows to support both `reco::CaloJetRef` and `reco::PFJetRef` (via template instantiations).

The existing plugin `PFJetsMatchedToFilteredCaloJetsProducer` remains in place. ~~but now as one instantiation of the new plugin template.~~

New classes ~~(the template itself, and the new instantiation to support `reco::PFJetRef`)~~ follow the HLT convention of having the plugin name start with `HLT`. The label `PF` is kept in the name to indicate the type of the output collection, which remains fixed (the plugin template could likely be made even more generic, but I would postpone this to a future PR).

~~The name of the existing plugin (i.e. `PFJetsMatchedToFilteredCaloJetsProducer`) is not modified in order to make this update transparent to all HLT configurations.~~

_Edit_ (see https://github.com/cms-sw/cmssw/pull/37057#issuecomment-1050093677): the existing plugin (i.e. `PFJetsMatchedToFilteredCaloJetsProducer`) is kept in the code base. It will be removed in a future PR, after it is replaced by `HLTPFJetsMatchedToFilteredCaloJetsProducer` in the HLT menus in ConfDB. This will only be a technical change, to update the name of the plugin.

~~_Edit_ (see https://github.com/cms-sw/cmssw/pull/37057#issuecomment-1050093677): the names of the parameters of `PFJetsMatchedToFilteredCaloJetsProducer` do change in this PR, because they now come from the plugin template, where they need to be made more generic. This requires a customisation of the HLT configurations, done in `customiseHLTforCMSSW`.~~

The original version of this PR evolved based on https://github.com/cms-sw/cmssw/pull/37057#issuecomment-1050093677 and https://github.com/cms-sw/cmssw/pull/37057#issuecomment-1050222548.

This PR simply adds a couple of plugins for HLT, and it does not affect any HLT menus nor any central wfs.

Merely technical. No changes expected.

#### PR validation:

`addOnTests` passed. Also, checked that TriggerResults and all TriggerObjects produced in the HLT step are unchanged for 100 events of a Run-3 MC file.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A