### PR TITLE
Fix `BeamSpotAnalyzer::fillDescriptions`

### DIFF
--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotAnalyzer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotAnalyzer.cc
@@ -216,13 +216,16 @@ void BeamSpotAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.setComment("Analyzer of BeamSpot Objects");
 
   edm::ParameterSetDescription bsAnalyzerParamsDesc;
-  std::vector<edm::ParameterSet> bsAnaDefaults(1);
-  bsAnaDefaults[0].addParameter("WriteToDB", false);
-  bsAnaDefaults[0].addParameter("RunAllFitters", false);
-  bsAnaDefaults[0].addUntrackedParameter("fitEveryNLumi", -1);
-  bsAnaDefaults[0].addUntrackedParameter("resetEveryNLumi", -1);
-  bsAnaDefaults[0].addParameter("RunBeamWidthFit", false);
-  desc.addVPSet("BSAnalyzerParameters", bsAnalyzerParamsDesc, bsAnaDefaults);
+  bsAnalyzerParamsDesc.add("WriteToDB", false);
+  bsAnalyzerParamsDesc.add("RunAllFitters", false);
+  bsAnalyzerParamsDesc.addUntracked("fitEveryNLumi", -1);
+  bsAnalyzerParamsDesc.addUntracked("resetEveryNLumi", -1);
+  bsAnalyzerParamsDesc.add("RunBeamWidthFit", false);
+  desc.add<edm::ParameterSetDescription>("BSAnalyzerParameters", bsAnalyzerParamsDesc);
+
+  BeamFitter::fillDescription(desc);
+  PVFitter::fillDescription(desc);
+
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotAnalyzer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotAnalyzer.cc
@@ -9,7 +9,6 @@ ________________________________________________________________**/
 
 // C++ standard
 #include <string>
-#include <string>
 
 // CMS
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"

--- a/RecoVertex/BeamSpotProducer/test/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/test/BuildFile.xml
@@ -14,3 +14,8 @@
     <flags TEST_RUNNER_ARGS="/bin/bash RecoVertex/BeamSpotProducer/test testReadWriteBSFromDB.sh"/>
   </bin>
 </environment>
+
+<bin file="testBeamSpotAnalyzer.cc">
+  <use name="FWCore/TestProcessor"/>
+  <use name="catch2"/>
+</bin>

--- a/RecoVertex/BeamSpotProducer/test/testBeamSpotAnalyzer.cc
+++ b/RecoVertex/BeamSpotProducer/test/testBeamSpotAnalyzer.cc
@@ -1,0 +1,22 @@
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+TEST_CASE("BeamSpotAnalyzer tests", "[BeamSpotAnalyzer]") {
+  //The python configuration
+  edm::test::TestProcessor::Config config{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+from RecoVertex.BeamSpotProducer.d0_phi_analyzer_cff import d0_phi_analyzer 
+process = TestProcess()
+process.beamAnalyzer = d0_phi_analyzer 
+process.moduleToTest(process.beamAnalyzer)
+)_"};
+
+  SECTION("Run with no Lumis") {
+    edm::test::TestProcessor tester{config};
+    tester.testRunWithNoLuminosityBlocks();
+    //get here without an exception or crashing
+    REQUIRE(true);
+  };
+}


### PR DESCRIPTION
#### PR description:

As reported by @francescobrivio, PR https://github.com/cms-sw/cmssw/pull/35236 introduced a wrong type for the parameter `BSAnalyzerParameters` (which should be a `PSet` and non a `VPSet`).
This is fixed in this PR, together with completing the rest of descriptions coming from the `BeamFitter` and `PVFitter` classes.
I profit of this PR to introduce a unit test to check the functionality of the analyzer.

#### PR validation:

Relies on the unit tests provided in this PR

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
