### PR TITLE
XML and FedId configuration update for PPS

### DIFF
--- a/CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml
+++ b/CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml
@@ -1,0 +1,248 @@
+<top>   
+  <arm id="0">  <!-- 45 -->
+    <station id="1">        <!-- 215 m -->
+      <rp_detector_set id="6">        <!-- Timing -->
+        <rp_plane_diamond id="0"> 
+          <diamond_channel id="0"         hw_id="0x206"           FEDId="583"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x201"           FEDId="583"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x207"           FEDId="583"             GOHId="3"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x20D"           FEDId="583"             GOHId="3"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x20A"           FEDId="583"             GOHId="3"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x202"           FEDId="583"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x204"           FEDId="583"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x20C"           FEDId="583"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x20B"           FEDId="583"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x203"           FEDId="583"             GOHId="3"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x209"           FEDId="583"             GOHId="3"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x20F"           FEDId="583"             GOHId="3"               IdxInFiber="15"/>  
+        </rp_plane_diamond>
+        <rp_plane_diamond id="1"> 
+          <diamond_channel id="0"         hw_id="0x216"           FEDId="583"             GOHId="4"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x211"           FEDId="583"             GOHId="4"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x217"           FEDId="583"             GOHId="4"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x21D"           FEDId="583"             GOHId="4"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x21A"           FEDId="583"             GOHId="4"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x212"           FEDId="583"             GOHId="4"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x214"           FEDId="583"             GOHId="4"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x21C"           FEDId="583"             GOHId="4"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x21B"           FEDId="583"             GOHId="4"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x213"           FEDId="583"             GOHId="4"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x219"           FEDId="583"             GOHId="4"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x21F"           FEDId="583"             GOHId="4"               IdxInFiber="15"/>
+<!--      OLD CLOCK <diamond_channel id="30"        hw_id="0x21F"           FEDId="583"             GOHId="4"               IdxInFiber="15"/>-->
+        </rp_plane_diamond>                             
+        <rp_plane_diamond id="2"> 
+          <diamond_channel id="0"         hw_id="0x106"           FEDId="583"             GOHId="1"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x101"           FEDId="583"             GOHId="1"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x107"           FEDId="583"             GOHId="1"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x10D"           FEDId="583"             GOHId="1"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x10A"           FEDId="583"             GOHId="1"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x102"           FEDId="583"             GOHId="1"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x104"           FEDId="583"             GOHId="1"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x10C"           FEDId="583"             GOHId="1"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x10B"           FEDId="583"             GOHId="1"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x103"           FEDId="583"             GOHId="1"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x109"           FEDId="583"             GOHId="1"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x10F"           FEDId="583"             GOHId="1"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="3">
+          <diamond_channel id="0"         hw_id="0x116"           FEDId="583"             GOHId="2"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x111"           FEDId="583"             GOHId="2"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x117"           FEDId="583"             GOHId="2"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x11D"           FEDId="583"             GOHId="2"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x11A"           FEDId="583"             GOHId="2"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x112"           FEDId="583"             GOHId="2"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x114"           FEDId="583"             GOHId="2"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x11C"           FEDId="583"             GOHId="2"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x11B"           FEDId="583"             GOHId="2"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x113"           FEDId="583"             GOHId="2"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x119"           FEDId="583"             GOHId="2"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x11F"           FEDId="583"             GOHId="2"               IdxInFiber="15"/>
+<!--      OLD CLOCK          <diamond_channel id="30"        hw_id="0x11F"           FEDId="583"             GOHId="2"               IdxInFiber="15"/>-->
+        </rp_plane_diamond>
+      </rp_detector_set>
+    </station>    
+    <station id="2">        <!-- 220 m near -->
+      <rp_detector_set id="2">        <!-- Timing -->
+        <rp_plane_diamond id="0"> 
+          <diamond_channel id="0"         hw_id="0x606"           FEDId="581"             GOHId="4"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x601"           FEDId="581"             GOHId="4"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x607"           FEDId="581"             GOHId="4"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x60D"           FEDId="581"             GOHId="4"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x60A"           FEDId="581"             GOHId="4"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x602"           FEDId="581"             GOHId="4"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x604"           FEDId="581"             GOHId="4"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x60C"           FEDId="581"             GOHId="4"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x60B"           FEDId="581"             GOHId="4"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x603"           FEDId="581"             GOHId="4"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x609"           FEDId="581"             GOHId="4"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x60F"           FEDId="581"             GOHId="4"               IdxInFiber="15"/>  
+        </rp_plane_diamond>
+        <rp_plane_diamond id="1"> 
+          <diamond_channel id="0"         hw_id="0x616"           FEDId="581"             GOHId="5"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x611"           FEDId="581"             GOHId="5"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x617"           FEDId="581"             GOHId="5"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x61D"           FEDId="581"             GOHId="5"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x61A"           FEDId="581"             GOHId="5"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x612"           FEDId="581"             GOHId="5"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x614"           FEDId="581"             GOHId="5"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x61C"           FEDId="581"             GOHId="5"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x61B"           FEDId="581"             GOHId="5"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x613"           FEDId="581"             GOHId="5"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x619"           FEDId="581"             GOHId="5"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x61F"           FEDId="581"             GOHId="5"               IdxInFiber="15"/>
+        </rp_plane_diamond>                             
+        <rp_plane_diamond id="2"> 
+          <diamond_channel id="0"         hw_id="0x506"           FEDId="581"             GOHId="9"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x501"           FEDId="581"             GOHId="9"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x507"           FEDId="581"             GOHId="9"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x50D"           FEDId="581"             GOHId="9"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x50A"           FEDId="581"             GOHId="9"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x502"           FEDId="581"             GOHId="9"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x504"           FEDId="581"             GOHId="9"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x50C"           FEDId="581"             GOHId="9"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x50B"           FEDId="581"             GOHId="9"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x503"           FEDId="581"             GOHId="9"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x509"           FEDId="581"             GOHId="9"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x50F"           FEDId="581"             GOHId="9"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="3">
+          <diamond_channel id="0"         hw_id="0x516"           FEDId="581"             GOHId="10"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x511"           FEDId="581"             GOHId="10"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x517"           FEDId="581"             GOHId="10"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x51D"           FEDId="581"             GOHId="10"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x51A"           FEDId="581"             GOHId="10"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x512"           FEDId="581"             GOHId="10"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x514"           FEDId="581"             GOHId="10"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x51C"           FEDId="581"             GOHId="10"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x51B"           FEDId="581"             GOHId="10"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x513"           FEDId="581"             GOHId="10"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x519"           FEDId="581"             GOHId="10"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x51F"           FEDId="581"             GOHId="10"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+      </rp_detector_set>
+    </station>
+  </arm>
+  <arm id="1">  <!-- 56 -->
+    <station id="1">        <!-- 215 m -->
+      <rp_detector_set id="6">        <!-- Timing -->
+        <rp_plane_diamond id="0"> 
+          <diamond_channel id="0"         hw_id="0x306"           FEDId="582"             GOHId="7"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x301"           FEDId="582"             GOHId="7"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x307"           FEDId="582"             GOHId="7"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x30D"           FEDId="582"             GOHId="7"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x30A"           FEDId="582"             GOHId="7"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x302"           FEDId="582"             GOHId="7"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x304"           FEDId="582"             GOHId="7"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x30C"           FEDId="582"             GOHId="7"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x30B"           FEDId="582"             GOHId="7"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x303"           FEDId="582"             GOHId="7"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x309"           FEDId="582"             GOHId="7"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x30F"           FEDId="582"             GOHId="7"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="1"> 
+          <diamond_channel id="0"         hw_id="0x316"           FEDId="582"             GOHId="8"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x311"           FEDId="582"             GOHId="8"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x317"           FEDId="582"             GOHId="8"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x31D"           FEDId="582"             GOHId="8"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x31A"           FEDId="582"             GOHId="8"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x312"           FEDId="582"             GOHId="8"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x314"           FEDId="582"             GOHId="8"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x31C"           FEDId="582"             GOHId="8"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x31B"           FEDId="582"             GOHId="8"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x313"           FEDId="582"             GOHId="8"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x319"           FEDId="582"             GOHId="8"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x31F"           FEDId="582"             GOHId="8"               IdxInFiber="15"/>
+<!--      <diamond_channel id="30"        hw_id="0x31F"           FEDId="582"             GOHId="8"               IdxInFiber="15"/>-->
+        </rp_plane_diamond>
+        <rp_plane_diamond id="2"> 
+          <diamond_channel id="0"         hw_id="0x406"           FEDId="582"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x401"           FEDId="582"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x407"           FEDId="582"             GOHId="3"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x40D"           FEDId="582"             GOHId="3"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x40A"           FEDId="582"             GOHId="3"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x402"           FEDId="582"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x404"           FEDId="582"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x40C"           FEDId="582"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x40B"           FEDId="582"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x403"           FEDId="582"             GOHId="3"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x409"           FEDId="582"             GOHId="3"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x40F"           FEDId="582"             GOHId="3"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="3">
+          <diamond_channel id="0"         hw_id="0x416"           FEDId="582"             GOHId="4"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x411"           FEDId="582"             GOHId="4"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x417"           FEDId="582"             GOHId="4"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x41D"           FEDId="582"             GOHId="4"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x41A"           FEDId="582"             GOHId="4"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x412"           FEDId="582"             GOHId="4"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x414"           FEDId="582"             GOHId="4"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x41C"           FEDId="582"             GOHId="4"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x41B"           FEDId="582"             GOHId="4"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x413"           FEDId="582"             GOHId="4"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x419"           FEDId="582"             GOHId="4"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x41F"           FEDId="582"             GOHId="4"               IdxInFiber="15"/>
+<!--      <diamond_channel id="30"        hw_id="0x41F"           FEDId="582"             GOHId="4"               IdxInFiber="15"/>-->
+        </rp_plane_diamond>
+      </rp_detector_set>
+    <station id="2">        <!-- 220 m near-->
+      <rp_detector_set id="2">        <!-- Timing -->
+        <rp_plane_diamond id="0"> 
+          <diamond_channel id="0"         hw_id="0x806"           FEDId="579"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x801"           FEDId="579"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x807"           FEDId="579"             GOHId="3"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x80D"           FEDId="579"             GOHId="3"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x80A"           FEDId="579"             GOHId="3"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x802"           FEDId="579"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x804"           FEDId="579"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x80C"           FEDId="579"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x80B"           FEDId="579"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x803"           FEDId="579"             GOHId="3"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x809"           FEDId="579"             GOHId="3"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x80F"           FEDId="579"             GOHId="3"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="1"> 
+          <diamond_channel id="0"         hw_id="0x816"           FEDId="579"             GOHId="4"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x811"           FEDId="579"             GOHId="4"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x817"           FEDId="579"             GOHId="4"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x81D"           FEDId="579"             GOHId="4"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x81A"           FEDId="579"             GOHId="4"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x812"           FEDId="579"             GOHId="4"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x814"           FEDId="579"             GOHId="4"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x81C"           FEDId="579"             GOHId="4"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x81B"           FEDId="579"             GOHId="4"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x813"           FEDId="579"             GOHId="4"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x819"           FEDId="579"             GOHId="4"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x81F"           FEDId="579"             GOHId="4"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="2"> 
+          <diamond_channel id="0"         hw_id="0x706"           FEDId="579"             GOHId="5"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x701"           FEDId="579"             GOHId="5"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x707"           FEDId="579"             GOHId="5"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x70D"           FEDId="579"             GOHId="5"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x70A"           FEDId="579"             GOHId="5"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x702"           FEDId="579"             GOHId="5"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x704"           FEDId="579"             GOHId="5"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x70C"           FEDId="579"             GOHId="5"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x70B"           FEDId="579"             GOHId="5"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x703"           FEDId="579"             GOHId="5"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x709"           FEDId="579"             GOHId="5"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x70F"           FEDId="579"             GOHId="5"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+        <rp_plane_diamond id="3">
+          <diamond_channel id="0"         hw_id="0x716"           FEDId="579"             GOHId="10"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x711"           FEDId="579"             GOHId="10"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x717"           FEDId="579"             GOHId="10"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x71D"           FEDId="579"             GOHId="10"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x71A"           FEDId="579"             GOHId="10"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x712"           FEDId="579"             GOHId="10"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x714"           FEDId="579"             GOHId="10"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x71C"           FEDId="579"             GOHId="10"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x71B"           FEDId="579"             GOHId="10"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x713"           FEDId="579"             GOHId="10"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x719"           FEDId="579"             GOHId="10"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x71F"           FEDId="579"             GOHId="10"               IdxInFiber="15"/>
+        </rp_plane_diamond>
+      </rp_detector_set>
+    </station>
+  </arm>

--- a/CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml
+++ b/CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml
@@ -185,6 +185,7 @@
 <!--      <diamond_channel id="30"        hw_id="0x41F"           FEDId="582"             GOHId="4"               IdxInFiber="15"/>-->
         </rp_plane_diamond>
       </rp_detector_set>
+    </station>
     <station id="2">        <!-- 220 m near-->
       <rp_detector_set id="2">        <!-- Timing -->
         <rp_plane_diamond id="0"> 

--- a/CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml
+++ b/CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml
@@ -65,60 +65,60 @@
     <station id="2">        <!-- 220 m near -->
       <rp_detector_set id="2">        <!-- Timing -->
         <rp_plane_diamond id="0"> 
-          <diamond_channel id="0"         hw_id="0x606"           FEDId="581"             GOHId="4"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x601"           FEDId="581"             GOHId="4"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x607"           FEDId="581"             GOHId="4"               IdxInFiber="7"/>
-          <diamond_channel id="3"         hw_id="0x60D"           FEDId="581"             GOHId="4"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x60A"           FEDId="581"             GOHId="4"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x602"           FEDId="581"             GOHId="4"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x604"           FEDId="581"             GOHId="4"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x60C"           FEDId="581"             GOHId="4"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x60B"           FEDId="581"             GOHId="4"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x603"           FEDId="581"             GOHId="4"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x609"           FEDId="581"             GOHId="4"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x60F"           FEDId="581"             GOHId="4"               IdxInFiber="15"/>  
+          <diamond_channel id="0"         hw_id="0x606"           FEDId="581"             GOHId="0"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x601"           FEDId="581"             GOHId="0"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x607"           FEDId="581"             GOHId="0"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x60D"           FEDId="581"             GOHId="0"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x60A"           FEDId="581"             GOHId="0"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x602"           FEDId="581"             GOHId="0"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x604"           FEDId="581"             GOHId="0"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x60C"           FEDId="581"             GOHId="0"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x60B"           FEDId="581"             GOHId="0"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x603"           FEDId="581"             GOHId="0"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x609"           FEDId="581"             GOHId="0"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x60F"           FEDId="581"             GOHId="0"               IdxInFiber="15"/>  
         </rp_plane_diamond>
         <rp_plane_diamond id="1"> 
-          <diamond_channel id="0"         hw_id="0x616"           FEDId="581"             GOHId="5"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x611"           FEDId="581"             GOHId="5"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x617"           FEDId="581"             GOHId="5"               IdxInFiber="7"/>
-          <diamond_channel id="3"         hw_id="0x61D"           FEDId="581"             GOHId="5"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x61A"           FEDId="581"             GOHId="5"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x612"           FEDId="581"             GOHId="5"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x614"           FEDId="581"             GOHId="5"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x61C"           FEDId="581"             GOHId="5"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x61B"           FEDId="581"             GOHId="5"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x613"           FEDId="581"             GOHId="5"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x619"           FEDId="581"             GOHId="5"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x61F"           FEDId="581"             GOHId="5"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x616"           FEDId="581"             GOHId="1"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x611"           FEDId="581"             GOHId="1"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x617"           FEDId="581"             GOHId="1"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x61D"           FEDId="581"             GOHId="1"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x61A"           FEDId="581"             GOHId="1"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x612"           FEDId="581"             GOHId="1"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x614"           FEDId="581"             GOHId="1"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x61C"           FEDId="581"             GOHId="1"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x61B"           FEDId="581"             GOHId="1"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x613"           FEDId="581"             GOHId="1"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x619"           FEDId="581"             GOHId="1"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x61F"           FEDId="581"             GOHId="1"               IdxInFiber="15"/>
         </rp_plane_diamond>                             
         <rp_plane_diamond id="2"> 
-          <diamond_channel id="0"         hw_id="0x506"           FEDId="581"             GOHId="9"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x501"           FEDId="581"             GOHId="9"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x507"           FEDId="581"             GOHId="9"               IdxInFiber="7"/>
-          <diamond_channel id="3"         hw_id="0x50D"           FEDId="581"             GOHId="9"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x50A"           FEDId="581"             GOHId="9"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x502"           FEDId="581"             GOHId="9"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x504"           FEDId="581"             GOHId="9"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x50C"           FEDId="581"             GOHId="9"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x50B"           FEDId="581"             GOHId="9"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x503"           FEDId="581"             GOHId="9"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x509"           FEDId="581"             GOHId="9"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x50F"           FEDId="581"             GOHId="9"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x506"           FEDId="581"             GOHId="2"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x501"           FEDId="581"             GOHId="2"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x507"           FEDId="581"             GOHId="2"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x50D"           FEDId="581"             GOHId="2"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x50A"           FEDId="581"             GOHId="2"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x502"           FEDId="581"             GOHId="2"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x504"           FEDId="581"             GOHId="2"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x50C"           FEDId="581"             GOHId="2"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x50B"           FEDId="581"             GOHId="2"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x503"           FEDId="581"             GOHId="2"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x509"           FEDId="581"             GOHId="2"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x50F"           FEDId="581"             GOHId="2"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="3">
-          <diamond_channel id="0"         hw_id="0x516"           FEDId="581"             GOHId="10"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x511"           FEDId="581"             GOHId="10"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x517"           FEDId="581"             GOHId="10"               IdxInFiber="7"/>
-          <diamond_channel id="3"         hw_id="0x51D"           FEDId="581"             GOHId="10"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x51A"           FEDId="581"             GOHId="10"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x512"           FEDId="581"             GOHId="10"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x514"           FEDId="581"             GOHId="10"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x51C"           FEDId="581"             GOHId="10"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x51B"           FEDId="581"             GOHId="10"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x513"           FEDId="581"             GOHId="10"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x519"           FEDId="581"             GOHId="10"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x51F"           FEDId="581"             GOHId="10"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x516"           FEDId="581"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x511"           FEDId="581"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x517"           FEDId="581"             GOHId="3"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x51D"           FEDId="581"             GOHId="3"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x51A"           FEDId="581"             GOHId="3"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x512"           FEDId="581"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x514"           FEDId="581"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x51C"           FEDId="581"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x51B"           FEDId="581"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x513"           FEDId="581"             GOHId="3"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x519"           FEDId="581"             GOHId="3"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x51F"           FEDId="581"             GOHId="3"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>
     </station>
@@ -188,60 +188,60 @@
     <station id="2">        <!-- 220 m near-->
       <rp_detector_set id="2">        <!-- Timing -->
         <rp_plane_diamond id="0"> 
-          <diamond_channel id="0"         hw_id="0x806"           FEDId="579"             GOHId="3"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x801"           FEDId="579"             GOHId="3"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x807"           FEDId="579"             GOHId="3"               IdxInFiber="7"/>
-          <diamond_channel id="3"         hw_id="0x80D"           FEDId="579"             GOHId="3"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x80A"           FEDId="579"             GOHId="3"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x802"           FEDId="579"             GOHId="3"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x804"           FEDId="579"             GOHId="3"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x80C"           FEDId="579"             GOHId="3"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x80B"           FEDId="579"             GOHId="3"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x803"           FEDId="579"             GOHId="3"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x809"           FEDId="579"             GOHId="3"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x80F"           FEDId="579"             GOHId="3"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x806"           FEDId="579"             GOHId="0"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x801"           FEDId="579"             GOHId="0"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x807"           FEDId="579"             GOHId="0"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x80D"           FEDId="579"             GOHId="0"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x80A"           FEDId="579"             GOHId="0"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x802"           FEDId="579"             GOHId="0"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x804"           FEDId="579"             GOHId="0"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x80C"           FEDId="579"             GOHId="0"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x80B"           FEDId="579"             GOHId="0"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x803"           FEDId="579"             GOHId="0"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x809"           FEDId="579"             GOHId="0"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x80F"           FEDId="579"             GOHId="0"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="1"> 
-          <diamond_channel id="0"         hw_id="0x816"           FEDId="579"             GOHId="4"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x811"           FEDId="579"             GOHId="4"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x817"           FEDId="579"             GOHId="4"               IdxInFiber="7"/>
-          <diamond_channel id="3"         hw_id="0x81D"           FEDId="579"             GOHId="4"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x81A"           FEDId="579"             GOHId="4"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x812"           FEDId="579"             GOHId="4"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x814"           FEDId="579"             GOHId="4"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x81C"           FEDId="579"             GOHId="4"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x81B"           FEDId="579"             GOHId="4"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x813"           FEDId="579"             GOHId="4"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x819"           FEDId="579"             GOHId="4"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x81F"           FEDId="579"             GOHId="4"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x816"           FEDId="579"             GOHId="1"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x811"           FEDId="579"             GOHId="1"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x817"           FEDId="579"             GOHId="1"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x81D"           FEDId="579"             GOHId="1"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x81A"           FEDId="579"             GOHId="1"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x812"           FEDId="579"             GOHId="1"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x814"           FEDId="579"             GOHId="1"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x81C"           FEDId="579"             GOHId="1"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x81B"           FEDId="579"             GOHId="1"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x813"           FEDId="579"             GOHId="1"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x819"           FEDId="579"             GOHId="1"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x81F"           FEDId="579"             GOHId="1"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="2"> 
-          <diamond_channel id="0"         hw_id="0x706"           FEDId="579"             GOHId="5"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x701"           FEDId="579"             GOHId="5"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x707"           FEDId="579"             GOHId="5"               IdxInFiber="7"/>
-          <diamond_channel id="3"         hw_id="0x70D"           FEDId="579"             GOHId="5"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x70A"           FEDId="579"             GOHId="5"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x702"           FEDId="579"             GOHId="5"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x704"           FEDId="579"             GOHId="5"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x70C"           FEDId="579"             GOHId="5"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x70B"           FEDId="579"             GOHId="5"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x703"           FEDId="579"             GOHId="5"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x709"           FEDId="579"             GOHId="5"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x70F"           FEDId="579"             GOHId="5"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x706"           FEDId="579"             GOHId="2"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x701"           FEDId="579"             GOHId="2"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x707"           FEDId="579"             GOHId="2"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x70D"           FEDId="579"             GOHId="2"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x70A"           FEDId="579"             GOHId="2"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x702"           FEDId="579"             GOHId="2"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x704"           FEDId="579"             GOHId="2"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x70C"           FEDId="579"             GOHId="2"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x70B"           FEDId="579"             GOHId="2"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x703"           FEDId="579"             GOHId="2"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x709"           FEDId="579"             GOHId="2"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x70F"           FEDId="579"             GOHId="2"               IdxInFiber="15"/>
         </rp_plane_diamond>
         <rp_plane_diamond id="3">
-          <diamond_channel id="0"         hw_id="0x716"           FEDId="579"             GOHId="10"               IdxInFiber="6"/>
-          <diamond_channel id="1"         hw_id="0x711"           FEDId="579"             GOHId="10"               IdxInFiber="1"/>
-          <diamond_channel id="2"         hw_id="0x717"           FEDId="579"             GOHId="10"               IdxInFiber="7"/>
-          <diamond_channel id="3"         hw_id="0x71D"           FEDId="579"             GOHId="10"               IdxInFiber="13"/>     
-          <diamond_channel id="4"         hw_id="0x71A"           FEDId="579"             GOHId="10"               IdxInFiber="10"/>
-          <diamond_channel id="5"         hw_id="0x712"           FEDId="579"             GOHId="10"               IdxInFiber="2"/>
-          <diamond_channel id="6"         hw_id="0x714"           FEDId="579"             GOHId="10"               IdxInFiber="4"/>
-          <diamond_channel id="7"         hw_id="0x71C"           FEDId="579"             GOHId="10"               IdxInFiber="12"/>
-          <diamond_channel id="8"         hw_id="0x71B"           FEDId="579"             GOHId="10"               IdxInFiber="11"/>
-          <diamond_channel id="9"         hw_id="0x713"           FEDId="579"             GOHId="10"               IdxInFiber="3"/>
-          <diamond_channel id="10"        hw_id="0x719"           FEDId="579"             GOHId="10"               IdxInFiber="9"/>
-          <diamond_channel id="11"        hw_id="0x71F"           FEDId="579"             GOHId="10"               IdxInFiber="15"/>
+          <diamond_channel id="0"         hw_id="0x716"           FEDId="579"             GOHId="3"               IdxInFiber="6"/>
+          <diamond_channel id="1"         hw_id="0x711"           FEDId="579"             GOHId="3"               IdxInFiber="1"/>
+          <diamond_channel id="2"         hw_id="0x717"           FEDId="579"             GOHId="3"               IdxInFiber="7"/>
+          <diamond_channel id="3"         hw_id="0x71D"           FEDId="579"             GOHId="3"               IdxInFiber="13"/>     
+          <diamond_channel id="4"         hw_id="0x71A"           FEDId="579"             GOHId="3"               IdxInFiber="10"/>
+          <diamond_channel id="5"         hw_id="0x712"           FEDId="579"             GOHId="3"               IdxInFiber="2"/>
+          <diamond_channel id="6"         hw_id="0x714"           FEDId="579"             GOHId="3"               IdxInFiber="4"/>
+          <diamond_channel id="7"         hw_id="0x71C"           FEDId="579"             GOHId="3"               IdxInFiber="12"/>
+          <diamond_channel id="8"         hw_id="0x71B"           FEDId="579"             GOHId="3"               IdxInFiber="11"/>
+          <diamond_channel id="9"         hw_id="0x713"           FEDId="579"             GOHId="3"               IdxInFiber="3"/>
+          <diamond_channel id="10"        hw_id="0x719"           FEDId="579"             GOHId="3"               IdxInFiber="9"/>
+          <diamond_channel id="11"        hw_id="0x71F"           FEDId="579"             GOHId="3"               IdxInFiber="15"/>
         </rp_plane_diamond>
       </rp_detector_set>
     </station>

