### PR TITLE
Add saturated EGM regression tags to Run-3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -64,19 +64,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v9',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v9',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v10',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v9',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v9',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v9',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v9',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v10',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '123X_mcRun4_realistic_v6'
+    'phase2_realistic'             : '123X_mcRun4_realistic_v7'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Add saturated electron and photon regression tags as requested in https://cms-talk.web.cern.ch/t/mc-update-of-new-egm-regression-conditions/4637/8


* 123X_mcRun3_2021_design_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_design_v9/123X_mcRun3_2021_design_v10
 * 123X_mcRun3_2021_realistic_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_v9/123X_mcRun3_2021_realistic_v10
 * 123X_mcRun3_2021cosmics_realistic_deco_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021cosmics_realistic_deco_v9/123X_mcRun3_2021cosmics_realistic_deco_v10
 * 123X_mcRun3_2021_realistic_HI_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_HI_v9/123X_mcRun3_2021_realistic_HI_v10
 * 123X_mcRun3_2023_realistic_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2023_realistic_v9/123X_mcRun3_2023_realistic_v10
 * 123X_mcRun3_2024_realistic_v10
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2024_realistic_v9/123X_mcRun3_2024_realistic_v10
 * 123X_mcRun4_realistic_v7
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun4_realistic_v6/123X_mcRun4_realistic_v7

Diffs are in the 8 requested tags alone, except for the Phase-2 GT where the new L1T menu was also added [as a leftover from https://github.com/cms-sw/cmssw/pull/37089] (no differences expected or observed related to this change.)

#### PR validation:

test parameters:
  - workflows = 12034.0,11634.0,7.23,159.0,12434.0,12834.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A