### PR TITLE
Add an option to cmsDriver for selecting the accelerators to use

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -89,6 +89,7 @@ defaultOptions.nThreads = '1'
 defaultOptions.nStreams = '0'
 defaultOptions.nConcurrentLumis = '0'
 defaultOptions.nConcurrentIOVs = '1'
+defaultOptions.accelerators = None
 
 # some helper routines
 def dumpPython(process,name):
@@ -2280,6 +2281,16 @@ class ConfigBuilder(object):
             self.process.options.numberOfStreams = int(self._options.nStreams)
             self.process.options.numberOfConcurrentLuminosityBlocks = int(self._options.nConcurrentLumis)
             self.process.options.eventSetup.numberOfConcurrentIOVs = int(self._options.nConcurrentIOVs)
+
+        if self._options.accelerators is not None:
+            accelerators = self._options.accelerators.split(',')
+            self.pythonCfgCode += "\n"
+            self.pythonCfgCode += "# Enable only these accelerator backends\n"
+            self.pythonCfgCode += "process.load('Configuration.StandardSequences.Accelerators_cff')\n"
+            self.pythonCfgCode += "process.options.accelerators = ['" + "', '".join(accelerators) + "']\n"
+            self.process.load('Configuration.StandardSequences.Accelerators_cff')
+            self.process.options.accelerators = accelerators
+
         #repacked version
         if self._options.isRepacked:
             self.pythonCfgCode +="\n"

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -414,3 +414,8 @@ expertSettings.add_option("--nConcurrentIOVs",
                           default=defaultOptions.nConcurrentIOVs,
                           dest='nConcurrentIOVs'
                           )
+expertSettings.add_option("--accelerators",
+                          help="Comma-separated list of accelerators to enable; if 'cpu' is not included, the job will fail if none of the accelerators is available (default is not set, enabling all available accelerators, including the cpu)",
+                          default=None,
+                          dest='accelerators'
+                          )


### PR DESCRIPTION
#### PR description:

Add an option to cmsDriver for passing a comma-separated list of accelerators to enable. If none of those accelerators is available, and 'cpu' is not part of the list, the job will fail.
The default value is not set, which enables all available accelerators, including the cpu fallback.

#### PR validation:

Tested that `cmsDriver.py ... --accelerator gpu-nvidia` behaves as expected.

