### PR TITLE
Fixes for L3 and L1 trigger object matching in Muon HLT

### DIFF
--- a/HLTrigger/Muon/plugins/BuildFile.xml
+++ b/HLTrigger/Muon/plugins/BuildFile.xml
@@ -22,4 +22,5 @@
 <use name="TrackingTools/PatternTools"/>
 <use name="TrackingTools/TransientTrack"/>
 <use name="RecoTracker/FinalTrackSelectors"/>
+<use name="MuonAnalysis/MuonAssociators"/>
 <flags EDM_PLUGIN="1"/>

--- a/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.cc
@@ -293,8 +293,8 @@ bool HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent,
           float etaForMatch = cand->eta();
           float phiForMatch = cand->phi();
           if (propagated.isValid()) {
-              etaForMatch = propagated.globalPosition().eta();
-              phiForMatch = propagated.globalPosition().phi();
+            etaForMatch = propagated.globalPosition().eta();
+            phiForMatch = propagated.globalPosition().phi();
           }
           iEvent.getByToken(l1CandToken_, level1Cands);
           level1Cands->getObjects(trigger::TriggerL1Mu, vl1cands);

--- a/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonDimuonL3Filter.h
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h"
 
 namespace edm {
   class ConfigurationDescriptions;
@@ -45,6 +46,8 @@ private:
                             const reco::RecoChargedCandidateRef&,
                             const reco::BeamSpot&,
                             const edm::ESHandle<MagneticField>&) const;
+
+  mutable PropagateToMuon prop_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> idealMagneticFieldRecordToken_;
   const edm::InputTag beamspotTag_;
   const edm::EDGetTokenT<reco::BeamSpot> beamspotToken_;

--- a/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
@@ -15,6 +15,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "TMath.h"
 
 #include <vector>
