### PR TITLE
introduce `SiStripApvGainFromFileBuilder` (reprise)

### DIFF
--- a/CondTools/SiStrip/README.md
+++ b/CondTools/SiStrip/README.md
@@ -13,3 +13,75 @@
 - _SiStripNoisesFromDBMiscalibrator_: reads Noise from DB and applies hierarchically a scale factor and/or gaussian smearing for each APV gain, down to the individual layer or disk level
   - To run: 
     - `cmsRun test/SiStripNoiseFromDBMiscalibrator_cfg.py globalTag=<inputGT> runNumber=<inputIOV>`
+
+- _SiStripApvGainFromFileBuilder_:
+The SiStripApvGainFromFileBuilder class is an analyzer that reads an ASCII file
+containing the APV gain scan at tickmarks and creates the corresponding payload
+in the offline Database. For each APV the tickmark file is expected to have one
+line with the following data:
+
+| offline detector id | online APV id | value of the gain scan |    
+| ------------------- | ------------- | ---------------------- |
+
+An example of tickmark file can be found in the data directory of this packages.
+The payload for the offline database requires to convert the online APV ids into
+the offline ones. For this conversion the detector cabling `SiStripDetCabling`
+and the reader of the ideal geometry `SiStripDetInfoFileReader` are used. The 
+former provides the APV connectivity into the FEDs and into the detector modules;
+the latter lists the full set of detector modules even those not actually cabled
+in the detector. The code loops over all the possible detector modules, finds
+the connected ones and associates the gain scan to the corresponding APV in the
+module. The uncabled modules, the channels missing in the scan, the channels in
+the scan appearing as uncabled and the channels off (giving a zero tickmark gain)
+or bad (giving a negative tickmark gain) are treated in a special way. According
+on the job configuration either a dummy gain value or a zero gain value is put in
+the offline database for these channels. At the end of the job, it is possible to
+dump the summary of the database insertion into ASCII files for both the regular
+channels and the special channel. The code can also produces ASCII files with the
+gain scan for the APVs to be given in input to a the tracker map. 
+
+A special attention must be reserved to the online to offline conversion of the 
+APV ids. The detector modules can have 3 APV pairs or 2 APV pair and the logic of
+the conversion is different according to the module type. The conversion logic is
+listed in the table below:
+
+##### Modules with 6 APVs
+
+| online APV id  | offline APV id |    
+| -------------- | -------------- |
+| 0 | 0 |
+| 1 | 1 |
+| 2 | 2 |
+| 3 | 3 |
+| 4 | 4 |
+| 5 | 5 |
+
+##### Modules with 4 APVs
+
+| online APV id | offline APV id |
+| ------------- | -------------- |
+| 0 | 0 |
+| 1 | 1 |
+| 4 | 2 |
+| 5 | 3 |
+
+This logic has been implemented inside the SiStripApvGainFromFileBuilder class,
+it cannot be deducted from the SiStrip cabling description code.
+
+##### Job Configuration
+The job to read the ASCII tickmark file and deploy the payload into the offline
+database is configured with the `SiStripApvGainFromASCIIFile_cfg.py` fragment put
+in the test directory. The `SiStripGainApvFromFileBuilder` analyzer is configured
+with the following options:
+
+| Options | Function | Default |
+| ------- | -------- | ------- |
+| `tickFile` | Path to the tickmark scan | `CondTools/SiStrip/data/tickheight.txt` |
+| `gainThreshold` | Lower limit for good scan value | 0. |
+| `dummyAPVGain` | Dummy value for the APV gain | 690./640. |
+| `putDummyIntoUncabled` | Switch to put dummy gain for uncabled channels | False |
+| `putDummyIntoUnscanned` | Switch to put dummy gain for unscanned channels | False |
+| `putDummyIntoOffChannels` | Switch to put dummy gain for OFF channels | False |
+| `putDummyIntoBadChannels` | Switch to put dummy gain for BAD channels | False |
+| `outputMaps` | Switch to output the ASCII text for the tracker map | False |
+| `outputSummary` | Switch to output the summary text file | False |

--- a/CondTools/SiStrip/plugins/SiStripApvGainFromFileBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvGainFromFileBuilder.cc
@@ -143,7 +143,7 @@ private:
   int online2offline(uint16_t onlineAPV_id, uint16_t totalAPVs) const;
 };
 
