### PR TITLE
Adding optionality for MTD timing in PFTICLProducer

### DIFF
--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -26,6 +26,7 @@ public:
 
 private:
   // parameters
+  const bool useMTDTiming_;
   const bool useTimingAverage_;
   const float timingQualityThreshold_;
 
@@ -40,7 +41,8 @@ private:
 DEFINE_FWK_MODULE(PFTICLProducer);
 
 PFTICLProducer::PFTICLProducer(const edm::ParameterSet& conf)
-    : useTimingAverage_(conf.getParameter<bool>("useTimingAverage")),
+    : useMTDTiming_(conf.getParameter<bool>("useMTDTiming")),
+      useTimingAverage_(conf.getParameter<bool>("useTimingAverage")),
       timingQualityThreshold_(conf.getParameter<double>("timingQualityThreshold")),
       ticl_candidates_(consumes<edm::View<TICLCandidate>>(conf.getParameter<edm::InputTag>("ticlCandidateSrc"))),
       srcTrackTime_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeValueMap"))),
@@ -59,6 +61,7 @@ void PFTICLProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<edm::InputTag>("trackTimeErrorMap", edm::InputTag("tofPID:sigmat0"));
   desc.add<edm::InputTag>("trackTimeQualityMap", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
   desc.add<double>("timingQualityThreshold", 0.5);
+  desc.addOptional<bool>("useMTDTiming", true);
   desc.add<bool>("useTimingAverage", false);
   // For PFMuonAlgo
   desc.add<edm::InputTag>("muonSrc", edm::InputTag("muons1stStep"));
@@ -143,7 +146,7 @@ void PFTICLProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
     auto time = ticl_cand.time();
     auto timeE = ticl_cand.timeError();
 
-    if (candidate.charge()) {
+    if (useMTDTiming_ and candidate.charge()) {
       // Ignore HGCAL timing until it will be TOF corrected
       time = -99.;
       timeE = -1.;

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -61,7 +61,7 @@ void PFTICLProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<edm::InputTag>("trackTimeErrorMap", edm::InputTag("tofPID:sigmat0"));
   desc.add<edm::InputTag>("trackTimeQualityMap", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
   desc.add<double>("timingQualityThreshold", 0.5);
-  desc.addOptional<bool>("useMTDTiming", true);
+  desc.add<bool>("useMTDTiming", true);
   desc.add<bool>("useTimingAverage", false);
   // For PFMuonAlgo
   desc.add<edm::InputTag>("muonSrc", edm::InputTag("muons1stStep"));


### PR DESCRIPTION
#### PR description:

We are facing a showstopper on porting the HLT Phase 2 Menu to CMSSW_12_3_0: for some reason, in our menu the link between MTD timing enabled tracks and PFCandidates is broken, and we are having difficulties in debugging it.

In view of the imminent closing of the prereleases, we would propose a blunt, but efficient alternative: adding a toggle to `PFTICLProducer` to use the MTD timing. Of course, by default it is set to true, but for the HLT menu it would temporarily be set to false.

As a bonus, it would cleanly allow to separate studies with timing from MTD vs timing from HGCAL, in the context of the HLT menu evolution. 

#### PR validation:

Did the full tests:
```
cmsrel CMSSW_12_3_DEVEL_X_2022-03-06-2300
cd CMSSW_12_3_DEVEL_X_2022-03-06-2300/src
git cms-init
git merge trtomei/devel_trtomei_TICL-MTD-optional
scram b distclean 
git cms-checkdeps -a -A
scram b -j 8
scram b runtests
```

and

`runTheMatrix.py -l limited -i all --ibeos`