--- a/CondFormats/PPSObjects/xml/mapping_totem_timing_2022.xml
+++ b/CondFormats/PPSObjects/xml/mapping_totem_timing_2022.xml
@@ -1,0 +1,321 @@
+<top>
+  <arm id="0">  <!-- 45 -->
+    <station id="1">        <!-- 215 m -->
+      <rp_detector_set id="6">                  
+        <timing_plane id="0">
+          <timing_channel id="0" hwId="0x00"/>
+          <timing_channel id="1" hwId="0x01"/>
+          <timing_channel id="2" hwId="0x02"/>
+          <timing_channel id="3" hwId="0x03"/>
+          <timing_channel id="8" hwId="0x04"/>
+          <timing_channel id="9" hwId="0x05"/>
+          <timing_channel id="10" hwId="0x06"/>
+          <timing_channel id="11" hwId="0x07"/>
+        </timing_plane>
+        <timing_plane id="1">
+          <timing_channel id="0" hwId="0x08"/>
+          <timing_channel id="1" hwId="0x09"/>
+          <timing_channel id="2" hwId="0x0A"/>
+          <timing_channel id="3" hwId="0x0B"/>
+          <timing_channel id="8" hwId="0x0C"/>
+          <timing_channel id="9" hwId="0x0D"/>
+          <timing_channel id="10" hwId="0x0E"/>
+          <timing_channel id="11" hwId="0x0F"/>
+        </timing_plane>    
+        <timing_plane id="2">
+          <timing_channel id="0" hwId="0x10"/>
+          <timing_channel id="1" hwId="0x11"/>
+          <timing_channel id="2" hwId="0x12"/>
+          <timing_channel id="3" hwId="0x13"/>
+          <timing_channel id="8" hwId="0x14"/>
+          <timing_channel id="9" hwId="0x15"/>
+          <timing_channel id="10" hwId="0x16"/>
+          <timing_channel id="11" hwId="0x17"/>
+        </timing_plane>
+        <timing_plane id="3">
+          <timing_channel id="0" hwId="0x18"/>
+          <timing_channel id="1" hwId="0x19"/>
+          <timing_channel id="2" hwId="0x1A"/>
+          <timing_channel id="3" hwId="0x1B"/>
+          <timing_channel id="8" hwId="0x1C"/>
+          <timing_channel id="9" hwId="0x1D"/>
+          <timing_channel id="10" hwId="0x1E"/>
+          <timing_channel id="11" hwId="0x1F"/>
+        </timing_plane>
+        <rp_sampic_board id="0">
+          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="5"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="5"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="5"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="5"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="5"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="587"     GOHId="5"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="5"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="5"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="5"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="5"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="5"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="5"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="5"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="5"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="5"       IdxInFiber="14"/>
+        </rp_sampic_board>
+        <rp_sampic_board id="1">
+          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="10"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="10"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="10"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="10"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="10"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="587"     GOHId="10"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="10"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="10"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="10"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="10"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="10"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="10"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="10"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="10"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="10"       IdxInFiber="14"/>
+        </rp_sampic_board>
+      </rp_detector_set>
+    </station>
+    <station id="2">        <!-- 220m near-->
+      <rp_detector_set id="2">                  
+        <timing_plane id="0">
+          <timing_channel id="0" hwId="0x20"/>
+          <timing_channel id="1" hwId="0x21"/>
+          <timing_channel id="2" hwId="0x22"/>
+          <timing_channel id="3" hwId="0x23"/>
+          <timing_channel id="8" hwId="0x24"/>
+          <timing_channel id="9" hwId="0x25"/>
+          <timing_channel id="10" hwId="0x26"/>
+          <timing_channel id="11" hwId="0x27"/>
+        </timing_plane>
+        <timing_plane id="1">
+          <timing_channel id="0" hwId="0x28"/>
+          <timing_channel id="1" hwId="0x29"/>
+          <timing_channel id="2" hwId="0x2A"/>
+          <timing_channel id="3" hwId="0x2B"/>
+          <timing_channel id="8" hwId="0x2C"/>
+          <timing_channel id="9" hwId="0x2D"/>
+          <timing_channel id="10" hwId="0x2E"/>
+          <timing_channel id="11" hwId="0x2F"/>
+        </timing_plane>    
+        <timing_plane id="2">
+          <timing_channel id="0" hwId="0x30"/>
+          <timing_channel id="1" hwId="0x31"/>
+          <timing_channel id="2" hwId="0x32"/>
+          <timing_channel id="3" hwId="0x33"/>
+          <timing_channel id="8" hwId="0x34"/>
+          <timing_channel id="9" hwId="0x35"/>
+          <timing_channel id="10" hwId="0x36"/>
+          <timing_channel id="11" hwId="0x37"/>
+        </timing_plane>
+        <timing_plane id="3">
+          <timing_channel id="0" hwId="0x38"/>
+          <timing_channel id="1" hwId="0x39"/>
+          <timing_channel id="2" hwId="0x3A"/>
+          <timing_channel id="3" hwId="0x3B"/>
+          <timing_channel id="8" hwId="0x3C"/>
+          <timing_channel id="9" hwId="0x3D"/>
+          <timing_channel id="10" hwId="0x3E"/>
+          <timing_channel id="11" hwId="0x3F"/>
+        </timing_plane>
+        <rp_sampic_board id="0">
+          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="3"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="3"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="3"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="3"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="3"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="3"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="3"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="3"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="3"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="3"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="3"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="3"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="3"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="3"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="3"       IdxInFiber="14"/>
+        </rp_sampic_board>
+        <rp_sampic_board id="1">
+          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="4"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="4"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="4"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="4"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="4"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="587"     GOHId="4"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="4"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="4"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="4"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="4"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="4"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="4"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="4"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="4"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="4"       IdxInFiber="14"/>
+        </rp_sampic_board>
+      </rp_detector_set>
+    </station>
+   </arm>
+   <arm id="1">  <!-- 56 -->
+    <station id="1">        <!-- 215 m -->
+      <rp_detector_set id="6">                  
+        <timing_plane id="0">
+          <timing_channel id="0" hwId="0x40"/>
+          <timing_channel id="1" hwId="0x41"/>
+          <timing_channel id="2" hwId="0x42"/>
+          <timing_channel id="3" hwId="0x43"/>
+          <timing_channel id="8" hwId="0x44"/>
+          <timing_channel id="9" hwId="0x45"/>
+          <timing_channel id="10" hwId="0x46"/>
+          <timing_channel id="11" hwId="0x47"/>
+        </timing_plane>
+        <timing_plane id="1">
+          <timing_channel id="0" hwId="0x48"/>
+          <timing_channel id="1" hwId="0x49"/>
+          <timing_channel id="2" hwId="0x4A"/>
+          <timing_channel id="3" hwId="0x4B"/>
+          <timing_channel id="8" hwId="0x4C"/>
+          <timing_channel id="9" hwId="0x4D"/>
+          <timing_channel id="10" hwId="0x4E"/>
+          <timing_channel id="11" hwId="0x4F"/>
+        </timing_plane>    
+        <timing_plane id="2">
+          <timing_channel id="0" hwId="0x50"/>
+          <timing_channel id="1" hwId="0x51"/>
+          <timing_channel id="2" hwId="0x52"/>
+          <timing_channel id="3" hwId="0x53"/>
+          <timing_channel id="8" hwId="0x54"/>
+          <timing_channel id="9" hwId="0x55"/>
+          <timing_channel id="10" hwId="0x56"/>
+          <timing_channel id="11" hwId="0x57"/>
+        </timing_plane>
+        <timing_plane id="3">
+          <timing_channel id="0" hwId="0x58"/>
+          <timing_channel id="1" hwId="0x59"/>
+          <timing_channel id="2" hwId="0x5A"/>
+          <timing_channel id="3" hwId="0x5B"/>
+          <timing_channel id="8" hwId="0x5C"/>
+          <timing_channel id="9" hwId="0x5D"/>
+          <timing_channel id="10" hwId="0x5E"/>
+          <timing_channel id="11" hwId="0x5F"/>
+        </timing_plane>
+        <rp_sampic_board id="0">
+          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="5"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="5"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="5"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="5"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="5"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="586"     GOHId="5"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="5"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="5"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="5"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="5"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="5"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="5"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="5"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="5"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="5"       IdxInFiber="14"/>
+        </rp_sampic_board>
+        <rp_sampic_board id="1">
+          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="10"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="10"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="10"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="10"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="10"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="586"     GOHId="10"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="10"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="10"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="10"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="10"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="10"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="10"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="10"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="10"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="10"       IdxInFiber="14"/>
+        </rp_sampic_board>
+      </rp_detector_set>
+    </station>     
+    <station id="2">        <!-- 220m near-->
+      <rp_detector_set id="2">                  
+        <timing_plane id="0">
+          <timing_channel id="0" hwId="0x60"/>
+          <timing_channel id="1" hwId="0x61"/>
+          <timing_channel id="2" hwId="0x62"/>
+          <timing_channel id="3" hwId="0x63"/>
+          <timing_channel id="8" hwId="0x64"/>
+          <timing_channel id="9" hwId="0x65"/>
+          <timing_channel id="10" hwId="0x66"/>
+          <timing_channel id="11" hwId="0x67"/>
+        </timing_plane>
+        <timing_plane id="1">
+          <timing_channel id="0" hwId="0x68"/>
+          <timing_channel id="1" hwId="0x69"/>
+          <timing_channel id="2" hwId="0x6A"/>
+          <timing_channel id="3" hwId="0x6B"/>
+          <timing_channel id="8" hwId="0x6C"/>
+          <timing_channel id="9" hwId="0x6D"/>
+          <timing_channel id="10" hwId="0x6E"/>
+          <timing_channel id="11" hwId="0x6F"/>
+        </timing_plane>    
+        <timing_plane id="2">
+          <timing_channel id="0" hwId="0x70"/>
+          <timing_channel id="1" hwId="0x71"/>
+          <timing_channel id="2" hwId="0x72"/>
+          <timing_channel id="3" hwId="0x73"/>
+          <timing_channel id="8" hwId="0x74"/>
+          <timing_channel id="9" hwId="0x75"/>
+          <timing_channel id="10" hwId="0x76"/>
+          <timing_channel id="11" hwId="0x77"/>
+        </timing_plane>
+        <timing_plane id="3">
+          <timing_channel id="0" hwId="0x78"/>
+          <timing_channel id="1" hwId="0x79"/>
+          <timing_channel id="2" hwId="0x7A"/>
+          <timing_channel id="3" hwId="0x7B"/>
+          <timing_channel id="8" hwId="0x7C"/>
+          <timing_channel id="9" hwId="0x7D"/>
+          <timing_channel id="10" hwId="0x7E"/>
+          <timing_channel id="11" hwId="0x7F"/>
+        </timing_plane>
+        <rp_sampic_board id="0">
+          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="3"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="3"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="3"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="3"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="3"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="3"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="3"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="3"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="3"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="3"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="3"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="3"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="3"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="3"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="3"       IdxInFiber="14"/>
+        </rp_sampic_board>
+        <rp_sampic_board id="1">
+          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="4"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="4"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="4"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="4"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="4"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="586"     GOHId="4"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="4"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="4"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="4"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="4"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="4"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="4"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="4"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="4"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="4"       IdxInFiber="14"/>
+        </rp_sampic_board>
+      </rp_detector_set>
+    </station>
+  </arm>
+</top>
+
+     
+ 

--- a/CondFormats/PPSObjects/xml/mapping_totem_timing_2022.xml
+++ b/CondFormats/PPSObjects/xml/mapping_totem_timing_2022.xml
@@ -43,38 +43,38 @@
           <timing_channel id="11" hwId="0x1F"/>
         </timing_plane>
         <rp_sampic_board id="0">
-          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="5"       IdxInFiber="0"/>
-          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="5"       IdxInFiber="1"/>
-          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="5"       IdxInFiber="2"/>
-          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="5"       IdxInFiber="3"/>
-          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="5"       IdxInFiber="4"/>
-          <rp_sampic_channel       id="5"        FEDId="587"     GOHId="5"       IdxInFiber="5"/>
-          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="5"       IdxInFiber="6"/>
-          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="5"       IdxInFiber="7"/>
-          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="5"       IdxInFiber="8"/>
-          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="5"       IdxInFiber="9"/>
-          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="5"       IdxInFiber="10"/>
-          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="5"       IdxInFiber="11"/>
-          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="5"       IdxInFiber="12"/>
-          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="5"       IdxInFiber="13"/>
-          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="5"       IdxInFiber="14"/>
+          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="2"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="2"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="2"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="2"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="2"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="587"     GOHId="2"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="2"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="2"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="2"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="2"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="2"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="2"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="2"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="2"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="2"       IdxInFiber="14"/>
         </rp_sampic_board>
         <rp_sampic_board id="1">
-          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="10"       IdxInFiber="0"/>
-          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="10"       IdxInFiber="1"/>
-          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="10"       IdxInFiber="2"/>
-          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="10"       IdxInFiber="3"/>
-          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="10"       IdxInFiber="4"/>
-          <rp_sampic_channel       id="5"        FEDId="587"     GOHId="10"       IdxInFiber="5"/>
-          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="10"       IdxInFiber="6"/>
-          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="10"       IdxInFiber="7"/>
-          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="10"       IdxInFiber="8"/>
-          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="10"       IdxInFiber="9"/>
-          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="10"       IdxInFiber="10"/>
-          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="10"       IdxInFiber="11"/>
-          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="10"       IdxInFiber="12"/>
-          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="10"       IdxInFiber="13"/>
-          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="10"       IdxInFiber="14"/>
+          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="3"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="3"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="3"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="3"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="3"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="587"     GOHId="3"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="3"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="3"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="3"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="3"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="3"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="3"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="3"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="3"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="3"       IdxInFiber="14"/>
         </rp_sampic_board>
       </rp_detector_set>
     </station>
