### PR TITLE
LHCInfo workflow for Run3: Implemented PPS feedback

### DIFF
--- a/CondFormats/RunInfo/interface/LHCInfo.h
+++ b/CondFormats/RunInfo/interface/LHCInfo.h
@@ -41,11 +41,7 @@ public:
     BEAM2_RF = 12,
     INST_LUMI = 13,
     INST_LUMI_ERR = 14,
-    XING_ANGLE_P5_X = 15,
-    XING_ANGLE_P5_Y = 16,
-    BETA_STAR_P5_X = 17,
-    BETA_STAR_P5_Y = 18,
-    FSIZE = 19
+    FSIZE = 15
   };
   enum TimeParamIndex { CREATE_TIME = 0, BEGIN_TIME = 1, END_TIME = 2, TSIZE = 3 };
   enum StringParamIndex { INJECTION_SCHEME = 0, LHC_STATE = 1, LHC_COMMENT = 2, CTPPS_STATUS = 3, SSIZE = 4 };
@@ -100,12 +96,6 @@ public:
   float const instLumi() const;
 
   float const instLumiError() const;
-
-  float const xingAngleP5X() const;
-  float const xingAngleP5Y() const;
-
-  float const betaStarP5X() const;
-  float const betaStarP5Y() const;
 
   cond::Time_t const createTime() const;
 
@@ -173,12 +163,6 @@ public:
   void setCrossingAngle(float const& angle);
 
   void setBetaStar(float const& betaStar);
-
-  void setXingAngleP5X(float const& angle);
-  void setXingAngleP5Y(float const& angle);
-
-  void setBetaStarP5X(float const& betaStar);
-  void setBetaStarP5Y(float const& betaStar);
 
   void setIntensityForBeam1(float const& intensity);
 

