### PR TITLE
ECAL DQM - Add WF .513 for ECAL GPU vs. CPU validation

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -33,12 +33,17 @@ The offsets currently in use are:
 * 0.5: Pixel tracking only + 0.1
 * 0.501: Patatrack, pixel only quadruplets, on CPU
 * 0.502: Patatrack, pixel only quadruplets, with automatic offload to GPU if available
+* 0.504: Patatrack, pixel only quadruplets, GPU profiling
 * 0.505: Patatrack, pixel only triplets, on CPU
 * 0.506: Patatrack, pixel only triplets, with automatic offload to GPU if available
+* 0.508: Patatrack, pixel only triplets, GPU profiling
 * 0.511: Patatrack, ECAL only, on CPU
 * 0.512: Patatrack, ECAL only, with automatic offload to GPU if available
+* 0.513: Patatrack, ECAL only, GPU vs. CPU validation
+* 0.514: Patatrack, ECAL only, GPU profiling
 * 0.521: Patatrack, HCAL only, on CPU
 * 0.522: Patatrack, HCAL only, with automatic offload to GPU if available
+* 0.524: Patatrack, HCAL only, GPU profiling
 * 0.591: Patatrack, full reco with pixel quadruplets, on CPU
 * 0.592: Patatrack, full reco with pixel quadruplets, with automatic offload to GPU if available
 * 0.595: Patatrack, full reco with pixel triplets, on CPU

--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -14,39 +14,39 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #just define all of them
 
 #WFs to run in IB:
-# mc 2018   (Patatrack pixel-only quadruplets: ZMM - on GPU, both CPU and GPU, auto)
-#           (Patatrack pixel-only triplets: ZMM - on GPU, both CPU and GPU, auto)
-#           (Patatrack pixel-only quadruplets: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack pixel-only triplets: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack ECAL-only: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack HCAL-only: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack full reco with pixel quadruplets: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack full reco with pixel triplets: TTbar - on GPU, both CPU and GPU, auto)
-# mc 2021   (Patatrack pixel-only quadruplets: ZMM - on GPU, both CPU and GPU, auto)
-#           (Patatrack pixel-only triplets: ZMM - on GPU, both CPU and GPU, auto)
-#           (Patatrack pixel-only quadruplets: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack pixel-only triplets: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack ECAL-only: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack HCAL-only: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack full reco with pixel quadruplets: TTbar - on GPU, both CPU and GPU, auto)
-#           (Patatrack full reco with pixel triplets: TTbar - on GPU, both CPU and GPU, auto)
+# mc 2018   (Patatrack pixel-only quadruplets: ZMM - on GPU, both CPU and GPU, profiling)
+#           (Patatrack pixel-only triplets: ZMM - on GPU, both CPU and GPU, profiling)
+#           (Patatrack pixel-only quadruplets: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack pixel-only triplets: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack ECAL-only: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack HCAL-only: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack full reco with pixel quadruplets: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack full reco with pixel triplets: TTbar - on GPU, both CPU and GPU, profiling)
+# mc 2021   (Patatrack pixel-only quadruplets: ZMM - on GPU, both CPU and GPU, profiling)
+#           (Patatrack pixel-only triplets: ZMM - on GPU, both CPU and GPU, profiling)
+#           (Patatrack pixel-only quadruplets: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack pixel-only triplets: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack ECAL-only: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack HCAL-only: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack full reco with pixel quadruplets: TTbar - on GPU, both CPU and GPU, profiling)
+#           (Patatrack full reco with pixel triplets: TTbar - on GPU, both CPU and GPU, profiling)
 numWFIB = [
-           10842.502, # 10842.503,10842.504,
-           10842.506, # 10842.507,10842.508,
-           10824.502, # 10824.503,10824.504,
-           10824.506, # 10824.507,10824.508,
-           10824.512, # 10824.513,10824.514,
-           10824.522, # 10824.523,10824.524,
-           10824.592, # 10824.593,10824.594,
-           10824.596, # 10824.597,10824.598,
-           11650.502, # 11650.503,11650.504,
-           11650.506, # 11650.507,11650.508,
-           11634.502, # 11634.503,11634.504,
-           11634.506, # 11634.507,11634.508,
-           11634.512, # 11634.513,11634.514,
-           11634.522, # 11634.523,11634.524
-           11634.592, # 11634.593,11634.594,
-           11634.596, # 11634.597,11634.598,
+           10842.502, # 10842.503, 10842.504,
+           10842.506, # 10842.507, 10842.508,
+           10824.502, # 10824.503, 10824.504,
+           10824.506, # 10824.507, 10824.508,
+           10824.512, 10824.513, # 10824.514,
+           10824.522, # 10824.523, 10824.524,
+           10824.592, # 10824.593, 10824.594,
+           10824.596, # 10824.597, 10824.598,
+           11650.502, # 11650.503, 11650.504,
+           11650.506, # 11650.507, 11650.508,
+           11634.502, # 11634.503, 11634.504,
+           11634.506, # 11634.507, 11634.508,
+           11634.512, 11634.513, # 11634.514,
+           11634.522, # 11634.523, 11634.524,
+           11634.592, # 11634.593, 11634.594,
+           11634.596, # 11634.597, 11634.598,
         ]
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows: continue

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -679,7 +679,7 @@ upgradeWFs['PatatrackECALOnlyGPU'] = PatatrackWorkflow(
     offset = 0.512,
 )
 
