### PR TITLE
Backport PythiaFiltertMultiAncestor fix to CMSSW_10_6 releases

### DIFF
--- a/GeneratorInterface/GenFilters/src/PythiaFilterMultiAncestor.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterMultiAncestor.cc
@@ -114,6 +114,7 @@ bool PythiaFilterMultiAncestor::filter(edm::Event& iEvent, const edm::EventSetup
           // use a counter, if there's enough daughter  that match the pdg and kinematic
           // criteria accept the event
           uint good_dau = 0;
+          uint good_dau_cc = 0;
           for (HepMC::GenVertex::particle_iterator dau = (*p)->end_vertex()->particles_begin(HepMC::children);
                dau != (*p)->end_vertex()->particles_end(HepMC::children);
                ++dau) {
@@ -131,9 +132,21 @@ bool PythiaFilterMultiAncestor::filter(edm::Event& iEvent, const edm::EventSetup
                   continue;
                 ++good_dau;
               }
+              // check charge conjugation
+              if (-(*dau)->pdg_id() == daughterIDs[i]) { // notice minus sign
+                if ((*dau)->momentum().perp() < daughterMinPts[i])
+                  continue;
+                if ((*dau)->momentum().perp() > daughterMaxPts[i])
+                  continue;
+                if ((*dau)->momentum().eta() < daughterMinEtas[i])
+                  continue;
+                if ((*dau)->momentum().eta() > daughterMaxEtas[i])
+                  continue;
+                ++good_dau_cc;
+              }
             }
           }
-          if (good_dau < daughterIDs.size())
+          if (good_dau < daughterIDs.size() && good_dau_cc < daughterIDs.size())
             accepted = false;
         }
 

--- a/GeneratorInterface/GenFilters/src/PythiaFilterMultiAncestor.cc
+++ b/GeneratorInterface/GenFilters/src/PythiaFilterMultiAncestor.cc
@@ -133,7 +133,7 @@ bool PythiaFilterMultiAncestor::filter(edm::Event& iEvent, const edm::EventSetup
                 ++good_dau;
               }
               // check charge conjugation
-              if (-(*dau)->pdg_id() == daughterIDs[i]) { // notice minus sign
+              if (-(*dau)->pdg_id() == daughterIDs[i]) {  // notice minus sign
                 if ((*dau)->momentum().perp() < daughterMinPts[i])
                   continue;
                 if ((*dau)->momentum().perp() > daughterMaxPts[i])


### PR DESCRIPTION
#### PR description:

Backport of #33491 

In this PR we address a design problem of PythiaFilterMultiAncestor.cc, where charge conjugation is implicitly assumed by default for the particle under investigation
https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/GenFilters/plugins/PythiaFilterMultiAncestor.cc#L147
for its ancestor
https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/GenFilters/plugins/PythiaFilterMultiAncestor.cc#L122
, but it is not for its daughters.
https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/GenFilters/plugins/PythiaFilterMultiAncestor.cc#L190

The problem was noticed in some private tests and should not affect any samples produced so far using this filter (which in fact is just a limited number of samples for a specific analysis and they are not affected because in that case it was based on a Jpsi->mumu decay).
However, a backport to 10_6 (and 11?) would be good to avoid having production releases where the filter behaves in an unintended way.

#### PR validation:

The problem was noticed when using the filter to enforce D0->K-pi+ decay.

D0ToKpiFromDstFilter = cms.EDFilter(
    "PythiaFilterMultiAncestor",
    DaughterIDs     = cms.untracked.vint32 ( -321,   211), # K-, pion+ 
    DaughterMaxEtas = cms.untracked.vdouble( 1.e9,  1.e9),
    DaughterMaxPts  = cms.untracked.vdouble( 1.e9,  1.e9),
    DaughterMinEtas = cms.untracked.vdouble(-1.e9, -1.e9),
    DaughterMinPts  = cms.untracked.vdouble(-1.0 , -1.0 ),
    MaxEta          = cms.untracked.double ( 99.0),
    MinEta          = cms.untracked.double (-99.0),
    MinPt           = cms.untracked.double (-1.0),
    MotherIDs       = cms.untracked.vint32 (413), # D*+
    ParticleID      = cms.untracked.int32  (421) # D0
)
Only one charge combination was present, but not the cc. The fix proposed here implements the correct behaviour.