--- a/CondFormats/RunInfo/src/LHCInfo.cc
+++ b/CondFormats/RunInfo/src/LHCInfo.cc
@@ -183,12 +183,6 @@ float const LHCInfo::crossingAngle() const { return LHCInfoImpl::getOneParam(m_f
 
 float const LHCInfo::betaStar() const { return LHCInfoImpl::getOneParam(m_floatParams, BETA_STAR); }
 
-float const LHCInfo::xingAngleP5X() const { return LHCInfoImpl::getOneParam(m_floatParams, XING_ANGLE_P5_X); }
-float const LHCInfo::xingAngleP5Y() const { return LHCInfoImpl::getOneParam(m_floatParams, XING_ANGLE_P5_Y); }
-
-float const LHCInfo::betaStarP5X() const { return LHCInfoImpl::getOneParam(m_floatParams, BETA_STAR_P5_X); }
-float const LHCInfo::betaStarP5Y() const { return LHCInfoImpl::getOneParam(m_floatParams, BETA_STAR_P5_Y); }
-
 float const LHCInfo::intensityForBeam1() const { return LHCInfoImpl::getOneParam(m_floatParams, INTENSITY_1); }
 
 float const LHCInfo::intensityForBeam2() const { return LHCInfoImpl::getOneParam(m_floatParams, INTENSITY_2); }
@@ -304,16 +298,6 @@ void LHCInfo::setParticleTypeForBeam2(LHCInfo::ParticleTypeId const& particleTyp
 void LHCInfo::setCrossingAngle(float const& angle) { LHCInfoImpl::setOneParam(m_floatParams, CROSSING_ANGLE, angle); }
 
 void LHCInfo::setBetaStar(float const& betaStar) { LHCInfoImpl::setOneParam(m_floatParams, BETA_STAR, betaStar); }
-
-void LHCInfo::setXingAngleP5X(float const& angle) { LHCInfoImpl::setOneParam(m_floatParams, XING_ANGLE_P5_X, angle); }
-void LHCInfo::setXingAngleP5Y(float const& angle) { LHCInfoImpl::setOneParam(m_floatParams, XING_ANGLE_P5_Y, angle); }
-
-void LHCInfo::setBetaStarP5X(float const& betaStar) {
-  LHCInfoImpl::setOneParam(m_floatParams, BETA_STAR_P5_X, betaStar);
-}
-void LHCInfo::setBetaStarP5Y(float const& betaStar) {
-  LHCInfoImpl::setOneParam(m_floatParams, BETA_STAR_P5_Y, betaStar);
-}
 
 void LHCInfo::setIntensityForBeam1(float const& intensity) {
   LHCInfoImpl::setOneParam(m_floatParams, INTENSITY_1, intensity);

--- a/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
+++ b/CondTools/RunInfo/src/LHCInfoPopConSourceHandler.cc
@@ -304,13 +304,9 @@ bool LHCInfoPopConSourceHandler::getCTTPSData(cond::persistency::Session& sessio
   CTPPSDataQuery->addToOutputList(std::string("DIP_UPDATE_TIME"));
   CTPPSDataQuery->addToOutputList(std::string("LHC_STATE"));
   CTPPSDataQuery->addToOutputList(std::string("LHC_COMMENT"));
-  // this variable has not been found in the above schema. Need to check with PPS if a replacement is needed/available
-  //CTPPSDataQuery->addToOutputList(std::string("CTPPS_STATUS"));
   CTPPSDataQuery->addToOutputList(std::string("LUMI_SECTION"));
   CTPPSDataQuery->addToOutputList(std::string("XING_ANGLE_P5_X_URAD"));
-  CTPPSDataQuery->addToOutputList(std::string("XING_ANGLE_P5_Y_URAD"));
   CTPPSDataQuery->addToOutputList(std::string("BETA_STAR_P5_X_M"));
-  CTPPSDataQuery->addToOutputList(std::string("BETA_STAR_P5_Y_M"));
   //WHERE CLAUSE
   coral::AttributeList CTPPSDataBindVariables;
   CTPPSDataBindVariables.extend<coral::TimeStamp>(std::string("beginFillTime"));
@@ -326,20 +322,16 @@ bool LHCInfoPopConSourceHandler::getCTTPSData(cond::persistency::Session& sessio
   CTPPSDataOutput.extend<coral::TimeStamp>(std::string("DIP_UPDATE_TIME"));
   CTPPSDataOutput.extend<std::string>(std::string("LHC_STATE"));
   CTPPSDataOutput.extend<std::string>(std::string("LHC_COMMENT"));
-  // see above comment...
-  //CTPPSDataOutput.extend<std::string>(std::string("CTPPS_STATUS"));
   CTPPSDataOutput.extend<int>(std::string("LUMI_SECTION"));
   CTPPSDataOutput.extend<float>(std::string("XING_ANGLE_P5_X_URAD"));
-  CTPPSDataOutput.extend<float>(std::string("XING_ANGLE_P5_Y_URAD"));
   CTPPSDataOutput.extend<float>(std::string("BETA_STAR_P5_X_M"));
-  CTPPSDataOutput.extend<float>(std::string("BETA_STAR_P5_Y_M"));
   CTPPSDataQuery->defineOutput(CTPPSDataOutput);
   //execute the query
   coral::ICursor& CTPPSDataCursor = CTPPSDataQuery->execute();
   cond::Time_t dipTime = 0;
   std::string lhcState = "", lhcComment = "", ctppsStatus = "";
   unsigned int lumiSection = 0;
-  float crossingAngle_x = 0., crossingAngle_y = 0., betastar_x = 0., betastar_y = 0.;
+  float crossingAngle = 0., betastar = 0.;
 
   bool ret = false;
   LHCInfoImpl::LumiSectionFilter filter(m_tmpBuffer);
@@ -361,11 +353,6 @@ bool LHCInfoPopConSourceHandler::getCTTPSData(cond::persistency::Session& sessio
         if (!lhcCommentAttribute.isNull()) {
           lhcComment = lhcCommentAttribute.data<std::string>();
         }
-        // missing variable in the new schema - see comments above
-        //coral::Attribute const& ctppsStatusAttribute = CTPPSDataCursor.currentRow()[std::string("CTPPS_STATUS")];
-        //if (!ctppsStatusAttribute.isNull()) {
-        //  ctppsStatus = ctppsStatusAttribute.data<std::string>();
-        //}
         coral::Attribute const& lumiSectionAttribute = CTPPSDataCursor.currentRow()[std::string("LUMI_SECTION")];
         if (!lumiSectionAttribute.isNull()) {
           lumiSection = lumiSectionAttribute.data<int>();
@@ -373,28 +360,17 @@ bool LHCInfoPopConSourceHandler::getCTTPSData(cond::persistency::Session& sessio
         coral::Attribute const& crossingAngleXAttribute =
             CTPPSDataCursor.currentRow()[std::string("XING_ANGLE_P5_X_URAD")];
         if (!crossingAngleXAttribute.isNull()) {
-          crossingAngle_x = crossingAngleXAttribute.data<float>();
-        }
-        coral::Attribute const& crossingAngleYAttribute =
-            CTPPSDataCursor.currentRow()[std::string("XING_ANGLE_P5_Y_URAD")];
-        if (!crossingAngleYAttribute.isNull()) {
-          crossingAngle_y = crossingAngleYAttribute.data<float>();
+          crossingAngle = crossingAngleXAttribute.data<float>();
         }
         coral::Attribute const& betaStarXAttribute = CTPPSDataCursor.currentRow()[std::string("BETA_STAR_P5_X_M")];
         if (!betaStarXAttribute.isNull()) {
-          betastar_x = betaStarXAttribute.data<float>();
-        }
-        coral::Attribute const& betaStarYAttribute = CTPPSDataCursor.currentRow()[std::string("BETA_STAR_P5_Y_M")];
-        if (!betaStarYAttribute.isNull()) {
-          betastar_y = betaStarYAttribute.data<float>();
+          betastar = betaStarXAttribute.data<float>();
         }
         for (auto it = filter.current(); it != m_tmpBuffer.end(); it++) {
           // set the current values to all of the payloads of the lumi section samples after the current since
           LHCInfo& payload = *(it->second);
-          payload.setXingAngleP5X(crossingAngle_x);
-          payload.setXingAngleP5Y(crossingAngle_y);
-          payload.setBetaStarP5X(betastar_x);
-          payload.setBetaStarP5Y(betastar_y);
+          payload.setCrossingAngle(crossingAngle);
+          payload.setBetaStar(betastar);
           payload.setLhcState(lhcState);
           payload.setLhcComment(lhcComment);
           payload.setCtppsStatus(ctppsStatus);


### PR DESCRIPTION
#### PR description:

After discussing the recent changes [here](https://indico.cern.ch/event/1132483/)

Some of the new variables introduced are finally dropped. The old variables betaStar and crossingAngle are filled up with the X values of the new parameters

