### PR TITLE
Fix AllStepsToTree option to runP_Tracker.py script

### DIFF
--- a/Validation/Geometry/interface/MaterialBudgetTree.h
+++ b/Validation/Geometry/interface/MaterialBudgetTree.h
@@ -21,7 +21,7 @@ private:
   void book();  // user booking
   std::unique_ptr<TFile> theFile;
   std::unique_ptr<TTree> theTree;
-  std::string fname;
+  std::string fname, tmpName;
 
   static const int MAXSTEPS = 10000;
 

--- a/Validation/Geometry/src/MaterialBudgetTree.cc
+++ b/Validation/Geometry/src/MaterialBudgetTree.cc
@@ -229,5 +229,5 @@ void MaterialBudgetTree::endOfRun() {
   }
 
   delete outFile;
-  unlink(tmpName.c_str()); // Clean up temp file
+  unlink(tmpName.c_str());  // Clean up temp file
 }

--- a/Validation/Geometry/src/MaterialBudgetTree.cc
+++ b/Validation/Geometry/src/MaterialBudgetTree.cc
@@ -6,11 +6,15 @@
 MaterialBudgetTree::MaterialBudgetTree(std::shared_ptr<MaterialBudgetData> data, const std::string &filename)
     : MaterialBudgetFormat(data) {
   fname = filename;
+  tmpName = "tmp" + fname;
   book();
 }
 
 void MaterialBudgetTree::book() {
-  LogDebug("MaterialBudget") << "MaterialBudgetTree: Booking user TTree";
+  TFile *tmpFile = new TFile(tmpName.c_str(), "RECREATE");
+  // Create temporary file to hold TTree when it grows beyond 1 MB in size
+
+  LogDebug("MaterialBudget") << "MaterialBudgetTree: Booking user TTree " << tmpFile->GetSize();
   // create the TTree
   theTree = std::make_unique<TTree>("T1", "GeometryTest Tree");
 
@@ -225,4 +229,5 @@ void MaterialBudgetTree::endOfRun() {
   }
 
   delete outFile;
+  unlink(tmpName.c_str()); // Clean up temp file
 }


### PR DESCRIPTION
Issue #31069 concerned the script `Validation/Geometry/test/runP_Tracker.py` that terminates with an exception if its `AllStepsToTree` is set to True. This PR fixes the problem and allows the script to run to completion and produce its output files.

The problem was that a `TTree` was created before its `TFile` was created. When the `TTree` reached 1 MB in memory, this exception was generated:
```
---- Begin Fatal Exception 28-Feb-2022 21:20:13 CET-----------------------
An exception of category 'FatalRootError' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 17 stream: 0
   [1] Running path 'p1'
   [2] Calling method for module OscarMTProducer/'g4SimHits'
   Additional Info:
      [a] Fatal Root Error: @SUB=TBranch::WriteBasketImpl
basket's WriteBuffer failed.

----- End Fatal Exception -------------------------------------------------
```
The fix is to create a temporary file for the `TTree` to use. This file can't be used for the actually writing, because the program has another file open that can clash with the temporary file. Thus, when the `TTree` is complete, the final output file is created and the temporary is removed.

#### PR validation:

The script runs successfully to completion and produces complete output files. Here are the commands to test the script:
```
cmsRun test/single_neutrino_cfg.py nEvents=1000
python3 test/runP_Tracker.py geom="Extended2017Plan1" label=Tracker 
```

No backport is needed.