### PR TITLE
Load Accelerators_cff unconditionally in customizeHLTforPatatrack.py, and clean up GPU/CPU forcing functions

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -36,19 +36,6 @@ def _clone_if_missing(_obj, _label, _config, _original_label = None, **kwargs):
     _clone(_obj, _label, _config, _original_label, _only_if_missing = True, **kwargs)
 
 
-# force the SwitchProducerCUDA choice to pick a specific backend: True for offloading to a gpu, False for running on cpu
-def forceGpuOffload(status = True):
-    import HeterogeneousCore.CUDACore.SwitchProducerCUDA
-    HeterogeneousCore.CUDACore.SwitchProducerCUDA._cuda_enabled_cached = bool(status)
-
-
-# reset the SwitchProducerCUDA choice to pick a backend depending on the availability of a supported gpu
-def resetGpuOffload():
-    import HeterogeneousCore.CUDACore.SwitchProducerCUDA
-    HeterogeneousCore.CUDACore.SwitchProducerCUDA._cuda_enabled_cached = None
-    HeterogeneousCore.CUDACore.SwitchProducerCUDA._switch_cuda()
-
-
 # customisation for running the Patatrack reconstruction, common parts
 def customiseCommon(process):
 

--- a/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
+++ b/HLTrigger/Configuration/python/customizeHLTforPatatrack.py
@@ -54,7 +54,7 @@ def customiseCommon(process):
 
     # Services
 
-    _load_if_missing(process, 'ProcessAcceleratorCUDA', 'HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA_cfi')
+    process.load('Configuration.StandardSequences.Accelerators_cff')
 
 #    # NVProfilerService is broken in CMSSW 12.0.x and later
 #    _load_if_missing(process, 'NVProfilerService', 'HeterogeneousCore.CUDAServices.NVProfilerService_cfi')


### PR DESCRIPTION
#### PR description:

Follow-up to https://github.com/cms-sw/cmssw/pull/36699#discussion_r808641430. Also clean up `forceGpuOffload()` and `resetGpuOffload()` functions in favor of `process.options.accelerators` that was added in #36699.

#### PR validation:

None