### PR TITLE
Update monopole skim for Run-3.

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
@@ -48,6 +48,8 @@ EXOMonopoleSkimContent.outputCommands.append('keep *_offlinePrimaryVertices_*_*'
 EXOMonopoleSkimContent.outputCommands.append('keep *_gedGsfElectrons_*_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_photons_*_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_pfMet_*_*')
+EXOMonopoleSkimContent.outputCommands.append('keep *_offlineBeamSpot_*_*')
+EXOMonopoleSkimContent.outputCommands.append('keep *_siPixelDigis_*_*')
 
 # monopole skim sequence
 EXOMonopoleSkimSequence = cms.Sequence(hltMonopole)

--- a/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
@@ -23,20 +23,27 @@ hltMonopole.andOr = True
 
 from Configuration.EventContent.EventContent_cff import AODEventContent
 EXOMonopoleSkimContent = AODEventContent.clone()
+EXOMonopoleSkimContent.outputCommands.append('drop *')
 EXOMonopoleSkimContent.outputCommands.append('keep *_hybridSuperClusters_*_*')
+EXOMonopoleSkimContent.outputCommands.append('keep *_multi5x5SuperClusters_multi5x5EndcapBasicClusters_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_multi5x5SuperClusters_multi5x5EndcapSuperClusters_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_multi5x5SuperClusters_uncleanOnlyMulti5x5EndcapBasicClusters_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_multi5x5SuperClusters_uncleanOnlyMulti5x5EndcapSuperClusters_*')
+EXOMonopoleSkimContent.outputCommands.append('keep *_uncleanSCRecovered_uncleanHybridBarrelBasicClusters_*') 
+EXOMonopoleSkimContent.outputCommands.append('keep *_uncleanEERecovered_uncleanEndcapBasicClusters_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_siStripClusters_*_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_siPixelClusters_*_*')
-EXOMonopoleSkimContent.outputCommands.append('drop *_generalTracks_*_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_generalTracks_*_*')
 EXOMonopoleSkimContent.outputCommands.append('drop *_generalTracks_QualityMasks_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_ecalRecHit_EcalRecHitsEB_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_ecalRecHit_EcalRecHitsEE_*')
 EXOMonopoleSkimContent.outputCommands.append('keep *_hbhereco_*_*')
+EXOMonopoleSkimContent.outputCommands.append('keep edmTriggerResults_TriggerResults_*_*')
+EXOMonopoleSkimContent.outputCommands.append('keep *_hltTriggerSummaryAOD_*_*')
+EXOMonopoleSkimContent.outputCommands.append('keep *_offlinePrimaryVertices_*_*')
+EXOMonopoleSkimContent.outputCommands.append('keep *_gedGsfElectrons_*_*')
+EXOMonopoleSkimContent.outputCommands.append('keep *_photons_*_*')
+EXOMonopoleSkimContent.outputCommands.append('keep *_pfMet_*_*')
 
 # monopole skim sequence
-EXOMonopoleSkimSequence = cms.Sequence(
-    hltMonopole
-    )
+EXOMonopoleSkimSequence = cms.Sequence(hltMonopole)

--- a/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXOMONOPOLE_cff.py
@@ -6,17 +6,21 @@ hltMonopole = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
 hltMonopole.TriggerResultsTag = cms.InputTag( "TriggerResults", "", "HLT" )
 hltMonopole.HLTPaths = cms.vstring(
     #2016
-    "HLT_Photon175_v*",
-    "HLT_DoublePhoton60_v*",
-    "HLT_PFMET300_v*",
-    "HLT_PFMET170_HBHE_BeamHaloCleaned_v*",
-    #2017 and 2018
+    #"HLT_Photon175_v*",
+    #"HLT_DoublePhoton60_v*",
+    #"HLT_PFMET300_v*",
+    #"HLT_PFMET170_HBHE_BeamHaloCleaned_v*",
+    #2017,2018
+    #"HLT_Photon200_v*",
+    #"HLT_Photon300_NoHE_v*",
+    #"HLT_DoublePhoton70_v*",
+    #"HLT_PFMET140_PFMHT140_IDTight_v*",
+    #"HLT_PFMET250_HBHECleaned_v*",
+    #"HLT_PFMET300_HBHECleaned_v*",
+    #2021: on EGamma dataset only
     "HLT_Photon200_v*",
-    "HLT_Photon300_NoHE_v*",
     "HLT_DoublePhoton70_v*",
-    "HLT_PFMET140_PFMHT140_IDTight_v*",
-    "HLT_PFMET250_HBHECleaned_v*",
-    "HLT_PFMET300_HBHECleaned_v*"
+    "HLT_DoublePhoton85_v*",
 )
 hltMonopole.throw = False
 hltMonopole.andOr = True


### PR DESCRIPTION
#### PR description:
This PR is to update the monopole skim for Run-3. The trigger should be updated, but from the current list at
https://docs.google.com/spreadsheets/d/1UIR0YISWX1r2wfk-r7bPlVmHwguoVgjvGEw3nTgZd-c/edit?usp=sharing
HLT_Photon200_v still be an unprescaled trigger for Run-3

Size comparison (see issue https://github.com/cms-sw/cmssw/issues/37150 for compression):
- Old without compression: 2.22 MB/event
- New without compression: 1.86 MB/event
- New with compression LZMA-level4: 1.66 MB/event (75% of Run-2)
- New with compression ZSTD-level4: 1.74 MB/event 

We should get the conclusion from the above issue first before merging the PR, i.e. if each team should take care for compression in their code, or it will be organized centrally somehow.

#### PR validation:
`cmsDriver.py step3 --conditions auto:run2_data -s RAW2DIGI,L1Reco,RECO,SKIM:EXOMONOPOLE+BPHSkim,PAT --datatier AOD,MINIAOD --eventcontent AOD,MINIAOD --data --process reRECO --scenario pp --era Run2_2018 --customise Configuration/DataProcessing/RecoTLR.customisePostEra_Run2_2018 --python MONOPOLE_cfg.py -n 500 --no_exec --filein file:root://eoscms.cern.ch//eos/cms/store/data/Run2018D/EGamma/RAW/v1/000/320/822/00000/1441432A-8997-E811-8BD0-FA163EA21B5C.root --fileout file:step3.root --nThreads 8`
(adapt from wf 136.886)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport and no need of backport.