### PR TITLE
Include HLT JEC and L1T Menu tags in data, mcRun3 and mcRun4 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,9 +38,9 @@ autoCond = {
     # GlobalTag for Run3 data relvals (express GT)
     'run3_data_express'            : '123X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '123X_dataRun3_Prompt_v4',
+    'run3_data_prompt'             : '123X_dataRun3_Prompt_v5',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '123X_dataRun3_v3',
+    'run3_data'                    : '123X_dataRun3_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -64,19 +64,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v10',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v10',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v11',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v10',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v10',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v10',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v10',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v11',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '123X_mcRun4_realistic_v7'
+    'phase2_realistic'             : '123X_mcRun4_realistic_v8'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR is to include:

- L1T Menu tag in mcRun3 and mcRun4 Queues as requested in https://cms-talk.web.cern.ch/t/mc-run3-gt-update-of-the-l1menu-tag-in-run3-mc-gts/7689

- HLT JEC tags in the the Prompt, offline, mcRun3 and mcRun4 GTs, as requested in https://cms-talk.web.cern.ch/t/gt-run3-hlt-jec-tags-for-123x/7607. 

The L1T menu tag included in the MC GTs is:
`L1Menu_Collisions2022_v0_1_6_xml`

The HLT JEC tags included in data are:
`Label: AK4CaloHLT , Tag: JetCorrectorParametersCollection_AK4CaloHLT_hlt_v1`
`Label: AK4PFClusterHLT , Tag: JetCorrectorParametersCollection_AK4PFClusterHLT_hlt_v1`
`Label: AK4PFHLT , Tag: JetCorrectorParametersCollection_AK4PFHLT_hlt_v1`
`Label: AK4PFPuppiHLT , Tag: JetCorrectorParametersCollection_AK4PFPuppiHLT_hlt_v1`
`Label: AK4PFchsHLT , Tag: JetCorrectorParametersCollection_AK4PFchsHLT_hlt_v1`
`Label: AK8CaloHLT , Tag: JetCorrectorParametersCollection_AK8CaloHLT_hlt_v1`
`Label: AK8PFClusterHLT , Tag: JetCorrectorParametersCollection_AK8PFClusterHLT_hlt_v1`
`Label: AK8PFHLT , Tag: JetCorrectorParametersCollection_AK8PFHLT_hlt_v1`
`Label: AK8PFPuppiHLT , Tag: JetCorrectorParametersCollection_AK8PFPuppiHLT_hlt_v1`
`Label: AK8PFchsHLT , Tag: JetCorrectorParametersCollection_AK8PFchsHLT_hlt_v1`

The HLT JEC tags included in MC are:
`Label: AK4CaloHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK4CaloHLT`
`Label: AK4PFClusterHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK4PFClusterHLT`
`Label: AK4PFHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK4PFHLT`
`Label: AK4PFPuppiHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK4PFPuppiHLT`
`Label: AK4PFchsHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK4PFchsHLT`
`Label: AK8CaloHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK8CaloHLT`
`Label: AK8PFClusterHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK8PFClusterHLT`
`Label: AK8PFHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK8PFHLT`
`Label: AK8PFPuppiHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK8PFPuppiHLT`
`Label: AK8PFchsHLT , Tag: JetCorrectorParametersCollection_Run3Winter21_V2_MC_AK8PFchsHLT`

The differences in GTs are only related to the JEC and L1T tags, as can be seen below:
**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_Prompt_v5/123X_dataRun3_Prompt_v4

**run3_data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_v4/123X_dataRun3_v3

**phase1_2021_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_design_v11/123X_mcRun3_2021_design_v10

**phase1_2021_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_realistic_v11/123X_mcRun3_2021_realistic_v10

**phase1_2021_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021cosmics_realistic_deco_v11/123X_mcRun3_2021cosmics_realistic_deco_v10

**phase1_2021_realistic_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2021_realistic_HI_v11/123X_mcRun3_2021_realistic_HI_v10

**phase1_2023_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2023_realistic_v11/123X_mcRun3_2023_realistic_v10

**phase1_2024_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun3_2024_realistic_v11/123X_mcRun3_2024_realistic_v10

**phase2_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_mcRun4_realistic_v8/123X_mcRun4_realistic_v7

#### PR validation:

`nohup runTheMatrix.py -l 138.4,139.002,12034.0,11634.0,7.23,159.0,12434.0,12834.0 --ibeos -j16`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
not a backport
