### PR TITLE
fixing obsolete EDAnalyzer in DQM/BeamMonitor

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.cc
@@ -70,6 +70,8 @@ void AlcaBeamMonitorClient::beginRun(const edm::Run& r, const EventSetup& contex
 void AlcaBeamMonitorClient::analyze(const Event& iEvent, const EventSetup& iSetup) {}
 
 //----------------------------------------------------------------------------------------------------------------------
+void AlcaBeamMonitorClient::beginLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {}
+
 void AlcaBeamMonitorClient::endLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {
   MonitorElement* tmp = nullptr;
   tmp = dbe_->get(monitorName_ + "Service/hHistoLumiValues");

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
@@ -12,7 +12,7 @@
 #include <string>
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -20,7 +20,7 @@
 //#include "DataFormats/VertexReco/interface/Vertex.h"
 //#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-class AlcaBeamMonitorClient : public edm::EDAnalyzer {
+class AlcaBeamMonitorClient : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks,edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
@@ -31,6 +31,7 @@ public:
 protected:
   void beginJob(void) override;
   void beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   void endLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void endRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitorClient.h
@@ -20,7 +20,7 @@
 //#include "DataFormats/VertexReco/interface/Vertex.h"
 //#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-class AlcaBeamMonitorClient : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks,edm::one::WatchRuns> {
+class AlcaBeamMonitorClient : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks, edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
@@ -55,8 +55,7 @@ void BeamConditionsMonitor::beginJob() {
   h_y0_lumi->getTH1()->SetOption("E1");
 }
 
-//--------------------------------------------------------
-void BeamConditionsMonitor::beginRun(const edm::Run& r, const EventSetup& context) {}
+
 
 //--------------------------------------------------------
 void BeamConditionsMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const EventSetup& context) {
@@ -75,8 +74,7 @@ void BeamConditionsMonitor::endLuminosityBlock(const LuminosityBlock& lumiSeg, c
   h_x0_lumi->ShiftFillLast(condBeamSpot.x(), condBeamSpot.xError(), 1);
   h_y0_lumi->ShiftFillLast(condBeamSpot.y(), condBeamSpot.yError(), 1);
 }
-//--------------------------------------------------------
-void BeamConditionsMonitor::endRun(const Run& r, const EventSetup& context) {}
+
 //--------------------------------------------------------
 void BeamConditionsMonitor::endJob() {}
 

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.cc
@@ -55,8 +55,6 @@ void BeamConditionsMonitor::beginJob() {
   h_y0_lumi->getTH1()->SetOption("E1");
 }
 
-
-
 //--------------------------------------------------------
 void BeamConditionsMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const EventSetup& context) {
   countLumi_++;

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
@@ -11,7 +11,7 @@
 #include <string>
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -23,7 +23,7 @@
 // class declaration
 //
 class BeamSpotObjectsRcd;
-class BeamConditionsMonitor : public edm::EDAnalyzer {
+class BeamConditionsMonitor : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
 public:
   BeamConditionsMonitor(const edm::ParameterSet&);
   ~BeamConditionsMonitor() override;
@@ -36,7 +36,7 @@ protected:
   void beginJob() override;
 
   // BeginRun
-  void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
+  // void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   // Fake Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
@@ -47,7 +47,7 @@ protected:
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
 
   // EndRun
-  void endRun(const edm::Run& r, const edm::EventSetup& c) override;
+  // void endRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   // Endjob
   void endJob() override;

--- a/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamConditionsMonitor.h
@@ -35,9 +35,6 @@ protected:
   // BeginJob
   void beginJob() override;
 
-  // BeginRun
-  // void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
-
   // Fake Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
@@ -45,9 +42,6 @@ protected:
 
   // DQM Client Diagnostic
   void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, const edm::EventSetup& c) override;
-
-  // EndRun
-  // void endRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   // Endjob
   void endJob() override;

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.h
@@ -22,7 +22,7 @@
 // class declaration
 //
 
-class BeamMonitorBx : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks,edm::one::WatchRuns> {
+class BeamMonitorBx : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks, edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.h
@@ -11,7 +11,7 @@
 #include <string>
 // CMS
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -22,7 +22,7 @@
 // class declaration
 //
 
-class BeamMonitorBx : public edm::EDAnalyzer {
+class BeamMonitorBx : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks,edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQM/BeamMonitor/plugins/PixelVTXMonitor.h
+++ b/DQM/BeamMonitor/plugins/PixelVTXMonitor.h
@@ -14,7 +14,7 @@
 #include <vector>
 #include <map>
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
@@ -27,7 +27,7 @@
 // class declaration
 //
 
-class PixelVTXMonitor : public edm::EDAnalyzer {
+class PixelVTXMonitor : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;

--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.h
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.h
@@ -12,7 +12,7 @@
 
 #include <memory>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 


### PR DESCRIPTION
#### PR description:

replacing EDAnalyzer with the appropriate edm::one version for various plugins in the DQM/BeamMonitor package.
No changes to ME expected.

#### PR validation:

DQM/BeamMonitor now compiles on CMSSW_12_3_CMSDEPRECATED_X_2022-02-21-2300 without warnings

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport
