### PR TITLE
Fix for the access of haloMVATaggerVal in the Run 1+2 files

### DIFF
--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -29,7 +29,10 @@ namespace reco {
     struct SaturationInfo;
 
     /// default constructor
-    Photon() : RecoCandidate() { pixelSeed_ = false; }
+    Photon() : RecoCandidate() {
+      pixelSeed_ = false;
+      haloTaggerMVAVal_ = 99;
+    }
 
     /// copy constructor
     Photon(const Photon&);

--- a/DataFormats/EgammaCandidates/src/Photon.cc
+++ b/DataFormats/EgammaCandidates/src/Photon.cc
@@ -8,7 +8,7 @@ Photon::Photon(const LorentzVector& p4, const Point& caloPos, const PhotonCoreRe
       caloPosition_(caloPos),
       photonCore_(core),
       pixelSeed_(false),
-      haloTaggerMVAVal_(-999) {}
+      haloTaggerMVAVal_(99) {}
 
 Photon::Photon(const Photon& rhs)
     : RecoCandidate(rhs),

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -17,9 +17,6 @@
    <version ClassVersion="13" checksum="2963666409"/>
    <version ClassVersion="14" checksum="753726370"/>
   </class>
-  <ioread sourceClass="reco::Photon" version="[1-17]" source="" targetClass="reco::Photon" target="haloTaggerMVAVal_">
-   <![CDATA[haloTaggerMVAVal_ = 99;]]>
-   </ioread>
   <class name="reco::Conversion" ClassVersion="11">
    <version ClassVersion="10" checksum="2140222741"/>
    <version ClassVersion="11" checksum="598717096"/>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -18,7 +18,7 @@
    <version ClassVersion="14" checksum="753726370"/>
   </class>
   <ioread sourceClass="reco::Photon" version="[1-17]" source="" targetClass="reco::Photon" target="haloTaggerMVAVal_">
-   <![CDATA[haloTaggerMVAVal_ = -99;]]>
+   <![CDATA[haloTaggerMVAVal_ = 99;]]>
    </ioread>
   <class name="reco::Conversion" ClassVersion="11">
    <version ClassVersion="10" checksum="2140222741"/>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -17,6 +17,9 @@
    <version ClassVersion="13" checksum="2963666409"/>
    <version ClassVersion="14" checksum="753726370"/>
   </class>
+  <ioread sourceClass="reco::Photon" version="[1-17]" source="" targetClass="reco::Photon" target="haloTaggerMVAVal_">
+   <![CDATA[haloTaggerMVAVal_ = -99;]]>
+   </ioread>
   <class name="reco::Conversion" ClassVersion="11">
    <version ClassVersion="10" checksum="2140222741"/>
    <version ClassVersion="11" checksum="598717096"/>


### PR DESCRIPTION
This PR fixes the problem caused by the PR: #36901 ,  first caught here: #37143
PR #36901 was missing the correct treatment to Run 1+2 files (e.g. WF 136.7611) which essentially picks the 2016 AOD files and tries to find the value of haloTaggerMVAVal_. Since this variable does not exist in those AOD files (which was added by PR: #36901 ), this was just taking some junk value and puts in haloTaggerMVAVal(). 
This PR fixes this issue by having the appropriate ioread rules. 


