### PR TITLE
get rid of `CMSDEPRECATED_X` warnings in `SimTracker`

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.cc
@@ -26,7 +26,6 @@
 #include "SimTracker/SiPhase2Digitizer/plugins/PixelBrickedDigitizerAlgorithm.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/DigitizerUtility.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"


### PR DESCRIPTION
#### PR description:

Technical, part of the migrations in https://github.com/cms-sw/cmssw/issues/31061 and https://github.com/cms-sw/cmssw/issues/36404.
Removed all of the CMSDEPRECATED_X warnings in the  `SimTracker` subsystems from [CMSSW_12_3_CMSDEPRECATED_X_2022-02-21-2300](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc7_amd64_gcc10/www/mon/12.3.CMSDEPRECATED-mon-23/CMSSW_12_3_CMSDEPRECATED_X_2022-02-21-2300)

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A