### PR TITLE
Update AlCaRecoTriggerBits record updater 

### DIFF
--- a/CondTools/HLT/plugins/AlCaRecoTriggerBitsRcdUpdate.cc
+++ b/CondTools/HLT/plugins/AlCaRecoTriggerBitsRcdUpdate.cc
@@ -10,6 +10,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <algorithm>
 
 // Framework
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -40,6 +41,8 @@ private:
   bool removeKeysFromMap(const std::vector<std::string> &keys, TriggerMap &triggerMap) const;
   bool replaceKeysFromMap(const std::vector<edm::ParameterSet> &alcarecoReplace, TriggerMap &triggerMap) const;
   bool addTriggerLists(const std::vector<edm::ParameterSet> &triggerListsAdd, AlCaRecoTriggerBits &bits) const;
+  bool addPathsFromMap(const std::vector<edm::ParameterSet> &pathsToAdd, AlCaRecoTriggerBits &bits) const;
+  bool removePathsFromMap(const std::vector<edm::ParameterSet> &pathsToRemove, AlCaRecoTriggerBits &bits) const;
   void writeBitsToDB(const AlCaRecoTriggerBits &bitsToWrite) const;
 
   const edm::ESGetToken<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd> triggerBitsToken_;
@@ -50,6 +53,8 @@ private:
   const std::vector<std::string> listNamesRemove_;
   const std::vector<edm::ParameterSet> triggerListsAdd_;
   const std::vector<edm::ParameterSet> alcarecoReplace_;
+  const std::vector<edm::ParameterSet> pathsToAdd_;
+  const std::vector<edm::ParameterSet> pathsToRemove_;
 };
 
 ///////////////////////////////////////////////////////////////////////
