### PR TITLE
Adapt to new range for BDT output for Run3 Saturated regression

### DIFF
--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -11,6 +11,7 @@ from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 from Configuration.Eras.Modifier_run3_nanoAOD_devel_cff import run3_nanoAOD_devel
+from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2021, dd4hep, run3_nanoAOD_devel)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2021, dd4hep, run3_nanoAOD_devel)
 

--- a/Configuration/Eras/python/Modifier_run3_egamma_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_egamma_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_egamma =cms.Modifier()

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -238,24 +238,31 @@ regressionModifier80X = \
 #by default we use the regression inappropriate to the main purpose of this release
 #life is simplier that way
 regressionModifier = regressionModifier94X.clone()
-
+regressionModifierRun2 = regressionModifier106XUL.clone()
 
 from Configuration.Eras.Modifier_run2_egamma_2016_cff import run2_egamma_2016
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 
-(run2_egamma_2016 | run2_egamma_2017 | run2_egamma_2018).toReplaceWith(regressionModifier,regressionModifier106XUL)
+(run2_egamma_2016 | run2_egamma_2017 | run2_egamma_2018).toReplaceWith(regressionModifier,regressionModifierRun2)
 
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(regressionModifier106XUL.eleRegs.ecalOnlyMean,
-      rangeMinHighEt = 0.2,
-      rangeMaxHighEt = 2.0
+regressionModifierRun3 = regressionModifierRun2.clone(
+    eleRegs = dict(
+        ecalOnlyMean = dict(
+            rangeMinHighEt = 0.2,
+            rangeMaxHighEt = 2.0
+        )
+    ),
+    phoRegs = dict(
+        ecalOnlyMean = dict(
+            rangeMinHighEt = 0.2,
+            rangeMaxHighEt = 2.0
+        )
+    )
 )
 
-run3_common.toModify(regressionModifier106XUL.phoRegs.ecalOnlyMean,
-      rangeMinHighEt = 0.2,
-      rangeMaxHighEt = 2.0
-)
+from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
+run3_egamma.toReplaceWith(regressionModifier,regressionModifierRun3)
 
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 egamma_lowPt_exclusive.toReplaceWith(regressionModifier,regressionModifier103XLowPtPho)

--- a/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
+++ b/RecoEgamma/EgammaTools/python/regressionModifier_cfi.py
@@ -246,5 +246,16 @@ from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
 
 (run2_egamma_2016 | run2_egamma_2017 | run2_egamma_2018).toReplaceWith(regressionModifier,regressionModifier106XUL)
 
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(regressionModifier106XUL.eleRegs.ecalOnlyMean,
+      rangeMinHighEt = 0.2,
+      rangeMaxHighEt = 2.0
+)
+
+run3_common.toModify(regressionModifier106XUL.phoRegs.ecalOnlyMean,
+      rangeMinHighEt = 0.2,
+      rangeMaxHighEt = 2.0
+)
+
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 egamma_lowPt_exclusive.toReplaceWith(regressionModifier,regressionModifier103XLowPtPho)


### PR DESCRIPTION
#### PR description:

This PR changes the range of BDT output of saturated e/gamma regression. 

Last time when saturated e/gamma regression was trained (several years ago during Run2), the BDT output range for correction factors was  -1 to 3. We have now retrained the regression for Run3, and we have used range 0.2 to 2.0 while training. This is because, 
 - the normal(as in, non-saturated) e/gamma regression currently use 0.2-2.0 range, so this way everything becomes aligned.
 - Also not sure why in the past the range started from negative values of correction factors. The current range makes more sense. 

Since the range was changed in training, a change in CMSSW is also needed. It is done using era modifier, so that Run2 UL still have the old range [-1,3] compatible with old training, and Run3 gets the new range [0.2,2] compatible with new training. The GT update for regression tags should go into the same release as well. That is progressing in parallel. 

Related github issue: [cms-sw/cmssw#36886](https://github.com/cms-sw/cmssw/issues/36886)
Talk describing the issues that were fixed + the outstanding issues:  https://indico.cern.ch/event/1127851/contributions/4733937/attachments/2390919/4087216/EGM_RegressionTags_Changes.pdf

#### PR validation:
From `CMSSW_12_3_0_pre5`, merged this branch and ran the AOD step[1] on this dataset[2] using updated conditions[3] and then ran the miniAOD step[4] on the output AOD. Then made response plots using genmatched `slimmedElectrons`, and compared that with Run2 regression available in old releases and old GTs. Response looks reasonable and as expected.

![compare_Saturated_ZPrimeEE_Response_EcalOnly_Barrel](https://user-images.githubusercontent.com/5052706/156187007-8d324547-1a32-4e69-bd12-57793352f8dc.png)

[1] `cmsDriver.py --filein file:/eos/cms/blah.root  --fileout file:AOD.root --mc --eventcontent AODSIM --runUnscheduled --customise Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions 123X_mcRun3_2021_realistic_Candidate_2022_03_01_08_47_07 --step RAW2DIGI,RECO --geometry DB:Extended --era Run3 --python_filename aod_cfg.py --beamspot Run3RoundOptics25ns13TeVLowSigmaZ --no_exec -n -1` 

[2] `/RelValZpToEE_m6000_14TeV/CMSSW_12_3_0_pre5-123X_mcRun3_2021_realistic_v6-v1/GEN-SIM-DIGI-RAW`

[3] https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_Candidate_2022_03_01_08_47_07/123X_mcRun3_2021_realistic_v9

[4] `cmsDriver.py  --filein file:/eos/cms/blah.root  --fileout file:Mini.root --mc --eventcontent MINIAODSIM --runUnscheduled --customise Configuration/DataProcessing/Utils.addMonitoring --datatier MINIAODSIM --conditions 123X_mcRun3_2021_realistic_Candidate_2022_03_01_08_47_07 --step PAT --geometry DB:Extended --era Run3 --python_filename miniaod_cfg.py --beamspot Run3RoundOptics25ns13TeVLowSigmaZ --no_exec -n -1`

This PR is not a backport. 
A backport to 12_2 is not meaningful anymore, as 12_2 MC production for 0.5B POG samples has already started. So most probably we won't do any backport of this PR.