@@ -110,8 +111,18 @@ bool HLTMuonL1TFilter::hltFilter(edm::Event& iEvent,
       MuonRef muon(allMuons, distance(allMuons->begin(allMuons->getFirstBX()), it));
 
       // Only select muons that were selected in the previous level
-      if (find(prevMuons.begin(), prevMuons.end(), muon) == prevMuons.end())
-        continue;
+      //new matching that also works if the collections are not one and the same
+      bool matchPrevL1 = false;
+      int prevSize = prevMuons.size();
+      for (int it2=0; it2<prevSize;it2++){
+         if (deltaR2(muon->eta(),muon->phi(),prevMuons[it2]->eta(),prevMuons[it2]->phi()) < 0.1) matchPrevL1 = true;
+      }
+      if (!matchPrevL1)
+         continue;
+      // old matching that fails 
+      //if (find(prevMuons.begin(), prevMuons.end(), muon) == prevMuons.end())
+        //continue;
+        
 
       //check maxEta cut
       if (fabs(muon->eta()) > maxEta_)

--- a/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
@@ -111,18 +111,14 @@ bool HLTMuonL1TFilter::hltFilter(edm::Event& iEvent,
       MuonRef muon(allMuons, distance(allMuons->begin(allMuons->getFirstBX()), it));
 
       // Only select muons that were selected in the previous level
-      //new matching that also works if the collections are not one and the same
       bool matchPrevL1 = false;
       int prevSize = prevMuons.size();
-      for (int it2=0; it2<prevSize;it2++){
-         if (deltaR2(muon->eta(),muon->phi(),prevMuons[it2]->eta(),prevMuons[it2]->phi()) < 0.1) matchPrevL1 = true;
+      for (int it2 = 0; it2 < prevSize; it2++) {
+        if (deltaR2(muon->eta(), muon->phi(), prevMuons[it2]->eta(), prevMuons[it2]->phi()) < 0.1)
+          matchPrevL1 = true;
       }
       if (!matchPrevL1)
-         continue;
-      // old matching that fails 
-      //if (find(prevMuons.begin(), prevMuons.end(), muon) == prevMuons.end())
-        //continue;
-        
+        continue;
 
       //check maxEta cut
       if (fabs(muon->eta()) > maxEta_)

--- a/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.cc
@@ -35,7 +35,7 @@ using namespace trigger;
 
 HLTMuonL3PreFilter::HLTMuonL3PreFilter(const ParameterSet& iConfig)
     : HLTFilter(iConfig),
-      prop_(iConfig, consumesCollector()), 
+      prop_(iConfig, consumesCollector()),
       beamspotTag_(iConfig.getParameter<edm::InputTag>("BeamSpotTag")),
       beamspotToken_(consumes<reco::BeamSpot>(beamspotTag_)),
       candTag_(iConfig.getParameter<InputTag>("CandTag")),
@@ -231,13 +231,13 @@ bool HLTMuonL3PreFilter::hltFilter(Event& iEvent,
         }  //MTL loop
 
         if (!l1CandTag_.label().empty() && check_l1match) {
-	  TrajectoryStateOnSurface propagated = prop_.extrapolate(*tk);
-	  float etaForMatch = cand->eta();
-	  float phiForMatch = cand->phi();
+          TrajectoryStateOnSurface propagated = prop_.extrapolate(*tk);
+          float etaForMatch = cand->eta();
+          float phiForMatch = cand->phi();
           if (propagated.isValid()) {
-                etaForMatch = propagated.globalPosition().eta();
-                phiForMatch = propagated.globalPosition().phi();
-	  }	  
+            etaForMatch = propagated.globalPosition().eta();
+            phiForMatch = propagated.globalPosition().phi();
+          }
           iEvent.getByToken(l1CandToken_, level1Cands);
           level1Cands->getObjects(trigger::TriggerL1Mu, vl1cands);
           const unsigned int nL1Muons(vl1cands.size());

--- a/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.cc
@@ -35,6 +35,7 @@ using namespace trigger;
 
 HLTMuonL3PreFilter::HLTMuonL3PreFilter(const ParameterSet& iConfig)
     : HLTFilter(iConfig),
+      prop_(iConfig, consumesCollector()), 
       beamspotTag_(iConfig.getParameter<edm::InputTag>("BeamSpotTag")),
       beamspotToken_(consumes<reco::BeamSpot>(beamspotTag_)),
       candTag_(iConfig.getParameter<InputTag>("CandTag")),
@@ -113,6 +114,10 @@ void HLTMuonL3PreFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.add<double>("L1MatchingdR", 0.3);
   desc.add<bool>("MatchToPreviousCand", true);
   desc.add<edm::InputTag>("InputLinks", edm::InputTag(""));
+  desc.add<bool>("useSimpleGeometry", true);
+  desc.add<bool>("useStation2", true);
+  desc.add<string>("useTrack", "tracker");
+  desc.add<string>("useState", "atVertex");
   descriptions.add("hltMuonL3PreFilter", desc);
 }
 
@@ -127,6 +132,8 @@ bool HLTMuonL3PreFilter::hltFilter(Event& iEvent,
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)
   // this HLT filter, and place it in the Event.
+
+  prop_.init(iSetup);
 
   if (saveTags())
     filterproduct.addCollectionTag(candTag_);
@@ -224,11 +231,19 @@ bool HLTMuonL3PreFilter::hltFilter(Event& iEvent,
         }  //MTL loop
 
         if (!l1CandTag_.label().empty() && check_l1match) {
+	  TrajectoryStateOnSurface propagated = prop_.extrapolate(*tk);
+	  float etaForMatch = cand->eta();
+	  float phiForMatch = cand->phi();
+          if (propagated.isValid()) {
+                etaForMatch = propagated.globalPosition().eta();
+                phiForMatch = propagated.globalPosition().phi();
+	  }	  
           iEvent.getByToken(l1CandToken_, level1Cands);
           level1Cands->getObjects(trigger::TriggerL1Mu, vl1cands);
           const unsigned int nL1Muons(vl1cands.size());
           for (unsigned int il1 = 0; il1 != nL1Muons; ++il1) {
-            if (deltaR(cand->eta(), cand->phi(), vl1cands[il1]->eta(), vl1cands[il1]->phi()) < L1MatchingdR_) {
+            if (deltaR2(etaForMatch, phiForMatch, vl1cands[il1]->eta(), vl1cands[il1]->phi()) <
+                L1MatchingdR_ * L1MatchingdR_) {
               MuonToL3s[i] = RecoChargedCandidateRef(cand);
             }
           }

--- a/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.h
@@ -24,6 +24,7 @@
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h"
 
 class HLTMuonL3PreFilter : public HLTFilter {
 public:
@@ -38,6 +39,7 @@ private:
   bool triggeredByLevel2(const reco::TrackRef& track, std::vector<reco::RecoChargedCandidateRef>& vcands) const;
   bool applySelection(const reco::RecoChargedCandidateRef&, const reco::BeamSpot&) const;
 
+  mutable PropagateToMuon prop_;
   const edm::InputTag beamspotTag_;
   const edm::EDGetTokenT<reco::BeamSpot> beamspotToken_;
   const edm::InputTag candTag_;  // input tag identifying product contains muons
@@ -78,6 +80,8 @@ private:
   const bool devDebug_;
   const edm::InputTag theL3LinksLabel;
   const edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;
+
+
 };
 
 #endif  //HLTMuonL3PreFilter_h

--- a/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.h
@@ -80,8 +80,6 @@ private:
   const bool devDebug_;
   const edm::InputTag theL3LinksLabel;
   const edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;
-
-
 };
 
 #endif  //HLTMuonL3PreFilter_h

--- a/HLTrigger/Muon/plugins/HLTMuonTrkFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkFilter.cc
@@ -27,7 +27,9 @@
 
 #include "DataFormats/Math/interface/deltaR.h"
 
-HLTMuonTrkFilter::HLTMuonTrkFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
+HLTMuonTrkFilter::HLTMuonTrkFilter(const edm::ParameterSet& iConfig)
+  : HLTFilter(iConfig),
+    prop_(iConfig, consumesCollector()) {
   m_muonsTag = iConfig.getParameter<edm::InputTag>("inputMuonCollection");
   m_muonsToken = consumes<reco::MuonCollection>(m_muonsTag);
   m_candsTag = iConfig.getParameter<edm::InputTag>("inputCandCollection");
@@ -62,12 +64,18 @@ void HLTMuonTrkFilter::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<double>("minPt", 24);
   desc.add<unsigned int>("minN", 1);
   desc.add<double>("maxAbsEta", 1e99);
+  desc.add<bool>("useSimpleGeometry", true);
+  desc.add<bool>("useStation2", true);
+  desc.add<string>("useTrack", "tracker");
+  desc.add<string>("useState", "atVertex");
   descriptions.add("hltMuonTrkFilter", desc);
 }
 
 bool HLTMuonTrkFilter::hltFilter(edm::Event& iEvent,
                                  const edm::EventSetup& iSetup,
                                  trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  prop_.init(iSetup);
+
   edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(m_muonsToken, muons);
   edm::Handle<reco::RecoChargedCandidateCollection> cands;
@@ -96,11 +104,20 @@ bool HLTMuonTrkFilter::hltFilter(edm::Event& iEvent,
   std::vector<unsigned int> filteredMuons;
   for (unsigned int i = 0; i < muons->size(); ++i) {
     const reco::Muon& muon(muons->at(i));
+    reco::RecoChargedCandidateRef cand(cands, i);
+    reco::TrackRef tk = cand->track();
     // check for dR match to L1 muons
     if (check_l1match) {
+      TrajectoryStateOnSurface propagated = prop_.extrapolate(*tk);
+      float etaForMatch = cand->eta();
+      float phiForMatch = cand->phi();
+      if (propagated.isValid()) {
+          etaForMatch = propagated.globalPosition().eta();
+          phiForMatch = propagated.globalPosition().phi();
+      }
       bool matchl1 = false;
       for (auto l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {
-        if (deltaR(muon, **l1cand) < 0.3) {
+        if (deltaR2(etaForMatch, phiForMatch, (*l1cand)->eta(), (*l1cand)->phi()) < 0.3 * 0.3) {
           matchl1 = true;
           break;
         }

--- a/HLTrigger/Muon/plugins/HLTMuonTrkFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkFilter.cc
@@ -28,8 +28,7 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 HLTMuonTrkFilter::HLTMuonTrkFilter(const edm::ParameterSet& iConfig)
-  : HLTFilter(iConfig),
-    prop_(iConfig, consumesCollector()) {
+    : HLTFilter(iConfig), prop_(iConfig, consumesCollector()) {
   m_muonsTag = iConfig.getParameter<edm::InputTag>("inputMuonCollection");
   m_muonsToken = consumes<reco::MuonCollection>(m_muonsTag);
   m_candsTag = iConfig.getParameter<edm::InputTag>("inputCandCollection");
@@ -112,8 +111,8 @@ bool HLTMuonTrkFilter::hltFilter(edm::Event& iEvent,
       float etaForMatch = cand->eta();
       float phiForMatch = cand->phi();
       if (propagated.isValid()) {
-          etaForMatch = propagated.globalPosition().eta();
-          phiForMatch = propagated.globalPosition().phi();
+        etaForMatch = propagated.globalPosition().eta();
+        phiForMatch = propagated.globalPosition().phi();
       }
       bool matchl1 = false;
       for (auto l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {

--- a/HLTrigger/Muon/plugins/HLTMuonTrkFilter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkFilter.h
@@ -4,8 +4,10 @@
 //  based on HLTDiMuonGlbTrkFilter.h
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h"
 
 namespace edm {
   class ConfigurationDescriptions;
@@ -21,6 +23,7 @@ public:
                  trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
 
 private:
+  mutable PropagateToMuon prop_;
   // WARNING: two input collection represent should be aligned and represent
   // the same list of muons, just stored in different containers
   edm::InputTag m_muonsTag;                             // input collection of muons

--- a/HLTrigger/Muon/plugins/HLTMuonTrkL1TFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkL1TFilter.cc
@@ -26,8 +26,7 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 HLTMuonTrkL1TFilter::HLTMuonTrkL1TFilter(const edm::ParameterSet& iConfig)
-  : HLTFilter(iConfig),
-    prop_(iConfig, consumesCollector()) {
+    : HLTFilter(iConfig), prop_(iConfig, consumesCollector()) {
   m_muonsTag = iConfig.getParameter<edm::InputTag>("inputMuonCollection");
   m_muonsToken = consumes<reco::MuonCollection>(m_muonsTag);
   m_candsTag = iConfig.getParameter<edm::InputTag>("inputCandCollection");
@@ -110,8 +109,8 @@ bool HLTMuonTrkL1TFilter::hltFilter(edm::Event& iEvent,
       float etaForMatch = cand->eta();
       float phiForMatch = cand->phi();
       if (propagated.isValid()) {
-          etaForMatch = propagated.globalPosition().eta();
-          phiForMatch = propagated.globalPosition().phi();
+        etaForMatch = propagated.globalPosition().eta();
+        phiForMatch = propagated.globalPosition().phi();
       }
       bool matchl1 = false;
       for (auto l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {

--- a/HLTrigger/Muon/plugins/HLTMuonTrkL1TFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkL1TFilter.cc
@@ -25,7 +25,9 @@
 
 #include "DataFormats/Math/interface/deltaR.h"
 
-HLTMuonTrkL1TFilter::HLTMuonTrkL1TFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
+HLTMuonTrkL1TFilter::HLTMuonTrkL1TFilter(const edm::ParameterSet& iConfig)
+  : HLTFilter(iConfig),
+    prop_(iConfig, consumesCollector()) {
   m_muonsTag = iConfig.getParameter<edm::InputTag>("inputMuonCollection");
   m_muonsToken = consumes<reco::MuonCollection>(m_muonsTag);
   m_candsTag = iConfig.getParameter<edm::InputTag>("inputCandCollection");
@@ -60,12 +62,18 @@ void HLTMuonTrkL1TFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<double>("minPt", 24);
   desc.add<unsigned int>("minN", 1);
   desc.add<double>("maxAbsEta", 1e99);
+  desc.add<bool>("useSimpleGeometry", true);
+  desc.add<bool>("useStation2", true);
+  desc.add<string>("useTrack", "tracker");
+  desc.add<string>("useState", "atVertex");
   descriptions.add("hltMuonTrkL1TFilter", desc);
 }
 
 bool HLTMuonTrkL1TFilter::hltFilter(edm::Event& iEvent,
                                     const edm::EventSetup& iSetup,
                                     trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  prop_.init(iSetup);
+
   edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(m_muonsToken, muons);
   edm::Handle<reco::RecoChargedCandidateCollection> cands;
@@ -94,11 +102,20 @@ bool HLTMuonTrkL1TFilter::hltFilter(edm::Event& iEvent,
   std::vector<unsigned int> filteredMuons;
   for (unsigned int i = 0; i < muons->size(); ++i) {
     const reco::Muon& muon(muons->at(i));
+    reco::RecoChargedCandidateRef cand(cands, i);
+    reco::TrackRef tk = cand->track();
     // check for dR match to L1 muons
     if (check_l1match) {
+      TrajectoryStateOnSurface propagated = prop_.extrapolate(*tk);
+      float etaForMatch = cand->eta();
+      float phiForMatch = cand->phi();
+      if (propagated.isValid()) {
+          etaForMatch = propagated.globalPosition().eta();
+          phiForMatch = propagated.globalPosition().phi();
+      }
       bool matchl1 = false;
       for (auto l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {
-        if (deltaR(muon, **l1cand) < 0.3) {
+        if (deltaR2(etaForMatch, phiForMatch, (*l1cand)->eta(), (*l1cand)->phi()) < 0.3 * 0.3) {
           matchl1 = true;
           break;
         }

--- a/HLTrigger/Muon/plugins/HLTMuonTrkL1TFilter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkL1TFilter.h
@@ -3,9 +3,11 @@
 // author D. Olivito
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h"
 
 namespace edm {
   class ConfigurationDescriptions;
@@ -21,6 +23,7 @@ public:
                  trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
 
 private:
+  mutable PropagateToMuon prop_;
   // WARNING: two input collection represent should be aligned and represent
   // the same list of muons, just stored in different containers
   edm::InputTag m_muonsTag;                             // input collection of muons


### PR DESCRIPTION
This PR improves the matching of L3 and L1 candidates in filters in the Muon HLT in two ways:

- For L3/L1 matching, the L3 muon is now propagated to the second muon station, since L1 parameters are defined there. This improves matching efficiency for very low pT muons. This change has negligible impact on overall HLT performance. Total HLT rate is virtually unchange (0.04% increase). Timing is virtually unchange as well, despite the added propagation (black is without, red is with the propagation)
![image](https://user-images.githubusercontent.com/4459228/155994255-d26642c6-4de2-4d43-8d19-31780ec4ff6e.png)

- In HLTMuonL1TFilter a match between L1 muons before and after different filters is performed. Currently the code expects the muons that are compared to be in the same collection. However, there are use cases in the current menu where the matching is performed with a copy of the L1 muon collection and thus always fails. This causes an inefficiency for low pT muons that are reconstructed only by L1-seeded reconstruction steps. Impact is mostly negligible, showing tiny efficiency improvements for high-pT muon from the Z:
 ![image](https://user-images.githubusercontent.com/4459228/155995310-c31a98e0-a8eb-420e-af7f-cbe2f5265f65.png)

Effect gets more visible for lower pT muons, for example in the turnon of the double-muon trigger:
![image](https://user-images.githubusercontent.com/4459228/155995381-ca6abbe6-33ce-4fef-8d4b-4d408e7b34dc.png)
 
However, the effect is significant for very low pT leptons. For the muon Bs -> mumu trigger (HLT_DoubleMu4_3_Bs_v14) we find a ~20% improvement of HLT efficiency on a sample of signal events provided by BPH.  
