### PR TITLE
[DD4hep] Add error message for undefined solid

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -1172,6 +1172,13 @@ static void convert_boolean(cms::DDParsingContext* context, xml_h element) {
     Converter<DDLTransform3D>(context->description, context, &trafo)(element);
     ns.context()->unresolvedShapes.emplace(nam,
                                            DDParsingContext::BooleanShape<TYPE>(solidName[0], solidName[1], trafo));
+    if (solids[0].isValid() == false) {
+      printout(ERROR, "DD4CMS", "++ Solid not defined yet: %s", solidName[0].c_str());
+    }
+    if (solids[1].isValid() == false) {
+      printout(ERROR, "DD4CMS", "++ Solid not defined yet: %s", solidName[1].c_str());
+    }
+    printout(ERROR, "DD4CMS", "++ Re-order XML files to prevent references to undefined solids");
   }
   if (!boolean.isValid()) {
     // Delay processing the shape


### PR DESCRIPTION
When processing XML files with DD4hep, if a solid is referenced before it is defined, in some cases a cryptic exception will be generated. Issue #31198 requested a more explanatory error message for this case.This PR adds an error message that names the missing solid and recommends to the user that the XML files need to be re-ordered to prevent references to undefined solids.

#### PR validation:

The XML geometry configuration for Phase 2 D88 was re-ordered so that the `muonBase:MUON` solid was referenced before it was defined by moving `cavern.xml` before `muonBase.xml`. This bad order then generated the new error message.

No backport is needed.