### PR TITLE
HCAL HcalTBSource: adding skipEvents parameter

### DIFF
--- a/IORawData/HcalTBInputService/plugins/HcalTBSource.cc
+++ b/IORawData/HcalTBInputService/plugins/HcalTBSource.cc
@@ -16,7 +16,9 @@ using namespace std;
 HcalTBSource::HcalTBSource(const edm::ParameterSet& pset, edm::InputSourceDescription const& desc)
     : edm::ProducerSourceFromFiles(pset, desc, true),
       m_quiet(pset.getUntrackedParameter<bool>("quiet", true)),
-      m_onlyRemapped(pset.getUntrackedParameter<bool>("onlyRemapped", false)) {
+      m_onlyRemapped(pset.getUntrackedParameter<bool>("onlyRemapped", false)),
+      m_skip(pset.getUntrackedParameter<uint32_t>("skipEvents",0)) 
+{
   m_tree = nullptr;
   m_fileCounter = -1;
   m_file = nullptr;
@@ -139,7 +141,7 @@ bool HcalTBSource::setRunAndEventInfo(EventID& id, TimeValue_t& time, edm::Event
     // ZERO is unacceptable for a run number from a technical point of view
     id = EventID((m_eventInfo->getRunNumber() == 0 ? 1 : m_eventInfo->getRunNumber()),
                  id.luminosityBlock(),
-                 m_eventInfo->getEventNumber() + m_eventNumberOffset);
+                 m_eventInfo->getEventNumber() + m_eventNumberOffset + m_skip);
   } else {
     id = EventID(m_fileCounter + 10, id.luminosityBlock(), m_i + 1);
   }

--- a/IORawData/HcalTBInputService/plugins/HcalTBSource.cc
+++ b/IORawData/HcalTBInputService/plugins/HcalTBSource.cc
@@ -17,8 +17,7 @@ HcalTBSource::HcalTBSource(const edm::ParameterSet& pset, edm::InputSourceDescri
     : edm::ProducerSourceFromFiles(pset, desc, true),
       m_quiet(pset.getUntrackedParameter<bool>("quiet", true)),
       m_onlyRemapped(pset.getUntrackedParameter<bool>("onlyRemapped", false)),
-      m_skip(pset.getUntrackedParameter<uint32_t>("skipEvents",0)) 
-{
+      m_skip(pset.getUntrackedParameter<uint32_t>("skipEvents", 0)) {
   m_tree = nullptr;
   m_fileCounter = -1;
   m_file = nullptr;

--- a/IORawData/HcalTBInputService/plugins/HcalTBSource.h
+++ b/IORawData/HcalTBInputService/plugins/HcalTBSource.h
@@ -38,7 +38,7 @@ private:
   int m_chunkIds[CHUNK_COUNT];
   std::map<std::string, int> m_sourceIdRemap;
   CDFEventInfo* m_eventInfo;
-  int m_eventNumberOffset;
+  int m_eventNumberOffset, m_skip;
 };
 
 #endif  // HcalTBSource_h_included


### PR DESCRIPTION
#### PR description:

Minor amendment to HCAL proprietary HcalTBSource in a way similar to regular source "skipEvents" for analysis convenience.

#### PR validation:

runTheMatrix -l limited  


