### PR TITLE
When open fails with XrdCl::errRedirectLimit, delay next active source check.

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -226,6 +226,7 @@ namespace XrdAdaptor {
     bool m_nextInitialSourceToggle;
     // The time when the next active source check should be performed.
     timespec m_nextActiveSourceCheck;
+    int m_redirectLimitDelayScale;
     bool searchMode;
 
     const std::string m_name;


### PR DESCRIPTION
backport of #35498
This PR backports the changes which were added in DEVEL IBs for xrootd 5.3. 