@@ -73,6 +78,18 @@ void AlCaRecoTriggerBitsRcdUpdate::fillDescriptions(edm::ConfigurationDescriptio
   std::vector<edm::ParameterSet> default_alcarecoToReplace;
   desc.addVPSet("alcarecoToReplace", desc_alcarecoToReplace, default_alcarecoToReplace);
 
+  edm::ParameterSetDescription desc_pathsToAdd;
+  desc_pathsToAdd.add<std::string>("listName");
+  desc_pathsToAdd.add<std::vector<std::string>>("hltPaths");
+  std::vector<edm::ParameterSet> default_pathsToAdd;
+  desc.addVPSet("pathsToAdd", desc_pathsToAdd, default_pathsToAdd);
+
+  edm::ParameterSetDescription desc_pathsToRemove;
+  desc_pathsToRemove.add<std::string>("listName");
+  desc_pathsToRemove.add<std::vector<std::string>>("hltPaths");
+  std::vector<edm::ParameterSet> default_pathsToRemove;
+  desc.addVPSet("pathsToRemove", desc_pathsToRemove, default_pathsToRemove);
+
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -85,7 +102,9 @@ AlCaRecoTriggerBitsRcdUpdate::AlCaRecoTriggerBitsRcdUpdate(const edm::ParameterS
       startEmpty_(cfg.getParameter<bool>("startEmpty")),
       listNamesRemove_(cfg.getParameter<std::vector<std::string>>("listNamesRemove")),
       triggerListsAdd_(cfg.getParameter<std::vector<edm::ParameterSet>>("triggerListsAdd")),
-      alcarecoReplace_(cfg.getParameter<std::vector<edm::ParameterSet>>("alcarecoToReplace")) {}
+      alcarecoReplace_(cfg.getParameter<std::vector<edm::ParameterSet>>("alcarecoToReplace")),
+      pathsToAdd_(cfg.getParameter<std::vector<edm::ParameterSet>>("pathsToAdd")),
+      pathsToRemove_(cfg.getParameter<std::vector<edm::ParameterSet>>("pathsToRemove")) {}
 
 ///////////////////////////////////////////////////////////////////////
 void AlCaRecoTriggerBitsRcdUpdate::analyze(const edm::Event &evt, const edm::EventSetup &iSetup) {
@@ -114,6 +133,12 @@ void AlCaRecoTriggerBitsRcdUpdate::analyze(const edm::Event &evt, const edm::Eve
   // now replace keys
   this->replaceKeysFromMap(alcarecoReplace_, bitsToWrite->m_alcarecoToTrig);
 
+  // add paths to the existing key
+  this->addPathsFromMap(pathsToAdd_, *bitsToWrite);
+
+  // remove paths from the existing key
+  this->removePathsFromMap(pathsToRemove_, *bitsToWrite);
+
   // finally write to DB
   this->writeBitsToDB(*bitsToWrite);
 }
@@ -123,10 +148,6 @@ bool AlCaRecoTriggerBitsRcdUpdate::removeKeysFromMap(const std::vector<std::stri
                                                      TriggerMap &triggerMap) const {
   for (std::vector<std::string>::const_iterator iKey = keys.begin(), endKey = keys.end(); iKey != endKey; ++iKey) {
     if (triggerMap.find(*iKey) != triggerMap.end()) {
-      // remove
-      //      edm::LogError("Temp") << "@SUB=removeKeysFromMap" << "Cannot yet remove '" << *iKey
-      // 			    << "' from map.";
-      // FIXME: test next line@
       triggerMap.erase(*iKey);
     } else {  // not in list ==> misconfiguartion!
       throw cms::Exception("BadConfig") << "[AlCaRecoTriggerBitsRcdUpdate::removeKeysFromMap] "
@@ -172,14 +193,13 @@ bool AlCaRecoTriggerBitsRcdUpdate::addTriggerLists(const std::vector<edm::Parame
   TriggerMap &triggerMap = bits.m_alcarecoToTrig;
 
   // loop on PSets, each containing the key (filter name) and a vstring with triggers
-  for (std::vector<edm::ParameterSet>::const_iterator iSet = triggerListsAdd.begin(); iSet != triggerListsAdd.end();
-       ++iSet) {
-    const std::vector<std::string> paths(iSet->getParameter<std::vector<std::string>>("hltPaths"));
+  for (const auto &iSet : triggerListsAdd) {
+    const std::vector<std::string> paths(iSet.getParameter<std::vector<std::string>>("hltPaths"));
     // We must avoid a map<string,vector<string> > in DB for performance reason,
     // so we have to merge the paths into one string that will be decoded when needed:
     const std::string mergedPaths = bits.compose(paths);
 
-    const std::string filter(iSet->getParameter<std::string>("listName"));
+    const std::string filter(iSet.getParameter<std::string>("listName"));
     if (triggerMap.find(filter) != triggerMap.end()) {
       throw cms::Exception("BadConfig") << "List name '" << filter << "' already in map, either "
                                         << "remove from 'triggerListsAdd' or "
@@ -192,17 +212,117 @@ bool AlCaRecoTriggerBitsRcdUpdate::addTriggerLists(const std::vector<edm::Parame
 }
 
 ///////////////////////////////////////////////////////////////////////
+bool AlCaRecoTriggerBitsRcdUpdate::addPathsFromMap(const std::vector<edm::ParameterSet> &pathsToAdd,
+                                                   AlCaRecoTriggerBits &bits) const {
+  TriggerMap &triggerMap = bits.m_alcarecoToTrig;  //read from the condition tag
+
+  // loop on PSets, each containing the key (filter name) and a vstring with triggers
+  for (const auto &iSet : pathsToAdd) {
+    const std::string filter(iSet.getParameter<std::string>("listName"));
+    std::string mergedPathsInKey;
+
+    for (const auto &imap : triggerMap) {
+      if (imap.first == filter)
+        mergedPathsInKey = imap.second;  //paths in the condition tag
+    }
+
+    if (mergedPathsInKey.empty()) {
+      throw cms::Exception("BadConfig") << "List name '" << filter << "' not found in the map, "
+                                        << "if you want to add new key/paths, please use 'addTriggerLists'.\n";
+    }
+
+    auto const &pathsInKey = bits.decompose(mergedPathsInKey);
+    auto const &paths = iSet.getParameter<std::vector<std::string>>("hltPaths");  //paths to add; from the configuration
+
+    if (paths.empty()) {  // nothing to add ==> misconfiguration!
+      throw cms::Exception("BadConfig") << "Didn't set any path to add!";
+    }
+
+    std::set<std::string> pathsSet{pathsInKey.begin(), pathsInKey.end()};
+    std::copy(paths.begin(), paths.end(), std::inserter(pathsSet, pathsSet.end()));
+    std::vector<std::string> const newPathsInKey{pathsSet.begin(), pathsSet.end()};
+
+    // We must avoid a map<string,vector<string> > in DB for performance reason,
+    // so we have to merge the paths into one string that will be decoded when needed:
+    triggerMap[filter] = bits.compose(newPathsInKey);
+  }
+
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////
+bool AlCaRecoTriggerBitsRcdUpdate::removePathsFromMap(const std::vector<edm::ParameterSet> &pathsToRemove,
+                                                      AlCaRecoTriggerBits &bits) const {
+  TriggerMap &triggerMap = bits.m_alcarecoToTrig;  //read from the condition tag
+
+  // loop on PSets, each containing the key (filter name) and a vstring with triggers
+  for (const auto &iSet : pathsToRemove) {
+    const std::string filter(iSet.getParameter<std::string>("listName"));
+    std::string mergedPathsInKey;
+
+    for (const auto &imap : triggerMap) {
+      if (imap.first == filter)
+        mergedPathsInKey = imap.second;  //paths in the condition tag
+    }
+
+    if (mergedPathsInKey.empty()) {
+      throw cms::Exception("BadConfig") << "List name '" << filter << "' not found in the map";
+    }
+
+    auto PathsInKey = bits.decompose(mergedPathsInKey);
+    auto const paths(
+        iSet.getParameter<std::vector<std::string>>("hltPaths"));  //paths to remove; from the configuration
+
+    if (paths.empty()) {  // nothing to remove ==> misconfiguration!
+      throw cms::Exception("BadConfig") << "Didn't set any path to remove!";
+    }
+
+    for (auto const &path : paths) {
+      PathsInKey.erase(std::remove(PathsInKey.begin(), PathsInKey.end(), path), PathsInKey.end());
+    }
+
+    // We must avoid a map<string,vector<string> > in DB for performance reason,
+    // so we have to merge the paths into one string that will be decoded when needed:
+    triggerMap[filter] = bits.compose(PathsInKey);
+  }
+
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////
 void AlCaRecoTriggerBitsRcdUpdate::writeBitsToDB(const AlCaRecoTriggerBits &bitsToWrite) const {
-  edm::LogInfo("") << "Uploading to the database...";
+  edm::LogInfo("AlCaRecoTriggerBitsRcdUpdate") << "Uploading to the database...";
 
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (!poolDbService.isAvailable()) {
     throw cms::Exception("NotAvailable") << "PoolDBOutputService not available.\n";
   }
 
-  poolDbService->writeOneIOV(bitsToWrite, firstRunIOV_, "AlCaRecoTriggerBitsRcd");
+  const std::string recordName("AlCaRecoTriggerBitsRcd");
 
-  edm::LogInfo("") << "...done for runs " << firstRunIOV_ << " to " << lastRunIOV_ << " (< 0 meaning infinity)!";
+  // when updating existing tag, compare payload hashs and skip appending new hash if it's same with last iov's
+  poolDbService->startTransaction();
+  auto newHash = poolDbService->session().storePayload(bitsToWrite);
+  cond::TagInfo_t tag_info;
+
+  if (poolDbService->tagInfo(recordName, tag_info)) {
+    if (newHash != tag_info.lastInterval.payloadId) {
+      edm::LogInfo("AlCaRecoTriggerBitsRcdUpdate") << "## Appending to existing tag...";
+      poolDbService->forceInit();
+      poolDbService->appendSinceTime(newHash, firstRunIOV_, recordName);
+    } else {
+      edm::LogInfo("AlCaRecoTriggerBitsRcdUpdate") << "## Skipping update since hash is the same...";
+    }
+
+  } else {
+    edm::LogInfo("AlCaRecoTriggerBitsRcdUpdate") << "## Creating new tag...";
+    poolDbService->forceInit();
+    poolDbService->createNewIOV(newHash, firstRunIOV_, recordName);
+  }
+  poolDbService->commitTransaction();
+
+  edm::LogInfo("AlCaRecoTriggerBitsRcdUpdate")
+      << "...done for runs " << firstRunIOV_ << " to " << lastRunIOV_ << " (< 0 meaning infinity)!";
 }
 
 //define this as a plug-in

--- a/CondTools/HLT/plugins/AlCaRecoTriggerBitsRcdUpdate.cc
+++ b/CondTools/HLT/plugins/AlCaRecoTriggerBitsRcdUpdate.cc
@@ -11,6 +11,7 @@
 #include <map>
 #include <vector>
 #include <algorithm>
+#include <set>
 
 // Framework
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

This PR consists of 2 updates on AlCaRecoTriggerBitsRcdUpdate.cc. 1. Adding new methods and 2. enhancing the existing record writer.

1. Methods to add/remove trigger bits to existing key
This is the most common use case of AlCaRecoTriggerBits update, where it has been achieved by existing methods: removeKeysFromMap followed by addTriggerLists. Since the former one remove set of key:paths, one has to input full list of the other paths in addition to being added/removed ones. This is for updating the record more efficiently. 

2. Skipping to append same hash functionality
As we will use the updater in new O2O workflow, this is needed to keep target tag history clean.  O2O will be called every run and the current writer will simply add new hash for every 'since', nevertheless the hash doesn't change. The idea is analogy to data writer in [L1O2O](https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/CondTools/L1TriggerExt/src/DataWriterExt.cc#L99-L103) and `writeBitsToDB` was modified with @ggovi's help. It won't harm the existing functionality. 

Also a python script to be called by O2O is added, where it implements the use case for SiStrip:https://indico.cern.ch/event/1041042/contributions/4373068/attachments/2249069/3815192/TriggerBitO2OforSiStrip.pdf#page=6
@mmusich hope it's fine to refer the slide and please have a look if the implementation is reasonable.

A test was done in November with private patch: https://cms-conddb.cern.ch/cmsDbBrowser/logs/O2O_logs/Prep/2021-11-26/2021-11-26/None/None
We wish to deploy it with the official release.

#### PR validation:

It passed runtests and code quality checks.

