### PR TITLE
Drop type specs for Trigger

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -19,140 +19,157 @@ from DQMOffline.Trigger.TopMonitor_cfi import hltTOPmonitoring
 # HLT_AK8PFHT900_TrimMass50_v*
 # HLT_AK8PFHT700_TrimR0p1PT0p03Mass50
 
-PFHT1050_Mjjmonitoring = hltMjjmonitoring.clone()
-PFHT1050_Mjjmonitoring.FolderName = cms.string('HLT/B2G/PFHT1050')
-PFHT1050_Mjjmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT1050_v*")
-PFHT1050_Mjjmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-PFHT1050_Mjjmonitoring.jetSelection = cms.string("pt > 200 && eta < 2.4")
+PFHT1050_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/PFHT1050',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_PFHT1050_v*"])     
+)
 
-PFHT1050_Softdropmonitoring = hltSoftdropmonitoring.clone()
-PFHT1050_Softdropmonitoring.FolderName = cms.string('HLT/B2G/PFHT1050')
-PFHT1050_Softdropmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT1050_v*")
-PFHT1050_Softdropmonitoring.jetSelection = cms.string("pt > 65 && eta < 2.4")
+PFHT1050_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/PFHT1050',
+    jetSelection = "pt > 65 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT1050_v*"])        
+)
+
+AK8PFJet500_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet500',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet500_v*"])
+)
+
+AK8PFJet500_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet500',
+    jetSelection = "pt > 65 && eta < 2.4",
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFJet500_v*"])
+)
+
+AK8PFHT750_TrimMass50_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT750_TrimMass50',
+    jets = "ak8PFJetsPuppi",
+    jetSelection      = "pt > 0 && eta < 2.5",
+    jetSelection_HT = "pt > 200 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT750_TrimMass50_v*"])
+)
+
+AK8PFHT750_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT750_TrimMass50',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT750_TrimMass50_v*"])
+)
+
+AK8PFHT750_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT750_TrimMass50',
+    jetSelection = "pt > 65 && eta < 2.4",
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFHT750_TrimMass50_v*"])
+)
+
+AK8PFHT800_TrimMass50_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT800_TrimMass50',
+    jets = "ak8PFJetsPuppi",
+    jetSelection      = "pt > 0 && eta < 2.5",
+    jetSelection_HT = "pt > 200 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT800_TrimMass50_v*"])
+)
+
+AK8PFHT800_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT800_TrimMass50',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFHT800_TrimMass50_v*"])
+)
+
+AK8PFHT800_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT800_TrimMass50',
+    jetSelection = "pt > 65 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT800_TrimMass50_v*"])
+)
+
+AK8PFHT850_TrimMass50_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT850_TrimMass50',
+    jets = "ak8PFJetsPuppi",
+    jetSelection      = "pt > 0 && eta < 2.5",
+    jetSelection_HT = "pt > 200 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT850_TrimMass50_v*"])
+)
+
+AK8PFHT850_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT850_TrimMass50',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT850_TrimMass50_v*"])
+)
+
+AK8PFHT850_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT850_TrimMass50',
+    jetSelection = "pt > 65 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT850_TrimMass50_v*"])
+)
+
+AK8PFHT900_TrimMass50_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT900_TrimMass50',
+    jets = "ak8PFJetsPuppi",
+    jetSelection      = "pt > 0 && eta < 2.5",
+    jetSelection_HT = "pt > 200 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT900_TrimMass50_v*"])
+)
+
+AK8PFHT900_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT900_TrimMass50',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT900_TrimMass50_v*"])
+)
+
+AK8PFHT900_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFHT900_TrimMass50',
+    jetSelection = "pt > 65 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT900_TrimMass50_v*"])
+)
 
 
-AK8PFJet500_Mjjmonitoring = hltMjjmonitoring.clone()
-AK8PFJet500_Mjjmonitoring.FolderName = cms.string('HLT/B2G/AK8PFJet500')
-AK8PFJet500_Mjjmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet500_v*")
-AK8PFJet500_Mjjmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet500_Mjjmonitoring.jetSelection = cms.string("pt > 200 && eta < 2.4")
+AK8PFJet360_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet360_TrimMass30',
+    ptcut = 360,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet360_TrimMass30_v*"])
+)
 
-AK8PFJet500_Softdropmonitoring = hltSoftdropmonitoring.clone()
-AK8PFJet500_Softdropmonitoring.FolderName = cms.string('HLT/B2G/AK8PFJet500')
-AK8PFJet500_Softdropmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet500_v*")
-AK8PFJet500_Softdropmonitoring.jetSelection = cms.string("pt > 65 && eta < 2.4")
-
-
-AK8PFHT750_TrimMass50_HTmonitoring = hltHTmonitoring.clone()
-AK8PFHT750_TrimMass50_HTmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT750_TrimMass50')
-AK8PFHT750_TrimMass50_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT750_TrimMass50_v*")
-AK8PFHT750_TrimMass50_HTmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFHT750_TrimMass50_HTmonitoring.jetSelection      = cms.string("pt > 0 && eta < 2.5")
-AK8PFHT750_TrimMass50_HTmonitoring.jetSelection_HT = cms.string("pt > 200 && eta < 2.5")
-
-AK8PFHT750_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone()
-AK8PFHT750_TrimMass50_Mjjmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT750_TrimMass50')
-AK8PFHT750_TrimMass50_Mjjmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT750_TrimMass50_v*")
-AK8PFHT750_TrimMass50_Mjjmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFHT750_TrimMass50_Mjjmonitoring.jetSelection = cms.string("pt > 200 && eta < 2.4")
-
-AK8PFHT750_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone()
-AK8PFHT750_TrimMass50_Softdropmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT750_TrimMass50')
-AK8PFHT750_TrimMass50_Softdropmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT750_TrimMass50_v*")
-AK8PFHT750_TrimMass50_Softdropmonitoring.jetSelection = cms.string("pt > 65 && eta < 2.4")
+AK8PFJet380_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet380_TrimMass30',
+    ptcut = 380,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet380_TrimMass30_v*"])
+)
 
 
-AK8PFHT800_TrimMass50_HTmonitoring = hltHTmonitoring.clone()
-AK8PFHT800_TrimMass50_HTmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT800_TrimMass50')
-AK8PFHT800_TrimMass50_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT800_TrimMass50_v*")
-AK8PFHT800_TrimMass50_HTmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFHT800_TrimMass50_HTmonitoring.jetSelection      = cms.string("pt > 0 && eta < 2.5")
-AK8PFHT800_TrimMass50_HTmonitoring.jetSelection_HT = cms.string("pt > 200 && eta < 2.5")
+AK8PFJet400_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet400_TrimMass30',
+    ptcut = 400,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_TrimMass30_v*"])
+)
 
-AK8PFHT800_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone()
-AK8PFHT800_TrimMass50_Mjjmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT800_TrimMass50')
-AK8PFHT800_TrimMass50_Mjjmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT800_TrimMass50_v*")
-AK8PFHT800_TrimMass50_Mjjmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFHT800_TrimMass50_Mjjmonitoring.jetSelection = cms.string("pt > 200 && eta < 2.4")
+AK8PFJet420_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet420_TrimMass30',
+    ptcut = 420,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet420_TrimMass30_v*"])
+)
 
-AK8PFHT800_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone()
-AK8PFHT800_TrimMass50_Softdropmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT800_TrimMass50')
-AK8PFHT800_TrimMass50_Softdropmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT800_TrimMass50_v*")
-AK8PFHT800_TrimMass50_Softdropmonitoring.jetSelection = cms.string("pt > 65 && eta < 2.4")
+hltDQMonitorB2G_MuEle = hltTOPmonitoring.clone(
+    FolderName = 'HLT/B2G/Dileptonic/HLT_MuXX_EleXX_CaloIdL_MW',
+    nelectrons = 1,
+    eleSelection = 'pt>20 & abs(eta)<2.5',
+    nmuons = 1,
+    muoSelection = 'pt>20 & abs(eta)<2.4 & ((pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25)  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu37_Ele27_CaloIdL_MW_v*', 'HLT_Mu27_Ele37_CaloIdL_MW_v*'])
+)
 
-
-AK8PFHT850_TrimMass50_HTmonitoring = hltHTmonitoring.clone()
-AK8PFHT850_TrimMass50_HTmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT850_TrimMass50')
-AK8PFHT850_TrimMass50_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT850_TrimMass50_v*")
-AK8PFHT850_TrimMass50_HTmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFHT850_TrimMass50_HTmonitoring.jetSelection      = cms.string("pt > 0 && eta < 2.5")
-AK8PFHT850_TrimMass50_HTmonitoring.jetSelection_HT = cms.string("pt > 200 && eta < 2.5")
-
-AK8PFHT850_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone()
-AK8PFHT850_TrimMass50_Mjjmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT850_TrimMass50')
-AK8PFHT850_TrimMass50_Mjjmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT850_TrimMass50_v*")
-AK8PFHT850_TrimMass50_Mjjmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFHT850_TrimMass50_Mjjmonitoring.jetSelection = cms.string("pt > 200 && eta < 2.4")
-
-AK8PFHT850_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone()
-AK8PFHT850_TrimMass50_Softdropmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT850_TrimMass50')
-AK8PFHT850_TrimMass50_Softdropmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT850_TrimMass50_v*")
-AK8PFHT850_TrimMass50_Softdropmonitoring.jetSelection = cms.string("pt > 65 && eta < 2.4")
-
-
-AK8PFHT900_TrimMass50_HTmonitoring = hltHTmonitoring.clone()
-AK8PFHT900_TrimMass50_HTmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT900_TrimMass50')
-AK8PFHT900_TrimMass50_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT900_TrimMass50_v*")
-AK8PFHT900_TrimMass50_HTmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFHT900_TrimMass50_HTmonitoring.jetSelection      = cms.string("pt > 0 && eta < 2.5")
-AK8PFHT900_TrimMass50_HTmonitoring.jetSelection_HT = cms.string("pt > 200 && eta < 2.5")
-
-AK8PFHT900_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone()
-AK8PFHT900_TrimMass50_Mjjmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT900_TrimMass50')
-AK8PFHT900_TrimMass50_Mjjmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT900_TrimMass50_v*")
-AK8PFHT900_TrimMass50_Mjjmonitoring.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFHT900_TrimMass50_Mjjmonitoring.jetSelection = cms.string("pt > 200 && eta < 2.4")
-
-AK8PFHT900_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone()
-AK8PFHT900_TrimMass50_Softdropmonitoring.FolderName = cms.string('HLT/B2G/AK8PFHT900_TrimMass50')
-AK8PFHT900_TrimMass50_Softdropmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFHT900_TrimMass50_v*")
-AK8PFHT900_TrimMass50_Softdropmonitoring.jetSelection = cms.string("pt > 65 && eta < 2.4")
-
-
-
-AK8PFJet360_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone()
-AK8PFJet360_TrimMass30_PromptMonitoring.FolderName = cms.string('HLT/B2G/AK8PFJet360_TrimMass30')
-AK8PFJet360_TrimMass30_PromptMonitoring.ptcut = cms.double(360)
-AK8PFJet360_TrimMass30_PromptMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet360_TrimMass30_v*")
-
-AK8PFJet380_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone()
-AK8PFJet380_TrimMass30_PromptMonitoring.FolderName = cms.string('HLT/B2G/AK8PFJet380_TrimMass30')
-AK8PFJet380_TrimMass30_PromptMonitoring.ptcut = cms.double(380)
-AK8PFJet380_TrimMass30_PromptMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet380_TrimMass30_v*")
-
-AK8PFJet400_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone()
-AK8PFJet400_TrimMass30_PromptMonitoring.FolderName = cms.string('HLT/B2G/AK8PFJet400_TrimMass30')
-AK8PFJet400_TrimMass30_PromptMonitoring.ptcut = cms.double(400)
-AK8PFJet400_TrimMass30_PromptMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet400_TrimMass30_v*")
-
-AK8PFJet420_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone()
-AK8PFJet420_TrimMass30_PromptMonitoring.FolderName = cms.string('HLT/B2G/AK8PFJet420_TrimMass30')
-AK8PFJet420_TrimMass30_PromptMonitoring.ptcut = cms.double(420)
-AK8PFJet420_TrimMass30_PromptMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet420_TrimMass30_v*")
-
-hltDQMonitorB2G_MuEle = hltTOPmonitoring.clone()
-hltDQMonitorB2G_MuEle.FolderName = 'HLT/B2G/Dileptonic/HLT_MuXX_EleXX_CaloIdL_MW'
-hltDQMonitorB2G_MuEle.nelectrons = 1
-hltDQMonitorB2G_MuEle.eleSelection = 'pt>20 & abs(eta)<2.5'
-hltDQMonitorB2G_MuEle.nmuons = 1
-hltDQMonitorB2G_MuEle.muoSelection = 'pt>20 & abs(eta)<2.4 & ((pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25)  & isPFMuon & (isTrackerMuon || isGlobalMuon)'
-hltDQMonitorB2G_MuEle.numGenericTriggerEventPSet.hltPaths = ['HLT_Mu37_Ele27_CaloIdL_MW_v*', 'HLT_Mu27_Ele37_CaloIdL_MW_v*']
-
-hltDQMonitorB2G_MuTkMu = hltTOPmonitoring.clone()
-hltDQMonitorB2G_MuTkMu.FolderName = 'HLT/B2G/Dileptonic/HLT_Mu37_TkMu27'
-hltDQMonitorB2G_MuTkMu.nmuons = 2
-hltDQMonitorB2G_MuTkMu.muoSelection = 'pt>20 & abs(eta)<2.4 & ((pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25)  & isPFMuon & (isTrackerMuon || isGlobalMuon)'
-hltDQMonitorB2G_MuTkMu.numGenericTriggerEventPSet.hltPaths = ['HLT_Mu37_TkMu27_v*']
+hltDQMonitorB2G_MuTkMu = hltTOPmonitoring.clone(
+    FolderName = 'HLT/B2G/Dileptonic/HLT_Mu37_TkMu27',
+    nmuons = 2,
+    muoSelection = 'pt>20 & abs(eta)<2.4 & ((pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25)  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu37_TkMu27_v*'])
+)
 
 b2gMonitorHLT = cms.Sequence(
 

--- a/DQMOffline/Trigger/python/B2GTnPMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/B2GTnPMonitor_cfi.py
@@ -107,7 +107,7 @@ egammaStdHistConfigs = cms.VPSet(
 egammaStdFiltersToMonitor= cms.VPSet(
     cms.PSet(
         folderName = cms.string("HLT/B2G/HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165"),
-        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges=cms.vstring("55:99999")),),
+        rangeCuts = cms.VPSet(etRangeCut.clone(allowedRanges= ["55:99999"]),),
         filterName = cms.string("hltEle50CaloIdVTGsfTrkIdTCentralPFJet165EleCleaned"),
         histTitle = cms.string(""),
         tagExtraFilter = cms.string(""),
@@ -134,9 +134,10 @@ B2GegHLTDQMOfflineTnPSource = DQMEDAnalyzer("HLTEleTagAndProbeOfflineSource",
 
 from RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff import egmGsfElectronIDs
 
-B2GegmGsfElectronIDsForDQM = egmGsfElectronIDs.clone()
-B2GegmGsfElectronIDsForDQM.physicsObjectsIDs = cms.VPSet()
-B2GegmGsfElectronIDsForDQM.physicsObjectSrc == cms.InputTag('gedGsfElectrons')
+B2GegmGsfElectronIDsForDQM = egmGsfElectronIDs.clone(
+    physicsObjectsIDs = cms.VPSet(),
+    physicsObjectSrc = 'gedGsfElectrons'
+)
 #note: be careful here to when selecting new ids that the vid tools doesnt do extra setup for them
 #for example the HEEP cuts need an extra producer which vid tools automatically handles
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import setupVIDSelection

--- a/DQMOffline/Trigger/python/BPHMonitor_cff.py
+++ b/DQMOffline/Trigger/python/BPHMonitor_cff.py
@@ -5,677 +5,697 @@ from DQMOffline.Trigger.BPHMonitor_cfi import hltBPHmonitoring
 # Tau3Mu
 from DQMOffline.Trigger.Tau3MuMonitor_cff import *
 
-Dimuon0_Jpsi_tnp = hltBPHmonitoring.clone()
-Dimuon0_Jpsi_tnp.FolderName = cms.string('HLT/BPH/DiMu0_Jpsi_L1_NO_OS_denTrack2/')
-Dimuon0_Jpsi_tnp.tnp = cms.bool(True)
-Dimuon0_Jpsi_tnp.enum = cms.int32(1)
-Dimuon0_Jpsi_tnp.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_L1_NoOS_v*")
-#Dimuon0_Jpsi_tnp.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_Jpsi_tnp.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu7p5_Track2_Jpsi_v*")
-#Dimuon0_Jpsi_tnp.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_SingleMu5_SQ OR L1_SingleMu7_SQ")
-Dimuon0_Jpsi_tnp.muoSelection_ref = cms.string("pt>7.5 && abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_Jpsi_tnp.muoSelection = cms.string("abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
+Dimuon0_Jpsi_tnp = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Jpsi_L1_NO_OS_denTrack2/',
+    tnp = True,
+    enum = 1,
+    muoSelection_ref = "pt>7.5 && abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    muoSelection = "abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_L1_NoOS_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu7p5_Track2_Jpsi_v*"])
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_SingleMu5_SQ OR L1_SingleMu7_SQ"])
+)
 
-Dimuon25_Jpsi_tnp = hltBPHmonitoring.clone()
-Dimuon25_Jpsi_tnp.FolderName = cms.string('HLT/BPH/DiMu25_Jpsi_noCorr/')
-Dimuon25_Jpsi_tnp.tnp = cms.bool(True)
-Dimuon25_Jpsi_tnp.enum = cms.int32(1)
-Dimuon25_Jpsi_tnp.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon25_Jpsi_noCorrL1_v*")
-#Dimuon25_Jpsi_tnp.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu8_SQ")
-Dimuon25_Jpsi_tnp.muoSelection_ref = cms.string("pt>7.5 && abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon25_Jpsi_tnp.muoSelection = cms.string("abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-
-##
-Dimuon0_Jpsi_tnp1 = hltBPHmonitoring.clone()
-Dimuon0_Jpsi_tnp1.FolderName = cms.string('HLT/BPH/DiMu0_Jpsi_L1_NO_OS_denTrack7/')
-Dimuon0_Jpsi_tnp1.tnp = cms.bool(True)
-Dimuon0_Jpsi_tnp1.enum = cms.int32(1)
-Dimuon0_Jpsi_tnp1.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_L1_NoOS_v*")
-#Dimuon0_Jpsi_tnp1.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_Jpsi_tnp1.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu7p5_Track7_Jpsi_v*")
-#Dimuon0_Jpsi_tnp1.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_SingleMu5_SQ OR L1_SingleMu7_SQ")
-Dimuon0_Jpsi_tnp1.muoSelection_ref = cms.string("pt>7.5 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_Jpsi_tnp1.muoSelection = cms.string("abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
+Dimuon25_Jpsi_tnp = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu25_Jpsi_noCorr/',
+    tnp = True,
+    enum = 1,
+    muoSelection_ref = "pt>7.5 && abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    muoSelection = "abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon25_Jpsi_noCorrL1_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu8_SQ"])
+)
 
 ##
-Dimuon0_Jpsi_tnp2 = hltBPHmonitoring.clone()
-Dimuon0_Jpsi_tnp2.FolderName = cms.string('HLT/BPH/DiMu0_Jpsi_L1_NO_OS_denTrack3p5/')
-Dimuon0_Jpsi_tnp2.tnp = cms.bool(True)
-Dimuon0_Jpsi_tnp2.enum = cms.int32(1)
-Dimuon0_Jpsi_tnp2.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_L1_NoOS_v*")
-#Dimuon0_Jpsi_tnp2.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_Jpsi_tnp2.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu7p5_Track3p5_Jpsi_v*")
-#Dimuon0_Jpsi_tnp2.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_SingleMu5_SQ OR L1_SingleMu7_SQ")
-Dimuon0_Jpsi_tnp2.muoSelection_ref = cms.string("pt>7.5 && abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_Jpsi_tnp2.muoSelection = cms.string("abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
+Dimuon0_Jpsi_tnp1 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Jpsi_L1_NO_OS_denTrack7/',
+    tnp = True,
+    enum = 1,
+    muoSelection_ref = "pt>7.5 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    muoSelection = "abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_L1_NoOS_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu7p5_Track7_Jpsi_v*"])
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_SingleMu5_SQ OR L1_SingleMu7_SQ"])
+)
 
+##
+Dimuon0_Jpsi_tnp2 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Jpsi_L1_NO_OS_denTrack3p5/',
+    tnp = True,
+    enum = 1,
+    muoSelection_ref = "pt>7.5 && abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    muoSelection = "abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_L1_NoOS_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu7p5_Track3p5_Jpsi_v*"])
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_SingleMu5_SQ OR L1_SingleMu7_SQ"])
+)
 
 ##
 
-Dimuon0_Jpsi_OS = hltBPHmonitoring.clone()
-Dimuon0_Jpsi_OS.FolderName = cms.string('HLT/BPH/DiMu0_Jpsi_L1_OS/')
-Dimuon0_Jpsi_OS.tnp = cms.bool(False)
-Dimuon0_Jpsi_OS.enum = cms.int32(2)
-Dimuon0_Jpsi_OS.Jpsi = cms.int32(1)
-Dimuon0_Jpsi_OS.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_v*")
-#Dimuon0_Jpsi_OS.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ_OS")
-Dimuon0_Jpsi_OS.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_L1_NoOS_v*")
-#Dimuon0_Jpsi_OS.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_Jpsi_OS.muoSelection_ref = cms.string("abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_Jpsi_OS.DMSelection_ref = cms.string("abs(Eta)<2.4")
+Dimuon0_Jpsi_OS = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Jpsi_L1_OS/',
+    tnp = False,
+    enum = 2,
+    Jpsi = 1,
+    muoSelection_ref = cms.string("abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 "),
+    DMSelection_ref = cms.string("abs(Eta)<2.4"),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_v*"]),
+    #numGenericTriggerEventPSet =dict(l1Algorithms = ["L1_DoubleMu0_SQ_OS"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_L1_NoOS_v*"])
+    #denGenericTriggerEventPSet =dict(l1Algorithms = ["L1_DoubleMu0_SQ"])
+)
 
 ###
 
-Dimuon0_er = hltBPHmonitoring.clone()
-Dimuon0_er.FolderName = cms.string('HLT/BPH/DiMu0_Lowmass_L1_er/')
-Dimuon0_er.tnp = cms.bool(False)
-Dimuon0_er.enum = cms.int32(3)
-Dimuon0_er.Jpsi = cms.int32(1)
-Dimuon0_er.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#Dimuon0_er.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-Dimuon0_er.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_v*")
-#Dimuon0_er.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ_OS")
-Dimuon0_er.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_er.DMSelection_ref = cms.string("abs(Eta)<1.5")
+Dimuon0_er = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Lowmass_L1_er/',
+    tnp = False,
+    enum = 3,
+    Jpsi = 1,
+    muoSelection_ref = "abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<1.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_0er1p5_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_v*"])
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ_OS"])
+)
 
 ###
-Dimuon0_Upsilon_er = hltBPHmonitoring.clone()
-Dimuon0_Upsilon_er.FolderName = cms.string('HLT/BPH/DiMu0_Upsilon_L1_er/')
-Dimuon0_Upsilon_er.tnp = cms.bool(False)
-Dimuon0_Upsilon_er.enum = cms.int32(3)##
-Dimuon0_Upsilon_er.Upsilon = cms.int32(1)
-Dimuon0_Upsilon_er.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*")
-#Dimuon0_Upsilon_er.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS")
-Dimuon0_Upsilon_er.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_L1_4p5_v*")
-#Dimuon0_Upsilon_er.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5_SQ_OS")
-Dimuon0_Upsilon_er.muoSelection_ref = cms.string("abs(eta)<2. &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_Upsilon_er.DMSelection_ref = cms.string("abs(Eta)<2. ")
+Dimuon0_Upsilon_er = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Upsilon_L1_er/',
+    tnp = False,
+    enum = 3, 
+    Upsilon = 1,
+    muoSelection_ref = "abs(eta)<2. &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4p5er2p0_SQ_OS"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Upsilon_L1_4p5_v*"]),
+    #denGenericTriggerEventPSet =dict(l1Algorithms = ["L1_DoubleMu4p5_SQ_OS"])
+)
 
 ###L1 dR cut
 
 ###
-DMu4_3_Bs_dRcut = hltBPHmonitoring.clone()
-DMu4_3_Bs_dRcut.FolderName = cms.string('HLT/BPH/DMu4_3_Bs_L1_dR/')
-DMu4_3_Bs_dRcut.tnp = cms.bool(False)
-DMu4_3_Bs_dRcut.enum = cms.int32(4)
-DMu4_3_Bs_dRcut.ptCut = cms.int32(1)
-DMu4_3_Bs_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_3_Bs_v*")
-#DMu4_3_Bs_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
-DMu4_3_Bs_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#DMu4_3_Bs_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-DMu4_3_Bs_dRcut.muoSelection_ref = cms.string("pt>4.5 && abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_3_Bs_dRcut.muoSelection = cms.string("pt>3.5 && abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_3_Bs_dRcut.DMSelection_ref = cms.string("abs(Eta)<1.5 && Pt>5.5 && M<5.9 && M>4.6")
-DMu4_3_Bs_dRcut.histoPSet.dRPSet = cms.PSet(
-  nbins = cms.uint32( 30 ),
-  xmin  = cms.double(0.4),
-  xmax  = cms.double(1.9),
-)
-DMu4_3_Bs_dRcut.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32(9),
-  xmin  = cms.double(  4.4),
-  xmax  = cms.double(6.2),
-)
-
-
-DMu4_3_Jpsi_dRcut = hltBPHmonitoring.clone()
-DMu4_3_Jpsi_dRcut.FolderName = cms.string('HLT/BPH/DMu4_3_Jpsi_L1_dR/')
-DMu4_3_Jpsi_dRcut.tnp = cms.bool(False)
-DMu4_3_Jpsi_dRcut.enum = cms.int32(4)
-DMu4_3_Jpsi_dRcut.Jpsi = cms.int32(1)
-DMu4_3_Jpsi_dRcut.ptCut = cms.int32(1)
-DMu4_3_Jpsi_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_3_Jpsi_v*")
-#DMu4_3_Jpsi_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
-DMu4_3_Jpsi_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#DMu4_3_Jpsi_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-DMu4_3_Jpsi_dRcut.muoSelection_ref = cms.string("pt>4.5 &&  abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_3_Jpsi_dRcut.muoSelection = cms.string("pt>3.5 && abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_3_Jpsi_dRcut.DMSelection_ref = cms.string("abs(Eta)<1.5")
-DMu4_3_Jpsi_dRcut.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 10 ),
-  xmin  = cms.double(2.8),
-  xmax  = cms.double(3.3),
+DMu4_3_Bs_dRcut = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DMu4_3_Bs_L1_dR/',
+    tnp = False,
+    enum = 4,
+    ptCut = 1,
+    muoSelection_ref = "pt>4.5 && abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    muoSelection = "pt>3.5 && abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<1.5 && Pt>5.5 && M<5.9 && M>4.6",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_3_Bs_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS_dR_1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_0er1p5_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS"]),
+    histoPSet = dict(dRPSet = dict(
+        nbins = 30,  
+        xmin  = 0.4,
+        xmax  = 1.9),
+    massPSet = dict(
+        nbins = 9,
+        xmin  = 4.4,
+        xmax  = 6.2)
+    )
 )
 
-
-Dimuon14_Phi_dRcut = hltBPHmonitoring.clone()
-Dimuon14_Phi_dRcut.FolderName = cms.string('HLT/BPH/DiMu14_Phi_L1_dR/')
-Dimuon14_Phi_dRcut.tnp = cms.bool(False)
-Dimuon14_Phi_dRcut.enum = cms.int32(4)
-Dimuon14_Phi_dRcut.seagull = cms.int32(1)
-Dimuon14_Phi_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon14_Phi_Barrel_Seagulls_v*")
-#Dimuon14_Phi_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
-Dimuon14_Phi_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#Dimuon14_Phi_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-Dimuon14_Phi_dRcut.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon14_Phi_dRcut.DMSelection_ref = cms.string("M>0.95 & M<1.1 & Pt>15 & abs(Eta)<1.2")
-Dimuon14_Phi_dRcut.histoPSet.dRPSet = cms.PSet(
-  nbins = cms.uint32( 35 ),
-  xmin  = cms.double(0),
-  xmax  = cms.double(0.7),
+DMu4_3_Jpsi_dRcut = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DMu4_3_Jpsi_L1_dR/',
+    tnp = False,
+    enum = 4,
+    Jpsi = 1,
+    ptCut = 1,
+    muoSelection_ref = "pt>4.5 &&  abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    muoSelection = "pt>3.5 && abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<1.5",
+    numGenericTriggerEventPSet =dict(hltPaths = ["HLT_DoubleMu4_3_Jpsi_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS_dR_1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_0er1p5_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS"]),
+    histoPSet = dict(massPSet = dict(
+        nbins = 10,
+        xmin  = 2.8,
+        xmax  = 3.3)
 )
-Dimuon14_Phi_dRcut.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 10 ),
-  xmin  = cms.double(0.95),
-  xmax  = cms.double(1.1),
 )
 
-
-DMu4_LowMassNonResonantTrk_Displaced_dRcut = hltBPHmonitoring.clone()
-DMu4_LowMassNonResonantTrk_Displaced_dRcut.FolderName = cms.string('HLT/BPH/DMu4_LowMassNonResonantTrk_Displaced_L1_dR/')
-DMu4_LowMassNonResonantTrk_Displaced_dRcut.tnp = cms.bool(False)
-DMu4_LowMassNonResonantTrk_Displaced_dRcut.enum = cms.int32(4)
-DMu4_LowMassNonResonantTrk_Displaced_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_LowMassNonResonantTrk_Displaced_v*")
-#DMu4_LowMassNonResonantTrk_Displaced_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#DMu4_LowMassNonResonantTrk_Displaced_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut.muoSelection_ref = cms.string("pt>5 & abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut.DMSelection_ref = cms.string("((M>1.1 & M<2.8) | (M>4.1 & M<4.7)) & abs(Eta)<1.5")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 10 ),
-  xmin  = cms.double(1.),
-  xmax  = cms.double(3.),
+Dimuon14_Phi_dRcut = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu14_Phi_L1_dR/',
+    tnp = False,
+    enum = 4,
+    seagull = 1,
+    muoSelection_ref = "abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M>0.95 & M<1.1 & Pt>15 & abs(Eta)<1.2",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon14_Phi_Barrel_Seagulls_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS_dR_1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_0er1p5_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS"]),
+    histoPSet = dict(dRPSet = dict(
+                        nbins = 35,
+                        xmin  = 0,    
+                        xmax  = 0.7),
+                    massPSet = dict(
+                        nbins =  10,
+                        xmin  = 0.95,
+                        xmax  = 1.1)
+   )
 )
 
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low = hltBPHmonitoring.clone()
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.FolderName = cms.string('HLT/BPH/DMu4_LowMassNonResonantTrk_Displaced_L1_dR_low/')
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.tnp = cms.bool(False)
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.enum = cms.int32(4)
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_LowMassNonResonantTrk_Displaced_v*")
-#DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
-#DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.muoSelection_ref = cms.string("pt>5 & abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.DMSelection_ref = cms.string("((M>1.1 & M<2.8) | (M>4.1 & M<4.7)) & abs(Eta)<2.4")
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.max_dR = cms.double(1.2)
-DMu4_LowMassNonResonantTrk_Displaced_dRcut_low.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 10 ),
-  xmin  = cms.double(1.),
-  xmax  = cms.double(3.),
+DMu4_LowMassNonResonantTrk_Displaced_dRcut = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DMu4_LowMassNonResonantTrk_Displaced_L1_dR/',
+    tnp = False,
+    enum = 4,
+    muoSelection_ref = "pt>5 & abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "((M>1.1 & M<2.8) | (M>4.1 & M<4.7)) & abs(Eta)<1.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_LowMassNonResonantTrk_Displaced_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS_dR_1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_0er1p5_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS"]),
+    histoPSet = dict(massPSet = dict(
+        nbins = 10,
+        xmin  = 1.,
+        xmax  = 3.)
+)
 )
 
-
-DMu4_JpsiTrk_Displaced_dRcut = hltBPHmonitoring.clone()
-DMu4_JpsiTrk_Displaced_dRcut.FolderName = cms.string('HLT/BPH/DMu4_JpsiTrk_Displaced_L1_dR/')
-DMu4_JpsiTrk_Displaced_dRcut.tnp = cms.bool(False)
-DMu4_JpsiTrk_Displaced_dRcut.enum = cms.int32(4)
-DMu4_JpsiTrk_Displaced_dRcut.Jpsi = cms.int32(1)
-DMu4_JpsiTrk_Displaced_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_JpsiTrk_Displaced_v*")
-#DMu4_JpsiTrk_Displaced_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
-DMu4_JpsiTrk_Displaced_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#DMu4_JpsiTrk_Displaced_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-DMu4_JpsiTrk_Displaced_dRcut.muoSelection_ref = cms.string("pt>5 & abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_JpsiTrk_Displaced_dRcut.DMSelection_ref = cms.string("abs(Eta)<1.5")
-DMu4_JpsiTrk_Displaced_dRcut.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 10 ),
-  xmin  = cms.double(2.8),
-  xmax  = cms.double(3.3),
+DMu4_LowMassNonResonantTrk_Displaced_dRcut_low = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DMu4_LowMassNonResonantTrk_Displaced_L1_dR_low/',
+    tnp = False,
+    enum = 4,
+    muoSelection_ref = "pt>5 & abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "((M>1.1 & M<2.8) | (M>4.1 & M<4.7)) & abs(Eta)<2.4",
+    max_dR = 1.2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_LowMassNonResonantTrk_Displaced_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_4_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms =["L1_DoubleMu4_SQ_OS"]),
+    histoPSet = dict(massPSet = dict(
+        nbins = 10,
+        xmin  = 1.,
+        xmax  = 3.)
+)
 )
 
-
-DMu4_JpsiTrk_Displaced_dRcut_low = hltBPHmonitoring.clone()
-DMu4_JpsiTrk_Displaced_dRcut_low.FolderName = cms.string('HLT/BPH/DMu4_JpsiTrk_Displaced_L1_dR_low/')
-DMu4_JpsiTrk_Displaced_dRcut_low.tnp = cms.bool(False)
-DMu4_JpsiTrk_Displaced_dRcut_low.enum = cms.int32(4)
-DMu4_JpsiTrk_Displaced_dRcut_low.Jpsi = cms.int32(1)
-DMu4_JpsiTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_JpsiTrk_Displaced_v*")
-#DMu4_JpsiTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2")
-DMu4_JpsiTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
-#DMu4_JpsiTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
-DMu4_JpsiTrk_Displaced_dRcut_low.muoSelection_ref = cms.string("pt>5 & abs(eta)<2.4  &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_JpsiTrk_Displaced_dRcut_low.DMSelection_ref = cms.string("abs(Eta)<2.4")
-DMu4_JpsiTrk_Displaced_dRcut_low.max_dR = cms.double(1.2)
-DMu4_JpsiTrk_Displaced_dRcut_low.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 10 ),
-  xmin  = cms.double(2.8),
-  xmax  = cms.double(3.3),
+DMu4_JpsiTrk_Displaced_dRcut = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DMu4_JpsiTrk_Displaced_L1_dR/',
+    tnp = False,
+    enum = 4,
+    Jpsi = 1,
+    muoSelection_ref = "pt>5 & abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<1.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_JpsiTrk_Displaced_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS_dR_1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_0er1p5_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS"]),
+    histoPSet = dict(massPSet = dict(
+        nbins = 10,
+        xmin  = 2.8,
+        xmax  = 3.3)
+)
 )
 
-DMu4_PsiPrimeTrk_Displaced_dRcut = hltBPHmonitoring.clone()
-DMu4_PsiPrimeTrk_Displaced_dRcut.FolderName = cms.string('HLT/BPH/DMu4_PsiPrimeTrk_Displaced_L1_dR/')
-DMu4_PsiPrimeTrk_Displaced_dRcut.tnp = cms.bool(False)
-DMu4_PsiPrimeTrk_Displaced_dRcut.enum = cms.int32(4)
-DMu4_PsiPrimeTrk_Displaced_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_PsiPrimeTrk_Displaced_v*")
-#DMu4_PsiPrimeTrk_Displaced_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
-DMu4_PsiPrimeTrk_Displaced_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#DMu4_PsiPrimeTrk_Displaced_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-DMu4_PsiPrimeTrk_Displaced_dRcut.muoSelection_ref = cms.string("pt>5 & abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_PsiPrimeTrk_Displaced_dRcut.DMSelection_ref = cms.string("M>3.4 & M<3.95 & abs(Eta)<1.5")
-DMu4_PsiPrimeTrk_Displaced_dRcut.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 12 ),
-  xmin  = cms.double(3.3),
-  xmax  = cms.double(3.9),
+DMu4_JpsiTrk_Displaced_dRcut_low = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DMu4_JpsiTrk_Displaced_L1_dR_low/',
+    tnp = False,
+    enum = 4,
+    Jpsi = 1,
+    muoSelection_ref = "pt>5 & abs(eta)<2.4  &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    max_dR = 1.2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_JpsiTrk_Displaced_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_4_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS"]),
+    histoPSet = dict(massPSet = dict(
+        nbins = 10 ,
+        xmin  = 2.8,
+        xmax  = 3.3)
+)
 )
 
-
-
-DMu4_PsiPrimeTrk_Displaced_dRcut_low = hltBPHmonitoring.clone()
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.FolderName = cms.string('HLT/BPH/DMu4_PsiPrimeTrk_Displaced_L1_dR_low/')
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.tnp = cms.bool(False)
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.enum = cms.int32(4)
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_PsiPrimeTrk_Displaced_v*")
-#DMu4_PsiPrimeTrk_Displaced_dRcut_low.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2")
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
-#DMu4_PsiPrimeTrk_Displaced_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.muoSelection_ref = cms.string("pt>5 & abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.DMSelection_ref = cms.string("M>3.4 & M<3.95 & abs(Eta)<2.4")
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.max_dR = cms.double(1.2)
-DMu4_PsiPrimeTrk_Displaced_dRcut_low.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 12 ),
-  xmin  = cms.double(3.3),
-  xmax  = cms.double(3.9),
+DMu4_PsiPrimeTrk_Displaced_dRcut = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DMu4_PsiPrimeTrk_Displaced_L1_dR/',
+    tnp = False,
+    enum = 4,
+    muoSelection_ref = "pt>5 & abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M>3.4 & M<3.95 & abs(Eta)<1.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_PsiPrimeTrk_Displaced_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS_dR_1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_0er1p5_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS"]),
+    histoPSet = dict(massPSet = dict(
+        nbins = 12,
+        xmin  = 3.3,
+        xmax  = 3.9)
+)
 )
 
 
-Dimuon25_Jpsi_dRcut = hltBPHmonitoring.clone()
-Dimuon25_Jpsi_dRcut.FolderName = cms.string('HLT/BPH/DiMu25_Jpsi_L1_dR/')
-Dimuon25_Jpsi_dRcut.tnp = cms.bool(False)
-Dimuon25_Jpsi_dRcut.enum = cms.int32(4)
-Dimuon25_Jpsi_dRcut.Jpsi = cms.int32(1)
-Dimuon25_Jpsi_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon25_Jpsi_v*")
-#Dimuon25_Jpsi_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
-Dimuon25_Jpsi_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#Dimuon25_Jpsi_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-Dimuon25_Jpsi_dRcut.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon25_Jpsi_dRcut.DMSelection_ref = cms.string("Pt>26 & abs(Eta)<1.5")
-Dimuon25_Jpsi_dRcut.histoPSet.dRPSet = cms.PSet(
-  nbins = cms.uint32( 20 ),
-  xmin  = cms.double(0.),
-  xmax  = cms.double(1.),
+DMu4_PsiPrimeTrk_Displaced_dRcut_low = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DMu4_PsiPrimeTrk_Displaced_L1_dR_low/',
+    tnp = False,
+    enum = 4,
+    muoSelection_ref = "pt>5 & abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M>3.4 & M<3.95 & abs(Eta)<2.4",
+    max_dR = 1.2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_PsiPrimeTrk_Displaced_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_4_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS"]),
+    histoPSet = dict(massPSet = dict(
+         nbins = 12,   
+         xmin  = 3.3,
+         xmax  = 3.9)   
+    )
 )
-Dimuon25_Jpsi_dRcut.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 10 ),
-  xmin  = cms.double(2.8),
-  xmax  = cms.double(3.3),
+
+Dimuon25_Jpsi_dRcut = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu25_Jpsi_L1_dR/',
+    tnp = False,
+    enum = 4,
+    Jpsi = 1,
+    muoSelection_ref = "abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "Pt>26 & abs(Eta)<1.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon25_Jpsi_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS_dR_1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_0er1p5_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS"]),
+    histoPSet = dict(dRPSet = dict(
+        nbins = 20,
+        xmin  = 0.,
+         xmax  = 1.),
+        massPSet = dict(
+        nbins  = 10 ,
+        xmin  = 2.8,
+        xmax  = 3.3)
+  )
+)
+
+Dimuon18_PsiPrime_dRcut = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu18_PsiPrime_L1_dR/',
+    tnp = False,
+    enum = 4,
+    muoSelection_ref = "abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M>3.4 & M<3.95 & Pt>19 & abs(Eta)<1.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon18_PsiPrime_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS_dR_1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_0er1p5_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0er1p5_SQ_OS"]),
+    histoPSet = dict(massPSet = dict(
+    nbins = 12 ,
+    xmin  = 3.3,
+    xmax  = 3.9,)
+)
+)
+
+Dimuon25_Jpsi_dRcut_low = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu25_Jpsi_L1_dR_low/',
+    tnp = False,
+    enum = 4,
+    Jpsi = 1,
+    muoSelection_ref = "pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "Pt>26 & abs(Eta)<2.4",
+    max_dR = 1.2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon25_Jpsi_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_4_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS"]),
+    histoPSet = dict(dRPSet = dict(
+        nbins = 18 ,
+        xmin  = 0.,
+        xmax  = 0.9,
+    ),
+        massPSet = dict(
+        nbins = 10 ,
+        xmin  = 2.8,
+        xmax  = 3.3)
+    )
 )
 
 
-Dimuon18_PsiPrime_dRcut = hltBPHmonitoring.clone()
-Dimuon18_PsiPrime_dRcut.FolderName = cms.string('HLT/BPH/DiMu18_PsiPrime_L1_dR/')
-Dimuon18_PsiPrime_dRcut.tnp = cms.bool(False)
-Dimuon18_PsiPrime_dRcut.enum = cms.int32(4)
-Dimuon18_PsiPrime_dRcut.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon18_PsiPrime_v*")
-#Dimuon18_PsiPrime_dRcut.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS_dR_1p4")
-Dimuon18_PsiPrime_dRcut.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_0er1p5_v*")
-#Dimuon18_PsiPrime_dRcut.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0er1p5_SQ_OS")
-Dimuon18_PsiPrime_dRcut.muoSelection_ref = cms.string("abs(eta)<1.5 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon18_PsiPrime_dRcut.DMSelection_ref = cms.string("M>3.4 & M<3.95 & Pt>19 & abs(Eta)<1.5")
-Dimuon18_PsiPrime_dRcut.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 12 ),
-  xmin  = cms.double(3.3),
-  xmax  = cms.double(3.9),
+Dimuon18_PsiPrime_dRcut_low = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu18_PsiPrime_L1_dR_low/',
+    tnp = False,
+    enum = 4,
+    muoSelection_ref = "pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M>3.4 & M<3.95 & Pt>19 & abs(Eta)<2.4",
+    max_dR = 1.2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon18_PsiPrime_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_4_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS"]),
+    histoPSet = dict(massPSet = dict(
+        nbins = 10 ,
+        xmin  = 3.4,
+        xmax  = 4.0)
+    )
 )
 
-Dimuon25_Jpsi_dRcut_low = hltBPHmonitoring.clone()
-Dimuon25_Jpsi_dRcut_low.FolderName = cms.string('HLT/BPH/DiMu25_Jpsi_L1_dR_low/')
-Dimuon25_Jpsi_dRcut_low.tnp = cms.bool(False)
-Dimuon25_Jpsi_dRcut_low.enum = cms.int32(4)
-Dimuon25_Jpsi_dRcut_low.Jpsi = cms.int32(1)
-Dimuon25_Jpsi_dRcut_low.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon25_Jpsi_v*")
-#Dimuon25_Jpsi_dRcut_low.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2")
-Dimuon25_Jpsi_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
-#Dimuon25_Jpsi_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
-Dimuon25_Jpsi_dRcut_low.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon25_Jpsi_dRcut_low.DMSelection_ref = cms.string("Pt>26 & abs(Eta)<2.4")
-Dimuon25_Jpsi_dRcut_low.max_dR = cms.double(1.2)
-Dimuon25_Jpsi_dRcut_low.histoPSet.dRPSet = cms.PSet(
-  nbins = cms.uint32( 18 ),
-  xmin  = cms.double(0.),
-  xmax  = cms.double(0.9),
-)
-Dimuon25_Jpsi_dRcut_low.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 10 ),
-  xmin  = cms.double(2.8),
-  xmax  = cms.double(3.3),
-)
-
-
-Dimuon18_PsiPrime_dRcut_low = hltBPHmonitoring.clone()
-Dimuon18_PsiPrime_dRcut_low.FolderName = cms.string('HLT/BPH/DiMu18_PsiPrime_L1_dR_low/')
-Dimuon18_PsiPrime_dRcut_low.tnp = cms.bool(False)
-Dimuon18_PsiPrime_dRcut_low.enum = cms.int32(4)
-Dimuon18_PsiPrime_dRcut_low.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon18_PsiPrime_v*")
-#Dimuon18_PsiPrime_dRcut_low.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2")
-Dimuon18_PsiPrime_dRcut_low.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_4_v*")
-#Dimuon18_PsiPrime_dRcut_low.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
-Dimuon18_PsiPrime_dRcut_low.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon18_PsiPrime_dRcut_low.DMSelection_ref = cms.string("M>3.4 & M<3.95 & Pt>19 & abs(Eta)<2.4")
-Dimuon18_PsiPrime_dRcut_low.max_dR = cms.double(1.2)
-Dimuon18_PsiPrime_dRcut_low.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 10 ),
-  xmin  = cms.double(3.4),
-  xmax  = cms.double(4.0),
-)
 
 ###
 ###mass cut
-Dimuon20_masscut1 = hltBPHmonitoring.clone()
-Dimuon20_masscut1.FolderName = cms.string('HLT/BPH/DiMu20_Upsilon_L1_masscut1/')
-Dimuon20_masscut1.tnp = cms.bool(False)
-Dimuon20_masscut1.Upsilon = cms.int32(1)
-Dimuon20_masscut1.enum = cms.int32(5)
-Dimuon20_masscut1.seagull = cms.int32(1)
-Dimuon20_masscut1.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon10_Upsilon_Barrel_Seagulls_v*")
-#Dimuon20_masscut1.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18")
-Dimuon20_masscut1.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*")
-#Dimuon20_masscut1.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS")
-Dimuon20_masscut1.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.0 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon20_masscut1.DMSelection_ref = cms.string("M<18 & M>7 & Pt>11 & abs(Eta)<1.2")
+Dimuon20_masscut1 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu20_Upsilon_L1_masscut1/',
+    tnp = False,
+    Upsilon = 1,
+    enum = 5,
+    seagull = 1,
+    muoSelection_ref = "pt>5 && abs(eta)<2.0 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M<18 & M>7 & Pt>11 & abs(Eta)<1.2",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon10_Upsilon_Barrel_Seagulls_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4p5er2p0_SQ_OS"])
+)
 
+Dimuon12_masscut2 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu12_Upsilon_L1_masscut2/',
+    tnp = False,
+    enum = 5,
+    Upsilon = 1,
+    muoSelection_ref = "pt>5 && abs(eta)<2.0 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "Pt>13 & abs(y)<1.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon12_Upsilon_y1p4_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4p5er2p0_SQ_OS"])
+)
 
+Trimuon2_masscut4 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/TripleMu2_Upsilon_L1_masscut4',
+    tnp = False,
+    enum = 5,
+    Upsilon = 1,
+    muoSelection_ref = "pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M<17 & M>5 & Pt>6 & abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Trimuon2_Upsilon5_Muon_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu5_3p5_2p2_DoubleMu5_2p5_Mass5to17"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Trimuon2_Upsilon5_Muon_NoL1Mass_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu5_3p5_2"])
+)
 
-Dimuon12_masscut2 = hltBPHmonitoring.clone()
-Dimuon12_masscut2.FolderName = cms.string('HLT/BPH/DiMu12_Upsilon_L1_masscut2/')
-Dimuon12_masscut2.tnp = cms.bool(False)
-Dimuon12_masscut2.enum = cms.int32(5)
-Dimuon12_masscut2.Upsilon = cms.int32(1)
-Dimuon12_masscut2.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon12_Upsilon_y1p4_v*")
-#Dimuon12_masscut2.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18")
-Dimuon12_masscut2.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_L1_4p5er2p0_v*")
-#Dimuon12_masscut2.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS")
-Dimuon12_masscut2.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.0 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon12_masscut2.DMSelection_ref = cms.string("Pt>13 & abs(y)<1.5")
+Trimuon2_masscut5 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DoubleMu3_Trk_L1_masscut5',
+    tnp = False,
+    enum = 5,
+    muoSelection_ref = "pt>4 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M<9 & abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu3_Trk_Tau3mu_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu_5SQ_3SQ_0OQ_DoubleMu5_3_SQ_Mass_Max9"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu3_Trk_Tau3mu_NoL1Mass_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu5_3p5_2"])
+)
 
-
-Trimuon2_masscut4 = hltBPHmonitoring.clone()
-Trimuon2_masscut4.FolderName = cms.string('HLT/BPH/TripleMu2_Upsilon_L1_masscut4')
-Trimuon2_masscut4.tnp = cms.bool(False)
-Trimuon2_masscut4.enum = cms.int32(5)
-Trimuon2_masscut4.Upsilon = cms.int32(1)
-Trimuon2_masscut4.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Trimuon2_Upsilon5_Muon_v*")
-#Trimuon2_masscut4.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu5_3p5_2p2_DoubleMu5_2p5_Mass5to17")
-Trimuon2_masscut4.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Trimuon2_Upsilon5_Muon_NoL1Mass_v*")
-#Trimuon2_masscut4.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu5_3p5_2")
-Trimuon2_masscut4.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Trimuon2_masscut4.DMSelection_ref = cms.string("M<17 & M>5 & Pt>6 & abs(Eta)<2.4")
-
-
-
-Trimuon2_masscut5 = hltBPHmonitoring.clone()
-Trimuon2_masscut5.FolderName = cms.string('HLT/BPH/DoubleMu3_Trk_L1_masscut5')
-Trimuon2_masscut5.tnp = cms.bool(False)
-Trimuon2_masscut5.enum = cms.int32(5)
-Trimuon2_masscut5.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu3_Trk_Tau3mu_v*")
-#Trimuon2_masscut5.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu_5SQ_3SQ_0OQ_DoubleMu5_3_SQ_Mass_Max9")
-Trimuon2_masscut5.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu3_Trk_Tau3mu_NoL1Mass_v*")
-#Trimuon2_masscut5.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu5_3p5_2")
-Trimuon2_masscut5.muoSelection_ref = cms.string("pt>4 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Trimuon2_masscut5.DMSelection_ref = cms.string("M<9 & abs(Eta)<2.4")
-
-
-
-Trimuon2_masscut6 = hltBPHmonitoring.clone()
-Trimuon2_masscut6.FolderName = cms.string('HLT/BPH/DoubleMu3_Trk_L1_masscut6')
-Trimuon2_masscut6.tnp = cms.bool(False)
-Trimuon2_masscut6.enum = cms.int32(5)
-Trimuon2_masscut6.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi3p5_Muon2_v*")
-#Trimuon2_masscut6.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu_5SQ_3SQ_0OQ_DoubleMu5_3_SQ_Mass_Max9")
-Trimuon2_masscut6.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_v*")
-#Trimuon2_masscut6.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ_OS")
-Trimuon2_masscut6.muoSelection_ref = cms.string("pt>3 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Trimuon2_masscut6.DMSelection_ref = cms.string("M<9 & abs(Eta)<2.4")
-Trimuon2_masscut6.histoPSet.dRPSet = cms.PSet(
-  nbins = cms.uint32( 30 ),
-  xmin  = cms.double(0.),
-  xmax  = cms.double(1.5),
+Trimuon2_masscut6 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DoubleMu3_Trk_L1_masscut6',
+    tnp = False,
+    enum = 5,
+    muoSelection_ref = "pt>3 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M<9 & abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi3p5_Muon2_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu_5SQ_3SQ_0OQ_DoubleMu5_3_SQ_Mass_Max9"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ_OS"]),
+    histoPSet = dict(dRPSet = dict(
+        nbins = 30,   
+        xmin  = 0.,
+        xmax  = 1.5)
+)
 )
 
 ###triple muon
 
-Dimuon0_tripleMu1 = hltBPHmonitoring.clone()
-Dimuon0_tripleMu1.FolderName = cms.string('HLT/BPH/DiMu0_Lowmass_L1_tripleMu1/')
-Dimuon0_tripleMu1.tnp = cms.bool(False)
-Dimuon0_tripleMu1.enum = cms.int32(6)
-Dimuon0_tripleMu1.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Trimuon2_Upsilon5_Muon_NoL1Mass_v*")
-#Dimuon0_tripleMu1.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu5_3p5_2")
-Dimuon0_tripleMu1.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_Muon_NoL1Mass_v*")
-#Dimuon0_tripleMu1.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu5_3p5_2")
-Dimuon0_tripleMu1.muoSelection_ref = cms.string("pt>4 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_tripleMu1.DMSelection_ref = cms.string("abs(Eta)<2.4")
+Dimuon0_tripleMu1 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Lowmass_L1_tripleMu1/',
+    tnp = False,
+    enum = 6,
+    muoSelection_ref = "pt>4 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Trimuon2_Upsilon5_Muon_NoL1Mass_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu5_3p5_2"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Upsilon_Muon_NoL1Mass_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu5_3p5_2"])
+)
+
+Dimuon0_tripleMu2 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Lowmass_L1_tripleMu2/',
+    tnp = False,
+    enum = 6,
+    muoSelection_ref = "pt>4 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Trimuon5_3p5_2_Upsilon_Muon_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu5_3p5_2"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Upsilon_Muon_NoL1Mass_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu0"])
+)
 
 
-
-Dimuon0_tripleMu2 = hltBPHmonitoring.clone()
-Dimuon0_tripleMu2.FolderName = cms.string('HLT/BPH/DiMu0_Lowmass_L1_tripleMu2/')
-Dimuon0_tripleMu2.tnp = cms.bool(False)
-Dimuon0_tripleMu2.enum = cms.int32(6)
-Dimuon0_tripleMu2.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Trimuon5_3p5_2_Upsilon_Muon_v*")
-#Dimuon0_tripleMu2.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu5_3p5_2")
-Dimuon0_tripleMu2.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_Muon_NoL1Mass_v*")
-#Dimuon0_tripleMu2.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu0")
-Dimuon0_tripleMu2.muoSelection_ref = cms.string("pt>4 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_tripleMu2.DMSelection_ref = cms.string("abs(Eta)<2.4")
-
-
-Dimuon0_tripleMu3 = hltBPHmonitoring.clone()
-Dimuon0_tripleMu3.FolderName = cms.string('HLT/BPH/DiMu0_Lowmass_L1_tripleMu3/')
-Dimuon0_tripleMu3.tnp = cms.bool(False)
-Dimuon0_tripleMu3.enum = cms.int32(6)
-Dimuon0_tripleMu3.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu3_Trk_Tau3mu_NoL1Mass_v*")
-#Dimuon0_tripleMu3.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu_5SQ_3SQ_0OQ")
-Dimuon0_tripleMu3.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_LowMass_L1_TM530_v*")
-#Dimuon0_tripleMu3.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_TripleMu_5SQ_3SQ_0OQ")
-Dimuon0_tripleMu3.muoSelection_ref = cms.string("pt>4 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_tripleMu3.DMSelection_ref = cms.string("abs(Eta)<2.4")
-
-
+Dimuon0_tripleMu3 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Lowmass_L1_tripleMu3/',
+    tnp = False,
+    enum = 6,
+    muoSelection_ref = "pt>4 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu3_Trk_Tau3mu_NoL1Mass_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu_5SQ_3SQ_0OQ"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_LowMass_L1_TM530_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_TripleMu_5SQ_3SQ_0OQ"]),
+)
 
 ###photon 
-Dimuon0_photon1 = hltBPHmonitoring.clone()
-Dimuon0_photon1.FolderName = cms.string('HLT/BPH/DiMu0_Lowmass_L1_photon1/')
-Dimuon0_photon1.tnp = cms.bool(False)
-Dimuon0_photon1.enum = cms.int32(7)
-Dimuon0_photon1.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu20_7_Mass0to30_Photon23_v*")
-#Dimuon0_photon1.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_EG12")
-Dimuon0_photon1.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu20_7_Mass0to30_L1_DM4EG_v*")
-#Dimuon0_photon1.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_EG12")
-Dimuon0_photon1.muoSelection_ref = cms.string("pt>10 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_photon1.DMSelection_ref = cms.string("M<30 && abs(Eta)<2.4")
+Dimuon0_photon1 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Lowmass_L1_photon1/',
+    tnp = False,
+    enum = 7,
+    muoSelection_ref = "pt>10 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M<30 && abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu20_7_Mass0to30_Photon23_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_EG12"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu20_7_Mass0to30_L1_DM4EG_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_EG12"])
+)
 
+Dimuon0_photon2 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Lowmass_L1_photon2/',
+    tnp = False,
+    enum = 7,
+    muoSelection_ref = "pt>10 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "M<30 && abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu20_7_Mass0to30_L1_DM4EG_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_EG12"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu20_7_Mass0to30_L1_DM4_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS"])
+)
 
-Dimuon0_photon2 = hltBPHmonitoring.clone()
-Dimuon0_photon2.FolderName = cms.string('HLT/BPH/DiMu0_Lowmass_L1_photon2/')
-Dimuon0_photon2.tnp = cms.bool(False)
-Dimuon0_photon2.enum = cms.int32(7)
-Dimuon0_photon2.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu20_7_Mass0to30_L1_DM4EG_v*")
-#Dimuon0_photon2.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_EG12")
-Dimuon0_photon2.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu20_7_Mass0to30_L1_DM4_v*")
-#Dimuon0_photon2.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS")
-Dimuon0_photon2.muoSelection_ref = cms.string("pt>10 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_photon2.DMSelection_ref = cms.string("M<30 && abs(Eta)<2.4")
-
-###
 ###L3 TnP
-Dimuon0_L3TnP_Jpsi = hltBPHmonitoring.clone()
-Dimuon0_L3TnP_Jpsi.FolderName = cms.string('HLT/BPH/DiMu0_L1_L3TnP_Jpsi/')
-Dimuon0_L3TnP_Jpsi.tnp = cms.bool(True)
-Dimuon0_L3TnP_Jpsi.L3 = cms.int32(1)
-Dimuon0_L3TnP_Jpsi.enum = cms.int32(1)
-##Dimuon0_L3TnP_Jpsi.Jpsi = cms.int32(1)
-Dimuon0_L3TnP_Jpsi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu7p5_L2Mu2_Jpsi_v*")
-#Dimuon0_L3TnP_Jpsi.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_L3TnP_Jpsi.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu7p5_L2Mu2_Jpsi_v*")
-#Dimuon0_L3TnP_Jpsi.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_L3TnP_Jpsi.muoSelection_ref = cms.string("pt>7.5 &  abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_L3TnP_Jpsi.muoSelection = cms.string("pt>7.5 & abs(eta)<2.4 & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
+Dimuon0_L3TnP_Jpsi = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_L1_L3TnP_Jpsi/',
+    tnp = True,
+    L3 = 1,
+    enum = 1,
+    ##Jpsi = 1,
+    muoSelection_ref = "pt>7.5 &  abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    muoSelection = "pt>7.5 & abs(eta)<2.4 & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu7p5_L2Mu2_Jpsi_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu7p5_L2Mu2_Jpsi_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"])
+)
 
-Dimuon0_L3TnP_Upsilon = hltBPHmonitoring.clone()
-Dimuon0_L3TnP_Upsilon.FolderName = cms.string('HLT/BPH/DiMu0_L1_L3TnP_Upsilon/')
-Dimuon0_L3TnP_Upsilon.tnp = cms.bool(True)
-Dimuon0_L3TnP_Upsilon.L3 = cms.int32(1)
-##Dimuon0_L3TnP_Upsilon.Upsilon = cms.int32(1)
-Dimuon0_L3TnP_Upsilon.enum = cms.int32(1)
-Dimuon0_L3TnP_Upsilon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu7p5_L2Mu2_Upsilon_v*")
-#Dimuon0_L3TnP_Upsilon.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_L3TnP_Upsilon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu7p5_L2Mu2_Upsilon_v*")
-#Dimuon0_L3TnP_Upsilon.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_L3TnP_Upsilon.muoSelection_ref = cms.string("pt>7.5 &  abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_L3TnP_Upsilon.muoSelection = cms.string("pt>7.5 & abs(eta)<2.4 & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-###
+Dimuon0_L3TnP_Upsilon = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_L1_L3TnP_Upsilon/',
+    tnp = True,
+    L3 = 1,
+    ##Upsilon = 1,
+    enum = 1,
+    muoSelection_ref = "pt>7.5 &  abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    muoSelection = "pt>7.5 & abs(eta)<2.4 & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu7p5_L2Mu2_Upsilon_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu7p5_L2Mu2_Upsilon_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"])
+)
+
 ###HLT OS 
 
-Dimuon0_HLT_OS = hltBPHmonitoring.clone()
-Dimuon0_HLT_OS.FolderName = cms.string('HLT/BPH/DiMu0_Jpsi_L1_HLT_OS/')
-Dimuon0_HLT_OS.tnp = cms.bool(False)
-Dimuon0_HLT_OS.enum = cms.int32(2)
-Dimuon0_HLT_OS.Jpsi = cms.int32(1)
-Dimuon0_HLT_OS.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_NoVertexing_v*")
-#Dimuon0_HLT_OS.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ_OS")
-Dimuon0_HLT_OS.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v*")
-#Dimuon0_HLT_OS.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_HLT_OS.muoSelection_ref = cms.string("abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_HLT_OS.DMSelection_ref = cms.string("abs(Eta)<2.4")
+Dimuon0_HLT_OS = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Jpsi_L1_HLT_OS/',
+    tnp = False,
+    enum = 2,
+    Jpsi = 1,
+    muoSelection_ref = "abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_NoVertexing_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ_OS"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"])
+)
 
-Dimuon0_HLT_OS1 = hltBPHmonitoring.clone()
-Dimuon0_HLT_OS1.FolderName = cms.string('HLT/BPH/DiMu0_Jpsi_L1_HLT_OS1/')
-Dimuon0_HLT_OS1.tnp = cms.bool(False)
-Dimuon0_HLT_OS1.enum = cms.int32(2)
-Dimuon0_HLT_OS1.Jpsi = cms.int32(1)
-Dimuon0_HLT_OS1.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_L1_NoOS_v*")
-#Dimuon0_HLT_OS1.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_HLT_OS1.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v*")
-#Dimuon0_HLT_OS1.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu0_SQ")
-Dimuon0_HLT_OS1.muoSelection_ref = cms.string("abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_HLT_OS1.DMSelection_ref = cms.string("abs(Eta)<2.4")
-
+Dimuon0_HLT_OS1 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_Jpsi_L1_HLT_OS1/',
+    tnp = False,
+    enum = 2,
+    Jpsi = 1,
+    muoSelection_ref = "abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_L1_NoOS_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu0_SQ"])
+)
 
 ###
 ###Loose vertex Jpsi
-Dimuon0_looseVtx_Jpsi = hltBPHmonitoring.clone()
-Dimuon0_looseVtx_Jpsi.FolderName = cms.string('HLT/BPH/DiMu0_L1_looseVtx_Jpsi/')
-Dimuon0_looseVtx_Jpsi.tnp = cms.bool(False)
-Dimuon0_looseVtx_Jpsi.enum = cms.int32(8)
-Dimuon0_looseVtx_Jpsi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_L1_4R_0er1p5R_v*")
-Dimuon0_looseVtx_Jpsi.Jpsi = cms.int32(1)
-#Dimuon0_looseVtx_Jpsi.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-Dimuon0_looseVtx_Jpsi.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_NoVertexing_v*")
-#Dimuon0_looseVtx_Jpsi.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-Dimuon0_looseVtx_Jpsi.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_looseVtx_Jpsi.DMSelection_ref = cms.string("abs(Eta)<1.5")
+Dimuon0_looseVtx_Jpsi = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_L1_looseVtx_Jpsi/',
+    tnp = False,
+    enum = 8,
+    Jpsi = 1,
+    muoSelection_ref = "pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<1.5",
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_NoVertexing_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"])
+)
+
 
 ####Loose vtx Upsilon
-Dimuon0_looseVtx_Upsilon = hltBPHmonitoring.clone()
-Dimuon0_looseVtx_Upsilon.FolderName = cms.string('HLT/BPH/DiMu0_L1_looseVtx_Upsilon/')
-Dimuon0_looseVtx_Upsilon.tnp = cms.bool(False)
-Dimuon0_looseVtx_Upsilon.enum = cms.int32(8)
-Dimuon0_looseVtx_Upsilon.Upsilon = cms.int32(1)
-Dimuon0_looseVtx_Upsilon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_L1_4p5er2p0M_v*")
-#Dimuon0_looseVtx_Upsilon.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18")
-Dimuon0_looseVtx_Upsilon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Upsilon_NoVertexing_v*")
-#Dimuon0_looseVtx_Upsilon.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18")
-Dimuon0_looseVtx_Upsilon.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.0 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_looseVtx_Upsilon.DMSelection_ref = cms.string("abs(Eta)<2.0")
+Dimuon0_looseVtx_Upsilon = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_L1_looseVtx_Upsilon/',
+    tnp = False,
+    enum = 8,
+    Upsilon = 1,
+    muoSelection_ref = "pt>5 && abs(eta)<2.0 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Upsilon_L1_4p5er2p0M_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Upsilon_NoVertexing_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4p5er2p0_SQ_OS_Mass_7to18"])
+)
 
 ###tight vtx
-Dimuon0_tightVtx_Jpsi = hltBPHmonitoring.clone()
-Dimuon0_tightVtx_Jpsi.FolderName = cms.string('HLT/BPH/DiMu0_L1_tightVtx_Jpsi/')
-Dimuon0_tightVtx_Jpsi.tnp = cms.bool(False)
-Dimuon0_tightVtx_Jpsi.Jpsi = cms.int32(1)
-Dimuon0_tightVtx_Jpsi.enum = cms.int32(8)
-Dimuon0_tightVtx_Jpsi.displaced = cms.int32(1)
-Dimuon0_tightVtx_Jpsi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_Jpsi_Displaced_v*")
-#Dimuon0_tightVtx_Jpsi.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-Dimuon0_tightVtx_Jpsi.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_Jpsi_NoVertexing_v*")
-#Dimuon0_tightVtx_Jpsi.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-Dimuon0_tightVtx_Jpsi.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_tightVtx_Jpsi.DMSelection_ref = cms.string("abs(Eta)<2.4")
-
+Dimuon0_tightVtx_Jpsi = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_L1_tightVtx_Jpsi/',
+    tnp = False,
+    Jpsi = 1,
+    enum = 8,
+    displaced = 1,
+    muoSelection_ref = "pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_Jpsi_Displaced_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_Jpsi_NoVertexing_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"])
+)
 
 ###additional track
 
-Dimuon0_addTrack_Jpsi = hltBPHmonitoring.clone()
-Dimuon0_addTrack_Jpsi.FolderName = cms.string('HLT/BPH/DiMu0_L1_addTrack_Jpsi/')
-Dimuon0_addTrack_Jpsi.tnp = cms.bool(False)
-Dimuon0_addTrack_Jpsi.enum = cms.int32(9)
-Dimuon0_addTrack_Jpsi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_JpsiTrk_Displaced_v*")
-#Dimuon0_addTrack_Jpsi.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-Dimuon0_addTrack_Jpsi.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_Jpsi_Displaced_v*")
-#Dimuon0_addTrack_Jpsi.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-Dimuon0_addTrack_Jpsi.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_addTrack_Jpsi.DMSelection_ref = cms.string("abs(Eta)<2.4")
-Dimuon0_addTrack_Jpsi.trOrMu = cms.int32(True)
-
-Dimuon0_addTrackTrack_Jpsi = hltBPHmonitoring.clone()
-Dimuon0_addTrackTrack_Jpsi.FolderName = cms.string('HLT/BPH/DiMu0_L1_addTrackTrack_Jpsi/')
-Dimuon0_addTrackTrack_Jpsi.tnp = cms.bool(False)
-Dimuon0_addTrackTrack_Jpsi.trOrMu = cms.int32(True)
-Dimuon0_addTrackTrack_Jpsi.enum = cms.int32(11)
-Dimuon0_addTrackTrack_Jpsi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_JpsiTrkTrk_Displaced_v*")
-#Dimuon0_addTrackTrack_Jpsi.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-Dimuon0_addTrackTrack_Jpsi.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_Jpsi_Displaced_v*")
-#Dimuon0_addTrackTrack_Jpsi.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-Dimuon0_addTrackTrack_Jpsi.muoSelection_ref = cms.string("pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_addTrackTrack_Jpsi.DMSelection_ref = cms.string("abs(Eta)<2.4")
-
-DM2_Jpsi_addTrackTrack_Phi = hltBPHmonitoring.clone()
-DM2_Jpsi_addTrackTrack_Phi.FolderName = cms.string('HLT/BPH/DM2_Jpsi_addTrackTrack_Phi/')
-DM2_Jpsi_addTrackTrack_Phi.tnp = cms.bool(False)
-DM2_Jpsi_addTrackTrack_Phi.enum = cms.int32(11)
-DM2_Jpsi_addTrackTrack_Phi.Jpsi = cms.int32(1)
-DM2_Jpsi_addTrackTrack_Phi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu2_Jpsi_DoubleTrk1_Phi1p05_v*")
-#DM2_Jpsi_addTrackTrack_Phi.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-DM2_Jpsi_addTrackTrack_Phi.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Dimuon0_Jpsi_NoVertexing_v*")
-#DM2_Jpsi_addTrackTrack_Phi.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4")
-#DM2_Jpsi_addTrackTrack_Phi.muoSelection = cms.string("pt>2 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DM2_Jpsi_addTrackTrack_Phi.muoSelection_ref = cms.string("pt>2 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-DM2_Jpsi_addTrackTrack_Phi.minprob = cms.double(0.1)
-DM2_Jpsi_addTrackTrack_Phi.mincos = cms.double(0.)
-DM2_Jpsi_addTrackTrack_Phi.minDS = cms.double(0.)
-DM2_Jpsi_addTrackTrack_Phi.trOrMu = cms.int32(True)
-DM2_Jpsi_addTrackTrack_Phi.trSelection_ref = cms.string("pt>1")
-DM2_Jpsi_addTrackTrack_Phi.minmassTkTk = cms.double(0.920)
-DM2_Jpsi_addTrackTrack_Phi.maxmassTkTk = cms.double(1.120)
-DM2_Jpsi_addTrackTrack_Phi.minmassJpsiTk = cms.double(0.)
-DM2_Jpsi_addTrackTrack_Phi.maxmassJpsiTk = cms.double(99.)
-DM2_Jpsi_addTrackTrack_Phi.histoPSet.ptBinning = [-0.5, 0, 0.5, 1, 1.5, 2, 4, 8, 10, 12, 14, 16, 18, 20]
-DM2_Jpsi_addTrackTrack_Phi.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.uint32( 32 ),
-  xmin  = cms.double(-3.2),
-  xmax  = cms.double( 3.2),
+Dimuon0_addTrack_Jpsi = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_L1_addTrack_Jpsi/',
+    tnp = False,
+    enum = 9,
+    muoSelection_ref = "pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    trOrMu = True,
+    numGenericTriggerEventPSet = dict(hltPaths =["HLT_DoubleMu4_JpsiTrk_Displaced_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_Jpsi_Displaced_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"])
 )
 
-DM2_Jpsi_addTkMuTkMu_Phi = DM2_Jpsi_addTrackTrack_Phi.clone()
-DM2_Jpsi_addTkMuTkMu_Phi.FolderName = cms.string('HLT/BPH/DM2_Jpsi_addTkMuTkMu_Phi/')
-DM2_Jpsi_addTkMuTkMu_Phi.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu2_Jpsi_DoubleTkMu0_Phi_v*")
-DM2_Jpsi_addTkMuTkMu_Phi.trSelection_ref = cms.string("")
+Dimuon0_addTrackTrack_Jpsi = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_L1_addTrackTrack_Jpsi/',
+    tnp = False,
+    trOrMu = True,
+    enum = 11,
+    muoSelection_ref = "pt>5 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_JpsiTrkTrk_Displaced_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_Jpsi_Displaced_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"])
+)
 
 
-Dimuon0_addTrackMu_Onia = hltBPHmonitoring.clone()
-Dimuon0_addTrackMu_Onia.FolderName = cms.string('HLT/BPH/DiMu0_L1_addTrackMu_Onia/')
-Dimuon0_addTrackMu_Onia.tnp = cms.bool(False)
-Dimuon0_addTrackMu_Onia.minmassJpsiTk = cms.double(3)
-Dimuon0_addTrackMu_Onia.maxmassJpsiTk = cms.double(3.2)
-Dimuon0_addTrackMu_Onia.enum = cms.int32(10)
-Dimuon0_addTrackMu_Onia.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu30_TkMu0_Onia_v*")
-#Dimuon0_addTrackMu_Onia.numGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_SingleMu22 OR L1_SingleMu25")
-Dimuon0_addTrackMu_Onia.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu27_v*")
-#Dimuon0_addTrackMu_Onia.denGenericTriggerEventPSet.l1Algorithms = cms.vstring("L1_SingleMu22 OR L1_SingleMu25")
-Dimuon0_addTrackMu_Onia.muoSelection_ref = cms.string("pt>32 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_addTrackMu_Onia.DMSelection_ref = cms.string("abs(Eta)<2.4")
-Dimuon0_addTrackMu_Onia.trOrMu = cms.int32(True)
+DM2_Jpsi_addTrackTrack_Phi = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DM2_Jpsi_addTrackTrack_Phi/',
+    tnp = False,
+    enum = 11,
+    Jpsi = 1,
+    #muoSelection = "pt>2 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    muoSelection_ref = "pt>2 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    minprob = 0.1,
+    mincos = 0.,
+    minDS = 0.,
+    trOrMu = True,
+    trSelection_ref = "pt>1",
+    minmassTkTk = 0.920,
+    maxmassTkTk = 1.120,
+    minmassJpsiTk = 0.,
+    maxmassJpsiTk = 99.,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu2_Jpsi_DoubleTrk1_Phi1p05_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Dimuon0_Jpsi_NoVertexing_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_DoubleMu4_SQ_OS_dR_Max1p2 OR L1_DoubleMu0er1p5_SQ_OS_dR_Max1p4"]),
+    histoPSet = dict(ptBinning = [-0.5, 0, 0.5, 1, 1.5, 2, 4, 8, 10, 12, 14, 16, 18, 20],
+                     phiPSet = dict(
+                        nbins = 32,
+                        xmin  = -3.2,
+                        xmax  = 3.2)
+    )  
+)
 
-Dimuon0_addTrackMu_Phi1 = hltBPHmonitoring.clone()
-Dimuon0_addTrackMu_Phi1.FolderName = cms.string('HLT/BPH/DiMu0_L1_addTrackMu_Phi1/')
-Dimuon0_addTrackMu_Phi1.tnp = cms.bool(False)
-Dimuon0_addTrackMu_Phi1.minmassJpsiTk = cms.double(0.920)
-Dimuon0_addTrackMu_Phi1.maxmassJpsiTk = cms.double(1.120)
-Dimuon0_addTrackMu_Phi1.enum = cms.int32(10)
-Dimuon0_addTrackMu_Phi1.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu25_TkMu0_Phi_v*")
-Dimuon0_addTrackMu_Phi1.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu20_v*")
-Dimuon0_addTrackMu_Phi1.muoSelection_ref = cms.string("pt>26 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ")
-Dimuon0_addTrackMu_Phi1.DMSelection_ref = cms.string("abs(Eta)<2.4")
-Dimuon0_addTrackMu_Phi1.trOrMu = cms.int32(True)
 
-DimuonX_HLT_OS_Vtx = hltBPHmonitoring.clone()
-DimuonX_HLT_OS_Vtx.FolderName = cms.string('HLT/BPH/DimuX_HLT_OS_Vtx/')
-DimuonX_HLT_OS_Vtx.tnp = cms.bool(False)
-DimuonX_HLT_OS_Vtx.enum = cms.int32(2)
-DimuonX_HLT_OS_Vtx.Jpsi = cms.int32(1)
-DimuonX_HLT_OS_Vtx.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Dimuon0_Jpsi_L1_NoOS_v*')
-#DimuonX_HLT_OS_Vtx.numGenericTriggerEventPSet.l1Algorithms = cms.vstring('L1_DoubleMu0_SQ')
-DimuonX_HLT_OS_Vtx.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v*')
-#DimuonX_HLT_OS_Vtx.denGenericTriggerEventPSet.l1Algorithms = cms.vstring('L1_DoubleMu0_SQ')
-DimuonX_HLT_OS_Vtx.muoSelection_ref = cms.string('abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0')
+DM2_Jpsi_addTkMuTkMu_Phi = DM2_Jpsi_addTrackTrack_Phi.clone(
+    FolderName = 'HLT/BPH/DM2_Jpsi_addTkMuTkMu_Phi/',
+    trSelection_ref = "",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu2_Jpsi_DoubleTkMu0_Phi_v*"])
+)
+
+Dimuon0_addTrackMu_Onia = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_L1_addTrackMu_Onia/',
+    tnp = False,
+    minmassJpsiTk = 3,
+    maxmassJpsiTk = 3.2,
+    enum = 10,
+    muoSelection_ref = "pt>32 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    trOrMu = True,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu30_TkMu0_Onia_v*"]),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ["L1_SingleMu22 OR L1_SingleMu25"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu27_v*"]),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ["L1_SingleMu22 OR L1_SingleMu25"])
+)
+
+Dimuon0_addTrackMu_Phi1 = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DiMu0_L1_addTrackMu_Phi1/',
+    tnp = False,
+    minmassJpsiTk = 0.920,
+    maxmassJpsiTk = 1.120,
+    enum = 10,
+    muoSelection_ref = "pt>26 && abs(eta)<2.4 &  isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 ",
+    DMSelection_ref = "abs(Eta)<2.4",
+    trOrMu = True,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu25_TkMu0_Phi_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20_v*"])
+)
+
+
+DimuonX_HLT_OS_Vtx = hltBPHmonitoring.clone(
+    FolderName = 'HLT/BPH/DimuX_HLT_OS_Vtx/',
+    tnp = False,
+    enum = 2,
+    Jpsi = 1,
+    muoSelection_ref = 'abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Dimuon0_Jpsi_L1_NoOS_v*']),
+    #numGenericTriggerEventPSet = dict(l1Algorithms = ['L1_DoubleMu0_SQ']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Dimuon0_Jpsi_NoVertexing_NoOS_v*']),
+    #denGenericTriggerEventPSet = dict(l1Algorithms = ['L1_DoubleMu0_SQ'])
+)
 
 #hltBPHmonitoring.histoPSet.ptBinning = [-0.5, 0, 2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 25, 30, 35, 40, 50, 70]
 #hltBPHmonitoring.histoPSet.dMuPtBinning = [-0.5, 0, 2, 4, 8, 10, 12, 14, 16, 18, 20, 22, 25, 30, 35, 40, 50, 70]

--- a/DQMOffline/Trigger/python/BPHMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BPHMonitor_cfi.py
@@ -2,119 +2,121 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.bphMonitoring_cfi import bphMonitoring as _bphMonitoring
 
-hltBPHmonitoring = _bphMonitoring.clone()
+hltBPHmonitoring = _bphMonitoring.clone(
+    FolderName = 'HLT/BPH/Dimuon_10_Jpsi_Barrel/',
+    tnp = True,
+    max_dR = 1.4,
+    minmass = 2.596,
+    maxmass = 3.596,
+    Upsilon = 0,
+    Jpsi = 0,
+    seagull = 0,
+    ptCut = 0,
+    displaced = 0,
 
 #hltBPHmonitoring.options = cms.untracked.PSet(
 #    SkipEvent = cms.untracked.vstring('ProductNotFound')
 #)
-hltBPHmonitoring.FolderName = cms.string('HLT/BPH/Dimuon_10_Jpsi_Barrel/')
-hltBPHmonitoring.tnp = cms.bool(True)
-hltBPHmonitoring.max_dR = cms.double(1.4)
-hltBPHmonitoring.minmass = cms.double(2.596)
-hltBPHmonitoring.maxmass = cms.double(3.596)
-hltBPHmonitoring.Upsilon = cms.int32(0)
-hltBPHmonitoring.Jpsi = cms.int32(0)
-hltBPHmonitoring.seagull = cms.int32(0)
-hltBPHmonitoring.ptCut = cms.int32(0)
-hltBPHmonitoring.displaced = cms.int32(0)
 
-hltBPHmonitoring.histoPSet.ptBinning = [-0.5, 0, 2, 4, 8, 10, 12, 16, 20, 25, 30, 35, 40, 50]
+    histoPSet = dict(
+        ptBinning = [-0.5, 0, 2, 4, 8, 10, 12, 16, 20, 25, 30, 35, 40, 50],
+        dMuPtBinning = [6, 8, 12, 16,  20,  25, 30, 35, 40, 50, 70],
+        phiPSet = dict(
+            nbins = 8,
+            xmin  = -3.2,
+            xmax  = 3.2,
+        ),
+        etaPSet = dict(
+            nbins = 12,
+            xmin  = -2.4,
+            xmax  = 2.4,
+        ),
+        d0PSet = dict(
+            nbins = 50,
+            xmin  = -5.,
+            xmax  = 5,
+        ),
+        z0PSet = dict(
+            nbins = 60,
+            xmin  = -15,
+            xmax  = 15,
+        ),
 
-hltBPHmonitoring.histoPSet.dMuPtBinning = [6, 8, 12, 16,  20,  25, 30, 35, 40, 50, 70]
+        dRPSet = dict(
+            nbins = 26,
+            xmin  = 0,
+            xmax  = 1.3,
+        ),
 
-hltBPHmonitoring.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.uint32(8),
-  xmin  = cms.double(-3.2),
-  xmax  = cms.double(3.2),
+        massPSet = dict(
+            nbins = 140,
+            xmin  = 0,
+            xmax  = 7.,
+        ),
+        BmassPSet = dict(
+            nbins = 20,
+            xmin  = 5.1,
+            xmax  = 5.5,
+        ),
+
+        dcaPSet = dict(
+            nbins = 10,
+            xmin  = 0,
+            xmax  = 0.5,
+        ),
+
+        dsPSet = dict(
+            nbins = 15,
+            xmin  = 0,
+            xmax  = 60,
+        ),
+
+        cosPSet = dict(
+            nbins = 10,
+            xmin  = 0.9,
+            xmax  = 1,
+        ),
+    
+        probBinning = [0.01,0.02,0.04,0.06,0.08,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0],
+    ),
+    tracks = "generalTracks", # tracks??
+    offlinePVs = "offlinePrimaryVertices", # PVs
+    beamSpot = "offlineBeamSpot", # 
+    muons = "muons", # 
+    photons = "photons", # 
+    hltTriggerSummaryAOD   = "hltTriggerSummaryAOD::HLT",
+    #DMSelection_ref = "",
+    #muoSelection_ref = "",
+    #muoSelection_ = "",
+
+    numGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        #dbLabel       = "BPHDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+        andOrHlt      = True, # True:=OR; False:=AND
+        andOrL1      = True, # True:=OR; False:=AND
+        hltInputTag   = "TriggerResults::HLT",
+        hltPaths      = ["HLT_Dimuon0_Jpsi_L1_NoOS_v*"], # HLT_ZeroBias_v*
+        #l1Algorithms      = ["L1_DoubleMu0_SQ"], # HLT_ZeroBias_v*
+        #hltDBKey      = "diMu10",
+        errorReplyHlt = False,
+        errorReplyL1 =  True,
+        l1BeforeMask = True, 
+        verbosityLevel = 0
+    ),
+    denGenericTriggerEventPSet = dict(
+        andOr         = False,
+        andOrHlt      = True,# True:=OR; False:=AND
+        #dcsInputTag   =  "scalersRawToDigi",
+        #dcsRecordInputTag = "onlineMetaDataDigis",
+        hltInputTag   =  "TriggerResults::HLT" ,
+        hltPaths  = ["HLT_Mu7p5_Track2_Jpsi_v*" ], #reference
+        #l1Algorithms      = ["L1_DoubleMu0_SQ"], # HLT_ZeroBias_v*
+        #dcsPartitions = [0,1,2,3,5,6,7,8,9,12,13,14,15,16,17,20,22,24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel
+        andOrDcs      = False,
+        errorReplyDcs =  True,
+        verbosityLevel = 0,
+    )
 )
-hltBPHmonitoring.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32(12),
-  xmin  = cms.double(-2.4),
-  xmax  = cms.double(2.4),
-)
-hltBPHmonitoring.histoPSet.d0PSet = cms.PSet(
-  nbins = cms.uint32(50),
-  xmin  = cms.double(-5.),
-  xmax  = cms.double(5),
-)
-hltBPHmonitoring.histoPSet.z0PSet = cms.PSet(
-  nbins = cms.uint32(60),
-  xmin  = cms.double(-15),
-  xmax  = cms.double(15),
-)
-
-hltBPHmonitoring.histoPSet.dRPSet = cms.PSet(
-  nbins = cms.uint32(26),
-  xmin  = cms.double(0),
-  xmax  = cms.double(1.3),
-)
-
-hltBPHmonitoring.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32(140),
-  xmin  = cms.double(0),
-  xmax  = cms.double(7.),
-)
-hltBPHmonitoring.histoPSet.BmassPSet = cms.PSet(
-  nbins = cms.uint32(20),
-  xmin  = cms.double(5.1),
-  xmax  = cms.double(5.5),
-)
-
-hltBPHmonitoring.histoPSet.dcaPSet = cms.PSet(
-  nbins = cms.uint32(10),
-  xmin  = cms.double(0),
-  xmax  = cms.double(0.5),
-)
-
-hltBPHmonitoring.histoPSet.dsPSet = cms.PSet(
-  nbins = cms.uint32(15),
-  xmin  = cms.double(0),
-  xmax  = cms.double(60),
-)
-
-hltBPHmonitoring.histoPSet.cosPSet = cms.PSet(
-  nbins = cms.uint32(10),
-  xmin  = cms.double(0.9),
-  xmax  = cms.double(1),
-)
-
-hltBPHmonitoring.histoPSet.probBinning = [0.01,0.02,0.04,0.06,0.08,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0]
-
-hltBPHmonitoring.tracks = cms.InputTag("generalTracks") # tracks??
-hltBPHmonitoring.offlinePVs = cms.InputTag("offlinePrimaryVertices") # PVs
-hltBPHmonitoring.beamSpot = cms.InputTag("offlineBeamSpot") # 
-
-hltBPHmonitoring.muons = cms.InputTag("muons") # 
-hltBPHmonitoring.photons = cms.InputTag("photons") # 
-hltBPHmonitoring.hltTriggerSummaryAOD   = cms.InputTag("hltTriggerSummaryAOD","","HLT")
-#hltBPHmonitoring.DMSelection_ref = cms.string("")
-#hltBPHmonitoring.muoSelection_ref = cms.string("")
-#hltBPHmonitoring.muoSelection_ = cms.string("")
-
-hltBPHmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-#hltBPHmonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("BPHDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
-hltBPHmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltBPHmonitoring.numGenericTriggerEventPSet.andOrL1      = cms.bool(True)# True:=OR; False:=AND
-hltBPHmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT")
-hltBPHmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_Dimuon0_Jpsi_L1_NoOS_v*") # HLT_ZeroBias_v*
-#hltBPHmonitoring.numGenericTriggerEventPSet.l1Algorithms      = cms.vstring("L1_DoubleMu0_SQ") # HLT_ZeroBias_v*
-#hltBPHmonitoring.numGenericTriggerEventPSet.hltDBKey      = cms.string("diMu10")
-hltBPHmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltBPHmonitoring.numGenericTriggerEventPSet.errorReplyL1 = cms.bool( True )
-hltBPHmonitoring.numGenericTriggerEventPSet.l1BeforeMask = cms.bool( True )
-hltBPHmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-
-hltBPHmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltBPHmonitoring.denGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-#hltBPHmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-#hltBPHmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltBPHmonitoring.denGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltBPHmonitoring.denGenericTriggerEventPSet.hltPaths  = cms.vstring( "HLT_Mu7p5_Track2_Jpsi_v*" )#reference
-#hltBPHmonitoring.denGenericTriggerEventPSet.l1Algorithms      = cms.vstring("L1_DoubleMu0_SQ") # HLT_ZeroBias_v*
-#hltBPHmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 0,1,2,3,5,6,7,8,9,12,13,14,15,16,17,20,22,24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel
-hltBPHmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltBPHmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltBPHmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 stage2L1Trigger.toModify(hltBPHmonitoring,

--- a/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/BTVHLTOfflineSource_cfi.py
@@ -60,37 +60,36 @@ referenceTracksForHLTBTag = cms.EDFilter('TrackSelector',
     cut = cms.string("quality('highPurity')")
 )
 
-bTagHLTTrackMonitoring_EmuCalo = trackToTrackComparisonHists.clone()
-bTagHLTTrackMonitoring_EmuCalo.dzWRTPvCut               = cms.double(0.1)
-bTagHLTTrackMonitoring_EmuCalo.monitoredTrack           = cms.InputTag("hltMergedTracksForBTag")
-bTagHLTTrackMonitoring_EmuCalo.referenceTrack           = cms.InputTag("referenceTracksForHLTBTag")
-bTagHLTTrackMonitoring_EmuCalo.monitoredBeamSpot        = cms.InputTag("hltOnlineBeamSpot")
-bTagHLTTrackMonitoring_EmuCalo.referenceBeamSpot        = cms.InputTag("offlineBeamSpot")
-bTagHLTTrackMonitoring_EmuCalo.topDirName               = cms.string("HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_CaloBtagDeepCSV_1p5Calo")
-bTagHLTTrackMonitoring_EmuCalo.referencePrimaryVertices = cms.InputTag("offlinePrimaryVertices")
-bTagHLTTrackMonitoring_EmuCalo.monitoredPrimaryVertices = cms.InputTag("hltVerticesL3")
-bTagHLTTrackMonitoring_EmuCalo.genericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_CaloBtagDeepCSV_1p5*")
+bTagHLTTrackMonitoring_EmuCalo = trackToTrackComparisonHists.clone(
+    dzWRTPvCut               = 0.1,
+    monitoredTrack           = "hltMergedTracksForBTag",
+    referenceTrack           = "referenceTracksForHLTBTag",
+    monitoredBeamSpot        = "hltOnlineBeamSpot",
+    referenceBeamSpot        = "offlineBeamSpot",
+    topDirName               = "HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_CaloBtagDeepCSV_1p5Calo",
+    referencePrimaryVertices = "offlinePrimaryVertices",
+    monitoredPrimaryVertices = "hltVerticesL3",
+    genericTriggerEventPSet = dict(hltPaths = ["HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_CaloBtagDeepCSV_1p5*"])
+)
 
-bTagHLTTrackMonitoring_SixJetCalo = bTagHLTTrackMonitoring_EmuCalo.clone()
-bTagHLTTrackMonitoring_SixJetCalo.topDirName               = cms.string("HLT/BTV/HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94PF")
-bTagHLTTrackMonitoring_SixJetCalo.genericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*")
+bTagHLTTrackMonitoring_SixJetCalo = bTagHLTTrackMonitoring_EmuCalo.clone(
+    topDirName               = "HLT/BTV/HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94PF",
+    genericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*"])
+)
 
+bTagHLTTrackMonitoring_EmuPF = bTagHLTTrackMonitoring_EmuCalo.clone(
+    monitoredTrack           = "hltMergedTracks",
+    monitoredPrimaryVertices = "hltVerticesPFSelector",
+    topDirName               = "HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepCSV_1p5PF",
+    genericTriggerEventPSet = dict(hltPaths = ["HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepCSV_1p5*"])
+)
 
-bTagHLTTrackMonitoring_EmuPF = bTagHLTTrackMonitoring_EmuCalo.clone()
-bTagHLTTrackMonitoring_EmuPF.monitoredTrack           = cms.InputTag("hltMergedTracks")
-bTagHLTTrackMonitoring_EmuPF.monitoredPrimaryVertices = cms.InputTag("hltVerticesPFSelector")
-bTagHLTTrackMonitoring_EmuPF.topDirName               = cms.string("HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepCSV_1p5PF")
-bTagHLTTrackMonitoring_EmuPF.genericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepCSV_1p5*")
-
-
-bTagHLTTrackMonitoring_SixJetPF = bTagHLTTrackMonitoring_EmuPF.clone()
-bTagHLTTrackMonitoring_SixJetPF.monitoredTrack           = cms.InputTag("hltMergedTracks")
-bTagHLTTrackMonitoring_SixJetPF.monitoredPrimaryVertices = cms.InputTag("hltVerticesPFSelector")
-bTagHLTTrackMonitoring_SixJetPF.topDirName               = cms.string("HLT/BTV/HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94PF")
-bTagHLTTrackMonitoring_SixJetPF.genericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*")
-
-
-
+bTagHLTTrackMonitoring_SixJetPF = bTagHLTTrackMonitoring_EmuPF.clone(
+    monitoredTrack           = "hltMergedTracks",
+    monitoredPrimaryVertices = "hltVerticesPFSelector",
+    topDirName               = "HLT/BTV/HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94PF",
+    genericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*"])
+)
 
 bTagHLTTrackMonitoringSequence = cms.Sequence(
     cms.ignore(referenceTracksForHLTBTag)

--- a/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitor_cfi.py
@@ -2,115 +2,107 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.topMonitoring_cfi import topMonitoring
 
-hltBTVmonitoring = topMonitoring.clone()
-hltBTVmonitoring.FolderName = cms.string('HLT/BTV/default/')
-hltBTVmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32 ( 250 ),
-  xmin  = cms.double(    0.),
-  xmax  = cms.double( 2500.),
-)
-hltBTVmonitoring.histoPSet.metPSet = cms.PSet(
-  nbins = cms.uint32(  30   ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  300  ),
-)
-hltBTVmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32( 2500 ),
-)
-hltBTVmonitoring.histoPSet.ptPSet = cms.PSet(
-  nbins = cms.uint32(  100  ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  1000 ),
-)
-hltBTVmonitoring.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.uint32(  32  ),
-  xmin  = cms.double( -3.2 ),
-  xmax  = cms.double(  3.2 ),
-)
-hltBTVmonitoring.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32(  24  ),
-  xmin  = cms.double( -2.4 ),
-  xmax  = cms.double(  2.4 ),
-)
-hltBTVmonitoring.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32(  100  ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  1000 ),
-)
-hltBTVmonitoring.histoPSet.csvPSet = cms.PSet(
-  nbins = cms.uint32( 20 ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 1.0  ),
-)
-hltBTVmonitoring.histoPSet.DRPSet = cms.PSet(
-  nbins = cms.uint32( 60  ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 6.0 ),
-)
-hltBTVmonitoring.histoPSet.invMassPSet = cms.PSet(
-  nbins = cms.uint32( 40 ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 80.0  ),
-)
-hltBTVmonitoring.histoPSet.MHTPSet = cms.PSet(
- nbins = cms.uint32(   80  ),
- xmin  = cms.double(   60   ),
- xmax  = cms.double(  300  ),
-)
+hltBTVmonitoring = topMonitoring.clone(
+    FolderName = 'HLT/BTV/default/',
+    
+    histoPSet = dict(
+         lsPSet = dict(
+                nbins = 2500,
+                xmin  =   0.,
+                xmax  =  2500.),
+         metPSet = dict(
+                nbins =  30,
+                xmin  =   0,
+                xmax  = 300),                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+         ptPSet = dict(
+               nbins =  100,
+               xmin  =   0,
+               xmax  =  1000),
+         phiPSet = dict(
+            nbins =  32,
+            xmin  = -3.2,
+            xmax  =   3.2),
+         etaPSet = dict(
+            nbins =   24,
+            xmin  =  -2.4,
+            xmax  =   2.4),
+         htPSet = dict(
+            nbins =   100,
+            xmin  =  0,
+            xmax  =  1000),
 
-#MET and HT binning
-hltBTVmonitoring.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200)
-hltBTVmonitoring.histoPSet.HTBinning  = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700)
-#Eta binning
-hltBTVmonitoring.histoPSet.eleEtaBinning = cms.vdouble(-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4)
-hltBTVmonitoring.histoPSet.jetEtaBinning = cms.vdouble(-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4)
-hltBTVmonitoring.histoPSet.muEtaBinning  = cms.vdouble(-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4)
-#pt binning
-hltBTVmonitoring.histoPSet.elePtBinning = cms.vdouble(0,3,5,8,15,20,25,30,40,50,60,80,120,200,400,700)
-hltBTVmonitoring.histoPSet.jetPtBinning = cms.vdouble(0,3,5,8,15,20,25,30,40,50,70,100,150,200,400,700,1000,1500,3000)
-hltBTVmonitoring.histoPSet.muPtBinning  = cms.vdouble(0,3,5,7,10,15,20,30,40,50,70,100,150,200,400,700)
-#Eta binning 2D
-hltBTVmonitoring.histoPSet.eleEtaBinning2D = cms.vdouble(-2.5,-1.5,-0.6,0.,0.6,1.5,2.5)
-hltBTVmonitoring.histoPSet.jetEtaBinning2D = cms.vdouble(-2.5,-1.5,-0.6,0.,0.6,1.5,2.5)
-hltBTVmonitoring.histoPSet.muEtaBinning2D  = cms.vdouble(-2.5,-1.5,-0.6,0.,0.6,1.5,2.5)
-#pt binning 2D
-hltBTVmonitoring.histoPSet.elePtBinning2D = cms.vdouble(0,15,20,30,40,60,80,100,200,400)
-hltBTVmonitoring.histoPSet.jetPtBinning2D = cms.vdouble(0,15,20,30,40,60,80,100,200,400)
-hltBTVmonitoring.histoPSet.muPtBinning2D  = cms.vdouble(0,15,20,30,40,60,80,100,200,400)
-#HT and phi binning 2D
-hltBTVmonitoring.histoPSet.HTBinning2D  = cms.vdouble(0,20,40,70,100,150,200,400,700)
-hltBTVmonitoring.histoPSet.phiBinning2D = cms.vdouble(-3.1416,-1.8849,-0.6283,0.6283,1.8849,3.1416)
+         csvPSet = dict(
+            nbins =  20,
+            xmin  =  0.0,
+            xmax  =  1.0),
+         DRPSet = dict(
+            nbins =  60,
+            xmin  =  0.0,
+            xmax  =  6.0),
+         invMassPSet = dict(
+            nbins =  40,
+            xmin  = 0.0,
+            xmax  =  80.0),
+         MHTPSet = dict(
+            nbins =    80,
+            xmin  =   60,
+            xmax  =  300),
 
-hltBTVmonitoring.met       = cms.InputTag("pfMet") # pfMet
-hltBTVmonitoring.jets      = cms.InputTag("ak4PFJetsCHS") # ak4PFJets, ak4PFJetsCHS, ak4PFJets
-hltBTVmonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-hltBTVmonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
+    #MET and HT binning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+        metBinning = [0,20,40,60,80,100,125,150,175,200],
+        HTBinning  = [0,20,40,60,80,100,125,150,175,200,300,400,500,700],
+        #Eta binning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+        eleEtaBinning = [-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4],
+        jetEtaBinning = [-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4],
+        muEtaBinning  = [-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4],
+        #pt binning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+        elePtBinning = [0,3,5,8,15,20,25,30,40,50,60,80,120,200,400,700],
+        jetPtBinning = [0,3,5,8,15,20,25,30,40,50,70,100,150,200,400,700,1000,1500,3000],
+        muPtBinning  = [0,3,5,7,10,15,20,30,40,50,70,100,150,200,400,700],
+        #Eta binning 2D                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+        eleEtaBinning2D = [-2.5,-1.5,-0.6,0.,0.6,1.5,2.5],
+        jetEtaBinning2D = [-2.5,-1.5,-0.6,0.,0.6,1.5,2.5],
+        muEtaBinning2D  = [-2.5,-1.5,-0.6,0.,0.6,1.5,2.5],
+        #pt binning 2D                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
+        elePtBinning2D = [0,15,20,30,40,60,80,100,200,400],
+        jetPtBinning2D = [0,15,20,30,40,60,80,100,200,400],
+        muPtBinning2D  = [0,15,20,30,40,60,80,100,200,400],
+        #HT and phi binning 2D                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+        HTBinning2D  =[0,20,40,70,100,150,200,400,700],
+        phiBinning2D = [-3.1416,-1.8849,-0.6283,0.6283,1.8849,3.1416],
+    ),
+    met       = "pfMet", # pfMet                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+    jets      = "ak4PFJetsCHS", # ak4PFJets, ak4PFJetsCHS, ak4PFJets                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+    electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+    muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
 
-hltBTVmonitoring.btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"]
-hltBTVmonitoring.workingpoint = cms.double(-1.) #no cut applied
+    btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"],
+    workingpoint = -1., #no cut applied                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 
-hltBTVmonitoring.HTdefinition = cms.string('pt>30 & abs(eta)<2.5')
-hltBTVmonitoring.leptJetDeltaRmin = cms.double(0.0)
-hltBTVmonitoring.bJetMuDeltaRmax  = cms.double(9999.)
-hltBTVmonitoring.bJetDeltaEtaMax  = cms.double(9999.)
-#always monitor CSV score for one jet
-hltBTVmonitoring.nbjets = cms.uint32(1)
-hltBTVmonitoring.bjetSelection = cms.string('pt>30 & abs(eta)<2.4')
+    HTdefinition = 'pt>30 & abs(eta)<2.5',
+    leptJetDeltaRmin = 0.0,
+    bJetMuDeltaRmax  = 9999.,
+    bJetDeltaEtaMax  = 9999.,
+    #always monitor CSV score for one jet                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
+    nbjets = 1,
+    bjetSelection = 'pt>30 & abs(eta)<2.4',
 
-hltBTVmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltBTVmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltBTVmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltBTVmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltBTVmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
+    numGenericTriggerEventPSet = dict(
+        andOr  =  False,
+        andOrHlt      = True,# True:=OR; False:=AND                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+        hltInputTag   =  "TriggerResults::HLT",
+        errorReplyHlt =  False,
+        verbosityLevel = 0),
 
-hltBTVmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltBTVmonitoring.denGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltBTVmonitoring.denGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltBTVmonitoring.denGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltBTVmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltBTVmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltBTVmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltBTVmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltBTVmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltBTVmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-
+    denGenericTriggerEventPSet = dict(
+        andOr= False,
+        andOrHlt      = True,# True:=OR; False:=AND                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+        hltInputTag   = "TriggerResults::HLT",
+        errorReplyHlt = False,
+        dcsInputTag   = "scalersRawToDigi",
+        dcsRecordInputTag = "onlineMetaDataDigis",
+        dcsPartitions = [24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+        andOrDcs      =  False,
+        errorReplyDcs = True,
+        verbosityLevel = 0)
+)

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_Client_cff.py
@@ -224,11 +224,11 @@ BTVEfficiency_OnlineTrackFake = DQMEDHarvester("DQMGenericClient",
 
 from DQMOffline.Trigger.TrackingMonitoring_Client_cff import TrackToTrackEfficiencies
 
-BJetTrackToTrackEfficiencies = TrackToTrackEfficiencies.clone()
-BJetTrackToTrackEfficiencies.subDirs = cms.untracked.vstring( "HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepCSV_1p5*",
-                                                              "HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_CaloBtagDeepCSV_1p5*",
-                                                              "HLT/BTV/HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94*")
-
+BJetTrackToTrackEfficiencies = TrackToTrackEfficiencies.clone(
+    subDirs =  ["HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_PFDiJet30_PFBtagDeepCSV_1p5*",
+                "HLT/BTV/HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_CaloDiJet30_CaloBtagDeepCSV_1p5*",
+                "HLT/BTV/HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94*"]
+)
 btaggingClient = cms.Sequence(
 
     BTVEfficiency_TurnOnCurves

--- a/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/BTaggingMonitoring_cff.py
@@ -3,568 +3,703 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.BTaggingMonitor_cfi import hltBTVmonitoring
 
 # BTagMu AK4
-BTagMu_AK4DiJet20_Mu5 = hltBTVmonitoring.clone()
-BTagMu_AK4DiJet20_Mu5.FolderName = cms.string('HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet20_Mu5')
-BTagMu_AK4DiJet20_Mu5.nmuons = cms.uint32(1)
-BTagMu_AK4DiJet20_Mu5.nelectrons = cms.uint32(0)
-BTagMu_AK4DiJet20_Mu5.njets = cms.uint32(2)
-BTagMu_AK4DiJet20_Mu5.muoSelection = cms.string('pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-BTagMu_AK4DiJet20_Mu5.jetSelection = cms.string('pt>10 & abs(eta)<2.4')
-BTagMu_AK4DiJet20_Mu5.bjetSelection = cms.string('pt>5 & abs(eta)<2.4')
-BTagMu_AK4DiJet20_Mu5.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_BTagMu_AK4DiJet20_Mu5_v*')
-BTagMu_AK4DiJet20_Mu5.histoPSet.jetPtBinning = cms.vdouble(0,10,15,20,30,50,70,100,150,200,400,700,1000,1500,3000)
+BTagMu_AK4DiJet20_Mu5 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet20_Mu5',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>10 & abs(eta)<2.4',
+    bjetSelection = 'pt>5 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet20_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,10,15,20,30,50,70,100,150,200,400,700,1000,1500,3000])
+)
 
-BTagMu_AK4DiJet40_Mu5 = hltBTVmonitoring.clone()
-BTagMu_AK4DiJet40_Mu5.FolderName = cms.string('HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet40_Mu5')
-BTagMu_AK4DiJet40_Mu5.nmuons = cms.uint32(1)
-BTagMu_AK4DiJet40_Mu5.nelectrons = cms.uint32(0)
-BTagMu_AK4DiJet40_Mu5.njets = cms.uint32(2)
-BTagMu_AK4DiJet40_Mu5.muoSelection = cms.string('pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-BTagMu_AK4DiJet40_Mu5.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-BTagMu_AK4DiJet40_Mu5.bjetSelection = cms.string('pt>20 & abs(eta)<2.4')
-BTagMu_AK4DiJet40_Mu5.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_BTagMu_AK4DiJet40_Mu5_v*')
-BTagMu_AK4DiJet40_Mu5.histoPSet.jetPtBinning = cms.vdouble(0,30,40,50,70,100,150,200,400,700,1000,1500,3000)
+BTagMu_AK4DiJet40_Mu5 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet40_Mu5',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    bjetSelection = 'pt>20 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet40_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,30,40,50,70,100,150,200,400,700,1000,1500,3000])
+)
 
-BTagMu_AK4DiJet70_Mu5 = hltBTVmonitoring.clone()
-BTagMu_AK4DiJet70_Mu5.FolderName = cms.string('HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet70_Mu5')
-BTagMu_AK4DiJet70_Mu5.nmuons = cms.uint32(1)
-BTagMu_AK4DiJet70_Mu5.nelectrons = cms.uint32(0)
-BTagMu_AK4DiJet70_Mu5.njets = cms.uint32(2)
-BTagMu_AK4DiJet70_Mu5.muoSelection = cms.string('pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-BTagMu_AK4DiJet70_Mu5.jetSelection = cms.string('pt>50 & abs(eta)<2.4')
-BTagMu_AK4DiJet70_Mu5.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_BTagMu_AK4DiJet70_Mu5_v*')
-BTagMu_AK4DiJet70_Mu5.histoPSet.jetPtBinning = cms.vdouble(0,50,60,70,80,90,100,150,200,400,700,1000,1500,3000)
+BTagMu_AK4DiJet70_Mu5 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet70_Mu5',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>50 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet70_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,50,60,70,80,90,100,150,200,400,700,1000,1500,3000])
+)
 
-BTagMu_AK4DiJet110_Mu5 = hltBTVmonitoring.clone()
-BTagMu_AK4DiJet110_Mu5.FolderName = cms.string('HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet110_Mu5')
-BTagMu_AK4DiJet110_Mu5.nmuons = cms.uint32(1)
-BTagMu_AK4DiJet110_Mu5.nelectrons = cms.uint32(0)
-BTagMu_AK4DiJet110_Mu5.njets = cms.uint32(2)
-BTagMu_AK4DiJet110_Mu5.muoSelection = cms.string('pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-BTagMu_AK4DiJet110_Mu5.jetSelection = cms.string('pt>90 & abs(eta)<2.4')
-BTagMu_AK4DiJet110_Mu5.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_BTagMu_AK4DiJet110_Mu5_v*')
-BTagMu_AK4DiJet110_Mu5.histoPSet.jetPtBinning = cms.vdouble(0,90,100,110,120,130,150,200,400,700,1000,1500,3000)
+BTagMu_AK4DiJet110_Mu5 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet110_Mu5',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>90 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet110_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,90,100,110,120,130,150,200,400,700,1000,1500,3000])
+)
 
-BTagMu_AK4DiJet170_Mu5 = hltBTVmonitoring.clone()
-BTagMu_AK4DiJet170_Mu5.FolderName = cms.string('HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet170_Mu5')
-BTagMu_AK4DiJet170_Mu5.nmuons = cms.uint32(1)
-BTagMu_AK4DiJet170_Mu5.nelectrons = cms.uint32(0)
-BTagMu_AK4DiJet170_Mu5.njets = cms.uint32(2)
-BTagMu_AK4DiJet170_Mu5.muoSelection = cms.string('pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-BTagMu_AK4DiJet170_Mu5.jetSelection = cms.string('pt>150 & abs(eta)<2.4')
-BTagMu_AK4DiJet170_Mu5.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_BTagMu_AK4DiJet170_Mu5_v*')
-BTagMu_AK4DiJet170_Mu5.histoPSet.jetPtBinning = cms.vdouble(0,150,160,170,180,190,200,400,700,1000,1500,3000)
 
-BTagMu_AK4Jet300_Mu5 = hltBTVmonitoring.clone()
-BTagMu_AK4Jet300_Mu5.FolderName = cms.string('HLT/BTV/BTagMu_Jet/BTagMu_AK4Jet300_Mu5')
-BTagMu_AK4Jet300_Mu5.nmuons = cms.uint32(1)
-BTagMu_AK4Jet300_Mu5.nelectrons = cms.uint32(0)
-BTagMu_AK4Jet300_Mu5.njets = cms.uint32(1)
-BTagMu_AK4Jet300_Mu5.muoSelection = cms.string('pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-BTagMu_AK4Jet300_Mu5.jetSelection = cms.string('pt>250 & abs(eta)<2.4')
-BTagMu_AK4Jet300_Mu5.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_BTagMu_AK4Jet300_Mu5_v*')
-BTagMu_AK4Jet300_Mu5.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500,3000)
+BTagMu_AK4DiJet170_Mu5 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK4DiJet170_Mu5',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>150 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4DiJet170_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
+)
+
+
+BTagMu_AK4Jet300_Mu5 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_Jet/BTagMu_AK4Jet300_Mu5',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 1,
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>250 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK4Jet300_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
+)
+
 
 #BTagMu AK8
-BTagMu_AK8DiJet170_Mu5 = hltBTVmonitoring.clone()
-BTagMu_AK8DiJet170_Mu5.FolderName = cms.string('HLT/BTV/BTagMu_DiJet/BTagMu_AK8DiJet170_Mu5')
-BTagMu_AK8DiJet170_Mu5.nmuons = cms.uint32(1)
-BTagMu_AK8DiJet170_Mu5.nelectrons = cms.uint32(0)
-BTagMu_AK8DiJet170_Mu5.njets = cms.uint32(2)
-BTagMu_AK8DiJet170_Mu5.jets = cms.InputTag("ak8PFJetsPuppi")
-BTagMu_AK8DiJet170_Mu5.muoSelection = cms.string('pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-BTagMu_AK8DiJet170_Mu5.jetSelection = cms.string('pt>150 & abs(eta)<2.4')
-BTagMu_AK8DiJet170_Mu5.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_BTagMu_AK8DiJet170_Mu5_v*')
-BTagMu_AK8DiJet170_Mu5.histoPSet.jetPtBinning = cms.vdouble(0,150,160,170,180,190,200,400,700,1000,1500,3000)
+BTagMu_AK8DiJet170_Mu5 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_DiJet/BTagMu_AK8DiJet170_Mu5',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 2,
+    jets = "ak8PFJetsPuppi",
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>150 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK8DiJet170_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
+)
 
-BTagMu_AK8Jet300_Mu5 = hltBTVmonitoring.clone()
-BTagMu_AK8Jet300_Mu5.FolderName = cms.string('HLT/BTV/BTagMu_Jet/BTagMu_AK8Jet300_Mu5')
-BTagMu_AK8Jet300_Mu5.nmuons = cms.uint32(1)
-BTagMu_AK8Jet300_Mu5.nelectrons = cms.uint32(0)
-BTagMu_AK8Jet300_Mu5.njets = cms.uint32(1)
-BTagMu_AK8Jet300_Mu5.jets = cms.InputTag("ak8PFJetsPuppi")
-BTagMu_AK8Jet300_Mu5.muoSelection = cms.string('pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-BTagMu_AK8Jet300_Mu5.jetSelection = cms.string('pt>250 & abs(eta)<2.4')
-BTagMu_AK8Jet300_Mu5.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_BTagMu_AK8Jet300_Mu5_v*')
-BTagMu_AK8Jet300_Mu5.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500,3000)
 
-BTagMu_AK8Jet170_DoubleMu5 = hltBTVmonitoring.clone()
-BTagMu_AK8Jet170_DoubleMu5.FolderName = cms.string('HLT/BTV/BTagDiMu_Jet/BTagMu_AK8Jet170_DoubleMu5')
-BTagMu_AK8Jet170_DoubleMu5.nmuons = cms.uint32(2)
-BTagMu_AK8Jet170_DoubleMu5.nelectrons = cms.uint32(0)
-BTagMu_AK8Jet170_DoubleMu5.njets = cms.uint32(1)
-BTagMu_AK8Jet170_DoubleMu5.jets = cms.InputTag("ak8PFJetsPuppi")
-BTagMu_AK8Jet170_DoubleMu5.muoSelection = cms.string('pt>7 & abs(eta)<2.4 & isPFMuon & isGlobalMuon & innerTrack.hitPattern.numberOfValidTrackerHits>7 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & numberOfMatchedStations>1 &globalTrack.normalizedChi2<10')
-BTagMu_AK8Jet170_DoubleMu5.jetSelection = cms.string('pt>150 & abs(eta)<2.4')
-BTagMu_AK8Jet170_DoubleMu5.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_BTagMu_AK8Jet170_DoubleMu5_v*')
-BTagMu_AK8Jet170_DoubleMu5.histoPSet.jetPtBinning = cms.vdouble(0,150,160,170,180,190,200,400,700,1000,1500,3000)
+BTagMu_AK8Jet300_Mu5 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagMu_Jet/BTagMu_AK8Jet300_Mu5',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    muoSelection = 'pt>3 & abs(eta)<2.4 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>250 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK8Jet300_Mu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500,3000])
+)
+
+
+BTagMu_AK8Jet170_DoubleMu5 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/BTagDiMu_Jet/BTagMu_AK8Jet170_DoubleMu5',
+    nmuons = 2,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    muoSelection = 'pt>7 & abs(eta)<2.4 & isPFMuon & isGlobalMuon & innerTrack.hitPattern.numberOfValidTrackerHits>7 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & numberOfMatchedStations>1 &globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>150 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_BTagMu_AK8Jet170_DoubleMu5_v*']),
+    histoPSet = dict(jetPtBinning = [0,150,160,170,180,190,200,400,700,1000,1500,3000])
+)
 
 # PFJet AK4
-PFJet40 = hltBTVmonitoring.clone()
-PFJet40.FolderName = cms.string('HLT/BTV/PFJet/PFJet40')
-PFJet40.nmuons = cms.uint32(0)
-PFJet40.nelectrons = cms.uint32(0)
-PFJet40.njets = cms.uint32(1)
-PFJet40.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-PFJet40.bjetSelection = cms.string('pt>20 & abs(eta)<2.4')
-PFJet40.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet40_v*')
-PFJet40.histoPSet.jetPtBinning = cms.vdouble(0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000)
+PFJet40 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet40',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    bjetSelection = 'pt>20 & abs(eta)<2.4',
+    histoPSet = dict(jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet40_v*'])
+)
 
-PFJet60 = hltBTVmonitoring.clone()
-PFJet60.FolderName = cms.string('HLT/BTV/PFJet/PFJet60')
-PFJet60.nmuons = cms.uint32(0)
-PFJet60.nelectrons = cms.uint32(0)
-PFJet60.njets = cms.uint32(1)
-PFJet60.jetSelection = cms.string('pt>50 & abs(eta)<2.4')
-PFJet60.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet60_v*')
-PFJet60.histoPSet.jetPtBinning = cms.vdouble(0,50,55,60,65,70,80,90,100,120,150,200,400,700,1000,1500,3000)
 
-PFJet80 = hltBTVmonitoring.clone()
-PFJet80.FolderName = cms.string('HLT/BTV/PFJet/PFJet80')
-PFJet80.nmuons = cms.uint32(0)
-PFJet80.nelectrons = cms.uint32(0)
-PFJet80.njets = cms.uint32(1)
-PFJet80.jetSelection = cms.string('pt>70 & abs(eta)<2.4')
-PFJet80.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet80_v*')
-PFJet80.histoPSet.jetPtBinning = cms.vdouble(0,70,75,80,85,90,100,120,150,200,400,700,1000,1500,3000)
+PFJet60 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet60',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>50 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet60_v*']),
+    histoPSet = dict(jetPtBinning = [0,50,55,60,65,70,80,90,100,120,150,200,400,700,1000,1500,3000])
+)
 
-PFJet140 = hltBTVmonitoring.clone()
-PFJet140.FolderName = cms.string('HLT/BTV/PFJet/PFJet140')
-PFJet140.nmuons = cms.uint32(0)
-PFJet140.nelectrons = cms.uint32(0)
-PFJet140.njets = cms.uint32(1)
-PFJet140.jetSelection = cms.string('pt>120 & abs(eta)<2.4')
-PFJet140.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet140_v*')
-PFJet140.histoPSet.jetPtBinning = cms.vdouble(0,120,130,140,150,160,170,200,400,700,1000,1500,3000)
 
-PFJet200 = hltBTVmonitoring.clone()
-PFJet200.FolderName = cms.string('HLT/BTV/PFJet/PFJet200')
-PFJet200.nmuons = cms.uint32(0)
-PFJet200.nelectrons = cms.uint32(0)
-PFJet200.njets = cms.uint32(1)
-PFJet200.jetSelection = cms.string('pt>170 & abs(eta)<2.4')
-PFJet200.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet200_v*')
-PFJet200.histoPSet.jetPtBinning = cms.vdouble(0,170,180,190,200,210,220,250,300,400,700,1000,1500,3000)
+PFJet80 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet80',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>70 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet80_v*']),
+    histoPSet = dict(jetPtBinning = [0,70,75,80,85,90,100,120,150,200,400,700,1000,1500,3000])
+)
 
-PFJet260 = hltBTVmonitoring.clone()
-PFJet260.FolderName = cms.string('HLT/BTV/PFJet/PFJet260')
-PFJet260.nmuons = cms.uint32(0)
-PFJet260.nelectrons = cms.uint32(0)
-PFJet260.njets = cms.uint32(1)
-PFJet260.jetSelection = cms.string('pt>220 & abs(eta)<2.4')
-PFJet260.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet260_v*')
-PFJet260.histoPSet.jetPtBinning = cms.vdouble(0,220,240,260,280,300,350,400,700,1000,1500,3000)
 
-PFJet320 = hltBTVmonitoring.clone()
-PFJet320.FolderName = cms.string('HLT/BTV/PFJet/PFJet320')
-PFJet320.nmuons = cms.uint32(0)
-PFJet320.nelectrons = cms.uint32(0)
-PFJet320.njets = cms.uint32(1)
-PFJet320.jetSelection = cms.string('pt>280 & abs(eta)<2.4')
-PFJet320.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet320_v*')
-PFJet320.histoPSet.jetPtBinning = cms.vdouble(0,280,300,320,340,360,400,500,700,1000,1500,3000)
+PFJet140 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet140',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>120 & abs(eta)<2.4',
+    histoPSet = dict(jetPtBinning = [0,120,130,140,150,160,170,200,400,700,1000,1500,3000]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet140_v*'])
+)
 
-PFJet400 = hltBTVmonitoring.clone()
-PFJet400.FolderName = cms.string('HLT/BTV/PFJet/PFJet400')
-PFJet400.nmuons = cms.uint32(0)
-PFJet400.nelectrons = cms.uint32(0)
-PFJet400.njets = cms.uint32(1)
-PFJet400.jetSelection = cms.string('pt>350 & abs(eta)<2.4')
-PFJet400.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet400_v*')
-PFJet400.histoPSet.jetPtBinning = cms.vdouble(0,350,380,400,420,450,500,700,1000,1500,3000)
 
-PFJet450 = hltBTVmonitoring.clone()
-PFJet450.FolderName = cms.string('HLT/BTV/PFJet/PFJet450')
-PFJet450.nmuons = cms.uint32(0)
-PFJet450.nelectrons = cms.uint32(0)
-PFJet450.njets = cms.uint32(1)
-PFJet450.jetSelection = cms.string('pt>400 & abs(eta)<2.4')
-PFJet450.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet450_v*')
-PFJet450.histoPSet.jetPtBinning = cms.vdouble(0,400,430,450,470,500,700,1000,1500,3000)
+PFJet200 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet200',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>170 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet200_v*']),
+    histoPSet = dict(jetPtBinning = [0,170,180,190,200,210,220,250,300,400,700,1000,1500,3000])
+)
 
-PFJet500 = hltBTVmonitoring.clone()
-PFJet500.FolderName = cms.string('HLT/BTV/PFJet/PFJet500')
-PFJet500.nmuons = cms.uint32(0)
-PFJet500.nelectrons = cms.uint32(0)
-PFJet500.njets = cms.uint32(1)
-PFJet500.jetSelection = cms.string('pt>450 & abs(eta)<2.4')
-PFJet500.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet500_v*')
-PFJet500.histoPSet.jetPtBinning = cms.vdouble(0,450,480,500,520,550,600,700,1000,1500,3000)
 
-PFJet550 = hltBTVmonitoring.clone()
-PFJet550.FolderName = cms.string('HLT/BTV/PFJet/PFJet550')
-PFJet550.nmuons = cms.uint32(0)
-PFJet550.nelectrons = cms.uint32(0)
-PFJet550.njets = cms.uint32(1)
-PFJet550.jetSelection = cms.string('pt>500 & abs(eta)<2.4')
-PFJet550.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet550_v*')
-PFJet550.histoPSet.jetPtBinning = cms.vdouble(0,500,520,550,600,700,1000,1500,3000)
+PFJet260 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet260',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>220 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet260_v*']),
+    histoPSet = dict(jetPtBinning = [0,220,240,260,280,300,350,400,700,1000,1500,3000])
+)
+
+
+PFJet320 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet320',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>280 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet320_v*']),
+    histoPSet = dict(jetPtBinning = [0,280,300,320,340,360,400,500,700,1000,1500,3000])
+)
+
+
+PFJet400 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet400',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>350 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet400_v*']),
+    histoPSet = dict(jetPtBinning = [0,350,380,400,420,450,500,700,1000,1500,3000])
+)
+
+
+PFJet450 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet450',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>400 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet450_v*']),
+    histoPSet = dict(jetPtBinning = [0,400,430,450,470,500,700,1000,1500,3000])
+)
+
+
+PFJet500 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet500',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>450 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet500_v*']),
+    histoPSet = dict(jetPtBinning = [0,450,480,500,520,550,600,700,1000,1500,3000])
+)
+
+
+PFJet550 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJet550',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>500 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet550_v*']),
+    histoPSet = dict(jetPtBinning = [0,500,520,550,600,700,1000,1500,3000])
+)
 
 # PFJet AK8
-AK8PFJet40 = hltBTVmonitoring.clone()
-AK8PFJet40.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet40')
-AK8PFJet40.nmuons = cms.uint32(0)
-AK8PFJet40.nelectrons = cms.uint32(0)
-AK8PFJet40.njets = cms.uint32(1)
-AK8PFJet40.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet40.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-AK8PFJet40.bjetSelection = cms.string('pt>20 & abs(eta)<2.4')
-AK8PFJet40.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet40_v*')
-AK8PFJet40.histoPSet.jetPtBinning = cms.vdouble(0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000)
+AK8PFJet40 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet40',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    bjetSelection = 'pt>20 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet40_v*']),
+    histoPSet = dict(jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000])
+)
 
-AK8PFJet60 = hltBTVmonitoring.clone()
-AK8PFJet60.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet60')
-AK8PFJet60.nmuons = cms.uint32(0)
-AK8PFJet60.nelectrons = cms.uint32(0)
-AK8PFJet60.njets = cms.uint32(1)
-AK8PFJet60.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet60.jetSelection = cms.string('pt>50 & abs(eta)<2.4')
-AK8PFJet60.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet60_v*')
-AK8PFJet60.histoPSet.jetPtBinning = cms.vdouble(0,50,55,60,65,70,80,90,100,120,150,200,400,700,1000,1500,3000)
 
-AK8PFJet80 = hltBTVmonitoring.clone()
-AK8PFJet80.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet80')
-AK8PFJet80.nmuons = cms.uint32(0)
-AK8PFJet80.nelectrons = cms.uint32(0)
-AK8PFJet80.njets = cms.uint32(1)
-AK8PFJet80.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet80.jetSelection = cms.string('pt>70 & abs(eta)<2.4')
-AK8PFJet80.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet80_v*')
-AK8PFJet80.histoPSet.jetPtBinning = cms.vdouble(0,70,75,80,85,90,100,120,150,200,400,700,1000,1500,3000)
+AK8PFJet60 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet60',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>50 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet60_v*']),
+    histoPSet = dict(jetPtBinning = [0,50,55,60,65,70,80,90,100,120,150,200,400,700,1000,1500,3000])
+)
 
-AK8PFJet140 = hltBTVmonitoring.clone()
-AK8PFJet140.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet140')
-AK8PFJet140.nmuons = cms.uint32(0)
-AK8PFJet140.nelectrons = cms.uint32(0)
-AK8PFJet140.njets = cms.uint32(1)
-AK8PFJet140.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet140.jetSelection = cms.string('pt>120 & abs(eta)<2.4')
-AK8PFJet140.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet140_v*')
-AK8PFJet140.histoPSet.jetPtBinning = cms.vdouble(0,120,130,140,150,160,170,200,400,700,1000,1500,3000)
+AK8PFJet80 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet80',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>70 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet80_v*']),
+    histoPSet = dict(jetPtBinning = [0,70,75,80,85,90,100,120,150,200,400,700,1000,1500,3000])
+)
 
-AK8PFJet200 = hltBTVmonitoring.clone()
-AK8PFJet200.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet200')
-AK8PFJet200.nmuons = cms.uint32(0)
-AK8PFJet200.nelectrons = cms.uint32(0)
-AK8PFJet200.njets = cms.uint32(1)
-AK8PFJet200.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet200.jetSelection = cms.string('pt>170 & abs(eta)<2.4')
-AK8PFJet200.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet200_v*')
-AK8PFJet200.histoPSet.jetPtBinning = cms.vdouble(0,170,180,190,200,210,220,250,300,400,700,1000,1500,3000)
 
-AK8PFJet260 = hltBTVmonitoring.clone()
-AK8PFJet260.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet260')
-AK8PFJet260.nmuons = cms.uint32(0)
-AK8PFJet260.nelectrons = cms.uint32(0)
-AK8PFJet260.njets = cms.uint32(1)
-AK8PFJet260.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet260.jetSelection = cms.string('pt>220 & abs(eta)<2.4')
-AK8PFJet260.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet260_v*')
-AK8PFJet260.histoPSet.jetPtBinning = cms.vdouble(0,220,240,260,280,300,350,400,700,1000,1500,3000)
+AK8PFJet140 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet140',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>120 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet140_v*']),
+    histoPSet = dict(jetPtBinning = [0,120,130,140,150,160,170,200,400,700,1000,1500,3000])
+)
 
-AK8PFJet320 = hltBTVmonitoring.clone()
-AK8PFJet320.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet320')
-AK8PFJet320.nmuons = cms.uint32(0)
-AK8PFJet320.nelectrons = cms.uint32(0)
-AK8PFJet320.njets = cms.uint32(1)
-AK8PFJet320.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet320.jetSelection = cms.string('pt>280 & abs(eta)<2.4')
-AK8PFJet320.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet320_v*')
-AK8PFJet320.histoPSet.jetPtBinning = cms.vdouble(0,280,300,320,340,360,400,500,700,1000,1500,3000)
 
-AK8PFJet400 = hltBTVmonitoring.clone()
-AK8PFJet400.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet400')
-AK8PFJet400.nmuons = cms.uint32(0)
-AK8PFJet400.nelectrons = cms.uint32(0)
-AK8PFJet400.njets = cms.uint32(1)
-AK8PFJet400.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet400.jetSelection = cms.string('pt>350 & abs(eta)<2.4')
-AK8PFJet400.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet400_v*')
-AK8PFJet400.histoPSet.jetPtBinning = cms.vdouble(0,350,380,400,420,450,500,700,1000,1500,3000)
+AK8PFJet200 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet200',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>170 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet200_v*']),
+    histoPSet = dict(jetPtBinning = [0,170,180,190,200,210,220,250,300,400,700,1000,1500,3000])
+)
 
-AK8PFJet450 = hltBTVmonitoring.clone()
-AK8PFJet450.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet450')
-AK8PFJet450.nmuons = cms.uint32(0)
-AK8PFJet450.nelectrons = cms.uint32(0)
-AK8PFJet450.njets = cms.uint32(1)
-AK8PFJet450.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet450.jetSelection = cms.string('pt>400 & abs(eta)<2.4')
-AK8PFJet450.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet450_v*')
-AK8PFJet450.histoPSet.jetPtBinning = cms.vdouble(0,400,430,450,470,500,700,1000,1500,3000)
 
-AK8PFJet500 = hltBTVmonitoring.clone()
-AK8PFJet500.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet500')
-AK8PFJet500.nmuons = cms.uint32(0)
-AK8PFJet500.nelectrons = cms.uint32(0)
-AK8PFJet500.njets = cms.uint32(1)
-AK8PFJet500.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet500.jetSelection = cms.string('pt>450 & abs(eta)<2.4')
-AK8PFJet500.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet500_v*')
-AK8PFJet500.histoPSet.jetPtBinning = cms.vdouble(0,450,480,500,520,550,600,700,1000,1500,3000)
+AK8PFJet260 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet260',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>220 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet260_v*']),
+    histoPSet = dict(jetPtBinning = [0,220,240,260,280,300,350,400,700,1000,1500,3000])
+)
 
-AK8PFJet550 = hltBTVmonitoring.clone()
-AK8PFJet550.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJet550')
-AK8PFJet550.nmuons = cms.uint32(0)
-AK8PFJet550.nelectrons = cms.uint32(0)
-AK8PFJet550.njets = cms.uint32(1)
-AK8PFJet550.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet550.jetSelection = cms.string('pt>500 & abs(eta)<2.4')
-AK8PFJet550.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJet550_v*')
-AK8PFJet550.histoPSet.jetPtBinning = cms.vdouble(0,500,520,550,600,700,1000,1500,3000)
+
+AK8PFJet320 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet320',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>280 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet320_v*']),
+    histoPSet = dict(jetPtBinning = [0,280,300,320,340,360,400,500,700,1000,1500,3000])
+)
+
+
+AK8PFJet400 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet400',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>350 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet400_v*']),
+    histoPSet = dict(jetPtBinning = [0,350,380,400,420,450,500,700,1000,1500,3000])
+)
+
+
+AK8PFJet450 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet450',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>400 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet450_v*']),
+    histoPSet = dict(jetPtBinning = [0,400,430,450,470,500,700,1000,1500,3000])
+)
+
+
+AK8PFJet500 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet500',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>450 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet500_v*']),
+    histoPSet = dict(jetPtBinning = [0,450,480,500,520,550,600,700,1000,1500,3000])
+)
+
+
+AK8PFJet550 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJet550',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>500 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJet550_v*']),
+    histoPSet = dict(jetPtBinning = [0,500,520,550,600,700,1000,1500,3000])
+)
+
 
 # PFJetFwd AK4
-PFJetFwd40 = hltBTVmonitoring.clone()
-PFJetFwd40.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd40')
-PFJetFwd40.nmuons = cms.uint32(0)
-PFJetFwd40.nelectrons = cms.uint32(0)
-PFJetFwd40.njets = cms.uint32(1)
-PFJetFwd40.jetSelection = cms.string('pt>30 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd40.bjetSelection = cms.string('pt>20 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd40.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd40_v*')
-PFJetFwd40.histoPSet.jetPtBinning = cms.vdouble(0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000)
-PFJetFwd40.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd40.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd40.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+PFJetFwd40 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd40',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>30 & abs(eta)>2.7 & abs(eta)<5.0',
+    bjetSelection = 'pt>20 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd40_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
-PFJetFwd60 = hltBTVmonitoring.clone()
-PFJetFwd60.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd60')
-PFJetFwd60.nmuons = cms.uint32(0)
-PFJetFwd60.nelectrons = cms.uint32(0)
-PFJetFwd60.njets = cms.uint32(1)
-PFJetFwd60.jetSelection = cms.string('pt>50 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd60.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd60_v*')
-PFJetFwd60.histoPSet.jetPtBinning = cms.vdouble(0,50,55,60,65,70,80,90,100,120,150,200,400,700,1000,1500,3000)
-PFJetFwd60.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd60.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd60.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
 
-PFJetFwd80 = hltBTVmonitoring.clone()
-PFJetFwd80.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd80')
-PFJetFwd80.nmuons = cms.uint32(0)
-PFJetFwd80.nelectrons = cms.uint32(0)
-PFJetFwd80.njets = cms.uint32(1)
-PFJetFwd80.jetSelection = cms.string('pt>70 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd80.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd80_v*')
-PFJetFwd80.histoPSet.jetPtBinning = cms.vdouble(0,70,75,80,85,90,100,120,150,200,400,700,1000,1500,3000)
-PFJetFwd80.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd80.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd80.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+PFJetFwd60 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd60',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>50 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd60_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,50,55,60,65,70,80,90,100,120,150,200,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
-PFJetFwd140 = hltBTVmonitoring.clone()
-PFJetFwd140.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd140')
-PFJetFwd140.nmuons = cms.uint32(0)
-PFJetFwd140.nelectrons = cms.uint32(0)
-PFJetFwd140.njets = cms.uint32(1)
-PFJetFwd140.jetSelection = cms.string('pt>120 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd140.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd140_v*')
-PFJetFwd140.histoPSet.jetPtBinning = cms.vdouble(0,120,130,140,150,160,170,200,400,700,1000,1500,3000)
-PFJetFwd140.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd140.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd140.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
 
-PFJetFwd200 = hltBTVmonitoring.clone()
-PFJetFwd200.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd200')
-PFJetFwd200.nmuons = cms.uint32(0)
-PFJetFwd200.nelectrons = cms.uint32(0)
-PFJetFwd200.njets = cms.uint32(1)
-PFJetFwd200.jetSelection = cms.string('pt>170 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd200.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd200_v*')
-PFJetFwd200.histoPSet.jetPtBinning = cms.vdouble(0,170,180,190,200,210,220,250,300,400,700,1000,1500,3000)
-PFJetFwd200.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd200.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd200.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+PFJetFwd80 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd80',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>70 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd80_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,70,75,80,85,90,100,120,150,200,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
-PFJetFwd260 = hltBTVmonitoring.clone()
-PFJetFwd260.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd260')
-PFJetFwd260.nmuons = cms.uint32(0)
-PFJetFwd260.nelectrons = cms.uint32(0)
-PFJetFwd260.njets = cms.uint32(1)
-PFJetFwd260.jetSelection = cms.string('pt>220 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd260.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd260_v*')
-PFJetFwd260.histoPSet.jetPtBinning = cms.vdouble(0,220,240,260,280,300,350,400,700,1000,1500,3000)
-PFJetFwd260.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd260.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd260.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
 
-PFJetFwd320 = hltBTVmonitoring.clone()
-PFJetFwd320.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd320')
-PFJetFwd320.nmuons = cms.uint32(0)
-PFJetFwd320.nelectrons = cms.uint32(0)
-PFJetFwd320.njets = cms.uint32(1)
-PFJetFwd320.jetSelection = cms.string('pt>280 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd320.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd320_v*')
-PFJetFwd320.histoPSet.jetPtBinning = cms.vdouble(0,280,300,320,340,360,400,500,700,1000,1500,3000)
-PFJetFwd320.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd320.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd320.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+PFJetFwd140 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd140',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>120 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd140_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,120,130,140,150,160,170,200,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
-PFJetFwd400 = hltBTVmonitoring.clone()
-PFJetFwd400.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd400')
-PFJetFwd400.nmuons = cms.uint32(0)
-PFJetFwd400.nelectrons = cms.uint32(0)
-PFJetFwd400.njets = cms.uint32(1)
-PFJetFwd400.jetSelection = cms.string('pt>350 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd400.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd400_v*')
-PFJetFwd400.histoPSet.jetPtBinning = cms.vdouble(0,350,380,400,420,450,500,700,1000,1500,3000)
-PFJetFwd400.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd400.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd400.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
 
-PFJetFwd450 = hltBTVmonitoring.clone()
-PFJetFwd450.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd450')
-PFJetFwd450.nmuons = cms.uint32(0)
-PFJetFwd450.nelectrons = cms.uint32(0)
-PFJetFwd450.njets = cms.uint32(1)
-PFJetFwd450.jetSelection = cms.string('pt>400 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd450.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd450_v*')
-PFJetFwd450.histoPSet.jetPtBinning = cms.vdouble(0,400,430,450,470,500,700,1000,1500,3000)
-PFJetFwd450.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd450.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd450.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+PFJetFwd200 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd200',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>170 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd200_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,170,180,190,200,210,220,250,300,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+     )
+)
 
-PFJetFwd500 = hltBTVmonitoring.clone()
-PFJetFwd500.FolderName = cms.string('HLT/BTV/PFJet/PFJetFwd500')
-PFJetFwd500.nmuons = cms.uint32(0)
-PFJetFwd500.nelectrons = cms.uint32(0)
-PFJetFwd500.njets = cms.uint32(1)
-PFJetFwd500.jetSelection = cms.string('pt>450 & abs(eta)>2.7 & abs(eta)<5.0')
-PFJetFwd500.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJetFwd500_v*')
-PFJetFwd500.histoPSet.jetPtBinning = cms.vdouble(0,450,480,500,520,550,600,700,1000,1500,3000)
-PFJetFwd500.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd500.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-PFJetFwd500.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+
+PFJetFwd260 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd260',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>220 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd260_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,220,240,260,280,300,350,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
+
+
+PFJetFwd320 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd320',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>280 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd320_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,280,300,320,340,360,400,500,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
+
+
+PFJetFwd400 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd400',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>350 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd400_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,350,380,400,420,450,500,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
+
+
+PFJetFwd450 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd450',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>400 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd450_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,400,430,450,470,500,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
+
+
+PFJetFwd500 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/PFJetFwd500',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jetSelection = 'pt>450 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJetFwd500_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,450,480,500,520,550,600,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
 # PFJetFwd AK8
-AK8PFJetFwd40 = hltBTVmonitoring.clone()
-AK8PFJetFwd40.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd40')
-AK8PFJetFwd40.nmuons = cms.uint32(0)
-AK8PFJetFwd40.nelectrons = cms.uint32(0)
-AK8PFJetFwd40.njets = cms.uint32(1)
-AK8PFJetFwd40.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd40.jetSelection = cms.string('pt>30 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd40.bjetSelection = cms.string('pt>20 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd40.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd40_v*')
-AK8PFJetFwd40.histoPSet.jetPtBinning = cms.vdouble(0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000)
-AK8PFJetFwd40.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd40.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd40.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+AK8PFJetFwd40 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd40',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>30 & abs(eta)>2.7 & abs(eta)<5.0',
+    bjetSelection = 'pt>20 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd40_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,30,35,40,45,50,60,70,100,150,200,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
-AK8PFJetFwd60 = hltBTVmonitoring.clone()
-AK8PFJetFwd60.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd60')
-AK8PFJetFwd60.nmuons = cms.uint32(0)
-AK8PFJetFwd60.nelectrons = cms.uint32(0)
-AK8PFJetFwd60.njets = cms.uint32(1)
-AK8PFJetFwd60.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd60.jetSelection = cms.string('pt>50 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd60.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd60_v*')
-AK8PFJetFwd60.histoPSet.jetPtBinning = cms.vdouble(0,50,55,60,65,70,80,90,100,120,150,200,400,700,1000,1500,3000)
-AK8PFJetFwd60.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd60.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd60.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
 
-AK8PFJetFwd80 = hltBTVmonitoring.clone()
-AK8PFJetFwd80.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd80')
-AK8PFJetFwd80.nmuons = cms.uint32(0)
-AK8PFJetFwd80.nelectrons = cms.uint32(0)
-AK8PFJetFwd80.njets = cms.uint32(1)
-AK8PFJetFwd80.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd80.jetSelection = cms.string('pt>70 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd80.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd80_v*')
-AK8PFJetFwd80.histoPSet.jetPtBinning = cms.vdouble(0,70,75,80,85,90,100,120,150,200,400,700,1000,1500,3000)
-AK8PFJetFwd80.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd80.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd80.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+AK8PFJetFwd60 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd60',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>50 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd60_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,50,55,60,65,70,80,90,100,120,150,200,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
-AK8PFJetFwd140 = hltBTVmonitoring.clone()
-AK8PFJetFwd140.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd140')
-AK8PFJetFwd140.nmuons = cms.uint32(0)
-AK8PFJetFwd140.nelectrons = cms.uint32(0)
-AK8PFJetFwd140.njets = cms.uint32(1)
-AK8PFJetFwd140.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd140.jetSelection = cms.string('pt>120 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd140.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd140_v*')
-AK8PFJetFwd140.histoPSet.jetPtBinning = cms.vdouble(0,120,130,140,150,160,170,200,400,700,1000,1500,3000)
-AK8PFJetFwd140.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd140.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd140.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
 
-AK8PFJetFwd200 = hltBTVmonitoring.clone()
-AK8PFJetFwd200.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd200')
-AK8PFJetFwd200.nmuons = cms.uint32(0)
-AK8PFJetFwd200.nelectrons = cms.uint32(0)
-AK8PFJetFwd200.njets = cms.uint32(1)
-AK8PFJetFwd200.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd200.jetSelection = cms.string('pt>170 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd200.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd200_v*')
-AK8PFJetFwd200.histoPSet.jetPtBinning = cms.vdouble(0,170,180,190,200,210,220,250,300,400,700,1000,1500,3000)
-AK8PFJetFwd200.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd200.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd200.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+AK8PFJetFwd80 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd80',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>70 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd80_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,70,75,80,85,90,100,120,150,200,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
-AK8PFJetFwd260 = hltBTVmonitoring.clone()
-AK8PFJetFwd260.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd260')
-AK8PFJetFwd260.nmuons = cms.uint32(0)
-AK8PFJetFwd260.nelectrons = cms.uint32(0)
-AK8PFJetFwd260.njets = cms.uint32(1)
-AK8PFJetFwd260.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd260.jetSelection = cms.string('pt>220 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd260.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd260_v*')
-AK8PFJetFwd260.histoPSet.jetPtBinning = cms.vdouble(0,220,240,260,280,300,350,400,700,1000,1500,3000)
-AK8PFJetFwd260.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd260.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd260.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
 
-AK8PFJetFwd320 = hltBTVmonitoring.clone()
-AK8PFJetFwd320.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd320')
-AK8PFJetFwd320.nmuons = cms.uint32(0)
-AK8PFJetFwd320.nelectrons = cms.uint32(0)
-AK8PFJetFwd320.njets = cms.uint32(1)
-AK8PFJetFwd320.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd320.jetSelection = cms.string('pt>280 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd320.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd320_v*')
-AK8PFJetFwd320.histoPSet.jetPtBinning = cms.vdouble(0,280,300,320,340,360,400,500,700,1000,1500,3000)
-AK8PFJetFwd320.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd320.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd320.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+AK8PFJetFwd140 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd140',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>120 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd140_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,120,130,140,150,160,170,200,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
-AK8PFJetFwd400 = hltBTVmonitoring.clone()
-AK8PFJetFwd400.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd400')
-AK8PFJetFwd400.nmuons = cms.uint32(0)
-AK8PFJetFwd400.nelectrons = cms.uint32(0)
-AK8PFJetFwd400.njets = cms.uint32(1)
-AK8PFJetFwd400.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd400.jetSelection = cms.string('pt>350 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd400.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd400_v*')
-AK8PFJetFwd400.histoPSet.jetPtBinning = cms.vdouble(0,350,380,400,420,450,500,700,1000,1500,3000)
-AK8PFJetFwd400.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd400.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd400.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
 
-AK8PFJetFwd450 = hltBTVmonitoring.clone()
-AK8PFJetFwd450.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd450')
-AK8PFJetFwd450.nmuons = cms.uint32(0)
-AK8PFJetFwd450.nelectrons = cms.uint32(0)
-AK8PFJetFwd450.njets = cms.uint32(1)
-AK8PFJetFwd450.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd450.jetSelection = cms.string('pt>400 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd450.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd450_v*')
-AK8PFJetFwd450.histoPSet.jetPtBinning = cms.vdouble(0,400,430,450,470,500,700,1000,1500,3000)
-AK8PFJetFwd450.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd450.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd450.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+AK8PFJetFwd200 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd200',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>170 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd200_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,170,180,190,200,210,220,250,300,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
 
-AK8PFJetFwd500 = hltBTVmonitoring.clone()
-AK8PFJetFwd500.FolderName = cms.string('HLT/BTV/PFJet/AK8PFJetFwd500')
-AK8PFJetFwd500.nmuons = cms.uint32(0)
-AK8PFJetFwd500.nelectrons = cms.uint32(0)
-AK8PFJetFwd500.njets = cms.uint32(1)
-AK8PFJetFwd500.jets = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd500.jetSelection = cms.string('pt>450 & abs(eta)>2.7 & abs(eta)<5.0')
-AK8PFJetFwd500.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_AK8PFJetFwd500_v*')
-AK8PFJetFwd500.histoPSet.jetPtBinning = cms.vdouble(0,450,480,500,520,550,600,700,1000,1500,3000)
-AK8PFJetFwd500.histoPSet.jetEtaBinning = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd500.histoPSet.jetEtaBinning2D = cms.vdouble(-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0)
-AK8PFJetFwd500.histoPSet.etaPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(-5.0), xmax=cms.double(5.0))
+
+AK8PFJetFwd260 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd260',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>220 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd260_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,220,240,260,280,300,350,400,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
+
+
+AK8PFJetFwd320 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd320',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>280 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd320_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,280,300,320,340,360,400,500,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins = 50, xmin = -5.0, xmax = 5.0)
+    )
+)
+
+
+AK8PFJetFwd400 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd400',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>350 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd400_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,350,380,400,420,450,500,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
+
+
+AK8PFJetFwd450 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd450',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>400 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd450_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,400,430,450,470,500,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
+
+
+AK8PFJetFwd500 = hltBTVmonitoring.clone(
+    FolderName = 'HLT/BTV/PFJet/AK8PFJetFwd500',
+    nmuons = 0,
+    nelectrons = 0,
+    njets = 1,
+    jets = "ak8PFJetsPuppi",
+    jetSelection = 'pt>450 & abs(eta)>2.7 & abs(eta)<5.0',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_AK8PFJetFwd500_v*']),
+    histoPSet = dict(
+        jetPtBinning = [0,450,480,500,520,550,600,700,1000,1500,3000],
+        jetEtaBinning = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        jetEtaBinning2D = [-5.0,-4.7,-4.4,-4.1,-3.8,-3.5,-3.2,-2.9,-2.7,-2.4,-2.1,0.0,2.1,2.4,2.7,2.9,3.2,3.5,3.8,4.1,4.4,4.7,5.0],
+        etaPSet = dict(nbins=50, xmin=-5.0, xmax=5.0)
+    )
+)
+
 
 ### Sequences
 

--- a/DQMOffline/Trigger/python/DQMOffline_LumiMontiroring_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_LumiMontiroring_cff.py
@@ -7,40 +7,41 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.HLTEvF.lumiMonitor_cfi import lumiMonitor
 
-hltLumiMonitor = lumiMonitor.clone()
-hltLumiMonitor.useBPixLayer1 = cms.bool( False )
-hltLumiMonitor.minPixelClusterCharge = cms.double( 15000.0 )
-hltLumiMonitor.histoPSet = cms.PSet(
-    lsPSet = cms.PSet(  
-      nbins = cms.int32( 2500 ) 
-    ),
-    pixelClusterPSet = cms.PSet(
-      nbins = cms.int32( 200 ),
-      xmin = cms.double( -0.5 ),
-      xmax = cms.double( 19999.5 )
-    ),
-    puPSet = cms.PSet(
-      nbins = cms.int32( 130  ),
-      xmin = cms.double(   0. ),
-      xmax = cms.double( 130. )
-    ),
-    lumiPSet = cms.PSet(
-      nbins = cms.int32(   440 ),
-      xmin = cms.double(     0.0 ),
-      xmax = cms.double( 22000.0 )
-    ),
-    pixellumiPSet = cms.PSet(
-      nbins = cms.int32( 300 ),
-      xmin = cms.double( 0.0 ),
-      xmax = cms.double( 3.0 )
-    )
-)
-hltLumiMonitor.minNumberOfPixelsPerCluster = cms.int32( 2 )
-hltLumiMonitor.FolderName = cms.string( "HLT/LumiMonitoring" )
-hltLumiMonitor.scalers = cms.InputTag( "scalersRawToDigi" )
-hltLumiMonitor.pixelClusters = cms.InputTag( "hltSiPixelClusters" )
-hltLumiMonitor.doPixelLumi = cms.bool( False )
+hltLumiMonitor = lumiMonitor.clone(
+    useBPixLayer1 =  False ,
+    minPixelClusterCharge = 15000.0, 
 
+    histoPSet = dict(
+                lsPSet = dict(  
+                        nbins = 2500 ), 
+                            
+                pixelClusterPSet = dict(
+                        nbins = 200 ,
+                        xmin = -0.5 ,
+                        xmax = 19999.5),
+    
+                puPSet = dict(
+                        nbins = 130,
+                        xmin =   0. ,
+                        xmax =  130.),
+    
+                lumiPSet = dict(
+                        nbins =   440 ,
+                        xmin =   0.0 ,
+                        xmax = 22000.0),
+    
+                pixellumiPSet = dict(
+                        nbins = 300 ,
+                        xmin =  0.0 ,
+                        xmax = 3.0 )
+        ),
+
+    minNumberOfPixelsPerCluster =  2,
+    FolderName =  "HLT/LumiMonitoring",
+    scalers = "scalersRawToDigi",
+    pixelClusters =  "hltSiPixelClusters",
+    doPixelLumi =  False
+)
 lumiMonitorHLTsequence = cms.Sequence(
 #    hltScalersRawToDigi4DQM +
     hltLumiMonitor

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -96,9 +96,9 @@ from DQMOffline.Trigger.HLTInclusiveVBFSource_cfi import *
 #from DQMOffline.Trigger.heavyionUCCDQM_cfi import * # OBSOLETE
 
 import DQMServices.Components.DQMEnvironment_cfi
-dqmEnvHLT = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
-dqmEnvHLT.subSystemFolder = 'HLT'
-
+dqmEnvHLT = DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone(
+    subSystemFolder = 'HLT'
+)
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 dqmInfoHLTMon = DQMEDAnalyzer('DQMEventInfo',
     subSystemFolder = cms.untracked.string('HLT')

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cosmics_cff.py
@@ -48,9 +48,9 @@ from DQMOffline.Trigger.HLTTauDQMOffline_cff import *
 from DQMOffline.Trigger.JetMETHLTOfflineSource_cfi import *
 
 import DQMServices.Components.DQMEnvironment_cfi
-dqmEnvHLT= DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone()
-dqmEnvHLT.subSystemFolder = 'HLT'
-
+dqmEnvHLT= DQMServices.Components.DQMEnvironment_cfi.dqmEnv.clone(
+    subSystemFolder = 'HLT'
+)
 offlineHLTSource = cms.Sequence(
     hltFiltersDQMonitor *
     egHLTOffDQMSource *

--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
@@ -3,35 +3,41 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.DiDispStaMuonMonitor_cfi import hltDiDispStaMuonMonitoring
 
 
-hltDiDispStaMuonCosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuonCosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu23NoVtx_2Cha_CosmicSeed/')
-hltDiDispStaMuonCosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
-
+hltDiDispStaMuonCosmicMonitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu23NoVtx_2Cha_CosmicSeed/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*"]) #HLT_ZeroBias_v*
+)
 ## Efficiency trigger
-hltDispStaMuon23Monitoring = hltDiDispStaMuonMonitoring.clone()
-hltDispStaMuon23Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/L2Mu23NoVtx_2Cha/')
-hltDispStaMuon23Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu23NoVtx_2Cha_v*") #HLT_ZeroBias_v*
+hltDispStaMuon23Monitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/L2Mu23NoVtx_2Cha/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L2Mu23NoVtx_2Cha_v*"]) #HLT_ZeroBias_v*
+)
 
-hltDispStaMuon23CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
-hltDispStaMuon23CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/L2Mu23NoVtx_2Cha_CosmicSeed/')
-hltDispStaMuon23CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu23NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
+hltDispStaMuon23CosmicMonitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/L2Mu23NoVtx_2Cha_CosmicSeed/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L2Mu23NoVtx_2Cha_CosmicSeed_v*"]) #HLT_ZeroBias_v*
+)
 
 ## Backup trigger
-hltDiDispStaMuon25Monitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuon25Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu25NoVtx_2Cha/')
-hltDiDispStaMuon25Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu25NoVtx_2Cha_v*") #HLT_ZeroBias_v*
+hltDiDispStaMuon25Monitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu25NoVtx_2Cha/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu25NoVtx_2Cha_v*"]) #HLT_ZeroBias_v*
+)
 
-hltDiDispStaMuon25CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuon25CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu25NoVtx_2Cha_CosmicSeed/')
-hltDiDispStaMuon25CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu25NoVtx_2Cha_CosmicSeed_v*") #HLT_ZeroBias_v*
+hltDiDispStaMuon25CosmicMonitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu25NoVtx_2Cha_CosmicSeed/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu25NoVtx_2Cha_CosmicSeed_v*"]) #HLT_ZeroBias_v*
+)
 
-hltDiDispStaMuon30Monitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuon30Monitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu30NoVtx_2Cha_Eta2p4/')
-hltDiDispStaMuon30Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu30NoVtx_2Cha_Eta2p4_v*") #HLT_ZeroBias_v*
+hltDiDispStaMuon30Monitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu30NoVtx_2Cha_Eta2p4/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu30NoVtx_2Cha_Eta2p4_v*"]) #HLT_ZeroBias_v*
+)
 
-hltDiDispStaMuon30CosmicMonitoring = hltDiDispStaMuonMonitoring.clone()
-hltDiDispStaMuon30CosmicMonitoring.FolderName = cms.string('HLT/EXO/DiDispStaMuon/DoubleL2Mu30NoVtx_2Cha_CosmicSeed_Eta2p4/')
-hltDiDispStaMuon30CosmicMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu30NoVtx_2Cha_CosmicSeed_Eta2p4_v*") #HLT_ZeroBias_v*
+hltDiDispStaMuon30CosmicMonitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu30NoVtx_2Cha_CosmicSeed_Eta2p4/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu30NoVtx_2Cha_CosmicSeed_Eta2p4_v*"]) #HLT_ZeroBias_v*
+)
 
 
 exoHLTdispStaMuonMonitoring = cms.Sequence(

--- a/DQMOffline/Trigger/python/DiJetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cff.py
@@ -3,144 +3,152 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.DiJetMonitor_cfi import DiPFjetAve40_Prommonitoring
 ### HLT_DiJet Triggers ###
 # DiPFjetAve60
-DiPFjetAve60_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve60_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve60/')
-DiPFjetAve60_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  75 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  150.),
+DiPFjetAve60_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve60/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                         nbins = 75,
+                         xmin  =  0.,
+                         xmax  = 150.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve60_v*"])
 )
-DiPFjetAve60_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_v*")
 
 # DiPFjetAve80
-DiPFjetAve80_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve80_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve80/')
-DiPFjetAve80_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  200.),
+DiPFjetAve80_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve80/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                     nbins = 100 ,
+                     xmin  = 0.,
+                     xmax  =  200.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve80_v*"])
+
 )
-DiPFjetAve80_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_v*")
+
 
 # DiPFjetAve140
-DiPFjetAve140_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve140_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve140/')
-DiPFjetAve140_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  70 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  350.),
+DiPFjetAve140_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve140/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                    nbins =  70,
+                    xmin  =  0.,
+                    xmax  =  350.)),
+numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve140_v*"])
 )
-DiPFjetAve140_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve140_v*")
+
 
 # DiPFjetAve200
-DiPFjetAve200_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve200_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve200/')
-DiPFjetAve200_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  500.),
+DiPFjetAve200_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve200/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                     nbins = 50 ,
+                     xmin  = 0.,
+                     xmax  =  500.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve200_v*"])
 )
-DiPFjetAve200_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve200_v*")
+
 
 # DiPFjetAve260
-DiPFjetAve260_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve260_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve260/')
-DiPFjetAve260_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  65 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  650.),
+DiPFjetAve260_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve260/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                     nbins = 65 ,
+                     xmin  =  0.,
+                     xmax  = 650.)),
+numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve260_v*"])
 )
-DiPFjetAve260_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve260_v*")
+
 
 # DiPFjetAve320
-DiPFjetAve320_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve320_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve320/')
-DiPFjetAve320_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  80 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  800.),
+DiPFjetAve320_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve320/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                         nbins = 80 ,
+                         xmin  =  0.,
+                         xmax  =  800.)),
+numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve320_v*"])
 )
-DiPFjetAve320_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve320_v*")
 
 # DiPFjetAve400
-DiPFjetAve400_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve400_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve400/')
-DiPFjetAve400_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  1000.),
+DiPFjetAve400_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve400/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                        nbins = 100 ,
+                        xmin  =  0.,
+                        xmax  = 1000.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve400_v*"])
 )
-DiPFjetAve400_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve400_v*")
+
 
 # DiPFjetAve500
-DiPFjetAve500_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve500_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve500/')
-DiPFjetAve500_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  125),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(1250),
+DiPFjetAve500_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve500/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                        nbins = 125,
+                        xmin  =  0.,
+                        xmax  = 1250)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve500_v*"])
 )
-DiPFjetAve500_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve500_v*")
 
 # HLT_DiPFJetAve60_HFJEC
-DiPFjetAve60_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve60_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve60_HFJEC/')
-DiPFjetAve60_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  75 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  150.),
+DiPFjetAve60_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve60_HFJEC/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                        nbins = 75 ,
+                        xmin  =  0.,
+                        xmax  =  150.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve60_HFJEC_v*"])
 )
-DiPFjetAve60_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve60_HFJEC_v*")
 
 # HLT_DiPFJetAve80_HFJEC
-DiPFjetAve80_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve80_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve80_HFJEC/')
-DiPFjetAve80_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  200.),
+DiPFjetAve80_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve80_HFJEC/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                         nbins = 100 ,
+                         xmin  =  0.,
+                         xmax  =  200.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve80_HFJEC_v*"])
 )
-DiPFjetAve80_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve80_HFJEC_v*")
+
 
 # HLT_DiPFJetAve100_HFJEC
-DiPFjetAve100_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve100_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve100_HFJEC/')
-DiPFjetAve100_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  250.),
+DiPFjetAve100_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve100_HFJEC/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                        nbins = 50 ,
+                        xmin  =  0.,
+                        xmax  =  250.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve100_HFJEC_v*"])
 )
-DiPFjetAve100_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve100_HFJEC_v*")
 
 # HLT_DiPFJetAve160_HFJEC
-DiPFjetAve160_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve160_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve160_HFJEC/')
-DiPFjetAve160_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  80 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  400.),
+DiPFjetAve160_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve160_HFJEC/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                        nbins = 80 ,
+                        xmin  =  0.,
+                        xmax  =  400.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve160_HFJEC_v*"])
 )
-DiPFjetAve160_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve160_HFJEC_v*")
+
 
 # HLT_DiPFJetAve220_HFJEC
-DiPFjetAve220_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve220_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve220_HFJEC/')
-DiPFjetAve220_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  55 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  550.),
+DiPFjetAve220_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve220_HFJEC/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                        nbins = 55 ,
+                        xmin  =  0.,
+                        xmax  =  550.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve220_HFJEC_v*"])
 )
-DiPFjetAve220_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve220_HFJEC_v*")
 
 # HLT_DiPFJetAve300_HFJEC
-DiPFjetAve300_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone()
-DiPFjetAve300_HFJEC_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve300_HFJEC/')
-DiPFjetAve300_HFJEC_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  75 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  750.),
+DiPFjetAve300_HFJEC_Prommonitoring = DiPFjetAve40_Prommonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve300_HFJEC/',
+    histoPSet = dict(dijetPtThrPSet = dict(
+                         nbins = 75 ,
+                         xmin  =  0.,
+                         xmax  = 750.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPFJetAve300_HFJEC_v*"])
 )
-DiPFjetAve300_HFJEC_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiPFJetAve300_HFJEC_v*")
 
 HLTDiJetmonitoring = cms.Sequence(
     DiPFjetAve40_Prommonitoring

--- a/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/DiJetMonitor_cfi.py
@@ -1,38 +1,38 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.dijetMonitoring_cfi import dijetMonitoring
-DiPFjetAve40_Prommonitoring = dijetMonitoring.clone()
-DiPFjetAve40_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve40/')
-DiPFjetAve40_Prommonitoring.histoPSet.dijetPSet = cms.PSet(
-  nbins = cms.uint32 (  200  ),
-  xmin  = cms.double(   0),
-  xmax  = cms.double(1000.),
+DiPFjetAve40_Prommonitoring = dijetMonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_DiPFJetAve40/',
+    met       = "pfMet", # pfMet
+    #pfjets    = "ak4PFJets", # ak4PFJets, ak4PFJetsCHS
+    dijetSrc  = "ak4PFJets", # ak4PFJets, ak4PFJetsCHS
+    electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
+    muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !
+    ptcut     = 20, # while pfIsolatedMuonsEI are reco::PFCandidate !
+
+    histoPSet = dict(dijetPSet = dict(
+            nbins = 200 ,
+            xmin  =  0,
+            xmax  = 1000.),
+                     dijetPtThrPSet = dict(
+                             nbins = 50 ,
+                             xmin  =  0.,
+                             xmax  = 100.)),
+
+    numGenericTriggerEventPSet = dict(andOr = False,
+                                      dbLabel = "JetMETDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !                                                                                                                                                        
+                                      andOrHlt      = True, # True:=OR; False:=AND                                                                                           
+                                      hltInputTag   = "TriggerResults::HLT" ,
+                                      hltPaths      = ["HLT_DiPFJetAve40_v*"], # HLT_ZeroBias_v*                                                                             
+                                      errorReplyHlt =  False,
+                                      verbosityLevel = 1),
+
+
+    denGenericTriggerEventPSet = dict(andOr = False,
+                                      dcsInputTag   = "scalersRawToDigi",
+                                      dcsRecordInputTag = "onlineMetaDataDigis",
+                                      dcsPartitions = [24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !                            
+                                      andOrDcs      = False,
+                                      errorReplyDcs = True,
+                                      verbosityLevel = 1)
 )
-DiPFjetAve40_Prommonitoring.histoPSet.dijetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(100.),
-)
-DiPFjetAve40_Prommonitoring.met       = cms.InputTag("pfMet") # pfMet
-#DiPFjetAve40_Prommonitoring.pfjets    = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
-DiPFjetAve40_Prommonitoring.dijetSrc  = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
-DiPFjetAve40_Prommonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-DiPFjetAve40_Prommonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
-DiPFjetAve40_Prommonitoring.ptcut     = cms.double(20) # while pfIsolatedMuonsEI are reco::PFCandidate !
-
-DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("JetMETDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
-DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_DiPFJetAve40_v*") # HLT_ZeroBias_v*
-DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-DiPFjetAve40_Prommonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
-
-DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-DiPFjetAve40_Prommonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
-

--- a/DQMOffline/Trigger/python/DisplacedJet_Monitor_cff.py
+++ b/DQMOffline/Trigger/python/DisplacedJet_Monitor_cff.py
@@ -5,138 +5,137 @@ from DQMOffline.Trigger.JetMonitor_cfi import hltJetMETmonitoring
 
 from DQMOffline.Trigger.TrackingMonitoring_cff import * 
 
-DisplacedJetIter2TracksMonitoringHLT = trackingMonHLT.clone()
-DisplacedJetIter2TracksMonitoringHLT.FolderName       = 'HLT/EXO/DisplacedJet/Tracking/iter2MergedForBTag'
-DisplacedJetIter2TracksMonitoringHLT.TrackProducer    = 'hltIter2MergedForBTag'
-DisplacedJetIter2TracksMonitoringHLT.allTrackProducer = 'hltIter2MergedForBTag'
-DisplacedJetIter2TracksMonitoringHLT.doEffFromHitPatternVsPU   = cms.bool(False)
-DisplacedJetIter2TracksMonitoringHLT.doEffFromHitPatternVsBX   = cms.bool(False)
-DisplacedJetIter2TracksMonitoringHLT.doEffFromHitPatternVsLUMI = cms.bool(False)
+DisplacedJetIter2TracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/EXO/DisplacedJet/Tracking/iter2MergedForBTag',
+    TrackProducer    = 'hltIter2MergedForBTag',
+    allTrackProducer = 'hltIter2MergedForBTag',
+    doEffFromHitPatternVsPU   = False,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
 
-
-DisplacedJetIter4TracksMonitoringHLT = trackingMonHLT.clone()
-DisplacedJetIter4TracksMonitoringHLT.FolderName       = 'HLT/EXO/DisplacedJet/Tracking/iter4ForDisplaced'
-DisplacedJetIter4TracksMonitoringHLT.TrackProducer    = 'hltDisplacedhltIter4PFlowTrackSelectionHighPurity'
-DisplacedJetIter4TracksMonitoringHLT.allTrackProducer = 'hltDisplacedhltIter4PFlowTrackSelectionHighPurity'
-DisplacedJetIter4TracksMonitoringHLT.doEffFromHitPatternVsPU   = cms.bool(True)
-DisplacedJetIter4TracksMonitoringHLT.doEffFromHitPatternVsBX   = cms.bool(False)
-DisplacedJetIter4TracksMonitoringHLT.doEffFromHitPatternVsLUMI = cms.bool(False)
-
+DisplacedJetIter4TracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/EXO/DisplacedJet/Tracking/iter4ForDisplaced',
+    TrackProducer    = 'hltDisplacedhltIter4PFlowTrackSelectionHighPurity',
+    allTrackProducer = 'hltDisplacedhltIter4PFlowTrackSelectionHighPurity',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
 trackingMonitorHLTDisplacedJet = cms.Sequence(
      DisplacedJetIter2TracksMonitoringHLT
     +DisplacedJetIter4TracksMonitoringHLT
 )
 
+hltHT_HT425_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_425/',
+    jetSelection_HT = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT425_v*"])
+)
 
-hltHT_HT425_Prommonitoring = hltHTmonitoring.clone()
-hltHT_HT425_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/HT/HT_425/')
-hltHT_HT425_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT425_v*")
-hltHT_HT425_Prommonitoring.jetSelection_HT = cms.string("pt > 40 && eta < 3.0")
+hltHT_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT400_DisplacedDijet40_DisplacedTrack',
+    jetSelection = "pt>40 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT400_DisplacedDijet40_DisplacedTrack_v*"])
+)
 
-hltHT_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone()
-hltHT_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT400_DisplacedDijet40_DisplacedTrack')
-hltHT_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT400_DisplacedDijet40_DisplacedTrack_v*")
-hltHT_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.jetSelection = cms.string("pt>40 && eta<2.0")
-hltHT_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.jetSelection_HT  = cms.string("pt > 40 && eta < 3.0")
+hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT430_DisplacedDijet40_DisplacedTrack',
+    jetSelection = "pt>40 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet40_DisplacedTrack_v*"])
+)
 
+hltHT_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT430_DisplacedDijet60_DisplacedTrack',
+    jetSelection = "pt>60 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet60_DisplacedTrack_v*"])
+)
 
-hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone()
-hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT430_DisplacedDijet40_DisplacedTrack')
-hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT430_DisplacedDijet40_DisplacedTrack_v*")
-hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.jetSelection = cms.string("pt>40 && eta<2.0")
-hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.jetSelection_HT  = cms.string("pt > 40 && eta < 3.0")
+hltHT_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT500_DisplacedDijet40_DisplacedTrack',
+    jetSelection = "pt>40 && eta<2.0",
+    jetSelection_HT = "pt > 40 && eta <3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT500_DisplacedDijet40_DisplacedTrack_v*"])
+)
 
+hltHT_HT550_DisplacedDijet60_Inclusive_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT550_DisplacedDijet60_Inclusive',
+    jetSelection = "pt>60 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT550_DisplacedDijet60_Inclusive_v*"])
+)
 
-hltHT_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone()
-hltHT_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT430_DisplacedDijet60_DisplacedTrack')
-hltHT_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT430_DisplacedDijet60_DisplacedTrack_v*")
-hltHT_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.jetSelection = cms.string("pt>60 && eta<2.0")
-hltHT_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.jetSelection_HT  = cms.string("pt > 40 && eta < 3.0")
+hltHT_HT650_DisplacedDijet60_Inclusive_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT650_DisplacedDijet60_Inclusive',
+    jetSelection = "pt>60 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT650_DisplacedDijet60_Inclusive_v*"])
+)
 
+hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT400_DisplacedDijet40_DisplacedTrack',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20.,26.,28.,30.,32.,34.,36.,38.,40.,42.,44.,46.,48.,50.,55.,60.,70.,80.,100.,120.,170.,220.,300.,400.]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT400_DisplacedDijet40_DisplacedTrack_v*"])
+)
 
-hltHT_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone()
-hltHT_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT500_DisplacedDijet40_DisplacedTrack')
-hltHT_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT500_DisplacedDijet40_DisplacedTrack_v*")
-hltHT_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.jetSelection = cms.string("pt>40 && eta<2.0")
-hltHT_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.jetSelection_HT = cms.string("pt > 40 && eta <3.0")
+hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT430_DisplacedDijet40_DisplacedTrack',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20.,26.,28.,30.,32.,34.,36.,38.,40.,42.,44.,46.,48.,50.,55.,60.,70.,80.,100.,120.,170.,220.,300.,400.]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet40_DisplacedTrack_v*"])
+)
 
+hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT430_DisplacedDijet60_DisplacedTrack',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20.,26.,30.,35.,40.,45.,50.,52.,53.,54.,56.,58.,60.,62.,64.,66.,68.,70.,72.,75.,80.,100.,120.,170.,220.,300.,400.]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet60_DisplacedTrack_v*"])
+)
 
-hltHT_HT550_DisplacedDijet60_Inclusive_Prommonitoring = hltHTmonitoring.clone()
-hltHT_HT550_DisplacedDijet60_Inclusive_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT550_DisplacedDijet60_Inclusive')
-hltHT_HT550_DisplacedDijet60_Inclusive_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT550_DisplacedDijet60_Inclusive_v*")
-hltHT_HT550_DisplacedDijet60_Inclusive_Prommonitoring.jetSelection = cms.string("pt>60 && eta<2.0")
-hltHT_HT550_DisplacedDijet60_Inclusive_Prommonitoring.jetSelection_HT  = cms.string("pt > 40 && eta < 3.0")
+hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT500_DisplacedDijet40_DisplacedTrack',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20.,26.,28.,30.,32.,34.,36.,38.,40.,42.,44.,46.,48.,50.,55.,60.,70.,80.,100.,120.,170.,220.,300.,400.]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT500_DisplacedDijet40_DisplacedTrack_v*"])
+)
 
+hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT550_DisplacedDijet60_Inclusive',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20.,26.,30.,35.,40.,45.,50.,52.,53.,54.,56.,58.,60.,62.,64.,66.,68.,70.,72.,75.,80.,100.,120.,170.,220.,300.,400.]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT550_DisplacedDijet60_Inclusive_v*"])
+)
 
-hltHT_HT650_DisplacedDijet60_Inclusive_Prommonitoring = hltHTmonitoring.clone()
-hltHT_HT650_DisplacedDijet60_Inclusive_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT650_DisplacedDijet60_Inclusive')
-hltHT_HT650_DisplacedDijet60_Inclusive_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT650_DisplacedDijet60_Inclusive_v*")
-hltHT_HT650_DisplacedDijet60_Inclusive_Prommonitoring.jetSelection = cms.string("pt>60 && eta<2.0")
-hltHT_HT650_DisplacedDijet60_Inclusive_Prommonitoring.jetSelection_HT  = cms.string("pt > 40 && eta < 3.0")
-
-
-hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone()
-hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.jetSrc = cms.InputTag("ak4CaloJets")
-hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT400_DisplacedDijet40_DisplacedTrack')
-hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.ptcut = cms.double(20)
-hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.histoPSet.jetptBinning = cms.vdouble(20.,26.,28.,30.,32.,34.,36.,38.,40.,42.,44.,46.,48.,50.,55.,60.,70.,80.,100.,120.,170.,220.,300.,400.)
-hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT400_DisplacedDijet40_DisplacedTrack_v*")
-hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.ispfjettrg = cms.bool(False)
-hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring.iscalojettrg = cms.bool(True)
-
-
-hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone()
-hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.jetSrc = cms.InputTag("ak4CaloJets")
-hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT430_DisplacedDijet40_DisplacedTrack')
-hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.ptcut = cms.double(20)
-hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.histoPSet.jetptBinning = cms.vdouble(20.,26.,28.,30.,32.,34.,36.,38.,40.,42.,44.,46.,48.,50.,55.,60.,70.,80.,100.,120.,170.,220.,300.,400.)
-hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT430_DisplacedDijet40_DisplacedTrack_v*")
-hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.ispfjettrg = cms.bool(False)
-hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring.iscalojettrg = cms.bool(True)
-
-
-hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone()
-hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.jetSrc = cms.InputTag("ak4CaloJets")
-hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT430_DisplacedDijet60_DisplacedTrack')
-hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.ptcut = cms.double(20)
-hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.histoPSet.jetptBinning = cms.vdouble(20.,26.,30.,35.,40.,45.,50.,52.,53.,54.,56.,58.,60.,62.,64.,66.,68.,70.,72.,75.,80.,100.,120.,170.,220.,300.,400.)
-hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT430_DisplacedDijet60_DisplacedTrack_v*")
-hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.ispfjettrg = cms.bool(False)
-hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring.iscalojettrg = cms.bool(True)
-
-
-hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone()
-hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.jetSrc = cms.InputTag("ak4CaloJets")
-hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT500_DisplacedDijet40_DisplacedTrack')
-hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.ptcut = cms.double(20)
-hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.histoPSet.jetptBinning = cms.vdouble(20.,26.,28.,30.,32.,34.,36.,38.,40.,42.,44.,46.,48.,50.,55.,60.,70.,80.,100.,120.,170.,220.,300.,400.)
-hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT500_DisplacedDijet40_DisplacedTrack_v*")
-hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.ispfjettrg = cms.bool(False)
-hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring.iscalojettrg = cms.bool(True)
-
-
-hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring = hltJetMETmonitoring.clone()
-hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring.jetSrc = cms.InputTag("ak4CaloJets")
-hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT550_DisplacedDijet60_Inclusive')
-hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring.ptcut = cms.double(20)
-hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring.histoPSet.jetptBinning = cms.vdouble(20.,26.,30.,35.,40.,45.,50.,52.,53.,54.,56.,58.,60.,62.,64.,66.,68.,70.,72.,75.,80.,100.,120.,170.,220.,300.,400.)
-hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT550_DisplacedDijet60_Inclusive_v*")
-hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring.ispfjettrg = cms.bool(False)
-hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring.iscalojettrg = cms.bool(True)
-
-
-hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring = hltJetMETmonitoring.clone()
-hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring.jetSrc = cms.InputTag("ak4CaloJets")
-hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring.FolderName = cms.string('HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT650_DisplacedDijet60_Inclusive')
-hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring.ptcut = cms.double(20)
-hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring.histoPSet.jetptBinning = cms.vdouble(20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400)
-hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_HT650_DisplacedDijet60_Inclusive_v*")
-hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring.ispfjettrg = cms.bool(False)
-hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring.iscalojettrg = cms.bool(True)
-
+hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT650_DisplacedDijet60_Inclusive',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT650_DisplacedDijet60_Inclusive_v*"])
+)
 
 exoHLTDisplacedJetmonitoring = cms.Sequence(
-
  hltHT_HT425_Prommonitoring
 +hltHT_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring
 +hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring

--- a/DQMOffline/Trigger/python/EgHLTOfflineSource_cff.py
+++ b/DQMOffline/Trigger/python/EgHLTOfflineSource_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 ### 
 from DQMOffline.Trigger.EgHLTOfflineSource_cfi import *
 
-egHLTOffDQMSource_HEP17 = egHLTOffDQMSource.clone()
-egHLTOffDQMSource_HEP17.subDQMDirName=cms.string('HEP17')
-egHLTOffDQMSource_HEP17.doHEP =cms.bool(True)
-
+egHLTOffDQMSource_HEP17 = egHLTOffDQMSource.clone(
+    subDQMDirName = 'HEP17',
+    doHEP = True
+)

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
@@ -237,12 +237,12 @@ exoticaClient = cms.Sequence(
 from DQMOffline.Trigger.TrackingMonitoring_Client_cff import *
 
 #DisplacedJet Track Monitoring
-trackingforDisplacedJetEffFromHitPatternHLT = trackingEffFromHitPatternHLT.clone()
-trackingforDisplacedJetEffFromHitPatternHLT.subDirs = cms.untracked.vstring(
+trackingforDisplacedJetEffFromHitPatternHLT = trackingEffFromHitPatternHLT.clone(
+    subDirs = [
     "HLT/EXO/DisplacedJet/Tracking/iter2MergedForBTag/HitEffFromHitPattern*",
     "HLT/EXO/DisplacedJet/Tracking/iter4ForDisplaced/HitEffFromHitPattern*",
+]
 )
-
 trackingForDisplacedJetMonitorClientHLT  = cms.Sequence(
     trackingforDisplacedJetEffFromHitPatternHLT
 )

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -69,8 +69,9 @@ def getZeroBias_SinglePixelTrackVPSet():
             )
     )
     ret.append(tracksCountZB)
-    tracksCountDenomZB = tracksCountZB.clone()
-    tracksCountDenomZB.triggerSelection = cms.string("HLT_ZeroBias_v*")
+    tracksCountDenomZB = tracksCountZB.clone(
+        triggerSelection = "HLT_ZeroBias_v*"
+    )
     tracksCountDenomZB.combinedObjectDrawables =  cms.VPSet(
         cms.PSet (name = cms.string("Eff_denominator"), expression = cms.string("0*at(0).pt()"),
                          bins = cms.int32(1), min = cms.double(-0.5), max = cms.double(0.5))
@@ -116,8 +117,9 @@ def getHighMultVPSet():
         )
         ret.append(tracksCount)				
 
-        tracksCountDenom = tracksCount.clone()
-        tracksCountDenom.triggerSelection = cms.string("TRUE")
+        tracksCountDenom = tracksCount.clone(
+            triggerSelection = "TRUE"
+        )
         tracksCountDenom.combinedObjectDrawables =  cms.VPSet(
             cms.PSet (name = cms.string("count_denominator"), expression = cms.string("at(0)"),
                              bins = cms.int32(tracksBins), min = cms.double(tracksL), max = cms.double(tracksH))
@@ -145,9 +147,10 @@ def getHighMultVPSet():
         )
         ret.append(hltPixelTracks)
 
-        hltPixelTracksEta16to18 = hltPixelTracks.clone()
-        hltPixelTracksEta16to18.singleObjectsPreselection='abs(eta) > 1.6 && abs(eta) < 1.8'
-        hltPixelTracksEta16to18.dqmhistolabel  = cms.string("hltPixelTracksEta16to18")
+        hltPixelTracksEta16to18 = hltPixelTracks.clone(
+            singleObjectsPreselection='abs(eta) > 1.6 && abs(eta) < 1.8',
+            dqmhistolabel  = "hltPixelTracksEta16to18"
+        )
         for i in hltPixelTracksEta16to18.singleObjectDrawables:
             if i.name == "eta":
                 hltPixelTracksEta16to18.singleObjectDrawables.remove(i)
@@ -351,10 +354,11 @@ def getPTAveVPSet(thresholds = [30, 60, 80, 100, 160, 220, 300], flavour="HFJEC"
                 )
             )
             ret.append(recoPFtopology)
-            recoPFtopologyDenom = recoPFtopology.clone()
-            #recoPFtopologyDenom.triggerSelection = cms.string("HLTriggerFirstPath*")
-            #recoPFtopologyDenom.triggerSelection = cms.string(partialPathName+"*")
-            recoPFtopologyDenom.triggerSelection = cms.string("TRUE")
+            recoPFtopologyDenom = recoPFtopology.clone(
+                #triggerSelection = "HLTriggerFirstPath*",
+                #triggerSelection = partialPathName+"*",
+                triggerSelection = "TRUE"
+            )
             recoPFtopologyDenom.combinedObjectDrawables =  cms.VPSet(
                 cms.PSet (name = cms.string("ptAve_denominator"), expression = cms.string("(at(0).pt+at(1).pt)/2"),
                              bins = cms.int32(ptBins), min = cms.double(ptBinLow), max = cms.double(ptBinHigh)  )
@@ -450,8 +454,9 @@ def getSinglePFJet(thresholds, flavour=None, etaMin=-1, srcType="genJets", parti
                     fromJets.combinedObjectDrawables.remove(p)
                     break
         else:
-            fromJetsDenom  = fromJets.clone()
-            fromJetsDenom.triggerSelection = cms.string("HLT_ZeroBias_v*")
+            fromJetsDenom  = fromJets.clone(
+                triggerSelection = "HLT_ZeroBias_v*"
+            )
             fromJetsDenom.singleObjectDrawables =  cms.VPSet()
             fromJetsDenom.combinedObjectDrawables =  cms.VPSet(
                 cms.PSet (name = cms.string("pt_denominator"), expression = cms.string("at(0).pt"),
@@ -546,8 +551,9 @@ def getDoublePFJet(thresholds, flavour=None, etaMin=-1, srcType="genJets" ):
                                                               min = cms.double(ptBinLow), 
                                                               max = cms.double(ptBinHigh)  ))
 
-            fromJetsDenom  = fromJets.clone()
-            fromJetsDenom.triggerSelection = cms.string("HLT_ZeroBias_v*")
+            fromJetsDenom  = fromJets.clone(
+                triggerSelection = "HLT_ZeroBias_v*"
+            )
             fromJetsDenom.singleObjectDrawables =  cms.VPSet()
             fromJetsDenom.combinedObjectDrawables =  cms.VPSet(
                 cms.PSet (name = cms.string("ptm_denominator"), expression = cms.string("min(at(0).pt, at(1).pt)"),

--- a/DQMOffline/Trigger/python/HILowLumiHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/HILowLumiHLTOfflineSource_cfi.py
@@ -23,33 +23,33 @@ def getHILowLumiTriggers():
     )
     ret.append(hltHICaloJet30)
 
-    hltHICaloJet40 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet40_v"),
-                                  triggerSelection = cms.string("HLT_AK4CaloJet40_v*"),
-                                  dqmhistolabel = cms.string("hltHICaloJet40")
+    hltHICaloJet40 = hltHICaloJet30.clone(partialPathName = "HLT_AK4CaloJet40_v",
+                                  triggerSelection = "HLT_AK4CaloJet40_v*",
+                                  dqmhistolabel = "hltHICaloJet40"
                                   )
     ret.append(hltHICaloJet40)
 
-    hltHICaloJet50 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet50_v"),
-                                  triggerSelection = cms.string("HLT_AK4CaloJet50_v*"),
-                                  dqmhistolabel = cms.string("hltHICaloJet50")
+    hltHICaloJet50 = hltHICaloJet30.clone(partialPathName = "HLT_AK4CaloJet50_v",
+                                  triggerSelection = "HLT_AK4CaloJet50_v*",
+                                  dqmhistolabel = "hltHICaloJet50"
     )
     ret.append(hltHICaloJet50)
 
-    hltHICaloJet80 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet80_v"),
-                                  triggerSelection = cms.string("HLT_AK4CaloJet80_v*"),
-                                  dqmhistolabel = cms.string("hltHICaloJet80")
+    hltHICaloJet80 = hltHICaloJet30.clone(partialPathName = "HLT_AK4CaloJet80_v",
+                                  triggerSelection = "HLT_AK4CaloJet80_v*",
+                                  dqmhistolabel = "hltHICaloJet80"
     )
     ret.append(hltHICaloJet80)
 
-    hltHICaloJet100 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet100_v"),
-                                  triggerSelection = cms.string("HLT_AK4CaloJet100_v*"),
-                                  dqmhistolabel = cms.string("hltHICaloJet100")
+    hltHICaloJet100 = hltHICaloJet30.clone(partialPathName = "HLT_AK4CaloJet100_v",
+                                  triggerSelection = "HLT_AK4CaloJet100_v*",
+                                  dqmhistolabel = "hltHICaloJet100"
     )
     ret.append(hltHICaloJet100)
 
-    hltHICaloJet30ForEndOfFill = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet30ForEndOfFill_v"),
-                                  triggerSelection = cms.string("HLT_AK4CaloJet30ForEndOfFill_v*"),
-                                  dqmhistolabel = cms.string("hltHICaloJet30ForEndOfFill")
+    hltHICaloJet30ForEndOfFill = hltHICaloJet30.clone(partialPathName = "HLT_AK4CaloJet30ForEndOfFill_v",
+                                  triggerSelection = "HLT_AK4CaloJet30ForEndOfFill_v*",
+                                  dqmhistolabel = "hltHICaloJet30ForEndOfFill"
     )
     ret.append(hltHICaloJet30ForEndOfFill)
 
@@ -59,73 +59,73 @@ def getHILowLumiTriggers():
     )
     ret.append(hltHICaloJet40ForEndOfFill)
 
-    hltHICaloJet50ForEndOfFill = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet50ForEndOfFill_v"),
-                                  triggerSelection = cms.string("HLT_AK4CaloJet50ForEndOfFill_v*"),
-                                  dqmhistolabel = cms.string("hltHICaloJet50ForEndOfFill")
+    hltHICaloJet50ForEndOfFill = hltHICaloJet30.clone(partialPathName = "HLT_AK4CaloJet50ForEndOfFill_v",
+                                  triggerSelection = "HLT_AK4CaloJet50ForEndOfFill_v*",
+                                  dqmhistolabel = "hltHICaloJet50ForEndOfFill"
     )
     ret.append(hltHICaloJet50ForEndOfFill)
 
 
-    hltHIPFJet30 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4PFJet30_v"),
-                                  triggerSelection = cms.string("HLT_AK4PFJet30_v*"),
-                                  dqmhistolabel = cms.string("hltHIPFJet30"),
-                                  partialFilterName  = cms.string("hltSingleAK4PFJet")
+    hltHIPFJet30 = hltHICaloJet30.clone(partialPathName = "HLT_AK4PFJet30_v",
+                                  triggerSelection = "HLT_AK4PFJet30_v*",
+                                  dqmhistolabel = "hltHIPFJet30",
+                                  partialFilterName  = "hltSingleAK4PFJet"
                                   )
     ret.append(hltHIPFJet30)
 
-    hltHIPFJet50 = hltHIPFJet30.clone(partialPathName = cms.string("HLT_AK4PFJet50_v"),
-                                  triggerSelection = cms.string("HLT_AK4PFJet50_v*"),
-                                  dqmhistolabel = cms.string("hltHIPFJet50")
+    hltHIPFJet50 = hltHIPFJet30.clone(partialPathName = "HLT_AK4PFJet50_v",
+                                  triggerSelection = "HLT_AK4PFJet50_v*",
+                                  dqmhistolabel = "hltHIPFJet50"
     )
     ret.append(hltHIPFJet50)
 
-    hltHIPFJet80 = hltHIPFJet30.clone(partialPathName = cms.string("HLT_AK4PFJet80_v"),
-                                  triggerSelection = cms.string("HLT_AK4PFJet80_v*"),
-                                  dqmhistolabel = cms.string("hltHIPFJet80")
+    hltHIPFJet80 = hltHIPFJet30.clone(partialPathName = "HLT_AK4PFJet80_v",
+                                  triggerSelection = "HLT_AK4PFJet80_v*",
+                                  dqmhistolabel = "hltHIPFJet80"
     )
     ret.append(hltHIPFJet80)
 
-    hltHIPFJet100 = hltHIPFJet30.clone(partialPathName = cms.string("HLT_AK4PFJet100_v"),
-                                  triggerSelection = cms.string("HLT_AK4PFJet100_v*"),
-                                  dqmhistolabel = cms.string("hltHIPFJet100")
+    hltHIPFJet100 = hltHIPFJet30.clone(partialPathName = "HLT_AK4PFJet100_v",
+                                  triggerSelection = "HLT_AK4PFJet100_v*",
+                                  dqmhistolabel = "hltHIPFJet100"
     )
     ret.append(hltHIPFJet100)
 
-    hltHIPFJet30ForEndOfFill = hltHIPFJet30.clone(partialPathName = cms.string("HLT_AK4PFJet30ForEndOfFill_v"),
-                                  triggerSelection = cms.string("HLT_AK4PFJet30ForEndOfFill_v*"),
-                                  dqmhistolabel = cms.string("hltHIPFJet30ForEndOfFill")
+    hltHIPFJet30ForEndOfFill = hltHIPFJet30.clone(partialPathName = "HLT_AK4PFJet30ForEndOfFill_v",
+                                  triggerSelection = "HLT_AK4PFJet30ForEndOfFill_v*",
+                                  dqmhistolabel = "hltHIPFJet30ForEndOfFill"
     )
     ret.append(hltHIPFJet30ForEndOfFill)
 
-    hltHIPFJet50ForEndOfFill = hltHIPFJet30.clone(partialPathName = cms.string("HLT_AK4PFJet50ForEndOfFill_v"),
-                                  triggerSelection = cms.string("HLT_AK4PFJet50ForEndOfFill_v*"),
-                                  dqmhistolabel = cms.string("hltHIPFJet50ForEndOfFill")
+    hltHIPFJet50ForEndOfFill = hltHIPFJet30.clone(partialPathName = "HLT_AK4PFJet50ForEndOfFill_v",
+                                  triggerSelection = "HLT_AK4PFJet50ForEndOfFill_v*",
+                                  dqmhistolabel = "hltHIPFJet50ForEndOfFill"
     )
     ret.append(hltHIPFJet50ForEndOfFill)
 
-    hltHISinglePhoton10 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_HISinglePhoton10_v"),
-                                               triggerSelection = cms.string("HLT_HISinglePhoton10_v*"),
-                                               dqmhistolabel = cms.string("hltHISinglePhoton10"),
-                                               partialFilterName  = cms.string("hltHIPhoton")
+    hltHISinglePhoton10 = hltHICaloJet30.clone(partialPathName = "HLT_HISinglePhoton10_v",
+                                               triggerSelection = "HLT_HISinglePhoton10_v*",
+                                               dqmhistolabel = "hltHISinglePhoton10",
+                                               partialFilterName  = "hltHIPhoton"
     )
     ret.append(hltHISinglePhoton10)
 
-    hltHISinglePhoton15 = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton15_v"),
-                                                    triggerSelection = cms.string("HLT_HISinglePhoton15_v*"),
-                                                    dqmhistolabel = cms.string("hltHISinglePhoton15")
+    hltHISinglePhoton15 = hltHISinglePhoton10.clone(partialPathName = "HLT_HISinglePhoton15_v",
+                                                    triggerSelection = "HLT_HISinglePhoton15_v*",
+                                                    dqmhistolabel = "hltHISinglePhoton15"
     )
     ret.append(hltHISinglePhoton15)
 
 
-    hltHISinglePhoton20 = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton20_v"),
-                                                    triggerSelection = cms.string("HLT_HISinglePhoton20_v*"),
-                                                    dqmhistolabel = cms.string("hltHISinglePhoton20")
+    hltHISinglePhoton20 = hltHISinglePhoton10.clone(partialPathName = "HLT_HISinglePhoton20_v",
+                                                    triggerSelection = "HLT_HISinglePhoton20_v*",
+                                                    dqmhistolabel = "hltHISinglePhoton20"
     )
     ret.append(hltHISinglePhoton20)
 
-    hltHISinglePhoton40 = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton40_v"),
-                                                    triggerSelection = cms.string("HLT_HISinglePhoton40_v*"),
-                                                    dqmhistolabel = cms.string("hltHISinglePhoton40")
+    hltHISinglePhoton40 = hltHISinglePhoton10.clone(partialPathName = "HLT_HISinglePhoton40_v",
+                                                    triggerSelection = "HLT_HISinglePhoton40_v*",
+                                                    dqmhistolabel = "hltHISinglePhoton40"
     )
     ret.append(hltHISinglePhoton40)
 
@@ -135,21 +135,21 @@ def getHILowLumiTriggers():
     )
     ret.append(hltHISinglePhoton60)
 
-    hltHISinglePhoton10ForEndOfFill = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton10ForEndOfFill_v"),
-                                                    triggerSelection = cms.string("HLT_HISinglePhoton10ForEndOfFill_v*"),
-                                                    dqmhistolabel = cms.string("hltHISinglePhoton10ForEndOfFill")
+    hltHISinglePhoton10ForEndOfFill = hltHISinglePhoton10.clone(partialPathName = "HLT_HISinglePhoton10ForEndOfFill_v",
+                                                    triggerSelection = "HLT_HISinglePhoton10ForEndOfFill_v*",
+                                                    dqmhistolabel = "hltHISinglePhoton10ForEndOfFill"
     )
     ret.append(hltHISinglePhoton10ForEndOfFill)
 
-    hltHISinglePhoton15ForEndOfFill = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton15ForEndOfFill_v"),
-                                                    triggerSelection = cms.string("HLT_HISinglePhoton15ForEndOfFill_v*"),
-                                                    dqmhistolabel = cms.string("hltHISinglePhoton15ForEndOfFill")
+    hltHISinglePhoton15ForEndOfFill = hltHISinglePhoton10.clone(partialPathName = "HLT_HISinglePhoton15ForEndOfFill_v",
+                                                    triggerSelection = "HLT_HISinglePhoton15ForEndOfFill_v*",
+                                                    dqmhistolabel = "hltHISinglePhoton15ForEndOfFill"
     )
     ret.append(hltHISinglePhoton15ForEndOfFill)
 
-    hltHISinglePhoton20ForEndOfFill = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton20ForEndOfFill_v"),
-                                                    triggerSelection = cms.string("HLT_HISinglePhoton20ForEndOfFill_v*"),
-                                                    dqmhistolabel = cms.string("hltHISinglePhoton20ForEndOfFill")
+    hltHISinglePhoton20ForEndOfFill = hltHISinglePhoton10.clone(partialPathName = "HLT_HISinglePhoton20ForEndOfFill_v",
+                                                    triggerSelection = "HLT_HISinglePhoton20ForEndOfFill_v*",
+                                                    dqmhistolabel = "hltHISinglePhoton20ForEndOfFill"
     )
     ret.append(hltHISinglePhoton20ForEndOfFill)
 
@@ -930,10 +930,10 @@ def getHILowPU2017Triggers():
     )
     ret.append(hltHICaloJet120)
 
-    hltHIPFJet120 = hltHICaloJet120.clone(partialPathName = cms.string("HLT_AK4PFJet120_v"),
-                                          triggerSelection = cms.string("HLT_AK4PFJet120_v*"),
-                                          dqmhistolabel = cms.string("hltHIPFJet120"),
-                                          partialFilterName = cms.string("hltSingleAK4PFJet"),
+    hltHIPFJet120 = hltHICaloJet120.clone(partialPathName = "HLT_AK4PFJet120_v",
+                                          triggerSelection = "HLT_AK4PFJet120_v*",
+                                          dqmhistolabel = "hltHIPFJet120",
+                                          partialFilterName = "hltSingleAK4PFJet",
                                           )
     ret.append(hltHIPFJet120)
 
@@ -945,10 +945,10 @@ def getHILowPU2017Triggers():
         inStringAsterisk = 'HLT_HISinglePhoton' + thresh + '_Eta3p1ForPPRef_v*'
         inStringHistoLabel = 'hltHIPhoton' + thresh
 
-        temp = hltHICaloJet120.clone(partialPathName = cms.string(inString),
-                                     triggerSelection = cms.string(inStringAsterisk),
-                                     dqmhistolabel = cms.string(inStringHistoLabel),
-                                     partialFilterName  = cms.string("hltHIPhoton"),
+        temp = hltHICaloJet120.clone(partialPathName = inString,
+                                     triggerSelection = inStringAsterisk,
+                                     dqmhistolabel = inStringHistoLabel,
+                                     partialFilterName  = "hltHIPhoton",
                                      singleObjectDrawables =  cms.VPSet(cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(58), min = cms.double(10), max = cms.double(300)),
                                                                         cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-3), max = cms.double(3)),
                                                                         cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
@@ -962,10 +962,10 @@ def getHILowPU2017Triggers():
         inStringHistoLabel = 'hltPhoton' + thresh
         filterName = "hltEG" + thresh + "EtFilterLoose"
 
-        temp = hltHICaloJet120.clone(partialPathName = cms.string(inString),
-                                     triggerSelection = cms.string(inStringAsterisk),
-                                     dqmhistolabel = cms.string(inStringHistoLabel),
-                                     partialFilterName  = cms.string(filterName),
+        temp = hltHICaloJet120.clone(partialPathName = inString,
+                                     triggerSelection = inStringAsterisk,
+                                     dqmhistolabel = inStringHistoLabel,
+                                     partialFilterName  = filterName,
                                      singleObjectDrawables =  cms.VPSet(cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(58), min = cms.double(10), max = cms.double(300)),
                                                                         cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-3), max = cms.double(3)),
                                                                         cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
@@ -1001,27 +1001,27 @@ def getPPRefHighPtVPSet():
     ret.append(hltHICaloJet60)
 
     # PF Jets: 40, 60
-    hltHIPFJet40 = hltHICaloJet60.clone(partialPathName = cms.string("HLT_AK4PFJet40_v"),
-        triggerSelection = cms.string("HLT_AK4PFJet40_v*"),
-        dqmhistolabel = cms.string("hltHIPFJet40"),
-        partialFilterName  = cms.string("hltSingleAK4PFJet")
+    hltHIPFJet40 = hltHICaloJet60.clone(partialPathName = "HLT_AK4PFJet40_v",
+        triggerSelection = "HLT_AK4PFJet40_v*",
+        dqmhistolabel = "hltHIPFJet40",
+        partialFilterName  = "hltSingleAK4PFJet"
     )
     ret.append(hltHIPFJet40)
 
-    hltHIPFJet60 = hltHICaloJet60.clone(partialPathName = cms.string("HLT_AK4PFJet60_v"),
-        triggerSelection = cms.string("HLT_AK4PFJet60_v*"),
-        dqmhistolabel = cms.string("hltHIPFJet60"),
-        partialFilterName  = cms.string("hltSingleAK4PFJet")
+    hltHIPFJet60 = hltHICaloJet60.clone(partialPathName = "HLT_AK4PFJet60_v",
+        triggerSelection = "HLT_AK4PFJet60_v*",
+        dqmhistolabel = "hltHIPFJet60",
+        partialFilterName  = "hltSingleAK4PFJet"
     )
     ret.append(hltHIPFJet60)
 
     # BJets: 30, 40, 60, 80
     BJetThresholds = ['30', '40', '60', '80']
     for thresh in BJetThresholds:
-        hltHIBJet = hltHICaloJet60.clone(partialPathName = cms.string("HLT_AK4PFJet" + thresh + "_bTag_v"),
-            triggerSelection = cms.string("HLT_AK4PFJet" + thresh + "_bTag_v*"),
-            dqmhistolabel = cms.string("hltHIPFBJet" + thresh + ""),
-            partialFilterName  = cms.string("hltSingleAK4PFJet" + thresh)
+        hltHIBJet = hltHICaloJet60.clone(partialPathName = "HLT_AK4PFJet" + thresh + "_bTag_v",
+            triggerSelection = "HLT_AK4PFJet" + thresh + "_bTag_v*",
+            dqmhistolabel = "hltHIPFBJet" + thresh + "",
+            partialFilterName  = "hltSingleAK4PFJet" + thresh
             )
         ret.append(hltHIBJet)
 
@@ -1038,10 +1038,10 @@ def getPPRefHighPtVPSet():
     # PF Jet FWD: 30, 40, 60, 80
     PFFWDThresholds = ['30', '40', '60', '80']
     for thresh in PFFWDThresholds:
-        hltHIPFJetFWD = hltHIPFJet60.clone(partialPathName = cms.string("HLT_AK4PFJet" + thresh + "FWD_v"),
-            triggerSelection = cms.string("HLT_AK4PFJet" + thresh + "FWD_v*"),
-            dqmhistolabel = cms.string("hltHIPFJet" + thresh + "FWD"),
-            partialFilterName  = cms.string("hltSingleAK4PFJet" + thresh + "FWD")
+        hltHIPFJetFWD = hltHIPFJet60.clone(partialPathName = "HLT_AK4PFJet" + thresh + "FWD_v",
+            triggerSelection = "HLT_AK4PFJet" + thresh + "FWD_v*",
+            dqmhistolabel = "hltHIPFJet" + thresh + "FWD",
+            partialFilterName  = "hltSingleAK4PFJet" + thresh + "FWD"
             )
         ret.append(hltHIPFJetFWD)
 
@@ -1052,10 +1052,10 @@ def getPPRefHighPtVPSet():
         inStringAsterisk = inString + '*'
         inStringHistoLabel = 'hltHIPhoton' + thresh + '1p5'
 
-        temp = hltHICaloJet60.clone(partialPathName = cms.string(inString),
-            triggerSelection = cms.string(inStringAsterisk),
-            dqmhistolabel = cms.string(inStringHistoLabel),
-            partialFilterName  = cms.string("hltHIPhoton" + thresh + "Eta1p5"),
+        temp = hltHICaloJet60.clone(partialPathName = inString,
+            triggerSelection = inStringAsterisk,
+            dqmhistolabel = inStringHistoLabel,
+            partialFilterName  = "hltHIPhoton" + thresh + "Eta1p5",
             singleObjectDrawables =  cms.VPSet(cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(58), min = cms.double(10), max = cms.double(300)),
                 cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-3), max = cms.double(3)),
                 cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
@@ -1071,10 +1071,10 @@ def getPPRefHighPtVPSet():
         inStringAsterisk = inString + '*'
         inStringHistoLabel = 'hltHIEle' + thresh
 
-        temp = hltHICaloJet60.clone(partialPathName = cms.string(inString),
-            triggerSelection = cms.string(inStringAsterisk),
-            dqmhistolabel = cms.string(inStringHistoLabel),
-            partialFilterName  = cms.string("hltEle" + thresh + 'WPLoose1GsfTrackIsoFilter'),
+        temp = hltHICaloJet60.clone(partialPathName = inString,
+            triggerSelection = inStringAsterisk,
+            dqmhistolabel = inStringHistoLabel,
+            partialFilterName  = "hltEle" + thresh + 'WPLoose1GsfTrackIsoFilter',
             singleObjectDrawables =  cms.VPSet(cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(58), min = cms.double(10), max = cms.double(300)),
                 cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-3), max = cms.double(3)),
                 cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
@@ -1083,18 +1083,18 @@ def getPPRefHighPtVPSet():
         ret.append(temp)
 
     # EG+Jet
-    hltHIEGJet = hltHIPFJet60.clone(partialPathName = cms.string("HLT_Ele20_eta2p1_WPTight_Gsf_CentralPFJet15_EleCleaned_v"),
-        triggerSelection = cms.string("HLT_Ele20_eta2p1_WPTight_Gsf_CentralPFJet15_EleCleaned_v*"),
-        dqmhistolabel = cms.string("hltHIEle20WPLooseAK4PFJet15"),
-        partialFilterName  = cms.string("hltEle20PFJet15EleCleaned")
+    hltHIEGJet = hltHIPFJet60.clone(partialPathName = "HLT_Ele20_eta2p1_WPTight_Gsf_CentralPFJet15_EleCleaned_v",
+        triggerSelection = "HLT_Ele20_eta2p1_WPTight_Gsf_CentralPFJet15_EleCleaned_v*",
+        dqmhistolabel = "hltHIEle20WPLooseAK4PFJet15",
+        partialFilterName  = "hltEle20PFJet15EleCleaned"
         )
     ret.append(hltHIEGJet)
 
     # Ele+Ele
-    hltHIEGEG = hltHIPFJet60.clone(partialPathName = cms.string("HLT_Ele20_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v"),
-        triggerSelection = cms.string("HLT_Ele20_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*"),
-        dqmhistolabel = cms.string("hltHIEle20Ele12CaloIdLTrackIdLIsoVLDZ"),
-        partialFilterName  = cms.string("hltEle20Ele12CaloIdLTrackIdLIsoVLDZFilter")
+    hltHIEGEG = hltHIPFJet60.clone(partialPathName = "HLT_Ele20_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v",
+        triggerSelection = "HLT_Ele20_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
+        dqmhistolabel = "hltHIEle20Ele12CaloIdLTrackIdLIsoVLDZ",
+        partialFilterName  = "hltEle20Ele12CaloIdLTrackIdLIsoVLDZFilter"
         )
     ret.append(hltHIEGEG)
 

--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cosmics_cff.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cosmics_cff.py
@@ -24,21 +24,23 @@ allMuonParams = cms.PSet(
     hltCuts  = cms.untracked.string("abs(eta) < 2.0"),
 )
 
-barrelAnalyzer = hltMuonOfflineAnalyzer.clone()
-barrelAnalyzer.destination = "HLT/Muon/DistributionsBarrel"
-barrelAnalyzer.targetParams = barrelMuonParams
+barrelAnalyzer = hltMuonOfflineAnalyzer.clone(
+    destination = "HLT/Muon/DistributionsBarrel",
+    targetParams = barrelMuonParams
+)
 barrelAnalyzer.probeParams = cms.PSet()
 
-endcapAnalyzer = hltMuonOfflineAnalyzer.clone()
-endcapAnalyzer.destination = "HLT/Muon/DistributionsEndcap"
-endcapAnalyzer.targetParams = endcapMuonParams
+endcapAnalyzer = hltMuonOfflineAnalyzer.clone(
+    destination = "HLT/Muon/DistributionsEndcap",
+    targetParams = endcapMuonParams
+)
 endcapAnalyzer.probeParams = cms.PSet()
 
-allAnalyzer = hltMuonOfflineAnalyzer.clone()
-allAnalyzer.destination = "HLT/Muon/DistributionsAll"
-allAnalyzer.targetParams = allMuonParams
-allAnalyzer.probeParams = allMuonParams
-
+allAnalyzer = hltMuonOfflineAnalyzer.clone(
+    destination = "HLT/Muon/DistributionsAll",
+    targetParams = allMuonParams,
+    probeParams = allMuonParams
+)
 hltMuonOfflineAnalyzers = cms.Sequence(
     barrelAnalyzer *
     endcapAnalyzer *

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -141,7 +141,7 @@ def TriggerSelectionParameters(hltpaths):
 
 
 hltTauOfflineMonitor_TagAndProbe = hltTauOfflineMonitor_PFTaus.clone(
-    DQMBaseFolder = cms.untracked.string("HLT/TAU/TagAndProbe"),
+    DQMBaseFolder = "HLT/TAU/TagAndProbe",
     Matching = cms.PSet(                                                                                                                                                                             
         doMatching            = cms.untracked.bool(True),                                                                                                                                            
         matchFilters          = cms.untracked.VPSet(                                                                                                                                                 

--- a/DQMOffline/Trigger/python/HMesonGammaMonitor_cff.py
+++ b/DQMOffline/Trigger/python/HMesonGammaMonitor_cff.py
@@ -3,20 +3,22 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.ObjMonitor_cfi import hltobjmonitoring
 
 # HLT_
-HMesonGammamonitoring = hltobjmonitoring.clone()
-HMesonGammamonitoring.FolderName = cms.string('HLT/HIG/HMesonGamma/')
-HMesonGammamonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults","","HLT" )
-HMesonGammamonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon35_TwoProngs35_v*")
-HMesonGammamonitoring.phoSelection = cms.string("pt > 35 && abs(eta)<2.1 && hadTowOverEm<0.1 && full5x5_r9>0.9 && chargedHadronIso<1.295 && neutralHadronIso < 5.931+0.0163*pt+0.000014*pt*pt && photonIso < 6.641+0.0034*pt")
-HMesonGammamonitoring.trkSelection = cms.string("pt > 5 && quality('highPurity')")
-HMesonGammamonitoring.nphotons = cms.int32(1)
-HMesonGammamonitoring.nmesons = cms.int32(1)
-HMesonGammamonitoring.doMETHistos = cms.bool(False)
-HMesonGammamonitoring.doJetHistos = cms.bool(False)
-HMesonGammamonitoring.doHTHistos = cms.bool(False)
-HMesonGammamonitoring.doHMesonGammaHistos = cms.bool(True) 
-#HMesonGammamonitoring.enableMETPlot = True
-#HMesonGammamonitoring.metSelection = cms.string("pt>150")
+HMesonGammamonitoring = hltobjmonitoring.clone(
+    FolderName = 'HLT/HIG/HMesonGamma/',
+    phoSelection = "pt > 35 && abs(eta)<2.1 && hadTowOverEm<0.1 && full5x5_r9>0.9 && chargedHadronIso<1.295 && neutralHadronIso < 5.931+0.0163*pt+0.000014*pt*pt && photonIso < 6.641+0.0034*pt",
+    trkSelection = "pt > 5 && quality('highPurity')",
+    nphotons = 1,
+    nmesons = 1,
+    doMETHistos = False,
+    doJetHistos = False,
+    doHTHistos = False,
+    doHMesonGammaHistos = True,
+    #enableMETPlot = True,
+    #metSelection = "pt>150",
+    numGenericTriggerEventPSet = dict(hltInputTag   = ["TriggerResults","","HLT" ],
+                                      hltPaths = ["HLT_Photon35_TwoProngs35_v*"])
+)
+
 
 hmesongammamonitoring = cms.Sequence(
     HMesonGammamonitoring

--- a/DQMOffline/Trigger/python/HTMonitor_cff.py
+++ b/DQMOffline/Trigger/python/HTMonitor_cff.py
@@ -4,219 +4,222 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.HTMonitor_cfi import hltHTmonitoring
 
 # HLT_PFMETNoMu90_PFMHTNoMu90_IDTight
-PFMETNoMu90_PFMHTNoMu90_HTmonitoring = hltHTmonitoring.clone()
-PFMETNoMu90_PFMHTNoMu90_HTmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETNoMu90/')
-PFMETNoMu90_PFMHTNoMu90_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v*")
-
+PFMETNoMu90_PFMHTNoMu90_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETNoMu90/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v*"])
+)
 # HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
-PFMETNoMu120_PFMHTNoMu120_HTmonitoring = hltHTmonitoring.clone()
-PFMETNoMu120_PFMHTNoMu120_HTmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETNoMu120/')
-PFMETNoMu120_PFMHTNoMu120_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+PFMETNoMu120_PFMHTNoMu120_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETNoMu120/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"])
+)
 
 # HLT_MET200
-MET200_HTmonitoring = hltHTmonitoring.clone()
-MET200_HTmonitoring.FolderName = cms.string('HLT/JME/MET/MET200/')
-MET200_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MET200_v*")
+MET200_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/MET/MET200/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MET200_v*"])
+)
 
 # HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight
-MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_HTmonitoring = hltHTmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu110/')
-MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight_v*")
-MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_HTmonitoring.jetSelection      = cms.string("pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu110/',
+    jetSelection      = "pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight_v*"])
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight
-MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_HTmonitoring = hltHTmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu120/')
-MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_HTmonitoring.jetSelection      = cms.string("pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu120/',
+    jetSelection      = "pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"])
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_IDTight
-MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_HTmonitoring = hltHTmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu130/')
-MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_IDTight_v*")
-MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_HTmonitoring.jetSelection      = cms.string("pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu130/',
+    jetSelection      = "pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_IDTight_v*"])
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_IDTight
-MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_HTmonitoring = hltHTmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu140/')
-MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_IDTight_v*")
-MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_HTmonitoring.jetSelection      = cms.string("pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu140/',
+    jetSelection      = "pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_IDTight_v*"])
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_IDTight
-MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_HTmonitoring = hltHTmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu90/')
-MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight_v*")
-MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu90/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight_v*"])
+)
 # HLT_PFHT350MinPFJet15
-PFHT350MinPFJet15_HTmonitoring = hltHTmonitoring.clone()
-PFHT350MinPFJet15_HTmonitoring.FolderName = cms.string('HLT/HT/HLT_PFHT350MinPFJet15/')
-PFHT350MinPFJet15_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT350MinPFJet15_v*")
-PFHT350MinPFJet15_HTmonitoring.jetSelection      = cms.string("pt > 15")
-PFHT350MinPFJet15_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT350MinPFJet15_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/HT/HLT_PFHT350MinPFJet15/',
+    jetSelection      = "pt > 15",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT350MinPFJet15_v*"])
+)
 # HLT_PFHT500_PFMET100_PFMHT100_IDTight                                                                                                                                                          
-PFHT500_PFMET100_PFMHT100_HTmonitoring = hltHTmonitoring.clone()
-PFHT500_PFMET100_PFMHT100_HTmonitoring.FolderName = cms.string('HLT/HT/PFHT500_PFMET100_PFMHT100/')
-PFHT500_PFMET100_PFMHT100_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT500_PFMET100_PFMHT100_IDTight_v*")
-PFHT500_PFMET100_PFMHT100_HTmonitoring.metSelection      = cms.string("pt > 200")
-PFHT500_PFMET100_PFMHT100_HTmonitoring.jetSelection      = cms.string("pt > 0")
-PFHT500_PFMET100_PFMHT100_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT500_PFMET100_PFMHT100_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/HT/PFHT500_PFMET100_PFMHT100/',
+    metSelection      = "pt > 200",
+    jetSelection      = "pt > 0",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT500_PFMET100_PFMHT100_IDTight_v*"])
+)
 # HLT_PFHT500_PFMET110_PFMHT110_IDTight                                                                                                                                                         
-PFHT500_PFMET110_PFMHT110_HTmonitoring = hltHTmonitoring.clone()
-PFHT500_PFMET110_PFMHT110_HTmonitoring.FolderName = cms.string('HLT/HT/PFHT500_PFMET110_PFMHT110/')
-PFHT500_PFMET110_PFMHT110_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT500_PFMET110_PFMHT110_IDTight_v*")
-PFHT500_PFMET110_PFMHT110_HTmonitoring.metSelection      = cms.string("pt > 210")
-PFHT500_PFMET110_PFMHT110_HTmonitoring.jetSelection      = cms.string("pt > 0")
-PFHT500_PFMET110_PFMHT110_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT500_PFMET110_PFMHT110_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/HT/PFHT500_PFMET110_PFMHT110/',
+    metSelection      = "pt > 210",
+    jetSelection      = "pt > 0",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT500_PFMET110_PFMHT110_IDTight_v*"])
+)
 # HLT_PFHT700_PFMET85_PFMHT85_IDTight                                                                                                                                                            
-PFHT700_PFMET85_PFMHT85_HTmonitoring = hltHTmonitoring.clone()
-PFHT700_PFMET85_PFMHT85_HTmonitoring.FolderName = cms.string('HLT/HT/PFHT700_PFMET85_PFMHT85/')
-PFHT700_PFMET85_PFMHT85_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT700_PFMET85_PFMHT85_IDTight_v*")
-PFHT700_PFMET85_PFMHT85_HTmonitoring.metSelection      = cms.string("pt > 185")
-PFHT700_PFMET85_PFMHT85_HTmonitoring.jetSelection      = cms.string("pt > 0")
-PFHT700_PFMET85_PFMHT85_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT700_PFMET85_PFMHT85_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/HT/PFHT700_PFMET85_PFMHT85/',
+    metSelection      = "pt > 185",
+    jetSelection      = "pt > 0",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT700_PFMET85_PFMHT85_IDTight_v*"])
+)
 # HLT_PFHT700_PFMET95_PFMHT95_IDTight                                                                                                                                                            
-PFHT700_PFMET95_PFMHT95_HTmonitoring = hltHTmonitoring.clone()
-PFHT700_PFMET95_PFMHT95_HTmonitoring.FolderName = cms.string('HLT/HT/PFHT700_PFMET95_PFMHT95/')
-PFHT700_PFMET95_PFMHT95_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT700_PFMET95_PFMHT95_IDTight_v*")
-PFHT700_PFMET95_PFMHT95_HTmonitoring.metSelection      = cms.string("pt > 195")
-PFHT700_PFMET95_PFMHT95_HTmonitoring.jetSelection      = cms.string("pt > 0")
-PFHT700_PFMET95_PFMHT95_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT700_PFMET95_PFMHT95_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/HT/PFHT700_PFMET95_PFMHT95/',
+    metSelection      = "pt > 195",
+    jetSelection      = "pt > 0",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT700_PFMET95_PFMHT95_IDTight_v*"])
+)
 # HLT_PFHT800_PFMET75_PFMHT75_IDTight                                                                                                                                                            
-PFHT800_PFMET75_PFMHT75_HTmonitoring = hltHTmonitoring.clone()
-PFHT800_PFMET75_PFMHT75_HTmonitoring.FolderName = cms.string('HLT/HT/PFHT800_PFMET75_PFMHT75/')
-PFHT800_PFMET75_PFMHT75_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT800_PFMET75_PFMHT75_IDTight_v*")
-PFHT800_PFMET75_PFMHT75_HTmonitoring.metSelection      = cms.string("pt > 175")
-PFHT800_PFMET75_PFMHT75_HTmonitoring.jetSelection      = cms.string("pt > 0")
-PFHT800_PFMET75_PFMHT75_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT800_PFMET75_PFMHT75_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/HT/PFHT800_PFMET75_PFMHT75/',
+    metSelection      = "pt > 175",
+    jetSelection      = "pt > 0",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT800_PFMET75_PFMHT75_IDTight_v*"])
+)
 # HLT_PFHT800_PFMET85_PFMHT85_IDTight                                                                                                                                                          
-PFHT800_PFMET85_PFMHT85_HTmonitoring = hltHTmonitoring.clone()
-PFHT800_PFMET85_PFMHT85_HTmonitoring.FolderName = cms.string('HLT/HT/PFHT800_PFMET85_PFMHT85/')
-PFHT800_PFMET85_PFMHT85_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT800_PFMET85_PFMHT85_IDTight_v*")
-PFHT800_PFMET85_PFMHT85_HTmonitoring.metSelection      = cms.string("pt > 185")
-PFHT800_PFMET85_PFMHT85_HTmonitoring.jetSelection      = cms.string("pt > 0")
-PFHT800_PFMET85_PFMHT85_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT800_PFMET85_PFMHT85_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/HT/PFHT800_PFMET85_PFMHT85/',
+    metSelection      = "pt > 185",
+    jetSelection      = "pt > 0",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT800_PFMET85_PFMHT85_IDTight_v*"])
+)
 # HLT_PFHT1050_v7
-PFHT1050_HTmonitoring = hltHTmonitoring.clone()
-PFHT1050_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT1050/')
-PFHT1050_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT1050_v*")
-PFHT1050_HTmonitoring.jetSelection      = cms.string("pt > 0")
-PFHT1050_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT1050_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT1050/',
+    jetSelection      = "pt > 0",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT1050_v*"])
+)
 #HLT_PFHT890
-PFHT890_HTmonitoring = hltHTmonitoring.clone()
-PFHT890_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT890/')
-PFHT890_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT890_v*")
-PFHT890_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT890_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT890/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT890_v*"])
+)
 #HLT_PFHT780
-PFHT780_HTmonitoring = hltHTmonitoring.clone()
-PFHT780_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT780/')
-PFHT780_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT780_v*")
-PFHT780_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT780_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT780/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT780_v*"])
+)
 #HLT_PFHT680
-PFHT680_HTmonitoring = hltHTmonitoring.clone()
-PFHT680_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT680/')
-PFHT680_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT680_v*")
-PFHT680_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
+PFHT680_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT680/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT680_v*"])
 
+)
 #HLT_PFHT590
-PFHT590_HTmonitoring = hltHTmonitoring.clone()
-PFHT590_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT590/')
-PFHT590_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT590_v*")
-PFHT590_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT590_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT590/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT590_v*"])
+)
 #HLT_PFHT510
-PFHT510_HTmonitoring = hltHTmonitoring.clone()
-PFHT510_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT510/')
-PFHT510_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT510_v*")
-PFHT510_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT510_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT510/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT510_v*"])
+)
 #HLT_PFHT430
-PFHT430_HTmonitoring = hltHTmonitoring.clone()
-PFHT430_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT430/')
-PFHT430_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT430_v*")
-PFHT430_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT430_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT430/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT430_v*"])
+)
 #HLT_PFHT370
-PFHT370_HTmonitoring = hltHTmonitoring.clone()
-PFHT370_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT370/')
-PFHT370_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT370_v*")
-PFHT370_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT370_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT370/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT370_v*"])
+)
 #HLT_PFHT250
-PFHT250_HTmonitoring = hltHTmonitoring.clone()
-PFHT250_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT250/')
-PFHT250_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT250_v*")
-PFHT250_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT250_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT250/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT250_v*"])
+)
 #HLT_PFHT180
-PFHT180_HTmonitoring = hltHTmonitoring.clone()
-PFHT180_HTmonitoring.FolderName = cms.string('HLT/JME/HT/PFHT180/')
-PFHT180_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT180_v*")
-PFHT180_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFHT180_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/JME/HT/PFHT180/',
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT180_v*"])
+)
 # HLT_PFMETTypeOne110_PFMHT110_IDTight                                                                                                                              
-PFMETTypeOne110_PFMHT110_HTmonitoring = hltHTmonitoring.clone()
-PFMETTypeOne110_PFMHT110_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMETTypeOne110/')
-PFMETTypeOne110_PFMHT110_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETTypeOne110_PFMHT110_IDTight_v*")
-PFMETTypeOne110_PFMHT110_HTmonitoring.jetSelection      = cms.string("pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-PFMETTypeOne110_PFMHT110_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFMETTypeOne110_PFMHT110_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETTypeOne110/',
+    jetSelection      = "pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne110_PFMHT110_IDTight_v*"])
+)
 # HLT_PFMETTypeOne120_PFMHT120_IDTight
-PFMETTypeOne120_PFMHT120_HTmonitoring = hltHTmonitoring.clone()
-PFMETTypeOne120_PFMHT120_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMETTypeOne120/')
-PFMETTypeOne120_PFMHT120_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PPFMETTypeOne120_PFMHT120_IDTight_v*")
-PFMETTypeOne120_PFMHT120_HTmonitoring.jetSelection      = cms.string("pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-PFMETTypeOne120_PFMHT120_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFMETTypeOne120_PFMHT120_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETTypeOne120/',
+    jetSelection      = "pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PPFMETTypeOne120_PFMHT120_IDTight_v*"])
+)
 # HLT_PFMETTypeOne130_PFMHT130_IDTight
-PFMETTypeOne130_PFMHT130_HTmonitoring = hltHTmonitoring.clone()
-PFMETTypeOne130_PFMHT130_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMETTypeOne130/')
-PFMETTypeOne130_PFMHT130_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETTypeOne130_PFMHT130_IDTight_v*")
-PFMETTypeOne130_PFMHT130_HTmonitoring.jetSelection      = cms.string("pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-PFMETTypeOne130_PFMHT130_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFMETTypeOne130_PFMHT130_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETTypeOne130/',
+    jetSelection      = "pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne130_PFMHT130_IDTight_v*"])
+)
 # HLT_PFMETTypeOne140_PFMHT140_IDTight
-PFMETTypeOne140_PFMHT140_HTmonitoring = hltHTmonitoring.clone()
-PFMETTypeOne140_PFMHT140_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMETTypeOne140/')
-PFMETTypeOne140_PFMHT140_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETTypeOne140_PFMHT140_IDTight_v*")
-PFMETTypeOne140_PFMHT140_HTmonitoring.jetSelection      = cms.string("pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-PFMETTypeOne140_PFMHT140_HTmonitoring.jetSelection_HT   = cms.string("pt > 30 && eta < 2.5")
-
+PFMETTypeOne140_PFMHT140_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETTypeOne140/',
+    jetSelection      = "pt > 100 && eta < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    jetSelection_HT   = "pt > 30 && eta < 2.5",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne140_PFMHT140_IDTight_v*"])
+)
 # HLT_PFMET120_PFMHT120_IDTight_PFHT60
-PFMET120_PFMHT120_IDTight_PFHT60_HTmonitoring = hltHTmonitoring.clone()
-PFMET120_PFMHT120_IDTight_PFHT60_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMET120_PFHT60/')
-PFMET120_PFMHT120_IDTight_PFHT60_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_PFHT60_v*")
-PFMET120_PFMHT120_IDTight_PFHT60_HTmonitoring.metSelection      = cms.string("pt > 220")
-PFMET120_PFMHT120_IDTight_PFHT60_HTmonitoring.jetSelection      = cms.string("pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMET120_PFMHT120_IDTight_PFHT60_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMET120_PFHT60/',
+    metSelection      = "pt > 220",
+    jetSelection      = "pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_PFHT60_v*"])
+)
 # HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60
-PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_HTmonitoring = hltHTmonitoring.clone()
-PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMETNoMu120_PFHT60/')
-PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_v*")
-PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_HTmonitoring.metSelection      = cms.string("pt > 220")
-PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_HTmonitoring.jetSelection      = cms.string("pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETNoMu120_PFHT60/',
+    metSelection      = "pt > 220",
+    jetSelection      = "pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_v*"])
+)
 # HLT_PFMETTypeOne120_PFMHT120_IDTight_PFHT60
-PFMETTypeOne120_PFMHT120_IDTight_PFHT60_HTmonitoring = hltHTmonitoring.clone()
-PFMETTypeOne120_PFMHT120_IDTight_PFHT60_HTmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMETTypeOne120_PFHT60/')
-PFMETTypeOne120_PFMHT120_IDTight_PFHT60_HTmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETTypeOne120_PFMHT120_IDTight_PFHT60_v*")
-PFMETTypeOne120_PFMHT120_IDTight_PFHT60_HTmonitoring.metSelection      = cms.string("pt > 220")
-PFMETTypeOne120_PFMHT120_IDTight_PFHT60_HTmonitoring.jetSelection      = cms.string("pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETTypeOne120_PFMHT120_IDTight_PFHT60_HTmonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETTypeOne120_PFHT60/',
+    metSelection      = "pt > 220",
+    jetSelection      = "pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne120_PFMHT120_IDTight_PFHT60_v*"])
+)
 exoHLTHTmonitoring = cms.Sequence(
     PFMETNoMu90_PFMHTNoMu90_HTmonitoring
     + PFMETNoMu120_PFMHTNoMu120_HTmonitoring

--- a/DQMOffline/Trigger/python/HTMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/HTMonitor_cfi.py
@@ -2,37 +2,42 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.htMonitoring_cfi import htMonitoring
 
-hltHTmonitoring = htMonitoring.clone()
-hltHTmonitoring.FolderName = cms.string('HLT/HT/PFMETNoMu120/')
-hltHTmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32(  250 ),
-  xmin  = cms.double(    0.),
-  xmax  = cms.double( 2500.),
-)
-hltHTmonitoring.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32 (  200  ),
-  xmin  = cms.double(   -0.5),
-  xmax  = cms.double(19999.5),
-)
-hltHTmonitoring.met       = cms.InputTag("pfMet") # pfMet
-hltHTmonitoring.jets      = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
-hltHTmonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-hltHTmonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
+hltHTmonitoring = htMonitoring.clone(
+    FolderName = 'HLT/HT/PFMETNoMu120/',
+    met       = "pfMet", # pfMet
+    jets      = "ak4PFJets", # ak4PFJets, ak4PFJetsCHS
+    electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
+    muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !
 
-hltHTmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-#hltHTmonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
-hltHTmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltHTmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltHTmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*") # HLT_ZeroBias_v*
-#hltHTmonitoring.numGenericTriggerEventPSet.hltDBKey      = cms.string("EXO_HLT_HT")
-hltHTmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltHTmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
+    histoPSet = dict(
+                 lsPSet = dict(
+                      nbins =   250,
+                      xmin  =    0.,
+                      xmax  = 2500.),
+                 htPSet = dict(
+                      nbins =  200,
+                      xmin  =  -0.5,
+                      xmax  = 19999.5)
+     ),
 
-hltHTmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltHTmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltHTmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltHTmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltHTmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltHTmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltHTmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-hltHTmonitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_IsoMu27_v*")
+    numGenericTriggerEventPSet = dict(
+          andOr         =  False,
+          #dbLabel      = "ExoDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+          andOrHlt      = True,# True:=OR; False:=AND
+          hltInputTag   =  "TriggerResults::HLT",
+          hltPaths      = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"], # HLT_ZeroBias_v*
+          #hltDBKey     = "EXO_HLT_HT",
+          errorReplyHlt =  False,
+          verbosityLevel= 0),
+
+   denGenericTriggerEventPSet = dict(
+          andOr         =  False,
+          dcsInputTag   = "scalersRawToDigi",
+          dcsRecordInputTag = "onlineMetaDataDigis",
+          dcsPartitions = [24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+          andOrDcs      = False,
+          errorReplyDcs = True,
+          verbosityLevel = 0,
+          hltPaths      = ["HLT_IsoMu27_v*"])
+)
+

--- a/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/HiggsMonitoring_cff.py
@@ -12,473 +12,509 @@ from DQMOffline.Trigger.HiggsMonitoring_cfi import hltHIGmonitoring
 from DQMOffline.Trigger.BTaggingMonitor_cfi import hltBTVmonitoring
 
 # HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1 MET monitoring
-PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-#PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET100_BTag/')
-PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET100_BTag/')
-PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_v")
-PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
+PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone(
+#FolderName = 'HLT/Higgs/PFMET100_BTag/'
+    FolderName = 'HLT/HIG/PFMET100_BTag/',
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1_v"])
+)
 
 # HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1 MET monitoring
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-#PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET110_BTag/')
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET110_BTag/')
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_v")
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-# HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1 b-tag monitoring
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone()
-#PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET110_BTag/')
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/HIG/PFMET110_BTag/')
-# Selection
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.leptJetDeltaRmin = cms.double(0.0)
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.njets            = cms.uint32(1)
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.HTcut            = cms.double(0)
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.nbjets           = cms.uint32(1)
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.workingpoint     = cms.double(0.8484) # Medium
-# Binning
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.HTBinning    = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-# Triggers
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_v')
-PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET110_PFMHT110_IDTight_v')
+PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone(
+    #FolderName = 'HLT/Higgs/PFMET110_BTag/',
+    FolderName = 'HLT/HIG/PFMET110_BTag/',
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_v"])
+)
 
+# HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1 b-tag monitoring
+PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone(
+    #FolderName= 'HLT/Higgs/PFMET110_BTag/',
+    FolderName= 'HLT/HIG/PFMET110_BTag/',
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 1,
+    jetSelection     = 'pt>30 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 0,
+    nbjets           = 1,
+    bjetSelection    = 'pt>30 & abs(eta)<2.4',
+    workingpoint     = 0.8484, # Medium
+    # Binning                                                                                                          
+    histoPSet = dict(
+        htPSet = dict(nbins=50, xmin=0.0, xmax=1000),
+        jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+        HTBinning    = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
+        metBinning = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900]
+    ),
+    # Triggers                                                                                                         
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFMET110_PFMHT110_IDTight_CaloBTagCSV_3p1_v']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFMET110_PFMHT110_IDTight_v'])
+)
 
 # HLT_PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1 MET monitoring
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-#PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET120_BTag/')
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET120_BTag/')
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_v")
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
+PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone(
+    #FolderName = 'HLT/Higgs/PFMET120_BTag/'
+    FolderName = 'HLT/HIG/PFMET120_BTag/',
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_v"])
+)
+
 # HLT_PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1 b-tag monitoring
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone()
-#PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET120_BTag/')
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/HIG/PFMET120_BTag/')
-# Selection
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.leptJetDeltaRmin = cms.double(0.0)
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.njets            = cms.uint32(1)
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.HTcut            = cms.double(0)
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.nbjets           = cms.uint32(1)
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.workingpoint     = cms.double(0.8484) # Medium
-# Binning
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.HTBinning    = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-# Triggers
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_v')
-PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET120_PFMHT120_IDTight_v')
+PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone(
+    #FolderName= 'HLT/Higgs/PFMET120_BTag/',
+    FolderName= 'HLT/HIG/PFMET120_BTag/',
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 1,
+    jetSelection     = 'pt>30 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 0,
+    nbjets           = 1,
+    bjetSelection    = 'pt>30 & abs(eta)<2.4',
+    workingpoint     = 0.8484, # Medium
+    # Binning                                                                                                         
+    histoPSet = dict(
+        htPSet = dict(nbins=50, xmin=0.0, xmax=1000 ),
+        jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+        HTBinning    = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
+        metBinning = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900]
+    ),
+    # Triggers                                                                                                        
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFMET120_PFMHT120_IDTight_CaloBTagCSV_3p1_v']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFMET120_PFMHT120_IDTight_v'])	
+)
 
 
 # HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1 MET monitoring
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-#PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET130_BTag/')
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET130_BTag/')
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_v")
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-# HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1 b-tag monitoring
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone()
-#PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET130_BTag/')
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/HIG/PFMET130_BTag/')
-# Selection
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.leptJetDeltaRmin = cms.double(0.0)
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.njets            = cms.uint32(1)
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.HTcut            = cms.double(0)
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.nbjets           = cms.uint32(1)
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.workingpoint     = cms.double(0.8484) # Medium
-# Binning
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,130,200,400)
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.HTBinning    = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-# Triggers
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_v')
-PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET130_PFMHT130_IDTight_v')
+PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone(
+    #FolderName = 'HLT/Higgs/PFMET130_BTag/',
+    FolderName = 'HLT/HIG/PFMET130_BTag/',
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_v"])
+)
 
+# HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1 b-tag monitoring
+PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone(
+    #FolderName= 'HLT/Higgs/PFMET130_BTag/'
+    FolderName= 'HLT/HIG/PFMET130_BTag/',
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 1,
+    jetSelection     = 'pt>30 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 0,
+    nbjets           = 1,
+    bjetSelection    = 'pt>30 & abs(eta)<2.4',
+    workingpoint     = 0.8484, # Medium
+    # Binning                                                                                                         
+    histoPSet = dict(
+        htPSet = dict(nbins=50, xmin=0.0, xmax=1000 ),
+        jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,130,200,400],
+        HTBinning    = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
+        metBinning = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900]
+    ),
+    # Triggers                                                                                                        
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFMET130_PFMHT130_IDTight_CaloBTagCSV_3p1_v']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFMET130_PFMHT130_IDTight_v'])
+)
 
 # HLT_PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1 MET monitoring
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone()
-#PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/Higgs/PFMET140_BTag/')
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring.FolderName = cms.string('HLT/HIG/PFMET140_BTag/')
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_v")
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
+PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_METmonitoring = hltMETmonitoring.clone(
+    #FolderName = 'HLT/Higgs/PFMET140_BTag/'
+    FolderName = 'HLT/HIG/PFMET140_BTag/',
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_v"])
+)
+
 # HLT_PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1 b-tag monitoring
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone()
-#PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/Higgs/PFMET140_BTag/')
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.FolderName= cms.string('HLT/HIG/PFMET140_BTag/')
-# Selection
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.leptJetDeltaRmin = cms.double(0.0)
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.njets            = cms.uint32(1)
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.HTcut            = cms.double(0)
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.nbjets           = cms.uint32(1)
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.workingpoint     = cms.double(0.8484) # Medium
-# Binning
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,140,200,400)
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.HTBinning    = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-# Triggers
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_v')
-PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET140_PFMHT140_IDTight_v')
+PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_TOPmonitoring = hltTOPmonitoring.clone(
+    #FolderName= 'HLT/Higgs/PFMET140_BTag/',
+    FolderName= 'HLT/HIG/PFMET140_BTag/',
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 1,
+    jetSelection     = 'pt>30 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 0,
+    nbjets           = 1,
+    bjetSelection    = 'pt>30 & abs(eta)<2.4',
+    workingpoint     = 0.8484, # Medium
+    # Binning                                                                                                         
+    histoPSet = dict(
+        htPSet = dict(nbins=50, xmin=0.0, xmax=1000 ),
+        jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,140,200,400],
+        HTBinning    = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
+        metBinning = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900]
+    ),
+    # Triggers                                                                                                        
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFMET140_PFMHT140_IDTight_CaloBTagCSV_3p1_v']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFMET140_PFMHT140_IDTight_v'])
+)
 
 #######for HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ####
-ele23Ele12CaloIdLTrackIdLIsoVL_dzmon = hltHIGmonitoring.clone()
-ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.nelectrons = cms.uint32(2)
-#ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ')
-ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ')
-ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*")
-ele23Ele12CaloIdLTrackIdLIsoVL_dzmon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*")
+ele23Ele12CaloIdLTrackIdLIsoVL_dzmon = hltHIGmonitoring.clone(
+    nelectrons = 2,
+    #FolderName = 'HLT/Higgs/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ',
+    FolderName = 'HLT/HIG/DiLepton/HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*"])
+)
 
 ##############################DiLepton cross triggers######################################################
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg = hltHIGmonitoring.clone()
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.nmuons = cms.uint32(1)
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.nelectrons = cms.uint32(1)
-#mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*")
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
-	"HLT_Mu20_v*","HLT_TkMu20_v*",
-	"HLT_IsoMu24_eta2p1_v*",
-	"HLT_IsoMu24_v*",
-	"HLT_IsoMu27_v*",
-	"HLT_IsoMu20_v*",
-	"HLT_IsoTkMu24_eta2p1_v*",
-	"HLT_IsoTkMu24_v*",
-	"HLT_IsoTkMu27_v*",
-	"HLT_IsoTkMu20_v*"
+mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_eleleg = hltHIGmonitoring.clone(
+    nmuons = 1,
+    nelectrons = 1,
+    #FolderName = 'HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg',
+    FolderName = 'HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20_v*","HLT_TkMu20_v*",
+                                                  "HLT_IsoMu24_eta2p1_v*",
+                                                  "HLT_IsoMu24_v*",
+                                                  "HLT_IsoMu27_v*",
+                                                  "HLT_IsoMu20_v*",
+                                                  "HLT_IsoTkMu24_eta2p1_v*",
+                                                  "HLT_IsoTkMu24_v*",
+                                                  "HLT_IsoTkMu27_v*",
+                                                  "HLT_IsoTkMu20_v*"])
 )
 
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg = hltHIGmonitoring.clone()
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.nmuons = cms.uint32(1)
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.nelectrons = cms.uint32(1)
-#mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*")
-mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
-        "HLT_Ele27_WPTight_Gsf_v*",
-	"HLT_Ele35_WPTight_Gsf_v*"
+mu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLDZ_muleg = hltHIGmonitoring.clone(
+    nmuons = 1,
+    nelectrons = 1,
+    #FolderName = 'HLT/Higgs/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg',
+    FolderName = 'HLT/HIG/DiLepton/HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ/muLeg',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele27_WPTight_Gsf_v*",
+                                                  "HLT_Ele35_WPTight_Gsf_v*"])
 )
+
 
 #####HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v#####
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg = hltHIGmonitoring.clone()
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.nmuons = cms.uint32(1)
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.nelectrons = cms.uint32(1)
-#mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg')
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*") #
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
-	"HLT_Mu20_v*",
-	"HLT_TkMu20_v*",
-	"HLT_IsoMu24_eta2p1_v*",
-	"HLT_IsoMu24_v*",
-	"HLT_IsoMu27_v*",
-	"HLT_IsoMu20_v*",
-	"HLT_IsoTkMu24_eta2p1_v*",
-	"HLT_IsoTkMu24_v*",
-	"HLT_IsoTkMu27_v*",
-	"HLT_IsoTkMu20_v*"
+mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_eleleg = hltHIGmonitoring.clone(
+    nmuons = 1,
+    nelectrons = 1,
+    #FolderName = 'HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg',
+    FolderName = 'HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/eleLeg',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*"]), #        
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20_v*",
+                                                  "HLT_TkMu20_v*",
+                                                  "HLT_IsoMu24_eta2p1_v*",
+                                                  "HLT_IsoMu24_v*",
+                                                  "HLT_IsoMu27_v*",
+                                                  "HLT_IsoMu20_v*",
+                                                  "HLT_IsoTkMu24_eta2p1_v*",
+                                                  "HLT_IsoTkMu24_v*",
+                                                  "HLT_IsoTkMu27_v*",
+                                                  "HLT_IsoTkMu20_v*"])
 )
 
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg = hltHIGmonitoring.clone()
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.nmuons = cms.uint32(1)
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.nelectrons = cms.uint32(1)
-#mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.FolderName = cms.string('HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg')
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*")
-mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
-        "HLT_Ele27_WPTight_Gsf_v*",
-	"HLT_Ele35_WPTight_Gsf_v*"
+
+mu12TrkIsoVVLEle23CaloIdLTrackIdLIsoVLDZ_muleg = hltHIGmonitoring.clone(
+    nmuons = 1,
+    nelectrons = 1,
+    #FolderName = 'HLT/Higgs/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg',
+    FolderName = 'HLT/HIG/DiLepton/HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ/muLeg',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele27_WPTight_Gsf_v*",
+                                                  "HLT_Ele35_WPTight_Gsf_v*"])
 )
 
 ###############################same flavour trilepton monitor####################################
 ########TripleMuon########
-higgsTrimumon = hltHIGmonitoring.clone()
-#higgsTrimumon.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_TripleMu_12_10_5/')
-higgsTrimumon.FolderName = cms.string('HLT/HIG/TriLepton/HLT_TripleMu_12_10_5/')
-higgsTrimumon.nmuons = cms.uint32(3)
-higgsTrimumon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TripleMu_12_10_5_v*") #
-higgsTrimumon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*","HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*")
+higgsTrimumon = hltHIGmonitoring.clone(
+    #FolderName = 'HLT/Higgs/TriLepton/HLT_TripleMu_12_10_5/',
+    FolderName = 'HLT/HIG/TriLepton/HLT_TripleMu_12_10_5/',
+    nmuons = 3,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TripleMu_12_10_5_v*"]), #                                      
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*","HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*"])
+)
 
-higgsTrimu10_5_5_dz_mon = hltHIGmonitoring.clone()
-#higgsTrimu10_5_5_dz_mon.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_TripleM_10_5_5_DZ/')
-higgsTrimu10_5_5_dz_mon.FolderName = cms.string('HLT/HIG/TriLepton/HLT_TripleM_10_5_5_DZ/')
-higgsTrimu10_5_5_dz_mon.nmuons = cms.uint32(3)
-higgsTrimu10_5_5_dz_mon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TripleMu_10_5_5_DZ_v*") #
-higgsTrimu10_5_5_dz_mon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*","HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*")
+higgsTrimu10_5_5_dz_mon = hltHIGmonitoring.clone(
+    #FolderName = 'HLT/Higgs/TriLepton/HLT_TripleM_10_5_5_DZ/',
+    FolderName = 'HLT/HIG/TriLepton/HLT_TripleM_10_5_5_DZ/',
+    nmuons = 3,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TripleMu_10_5_5_DZ_v*"]), #                                    
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*","HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*"])
+)
 
 #######TripleElectron####
-higgsTrielemon = hltHIGmonitoring.clone()
-#higgsTrielemon.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/')
-higgsTrielemon.FolderName = cms.string('HLT/HIG/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/')
-higgsTrielemon.nelectrons = cms.uint32(3)
-higgsTrielemon.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v*") #
-higgsTrielemon.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*")
+higgsTrielemon = hltHIGmonitoring.clone(
+    #FolderName = 'HLT/Higgs/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/',
+    FolderName = 'HLT/HIG/TriLepton/HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL/',
+    nelectrons = 3,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v*"]), #                     
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*"])
+)
 
 ###############################cross flavour trilepton monitor####################################
 #########DiMuon+Single Ele Trigger###################
-diMu9Ele9CaloIdLTrackIdL_muleg = hltHIGmonitoring.clone()
-#diMu9Ele9CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg')
-diMu9Ele9CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg')
-diMu9Ele9CaloIdLTrackIdL_muleg.nelectrons = cms.uint32(1)
-diMu9Ele9CaloIdLTrackIdL_muleg.nmuons = cms.uint32(2)
-diMu9Ele9CaloIdLTrackIdL_muleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v*")
-diMu9Ele9CaloIdLTrackIdL_muleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
-         "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
-         "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*"
+diMu9Ele9CaloIdLTrackIdL_muleg = hltHIGmonitoring.clone(
+#FolderName = 'HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg',
+    FolderName = 'HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/muLeg',
+    nelectrons = 1,
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
+                                                  "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*"])
 )
 
-diMu9Ele9CaloIdLTrackIdL_eleleg = hltHIGmonitoring.clone()
-#diMu9Ele9CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg')
-diMu9Ele9CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg')
-diMu9Ele9CaloIdLTrackIdL_eleleg.nelectrons = cms.uint32(1)
-diMu9Ele9CaloIdLTrackIdL_eleleg.nmuons = cms.uint32(2)
-diMu9Ele9CaloIdLTrackIdL_eleleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v*")
-diMu9Ele9CaloIdLTrackIdL_eleleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
-	"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
-	"HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
-	"HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*",
-	"HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*",
-	"HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*",
-	"HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*"
+
+diMu9Ele9CaloIdLTrackIdL_eleleg = hltHIGmonitoring.clone(
+    #FolderName = 'HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg',
+    FolderName = 'HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/eleLeg',
+    nelectrons = 1,
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*",
+                                                  "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*",
+                                                  "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*",
+                                                  "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*",
+                                                  "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*",
+                                                  "HLT_TkMu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v*"])
 )
 
 ##Eff of the HLT with DZ w.ref to non-DZ one
-diMu9Ele9CaloIdLTrackIdL_dz = hltHIGmonitoring.clone()
-#diMu9Ele9CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon')
-diMu9Ele9CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon')
-diMu9Ele9CaloIdLTrackIdL_dz.nelectrons = cms.uint32(1)
-diMu9Ele9CaloIdLTrackIdL_dz.nmuons = cms.uint32(2)
+diMu9Ele9CaloIdLTrackIdL_dz = hltHIGmonitoring.clone(
+    #FolderName = 'HLT/Higgs/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon',
+    FolderName = 'HLT/HIG/TriLepton/HLT_DiMu9_Ele9_CaloIdL_TrackIdL/dzMon',
+    nelectrons = 1,
+    nmuons = 2
+)
 diMu9Ele9CaloIdLTrackIdL_dz.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_DZ_v*")
 diMu9Ele9CaloIdLTrackIdL_dz.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiMu9_Ele9_CaloIdL_TrackIdL_v*")
 
 #################DiElectron+Single Muon Trigger##################
-mu8diEle12CaloIdLTrackIdL_eleleg = hltHIGmonitoring.clone()
-#mu8diEle12CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg')
-mu8diEle12CaloIdLTrackIdL_eleleg.FolderName = cms.string('HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg')
-mu8diEle12CaloIdLTrackIdL_eleleg.nelectrons = cms.uint32(2)
-mu8diEle12CaloIdLTrackIdL_eleleg.nmuons = cms.uint32(1)
-mu8diEle12CaloIdLTrackIdL_eleleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v*")
-mu8diEle12CaloIdLTrackIdL_eleleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
-	"HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
-       	"HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*"
+mu8diEle12CaloIdLTrackIdL_eleleg = hltHIGmonitoring.clone(
+    #FolderName = 'HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg',
+    FolderName = 'HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/eleLeg',
+    nelectrons = 2,
+    nmuons = 1,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*",
+                                                  "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*"])
 )
 
-mu8diEle12CaloIdLTrackIdL_muleg = hltHIGmonitoring.clone()
-#mu8diEle12CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg')
-mu8diEle12CaloIdLTrackIdL_muleg.FolderName = cms.string('HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg')
-mu8diEle12CaloIdLTrackIdL_muleg.nelectrons = cms.uint32(2)
-mu8diEle12CaloIdLTrackIdL_muleg.nmuons = cms.uint32(1)
-mu8diEle12CaloIdLTrackIdL_muleg.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v*")
-mu8diEle12CaloIdLTrackIdL_muleg.denGenericTriggerEventPSet.hltPaths = cms.vstring(
-	"HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*"
+mu8diEle12CaloIdLTrackIdL_muleg = hltHIGmonitoring.clone(
+    #FolderName = 'HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg',
+    FolderName = 'HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/muLeg',
+    nelectrons = 2,
+    nmuons = 1,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*"])
+
 )
 
 ##Eff of the HLT with DZ w.ref to non-DZ one
-mu8diEle12CaloIdLTrackIdL_dz = hltHIGmonitoring.clone()
-#mu8diEle12CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon')
-mu8diEle12CaloIdLTrackIdL_dz.FolderName = cms.string('HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon')
-mu8diEle12CaloIdLTrackIdL_dz.nelectrons = cms.uint32(2)
-mu8diEle12CaloIdLTrackIdL_dz.nmuons = cms.uint32(1)
-mu8diEle12CaloIdLTrackIdL_dz.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_DZ_v*")
-mu8diEle12CaloIdLTrackIdL_dz.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v*")
+mu8diEle12CaloIdLTrackIdL_dz = hltHIGmonitoring.clone(
+    #FolderName = 'HLT/Higgs/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon',
+    FolderName = 'HLT/HIG/TriLepton/HLT_Mu8_DiEle12_CaloIdL_TrackIdL/dzMon',
+    nelectrons = 2,
+    nmuons = 1,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu8_DiEle12_CaloIdL_TrackIdL_DZ_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu8_DiEle12_CaloIdL_TrackIdL_v*"])
+)
+
 
 ##VBF triggers##
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1 = hltTOPmonitoring.clone()
-#QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1_v')
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1_v')
-# Selection
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.leptJetDeltaRmin = cms.double(0.0)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.njets            = cms.uint32(4)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.jetSelection     = cms.string('pt>15 & abs(eta)<4.7')
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.HTcut            = cms.double(0)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.nbjets           = cms.uint32(2)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.bjetSelection    = cms.string('pt>15 & abs(eta)<4.7')
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.btagAlgos        = ["pfCombinedMVAV2BJetTags"]
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.workingpoint     = cms.double(-0.715) # Loose
-# Binning
-#QuadPFJet_BTagCSV_p016_p11_VBF_Mqq240.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.histoPSet.HTBinning    = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-# Triggers
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1_v*')
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.histoPSet.csvPSet = cms.PSet(
-  nbins = cms.uint32( 20 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
-QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.histoPSet.ptPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
+QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1 = hltTOPmonitoring.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1_v',
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1_v',
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 4,
+    jetSelection     = 'pt>15 & abs(eta)<4.7',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 0,
+    nbjets           = 2,
+    bjetSelection    = 'pt>15 & abs(eta)<4.7',
+    btagAlgos        = ["pfCombinedMVAV2BJetTags"],
+    workingpoint     = -0.715, # Loose
+    # Triggers                                                                                                                                                                                                                                                                  
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1_v*']),
+    # Binning                                                                                                                                                                                                                                                                   
+    #QuadPFJet_BTagCSV_p016_p11_VBF_Mqq240.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )                                                                                                                                                
+    histoPSet = dict(
+        jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+        HTBinning    = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
+        metBinning = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
 
+        lsPSet = dict(
+            nbins =  1
+        ),
 
-QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1 = QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.clone()
-#QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v')
-QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v')
-QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v*')
-
-
-QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1 = QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.clone()
-#QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v')
-QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v')
-QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v*')
-
-
-QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1 = QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.clone()
-#QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v')
-QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v')
-QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v*')
-
-
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1 = hltTOPmonitoring.clone()
-#QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2_v')
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2_v')
-# Selection
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.leptJetDeltaRmin = cms.double(0.0)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.njets            = cms.uint32(4)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.jetSelection     = cms.string('pt>15 & abs(eta)<4.7')
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.HTcut            = cms.double(0)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.nbjets           = cms.uint32(1)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.bjetSelection    = cms.string('pt>15 & abs(eta)<4.7')
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.btagAlgos        = ["pfCombinedMVAV2BJetTags"]
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.workingpoint     = cms.double(-0.715) # Loose
-# Binning
-#QuadPFJet_BTagCSV_p016_p11_VBF_Mqq240.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.histoPSet.HTBinning    = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-# Triggers
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2_v*')
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.histoPSet.csvPSet = cms.PSet(
-  nbins = cms.uint32( 20 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
-QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.histoPSet.ptPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
+        htPSet = dict(
+            nbins =  1 ,
+            xmin  =  0 ,
+            xmax  =  1
+        ),
+        csvPSet = dict(
+            nbins = 20 ,
+            xmin  = 0 ,
+            xmax  = 1
+        ),
+        etaPSet = dict(
+            nbins =  1 ,
+            xmin  =  0 ,
+            xmax  =  1
+        ),
+        ptPSet = dict(
+            nbins = 1,
+            xmin  = 0 ,
+            xmax  = 1
+        )
+    )
 )
 
-QuadPFJet103_88_75_15_BTagCSV_p013_VBF1 = QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.clone()
-#QuadPFJet103_88_75_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v')
-QuadPFJet103_88_75_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v')
-QuadPFJet103_88_75_15_BTagCSV_p013_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v*')
-
-
-QuadPFJet105_88_76_15_BTagCSV_p013_VBF1 = QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.clone()
-#QuadPFJet105_88_76_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v')
-QuadPFJet105_88_76_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v')
-QuadPFJet105_88_76_15_BTagCSV_p013_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v*')
-
-
-QuadPFJet111_90_80_15_BTagCSV_p013_VBF1 = QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.clone()
-#QuadPFJet111_90_80_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v')
-QuadPFJet111_90_80_15_BTagCSV_p013_VBF1.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v')
-QuadPFJet111_90_80_15_BTagCSV_p013_VBF1.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v*')
-
-QuadPFJet98_83_71_15 = hltTOPmonitoring.clone()
-#QuadPFJet98_83_71_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_v')
-QuadPFJet98_83_71_15.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet98_83_71_15_v')
-# Selection
-QuadPFJet98_83_71_15.leptJetDeltaRmin = cms.double(0.0)
-QuadPFJet98_83_71_15.njets            = cms.uint32(4)
-QuadPFJet98_83_71_15.jetSelection     = cms.string('pt>15 & abs(eta)<4.7')
-QuadPFJet98_83_71_15.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-QuadPFJet98_83_71_15.HTcut            = cms.double(0)
-QuadPFJet98_83_71_15.nbjets           = cms.uint32(0)
-QuadPFJet98_83_71_15.bjetSelection    = cms.string('pt>15 & abs(eta)<4.7')
-QuadPFJet98_83_71_15.btagAlgos        = ["pfCombinedMVAV2BJetTags"]
-QuadPFJet98_83_71_15.workingpoint     = cms.double(-0.715) # Loose
-# Binning
-#QuadPFJet_BTagCSV_p016_p11_VBF_Mqq240.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-QuadPFJet98_83_71_15.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
-QuadPFJet98_83_71_15.histoPSet.HTBinning    = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-QuadPFJet98_83_71_15.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700,900)
-# Triggers
-QuadPFJet98_83_71_15.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet98_83_71_15_v*')
-QuadPFJet98_83_71_15.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-)
-QuadPFJet98_83_71_15.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
-QuadPFJet98_83_71_15.histoPSet.csvPSet = cms.PSet(
-  nbins = cms.uint32( 20 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
-QuadPFJet98_83_71_15.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
-)
-QuadPFJet98_83_71_15.histoPSet.ptPSet = cms.PSet(
-  nbins = cms.uint32( 1 ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(   1   ),
+QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1 = QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v',                                                          
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet103_88_75_15_DoubleBTagCSV_p013_p08_VBF1_v*'])
 )
 
-QuadPFJet103_88_75_15 = QuadPFJet98_83_71_15.clone()
-#QuadPFJet103_88_75_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_v')
-QuadPFJet103_88_75_15.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet103_88_75_15_v')
-QuadPFJet103_88_75_15.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet103_88_75_15_v*')
+QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1 = QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v',                                                          
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet105_90_76_15_DoubleBTagCSV_p013_p08_VBF1_v*'])
+)
 
+QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1 = QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v',                                                          
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet111_90_80_15_DoubleBTagCSV_p013_p08_VBF1_v*'])
+)
 
-QuadPFJet105_88_76_15 = QuadPFJet98_83_71_15.clone()
-#QuadPFJet105_88_76_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet105_88_76_15_v')
-QuadPFJet105_88_76_15.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet105_88_76_15_v')
-QuadPFJet105_88_76_15.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet105_88_76_15_v*')
+QuadPFJet98_83_71_15_BTagCSV_p013_VBF1 = hltTOPmonitoring.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2_v',                                                                     
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2_v',
+    # Selection                                                                                                                                       
+    leptJetDeltaRmin = 0.0,
+    njets            = 4,
+    jetSelection     = 'pt>15 & abs(eta)<4.7',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 0,
+    nbjets           = 1,
+    bjetSelection    = 'pt>15 & abs(eta)<4.7',
+    btagAlgos        = ["pfCombinedMVAV2BJetTags"],
+    workingpoint     = -0.715, # Loose                                                                                                                
+    # Triggers                                                                                                                                        
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2_v*']),
+    # Binning                                                                                                                                         
+    #QuadPFJet_BTagCSV_p016_p11_VBF_Mqq240.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )                      
+    histoPSet = dict(
+        jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+        HTBinning    = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
+        metBinning = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
 
+        lsPSet = dict(
+            nbins =  1 ,
+        ),
+        htPSet = dict(
+            nbins = 1 ,
+            xmin  = 0 ,
+            xmax  = 1 ,
+        ),
+        csvPSet = dict(
+            nbins = 20,
+            xmin  = 0 ,
+            xmax  = 1 ,
+        ),
+        etaPSet = dict(
+            nbins =  1,
+            xmin  =  0 ,
+            xmax  =  1 ,
+        ),
+        ptPSet = dict(
+            nbins =  1 ,
+            xmin  =  0 ,
+            xmax  =  1 ,
+        )
+    )
+)
 
-QuadPFJet111_90_80_15 = QuadPFJet98_83_71_15.clone()
-#QuadPFJet111_90_80_15.FolderName= cms.string('HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_v')
-QuadPFJet111_90_80_15.FolderName= cms.string('HLT/HIG/VBFHbb/HLT_QuadPFJet111_90_80_15_v')
-QuadPFJet111_90_80_15.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_QuadPFJet111_90_80_15_v*')
+QuadPFJet103_88_75_15_BTagCSV_p013_VBF1 = QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v',
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet103_88_75_15_BTagCSV_p013_VBF2_v*'])
+)
+
+QuadPFJet105_88_76_15_BTagCSV_p013_VBF1 = QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v',
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet105_88_76_15_BTagCSV_p013_VBF2_v*'])
+)
+
+QuadPFJet111_90_80_15_BTagCSV_p013_VBF1 = QuadPFJet98_83_71_15_BTagCSV_p013_VBF1.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v',
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet111_90_80_15_BTagCSV_p013_VBF2_v*'])
+)
+
+QuadPFJet98_83_71_15 = hltTOPmonitoring.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet98_83_71_15_v',
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet98_83_71_15_v',
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 4,
+    jetSelection     = 'pt>15 & abs(eta)<4.7',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 0,
+    nbjets           = 0,
+    bjetSelection    = 'pt>15 & abs(eta)<4.7',
+    btagAlgos        = ["pfCombinedMVAV2BJetTags"],
+    workingpoint     = -0.715, # Loose
+	# Triggers                                                                                                                                        
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet98_83_71_15_v*']),
+    # Binning                                                                                                                                         
+    #QuadPFJet_BTagCSV_p016_p11_VBF_Mqq240.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )                      
+    histoPSet = dict(
+    jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+        HTBinning    = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
+        metBinning = [0,20,40,60,80,100,125,150,175,200,300,400,500,700,900],
+
+        lsPSet = dict(
+            nbins = 1
+        ),
+        htPSet = dict(
+            nbins = 1 ,
+            xmin  = 0 ,
+            xmax  = 1
+        ),
+        csvPSet = dict(
+            nbins =  20,
+            xmin  =  0 ,
+            xmax  =  1
+        ),
+        etaPSet = dict(
+            nbins = 1 ,
+            xmin  = 0 ,
+            xmax  = 1
+        ),
+        ptPSet = dict(
+            nbins =  1 ,
+            xmin  =  0 ,
+            xmax  =  1
+        )
+    )
+)
+
+QuadPFJet103_88_75_15 = QuadPFJet98_83_71_15.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet103_88_75_15_v',
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet103_88_75_15_v',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet103_88_75_15_v*'])
+)
+
+QuadPFJet105_88_76_15 = QuadPFJet98_83_71_15.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet105_88_76_15_v',
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet105_88_76_15_v',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet105_88_76_15_v*'])
+)
+
+QuadPFJet111_90_80_15 = QuadPFJet98_83_71_15.clone(
+    #FolderName= 'HLT/Higgs/VBFHbb/HLT_QuadPFJet111_90_80_15_v',
+    FolderName= 'HLT/HIG/VBFHbb/HLT_QuadPFJet111_90_80_15_v',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_QuadPFJet111_90_80_15_v*'])
+)
 
 ###############################Higgs Monitor HLT##############################################
 higgsMonitorHLT = cms.Sequence(

--- a/DQMOffline/Trigger/python/HiggsMonitoring_cfi.py
+++ b/DQMOffline/Trigger/python/HiggsMonitoring_cfi.py
@@ -2,129 +2,121 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.topMonitoring_cfi import topMonitoring
 
-hltHIGmonitoring = topMonitoring.clone()
-#hltHIGmonitoring.FolderName = cms.string('HLT/Higgs/default/')
-hltHIGmonitoring.FolderName = cms.string('HLT/HIG/default/')
-hltHIGmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32 ( 250 ),
-  xmin  = cms.double(    0.),
-  xmax  = cms.double( 2500.),
+hltHIGmonitoring = topMonitoring.clone(
+    #FolderName = 'HLT/Higgs/default/',
+    FolderName = 'HLT/HIG/default/',
+
+    histoPSet = dict(
+        lsPSet = dict(
+            nbins =  2500,
+            xmin  =  0.,
+            xmax  = 2500.),
+        
+        metPSet = dict(
+            nbins = 30,
+            xmin  =  0 ,
+            xmax  =  300),
+
+        ptPSet = dict(
+            nbins =   60 ,
+            xmin  =   0 ,
+            xmax  =  300),
+
+        phiPSet = dict(
+            nbins =  32 ,
+            xmin  = -3.2,
+            xmax  =  3.2),
+
+        etaPSet = dict(
+             nbins =  30 ,
+             xmin  =  -3.0,
+             xmax  =  3.0),
+
+        htPSet = dict(
+            nbins =   60 ,
+            xmin  =   0 ,
+            xmax  =  600),
+        # Marina
+        csvPSet = dict(
+            nbins =  50 ,
+            xmin  =  0.0 ,
+            xmax  =  1.0 ),
+
+        DRPSet = dict(
+            nbins =  60 ,
+            xmin  =  0.0 ,
+            xmax  = 6.0),
+
+        invMassPSet = dict(
+            nbins =  40 ,
+             xmin  =  0.0 ,
+             xmax  =  80.0),
+
+         MHTPSet = dict(
+            nbins =  80 ,
+            xmin  =   60 ,
+            xmax  =  300),
+
+         #MET and HT binning
+         metBinning = [0,20,40,60,80,100,125,150,175,200],
+         HTBinning  = [0,20,40,60,80,100,125,150,175,200,300,400,500,700],
+         #Eta binning
+         eleEtaBinning = [-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.566,-1.4442,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1.1,1.2,1.3,1.4442,1.566,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5],
+         jetEtaBinning = [-4.7,-3.2,-3.0,-2.5,-2.1,-1.8,-1.5,-1.2,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.2,1.5,1.8,2.1,2.5,3.0,3.2,4.7],
+         muEtaBinning  = [-2.4,-2.1,-1.7,-1.2,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.2,1.7,2.1,2.4],
+         #pt binning
+         elePtBinning = [0,3,5,8,10,15,20,25,30,40,50,60,80,120,200,400],
+         jetPtBinning = [0,3,5,8,10,15,20,25,30,40,50,60,80,120,200,400],
+         muPtBinning  = [0,3,5,8,10,15,20,25,30,40,50,60,80,120,200,400],
+         #Eta binning 2D
+         eleEtaBinning2D = [-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.566,-1.4442,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1.1,1.2,1.3,1.4442,1.566,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5],
+         jetEtaBinning2D = [-4.7,-3.2,-3.0,-2.5,-2.1,-1.8,-1.5,-1.2,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.2,1.5,1.8,2.1,2.5,3.0,3.2,4.7],
+         muEtaBinning2D  = [-2.4,-2.1,-1.7,-1.2,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.2,1.7,2.1,2.4],
+
+         #pt binning 2D
+         elePtBinning2D = [0,15,20,30,40,60,80,100,200,400],
+         jetPtBinning2D = [0,15,20,30,40,60,80,100,200,400],
+         muPtBinning2D  = [0,15,20,30,40,60,80,100,200,400],
+         #HT and phi binning 2D
+         HTBinning2D  = [0,20,40,70,100,150,200,400,700],
+         phiBinning2D = [-3.1416,-2.5132,-1.8849,-1.2566,-0.6283,0,0.6283,1.2566,1.8849,2.5132,3.1416],
+    ),
+    applyLeptonPVcuts = True,
+    leptonPVcuts = dict(
+         dxy =  0.5,
+         dz  =  1.),
+
+    met       = "pfMet", # pfMet
+    jets      = "ak4PFJets", # ak4PFJets, ak4PFJetsCHS
+    electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
+    muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !
+    vertices  = "offlinePrimaryVertices",
+
+    HTdefinition = 'pt>30 & abs(eta)<2.5',
+    leptJetDeltaRmin = 0.4,
+    eleSelection =  'pt > 7. && abs(eta) < 2.5', 
+    muoSelection =  'pt > 5 &&  abs(eta) < 2.4 && (isGlobalMuon || (isTrackerMuon && numberOfMatches>0)) && muonBestTrackType != 2',
+    vertexSelection = '!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2',
+
+    nmuons     = 0,
+    nelectrons = 0,
+    njets      = 0,
+
+
+    numGenericTriggerEventPSet = dict(
+             andOr         =  False,
+             andOrHlt      = True,# True:=OR; False:=AND
+             verbosityLevel = 1,
+             hltInputTag   = "TriggerResults::HLT",
+             errorReplyHlt =  False ),
+
+    denGenericTriggerEventPSet = dict(
+            andOr         = False,
+            dcsInputTag   = "scalersRawToDigi",
+            dcsRecordInputTag = "onlineMetaDataDigis",
+            dcsPartitions = [24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+            andOrDcs      =  False,
+            errorReplyDcs =  True,
+            verbosityLevel = 1)
 )
-hltHIGmonitoring.histoPSet.metPSet = cms.PSet(
-  nbins = cms.uint32 (  30   ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  300  ),
-)
-hltHIGmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32( 2500 ),
-)
-hltHIGmonitoring.histoPSet.ptPSet = cms.PSet(
-  nbins = cms.uint32 (  60   ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  300  ),
-)
-hltHIGmonitoring.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.uint32 (  32  ),
-  xmin  = cms.double( -3.2 ),
-  xmax  = cms.double(  3.2 ),
-)
-hltHIGmonitoring.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32 (  30  ),
-  xmin  = cms.double( -3.0 ),
-  xmax  = cms.double(  3.0 ),
-)
-hltHIGmonitoring.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32 (   60  ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  600  ),
-)
-
-# Marina
-hltHIGmonitoring.histoPSet.csvPSet = cms.PSet(
-  nbins = cms.uint32 ( 50 ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 1.0  ),
-)
-
-hltHIGmonitoring.histoPSet.DRPSet = cms.PSet(
-   nbins = cms.uint32 ( 60  ),
-   xmin  = cms.double( 0.0 ),
-   xmax  = cms.double( 6.0 ),
-)
-
-hltHIGmonitoring.applyLeptonPVcuts = True
-hltHIGmonitoring.leptonPVcuts = cms.PSet(
-  dxy = cms.double(   0.5  ),
-  dz  = cms.double(   1.   ),
-)
-hltHIGmonitoring.histoPSet.invMassPSet = cms.PSet(
-  nbins = cms.uint32( 40 ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 80.0  ),
-)
-hltHIGmonitoring.histoPSet.MHTPSet = cms.PSet(
- nbins = cms.uint32(   80  ),
- xmin  = cms.double(   60   ),
- xmax  = cms.double(  300  ),
-)
-
-
-#MET and HT binning
-hltHIGmonitoring.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200)
-hltHIGmonitoring.histoPSet.HTBinning  = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700)
-#Eta binning
-hltHIGmonitoring.histoPSet.eleEtaBinning = cms.vdouble(-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.566,-1.4442,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1.1,1.2,1.3,1.4442,1.566,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5)
-hltHIGmonitoring.histoPSet.jetEtaBinning = cms.vdouble(-4.7,-3.2,-3.0,-2.5,-2.1,-1.8,-1.5,-1.2,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.2,1.5,1.8,2.1,2.5,3.0,3.2,4.7)
-hltHIGmonitoring.histoPSet.muEtaBinning  = cms.vdouble(-2.4,-2.1,-1.7,-1.2,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.2,1.7,2.1,2.4)
-#pt binning
-hltHIGmonitoring.histoPSet.elePtBinning = cms.vdouble(0,3,5,8,10,15,20,25,30,40,50,60,80,120,200,400)
-hltHIGmonitoring.histoPSet.jetPtBinning = cms.vdouble(0,3,5,8,10,15,20,25,30,40,50,60,80,120,200,400)
-hltHIGmonitoring.histoPSet.muPtBinning  = cms.vdouble(0,3,5,8,10,15,20,25,30,40,50,60,80,120,200,400)
-#Eta binning 2D
-hltHIGmonitoring.histoPSet.eleEtaBinning2D = cms.vdouble(-2.5,-2.4,-2.3,-2.2,-2.1,-2.0,-1.9,-1.8,-1.7,-1.566,-1.4442,-1.3,-1.2,-1.1,-1.0,-0.9,-0.8,-0.7,-0.6,-0.5,-0.4,-0.3,-0.2,-0.1,0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1,1.1,1.2,1.3,1.4442,1.566,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5)
-hltHIGmonitoring.histoPSet.jetEtaBinning2D = cms.vdouble(-4.7,-3.2,-3.0,-2.5,-2.1,-1.8,-1.5,-1.2,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.2,1.5,1.8,2.1,2.5,3.0,3.2,4.7)
-hltHIGmonitoring.histoPSet.muEtaBinning2D  = cms.vdouble(-2.4,-2.1,-1.7,-1.2,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.2,1.7,2.1,2.4)
-
-#pt binning 2D
-hltHIGmonitoring.histoPSet.elePtBinning2D = cms.vdouble(0,15,20,30,40,60,80,100,200,400)
-hltHIGmonitoring.histoPSet.jetPtBinning2D = cms.vdouble(0,15,20,30,40,60,80,100,200,400)
-hltHIGmonitoring.histoPSet.muPtBinning2D  = cms.vdouble(0,15,20,30,40,60,80,100,200,400)
-#HT and phi binning 2D
-hltHIGmonitoring.histoPSet.HTBinning2D  = cms.vdouble(0,20,40,70,100,150,200,400,700)
-hltHIGmonitoring.histoPSet.phiBinning2D = cms.vdouble(-3.1416,-2.5132,-1.8849,-1.2566,-0.6283,0,0.6283,1.2566,1.8849,2.5132,3.1416)
-
-
-hltHIGmonitoring.met       = cms.InputTag("pfMet") # pfMet
-hltHIGmonitoring.jets      = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
-hltHIGmonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-hltHIGmonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
-hltHIGmonitoring.vertices  = cms.InputTag("offlinePrimaryVertices")
-
-hltHIGmonitoring.HTdefinition = cms.string('pt>30 & abs(eta)<2.5')
-hltHIGmonitoring.leptJetDeltaRmin = cms.double(0.4)
-hltHIGmonitoring.eleSelection =  cms.string('pt > 7. && abs(eta) < 2.5') 
-hltHIGmonitoring.muoSelection =  cms.string('pt > 5 &&  abs(eta) < 2.4 && (isGlobalMuon || (isTrackerMuon && numberOfMatches>0)) && muonBestTrackType != 2')
-hltHIGmonitoring.vertexSelection = cms.string('!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2')
-
-hltHIGmonitoring.nmuons     = cms.uint32(0)
-hltHIGmonitoring.nelectrons = cms.uint32(0)
-hltHIGmonitoring.njets      = cms.uint32(0)
-
-
-hltHIGmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltHIGmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltHIGmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltHIGmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltHIGmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
-
-hltHIGmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltHIGmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltHIGmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltHIGmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltHIGmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltHIGmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltHIGmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltHIGmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltHIGmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltHIGmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
 

--- a/DQMOffline/Trigger/python/JetMETHLTOfflineClient_cfi.py
+++ b/DQMOffline/Trigger/python/JetMETHLTOfflineClient_cfi.py
@@ -9,8 +9,8 @@ jetMETHLTOfflineClientAK4 = DQMEDHarvester("JetMETHLTOfflineClient",
 
 )
 
-jetMETHLTOfflineClientAK8 = jetMETHLTOfflineClientAK4.clone( DQMDirName = cms.string('HLT/JME/Jets/AK8'))
-jetMETHLTOfflineClientAK4Fwd = jetMETHLTOfflineClientAK4.clone( DQMDirName = cms.string('HLT/JME/Jets/AK4Fwd'))
-jetMETHLTOfflineClientAK8Fwd = jetMETHLTOfflineClientAK4.clone( DQMDirName = cms.string('HLT/JME/Jets/AK8Fwd'))
+jetMETHLTOfflineClientAK8 = jetMETHLTOfflineClientAK4.clone( DQMDirName = 'HLT/JME/Jets/AK8')
+jetMETHLTOfflineClientAK4Fwd = jetMETHLTOfflineClientAK4.clone( DQMDirName = 'HLT/JME/Jets/AK4Fwd')
+jetMETHLTOfflineClientAK8Fwd = jetMETHLTOfflineClientAK4.clone( DQMDirName = 'HLT/JME/Jets/AK8Fwd')
 
 jetMETHLTOfflineClient = cms.Sequence( jetMETHLTOfflineClientAK4 * jetMETHLTOfflineClientAK8 * jetMETHLTOfflineClientAK4Fwd * jetMETHLTOfflineClientAK8Fwd)

--- a/DQMOffline/Trigger/python/JetMETHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/JetMETHLTOfflineSource_cfi.py
@@ -101,16 +101,14 @@ jetMETHLTOfflineSourceAK4 = DQMEDAnalyzer(
 
 
 jetMETHLTOfflineSourceAK8 = jetMETHLTOfflineSourceAK4.clone(
-    dirname = cms.untracked.string('HLT/JME/Jets/AK8'),
-    #    CaloJetCollectionLabel = cms.InputTag("ak4CaloJets"), #ak8 not available in RECO anymore, so keep ak4...
-    #    PFJetCollectionLabel   = cms.InputTag("ak8PFJetsPuppi"), # does not work in all matrix tests, yet
-    #    PFJetCorLabel        = cms.InputTag("ak8PFCHSL1FastjetL2L3ResidualCorrector"), # does not work in all matrix tests, yet 
-    PFJetCollectionLabel   = cms.InputTag("ak4PFJets"),
-    PFJetCorLabel        = cms.InputTag("ak4PFL1FastL2L3ResidualCorrector"), #dummy residual corrections now also provided for MC GTs
+    dirname = 'HLT/JME/Jets/AK8',
+    #    CaloJetCollectionLabel = "ak4CaloJets", #ak8 not available in RECO anymore, so keep ak4...
+    #    PFJetCollectionLabel   = "ak8PFJetsPuppi", # does not work in all matrix tests, yet
+    #    PFJetCorLabel        = "ak8PFCHSL1FastjetL2L3ResidualCorrector", # does not work in all matrix tests, yet 
+    PFJetCollectionLabel   = "ak4PFJets",
+    PFJetCorLabel        = "ak4PFL1FastL2L3ResidualCorrector", #dummy residual corrections now also provided for MC GTs 
+    pathFilter = ['HLT_AK8PFJet'],
 
- 
-    pathFilter = cms.untracked.vstring('HLT_AK8PFJet', 
-    ),
     pathPairs = cms.VPSet(cms.PSet(
         denompathname = cms.string('HLT_AK8PFJet40_v'),
         pathname = cms.string('HLT_AK8PFJet60_v')
@@ -151,12 +149,11 @@ jetMETHLTOfflineSourceAK8 = jetMETHLTOfflineSourceAK4.clone(
 )
 
 jetMETHLTOfflineSourceAK8Fwd = jetMETHLTOfflineSourceAK4.clone(
-    dirname = cms.untracked.string('HLT/JME/Jets/AK8Fwd'),
-    PFJetCollectionLabel   = cms.InputTag("ak4PFJets"),
-    PFJetCorLabel        = cms.InputTag("ak4PFL1FastL2L3ResidualCorrector"), #dummy residual corrections now also provided for MC GTs
+    dirname = 'HLT/JME/Jets/AK8Fwd',
+    PFJetCollectionLabel   = "ak4PFJets",
+    PFJetCorLabel        = "ak4PFL1FastL2L3ResidualCorrector", #dummy residual corrections now also provided for MC GTs
+    pathFilter = ['HLT_AK8PFJetFwd'],
 
-    pathFilter = cms.untracked.vstring('HLT_AK8PFJetFwd', 
-    ),
     pathPairs = cms.VPSet(cms.PSet(
         denompathname = cms.string('HLT_AK8PFJetFwd40_v'),
         pathname = cms.string('HLT_AK8PFJetFwd60_v')
@@ -197,12 +194,11 @@ jetMETHLTOfflineSourceAK8Fwd = jetMETHLTOfflineSourceAK4.clone(
 )
 
 jetMETHLTOfflineSourceAK4Fwd = jetMETHLTOfflineSourceAK4.clone(
-    dirname = cms.untracked.string('HLT/JME/Jets/AK4Fwd'),
-    PFJetCollectionLabel   = cms.InputTag("ak4PFJets"),
-    PFJetCorLabel        = cms.InputTag("ak4PFL1FastL2L3ResidualCorrector"), #dummy residual corrections now also provided for MC GTs
+    dirname = 'HLT/JME/Jets/AK4Fwd',
+    PFJetCollectionLabel   = "ak4PFJets",
+    PFJetCorLabel        = "ak4PFL1FastL2L3ResidualCorrector", #dummy residual corrections now also provided for MC GTs
+    pathFilter = ['HLT_PFJetFwd'],
 
-    pathFilter = cms.untracked.vstring('HLT_PFJetFwd', 
-    ),
     pathPairs = cms.VPSet(cms.PSet(
         denompathname = cms.string('HLT_PFJetFwd40_v'),
         pathname = cms.string('HLT_PFJetFwd60_v')

--- a/DQMOffline/Trigger/python/JetMonitor_cff.py
+++ b/DQMOffline/Trigger/python/JetMonitor_cff.py
@@ -4,481 +4,516 @@ from DQMOffline.Trigger.JetMonitor_cfi import hltJetMETmonitoring
 
 ### HLT_PFJet Triggers ###
 # HLT_PFJet450
-PFJet450_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet450_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet450/')
-PFJet450_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  112 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double( 1120.),
+PFJet450_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet450/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  112 ,
+                xmin  =   0.,
+                xmax  = 1120.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet450_v*"])
 )
-PFJet450_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet450_v*")
+
 
 # HLT_PFJet40
-PFJet40_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet40_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet40/')
-PFJet40_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double( 100.),
+PFJet40_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet40/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  50 ,
+                xmin  =  0.,
+                xmax  = 100.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet40_v*"])
 )
-PFJet40_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet40_v*")
 
 # HLT_PFJet60
-PFJet60_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet60_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet60/')
-PFJet60_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  75 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  150.),
+PFJet60_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet60/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  75 ,
+                xmin  =  0.,
+                xmax  =  150.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet60_v*"])
 )
-PFJet60_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet60_v*")
+
 
 # HLT_PFJet80
-PFJet80_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet80_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet80/')
-PFJet80_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  200.),
+PFJet80_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet80/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  100,
+                xmin  =  0.,
+                xmax  =  200.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet80_v*"])
 )
-PFJet80_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet80_v*")
 
 # HLT_PFJet140
-PFJet140_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet140_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet140/')
-PFJet140_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  70 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  350.),
+PFJet140_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet140/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  70 ,
+                xmin  =  0.,
+                xmax  =  350.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet140_v*"])
 )
-PFJet140_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet140_v*")
 
 # HLT_PFJet200
-PFJet200_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet200_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet200/')
-PFJet200_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  500.),
+PFJet200_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet200/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  50 ,
+                xmin  =   0.,
+                xmax  =  500.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet200_v*"])
 )
-PFJet200_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet200_v*")
+
 
 # HLT_PFJet260
-PFJet260_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet260_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet260/')
-PFJet260_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  65 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  650.),
+PFJet260_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet260/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins = 65,
+                xmin  = 0.,
+                xmax  =  650.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet260_v*"])
+
 )
-PFJet260_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet260_v*")
 
 # HLT_PFJet320
-PFJet320_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet320_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet320/')
-PFJet320_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  80 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  800.),
+PFJet320_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet320/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins = 80 ,
+                xmin  =  0.,
+                xmax  = 800.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet320_v*"])
 )
-PFJet320_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet320_v*")
+
 
 # HLT_PFJet400
-PFJet400_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet400_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet400/')
-PFJet400_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  1000.),
+PFJet400_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet400/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins = 100 ,
+                xmin  =  0.,
+                xmax  =  1000.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet400_v*"])
+
 )
-PFJet400_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet400_v*")
 
 # HLT_PFJet500
-PFJet500_Prommonitoring = hltJetMETmonitoring.clone()
-PFJet500_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PF/HLT_PFJet500/')
-PFJet500_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  125),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(1250),
+PFJet500_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PF/HLT_PFJet500/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  125,
+                xmin  =  0.,
+                xmax  = 1250)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet500_v*"])
 )
-PFJet500_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet500_v*")
+
 
 ### HLT_PFJetFwd Triggers ###
 # HLT_PFJetFwd450
-PFJetFwd450_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd450_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd450/')
-PFJetFwd450_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  112 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double( 1120.),
+PFJetFwd450_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd450/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  112 ,
+                xmin  =  0.,
+                xmax  = 1120.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd450_v*"])
 )
-PFJetFwd450_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd450_v*")
 
 # HLT_PFJetFwd40
-PFJetFwd40_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd40_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd40/')
-PFJetFwd40_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double( 100.),
+PFJetFwd40_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd40/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  50 ,
+                xmin  =   0.,
+                xmax  = 100.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd40_v*"])
 )
-PFJetFwd40_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd40_v*")
+
 
 # HLT_PFJetFwd60
-PFJetFwd60_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd60_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd60/')
-PFJetFwd60_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  75 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  150.),
+PFJetFwd60_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd60/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  75 ,
+                xmin  =   0.,
+                xmax  =  150.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd60_v*"])
 )
-PFJetFwd60_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd60_v*")
+
 
 # HLT_PFJetFwd80
-PFJetFwd80_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd80_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd80/')
-PFJetFwd80_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  200.),
+PFJetFwd80_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd80/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  100,
+                xmin  =   0.,
+                xmax  =  200.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd80_v*"])
+
 )
-PFJetFwd80_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd80_v*")
 
 # HLT_PFJetFwd140
-PFJetFwd140_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd140_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd140/')
-PFJetFwd140_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  70 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  350.),
+PFJetFwd140_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd140/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  70 ,
+                xmin  =   0.,
+                xmax  =  350.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd140_v*"])
 )
-PFJetFwd140_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd140_v*")
+
 
 # HLT_PFJetFwd200
-PFJetFwd200_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd200_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd200/')
-PFJetFwd200_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  500.),
+PFJetFwd200_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd200/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins = 50 ,
+                xmin  =   0.,
+                xmax  =  500.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd200_v*"])
 )
-PFJetFwd200_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd200_v*")
+
 
 # HLT_PFJetFwd260
-PFJetFwd260_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd260_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd260/')
-PFJetFwd260_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  65 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  650.),
+PFJetFwd260_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd260/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins = 65 ,
+                xmin  =  0.,
+                xmax  = 650.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd260_v*"])
 )
-PFJetFwd260_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd260_v*")
+
 
 # HLT_PFJetFwd320
-PFJetFwd320_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd320_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd320/')
-PFJetFwd320_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  80 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  800.),
+PFJetFwd320_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd320/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins = 80 ,
+                xmin  =  0.,
+                xmax  = 800.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd320_v*"])
 )
-PFJetFwd320_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd320_v*")
+
 
 # HLT_PFJetFwd400
-PFJetFwd400_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd400_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd400/')
-PFJetFwd400_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  1000.),
+PFJetFwd400_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd400/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins = 100 ,
+                xmin  =  0.,
+                xmax  =  1000.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd400_v*"])
 )
-PFJetFwd400_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd400_v*")
+
 
 # HLT_PFJetFwd500
-PFJetFwd500_Prommonitoring = hltJetMETmonitoring.clone()
-PFJetFwd500_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd500/')
-PFJetFwd500_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  125),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(1250),
+PFJetFwd500_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4Fwd/PF/HLT_PFJetFwd500/',
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins = 125,
+                xmin  =   0.,
+                xmax  = 1250)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJetFwd500_v*"])
 )
-PFJetFwd500_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJetFwd500_v*")
+
 
 ### HLT_AK8 Triggers ###
 # HLT_AK8PFJet40
-AK8PFJet40_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet40_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet40/')
-AK8PFJet40_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet40_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double( 100.),
+AK8PFJet40_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet40/',
+    jetSrc = "ak8PFJetsPuppi",
+    histoPSet =dict(jetPtThrPSet = dict(
+                nbins =  50 ,
+                xmin  =   0.,
+                xmax  = 100.)),
+
+    ispfjettrg = True,
+    iscalojettrg = False,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet40_v*"])
 )
-AK8PFJet40_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet40_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet40_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet40_v*")
+
 
 # HLT_AK8PFJet60
-AK8PFJet60_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet60_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet60/')
-AK8PFJet60_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet60_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  75 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  150.),
+AK8PFJet60_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet60/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  75 ,
+                xmin  =  0.,
+                xmax  =  150.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet60_v*"])
 )
-AK8PFJet60_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet60_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet60_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet60_v*")
+
 
 # HLT_AK8PFJet80
-AK8PFJet80_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet80_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet80/')
-AK8PFJet80_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet80_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  200.),
+AK8PFJet80_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet80/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  100 ,
+                xmin  =   0.,
+                xmax  =  200.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet80_v*"])
+
 )
-AK8PFJet80_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet80_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet80_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet80_v*")
 
 # HLT_AK8PFJet140
-AK8PFJet140_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet140_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet140/')
-AK8PFJet140_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet140_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  70 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  350.),
+AK8PFJet140_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet140/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  70 ,
+                xmin  =   0.,
+                xmax  = 350.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet140_v*"])
 )
-AK8PFJet140_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet140_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet140_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet140_v*")
+
 
 # HLT_AK8PFJet200
-AK8PFJet200_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet200_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet200/')
-AK8PFJet200_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet200_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  500.),
+AK8PFJet200_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet200/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  50,
+                xmin  =  0.,
+                xmax  =  500.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet200_v*"])
 )
-AK8PFJet200_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet200_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet200_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet200_v*")
+
 
 # HLT_AK8PFJet260
-AK8PFJet260_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet260_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet260/')
-AK8PFJet260_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet260_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  65 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  650.),
+AK8PFJet260_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet260/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  65 ,
+                xmin  =   0.,
+                xmax  =  650.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet260_v*"])
 )
-AK8PFJet260_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet260_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet260_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet260_v*")
+
 
 # HLT_AK8PFJet320
-AK8PFJet320_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet320_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet320/')
-AK8PFJet320_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet320_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  80 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  800.),
+AK8PFJet320_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet320/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  80 ,
+                xmin  =  0.,
+                xmax  = 800.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet320_v*"])
 )
-AK8PFJet320_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet320_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet320_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet320_v*")
+
 
 # HLT_AK8PFJet400
-AK8PFJet400_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet400_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet400/')
-AK8PFJet400_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet400_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  1000.),
+AK8PFJet400_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet400/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  100 ,
+                xmin  =  0.,
+                xmax  =  1000.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_v*"])
 )
-AK8PFJet400_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet400_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet400_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet400_v*")
+
 
 # HLT_AK8PFJet450
-AK8PFJet450_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet450_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet450/')
-AK8PFJet450_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet450_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  112 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double( 1120.),
+AK8PFJet450_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet450/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  112 ,
+                xmin  =   0.,
+                xmax  =  1120.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet450_v*"])
 )
-AK8PFJet450_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet450_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet450_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet450_v*")
+
 
 # HLT_AK8PFJet500
-AK8PFJet500_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJet500_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8/PF/HLT_AK8PFJet500/')
-AK8PFJet500_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJet500_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  125),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(1250),
+AK8PFJet500_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8/PF/HLT_AK8PFJet500/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  125,
+                xmin  =  0.,
+                xmax  = 1250)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet500_v*"])
+
 )
-AK8PFJet500_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJet500_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJet500_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJet500_v*")
 
 ### HLT_AK8Fwd Triggers ###
 # HLT_AK8PFJetFwd40
-AK8PFJetFwd40_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd40_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd40/')
-AK8PFJetFwd40_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd40_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double( 100.),
+AK8PFJetFwd40_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd40/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  50 ,
+                xmin  =  0.,
+                xmax  = 100.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJetFwd40_v*"])
 )
-AK8PFJetFwd40_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd40_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd40_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd40_v*")
+
 
 # HLT_AK8PFJetFwd60
-AK8PFJetFwd60_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd60_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd60/')
-AK8PFJetFwd60_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd60_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  75 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  150.),
+AK8PFJetFwd60_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd60/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  75 ,
+                xmin  =   0.,
+                xmax  =  150.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJetFwd60_v*"])
 )
-AK8PFJetFwd60_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd60_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd60_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd60_v*")
+
 
 # HLT_AK8PFJetFwd80
-AK8PFJetFwd80_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd80_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd80/')
-AK8PFJetFwd80_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd80_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  200.),
+AK8PFJetFwd80_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd80/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  100 ,
+                xmin  =   0.,
+                xmax  =  200.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJetFwd80_v*"])
 )
-AK8PFJetFwd80_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd80_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd80_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd80_v*")
+
 
 # HLT_AK8PFJetFwd140
-AK8PFJetFwd140_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd140_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd140/')
-AK8PFJetFwd140_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd140_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  70 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  350.),
+AK8PFJetFwd140_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd140/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  70 ,
+                xmin  =   0.,
+                xmax  =  350.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJetFwd140_v*"])
 )
-AK8PFJetFwd140_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd140_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd140_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd140_v*")
+
 
 # HLT_AK8PFJetFwd200
-AK8PFJetFwd200_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd200_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd200/')
-AK8PFJetFwd200_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd200_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  50 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  500.),
+AK8PFJetFwd200_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd200/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  50 ,
+                xmin  =   0.,
+                xmax  =  500.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJetFwd200_v*"])
 )
-AK8PFJetFwd200_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd200_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd200_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd200_v*")
+
 
 # HLT_AK8PFJetFwd260
-AK8PFJetFwd260_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd260_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd260/')
-AK8PFJetFwd260_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd260_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  65 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  650.),
+AK8PFJetFwd260_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd260/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  65 ,
+                xmin  =   0.,
+                xmax  =  650.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJetFwd260_v*"])
 )
-AK8PFJetFwd260_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd260_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd260_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd260_v*")
+
 
 # HLT_AK8PFJetFwd320
-AK8PFJetFwd320_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd320_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd320/')
-AK8PFJetFwd320_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd320_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  80 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  800.),
+AK8PFJetFwd320_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd320/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  80 ,
+                xmin  =  0.,
+                xmax  = 800.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJetFwd320_v*"])
 )
-AK8PFJetFwd320_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd320_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd320_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd320_v*")
+
 
 # HLT_AK8PFJetFwd400
-AK8PFJetFwd400_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd400_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd400/')
-AK8PFJetFwd400_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd400_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  100 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(  1000.),
+AK8PFJetFwd400_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd400/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  100 ,
+                xmin  =   0.,
+                xmax  =  1000.)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJetFwd400_v*"])
 )
-AK8PFJetFwd400_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd400_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd400_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd400_v*")
 
 # HLT_AK8PFJetFwd450
-AK8PFJetFwd450_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd450_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd450/')
-AK8PFJetFwd450_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd450_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  112 ),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double( 1120.),
+AK8PFJetFwd450_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd450/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =   112 ,
+                xmin  =  0.,
+                xmax  = 1120.)),
+    numGenericTriggerEventPSet = dict(hltPaths =["HLT_AK8PFJetFwd450_v*"])
 )
-AK8PFJetFwd450_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd450_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd450_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd450_v*")
+
 
 # HLT_AK8PFJetFwd500
-AK8PFJetFwd500_Prommonitoring = hltJetMETmonitoring.clone()
-AK8PFJetFwd500_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd500/')
-AK8PFJetFwd500_Prommonitoring.jetSrc = cms.InputTag("ak8PFJetsPuppi")
-AK8PFJetFwd500_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  125),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(1250),
+AK8PFJetFwd500_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK8Fwd/PF/HLT_AK8PFJetFwd500/',
+    jetSrc = "ak8PFJetsPuppi",
+    ispfjettrg = True,
+    iscalojettrg = False,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  125,
+                xmin  =   0.,
+                xmax  = 1250)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJetFwd500_v*"])
+
 )
-AK8PFJetFwd500_Prommonitoring.ispfjettrg = cms.bool(True)
-AK8PFJetFwd500_Prommonitoring.iscalojettrg = cms.bool(False)
-AK8PFJetFwd500_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_AK8PFJetFwd500_v*")
 
 # HLT_CaloJet500_NoJetID
-CaloJet500_NoJetID_Prommonitoring = hltJetMETmonitoring.clone()
-CaloJet500_NoJetID_Prommonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/Calo/HLT_CaloJet500_NoJetID/')
-CaloJet500_NoJetID_Prommonitoring.jetSrc = cms.InputTag("ak4CaloJets")
-CaloJet500_NoJetID_Prommonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32 (  125),
-  xmin  = cms.double(   0.),
-  xmax  = cms.double(1250),
+CaloJet500_NoJetID_Prommonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/Calo/HLT_CaloJet500_NoJetID/',
+    jetSrc = "ak4CaloJets",
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetPtThrPSet = dict(
+                nbins =  125,
+                xmin  =   0.,
+                xmax  = 1250)),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloJet500_NoJetID_v*"])
 )
-CaloJet500_NoJetID_Prommonitoring.ispfjettrg = cms.bool(False)
-CaloJet500_NoJetID_Prommonitoring.iscalojettrg = cms.bool(True)
-CaloJet500_NoJetID_Prommonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloJet500_NoJetID_v*")
-
 
 
 HLTJetmonitoring = cms.Sequence(

--- a/DQMOffline/Trigger/python/JetMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/JetMonitor_cfi.py
@@ -2,43 +2,46 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.jetMonitoring_cfi import jetMonitoring
 
-hltJetMETmonitoring = jetMonitoring.clone()
-hltJetMETmonitoring.FolderName = cms.string('HLT/JME/Jets/AK4/PFJet/HLT_PFJet450/')
-hltJetMETmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32(250),
-  xmin  = cms.double(0.),
-  xmax  = cms.double(2500.),
-)
-hltJetMETmonitoring.histoPSet.jetPSet = cms.PSet(
-  nbins = cms.uint32(200),
-  xmin  = cms.double(-0.5),
-  xmax  = cms.double(999.5),
-)
-hltJetMETmonitoring.histoPSet.jetPtThrPSet = cms.PSet(
-  nbins = cms.uint32(180),
-  xmin  = cms.double(0.),
-  xmax  = cms.double(900),
-)
-hltJetMETmonitoring.jetSrc = 'ak4PFJets' # ak4PFJets, ak4PFJetsCHS
-hltJetMETmonitoring.ptcut = 20.
-hltJetMETmonitoring.ispfjettrg = True # is PFJet Trigger ?
-hltJetMETmonitoring.iscalojettrg = False # is CaloJet Trigger ?
+hltJetMETmonitoring = jetMonitoring.clone(
+    FolderName = 'HLT/JME/Jets/AK4/PFJet/HLT_PFJet450/',
 
-hltJetMETmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltJetMETmonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("JetMETDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
-hltJetMETmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltJetMETmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltJetMETmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_PFJet450_v*") # HLT_ZeroBias_v*
-hltJetMETmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltJetMETmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+    histoPSet = dict(
+        lsPSet = dict(
+                nbins = 250,
+                xmin  = 0.,
+                xmax  = 2500.),
+        jetPSet = dict(
+                nbins = 200,
+                xmin  = -0.5,
+                xmax  = 999.5),
+        jetPtThrPSet = dict(
+                nbins = 180,
+                xmin  = 0.,
+                xmax  = 900),
+    ),
+    jetSrc = 'ak4PFJets', # ak4PFJets, ak4PFJetsCHS
+    ptcut = 20.,
+    ispfjettrg = True, # is PFJet Trigger ?
+    iscalojettrg = False, # is CaloJet Trigger ?
 
-hltJetMETmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltJetMETmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltJetMETmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltJetMETmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltJetMETmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltJetMETmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltJetMETmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+    numGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        dbLabel       = "JetMETDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+        andOrHlt      = True, # True:=OR; False:=AND
+        hltInputTag   =  "TriggerResults::HLT",
+        hltPaths      = ["HLT_PFJet450_v*"], # HLT_ZeroBias_v*
+        errorReplyHlt = False,
+        verbosityLevel = 1),
+
+    denGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        dcsInputTag   =  "scalersRawToDigi",
+        dcsRecordInputTag = "onlineMetaDataDigis",
+        dcsPartitions = [ 24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+        andOrDcs      = False,
+        errorReplyDcs =  True,
+        verbosityLevel = 1)
+)
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 stage2L1Trigger.toModify(hltJetMETmonitoring,
@@ -50,4 +53,5 @@ stage2L1Trigger.toModify(hltJetMETmonitoring,
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            ReadPrescalesFromFile = cms.bool(True)))
+
 

--- a/DQMOffline/Trigger/python/LepHTMonitor_cff.py
+++ b/DQMOffline/Trigger/python/LepHTMonitor_cff.py
@@ -84,81 +84,93 @@ DQMOffline_Ele15_HT600 = DQMEDAnalyzer('LepHTMonitor',
                                                 ),
                                             )
 
-DQMOffline_Ele15_HT450 = DQMOffline_Ele15_HT600.clone()
-DQMOffline_Ele15_HT450.folderName =  cms.string('HLT_Ele15_IsoVVVL_PFHT450')
-DQMOffline_Ele15_HT450.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele15_IsoVVVL_PFHT450_v*")
+DQMOffline_Ele15_HT450 = DQMOffline_Ele15_HT600.clone(
+    folderName =  'HLT_Ele15_IsoVVVL_PFHT450',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele15_IsoVVVL_PFHT450_v*"])
+)
 
-DQMOffline_Ele50_HT450 = DQMOffline_Ele15_HT600.clone()
-DQMOffline_Ele50_HT450.folderName =  cms.string('HLT_Ele50_IsoVVVL_PFH450')
-DQMOffline_Ele50_HT450.leptonPtPlateau = cms.untracked.double(60.0)
-DQMOffline_Ele50_HT450.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele50_IsoVVVL_PFHT450_v*")
+DQMOffline_Ele50_HT450 = DQMOffline_Ele15_HT600.clone(
+    folderName =  'HLT_Ele50_IsoVVVL_PFH450',
+    leptonPtPlateau = 60.0,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele50_IsoVVVL_PFHT450_v*"])
+)
 
 ### Single Muon + HT triggers
-DQMOffline_Mu15_HT600 = DQMOffline_Ele15_HT600.clone()
-DQMOffline_Mu15_HT600.electronCollection = cms.InputTag('')
-DQMOffline_Mu15_HT600.conversionCollection = cms.InputTag('')
-DQMOffline_Mu15_HT600.muonCollection = cms.InputTag('muons')
-DQMOffline_Mu15_HT600.muonIDlevel = cms.untracked.int32(2) ## 1: loose, 2: medium, 3: tight
-DQMOffline_Mu15_HT600.nels = cms.untracked.double(0)
-DQMOffline_Mu15_HT600.nmus = cms.untracked.double(1)
-DQMOffline_Mu15_HT600.lepIsoCut = cms.untracked.double(0.2) 
-DQMOffline_Mu15_HT600.lepEtaCut = cms.untracked.double(2.4)
-DQMOffline_Mu15_HT600.lep_d0_cut_b = cms.untracked.double(0.2) #endcap parameter not used for muons 
-DQMOffline_Mu15_HT600.lep_dz_cut_b = cms.untracked.double(0.5)
-                                              
-DQMOffline_Mu15_HT600.folderName =  cms.string('HLT_Mu15_IsoVVVL_PFH600')
-DQMOffline_Mu15_HT600.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu15_IsoVVVL_PFHT600_v*")
-DQMOffline_Mu15_HT600.den_HT_GenericTriggerEventPSet.hltPaths = cms.vstring("HLT_IsoMu27_v*","HLT_IsoMu24_v*")
+DQMOffline_Mu15_HT600 = DQMOffline_Ele15_HT600.clone(
+    electronCollection = '',
+    conversionCollection = '',
+    muonCollection = 'muons',
+    muonIDlevel = 2, ## 1: loose, 2: medium, 3: tight
+    nels = 0,
+    nmus = 1,
+    lepIsoCut = 0.2, 
+    lepEtaCut = 2.4,
+    lep_d0_cut_b = 0.2, #endcap parameter not used for muons 
+    lep_dz_cut_b = 0.5,
+    folderName =  'HLT_Mu15_IsoVVVL_PFH600',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu15_IsoVVVL_PFHT600_v*"]),
+    den_HT_GenericTriggerEventPSet = dict(hltPaths = ["HLT_IsoMu27_v*","HLT_IsoMu24_v*"])
+)
 
-DQMOffline_Mu15_HT450 = DQMOffline_Mu15_HT600.clone()
-DQMOffline_Mu15_HT450.folderName =  cms.string('HLT_Mu15_IsoVVVL_PFHT450')
-DQMOffline_Mu15_HT450.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu15_IsoVVVL_PFHT450_v*")
+DQMOffline_Mu15_HT450 = DQMOffline_Mu15_HT600.clone(
+    folderName =  'HLT_Mu15_IsoVVVL_PFHT450',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu15_IsoVVVL_PFHT450_v*"])
+)
 
-DQMOffline_Mu50_HT450 = DQMOffline_Mu15_HT600.clone()
-DQMOffline_Mu50_HT450.folderName =  cms.string('HLT_Mu50_IsoVVVL_PFH450')
-DQMOffline_Mu50_HT450.leptonPtPlateau = cms.untracked.double(60.0)
-DQMOffline_Mu50_HT450.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu50_IsoVVVL_PFHT450_v*")
+DQMOffline_Mu50_HT450 = DQMOffline_Mu15_HT600.clone(
+    folderName =  'HLT_Mu50_IsoVVVL_PFH450',
+    leptonPtPlateau = 60.0,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu50_IsoVVVL_PFHT450_v*"])
+)
 
 ### Dilepton + HT triggers
-DQMOffline_DoubleMu4_Mass8_DZ_PFHT350 = DQMOffline_Mu15_HT600.clone()
-DQMOffline_DoubleMu4_Mass8_DZ_PFHT350.nmus = cms.untracked.double(2)
-DQMOffline_DoubleMu4_Mass8_DZ_PFHT350.folderName =  cms.string('HLT_DoubleMu4_Mass8_DZ_PFHT350')
-DQMOffline_DoubleMu4_Mass8_DZ_PFHT350.leptonPtPlateau = cms.untracked.double(6.0)
-DQMOffline_DoubleMu4_Mass8_DZ_PFHT350.leptonCountingThreshold = cms.untracked.double(4.0)
-DQMOffline_DoubleMu4_Mass8_DZ_PFHT350.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_Mass8_DZ_PFHT350_v*")
-DQMOffline_DoubleMu4_Mass8_DZ_PFHT350.den_lep_GenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu15_IsoVVVL_PFHT450_v*")
-DQMOffline_DoubleMu4_Mass8_DZ_PFHT350.den_HT_GenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*")
+DQMOffline_DoubleMu4_Mass8_DZ_PFHT350 = DQMOffline_Mu15_HT600.clone(
+    nmus = 2,
+    folderName =  'HLT_DoubleMu4_Mass8_DZ_PFHT350',
+    leptonPtPlateau = 6.0,
+    leptonCountingThreshold = 4.0,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_Mass8_DZ_PFHT350_v*"]),
+    den_lep_GenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu15_IsoVVVL_PFHT450_v*"]),
+    den_HT_GenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*"])
+)
 
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350 = DQMOffline_Ele15_HT600.clone()
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.nels = cms.untracked.double(2)
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.folderName =  cms.string('HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350')
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.leptonPtPlateau = cms.untracked.double(10.0)
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.leptonCountingThreshold = cms.untracked.double(8.0)
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350_v*")
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.den_lep_GenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele15_IsoVVVL_PFHT450_v*")
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.den_HT_GenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ*")
 
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ = DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.clone()
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ.muonCollection = cms.InputTag('muons')
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ.nels = cms.untracked.double(1)
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ.nmus = cms.untracked.double(1)
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ.folderName =  cms.string('HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ')
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ_v*")
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ.den_lep_GenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele15_IsoVVVL_PFHT450_v*","HLT_Mu15_IsoVVVL_PFHT450_v*")
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ.den_HT_GenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*", "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*","HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*")
+DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350 = DQMOffline_Ele15_HT600.clone(
+    nels = 2,
+    folderName =  'HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350',
+    leptonPtPlateau = 10.0,
+    leptonCountingThreshold = 8.0,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350_v*"]),
+    den_lep_GenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele15_IsoVVVL_PFHT450_v*"]),
+    den_HT_GenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ*"])
+)
+
+
+DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ = DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.clone(
+    muonCollection = 'muons',
+    nels = 1,
+    nmus = 1,
+    folderName =  'HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ_v*"]),
+    den_lep_GenericTriggerEventPSet = dict(hltPaths = ["HLT_Ele15_IsoVVVL_PFHT450_v*","HLT_Mu15_IsoVVVL_PFHT450_v*"]),
+    den_HT_GenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*", "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*","HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*"])
+)
 
 ### Alternate dilepton + HT without DZ requirement
-DQMOffline_DoubleMu4_Mass8_PFHT350 = DQMOffline_DoubleMu4_Mass8_DZ_PFHT350.clone()
-DQMOffline_DoubleMu4_Mass8_PFHT350.folderName =  cms.string('HLT_DoubleMu4_Mass8_PFHT350')
-DQMOffline_DoubleMu4_Mass8_PFHT350.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu4_Mass8_PFHT350_v*")
+DQMOffline_DoubleMu4_Mass8_PFHT350 = DQMOffline_DoubleMu4_Mass8_DZ_PFHT350.clone(
+    folderName =  'HLT_DoubleMu4_Mass8_PFHT350',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu4_Mass8_PFHT350_v*"])
+)
 
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350 = DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.clone()
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350.folderName =  cms.string('HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350')
-DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350_v*")
+DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350 = DQMOffline_DoubleEle8_CaloIdM_TrackIdM_Mass8_DZ_PFHT350.clone(
+    folderName =  'HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT350_v*"])
+)
 
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350 = DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ.clone()
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350.folderName =  cms.string('HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350')
-DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_v*")
+DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350 = DQMOffline_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_DZ.clone(
+    folderName =  'HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT350_v*"]) 
+)
 
 # fastsim has no conversion collection
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/DQMOffline/Trigger/python/METMonitor_cff.py
+++ b/DQMOffline/Trigger/python/METMonitor_cff.py
@@ -3,267 +3,267 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.METMonitor_cfi import hltMETmonitoring
 
 # HLT_PFMET110_PFMHT110_IDTight
-PFMET110_PFMHT110_IDTight_METmonitoring = hltMETmonitoring.clone()
-PFMET110_PFMHT110_IDTight_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMET110/')
-PFMET110_PFMHT110_IDTight_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET110_PFMHT110_IDTight_v*")
-PFMET110_PFMHT110_IDTight_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMET110_PFMHT110_IDTight_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMET110/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET110_PFMHT110_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 #HLT_PFMET120_PFMHT120_IDTight
-PFMET120_PFMHT120_IDTight_METmonitoring = hltMETmonitoring.clone()
-PFMET120_PFMHT120_IDTight_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMET120')
-PFMET120_PFMHT120_IDTight_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*")
-PFMET120_PFMHT120_IDTight_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMET120_PFMHT120_IDTight_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMET120',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMET130_PFMHT130_IDTight
-PFMET130_PFMHT130_IDTight_METmonitoring = hltMETmonitoring.clone()
-PFMET130_PFMHT130_IDTight_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMET130/')
-PFMET130_PFMHT130_IDTight_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET130_PFMHT130_IDTight_v*")
-PFMET130_PFMHT130_IDTight_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMET130_PFMHT130_IDTight_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMET130/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET130_PFMHT130_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMET140_PFMHT140_IDTight
-PFMET140_PFMHT140_IDTight_METmonitoring = hltMETmonitoring.clone()
-PFMET140_PFMHT140_IDTight_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMET140/')
-PFMET140_PFMHT140_IDTight_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET140_PFMHT140_IDTight_v*")
-PFMET140_PFMHT140_IDTight_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMET140_PFMHT140_IDTight_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMET140/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET140_PFMHT140_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETTypeOne110_PFMHT110_IDTight                                                                                                                              
-PFMETTypeOne110_PFMHT110_METmonitoring = hltMETmonitoring.clone()
-PFMETTypeOne110_PFMHT110_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETTypeOne110/')
-PFMETTypeOne110_PFMHT110_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETTypeOne110_PFMHT110_IDTight_v*")
-PFMETTypeOne110_PFMHT110_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETTypeOne110_PFMHT110_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETTypeOne110/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne110_PFMHT110_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETTypeOne120_PFMHT120_IDTight
-PFMETTypeOne120_PFMHT120_METmonitoring = hltMETmonitoring.clone()
-PFMETTypeOne120_PFMHT120_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETTypeOne120/')
-PFMETTypeOne120_PFMHT120_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PPFMETTypeOne120_PFMHT120_IDTight_v*")
-PFMETTypeOne120_PFMHT120_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETTypeOne120_PFMHT120_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETTypeOne120/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PPFMETTypeOne120_PFMHT120_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETTypeOne130_PFMHT130_IDTight
-PFMETTypeOne130_PFMHT130_METmonitoring = hltMETmonitoring.clone()
-PFMETTypeOne130_PFMHT130_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETTypeOne130/')
-PFMETTypeOne130_PFMHT130_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETTypeOne130_PFMHT130_IDTight_v*")
-PFMETTypeOne130_PFMHT130_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETTypeOne130_PFMHT130_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETTypeOne130/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne130_PFMHT130_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETTypeOne140_PFMHT140_IDTight
-PFMETTypeOne140_PFMHT140_METmonitoring = hltMETmonitoring.clone()
-PFMETTypeOne140_PFMHT140_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETTypeOne140/')
-PFMETTypeOne140_PFMHT140_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETTypeOne140_PFMHT140_IDTight_v*")
-PFMETTypeOne140_PFMHT140_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETTypeOne140_PFMHT140_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETTypeOne140/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne140_PFMHT140_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETNoMu90_PFMHTNoMu90_IDTight
-PFMETNoMu90_PFMHTNoMu90_METmonitoring = hltMETmonitoring.clone()
-PFMETNoMu90_PFMHTNoMu90_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETNoMu90/')
-PFMETNoMu90_PFMHTNoMu90_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v*")
-PFMETNoMu90_PFMHTNoMu90_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETNoMu90_PFMHTNoMu90_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETNoMu90/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETNoMu110_PFMHTNoMu110_IDTight
-PFMETNoMu110_PFMHTNoMu110_METmonitoring = hltMETmonitoring.clone()
-PFMETNoMu110_PFMHTNoMu110_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETNoMu110/')
-PFMETNoMu110_PFMHTNoMu110_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_v*")
-PFMETNoMu110_PFMHTNoMu110_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETNoMu110_PFMHTNoMu110_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETNoMu110/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
-PFMETNoMu120_PFMHTNoMu120_METmonitoring = hltMETmonitoring.clone()
-PFMETNoMu120_PFMHTNoMu120_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETNoMu120/')
-PFMETNoMu120_PFMHTNoMu120_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-PFMETNoMu120_PFMHTNoMu120_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETNoMu120_PFMHTNoMu120_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETNoMu120/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETNoMu130_PFMHTNoMu130_IDTight
-PFMETNoMu130_PFMHTNoMu130_METmonitoring = hltMETmonitoring.clone()
-PFMETNoMu130_PFMHTNoMu130_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETNoMu130/')
-PFMETNoMu130_PFMHTNoMu130_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETNoMu130_PFMHTNoMu130_IDTight_v*")
-PFMETNoMu130_PFMHTNoMu130_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETNoMu130_PFMHTNoMu130_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETNoMu130/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu130_PFMHTNoMu130_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETNoMu140_PFMHTNoMu140_IDTight
-PFMETNoMu140_PFMHTNoMu140_METmonitoring = hltMETmonitoring.clone()
-PFMETNoMu140_PFMHTNoMu140_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETNoMu140/')
-PFMETNoMu140_PFMHTNoMu140_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETNoMu140_PFMHTNoMu140_IDTight_v*")
-PFMETNoMu140_PFMHTNoMu140_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETNoMu140_PFMHTNoMu140_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETNoMu140/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu140_PFMHTNoMu140_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_MET200
-MET200_METmonitoring = hltMETmonitoring.clone()
-MET200_METmonitoring.FolderName = cms.string('HLT/JME/MET/MET200/')
-MET200_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MET200_v*")
-
+MET200_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/MET200/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MET200_v*"])
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight
-MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_METmonitoring = hltMETmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_METmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu110/')
-MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight")
-MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu110/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight
-MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_METmonitoring = hltMETmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_METmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu120/')
-MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu120/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_IDTight
-MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_METmonitoring = hltMETmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_METmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu130/')
-MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_IDTight_v*")
-MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu130/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_IDTight
-MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_METmonitoring = hltMETmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_METmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu140/')
-MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_IDTight_v*")
-MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu140/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_IDTight
-MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_METmonitoring = hltMETmonitoring.clone()
-MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_METmonitoring.FolderName = cms.string('HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu90/')
-MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight_v*")
-MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_METmonitoring.jetSelection      = cms.string("pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu90/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight_v*"]),
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFHT500_PFMET100_PFMHT100_IDTight
-PFHT500_PFMET100_PFMHT100_METmonitoring = hltMETmonitoring.clone()
-PFHT500_PFMET100_PFMHT100_METmonitoring.FolderName = cms.string('HLT/EXO/MET/PFHT500_PFMET100_PFMHT100/')
-PFHT500_PFMET100_PFMHT100_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT500_PFMET100_PFMHT100_IDTight_v*")
-
+PFHT500_PFMET100_PFMHT100_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFHT500_PFMET100_PFMHT100/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT500_PFMET100_PFMHT100_IDTight_v*"])
+)
 # HLT_PFHT500_PFMET110_PFMHT110_IDTight
-PFHT500_PFMET110_PFMHT110_METmonitoring = hltMETmonitoring.clone()
-PFHT500_PFMET110_PFMHT110_METmonitoring.FolderName = cms.string('HLT/EXO/MET/PFHT500_PFMET110_PFMHT110/')
-PFHT500_PFMET110_PFMHT110_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT500_PFMET110_PFMHT110_IDTight_v*")
-
+PFHT500_PFMET110_PFMHT110_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFHT500_PFMET110_PFMHT110/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT500_PFMET110_PFMHT110_IDTight_v*"])
+)
 # HLT_PFHT700_PFMET85_PFMHT85_IDTight
-PFHT700_PFMET85_PFMHT85_METmonitoring = hltMETmonitoring.clone()
-PFHT700_PFMET85_PFMHT85_METmonitoring.FolderName = cms.string('HLT/EXO/MET/PFHT700_PFMET85_PFMHT85/')
-PFHT700_PFMET85_PFMHT85_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT700_PFMET85_PFMHT85_IDTight_v*")
-
+PFHT700_PFMET85_PFMHT85_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFHT700_PFMET85_PFMHT85/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT700_PFMET85_PFMHT85_IDTight_v*"])
+)
 # HLT_PFHT700_PFMET95_PFMHT95_IDTight
-PFHT700_PFMET95_PFMHT95_METmonitoring = hltMETmonitoring.clone()
-PFHT700_PFMET95_PFMHT95_METmonitoring.FolderName = cms.string('HLT/EXO/MET/PFHT700_PFMET95_PFMHT95/')
-PFHT700_PFMET95_PFMHT95_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT700_PFMET95_PFMHT95_IDTight_v*")
-
+PFHT700_PFMET95_PFMHT95_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFHT700_PFMET95_PFMHT95/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT700_PFMET95_PFMHT95_IDTight_v*"])
+)
 # HLT_PFHT800_PFMET75_PFMHT75_IDTight
-PFHT800_PFMET75_PFMHT75_METmonitoring = hltMETmonitoring.clone()
-PFHT800_PFMET75_PFMHT75_METmonitoring.FolderName = cms.string('HLT/EXO/MET/PFHT800_PFMET75_PFMHT75/')
-PFHT800_PFMET75_PFMHT75_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT800_PFMET75_PFMHT75_IDTight_v*")
-
+PFHT800_PFMET75_PFMHT75_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFHT800_PFMET75_PFMHT75/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT800_PFMET75_PFMHT75_IDTight_v*"])
+)
 # HLT_PFHT800_PFMET85_PFMHT85_IDTight
-PFHT800_PFMET85_PFMHT85_METmonitoring = hltMETmonitoring.clone()
-PFHT800_PFMET85_PFMHT85_METmonitoring.FolderName = cms.string('HLT/EXO/MET/PFHT800_PFMET85_PFMHT85/')
-PFHT800_PFMET85_PFMHT85_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFHT800_PFMET85_PFMHT85_IDTight_v*")
-
+PFHT800_PFMET85_PFMHT85_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFHT800_PFMET85_PFMHT85/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFHT800_PFMET85_PFMHT85_IDTight_v*"])
+)
 # HLT_PFMET120_PFMHT120_IDTight_PFHT60
-PFMET120_PFMHT120_IDTight_PFHT60_METmonitoring = hltMETmonitoring.clone()
-PFMET120_PFMHT120_IDTight_PFHT60_METmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMET120_PFHT60/')
-PFMET120_PFMHT120_IDTight_PFHT60_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_PFHT60_v*")
-PFMET120_PFMHT120_IDTight_PFHT60_METmonitoring.jetSelection      = cms.string("pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMET120_PFMHT120_IDTight_PFHT60_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMET120_PFHT60/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_PFHT60_v*"]),
+    jetSelection      = "pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60
-PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_METmonitoring = hltMETmonitoring.clone()
-PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_METmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMETNoMu120_PFHT60/')
-PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_v*")
-PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_METmonitoring.jetSelection      = cms.string("pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETNoMu120_PFHT60/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60_v*"]),
+    jetSelection      = cms.string("pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
+)
 # HLT_PFMETTypeOne120_PFMHT120_IDTight_PFHT60
-PFMETTypeOne120_PFMHT120_IDTight_PFHT60_METmonitoring = hltMETmonitoring.clone()
-PFMETTypeOne120_PFMHT120_IDTight_PFHT60_METmonitoring.FolderName = cms.string('HLT/EXO/MET/PFMETTypeOne120_PFHT60/')
-PFMETTypeOne120_PFMHT120_IDTight_PFHT60_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETTypeOne120_PFMHT120_IDTight_PFHT60_v*")
-PFMETTypeOne120_PFMHT120_IDTight_PFHT60_METmonitoring.jetSelection      = cms.string("pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1")
-
+PFMETTypeOne120_PFMHT120_IDTight_PFHT60_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETTypeOne120_PFHT60/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne120_PFMHT120_IDTight_PFHT60_v*"]),
+    jetSelection      = "pt > 70 && abs(eta) < 2.4 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 ## Add Pure MET Trigger ##
 # HLT_L1ETMHadSeeds_v 
-L1ETMHadSeeds_METmonitoring = hltMETmonitoring.clone()
-L1ETMHadSeeds_METmonitoring.FolderName = cms.string('HLT/JME/MET/L1ETMHadSeeds/')
-L1ETMHadSeeds_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L1ETMHadSeeds_v*")
-
+L1ETMHadSeeds_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/L1ETMHadSeeds/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L1ETMHadSeeds_v*"])
+)
 # HLT_CaloMHT90_v 
-CaloMHT90_METmonitoring = hltMETmonitoring.clone()
-CaloMHT90_METmonitoring.FolderName = cms.string('HLT/JME/CaloMHT/CaloMHT90/')
-CaloMHT90_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMHT90_v*")
-
+CaloMHT90_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/CaloMHT/CaloMHT90/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMHT90_v*"])
+)
 # HLT_CaloMET70_HBHECleaned_v 
-CaloMET70_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET70_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET70_HBHECleaned/')
-CaloMET70_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET70_HBHECleaned_v*")
-
+CaloMET70_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET70_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET70_HBHECleaned_v*"])
+)
 # HLT_CaloMET80_HBHECleaned_v 
-CaloMET80_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET80_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET80_HBHECleaned/')
-CaloMET80_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET80_HBHECleaned_v*")
-
+CaloMET80_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET80_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET80_HBHECleaned_v*"])
+)
 # HLT_CaloMET80_NotCleaned_v 
-CaloMET80_NotCleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET80_NotCleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET80_NotCleaned/')
-CaloMET80_NotCleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET80_NotCleaned_v*")
-
+CaloMET80_NotCleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET80_NotCleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET80_NotCleaned_v*"])
+)
 # HLT_CaloMET90_HBHECleaned_v 
-CaloMET90_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET90_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET90_HBHECleaned/')
-CaloMET90_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET90_HBHECleaned_v*")
-
+CaloMET90_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET90_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET90_HBHECleaned_v*"])
+)
 # HLT_CaloMET90_NotCleaned_v 
-CaloMET90_NotCleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET90_NotCleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET90_NotCleaned/')
-CaloMET90_NotCleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET90_NotCleaned_v*")
-
+CaloMET90_NotCleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET90_NotCleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET90_NotCleaned_v*"])
+)
 # HLT_CaloMET100_HBHECleaned_v 
-CaloMET100_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET100_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET100_HBHECleaned/')
-CaloMET100_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET100_HBHECleaned_v*")
-
+CaloMET100_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET100_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET100_HBHECleaned_v*"])
+)
 # HLT_CaloMET100_NotCleaned_v 
-CaloMET100_NotCleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET100_NotCleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET100_NotCleaned/')
-CaloMET100_NotCleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET100_NotCleaned_v*")
-
+CaloMET100_NotCleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET100_NotCleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET100_NotCleaned_v*"])
+)
 # HLT_CaloMET110_NotCleaned_v 
-CaloMET110_NotCleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET110_NotCleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET110_NotCleaned/')
-CaloMET110_NotCleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET110_NotCleaned_v*")
-
+CaloMET110_NotCleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET110_NotCleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET110_NotCleaned_v*"])
+)
 # HLT_CaloMET250_HBHECleaned_v 
-CaloMET250_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET250_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET250_HBHECleaned/')
-CaloMET250_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET250_HBHECleaned_v*")
-
+CaloMET250_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET250_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET250_HBHECleaned_v*"])
+)
 # HLT_CaloMET250_NotCleaned_v 
-CaloMET250_NotCleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET250_NotCleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET250_NotCleaned/')
-CaloMET250_NotCleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET250_NotCleaned_v*")
-
+CaloMET250_NotCleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET250_NotCleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET250_NotCleaned_v*"])
+)
 # HLT_CaloMET300_HBHECleaned_v 
-CaloMET300_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET300_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET300_HBHECleaned/')
-CaloMET300_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET300_HBHECleaned_v*")
-
+CaloMET300_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET300_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET300_HBHECleaned_v*"])
+)
 # HLT_CaloMET300_HBHECleaned_v 
-CaloMET350_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-CaloMET350_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/Calo/CaloMET350_HBHECleaned/')
-CaloMET350_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_CaloMET350_HBHECleaned_v*")
-
+CaloMET350_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/Calo/CaloMET350_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_CaloMET350_HBHECleaned_v*"])
+)
 # HLT_CaloMET300_HBHECleaned_v 
-PFMET200_HBHE_BeamHaloCleaned_METmonitoring = hltMETmonitoring.clone()
-PFMET200_HBHE_BeamHaloCleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMET200_HBHE_BeamHaloCleaned/')
-PFMET200_HBHE_BeamHaloCleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET200_HBHE_BeamHaloCleaned_v*")
-
+PFMET200_HBHE_BeamHaloCleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMET200_HBHE_BeamHaloCleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET200_HBHE_BeamHaloCleaned_v*"])
+)
 # HLT_CaloMET300_HBHECleaned_v 
-PFMET200_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-PFMET200_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMET200_HBHECleaned/')
-PFMET200_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET200_HBHECleaned_v*")
-
+PFMET200_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMET200_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET200_HBHECleaned_v*"])
+)
 # HLT_CaloMET300_HBHECleaned_v 
-PFMET200_NotCleaned_METmonitoring = hltMETmonitoring.clone()
-PFMET200_NotCleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMET200_NotCleaned/')
-PFMET200_NotCleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET200_NotCleaned_v*")
-
+PFMET200_NotCleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMET200_NotCleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET200_NotCleaned_v*"])
+)
 # HLT_CaloMET300_HBHECleaned_v 
-PFMET250_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-PFMET250_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMET250_HBHECleaned/')
-PFMET250_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET250_HBHECleaned_v*")
-
+PFMET250_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMET250_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET250_HBHECleaned_v*"])
+)
 # HLT_CaloMET300_HBHECleaned_v 
-PFMET300_HBHECleaned_METmonitoring = hltMETmonitoring.clone()
-PFMET300_HBHECleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMET300_HBHECleaned/')
-PFMET300_HBHECleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET300_HBHECleaned_v*")
-
+PFMET300_HBHECleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMET300_HBHECleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET300_HBHECleaned_v*"])
+)
 # HLT_CaloMET300_HBHECleaned_v 
-PFMETTypeOne200_HBHE_BeamHaloCleaned_METmonitoring = hltMETmonitoring.clone()
-PFMETTypeOne200_HBHE_BeamHaloCleaned_METmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETTypeOne200_HBHE_BeamHaloCleaned/')
-PFMETTypeOne200_HBHE_BeamHaloCleaned_METmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMETTypeOne200_HBHE_BeamHaloCleaned_v*")
-
+PFMETTypeOne200_HBHE_BeamHaloCleaned_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETTypeOne200_HBHE_BeamHaloCleaned/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne200_HBHE_BeamHaloCleaned_v*"])
+)
 exoHLTMETmonitoring = cms.Sequence(
     PFMET110_PFMHT110_IDTight_METmonitoring
     + PFMET120_PFMHT120_IDTight_METmonitoring
@@ -314,4 +314,3 @@ exoHLTMETmonitoring = cms.Sequence(
     + PFMET300_HBHECleaned_METmonitoring
     + PFMETTypeOne200_HBHE_BeamHaloCleaned_METmonitoring  
 )
-

--- a/DQMOffline/Trigger/python/METMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/METMonitor_cfi.py
@@ -2,42 +2,44 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.metMonitoring_cfi import metMonitoring
 
-hltMETmonitoring = metMonitoring.clone()
-hltMETmonitoring.FolderName = cms.string('HLT/JME/MET/PFMETNoMu120/')
-hltMETmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32 ( 250 ),
-  xmin  = cms.double(    0.),
-  xmax  = cms.double( 2500.),
+hltMETmonitoring = metMonitoring.clone(
+    FolderName = 'HLT/JME/MET/PFMETNoMu120/',
+    met       = "pfMet", # pfMet
+    jets      = "ak4PFJets", # ak4PFJets, ak4PFJetsCHS
+    electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
+    muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !
+
+    histoPSet = dict(lsPSet = dict(
+                         nbins =  250,
+                         xmin  =   0.,
+                         xmax  =  2500.),
+                    metPSet = dict(
+                         nbins = 200,
+                         xmin  = -0.5,
+                         xmax  = 19999.5)
+                    ),
+
+    numGenericTriggerEventPSet = dict(
+        andOr         = False,
+        #dbLabel       = "ExoDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+        andOrHlt      = True, # True:=OR; False:=AND
+        hltInputTag   =  "TriggerResults::HLT",
+        hltPaths      = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"], # HLT_ZeroBias_v
+        #hltDBKey      = "EXO_HLT_MET",
+        errorReplyHlt =  False,
+        verbosityLevel = 0),
+
+    denGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        dcsInputTag   = "scalersRawToDigi",
+        dcsRecordInputTag = "onlineMetaDataDigis",
+        dcsPartitions = [24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+        andOrDcs      = False, 
+        errorReplyDcs = True, 
+        verbosityLevel = 1,
+        #hltPaths      = ["HLT_IsoMu27_v*"],
+        hltPaths      = [])
 )
-hltMETmonitoring.histoPSet.metPSet = cms.PSet(
-  nbins = cms.uint32 (200),
-  xmin  = cms.double(-0.5),
-  xmax  = cms.double(19999.5),
-)
-
-hltMETmonitoring.met       = cms.InputTag("pfMet") # pfMet
-hltMETmonitoring.jets      = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
-hltMETmonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-hltMETmonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
-
-hltMETmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-#hltMETmonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
-hltMETmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltMETmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltMETmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*") # HLT_ZeroBias_v
-#hltMETmonitoring.numGenericTriggerEventPSet.hltDBKey      = cms.string("EXO_HLT_MET")
-hltMETmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltMETmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-
-hltMETmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltMETmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltMETmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltMETmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltMETmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltMETmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltMETmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
-#hltMETmonitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_IsoMu27_v*");
-hltMETmonitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring();
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 stage2L1Trigger.toModify(hltMETmonitoring,
@@ -49,4 +51,5 @@ stage2L1Trigger.toModify(hltMETmonitoring,
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            ReadPrescalesFromFile = cms.bool(True)))
+
 

--- a/DQMOffline/Trigger/python/METplusTrackMonitor_cff.py
+++ b/DQMOffline/Trigger/python/METplusTrackMonitor_cff.py
@@ -3,19 +3,19 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.METplusTrackMonitor_cfi import hltMETplusTrackMonitoring
 
 # HLT_MET105_IsoTrk50
-MET105_IsoTrk50monitoring = hltMETplusTrackMonitoring.clone()
-MET105_IsoTrk50monitoring.FolderName = cms.string('HLT/MET/MET105_IsoTrk50/')
+MET105_IsoTrk50monitoring = hltMETplusTrackMonitoring.clone(
+    FolderName = 'HLT/MET/MET105_IsoTrk50/',
+    hltMetFilter = 'hltMET105::HLT',
+    hltMetCleanFilter = 'hltMETClean65::HLT'
+)
 MET105_IsoTrk50monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MET105_IsoTrk50_v*")
-MET105_IsoTrk50monitoring.hltMetFilter = cms.InputTag('hltMET105', '', 'HLT')
-MET105_IsoTrk50monitoring.hltMetCleanFilter = cms.InputTag('hltMETClean65', '', 'HLT')
-
 # HLT_MET120_IsoTrk50
-MET120_IsoTrk50monitoring = hltMETplusTrackMonitoring.clone()
-MET120_IsoTrk50monitoring.FolderName = cms.string('HLT/MET/MET120_IsoTrk50/')
+MET120_IsoTrk50monitoring = hltMETplusTrackMonitoring.clone(
+    FolderName = 'HLT/MET/MET120_IsoTrk50/',
+    hltMetFilter = 'hltMET120::HLT',
+    hltMetCleanFilter = 'hltMETClean65::HLT'
+)
 MET120_IsoTrk50monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MET120_IsoTrk50_v*")
-MET120_IsoTrk50monitoring.hltMetFilter = cms.InputTag('hltMET120', '', 'HLT')
-MET120_IsoTrk50monitoring.hltMetCleanFilter = cms.InputTag('hltMETClean65', '', 'HLT')
-
 exoHLTMETplusTrackMonitoring = cms.Sequence(
     MET105_IsoTrk50monitoring
     + MET120_IsoTrk50monitoring

--- a/DQMOffline/Trigger/python/METplusTrackMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/METplusTrackMonitor_cfi.py
@@ -1,35 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.metPlusTrackMonitoring_cfi import metPlusTrackMonitoring
-
-hltMETplusTrackMonitoring = metPlusTrackMonitoring.clone()
-hltMETplusTrackMonitoring.FolderName = cms.string('HLT/MET/MET105_IsoTrk50/')
-hltMETplusTrackMonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32(  250 ),
-  xmin  = cms.double(    0.),
-  xmax  = cms.double( 2500.),
-)
-hltMETplusTrackMonitoring.histoPSet.metPSet = cms.PSet(
-  nbins = cms.uint32 (100),
-  xmin  = cms.double(-0.5),
-  xmax  = cms.double(999.5),
-)
-hltMETplusTrackMonitoring.histoPSet.ptPSet = cms.PSet(
-  nbins = cms.uint32 (100),
-  xmin  = cms.double(-0.5),
-  xmax  = cms.double(999.5),
-)
-hltMETplusTrackMonitoring.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32 (24),
-  xmin  = cms.double(-2.4),
-  xmax  = cms.double(2.4),
-)
-hltMETplusTrackMonitoring.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.uint32(32),
-  xmin  = cms.double(-3.2),
-  xmax  = cms.double(3.2),
-)
-
 # Define 100 logarithmic bins from 10^0 to 10^3 GeV
 binsLogX_METplusTrack = []
 nBinsLogX_METplusTrack = 100
@@ -37,34 +8,67 @@ powerLo_METplusTrack = 0.0
 powerHi_METplusTrack = 3.0
 binPowerWidth_METplusTrack = (powerHi_METplusTrack - powerLo_METplusTrack) / nBinsLogX_METplusTrack
 for ibin in range(nBinsLogX_METplusTrack + 1):
-    binsLogX_METplusTrack.append( pow(10, powerLo_METplusTrack + ibin * binPowerWidth_METplusTrack) )
+   binsLogX_METplusTrack.append( pow(10, powerLo_METplusTrack + ibin * binPowerWidth_METplusTrack) )
 
-hltMETplusTrackMonitoring.histoPSet.metBinning = cms.vdouble(binsLogX_METplusTrack)
-hltMETplusTrackMonitoring.histoPSet.ptBinning = cms.vdouble(binsLogX_METplusTrack)
+hltMETplusTrackMonitoring = metPlusTrackMonitoring.clone(
+  FolderName = 'HLT/MET/MET105_IsoTrk50/',
+  histoPSet = dict(
+          lsPSet = dict(
+                    nbins = 250 ,
+                    xmin  =  0.,
+                    xmax  = 2500.),
 
-hltMETplusTrackMonitoring.met       = cms.InputTag("caloMet") # caloMet
-hltMETplusTrackMonitoring.jets      = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
-hltMETplusTrackMonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
+          metPSet = dict(
+                    nbins = 100,
+                    xmin  = -0.5,
+                    xmax  = 999.5),
 
-hltMETplusTrackMonitoring.muonSelection = cms.string('pt>26 && abs(eta)<2.1 && (pfIsolationR04.sumChargedHadronPt+pfIsolationR04.sumPhotonEt+pfIsolationR04.sumNeutralHadronEt-0.5*pfIsolationR04.sumPUPt)/pt<0.12')
-hltMETplusTrackMonitoring.vtxSelection = cms.string('ndof>=4 && abs(z)<24.0 && position.Rho<2.0')
-hltMETplusTrackMonitoring.nmuons = cms.uint32(1)
-hltMETplusTrackMonitoring.leadJetEtaCut = cms.double(2.4)
+          ptPSet = dict(
+                    nbins = 100,
+                    xmin  = -0.5,
+                    xmax  = 999.5),
 
-hltMETplusTrackMonitoring.numGenericTriggerEventPSet.andOr          = cms.bool( False )
-#hltMETplusTrackMonitoring.numGenericTriggerEventPSet.dbLabel        = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
-hltMETplusTrackMonitoring.numGenericTriggerEventPSet.andOrHlt       = cms.bool(True)# True:=OR; False:=AND
-hltMETplusTrackMonitoring.numGenericTriggerEventPSet.hltInputTag    = cms.InputTag( "TriggerResults::HLT" )
-hltMETplusTrackMonitoring.numGenericTriggerEventPSet.hltPaths       = cms.vstring("HLT_MET105_IsoTrk50_v*") # HLT_ZeroBias_v
-#hltMETplusTrackMonitoring.numGenericTriggerEventPSet.hltDBKey       = cms.string("EXO_HLT_MET")
-hltMETplusTrackMonitoring.numGenericTriggerEventPSet.errorReplyHlt  = cms.bool( False )
-hltMETplusTrackMonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
+          etaPSet = dict(
+                    nbins = 24,
+                    xmin  = -2.4,
+                    xmax  = 2.4),
 
-hltMETplusTrackMonitoring.denGenericTriggerEventPSet.andOr          = cms.bool( False )
-hltMETplusTrackMonitoring.denGenericTriggerEventPSet.dcsInputTag    = cms.InputTag( "scalersRawToDigi" )
-hltMETplusTrackMonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltMETplusTrackMonitoring.denGenericTriggerEventPSet.dcsPartitions  = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltMETplusTrackMonitoring.denGenericTriggerEventPSet.andOrDcs       = cms.bool( False )
-hltMETplusTrackMonitoring.denGenericTriggerEventPSet.errorReplyDcs  = cms.bool( True )
-hltMETplusTrackMonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
-hltMETplusTrackMonitoring.denGenericTriggerEventPSet.hltPaths       = cms.vstring("HLT_IsoMu27_v*")
+          phiPSet = dict(
+                    nbins = 32,
+                    xmin  = -3.2,
+                    xmax  = 3.2),
+    
+          metBinning = binsLogX_METplusTrack,
+          ptBinning = binsLogX_METplusTrack
+      ),
+  met       = "caloMet", # caloMet
+  jets      = "ak4PFJets", # ak4PFJets, ak4PFJetsCHS
+  muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !
+
+  muonSelection = 'pt>26 && abs(eta)<2.1 && (pfIsolationR04.sumChargedHadronPt+pfIsolationR04.sumPhotonEt+pfIsolationR04.sumNeutralHadronEt-0.5*pfIsolationR04.sumPUPt)/pt<0.12',
+  vtxSelection = 'ndof>=4 && abs(z)<24.0 && position.Rho<2.0',
+  nmuons = 1,
+  leadJetEtaCut = 2.4,
+
+  numGenericTriggerEventPSet = dict(
+    andOr          = False,
+    #dbLabel        = "ExoDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+    andOrHlt       = True,# True:=OR; False:=AND
+    hltInputTag    = "TriggerResults::HLT",
+    hltPaths       = ["HLT_MET105_IsoTrk50_v*"], # HLT_ZeroBias_v
+    #hltDBKey       = "EXO_HLT_MET",
+    errorReplyHlt  = False,
+    verbosityLevel = 0
+  ),
+
+  denGenericTriggerEventPSet = dict(
+    andOr          =  False ,
+    dcsInputTag    =  "scalersRawToDigi",
+    dcsRecordInputTag = "onlineMetaDataDigis",
+    dcsPartitions  = [24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+    andOrDcs       = False,
+    errorReplyDcs  = True,
+    verbosityLevel = 1,
+    hltPaths       = ["HLT_IsoMu27_v*"])
+)
+

--- a/DQMOffline/Trigger/python/MjjMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/MjjMonitor_cfi.py
@@ -5,34 +5,37 @@ from DQMOffline.Trigger.htMonitoring_cfi import htMonitoring
 # config file for monitoring the trigger efficiency vs invariant dijetmass of the two leading jets
 # see python/HTMonitor_cfi.py or plugins/HTMonitor.h or plugins/HTMonitor.cc for more details
 
-hltMjjmonitoring = htMonitoring.clone()
-hltMjjmonitoring.FolderName = cms.string('HLT/HT/PFMETNoMu120/')
-hltMjjmonitoring.quantity = cms.string('Mjj') # set quantity to invariant dijetmass
-hltMjjmonitoring.jetSelection = cms.string("pt > 200 && eta < 2.4")
-hltMjjmonitoring.dEtaCut     = cms.double(1.3)
-hltMjjmonitoring.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32 (  200  ),
-  xmin  = cms.double(   -0.5),
-  xmax  = cms.double(19999.5),
+hltMjjmonitoring = htMonitoring.clone(
+    FolderName = 'HLT/HT/PFMETNoMu120/',
+    quantity = 'Mjj', # set quantity to invariant dijetmass
+    jetSelection = "pt > 200 && eta < 2.4",
+    dEtaCut     = 1.3,
+    met       = "pfMet",
+    jets      = "ak8PFJetsPuppi",
+    electrons = "gedGsfElectrons",
+    muons     = "muons",
+    
+    histoPSet = dict(htPSet = dict(
+            nbins =  200,
+            xmin  =  -0.5,
+            xmax  = 19999.5)),
+
+    numGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        andOrHlt      = True, # True:=OR; False:=AND
+        hltInputTag   =  "TriggerResults::HLT",
+        hltPaths      = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"],
+        errorReplyHlt = False,
+        verbosityLevel = 0),
+
+    denGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        dcsInputTag   =  "scalersRawToDigi",
+        dcsRecordInputTag = "onlineMetaDataDigis",
+        dcsPartitions = [ 24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29
+        andOrDcs      =  False,
+        errorReplyDcs = True,
+        verbosityLevel = 0,
+        hltPaths      = ["HLT_IsoMu27_v*"])
 )
-hltMjjmonitoring.met       = cms.InputTag("pfMet")
-hltMjjmonitoring.jets      = cms.InputTag("ak8PFJetsPuppi")
-hltMjjmonitoring.electrons = cms.InputTag("gedGsfElectrons")
-hltMjjmonitoring.muons     = cms.InputTag("muons")
 
-hltMjjmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-
-hltMjjmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltMjjmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltMjjmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-hltMjjmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltMjjmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-
-hltMjjmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltMjjmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltMjjmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag ( "onlineMetaDataDigis" )
-hltMjjmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29
-hltMjjmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltMjjmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltMjjmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-hltMjjmonitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_IsoMu27_v*")

--- a/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_Client_cfi.py
+++ b/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_Client_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 mssmHbbBtag = DQMEDHarvester("DQMGenericClient",
-#    subDirs        = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon/"),
     subDirs        = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution     = cms.vstring(),
@@ -14,34 +13,30 @@ mssmHbbBtag = DQMEDHarvester("DQMGenericClient",
     ),
 )
 
-mssmHbbBtagSL40noMu = mssmHbbBtag.clone()
-mssmHbbBtagSL40noMu.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon")
-
-mssmHbbBtagSL40 = mssmHbbBtag.clone()
-#mssmHbbBtagSL40.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt40/")
-mssmHbbBtagSL40.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40/")
-
-mssmHbbBtagSL100 = mssmHbbBtag.clone()
-#mssmHbbBtagSL100.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt100/")
-mssmHbbBtagSL100.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt100/")
-
-mssmHbbBtagSL200 = mssmHbbBtag.clone()
-#mssmHbbBtagSL200.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt200/")
-mssmHbbBtagSL200.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt200/")
-
-mssmHbbBtagSL350 = mssmHbbBtag.clone()
-#mssmHbbBtagSL350.subDirs = cms.untracked.vstring("HLT/Higgs/MssmHbb/semileptonic/BtagTrigger/pt350/")
-mssmHbbBtagSL350.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt350/")
-
-mssmHbbBtagAH100 = mssmHbbBtag.clone()
-mssmHbbBtagAH100.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt100/")
-
-mssmHbbBtagAH200 = mssmHbbBtag.clone()
-mssmHbbBtagAH200.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt200/")
-
-mssmHbbBtagAH350 = mssmHbbBtag.clone()
-mssmHbbBtagAH350.subDirs = cms.untracked.vstring("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt350/")
-
+mssmHbbBtagSL40noMu = mssmHbbBtag.clone(
+    subDirs = ["HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon"]
+)
+mssmHbbBtagSL40 = mssmHbbBtag.clone(
+    subDirs = ["HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40/"]
+)
+mssmHbbBtagSL100 = mssmHbbBtag.clone(
+    subDirs = ["HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt100/"]
+)
+mssmHbbBtagSL200 = mssmHbbBtag.clone(
+    subDirs = ["HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt200/"]
+)
+mssmHbbBtagSL350 = mssmHbbBtag.clone(
+    subDirs = ["HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt350/"]
+)
+mssmHbbBtagAH100 = mssmHbbBtag.clone(
+    subDirs = ["HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt100/"]
+)
+mssmHbbBtagAH200 = mssmHbbBtag.clone(
+    subDirs = ["HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt200/"]
+)
+mssmHbbBtagAH350 = mssmHbbBtag.clone(
+    subDirs = ["HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt350/"]
+)
 
 
 mssmHbbBtagTriggerEfficiency = cms.Sequence(

--- a/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/MssmHbbBtagTriggerMonitor_cfi.py
@@ -39,58 +39,74 @@ mssmHbbBtagTriggerMonitor = DQMEDAnalyzer("TagAndProbeBtagTriggerMonitor",
 
 # online btagging monitor
 
-mssmHbbBtagTriggerMonitorSL40noMu = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL40noMu.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon")
-mssmHbbBtagTriggerMonitorSL40noMu.jetPtMin = cms.double(40)
-mssmHbbBtagTriggerMonitorSL40noMu.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
-mssmHbbBtagTriggerMonitorSL40noMu.histoPSet.jetPt = cms.vdouble(40,45,50,55,60,65,70,75,80,85,90,95,100)
-mssmHbbBtagTriggerMonitorSL40noMu.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets40_CaloBTagDeepCSV_p71_v*')
+mssmHbbBtagTriggerMonitorSL40noMu = mssmHbbBtagTriggerMonitor.clone(
+    dirname = "HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40_noMuon",
+    jetPtMin = 40,
+    triggerobjbtag = "hltBTagCaloDeepCSV0p71Single8Jets30",
+    histoPSet = dict(jetPt = [40,45,50,55,60,65,70,75,80,85,90,95,100]),
+    genericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets40_CaloBTagDeepCSV_p71_v*'])
+)
 
-mssmHbbBtagTriggerMonitorSL40 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL40.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40")
-mssmHbbBtagTriggerMonitorSL40.jetPtMin = cms.double(40)
-mssmHbbBtagTriggerMonitorSL40.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
-mssmHbbBtagTriggerMonitorSL40.histoPSet.jetPt = cms.vdouble(40,45,50,55,60,65,70,75,80,85,90,95,100)
-mssmHbbBtagTriggerMonitorSL40.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_DoublePFJets40_CaloBTagDeepCSV_p71_v*')
 
-mssmHbbBtagTriggerMonitorSL100 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL100.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt100")
-mssmHbbBtagTriggerMonitorSL100.jetPtMin = cms.double(100)
-mssmHbbBtagTriggerMonitorSL100.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
-mssmHbbBtagTriggerMonitorSL100.histoPSet.jetPt = cms.vdouble(100,110,120,130,140,150,160,170,180,190,200)
-mssmHbbBtagTriggerMonitorSL100.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_DoublePFJets100_CaloBTagDeepCSV_p71_v*')
+mssmHbbBtagTriggerMonitorSL40 = mssmHbbBtagTriggerMonitor.clone(
+    dirname = "HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt40",
+    jetPtMin = 40,
+    triggerobjbtag = "hltBTagCaloDeepCSV0p71Single8Jets30",
+    histoPSet = dict(jetPt = [40,45,50,55,60,65,70,75,80,85,90,95,100]),
+    genericTriggerEventPSet = dict(hltPaths = ['HLT_Mu12_DoublePFJets40_CaloBTagDeepCSV_p71_v*'])
+)
 
-mssmHbbBtagTriggerMonitorSL200 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL200.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt200")
-mssmHbbBtagTriggerMonitorSL200.jetPtMin = cms.double(200)
-mssmHbbBtagTriggerMonitorSL200.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
-mssmHbbBtagTriggerMonitorSL200.histoPSet.jetPt = cms.vdouble(200,210,220,230,240,250,260,270,280,290,300,310,320,330,340,350)
-mssmHbbBtagTriggerMonitorSL200.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_DoublePFJets200_CaloBTagDeepCSV_p71_v*')
 
-mssmHbbBtagTriggerMonitorSL350 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorSL350.dirname = cms.string("HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt350")
-mssmHbbBtagTriggerMonitorSL350.jetPtMin = cms.double(350)
-mssmHbbBtagTriggerMonitorSL350.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single8Jets30")
-mssmHbbBtagTriggerMonitorSL350.histoPSet.jetPt = cms.vdouble(350,360,370,380,390,400,410,420,430,440,450,460,470,480,490,500,510,520,530,540,550,560,570,580,590,600)
-mssmHbbBtagTriggerMonitorSL350.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_DoublePFJets350_CaloBTagDeepCSV_p71_v*')
+mssmHbbBtagTriggerMonitorSL100 = mssmHbbBtagTriggerMonitor.clone(
+    dirname = "HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt100",
+    jetPtMin = 100,
+    triggerobjbtag = "hltBTagCaloDeepCSV0p71Single8Jets30",
+    histoPSet = dict(jetPt = [100,110,120,130,140,150,160,170,180,190,200]),
+    genericTriggerEventPSet = dict(hltPaths = ['HLT_Mu12_DoublePFJets100_CaloBTagDeepCSV_p71_v*'])
+)
 
-mssmHbbBtagTriggerMonitorAH100 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorAH100.dirname = cms.string("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt100")
-mssmHbbBtagTriggerMonitorAH100.jetPtMin = cms.double(100)
-mssmHbbBtagTriggerMonitorAH100.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single6Jets80")
-mssmHbbBtagTriggerMonitorAH100.histoPSet.jetPt = cms.vdouble(100,110,120,130,140,150,160,170,180,190,200)
-mssmHbbBtagTriggerMonitorAH100.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets100_CaloBTagDeepCSV_p71_v*')
 
-mssmHbbBtagTriggerMonitorAH200 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorAH200.dirname = cms.string("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt200")
-mssmHbbBtagTriggerMonitorAH200.jetPtMin = cms.double(200)
-mssmHbbBtagTriggerMonitorAH200.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single6Jets80")
-mssmHbbBtagTriggerMonitorAH200.histoPSet.jetPt = cms.vdouble(200,210,220,230,240,250,260,270,280,290,300,310,320,330,340,350)
-mssmHbbBtagTriggerMonitorAH200.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets200_CaloBTagDeepCSV_p71_v*')
+mssmHbbBtagTriggerMonitorSL200 = mssmHbbBtagTriggerMonitor.clone(
+    dirname = "HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt200",
+    jetPtMin = 200,
+    triggerobjbtag = "hltBTagCaloDeepCSV0p71Single8Jets30",
+    histoPSet = dict(jetPt = [200,210,220,230,240,250,260,270,280,290,300,310,320,330,340,350]),
+    genericTriggerEventPSet = dict(hltPaths = ['HLT_Mu12_DoublePFJets200_CaloBTagDeepCSV_p71_v*'])
+)
 
-mssmHbbBtagTriggerMonitorAH350 = mssmHbbBtagTriggerMonitor.clone()
-mssmHbbBtagTriggerMonitorAH350.dirname = cms.string("HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt350")
-mssmHbbBtagTriggerMonitorAH350.jetPtMin = cms.double(350)
-mssmHbbBtagTriggerMonitorAH350.triggerobjbtag = cms.string("hltBTagCaloDeepCSV0p71Single6Jets80")
-mssmHbbBtagTriggerMonitorAH350.histoPSet.jetPt = cms.vdouble(350,360,370,380,390,400,410,420,430,440,450,460,470,480,490,500,510,520,530,540,550,560,570,580,590,600)
-mssmHbbBtagTriggerMonitorAH350.genericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets350_CaloBTagDeepCSV_p71_v*')
+
+mssmHbbBtagTriggerMonitorSL350 = mssmHbbBtagTriggerMonitor.clone(
+    dirname = "HLT/HIG/MssmHbb/semileptonic/BtagTrigger/pt350",
+    jetPtMin = 350,
+    triggerobjbtag = "hltBTagCaloDeepCSV0p71Single8Jets30",
+    histoPSet = dict(jetPt = [350,360,370,380,390,400,410,420,430,440,450,460,470,480,490,500,510,520,530,540,550,560,570,580,590,600]),
+    genericTriggerEventPSet = dict(hltPaths = ['HLT_Mu12_DoublePFJets350_CaloBTagDeepCSV_p71_v*'])
+)
+
+
+mssmHbbBtagTriggerMonitorAH100 = mssmHbbBtagTriggerMonitor.clone(
+    dirname = "HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt100",
+    jetPtMin = 100,
+    triggerobjbtag = "hltBTagCaloDeepCSV0p71Single6Jets80",
+    histoPSet = dict(jetPt = [100,110,120,130,140,150,160,170,180,190,200]),
+    genericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets100_CaloBTagDeepCSV_p71_v*'])
+)
+
+
+mssmHbbBtagTriggerMonitorAH200 = mssmHbbBtagTriggerMonitor.clone(
+    dirname = "HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt200",
+    jetPtMin = 200,
+    triggerobjbtag = "hltBTagCaloDeepCSV0p71Single6Jets80",
+    histoPSet = dict(jetPt = [200,210,220,230,240,250,260,270,280,290,300,310,320,330,340,350]),
+    genericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets200_CaloBTagDeepCSV_p71_v*'])
+)
+
+
+mssmHbbBtagTriggerMonitorAH350 = mssmHbbBtagTriggerMonitor.clone(
+    dirname = "HLT/HIG/MssmHbb/fullhadronic/BtagTrigger/pt350",
+    jetPtMin = 350,
+    triggerobjbtag = "hltBTagCaloDeepCSV0p71Single6Jets80",
+    histoPSet = dict(jetPt = [350,360,370,380,390,400,410,420,430,440,450,460,470,480,490,500,510,520,530,540,550,560,570,580,590,600]),
+    genericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets350_CaloBTagDeepCSV_p71_v*'])
+)
+

--- a/DQMOffline/Trigger/python/MssmHbbMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/MssmHbbMonitoring_cff.py
@@ -3,83 +3,95 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.MssmHbbMonitoring_cfi import mssmHbbMonitoring
 
 #Define MssmHbb specific cuts 
-hltMssmHbbmonitoring =  mssmHbbMonitoring.clone()
-hltMssmHbbmonitoring.btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"]
-hltMssmHbbmonitoring.workingpoint    = cms.double(0.92) # tight WP
-hltMssmHbbmonitoring.bJetDeltaEtaMax = cms.double(1.6)   # deta cut between leading bjets
-hltMssmHbbmonitoring.bJetMuDeltaRmax = cms.double(0.4)   # dR(mu,nbjet) cone; only if #mu >1
-
+hltMssmHbbmonitoring =  mssmHbbMonitoring.clone(
+    btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"],
+    workingpoint    = 0.92, # tight WP
+    bJetDeltaEtaMax = 1.6,   # deta cut between leading bjets
+    bJetMuDeltaRmax = 0.4   # dR(mu,nbjet) cone; only if #mu >1
+)
 # Fully-hadronic MssmHbb
-hltMssmHbbmonitoringAL100 = hltMssmHbbmonitoring.clone()
-#hltMssmHbbmonitoringAL100.FolderName = cms.string('HLT/Higgs/MssmHbb/fullhadronic/pt100')
-hltMssmHbbmonitoringAL100.FolderName = cms.string('HLT/HIG/MssmHbb/fullhadronic/pt100')
-hltMssmHbbmonitoringAL100.nmuons = cms.uint32(0)
-hltMssmHbbmonitoringAL100.nbjets = cms.uint32(2)
-hltMssmHbbmonitoringAL100.bjetSelection = cms.string('pt>110 & abs(eta)<2.2')
-hltMssmHbbmonitoringAL100.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets100MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*')
-hltMssmHbbmonitoringAL100.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
+hltMssmHbbmonitoringAL100 = hltMssmHbbmonitoring.clone(
+    #FolderName = 'HLT/Higgs/MssmHbb/fullhadronic/pt100'
+    FolderName = 'HLT/HIG/MssmHbb/fullhadronic/pt100',
+    nmuons = 0,
+    nbjets = 2,
+    bjetSelection = 'pt>110 & abs(eta)<2.2',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets100MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500])
+)
 
-hltMssmHbbmonitoringAL116 = hltMssmHbbmonitoring.clone()
-#hltMssmHbbmonitoringAL116.FolderName = cms.string('HLT/Higgs/MssmHbb/fullhadronic/pt116')
-hltMssmHbbmonitoringAL116.FolderName = cms.string('HLT/HIG/MssmHbb/fullhadronic/pt116')
-hltMssmHbbmonitoringAL116.nmuons = cms.uint32(0)
-hltMssmHbbmonitoringAL116.nbjets = cms.uint32(2)
-hltMssmHbbmonitoringAL116.bjetSelection = cms.string('pt>116 & abs(eta)<2.2')
-hltMssmHbbmonitoringAL116.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets116MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*')
-hltMssmHbbmonitoringAL116.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
 
-hltMssmHbbmonitoringAL128 = hltMssmHbbmonitoring.clone()
-#hltMssmHbbmonitoringAL128.FolderName = cms.string('HLT/Higgs/MssmHbb/fullhadronic/pt128')
-hltMssmHbbmonitoringAL128.FolderName = cms.string('HLT/HIG/MssmHbb/fullhadronic/pt128')
-hltMssmHbbmonitoringAL128.nmuons = cms.uint32(0)
-hltMssmHbbmonitoringAL128.nbjets = cms.uint32(2)
-hltMssmHbbmonitoringAL128.bjetSelection = cms.string('pt>128 & abs(eta)<2.2')
-hltMssmHbbmonitoringAL128.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets128MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*')
-hltMssmHbbmonitoringAL128.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
+hltMssmHbbmonitoringAL116 = hltMssmHbbmonitoring.clone(
+    #FolderName = 'HLT/Higgs/MssmHbb/fullhadronic/pt116',
+    FolderName = 'HLT/HIG/MssmHbb/fullhadronic/pt116',
+    nmuons = 0,
+    nbjets = 2,
+    bjetSelection = 'pt>116 & abs(eta)<2.2',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets116MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500])
+)
+
+
+hltMssmHbbmonitoringAL128 = hltMssmHbbmonitoring.clone(
+    #FolderName = 'HLT/Higgs/MssmHbb/fullhadronic/pt128',
+    FolderName = 'HLT/HIG/MssmHbb/fullhadronic/pt128',
+    nmuons = 0,
+    nbjets = 2,
+    bjetSelection = 'pt>128 & abs(eta)<2.2',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets128MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500])
+)
+
 
 # Semi-leptonic MssmHbb(mu)
-hltMssmHbbmonitoringSL40 = hltMssmHbbmonitoring.clone()
-#hltMssmHbbmonitoringSL40.FolderName = cms.string('HLT/Higgs/MssmHbb/semileptonic/pt40')
-hltMssmHbbmonitoringSL40.FolderName = cms.string('HLT/HIG/MssmHbb/semileptonic/pt40')
-hltMssmHbbmonitoringSL40.nmuons = cms.uint32(1)
-hltMssmHbbmonitoringSL40.nbjets = cms.uint32(2)
-hltMssmHbbmonitoringSL40.muoSelection = cms.string('pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-hltMssmHbbmonitoringSL40.bjetSelection = cms.string('pt>40 & abs(eta)<2.2')
-hltMssmHbbmonitoringSL40.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets40MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*')
-hltMssmHbbmonitoringSL40.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
+hltMssmHbbmonitoringSL40 = hltMssmHbbmonitoring.clone(
+    #FolderName = 'HLT/Higgs/MssmHbb/semileptonic/pt40',
+    FolderName = 'HLT/HIG/MssmHbb/semileptonic/pt40',
+    nmuons = 1,
+    nbjets = 2,
+    muoSelection = 'pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    bjetSelection = 'pt>40 & abs(eta)<2.2',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets40MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500])
+)
 
-hltMssmHbbmonitoringSL54 = hltMssmHbbmonitoring.clone()
-#hltMssmHbbmonitoringSL54.FolderName = cms.string('HLT/Higgs/MssmHbb/semileptonic/pt54')
-hltMssmHbbmonitoringSL54.FolderName = cms.string('HLT/HIG/MssmHbb/semileptonic/pt54')
-hltMssmHbbmonitoringSL54.nmuons = cms.uint32(1)
-hltMssmHbbmonitoringSL54.nbjets = cms.uint32(2)
-hltMssmHbbmonitoringSL54.muoSelection = cms.string('pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-hltMssmHbbmonitoringSL54.bjetSelection = cms.string('pt>54 & abs(eta)<2.2')
-hltMssmHbbmonitoringSL54.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets54MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*')
-hltMssmHbbmonitoringSL54.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
+hltMssmHbbmonitoringSL54 = hltMssmHbbmonitoring.clone(
+    #FolderName = 'HLT/Higgs/MssmHbb/semileptonic/pt54',
+    FolderName = 'HLT/HIG/MssmHbb/semileptonic/pt54',
+    nmuons = 1,
+    nbjets = 2,
+    muoSelection = 'pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    bjetSelection = 'pt>54 & abs(eta)<2.2',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets54MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500])
+)
 
-hltMssmHbbmonitoringSL62 = hltMssmHbbmonitoring.clone()
-#hltMssmHbbmonitoringSL62.FolderName = cms.string('HLT/Higgs/MssmHbb/semileptonic/pt62')
-hltMssmHbbmonitoringSL62.FolderName = cms.string('HLT/HIG/MssmHbb/semileptonic/pt62')
-hltMssmHbbmonitoringSL62.nmuons = cms.uint32(1)
-hltMssmHbbmonitoringSL62.nbjets = cms.uint32(2)
-hltMssmHbbmonitoringSL62.muoSelection = cms.string('pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-hltMssmHbbmonitoringSL62.bjetSelection = cms.string('pt>62 & abs(eta)<2.2')
-hltMssmHbbmonitoringSL62.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_DoublePFJets62MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*')
-hltMssmHbbmonitoringSL62.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
+
+hltMssmHbbmonitoringSL62 = hltMssmHbbmonitoring.clone(
+    #FolderName = 'HLT/Higgs/MssmHbb/semileptonic/pt62'
+    FolderName = 'HLT/HIG/MssmHbb/semileptonic/pt62',
+    nmuons = 1,
+    nbjets = 2,
+    muoSelection = 'pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    bjetSelection = 'pt>62 & abs(eta)<2.2',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_DoublePFJets62MaxDeta1p6_DoubleCaloBTagDeepCSV_p71_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500])
+)
+
 
 #control b-tagging 
-hltMssmHbbmonitoringControl = hltMssmHbbmonitoring.clone()
-#hltMssmHbbmonitoringControl.FolderName = cms.string('HLT/Higgs/MssmHbb/control/mu12_pt30_nobtag')
-hltMssmHbbmonitoringControl.FolderName = cms.string('HLT/HIG/MssmHbb/control/mu12_pt30_nobtag')
-hltMssmHbbmonitoringControl.nmuons = cms.uint32(1)
-hltMssmHbbmonitoringControl.nbjets = cms.uint32(0)
-hltMssmHbbmonitoringControl.njets = cms.uint32(1)
-hltMssmHbbmonitoringControl.muoSelection = cms.string('pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrac\
-k.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10')
-hltMssmHbbmonitoringControl.jetSelection = cms.string('pt>40 & abs(eta)<2.2')
-hltMssmHbbmonitoringControl.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_SingleJet30_Mu12_SinglePFJet40_v*')
-hltMssmHbbmonitoringControl.histoPSet.jetPtBinning = cms.vdouble(0,250,280,300,320,360,400,700,1000,1500)
+hltMssmHbbmonitoringControl = hltMssmHbbmonitoring.clone(
+    #FolderName = 'HLT/Higgs/MssmHbb/control/mu12_pt30_nobtag',
+    FolderName = 'HLT/HIG/MssmHbb/control/mu12_pt30_nobtag',
+    nmuons = 1,
+    nbjets = 0,
+    njets = 1,
+    muoSelection = 'pt>12 & abs(eta)<2.2 & isPFMuon & isGlobalMuon  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0 & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10',
+    jetSelection = 'pt>40 & abs(eta)<2.2',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_SingleJet30_Mu12_SinglePFJet40_v*']),
+    histoPSet = dict(jetPtBinning = [0,250,280,300,320,360,400,700,1000,1500])
+)
+
 
 
 mssmHbbMonitorHLT = cms.Sequence(

--- a/DQMOffline/Trigger/python/MssmHbbMonitoring_cfi.py
+++ b/DQMOffline/Trigger/python/MssmHbbMonitoring_cfi.py
@@ -2,130 +2,132 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.topMonitoring_cfi import topMonitoring
 
-mssmHbbMonitoring = topMonitoring.clone()
-mssmHbbMonitoring.FolderName = cms.string('HLT/HIG/default/')
-mssmHbbMonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32 ( 250 ),
-  xmin  = cms.double(    0.),
-  xmax  = cms.double( 2500.),
-)
-mssmHbbMonitoring.histoPSet.metPSet = cms.PSet(
-  nbins = cms.uint32(  30   ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  300  ),
-)
-mssmHbbMonitoring.histoPSet.ptPSet = cms.PSet(
-  nbins = cms.uint32(  100   ), #60
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  1000  ), #300
-)
-mssmHbbMonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32( 2500 ),
-)
-mssmHbbMonitoring.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.uint32(  32  ),
-  xmin  = cms.double( -3.2 ),
-  xmax  = cms.double(  3.2 ),
-)
-mssmHbbMonitoring.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32(  24  ),
-  xmin  = cms.double( -2.4 ),
-  xmax  = cms.double(  2.4 ),
-)
-mssmHbbMonitoring.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32(   100  ), #60
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  1000  ), #600
-)
-mssmHbbMonitoring.histoPSet.csvPSet = cms.PSet(
-  nbins = cms.uint32( 50 ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 1.0  ),
-)
-mssmHbbMonitoring.histoPSet.DRPSet = cms.PSet(
-  nbins = cms.uint32( 60  ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 6.0 ),
-)
+mssmHbbMonitoring = topMonitoring.clone(
+  FolderName = 'HLT/HIG/default/',
+  histoPSet = dict(
+     lsPSet = dict(
+              nbins = 2500,
+              xmin  =  0.,
+              xmax  = 2500.),
 
-mssmHbbMonitoring.applyLeptonPVcuts = False
-mssmHbbMonitoring.leptonPVcuts = cms.PSet(
-  dxy = cms.double(   9999.   ),
-  dz  = cms.double(   9999.   ),
-)
-mssmHbbMonitoring.histoPSet.invMassPSet = cms.PSet(
-  nbins = cms.uint32( 40 ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 80.0  ),
-)
-mssmHbbMonitoring.histoPSet.MHTPSet = cms.PSet(
- nbins = cms.uint32(   80  ),
- xmin  = cms.double(   60   ),
- xmax  = cms.double(  300  ),
-)
+      metPSet = dict(
+              nbins =  30 ,
+              xmin  =  0 ,
+              xmax  =  300),
 
-#MET and HT binning
-mssmHbbMonitoring.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200)
-mssmHbbMonitoring.histoPSet.HTBinning  = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700)
-#Eta binning
-mssmHbbMonitoring.histoPSet.eleEtaBinning = cms.vdouble(-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4)
-mssmHbbMonitoring.histoPSet.jetEtaBinning = cms.vdouble(-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4)
-mssmHbbMonitoring.histoPSet.muEtaBinning  = cms.vdouble(-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4)
-#pt binning
-#mssmHbbMonitoring.histoPSet.elePtBinning = cms.vdouble(0,5,10,20,30,40,50,70,100,200,400)
-#mssmHbbMonitoring.histoPSet.jetPtBinning = cms.vdouble(0,5,10,20,30,40,50,70,100,200,400)
-#mssmHbbMonitoring.histoPSet.muPtBinning  = cms.vdouble(0,5,10,20,30,40,50,70,100,200,400)
-mssmHbbMonitoring.histoPSet.elePtBinning = cms.vdouble(0,3,5,8,15,20,25,30,40,50,60,80,120,200,400,700)
-mssmHbbMonitoring.histoPSet.jetPtBinning = cms.vdouble(0,3,5,8,15,20,25,30,40,50,70,100,150,200,400,700,1000,1500)
-mssmHbbMonitoring.histoPSet.muPtBinning = cms.vdouble(0,3,5,7,10,15,20,30,40,50,70,100,150,200,400,700)
-#Eta binning 2D
-mssmHbbMonitoring.histoPSet.eleEtaBinning2D = cms.vdouble(-2.5,-1.5,-0.6,0.,0.6,1.5,2.5)
-mssmHbbMonitoring.histoPSet.jetEtaBinning2D = cms.vdouble(-2.5,-1.5,-0.6,0.,0.6,1.5,2.5)
-mssmHbbMonitoring.histoPSet.muEtaBinning2D  = cms.vdouble(-2.5,-1.5,-0.6,0.,0.6,1.5,2.5)
-#pt binning 2D
-#mssmHbbMonitoring.histoPSet.elePtBinning2D = cms.vdouble(0,20,30,50,100,200,400)
-#mssmHbbMonitoring.histoPSet.jetPtBinning2D = cms.vdouble(0,20,30,50,100,200,400)
-#mssmHbbMonitoring.histoPSet.muPtBinning2D  = cms.vdouble(0,20,30,50,100,200,400)
-mssmHbbMonitoring.histoPSet.elePtBinning2D = cms.vdouble(0,15,20,30,40,60,80,100,200,400)
-mssmHbbMonitoring.histoPSet.jetPtBinning2D = cms.vdouble(0,15,20,30,40,60,80,100,200,400)
-mssmHbbMonitoring.histoPSet.muPtBinning2D = cms.vdouble(0,15,20,30,40,60,80,100,200,400)
-#HT and phi binning 2D
-mssmHbbMonitoring.histoPSet.HTBinning2D  = cms.vdouble(0,20,40,70,100,150,200,400,700)
-mssmHbbMonitoring.histoPSet.phiBinning2D = cms.vdouble(-3.1416,-1.8849,-0.6283,0.6283,1.8849,3.1416)
+      ptPSet = dict(
+              nbins = 100 , #60
+              xmin  =   0 ,
+              xmax  =  1000), #300
 
+      phiPSet = dict(
+              nbins =  32  ,
+              xmin  = -3.2 ,
+              xmax  =   3.2 ),
 
-mssmHbbMonitoring.met       = cms.InputTag("pfMet") # pfMet
-mssmHbbMonitoring.jets      = cms.InputTag("ak4PFJetsCHS") # ak4PFJets, ak4PFJetsCHS, ak4PFJets
-mssmHbbMonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-mssmHbbMonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
-#Suvankar
-mssmHbbMonitoring.vertices  = cms.InputTag("offlinePrimaryVertices")
+      etaPSet = dict(
+              nbins =  24 ,
+              xmin  = -2.4 ,
+              xmax  =  2.4 ),
 
-# Marina
-mssmHbbMonitoring.btagAlgos        = ["pfCombinedSecondaryVertexV2BJetTags"]
-mssmHbbMonitoring.workingpoint     = cms.double(0.92) # tight
+      htPSet = dict(
+              nbins =   100 , #60
+              xmin  =  0 ,
+              xmax  =  1000 ), #600
+
+      csvPSet = dict(
+              nbins = 50 ,
+              xmin  =  0.0,
+              xmax  = 1.0  ),
+
+      DRPSet = dict(
+              nbins = 60 ,
+              xmin  = 0.0 ,
+              xmax  = 6.0 ),
+
+      invMassPSet = dict(
+              nbins =  40,
+              xmin  = 0.0 ,
+              xmax  = 80.0 ),
+
+      MHTPSet = dict(
+              nbins =  80 ,
+              xmin  =  60 ,
+              xmax  =  300  ),
+
+    #MET and HT binning
+    metBinning = [0,20,40,60,80,100,125,150,175,200],
+    HTBinning  = [0,20,40,60,80,100,125,150,175,200,300,400,500,700],
+    #Eta binning
+    eleEtaBinning = [-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4],
+    jetEtaBinning = [-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4],
+    muEtaBinning  = [-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4],
+    #pt binning
+    #elePtBinning = [0,5,10,20,30,40,50,70,100,200,400],
+    #jetPtBinning = [0,5,10,20,30,40,50,70,100,200,400],
+    #muPtBinning  = [0,5,10,20,30,40,50,70,100,200,400],
+    elePtBinning = [0,3,5,8,15,20,25,30,40,50,60,80,120,200,400,700],
+    jetPtBinning = [0,3,5,8,15,20,25,30,40,50,70,100,150,200,400,700,1000,1500],
+    muPtBinning = [0,3,5,7,10,15,20,30,40,50,70,100,150,200,400,700],
+    #Eta binning 2D
+    eleEtaBinning2D = [-2.5,-1.5,-0.6,0.,0.6,1.5,2.5],
+    jetEtaBinning2D = [-2.5,-1.5,-0.6,0.,0.6,1.5,2.5],
+    muEtaBinning2D  = [-2.5,-1.5,-0.6,0.,0.6,1.5,2.5],
+    #pt binning 2D
+    #elePtBinning2D = [0,20,30,50,100,200,400],
+    #jetPtBinning2D = [0,20,30,50,100,200,400],
+    #muPtBinning2D  = [0,20,30,50,100,200,400],
+    elePtBinning2D = [0,15,20,30,40,60,80,100,200,400],
+    jetPtBinning2D = [0,15,20,30,40,60,80,100,200,400],
+    muPtBinning2D = [0,15,20,30,40,60,80,100,200,400],
+    #HT and phi binning 2D
+    HTBinning2D  = [0,20,40,70,100,150,200,400,700],
+    phiBinning2D = [-3.1416,-1.8849,-0.6283,0.6283,1.8849,3.1416]
+  ),
+  applyLeptonPVcuts = False,
+  leptonPVcuts = dict(
+     dxy =   9999. ,
+      dz  =  9999. ),
+
+  met       = "pfMet", # pfMet
+  jets      = "ak4PFJetsCHS", # ak4PFJets, ak4PFJetsCHS, ak4PFJets
+  electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
+  muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !
+  #Suvankar
+  vertices  = "offlinePrimaryVertices",
+
+  # Marina
+  btagAlgos        = ["pfCombinedSecondaryVertexV2BJetTags"],
+  workingpoint     = 0.92, # tight
 
 
-mssmHbbMonitoring.HTdefinition = cms.string('pt>30 & abs(eta)<2.5')
-#mssmHbbMonitoring.leptJetDeltaRmin = cms.double(0.4) # MuonJet dRcone
+  HTdefinition = 'pt>30 & abs(eta)<2.5',
+  #leptJetDeltaRmin = 0.4, # MuonJet dRcone
 
-#always monitor CSV score for one jet if set DeltaRmin = 0.0 and WP to -1 
-#mssmHbbMonitoring.nbjets = cms.uint32(1)
-#mssmHbbMonitoring.bjetSelection = cms.string('pt>30 & abs(eta)<2.4')
+  #always monitor CSV score for one jet if set DeltaRmin = 0.0 and WP to -1 
+  #nbjets = 1,
+  #bjetSelection = 'pt>30 & abs(eta)<2.4',
 
-mssmHbbMonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-mssmHbbMonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-mssmHbbMonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" ) #change to HLT for PR !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-mssmHbbMonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-mssmHbbMonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
+  numGenericTriggerEventPSet = dict(
+    andOr         =  False,
+    andOrHlt      = True,# True:=OR; False:=AND
+    hltInputTag   = "TriggerResults::HLT", #change to HLT for PR !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    errorReplyHlt = False,
+    verbosityLevel = 0),
 
-mssmHbbMonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-mssmHbbMonitoring.denGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-mssmHbbMonitoring.denGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )  #change to HLT for PR !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-mssmHbbMonitoring.denGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-mssmHbbMonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-mssmHbbMonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-mssmHbbMonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-mssmHbbMonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-mssmHbbMonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-mssmHbbMonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
+  denGenericTriggerEventPSet = dict(
+    andOr         = False,
+    andOrHlt      = True, # True:=OR; False:=AND
+    hltInputTag   = "TriggerResults::HLT",  #change to HLT for PR !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    errorReplyHlt = False,
+    dcsInputTag   = "scalersRawToDigi",
+    dcsRecordInputTag = "onlineMetaDataDigis",
+    dcsPartitions = [ 24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+    andOrDcs      = False,
+    errorReplyDcs = True,
+    verbosityLevel = 0)
+)
+
+
+
+

--- a/DQMOffline/Trigger/python/MuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/MuonMonitor_cff.py
@@ -3,179 +3,176 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.MuonMonitor_cfi import hltMuonmonitoring
 
 
-TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone()
-TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring.FolderName = cms.string('HLT/EXO/TrkMu12_DoubleTrkMu5NoFiltersNoVtx/')
+TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/TrkMu12_DoubleTrkMu5NoFiltersNoVtx/'
+)
 TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*")
 TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet40_v*","HLT_PFJet60_v*","HLT_PFJet80_v*") 
 
-TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone()
-TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring.FolderName = cms.string('HLT/EXO/TrkMu16_DoubleTrkMu6NoFiltersNoVtx/')
+TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/TrkMu16_DoubleTrkMu6NoFiltersNoVtx/'
+)
 TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v*")
 TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*") 
 
-TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone()
-TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring.FolderName = cms.string('HLT/EXO/TrkMu17_DoubleTrkMu8NoFiltersNoVtx/')
+TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/TrkMu17_DoubleTrkMu8NoFiltersNoVtx/'
+)
 TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v*")
 TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*")
 
-
-
-DoubleMu43NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone()
-DoubleMu43NoFiltersNoVtx_monitoring.FolderName = cms.string('HLT/EXO/DoubleMu43NoFiltersNoVtx/')
-DoubleMu43NoFiltersNoVtx_monitoring.nmuons = cms.uint32(2)
+DoubleMu43NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/DoubleMu43NoFiltersNoVtx/',
+    nmuons = 2
+)
 DoubleMu43NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu43NoFiltersNoVtx_v*")
 DoubleMu43NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 
-DoubleMu48NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone()
-DoubleMu48NoFiltersNoVtx_monitoring.FolderName = cms.string('HLT/EXO/DoubleMu48NoFiltersNoVtx/')
-DoubleMu48NoFiltersNoVtx_monitoring.nmuons = cms.uint32(2)
+DoubleMu48NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/DoubleMu48NoFiltersNoVtx/',
+    nmuons = 2
+)
 DoubleMu48NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu48NoFiltersNoVtx_v*")
 DoubleMu48NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 
-
-DoubleMu33NoFiltersNoVtxDisplaced_monitoring = hltMuonmonitoring.clone()
-DoubleMu33NoFiltersNoVtxDisplaced_monitoring.FolderName = cms.string('HLT/EXO/DoubleMu33NoFiltersNoVtxDisplaced/')
-DoubleMu33NoFiltersNoVtxDisplaced_monitoring.nmuons = cms.uint32(2)
+DoubleMu33NoFiltersNoVtxDisplaced_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/DoubleMu33NoFiltersNoVtxDisplaced/',
+    nmuons = 2
+)
 DoubleMu33NoFiltersNoVtxDisplaced_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu33NoFiltersNoVtxDisplaced_v*")
 DoubleMu33NoFiltersNoVtxDisplaced_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-DoubleMu40NoFiltersNoVtxDisplaced_monitoring = hltMuonmonitoring.clone()
-DoubleMu40NoFiltersNoVtxDisplaced_monitoring.FolderName = cms.string('HLT/EXO/DoubleMu40NoFiltersNoVtxDisplaced/')
-DoubleMu40NoFiltersNoVtxDisplaced_monitoring.nmuons = cms.uint32(2)
+DoubleMu40NoFiltersNoVtxDisplaced_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/DoubleMu40NoFiltersNoVtxDisplaced/',
+    nmuons = 2
+)
 DoubleMu40NoFiltersNoVtxDisplaced_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu40NoFiltersNoVtxDisplaced_v*")
 DoubleMu40NoFiltersNoVtxDisplaced_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 #--------------------------------------------------
-DoubleL2Mu23NoVtx_2Cha_monitoring = hltMuonmonitoring.clone()
-DoubleL2Mu23NoVtx_2Cha_monitoring.FolderName = cms.string('HLT/EXO/DoubleL2Mu23NoVtx_2Cha/')
-DoubleL2Mu23NoVtx_2Cha_monitoring.nmuons = cms.uint32(2)
+DoubleL2Mu23NoVtx_2Cha_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/DoubleL2Mu23NoVtx_2Cha/',
+    nmuons = 2
+)
 DoubleL2Mu23NoVtx_2Cha_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_v*")
 DoubleL2Mu23NoVtx_2Cha_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 
-DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring = hltMuonmonitoring.clone()
-DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.FolderName = cms.string('HLT/EXO/DoubleL2Mu23NoVtx_2Cha_CosmicSeed/')
-DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.nmuons = cms.uint32(2)
+DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/DoubleL2Mu23NoVtx_2Cha_CosmicSeed/',
+    nmuons = 2
+)
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*")
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 #--------------------------------------------------
 
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring = hltMuonmonitoring.clone()
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring.FolderName = cms.string('HLT/EXO/Mu43NoFiltersNoVtx_Photon43_CaloIdL/')
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring.nmuons = cms.uint32(1)
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring.nelectrons = cms.uint32(1)
+Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtx_Photon43_CaloIdL/',
+    nmuons = 1,
+    nelectrons = 1
+)
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*")
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 
-
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone()
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.FolderName = cms.string('HLT/EXO/Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg/')
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.nmuons = cms.uint32(1)
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.nelectrons = cms.uint32(1)
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.eleSelection = cms.string('pt > 43')
+Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg/',
+    nmuons = 1,
+    nelectrons = 1,
+    eleSelection = 'pt > 43'
+)
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*")
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-
-
-
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone()
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.FolderName = cms.string('HLT/EXO/Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg/')
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.nmuons = cms.uint32(1)
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.nelectrons = cms.uint32(1)
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.muonSelection = cms.string('pt > 43')
+Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg/',
+    nmuons = 1,
+    nelectrons = 1,
+    muonSelection = 'pt > 43'
+)
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*")
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring = hltMuonmonitoring.clone()
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring.FolderName = cms.string('HLT/EXO/Mu48NoFiltersNoVtx_Photon48_CaloIdL/')
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring.nmuons = cms.uint32(1)
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring.nelectrons = cms.uint32(1)
+Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu48NoFiltersNoVtx_Photon48_CaloIdL/',
+    nmuons = 1,
+    nelectrons = 1
+)
 Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v*")
 Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-
-
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone()
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring.FolderName = cms.string('HLT/EXO/Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg/')
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring.nmuons = cms.uint32(1)
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring.nelectrons = cms.uint32(1)
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring.eleSelection = cms.string('pt > 48')
+Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg/',
+    nmuons = 1,
+    nelectrons = 1,
+    eleSelection = 'pt > 48'
+)
 Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v*")
 Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-
-
-
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone()
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring.FolderName = cms.string('HLT/EXO/Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg/')
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring.nmuons = cms.uint32(1)
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring.nelectrons = cms.uint32(1)
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring.muonSelection = cms.string('pt > 48')
+Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg/',
+    nmuons = 1,
+    nelectrons = 1,
+    muonSelection = 'pt > 48'
+)
 Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v*")
 Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-
-
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring = hltMuonmonitoring.clone()
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring.FolderName = cms.string('HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL/')
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring.nmuons = cms.uint32(1)
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring.nelectrons = cms.uint32(1)
+Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL/',
+    nmuons = 1,
+    nelectrons = 1
+)
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*")
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 
-
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone()
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.FolderName = cms.string('HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg/')
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.nmuons = cms.uint32(1)
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.nelectrons = cms.uint32(1)
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.eleSelection = cms.string('pt > 38')
+Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg/',
+    nmuons = 1,
+    nelectrons = 1,
+    eleSelection = 'pt > 38'
+)
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*")
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-
-
-
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone()
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.FolderName = cms.string('HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg/')
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.nmuons = cms.uint32(1)
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.nelectrons = cms.uint32(1)
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.muonSelection = cms.string('pt > 38')
+Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg/',
+    nmuons = 1,
+    nelectrons = 1,
+    muonSelection = 'pt > 38'
+)
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*")
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-
-
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring = hltMuonmonitoring.clone()
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring.FolderName = cms.string('HLT/EXO/Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL/')
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring.nmuons = cms.uint32(1)
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring.nelectrons = cms.uint32(1)
+Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL/',
+    nmuons = 1,
+    nelectrons = 1
+)
 Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v*")
 Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-
-
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone()
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring.FolderName = cms.string('HLT/EXO/Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg/')
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring.nmuons = cms.uint32(1)
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring.nelectrons = cms.uint32(1)
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring.eleSelection = cms.string('pt > 43')
+Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg/',
+    nmuons = 1,
+    nelectrons = 1,
+    eleSelection = 'pt > 43'
+)
 Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v*")
 Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 
-
-
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone()
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring.FolderName = cms.string('HLT/EXO/Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg/')
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring.nmuons = cms.uint32(1)
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring.nelectrons = cms.uint32(1)
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring.muonSelection = cms.string('pt > 43')
+Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg/',
+    nmuons = 1,
+    nelectrons = 1,
+    muonSelection = 'pt > 43'
+)
 Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v*")
 Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 

--- a/DQMOffline/Trigger/python/MuonMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/MuonMonitor_cfi.py
@@ -2,43 +2,46 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.muonMonitoring_cfi import muonMonitoring
 
-hltMuonmonitoring = muonMonitoring.clone()
-hltMuonmonitoring.FolderName = cms.string('HLT/Muon/TrkMu16_DoubleTrkMu6NoFiltersNoVtx/')
-hltMuonmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32 ( 250 ),
-  xmin  = cms.double(    0.),
-  xmax  = cms.double( 2500.),
+hltMuonmonitoring = muonMonitoring.clone(
+    FolderName = 'HLT/Muon/TrkMu16_DoubleTrkMu6NoFiltersNoVtx/',
+    met       = "pfMet", # pfMet
+    muons = "muons", # while pfIsolatedElectronsEI are reco::PFCandidate !
+    nmuons = 0,
+
+    histoPSet = dict(
+        lsPSet = dict(
+                    nbins =  250 ,
+                    xmin  =   0.,
+                    xmax  =  2500.),
+        muonPSet = dict(
+                    nbins =  500 , ### THIS SHOULD BE VARIABLE BINNING !!!!!
+                    xmin  =  0.0,
+                    xmax  = 500),
+    ),
+
+    numGenericTriggerEventPSet = dict(
+        andOr         = False,
+        #dbLabel       = "ExoDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+        andOrHlt      = True,# True:=OR; False:=AND
+        hltInputTag   =  "TriggerResults::HLT" ,
+        hltPaths      = ["HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v*"], # HLT_ZeroBias_v*
+        #hltDBKey      = "EXO_HLT_MET",
+        errorReplyHlt =  False,
+        verbosityLevel = 1),
+
+    denGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        andOrHlt      =  True,
+        hltInputTag   = "TriggerResults::HLT",
+        hltPaths      = [""], # HLT_ZeroBias_v*
+        errorReplyHlt = False,
+        dcsInputTag   = "scalersRawToDigi",
+        dcsRecordInputTag = "onlineMetaDataDigis",
+        dcsPartitions = [24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+        andOrDcs      =  False,
+        errorReplyDcs =  True,
+        verbosityLevel = 1)
 )
-hltMuonmonitoring.histoPSet.muonPSet = cms.PSet(
-  nbins = cms.uint32(  500  ), ### THIS SHOULD BE VARIABLE BINNING !!!!!
-  xmin  = cms.double(  0.0),
-  xmax  = cms.double(500),
-)
-hltMuonmonitoring.met       = cms.InputTag("pfMet") # pfMet
-hltMuonmonitoring.muons = cms.InputTag("muons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-hltMuonmonitoring.nmuons = cms.uint32(0)
-
-
-hltMuonmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-#hltMuonmonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
-hltMuonmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltMuonmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltMuonmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v*") # HLT_ZeroBias_v*
-#hltMuonmonitoring.numGenericTriggerEventPSet.hltDBKey      = cms.string("EXO_HLT_MET")
-hltMuonmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltMuonmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
-
-hltMuonmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltMuonmonitoring.denGenericTriggerEventPSet.andOrHlt        = cms.bool( True )
-hltMuonmonitoring.denGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltMuonmonitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("") # HLT_ZeroBias_v*
-hltMuonmonitoring.denGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltMuonmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltMuonmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltMuonmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltMuonmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltMuonmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltMuonmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
 
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
 stage2L1Trigger.toModify(hltMuonmonitoring,
@@ -50,4 +53,5 @@ stage2L1Trigger.toModify(hltMuonmonitoring,
                                                            l1tAlgBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            l1tExtBlkInputTag = cms.InputTag("gtStage2Digis"),
                                                            ReadPrescalesFromFile = cms.bool(True)))
+
 

--- a/DQMOffline/Trigger/python/NoBPTXMonitor_cff.py
+++ b/DQMOffline/Trigger/python/NoBPTXMonitor_cff.py
@@ -2,17 +2,20 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.NoBPTXMonitor_cfi import hltNoBPTXmonitoring
 
-hltNoBPTXJetE70Monitoring = hltNoBPTXmonitoring.clone()
-hltNoBPTXJetE70Monitoring.FolderName = cms.string('HLT/EXO/NoBPTX/JetE70/')
-hltNoBPTXJetE70Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_UncorrectedJetE70_NoBPTX3BX_v*") #HLT_ZeroBias_v*
+hltNoBPTXJetE70Monitoring = hltNoBPTXmonitoring.clone(
+    FolderName = 'HLT/EXO/NoBPTX/JetE70/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_UncorrectedJetE70_NoBPTX3BX_v*"]) #HLT_ZeroBias_v*
+)
 
-hltNoBPTXL2Mu40Monitoring = hltNoBPTXmonitoring.clone()
-hltNoBPTXL2Mu40Monitoring.FolderName = cms.string('HLT/EXO/NoBPTX/L2Mu40/')
-hltNoBPTXL2Mu40Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX_v*") #HLT_ZeroBias_v*
+hltNoBPTXL2Mu40Monitoring = hltNoBPTXmonitoring.clone(
+    FolderName = 'HLT/EXO/NoBPTX/L2Mu40/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX_v*"]) #HLT_ZeroBias_v*
+)
 
-hltNoBPTXL2Mu45Monitoring = hltNoBPTXmonitoring.clone()
-hltNoBPTXL2Mu45Monitoring.FolderName = cms.string('HLT/EXO/NoBPTX/L2Mu45/')
-hltNoBPTXL2Mu45Monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v*") #HLT_ZeroBias_v*
+hltNoBPTXL2Mu45Monitoring = hltNoBPTXmonitoring.clone(
+    FolderName = 'HLT/EXO/NoBPTX/L2Mu45/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v*"]) #HLT_ZeroBias_v*
+)
 
 exoHLTNoBPTXmonitoring = cms.Sequence(
     hltNoBPTXmonitoring

--- a/DQMOffline/Trigger/python/NoBPTXMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/NoBPTXMonitor_cfi.py
@@ -2,65 +2,70 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.NoBPTXMonitoring_cfi import NoBPTXMonitoring
 
-hltNoBPTXmonitoring = NoBPTXMonitoring.clone()
-hltNoBPTXmonitoring.FolderName = cms.string('HLT/EXO/NoBPTX/JetE60/')
-hltNoBPTXmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32(250),
-  xmin  = cms.double(0.),
-  xmax  = cms.double(2500.),
-)
-hltNoBPTXmonitoring.histoPSet.jetEPSet = cms.PSet(
-    nbins = cms.uint32(100),
-    xmin  = cms.double(-0.5),
-    xmax  = cms.double(999.5),
-)
-hltNoBPTXmonitoring.histoPSet.jetEtaPSet = cms.PSet(
-    nbins = cms.uint32(100),
-    xmin  = cms.double(-5.),
-    xmax  = cms.double(5.),
-)
-hltNoBPTXmonitoring.histoPSet.jetPhiPSet = cms.PSet(
-    nbins = cms.uint32(64),
-    xmin  = cms.double(-3.2),
-    xmax  = cms.double(3.2),
-)
-hltNoBPTXmonitoring.histoPSet.muonPtPSet = cms.PSet(
-    nbins = cms.uint32(100),
-    xmin  = cms.double(-0.5),
-    xmax  = cms.double(999.5),
-)
-hltNoBPTXmonitoring.histoPSet.muonEtaPSet = cms.PSet(
-    nbins = cms.uint32(100),
-    xmin  = cms.double(-5.),
-    xmax  = cms.double(5.),
-)
-hltNoBPTXmonitoring.histoPSet.muonPhiPSet = cms.PSet(
-    nbins = cms.uint32(64),
-    xmin  = cms.double(-3.2),
-    xmax  = cms.double(3.2),
-)
-hltNoBPTXmonitoring.histoPSet.bxPSet = cms.PSet(
-    nbins = cms.uint32(1800),
-)
-hltNoBPTXmonitoring.jets = cms.InputTag("ak4CaloJets")
-hltNoBPTXmonitoring.muons = cms.InputTag("displacedStandAloneMuons")
+hltNoBPTXmonitoring = NoBPTXMonitoring.clone(
+    FolderName = 'HLT/EXO/NoBPTX/JetE60/',
+    jets = "ak4CaloJets",
+    muons = "displacedStandAloneMuons",
+    muonSelection = "hitPattern.dtStationsWithValidHits > 3 & hitPattern.numberOfValidMuonRPCHits > 1 & hitPattern.numberOfValidMuonCSCHits < 1",
+    jetSelection = "abs(eta) < 1.",
 
-hltNoBPTXmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-#hltNoBPTXmonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !                                                                                                           
-hltNoBPTXmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND 
-hltNoBPTXmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltNoBPTXmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_UncorrectedJetE60_NoBPTX3BX_v*") # HLT_ZeroBias_v*
-#hltNoBPTXmonitoring.numGenericTriggerEventPSet.hltDBKey      = cms.string("EXO_HLT_NoBPTX") 
-hltNoBPTXmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltNoBPTXmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+    histoPSet = dict(
+        lsPSet = dict(
+                nbins = 250,
+                xmin  = 0.,
+                xmax  = 2500.),
+        jetEPSet = dict(
+                nbins = 100,
+                xmin  = -0.5,
+                xmax  = 999.5),
 
-hltNoBPTXmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltNoBPTXmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltNoBPTXmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltNoBPTXmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltNoBPTXmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltNoBPTXmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltNoBPTXmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+        jetEtaPSet = dict(
+                nbins = 100,
+                xmin  = -5.,
+                xmax  = 5.),
 
-hltNoBPTXmonitoring.muonSelection = cms.string("hitPattern.dtStationsWithValidHits > 3 & hitPattern.numberOfValidMuonRPCHits > 1 & hitPattern.numberOfValidMuonCSCHits < 1")
-hltNoBPTXmonitoring.jetSelection = cms.string("abs(eta) < 1.")
+        jetPhiPSet = dict(
+                nbins = 64,
+                xmin  = -3.2,
+                xmax  = 3.2),
+
+        muonPtPSet = dict(
+                nbins = 100,
+                xmin  = -0.5,
+                xmax  = 999.5),
+    
+        muonEtaPSet = dict(
+                nbins = 100,
+                xmin  = -5.,
+                xmax  = 5.),
+
+        muonPhiPSet = dict(
+                nbins = 64,
+                xmin  = -3.2,
+                xmax  = 3.2),
+
+        bxPSet = dict(
+                nbins = 1800)
+    ),
+ 
+    numGenericTriggerEventPSet = dict(
+        andOr         = False,
+        #dbLabel       = "ExoDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !                                                                                                           
+        andOrHlt      = True,# True:=OR; False:=AND 
+        hltInputTag   =  "TriggerResults::HLT",
+        hltPaths      = ["HLT_UncorrectedJetE60_NoBPTX3BX_v*"], # HLT_ZeroBias_v*
+        #hltDBKey      = "EXO_HLT_NoBPTX", 
+        errorReplyHlt =  False,
+        verbosityLevel = 1),
+
+    denGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        dcsInputTag   =  "scalersRawToDigi",
+        dcsRecordInputTag = "onlineMetaDataDigis",
+        dcsPartitions = [ 24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+        andOrDcs      = False,
+        errorReplyDcs = True, 
+        verbosityLevel = 1)
+)
+
+

--- a/DQMOffline/Trigger/python/ObjMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/ObjMonitor_cfi.py
@@ -2,74 +2,79 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.objMonitoring_cfi import objMonitoring
 
-hltobjmonitoring = objMonitoring.clone()
-hltobjmonitoring.FolderName = cms.string('HLT/GENERIC/')
-hltobjmonitoring.doMETHistos = cms.bool(True)
-hltobjmonitoring.histoPSet.metPSet = cms.PSet(
-  nbins = cms.uint32 (  200  ),
-  xmin  = cms.double(   -0.5),
-  xmax  = cms.double(19999.5),
-)
-hltobjmonitoring.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.uint32 (  64  ),
-  xmin  = cms.double(   -3.1416),
-  xmax  = cms.double(3.1416),
-)
-hltobjmonitoring.doJetHistos = cms.bool(True)
-hltobjmonitoring.histoPSet.jetetaPSet = cms.PSet(
-  nbins = cms.uint32 (  100  ),
-  xmin  = cms.double(   -5),
-  xmax  = cms.double(5),
-)
-hltobjmonitoring.histoPSet.detajjPSet = cms.PSet(
-  nbins = cms.uint32 (  90  ),
-  xmin  = cms.double(   0),
-  xmax  = cms.double(9),
-)
-hltobjmonitoring.histoPSet.dphijjPSet = cms.PSet(
-  nbins = cms.uint32 (  64  ),
-  xmin  = cms.double(   0),
-  xmax  = cms.double(3.1416),
-)
-hltobjmonitoring.histoPSet.mindphijmetPSet = cms.PSet(
-  nbins = cms.uint32 (  64  ),
-  xmin  = cms.double(   0),
-  xmax  = cms.double(3.1416),
-)
-hltobjmonitoring.doHTHistos = cms.bool(True)
-hltobjmonitoring.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32 (  60  ),
-  xmin  = cms.double(   -0.5),
-  xmax  = cms.double(1499.5),
-)
-hltobjmonitoring.doHMesonGammaHistos = cms.bool(False)
-hltobjmonitoring.histoPSet.hmgetaPSet = cms.PSet(
-  nbins = cms.uint32 (  60  ),
-  xmin  = cms.double(   -2.6),
-  xmax  = cms.double(2.6),
+hltobjmonitoring = objMonitoring.clone(
+    FolderName = 'HLT/GENERIC/',
+    doMETHistos = True,
+    met       = "pfMet",
+    jets      = "ak4PFJetsCHS",
+    electrons = "gedGsfElectrons",
+    muons     = "muons",
+    photons   = "gedPhotons",
+    tracks    = "generalTracks",
+    doJetHistos = True,
+    doHTHistos = True,
+    doHMesonGammaHistos = False,
+
+    histoPSet = dict(
+            metPSet = dict(
+                    nbins =  200  ,
+                    xmin  =   -0.5,
+                    xmax  = 19999.5),
+
+            phiPSet = dict(
+                    nbins =  64  ,
+                    xmin  =   -3.1416,
+                    xmax  = 3.1416),
+
+            jetetaPSet = dict(
+                    nbins = 100 ,
+                    xmin  = -5,
+                    xmax  = 5),
+
+            detajjPSet = dict(
+                    nbins = 90 ,
+                    xmin  = 0,
+                    xmax  = 9),
+
+            dphijjPSet = dict(
+                    nbins =  64 ,
+                    xmin  =  0,
+                    xmax  = 3.1416),
+
+            mindphijmetPSet = dict(
+                    nbins =  64,
+                    xmin  =  0,
+                    xmax  = 3.1416),
+
+            htPSet = dict(
+                    nbins = 60  ,
+                    xmin  = -0.5,
+                    xmax  = 1499.5),
+
+            hmgetaPSet = dict(
+                    nbins = 60  ,
+                    xmin  = -2.6,
+                    xmax  = 2.6),
+        ),
+
+    numGenericTriggerEventPSet = dict(
+        andOr         = False,
+        #dbLabel       = "ExoDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+        andOrHlt      = True, # True:=OR; False:=AND
+        hltInputTag   =  "TriggerResults::HLT",
+        hltPaths      = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"], # HLT_ZeroBias_v*
+        #hltDBKey      = "EXO_HLT_MET",
+        errorReplyHlt =  False,
+        verbosityLevel = 1),
+
+    denGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        dcsInputTag   =  "scalersRawToDigi",
+        dcsRecordInputTag = "onlineMetaDataDigis",
+        dcsPartitions = [ 24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+        andOrDcs      =  False,
+        errorReplyDcs = True,
+        verbosityLevel = 1)
 )
 
-hltobjmonitoring.met       = cms.InputTag("pfMet")
-hltobjmonitoring.jets      = cms.InputTag("ak4PFJetsCHS")
-hltobjmonitoring.electrons = cms.InputTag("gedGsfElectrons")
-hltobjmonitoring.muons     = cms.InputTag("muons")
-hltobjmonitoring.photons   = cms.InputTag("gedPhotons")
-hltobjmonitoring.tracks    = cms.InputTag("generalTracks")
-
-hltobjmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-#hltobjmonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
-hltobjmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltobjmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltobjmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*") # HLT_ZeroBias_v*
-#hltobjmonitoring.numGenericTriggerEventPSet.hltDBKey      = cms.string("EXO_HLT_MET")
-hltobjmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltobjmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
-
-hltobjmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltobjmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltobjmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltobjmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltobjmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltobjmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltobjmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
 

--- a/DQMOffline/Trigger/python/PhotonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/PhotonMonitor_cff.py
@@ -3,60 +3,72 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.PhotonMonitor_cfi import hltPhotonmonitoring
 
 #HLT_SinglePhoton200_IDTight
-SinglePhoton300_monitoring = hltPhotonmonitoring.clone()
-SinglePhoton300_monitoring.FolderName = cms.string('HLT/EGM/Photon/Photon300/')
-SinglePhoton300_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon300_NoHE_v*")
+SinglePhoton300_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EGM/Photon/Photon300/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon300_NoHE_v*"])
+)
 
 
 # HLT_SinglePhoton200_IDTight
-SinglePhoton200_monitoring = hltPhotonmonitoring.clone()
-SinglePhoton200_monitoring.FolderName = cms.string('HLT/EGM/Photon/Photon200/')
-SinglePhoton200_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon200_v*")
+SinglePhoton200_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EGM/Photon/Photon200/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon200_v*"])
+)
 
-SinglePhoton50_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone()
-SinglePhoton50_R9Id90_HE10_IsoM_monitoring.FolderName = cms.string('HLT/EGM/Photon/Photon50_R9Id90_HE10_IsoM/')
-SinglePhoton50_R9Id90_HE10_IsoM_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon50_R9Id90_HE10_IsoM_v*")
-
-
-SinglePhoton75_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone()
-SinglePhoton75_R9Id90_HE10_IsoM_monitoring.FolderName = cms.string('HLT/EGM/Photon/Photon75_R9Id90_HE10_IsoM/')
-SinglePhoton75_R9Id90_HE10_IsoM_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon75_R9Id90_HE10_IsoM_v*")
+SinglePhoton50_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EGM/Photon/Photon50_R9Id90_HE10_IsoM/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon50_R9Id90_HE10_IsoM_v*"])
+)
 
 
-SinglePhoton90_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone()
-SinglePhoton90_R9Id90_HE10_IsoM_monitoring.FolderName = cms.string('HLT/EGM/Photon/Photon90_R9Id90_HE10_IsoM/')
-SinglePhoton90_R9Id90_HE10_IsoM_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon90_R9Id90_HE10_IsoM_v*")
-
-SinglePhoton120_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone()
-SinglePhoton120_R9Id90_HE10_IsoM_monitoring.FolderName = cms.string('HLT/EGM/Photon/Photon120_R9Id90_HE10_IsoM/')
-SinglePhoton120_R9Id90_HE10_IsoM_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon120_R9Id90_HE10_IsoM_v*")
-
-SinglePhoton165_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone()
-SinglePhoton165_R9Id90_HE10_IsoM_monitoring.FolderName = cms.string('HLT/EGM/Photon/Photon165_R9Id90_HE10_IsoM/')
-SinglePhoton165_R9Id90_HE10_IsoM_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon165_R9Id90_HE10_IsoM_v*")
+SinglePhoton75_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EGM/Photon/Photon75_R9Id90_HE10_IsoM/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon75_R9Id90_HE10_IsoM_v*"])
+)
 
 
-Photon60_monitoring = hltPhotonmonitoring.clone()
-Photon60_monitoring.FolderName = cms.string('HLT/EGM/Photon/Photon60/')
-Photon60_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring()
-Photon60_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon60_R9Id90_CaloIdL_IsoL_v*")
-Photon60_monitoring.photonSelection = cms.string("pt > 20 && r9() < 0.1 && ((eta<1.4442 && hadTowOverEm<0.0597 && full5x5_sigmaIetaIeta()<0.01031 && chargedHadronIso<1.295) || (eta<2.5 && eta>1.566 && hadTowOverEm<0.0481 && full5x5_sigmaIetaIeta()<0.03013 && chargedHadronIso<1.011))")
+SinglePhoton90_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EGM/Photon/Photon90_R9Id90_HE10_IsoM/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon90_R9Id90_HE10_IsoM_v*"])
+)
 
-Photon60_DisplacedIdL_monitoring = Photon60_monitoring.clone()
-Photon60_DisplacedIdL_monitoring.FolderName = cms.string('HLT/EXO/DisplacedPhoton/Photon60_DisplacedIdL/')
-Photon60_DisplacedIdL_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon60_R9Id90_CaloIdL_IsoL_v*")
-Photon60_DisplacedIdL_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_v*")
+SinglePhoton120_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EGM/Photon/Photon120_R9Id90_HE10_IsoM/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon120_R9Id90_HE10_IsoM_v*"])
+)
 
-Photon60_DisplacedIdL_PFJet350MinPFJet15_monitoring = Photon60_DisplacedIdL_monitoring.clone()
-Photon60_DisplacedIdL_PFJet350MinPFJet15_monitoring.denGenericTriggerEventPSet.andOrHlt = cms.bool(False)
-Photon60_DisplacedIdL_PFJet350MinPFJet15_monitoring.FolderName = cms.string('HLT/EXO/DisplacedPhoton/Photon60_DisplacedIdL_PFJet350MinPFJet15/')
-Photon60_DisplacedIdL_PFJet350MinPFJet15_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon60_R9Id90_CaloIdL_IsoL_v*","HLT_PFHT350MinPFJet15_v*")
-Photon60_DisplacedIdL_PFJet350MinPFJet15_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350MinPFJet15_v*")
+SinglePhoton165_R9Id90_HE10_IsoM_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EGM/Photon/Photon165_R9Id90_HE10_IsoM/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon165_R9Id90_HE10_IsoM_v*"])
+)
+
+Photon60_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EGM/Photon/Photon60/',
+    photonSelection = "pt > 20 && r9() < 0.1 && ((eta<1.4442 && hadTowOverEm<0.0597 && full5x5_sigmaIetaIeta()<0.01031 && chargedHadronIso<1.295) || (eta<2.5 && eta>1.566 && hadTowOverEm<0.0481 && full5x5_sigmaIetaIeta()<0.03013 && chargedHadronIso<1.011))",
+    denGenericTriggerEventPSet = dict(hltPaths = []),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_v*"])
+)
+
+
+Photon60_DisplacedIdL_monitoring = Photon60_monitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedPhoton/Photon60_DisplacedIdL/',
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_v*"]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_v*"])
+)
+
+
+Photon60_DisplacedIdL_PFJet350MinPFJet15_monitoring = Photon60_DisplacedIdL_monitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedPhoton/Photon60_DisplacedIdL_PFJet350MinPFJet15/',
+    denGenericTriggerEventPSet = dict(andOrHlt = False,
+                                      hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_v*","HLT_PFHT350MinPFJet15_v*"]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350MinPFJet15_v*"])
+)
+
 
 from DQMOffline.Trigger.ObjMonitor_cfi import hltobjmonitoring
 
 Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50_monitoring = hltobjmonitoring.clone(
-#    FolderName = 'HLT/Photon/Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50/',
+    #FolderName = 'HLT/Photon/Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50/',
     FolderName = 'HLT/EXO/Photon/Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50/',
     denGenericTriggerEventPSet = hltobjmonitoring.numGenericTriggerEventPSet.clone(
         hltPaths = ["HLT_Photon50_R9Id90_HE10_IsoM_v*"]
@@ -69,14 +81,16 @@ Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50_monitoring = hltobjmo
     jetSelection = "pt > 30 & abs(eta) < 5.0",
     jetId = "tight",
     njets = 2,
-    doHTHistos = False
+    doHTHistos = False,
+    histoPSet = dict(
+        mjjBinning = [20. * x for x in range(30)],
+        metPSet = dict(
+                nbins = 20,
+                xmin = -0.5,
+                xmax = 200.)
+        )
 )
-Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50_monitoring.histoPSet.mjjBinning = cms.vdouble([20. * x for x in range(30)])
-Photon50_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_PFMET50_monitoring.histoPSet.metPSet = cms.PSet(
-    nbins = cms.uint32(20),
-    xmin = cms.double(-0.5),
-    xmax = cms.double(200.)
-)
+
 
 Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_monitoring = hltobjmonitoring.clone(
 #    FolderName = 'HLT/Photon/Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3/',
@@ -93,9 +107,9 @@ Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_monitoring = hltobjmonitoring
     jetId = "tight",
     njets = 2,
     doMETHistos = False,
-    doHTHistos = False
+    doHTHistos = False,
+    histoPSet = dict(mjjBinning = [20. * x for x in range(30)])
 )
-Photon75_R9Id90_HE10_IsoM_EBOnly_PFJetsMJJ300DEta3_monitoring.histoPSet.mjjBinning = cms.vdouble([20. * x for x in range(30)])
 
 exoHLTPhotonmonitoring = cms.Sequence(
     SinglePhoton300_monitoring
@@ -113,61 +127,73 @@ exoHLTPhotonmonitoring = cms.Sequence(
 )
 
 
-DiphotonMass90_monitoring = hltPhotonmonitoring.clone()
-DiphotonMass90_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass90/')
-DiphotonMass90_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90_v*")
-DiphotonMass90_monitoring.nphotons = cms.uint32(2)
-DiphotonMass90_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")
+DiphotonMass90_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/HIG/DiPhoton/diphotonMass90/',
+    nphotons = 2,
+    photonSelection = "(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90_v*"])
+)
 
-DiphotonMass95_monitoring = hltPhotonmonitoring.clone()
-DiphotonMass95_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass95/')
-DiphotonMass95_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v*")
-DiphotonMass95_monitoring.nphotons = cms.uint32(2)
-DiphotonMass95_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")
+DiphotonMass95_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/HIG/DiPhoton/diphotonMass95/',
+    nphotons = 2,
+    photonSelection = "(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass95_v*"])
+)
+DiphotonMass55AND_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/HIG/DiPhoton/diphotonMass55AND/',
+    nphotons = 2,
+    photonSelection = "(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v*"]),
+    histoPSet = dict(massBinning = [50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.])
+)
 
-DiphotonMass55AND_monitoring = hltPhotonmonitoring.clone()
-DiphotonMass55AND_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass55AND/')
-DiphotonMass55AND_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v*")
-DiphotonMass55AND_monitoring.nphotons = cms.uint32(2)
-DiphotonMass55AND_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")
-DiphotonMass55AND_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.)
 
-DiphotonMass55EB_monitoring = hltPhotonmonitoring.clone()
-DiphotonMass55EB_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass55EB/')
-DiphotonMass55EB_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v*")
-DiphotonMass55EB_monitoring.nphotons = cms.uint32(2)
-DiphotonMass55EB_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)")
-DiphotonMass55EB_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.)
+DiphotonMass55EB_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/HIG/DiPhoton/diphotonMass55EB/',
+    nphotons = 2,
+    photonSelection = "(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v*"]),
+    histoPSet = dict(massBinning = [50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.])
+)
 
-DiphotonMass55ANDnoPV_monitoring = hltPhotonmonitoring.clone()
-DiphotonMass55ANDnoPV_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass55ANDnoPV/')
-DiphotonMass55ANDnoPV_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v*")
-DiphotonMass55ANDnoPV_monitoring.nphotons = cms.uint32(2)
-DiphotonMass55ANDnoPV_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")
-DiphotonMass55EB_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.)
+DiphotonMass55ANDnoPV_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/HIG/DiPhoton/diphotonMass55ANDnoPV/',
+    nphotons = 2,
+    photonSelection = "(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v*"]),
+    histoPSet = dict(massBinning = [50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.])
+)
 
-DiphotonMass55EBnoPV_monitoring = hltPhotonmonitoring.clone()
-DiphotonMass55EBnoPV_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass55EBnoPV/')
-DiphotonMass55EBnoPV_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v*")
-DiphotonMass55EBnoPV_monitoring.nphotons = cms.uint32(2)
-DiphotonMass55EBnoPV_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)")
-DiphotonMass55EBnoPV_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.)
 
-DiphotonMass55NewAND_monitoring = hltPhotonmonitoring.clone()
-#DiphotonMass55NewAND_monitoring.FolderName = cms.string('HLT/Photon/diphotonMass55NewAND/')
-DiphotonMass55NewAND_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass55NewAND/')
-DiphotonMass55NewAND_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v*")
-DiphotonMass55NewAND_monitoring.nphotons = cms.uint32(2)
-DiphotonMass55NewAND_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")
-DiphotonMass55NewAND_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.)
+DiphotonMass55EBnoPV_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/HIG/DiPhoton/diphotonMass55EBnoPV/',
+    nphotons = 2,
+    photonSelection = "(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Diphoton30EB_18EB_R9Id_OR_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v*"]),
+    histoPSet = dict(massBinning = [50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.])
+)
 
-DiphotonMass55NewANDnoPV_monitoring = hltPhotonmonitoring.clone()
+
+DiphotonMass55NewAND_monitoring = hltPhotonmonitoring.clone(
+    #FolderName = 'HLT/Photon/diphotonMass55NewAND/',
+    FolderName = 'HLT/HIG/DiPhoton/diphotonMass55NewAND/',
+    nphotons = 2,
+    photonSelection = "(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v*"]),
+    histoPSet = dict(massBinning = [50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.])
+)
+
+
+DiphotonMass55NewANDnoPV_monitoring = hltPhotonmonitoring.clone(
 #DiphotonMass55NewANDnoPV_monitoring.FolderName = cms.string('HLT/Photon/diphotonMass55NewANDnoPV/')
-DiphotonMass55NewANDnoPV_monitoring.FolderName = cms.string('HLT/HIG/DiPhoton/diphotonMass55NewANDnoPV/')
-DiphotonMass55NewANDnoPV_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v*")
-DiphotonMass55NewANDnoPV_monitoring.nphotons = cms.uint32(2)
-DiphotonMass55NewANDnoPV_monitoring.photonSelection = cms.string("(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)")
-DiphotonMass55NewANDnoPV_monitoring.histoPSet.massBinning = cms.vdouble(50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.)
+    FolderName = 'HLT/HIG/DiPhoton/diphotonMass55NewANDnoPV/',
+    nphotons = 2,
+    photonSelection = "(pt > 20 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 20 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Diphoton30_18_PVrealAND_R9Id_AND_IsoCaloId_AND_HE_R9Id_NoPixelVeto_Mass55_v*"]),
+    histoPSet = dict(massBinning = [50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.])
+)
+
 
 higgsHLTDiphotonMonitoring = cms.Sequence(
     DiphotonMass90_monitoring

--- a/DQMOffline/Trigger/python/PhotonMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/PhotonMonitor_cfi.py
@@ -2,40 +2,47 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.photonMonitoring_cfi import photonMonitoring
 
-hltPhotonmonitoring = photonMonitoring.clone()
-hltPhotonmonitoring.FolderName = cms.string('HLT/Photon/Photon200/')
-hltPhotonmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32 ( 250 ),
-  xmin  = cms.double(    0.),
-  xmax  = cms.double( 2500.),
-)
-hltPhotonmonitoring.histoPSet.photonPSet = cms.PSet(
-  nbins = cms.uint32(  500  ),
-  xmin  = cms.double(  0.0),
-  xmax  = cms.double(5000),
-)
-hltPhotonmonitoring.met       = cms.InputTag("pfMet") # pfMet
-hltPhotonmonitoring.jets      = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
-hltPhotonmonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-hltPhotonmonitoring.photons = cms.InputTag("gedPhotons") # while pfIsolatedElectronsEI are reco::PFCandidate !
+hltPhotonmonitoring = photonMonitoring.clone(
+    FolderName = 'HLT/Photon/Photon200/',
+    met       = "pfMet", # pfMet
+    jets      = "ak4PFJets", # ak4PFJets, ak4PFJetsCHS
+    electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
+    photons = "gedPhotons", # while pfIsolatedElectronsEI are reco::PFCandidate !
 
-hltPhotonmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-#hltPhotonmonitoring.numGenericTriggerEventPSet.dbLabel       = cms.string("ExoDQMTrigger") # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
-hltPhotonmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltPhotonmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltPhotonmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_Photon175_v*") # HLT_ZeroBias_v*
-#hltPhotonmonitoring.numGenericTriggerEventPSet.hltDBKey      = cms.string("EXO_HLT_MET")
-hltPhotonmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltPhotonmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+    histoPSet = dict(
+        lsPSet = dict(
+            nbins =  250,
+            xmin  =   0.,
+            xmax  =  2500.),
 
-hltPhotonmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltPhotonmonitoring.denGenericTriggerEventPSet.andOrHlt        = cms.bool( True )
-hltPhotonmonitoring.denGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltPhotonmonitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_PFJet40_v*","HLT_PFJet60_v*","HLT_PFJet80_v*") # HLT_ZeroBias_v*
-hltPhotonmonitoring.denGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltPhotonmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltPhotonmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltPhotonmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltPhotonmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltPhotonmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltPhotonmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+        photonPSet = dict(
+            nbins =  500 ,
+            xmin  =  0.0,
+            xmax  = 5000)
+    ),
+
+    numGenericTriggerEventPSet = dict(
+        andOr         = False,
+        #dbLabel       = "ExoDQMTrigger", # it does not exist yet, we should consider the possibility of using the DB, but as it is now it will need a label per path !
+        andOrHlt      = True, # True:=OR; False:=AND
+        hltInputTag   = "TriggerResults::HLT",
+        hltPaths      = ["HLT_Photon175_v*"], # HLT_ZeroBias_v*
+        #hltDBKey      = "EXO_HLT_MET",
+        errorReplyHlt =  False,
+        verbosityLevel = 1),
+
+
+    denGenericTriggerEventPSet = dict(
+        andOr         =  False,
+        andOrHlt      = True,
+        hltInputTag   = "TriggerResults::HLT",
+        hltPaths      = ["HLT_PFJet40_v*","HLT_PFJet60_v*","HLT_PFJet80_v*"], # HLT_ZeroBias_v*
+        errorReplyHlt =  False,
+        dcsInputTag   = "scalersRawToDigi",
+        dcsRecordInputTag = "onlineMetaDataDigis",
+        dcsPartitions = [ 24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+        andOrDcs      =  False,
+        errorReplyDcs = True,
+        verbosityLevel = 1)
+)
+

--- a/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/PrimaryVertexMonitoring_cff.py
@@ -2,31 +2,31 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.RecoB.PrimaryVertexMonitor_cff import pvMonitor
 
-hltVerticesMonitoring = pvMonitor.clone()
-hltVerticesMonitoring.beamSpotLabel = cms.InputTag("hltOnlineBeamSpot")
-
-hltPixelVerticesMonitoring = hltVerticesMonitoring.clone()
-hltPixelVerticesMonitoring.TopFolderName = cms.string("HLT/Vertexing/hltPixelVertices")
-hltPixelVerticesMonitoring.vertexLabel   = cms.InputTag("hltPixelVertices")
-hltPixelVerticesMonitoring.ndof          = cms.int32(1)
-hltPixelVerticesMonitoring.useHPforAlignmentPlots = cms.bool(False)
-
-hltTrimmedPixelVerticesMonitoring = hltVerticesMonitoring.clone()
-hltTrimmedPixelVerticesMonitoring.TopFolderName = cms.string("HLT/Vertexing/hltTrimmedPixelVertices")
-hltTrimmedPixelVerticesMonitoring.vertexLabel   = cms.InputTag("hltTrimmedPixelVertices")
-hltTrimmedPixelVerticesMonitoring.ndof          = cms.int32(1)
-hltTrimmedPixelVerticesMonitoring.useHPforAlignmentPlots = cms.bool(False)
-
-hltVerticesPFFilterMonitoring = hltVerticesMonitoring.clone()
-hltVerticesPFFilterMonitoring.TopFolderName = cms.string("HLT/Vertexing/hltVerticesPFFilter")
-hltVerticesPFFilterMonitoring.vertexLabel   = cms.InputTag("hltVerticesPFFilter")
-hltVerticesPFFilterMonitoring.useHPforAlignmentPlots = cms.bool(False)
-
-hltVerticesL3PFBjetsMonitoring = hltVerticesMonitoring.clone()
-hltVerticesL3PFBjetsMonitoring.TopFolderName = cms.string("HLT/Vertexing/hltVerticesL3PFBjets")
-hltVerticesL3PFBjetsMonitoring.vertexLabel   = cms.InputTag("hltVerticesL3PFBjets")
-hltVerticesL3PFBjetsMonitoring.useHPforAlignmentPlots = cms.bool(False)
-
+hltVerticesMonitoring = pvMonitor.clone(
+    beamSpotLabel = "hltOnlineBeamSpot"
+)
+hltPixelVerticesMonitoring = hltVerticesMonitoring.clone(
+    TopFolderName = "HLT/Vertexing/hltPixelVertices",
+    vertexLabel   = "hltPixelVertices",
+    ndof          = 1,
+    useHPforAlignmentPlots = False
+)
+hltTrimmedPixelVerticesMonitoring = hltVerticesMonitoring.clone(
+    TopFolderName = "HLT/Vertexing/hltTrimmedPixelVertices",
+    vertexLabel   = "hltTrimmedPixelVertices",
+    ndof          = 1,
+    useHPforAlignmentPlots = False
+)
+hltVerticesPFFilterMonitoring = hltVerticesMonitoring.clone(
+    TopFolderName = "HLT/Vertexing/hltVerticesPFFilter",
+    vertexLabel   = "hltVerticesPFFilter",
+    useHPforAlignmentPlots = False
+)
+hltVerticesL3PFBjetsMonitoring = hltVerticesMonitoring.clone(
+    TopFolderName = "HLT/Vertexing/hltVerticesL3PFBjets",
+    vertexLabel   = "hltVerticesL3PFBjets",
+    useHPforAlignmentPlots = False
+)
 vertexingMonitorHLT = cms.Sequence(
     hltPixelVerticesMonitoring
     + hltTrimmedPixelVerticesMonitoring

--- a/DQMOffline/Trigger/python/RazorMonitor_cff.py
+++ b/DQMOffline/Trigger/python/RazorMonitor_cff.py
@@ -4,71 +4,71 @@ from DQMOffline.Trigger.razorHemispheres_cff import *
 from DQMOffline.Trigger.RazorMonitor_cfi import hltRazorMonitoring
 
 # HLT_Rsq0p35_v* 
-Rsq0p35_RazorMonitoring = hltRazorMonitoring.clone()
-Rsq0p35_RazorMonitoring.FolderName = cms.string('HLT/SUSY/Rsq0p35/')
-Rsq0p35_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Rsq0p35_v*")
-
+Rsq0p35_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/Rsq0p35/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Rsq0p35_v*"])
+)
 # HLT_Rsq0p35_v* tight
-Rsq0p35_Tight_RazorMonitoring = hltRazorMonitoring.clone()
-Rsq0p35_Tight_RazorMonitoring.FolderName = cms.string('HLT/SUSY/Rsq0p35_Tight/')
-Rsq0p35_Tight_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Rsq0p35_v*")
-Rsq0p35_Tight_RazorMonitoring.jetSelection = cms.string("pt>120")
-
+Rsq0p35_Tight_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/Rsq0p35_Tight/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Rsq0p35_v*"]),
+        jetSelection = "pt>120",
+)
 # HLT_Rsq0p40_v*
-Rsq0p40_RazorMonitoring = hltRazorMonitoring.clone()
-Rsq0p40_RazorMonitoring.FolderName = cms.string('HLT/SUSY/Rsq0p40/')
-Rsq0p40_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Rsq0p40_v*")
-
+Rsq0p40_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/Rsq0p40/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Rsq0p40_v*"])
+)
 # HLT_Rsq0p40_v* tight
-Rsq0p40_Tight_RazorMonitoring = hltRazorMonitoring.clone()
-Rsq0p40_Tight_RazorMonitoring.FolderName = cms.string('HLT/SUSY/Rsq0p40_Tight/')
-Rsq0p40_Tight_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Rsq0p40_v*")
-Rsq0p40_Tight_RazorMonitoring.jetSelection = cms.string("pt>120")
-
+Rsq0p40_Tight_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/Rsq0p40_Tight/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Rsq0p40_v*"]),
+        jetSelection = "pt>120"
+)
 # HLT_RsqMR300_Rsq0p09_MR200_v*
-RsqMR300_Rsq0p09_MR200_RazorMonitoring = hltRazorMonitoring.clone()
-RsqMR300_Rsq0p09_MR200_RazorMonitoring.FolderName = cms.string('HLT/SUSY/RsqMR300_Rsq0p09_MR200/')
-RsqMR300_Rsq0p09_MR200_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_RsqMR300_Rsq0p09_MR200_v*")
-
+RsqMR300_Rsq0p09_MR200_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/RsqMR300_Rsq0p09_MR200/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_RsqMR300_Rsq0p09_MR200_v*"])
+)
 # HLT_RsqMR300_Rsq0p09_MR200_v* tight
-RsqMR300_Rsq0p09_MR200_Tight_RazorMonitoring = hltRazorMonitoring.clone()
-RsqMR300_Rsq0p09_MR200_Tight_RazorMonitoring.FolderName = cms.string('HLT/SUSY/RsqMR300_Rsq0p09_MR200_Tight/')
-RsqMR300_Rsq0p09_MR200_Tight_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_RsqMR300_Rsq0p09_MR200_v*")
-RsqMR300_Rsq0p09_MR200_Tight_RazorMonitoring.jetSelection = cms.string("pt>120")
-
+RsqMR300_Rsq0p09_MR200_Tight_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/RsqMR300_Rsq0p09_MR200_Tight/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_RsqMR300_Rsq0p09_MR200_v*"]),
+        jetSelection = "pt>120"
+)
 # HLT_RsqMR320_Rsq0p09_MR200_v*
-RsqMR320_Rsq0p09_MR200_RazorMonitoring = hltRazorMonitoring.clone()
-RsqMR320_Rsq0p09_MR200_RazorMonitoring.FolderName = cms.string('HLT/SUSY/RsqMR320_Rsq0p09_MR200/')
-RsqMR320_Rsq0p09_MR200_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_RsqMR320_Rsq0p09_MR200_v*")
-
+RsqMR320_Rsq0p09_MR200_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/RsqMR320_Rsq0p09_MR200/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_RsqMR320_Rsq0p09_MR200_v*"])
+)
 # HLT_RsqMR320_Rsq0p09_MR200_v* tight
-RsqMR320_Rsq0p09_MR200_Tight_RazorMonitoring = hltRazorMonitoring.clone()
-RsqMR320_Rsq0p09_MR200_Tight_RazorMonitoring.FolderName = cms.string('HLT/SUSY/RsqMR320_Rsq0p09_MR200_Tight/')
-RsqMR320_Rsq0p09_MR200_Tight_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_RsqMR320_Rsq0p09_MR200_v*")
-RsqMR320_Rsq0p09_MR200_Tight_RazorMonitoring.jetSelection = cms.string("pt>120")
-
+RsqMR320_Rsq0p09_MR200_Tight_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/RsqMR320_Rsq0p09_MR200_Tight/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_RsqMR320_Rsq0p09_MR200_v*"]),
+        jetSelection = "pt>120"
+)
 # HLT_RsqMR300_Rsq0p09_MR200_4jet_v*
-RsqMR300_Rsq0p09_MR200_4jet_RazorMonitoring = hltRazorMonitoring.clone()
-RsqMR300_Rsq0p09_MR200_4jet_RazorMonitoring.FolderName = cms.string('HLT/SUSY/RsqMR300_Rsq0p09_MR200_4jet/')
-RsqMR300_Rsq0p09_MR200_4jet_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_RsqMR300_Rsq0p09_MR200_4jet_v*")
-
+RsqMR300_Rsq0p09_MR200_4jet_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/RsqMR300_Rsq0p09_MR200_4jet/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_RsqMR300_Rsq0p09_MR200_4jet_v*"])
+)
 # HLT_RsqMR300_Rsq0p09_MR200_4jet_v* tight
-RsqMR300_Rsq0p09_MR200_4jet_Tight_RazorMonitoring = hltRazorMonitoring.clone()
-RsqMR300_Rsq0p09_MR200_4jet_Tight_RazorMonitoring.FolderName = cms.string('HLT/SUSY/RsqMR300_Rsq0p09_MR200_4jet_Tight/')
-RsqMR300_Rsq0p09_MR200_4jet_Tight_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_RsqMR300_Rsq0p09_MR200_4jet_v*")
-RsqMR300_Rsq0p09_MR200_4jet_Tight_RazorMonitoring.jetSelection = cms.string("pt>120")
-
+RsqMR300_Rsq0p09_MR200_4jet_Tight_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/RsqMR300_Rsq0p09_MR200_4jet_Tight/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_RsqMR300_Rsq0p09_MR200_4jet_v*"]),
+        jetSelection = "pt>120"
+)
 # HLT_RsqMR320_Rsq0p09_MR200_4jet_v*
-RsqMR320_Rsq0p09_MR200_4jet_RazorMonitoring = hltRazorMonitoring.clone()
-RsqMR320_Rsq0p09_MR200_4jet_RazorMonitoring.FolderName = cms.string('HLT/SUSY/RsqMR320_Rsq0p09_MR200_4jet/')
-RsqMR320_Rsq0p09_MR200_4jet_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_RsqMR320_Rsq0p09_MR200_4jet_v*")
-
+RsqMR320_Rsq0p09_MR200_4jet_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/RsqMR320_Rsq0p09_MR200_4jet/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_RsqMR320_Rsq0p09_MR200_4jet_v*"])
+)
 # HLT_RsqMR320_Rsq0p09_MR200_4jet_v* tight
-RsqMR320_Rsq0p09_MR200_4jet_Tight_RazorMonitoring = hltRazorMonitoring.clone()
-RsqMR320_Rsq0p09_MR200_4jet_Tight_RazorMonitoring.FolderName = cms.string('HLT/SUSY/RsqMR320_Rsq0p09_MR200_4jet_Tight/')
-RsqMR320_Rsq0p09_MR200_4jet_Tight_RazorMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_RsqMR320_Rsq0p09_MR200_4jet_v*")
-RsqMR320_Rsq0p09_MR200_4jet_Tight_RazorMonitoring.jetSelection = cms.string("pt>120")
-
+RsqMR320_Rsq0p09_MR200_4jet_Tight_RazorMonitoring = hltRazorMonitoring.clone(
+        FolderName = 'HLT/SUSY/RsqMR320_Rsq0p09_MR200_4jet_Tight/',
+        numGenericTriggerEventPSet = dict(hltPaths = ["HLT_RsqMR320_Rsq0p09_MR200_4jet_v*"]),
+        jetSelection = "pt>120"
+)
 susyHLTRazorMonitoring = cms.Sequence(
         cms.ignore(hemispheresDQM)+ #for razor triggers
         cms.ignore(caloHemispheresDQM)+ #for razor triggers

--- a/DQMOffline/Trigger/python/RazorMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/RazorMonitor_cfi.py
@@ -2,25 +2,29 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.razorMonitoring_cfi import razorMonitoring
 
-hltRazorMonitoring = razorMonitoring.clone()
-hltRazorMonitoring.FolderName = cms.string('HLT/SUSY/RsqMR270_Rsq0p09_MR200')
+hltRazorMonitoring = razorMonitoring.clone(
+    FolderName = 'HLT/SUSY/RsqMR270_Rsq0p09_MR200',
+    met       = "pfMet", # pfMet
+    jets      = "ak4PFJets", # ak4PFJets, ak4PFJetsCHS
 
-hltRazorMonitoring.met       = cms.InputTag("pfMet") # pfMet
-hltRazorMonitoring.jets      = cms.InputTag("ak4PFJets") # ak4PFJets, ak4PFJetsCHS
 
-hltRazorMonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltRazorMonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True) # True:=OR; False:=AND
-hltRazorMonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltRazorMonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_RsqMR300_Rsq0p09_MR200_v*") 
-hltRazorMonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltRazorMonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
+    numGenericTriggerEventPSet = dict(
+        andOr     =  False,
+        andOrHlt      = True, # True:=OR; False:=AND
+        hltInputTag   = "TriggerResults::HLT" ,
+        hltPaths      = ["HLT_RsqMR300_Rsq0p09_MR200_v*"], 
+        errorReplyHlt =  False,
+        verbosityLevel = 1),
 
-hltRazorMonitoring.denGenericTriggerEventPSet.andOr          = cms.bool( False )
-hltRazorMonitoring.denGenericTriggerEventPSet.andOrHlt       = cms.bool( True )
-hltRazorMonitoring.denGenericTriggerEventPSet.dcsInputTag    = cms.InputTag( "scalersRawToDigi" )
-hltRazorMonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag ( "onlineMetaDataDigis" )
-hltRazorMonitoring.denGenericTriggerEventPSet.dcsPartitions  = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltRazorMonitoring.denGenericTriggerEventPSet.andOrDcs       = cms.bool( False )
-hltRazorMonitoring.denGenericTriggerEventPSet.errorReplyDcs  = cms.bool( True )
-hltRazorMonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(1)
-hltRazorMonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Ele27_WPTight_Gsf*", "HLT_Ele30_WPTight_Gsf*", "HLT_Ele32_WPTight_Gsf*")
+    denGenericTriggerEventPSet = dict(
+        andOr          = False,
+        andOrHlt       =  True,
+        dcsInputTag    =  "scalersRawToDigi",
+        dcsRecordInputTag = "onlineMetaDataDigis",
+        dcsPartitions  = [24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+        andOrDcs       =  False,
+        errorReplyDcs  = True ,
+        verbosityLevel = 1,
+        hltPaths = ["HLT_Ele27_WPTight_Gsf*", "HLT_Ele30_WPTight_Gsf*", "HLT_Ele32_WPTight_Gsf*"])
+)
+

--- a/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_HistogramManager_cfi.py
+++ b/DQMOffline/Trigger/python/SiPixel_OfflineMonitoring_HistogramManager_cfi.py
@@ -7,22 +7,22 @@ OverlayCurvesForTiming.enabled = False #switch to overlay digi/clusters curves f
 #PerLayer2D.enabled             = True # 2D maps/profiles of layers
 #PerLayer1D.enabled             = True # normal histos per layer
 
-hltSiPixelPhase1Geometry = SiPixelPhase1Geometry.clone()
-hltSiPixelPhase1Geometry.max_lumisection   = 2500
-hltSiPixelPhase1Geometry.max_bunchcrossing = 3600
-# online-specific things
-hltSiPixelPhase1Geometry.onlineblock    =  20 # #LS after which histograms are reset
-hltSiPixelPhase1Geometry.n_onlineblocks = 100 # #blocks to keep for histograms with history
-
-hltDefaultHistoDigiCluster = DefaultHistoDigiCluster.clone()
-hltDefaultHistoDigiCluster.topFolderName = cms.string("HLT/Pixel")
-
-hltDefaultHistoReadout = DefaultHistoReadout.clone()
-hltDefaultHistoReadout.topFolderName = cms.string("HLT/Pixel")
-
-hltDefaultHistoTrack = DefaultHistoTrack.clone()
-hltDefaultHistoTrack.topFolderName= cms.string("HLT/Pixel/TrackClusters")
-
+hltSiPixelPhase1Geometry = SiPixelPhase1Geometry.clone(
+    max_lumisection   = 2500,
+    max_bunchcrossing = 3600,
+    # online-specific things
+    onlineblock    =  20, # #LS after which histograms are reset
+    n_onlineblocks = 100 # #blocks to keep for histograms with history
+)
+hltDefaultHistoDigiCluster = DefaultHistoDigiCluster.clone(
+    topFolderName = "HLT/Pixel"
+)
+hltDefaultHistoReadout = DefaultHistoReadout.clone(
+    topFolderName = "HLT/Pixel"
+)
+hltDefaultHistoTrack = DefaultHistoTrack.clone(
+    topFolderName= "HLT/Pixel/TrackClusters"
+)
 hltStandardSpecificationPixelmapProfile = [#produces pixel map with the mean (TProfile)
     Specification(PerLayer2D)
        .groupBy("PXBarrel/PXLayer/SignedLadderCoord/SignedModuleCoord")

--- a/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SiStrip_OfflineMonitoring_cff.py
@@ -8,10 +8,13 @@ import FWCore.ParameterSet.Config as cms
 
 # SiStripCluster monitoring
 import DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi
-HLTSiStripMonitorCluster = DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi.SiStripMonitorCluster.clone()
-HLTSiStripMonitorCluster.ClusterProducerStrip = cms.InputTag("hltSiStripRawToClustersFacility")
-HLTSiStripMonitorCluster.ClusterProducerPix   = cms.InputTag("hltSiPixelClusters")
-HLTSiStripMonitorCluster.TopFolderName        = cms.string("HLT/SiStrip")
+HLTSiStripMonitorCluster = DQM.SiStripMonitorCluster.SiStripMonitorCluster_cfi.SiStripMonitorCluster.clone(
+    ClusterProducerStrip = "hltSiStripRawToClustersFacility",
+    ClusterProducerPix   = "hltSiPixelClusters",
+    TopFolderName        = "HLT/SiStrip",
+    ClusterHisto         = True,
+    Mod_On               = False
+)
 HLTSiStripMonitorCluster.TH1TotalNumberOfClusters.subdetswitchon   = cms.bool(True)
 HLTSiStripMonitorCluster.TProfClustersApvCycle.subdetswitchon      = cms.bool(False)
 HLTSiStripMonitorCluster.TProfTotalNumberOfClusters.subdetswitchon = cms.bool(True)
@@ -20,8 +23,7 @@ HLTSiStripMonitorCluster.TH1MultiplicityRegions.globalswitchon  = cms.bool(True)
 HLTSiStripMonitorCluster.TH1MainDiagonalPosition.globalswitchon = cms.bool(True)
 HLTSiStripMonitorCluster.TH1StripNoise2ApvCycle.globalswitchon  = cms.bool(False)
 HLTSiStripMonitorCluster.TH1StripNoise3ApvCycle.globalswitchon  = cms.bool(False)
-HLTSiStripMonitorCluster.ClusterHisto = cms.bool(True)
-HLTSiStripMonitorCluster.Mod_On            = cms.bool(False)
+
 HLTSiStripMonitorCluster.BPTXfilter = cms.PSet(
         andOr         = cms.bool( False ),
             dbLabel       = cms.string("SiStripDQMTrigger"),
@@ -131,25 +133,26 @@ hltESPStripCPEfromTrackAngle = cms.ESProducer( "StripCPEESProducer",
 )
 
 from RecoTracker.TrackProducer.TrackRefitter_cfi import *
-hltTrackRefitterForSiStripMonitorTrack = TrackRefitter.clone()
-hltTrackRefitterForSiStripMonitorTrack.beamSpot                = cms.InputTag("hltOnlineBeamSpot")
-hltTrackRefitterForSiStripMonitorTrack.MeasurementTrackerEvent = cms.InputTag('MeasurementTrackerEvent')
-hltTrackRefitterForSiStripMonitorTrack.TrajectoryInEvent       = cms.bool(True)
-hltTrackRefitterForSiStripMonitorTrack.useHitsSplitting        = cms.bool(False)
-#hltTrackRefitterForSiStripMonitorTrack.src                     = cms.InputTag("hltIter4Merged") # scenario 0
-hltTrackRefitterForSiStripMonitorTrack.src                     = cms.InputTag("hltMergedTracks") # hltIter2Merged # scenario 1
-#hltTrackRefitterForSiStripMonitorTrack.TTRHBuilder             = cms.string('hltESPTTRHBuilderAngleAndTemplate')
-hltTrackRefitterForSiStripMonitorTrack.TTRHBuilder             = cms.string('hltESPTTRHBWithTrackAngle')
-
+hltTrackRefitterForSiStripMonitorTrack = TrackRefitter.clone(
+    beamSpot                = "hltOnlineBeamSpot",
+    MeasurementTrackerEvent = 'MeasurementTrackerEvent',
+    TrajectoryInEvent       = True,
+    useHitsSplitting        = False,
+    #src                     = "hltIter4Merged", # scenario 0
+    src                     = "hltMergedTracks", # hltIter2Merged # scenario 1
+    #TTRHBuilder             = 'hltESPTTRHBuilderAngleAndTemplate',
+    TTRHBuilder             = 'hltESPTTRHBWithTrackAngle'
+)
 import DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi
-HLTSiStripMonitorTrack = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone()
-HLTSiStripMonitorTrack.TrackProducer     = 'hltTrackRefitterForSiStripMonitorTrack' 
-HLTSiStripMonitorTrack.TrackLabel        = ''
-HLTSiStripMonitorTrack.AlgoName          = cms.string("HLT")
-HLTSiStripMonitorTrack.Cluster_src       = cms.InputTag('hltSiStripRawToClustersFacility')
-HLTSiStripMonitorTrack.Trend_On          = cms.bool(True)
-HLTSiStripMonitorTrack.TopFolderName     = cms.string('HLT/SiStrip')
-HLTSiStripMonitorTrack.Mod_On            = cms.bool(False)
+HLTSiStripMonitorTrack = DQM.SiStripMonitorTrack.SiStripMonitorTrack_cfi.SiStripMonitorTrack.clone(
+    TrackProducer     = 'hltTrackRefitterForSiStripMonitorTrack',
+    TrackLabel        = '',
+    AlgoName          = "HLT",
+    Cluster_src       = 'hltSiStripRawToClustersFacility',
+    Trend_On          = True,
+    TopFolderName     = 'HLT/SiStrip',
+    Mod_On            = False
+)
 sistripMonitorHLTsequence = cms.Sequence(
     HLTSiStripMonitorCluster
     * hltTrackRefitterForSiStripMonitorTrack

--- a/DQMOffline/Trigger/python/SoftMuHardJetMETSUSYMonitor_cff.py
+++ b/DQMOffline/Trigger/python/SoftMuHardJetMETSUSYMonitor_cff.py
@@ -5,87 +5,84 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.SusyMonitor_cfi import hltSUSYmonitoring
 
-SoftMuHardJetMETSUSYmonitoring = hltSUSYmonitoring.clone()
-SoftMuHardJetMETSUSYmonitoring.FolderName = cms.string('HLT/SUSY/SoftMuHardJetMET/')
-
-SoftMuHardJetMETSUSYmonitoring.numGenericTriggerEventPSet.hltInputTag = cms.InputTag("TriggerResults","","HLT")
-SoftMuHardJetMETSUSYmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring(
-    "HLT_Mu3er1p5_PFJet100er2p5_PFMET70_PFMHT70_IDTight_v*",
-    "HLT_Mu3er1p5_PFJet100er2p5_PFMET80_PFMHT80_IDTight_v*",
-    "HLT_Mu3er1p5_PFJet100er2p5_PFMET90_PFMHT90_IDTight_v*" 
+SoftMuHardJetMETSUSYmonitoring = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/SoftMuHardJetMET/',
+    met   = "pfMet",
+    jets  = "ak4PFJetsCHS",
+    muons = "muons",
+    HTdefinition     = 'pt>30 & abs(eta)<2.5',
+    leptJetDeltaRmin = 0.4,
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltInputTag = ["TriggerResults","","HLT"],
+                                      hltPaths = ["HLT_Mu3er1p5_PFJet100er2p5_PFMET70_PFMHT70_IDTight_v*",
+                                                  "HLT_Mu3er1p5_PFJet100er2p5_PFMET80_PFMHT80_IDTight_v*",
+                                                  "HLT_Mu3er1p5_PFJet100er2p5_PFMET90_PFMHT90_IDTight_v*" ])
 )
 
-SoftMuHardJetMETSUSYmonitoring.met   = cms.InputTag("pfMetEI")
-SoftMuHardJetMETSUSYmonitoring.jets  = cms.InputTag("ak4PFJetsCHS")
-SoftMuHardJetMETSUSYmonitoring.muons = cms.InputTag("muons")
-
-SoftMuHardJetMETSUSYmonitoring.HTdefinition     = cms.string('pt>30 & abs(eta)<2.5')
-SoftMuHardJetMETSUSYmonitoring.leptJetDeltaRmin = cms.double(0.4)
-SoftMuHardJetMETSUSYmonitoring.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
 
 ###############
 ### Muon pt ###
 ###############
-SoftMuHardJetMETSUSYmonitoring_muPt            = SoftMuHardJetMETSUSYmonitoring.clone()
-SoftMuHardJetMETSUSYmonitoring_muPt.FolderName = cms.string('HLT/SUSY/SoftMuHardJetMET/Muon')
+SoftMuHardJetMETSUSYmonitoring_muPt            = SoftMuHardJetMETSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/SoftMuHardJetMET/Muon',
+    # Muon selection
+    nmuons       = 1,
+    muoSelection = 'abs(eta)<1.5',
+    # Jet selection
+    njets = 1,
+    jetSelection = "pt>130 & abs(eta)<2.5",
+    # MET selection
+    enableMETPlot = True,
+    metSelection = 'pt>150',
+    MHTcut       = 150,
+    ## Selection ##
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFMET120_PFMHT120_IDTight_v*', 'HLT_PFMET130_PFMHT130_IDTight_v*', 'HLT_PFMET140_PFMHT140_IDTight_v*']),
+    ## Binning ##
+    histoPSet = dict(muPtBinning = [0,2,5,7,10,12,15,17,20,25,30,50])
+)
 
-## Selection ##
-SoftMuHardJetMETSUSYmonitoring_muPt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET120_PFMHT120_IDTight_v*', 'HLT_PFMET130_PFMHT130_IDTight_v*', 'HLT_PFMET140_PFMHT140_IDTight_v*')
-# Muon selection
-SoftMuHardJetMETSUSYmonitoring_muPt.nmuons       = cms.uint32(1)
-SoftMuHardJetMETSUSYmonitoring_muPt.muoSelection = cms.string('abs(eta)<1.5')
-# Jet selection
-SoftMuHardJetMETSUSYmonitoring_muPt.njets = cms.uint32(1)
-SoftMuHardJetMETSUSYmonitoring_muPt.jetSelection = cms.string("pt>130 & abs(eta)<2.5")
-# MET selection
-SoftMuHardJetMETSUSYmonitoring_muPt.enableMETPlot = True
-SoftMuHardJetMETSUSYmonitoring_muPt.metSelection = cms.string('pt>150')
-SoftMuHardJetMETSUSYmonitoring_muPt.MHTcut       = cms.double(150)
-
-## Binning ##
-SoftMuHardJetMETSUSYmonitoring_muPt.histoPSet.muPtBinning = cms.vdouble(0,2,5,7,10,12,15,17,20,25,30,50)
 
 ##############
 ### Jet pt ###
 ##############
-SoftMuHardJetMETSUSYmonitoring_jetPt = SoftMuHardJetMETSUSYmonitoring.clone()
-SoftMuHardJetMETSUSYmonitoring_jetPt.FolderName = cms.string('HLT/SUSY/SoftMuHardJetMET/Jet')
+SoftMuHardJetMETSUSYmonitoring_jetPt = SoftMuHardJetMETSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/SoftMuHardJetMET/Jet',
+    # Muon selection
+    nmuons       = 1,
+    muoSelection = 'pt>30 & abs(eta)<1.5',
+    # Jet selection
+    njets        = 1,
+    jetSelection = "abs(eta)<2.5",
+    # MET selection
+    enableMETPlot = True,
+    metSelection  = 'pt>150',
+    MHTcut        = 150,
+    ## Selection ##
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_IsoMu27_v*"]),
+    # Binning
+    histoPSet = dict(jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400]) 
+)
 
-## Selection ##
-SoftMuHardJetMETSUSYmonitoring_jetPt.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_IsoMu27_v*")
-# Muon selection
-SoftMuHardJetMETSUSYmonitoring_jetPt.nmuons       = cms.uint32(1)
-SoftMuHardJetMETSUSYmonitoring_jetPt.muoSelection = cms.string('pt>30 & abs(eta)<1.5')
-# Jet selection
-SoftMuHardJetMETSUSYmonitoring_jetPt.njets        = cms.uint32(1)
-SoftMuHardJetMETSUSYmonitoring_jetPt.jetSelection = cms.string("abs(eta)<2.5")
-# MET selection
-SoftMuHardJetMETSUSYmonitoring_jetPt.enableMETPlot = True
-SoftMuHardJetMETSUSYmonitoring_jetPt.metSelection  = cms.string('pt>150')
-SoftMuHardJetMETSUSYmonitoring_jetPt.MHTcut        = cms.double(150)
-
-# Binning
-SoftMuHardJetMETSUSYmonitoring_jetPt.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400) 
 
 ##############
 ### MET pt ###
 ##############
-SoftMuHardJetMETSUSYmonitoring_metPt = SoftMuHardJetMETSUSYmonitoring.clone()
-SoftMuHardJetMETSUSYmonitoring_metPt.FolderName = cms.string('HLT/SUSY/SoftMuHardJetMET/MET')
+SoftMuHardJetMETSUSYmonitoring_metPt = SoftMuHardJetMETSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/SoftMuHardJetMET/MET',
+    # Muon selection
+    nmuons       = 1,
+    muoSelection = 'pt>30 & abs(eta)<1.5',
+    # Jet selection
+    njets        = 1,
+    jetSelection = "pt>130 & abs(eta)<2.5",
+    # MET selection
+    enableMETPlot = True,
+    ## Selection ##
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_IsoMu27_v*"]),
+    # Binning
+    histoPSet = dict(metPSet = dict(nbins= 50,xmin= 50,xmax= 300))
+)
 
-## Selection ##
-SoftMuHardJetMETSUSYmonitoring_metPt.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_IsoMu27_v*")
-# Muon selection
-SoftMuHardJetMETSUSYmonitoring_metPt.nmuons       = cms.uint32(1)
-SoftMuHardJetMETSUSYmonitoring_metPt.muoSelection = cms.string('pt>30 & abs(eta)<1.5')
-# Jet selection
-SoftMuHardJetMETSUSYmonitoring_metPt.njets        = cms.uint32(1)
-SoftMuHardJetMETSUSYmonitoring_metPt.jetSelection = cms.string("pt>130 & abs(eta)<2.5")
-# MET selection
-SoftMuHardJetMETSUSYmonitoring_metPt.enableMETPlot = True
-
-# Binning
-SoftMuHardJetMETSUSYmonitoring_metPt.histoPSet.metPSet = cms.PSet(nbins=cms.uint32(50),xmin=cms.double(50),xmax=cms.double(300))
 
 susyHLTSoftMuHardJetMETMonitoring = cms.Sequence(
     SoftMuHardJetMETSUSYmonitoring_muPt

--- a/DQMOffline/Trigger/python/SoftdropMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/SoftdropMonitor_cfi.py
@@ -5,35 +5,37 @@ from DQMOffline.Trigger.htMonitoring_cfi import htMonitoring
 # config file for monitoring the trigger efficiency vs softdropmass of the leading jet
 # see python/HTMonitor_cfi.py or plugins/HTMonitor.h or plugins/HTMonitor.cc for more details
 
-hltSoftdropmonitoring = htMonitoring.clone()
-hltSoftdropmonitoring.FolderName = cms.string('HLT/HT/PFMETNoMu120/')
-hltSoftdropmonitoring.quantity = cms.string('softdrop') # set quantity to leading jet softdropmass
-hltSoftdropmonitoring.jetSelection = cms.string("pt > 65 && eta < 2.4")
-hltSoftdropmonitoring.dEtaCut     = cms.double(1.3)
-hltSoftdropmonitoring.histoPSet.htBinning = cms.vdouble (0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50., 55., 60., 65., 70., 75., 80., 85., 90., 95., 100., 105., 110., 115., 120., 125., 130., 135., 140., 145., 150., 155., 160., 165., 170., 175., 180., 185., 190., 195., 200.)
-hltSoftdropmonitoring.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32 (  200  ),
-  xmin  = cms.double(   -0.5),
-  xmax  = cms.double(19999.5),
+hltSoftdropmonitoring = htMonitoring.clone(
+    FolderName = 'HLT/HT/PFMETNoMu120/',
+    quantity = 'softdrop', # set quantity to leading jet softdropmass
+    jetSelection = "pt > 65 && eta < 2.4",
+    dEtaCut     = 1.3,
+    met       = "pfMet",
+    jets      = "ak8PFJetsPuppiSoftDrop", # dont set this to non-SoftdropJets
+    electrons = "gedGsfElectrons",
+    muons     = "muons",
+    histoPSet = dict(htBinning = [0., 5., 10., 15., 20., 25., 30., 35., 40., 45., 50., 55., 60., 65., 70., 75., 80., 85., 90., 95., 100., 105., 110., 115., 120., 125., 130., 135., 140., 145., 150., 155., 160., 165., 170., 175., 180., 185., 190., 195., 200.],
+                     htPSet = dict(
+                            nbins =  200,
+                            xmin  = -0.5,
+                            xmax  = 19999.5)),
+    
+numGenericTriggerEventPSet = dict(
+    andOr  = False,
+    andOrHlt      = True, # True:=OR; False:=AND
+    hltInputTag   = "TriggerResults::HLT",
+    hltPaths      = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"],
+    errorReplyHlt = False,
+    verbosityLevel = 0),
+
+denGenericTriggerEventPSet = dict(
+    andOr  = False,
+    dcsInputTag   = "scalersRawToDigi",
+    dcsRecordInputTag = "onlineMetaDataDigis",
+    dcsPartitions = [24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29
+    andOrDcs      = False,
+    errorReplyDcs = True,
+    verbosityLevel = 0,
+    hltPaths      = ["HLT_IsoMu27_v*"])
 )
-hltSoftdropmonitoring.met       = cms.InputTag("pfMet")
-hltSoftdropmonitoring.jets      = cms.InputTag("ak8PFJetsPuppiSoftDrop") # dont set this to non-SoftdropJets
-hltSoftdropmonitoring.electrons = cms.InputTag("gedGsfElectrons")
-hltSoftdropmonitoring.muons     = cms.InputTag("muons")
 
-hltSoftdropmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-
-hltSoftdropmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltSoftdropmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltSoftdropmonitoring.numGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-hltSoftdropmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltSoftdropmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-
-hltSoftdropmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltSoftdropmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltSoftdropmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltSoftdropmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29
-hltSoftdropmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltSoftdropmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltSoftdropmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-hltSoftdropmonitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_IsoMu27_v*")

--- a/DQMOffline/Trigger/python/SusyMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/SusyMonitor_cfi.py
@@ -2,125 +2,122 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.topMonitoring_cfi import topMonitoring
 
-hltSUSYmonitoring = topMonitoring.clone()
-hltSUSYmonitoring.FolderName = cms.string('HLT/SUSY/default/')
-hltSUSYmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32 ( 250 ),
-  xmin  = cms.double(    0.),
-  xmax  = cms.double( 2500.),
-)
-hltSUSYmonitoring.histoPSet.metPSet = cms.PSet(
-  nbins = cms.uint32(  30   ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  300  ),
-)
-hltSUSYmonitoring.histoPSet.lsPSet = cms.PSet(
-  nbins = cms.uint32( 2500 ),
-)
-hltSUSYmonitoring.histoPSet.ptPSet = cms.PSet(
-  nbins = cms.uint32(  60   ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  300  ),
-)
-hltSUSYmonitoring.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.uint32(  32  ),
-  xmin  = cms.double( -3.2 ),
-  xmax  = cms.double(  3.2 ),
-)
-hltSUSYmonitoring.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32(  24  ),
-  xmin  = cms.double( -2.4 ),
-  xmax  = cms.double(  2.4 ),
-)
-hltSUSYmonitoring.histoPSet.htPSet = cms.PSet(
-  nbins = cms.uint32(   60  ),
-  xmin  = cms.double(   0   ),
-  xmax  = cms.double(  600  ),
-)
-# Marina
-hltSUSYmonitoring.histoPSet.csvPSet = cms.PSet(
-  nbins = cms.uint32( 50 ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 1.0  ),
-)
-#BTV
-hltSUSYmonitoring.histoPSet.DRPSet = cms.PSet(
-  nbins = cms.uint32( 60  ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 6.0 ),
-)
+hltSUSYmonitoring = topMonitoring.clone(
+  FolderName = 'HLT/SUSY/default/',
+  histoPSet = dict(
+      lsPSet = dict(
+            nbins =  2500,
+            xmin  =    0.,
+            xmax  =  2500.),
 
-#Suvankar
-hltSUSYmonitoring.applyLeptonPVcuts = False
-hltSUSYmonitoring.leptonPVcuts = cms.PSet(
-  dxy = cms.double(   9999.   ),
-  dz  = cms.double(   9999.   ),
-)
+      metPSet = dict(
+            nbins =   30 ,
+            xmin  =   0 ,
+            xmax  =  300),
 
-hltSUSYmonitoring.histoPSet.invMassPSet = cms.PSet(
-  nbins = cms.uint32( 40 ),
-  xmin  = cms.double( 0.0 ),
-  xmax  = cms.double( 80.0  ),
-)
-hltSUSYmonitoring.histoPSet.MHTPSet = cms.PSet(
- nbins = cms.uint32(   80  ),
- xmin  = cms.double(   60   ),
- xmax  = cms.double(  300  ),
-)
+      ptPSet = dict(
+            nbins =  60 ,
+            xmin  =  0 ,
+            xmax  = 300 ),
+
+      phiPSet = dict(
+            nbins =  32 ,
+            xmin  =  -3.2 ,
+            xmax  =  3.2 ),
+     
+      etaPSet = dict(
+            nbins =  24  ,
+            xmin  =  -2.4 ,
+            xmax  =  2.4 ),
+
+      htPSet = dict(
+            nbins =  60 ,
+            xmin  =   0 ,
+            xmax  =  600),
+
+      # Marina
+      csvPSet = dict(
+            nbins = 50 ,
+            xmin  =  0.0 ,
+            xmax  = 1.0 ),
+
+      #BTV
+        DRPSet = dict(
+             nbins = 60 ,
+             xmin  = 0.0 ,
+             xmax  =  6.0),
 
 
-#MET and HT binning
-hltSUSYmonitoring.histoPSet.metBinning = cms.vdouble(0,20,40,60,80,100,125,150,175,200)
-hltSUSYmonitoring.histoPSet.HTBinning  = cms.vdouble(0,20,40,60,80,100,125,150,175,200,300,400,500,700)
-#Eta binning
-hltSUSYmonitoring.histoPSet.eleEtaBinning = cms.vdouble(-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4)
-hltSUSYmonitoring.histoPSet.jetEtaBinning = cms.vdouble(-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4)
-hltSUSYmonitoring.histoPSet.muEtaBinning  = cms.vdouble(-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4)
-#pt binning
-hltSUSYmonitoring.histoPSet.elePtBinning = cms.vdouble(0,5,10,20,30,40,50,70,100,200,400)
-hltSUSYmonitoring.histoPSet.jetPtBinning = cms.vdouble(0,5,10,20,30,40,50,70,100,200,400)
-hltSUSYmonitoring.histoPSet.muPtBinning  = cms.vdouble(0,5,10,20,30,40,50,70,100,200,400)
-#Eta binning 2D
-hltSUSYmonitoring.histoPSet.eleEtaBinning2D = cms.vdouble(-2.5,-1.5,-0.6,0.,0.6,1.5,2.5)
-hltSUSYmonitoring.histoPSet.jetEtaBinning2D = cms.vdouble(-2.5,-1.5,-0.6,0.,0.6,1.5,2.5)
-hltSUSYmonitoring.histoPSet.muEtaBinning2D  = cms.vdouble(-2.5,-1.5,-0.6,0.,0.6,1.5,2.5)
-#pt binning 2D
-hltSUSYmonitoring.histoPSet.elePtBinning2D = cms.vdouble(0,20,30,50,100,200,400)
-hltSUSYmonitoring.histoPSet.jetPtBinning2D = cms.vdouble(0,20,30,50,100,200,400)
-hltSUSYmonitoring.histoPSet.muPtBinning2D  = cms.vdouble(0,20,30,50,100,200,400)
-#HT and phi binning 2D
-hltSUSYmonitoring.histoPSet.HTBinning2D  = cms.vdouble(0,20,40,70,100,150,200,400,700)
-hltSUSYmonitoring.histoPSet.phiBinning2D = cms.vdouble(-3.1416,-1.8849,-0.6283,0.6283,1.8849,3.1416)
+        invMassPSet = dict(
+              nbins = 40 ,
+              xmin  =  0.0 ,
+              xmax  = 80.0 ),
+
+        MHTPSet = dict(
+              nbins =  80,
+              xmin  =   60,
+              xmax  =   300),
+   
+    #MET and HT binning
+    metBinning = [0,20,40,60,80,100,125,150,175,200],
+    HTBinning  = [0,20,40,60,80,100,125,150,175,200,300,400,500,700],
+    #Eta binning
+    eleEtaBinning = [-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4],
+    jetEtaBinning = [-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4],
+    muEtaBinning  = [-2.4,-2.1,-1.5,-0.9,-0.3,0.,0.3,0.9,1.5,2.1,2.4],
+    #pt binning
+    elePtBinning = [0,5,10,20,30,40,50,70,100,200,400],
+    jetPtBinning = [0,5,10,20,30,40,50,70,100,200,400],
+    muPtBinning  = [0,5,10,20,30,40,50,70,100,200,400],
+    #Eta binning 2D
+    eleEtaBinning2D = [-2.5,-1.5,-0.6,0.,0.6,1.5,2.5],
+    jetEtaBinning2D = [-2.5,-1.5,-0.6,0.,0.6,1.5,2.5],
+    muEtaBinning2D  = [-2.5,-1.5,-0.6,0.,0.6,1.5,2.5],
+    #pt binning 2D
+    elePtBinning2D = [0,20,30,50,100,200,400],
+    jetPtBinning2D = [0,20,30,50,100,200,400],
+    muPtBinning2D  = [0,20,30,50,100,200,400],
+    #HT and phi binning 2D
+    HTBinning2D  = [0,20,40,70,100,150,200,400,700],
+    phiBinning2D = [-3.1416,-1.8849,-0.6283,0.6283,1.8849,3.1416],
+  ),
+  #Suvankar
+  applyLeptonPVcuts = False,
+  leptonPVcuts = dict(
+        dxy =   9999.,
+        dz  =   9999.),
+  met       = "pfMet", # pfMet
+  jets      = "ak4PFJetsCHS", # ak4PFJets, ak4PFJetsCHS, pfJetsEI
+  electrons = "gedGsfElectrons", # while pfIsolatedElectronsEI are reco::PFCandidate !
+  muons     = "muons", # while pfIsolatedMuonsEI are reco::PFCandidate !
 
 
-hltSUSYmonitoring.met       = cms.InputTag("pfMet") # pfMet
-hltSUSYmonitoring.jets      = cms.InputTag("ak4PFJetsCHS") # ak4PFJets, ak4PFJetsCHS, ak4PFJets
-hltSUSYmonitoring.electrons = cms.InputTag("gedGsfElectrons") # while pfIsolatedElectronsEI are reco::PFCandidate !
-hltSUSYmonitoring.muons     = cms.InputTag("muons") # while pfIsolatedMuonsEI are reco::PFCandidate !
-#Suvankar
-hltSUSYmonitoring.vertices  = cms.InputTag("offlinePrimaryVertices")
+  #Suvankar
+  vertices  = "offlinePrimaryVertices",
 
-# Marina
-hltSUSYmonitoring.btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"]
-hltSUSYmonitoring.workingpoint = cms.double(0.8484) # Medium
+  # Marina
+  btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"],
+  workingpoint = 0.8484, # Medium
 
-hltSUSYmonitoring.HTdefinition = cms.string('pt>30 & abs(eta)<2.5')
-hltSUSYmonitoring.leptJetDeltaRmin = cms.double(0.4)
+  HTdefinition = 'pt>30 & abs(eta)<2.5',
+  leptJetDeltaRmin = 0.4,
 
-hltSUSYmonitoring.numGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltSUSYmonitoring.numGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltSUSYmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltSUSYmonitoring.numGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltSUSYmonitoring.numGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
+  numGenericTriggerEventPSet = dict(
+    andOr         =  False,
+    andOrHlt      = True,# True:=OR; False:=AND
+    hltInputTag   = "TriggerResults::HLT",
+    errorReplyHlt =  False,
+    verbosityLevel = 0),
 
-hltSUSYmonitoring.denGenericTriggerEventPSet.andOr         = cms.bool( False )
-hltSUSYmonitoring.denGenericTriggerEventPSet.andOrHlt      = cms.bool(True)# True:=OR; False:=AND
-hltSUSYmonitoring.denGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
-hltSUSYmonitoring.denGenericTriggerEventPSet.errorReplyHlt = cms.bool( False )
-hltSUSYmonitoring.denGenericTriggerEventPSet.dcsInputTag   = cms.InputTag( "scalersRawToDigi" )
-hltSUSYmonitoring.denGenericTriggerEventPSet.dcsRecordInputTag = cms.InputTag("onlineMetaDataDigis")
-hltSUSYmonitoring.denGenericTriggerEventPSet.dcsPartitions = cms.vint32 ( 24, 25, 26, 27, 28, 29 ) # 24-27: strip, 28-29: pixel, we should add all other detectors !
-hltSUSYmonitoring.denGenericTriggerEventPSet.andOrDcs      = cms.bool( False )
-hltSUSYmonitoring.denGenericTriggerEventPSet.errorReplyDcs = cms.bool( True )
-hltSUSYmonitoring.denGenericTriggerEventPSet.verbosityLevel = cms.uint32(0)
-
+  denGenericTriggerEventPSet = dict(
+    andOr         =  False,
+    andOrHlt      = True,# True:=OR; False:=AND
+    hltInputTag   =  "TriggerResults::HLT",
+    errorReplyHlt =  False,
+    dcsInputTag   =  "scalersRawToDigi",
+    dcsRecordInputTag = "onlineMetaDataDigis",
+    dcsPartitions = [ 24, 25, 26, 27, 28, 29], # 24-27: strip, 28-29: pixel, we should add all other detectors !
+    andOrDcs      = False,
+    errorReplyDcs = True,
+    verbosityLevel = 0)
+)

--- a/DQMOffline/Trigger/python/SusyMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/SusyMonitoring_cff.py
@@ -8,18 +8,19 @@ from DQMOffline.Trigger.SoftMuHardJetMETSUSYMonitor_cff import *
 from DQMOffline.Trigger.TopMonitor_cfi import hltTOPmonitoring
 
 # muon
-double_soft_muon_muonpt = hltTOPmonitoring.clone()
-double_soft_muon_muonpt.FolderName   = cms.string('HLT/SUSY/SOS/Muon/')
-# Selections
-double_soft_muon_muonpt.nmuons           = cms.uint32(2)
-double_soft_muon_muonpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_muonpt.HTcut            = cms.double(60)
-double_soft_muon_muonpt.enableMETPlot = True
-double_soft_muon_muonpt.metSelection     =cms.string('pt>150')
-double_soft_muon_muonpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_muonpt.MHTcut           = cms.double(150)
-double_soft_muon_muonpt.invMassUppercut  = cms.double(50)
-double_soft_muon_muonpt.invMassLowercut  = cms.double(10)
+double_soft_muon_muonpt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/Muon/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    enableMETPlot = True,
+    metSelection     ='pt>150',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    MHTcut           = 150,
+    invMassUppercut  = 50,
+    invMassLowercut  = 10
+)
 # Binning
 double_soft_muon_muonpt.histoPSet.muPtBinning      =cms.vdouble(0,2,5,7,10,12,15,17,20,25,30,50)
 double_soft_muon_muonpt.histoPSet.muPtBinning2D    =cms.vdouble(0,2,5,7,10,12,15,17,20,25,30,50)
@@ -28,18 +29,19 @@ double_soft_muon_muonpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_D
 double_soft_muon_muonpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET140_PFMHT140_v*')
 
 # met
-double_soft_muon_metpt = hltTOPmonitoring.clone()
-double_soft_muon_metpt.FolderName   = cms.string('HLT/SUSY/SOS/MET/')
-# Selections
-double_soft_muon_metpt.nmuons           = cms.uint32(2)
-double_soft_muon_metpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_metpt.HTcut            = cms.double(60)
-double_soft_muon_metpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.4')
-double_soft_muon_metpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_metpt.MHTcut           = cms.double(150)
-double_soft_muon_metpt.invMassUppercut       = cms.double(50)
-double_soft_muon_metpt.invMassLowercut       = cms.double(10)
-double_soft_muon_metpt.enableMETPlot = True
+double_soft_muon_metpt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/MET/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    muoSelection     = 'pt>18 & abs(eta)<2.4',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    MHTcut           = 150,
+    invMassUppercut  = 50,
+    invMassLowercut  = 10,
+    enableMETPlot    = True
+)
 # Binning
 double_soft_muon_metpt.histoPSet.metPSet   =cms.PSet(nbins=cms.uint32(50),xmin=cms.double(50),xmax=cms.double(300) )
 # Triggers
@@ -47,17 +49,18 @@ double_soft_muon_metpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Do
 double_soft_muon_metpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
 # inv Mass
-double_soft_muon_mll = hltTOPmonitoring.clone()
-double_soft_muon_mll.FolderName   = cms.string('HLT/SUSY/SOS/Mll/')
-# Selections
-double_soft_muon_mll.nmuons           = cms.uint32(2)
-double_soft_muon_mll.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_mll.HTcut            = cms.double(60)
-double_soft_muon_mll.muoSelection     =cms.string('pt>10 & abs(eta)<2.4')
-double_soft_muon_mll.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_mll.MHTcut            = cms.double(150)
-double_soft_muon_mll.enableMETPlot = True
-double_soft_muon_mll.metSelection      = cms.string('pt>150')
+double_soft_muon_mll = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/Mll/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    muoSelection     = 'pt>10 & abs(eta)<2.4',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    MHTcut            = 150,
+    enableMETPlot = True,
+    metSelection      = 'pt>150'
+)
 # Binning
 double_soft_muon_mll.histoPSet.invMassVariableBinning      =cms.vdouble(8,12,15,20,25,30,35,40,45,47,50,60)
 
@@ -66,18 +69,19 @@ double_soft_muon_mll.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Doub
 double_soft_muon_mll.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Dimuon12_Upsilon_eta1p5_v*')
 
 # mht
-double_soft_muon_mhtpt = hltTOPmonitoring.clone()
-double_soft_muon_mhtpt.FolderName   = cms.string('HLT/SUSY/SOS/MHT/')
-# Selections
-double_soft_muon_mhtpt.nmuons           = cms.uint32(2)
-double_soft_muon_mhtpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_mhtpt.HTcut            = cms.double(60)
-double_soft_muon_mhtpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.0')
-double_soft_muon_mhtpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_mhtpt.enableMETPlot = True
-double_soft_muon_mhtpt.metSelection     = cms.string('pt>150')
-double_soft_muon_mhtpt.invMassUppercut       = cms.double(50)
-double_soft_muon_mhtpt.invMassLowercut       = cms.double(10)
+double_soft_muon_mhtpt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/MHT/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    muoSelection     = 'pt>18 & abs(eta)<2.0',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    enableMETPlot = True,
+    metSelection     = 'pt>150',
+    invMassUppercut       = 50,
+    invMassLowercut       = 10
+)
 # Binning
 double_soft_muon_mhtpt.histoPSet.MHTVariableBinning      =cms.vdouble(50,60,70,80,90,100,110,120,130,150,200,300)
 
@@ -86,18 +90,19 @@ double_soft_muon_mhtpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Do
 double_soft_muon_mhtpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
 # backup1, met
-double_soft_muon_backup_70_metpt = hltTOPmonitoring.clone()
-double_soft_muon_backup_70_metpt.FolderName   = cms.string('HLT/SUSY/SOS/backup70/MET/')
-# Selections
-double_soft_muon_backup_70_metpt.nmuons           = cms.uint32(2)
-double_soft_muon_backup_70_metpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_backup_70_metpt.HTcut            = cms.double(60)
-double_soft_muon_backup_70_metpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.4')
-double_soft_muon_backup_70_metpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_backup_70_metpt.MHTcut           = cms.double(150)
-double_soft_muon_backup_70_metpt.invMassUppercut       = cms.double(50)
-double_soft_muon_backup_70_metpt.invMassLowercut       = cms.double(10)
-double_soft_muon_backup_70_metpt.enableMETPlot = True
+double_soft_muon_backup_70_metpt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/backup70/MET/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    muoSelection     = 'pt>18 & abs(eta)<2.4',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    MHTcut           = 150,
+    invMassUppercut       = 50,
+    invMassLowercut       = 10,
+    enableMETPlot = True
+)
 # Binning
 double_soft_muon_backup_70_metpt.histoPSet.metPSet   =cms.PSet(nbins=cms.uint32(50),xmin=cms.double(50),xmax=cms.double(300) )
 # Triggers
@@ -105,18 +110,19 @@ double_soft_muon_backup_70_metpt.numGenericTriggerEventPSet.hltPaths = cms.vstri
 double_soft_muon_backup_70_metpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
 # backup1, mht
-double_soft_muon_backup_70_mhtpt = hltTOPmonitoring.clone()
-double_soft_muon_backup_70_mhtpt.FolderName   = cms.string('HLT/SUSY/SOS/backup70/MHT/')
-# Selections
-double_soft_muon_backup_70_mhtpt.nmuons           = cms.uint32(2)
-double_soft_muon_backup_70_mhtpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_backup_70_mhtpt.HTcut            = cms.double(60)
-double_soft_muon_backup_70_mhtpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.0')
-double_soft_muon_backup_70_mhtpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_backup_70_mhtpt.enableMETPlot = True
-double_soft_muon_backup_70_mhtpt.metSelection     = cms.string('pt>150')
-double_soft_muon_backup_70_mhtpt.invMassUppercut       = cms.double(50)
-double_soft_muon_backup_70_mhtpt.invMassLowercut       = cms.double(10)
+double_soft_muon_backup_70_mhtpt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/backup70/MHT/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    muoSelection     = 'pt>18 & abs(eta)<2.0',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    enableMETPlot = True,
+    metSelection     = 'pt>150',
+    invMassUppercut       = 50,
+    invMassLowercut       = 10
+)
 # Binning
 double_soft_muon_backup_70_mhtpt.histoPSet.MHTVariableBinning      =cms.vdouble(50,60,70,80,90,100,110,120,130,150,200,300)
 
@@ -125,18 +131,19 @@ double_soft_muon_backup_70_mhtpt.numGenericTriggerEventPSet.hltPaths = cms.vstri
 double_soft_muon_backup_70_mhtpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
 # backup2, met
-double_soft_muon_backup_90_metpt = hltTOPmonitoring.clone()
-double_soft_muon_backup_90_metpt.FolderName   = cms.string('HLT/SUSY/SOS/backup90/MET/')
-# Selections
-double_soft_muon_backup_90_metpt.nmuons           = cms.uint32(2)
-double_soft_muon_backup_90_metpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_backup_90_metpt.HTcut            = cms.double(60)
-double_soft_muon_backup_90_metpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.4')
-double_soft_muon_backup_90_metpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_backup_90_metpt.MHTcut           = cms.double(150)
-double_soft_muon_backup_90_metpt.invMassUppercut       = cms.double(50)
-double_soft_muon_backup_90_metpt.invMassLowercut       = cms.double(10)
-double_soft_muon_backup_90_metpt.enableMETPlot = True
+double_soft_muon_backup_90_metpt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/backup90/MET/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    muoSelection     = 'pt>18 & abs(eta)<2.4',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    MHTcut           = 150,
+    invMassUppercut       = 50,
+    invMassLowercut       = 10,
+    enableMETPlot = True
+)
 # Binning
 double_soft_muon_backup_90_metpt.histoPSet.metPSet   =cms.PSet(nbins=cms.uint32(50),xmin=cms.double(50),xmax=cms.double(300) )
 # Triggers
@@ -144,18 +151,19 @@ double_soft_muon_backup_90_metpt.numGenericTriggerEventPSet.hltPaths = cms.vstri
 double_soft_muon_backup_90_metpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
 # backup2, mht
-double_soft_muon_backup_90_mhtpt = hltTOPmonitoring.clone()
-double_soft_muon_backup_90_mhtpt.FolderName   = cms.string('HLT/SUSY/SOS/backup90/MHT/')
-# Selections
-double_soft_muon_backup_90_mhtpt.nmuons           = cms.uint32(2)
-double_soft_muon_backup_90_mhtpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_backup_90_mhtpt.HTcut            = cms.double(60)
-double_soft_muon_backup_90_mhtpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.0')
-double_soft_muon_backup_90_mhtpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_backup_90_mhtpt.enableMETPlot = True
-double_soft_muon_backup_90_mhtpt.metSelection     = cms.string('pt>150')
-double_soft_muon_backup_90_mhtpt.invMassUppercut       = cms.double(50)
-double_soft_muon_backup_90_mhtpt.invMassLowercut       = cms.double(10)
+double_soft_muon_backup_90_mhtpt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/backup90/MHT/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    muoSelection     = 'pt>18 & abs(eta)<2.0',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    enableMETPlot = True,
+    metSelection     = 'pt>150',
+    invMassUppercut       = 50,
+    invMassLowercut       = 10
+)
 # Binning
 double_soft_muon_backup_90_mhtpt.histoPSet.MHTVariableBinning      =cms.vdouble(50,60,70,80,90,100,110,120,130,150,200,300)
 # Triggers
@@ -163,57 +171,61 @@ double_soft_muon_backup_90_mhtpt.numGenericTriggerEventPSet.hltPaths = cms.vstri
 double_soft_muon_backup_90_mhtpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
 
 # triple muon
-triple_muon_mupt = hltTOPmonitoring.clone()
-triple_muon_mupt.FolderName   = cms.string('HLT/SUSY/SOS/TripleMu/Muon')
-# Selections
-triple_muon_mupt.nmuons           = cms.uint32(3)
-triple_muon_mupt.muoSelection     =cms.string('isGlobalMuon()')
-triple_muon_mupt.invMassUppercut       = cms.double(50)
-triple_muon_mupt.invMassLowercut       = cms.double(10)
-triple_muon_mupt.invMassCutInAllMuPairs=cms.bool(True)
+triple_muon_mupt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/TripleMu/Muon',
+    # Selections
+    nmuons           = 3,
+    muoSelection     = 'isGlobalMuon()',
+    invMassUppercut       = 50,
+    invMassLowercut       = 10,
+    invMassCutInAllMuPairs= True
+)
 # Triggers
 triple_muon_mupt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_TripleMu_5_3_3_Mass3p8to60_DZ_v*')
 triple_muon_mupt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Trimuon5_3p5_2_Upsilon_Muon_v*')
 
 # triplemu dca
-triple_muon_dca_mupt = hltTOPmonitoring.clone()
-triple_muon_dca_mupt.FolderName   = cms.string('HLT/SUSY/SOS/TripleMu/DCA/Muon')
-# Selections
-triple_muon_dca_mupt.nmuons           = cms.uint32(3)
-triple_muon_dca_mupt.muoSelection     =cms.string('isGlobalMuon()')
-triple_muon_dca_mupt.invMassUppercut       = cms.double(50)
-triple_muon_dca_mupt.invMassLowercut       = cms.double(10)
-triple_muon_dca_mupt.invMassCutInAllMuPairs=cms.bool(True)
+triple_muon_dca_mupt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/TripleMu/DCA/Muon',
+    # Selections
+    nmuons           = 3,
+    muoSelection     = 'isGlobalMuon()',
+    invMassUppercut       = 50,
+    invMassLowercut       = 10,
+    invMassCutInAllMuPairs =True
+)
 # Triggers
 triple_muon_dca_mupt.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_TripleMu_5_3_3_Mass3p8to60_DCA_v*')
 triple_muon_dca_mupt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Trimuon5_3p5_2_Upsilon_Muon_v*')
 
 # MuonEG
-susyMuEGMonitoring = hltTOPmonitoring.clone()
-susyMuEGMonitoring.FolderName = cms.string('HLT/SUSY/MuonEG/')
-susyMuEGMonitoring.nmuons = cms.uint32(1)
-susyMuEGMonitoring.nphotons = cms.uint32(1)
-susyMuEGMonitoring.nelectrons = cms.uint32(0)
-susyMuEGMonitoring.njets = cms.uint32(0)
-susyMuEGMonitoring.enablePhotonPlot =  cms.bool(True)
-susyMuEGMonitoring.muoSelection = cms.string('pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15') 
-susyMuEGMonitoring.phoSelection = cms.string('(pt > 30 && abs(eta)<1.4442 && hadTowOverEm<0.0597 && full5x5_sigmaIetaIeta()<0.01031 && chargedHadronIso<1.295 && neutralHadronIso < 5.931+0.0163*pt+0.000014*pt*pt && photonIso < 6.641+0.0034*pt) || (pt > 30 && abs(eta)>1.4442 && hadTowOverEm<0.0481 && full5x5_sigmaIetaIeta()<0.03013 && chargedHadronIso<1.011 && neutralHadronIso < 1.715+0.0163*pt+0.000014*pt*pt && photonIso < 3.863+0.0034*pt)')
+susyMuEGMonitoring = hltTOPmonitoring.clone(
+    FolderName = 'HLT/SUSY/MuonEG/',
+    nmuons = 1,
+    nphotons = 1,
+    nelectrons = 0,
+    njets = 0,
+    enablePhotonPlot =  True,
+    muoSelection = 'pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15',
+    phoSelection = '(pt > 30 && abs(eta)<1.4442 && hadTowOverEm<0.0597 && full5x5_sigmaIetaIeta()<0.01031 && chargedHadronIso<1.295 && neutralHadronIso < 5.931+0.0163*pt+0.000014*pt*pt && photonIso < 6.641+0.0034*pt) || (pt > 30 && abs(eta)>1.4442 && hadTowOverEm<0.0481 && full5x5_sigmaIetaIeta()<0.03013 && chargedHadronIso<1.011 && neutralHadronIso < 1.715+0.0163*pt+0.000014*pt*pt && photonIso < 3.863+0.0034*pt)'
+)
 susyMuEGMonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_Photon30_IsoCaloId*')
 susyMuEGMonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring('')
 
 # muon dca
-double_soft_muon_dca_muonpt = hltTOPmonitoring.clone()
-double_soft_muon_dca_muonpt.FolderName   = cms.string('HLT/SUSY/SOS/DCA/Muon/')
-# Selections
-double_soft_muon_dca_muonpt.nmuons           = cms.uint32(2)
-double_soft_muon_dca_muonpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_dca_muonpt.HTcut            = cms.double(60)
-double_soft_muon_dca_muonpt.enableMETPlot = True
-double_soft_muon_dca_muonpt.metSelection     =cms.string('pt>150')
-double_soft_muon_dca_muonpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_dca_muonpt.MHTcut           = cms.double(150)
-double_soft_muon_dca_muonpt.invMassUppercut  = cms.double(50)
-double_soft_muon_dca_muonpt.invMassLowercut  = cms.double(10)
+double_soft_muon_dca_muonpt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/DCA/Muon/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    enableMETPlot = True,
+    metSelection     = 'pt>150',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    MHTcut           = 150,
+    invMassUppercut  = 50,
+    invMassLowercut  = 10
+)
 # Binning
 double_soft_muon_dca_muonpt.histoPSet.muPtBinning      =cms.vdouble(0,2,5,7,10,12,15,17,20,25,30,50)
 double_soft_muon_dca_muonpt.histoPSet.muPtBinning2D    =cms.vdouble(0,2,5,7,10,12,15,17,20,25,30,50)
@@ -222,18 +234,19 @@ double_soft_muon_dca_muonpt.numGenericTriggerEventPSet.hltPaths = cms.vstring('H
 double_soft_muon_dca_muonpt.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFMET140_PFMHT140_v*')
 
 # met
-double_soft_muon_dca_metpt = hltTOPmonitoring.clone()
-double_soft_muon_dca_metpt.FolderName   = cms.string('HLT/SUSY/SOS/DCA/MET/')
-# Selections
-double_soft_muon_dca_metpt.nmuons           = cms.uint32(2)
-double_soft_muon_dca_metpt.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_dca_metpt.HTcut            = cms.double(60)
-double_soft_muon_dca_metpt.muoSelection     =cms.string('pt>18 & abs(eta)<2.4')
-double_soft_muon_dca_metpt.MHTdefinition    = cms.string('pt>30 & abs(eta)<2.4')
-double_soft_muon_dca_metpt.MHTcut           = cms.double(150)
-double_soft_muon_dca_metpt.invMassUppercut       = cms.double(50)
-double_soft_muon_dca_metpt.invMassLowercut       = cms.double(10)
-double_soft_muon_dca_metpt.enableMETPlot = True
+double_soft_muon_dca_metpt = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/SUSY/SOS/DCA/MET/',
+    # Selections
+    nmuons           = 2,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 60,
+    muoSelection     = 'pt>18 & abs(eta)<2.4',
+    MHTdefinition    = 'pt>30 & abs(eta)<2.4',
+    MHTcut           = 150,
+    invMassUppercut       = 50,
+    invMassLowercut       = 10,
+    enableMETPlot = True
+)
 # Binning
 double_soft_muon_dca_metpt.histoPSet.metPSet   =cms.PSet(nbins=cms.uint32(50),xmin=cms.double(50),xmax=cms.double(300) )
 # Triggers

--- a/DQMOffline/Trigger/python/Tau3MuMonitor_cff.py
+++ b/DQMOffline/Trigger/python/Tau3MuMonitor_cff.py
@@ -2,25 +2,29 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.Tau3MuMonitor_cfi import hltTau3Mumonitoring
 
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Monitoring                                             = hltTau3Mumonitoring.clone()
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Monitoring.FolderName                                  = cms.string('HLT/BPH/Tau3Mu/Mu7_Mu1_TkMu1_Tau15')
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Monitoring.taus                                        = cms.InputTag('hltTauPt15MuPts711Mass1p3to2p1Iso', 'Taus') # 3-muon candidates
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Monitoring.GenericTriggerEventPSet.hltPaths            = cms.vstring('HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_v*')
+HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Monitoring  = hltTau3Mumonitoring.clone(
+    FolderName   = 'HLT/BPH/Tau3Mu/Mu7_Mu1_TkMu1_Tau15',
+    taus         = 'hltTauPt15MuPts711Mass1p3to2p1Iso:Taus',# 3-muon candidates
+    GenericTriggerEventPSet = dict(hltPaths = ['HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_v*'])
+)
 
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Charge1_Monitoring                                     = hltTau3Mumonitoring.clone()
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Charge1_Monitoring.FolderName                          = cms.string('HLT/BPH/Tau3Mu/Mu7_Mu1_TkMu1_Tau15_Charge1')
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Charge1_Monitoring.taus                                = cms.InputTag('hltTauPt15MuPts711Mass1p3to2p1IsoCharge1', 'Taus') # 3-muon candidates, charge = 1
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Charge1_Monitoring.GenericTriggerEventPSet.hltPaths    = cms.vstring('HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Charge1_v*')
+HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Charge1_Monitoring  = hltTau3Mumonitoring.clone(
+    FolderName = 'HLT/BPH/Tau3Mu/Mu7_Mu1_TkMu1_Tau15_Charge1',
+    taus       = 'hltTauPt15MuPts711Mass1p3to2p1IsoCharge1:Taus', # 3-muon candidates, charge = 1
+    GenericTriggerEventPSet = dict(hltPaths    = ['HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Charge1_v*'])
+)
 
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Monitoring                                          = hltTau3Mumonitoring.clone()
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Monitoring.FolderName                               = cms.string('HLT/BPH/Tau3Mu/Mu7_Mu1_TkMu1_IsoTau15')
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Monitoring.taus                                     = cms.InputTag('hltTauPt15MuPts711Mass1p3to2p1Iso', 'SelectedTaus') # 3-muon isolated candidates
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Monitoring.GenericTriggerEventPSet.hltPaths         = cms.vstring('HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_v*')
+HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Monitoring  = hltTau3Mumonitoring.clone(
+    FolderName   = 'HLT/BPH/Tau3Mu/Mu7_Mu1_TkMu1_IsoTau15',
+    taus        = 'hltTauPt15MuPts711Mass1p3to2p1Iso:SelectedTaus', # 3-muon isolated candidates
+    GenericTriggerEventPSet = dict(hltPaths = ['HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_v*'])
+)
 
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Charge1_Monitoring                                  = hltTau3Mumonitoring.clone()
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Charge1_Monitoring.FolderName                       = cms.string('HLT/BPH/Tau3Mu/Mu7_Mu1_TkMu1_IsoTau15_Charge1')
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Charge1_Monitoring.taus                             = cms.InputTag('hltTauPt15MuPts711Mass1p3to2p1IsoCharge1', 'SelectedTaus') # 3-muon isolated candidates, charge = 1
-HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Charge1_Monitoring.GenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Charge1_v*')
+HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Charge1_Monitoring  = hltTau3Mumonitoring.clone(
+    FolderName = 'HLT/BPH/Tau3Mu/Mu7_Mu1_TkMu1_IsoTau15_Charge1',
+    taus = 'hltTauPt15MuPts711Mass1p3to2p1IsoCharge1:SelectedTaus', # 3-muon isolated candidates, charge = 1
+    GenericTriggerEventPSet = dict(hltPaths = ['HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_Charge1_v*'])
+)
 
 tau3MuMonitorHLT = cms.Sequence(
     HLT_Tau3Mu_Mu7_Mu1_TkMu1_Tau15_Monitoring            +

--- a/DQMOffline/Trigger/python/Tau3MuMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/Tau3MuMonitor_cfi.py
@@ -4,41 +4,43 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.tau3muMonitoring_cfi import tau3muMonitoring
 
-hltTau3Mumonitoring = tau3muMonitoring.clone()
+hltTau3Mumonitoring = tau3muMonitoring.clone(
 
-# DQM directory
-hltTau3Mumonitoring.FolderName = cms.string('HLT/BPH/Tau3Mu/')
+  # DQM directory
+  FolderName = 'HLT/BPH/Tau3Mu/',
 
-# histogram binning
-hltTau3Mumonitoring.histoPSet.ptPSet = cms.PSet(
-  nbins = cms.uint32( 40  ),
-  xmin  = cms.double(- 0.5),
-  xmax  = cms.double( 99.5),
-)
-hltTau3Mumonitoring.histoPSet.etaPSet = cms.PSet(
-  nbins = cms.uint32( 10  ),
-  xmin  = cms.double(- 2.6),
-  xmax  = cms.double(  2.6),
-)
-hltTau3Mumonitoring.histoPSet.phiPSet = cms.PSet(
-  nbins = cms.uint32( 10),
-  xmin  = cms.double(-pi),
-  xmax  = cms.double( pi),
-)
-hltTau3Mumonitoring.histoPSet.massPSet = cms.PSet(
-  nbins = cms.uint32( 40  ),
-  xmin  = cms.double(  0.5),
-  xmax  = cms.double(  3. ),
-)
+  # histogram binning
+  histoPSet = dict(
+      ptPSet = dict(
+          nbins =  40  ,
+          xmin  = - 0.5,
+          xmax  =  99.5),
 
-hltTau3Mumonitoring.taus = cms.InputTag("hltTauPt15MuPts711Mass1p3to2p1Iso", "Taus") # 3-muon candidates
+      etaPSet = dict(
+          nbins = 10  ,
+          xmin  = - 2.6,
+          xmax  =  2.6),
 
-hltTau3Mumonitoring.GenericTriggerEventPSet.andOr          = cms.bool( False ) # https://github.com/cms-sw/cmssw/blob/76d343005c33105be1e01b7b7278c07d753398db/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc#L249
-hltTau3Mumonitoring.GenericTriggerEventPSet.andOrHlt       = cms.bool( True  ) # https://github.com/cms-sw/cmssw/blob/76d343005c33105be1e01b7b7278c07d753398db/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc#L114
-hltTau3Mumonitoring.GenericTriggerEventPSet.hltPaths       = cms.vstring("HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_v*")
-# determine the DCS partitions to be active https://github.com/cms-sw/cmssw/blob/b767924e38a6b75340e6e120ece95b648bd11d2d/DataFormats/Scalers/interface/DcsStatus.h#L35
-# RPC (12) + DT (13-15) + CSC (16-17) + TRK (24-27) + PIX (28-29)
-hltTau3Mumonitoring.GenericTriggerEventPSet.dcsPartitions = cms.vint32(12, 13, 14, 15, 16, 17, 24, 25, 26, 27, 28, 29) 
-# hltTau3Mumonitoring.GenericTriggerEventPSet.verbosityLevel = cms.uint32(2) # set to 2 for debugging
-# hltTau3Mumonitoring.GenericTriggerEventPSet.hltInputTag    = cms.InputTag("TriggerResults::reHLT") # change the process name to reHLT when running tests (if the process used to rerun the HLT is reHLT, of course)
+      phiPSet = dict(
+          nbins = 10,
+          xmin  = -pi,
+          xmax  =  pi),
 
+      massPSet = dict(
+          nbins =  40  ,
+          xmin  =  0.5,
+          xmax  =  3. ),
+  ),
+
+  taus = "hltTauPt15MuPts711Mass1p3to2p1Iso:Taus", # 3-muon candidates
+
+  GenericTriggerEventPSet = dict(
+    andOr          = False, # https://github.com/cms-sw/cmssw/blob/76d343005c33105be1e01b7b7278c07d753398db/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc#L249
+    andOrHlt       =  True , # https://github.com/cms-sw/cmssw/blob/76d343005c33105be1e01b7b7278c07d753398db/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc#L114
+    hltPaths       = ["HLT_Tau3Mu_Mu7_Mu1_TkMu1_IsoTau15_v*"],
+    # determine the DCS partitions to be active https://github.com/cms-sw/cmssw/blob/b767924e38a6b75340e6e120ece95b648bd11d2d/DataFormats/Scalers/interface/DcsStatus.h#L35
+    # RPC (12) + DT (13-15) + CSC (16-17) + TRK (24-27) + PIX (28-29)
+    dcsPartitions = [12, 13, 14, 15, 16, 17, 24, 25, 26, 27, 28, 29])
+    # verbosityLevel = 2, # set to 2 for debugging
+    # hltInputTag    = "TriggerResults::reHLT") # change the process name to reHLT when running tests (if the process used to rerun the HLT is reHLT, of course)
+  )

--- a/DQMOffline/Trigger/python/TopMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TopMonitoring_cff.py
@@ -10,428 +10,430 @@ from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTcond
 ### Ele+Jet
 ###
 
-topEleJet_jet = hltTOPmonitoring.clone()
-topEleJet_jet.FolderName = cms.string('HLT/TOP/EleJet/JetMonitor')
-topEleJet_jet.nmuons = cms.uint32(0)
-topEleJet_jet.nelectrons = cms.uint32(1)
-topEleJet_jet.njets = cms.uint32(1)
-topEleJet_jet.eleSelection = cms.string('pt>50 & abs(eta)<2.1')
-topEleJet_jet.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topEleJet_jet.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-topEleJet_jet.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-topEleJet_jet.histoPSet.elePtBinning = cms.vdouble(0,50,60,80,120,200,400)
-topEleJet_jet.histoPSet.elePtBinning2D = cms.vdouble(0,50,70,120,200,400)
-topEleJet_jet.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-topEleJet_jet.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-topEleJet_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned_v*')
-topEleJet_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele35_WPTight_Gsf_v*',
-                                                                'HLT_Ele38_WPTight_Gsf_v*',
-                                                                'HLT_Ele40_WPTight_Gsf_v*',)
+topEleJet_jet = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/EleJet/JetMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>50 & abs(eta)<2.1',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,50,60,80,120,200,400],
+                     elePtBinning2D = [0,50,70,120,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet= dict(hltPaths = ['HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele35_WPTight_Gsf_v*',
+                                                  'HLT_Ele38_WPTight_Gsf_v*',
+                                                  'HLT_Ele40_WPTight_Gsf_v*',])
+)
 ### ---
 
-topEleJet_ele = hltTOPmonitoring.clone()
-topEleJet_ele.FolderName = cms.string('HLT/TOP/EleJet/ElectronMonitor')
-topEleJet_ele.nmuons = cms.uint32(0)
-topEleJet_ele.nelectrons = cms.uint32(1)
-topEleJet_ele.njets = cms.uint32(1)
-topEleJet_ele.eleSelection = cms.string('pt>25 & abs(eta)<2.1')
-topEleJet_ele.jetSelection = cms.string('pt>50 & abs(eta)<2.4')
-topEleJet_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-topEleJet_ele.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-topEleJet_ele.histoPSet.elePtBinning = cms.vdouble(0,25,30,32.5,35,40,45,50,60,80,120,200,400)
-topEleJet_ele.histoPSet.elePtBinning2D = cms.vdouble(0,25,30,40,50,60,80,100,200,400)
-topEleJet_ele.histoPSet.jetPtBinning = cms.vdouble(0,50,60,80,120,200,400)
-topEleJet_ele.histoPSet.jetPtBinning2D = cms.vdouble(0,50,60,80,100,200,400)
-topEleJet_ele.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned_v*')
-topEleJet_ele.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet60_v*',
-                                                                'HLT_PFJet80_v*',
-                                                                'HLT_PFJet140_v*',
-                                                                'HLT_PFJet200_v*',
-                                                                'HLT_PFJet260_v*',
-                                                                'HLT_PFJet320_v*',
-                                                                'HLT_PFJet400_v*',
-                                                                'HLT_PFJet450_v*',
-                                                                'HLT_PFJet500_v*',
-                                                                'HLT_PFJet550_v*',)
+topEleJet_ele = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/EleJet/ElectronMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>25 & abs(eta)<2.1',
+    jetSelection = 'pt>50 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet60_v*',
+                                                  'HLT_PFJet80_v*',
+                                                  'HLT_PFJet140_v*',
+                                                  'HLT_PFJet200_v*',
+                                                  'HLT_PFJet260_v*',
+                                                  'HLT_PFJet320_v*',
+                                                  'HLT_PFJet400_v*',
+                                                  'HLT_PFJet450_v*',
+                                                  'HLT_PFJet500_v*',
+                                                  'HLT_PFJet550_v*'])
+)
 ### ---
-topEleJet_all = hltTOPmonitoring.clone()
-topEleJet_all.FolderName = cms.string('HLT/TOP/EleJet/GlobalMonitor')
-topEleJet_all.nmuons = cms.uint32(0)
-topEleJet_all.nelectrons = cms.uint32(1)
-topEleJet_all.njets = cms.uint32(1)
-topEleJet_all.eleSelection = cms.string('pt>25 & abs(eta)<2.1')
-topEleJet_all.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topEleJet_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-topEleJet_all.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-topEleJet_all.histoPSet.elePtBinning = cms.vdouble(0,25,30,32.5,35,40,45,50,60,80,120,200,400)
-topEleJet_all.histoPSet.elePtBinning2D = cms.vdouble(0,25,30,40,50,60,80,100,200,400)
-topEleJet_all.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-topEleJet_all.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-topEleJet_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned_v*')
-# topEleJet_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_v*')
-
+topEleJet_all = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/EleJet/GlobalMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>25 & abs(eta)<2.1',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned_v*']),
+    #denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu24_v*'])
+)
 ###
 ### Ele+HT
 ###
 
-topEleHT_ht = hltTOPmonitoring.clone()
-topEleHT_ht.FolderName = cms.string('HLT/TOP/EleHT/HTMonitor')
-topEleHT_ht.nmuons = cms.uint32(0)
-topEleHT_ht.nelectrons = cms.uint32(1)
-topEleHT_ht.njets = cms.uint32(2)
-topEleHT_ht.eleSelection = cms.string('pt>50 & abs(eta)<2.1')
-topEleHT_ht.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topEleHT_ht.HTcut = cms.double(100)
-topEleHT_ht.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-topEleHT_ht.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-topEleHT_ht.histoPSet.elePtBinning = cms.vdouble(0,50,60,80,120,200,400)
-topEleHT_ht.histoPSet.elePtBinning2D = cms.vdouble(0,50,70,120,200,400)
-topEleHT_ht.histoPSet.jetPtBinning = cms.vdouble(0,30,40,50,60,80,120,200,400)
-topEleHT_ht.histoPSet.jetPtBinning2D = cms.vdouble(0,30,40,60,80,100,200,400)
-topEleHT_ht.histoPSet.HTBinning  = cms.vdouble(0,100,120,140,150,160,175,200,300,400,500,700)
-topEleHT_ht.histoPSet.HTBinning2D  = cms.vdouble(0,100,125,150,175,200,400,700)
-topEleHT_ht.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele28_eta2p1_WPTight_Gsf_HT150_v*')
-topEleHT_ht.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele35_WPTight_Gsf_v*',
-                                                              'HLT_Ele38_WPTight_Gsf_v*',
-                                                              'HLT_Ele40_WPTight_Gsf_v*',)
-
+topEleHT_ht = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/EleHT/HTMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 2,
+    eleSelection = 'pt>50 & abs(eta)<2.1',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    HTcut = 100,
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,50,60,80,120,200,400],
+                     elePtBinning2D = [0,50,70,120,200,400],
+                     jetPtBinning = [0,30,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,40,60,80,100,200,400],
+                     HTBinning  = [0,100,120,140,150,160,175,200,300,400,500,700],
+                     HTBinning2D  = [0,100,125,150,175,200,400,700]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele28_eta2p1_WPTight_Gsf_HT150_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele35_WPTight_Gsf_v*',
+                                                  'HLT_Ele38_WPTight_Gsf_v*',
+                                                  'HLT_Ele40_WPTight_Gsf_v*'])
+)
 ### ---
 
-topEleHT_ele = hltTOPmonitoring.clone()
-topEleHT_ele.FolderName = cms.string('HLT/TOP/EleHT/ElectronMonitor')
-topEleHT_ele.nmuons = cms.uint32(0)
-topEleHT_ele.nelectrons = cms.uint32(1)
-topEleHT_ele.njets = cms.uint32(2)
-topEleHT_ele.eleSelection = cms.string('pt>25 & abs(eta)<2.1')
-topEleHT_ele.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topEleHT_ele.HTcut = cms.double(200)
-topEleHT_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-topEleHT_ele.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-topEleHT_ele.histoPSet.elePtBinning = cms.vdouble(0,25,30,32.5,35,40,45,50,60,80,120,200,400)
-topEleHT_ele.histoPSet.elePtBinning2D = cms.vdouble(0,25,30,40,50,60,80,100,200,400)
-topEleHT_ele.histoPSet.jetPtBinning = cms.vdouble(0,30,40,50,60,80,120,200,400)
-topEleHT_ele.histoPSet.jetPtBinning2D = cms.vdouble(0,30,40,60,80,100,200,400)
-topEleHT_ele.histoPSet.HTBinning  = cms.vdouble(0,200,250,300,350,400,500,700)
-topEleHT_ele.histoPSet.HTBinning2D  = cms.vdouble(0,200,250,300,400,500,700)
-topEleHT_ele.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele28_eta2p1_WPTight_Gsf_HT150_v*')
-topEleHT_ele.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT250_v*',
-                                                               'HLT_PFHT370_v*',
-                                                               'HLT_PFHT430_v*',
-                                                               'HLT_PFHT510_v*',
-                                                               'HLT_PFHT590_v*',
-                                                               'HLT_PFHT680_v*',
-                                                               'HLT_PFHT780_v*',
-                                                               'HLT_PFHT890_v*',)
-
+topEleHT_ele = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/EleHT/ElectronMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 2,
+    eleSelection = 'pt>25 & abs(eta)<2.1',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    HTcut = 200,
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,30,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,40,60,80,100,200,400],
+                     HTBinning  = [0,200,250,300,350,400,500,700],
+                     HTBinning2D  = [0,200,250,300,400,500,700]),
+    numGenericTriggerEventPSet =dict(hltPaths = ['HLT_Ele28_eta2p1_WPTight_Gsf_HT150_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT250_v*',
+                                                  'HLT_PFHT370_v*',
+                                                  'HLT_PFHT430_v*',
+                                                  'HLT_PFHT510_v*',
+                                                  'HLT_PFHT590_v*',
+                                                  'HLT_PFHT680_v*',
+                                                  'HLT_PFHT780_v*',
+                                                  'HLT_PFHT890_v*'])
+)
 ### ---
 
-topEleHT_all = hltTOPmonitoring.clone()
-topEleHT_all.FolderName = cms.string('HLT/TOP/EleHT/GlobalMonitor')
-topEleHT_all.nmuons = cms.uint32(0)
-topEleHT_all.nelectrons = cms.uint32(1)
-topEleHT_all.njets = cms.uint32(2)
-topEleHT_all.eleSelection = cms.string('pt>25 & abs(eta)<2.1')
-topEleHT_all.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topEleHT_all.HTcut = cms.double(100)
-topEleHT_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-topEleHT_all.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-topEleHT_all.histoPSet.elePtBinning = cms.vdouble(0,25,30,32.5,35,40,45,50,60,80,120,200,400)
-topEleHT_all.histoPSet.elePtBinning2D = cms.vdouble(0,25,30,40,50,60,80,100,200,400)
-topEleHT_all.histoPSet.jetPtBinning = cms.vdouble(0,30,40,50,60,80,120,200,400)
-topEleHT_all.histoPSet.jetPtBinning2D = cms.vdouble(0,30,40,60,80,100,200,400)
-topEleHT_all.histoPSet.HTBinning  = cms.vdouble(0,100,120,140,150,160,175,200,300,400,500,700)
-topEleHT_all.histoPSet.HTBinning2D  = cms.vdouble(0,100,125,150.175,200,400,700)
-topEleHT_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele28_eta2p1_WPTight_Gsf_HT150_v*')
-# topEleHT_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_v*')
-
+topEleHT_all = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/EleHT/GlobalMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 2,
+    eleSelection = 'pt>25 & abs(eta)<2.1',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    HTcut = 100,
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,30,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,40,60,80,100,200,400],
+                     HTBinning  = [0,100,120,140,150,160,175,200,300,400,500,700],
+                     HTBinning2D  = [0,100,125,150.175,200,400,700]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele28_eta2p1_WPTight_Gsf_HT150_v*'])
+    #denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu24_v*'])
+)
 ###
 ### SingleMuon
 ###
 
-topSingleMuonHLTMonitor_Mu24 = hltTOPmonitoring.clone()
-topSingleMuonHLTMonitor_Mu24.FolderName = cms.string('HLT/TOP/SingleLepton/SingleMuon/Mu24/')
-topSingleMuonHLTMonitor_Mu24.nmuons = cms.uint32(1)
-topSingleMuonHLTMonitor_Mu24.nelectrons = cms.uint32(0)
-topSingleMuonHLTMonitor_Mu24.njets = cms.uint32(0)
-topSingleMuonHLTMonitor_Mu24.eleSelection = cms.string('pt>30 & abs(eta)<2.4')
-topSingleMuonHLTMonitor_Mu24.muoSelection = cms.string('pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15')
-topSingleMuonHLTMonitor_Mu24.jetSelection = cms.string('pt>20 & abs(eta)<2.4')
-topSingleMuonHLTMonitor_Mu24.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_eta2p1_v*', 'HLT_IsoMu24_v*')
-
+topSingleMuonHLTMonitor_Mu24 = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/SingleLepton/SingleMuon/Mu24/',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 0,
+    eleSelection = 'pt>30 & abs(eta)<2.4',
+    muoSelection = 'pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15',
+    jetSelection = 'pt>20 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu24_eta2p1_v*', 'HLT_IsoMu24_v*'])
+)
 ### ---
 
-topSingleMuonHLTMonitor_Mu27 = hltTOPmonitoring.clone()
-topSingleMuonHLTMonitor_Mu27.FolderName = cms.string('HLT/TOP/SingleLepton/SingleMuon/Mu27/')
-topSingleMuonHLTMonitor_Mu27.nmuons = cms.uint32(1)
-topSingleMuonHLTMonitor_Mu27.nelectrons = cms.uint32(0)
-topSingleMuonHLTMonitor_Mu27.njets = cms.uint32(0)
-topSingleMuonHLTMonitor_Mu27.eleSelection = cms.string('pt>30 & abs(eta)<2.4')
-topSingleMuonHLTMonitor_Mu27.muoSelection = cms.string('pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15')
-topSingleMuonHLTMonitor_Mu27.jetSelection = cms.string('pt>20 & abs(eta)<2.4')
-topSingleMuonHLTMonitor_Mu27.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
+topSingleMuonHLTMonitor_Mu27 = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/SingleLepton/SingleMuon/Mu27/',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 0,
+    eleSelection = 'pt>30 & abs(eta)<2.4',
+    muoSelection = 'pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15',
+    jetSelection = 'pt>20 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
 ### ---
 
-topSingleMuonHLTMonitor_Mu50 = hltTOPmonitoring.clone()
-topSingleMuonHLTMonitor_Mu50.FolderName = cms.string('HLT/TOP/SingleLepton/SingleMuon/Mu50/')
-topSingleMuonHLTMonitor_Mu50.nmuons = cms.uint32(1)
-topSingleMuonHLTMonitor_Mu50.nelectrons = cms.uint32(0)
-topSingleMuonHLTMonitor_Mu50.njets = cms.uint32(0)
-topSingleMuonHLTMonitor_Mu50.eleSelection = cms.string('pt>30 & abs(eta)<2.4')
-topSingleMuonHLTMonitor_Mu50.muoSelection = cms.string('pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15')
-topSingleMuonHLTMonitor_Mu50.jetSelection = cms.string('pt>20 & abs(eta)<2.4')
-topSingleMuonHLTMonitor_Mu50.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu50_v*')
-
+topSingleMuonHLTMonitor_Mu50 = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/SingleLepton/SingleMuon/Mu50/',
+    nmuons = 1,
+    nelectrons = 0,
+    njets = 0,
+    eleSelection = 'pt>30 & abs(eta)<2.4',
+    muoSelection = 'pt>26 & abs(eta)<2.1 & isPFMuon & isGlobalMuon & isTrackerMuon & numberOfMatches>1  & innerTrack.hitPattern.trackerLayersWithMeasurement>5 & innerTrack.hitPattern.numberOfValidPixelHits>0  & globalTrack.hitPattern.numberOfValidMuonHits>0 & globalTrack.normalizedChi2<10 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.) )/pt<0.15',
+    jetSelection = 'pt>20 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu50_v*'])
+)
 ###
 ### DiElectron
 ###
 
-topDiElectronHLTMonitor = hltTOPmonitoring.clone()
-topDiElectronHLTMonitor.FolderName = cms.string('HLT/TOP/DiLepton/DiElectron/Ele23Ele12/')
-topDiElectronHLTMonitor.nmuons = cms.uint32(0)
-topDiElectronHLTMonitor.nelectrons = cms.uint32(2)
-topDiElectronHLTMonitor.njets = cms.uint32(0)
-topDiElectronHLTMonitor.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
-topDiElectronHLTMonitor.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
-topDiElectronHLTMonitor.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topDiElectronHLTMonitor.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*')
-
+topDiElectronHLTMonitor = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/DiLepton/DiElectron/Ele23Ele12/',
+    nmuons = 0,
+    nelectrons = 2,
+    njets = 0,
+    eleSelection = 'pt>15 & abs(eta)<2.4',
+    muoSelection = 'pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*'])
+)
 ### ---
 
-topDiElectronHLTMonitor_Dz = topDiElectronHLTMonitor.clone()
-topDiElectronHLTMonitor_Dz.FolderName = cms.string('HLT/TOP/DiLepton/DiElectron/Ele23Ele12_DzEfficiency/')
-topDiElectronHLTMonitor_Dz.denGenericTriggerEventPSet.hltPaths = cms.vstring(['HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*'])
-
+topDiElectronHLTMonitor_Dz = topDiElectronHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/DiElectron/Ele23Ele12_DzEfficiency/',
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*'])
+)
 ###
 ### DiMuon
 ###
 
-topDiMuonHLTMonitor_noDz = hltTOPmonitoring.clone()
-topDiMuonHLTMonitor_noDz.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mu17_Mu8/')
-topDiMuonHLTMonitor_noDz.nmuons = cms.uint32(2)
-topDiMuonHLTMonitor_noDz.nelectrons = cms.uint32(0)
-topDiMuonHLTMonitor_noDz.njets = cms.uint32(0)
-topDiMuonHLTMonitor_noDz.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
-topDiMuonHLTMonitor_noDz.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
-topDiMuonHLTMonitor_noDz.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topDiMuonHLTMonitor_noDz.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*')
-
+topDiMuonHLTMonitor_noDz = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/DiLepton/DiMuon/Mu17_Mu8/',
+    nmuons = 2,
+    nelectrons = 0,
+    njets = 0,
+    eleSelection = 'pt>15 & abs(eta)<2.4',
+    muoSelection = 'pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*'])
+)
 ### ---
 
-topDiMuonHLTMonitor_Dz = hltTOPmonitoring.clone()
-topDiMuonHLTMonitor_Dz.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Dz/')
-topDiMuonHLTMonitor_Dz.nmuons = cms.uint32(2)
-topDiMuonHLTMonitor_Dz.nelectrons = cms.uint32(0)
-topDiMuonHLTMonitor_Dz.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Dz.eleSelection = cms.string('pt>15 & abs(eta)<2.4')              
-topDiMuonHLTMonitor_Dz.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
-topDiMuonHLTMonitor_Dz.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topDiMuonHLTMonitor_Dz.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
-
+topDiMuonHLTMonitor_Dz = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Dz/',
+    nmuons = 2,
+    nelectrons = 0,
+    njets = 0,
+    eleSelection = 'pt>15 & abs(eta)<2.4',              
+    muoSelection = 'pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    numGenericTriggerEventPSet =dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*'])
+)
 ### ---
 
-topDiMuonHLTMonitor_Dz_Mu17_Mu8 = topDiMuonHLTMonitor_Dz.clone()
-topDiMuonHLTMonitor_Dz_Mu17_Mu8.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_DzEfficiency/')
-topDiMuonHLTMonitor_Dz_Mu17_Mu8.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
-topDiMuonHLTMonitor_Dz_Mu17_Mu8.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*')
-
+topDiMuonHLTMonitor_Dz_Mu17_Mu8 = topDiMuonHLTMonitor_Dz.clone(
+    FolderName = 'HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_DzEfficiency/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*'])
+)
 ### ---
 
-topDiMuonHLTMonitor_Mass8 = hltTOPmonitoring.clone()
-topDiMuonHLTMonitor_Mass8.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mass8/')
-topDiMuonHLTMonitor_Mass8.nmuons = cms.uint32(2)
-topDiMuonHLTMonitor_Mass8.nelectrons = cms.uint32(0)
-topDiMuonHLTMonitor_Mass8.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Mass8.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
-topDiMuonHLTMonitor_Mass8.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
-topDiMuonHLTMonitor_Mass8.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topDiMuonHLTMonitor_Mass8.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*')
-
+topDiMuonHLTMonitor_Mass8 = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/DiLepton/DiMuon/Mass8/',
+    nmuons = 2,
+    nelectrons = 0,
+    njets = 0,
+    eleSelection = 'pt>15 & abs(eta)<2.4',
+    muoSelection = 'pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*'])
+)
 ### ---
 
-topDiMuonHLTMonitor_Mass3p8 = hltTOPmonitoring.clone()
-topDiMuonHLTMonitor_Mass3p8.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mass3p8/')
-topDiMuonHLTMonitor_Mass3p8.nmuons = cms.uint32(2)
-topDiMuonHLTMonitor_Mass3p8.nelectrons = cms.uint32(0)
-topDiMuonHLTMonitor_Mass3p8.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Mass3p8.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
-topDiMuonHLTMonitor_Mass3p8.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
-topDiMuonHLTMonitor_Mass3p8.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topDiMuonHLTMonitor_Mass3p8.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*')
-
+topDiMuonHLTMonitor_Mass3p8 = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/DiLepton/DiMuon/Mass3p8/',
+    nmuons = 2,
+    nelectrons = 0,
+    njets = 0,
+    eleSelection = 'pt>15 & abs(eta)<2.4',
+    muoSelection = 'pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*'])
+)
 ### ---
 
-topDiMuonHLTMonitor_Mass8Mon = hltTOPmonitoring.clone()
-#topDiMuonHLTMonitor_Mass8Mon.FolderName = cms.string('HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass8Efficiency/')
-topDiMuonHLTMonitor_Mass8Mon.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Mass8Efficiency/')
-topDiMuonHLTMonitor_Mass8Mon.nmuons = cms.uint32(2)
-topDiMuonHLTMonitor_Mass8Mon.nelectrons = cms.uint32(0)
-topDiMuonHLTMonitor_Mass8Mon.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Mass8Mon.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
-topDiMuonHLTMonitor_Mass8Mon.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
-topDiMuonHLTMonitor_Mass8Mon.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topDiMuonHLTMonitor_Mass8Mon.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*')
-topDiMuonHLTMonitor_Mass8Mon.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
-
+topDiMuonHLTMonitor_Mass8Mon = hltTOPmonitoring.clone(
+    #FolderName = 'HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass8Efficiency/',
+    FolderName = 'HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Mass8Efficiency/',
+    nmuons = 2,
+    nelectrons = 0,
+    njets = 0,
+    eleSelection = 'pt>15 & abs(eta)<2.4',
+    muoSelection = 'pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*'])
+)
 ### ---
 
-topDiMuonHLTMonitor_Mass3p8Mon = hltTOPmonitoring.clone()
-#topDiMuonHLTMonitor_Mass3p8Mon.FolderName = cms.string('HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass3p8Efficiency/')
-topDiMuonHLTMonitor_Mass3p8Mon.FolderName = cms.string('HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Mass3p8Efficiency/')
-topDiMuonHLTMonitor_Mass3p8Mon.nmuons = cms.uint32(2)
-topDiMuonHLTMonitor_Mass3p8Mon.nelectrons = cms.uint32(0)
-topDiMuonHLTMonitor_Mass3p8Mon.njets = cms.uint32(0)
-topDiMuonHLTMonitor_Mass3p8Mon.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
-topDiMuonHLTMonitor_Mass3p8Mon.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)')
-topDiMuonHLTMonitor_Mass3p8Mon.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topDiMuonHLTMonitor_Mass3p8Mon.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*')
-topDiMuonHLTMonitor_Mass3p8Mon.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*')
-
+topDiMuonHLTMonitor_Mass3p8Mon = hltTOPmonitoring.clone(
+    #FolderName = 'HLT/TopHLTOffline/TopMonitor/DiLepton/DiMuon/Mu17_Mu8_Mass3p8Efficiency/',
+    FolderName = 'HLT/TOP/DiLepton/DiMuon/Mu17_Mu8_Mass3p8Efficiency/',
+    nmuons = 2,
+    nelectrons = 0,
+    njets = 0,
+    eleSelection = 'pt>15 & abs(eta)<2.4',
+    muoSelection = 'pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*'])
+)
 ###
 ### ElecMuon
 ###
 
-topElecMuonHLTMonitor = hltTOPmonitoring.clone()
-topElecMuonHLTMonitor.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/OR/')
-topElecMuonHLTMonitor.nmuons = cms.uint32(1)
-topElecMuonHLTMonitor.nelectrons = cms.uint32(1)
-topElecMuonHLTMonitor.njets = cms.uint32(0)
-topElecMuonHLTMonitor.eleSelection = cms.string('pt>15 & abs(eta)<2.4')
-topElecMuonHLTMonitor.muoSelection = cms.string('pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)') 
-topElecMuonHLTMonitor.jetSelection = cms.string('pt>30 & abs(eta)<2.4')
-topElecMuonHLTMonitor.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*',
-                                                                        'HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*',
-                                                                        'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*',
-                                                                        'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*',
-                                                                        'HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*',
-                                                                        'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*',)
-
+topElecMuonHLTMonitor = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/OR/',
+    nmuons = 1,
+    nelectrons = 1,
+    njets = 0,
+    eleSelection = 'pt>15 & abs(eta)<2.4',
+    muoSelection = 'pt>15 & abs(eta)<2.4 & (pfIsolationR04.sumChargedHadronPt + max(pfIsolationR04.sumNeutralHadronEt + pfIsolationR04.sumPhotonEt - (pfIsolationR04.sumPUPt)/2.,0.))/pt < 0.25  & isPFMuon & (isTrackerMuon || isGlobalMuon)',
+    jetSelection = 'pt>30 & abs(eta)<2.4',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*',
+                                                  'HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*',
+                                                  'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*',
+                                                  'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*',
+                                                  'HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*',
+                                                  'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*'])
+)
 ### ---
 
-topElecMuonHLTMonitor_Dz_Mu12Ele23 = topElecMuonHLTMonitor.clone()
-topElecMuonHLTMonitor_Dz_Mu12Ele23.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/Mu12Ele23_DzEfficiency/')
-topElecMuonHLTMonitor_Dz_Mu12Ele23.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*')
-topElecMuonHLTMonitor_Dz_Mu12Ele23.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*')
-
+topElecMuonHLTMonitor_Dz_Mu12Ele23 = topElecMuonHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/Mu12Ele23_DzEfficiency/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*'])
+)
 ### ---
 
-topElecMuonHLTMonitor_Dz_Mu8Ele23 = topElecMuonHLTMonitor.clone()
-topElecMuonHLTMonitor_Dz_Mu8Ele23.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/Mu8Ele23_DzEfficiency/')
-topElecMuonHLTMonitor_Dz_Mu8Ele23.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*')
-topElecMuonHLTMonitor_Dz_Mu8Ele23.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*')
-
+topElecMuonHLTMonitor_Dz_Mu8Ele23 = topElecMuonHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/Mu8Ele23_DzEfficiency/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*'])
+)
 ### ---
 
-topElecMuonHLTMonitor_Dz_Mu23Ele12 = topElecMuonHLTMonitor.clone()
-topElecMuonHLTMonitor_Dz_Mu23Ele12.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/Mu23Ele12_DzEfficiency/')
-topElecMuonHLTMonitor_Dz_Mu23Ele12.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*')
-topElecMuonHLTMonitor_Dz_Mu23Ele12.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*')
-
+topElecMuonHLTMonitor_Dz_Mu23Ele12 = topElecMuonHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/Mu23Ele12_DzEfficiency/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*'])
+)
 ### ---
 
-topElecMuonHLTMonitor_Mu12Ele23 = topElecMuonHLTMonitor.clone()
-topElecMuonHLTMonitor_Mu12Ele23.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/Mu12Ele23/')
-topElecMuonHLTMonitor_Mu12Ele23.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*')
-
+topElecMuonHLTMonitor_Mu12Ele23 = topElecMuonHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/Mu12Ele23/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*'])
+)
 ### ---
 
-topElecMuonHLTMonitor_Mu8Ele23 = topElecMuonHLTMonitor.clone()
-topElecMuonHLTMonitor_Mu8Ele23.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/Mu8Ele23/')
-topElecMuonHLTMonitor_Mu8Ele23.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*')
-
+topElecMuonHLTMonitor_Mu8Ele23 = topElecMuonHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/Mu8Ele23/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v*'])
+)
 ### ---
 
-topElecMuonHLTMonitor_Mu23Ele12 = topElecMuonHLTMonitor.clone()
-topElecMuonHLTMonitor_Mu23Ele12.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/Mu23Ele12/')
-topElecMuonHLTMonitor_Mu23Ele12.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*')
-
+topElecMuonHLTMonitor_Mu23Ele12 = topElecMuonHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/Mu23Ele12/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*'])
+)
 ### ---
 
-topElecMuonHLTMonitor_Mu12Ele23_ref = topElecMuonHLTMonitor.clone()
-topElecMuonHLTMonitor_Mu12Ele23_ref.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/Mu12Ele23_Ref/')
-topElecMuonHLTMonitor_Mu12Ele23_ref.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*')
-
+topElecMuonHLTMonitor_Mu12Ele23_ref = topElecMuonHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/Mu12Ele23_Ref/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*'])
+)
 ### ---
 
-topElecMuonHLTMonitor_Mu8Ele23_ref = topElecMuonHLTMonitor.clone()
-topElecMuonHLTMonitor_Mu8Ele23_ref.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/Mu8Ele23_Ref/')
-topElecMuonHLTMonitor_Mu8Ele23_ref.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*')
-
+topElecMuonHLTMonitor_Mu8Ele23_ref = topElecMuonHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/Mu8Ele23_Ref/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v*'])
+)
 ### ---
 
-topElecMuonHLTMonitor_Mu23Ele12_ref = topElecMuonHLTMonitor.clone()
-topElecMuonHLTMonitor_Mu23Ele12_ref.FolderName = cms.string('HLT/TOP/DiLepton/ElecMuon/Mu23Ele12_Ref/')
-topElecMuonHLTMonitor_Mu23Ele12_ref.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*')
-
+topElecMuonHLTMonitor_Mu23Ele12_ref = topElecMuonHLTMonitor.clone(
+    FolderName = 'HLT/TOP/DiLepton/ElecMuon/Mu23Ele12_Ref/',
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*'])
+)
 ###
 ### FullyHadronic
 ###
 
-fullyhadronic_ref350 = hltTOPmonitoring.clone()
-fullyhadronic_ref350.FolderName = cms.string('HLT/TOP/FullyHadronic/Reference/PFHT350Monitor/')
-# Selections
-fullyhadronic_ref350.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_ref350.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_ref350.HTcut            = cms.double(250)
-# Binning
-fullyhadronic_ref350.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_ref350.histoPSet.HTBinning = cms.vdouble(0,240,260,280,300,320,340,360,380,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900,1000)
-# Trigger
-fullyhadronic_ref350.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT350_v*')
-fullyhadronic_ref350.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
+fullyhadronic_ref350 = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/FullyHadronic/Reference/PFHT350Monitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 250,
+    # Binning
+    histoPSet =dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000 ),
+                    HTBinning = [0,240,260,280,300,320,340,360,380,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900,1000]),
+    # Trigger
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT350_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
 ### ---
 
-fullyhadronic_ref370 = hltTOPmonitoring.clone()
-fullyhadronic_ref370.FolderName = cms.string('HLT/TOP/FullyHadronic/Reference/PFHT370Monitor/')
-# Selections
-fullyhadronic_ref370.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_ref370.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_ref370.HTcut            = cms.double(250)
-# Binning
-fullyhadronic_ref370.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_ref370.histoPSet.HTBinning = cms.vdouble(0,240,260,280,300,320,340,360,380,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900,1000)
-# Trigger
-fullyhadronic_ref370.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT370_v*')
-fullyhadronic_ref370.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
+fullyhadronic_ref370 = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/FullyHadronic/Reference/PFHT370Monitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 250,
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     HTBinning = [0,240,260,280,300,320,340,360,380,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900,1000]),
+    # Trigger
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT370_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
 ### ---
 
-fullyhadronic_ref430 = hltTOPmonitoring.clone()
-fullyhadronic_ref430.FolderName = cms.string('HLT/TOP/FullyHadronic/Reference/PFHT430Monitor/')
-# Selections
-fullyhadronic_ref430.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_ref430.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_ref430.HTcut            = cms.double(250)
-# Binning
-fullyhadronic_ref430.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_ref430.histoPSet.HTBinning = cms.vdouble(0,240,260,280,300,320,340,360,380,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900,1000)
-# Trigger
-fullyhadronic_ref430.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT430_v*')
-fullyhadronic_ref430.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
+fullyhadronic_ref430 = hltTOPmonitoring.clone(
+    FolderName = 'HLT/TOP/FullyHadronic/Reference/PFHT430Monitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 250,
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000 ),
+                     HTBinning = [0,240,260,280,300,320,340,360,380,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900,1000]),
+    # Trigger
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT430_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
 ### ---
 
-fullyhadronic_DoubleBTag_all = hltTOPmonitoring.clone()
-fullyhadronic_DoubleBTag_all.FolderName   = cms.string('HLT/TOP/FullyHadronic/DoubleBTag/GlobalMonitor/')
-# Selections
-fullyhadronic_DoubleBTag_all.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_DoubleBTag_all.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_all.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_all.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_all.HTcut            = cms.double(500)
-fullyhadronic_DoubleBTag_all.nbjets           = cms.uint32(2)
-fullyhadronic_DoubleBTag_all.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_all.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_DoubleBTag_all.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_DoubleBTag_all.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_DoubleBTag_all.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_DoubleBTag_all.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers 
-fullyhadronic_DoubleBTag_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*')
-fullyhadronic_DoubleBTag_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
+fullyhadronic_DoubleBTag_all = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTag/GlobalMonitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers 
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
 # conditions 2016
 run2_HLTconditions_2016.toModify(fullyhadronic_DoubleBTag_all, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2016.toModify(fullyhadronic_DoubleBTag_all, workingpoint = 0.8484)
@@ -446,26 +448,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_all, workingpoint = 0.
 run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_all.numGenericTriggerEventPSet, hltPaths = ['HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*'])
 ### ---
 
-fullyhadronic_DoubleBTag_jet = hltTOPmonitoring.clone()
-fullyhadronic_DoubleBTag_jet.FolderName   = cms.string('HLT/TOP/FullyHadronic/DoubleBTag/JetMonitor/')
-# Selections
-fullyhadronic_DoubleBTag_jet.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_DoubleBTag_jet.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_jet.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_jet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_jet.HTcut            = cms.double(500)
-fullyhadronic_DoubleBTag_jet.nbjets           = cms.uint32(2)
-fullyhadronic_DoubleBTag_jet.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_jet.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_DoubleBTag_jet.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning 
-fullyhadronic_DoubleBTag_jet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_DoubleBTag_jet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_DoubleBTag_jet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_DoubleBTag_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_v*')
-fullyhadronic_DoubleBTag_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT370_v*')
-
+fullyhadronic_DoubleBTag_jet = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTag/JetMonitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>30 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>30 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning 
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT400_SixPFJet32_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT370_v*'])
+)
 # conditions 2016
 run2_HLTconditions_2016.toModify(fullyhadronic_DoubleBTag_jet, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2016.toModify(fullyhadronic_DoubleBTag_jet, workingpoint = 0.8484)
@@ -483,26 +485,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_jet.numGenericTriggerE
 run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_jet.denGenericTriggerEventPSet, hltPaths = ['HLT_PFHT370_v*'])
 ### ---
 
-fullyhadronic_DoubleBTag_bjet = hltTOPmonitoring.clone()
-fullyhadronic_DoubleBTag_bjet.FolderName   = cms.string('HLT/TOP/FullyHadronic/DoubleBTag/BJetMonitor/')
-# Selections
-fullyhadronic_DoubleBTag_bjet.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_DoubleBTag_bjet.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_bjet.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_bjet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_bjet.HTcut            = cms.double(500)
-fullyhadronic_DoubleBTag_bjet.nbjets           = cms.uint32(2)
-fullyhadronic_DoubleBTag_bjet.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_bjet.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_DoubleBTag_bjet.workingpoint     = cms.double(0.1522) # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_DoubleBTag_bjet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_DoubleBTag_bjet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_DoubleBTag_bjet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_DoubleBTag_bjet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*')
-fullyhadronic_DoubleBTag_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_v*')
-
+fullyhadronic_DoubleBTag_bjet = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTag/BJetMonitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.1522, # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT400_SixPFJet32_v*'])
+)
 # conditions 2016
 run2_HLTconditions_2016.toModify(fullyhadronic_DoubleBTag_bjet, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2016.toModify(fullyhadronic_DoubleBTag_bjet, workingpoint = 0.5426)
@@ -521,26 +523,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_bjet.denGenericTrigger
 
 ### ---
 
-fullyhadronic_DoubleBTag_ref = hltTOPmonitoring.clone()
-fullyhadronic_DoubleBTag_ref.FolderName   = cms.string('HLT/TOP/FullyHadronic/DoubleBTag/RefMonitor/')
-# Selections
-fullyhadronic_DoubleBTag_ref.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_DoubleBTag_ref.njets            = cms.uint32(6)
-fullyhadronic_DoubleBTag_ref.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_ref.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_ref.HTcut            = cms.double(500)
-fullyhadronic_DoubleBTag_ref.nbjets           = cms.uint32(0)
-fullyhadronic_DoubleBTag_ref.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_DoubleBTag_ref.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_DoubleBTag_ref.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_DoubleBTag_ref.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_DoubleBTag_ref.histoPSet.jetPtBinning = cms.vdouble(0,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_DoubleBTag_ref.histoPSet.HTBinning    = cms.vdouble(0,360,380,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_DoubleBTag_ref.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT400_SixPFJet32_v*')
-fullyhadronic_DoubleBTag_ref.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
+fullyhadronic_DoubleBTag_ref = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/TOP/FullyHadronic/DoubleBTag/RefMonitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 0,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,360,380,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT400_SixPFJet32_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
 # conditions 2016
 run2_HLTconditions_2016.toModify(fullyhadronic_DoubleBTag_ref, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2016.toModify(fullyhadronic_DoubleBTag_ref, workingpoint = 0.8484)
@@ -556,26 +558,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_DoubleBTag_ref.numGenericTriggerE
 
 ### ---
 
-fullyhadronic_SingleBTag_all = hltTOPmonitoring.clone()
-fullyhadronic_SingleBTag_all.FolderName= cms.string('HLT/TOP/FullyHadronic/SingleBTag/GlobalMonitor/')
-# Selections
-fullyhadronic_SingleBTag_all.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_SingleBTag_all.njets            = cms.uint32(6)
-fullyhadronic_SingleBTag_all.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_all.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_all.HTcut            = cms.double(500)
-fullyhadronic_SingleBTag_all.nbjets           = cms.uint32(2)
-fullyhadronic_SingleBTag_all.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_all.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_SingleBTag_all.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_SingleBTag_all.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_SingleBTag_all.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_SingleBTag_all.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_SingleBTag_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59_v*')
-fullyhadronic_SingleBTag_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
+fullyhadronic_SingleBTag_all = hltTOPmonitoring.clone(
+    FolderName= 'HLT/TOP/FullyHadronic/SingleBTag/GlobalMonitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
 # conditions 2016
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_all, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_all, workingpoint = 0.8484)
@@ -591,26 +593,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_SingleBTag_all.numGenericTriggerE
 
 ### ---
 
-fullyhadronic_SingleBTag_jet = hltTOPmonitoring.clone()
-fullyhadronic_SingleBTag_jet.FolderName= cms.string('HLT/TOP/FullyHadronic/SingleBTag/JetMonitor/')
-# Selection
-fullyhadronic_SingleBTag_jet.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_SingleBTag_jet.njets            = cms.uint32(6)
-fullyhadronic_SingleBTag_jet.jetSelection     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_jet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_jet.HTcut            = cms.double(500)
-fullyhadronic_SingleBTag_jet.nbjets           = cms.uint32(2)
-fullyhadronic_SingleBTag_jet.bjetSelection    = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_jet.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_SingleBTag_jet.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_SingleBTag_jet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_SingleBTag_jet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_SingleBTag_jet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_SingleBTag_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_v*')
-fullyhadronic_SingleBTag_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT430_v*')
-
+fullyhadronic_SingleBTag_jet = hltTOPmonitoring.clone(
+    FolderName= 'HLT/TOP/FullyHadronic/SingleBTag/JetMonitor/',
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>30 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>30 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                 jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                 HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT430_v*'])
+)
 # conditions 2016
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_jet, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_jet, workingpoint = 0.8484)
@@ -629,26 +631,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_SingleBTag_jet.denGenericTriggerE
 
 ### ---
 
-fullyhadronic_SingleBTag_bjet = hltTOPmonitoring.clone()
-fullyhadronic_SingleBTag_bjet.FolderName= cms.string('HLT/TOP/FullyHadronic/SingleBTag/BJetMonitor/')
-# Selection
-fullyhadronic_SingleBTag_bjet.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_SingleBTag_bjet.njets            = cms.uint32(6)
-fullyhadronic_SingleBTag_bjet.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_bjet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_bjet.HTcut            = cms.double(500)
-fullyhadronic_SingleBTag_bjet.nbjets           = cms.uint32(2)
-fullyhadronic_SingleBTag_bjet.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_bjet.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_SingleBTag_bjet.workingpoint     = cms.double(0.1522) # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_SingleBTag_bjet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_SingleBTag_bjet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_SingleBTag_bjet.histoPSet.HTBinning    = cms.vdouble(0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_SingleBTag_bjet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59_v*')
-fullyhadronic_SingleBTag_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_v*')
-
+fullyhadronic_SingleBTag_bjet = hltTOPmonitoring.clone(
+    FolderName= 'HLT/TOP/FullyHadronic/SingleBTag/BJetMonitor/',
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 2,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.1522, # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_v*'])
+)
 # conditions 2016
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_bjet, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_bjet, workingpoint = 0.5426)
@@ -667,26 +669,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_SingleBTag_bjet.denGenericTrigger
 
 ### ---
 
-fullyhadronic_SingleBTag_ref = hltTOPmonitoring.clone()
-fullyhadronic_SingleBTag_ref.FolderName= cms.string('HLT/TOP/FullyHadronic/SingleBTag/RefMonitor/')
-# Selection
-fullyhadronic_SingleBTag_ref.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_SingleBTag_ref.njets            = cms.uint32(6)
-fullyhadronic_SingleBTag_ref.jetSelection     = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_ref.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_ref.HTcut            = cms.double(500)
-fullyhadronic_SingleBTag_ref.nbjets           = cms.uint32(0)
-fullyhadronic_SingleBTag_ref.bjetSelection    = cms.string('pt>40 & abs(eta)<2.4')
-fullyhadronic_SingleBTag_ref.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_SingleBTag_ref.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_SingleBTag_ref.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_SingleBTag_ref.histoPSet.jetPtBinning = cms.vdouble(0,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200)
-fullyhadronic_SingleBTag_ref.histoPSet.HTBinning    = cms.vdouble(0,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_SingleBTag_ref.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT450_SixPFJet36_v*')
-fullyhadronic_SingleBTag_ref.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
+fullyhadronic_SingleBTag_ref = hltTOPmonitoring.clone(
+    FolderName= 'HLT/TOP/FullyHadronic/SingleBTag/RefMonitor/',
+    # Selection
+    leptJetDeltaRmin = 0.0,
+    njets            = 6,
+    jetSelection     = 'pt>40 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 0,
+    bjetSelection    = 'pt>40 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                     jetPtBinning = [0,30,35,40,45,50,55,60,65,70,75,80,90,100,120,140,160,200],
+                     HTBinning    = [0,400,420,440,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT450_SixPFJet36_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
 # conditions 2016
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_ref, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2016.toModify(fullyhadronic_SingleBTag_ref, workingpoint = 0.8484)
@@ -702,26 +704,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_SingleBTag_ref.numGenericTriggerE
 
 ### ---
 
-fullyhadronic_TripleBTag_all = hltTOPmonitoring.clone()
-fullyhadronic_TripleBTag_all.FolderName   = cms.string('HLT/TOP/FullyHadronic/TripleBTag/GlobalMonitor/')
-# Selections
-fullyhadronic_TripleBTag_all.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_TripleBTag_all.njets            = cms.uint32(4)
-fullyhadronic_TripleBTag_all.jetSelection     = cms.string('pt>45 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_all.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_all.HTcut            = cms.double(500)
-fullyhadronic_TripleBTag_all.nbjets           = cms.uint32(4)
-fullyhadronic_TripleBTag_all.bjetSelection    = cms.string('pt>45 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_all.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_TripleBTag_all.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_TripleBTag_all.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_TripleBTag_all.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
-fullyhadronic_TripleBTag_all.histoPSet.HTBinning    = cms.vdouble(0,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_TripleBTag_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5_v*')
-fullyhadronic_TripleBTag_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu27_v*')
-
+fullyhadronic_TripleBTag_all = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/TOP/FullyHadronic/TripleBTag/GlobalMonitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 4,
+    jetSelection     = 'pt>45 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 4,
+    bjetSelection    = 'pt>45 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet =dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                 jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+                 HTBinning    = [0,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu27_v*'])
+)
 # conditions 2017
 run2_HLTconditions_2017.toModify(fullyhadronic_TripleBTag_all, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2017.toModify(fullyhadronic_TripleBTag_all, workingpoint = 0.8484)
@@ -732,26 +734,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_TripleBTag_all, workingpoint = 0.
 run2_HLTconditions_2018.toModify(fullyhadronic_TripleBTag_all.numGenericTriggerEventPSet, hltPaths = ['HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5_v*'])
 ### ---
 
-fullyhadronic_TripleBTag_jet = hltTOPmonitoring.clone()
-fullyhadronic_TripleBTag_jet.FolderName   = cms.string('HLT/TOP/FullyHadronic/TripleBTag/JetMonitor/')
-# Selections
-fullyhadronic_TripleBTag_jet.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_TripleBTag_jet.njets            = cms.uint32(4)
-fullyhadronic_TripleBTag_jet.jetSelection     = cms.string('pt>45 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_jet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_jet.HTcut            = cms.double(500)
-fullyhadronic_TripleBTag_jet.nbjets           = cms.uint32(4)
-fullyhadronic_TripleBTag_jet.bjetSelection    = cms.string('pt>45 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_jet.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_TripleBTag_jet.workingpoint     = cms.double(0.4941) # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_TripleBTag_jet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_TripleBTag_jet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
-fullyhadronic_TripleBTag_jet.histoPSet.HTBinning    = cms.vdouble(0,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers
-fullyhadronic_TripleBTag_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v*')
-fullyhadronic_TripleBTag_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT350_v*')
-
+fullyhadronic_TripleBTag_jet = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/TOP/FullyHadronic/TripleBTag/JetMonitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 4,
+    jetSelection     = 'pt>45 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 4,
+    bjetSelection    = 'pt>45 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.4941, # Medium (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                 jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+                 HTBinning    = [0,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT350_v*'])
+)
 # conditions 2017
 run2_HLTconditions_2017.toModify(fullyhadronic_TripleBTag_jet, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2017.toModify(fullyhadronic_TripleBTag_jet, workingpoint = 0.8484)
@@ -763,26 +765,26 @@ run2_HLTconditions_2018.toModify(fullyhadronic_TripleBTag_jet.numGenericTriggerE
 
 ### ---
 
-fullyhadronic_TripleBTag_bjet = hltTOPmonitoring.clone()
-fullyhadronic_TripleBTag_bjet.FolderName   = cms.string('HLT/TOP/FullyHadronic/TripleBTag/BJetMonitor/')
-# Selections
-fullyhadronic_TripleBTag_bjet.leptJetDeltaRmin = cms.double(0.0)
-fullyhadronic_TripleBTag_bjet.njets            = cms.uint32(4)
-fullyhadronic_TripleBTag_bjet.jetSelection     = cms.string('pt>45 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_bjet.HTdefinition     = cms.string('pt>30 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_bjet.HTcut            = cms.double(500)
-fullyhadronic_TripleBTag_bjet.nbjets           = cms.uint32(4)
-fullyhadronic_TripleBTag_bjet.bjetSelection    = cms.string('pt>45 & abs(eta)<2.4')
-fullyhadronic_TripleBTag_bjet.btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"]
-fullyhadronic_TripleBTag_bjet.workingpoint     = cms.double(0.1522) # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
-# Binning
-fullyhadronic_TripleBTag_bjet.histoPSet.htPSet = cms.PSet(nbins=cms.uint32(50), xmin=cms.double(0.0), xmax=cms.double(1000) )
-fullyhadronic_TripleBTag_bjet.histoPSet.jetPtBinning = cms.vdouble(0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400)
-fullyhadronic_TripleBTag_bjet.histoPSet.HTBinning    = cms.vdouble(0,460,480,500,520,540,560,580,600,650,700,750,800,850,900)
-# Triggers 
-fullyhadronic_TripleBTag_bjet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5_v*')
-fullyhadronic_TripleBTag_bjet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v*')
-
+fullyhadronic_TripleBTag_bjet = hltTOPmonitoring.clone(
+    FolderName   = 'HLT/TOP/FullyHadronic/TripleBTag/BJetMonitor/',
+    # Selections
+    leptJetDeltaRmin = 0.0,
+    njets            = 4,
+    jetSelection     = 'pt>45 & abs(eta)<2.4',
+    HTdefinition     = 'pt>30 & abs(eta)<2.4',
+    HTcut            = 500,
+    nbjets           = 4,
+    bjetSelection    = 'pt>45 & abs(eta)<2.4',
+    btagAlgos        = ["pfDeepCSVJetTags:probb", "pfDeepCSVJetTags:probbb"],
+    workingpoint     = 0.1522, # Loose (According to: https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation94X)
+    # Binning
+    histoPSet = dict(htPSet = dict(nbins= 50, xmin= 0.0, xmax= 1000),
+                 jetPtBinning = [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,90,100,120,200,400],
+                 HTBinning    = [0,460,480,500,520,540,560,580,600,650,700,750,800,850,900]),
+    # Triggers 
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFHT330PT30_QuadPFJet_75_60_45_40_v*'])
+)
 # conditions 2017
 run2_HLTconditions_2017.toModify(fullyhadronic_TripleBTag_bjet, btagAlgos = ["pfCombinedSecondaryVertexV2BJetTags"])
 run2_HLTconditions_2017.toModify(fullyhadronic_TripleBTag_bjet, workingpoint = 0.5426)

--- a/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackToTrackMonitoring_cff.py
@@ -8,30 +8,30 @@ trackSelector = cms.EDFilter('TrackSelector',
     src = cms.InputTag('generalTracks'),
     cut = cms.string("")
 )
-highPurityTracks = trackSelector.clone()
-highPurityTracks.cut = cms.string("quality('highPurity')")
+highPurityTracks = trackSelector.clone(
+    cut = "quality('highPurity')"
+)
 
+hltMerged2highPurity = trackToTrackComparisonHists.clone(
+    monitoredTrack           = "hltMergedTracks",
+    referenceTrack           = "highPurityTracks",
+    monitoredBeamSpot        = "hltOnlineBeamSpot",
+    referenceBeamSpot        = "offlineBeamSpot",
+    topDirName               = "HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurity",
+    referencePrimaryVertices = "offlinePrimaryVertices",
+    monitoredPrimaryVertices = "hltVerticesPFSelector"
+)
 
-hltMerged2highPurity = trackToTrackComparisonHists.clone()
-hltMerged2highPurity.monitoredTrack           = cms.InputTag("hltMergedTracks")
-hltMerged2highPurity.referenceTrack           = cms.InputTag("highPurityTracks")
-hltMerged2highPurity.monitoredBeamSpot        = cms.InputTag("hltOnlineBeamSpot")
-hltMerged2highPurity.referenceBeamSpot        = cms.InputTag("offlineBeamSpot")
-hltMerged2highPurity.topDirName               = cms.string("HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurity")
-hltMerged2highPurity.referencePrimaryVertices = cms.InputTag("offlinePrimaryVertices")
-hltMerged2highPurity.monitoredPrimaryVertices = cms.InputTag("hltVerticesPFSelector")
-
-
-hltMerged2highPurityPV = trackToTrackComparisonHists.clone()
-hltMerged2highPurityPV.dzWRTPvCut               = cms.double(0.1)
-hltMerged2highPurityPV.monitoredTrack           = cms.InputTag("hltMergedTracks")
-hltMerged2highPurityPV.referenceTrack           = cms.InputTag("highPurityTracks")
-hltMerged2highPurityPV.monitoredBeamSpot        = cms.InputTag("hltOnlineBeamSpot")
-hltMerged2highPurityPV.referenceBeamSpot        = cms.InputTag("offlineBeamSpot")
-hltMerged2highPurityPV.topDirName               = cms.string("HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurityPV")
-hltMerged2highPurityPV.referencePrimaryVertices = cms.InputTag("offlinePrimaryVertices")
-hltMerged2highPurityPV.monitoredPrimaryVertices = cms.InputTag("hltVerticesPFSelector")
-
+hltMerged2highPurityPV = trackToTrackComparisonHists.clone(
+    dzWRTPvCut               = 0.1,
+    monitoredTrack           = "hltMergedTracks",
+    referenceTrack           = "highPurityTracks",
+    monitoredBeamSpot        = "hltOnlineBeamSpot",
+    referenceBeamSpot        = "offlineBeamSpot",
+    topDirName               = "HLT/Tracking/ValidationWRTOffline/hltMergedWrtHighPurityPV",
+    referencePrimaryVertices = "offlinePrimaryVertices",
+    monitoredPrimaryVertices = "hltVerticesPFSelector"
+)
 hltToOfflineTrackValidatorSequence = cms.Sequence(
     cms.ignore(highPurityTracks)
     + hltMerged2highPurity

--- a/DQMOffline/Trigger/python/TrackingMonitoringPA_Client_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoringPA_Client_cff.py
@@ -2,21 +2,19 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.TrackingMonitorClient.TrackingEffFromHitPatternClientConfig_cff import trackingEffFromHitPattern
 
-PAtrackingEffFromHitPatternHLT = trackingEffFromHitPattern.clone()
-PAtrackingEffFromHitPatternHLT.subDirs = cms.untracked.vstring(
-   "HLT/TrackingPA/pixelTracks/HitEffFromHitPattern*",
-   "HLT/TrackingPA/pixelTracksForHighMult/HitEffFromHitPattern*",
-   "HLT/TrackingPA/iter0/HitEffFromHitPattern*",
-   "HLT/TrackingPA/iter1/HitEffFromHitPattern*",
-   "HLT/TrackingPA/iter2/HitEffFromHitPattern*",
-   "HLT/TrackingPA/iter3/HitEffFromHitPattern*",
-   "HLT/TrackingPA/iter4/HitEffFromHitPattern*",
-   "HLT/TrackingPA/iter5/HitEffFromHitPattern*",
-   "HLT/TrackingPA/iter6/HitEffFromHitPattern*",
-   "HLT/TrackingPA/iter7/HitEffFromHitPattern*",
-   "HLT/TrackingPA/iterMerged/HitEffFromHitPattern*",
+PAtrackingEffFromHitPatternHLT = trackingEffFromHitPattern.clone(
+    subDirs = ["HLT/TrackingPA/pixelTracks/HitEffFromHitPattern*",
+               "HLT/TrackingPA/pixelTracksForHighMult/HitEffFromHitPattern*",
+               "HLT/TrackingPA/iter0/HitEffFromHitPattern*",
+               "HLT/TrackingPA/iter1/HitEffFromHitPattern*",
+               "HLT/TrackingPA/iter2/HitEffFromHitPattern*",
+               "HLT/TrackingPA/iter3/HitEffFromHitPattern*",
+               "HLT/TrackingPA/iter4/HitEffFromHitPattern*",
+               "HLT/TrackingPA/iter5/HitEffFromHitPattern*",
+               "HLT/TrackingPA/iter6/HitEffFromHitPattern*",
+               "HLT/TrackingPA/iter7/HitEffFromHitPattern*",
+               "HLT/TrackingPA/iterMerged/HitEffFromHitPattern*",]
 )
-
 # Sequence
 PAtrackingMonitorClientHLT = cms.Sequence(
     PAtrackingEffFromHitPatternHLT

--- a/DQMOffline/Trigger/python/TrackingMonitoringPA_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoringPA_cff.py
@@ -1,87 +1,87 @@
 import FWCore.ParameterSet.Config as cms
 
 import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
-PAtrackingMonHLT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-PAtrackingMonHLT.beamSpot         = cms.InputTag("hltOnlineBeamSpot")
-PAtrackingMonHLT.primaryVertex    = cms.InputTag("hltPixelVertices")
-PAtrackingMonHLT.doAllPlots       = cms.bool(False)
-PAtrackingMonHLT.doLumiAnalysis   = cms.bool(False)     
-PAtrackingMonHLT.doProfilesVsLS   = cms.bool(True)
-PAtrackingMonHLT.doDCAPlots       = cms.bool(True)
-PAtrackingMonHLT.doPUmonitoring   = cms.bool(False)
-PAtrackingMonHLT.doPlotsVsGoodPVtx = cms.bool(False)
-PAtrackingMonHLT.doEffFromHitPatternVsPU = cms.bool(False)
-PAtrackingMonHLT.pvNDOF           = cms.int32(1)
-PAtrackingMonHLT.numCut           = cms.string(" pt >= 0.4 & quality('highPurity') ")
-PAtrackingMonHLT.denCut           = cms.string(" pt >= 0.4")
-PAtrackingMonHLT.FolderName       = cms.string("TrackingPA/GlobalParameters")
-PAtrackingMonHLT.BSFolderName     = cms.string("TrackingPA/ParametersVsBeamSpot")
-
-PApixelTracksMonitoringHLT = PAtrackingMonHLT.clone()
-PApixelTracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/pixelTracks'
-PApixelTracksMonitoringHLT.TrackProducer    = 'hltPixelTracks'
-PApixelTracksMonitoringHLT.allTrackProducer = 'hltPixelTracks'
-
-PApixelTracksForHighMultMonitoringHLT = PAtrackingMonHLT.clone()
-PApixelTracksForHighMultMonitoringHLT.FolderName       = 'HLT/TrackingPA/pixelTracksForHighMult'
-PApixelTracksForHighMultMonitoringHLT.primaryVertex    = 'hltPixelVerticesForHighMult'
-PApixelTracksForHighMultMonitoringHLT.TrackProducer    = 'hltPixelTracksForHighMult'
-PApixelTracksForHighMultMonitoringHLT.allTrackProducer = 'hltPixelTracksForHighMult'
-
-PAiter0TracksMonitoringHLT = PAtrackingMonHLT.clone()
-PAiter0TracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/iter0'
-PAiter0TracksMonitoringHLT.primaryVertex    = 'hltPAOnlinePrimaryVertices'
-PAiter0TracksMonitoringHLT.TrackProducer    = 'hltPAIter0CtfWithMaterialTracks'
-PAiter0TracksMonitoringHLT.allTrackProducer = 'hltPAIter0CtfWithMaterialTracks'
-
-PAiter1TracksMonitoringHLT = PAtrackingMonHLT.clone()
-PAiter1TracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/iter1'
-PAiter1TracksMonitoringHLT.primaryVertex    = 'hltPAOnlinePrimaryVertices'
-PAiter1TracksMonitoringHLT.TrackProducer    = 'hltPAIter1CtfWithMaterialTracks'
-PAiter1TracksMonitoringHLT.allTrackProducer = 'hltPAIter1CtfWithMaterialTracks'
-
-PAiter2TracksMonitoringHLT = PAtrackingMonHLT.clone()
-PAiter2TracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/iter2'
-PAiter2TracksMonitoringHLT.primaryVertex    = 'hltPAOnlinePrimaryVertices'
-PAiter2TracksMonitoringHLT.TrackProducer    = 'hltPAIter2CtfWithMaterialTracks'
-PAiter2TracksMonitoringHLT.allTrackProducer = 'hltPAIter2CtfWithMaterialTracks'
-
-PAiter3TracksMonitoringHLT = PAtrackingMonHLT.clone()
-PAiter3TracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/iter3'
-PAiter3TracksMonitoringHLT.primaryVertex    = 'hltPAOnlinePrimaryVertices'
-PAiter3TracksMonitoringHLT.TrackProducer    = 'hltPAIter3CtfWithMaterialTracks'
-PAiter3TracksMonitoringHLT.allTrackProducer = 'hltPAIter3CtfWithMaterialTracks'
-
-PAiter4TracksMonitoringHLT = PAtrackingMonHLT.clone()
-PAiter4TracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/iter4'
-PAiter4TracksMonitoringHLT.primaryVertex    = 'hltPAOnlinePrimaryVertices'
-PAiter4TracksMonitoringHLT.TrackProducer    = 'hltPAIter4CtfWithMaterialTracks'
-PAiter4TracksMonitoringHLT.allTrackProducer = 'hltPAIter4CtfWithMaterialTracks'
-
-PAiter5TracksMonitoringHLT = PAtrackingMonHLT.clone()
-PAiter5TracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/iter5'
-PAiter5TracksMonitoringHLT.primaryVertex    = 'hltPAOnlinePrimaryVertices'
-PAiter5TracksMonitoringHLT.TrackProducer    = 'hltPAIter5CtfWithMaterialTracks'
-PAiter5TracksMonitoringHLT.allTrackProducer = 'hltPAIter5CtfWithMaterialTracks'
-
-PAiter6TracksMonitoringHLT = PAtrackingMonHLT.clone()
-PAiter6TracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/iter6'
-PAiter6TracksMonitoringHLT.primaryVertex    = 'hltPAOnlinePrimaryVertices'
-PAiter6TracksMonitoringHLT.TrackProducer    = 'hltPAIter6CtfWithMaterialTracks'
-PAiter6TracksMonitoringHLT.allTrackProducer = 'hltPAIter6CtfWithMaterialTracks'
-
-PAiter7TracksMonitoringHLT = PAtrackingMonHLT.clone()
-PAiter7TracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/iter7'
-PAiter7TracksMonitoringHLT.primaryVertex    = 'hltPAOnlinePrimaryVertices'
-PAiter7TracksMonitoringHLT.TrackProducer    = 'hltPAIter7CtfWithMaterialTracks'
-PAiter7TracksMonitoringHLT.allTrackProducer = 'hltPAIter7CtfWithMaterialTracks'
-
-PAiterHLTTracksMonitoringHLT = PAtrackingMonHLT.clone()
-PAiterHLTTracksMonitoringHLT.FolderName       = 'HLT/TrackingPA/iterMerged'
-PAiterHLTTracksMonitoringHLT.primaryVertex    = 'hltPAOnlinePrimaryVertices'
-PAiterHLTTracksMonitoringHLT.TrackProducer    = 'hltPAIterativeTrackingMerged'
-PAiterHLTTracksMonitoringHLT.allTrackProducer = 'hltPAIterativeTrackingMerged'
-
+PAtrackingMonHLT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone(
+    beamSpot         = "hltOnlineBeamSpot",
+    primaryVertex    = "hltPixelVertices",
+    doAllPlots       = False,
+    doLumiAnalysis   = False,     
+    doProfilesVsLS   = True,
+    doDCAPlots       = True,
+    doPUmonitoring   = False,
+    doPlotsVsGoodPVtx = False,
+    doEffFromHitPatternVsPU = False,
+    pvNDOF           = 1,
+    numCut           = " pt >= 0.4 & quality('highPurity') ",
+    denCut           = " pt >= 0.4",
+    FolderName       = "TrackingPA/GlobalParameters",
+    BSFolderName     = "TrackingPA/ParametersVsBeamSpot"
+)
+PApixelTracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/pixelTracks',
+    TrackProducer    = 'hltPixelTracks',
+    allTrackProducer = 'hltPixelTracks',
+)
+PApixelTracksForHighMultMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/pixelTracksForHighMult',
+    primaryVertex    = 'hltPixelVerticesForHighMult',
+    TrackProducer    = 'hltPixelTracksForHighMult',
+    allTrackProducer = 'hltPixelTracksForHighMult'
+)
+PAiter0TracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/iter0',
+    primaryVertex    = 'hltPAOnlinePrimaryVertices',
+    TrackProducer    = 'hltPAIter0CtfWithMaterialTracks',
+    allTrackProducer = 'hltPAIter0CtfWithMaterialTracks'
+)
+PAiter1TracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/iter1',
+    primaryVertex    = 'hltPAOnlinePrimaryVertices',
+    TrackProducer    = 'hltPAIter1CtfWithMaterialTracks',
+    allTrackProducer = 'hltPAIter1CtfWithMaterialTracks'
+)
+PAiter2TracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/iter2',
+    primaryVertex    = 'hltPAOnlinePrimaryVertices',
+    TrackProducer    = 'hltPAIter2CtfWithMaterialTracks',
+    allTrackProducer = 'hltPAIter2CtfWithMaterialTracks'
+)
+PAiter3TracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/iter3',
+    primaryVertex    = 'hltPAOnlinePrimaryVertices',
+    TrackProducer    = 'hltPAIter3CtfWithMaterialTracks',
+    allTrackProducer = 'hltPAIter3CtfWithMaterialTracks'
+)
+PAiter4TracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/iter4',
+    primaryVertex    = 'hltPAOnlinePrimaryVertices',
+    TrackProducer    = 'hltPAIter4CtfWithMaterialTracks',
+    allTrackProducer = 'hltPAIter4CtfWithMaterialTracks'
+)
+PAiter5TracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/iter5',
+    primaryVertex    = 'hltPAOnlinePrimaryVertices',
+    TrackProducer    = 'hltPAIter5CtfWithMaterialTracks',
+    allTrackProducer = 'hltPAIter5CtfWithMaterialTracks'
+)
+PAiter6TracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/iter6',
+    primaryVertex    = 'hltPAOnlinePrimaryVertices',
+    TrackProducer    = 'hltPAIter6CtfWithMaterialTracks',
+    allTrackProducer = 'hltPAIter6CtfWithMaterialTracks'
+)
+PAiter7TracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/iter7',
+    primaryVertex    = 'hltPAOnlinePrimaryVertices',
+    TrackProducer    = 'hltPAIter7CtfWithMaterialTracks',
+    allTrackProducer = 'hltPAIter7CtfWithMaterialTracks'
+)
+PAiterHLTTracksMonitoringHLT = PAtrackingMonHLT.clone(
+    FolderName       = 'HLT/TrackingPA/iterMerged',
+    primaryVertex    = 'hltPAOnlinePrimaryVertices',
+    TrackProducer    = 'hltPAIterativeTrackingMerged',
+    allTrackProducer = 'hltPAIterativeTrackingMerged'
+)
 PAtrackingMonitorHLT = cms.Sequence(
     PApixelTracksMonitoringHLT
     + PApixelTracksForHighMultMonitoringHLT

--- a/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
@@ -4,28 +4,24 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
 from DQM.TrackingMonitorClient.TrackingEffFromHitPatternClientConfig_cff import trackingEffFromHitPattern
 
-trackingEffFromHitPatternHLT = trackingEffFromHitPattern.clone()
-trackingEffFromHitPatternHLT.subDirs = cms.untracked.vstring(
-   "HLT/Tracking/pixelTracks/HitEffFromHitPattern*",
-   "HLT/Tracking/iter0HP/HitEffFromHitPattern*",
-   "HLT/Tracking/iter2Merged/HitEffFromHitPattern*",
-   "HLT/Tracking/tracks/HitEffFromHitPattern*"
+trackingEffFromHitPatternHLT = trackingEffFromHitPattern.clone(
+    subDirs = ["HLT/Tracking/pixelTracks/HitEffFromHitPattern*",
+               "HLT/Tracking/iter0HP/HitEffFromHitPattern*",
+               "HLT/Tracking/iter2Merged/HitEffFromHitPattern*",
+               "HLT/Tracking/tracks/HitEffFromHitPattern*"]
 )
-
 # Sequence
 trackingMonitorClientHLT = cms.Sequence(
     trackingEffFromHitPatternHLT
 )
 
 # EGM tracking
-trackingForElectronsEffFromHitPatternHLT = trackingEffFromHitPattern.clone()
-trackingForElectronsEffFromHitPatternHLT.subDirs = cms.untracked.vstring(
-   "HLT/EGM/Tracking/GSF/HitEffFromHitPattern*",
-   "HLT/EGM/Tracking/pixelTracks/HitEffFromHitPattern*",
-   "HLT/EGM/Tracking/iter0HP/HitEffFromHitPattern*",
-   "HLT/EGM/Tracking/iter2Merged/HitEffFromHitPattern*"
+trackingForElectronsEffFromHitPatternHLT = trackingEffFromHitPattern.clone(
+    subDirs = ["HLT/EGM/Tracking/GSF/HitEffFromHitPattern*",
+               "HLT/EGM/Tracking/pixelTracks/HitEffFromHitPattern*",
+               "HLT/EGM/Tracking/iter0HP/HitEffFromHitPattern*",
+               "HLT/EGM/Tracking/iter2Merged/HitEffFromHitPattern*"]
 )
-
 # Sequence
 trackingForElectronsMonitorClientHLT = cms.Sequence(
     trackingForElectronsEffFromHitPatternHLT

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -1,109 +1,109 @@
 import FWCore.ParameterSet.Config as cms
 
 import DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi
-trackingMonHLT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone()
-trackingMonHLT.beamSpot                = cms.InputTag("hltOnlineBeamSpot")
-trackingMonHLT.primaryVertex           = cms.InputTag("hltPixelVertices")
-trackingMonHLT.doAllPlots              = cms.bool(False)
-trackingMonHLT.doLumiAnalysis          = cms.bool(False)     
-trackingMonHLT.doProfilesVsLS          = cms.bool(True)
-trackingMonHLT.doDCAPlots              = cms.bool(True)
-trackingMonHLT.pvNDOF                  = cms.int32(1)
-trackingMonHLT.doProfilesVsLS          = cms.bool(True)
-trackingMonHLT.doPlotsVsGoodPVtx       = cms.bool(True)
-trackingMonHLT.doEffFromHitPatternVsPU = cms.bool(True)
-trackingMonHLT.doEffFromHitPatternVsBX = cms.bool(True)
-trackingMonHLT.doEffFromHitPatternVsLUMI = cms.bool(True)
-trackingMonHLT.doPlotsVsGoodPVtx       = cms.bool(True)
-trackingMonHLT.doPlotsVsLUMI           = cms.bool(True)
-trackingMonHLT.doPlotsVsBX             = cms.bool(True)
-
-pixelTracksMonitoringHLT = trackingMonHLT.clone()
-pixelTracksMonitoringHLT.FolderName       = 'HLT/Tracking/pixelTracks'
-pixelTracksMonitoringHLT.TrackProducer    = 'hltPixelTracks'
-pixelTracksMonitoringHLT.allTrackProducer = 'hltPixelTracks'
-pixelTracksMonitoringHLT.doEffFromHitPatternVsPU   = False
-pixelTracksMonitoringHLT.doEffFromHitPatternVsBX   = False
-pixelTracksMonitoringHLT.doEffFromHitPatternVsLUMI = False
-
-iter0TracksMonitoringHLT = trackingMonHLT.clone()
-iter0TracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter0'
-iter0TracksMonitoringHLT.TrackProducer    = 'hltIter0PFlowCtfWithMaterialTracks'
-iter0TracksMonitoringHLT.allTrackProducer = 'hltIter0PFlowCtfWithMaterialTracks'
-iter0TracksMonitoringHLT.doEffFromHitPatternVsPU   = True
-iter0TracksMonitoringHLT.doEffFromHitPatternVsBX   = False
-iter0TracksMonitoringHLT.doEffFromHitPatternVsLUMI = False
-
-iter0HPTracksMonitoringHLT = trackingMonHLT.clone()
-iter0HPTracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter0HP'
-iter0HPTracksMonitoringHLT.TrackProducer    = 'hltIter0PFlowTrackSelectionHighPurity'
-iter0HPTracksMonitoringHLT.allTrackProducer = 'hltIter0PFlowTrackSelectionHighPurity'
-iter0HPTracksMonitoringHLT.doEffFromHitPatternVsPU   = True
-iter0HPTracksMonitoringHLT.doEffFromHitPatternVsBX   = False
-iter0HPTracksMonitoringHLT.doEffFromHitPatternVsLUMI = False
-
-iter1TracksMonitoringHLT = trackingMonHLT.clone()
-iter1TracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter1'
-iter1TracksMonitoringHLT.TrackProducer    = 'hltIter1PFlowCtfWithMaterialTracks'
-iter1TracksMonitoringHLT.allTrackProducer = 'hltIter1PFlowCtfWithMaterialTracks'
-iter1TracksMonitoringHLT.doEffFromHitPatternVsPU   = True
-iter1TracksMonitoringHLT.doEffFromHitPatternVsBX   = False
-iter1TracksMonitoringHLT.doEffFromHitPatternVsLUMI = False
-
-iter1HPTracksMonitoringHLT = trackingMonHLT.clone()
-iter1HPTracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter1HP'
-iter1HPTracksMonitoringHLT.TrackProducer    = 'hltIter1PFlowTrackSelectionHighPurity'
-iter1HPTracksMonitoringHLT.allTrackProducer = 'hltIter1PFlowTrackSelectionHighPurity'
-iter1HPTracksMonitoringHLT.doEffFromHitPatternVsPU   = True
-iter1HPTracksMonitoringHLT.doEffFromHitPatternVsBX   = False
-iter1HPTracksMonitoringHLT.doEffFromHitPatternVsLUMI = False
-
-iter2TracksMonitoringHLT = trackingMonHLT.clone()
-iter2TracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter2'
-iter2TracksMonitoringHLT.TrackProducer    = 'hltIter2PFlowCtfWithMaterialTracks'
-iter2TracksMonitoringHLT.allTrackProducer = 'hltIter2PFlowCtfWithMaterialTracks'
-iter2TracksMonitoringHLT.doEffFromHitPatternVsPU   = True
-iter2TracksMonitoringHLT.doEffFromHitPatternVsBX   = False
-iter2TracksMonitoringHLT.doEffFromHitPatternVsLUMI = False
-
-iter2HPTracksMonitoringHLT = trackingMonHLT.clone()
-iter2HPTracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter2HP'
-iter2HPTracksMonitoringHLT.TrackProducer    = 'hltIter2PFlowTrackSelectionHighPurity'
-iter2HPTracksMonitoringHLT.allTrackProducer = 'hltIter2PFlowTrackSelectionHighPurity'
-iter2HPTracksMonitoringHLT.doEffFromHitPatternVsPU   = True
-iter2HPTracksMonitoringHLT.doEffFromHitPatternVsBX   = False
-iter2HPTracksMonitoringHLT.doEffFromHitPatternVsLUMI = False
-
-iter2MergedTracksMonitoringHLT = trackingMonHLT.clone()
-iter2MergedTracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter2Merged'
-iter2MergedTracksMonitoringHLT.TrackProducer    = 'hltIter2Merged'
-iter2MergedTracksMonitoringHLT.allTrackProducer = 'hltIter2Merged'
-iter2MergedTracksMonitoringHLT.doEffFromHitPatternVsPU   = True
-iter2MergedTracksMonitoringHLT.doEffFromHitPatternVsBX   = False
-iter2MergedTracksMonitoringHLT.doEffFromHitPatternVsLUMI = False
-
-iterHLTTracksMonitoringHLT = trackingMonHLT.clone()
-iterHLTTracksMonitoringHLT.FolderName       = 'HLT/Tracking/tracks'
-iterHLTTracksMonitoringHLT.TrackProducer    = 'hltMergedTracks'
-iterHLTTracksMonitoringHLT.allTrackProducer = 'hltMergedTracks'
-iterHLTTracksMonitoringHLT.doEffFromHitPatternVsPU   = True
-iterHLTTracksMonitoringHLT.doEffFromHitPatternVsBX   = True
-iterHLTTracksMonitoringHLT.doEffFromHitPatternVsLUMI = True
-iterHLTTracksMonitoringHLT.doDCAPlots                = True
-iterHLTTracksMonitoringHLT.doPVPlots                 = cms.bool(True)
-iterHLTTracksMonitoringHLT.doBSPlots                 = cms.bool(True)
-iterHLTTracksMonitoringHLT.doSIPPlots                = cms.bool(True)
-
-iter3TracksMonitoringHLT = trackingMonHLT.clone()
-iter3TracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter3Merged'
-iter3TracksMonitoringHLT.TrackProducer    = 'hltIter3Merged'
-iter3TracksMonitoringHLT.allTrackProducer = 'hltIter3Merged'
-
-iter4TracksMonitoringHLT = trackingMonHLT.clone()
-iter4TracksMonitoringHLT.FolderName       = 'HLT/Tracking/iter4Merged'
-iter4TracksMonitoringHLT.TrackProducer    = 'hltIter4Merged'
-iter4TracksMonitoringHLT.allTrackProducer = 'hltIter4Merged'
-
+trackingMonHLT = DQM.TrackingMonitor.TrackerCollisionTrackingMonitor_cfi.TrackerCollisionTrackMon.clone(
+    beamSpot                = "hltOnlineBeamSpot",
+    primaryVertex           = "hltPixelVertices",
+    doAllPlots              = False,
+    doLumiAnalysis          = False,     
+    #doProfilesVsLS          = True,
+    doDCAPlots              = True,
+    pvNDOF                  = 1,
+    doProfilesVsLS          = True,
+    #doPlotsVsGoodPVtx       = True,
+    doEffFromHitPatternVsPU = True,
+    doEffFromHitPatternVsBX = True,
+    doEffFromHitPatternVsLUMI = True,
+    doPlotsVsGoodPVtx       = True,
+    doPlotsVsLUMI           = True,
+    doPlotsVsBX             = True
+)
+pixelTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/pixelTracks',
+    TrackProducer    = 'hltPixelTracks',
+    allTrackProducer = 'hltPixelTracks',
+    doEffFromHitPatternVsPU   = False,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+iter0TracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/iter0',
+    TrackProducer    = 'hltIter0PFlowCtfWithMaterialTracks',
+    allTrackProducer = 'hltIter0PFlowCtfWithMaterialTracks',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+iter0HPTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/iter0HP',
+    TrackProducer    = 'hltIter0PFlowTrackSelectionHighPurity',
+    allTrackProducer = 'hltIter0PFlowTrackSelectionHighPurity',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+iter1TracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/iter1',
+    TrackProducer    = 'hltIter1PFlowCtfWithMaterialTracks',
+    allTrackProducer = 'hltIter1PFlowCtfWithMaterialTracks',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+iter1HPTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/iter1HP',
+    TrackProducer    = 'hltIter1PFlowTrackSelectionHighPurity',
+    allTrackProducer = 'hltIter1PFlowTrackSelectionHighPurity',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+iter2TracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/iter2',
+    TrackProducer    = 'hltIter2PFlowCtfWithMaterialTracks',
+    allTrackProducer = 'hltIter2PFlowCtfWithMaterialTracks',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+iter2HPTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/iter2HP',
+    TrackProducer    = 'hltIter2PFlowTrackSelectionHighPurity',
+    allTrackProducer = 'hltIter2PFlowTrackSelectionHighPurity',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+iter2MergedTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/iter2Merged',
+    TrackProducer    = 'hltIter2Merged',
+    allTrackProducer = 'hltIter2Merged',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False
+)
+iterHLTTracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/tracks',
+    TrackProducer    = 'hltMergedTracks',
+    allTrackProducer = 'hltMergedTracks',
+    doEffFromHitPatternVsPU   = True,
+    doEffFromHitPatternVsBX   = True,
+    doEffFromHitPatternVsLUMI = True,
+    doDCAPlots                = True,
+    doPVPlots                 = cms.bool(True),
+    doBSPlots                 = cms.bool(True),
+    doSIPPlots                = cms.bool(True)
+)
+iter3TracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/iter3Merged',
+    TrackProducer    = 'hltIter3Merged',
+    allTrackProducer = 'hltIter3Merged'
+)
+iter4TracksMonitoringHLT = trackingMonHLT.clone(
+    FolderName       = 'HLT/Tracking/iter4Merged',
+    TrackProducer    = 'hltIter4Merged',
+    allTrackProducer = 'hltIter4Merged'
+)
 trackingMonitorHLT = cms.Sequence(
     pixelTracksMonitoringHLT
     + iter0HPTracksMonitoringHLT
@@ -133,62 +133,62 @@ trackingMonitorHLTall = cms.Sequence(
 # Iter0: process.hltIter0ElectronsTrackSelectionHighPurity
 # Iter1HP: hltIter1MergedForElectrons
 # Iter2HP: hltIter2MergedForElectrons
-egmTrackingMonHLT = trackingMonHLT.clone()
-egmTrackingMonHLT.primaryVertex = cms.InputTag("hltElectronsVertex")
-egmTrackingMonHLT.doEffFromHitPatternVsPU   = False
-egmTrackingMonHLT.doEffFromHitPatternVsBX   = False
-egmTrackingMonHLT.doEffFromHitPatternVsLUMI = False 
-
-gsfTracksMonitoringHLT = egmTrackingMonHLT.clone()
-gsfTracksMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/GSF'
-gsfTracksMonitoringHLT.TrackProducer    = 'hltEgammaGsfTracks'
-gsfTracksMonitoringHLT.allTrackProducer = 'hltEgammaGsfTracks'
-
-pixelTracksForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone()
-pixelTracksForElectronsTracksMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/pixelTracks'
-pixelTracksForElectronsTracksMonitoringHLT.TrackProducer    = 'hltPixelTracksElectrons'
-pixelTracksForElectronsTracksMonitoringHLT.allTrackProducer = 'hltPixelTracksElectrons'
-
-iter0ForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone()
-iter0ForElectronsTracksMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/iter0'
-iter0ForElectronsTracksMonitoringHLT.TrackProducer    = 'hltIter0ElectronsCtfWithMaterialTracks'
-iter0ForElectronsTracksMonitoringHLT.allTrackProducer = 'hltIter0ElectronsCtfWithMaterialTracks'
-
-iter0HPForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone()
-iter0HPForElectronsTracksMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/iter0HP'
-iter0HPForElectronsTracksMonitoringHLT.TrackProducer    = 'hltIter0ElectronsTrackSelectionHighPurity'
-iter0HPForElectronsTracksMonitoringHLT.allTrackProducer = 'hltIter0ElectronsTrackSelectionHighPurity'
-
-iter1ForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone()
-iter1ForElectronsTracksMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/iter1'
-iter1ForElectronsTracksMonitoringHLT.TrackProducer    = 'hltIter1ElectronsCtfWithMaterialTracks'
-iter1ForElectronsTracksMonitoringHLT.allTrackProducer = 'hltIter1ElectronsCtfWithMaterialTracks'
-
-iter1HPForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone()
-iter1HPForElectronsTracksMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/iter1HP'
-iter1HPForElectronsTracksMonitoringHLT.TrackProducer    = 'hltIter1ElectronsTrackSelectionHighPurity'
-iter1HPForElectronsTracksMonitoringHLT.allTrackProducer = 'hltIter1ElectronsTrackSelectionHighPurity'
-
-iter1MergedForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone()
-iter1MergedForElectronsTracksMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/iter1Merged'
-iter1MergedForElectronsTracksMonitoringHLT.TrackProducer    = 'hltIter1MergedForElectrons'
-iter1MergedForElectronsTracksMonitoringHLT.allTrackProducer = 'hltIter1MergedForElectrons'
-
-iter2ForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone()
-iter2ForElectronsTracksMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/iter2'
-iter2ForElectronsTracksMonitoringHLT.TrackProducer    = 'hltIter2ElectronsCtfWithMaterialTracks'
-iter2ForElectronsTracksMonitoringHLT.allTrackProducer = 'hltIter2ElectronsCtfWithMaterialTracks'
-
-iter2HPForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone()
-iter2HPForElectronsTracksMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/iter2HP'
-iter2HPForElectronsTracksMonitoringHLT.TrackProducer    = 'hltIter2ElectronsTrackSelectionHighPurity'
-iter2HPForElectronsTracksMonitoringHLT.allTrackProducer = 'hltIter2ElectronsTrackSelectionHighPurity'
-
-iterHLTTracksForElectronsMonitoringHLT = egmTrackingMonHLT.clone()
-iterHLTTracksForElectronsMonitoringHLT.FolderName       = 'HLT/EGM/Tracking/iter2Merged'
-iterHLTTracksForElectronsMonitoringHLT.TrackProducer    = 'hltIter2MergedForElectrons'
-iterHLTTracksForElectronsMonitoringHLT.allTrackProducer = 'hltIter2MergedForElectrons'
- 
+egmTrackingMonHLT = trackingMonHLT.clone(
+    primaryVertex = "hltElectronsVertex",
+    doEffFromHitPatternVsPU   = False,
+    doEffFromHitPatternVsBX   = False,
+    doEffFromHitPatternVsLUMI = False 
+)
+gsfTracksMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/GSF',
+    TrackProducer    = 'hltEgammaGsfTracks',
+    allTrackProducer = 'hltEgammaGsfTracks'
+)
+pixelTracksForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/pixelTracks',
+    TrackProducer    = 'hltPixelTracksElectrons',
+    allTrackProducer = 'hltPixelTracksElectrons'
+)
+iter0ForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/iter0',
+    TrackProducer    = 'hltIter0ElectronsCtfWithMaterialTracks',
+    allTrackProducer = 'hltIter0ElectronsCtfWithMaterialTracks'
+)
+iter0HPForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/iter0HP',
+    TrackProducer    = 'hltIter0ElectronsTrackSelectionHighPurity',
+    allTrackProducer = 'hltIter0ElectronsTrackSelectionHighPurity'
+)
+iter1ForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/iter1',
+    TrackProducer    = 'hltIter1ElectronsCtfWithMaterialTracks',
+    allTrackProducer = 'hltIter1ElectronsCtfWithMaterialTracks'
+)
+iter1HPForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/iter1HP',
+    TrackProducer    = 'hltIter1ElectronsTrackSelectionHighPurity',
+    allTrackProducer = 'hltIter1ElectronsTrackSelectionHighPurity'
+)
+iter1MergedForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/iter1Merged',
+    TrackProducer    = 'hltIter1MergedForElectrons',
+    allTrackProducer = 'hltIter1MergedForElectrons'
+)
+iter2ForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/iter2',
+    TrackProducer    = 'hltIter2ElectronsCtfWithMaterialTracks',
+    allTrackProducer = 'hltIter2ElectronsCtfWithMaterialTracks'
+)
+iter2HPForElectronsTracksMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/iter2HP',
+    TrackProducer    = 'hltIter2ElectronsTrackSelectionHighPurity',
+    allTrackProducer = 'hltIter2ElectronsTrackSelectionHighPurity'
+)
+iterHLTTracksForElectronsMonitoringHLT = egmTrackingMonHLT.clone(
+    FolderName       = 'HLT/EGM/Tracking/iter2Merged',
+    TrackProducer    = 'hltIter2MergedForElectrons',
+    allTrackProducer = 'hltIter2MergedForElectrons'
+)
 
 egmTrackingMonitorHLT = cms.Sequence(
     gsfTracksMonitoringHLT

--- a/DQMOffline/Trigger/python/VBFMETMonitor_cff.py
+++ b/DQMOffline/Trigger/python/VBFMETMonitor_cff.py
@@ -3,22 +3,20 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.ObjMonitor_cfi import hltobjmonitoring
 
 # HLT_
-DiJetVBFmonitoring = hltobjmonitoring.clone()
-#DiJetVBFmonitoring.FolderName = cms.string('HLT/Higgs/VBFMET/DiJet/')
-DiJetVBFmonitoring.FolderName = cms.string('HLT/HIG/VBFMET/DiJet/')
-DiJetVBFmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults","","HLT" )
-DiJetVBFmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DiJet110_35_Mjj650_PFMET110_v*","HLT_DiJet110_35_Mjj650_PFMET120_v*","HLT_DiJet110_35_Mjj650_PFMET130_v*")
-DiJetVBFmonitoring.jetSelection = cms.string("pt>40 & abs(eta)<4.7")
-DiJetVBFmonitoring.jetId = cms.string("loose")
-DiJetVBFmonitoring.njets = cms.int32(2)
-#DiJetVBFmonitoring.enableMETPlot = True
-#DiJetVBFmonitoring.metSelection = cms.string("pt>150")
-
-TripleJetVBFmonitoring = DiJetVBFmonitoring.clone()
-#TripleJetVBFmonitoring.FolderName = cms.string('HLT/Higgs/VBFMET/TripleJet/')
-TripleJetVBFmonitoring.FolderName = cms.string('HLT/HIG/VBFMET/TripleJet/')
-TripleJetVBFmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TripleJet110_35_35_Mjj650_PFMET110_v*","HLT_TripleJet110_35_35_Mjj650_PFMET120_v*","HLT_TripleJet110_35_35_Mjj650_PFMET130_v*")
-
+DiJetVBFmonitoring = hltobjmonitoring.clone(
+    FolderName = 'HLT/HIG/VBFMET/DiJet/',
+    numGenericTriggerEventPSet = dict(hltInputTag   = "TriggerResults::HLT",
+                                      hltPaths = ["HLT_DiJet110_35_Mjj650_PFMET110_v*","HLT_DiJet110_35_Mjj650_PFMET120_v*","HLT_DiJet110_35_Mjj650_PFMET130_v*"]),
+    jetSelection = "pt>40 & abs(eta)<4.7",
+    jetId = "loose",
+    njets = 2
+    #enableMETPlot = True
+    #metSelection = "pt>150",
+)
+TripleJetVBFmonitoring = DiJetVBFmonitoring.clone(
+    FolderName = 'HLT/HIG/VBFMET/TripleJet/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TripleJet110_35_35_Mjj650_PFMET110_v*","HLT_TripleJet110_35_35_Mjj650_PFMET120_v*","HLT_TripleJet110_35_35_Mjj650_PFMET130_v*"])
+)
 higgsinvHLTJetMETmonitoring = cms.Sequence(
     DiJetVBFmonitoring
     *TripleJetVBFmonitoring

--- a/DQMOffline/Trigger/python/VBFSUSYMonitor_cff.py
+++ b/DQMOffline/Trigger/python/VBFSUSYMonitor_cff.py
@@ -3,17 +3,17 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.ObjMonitor_cfi import hltobjmonitoring
 
 # HLT_Mu8_TrkIsoVVL_DiPFJet40_DEta3p5_MJJ750_HTT300_PFMETNoMu60_v* and 
-VBFSUSYmonitoring = hltobjmonitoring.clone()
-VBFSUSYmonitoring.FolderName = cms.string('HLT/SUSY/VBF/DiJet/')
-VBFSUSYmonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults","","HLT" )
-VBFSUSYmonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu8_TrkIsoVVL_DiPFJet40_DEta3p5_MJJ750_HTT300_PFMETNoMu60_v*","HLT_Mu10_TrkIsoVVL_DiPFJet40_DEta3p5_MJJ750_HTT350_PFMETNoMu60_v*")
-VBFSUSYmonitoring.jetSelection = cms.string("pt>40 & abs(eta)<5.0")
-VBFSUSYmonitoring.jetId = cms.string("loose")
-VBFSUSYmonitoring.njets = cms.int32(2)
-#VBFSUSYmonitoring.enableMETPlot = True
-#VBFSUSYmonitoring.metSelection = cms.string("pt>50")
-VBFSUSYmonitoring.htjetSelection = cms.string("pt>30 & abs(eta)<5.0")
-
+VBFSUSYmonitoring = hltobjmonitoring.clone(
+    FolderName = 'HLT/SUSY/VBF/DiJet/',
+    numGenericTriggerEventPSet = dict(hltInputTag = "TriggerResults::HLT" ,
+                                  hltPaths = ["HLT_Mu8_TrkIsoVVL_DiPFJet40_DEta3p5_MJJ750_HTT300_PFMETNoMu60_v*","HLT_Mu10_TrkIsoVVL_DiPFJet40_DEta3p5_MJJ750_HTT350_PFMETNoMu60_v*"]),
+    jetSelection = "pt>40 & abs(eta)<5.0",
+    jetId = "loose",
+    njets = 2,
+    #enableMETPlot = True,
+    #metSelection = "pt>50",
+    htjetSelection = "pt>30 & abs(eta)<5.0"
+)
 susyHLTVBFMonitoring = cms.Sequence(
     VBFSUSYmonitoring
 )

--- a/DQMOffline/Trigger/python/VBFTauMonitor_cff.py
+++ b/DQMOffline/Trigger/python/VBFTauMonitor_cff.py
@@ -3,24 +3,20 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.ObjMonitor_cfi import hltobjmonitoring
 
 # HLT_
-VBFtaumonitoring = hltobjmonitoring.clone()
+VBFtaumonitoring = hltobjmonitoring.clone(
 
-#VBFtaumonitoring.FolderName = cms.string('HLT/Higgs/VBFTau')
-VBFtaumonitoring.FolderName = cms.string('HLT/HIG/VBFTau')
-VBFtaumonitoring.numGenericTriggerEventPSet.hltInputTag   = cms.InputTag( "TriggerResults","","HLT" )
-VBFtaumonitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring(
-  "HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v*",
-  "HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v*",
-  "HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v*"
+    #FolderName = 'HLT/Higgs/VBFTau',
+    FolderName = 'HLT/HIG/VBFTau',
+    numGenericTriggerEventPSet = dict(hltInputTag   = "TriggerResults::HLT",
+                                    hltPaths = ["HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v*",
+                                                "HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v*",
+                                                "HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v*"]),
+    jetSelection = "pt>40 & abs(eta)<4.7",
+    jetId = "loose",
+    njets = 2,
+
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMediumChargedIsoPFTau35_Trk1_eta2p1_Reg_v*"])
 )
-VBFtaumonitoring.jetSelection = cms.string("pt>40 & abs(eta)<4.7")
-VBFtaumonitoring.jetId = cms.string("loose")
-VBFtaumonitoring.njets = cms.int32(2)
-
-VBFtaumonitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring(
-  "HLT_DoubleMediumChargedIsoPFTau35_Trk1_eta2p1_Reg_v*"
-)
-
 higgstautauHLTVBFmonitoring = cms.Sequence(
   VBFtaumonitoring
 )

--- a/DQMOffline/Trigger/python/susyHLTEleCaloJets_cff.py
+++ b/DQMOffline/Trigger/python/susyHLTEleCaloJets_cff.py
@@ -3,294 +3,294 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Trigger.SusyMonitor_cfi import hltSUSYmonitoring
 
 #This is added by Pablo in order to monitor the auxiliary paths for electron fake rate calculation
-susyEle8CaloJet30_jet = hltSUSYmonitoring.clone()
-susyEle8CaloJet30_jet.FolderName = cms.string('HLT/SUSY/Ele8CaloJet30/JetMonitor')
-susyEle8CaloJet30_jet.nmuons = cms.uint32(0)
-susyEle8CaloJet30_jet.nelectrons = cms.uint32(1)
-susyEle8CaloJet30_jet.njets = cms.uint32(1)
-susyEle8CaloJet30_jet.eleSelection = cms.string('pt>50 & abs(eta)<2.4')
-susyEle8CaloJet30_jet.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle8CaloJet30_jet.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle8CaloJet30_jet.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle8CaloJet30_jet.histoPSet.elePtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle8CaloJet30_jet.histoPSet.elePtBinning2D = cms.vdouble(0,50,70,120,200,400)
-susyEle8CaloJet30_jet.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle8CaloJet30_jet.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle8CaloJet30_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele8_CaloIdL_TrackIdL_IsoVL_PFJet30_v*')
-susyEle8CaloJet30_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*')
-
-susyEle8CaloJet30_ele = hltSUSYmonitoring.clone()
-susyEle8CaloJet30_ele.FolderName = cms.string('HLT/SUSY/Ele8CaloJet30/ElectronMonitor')
-susyEle8CaloJet30_ele.nmuons = cms.uint32(0)
-susyEle8CaloJet30_ele.nelectrons = cms.uint32(1)
-susyEle8CaloJet30_ele.njets = cms.uint32(1)
-susyEle8CaloJet30_ele.eleSelection = cms.string('pt>10 & abs(eta)<2.4')
-susyEle8CaloJet30_ele.jetSelection = cms.string('pt>80 & abs(eta)<2.4')
-susyEle8CaloJet30_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle8CaloJet30_ele.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle8CaloJet30_ele.histoPSet.elePtBinning = cms.vdouble(0,10,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle8CaloJet30_ele.histoPSet.elePtBinning2D = cms.vdouble(0,10,25,30,40,50,60,80,100,200,400)
-susyEle8CaloJet30_ele.histoPSet.jetPtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle8CaloJet30_ele.histoPSet.jetPtBinning2D = cms.vdouble(0,50,60,80,100,200,400)
-susyEle8CaloJet30_ele.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele8_CaloIdL_TrackIdL_IsoVL_PFJet30_v*')
-susyEle8CaloJet30_ele.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet60_v*')
-
-susyEle8CaloJet30_all = hltSUSYmonitoring.clone()
-susyEle8CaloJet30_all.FolderName = cms.string('HLT/SUSY/Ele8CaloJet30/GlobalMonitor')
-susyEle8CaloJet30_all.nmuons = cms.uint32(0)
-susyEle8CaloJet30_all.nelectrons = cms.uint32(1)
-susyEle8CaloJet30_all.njets = cms.uint32(1)
-susyEle8CaloJet30_all.eleSelection = cms.string('pt>10 & abs(eta)<2.4')
-susyEle8CaloJet30_all.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle8CaloJet30_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle8CaloJet30_all.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle8CaloJet30_all.histoPSet.elePtBinning = cms.vdouble(0,10,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle8CaloJet30_all.histoPSet.elePtBinning2D = cms.vdouble(0,10,25,30,40,50,60,80,100,200,400)
-susyEle8CaloJet30_all.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle8CaloJet30_all.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle8CaloJet30_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele8_CaloIdL_TrackIdL_IsoVL_PFJet30_v*')
-# susyEle8CaloJet30_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_v*')
-
-susyEle8CaloIdMJet30_jet = hltSUSYmonitoring.clone()
-susyEle8CaloIdMJet30_jet.FolderName = cms.string('HLT/SUSY/Ele8CaloIdMJet30/JetMonitor')
-susyEle8CaloIdMJet30_jet.nmuons = cms.uint32(0)
-susyEle8CaloIdMJet30_jet.nelectrons = cms.uint32(1)
-susyEle8CaloIdMJet30_jet.njets = cms.uint32(1)
-susyEle8CaloIdMJet30_jet.eleSelection = cms.string('pt>50 & abs(eta)<2.4')
-susyEle8CaloIdMJet30_jet.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle8CaloIdMJet30_jet.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle8CaloIdMJet30_jet.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle8CaloIdMJet30_jet.histoPSet.elePtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle8CaloIdMJet30_jet.histoPSet.elePtBinning2D = cms.vdouble(0,50,70,120,200,400)
-susyEle8CaloIdMJet30_jet.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle8CaloIdMJet30_jet.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle8CaloIdMJet30_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele8_CaloIdM_TrackIdM_PFJet30_v*')
-susyEle8CaloIdMJet30_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*')
-
-susyEle8CaloIdMJet30_ele = hltSUSYmonitoring.clone()
-susyEle8CaloIdMJet30_ele.FolderName = cms.string('HLT/SUSY/Ele8CaloIdMJet30/ElectronMonitor')
-susyEle8CaloIdMJet30_ele.nmuons = cms.uint32(0)
-susyEle8CaloIdMJet30_ele.nelectrons = cms.uint32(1)
-susyEle8CaloIdMJet30_ele.njets = cms.uint32(1)
-susyEle8CaloIdMJet30_ele.eleSelection = cms.string('pt>10 & abs(eta)<2.4')
-susyEle8CaloIdMJet30_ele.jetSelection = cms.string('pt>80 & abs(eta)<2.4')
-susyEle8CaloIdMJet30_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle8CaloIdMJet30_ele.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle8CaloIdMJet30_ele.histoPSet.elePtBinning = cms.vdouble(0,10,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle8CaloIdMJet30_ele.histoPSet.elePtBinning2D = cms.vdouble(0,10,25,30,40,50,60,80,100,200,400)
-susyEle8CaloIdMJet30_ele.histoPSet.jetPtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle8CaloIdMJet30_ele.histoPSet.jetPtBinning2D = cms.vdouble(0,50,60,80,100,200,400)
-susyEle8CaloIdMJet30_ele.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele8_CaloIdM_TrackIdM_PFJet30_v*')
-susyEle8CaloIdMJet30_ele.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet60_v*')
-
-susyEle8CaloIdMJet30_all = hltSUSYmonitoring.clone()
-susyEle8CaloIdMJet30_all.FolderName = cms.string('HLT/SUSY/Ele8CaloIdMJet30/GlobalMonitor')
-susyEle8CaloIdMJet30_all.nmuons = cms.uint32(0)
-susyEle8CaloIdMJet30_all.nelectrons = cms.uint32(1)
-susyEle8CaloIdMJet30_all.njets = cms.uint32(1)
-susyEle8CaloIdMJet30_all.eleSelection = cms.string('pt>10 & abs(eta)<2.4')
-susyEle8CaloIdMJet30_all.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle8CaloIdMJet30_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle8CaloIdMJet30_all.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle8CaloIdMJet30_all.histoPSet.elePtBinning = cms.vdouble(0,10,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle8CaloIdMJet30_all.histoPSet.elePtBinning2D = cms.vdouble(0,10,25,30,40,50,60,80,100,200,400)
-susyEle8CaloIdMJet30_all.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle8CaloIdMJet30_all.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle8CaloIdMJet30_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele8_CaloIdM_TrackIdM_PFJet30_v*')
-# susyEle8CaloIdMJet30_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_v*')
-
-susyEle12CaloJet30_jet = hltSUSYmonitoring.clone()
-susyEle12CaloJet30_jet.FolderName = cms.string('HLT/SUSY/Ele12CaloJet30/JetMonitor')
-susyEle12CaloJet30_jet.nmuons = cms.uint32(0)
-susyEle12CaloJet30_jet.nelectrons = cms.uint32(1)
-susyEle12CaloJet30_jet.njets = cms.uint32(1)
-susyEle12CaloJet30_jet.eleSelection = cms.string('pt>50 & abs(eta)<2.4')
-susyEle12CaloJet30_jet.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle12CaloJet30_jet.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle12CaloJet30_jet.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle12CaloJet30_jet.histoPSet.elePtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle12CaloJet30_jet.histoPSet.elePtBinning2D = cms.vdouble(0,50,70,120,200,400)
-susyEle12CaloJet30_jet.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle12CaloJet30_jet.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle12CaloJet30_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele12_CaloIdL_TrackIdL_IsoVL_PFJet30_v*')
-susyEle12CaloJet30_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*')
-
-susyEle12CaloJet30_ele = hltSUSYmonitoring.clone()
-susyEle12CaloJet30_ele.FolderName = cms.string('HLT/SUSY/Ele12CaloJet30/ElectronMonitor')
-susyEle12CaloJet30_ele.nmuons = cms.uint32(0)
-susyEle12CaloJet30_ele.nelectrons = cms.uint32(1)
-susyEle12CaloJet30_ele.njets = cms.uint32(1)
-susyEle12CaloJet30_ele.eleSelection = cms.string('pt>14 & abs(eta)<2.4')
-susyEle12CaloJet30_ele.jetSelection = cms.string('pt>80 & abs(eta)<2.4')
-susyEle12CaloJet30_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle12CaloJet30_ele.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle12CaloJet30_ele.histoPSet.elePtBinning = cms.vdouble(0,12,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle12CaloJet30_ele.histoPSet.elePtBinning2D = cms.vdouble(0,12,25,30,40,50,60,80,100,200,400)
-susyEle12CaloJet30_ele.histoPSet.jetPtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle12CaloJet30_ele.histoPSet.jetPtBinning2D = cms.vdouble(0,50,60,80,100,200,400)
-susyEle12CaloJet30_ele.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele12_CaloIdL_TrackIdL_IsoVL_PFJet30_v*')
-susyEle12CaloJet30_ele.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet60_v*')
-
-susyEle12CaloJet30_all = hltSUSYmonitoring.clone()
-susyEle12CaloJet30_all.FolderName = cms.string('HLT/SUSY/Ele12CaloJet30/GlobalMonitor')
-susyEle12CaloJet30_all.nmuons = cms.uint32(0)
-susyEle12CaloJet30_all.nelectrons = cms.uint32(1)
-susyEle12CaloJet30_all.njets = cms.uint32(1)
-susyEle12CaloJet30_all.eleSelection = cms.string('pt>14 & abs(eta)<2.4')
-susyEle12CaloJet30_all.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle12CaloJet30_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle12CaloJet30_all.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle12CaloJet30_all.histoPSet.elePtBinning = cms.vdouble(0,12,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle12CaloJet30_all.histoPSet.elePtBinning2D = cms.vdouble(0,12,25,30,40,50,60,80,100,200,400)
-susyEle12CaloJet30_all.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle12CaloJet30_all.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle12CaloJet30_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele12_CaloIdL_TrackIdL_IsoVL_PFJet30_v*')
-# susyEle12CaloJet30_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_v*')
-
-susyEle17CaloIdMJet30_jet = hltSUSYmonitoring.clone()
-susyEle17CaloIdMJet30_jet.FolderName = cms.string('HLT/SUSY/Ele17CaloIdMJet30/JetMonitor')
-susyEle17CaloIdMJet30_jet.nmuons = cms.uint32(0)
-susyEle17CaloIdMJet30_jet.nelectrons = cms.uint32(1)
-susyEle17CaloIdMJet30_jet.njets = cms.uint32(1)
-susyEle17CaloIdMJet30_jet.eleSelection = cms.string('pt>50 & abs(eta)<2.4')
-susyEle17CaloIdMJet30_jet.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle17CaloIdMJet30_jet.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle17CaloIdMJet30_jet.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle17CaloIdMJet30_jet.histoPSet.elePtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle17CaloIdMJet30_jet.histoPSet.elePtBinning2D = cms.vdouble(0,50,70,120,200,400)
-susyEle17CaloIdMJet30_jet.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle17CaloIdMJet30_jet.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle17CaloIdMJet30_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele17_CaloIdM_TrackIdM_PFJet30_v*')
-susyEle17CaloIdMJet30_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*')
-
-susyEle17CaloIdMJet30_ele = hltSUSYmonitoring.clone()
-susyEle17CaloIdMJet30_ele.FolderName = cms.string('HLT/SUSY/Ele17CaloIdMJet30/ElectronMonitor')
-susyEle17CaloIdMJet30_ele.nmuons = cms.uint32(0)
-susyEle17CaloIdMJet30_ele.nelectrons = cms.uint32(1)
-susyEle17CaloIdMJet30_ele.njets = cms.uint32(1)
-susyEle17CaloIdMJet30_ele.eleSelection = cms.string('pt>19 & abs(eta)<2.4')
-susyEle17CaloIdMJet30_ele.jetSelection = cms.string('pt>80 & abs(eta)<2.4')
-susyEle17CaloIdMJet30_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle17CaloIdMJet30_ele.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle17CaloIdMJet30_ele.histoPSet.elePtBinning = cms.vdouble(0,19,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle17CaloIdMJet30_ele.histoPSet.elePtBinning2D = cms.vdouble(0,19,25,30,40,50,60,80,100,200,400)
-susyEle17CaloIdMJet30_ele.histoPSet.jetPtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle17CaloIdMJet30_ele.histoPSet.jetPtBinning2D = cms.vdouble(0,50,60,80,100,200,400)
-susyEle17CaloIdMJet30_ele.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele17_CaloIdM_TrackIdM_PFJet30_v*')
-susyEle17CaloIdMJet30_ele.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet60_v*')
-
-susyEle17CaloIdMJet30_all = hltSUSYmonitoring.clone()
-susyEle17CaloIdMJet30_all.FolderName = cms.string('HLT/SUSY/Ele17CaloIdMJet30/GlobalMonitor')
-susyEle17CaloIdMJet30_all.nmuons = cms.uint32(0)
-susyEle17CaloIdMJet30_all.nelectrons = cms.uint32(1)
-susyEle17CaloIdMJet30_all.njets = cms.uint32(1)
-susyEle17CaloIdMJet30_all.eleSelection = cms.string('pt>19 & abs(eta)<2.4')
-susyEle17CaloIdMJet30_all.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle17CaloIdMJet30_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle17CaloIdMJet30_all.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle17CaloIdMJet30_all.histoPSet.elePtBinning = cms.vdouble(0,19,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle17CaloIdMJet30_all.histoPSet.elePtBinning2D = cms.vdouble(0,19,25,30,40,50,60,80,100,200,400)
-susyEle17CaloIdMJet30_all.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle17CaloIdMJet30_all.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle17CaloIdMJet30_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele17_CaloIdM_TrackIdM_PFJet30_v*')
-# susyEle17CaloIdMJet30_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_v*')
-
-susyEle23CaloJet30_jet = hltSUSYmonitoring.clone()
-susyEle23CaloJet30_jet.FolderName = cms.string('HLT/SUSY/Ele23CaloJet30/JetMonitor')
-susyEle23CaloJet30_jet.nmuons = cms.uint32(0)
-susyEle23CaloJet30_jet.nelectrons = cms.uint32(1)
-susyEle23CaloJet30_jet.njets = cms.uint32(1)
-susyEle23CaloJet30_jet.eleSelection = cms.string('pt>50 & abs(eta)<2.4')
-susyEle23CaloJet30_jet.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle23CaloJet30_jet.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle23CaloJet30_jet.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle23CaloJet30_jet.histoPSet.elePtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle23CaloJet30_jet.histoPSet.elePtBinning2D = cms.vdouble(0,50,70,120,200,400)
-susyEle23CaloJet30_jet.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle23CaloJet30_jet.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle23CaloJet30_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele23_CaloIdL_TrackIdL_IsoVL_PFJet30_v*')
-susyEle23CaloJet30_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*')
-
-susyEle23CaloJet30_ele = hltSUSYmonitoring.clone()
-susyEle23CaloJet30_ele.FolderName = cms.string('HLT/SUSY/Ele23CaloJet30/ElectronMonitor')
-susyEle23CaloJet30_ele.nmuons = cms.uint32(0)
-susyEle23CaloJet30_ele.nelectrons = cms.uint32(1)
-susyEle23CaloJet30_ele.njets = cms.uint32(1)
-susyEle23CaloJet30_ele.eleSelection = cms.string('pt>25 & abs(eta)<2.4')
-susyEle23CaloJet30_ele.jetSelection = cms.string('pt>80 & abs(eta)<2.4')
-susyEle23CaloJet30_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle23CaloJet30_ele.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle23CaloJet30_ele.histoPSet.elePtBinning = cms.vdouble(0,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle23CaloJet30_ele.histoPSet.elePtBinning2D = cms.vdouble(0,25,30,40,50,60,80,100,200,400)
-susyEle23CaloJet30_ele.histoPSet.jetPtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle23CaloJet30_ele.histoPSet.jetPtBinning2D = cms.vdouble(0,50,60,80,100,200,400)
-susyEle23CaloJet30_ele.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele23_CaloIdL_TrackIdL_IsoVL_PFJet30_v*')
-susyEle23CaloJet30_ele.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet60_v*')
-
-susyEle23CaloJet30_all = hltSUSYmonitoring.clone()
-susyEle23CaloJet30_all.FolderName = cms.string('HLT/SUSY/Ele23CaloJet30/GlobalMonitor')
-susyEle23CaloJet30_all.nmuons = cms.uint32(0)
-susyEle23CaloJet30_all.nelectrons = cms.uint32(1)
-susyEle23CaloJet30_all.njets = cms.uint32(1)
-susyEle23CaloJet30_all.eleSelection = cms.string('pt>14 & abs(eta)<2.4')
-susyEle23CaloJet30_all.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle23CaloJet30_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle23CaloJet30_all.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle23CaloJet30_all.histoPSet.elePtBinning = cms.vdouble(0,12,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle23CaloJet30_all.histoPSet.elePtBinning2D = cms.vdouble(0,12,25,30,40,50,60,80,100,200,400)
-susyEle23CaloJet30_all.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle23CaloJet30_all.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle23CaloJet30_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele23_CaloIdL_TrackIdL_IsoVL_PFJet30_v*')
-# susyEle23CaloJet30_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_v*')
-
-susyEle23CaloIdMJet30_jet = hltSUSYmonitoring.clone()
-susyEle23CaloIdMJet30_jet.FolderName = cms.string('HLT/SUSY/Ele23CaloIdMJet30/JetMonitor')
-susyEle23CaloIdMJet30_jet.nmuons = cms.uint32(0)
-susyEle23CaloIdMJet30_jet.nelectrons = cms.uint32(1)
-susyEle23CaloIdMJet30_jet.njets = cms.uint32(1)
-susyEle23CaloIdMJet30_jet.eleSelection = cms.string('pt>50 & abs(eta)<2.4')
-susyEle23CaloIdMJet30_jet.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle23CaloIdMJet30_jet.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle23CaloIdMJet30_jet.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle23CaloIdMJet30_jet.histoPSet.elePtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle23CaloIdMJet30_jet.histoPSet.elePtBinning2D = cms.vdouble(0,50,70,120,200,400)
-susyEle23CaloIdMJet30_jet.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle23CaloIdMJet30_jet.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle23CaloIdMJet30_jet.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele23_CaloIdM_TrackIdM_PFJet30_v*')
-susyEle23CaloIdMJet30_jet.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*')
-
-susyEle23CaloIdMJet30_ele = hltSUSYmonitoring.clone()
-susyEle23CaloIdMJet30_ele.FolderName = cms.string('HLT/SUSY/Ele23CaloIdMJet30/ElectronMonitor')
-susyEle23CaloIdMJet30_ele.nmuons = cms.uint32(0)
-susyEle23CaloIdMJet30_ele.nelectrons = cms.uint32(1)
-susyEle23CaloIdMJet30_ele.njets = cms.uint32(1)
-susyEle23CaloIdMJet30_ele.eleSelection = cms.string('pt>25 & abs(eta)<2.4')
-susyEle23CaloIdMJet30_ele.jetSelection = cms.string('pt>80 & abs(eta)<2.4')
-susyEle23CaloIdMJet30_ele.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle23CaloIdMJet30_ele.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle23CaloIdMJet30_ele.histoPSet.elePtBinning = cms.vdouble(0,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle23CaloIdMJet30_ele.histoPSet.elePtBinning2D = cms.vdouble(0,25,30,40,50,60,80,100,200,400)
-susyEle23CaloIdMJet30_ele.histoPSet.jetPtBinning = cms.vdouble(0,50,60,80,120,200,400)
-susyEle23CaloIdMJet30_ele.histoPSet.jetPtBinning2D = cms.vdouble(0,50,60,80,100,200,400)
-susyEle23CaloIdMJet30_ele.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele23_CaloIdM_TrackIdM_PFJet30_v*')
-susyEle23CaloIdMJet30_ele.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_PFJet60_v*')
-
-susyEle23CaloIdMJet30_all = hltSUSYmonitoring.clone()
-susyEle23CaloIdMJet30_all.FolderName = cms.string('HLT/SUSY/Ele23CaloIdMJet30/GlobalMonitor')
-susyEle23CaloIdMJet30_all.nmuons = cms.uint32(0)
-susyEle23CaloIdMJet30_all.nelectrons = cms.uint32(1)
-susyEle23CaloIdMJet30_all.njets = cms.uint32(1)
-susyEle23CaloIdMJet30_all.eleSelection = cms.string('pt>14 & abs(eta)<2.4')
-susyEle23CaloIdMJet30_all.jetSelection = cms.string('pt>35 & abs(eta)<2.4')
-susyEle23CaloIdMJet30_all.histoPSet.eleEtaBinning = cms.vdouble(-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1)
-susyEle23CaloIdMJet30_all.histoPSet.eleEtaBinning2D = cms.vdouble(-2.1,-1.5,-0.6,0,0.6,1.5,2.1)
-susyEle23CaloIdMJet30_all.histoPSet.elePtBinning = cms.vdouble(0,12,25,30,32.5,35,40,45,50,60,80,120,200,400)
-susyEle23CaloIdMJet30_all.histoPSet.elePtBinning2D = cms.vdouble(0,12,25,30,40,50,60,80,100,200,400)
-susyEle23CaloIdMJet30_all.histoPSet.jetPtBinning = cms.vdouble(0,30,35,37.5,40,50,60,80,120,200,400)
-susyEle23CaloIdMJet30_all.histoPSet.jetPtBinning2D = cms.vdouble(0,30,35,40,50,60,80,100,200,400)
-susyEle23CaloIdMJet30_all.numGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_Ele23_CaloIdM_TrackIdM_PFJet30_v*')
-# susyEle23CaloIdMJet30_all.denGenericTriggerEventPSet.hltPaths = cms.vstring('HLT_IsoMu24_v*')
-
+susyEle8CaloJet30_jet = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele8CaloJet30/JetMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>50 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,50,60,80,120,200,400],
+                     elePtBinning2D = [0,50,70,120,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele8_CaloIdL_TrackIdL_IsoVL_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*'])
+)
+susyEle8CaloJet30_ele = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele8CaloJet30/ElectronMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>10 & abs(eta)<2.4',
+    jetSelection = 'pt>80 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,10,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,10,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele8_CaloIdL_TrackIdL_IsoVL_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet60_v*'])
+)
+susyEle8CaloJet30_all = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele8CaloJet30/GlobalMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>10 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,10,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,10,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele8_CaloIdL_TrackIdL_IsoVL_PFJet30_v*'])
+    #denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu24_v*'])
+)
+susyEle8CaloIdMJet30_jet = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele8CaloIdMJet30/JetMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>50 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,50,60,80,120,200,400],
+                     elePtBinning2D = [0,50,70,120,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele8_CaloIdM_TrackIdM_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*'])
+)
+susyEle8CaloIdMJet30_ele = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele8CaloIdMJet30/ElectronMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>10 & abs(eta)<2.4',
+    jetSelection = 'pt>80 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,10,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,10,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele8_CaloIdM_TrackIdM_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet60_v*'])
+)
+susyEle8CaloIdMJet30_all = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele8CaloIdMJet30/GlobalMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>10 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,10,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,10,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele8_CaloIdM_TrackIdM_PFJet30_v*'])
+    #denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu24_v*'])
+)
+susyEle12CaloJet30_jet = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele12CaloJet30/JetMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>50 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,50,60,80,120,200,400],
+                     elePtBinning2D = [0,50,70,120,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele12_CaloIdL_TrackIdL_IsoVL_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*'])
+)
+susyEle12CaloJet30_ele = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele12CaloJet30/ElectronMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>14 & abs(eta)<2.4',
+    jetSelection = 'pt>80 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,12,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,12,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele12_CaloIdL_TrackIdL_IsoVL_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet60_v*'])
+)
+susyEle12CaloJet30_all = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele12CaloJet30/GlobalMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>14 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,12,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,12,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele12_CaloIdL_TrackIdL_IsoVL_PFJet30_v*'])
+    #denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu24_v*'])
+)
+susyEle17CaloIdMJet30_jet = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele17CaloIdMJet30/JetMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>50 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,50,60,80,120,200,400],
+                     elePtBinning2D = [0,50,70,120,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele17_CaloIdM_TrackIdM_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*'])
+)
+susyEle17CaloIdMJet30_ele = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele17CaloIdMJet30/ElectronMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>19 & abs(eta)<2.4',
+    jetSelection = 'pt>80 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,19,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,19,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele17_CaloIdM_TrackIdM_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet60_v*'])
+)
+susyEle17CaloIdMJet30_all = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele17CaloIdMJet30/GlobalMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>19 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,19,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,19,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele17_CaloIdM_TrackIdM_PFJet30_v*']),
+    #denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu24_v*'])
+)
+susyEle23CaloJet30_jet = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele23CaloJet30/JetMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>50 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,50,60,80,120,200,400],
+                     elePtBinning2D = [0,50,70,120,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele23_CaloIdL_TrackIdL_IsoVL_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*'])
+)
+susyEle23CaloJet30_ele = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele23CaloJet30/ElectronMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>25 & abs(eta)<2.4',
+    jetSelection = 'pt>80 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele23_CaloIdL_TrackIdL_IsoVL_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet60_v*'])
+)
+susyEle23CaloJet30_all = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele23CaloJet30/GlobalMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>14 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,12,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,12,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele23_CaloIdL_TrackIdL_IsoVL_PFJet30_v*']),
+    #denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu24_v*'])
+)
+susyEle23CaloIdMJet30_jet = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele23CaloIdMJet30/JetMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>50 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,50,60,80,120,200,400],
+                     elePtBinning2D = [0,50,70,120,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele23_CaloIdM_TrackIdM_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele35_WPTight_Gsf_v*', 'HLT_Ele38_WPTight_Gsf_v*', 'HLT_Ele40_WPTight_Gsf_v*'])
+)
+susyEle23CaloIdMJet30_ele = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele23CaloIdMJet30/ElectronMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>25 & abs(eta)<2.4',
+    jetSelection = 'pt>80 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele23_CaloIdM_TrackIdM_PFJet30_v*']),
+    denGenericTriggerEventPSet = dict(hltPaths = ['HLT_PFJet60_v*'])
+)
+susyEle23CaloIdMJet30_all = hltSUSYmonitoring.clone(
+    FolderName = 'HLT/SUSY/Ele23CaloIdMJet30/GlobalMonitor',
+    nmuons = 0,
+    nelectrons = 1,
+    njets = 1,
+    eleSelection = 'pt>14 & abs(eta)<2.4',
+    jetSelection = 'pt>35 & abs(eta)<2.4',
+    histoPSet = dict(eleEtaBinning = [-2.1,-1.5,-0.9,-0.6,-0.3,-0.1,0,0.1,0.3,0.6,0.9,1.5,2.1],
+                     eleEtaBinning2D = [-2.1,-1.5,-0.6,0,0.6,1.5,2.1],
+                     elePtBinning = [0,12,25,30,32.5,35,40,45,50,60,80,120,200,400],
+                     elePtBinning2D = [0,12,25,30,40,50,60,80,100,200,400],
+                     jetPtBinning = [0,30,35,37.5,40,50,60,80,120,200,400],
+                     jetPtBinning2D = [0,30,35,40,50,60,80,100,200,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Ele23_CaloIdM_TrackIdM_PFJet30_v*']),
+    #denGenericTriggerEventPSet = dict(hltPaths = ['HLT_IsoMu24_v*'])
+)
 susyHLTEleCaloJets = cms.Sequence(
     susyEle8CaloJet30_ele
   + susyEle8CaloJet30_jet


### PR DESCRIPTION
#### PR description:

Drop type specs in DQMOffline/Trigger python configuration files.

Central DQM migration campaign for drop type specs following
https://cms-sw.github.io/cms_coding_rules.html#6--packaging-rules-1
and update the safer syntax for existing parameters like: (1) drop type specifications where the original parameter exists. (2) using "clone" instead of "deepcopy" (3) move all parameters inside the clone

MET hanlde not valid" message now disappears, this was due to a wrong collection set BEFORE the PR, since Event Interpretation has been removed back in 2021.
This PR corrected above by setting to met = "pfMet", right above. Since the SoftMuHardJetMETSUSYmonitoring is cloned several times below, it seems it just complained but no crash. Now it should be reading an existing collection.

Moreover, the binning for diphotonMass55ANDnoPV module was corrected set to 50-150 in https://github.com/cms-sw/cmssw/pull/37133/files#diff-f0c298feb52e2a455f0a07a4ea80c12b3b660e38e6737d177570ccc9a94775d3R165

since it was wrongly set to 90-200 due to a typo in https://github.com/cms-sw/cmssw/pull/37133/files#diff-f0c298feb52e2a455f0a07a4ea80c12b3b660e38e6737d177570ccc9a94775d3L147

#### PR validation:
Tested in CMSSW_12_3_X via runTheMatrix.py -l limited -i all --ibeos
