### PR TITLE
Update das-selected-lumis to cope with the latest changes in DAS server

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
+++ b/Configuration/PyReleaseValidation/scripts/das-selected-lumis.py
@@ -37,13 +37,14 @@ def process_lumi(data):
     else:
       lumi_nums = lumi_info['lumi']['number']
       lumi_file = lumi_info['file']['name']
-    if not isinstance(lumi_nums[0], list): lumi_rang = [ [n,n] for n in lumi_nums ]
+    if isinstance(lumi_nums, int): lumi_rang = [ [lumi_nums, lumi_nums] ]
+    elif not isinstance(lumi_nums[0], list): lumi_rang = [ [n,n] for n in lumi_nums ]
     else: lumi_rang = lumi_nums
     for sub_list in lumi_rang:
       if check_lumi_ranges(input_range,tuple(sub_list)):
         output_files_list.append(lumi_file)
         break
-  for out_file_name in output_files_list:
+  for out_file_name in set(output_files_list):
     print(out_file_name)
 
 #Get file names for desired lumi ranges


### PR DESCRIPTION
#### PR description:

In the most recent IBs `runTheMatrix` step1 doesn't work.

It seems to be due to the fact that in the new DBS server the DAS return output is a list, while old DBS server returned a dictionary output 

#### PR validation:

Before this PR doing `runTheMatrix -l 138.4` I got
```
# in: /afs/cern.ch/user/t/tvami/public/PRsToCMSSW/removeCastorTags/CMSSW_12_3_X_2022-02-25-1100/src going to execute cd 138.4_PromptCollisions+RunMinimumBias2021+ALCARECOPROMPTR3+HARVESTDPROMPTR3
 (dasgoclient --limit 0 --query 'lumi,file dataset=/MinimumBias/Commissioning2021-v1/RAW run=346512' --format json | das-selected-lumis.py 250,300 ) | sort -u > step1_dasquery.log  2>&1
 
Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/nweek-02721/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_3_X_2022-02-24-2300/bin/slc7_amd64_gcc10/das-selected-lumis.py", line 50, in <module>
    process_lumi(lumi_data)
  File "/cvmfs/cms-ib.cern.ch/nweek-02721/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_3_X_2022-02-24-2300/bin/slc7_amd64_gcc10/das-selected-lumis.py", line 40, in process_lumi
    if not isinstance(lumi_nums[0], list): lumi_rang = [ [n,n] for n in lumi_nums ]
TypeError: 'int' object has no attribute '__getitem__'
```

After the PR, it works.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