@@ -121,38 +121,38 @@
           <timing_channel id="11" hwId="0x3F"/>
         </timing_plane>
         <rp_sampic_board id="0">
-          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="3"       IdxInFiber="0"/>
-          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="3"       IdxInFiber="1"/>
-          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="3"       IdxInFiber="2"/>
-          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="3"       IdxInFiber="3"/>
-          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="3"       IdxInFiber="4"/>
-          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="3"       IdxInFiber="5"/>
-          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="3"       IdxInFiber="6"/>
-          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="3"       IdxInFiber="7"/>
-          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="3"       IdxInFiber="8"/>
-          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="3"       IdxInFiber="9"/>
-          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="3"       IdxInFiber="10"/>
-          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="3"       IdxInFiber="11"/>
-          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="3"       IdxInFiber="12"/>
-          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="3"       IdxInFiber="13"/>
-          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="3"       IdxInFiber="14"/>
+          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="0"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="0"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="0"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="0"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="0"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="0"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="0"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="0"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="0"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="0"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="0"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="0"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="0"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="0"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="0"       IdxInFiber="14"/>
         </rp_sampic_board>
         <rp_sampic_board id="1">
-          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="4"       IdxInFiber="0"/>
-          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="4"       IdxInFiber="1"/>
-          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="4"       IdxInFiber="2"/>
-          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="4"       IdxInFiber="3"/>
-          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="4"       IdxInFiber="4"/>
-          <rp_sampic_channel       id="5"        FEDId="587"     GOHId="4"       IdxInFiber="5"/>
-          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="4"       IdxInFiber="6"/>
-          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="4"       IdxInFiber="7"/>
-          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="4"       IdxInFiber="8"/>
-          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="4"       IdxInFiber="9"/>
-          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="4"       IdxInFiber="10"/>
-          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="4"       IdxInFiber="11"/>
-          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="4"       IdxInFiber="12"/>
-          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="4"       IdxInFiber="13"/>
-          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="4"       IdxInFiber="14"/>
+          <rp_sampic_channel       id="0"        FEDId="587"     GOHId="1"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="587"     GOHId="1"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="587"     GOHId="1"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="587"     GOHId="1"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="587"     GOHId="1"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="587"     GOHId="1"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="587"     GOHId="1"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="587"     GOHId="1"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="587"     GOHId="1"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="587"     GOHId="1"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="587"     GOHId="1"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="587"     GOHId="1"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="587"     GOHId="1"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="587"     GOHId="1"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="587"     GOHId="1"       IdxInFiber="14"/>
         </rp_sampic_board>
       </rp_detector_set>
     </station>
@@ -201,38 +201,38 @@
           <timing_channel id="11" hwId="0x5F"/>
         </timing_plane>
         <rp_sampic_board id="0">
-          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="5"       IdxInFiber="0"/>
-          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="5"       IdxInFiber="1"/>
-          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="5"       IdxInFiber="2"/>
-          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="5"       IdxInFiber="3"/>
-          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="5"       IdxInFiber="4"/>
-          <rp_sampic_channel       id="5"        FEDId="586"     GOHId="5"       IdxInFiber="5"/>
-          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="5"       IdxInFiber="6"/>
-          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="5"       IdxInFiber="7"/>
-          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="5"       IdxInFiber="8"/>
-          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="5"       IdxInFiber="9"/>
-          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="5"       IdxInFiber="10"/>
-          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="5"       IdxInFiber="11"/>
-          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="5"       IdxInFiber="12"/>
-          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="5"       IdxInFiber="13"/>
-          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="5"       IdxInFiber="14"/>
+          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="2"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="2"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="2"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="2"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="2"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="586"     GOHId="2"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="2"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="2"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="2"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="2"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="2"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="2"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="2"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="2"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="2"       IdxInFiber="14"/>
         </rp_sampic_board>
         <rp_sampic_board id="1">
-          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="10"       IdxInFiber="0"/>
-          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="10"       IdxInFiber="1"/>
-          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="10"       IdxInFiber="2"/>
-          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="10"       IdxInFiber="3"/>
-          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="10"       IdxInFiber="4"/>
-          <rp_sampic_channel       id="5"        FEDId="586"     GOHId="10"       IdxInFiber="5"/>
-          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="10"       IdxInFiber="6"/>
-          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="10"       IdxInFiber="7"/>
-          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="10"       IdxInFiber="8"/>
-          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="10"       IdxInFiber="9"/>
-          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="10"       IdxInFiber="10"/>
-          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="10"       IdxInFiber="11"/>
-          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="10"       IdxInFiber="12"/>
-          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="10"       IdxInFiber="13"/>
-          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="10"       IdxInFiber="14"/>
+          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="3"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="3"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="3"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="3"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="3"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="586"     GOHId="3"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="3"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="3"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="3"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="3"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="3"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="3"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="3"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="3"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="3"       IdxInFiber="14"/>
         </rp_sampic_board>
       </rp_detector_set>
     </station>     
@@ -279,38 +279,38 @@
           <timing_channel id="11" hwId="0x7F"/>
         </timing_plane>
         <rp_sampic_board id="0">
-          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="3"       IdxInFiber="0"/>
-          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="3"       IdxInFiber="1"/>
-          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="3"       IdxInFiber="2"/>
-          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="3"       IdxInFiber="3"/>
-          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="3"       IdxInFiber="4"/>
-          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="3"       IdxInFiber="5"/>
-          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="3"       IdxInFiber="6"/>
-          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="3"       IdxInFiber="7"/>
-          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="3"       IdxInFiber="8"/>
-          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="3"       IdxInFiber="9"/>
-          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="3"       IdxInFiber="10"/>
-          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="3"       IdxInFiber="11"/>
-          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="3"       IdxInFiber="12"/>
-          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="3"       IdxInFiber="13"/>
-          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="3"       IdxInFiber="14"/>
+          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="0"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="0"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="0"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="0"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="0"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="0"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="0"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="0"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="0"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="0"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="0"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="0"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="0"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="0"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="0"       IdxInFiber="14"/>
         </rp_sampic_board>
         <rp_sampic_board id="1">
-          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="4"       IdxInFiber="0"/>
-          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="4"       IdxInFiber="1"/>
-          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="4"       IdxInFiber="2"/>
-          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="4"       IdxInFiber="3"/>
-          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="4"       IdxInFiber="4"/>
-          <rp_sampic_channel       id="5"        FEDId="586"     GOHId="4"       IdxInFiber="5"/>
-          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="4"       IdxInFiber="6"/>
-          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="4"       IdxInFiber="7"/>
-          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="4"       IdxInFiber="8"/>
-          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="4"       IdxInFiber="9"/>
-          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="4"       IdxInFiber="10"/>
-          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="4"       IdxInFiber="11"/>
-          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="4"       IdxInFiber="12"/>
-          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="4"       IdxInFiber="13"/>
-          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="4"       IdxInFiber="14"/>
+          <rp_sampic_channel       id="0"        FEDId="586"     GOHId="1"       IdxInFiber="0"/>
+          <rp_sampic_channel       id="1"        FEDId="586"     GOHId="1"       IdxInFiber="1"/>
+          <rp_sampic_channel       id="2"        FEDId="586"     GOHId="1"       IdxInFiber="2"/>
+          <rp_sampic_channel       id="3"        FEDId="586"     GOHId="1"       IdxInFiber="3"/>
+          <rp_sampic_channel       id="4"        FEDId="586"     GOHId="1"       IdxInFiber="4"/>
+          <rp_sampic_channel       id="5"        FEDId="586"     GOHId="1"       IdxInFiber="5"/>
+          <rp_sampic_channel       id="6"        FEDId="586"     GOHId="1"       IdxInFiber="6"/>
+          <rp_sampic_channel       id="7"        FEDId="586"     GOHId="1"       IdxInFiber="7"/>
+          <rp_sampic_channel       id="8"        FEDId="586"     GOHId="1"       IdxInFiber="8"/>
+          <rp_sampic_channel       id="9"        FEDId="586"     GOHId="1"       IdxInFiber="9"/>
+          <rp_sampic_channel       id="10"       FEDId="586"     GOHId="1"       IdxInFiber="10"/>
+          <rp_sampic_channel       id="11"       FEDId="586"     GOHId="1"       IdxInFiber="11"/>
+          <rp_sampic_channel       id="12"       FEDId="586"     GOHId="1"       IdxInFiber="12"/>
+          <rp_sampic_channel       id="13"       FEDId="586"     GOHId="1"       IdxInFiber="13"/>
+          <rp_sampic_channel       id="14"       FEDId="586"     GOHId="1"       IdxInFiber="14"/>
         </rp_sampic_board>
       </rp_detector_set>
     </station>

--- a/CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml
+++ b/CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml
@@ -387,16 +387,16 @@
 					<vfat id="3" hw_id="0xe1e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="15"/>
 				</rp_plane>
 				<rp_plane id="8">
-					<vfat id="0" hw_id="0xe972" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="0"/>
-					<vfat id="1" hw_id="0xc972" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="1"/>
-					<vfat id="2" hw_id="0xa572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="2"/>
-					<vfat id="3" hw_id="0xe9f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="3"/>
+					<vfat id="0" hw_id="0xe972" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="3" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xc972" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="3" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xa572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="3" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xe9f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="3" IdxInFiber="3"/>
 				</rp_plane>
 				<rp_plane id="9">
-					<vfat id="0" hw_id="0xf572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="4"/>
-					<vfat id="1" hw_id="0xf5f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="5"/>
-					<vfat id="2" hw_id="0xa172" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="6"/>
-					<vfat id="3" hw_id="0xc572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="7"/>
+					<vfat id="0" hw_id="0xf572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="3" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xf5f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="3" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xa172" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="3" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xc572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="3" IdxInFiber="7"/>
 				</rp_plane>
 			</rp_detector_set>
 		</station>

