### PR TITLE
fix L1 candidate matching in HLTMuonL1TFilter

### DIFF
--- a/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
@@ -15,6 +15,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "TMath.h"
 
 #include <vector>
@@ -27,6 +28,8 @@ HLTMuonL1TFilter::HLTMuonL1TFilter(const edm::ParameterSet& iConfig)
       previousCandToken_(consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)),
       maxEta_(iConfig.getParameter<double>("MaxEta")),
       minPt_(iConfig.getParameter<double>("MinPt")),
+      maxDR_(iConfig.getParameter<double>("MaxDeltaR")),
+      maxDR2_(maxDR_ * maxDR_),
       minN_(iConfig.getParameter<int>("MinN")),
       centralBxOnly_(iConfig.getParameter<bool>("CentralBxOnly")) {
   //set the quality bit mask
@@ -38,7 +41,11 @@ HLTMuonL1TFilter::HLTMuonL1TFilter(const edm::ParameterSet& iConfig)
     //     }
     qualityBitMask_ |= 1 << selectQualitie;
   }
-
+  //make sure cut parameter for candidate matching is strictly positive
+  if (maxDR_ <= 0.) {
+    throw cms::Exception("HLTMuonL1TFilterConfiguration")
+        << "invalid value for parameter \"MaxDeltaR\" (must be > 0): " << maxDR_;
+  }
   // dump parameters for debugging
   if (edm::isDebugEnabled()) {
     ostringstream ss;
@@ -67,6 +74,7 @@ void HLTMuonL1TFilter::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<edm::InputTag>("PreviousCandTag", edm::InputTag(""));
   desc.add<double>("MaxEta", 2.5);
   desc.add<double>("MinPt", 0.0);
+  desc.add<double>("MaxDeltaR", 0.3);
   desc.add<int>("MinN", 1);
   desc.add<bool>("CentralBxOnly", true);
   {
@@ -110,7 +118,15 @@ bool HLTMuonL1TFilter::hltFilter(edm::Event& iEvent,
       MuonRef muon(allMuons, distance(allMuons->begin(allMuons->getFirstBX()), it));
 
       // Only select muons that were selected in the previous level
-      if (find(prevMuons.begin(), prevMuons.end(), muon) == prevMuons.end())
+      bool matchPrevL1 = false;
+      int prevSize = prevMuons.size();
+      for (int it2 = 0; it2 < prevSize; it2++) {
+        if (deltaR2(muon->eta(), muon->phi(), prevMuons[it2]->eta(), prevMuons[it2]->phi()) < maxDR2_) {
+          matchPrevL1 = true;
+          break;
+        }
+      }
+      if (!matchPrevL1)
         continue;
 
       //check maxEta cut

--- a/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL1TFilter.cc
@@ -117,18 +117,6 @@ bool HLTMuonL1TFilter::hltFilter(edm::Event& iEvent,
     for (auto it = allMuons->begin(ibx); it != allMuons->end(ibx); it++) {
       MuonRef muon(allMuons, distance(allMuons->begin(allMuons->getFirstBX()), it));
 
-      // Only select muons that were selected in the previous level
-      bool matchPrevL1 = false;
-      int prevSize = prevMuons.size();
-      for (int it2 = 0; it2 < prevSize; it2++) {
-        if (deltaR2(muon->eta(), muon->phi(), prevMuons[it2]->eta(), prevMuons[it2]->phi()) < maxDR2_) {
-          matchPrevL1 = true;
-          break;
-        }
-      }
-      if (!matchPrevL1)
-        continue;
-
       //check maxEta cut
       if (fabs(muon->eta()) > maxEta_)
         continue;
@@ -143,6 +131,18 @@ bool HLTMuonL1TFilter::hltFilter(edm::Event& iEvent,
         if ((quality & qualityBitMask_) == 0)
           continue;
       }
+
+      // Only select muons that were selected in the previous level
+      bool matchPrevL1 = false;
+      int prevSize = prevMuons.size();
+      for (int it2 = 0; it2 < prevSize; it2++) {
+        if (deltaR2(muon->eta(), muon->phi(), prevMuons[it2]->eta(), prevMuons[it2]->phi()) < maxDR2_) {
+          matchPrevL1 = true;
+          break;
+        }
+      }
+      if (!matchPrevL1)
+        continue;
 
       //we have a good candidate
       n++;

--- a/HLTrigger/Muon/plugins/HLTMuonL1TFilter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonL1TFilter.h
@@ -38,6 +38,10 @@ private:
   /// pT threshold
   double minPt_;
 
+  /// max dRs for L1 candidate matching
+  double maxDR_;
+  double maxDR2_;
+
   /// Quality codes:
   /// to be updated with new L1 quality definitions
   int qualityBitMask_;

--- a/HLTrigger/Muon/plugins/HLTMuonL1TFilter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonL1TFilter.h
@@ -33,24 +33,24 @@ private:
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_;
 
   /// max Eta cut
-  double maxEta_;
+  const double maxEta_;
 
   /// pT threshold
-  double minPt_;
+  const double minPt_;
 
   /// max dRs for L1 candidate matching
-  double maxDR_;
-  double maxDR2_;
+  const double maxDR_;
+  const double maxDR2_;
 
   /// Quality codes:
   /// to be updated with new L1 quality definitions
   int qualityBitMask_;
 
   /// min N objects
-  double minN_;
+  const double minN_;
 
   /// use central bx only muons
-  bool centralBxOnly_;
+  const bool centralBxOnly_;
 };
 
 #endif  //HLTMuonL1TFilter_h


### PR DESCRIPTION
(split from #37086)

Fix to the L1 candidate matching in HLTMuonL1TFilter. In this filter a match between L1 muons before and after different filters is performed. Currently the code expects the muons that are compared to be in the same collection. However, there are use cases in the current menu where the matching is performed with a copy of the L1 muon collection and thus always fails. This causes an inefficiency for low pT muons that are reconstructed only by L1-seeded reconstruction steps. Impact is mostly negligible, showing tiny efficiency improvements for high-pT muon from the Z:
![image](https://user-images.githubusercontent.com/4459228/156228489-1a576146-f76e-46e5-a827-44b0524644ba.png)

Effect gets more visible for lower pT muons, for example in the turnon of the double-muon trigger:
![image](https://user-images.githubusercontent.com/4459228/156228543-8bee4a1b-d947-43bf-96a4-67b547c1e05b.png)

However, the effect is significant for very low pT leptons. For the muon Bs -> mumu trigger (HLT_DoubleMu4_3_Bs_v14) we find a ~20% improvement of HLT efficiency on a sample of signal events provided by BPH.