### PR TITLE
Speed-up seed/dup. cleaning mkFit

### DIFF
--- a/RecoTracker/MkFitCMS/src/MkStdSeqs.cc
+++ b/RecoTracker/MkFitCMS/src/MkStdSeqs.cc
@@ -179,8 +179,8 @@ namespace mkfit {
         // To study some more details -- need EventOfHits for this
         int n_ovlp_hits_added = 0;
 
-        auto phi_rng = ax_phi.Rrdr_to_N_bins(oldPhi[ts], 0.08f);
-        auto eta_rng = ax_eta.Rrdr_to_N_bins(eta[ts], .1f);
+        auto phi_rng = ax_phi.from_R_rdr_to_N_bins(oldPhi[ts], 0.08f);
+        auto eta_rng = ax_eta.from_R_rdr_to_N_bins(eta[ts], .1f);
 
         for (auto i_phi = phi_rng.begin; i_phi != phi_rng.end; i_phi = ax_phi.next_N_bin(i_phi)) {
           for (auto i_eta = eta_rng.begin; i_eta != eta_rng.end; i_eta = ax_eta.next_N_bin(i_eta)) {

--- a/RecoTracker/MkFitCore/interface/binnor.h
+++ b/RecoTracker/MkFitCore/interface/binnor.h
@@ -144,7 +144,7 @@ namespace mkfit {
 
     // Pair of axis bin indices packed into unsigned.
     struct B_pair {
-      unsigned int packed_value; // bin1 in A1::c_M lower bits, bin2 above
+      unsigned int packed_value;  // bin1 in A1::c_M lower bits, bin2 above
 
       B_pair() : packed_value(0) {}
       B_pair(typename A1::index_t i1, typename A2::index_t i2) : packed_value(i2 << A1::c_M | i1) {}
@@ -176,7 +176,9 @@ namespace mkfit {
 
     // Access
 
-    B_pair m_bin_to_n_bin(B_pair m_bin) { return {m_a1.M_bin_to_N_bin(m_bin.bin1()), m_a2.M_bin_to_N_bin(m_bin.bin2())}; }
+    B_pair m_bin_to_n_bin(B_pair m_bin) {
+      return {m_a1.M_bin_to_N_bin(m_bin.bin1()), m_a2.M_bin_to_N_bin(m_bin.bin2())};
+    }
 
     B_pair get_n_bin(typename A1::index_t n1, typename A2::index_t n2) const { return {n1, n2}; }
 

--- a/RecoTracker/MkFitCore/interface/binnor.h
+++ b/RecoTracker/MkFitCore/interface/binnor.h
@@ -48,9 +48,9 @@ namespace mkfit {
           m_N_fac(N_size / (max - min)),
           m_last_M_bin(M_size - 1),
           m_last_N_bin(N_size - 1) {
-            // Requested number of bins must fit within the intended bit-field (declared by binnor, later).
-           assert(N_size <= (1 << N));
-          }
+      // Requested number of bins must fit within the intended bit-field (declared by binnor, later).
+      assert(N_size <= (1 << N));
+    }
 
     I from_R_to_M_bin(R r) const { return (r - m_R_min) * m_M_fac; }
     I from_R_to_N_bin(R r) const { return (r - m_R_min) * m_N_fac; }

--- a/RecoTracker/MkFitCore/standalone/test/binnor_demo.cxx
+++ b/RecoTracker/MkFitCore/standalone/test/binnor_demo.cxx
@@ -1,5 +1,6 @@
 #include "../../interface/binnor.h"
 #include <random>
+#include <chrono>
 
 // build as:
 // c++ -o binnor_demo -std=c++17 binnor_demo.cxx
@@ -21,9 +22,9 @@ int main()
     /*
     for (float p = -TwoPI; p < TwoPI; p += TwoPI / 15.4f) {
         printf("  phi=%-9f m=%5d n=%3d m2n=%3d n_safe=%3d\n", p,
-               phi.R_to_M_bin(p), phi.R_to_N_bin(p),
-               phi.M_bin_to_N_bin( phi.R_to_M_bin(p) ),
-               phi.R_to_N_bin_safe(p) );
+               phi.from_R_to_M_bin(p), phi.from_R_to_N_bin(p),
+               phi.from_M_bin_to_N_bin( phi.from_R_to_M_bin(p) ),
+               phi.from_R_to_N_bin_safe(p) );
     }
     */
 
@@ -48,6 +49,8 @@ int main()
     std::vector<track> tracks;
     tracks.reserve(NN);
 
+    auto start = std::chrono::high_resolution_clock::now();
+
     b.begin_registration(NN); // optional, reserves construction vector
 
     for (int i = 0; i < NN; ++i)
@@ -58,6 +61,9 @@ int main()
     }
 
     b.finalize_registration();
+
+    auto stop = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
 
     // for (int i = 0; i < NN; ++i)
     // {
@@ -75,8 +81,8 @@ int main()
     }
 
     printf("\n\n--- Range access for phi=[(-PI+0.02 +- 0.1], eta=[1.3 +- .2]:\n\n");
-    auto phi_rng = phi.Rrdr_to_N_bins(-PI+0.02, 0.1);
-    auto eta_rng = eta.Rrdr_to_N_bins(1.3, .2);
+    auto phi_rng = phi.from_R_rdr_to_N_bins(-PI+0.02, 0.1);
+    auto eta_rng = eta.from_R_rdr_to_N_bins(1.3, .2);
     printf("phi bin range: %u, %u; eta %u, %u\n", phi_rng.begin, phi_rng.end, eta_rng.begin, eta_rng.end);
     for (auto i_phi = phi_rng.begin; i_phi != phi_rng.end; i_phi = phi.next_N_bin(i_phi))
     {
@@ -91,291 +97,9 @@ int main()
         }
     }
 
+    printf("\nBinning time for %d points: %f sec\n", NN, 1.e-6*duration.count());
 
     b.reset_contents();
 
     return 0;
 }
-
-
-
-// buildtestMPlex.cc::runBtpCe_MultiIter(), loop over seed cleaning multiple times to measure time:
-/*
-    if ( itconf.m_requires_dupclean_tight ) {
-      double t0 = dtime();
-      TrackVec xxx; int n_comp;
-      for (int i=0;i<1000;++i) {
-      xxx = seeds;
-      n_comp = StdSeq::clean_cms_seedtracks_iter(&xxx, itconf, eoh.m_beam_spot);
-      }
-      printf("Seedacleena of %d seeds, out_seeds %d, 1000 times, N_comparisons=%d, took %.5fs\n",
-             (int)seeds.size(), (int)xxx.size(), n_comp, dtime() - t0);
-      seeds = xxx;
-    }
-*/
-
-// Example clean seeds using binnor.
-// Further enhancements possible by moving the iteration into binnor class (+iterator),
-// doing pre-selection on m_cons fine m-bins.
-// Perf notes: https://gist.github.com/osschar/2dcd2b01e7c15cc25aa6489f3b242ccb
-/*
-//=========================================================================
-// Seed cleaning (multi-iter)
-//=========================================================================
-int clean_cms_seedtracks_iter(TrackVec *seed_ptr, const IterationConfig& itrcfg, const BeamSpot &bspot)
-{
-  const float etamax_brl = Config::c_etamax_brl;
-  const float dpt_common = Config::c_dpt_common;
-
-  const float dzmax_bh = itrcfg.m_params.c_dzmax_bh;
-  const float drmax_bh = itrcfg.m_params.c_drmax_bh;
-  const float dzmax_eh = itrcfg.m_params.c_dzmax_eh;
-  const float drmax_eh = itrcfg.m_params.c_drmax_eh;
-  const float dzmax_bl = itrcfg.m_params.c_dzmax_bl;
-  const float drmax_bl = itrcfg.m_params.c_drmax_bl;
-  const float dzmax_el = itrcfg.m_params.c_dzmax_el;
-  const float drmax_el = itrcfg.m_params.c_drmax_el;
-
-  const float ptmin_hpt  = itrcfg.m_params.c_ptthr_hpt;
-
-  const float dzmax2_inv_bh = 1.f/(dzmax_bh*dzmax_bh);
-  const float drmax2_inv_bh = 1.f/(drmax_bh*drmax_bh);
-  const float dzmax2_inv_eh = 1.f/(dzmax_eh*dzmax_eh);
-  const float drmax2_inv_eh = 1.f/(drmax_eh*drmax_eh);
-  const float dzmax2_inv_bl = 1.f/(dzmax_bl*dzmax_bl);
-  const float drmax2_inv_bl = 1.f/(drmax_bl*drmax_bl);
-  const float dzmax2_inv_el = 1.f/(dzmax_el*dzmax_el);
-  const float drmax2_inv_el = 1.f/(drmax_el*drmax_el);
-
-  // Merge hits from overlapping seeds?
-  // For now always true, we require extra hits after seed.
-  const bool  merge_hits = true; // itrcfg.merge_seed_hits_during_cleaning();
-
-  if (seed_ptr == nullptr) return 0;
-  TrackVec &seeds = *seed_ptr;
-
-  const int ns = seeds.size();
-  #ifdef DEBUG
-   std::cout << "before seed cleaning "<< seeds.size()<<std::endl;
-  #endif
-  TrackVec cleanSeedTracks;
-  cleanSeedTracks.reserve(ns);
-  std::vector<bool> writetrack(ns, true);
-
-  const float invR1GeV = 1.f/Config::track1GeVradius;
-
-  std::vector<int>    nHits(ns);
-  std::vector<int>    charge(ns);
-  std::vector<float>  oldPhi(ns);
-  std::vector<float>  pos2(ns);
-  std::vector<float>  eta(ns);
-  std::vector<float>  ctheta(ns);
-  std::vector<float>  invptq(ns);
-  std::vector<float>  pt(ns);
-  std::vector<float>  x(ns);
-  std::vector<float>  y(ns);
-  std::vector<float>  z(ns);
-  std::vector<float>  d0(ns);
-  int i1,i2; //for the sorting
-
-  axis_pow2_u1<float, unsigned short, 16, 8> ax_phi(-Config::PI, Config::PI);
-  axis<float, unsigned short, 8, 8>         ax_eta(-2.6, 2.6, 30u);
-
-  binnor<unsigned int, decltype(ax_phi), decltype(ax_eta), 24, 8> b(ax_phi, ax_eta);
-  b.begin_registration(ns);
-
-  for(int ts=0; ts<ns; ts++){
-    const Track & tk = seeds[ts];
-    nHits[ts] = tk.nFoundHits();
-    charge[ts] = tk.charge();
-    oldPhi[ts] = tk.momPhi();
-    pos2[ts] = std::pow(tk.x(), 2) + std::pow(tk.y(), 2);
-    eta[ts] = tk.momEta();
-    ctheta[ts] = 1.f/std::tan(tk.theta());
-    invptq[ts] = tk.charge()*tk.invpT();
-    pt[ts] = tk.pT();
-    x[ts] = tk.x();
-    y[ts] = tk.y();
-    z[ts] = tk.z();
-    d0[ts] = tk.d0BeamSpot(bspot.x,bspot.y);
-
-    // If one is sure values are *within* axis ranges:
-    // b.register_entry(oldPhi[ts], eta[ts]);
-    b.register_entry_safe(oldPhi[ts], eta[ts]);
-  }
-
-  b.finalize_registration();
-
-  int n_comparisons = 0;
-
-  // for(int ts=0; ts<ns; ts++){
-  for(int sorted_ts=0; sorted_ts<ns; sorted_ts++){
-    int ts = b.m_ranks[sorted_ts];
-
-    // printf("Checking sorted_ts=%d ts=%d wwrite=%d\n", sorted_ts, ts, (int) writetrack[ts]);
-    if (not writetrack[ts]) continue;//FIXME: this speed up prevents transitive masking; check build cost!
-
-    const float oldPhi1 = oldPhi[ts];
-    const float pos2_first = pos2[ts];
-    const float Eta1 = eta[ts];
-    const float Pt1 = pt[ts];
-    const float invptq_first = invptq[ts];
-
-    // To study some more details -- need EventOfHits for this
-    int  n_ovlp_hits_added = 0;
-    // int  n_ovlp_hits_same_module = 0;
-    // int  n_ovlp_hits_shared = 0;
-    // int  n_ovlp_tracks = 0;
-
-    auto phi_rng = ax_phi.Rrdr_to_N_bins(oldPhi[ts], 0.08);
-    auto eta_rng = ax_eta.Rrdr_to_N_bins(eta[ts], .1);
-    // printf("sorted_ts=%d ts=%d -- phi bin range: %u, %u; eta %u, %u\n", sorted_ts, ts, phi_rng.begin, phi_rng.end, eta_rng.begin, eta_rng.end);
-    for (auto i_phi = phi_rng.begin; i_phi != phi_rng.end; i_phi = ax_phi.next_N_bin(i_phi))
-    {
-    for (auto i_eta = eta_rng.begin; i_eta != eta_rng.end; i_eta = ax_eta.next_N_bin(i_eta))
-    {
-    // printf(" at i_phi=%u, i_eta=%u\n", i_phi, i_eta);
-    const auto cbin = b.get_content(i_phi, i_eta);
-    for (auto i = cbin.first; i < cbin.end(); ++i)
-    {
-    //#pragma simd // Vectorization via simd had issues with icc
-    // for (int tss= ts+1; tss<ns; tss++)
-    //for (int sorted_tss= sorted_ts+1; sorted_tss<ns; sorted_tss++)
-    // {
-      int tss = b.m_ranks[i];
-      if (tss <= ts) continue;
-
-      const float Pt2 = pt[tss];
-
-      ////// Always require charge consistency. If different charge is assigned, do not remove seed-track
-      if(charge[tss] != charge[ts])
-        continue;
-
-      const float thisDPt = std::abs(Pt2-Pt1);
-      ////// Require pT consistency between seeds. If dpT is large, do not remove seed-track.
-      if( thisDPt > dpt_common*(Pt1) )
-        // continue;
-        break; // following seeds will only be farther away in pT
-
-      ++n_comparisons;
-
-      const float Eta2 = eta[tss];
-      const float deta2 = std::pow(Eta1-Eta2, 2);
-
-      const float oldPhi2 = oldPhi[tss];
-
-      const float pos2_second = pos2[tss];
-      const float thisDXYSign05 = pos2_second > pos2_first ? -0.5f : 0.5f;
-
-      const float thisDXY = thisDXYSign05*sqrt( std::pow(x[ts]-x[tss], 2) + std::pow(y[ts]-y[tss], 2) );
-
-      const float invptq_second = invptq[tss];
-
-      const float newPhi1 = oldPhi1-thisDXY*invR1GeV*invptq_first;
-      const float newPhi2 = oldPhi2+thisDXY*invR1GeV*invptq_second;
-
-      const float dphi = cdist(std::abs(newPhi1-newPhi2));
-
-      const float dr2 = deta2+dphi*dphi;
-
-      const float thisDZ = z[ts]-z[tss]-thisDXY*(ctheta[ts]+ctheta[tss]);
-      const float dz2 = thisDZ*thisDZ;
-
-      ////// Reject tracks within dR-dz elliptical window.
-      ////// Adaptive thresholds, based on observation that duplicates are more abundant at large pseudo-rapidity and low track pT
-      bool overlapping = false;
-      if(std::abs(Eta1)<etamax_brl){
-        if(Pt1>ptmin_hpt){if(dz2*dzmax2_inv_bh+dr2*drmax2_inv_bh<1.0f) overlapping=true; }
-        else{if(dz2*dzmax2_inv_bl+dr2*drmax2_inv_bl<1.0f) overlapping=true; }
-      }
-      else {
-        if(Pt1>ptmin_hpt){if(dz2*dzmax2_inv_eh+dr2*drmax2_inv_eh<1.0f) overlapping=true; }
-        else{if(dz2*dzmax2_inv_el+dr2*drmax2_inv_el<1.0f) overlapping=true; }
-      }
-
-      if(overlapping){
-        //Mark tss as a duplicate
-        i1=ts;
-        i2=tss;
-        if (d0[tss]>d0[ts])
-          writetrack[tss] = false;
-        else {
-          writetrack[ts] = false;
-          i2 = ts;
-          i1 = tss;
-        }
-        // Add hits from tk2 to the seed we are keeping.
-        // NOTE: We only have 3 bits in Track::Status for number of seed hits.
-        //       There is a check at entry and after adding of a new hit.
-        Track &tk = seeds[i1];
-        if (merge_hits && tk.nTotalHits() < 15)
-        {
-          const Track &tk2 = seeds[i2];
-          //We are not actually fitting to the extra hits; use chi2 of 0
-          float fakeChi2 = 0.0;
-
-          for (int j = 0; j < tk2.nTotalHits(); ++j)
-          {
-            int hitidx = tk2.getHitIdx(j);
-            int hitlyr = tk2.getHitLyr(j);
-            if (hitidx >= 0)
-            {
-              bool unique = true;
-              for (int i = 0; i < tk.nTotalHits(); ++i)
-              {
-                if ((hitidx == tk.getHitIdx(i)) && (hitlyr == tk.getHitLyr(i))) {
-                  unique = false;
-                  break;
-                }
-              }
-              if (unique) {
-                tk.addHitIdx(tk2.getHitIdx(j), tk2.getHitLyr(j), fakeChi2);
-                ++n_ovlp_hits_added;
-                if (tk.nTotalHits() >= 15)
-                  break;
-              }
-            }
-          }
-        }
-        if (n_ovlp_hits_added > 0) {
-           tk.sortHitsByLayer();
-           n_ovlp_hits_added = 0;
-        }
-
-        if ( ! writetrack[ts]) goto end_ts_loop;
-      }
-    } //end of inner loop over tss
-    }
-    }
-
-    if (writetrack[ts])
-    {
-      cleanSeedTracks.emplace_back(seeds[ts]);
-    }
-end_ts_loop: ;
-  }
-
-  seeds.swap(cleanSeedTracks);
-
-#ifdef DEBUG
-  {
-    const int ns2 = seeds.size();
-    printf("Number of CMS seeds before %d --> after %d cleaning\n", ns, ns2);
-
-    for (int it = 0; it < ns2; it++)
-    {
-      const Track& ss = seeds[it];
-      printf("  %3i q=%+i pT=%7.3f eta=% 7.3f nHits=%i label=% i\n",
-             it,ss.charge(),ss.pT(),ss.momEta(),ss.nFoundHits(),ss.label());
-    }
-  }
-#endif
-
-#ifdef DEBUG  
-  std::cout << "AFTER seed cleaning "<< seeds.size()<<std::endl;
-#endif
-
-  return n_comparisons; // seeds.size();
-}
-
-*/

--- a/RecoTracker/MkFitCore/standalone/test/binnor_demo.cxx
+++ b/RecoTracker/MkFitCore/standalone/test/binnor_demo.cxx
@@ -1,4 +1,4 @@
-#include "binnor.h"
+#include "../../interface/binnor.h"
 #include <random>
 
 // build as:
@@ -29,8 +29,8 @@ int main()
 
     axis<float, unsigned short, 12, 6> eta(-2.6, 2.6, 20u);
 
-    printf("Axis eta: M-bits=%d, N-bits=%d    n_bins=%d\n",
-           eta.c_M, eta.c_N, eta.m_n_bins);
+    printf("Axis eta: M-bits=%d, N-bits=%d  m_bins=%d n_bins=%d\n",
+           eta.c_M, eta.c_N, eta.size_of_M(), eta.size_of_N());
 
     binnor<unsigned int, decltype(phi), decltype(eta), 24, 8> b(phi, eta);
 
@@ -65,16 +65,16 @@ int main()
     //     printf("%3d  %3d  phi=%f  eta=%f\n", i, b.m_ranks[i], t.phi, t.eta);
     // }
 
-    printf("\n\n--- Single bin access:\n\n");
+    printf("\n\n--- Single bin access for (phi, eta) = (0,0):\n\n");
     auto nbin = b.get_n_bin(0.f, 0.f);
     auto cbin = b.get_content(0.f, 0.f);
-    printf("For (phi 0, eta 0; %u, %u) got first %d, count %d\n", nbin.bin1, nbin.bin2, cbin.first, cbin.count);
+    printf("For (phi 0, eta 0; %u, %u) got first %d, count %d\n", nbin.bin1(), nbin.bin2(), cbin.first, cbin.count);
     for (auto i = cbin.first; i < cbin.first + cbin.count; ++i) {
         const track &t = tracks[ b.m_ranks[i] ];
         printf("%3d  %3d  phi=%f  eta=%f\n", i, b.m_ranks[i], t.phi, t.eta);
     }
 
-    printf("\n\n--- Range access:\n\n");
+    printf("\n\n--- Range access for phi=[(-PI+0.02 +- 0.1], eta=[1.3 +- .2]:\n\n");
     auto phi_rng = phi.Rrdr_to_N_bins(-PI+0.02, 0.1);
     auto eta_rng = eta.Rrdr_to_N_bins(1.3, .2);
     printf("phi bin range: %u, %u; eta %u, %u\n", phi_rng.begin, phi_rng.end, eta_rng.begin, eta_rng.end);


### PR DESCRIPTION
#### PR description:

The seed cleaning algorithm (used in initial, high pT triplet, detached quad, and triplet) and the duplicate cleaning used in the pixelLess iteration are updated to reduce the processing time, while the physics is unchanged.

- the seed cleaning is updated from an N^2 comparison of all the pairs to a comparison of the tracks that can be approximately 
compatible for removal only. The tracks are binned in phi and eta and for each track, the comparison is made only inside compatible bins

- the duplicate cleaning consisted of a nested loop comparing hits. The new algorithm uses 2 simple loops per track: 1 to map hits to tracks and the second to find all the tracks sharing hits with the one examined (similarly to [TrajectoryCleanerBySharedHits](https://github.com/cms-sw/cmssw/blob/master/TrackingTools/TrajectoryCleaning/src/TrajectoryCleanerBySharedHits.cc))

The seed cleaning update is described here:
[Jan 31 update](https://indico.cern.ch/event/1117555/contributions/4701579/attachments/2381731/4069638/mkFit%20-%20update.pdf)

The duplicate cleaning is mentioned here (p.23):
[Feb 14 update](https://indico.cern.ch/event/1128089/contributions/4735248/attachments/2390777/4086913/mkFit_TRKPOG_14February2022.pdf)


#### PR validation:

The physics is validated with TTbar PU50, where blue is before PR and red is after PR

http://legianni.web.cern.ch/legianni/plots-PR37122/

CPU profiling with igprof can be found here  

- old
[global](https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/mkfit-update/igreport_perf_old)
[seed cleaning](https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/mkfit-update/igreport_perf_old/636)
[dup cleaning](https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/mkfit-update/igreport_perf_old/1002)
- new
[global](https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/mkfit-update/igreport_perf_new)
[seed cleaning](https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/mkfit-update/igreport_perf_new/2139)
[dup cleaning](https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/mkfit-update/igreport_perf_new/2048)
