### PR TITLE
[MkFit] round up size arguments to aligned_alloc upwards to align value.

### DIFF
--- a/RecoTracker/MkFitCore/src/HitStructures.cc
+++ b/RecoTracker/MkFitCore/src/HitStructures.cc
@@ -1,7 +1,7 @@
 #include "RecoTracker/MkFitCore/interface/HitStructures.h"
 
 #include "RecoTracker/MkFitCore/interface/IterationConfig.h"
-#include "RecoTracker/MkFitCore/src/Matriplex/Memory.h"
+#include "Matriplex/Memory.h"
 #include "Ice/IceRevisitedRadix.h"
 
 #include "Debug.h"

--- a/RecoTracker/MkFitCore/src/HitStructures.cc
+++ b/RecoTracker/MkFitCore/src/HitStructures.cc
@@ -1,7 +1,7 @@
 #include "RecoTracker/MkFitCore/interface/HitStructures.h"
 
 #include "RecoTracker/MkFitCore/interface/IterationConfig.h"
-
+#include "RecoTracker/MkFitCore/src/Matriplex/Memory.h"
 #include "Ice/IceRevisitedRadix.h"
 
 #include "Debug.h"
@@ -17,7 +17,7 @@ namespace mkfit {
 
 #ifdef COPY_SORTED_HITS
   void LayerOfHits::alloc_hits(int size) {
-    m_hits = (Hit *)std::aligned_alloc(64, sizeof(Hit) * size);
+    m_hits = (Hit *)Matriplex::aligned_alloc64(sizeof(Hit) * size);
     m_capacity = size;
     for (int ihit = 0; ihit < m_capacity; ihit++) {
       m_hits[ihit] = Hit();

--- a/RecoTracker/MkFitCore/src/Matriplex/MatriplexCommon.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/MatriplexCommon.h
@@ -13,10 +13,7 @@
 #if defined(__x86_64__)
 #include "immintrin.h"
 #else
-#include <stdlib.h>
-#define _mm_malloc(a, b) aligned_alloc(b, a)
-#define _mm_free(p) free(p)
-#define _mm_prefetch(a, b) __builtin_prefetch(a)
+#include <cstdlib>
 #endif
 
 #if defined(MPLEX_USE_INTRINSICS)

--- a/RecoTracker/MkFitCore/src/Matriplex/MatriplexVector.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/MatriplexVector.h
@@ -18,7 +18,7 @@ namespace Matriplex {
     typedef typename MP::value_type T;
 
   public:
-    MatriplexVector(idx_t n) : fN(n) { fV = (MP*) aligned_alloc64(sizeof(MP) * fN); }
+    MatriplexVector(idx_t n) : fN(n) { fV = (MP*)aligned_alloc64(sizeof(MP) * fN); }
 
     ~MatriplexVector() { std::free(fV); }
 

--- a/RecoTracker/MkFitCore/src/Matriplex/MatriplexVector.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/MatriplexVector.h
@@ -2,7 +2,7 @@
 #define RecoTracker_MkFitCore_src_Matriplex_MatriplexVector_h
 
 #include "Matriplex.h"
-
+#include "Memory.h"
 #include <vector>
 #include <cassert>
 
@@ -18,7 +18,7 @@ namespace Matriplex {
     typedef typename MP::value_type T;
 
   public:
-    MatriplexVector(idx_t n) : fN(n) { fV = (MP*)std::aligned_alloc(64, sizeof(MP) * fN); }
+    MatriplexVector(idx_t n) : fN(n) { fV = (MP*) aligned_alloc64(sizeof(MP) * fN); }
 
     ~MatriplexVector() { std::free(fV); }
 

--- a/RecoTracker/MkFitCore/src/Matriplex/Memory.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/Memory.h
@@ -1,0 +1,19 @@
+#ifndef RecoTracker_MkFitCore_src_Matriplex_Memory_h
+#define RecoTracker_MkFitCore_src_Matriplex_Memory_h
+
+#include <cstdlib>
+
+namespace Matriplex {
+
+  constexpr std::size_t round_up_align64(std::size_t size) {
+    constexpr std::size_t mask = 64 - 1;
+    return size & mask ? (size & ~mask) + 64 : size;
+  }
+
+  inline void* aligned_alloc64(std::size_t size) {
+    return std::aligned_alloc(64, round_up_align64(size));
+  }
+
+}
+
+#endif

--- a/RecoTracker/MkFitCore/src/Matriplex/Memory.h
+++ b/RecoTracker/MkFitCore/src/Matriplex/Memory.h
@@ -10,10 +10,8 @@ namespace Matriplex {
     return size & mask ? (size & ~mask) + 64 : size;
   }
 
-  inline void* aligned_alloc64(std::size_t size) {
-    return std::aligned_alloc(64, round_up_align64(size));
-  }
+  inline void* aligned_alloc64(std::size_t size) { return std::aligned_alloc(64, round_up_align64(size)); }
 
-}
+}  // namespace Matriplex
 
 #endif

--- a/RecoTracker/MkFitCore/src/Pool.h
+++ b/RecoTracker/MkFitCore/src/Pool.h
@@ -1,7 +1,7 @@
 #ifndef RecoTracker_MkFitCore_src_Pool_h
 #define RecoTracker_MkFitCore_src_Pool_h
 
-#include "RecoTracker/MkFitCore/src/Matriplex/Memory.h"
+#include "Matriplex/Memory.h"
 #include "oneapi/tbb/concurrent_queue.h"
 
 namespace mkfit {

--- a/RecoTracker/MkFitCore/src/Pool.h
+++ b/RecoTracker/MkFitCore/src/Pool.h
@@ -1,6 +1,7 @@
 #ifndef RecoTracker_MkFitCore_src_Pool_h
 #define RecoTracker_MkFitCore_src_Pool_h
 
+#include "RecoTracker/MkFitCore/src/Matriplex/Memory.h"
 #include "oneapi/tbb/concurrent_queue.h"
 
 namespace mkfit {
@@ -38,7 +39,7 @@ namespace mkfit {
     }
 
   private:
-    TT *create() { return new (std::aligned_alloc(64, sizeof(TT))) TT; };
+    TT *create() { return new (Matriplex::aligned_alloc64(sizeof(TT))) TT; };
 
     void destroy(TT *x) {
       x->~TT();


### PR DESCRIPTION
std::aligned_alloc calls were passing the desired allocated size, not rounded up to a multiple of align argument which seems to result in UB according to the standard.

All allocations in mkFit are aligned to cache-line (64) required for vector intrinsics.

This PR addresses #37096.
