### PR TITLE
Add new L1T menu for Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,17 +64,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v8',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v8',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v8',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v8',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v8',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v8',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '123X_mcRun4_realistic_v6'
 }


### PR DESCRIPTION
#### PR description:

Add new L1T menu for Run-3 MC GTs as requested in https://cms-talk.web.cern.ch/t/mc-run3-update-l1menu-in-gts/7522

The new GTs, and their diffs wrt to the autoCond are
 * 123X_mcRun3_2021_design_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_design_v8/123X_mcRun3_2021_design_v9
 * 123X_mcRun3_2021_realistic_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_v8/123X_mcRun3_2021_realistic_v9
 * 123X_mcRun3_2021cosmics_realistic_deco_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021cosmics_realistic_deco_v8/123X_mcRun3_2021cosmics_realistic_deco_v9
 * 123X_mcRun3_2021_realistic_HI_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_HI_v8/123X_mcRun3_2021_realistic_HI_v9
 * 123X_mcRun3_2023_realistic_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2023_realistic_v8/123X_mcRun3_2023_realistic_v9
 * 123X_mcRun3_2024_realistic_v9
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2024_realistic_v8/123X_mcRun3_2024_realistic_v9

Diffs are in the requested `L1Menu_Collisions2022_v0_1_5_xml` tag only.

#### PR validation:

workflows = 12034.0,11634.0,7.23,159.0,12434.0,12834.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
