### PR TITLE
[123X] Migrate DQM clients to Run3 era

### DIFF
--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -9,8 +9,6 @@ BSOnlineJobName = 'BeamSpotOnlineHLT'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True
 
-#from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-#process = cms.Process("BeamMonitor", Run2_2018) # FIMXE
 import sys
 from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process("BeamMonitor", Run3)

--- a/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamspotdip_dqm_sourceclient-live_cfg.py
@@ -10,7 +10,8 @@ print("copying " + configFile + " to local")
 copy(configFile,".")
 
 #
-process = cms.Process("BeamSpotDipServer")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("BeamSpotDipServer", Run3)
 process.load("DQMServices.Core.DQM_cfg")
 
 # message logger

--- a/DQM/Integration/python/clients/bril_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/bril_dqm_clientPB-live_cfg.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-process = cms.Process("HARVESTING")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("HARVESTING", Run3)
 
 #----------------------------
 #### Histograms Source

--- a/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import sys
 
-process = cms.Process("CASTORDQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("CASTORDQM", Run3)
 
 unitTest=False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import sys
 
-process = cms.Process("CSCDQMLIVE")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("CSCDQMLIVE", Run3)
 
 #-------------------------------------------------
 # DQM Module Configuration

--- a/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 import sys
 import os
 
-process = cms.Process("DTDQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("DTDQM", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import sys
 
-process = cms.Process("DTDQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("DTDQM", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import sys
 
-process = cms.Process("ESDQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("ESDQM", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/fed_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 import sys
 
 # Process initialization
-process = cms.Process('FED')
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process('FED', Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-from Configuration.StandardSequences.Eras import eras
-process = cms.Process('GEMDQM', eras.Run3)
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process('GEMDQM', Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_clientPB-live_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-process = cms.Process("HARVESTING")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("HARVESTING", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/hltrates_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hltrates_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("DQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("DQM", Run3)
 process.options = cms.untracked.PSet(
   SkipEvent = cms.untracked.vstring('ProductNotFound') 
 )

--- a/DQM/Integration/python/clients/hlx_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlx_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("hlxdqmlive")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("hlxdqmlive", Run3)
 
 from FWCore.MessageLogger.MessageLogger_cfi import *
 

--- a/DQM/Integration/python/clients/info_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/info_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-process = cms.Process("DQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("DQM", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/l1t_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1t_dqm_sourceclient-live_cfg.py
@@ -8,7 +8,8 @@ from __future__ import print_function
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("DQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("DQM", Run3)
 
 
 #----------------------------

--- a/DQM/Integration/python/clients/l1temulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1temulator_dqm_sourceclient-live_cfg.py
@@ -8,7 +8,8 @@ from __future__ import print_function
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("L1TEmuDQMlive")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("L1TEmuDQMlive", Run3)
 
 
 #----------------------------

--- a/DQM/Integration/python/clients/l1tstage1_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage1_dqm_sourceclient-live_cfg.py
@@ -8,7 +8,8 @@ from __future__ import print_function
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("DQM")
+nano from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("DQM", Run3)
 
 
 #----------------------------

--- a/DQM/Integration/python/clients/l1tstage1_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage1_dqm_sourceclient-live_cfg.py
@@ -8,7 +8,7 @@ from __future__ import print_function
 
 import FWCore.ParameterSet.Config as cms
 
-nano from Configuration.Eras.Era_Run3_cff import Run3
+from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process("DQM", Run3)
 
 

--- a/DQM/Integration/python/clients/l1tstage1emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage1emulator_dqm_sourceclient-live_cfg.py
@@ -8,7 +8,8 @@ from __future__ import print_function
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("L1TEmuDQMlive")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("L1TEmuDQMlive", Run3)
 
 
 #----------------------------

--- a/DQM/Integration/python/clients/lumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/lumi_dqm_sourceclient-live_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("DQMLumi")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("DQMLumi", Run3)
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 

--- a/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 
 import sys
 from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
-process = cms.Process("MUTRKDQM", Run2_2018_pp_on_AA)
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("MUTRKDQM", Run3)
 
 live=True
 unitTest=False

--- a/DQM/Integration/python/clients/physics_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/physics_dqm_sourceclient-live_cfg.py
@@ -3,7 +3,8 @@ from __future__ import print_function
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("Physics")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("Physics", Run3)
 
 #----------------------------
 # Event Source

--- a/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import sys
 
-process = cms.Process("PixelLumiDQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("PixelLumiDQM", Run3)
 
 unitTest=False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/ramdisk_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ramdisk_dqm_sourceclient-live_cfg.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 import sys
 
 subsystem = "Ramdisk"
-process = cms.Process(subsystem)
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process(subsystem, Run3)
 
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing

--- a/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
@@ -11,7 +11,8 @@ unitTest = False
 if 'unitTest=True' in sys.argv:
     unitTest=True
 
-process = cms.Process("RPCDQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("RPCDQM", Run3)
 
 ############## Event Source #####################
 

--- a/DQM/Integration/python/clients/scal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/scal_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 import sys
 
-process = cms.Process("DQM")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("DQM", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/sistriplas_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistriplas_dqm_sourceclient-live_cfg.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process( "sistriplaserDQMLive" )
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process( "sistriplaserDQMLive", Run3 )
 process.MessageLogger = cms.Service( "MessageLogger",
   cout = cms.untracked.PSet(threshold = cms.untracked.string( 'ERROR' )),
   destinations = cms.untracked.vstring( 'cout')


### PR DESCRIPTION
#### PR description:
As this week's ORM, I took the liberty of forward-porting #37081

Change `process = cms.Process("name")` to `process = cms.Process("name", Run3)`
following suggestion at https://github.com/cms-sw/cmssw/pull/36947#issuecomment-1039066183
Similar to https://github.com/cms-sw/cmssw/pull/36959

#### PR validation:
Backport already deployed succesfully in P5 online DQM machines

#### Backport
Forward-port of #37081

FYI @pmandrik 