### PR TITLE
Revisit usage of HitPattern in DataFormats/Scouting

### DIFF
--- a/DataFormats/Scouting/BuildFile.xml
+++ b/DataFormats/Scouting/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="DataFormats/TrackReco"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h
@@ -2,6 +2,7 @@
 #define DataFormats_Scouting_Run3Scouting_HitPatternPOD_h
 
 #include <vector>
+#include <cstdint>
 
 struct Run3ScoutingHitPatternPOD {
   uint8_t hitCount;

--- a/DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h
@@ -1,0 +1,17 @@
+#ifndef DataFormats_Scouting_Run3Scouting_HitPatternPOD_h
+#define DataFormats_Scouting_Run3Scouting_HitPatternPOD_h
+
+#include <vector>
+
+struct Run3ScoutingHitPatternPOD {
+  uint8_t hitCount;
+  uint8_t beginTrackHits;
+  uint8_t endTrackHits;
+  uint8_t beginInner;
+  uint8_t endInner;
+  uint8_t beginOuter;
+  uint8_t endOuter;
+  std::vector<uint16_t> hitPattern;
+};
+
+#endif

--- a/DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_Scouting_Run3Scouting_HitPatternPOD_h
-#define DataFormats_Scouting_Run3Scouting_HitPatternPOD_h
+#ifndef DataFormats_Scouting_Run3ScoutingHitPatternPOD_h
+#define DataFormats_Scouting_Run3ScoutingHitPatternPOD_h
 
 #include <vector>
 #include <cstdint>

--- a/DataFormats/Scouting/interface/Run3ScoutingMuon.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingMuon.h
@@ -1,5 +1,5 @@
-#ifndef DataFormats_Run3ScoutingMuon_h
-#define DataFormats_Run3ScoutingMuon_h
+#ifndef DataFormats_Scouting_Run3ScoutingMuon_h
+#define DataFormats_Scouting_Run3ScoutingMuon_h
 
 #include <vector>
 #include "DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h"

--- a/DataFormats/Scouting/interface/Run3ScoutingMuon.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingMuon.h
@@ -2,6 +2,7 @@
 #define DataFormats_Run3ScoutingMuon_h
 
 #include <vector>
+#include "DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
 // Class for holding muon information, for use in data scouting
@@ -63,8 +64,8 @@ public:
                    float trk_vx,
                    float trk_vy,
                    float trk_vz,
-                   reco::HitPattern trk_hitPattern,
-                   std::vector<int> vtxIndx)
+                   std::vector<int> vtxIndx,
+                   Run3ScoutingHitPatternPOD trk_hitPattern)
       : pt_(pt),
         eta_(eta),
         phi_(phi),
@@ -119,8 +120,8 @@ public:
         trk_vx_(trk_vx),
         trk_vy_(trk_vy),
         trk_vz_(trk_vz),
-        trk_hitPattern_(trk_hitPattern),
-        vtxIndx_(std::move(vtxIndx)) {}
+        vtxIndx_(std::move(vtxIndx)),
+        trk_hitPattern_(trk_hitPattern) {}
   //default constructor
   Run3ScoutingMuon()
       : pt_(0),
@@ -237,8 +238,8 @@ public:
   float trk_vx() const { return trk_vx_; }
   float trk_vy() const { return trk_vy_; }
   float trk_vz() const { return trk_vz_; }
-  reco::HitPattern const& trk_hitPattern() const { return trk_hitPattern_; }
   std::vector<int> const& vtxIndx() const { return vtxIndx_; }
+  Run3ScoutingHitPatternPOD const& trk_hitPattern() const { return trk_hitPattern_; }
 
 private:
   float pt_;
@@ -295,8 +296,8 @@ private:
   float trk_vx_;
   float trk_vy_;
   float trk_vz_;
-  reco::HitPattern trk_hitPattern_;
   std::vector<int> vtxIndx_;
