### PR TITLE
added unit test for das-selected-lumis.py

### DIFF
--- a/Configuration/PyReleaseValidation/test/BuildFile.xml
+++ b/Configuration/PyReleaseValidation/test/BuildFile.xml
@@ -1,0 +1,3 @@
+<test name="test-das-selected-lumis" command="test-das-selected-lumis.sh">
+  <flags USE_UNITTEST_DIR="1"/>
+</test>

--- a/Configuration/PyReleaseValidation/test/test-das-selected-lumis.sh
+++ b/Configuration/PyReleaseValidation/test/test-das-selected-lumis.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
 export CMS_BOT_USE_DASGOCLIENT=true
 QUERY="lumi,file dataset=/HIHardProbes/HIRun2018A-v1/RAW run=326479"
-dasgoclient --limit 0 --query "${QUERY}" --format json | das-selected-lumis.py 1,23 | sort > original.txt
-export CMS_BOT_USE_DASGOCLIENT=false
-dasgoclient --limit 0 --query "${QUERY}" --format json | das-selected-lumis.py 1,23 | sort > cached.txt
-diff -u original.txt cached.txt
-
+dasgoclient --limit 0 --query "${QUERY}" --format json | das-selected-lumis.py 1,23 | grep '^/store/' > original.txt
+cat original.txt
+if [ $(cat original.txt | wc -l) -eq 0 ] ; then
+  exit 1
+fi

--- a/Configuration/PyReleaseValidation/test/test-das-selected-lumis.sh
+++ b/Configuration/PyReleaseValidation/test/test-das-selected-lumis.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+export CMS_BOT_USE_DASGOCLIENT=true
+QUERY="lumi,file dataset=/HIHardProbes/HIRun2018A-v1/RAW run=326479"
+dasgoclient --limit 0 --query "${QUERY}" --format json | das-selected-lumis.py 1,23 | sort > original.txt
+export CMS_BOT_USE_DASGOCLIENT=false
+dasgoclient --limit 0 --query "${QUERY}" --format json | das-selected-lumis.py 1,23 | sort > cached.txt
+diff -u original.txt cached.txt
+


### PR DESCRIPTION
Latest dasgoclient changed json output which broke `das-selected-lumis.py` ( see https://github.com/cms-sw/cmssw/issues/37052 ). This PR adds unit test to run `das-selected-lumis.py` to to make sure that it can properly read `dasgoclient` json output.  
