### PR TITLE
add quality selections in MkFitOutputConverter

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -288,8 +288,29 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
             GlobalPoint(param[0], param[1], param[2]), GlobalVector(param[3], param[4], param[5]), state.charge, &mf),
         CurvilinearTrajectoryError(cov));
     if (!fts.curvilinearError().posDef()) {
-      edm::LogInfo("MkFitOutputConverter") << "Curvilinear error not pos-def\n"
-                                           << fts.curvilinearError().matrix() << "\ncandidate ignored";
+      edm::LogInfo("MkFitOutputConverter")
+          << "Curvilinear error not pos-def\n"
+          << fts.curvilinearError().matrix() << "\ncandidate " << candIndex << "ignored";
+      continue;
+    }
+
+    //Sylvester's rule, start from the smaller submatrix size
+    double det = 0;
+    if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix22>(0, 0).Det(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Fail pos-def check sub2.det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    } else if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix33>(0, 0).Det(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Fail pos-def check sub3.det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    } else if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix44>(0, 0).Det(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Fail pos-def check sub4.det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    } else if ((!fts.curvilinearError().matrix().Det2(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Fail pos-def check det for candidate " << candIndex << " with fts " << fts;
       continue;
     }
 

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -103,9 +103,11 @@ private:
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> mkFitGeomToken_;
   const edm::EDPutTokenT<TrackCandidateCollection> putTrackCandidateToken_;
   const edm::EDPutTokenT<std::vector<SeedStopInfo>> putSeedStopInfoToken_;
-  const std::string ttrhBuilderName_;
-  const std::string propagatorAlongName_;
-  const std::string propagatorOppositeName_;
+
+  const float qualityMaxInvPt_;
+  const float qualityMaxRsq_;
+  const float qualityMaxZ_;
+  const bool qualitySignPt_;
 };
 
 MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
@@ -124,7 +126,11 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
           iConfig.getParameter<edm::ESInputTag>("ttrhBuilder"))},
       mkFitGeomToken_{esConsumes<MkFitGeometry, TrackerRecoGeometryRecord>()},
       putTrackCandidateToken_{produces<TrackCandidateCollection>()},
-      putSeedStopInfoToken_{produces<std::vector<SeedStopInfo>>()} {}
+      putSeedStopInfoToken_{produces<std::vector<SeedStopInfo>>()},
+      qualityMaxInvPt_{float(iConfig.getParameter<double>("qualityMaxInvPt"))},
+      qualityMaxRsq_{float(pow(iConfig.getParameter<double>("qualityMaxR"), 2))},
+      qualityMaxZ_{float(iConfig.getParameter<double>("qualityMaxZ"))},
+      qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")} {}
 
 void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -138,6 +144,11 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add("ttrhBuilder", edm::ESInputTag{"", "WithTrackAngle"});
   desc.add("propagatorAlong", edm::ESInputTag{"", "PropagatorWithMaterial"});
   desc.add("propagatorOpposite", edm::ESInputTag{"", "PropagatorWithMaterialOpposite"});
+
+  desc.add<double>("qualityMaxInvPt", 100)->setComment("max(1/pt) for converted tracks");
+  desc.add<double>("qualityMaxR", 120)->setComment("max(R) for the state position for converted tracks");
+  desc.add<double>("qualityMaxZ", 280)->setComment("max(|Z|) for the state position for converted tracks");
+  desc.add<bool>("qualitySignPt", true)->setComment("check sign of 1/pt for converted tracks");
 
   descriptions.addWithDefaultLabel(desc);
 }
@@ -193,6 +204,56 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     ++candIndex;
     LogTrace("MkFitOutputConverter") << "Candidate " << candIndex << " pT " << cand.pT() << " eta " << cand.momEta()
                                      << " phi " << cand.momPhi() << " chi2 " << cand.chi2();
+
+    // state: check for basic quality first
+    if (cand.state().invpT() > qualityMaxInvPt_ || (qualitySignPt_ && cand.state().invpT() < 0) ||
+        cand.state().posRsq() > qualityMaxRsq_ || std::abs(cand.state().z()) > qualityMaxZ_) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Candidate " << candIndex << " failed state quality checks" << cand.state().parameters;
+      continue;
+    }
+
+    auto state = cand.state();  // copy because have to modify
+    state.convertFromCCSToGlbCurvilinear();
+    const auto& param = state.parameters;
+    const auto& err = state.errors;
+    AlgebraicSymMatrix55 cov;
+    for (int i = 0; i < 5; ++i) {
+      for (int j = i; j < 5; ++j) {
+        cov[i][j] = err.At(i, j);
+      }
+    }
+
+    auto fts = FreeTrajectoryState(
+        GlobalTrajectoryParameters(
+            GlobalPoint(param[0], param[1], param[2]), GlobalVector(param[3], param[4], param[5]), state.charge, &mf),
+        CurvilinearTrajectoryError(cov));
+    if (!fts.curvilinearError().posDef()) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Curvilinear error not pos-def\n"
+          << fts.curvilinearError().matrix() << "\ncandidate " << candIndex << "ignored";
+      continue;
+    }
+
+    //Sylvester's criterion, start from the smaller submatrix size
+    double det = 0;
+    if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix22>(0, 0).Det(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Fail pos-def check sub2.det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    } else if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix33>(0, 0).Det(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Fail pos-def check sub3.det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    } else if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix44>(0, 0).Det(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Fail pos-def check sub4.det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    } else if ((!fts.curvilinearError().matrix().Det2(det)) || det < 0) {
+      edm::LogInfo("MkFitOutputConverter")
+          << "Fail pos-def check det for candidate " << candIndex << " with fts " << fts;
+      continue;
+    }
 
     // hits
     edm::OwnVector<TrackingRecHit> recHits;