+  Run3ScoutingHitPatternPOD trk_hitPattern_;
 };
 
 typedef std::vector<Run3ScoutingMuon> Run3ScoutingMuonCollection;

--- a/DataFormats/Scouting/interface/Run3ScoutingMuon.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingMuon.h
@@ -3,7 +3,6 @@
 
 #include <vector>
 #include "DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h"
-#include "DataFormats/TrackReco/interface/Track.h"
 
 // Class for holding muon information, for use in data scouting
 // IMPORTANT: the content of this class should be changed only in backwards compatible ways!

--- a/DataFormats/Scouting/src/classes.h
+++ b/DataFormats/Scouting/src/classes.h
@@ -7,6 +7,7 @@
 #include "DataFormats/Scouting/interface/ScoutingMuon.h"
 #include "DataFormats/Scouting/interface/ScoutingPhoton.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingCaloJet.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingPFJet.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingParticle.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingTrack.h"

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -55,7 +55,9 @@
   <class name="Run3ScoutingTrack" ClassVersion="3">
       <version ClassVersion="3" checksum="3352318277"/>
   </class>
-  <class name="Run3ScoutingHitPatternPOD"/>
+  <class name="Run3ScoutingHitPatternPOD" ClassVersion="3">
+   <version ClassVersion="3" checksum="1448115564"/>
+  </class>
   <class name="std::vector<ScoutingCaloJet>"/>
   <class name="std::vector<ScoutingPFJet>"/>
   <class name="std::vector<ScoutingParticle>"/>

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -44,8 +44,9 @@
       <version ClassVersion="3" checksum="1086011373"/>
       <version ClassVersion="4" checksum="1250202632"/>
   </class>
-  <class name="Run3ScoutingMuon" ClassVersion="3">
+  <class name="Run3ScoutingMuon" ClassVersion="4">
       <version ClassVersion="3" checksum="3882497397"/>
+      <version ClassVersion="4" checksum="4206297195"/>
   </class>
   <class name="Run3ScoutingPhoton" ClassVersion="4">
       <version ClassVersion="3" checksum="1683146807"/>
@@ -54,6 +55,7 @@
   <class name="Run3ScoutingTrack" ClassVersion="3">
       <version ClassVersion="3" checksum="3352318277"/>
   </class>
+  <class name="Run3ScoutingHitPatternPOD"/>
   <class name="std::vector<ScoutingCaloJet>"/>
   <class name="std::vector<ScoutingPFJet>"/>
   <class name="std::vector<ScoutingParticle>"/>

