### PR TITLE
Added unit test to run pede from millepede

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -1,3 +1,7 @@
 <test name="test_PrepareInputDb" command="mps_prepare_input_db.py -g auto:run2_data -r 1 -o ${LOCALTOP}/tmp/test_input.db"/>
 <test name="test_MpsWorkFlow" command="test_mps-workflow.sh"/>
 <test name="test_CreateFileLists" command="mps_create_file_lists.py --test-mode --force -i /OVERRIDDEN/IN/TESTMODE -o ${LOCALTOP}/tmp/mps_create_file_lists -n 200000 --iov 42 --iov 174"/>
+<test name="test-pede" command="pede -t">
+  <use name="millepede"/>
+  <flags USE_UNITTEST_DIR="1"/>
+</test>


### PR DESCRIPTION
This PR adds a simple unit test to run `pede -t` to test `millepede` changes