--- a/CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml
+++ b/CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml
@@ -1,0 +1,534 @@
+<!--CondFormats/PPSObjects/xml/-->
+<top>	
+	<arm id="0">
+		<station id="2">		
+			<!--6e / FED 585 -- 220 45 FR BOT --><!--it was 5b, planes swapped-->
+			<rp_detector_set id="5">
+				<trigger_vfat hw_id="0xa161"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="2" IdxInFiber="8"/>  
+				<rp_plane id="9">	
+					<vfat id="0" hw_id="0xc9e0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xeb60"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xa360"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xcb60"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="3"/>
+				</rp_plane>			
+				<rp_plane id="8">
+					<vfat id="0" hw_id="0xe5e0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0x91e0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0x9f60"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0x9de0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="7"/>         
+				</rp_plane>			
+				<rp_plane id="7">
+					<vfat id="0" hw_id="0xa35e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0xf160"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0xf1e0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xb1e0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="11"/>         
+				</rp_plane>			
+				<rp_plane id="6">
+					<vfat id="0" hw_id="0xf9de"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xeb5e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xebde"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xa95e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="0" IdxInFiber="15"/>           
+				</rp_plane>			
+				<rp_plane id="5">
+					<vfat id="0" hw_id="0xafde"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xdb5e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xadde"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xbf5e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="3"/>          
+				</rp_plane>			
+				<rp_plane id="4">
+					<vfat id="0" hw_id="0xb96b"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xf55e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xf5de"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xe35e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="7"/>
+				</rp_plane>			
+				<rp_plane id="3">
+					<vfat id="0" hw_id="0x8b5e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0x89de"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0x895e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xdf5e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="11"/>
+				</rp_plane>			
+				<rp_plane id="2">
+					<vfat id="0" hw_id="0xa160"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xb5de"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xade0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xc360"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="1" IdxInFiber="15"/>
+				</rp_plane>			
+				<rp_plane id="1">
+					<vfat id="0" hw_id="0xe3ec"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="2" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xe1ec"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="2" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xf5ec"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="2" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xcfec"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="2" IdxInFiber="3"/>
+				</rp_plane>			
+				<rp_plane id="0">
+					<vfat id="0" hw_id="0xd5e0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="2" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xcde0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="2" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xb35e"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="2" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xe1e0"  SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="2" IdxInFiber="7"/>	
+				</rp_plane>
+			</rp_detector_set>
+			<!--6d / FED 585 --  220 45 FR TOP -->	
+			<rp_detector_set id="4">
+				<trigger_vfat hw_id="0xb1e1" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="8" IdxInFiber="8"/> 			
+				<rp_plane id="0">
+					<vfat id="0" hw_id="0xd969" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xe9e9" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xd7e9" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xd769" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="3"/>
+				</rp_plane>			
+				<rp_plane id="1">
+					<vfat id="0" hw_id="0xc9e1" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xeb61" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xaf61" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xdbe1" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="7"/>           
+				</rp_plane>			
+				<rp_plane id="2">
+					<vfat id="0" hw_id="0xa7e9" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0xb969" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0xb9e9" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0x9769" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="11"/>             
+				</rp_plane>			
+				<rp_plane id="3">
+					<vfat id="0" hw_id="0xb169" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xc169" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xafe9" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0x9169" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="6" IdxInFiber="15"/>             
+				</rp_plane>			
+				<rp_plane id="4">
+					<vfat id="0" hw_id="0xb5dd" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xb55d" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xa3dd" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xd95d" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="3"/>             
+				</rp_plane>			
+				<rp_plane id="5">
+					<vfat id="0" hw_id="0xcd69" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xa9e9" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xbb69" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xbbe9" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="7"/>
+				</rp_plane>			
+				<rp_plane id="6">
+					<vfat id="0" hw_id="0xbde2" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0x89dc" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0xf962" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xe35d" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="11"/>
+				</rp_plane>			
+				<rp_plane id="7">
+					<vfat id="0" hw_id="0x99dc" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xab5c" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xabdc" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0x8ddc" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="7" IdxInFiber="15"/>
+				</rp_plane>			
+				<rp_plane id="8">
+					<vfat id="0" hw_id="0xaddc" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="8" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0x95dc" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="8" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xd3dc" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="8" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xaf5c" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="8" IdxInFiber="3"/>
+				</rp_plane>			
+				<rp_plane id="9">
+					<vfat id="0" hw_id="0xc1dc" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="8" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xd9dd" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="8" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xd75d" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="8" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0x9bdc" SubSystemId="4" TOTFEDId="18" OptoRxId="1" GOHId="8" IdxInFiber="7"/>
+				</rp_plane>
+			</rp_detector_set>
+		</station>
+		<station id="0">
+			<!--4e / FED 578 -- 210 45 FR BOT -->	
+			<rp_detector_set id="5">
+				<trigger_vfat hw_id="0xd260" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="8"/>  				
+				<rp_plane id="0">
+					<vfat id="0" hw_id="0x9f6a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0x916a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xbb6a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xc3ea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="3"/>
+				</rp_plane>			
+				<rp_plane id="1">
+					<vfat id="0" hw_id="0xf3e2" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xafe2" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0x9d5d" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0x91dd" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="7"/>           
+				</rp_plane>			
+				<rp_plane id="2">
+					<vfat id="0" hw_id="0xf7dd" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0xc15d" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0x9d69" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xafdd" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="11"/>            
+				</rp_plane>			
+				<rp_plane id="3">
+					<vfat id="0" hw_id="0xabea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xf3ea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xff6a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xab6a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="3" IdxInFiber="15"/>            
+				</rp_plane>			
+				<rp_plane id="4">
+					<vfat id="0" hw_id="0xb1e8" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xc368" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xe7e9" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xaf68" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="3"/>             
+				</rp_plane>			
+				<rp_plane id="5">
+					<vfat id="0" hw_id="0xaf5d" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xc35d" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xc3dd" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xf5e9" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="7"/>
+				</rp_plane>			
+				<rp_plane id="6">
+					<vfat id="0" hw_id="0xadea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0x9d6a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0xb1ea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xc1ea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="11"/>
+				</rp_plane>			
+				<rp_plane id="7">
+					<vfat id="0" hw_id="0xf9ea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xdfea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xddea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xf96a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="1" IdxInFiber="15"/>
+				</rp_plane>			
+				<rp_plane id="8">
+					<vfat id="0" hw_id="0xe769" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xf368" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0x9de9" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0x9f68" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="3"/>
+				</rp_plane>			
+				<rp_plane id="9">
+				        <!-- plane exchanged in 2022
+					<vfat id="0" hw_id="0xc36a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0x8d6a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0x996a" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0x99ea" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="7"/>
+					-->
+					<vfat id="0" hw_id="0xfbe8" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xa168" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xed68" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xede8" SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="2" IdxInFiber="7"/>		
+				</rp_plane>
+			<!--4d / FED 578 -- 210 45 FAR TOP-->		        
+			<rp_detector_set id="4">
+				<trigger_vfat hw_id="0xb961"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="8" IdxInFiber="8" />				
+				<rp_plane id="0">
+					<vfat id="0" hw_id="0x995d"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="0" />
+					<vfat id="1" hw_id="0x8ddd"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="1" />
+					<vfat id="2" hw_id="0x8d5d"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="2" />
+					<vfat id="3" hw_id="0xab5d"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="3" />
+				</rp_plane>			
+				<rp_plane id="1">
+					<vfat id="0" hw_id="0xfdea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="4" />
+					<vfat id="1" hw_id="0xf16a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="5" />
+					<vfat id="2" hw_id="0xe1ea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="6" />
+					<vfat id="3" hw_id="0xe56a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="7" />
+				</rp_plane>			
+				<rp_plane id="2">
+					<vfat id="0" hw_id="0xdb6a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="8" />
+					<vfat id="1" hw_id="0xebea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="9" />
+					<vfat id="2" hw_id="0xe5ea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="10" />
+					<vfat id="3" hw_id="0xbdea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="11" />
+				</rp_plane>			
+				<rp_plane id="3">
+					<vfat id="0" hw_id="0x9fdd"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="12" />
+					<vfat id="1" hw_id="0xb1dd"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="13" />
+					<vfat id="2" hw_id="0xcde9"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="14" />
+					<vfat id="3" hw_id="0xfbdd"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="6" IdxInFiber="15" />
+				</rp_plane>			
+				<rp_plane id="4">
+					<vfat id="0" hw_id="0xa96a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="0" />
+					<vfat id="1" hw_id="0xc76a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="1" />
+					<vfat id="2" hw_id="0xb76a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="2" />
+					<vfat id="3" hw_id="0xa56a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="3" />
+				</rp_plane>
+				<rp_plane id="5">
+					<vfat id="0" hw_id="0xf76a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="4" />
+					<vfat id="1" hw_id="0xe36a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="5" />
+					<vfat id="2" hw_id="0xdbea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="6" />
+					<vfat id="3" hw_id="0xe76a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="7" />
+				</rp_plane>			
+				<rp_plane id="6">
+					<vfat id="0" hw_id="0xa3ea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="8" />
+					<vfat id="1" hw_id="0xb7ea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="9" />
+					<vfat id="2" hw_id="0x936a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="10" />
+					<vfat id="3" hw_id="0x93ea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="11" />
+				</rp_plane>			
+				<rp_plane id="7">
+					<vfat id="0" hw_id="0x9b5d"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="12" />
+					<vfat id="1" hw_id="0x8fdd"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="13" />
+					<vfat id="2" hw_id="0x8f5d"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="14" />
+					<vfat id="3" hw_id="0xad5d"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="7" IdxInFiber="15" />
+				</rp_plane>			
+				<rp_plane id="8">
+					<vfat id="0" hw_id="0xa5ea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="8" IdxInFiber="0" />
+					<vfat id="1" hw_id="0x896a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="8" IdxInFiber="1" />
+					<vfat id="2" hw_id="0xcb6a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="8" IdxInFiber="2" />
+					<vfat id="3" hw_id="0x8b6a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="8" IdxInFiber="3" />
+				</rp_plane>			
+				<rp_plane id="9">
+					<vfat id="0" hw_id="0x956a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="8" IdxInFiber="4" />
+					<vfat id="1" hw_id="0xb96a"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="8" IdxInFiber="5" />
+					<vfat id="2" hw_id="0x89ea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="8" IdxInFiber="6" />
+					<vfat id="3" hw_id="0xb9ea"  SubSystemId="4" TOTFEDId="16" OptoRxId="2" GOHId="8" IdxInFiber="7" />
+				</rp_plane>
+			</rp_detector_set> 		
+		</station>
+	</arm>
+	
+				
+	<arm id="1">
+		<station id="2">
+			<!--7d / FED 584 -- 220 56 FAR TOP-->
+			<rp_detector_set id="4">
+				<trigger_vfat hw_id="0xabe1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="8" IdxInFiber="8"/> 			
+				<rp_plane id="0">
+					<vfat id="0" hw_id="0xcde1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xdf61" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xffe1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xff61" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="3"/>
+				</rp_plane>
+				<rp_plane id="1">
+					<vfat id="0" hw_id="0xf561" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xe5e1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xe3e1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xe361" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="7"/>              
+				</rp_plane>
+				<rp_plane id="2">
+					<vfat id="0" hw_id="0xcd61" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0xfd61" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0xef61" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xd1e1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="11"/>                
+				</rp_plane>
+				<rp_plane id="3">
+					<vfat id="0" hw_id="0xb962" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xa7e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xb562" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xa3e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="6" IdxInFiber="15"/>               
+				</rp_plane>
+				<rp_plane id="4">
+					<vfat id="0" hw_id="0xe761" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xefe1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xdde1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xf161" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="3"/>               
+				</rp_plane>
+				<rp_plane id="5">
+					<vfat id="0" hw_id="0xd5e1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xf1e1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xe161" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0x8f61" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="7"/>
+				</rp_plane>
+				<rp_plane id="6">
+					<vfat id="0" hw_id="0xeb62" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0xe762" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0xdb62" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xd962" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="11"/>
+				</rp_plane>
+				<rp_plane id="7">
+					<vfat id="0" hw_id="0xb9e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0x89e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xb5e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0x9762" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="7" IdxInFiber="15"/>
+				</rp_plane>
+				<rp_plane id="8">
+					<vfat id="0" hw_id="0xa762" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="8" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0x8be2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="8" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xa562" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="8" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0x8de2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="8" IdxInFiber="3"/>
+				</rp_plane>
+				<rp_plane id="9">
+					<vfat id="0" hw_id="0xd7e1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="8" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xbfe1" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="8" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xe961" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="8" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0x9761" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="8" IdxInFiber="7"/>
+				</rp_plane>
+			</rp_detector_set> 	
+			<!--7e/ FED 584 -- 220 56 FAR BOT-->
+			<rp_detector_set id="5">
+				<trigger_vfat hw_id="0xcd72" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="8"/>
+				<rp_plane id="0">
+					<vfat id="0" hw_id="0xf7eb" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xf6eb" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xc9f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xdb72" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="3"/>
+				</rp_plane>
+				<rp_plane id="1">
+					<vfat id="0" hw_id="0xaf72" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xd3f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xe572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xc172" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="7"/>              
+				</rp_plane>
+				<rp_plane id="2">
+					<vfat id="0" hw_id="0x95f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0x93f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0xa5f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0x8972" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="11"/>                
+				</rp_plane>
+				<rp_plane id="3">
+					<vfat id="0" hw_id="0xdbf2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xeb72" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xebf2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xa3f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="0" IdxInFiber="15"/>                
+				</rp_plane>
+				<rp_plane id="4">
+					<vfat id="0" hw_id="0xffff" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xf3f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xf372" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xbfff" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="3"/>               
+				</rp_plane>
+				<rp_plane id="5">
+					<vfat id="0" hw_id="0xade2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xc162" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xdd62" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xc3e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="7"/>
+				</rp_plane>
+				<rp_plane id="6">
+					<vfat id="0" hw_id="0xe5e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0xd5e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0x8f62" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xef62" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="11"/>
+				</rp_plane>
+				<rp_plane id="7">
+					<vfat id="0" hw_id="0xfbe2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xcf62" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xad62" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xe1e2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="1" IdxInFiber="15"/>
+				</rp_plane>
+				<rp_plane id="8">
+					<vfat id="0" hw_id="0xe972" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xc972" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xa572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xe9f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="3"/>
+				</rp_plane>
+				<rp_plane id="9">
+					<vfat id="0" hw_id="0xf572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xf5f2" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xa172" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xc572" SubSystemId="4" TOTFEDId="18" OptoRxId="0" GOHId="2" IdxInFiber="7"/>
+				</rp_plane>
+			</rp_detector_set>
+		</station>
+       	        <station id="0">
+			<!--5e / FED 580 --  210 56 FAR BOTTOM -->
+			<rp_detector_set id="5">
+				<trigger_vfat hw_id="0x8d61" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="2" IdxInFiber="8"/>    				
+				<rp_plane id="0">	
+					<vfat id="0" hw_id="0xe3e7" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xbfe7" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xebe7" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0xe967" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="3"/>
+				</rp_plane>			
+				<rp_plane id="1">
+					<vfat id="0" hw_id="0x97ea" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0x976a" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xd9e7" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0x9bea" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="7"/>           
+				</rp_plane>			
+				<rp_plane id="2">
+					<vfat id="0" hw_id="0xd75e" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0xe1de" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0xd9de" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xfb5e" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="11"/>           
+				</rp_plane>			
+				<rp_plane id="3">
+					<vfat id="0" hw_id="0xaf6b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xc16b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xc36b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xc1eb" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="0" IdxInFiber="15"/>            
+				</rp_plane>			
+				<rp_plane id="4">
+					<vfat id="0" hw_id="0xddec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0xf96c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xc9ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0x996b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="3"/>             
+				</rp_plane>			
+				<rp_plane id="5">
+					<vfat id="0" hw_id="0xa16b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0xf36b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xf3eb" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xff6b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="7"/>
+				</rp_plane>			
+				<rp_plane id="6">
+					<vfat id="0" hw_id="0xd36b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="8"/>
+					<vfat id="1" hw_id="0xcf6b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="9"/>
+					<vfat id="2" hw_id="0xbdeb" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="10"/>
+					<vfat id="3" hw_id="0xbd6b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="11"/>
+				</rp_plane>			
+				<rp_plane id="7">
+					<vfat id="0" hw_id="0xefeb" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="12"/>
+					<vfat id="1" hw_id="0xcfeb" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="13"/>
+					<vfat id="2" hw_id="0xf16b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xf1eb" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="1" IdxInFiber="15"/>
+				</rp_plane>			
+				<rp_plane id="8">
+					<vfat id="0" hw_id="0xcb6c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="2" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0x896c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="2" IdxInFiber="1"/>
+					<vfat id="2" hw_id="0xb9ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="2" IdxInFiber="2"/>
+					<vfat id="3" hw_id="0x89ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="2" IdxInFiber="3"/>
+				</rp_plane>			
+				<rp_plane id="9">
+					<vfat id="0" hw_id="0x936c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="2" IdxInFiber="4"/>
+					<vfat id="1" hw_id="0x93ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="2" IdxInFiber="5"/>
+					<vfat id="2" hw_id="0xb5ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="2" IdxInFiber="6"/>
+					<vfat id="3" hw_id="0xa36c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="2" IdxInFiber="7"/>
+				</rp_plane>
+			</rp_detector_set> 
+			<!-- 5d /FED 580 --  210 56 FAR TOP -->		        
+			<rp_detector_set id="4">	
+				<trigger_vfat hw_id="0xa5e1" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="8" IdxInFiber="8" />				
+				<rp_plane id="0">
+					<vfat id="0" hw_id="0xd3e0" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="0"/>
+					<vfat id="1" hw_id="0x9d60" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="1" />
+					<vfat id="2" hw_id="0x9fe0" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="2" />
+					<vfat id="3" hw_id="0xad60" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="3" />
+				</rp_plane>			
+				<rp_plane id="1">
+					<vfat id="0" hw_id="0xc9de" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="4" />
+					<vfat id="1" hw_id="0xc95e" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="5" />
+					<vfat id="2" hw_id="0xedde" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="6" />
+					<vfat id="3" hw_id="0xddde" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="7" />
+				</rp_plane>			
+				<rp_plane id="2">
+					<vfat id="0" hw_id="0xff6c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="8" />
+					<vfat id="1" hw_id="0xffec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="9" />
+					<vfat id="2" hw_id="0x99ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="10" />
+					<vfat id="3" hw_id="0x996c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="11" />
+				</rp_plane>			
+				<rp_plane id="3">
+					<vfat id="0" hw_id="0xe9ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="12" />
+					<vfat id="1" hw_id="0xafec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="13" />
+					<vfat id="2" hw_id="0xaf6c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="14" />
+					<vfat id="3" hw_id="0x9fec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="6" IdxInFiber="15" />
+				</rp_plane>			
+				<rp_plane id="4">
+					<vfat id="0" hw_id="0xe360" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="0" />
+					<vfat id="1" hw_id="0xcd60" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="1" />
+					<vfat id="2" hw_id="0xd760" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="2" />
+					<vfat id="3" hw_id="0xd360" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="3" />
+				</rp_plane>			
+				<rp_plane id="5">
+					<vfat id="0" hw_id="0xb7eb" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="4" />
+					<vfat id="1" hw_id="0x8deb" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="5" />
+					<vfat id="2" hw_id="0xc96b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="6" />
+					<vfat id="3" hw_id="0x8d6b" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="7" />
+				</rp_plane>			
+				<rp_plane id="6">
+					<vfat id="0" hw_id="0x8960" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="8" />
+					<vfat id="1" hw_id="0xa560" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="9" />
+					<vfat id="2" hw_id="0x8be0" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="10" />
+					<vfat id="3" hw_id="0xa7e0" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="11" />
+				</rp_plane>			
+				<rp_plane id="7">
+					<vfat id="0" hw_id="0xe16c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="12" />
+					<vfat id="1" hw_id="0xf3ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="13" />
+					<vfat id="2" hw_id="0xa3ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="14"/>
+					<vfat id="3" hw_id="0xb56c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="7" IdxInFiber="15" />
+				</rp_plane>			
+				<rp_plane id="8">
+					<vfat id="0" hw_id="0xbbec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="8" IdxInFiber="0" />
+					<vfat id="1" hw_id="0xc3ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="8" IdxInFiber="1" />
+					<vfat id="2" hw_id="0xc1ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="8" IdxInFiber="2" />
+					<vfat id="3" hw_id="0xd36c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="8" IdxInFiber="3" />
+				</rp_plane>			
+				<rp_plane id="9">
+					<vfat id="0" hw_id="0xf16c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="8" IdxInFiber="4" />
+					<vfat id="1" hw_id="0xe5ec" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="8" IdxInFiber="5" />
+					<vfat id="2" hw_id="0xc76c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="8" IdxInFiber="6" />
+					<vfat id="3" hw_id="0xa16c" SubSystemId="4" TOTFEDId="17" OptoRxId="0" GOHId="8" IdxInFiber="7" />
+				</rp_plane>
+			</rp_detector_set> 
+		</station>
+	</arm>
+</top>

