### PR TITLE
modernize `TriggerHelper` and migrate to usage of `DCSRecord`

### DIFF
--- a/DQM/TrackerCommon/BuildFile.xml
+++ b/DQM/TrackerCommon/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="CondFormats/DataRecord"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Scalers"/>
+<use name="DataFormats/OnlineMetaData"/>
 <use name="DataFormats/L1GlobalTrigger"/>
 <use name="L1Trigger/GlobalTriggerAnalyzer"/>
 <use name="HLTrigger/HLTcore"/>


### PR DESCRIPTION
#### PR description:

Addresses comment https://github.com/cms-sw/cmssw/pull/37084#issuecomment-1057769384, by performing the same changes done in `GenericTriggerEventFlag` (to fall back to DCSRecord data provided by the software FED n. 1022, in case the DCS status from SCAL is not available) in PR https://github.com/cms-sw/cmssw/pull/37084 also in `TriggerHelper` class.

#### PR validation:

`cmssw` compiles, the class is not currently used anywhere else in cmssw, see: https://cmssdt.cern.ch/dxr/CMSSW/search?q=TriggerHelper&case=true

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A