-struct clean_up {
+static const struct clean_up {
   void operator()(SiStripApvGainFromFileBuilder::Gain* el) {
     if (el != nullptr) {
       el->clear();
@@ -400,13 +400,18 @@ void SiStripApvGainFromFileBuilder::read_tickmark() {
       }
 
       // insert the gain value in the map
-      std::pair<Gain::iterator, bool> ret = map->insert(std::pair<uint32_t, float>(det_id, tick_h));
-      if (ret.second == false) {
-        edm::LogError("MapError") << "@SUB=read_tickmark"
-                                  << "Cannot not insert gain for detector id " << det_id
-                                  << " into the internal map: detector id already in the map." << std::endl;
-      }
+      if (map) {
+        std::pair<Gain::iterator, bool> ret = map->insert(std::pair<uint32_t, float>(det_id, tick_h));
 
+        if (ret.second == false) {
+          edm::LogError("MapError") << "@SUB=read_tickmark"
+                                    << "Cannot not insert gain for detector id " << det_id
+                                    << " into the internal map: detector id already in the map." << std::endl;
+        }
+      } else {
+        edm::LogError("MapError") << "@SUB=read_tickmark"
+                                  << "Cannot get the online-offline APV mapping!" << std::endl;
+      }
     } else if (thickmark_heights.eof()) {
       edm::LogInfo("SiStripApvGainFromFileBuilder") << "@SUB=read_tickmark"
                                                     << "EOF of " << filename.c_str() << " reached." << std::endl;

--- a/CondTools/SiStrip/plugins/SiStripApvGainFromFileBuilder.cc
+++ b/CondTools/SiStrip/plugins/SiStripApvGainFromFileBuilder.cc
@@ -1,0 +1,603 @@
+// STL includes
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+// user includes
+#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
+#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+class SiStripApvGainFromFileBuilder : public edm::one::EDAnalyzer<> {
+public:
+  //enum ExceptionType = { NotConnected, ZeroGainFromScan, NegativeGainFromScan };
+
+  typedef std::map<uint32_t, float> Gain;
+
+  typedef struct {
+    uint32_t det_id;
+    uint16_t offlineAPV_id;
+    int onlineAPV_id;
+    int FED_id;
+    int FED_ch;
+    int i2cAdd;
+    bool is_connected;
+    bool is_scanned;
+    float gain_from_scan;
+    float gain_in_db;
+  } Summary;
+
+  /** Brief Constructor.
+   */
+  explicit SiStripApvGainFromFileBuilder(const edm::ParameterSet& iConfig);
+
+  /** Brief Destructor performing the memory cleanup.
+   */
+  ~SiStripApvGainFromFileBuilder() override;
+
+  /** Brief One dummy-event analysis to create the database record.
+   */
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  const edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> cablingToken_; /*!< ES token for the cabling */
+  edm::FileInPath tfp_;        /*!< File Path for the tickmark scan with the APV gains. */
+  double gainThreshold_;       /*!< Threshold for accepting the APV gain in the tickmark scan file. */
+  double dummyAPVGain_;        /*!< Dummy value for the APV gain. */
+  bool putDummyIntoUncabled_;  /*!< Flag for putting the dummy gain in the channels not actuall cabled. */
+  bool putDummyIntoUnscanned_; /*!< Flag for putting the dummy gain in the chennals not scanned. */
+  bool putDummyIntoOffChannels_; /*!< Flag for putting the dummy gain in the channels that were off during the tickmark scan. */
+  bool putDummyIntoBadChannels_; /*!< Flag for putting the dummy gain in the channels with negative gains. */
+  bool outputMaps_;              /*!< Flag for dumping the internal maps on ASCII files. */
+  bool outputSummary_;           /*!< Flag for dumping the summary of the exceptions during the DB filling. */
+
+  const SiStripDetCabling* detCabling_; /*!< Description of detector cabling. */
+
+  /** Brief Maps [det_id <--> gains] arranged per APV indexes.
+   */
+  std::vector<Gain*> gains_;          /*!< Mapping channels with positive heights. */
+  std::vector<Gain*> negative_gains_; /*!< Mapping channels sending bad data. */
+  std::vector<Gain*> null_gains_;     /*!< Mapping channels switched off during the scan. */
+
+  /** Brief Collection of the channels entered in the DB without exceptions.
+   * The channels whose APV gain has been input in the DB straight from the 
+   * tickmark scan are collected in the summary vector. The summary list is
+   * dumped in the SiStripApvGainSummary.txt at the end of the job. 
+   */
+  std::vector<Summary> summary_; /*!< Collection of channel with no DB filling exceptions. */
+
+  /** Brief Collection of the exceptions encountered when filling the DB. 
+   * An exception occur for all the non-cabled channels ( no gain associated
+   * in the tikmark file) and for all the channels that were off ( with zero
+   * gain associated) or sending corrupted data (with negative values in the
+   * tickmark file). At the end of the job the exception summary is dumped in
+   * SiStripApvGainExceptionSummary.txt.
+   */
+  std::vector<Summary> ex_summary_; /*!< Collection of DB filling exceptions. */
+
+  /** Brief Read the ASCII file containing the tickmark gains.
+   * This method reads the ASCII files that contains the tickmark heights for 
+   * every APV. The heights are first translated into gains, dividing by 640,
+   * then are stored into maps to be associated to the detector ids. Maps are
+   * created for every APV index. 
+   * Negative and Zero heights, yielding to a non physical gain, are stored 
+   * into separate maps.
+   *   Negative gain: channels sending bad data at the tickmark scan. 
+   *   Zero gain    : channels switched off during the tickmark scan. 
+   */
+  void read_tickmark(void);
+
+  /** Brief Returns the mapping among channels and gain heights for the APVs.
+   * This method searchs the mapping of detector Ids <-> gains provided. If the
+   * mapping exists for the requested APV it is returned; if not a new empty
+   * mapping is created, inserted and retruned. The methods accepts onlineIDs
+   * running from 0 to 5. 
+   */
+  Gain* get_map(std::vector<Gain*>* maps, int onlineAPV_id);
+
+  /** Brief Dumps the internal mapping on a ASCII files.
+   * This method dumps the detector id <-> gain maps into acii files separated
+   * for each APV. The basenmae of for the acii file has to be provided as a
+   * input parameter.
+   */
+  void output_maps(std::vector<Gain*>* maps, const char* basename) const;
+
+  /** Brief Dump the exceptions summary on a ASCII file.
+   * This method dumps the online coordinate of the channels for which  there
+   * was an exception for filling the database record. Exceptions are the non
+   * cabled modules, the channels that were off during the tickmark scan, the
+   * channels sending corrupted data duirng the tickmark scan. These exceptions
+   * have been solved putting a dummy gain into the DB record or putting a zero
+   * gain.
+   */
+  void output_summary() const;
+
+  /** Brief Format the output line for the channel summary.
+   */
+  void format_summary(std::stringstream& line, Summary summary) const;
+
+  /** Brief Find the gain value for a pair det_id, APV_id in the internal maps.
+   */
+  bool gain_from_maps(uint32_t det_id, int onlineAPV_id, float& gain);
+  void gain_from_maps(uint32_t det_id, uint16_t totalAPVs, std::vector<std::pair<int, float>>& gain) const;
+
+  /** Brief Convert online APV id into offline APV id.
+   */
+  int online2offline(uint16_t onlineAPV_id, uint16_t totalAPVs) const;
+};
+
+struct clean_up {
+  void operator()(SiStripApvGainFromFileBuilder::Gain* el) {
+    if (el != nullptr) {
+      el->clear();
+      delete el;
+      el = nullptr;
+    }
+  }
+} CleanUp;
+
+SiStripApvGainFromFileBuilder::~SiStripApvGainFromFileBuilder() {
+  for_each(gains_.begin(), gains_.end(), CleanUp);
+  for_each(negative_gains_.begin(), negative_gains_.end(), CleanUp);
+  for_each(null_gains_.begin(), null_gains_.end(), CleanUp);
+}
+
+SiStripApvGainFromFileBuilder::SiStripApvGainFromFileBuilder(const edm::ParameterSet& iConfig)
+    : cablingToken_(esConsumes()),
+      tfp_(iConfig.getUntrackedParameter<edm::FileInPath>("tickFile",
+                                                          edm::FileInPath("CondTools/SiStrip/data/tickheight.txt"))),
+      gainThreshold_(iConfig.getUntrackedParameter<double>("gainThreshold", 0.)),
+      dummyAPVGain_(iConfig.getUntrackedParameter<double>("dummyAPVGain", 690. / 640.)),
+      putDummyIntoUncabled_(iConfig.getUntrackedParameter<bool>("putDummyIntoUncabled", false)),
+      putDummyIntoUnscanned_(iConfig.getUntrackedParameter<bool>("putDummyIntoUnscanned", false)),
+      putDummyIntoOffChannels_(iConfig.getUntrackedParameter<bool>("putDummyIntoOffChannels", 0.)),
+      putDummyIntoBadChannels_(iConfig.getUntrackedParameter<bool>("putDummyIntoBadChannels", 0.)),
+      outputMaps_(iConfig.getUntrackedParameter<bool>("outputMaps", false)),
+      outputSummary_(iConfig.getUntrackedParameter<bool>("outputSummary", false)) {}
+
+void SiStripApvGainFromFileBuilder::analyze(const edm::Event& evt, const edm::EventSetup& iSetup) {
+  //unsigned int run=evt.id().run();
+
+  edm::LogInfo("SiStripApvGainFromFileBuilder") << "@SUB=analyze"
+                                                << "Insert SiStripApvGain Data." << std::endl;
+  this->read_tickmark();
+
+  if (outputMaps_) {
+    try {
+      this->output_maps(&gains_, "tickmark_heights");
+      this->output_maps(&negative_gains_, "negative_tickmark");
+      this->output_maps(&null_gains_, "zero_tickmark");
+    } catch (std::exception& e) {
+      std::cerr << e.what() << std::endl;
+    }
+  }
+
+  // Retrieve the SiStripDetCabling description
+  detCabling_ = &iSetup.getData(cablingToken_);
+
+  // APV gain record to be filled with gains and delivered into the database.
+  auto obj = std::make_unique<SiStripApvGain>();
+
+  const auto& reader =
+      SiStripDetInfoFileReader::read(edm::FileInPath{SiStripDetInfoFileReader::kDefaultFile}.fullPath());
+  const auto& DetInfos = reader.getAllData();
+
+  LogTrace("SiStripApvGainFromFileBuilder") << "  det id  |APVOF| CON |APVON| FED |FEDCH|i2cAd|tickGain|" << std::endl;
+
+  for (const auto& it : DetInfos) {
+    // check if det id is correct and if it is actually cabled in the detector
+    if (it.first == 0 || it.first == 0xFFFFFFFF) {
+      edm::LogError("DetIdNotGood") << "@SUB=analyze"
+                                    << "Wrong det id: " << it.first << "  ... neglecting!" << std::endl;
+      continue;
+    }
+
+    // For the cabled det_id retrieve the number of APV connected
+    // to the module with the FED cabling
+    uint16_t nAPVs = 0;
+    const std::vector<const FedChannelConnection*> connection = detCabling_->getConnections(it.first);
+    for (unsigned int ca = 0; ca < connection.size(); ca++) {
+      if (connection[ca] != nullptr) {
+        nAPVs += (connection[ca])->nApvs();
+        break;
+      }
+    }
+
+    // check consistency among FED cabling and ideal cabling, exit on error
+    if (!connection.empty() && nAPVs != (uint16_t)it.second.nApvs) {
+      edm::LogError("SiStripCablingError") << "@SUB=analyze"
+                                           << "det id " << it.first << ": APV number from FedCabling (" << nAPVs
+                                           << ") is different from the APV number retrieved from the ideal cabling ("
+                                           << it.second.nApvs << ")." << std::endl;
+      throw("Inconsistency on the number of APVs.");
+    }
+
+    // eventually separate the processing for the module that are fully
+    // uncabled. This is worth only if we decide not tu put the record
+    // in the DB for the uncabled det_id.
+    //if( !detCabling_->IsConnected(it.first) ) {
+    //
+    //  continue;
+    //}
+
+    //Gather the APV online id
+    std::vector<std::pair<int, float>> tickmark_for_detId(it.second.nApvs, std::pair<int, float>(-1, 999999.));
+    for (unsigned int ca = 0; ca < connection.size(); ca++) {
+      if (connection[ca] != nullptr) {
+        uint16_t id1 = (connection[ca])->i2cAddr(0) % 32;
+        uint16_t id2 = (connection[ca])->i2cAddr(1) % 32;
+        tickmark_for_detId[online2offline(id1, it.second.nApvs)].first = id1;
+        tickmark_for_detId[online2offline(id2, it.second.nApvs)].first = id2;
+      }
+    }
+    gain_from_maps(it.first, it.second.nApvs, tickmark_for_detId);
+    std::vector<float> theSiStripVector;
+
+    // Fill the gain in the DB object, apply the logic for the dummy values
+    for (unsigned short j = 0; j < it.second.nApvs; j++) {
+      Summary summary;
+      summary.det_id = it.first;
+      summary.offlineAPV_id = j;
+      summary.onlineAPV_id = tickmark_for_detId.at(j).first;
+      summary.is_connected = false;
+      summary.FED_id = -1;
+      summary.FED_ch = -1;
+      summary.i2cAdd = -1;
+
+      for (unsigned int ca = 0; ca < connection.size(); ca++) {
+        if (connection[ca] != nullptr && (connection[ca])->i2cAddr(j % 2) % 32 == summary.onlineAPV_id) {
+          summary.is_connected = (connection[ca])->isConnected();
+          summary.FED_id = (connection[ca])->fedId();
+          summary.FED_ch = (connection[ca])->fedCh();
+          summary.i2cAdd = (connection[ca])->i2cAddr(j % 2);
+        }
+      }
+
+      try {
+        float gain = tickmark_for_detId[j].second;
+        summary.gain_from_scan = gain;
+        LogTrace("SiStripApvGainFromFileBuilder")
+            << it.first << "  " << std::setw(3) << j << "   " << std::setw(3) << connection.size() << "   "
+            << std::setw(3) << summary.onlineAPV_id << "    " << std::setw(3) << summary.FED_id << "   " << std::setw(3)
+            << summary.FED_ch << "   " << std::setw(3) << summary.i2cAdd << "   " << std::setw(7)
+            << summary.gain_from_scan << std::endl;
+
+        if (gain != 999999.) {
+          summary.is_scanned = true;
+          if (gain > gainThreshold_) {
+            summary.gain_in_db = gain;
+            if (!summary.is_connected)
+              ex_summary_.push_back(summary);
+            else
+              summary_.push_back(summary);
+          } else {
+            if (gain == 0.) {
+              if (putDummyIntoOffChannels_)
+                summary.gain_in_db = dummyAPVGain_;
+              else
+                summary.gain_in_db = 0.;
+              ex_summary_.push_back(summary);
+            }
+            if (gain < 0.) {
+              if (putDummyIntoBadChannels_)
+                summary.gain_in_db = dummyAPVGain_;
+              else
+                summary.gain_in_db = 0.;
+              ex_summary_.push_back(summary);
+            }
+          }
+        } else {
+          summary.is_scanned = false;
+          if (!summary.is_connected) {
+            if (putDummyIntoUncabled_)
+              summary.gain_in_db = dummyAPVGain_;
+            else
+              summary.gain_in_db = 0.;
+          } else {
+            if (putDummyIntoUnscanned_)
+              summary.gain_in_db = dummyAPVGain_;
+            else
+              summary.gain_in_db = 0.;
+          }
+          ex_summary_.push_back(summary);
+        }
+
+        theSiStripVector.push_back(summary.gain_in_db);
+
+      } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        edm::LogError("MappingError") << "@SUB=analyze"
+                                      << "Job end prematurely." << std::endl;
+        return;
+      }
+    }
+
+    SiStripApvGain::Range range(theSiStripVector.begin(), theSiStripVector.end());
+    if (!obj->put(it.first, range))
+      edm::LogError("IndexError") << "@SUB=analyze"
+                                  << "detid already exists." << std::endl;
+  }
+
+  if (outputSummary_)
+    output_summary();
+
+  //End now write sistripnoises data in DB
+  edm::Service<cond::service::PoolDBOutputService> mydbservice;
+
+  if (mydbservice.isAvailable()) {
+    if (mydbservice->isNewTagRequest("SiStripApvGainRcd")) {
+      mydbservice->createOneIOV<SiStripApvGain>(*obj, mydbservice->beginOfTime(), "SiStripApvGainRcd");
+    } else {
+      mydbservice->appendOneIOV<SiStripApvGain>(*obj, mydbservice->currentTime(), "SiStripApvGainRcd");
+    }
+  } else {
+    edm::LogError("DBServiceNotAvailable") << "@SUB=analyze"
+                                           << "DB Service is unavailable" << std::endl;
+  }
+}
+
+void SiStripApvGainFromFileBuilder::read_tickmark() {
+  // Connect file for input
+  const auto& filename = tfp_.fullPath();
+  std::ifstream thickmark_heights(filename.c_str());
+
+  if (!thickmark_heights.is_open()) {
+    edm::LogError("FileNotFound") << "@SUB=read_ticlmark"
+                                  << "File with thickmark height file " << filename.c_str() << " cannot be opened!"
+                                  << std::endl;
+    return;
+  }
+
+  // clear internal maps
+  for_each(gains_.begin(), gains_.end(), CleanUp);
+  for_each(negative_gains_.begin(), negative_gains_.end(), CleanUp);
+  for_each(null_gains_.begin(), null_gains_.end(), CleanUp);
+
+  // read file and fill internal map
+  uint32_t det_id = 0;
+  uint32_t APV_id = 0;
+  float tick_h = 0.;
+
+  int count = -1;
+
+  for (;;) {
+    count++;
+    thickmark_heights >> det_id >> APV_id >> tick_h;
+
+    if (!(thickmark_heights.eof() || thickmark_heights.fail())) {
+      if (count == 0) {
+        LogTrace("Debug") << "Reading " << filename.c_str() << " for gathering the tickmark heights" << std::endl;
+        LogTrace("Debug") << "|  Det Id   |  APV Id  |  Tickmark" << std::endl;
+        LogTrace("Debug") << "+-----------+----------+----------" << std::endl;
+      }
+      LogTrace("Debug") << std::setw(11) << det_id << std::setw(8) << APV_id << std::setw(14) << tick_h << std::endl;
+
+      // retrieve the map corresponding to the gain collection
+      Gain* map = nullptr;
+      if (tick_h > 0.) {
+        map = get_map(&gains_, APV_id);
+      } else if (tick_h < 0.) {
+        map = get_map(&negative_gains_, APV_id);
+      } else if (tick_h == 0.) {
+        map = get_map(&null_gains_, APV_id);
+      }
+
+      // insert the gain value in the map
+      std::pair<Gain::iterator, bool> ret = map->insert(std::pair<uint32_t, float>(det_id, tick_h));
+      if (ret.second == false) {
+        edm::LogError("MapError") << "@SUB=read_tickmark"
+                                  << "Cannot not insert gain for detector id " << det_id
+                                  << " into the internal map: detector id already in the map." << std::endl;
+      }
+
+    } else if (thickmark_heights.eof()) {
+      edm::LogInfo("SiStripApvGainFromFileBuilder") << "@SUB=read_tickmark"
+                                                    << "EOF of " << filename.c_str() << " reached." << std::endl;
+      break;
+    } else if (thickmark_heights.fail()) {
+      edm::LogError("FileiReadError") << "@SUB=read_tickmark"
+                                      << "error while reading " << filename.c_str() << std::endl;
+      break;
+    }
+  }
+
+  thickmark_heights.close();
+}
+
+SiStripApvGainFromFileBuilder::Gain* SiStripApvGainFromFileBuilder::get_map(std::vector<Gain*>* maps,
+                                                                            int onlineAPV_id) {
+  Gain* map = nullptr;
+  if (onlineAPV_id < 0 || onlineAPV_id > 5)
+    return map;
+
+  try {
+    map = maps->at(onlineAPV_id);
+  } catch (const std::out_of_range&) {
+    if (maps->size() < static_cast<unsigned int>(onlineAPV_id))
+      maps->resize(onlineAPV_id);
+    maps->insert(maps->begin() + onlineAPV_id, new Gain());
+    map = (*maps)[onlineAPV_id];
+  }
+
+  if (map == nullptr) {
+    (*maps)[onlineAPV_id] = new Gain();
+    map = (*maps)[onlineAPV_id];
+  }
+
+  return map;
+}
+
+void SiStripApvGainFromFileBuilder::output_maps(std::vector<Gain*>* maps, const char* basename) const {
+  for (unsigned int APV = 0; APV < maps->size(); APV++) {
+    Gain* map = (*maps)[APV];
+    if (map != nullptr) {
+      // open output file
+      std::stringstream name;
+      name << basename << "_APV" << APV << ".txt";
+      std::ofstream* ofile = new std::ofstream(name.str(), std::ofstream::trunc);
+      if (!ofile->is_open())
+        throw "cannot open output file!";
+      for (Gain::const_iterator el = map->begin(); el != map->end(); el++) {
+        (*ofile) << (*el).first << "    " << (*el).second << std::endl;
+      }
+      ofile->close();
+      delete ofile;
+    }
+  }
+}
+
+void SiStripApvGainFromFileBuilder::output_summary() const {
+  std::ofstream* ofile = new std::ofstream("SiStripApvGainSummary.txt", std::ofstream::trunc);
+  (*ofile) << "  det id  | APV | isConnected | FED |FEDCH|i2cAd|APVON| is_scanned |tickGain|gainInDB|" << std::endl;
+  (*ofile) << "----------+-----+-------------+-----+-----+-----+-----+------------+--------+--------+" << std::endl;
+  for (unsigned int s = 0; s < summary_.size(); s++) {
+    Summary summary = summary_[s];
+
+    std::stringstream line;
+
+    format_summary(line, summary);
+
+    (*ofile) << line.str() << std::endl;
+  }
+  ofile->close();
+  delete ofile;
+
+  ofile = new std::ofstream("SiStripApvGainExceptionSummary.txt", std::ofstream::trunc);
+  (*ofile) << "  det id  | APV | isConnected | FED |FEDCH|i2cAd|APVON| is_scanned |tickGain|gainInDB|" << std::endl;
+  (*ofile) << "----------+-----+-------------+-----+-----+-----+-----+------------+--------+--------+" << std::endl;
+  for (unsigned int s = 0; s < ex_summary_.size(); s++) {
+    Summary summary = ex_summary_[s];
+
+    std::stringstream line;
+
+    format_summary(line, summary);
+
+    (*ofile) << line.str() << std::endl;
+  }
+  ofile->close();
+  delete ofile;
+}
+
+void SiStripApvGainFromFileBuilder::format_summary(std::stringstream& line, Summary summary) const {
+  std::string conn = (summary.is_connected) ? "CONNECTED" : "NOT_CONNECTED";
+  std::string scan = (summary.is_scanned) ? "IN_SCAN" : "NOT_IN_SCAN";
+
+  line << summary.det_id << "  " << std::setw(3) << summary.offlineAPV_id << "  " << std::setw(13) << conn << "   "
+       << std::setw(3) << summary.FED_id << "   " << std::setw(3) << summary.FED_ch << "   " << std::setw(3)
+       << summary.i2cAdd << "  " << std::setw(3) << summary.onlineAPV_id << "   " << std::setw(11) << scan << "  "
+       << std::setw(7) << summary.gain_from_scan << "  " << std::setw(7) << summary.gain_in_db;
+}
+
+bool SiStripApvGainFromFileBuilder::gain_from_maps(uint32_t det_id, int onlineAPV_id, float& gain) {
+  Gain* map = nullptr;
+
+  // search det_id and APV in the good scan map
+  map = get_map(&gains_, onlineAPV_id);
+  if (map != nullptr) {
+    Gain::const_iterator el = map->find(det_id);
+    if (el != map->end()) {
+      gain = el->second;
+      return true;
+    }
+  }
+
+  // search det_id and APV in the zero gain scan map
+  map = get_map(&negative_gains_, onlineAPV_id);
+  if (map != nullptr) {
+    Gain::const_iterator el = map->find(det_id);
+    if (el != map->end()) {
+      gain = el->second;
+      return true;
+    }
+  }
+
+  //search det_id and APV in the negative gain scan map
+  map = get_map(&null_gains_, onlineAPV_id);
+  if (map != nullptr) {
+    Gain::const_iterator el = map->find(det_id);
+    if (el != map->end()) {
+      gain = el->second;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void SiStripApvGainFromFileBuilder::gain_from_maps(uint32_t det_id,
+                                                   uint16_t totalAPVs,
+                                                   std::vector<std::pair<int, float>>& gain) const {
+  std::stringstream ex_msg;
+  ex_msg << "two APVs with the same online id for det id " << det_id
+         << ". Please check the tick mark file or the read_tickmark routine." << std::endl;
+
+  for (unsigned int i = 0; i < 6; i++) {
+    int offlineAPV_id = online2offline(i, totalAPVs);
+    try {
+      Gain* map = gains_.at(i);
+      if (map != nullptr) {
+        Gain::const_iterator el = map->find(det_id);
+        if (el != map->end()) {
+          if (gain[offlineAPV_id].second != 999999.)
+            throw(ex_msg.str());
+          gain[offlineAPV_id].second = el->second;
+        }
+      }
+    } catch (const std::out_of_range&) {
+      // nothing to do, just pass over
+    }
+
+    try {
+      Gain* map = negative_gains_.at(i);
+      if (map != nullptr) {
+        Gain::const_iterator el = map->find(det_id);
+        if (el != map->end()) {
+          if (gain[offlineAPV_id].second != 999999.)
+            throw(ex_msg.str());
+          gain[offlineAPV_id].second = el->second;
+        }
+      }
+    } catch (const std::out_of_range&) {
+      // nothing to do, just pass over
+    }
+
+    try {
+      Gain* map = null_gains_.at(i);
+      if (map != nullptr) {
+        Gain::const_iterator el = map->find(det_id);
+        if (el != map->end()) {
+          if (gain[offlineAPV_id].second != 999999.)
+            throw(ex_msg.str());
+          gain[offlineAPV_id].second = el->second;
+        }
+      }
+    } catch (const std::out_of_range&) {
+      // nothing to do, just pass over
+    }
+  }
+}
+
+int SiStripApvGainFromFileBuilder::online2offline(uint16_t onlineAPV_id, uint16_t totalAPVs) const {
+  return (onlineAPV_id >= totalAPVs) ? onlineAPV_id - 2 : onlineAPV_id;
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(SiStripApvGainFromFileBuilder);

--- a/CondTools/SiStrip/test/README.md
+++ b/CondTools/SiStrip/test/README.md
@@ -1,0 +1,6 @@
+Some data files are found in the external area, see `CMSSW_SEARCH_PATH` for its location.
+The files are visible in the search path (`CMSSW_SEARCH_PATH`) assuming all the files are accessed with `edm::FileInPath`, instead of direct filesystem calls.
+These files can be found under the same path, as they would be under the usual software area.
+
+Examples:
+   * `CondTools/SiStrip/data` is the location of the input file for the `SiStripApvGainFromASCIIFile_cfg.py` unit test

--- a/CondTools/SiStrip/test/SiStripApvGainFromASCIIFile_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvGainFromASCIIFile_cfg.py
@@ -61,11 +61,14 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     ))
 )
 
-process.prod = cms.EDAnalyzer("SiStripApvGainFromFileBuilder",
-    outputMaps    = cms.untracked.bool(True),
-    outputSummary = cms.untracked.bool(True),
-)
-
+from CondTools.SiStrip.siStripApvGainFromFileBuilder_cfi import siStripApvGainFromFileBuilder
+process.prod = siStripApvGainFromFileBuilder.clone(doGainNormalization = True,      # do normalize the gains
+                                                   putDummyIntoUncabled = True,     # all defects to default
+                                                   putDummyIntoUnscanned = True,    # all defects to default
+                                                   putDummyIntoOffChannels = True,  # all defects to default
+                                                   putDummyIntoBadChannels = True,  # all defects to default
+                                                   outputMaps = True,
+                                                   outputSummary = True)
 process.p = cms.Path(process.prod)
 
 

--- a/CondTools/SiStrip/test/SiStripApvGainFromASCIIFile_cfg.py
+++ b/CondTools/SiStrip/test/SiStripApvGainFromASCIIFile_cfg.py
@@ -1,0 +1,71 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ICALIB")
+process.source = cms.Source("EmptyIOVSource",
+    firstValue = cms.uint64(325642),
+    lastValue = cms.uint64(325642),
+    timetype = cms.string('runnumber'),
+    interval = cms.uint64(1)
+)
+
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.SiStripApvGainFromFileBuilder=dict()  
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("DEBUG"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiStripApvGainFromFileBuilder = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    enableStatistics = cms.untracked.bool(True)
+    )
+
+#process.load('Configuration.Geometry.GeometryDB_cff')
+#process.load('Configuration.Geometry.GeometryIdeal_cff')
+
+process.load("Configuration.Geometry.GeometryExtended2017_cff")
+process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
+process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
+
+#Setup the SiSTripFedCabling and the SiStripDetCabling
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect='frontier://FrontierProd/CMS_CONDITIONS'
+
+process.poolDBESSource = cms.ESSource('PoolDBESSource',
+                                      process.CondDB,
+                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+                                      toGet = cms.VPSet( cms.PSet(record = cms.string('SiStripFedCablingRcd'),
+                                                                  tag    = cms.string('SiStripFedCabling_GR10_v1_hlt')
+                                                                  )
+                                                        )
+                                     )
+                                                                    
+process.load("CalibTracker.SiStripESProducers.SiStripConnectivity_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+    DBParameters = cms.PSet(
+        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:dbfile.db'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiStripApvGainRcd'),
+        tag = cms.string('SiStripApvGainRcd_v1')
+    ))
+)
+
+process.prod = cms.EDAnalyzer("SiStripApvGainFromFileBuilder",
+    outputMaps    = cms.untracked.bool(True),
+    outputSummary = cms.untracked.bool(True),
+)
+
+process.p = cms.Path(process.prod)
+
+

