### PR TITLE
properly treat averaging with self in GhostTrackVertexFinder::vtxMean

### DIFF
--- a/RecoVertex/GhostTrackFitter/BuildFile.xml
+++ b/RecoVertex/GhostTrackFitter/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/GeometryVector"/>

--- a/RecoVertex/GhostTrackFitter/src/GhostTrackVertexFinder.cc
+++ b/RecoVertex/GhostTrackFitter/src/GhostTrackVertexFinder.cc
@@ -46,6 +46,8 @@
 
 #include "RecoVertex/GhostTrackFitter/interface/GhostTrackVertexFinder.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 // #define DEBUG
 
 #ifdef DEBUG
@@ -122,6 +124,11 @@ static double vtxErrorLong(const GlobalError &error, const GlobalVector &dir) {
 
 static GlobalPoint vtxMean(const GlobalPoint &p1, const GlobalError &e1, const GlobalPoint &p2, const GlobalError &e2) {
   GlobalVector diff = p2 - p1;
+
+  if UNLIKELY (p1 == p2) {
+    edm::LogWarning("GhostTrackVertexFinder") << "Averaging with self at " << p1;
+    return p1;
+  }
 
   double err1 = vtxErrorLong(e1, diff);
   double err2 = vtxErrorLong(e2, diff);


### PR DESCRIPTION
while debugging in some corner of phase space I noticed that a relatively benign case of averaging of two identical points in `GhostTrackVertexFinder::vtxMean` can lead to a NaN in the results.
The NaN eventually propagates downstream and leads to 
an exception thrown in `PerigeeConversions::ftsToPerigeeParameters` (`cms::Exception("PerigeeConversions", "Track with pt=0")`), which is actually caught in https://github.com/cms-sw/cmssw/blob/14da925d52a1bf0b6a0580000f6fc2bd703deb61/TrackingTools/TrajectoryState/src/TrajectoryStateClosestToPoint.cc#L17-L22. Apparently, given no checks for finiteness,  a perp computed on a 3D vector of NaN values looks like a zero.

I'm proposing a simple fix to return one of the identical points.

I'm adding a warning only because this condition was previously leading to a (caught) exception.

(~Also, I'm not familiar enough with `GhostTrackVertexFinder` to conclude that an averaging with self is an indication of a logic error and that a fix upstream is needed.~)
After some tests in relvals, the conditions seems to happen in ` O(1e-3)` events.
