### PR TITLE
Fix mkedlpr and mkesprod scripts for python3

### DIFF
--- a/FWCore/Skeletons/scripts/mkedlpr
+++ b/FWCore/Skeletons/scripts/mkedlpr
@@ -55,7 +55,7 @@ def config(tmpl, pkg_help):
             print(pkg_help)
             sys.exit(0)
         kwds['pname'] = sys.argv[1]
-        for idx in xrange(2, len(sys.argv)):
+        for idx in range(2, len(sys.argv)):
             opt = sys.argv[idx]
             if  opt == '-author':
                 kwds['author'] = sys.argv[idx+1]

--- a/FWCore/Skeletons/scripts/mkesprod
+++ b/FWCore/Skeletons/scripts/mkesprod
@@ -58,7 +58,7 @@ def config(tmpl, pkg_help):
             print(pkg_help)
             sys.exit(0)
         kwds['pname'] = sys.argv[1]
-        for idx in xrange(2, len(sys.argv)):
+        for idx in range(2, len(sys.argv)):
             opt = sys.argv[idx]
             if  opt == '-author':
                 kwds['author'] = sys.argv[idx+1]


### PR DESCRIPTION
#### PR description:

@thomreis pointed out in https://mattermost.web.cern.ch/cms-o-and-c/pl/kgpdtbtdzfyi8ezs9brdqf7awc that `mkesprod` didn't work. This PR makes the minimal job to make all `mk*` scripts to run (with the exception of `mktmpl` that has been broken for longer time already).

#### PR validation:

The scripts run.