### PR TITLE
Update of L1 prescales and masks files coherent with the latest L1 menu for Run 3

### DIFF
--- a/L1Trigger/Configuration/python/customiseUtils.py
+++ b/L1Trigger/Configuration/python/customiseUtils.py
@@ -76,7 +76,7 @@ def L1TGlobalDigisSummary(process):
 def L1TGlobalMenuXML(process):
     process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
     process.load('L1Trigger.L1TGlobal.TriggerMenu_cff')
-    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2016_v2c.xml')
+    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2022_v0_1_6.xml')
     return process
 
 def L1TGlobalSimDigisSummary(process):

--- a/L1Trigger/L1TGlobal/python/PrescalesVetosFract_cff.py
+++ b/L1Trigger/L1TGlobal/python/PrescalesVetosFract_cff.py
@@ -16,9 +16,9 @@ L1TGlobalPrescalesVetosFract = cms.ESProducer("L1TGlobalPrescalesVetosFractESPro
     TriggerMenuLuminosity = cms.string('startup'),
     Verbosity = cms.int32(0),
     AlgoBxMaskDefault = cms.int32(1),
-    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_v11.xml'),
-    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_V1.xml'),
-    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_v17.xml'),
-    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_v1.xml'),
+    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_L1MenuCollisions2022_v6.xml'),
+    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_L1MenuCollisions2022_v6.xml'),
+    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_L1MenuCollisions2022_v6.xml'),
+    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_L1MenuCollisions2022_v6.xml'),
 
 )

--- a/L1Trigger/L1TGlobal/python/PrescalesVetos_cff.py
+++ b/L1Trigger/L1TGlobal/python/PrescalesVetos_cff.py
@@ -15,10 +15,10 @@ L1TGlobalPrescalesVetos = cms.ESProducer("L1TGlobalPrescalesVetosESProducer",
     TriggerMenuLuminosity = cms.string('startup'),
     Verbosity = cms.int32(0),
     AlgoBxMaskDefault = cms.int32(1),
-    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_v11.xml'),
-    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_V1.xml'),
-    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_v17.xml'),
-    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_v1.xml'),
+    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_L1MenuCollisions2022_v6.xml'),                                                        
+    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_L1MenuCollisions2022_v6.xml'),                                   
+    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_L1MenuCollisions2022_v6.xml'),                                              
+    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_L1MenuCollisions2022_v6.xml'),              
 
 )
 


### PR DESCRIPTION
#### PR description:
A full set of xml files for the L1 emulation of prescales and masks coherent with the updated L1 menu for Run 3 has been created and pushed to [L1Trigger-L1TGlobal](https://github.com/cms-data/L1Trigger-L1TGlobal) ([PR#8](https://github.com/cms-data/L1Trigger-L1TGlobal/pull/8)). Once that these new files will be available in _cms-data_, we will proceed with the coherent update of these files.
The current version of the updated L1 Menu is [L1Menu_Collisions2022_v0_1_6](https://github.com/cms-l1-dpg/L1MenuRun3/tree/master/preliminary/L1Menu_Collisions2022_v0_1_6).

In the context of the trigger studies for the preparation of the Run 3 menu (L1+HLT), we recently faced an issue related to the emulation of the L1 prescales. Two different issues were found out:
- format of the PS table (some documentation and a recipe can be found [here](https://github.com/cms-l1-dpg/L1MenuRun3/tree/master/preliminary/L1Menu_Collisions2022_v0_1_6/PrescaleTable));
- usage of the fractional PS ([PR#37046](https://github.com/cms-sw/cmssw/pull/37046)).

#### PR validation:
Basic tests performed successfully starting from CMSSW_12_3_X_2022-03-01-1100.
From CMSSW_12_3_X_2022-03-01-1100/src:
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests
> scram build code-checks
> scram build code-format
> runTheMatrix.py -l limited -i all --ibeos