@@ -270,49 +331,6 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     // seed
     const auto seedIndex = cand.label();
     LogTrace("MkFitOutputConverter") << " from seed " << seedIndex << " seed hits";
-
-    // state
-    auto state = cand.state();  // copy because have to modify
-    state.convertFromCCSToGlbCurvilinear();
-    const auto& param = state.parameters;
-    const auto& err = state.errors;
-    AlgebraicSymMatrix55 cov;
-    for (int i = 0; i < 5; ++i) {
-      for (int j = i; j < 5; ++j) {
-        cov[i][j] = err.At(i, j);
-      }
-    }
-
-    auto fts = FreeTrajectoryState(
-        GlobalTrajectoryParameters(
-            GlobalPoint(param[0], param[1], param[2]), GlobalVector(param[3], param[4], param[5]), state.charge, &mf),
-        CurvilinearTrajectoryError(cov));
-    if (!fts.curvilinearError().posDef()) {
-      edm::LogInfo("MkFitOutputConverter")
-          << "Curvilinear error not pos-def\n"
-          << fts.curvilinearError().matrix() << "\ncandidate " << candIndex << "ignored";
-      continue;
-    }
-
-    //Sylvester's rule, start from the smaller submatrix size
-    double det = 0;
-    if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix22>(0, 0).Det(det)) || det < 0) {
-      edm::LogInfo("MkFitOutputConverter")
-          << "Fail pos-def check sub2.det for candidate " << candIndex << " with fts " << fts;
-      continue;
-    } else if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix33>(0, 0).Det(det)) || det < 0) {
-      edm::LogInfo("MkFitOutputConverter")
-          << "Fail pos-def check sub3.det for candidate " << candIndex << " with fts " << fts;
-      continue;
-    } else if ((!fts.curvilinearError().matrix().Sub<AlgebraicSymMatrix44>(0, 0).Det(det)) || det < 0) {
-      edm::LogInfo("MkFitOutputConverter")
-          << "Fail pos-def check sub4.det for candidate " << candIndex << " with fts " << fts;
-      continue;
-    } else if ((!fts.curvilinearError().matrix().Det2(det)) || det < 0) {
-      edm::LogInfo("MkFitOutputConverter")
-          << "Fail pos-def check det for candidate " << candIndex << " with fts " << fts;
-      continue;
-    }
 
     auto tsosDet =
         mkFitOutput.propagatedToFirstLayer()


### PR DESCRIPTION
This PR intends to address #35798, to reduce warnings about bad track states downstream of mkFit track building.

In addition to already present check for positive-definiteness of the covariance based on the diagonal elements, more selections were added to MkFitOutputConverter in order to send only trackable candidates:
- the covariance matrix is checked using the Sylvester's criterion to have a full check of positive-definiteness
- "sanity" checks for the track candidate parameters:
    - pt > 10 MeV
    - θ ∈ [0.01, π–0.01]
    - state position inside the tracker: r < 120 cm and |z| < 280 cm; position uncertainty below 100 cm

The CPU cost in the converter goes up by about 0.02% of the reco time based on wf 136.874: [before](https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/sw-123X/CMSSW_12_3_0_pre1-sign1131.pass-e731805.136.874.step3.100.pp/1873) vs [after](https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/sw-123X/CMSSW_12_3_0_pre1-sign1131.pass-bce63d6.136.874.step3.100.pp/1716)

The number of logWarnings went down, focusing on the ones with ` not pos` in the warning message (using `CMSSW_12_3_0_pre1` as a reference):
- in 136.874 on 100 events: baseline 112, noMkFit baseline 3, this PR 12.
    - the warnings are in modules not directly reading mkFit track candidates
- in wf 11834.21 on 400 events: baseline 2636, noMkFit 31, this PR 19
    - the warnings are in modules not directly reading mkFit track candidates
- in a trackingOnly test similar to 11834.21 with PU50 on 1000 events: baseline 2209, noMkFit 19, this PR 17
    - here 14 warnings are in modules reading mkFit track candidates

On average, it seems that the number of warnings is roughly back to the rate seen with the  old setup using just the CKF builder.

Small changes are expected due to rejection of mainly bad tracks.
@leonardogiannini checked in a sample with pileup 50 on 1000 evens, there are negligible or [no differences in the MTV plots](http://uaf-10.t2.ucsd.edu/~legianni/plotsMTV-FebTRKPOG/checkDeterminant/checkWarnings-final/plots_ootb.html):
looking at all tracks
<img width="696" alt="image" src="https://user-images.githubusercontent.com/4676718/156694265-3b08286a-538b-419b-8b6d-0e3e077ce3e9.png">
The effect is a bit more visible in the pixelLess iteration, the most affected iteration
<img width="696" alt="image" src="https://user-images.githubusercontent.com/4676718/156839098-46d6a4af-05d9-46aa-b116-a080abf45811.png">


@osschar @makortel @mmasciov 
@cms-sw/tracking-pog-l2 