--- a/CondTools/SiStrip/test/testBuildersReaders.sh
+++ b/CondTools/SiStrip/test/testBuildersReaders.sh
@@ -35,6 +35,15 @@ echo -e " Done with the readers \n\n"
 
 sleep 5
 
+## do the builders from file
+for entry in "${LOCAL_TEST_DIR}/"SiStripApv*FromASCIIFile_cfg.py
+do
+  echo "===== Test \"cmsRun $entry \" ===="
+  (cmsRun $entry) || die "Failure using cmsRun $entry" $?
+done
+
+echo -e " Done with the builders from file \n\n"
+
 ## do the miscalibrators
 for entry in "${LOCAL_TEST_DIR}/"SiStrip*Miscalibrator_cfg.py
 do


### PR DESCRIPTION
#### PR description:

This is a re-cast of PR https://github.com/cms-sw/cmssw/pull/8621 that never landed in `cmssw`, after having applied all the necessary modifications to comply with recent migrations.
The introduced plugin reads an ASCII input file containing the SiStrip APV gain from tick mark (G1 gain) and creates the payload in the sqlite file database. In normal operations this is carried out via O2O, but the functionality is kept here as a back-up.
The input file (`CondTools/SiStrip/data/tickheight.txt`) has been proposed to the `CondTools-SiStrip` data repo in the companion PR https://github.com/cms-data/CondTools-SiStrip/pull/1.

#### PR validation:

The unit test introduced here runs successfully.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