--- a/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
@@ -13,11 +13,6 @@ ctppsDiamondRawToDigi = totemVFATRawToDigi.clone(
         testCRC = 0,                     # no need to test CRC for diamond frames
         testECMostFrequent = 0, # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
     )
-    fedIds = cms.vuint32(579, 581, 582, 583),
-    RawToDigi = totemVFATRawToDigi.RawToDigi.clone(
-        testCRC = cms.uint32(0), # no need to test CRC for diamond frames
-        testECMostFrequent = cms.uint32(0) # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
-    )
 )
 
 # for Run 2 backward compatibility

--- a/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
@@ -8,7 +8,7 @@ from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 ctppsDiamondRawToDigi = totemVFATRawToDigi.clone(
     subSystem = 'TimingDiamond',
-    fedIds = [579, 581, 582, 583],
+    fedIds = [579, 581, 582, 583], #as declared in DataFormats/FEDRawData/interface/FEDNumbering.h
     RawToDigi = dict(
         testCRC = 0,                     # no need to test CRC for diamond frames
         testECMostFrequent = 0, # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker

--- a/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
@@ -7,7 +7,12 @@ from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 ctppsDiamondRawToDigi = totemVFATRawToDigi.clone(
-    subSystem = cms.string('TimingDiamond'),
+    subSystem = 'TimingDiamond',
+    fedIds = [579, 581, 582, 583],
+    RawToDigi = dict(
+        testCRC = 0,                     # no need to test CRC for diamond frames
+        testECMostFrequent = 0, # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
+    )
     fedIds = cms.vuint32(579, 581, 582, 583),
     RawToDigi = totemVFATRawToDigi.RawToDigi.clone(
         testCRC = cms.uint32(0), # no need to test CRC for diamond frames
@@ -17,4 +22,4 @@ ctppsDiamondRawToDigi = totemVFATRawToDigi.clone(
 
 # for Run 2 backward compatibility
 (ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsDiamondRawToDigi,
-fedIds = cms.vuint32())
+fedIds = [] )

--- a/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsDiamondRawToDigi_cfi.py
@@ -1,11 +1,20 @@
 import FWCore.ParameterSet.Config as cms
 
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 ctppsDiamondRawToDigi = totemVFATRawToDigi.clone(
     subSystem = cms.string('TimingDiamond'),
+    fedIds = cms.vuint32(579, 581, 582, 583),
     RawToDigi = totemVFATRawToDigi.RawToDigi.clone(
         testCRC = cms.uint32(0), # no need to test CRC for diamond frames
         testECMostFrequent = cms.uint32(0) # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
     )
 )
+
+# for Run 2 backward compatibility
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsDiamondRawToDigi,
+fedIds = cms.vuint32())

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -35,10 +35,17 @@ totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSource
     ),
     # 2018
     cms.PSet(
-      validityRange = cms.EventRange("311626:min - 999999999:max"),
+      validityRange = cms.EventRange("311626:min - 325175:max"),
       mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2018.xml"),
       maskFileNames = cms.vstring()
+    ),
+    # 2022
+    cms.PSet(
+      validityRange = cms.EventRange("340000:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml"),
+      maskFileNames = cms.vstring()
     )
+    
   )
 )
 