--- a/DataFormats/TrackReco/BuildFile.xml
+++ b/DataFormats/TrackReco/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/MuonDetId"/>
+<use name="DataFormats/Scouting"/>
 <use name="DataFormats/SiPixelCluster"/>
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/SiStripCluster"/>

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -124,6 +124,7 @@
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "DataFormats/ForwardDetId/interface/MTDDetId.h"
+#include "DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "FWCore/Utilities/interface/Likely.h"
@@ -228,6 +229,8 @@ namespace reco {
     ~HitPattern();
 
     HitPattern(const HitPattern &other);
+
+    HitPattern(const Run3ScoutingHitPatternPOD &other);
 
     HitPattern &operator=(const HitPattern &other);
 
@@ -423,6 +426,9 @@ namespace reco {
     int numberOfDTStationsWithRPhiView() const;
     int numberOfDTStationsWithRZView() const;
     int numberOfDTStationsWithBothViews() const;
+
+    // fill Run3ScoutingHitPatternPOD struct
+    Run3ScoutingHitPatternPOD run3ScoutingHitPatternPOD() const;
 
     //only used by ROOT IO rule to read v12 HitPatterns
     static bool fillNewHitPatternWithOldHitPattern_v12(const uint16_t oldHitPattern[],

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -40,9 +40,9 @@ HitPattern::HitPattern(const Run3ScoutingHitPatternPOD& other)
       endInner(other.endInner),
       beginOuter(other.beginOuter),
       endOuter(other.endOuter) {
-  const static unsigned short max_vector_length_ =
+  const unsigned short max_vector_length =
       (other.hitPattern.size() > HitPattern::ARRAY_LENGTH) ? HitPattern::ARRAY_LENGTH : other.hitPattern.size();
-  std::copy(other.hitPattern.begin(), other.hitPattern.begin() + max_vector_length_, this->hitPattern);
+  std::copy(other.hitPattern.begin(), other.hitPattern.begin() + max_vector_length, this->hitPattern);
 }
 
 HitPattern::~HitPattern() { ; }
@@ -1028,15 +1028,15 @@ bool HitPattern::insertExpectedOuterHit(const uint16_t pattern) {
 }
 
 Run3ScoutingHitPatternPOD HitPattern::run3ScoutingHitPatternPOD() const {
-  Run3ScoutingHitPatternPOD run3ScoutingHitPatternPOD_;
-  run3ScoutingHitPatternPOD_.hitCount = hitCount;
-  run3ScoutingHitPatternPOD_.beginTrackHits = beginTrackHits;
-  run3ScoutingHitPatternPOD_.endTrackHits = endTrackHits;
-  run3ScoutingHitPatternPOD_.beginInner = beginInner;
-  run3ScoutingHitPatternPOD_.endInner = endInner;
-  run3ScoutingHitPatternPOD_.beginOuter = beginOuter;
-  run3ScoutingHitPatternPOD_.endOuter = endOuter;
-  run3ScoutingHitPatternPOD_.hitPattern.insert(
-      run3ScoutingHitPatternPOD_.hitPattern.begin(), hitPattern, hitPattern + HitPattern::ARRAY_LENGTH);
-  return run3ScoutingHitPatternPOD_;
+  Run3ScoutingHitPatternPOD run3ScoutingHitPatternPOD;
+  run3ScoutingHitPatternPOD.hitCount = hitCount;
+  run3ScoutingHitPatternPOD.beginTrackHits = beginTrackHits;
+  run3ScoutingHitPatternPOD.endTrackHits = endTrackHits;
+  run3ScoutingHitPatternPOD.beginInner = beginInner;
+  run3ScoutingHitPatternPOD.endInner = endInner;
+  run3ScoutingHitPatternPOD.beginOuter = beginOuter;
+  run3ScoutingHitPatternPOD.endOuter = endOuter;
+  run3ScoutingHitPatternPOD.hitPattern.insert(
+      run3ScoutingHitPatternPOD.hitPattern.begin(), hitPattern, hitPattern + HitPattern::ARRAY_LENGTH);
+  return run3ScoutingHitPatternPOD;
 }

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -32,6 +32,19 @@ HitPattern::HitPattern(const HitPattern& other)
   memcpy(this->hitPattern, other.hitPattern, sizeof(uint16_t) * HitPattern::ARRAY_LENGTH);
 }
 
+HitPattern::HitPattern(const Run3ScoutingHitPatternPOD& other)
+    : hitCount(other.hitCount),
+      beginTrackHits(other.beginTrackHits),
+      endTrackHits(other.endTrackHits),
+      beginInner(other.beginInner),
+      endInner(other.endInner),
+      beginOuter(other.beginOuter),
+      endOuter(other.endOuter) {
+  const static unsigned short max_vector_length_ =
+      (other.hitPattern.size() > HitPattern::ARRAY_LENGTH) ? HitPattern::ARRAY_LENGTH : other.hitPattern.size();
+  std::copy(other.hitPattern.begin(), other.hitPattern.begin() + max_vector_length_, this->hitPattern);
+}
+
 HitPattern::~HitPattern() { ; }
 
 HitPattern& HitPattern::operator=(const HitPattern& other) {
@@ -1012,4 +1025,18 @@ bool HitPattern::insertExpectedOuterHit(const uint16_t pattern) {
   endOuter++;
 
   return true;
+}
+
+Run3ScoutingHitPatternPOD HitPattern::run3ScoutingHitPatternPOD() const {
+  Run3ScoutingHitPatternPOD run3ScoutingHitPatternPOD_;
+  run3ScoutingHitPatternPOD_.hitCount = hitCount;
+  run3ScoutingHitPatternPOD_.beginTrackHits = beginTrackHits;
+  run3ScoutingHitPatternPOD_.endTrackHits = endTrackHits;
+  run3ScoutingHitPatternPOD_.beginInner = beginInner;
+  run3ScoutingHitPatternPOD_.endInner = endInner;
+  run3ScoutingHitPatternPOD_.beginOuter = beginOuter;
+  run3ScoutingHitPatternPOD_.endOuter = endOuter;
+  run3ScoutingHitPatternPOD_.hitPattern.insert(
+      run3ScoutingHitPatternPOD_.hitPattern.begin(), hitPattern, hitPattern + HitPattern::ARRAY_LENGTH);
+  return run3ScoutingHitPatternPOD_;
 }

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -1028,15 +1028,14 @@ bool HitPattern::insertExpectedOuterHit(const uint16_t pattern) {
 }
 
 Run3ScoutingHitPatternPOD HitPattern::run3ScoutingHitPatternPOD() const {
-  Run3ScoutingHitPatternPOD run3ScoutingHitPatternPOD;
-  run3ScoutingHitPatternPOD.hitCount = hitCount;
-  run3ScoutingHitPatternPOD.beginTrackHits = beginTrackHits;
-  run3ScoutingHitPatternPOD.endTrackHits = endTrackHits;
-  run3ScoutingHitPatternPOD.beginInner = beginInner;
-  run3ScoutingHitPatternPOD.endInner = endInner;
-  run3ScoutingHitPatternPOD.beginOuter = beginOuter;
-  run3ScoutingHitPatternPOD.endOuter = endOuter;
-  run3ScoutingHitPatternPOD.hitPattern.insert(
-      run3ScoutingHitPatternPOD.hitPattern.begin(), hitPattern, hitPattern + HitPattern::ARRAY_LENGTH);
-  return run3ScoutingHitPatternPOD;
+  Run3ScoutingHitPatternPOD result{
+      .hitCount = hitCount,
+      .beginTrackHits = beginTrackHits,
+      .endTrackHits = endTrackHits,
+      .beginInner = beginInner,
+      .endInner = endInner,
+      .beginOuter = beginOuter,
+      .endOuter = endOuter,
+      .hitPattern = std::vector<uint16_t>(hitPattern, hitPattern + HitPattern::ARRAY_LENGTH)};
+  return result;
 }

--- a/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.cc
+++ b/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.cc
@@ -284,8 +284,8 @@ void HLTScoutingMuonProducer::produce(edm::StreamID sid, edm::Event& iEvent, edm
                            track->vx(),
                            track->vy(),
                            track->vz(),
-                           track->hitPattern(),
-                           vtxInd);
+                           vtxInd,
+                           track->hitPattern().run3ScoutingHitPatternPOD());
     vtxInd.clear();
   }
 

--- a/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.h
+++ b/HLTrigger/Muon/plugins/HLTScoutingMuonProducer.h
@@ -39,6 +39,7 @@ Description: Producer for Run3ScoutingMuon
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+#include "DataFormats/Scouting/interface/Run3ScoutingHitPatternPOD.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingMuon.h"
 #include "DataFormats/Scouting/interface/Run3ScoutingVertex.h"
 


### PR DESCRIPTION
### PR description:

This PR is meant to address issue #32219 and supersedes PR #35685.
It is introducing a new `Run3ScoutingHitPatternPOD` class in `DataFormats/Scouting`, to be used for Run-3 scouting (in `Run3ScoutingMuon`). The class is a POD-like version of `reco::HitPattern`.
A function is defined in `reco::HitPattern` to fill `Run3ScoutingHitPatternPOD`, together with a `reco::HitPattern` constructor from `Run3ScoutingHitPatternPOD`.

FYI @dsperka, @makortel 