-# add here a .513 workflow for GPU vs CPU validation
+# add here a .513 workflow for GPU with fallback to CPU
 
 upgradeWFs['PatatrackECALOnlyGPUProfiling'] = PatatrackWorkflow(
     digi = {
@@ -693,6 +693,21 @@ upgradeWFs['PatatrackECALOnlyGPUProfiling'] = PatatrackWorkflow(
     harvest = None,
     suffix = 'Patatrack_ECALOnlyGPU_Profiling',
     offset = 0.514,
+)
+
+upgradeWFs['PatatrackECALOnlyGPU_Validation'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'gpu,gpuValidationEcal'
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
+        '--procModifiers': 'gpu,gpuValidationEcal'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@ecalOnlyValidation+@ecal'
+    },
+    suffix = 'Patatrack_ECALOnlyGPU_Validation',
+    offset = 0.515,
 )
 
 upgradeWFs['PatatrackHCALOnlyCPU'] = PatatrackWorkflow(

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -681,10 +681,12 @@ upgradeWFs['PatatrackECALOnlyGPU'] = PatatrackWorkflow(
 
 upgradeWFs['PatatrackECALOnlyGPUValidation'] = PatatrackWorkflow(
     digi = {
+        '--accelerators': 'gpu-nvidia'
         '--procModifiers': 'gpu,gpuValidationEcal'
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
+        '--accelerators': 'gpu-nvidia'
         '--procModifiers': 'gpu,gpuValidationEcal'
     },
     harvest = {

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -682,12 +682,12 @@ upgradeWFs['PatatrackECALOnlyGPU'] = PatatrackWorkflow(
 upgradeWFs['PatatrackECALOnlyGPUValidation'] = PatatrackWorkflow(
     digi = {
         '--accelerators': 'gpu-nvidia',
-        '--procModifiers': 'gpu,gpuValidationEcal'
+        '--procModifiers': 'gpu'
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
         '--accelerators': 'gpu-nvidia',
-        '--procModifiers': 'gpu,gpuValidationEcal'
+        '--procModifiers': 'gpuValidation'
     },
     harvest = {
         '-s': 'HARVESTING:@ecalOnlyValidation+@ecal'

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -679,7 +679,20 @@ upgradeWFs['PatatrackECALOnlyGPU'] = PatatrackWorkflow(
     offset = 0.512,
 )
 
-# add here a .513 workflow for GPU with fallback to CPU
+upgradeWFs['PatatrackECALOnlyGPUValidation'] = PatatrackWorkflow(
+    digi = {
+        '--procModifiers': 'gpu,gpuValidationEcal'
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
+        '--procModifiers': 'gpu,gpuValidationEcal'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@ecalOnlyValidation+@ecal'
+    },
+    suffix = 'Patatrack_ECALOnlyGPU_Validation',
+    offset = 0.513,
+)
 
 upgradeWFs['PatatrackECALOnlyGPUProfiling'] = PatatrackWorkflow(
     digi = {
@@ -693,21 +706,6 @@ upgradeWFs['PatatrackECALOnlyGPUProfiling'] = PatatrackWorkflow(
     harvest = None,
     suffix = 'Patatrack_ECALOnlyGPU_Profiling',
     offset = 0.514,
-)
-
-upgradeWFs['PatatrackECALOnlyGPU_Validation'] = PatatrackWorkflow(
-    digi = {
-        '--procModifiers': 'gpu,gpuValidationEcal'
-    },
-    reco = {
-        '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
-        '--procModifiers': 'gpu,gpuValidationEcal'
-    },
-    harvest = {
-        '-s': 'HARVESTING:@ecalOnlyValidation+@ecal'
-    },
-    suffix = 'Patatrack_ECALOnlyGPU_Validation',
-    offset = 0.515,
 )
 
 upgradeWFs['PatatrackHCALOnlyCPU'] = PatatrackWorkflow(

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -681,12 +681,12 @@ upgradeWFs['PatatrackECALOnlyGPU'] = PatatrackWorkflow(
 
 upgradeWFs['PatatrackECALOnlyGPUValidation'] = PatatrackWorkflow(
     digi = {
-        '--accelerators': 'gpu-nvidia'
+        '--accelerators': 'gpu-nvidia',
         '--procModifiers': 'gpu,gpuValidationEcal'
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
-        '--accelerators': 'gpu-nvidia'
+        '--accelerators': 'gpu-nvidia',
         '--procModifiers': 'gpu,gpuValidationEcal'
     },
     harvest = {

--- a/DQM/EcalMonitorTasks/python/EcalMonitorTask_cff.py
+++ b/DQM/EcalMonitorTasks/python/EcalMonitorTask_cff.py
@@ -6,6 +6,6 @@ from DQM.EcalMonitorTasks.EcalMonitorTask_cfi import *
 from Configuration.ProcessModifiers.gpuValidationEcal_cff import gpuValidationEcal
 from DQM.EcalMonitorTasks.ecalGpuTask_cfi import ecalGpuTask
 
-gpuValidationEcal.toModify(ecalGpuTask.params, runGpuTask = cms.untracked.bool(True))
+gpuValidationEcal.toModify(ecalGpuTask.params, runGpuTask = True)
 gpuValidationEcal.toModify(ecalMonitorTask.workers, func = lambda workers: workers.append("GpuTask"))
 gpuValidationEcal.toModify(ecalMonitorTask, workerParameters = dict(GpuTask = ecalGpuTask))


### PR DESCRIPTION
#### PR description:

This PR adds a new type of WFs with suffix ~~.515~~ .513 to do the ECAL GPU vs. CPU validation. It also addresses an issue with the configuration raised during the review of #36742 .
Both changes are tracked in #37025.

~~The WF suffix .515 was chosen because the initially planned .513 is foreseen for a GPU with CPU fallback WF now.~~

#### PR validation:

Passes 11634.513 and validation histograms are produced.