@@ -76,10 +83,17 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
     ),
     # 2018
     cms.PSet(
-      validityRange = cms.EventRange("310001:min - 999999999:max"),
+      validityRange = cms.EventRange("310001:min - 325175:max"),
       mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2018.xml"),
       maskFileNames = cms.vstring()
+    ),
+    # 2022
+    cms.PSet(
+      validityRange = cms.EventRange("340000:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml"),
+      maskFileNames = cms.vstring()
     )
+    
   )
 )
 
@@ -99,8 +113,14 @@ totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXM
     ),
     # 2018
     cms.PSet(
-      validityRange = cms.EventRange("310001:min - 999999999:max"),
+      validityRange = cms.EventRange("310001:min - 325175:max"),
       mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2018.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2022
+    cms.PSet(
+      validityRange = cms.EventRange("340000:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2022.xml"),
       maskFileNames = cms.vstring()
     )
   )

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -35,7 +35,7 @@ totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSource
     ),
     # 2018
     cms.PSet(
-      validityRange = cms.EventRange("311626:min - 325175:max"),
+      validityRange = cms.EventRange("311626:min - 339999:max"),
       mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2018.xml"),
       maskFileNames = cms.vstring()
     ),
@@ -83,7 +83,7 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
     ),
     # 2018
     cms.PSet(
-      validityRange = cms.EventRange("310001:min - 325175:max"),
+      validityRange = cms.EventRange("310001:min - 339999:max"),
       mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2018.xml"),
       maskFileNames = cms.vstring()
     ),
@@ -113,7 +113,7 @@ totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXM
     ),
     # 2018
     cms.PSet(
-      validityRange = cms.EventRange("310001:min - 325175:max"),
+      validityRange = cms.EventRange("310001:min - 339999:max"),
       mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2018.xml"),
       maskFileNames = cms.vstring()
     ),

--- a/EventFilter/CTPPSRawToDigi/python/totemRPRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemRPRawToDigi_cfi.py
@@ -1,7 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 totemRPRawToDigi = totemVFATRawToDigi.clone(
-    subSystem = cms.string('TrackingStrip')
+    subSystem = cms.string('TrackingStrip'),
+    fedIds = cms.vuint32(578, 580, 584, 585)
 )
+
+# for Run 2 backward compatibility
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemRPRawToDigi,
+fedIds = cms.vuint32())

--- a/EventFilter/CTPPSRawToDigi/python/totemRPRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemRPRawToDigi_cfi.py
@@ -7,10 +7,10 @@ from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 totemRPRawToDigi = totemVFATRawToDigi.clone(
-    subSystem = cms.string('TrackingStrip'),
-    fedIds = cms.vuint32(578, 580, 584, 585)
+    subSystem = 'TrackingStrip',
+    fedIds = [578, 580, 584, 585]
 )
 
 # for Run 2 backward compatibility
 (ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemRPRawToDigi,
-fedIds = cms.vuint32())
+fedIds = [] )

--- a/EventFilter/CTPPSRawToDigi/python/totemRPRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemRPRawToDigi_cfi.py
@@ -8,7 +8,7 @@ from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 totemRPRawToDigi = totemVFATRawToDigi.clone(
     subSystem = 'TrackingStrip',
-    fedIds = [578, 580, 584, 585]
+    fedIds = [578, 580, 584, 585] #as declared in DataFormats/FEDRawData/interface/FEDNumbering.h
 )
 
 # for Run 2 backward compatibility

--- a/EventFilter/CTPPSRawToDigi/python/totemTimingRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemTimingRawToDigi_cfi.py
@@ -9,7 +9,7 @@ from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 totemTimingRawToDigi = totemVFATRawToDigi.clone(
     subSystem = 'TotemTiming',
     
-    fedIds = cms.vuint32(586, 587),
+    fedIds = cms.vuint32(586, 587), #as declared in DataFormats/FEDRawData/interface/FEDNumbering.h
     
     RawToDigi = cms.PSet(
     verbosity = cms.untracked.uint32(0),

--- a/EventFilter/CTPPSRawToDigi/python/totemTimingRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemTimingRawToDigi_cfi.py
@@ -1,13 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 totemTimingRawToDigi = totemVFATRawToDigi.clone(
     subSystem = cms.string('TotemTiming'),
     
-    # IMPORTANT: leave empty to load the default configuration from
-    #    DataFormats/FEDRawData/interface/FEDNumbering.h
-    fedIds = cms.vuint32(),
+    fedIds = cms.vuint32(586, 587),
     
     RawToDigi = cms.PSet(
     verbosity = cms.untracked.uint32(0),
@@ -26,3 +28,7 @@ totemTimingRawToDigi = totemVFATRawToDigi.clone(
     printUnknownFrameSummary = cms.untracked.uint32(0)
   )
 )
+
+# for Run 2 backward compatibility
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemTimingRawToDigi,
+fedIds = cms.vuint32())

--- a/EventFilter/CTPPSRawToDigi/python/totemTimingRawToDigi_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemTimingRawToDigi_cfi.py
@@ -7,7 +7,7 @@ from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 
 totemTimingRawToDigi = totemVFATRawToDigi.clone(
-    subSystem = cms.string('TotemTiming'),
+    subSystem = 'TotemTiming',
     
     fedIds = cms.vuint32(586, 587),
     
@@ -31,4 +31,4 @@ totemTimingRawToDigi = totemVFATRawToDigi.clone(
 
 # for Run 2 backward compatibility
 (ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemTimingRawToDigi,
-fedIds = cms.vuint32())
+fedIds = [] )


### PR DESCRIPTION
#### PR description:
This PR updates the xml mappings and FedId configuration for PPS run3. Backward compatibility is sustained.

#### PR validation:
This PR was validated with relvals 136.793, 136.874 (which run PPS reconstruction). New run3 xml's were parsed without issue. We lack the run3 data to conduct more sophisticated tests. For the run2 data, there should be no changes as to the results.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
no