### PR TITLE
Use ZSTD and default compression for PoolOutputModule

### DIFF
--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -460,8 +460,8 @@ namespace edm {
         ->setComment(
             "Maximum output file size, in kB.\n"
             "If over maximum, new output file will be started at next input file transition.");
-    desc.addUntracked<int>("compressionLevel", 9)->setComment("ROOT compression level of output file.");
-    desc.addUntracked<std::string>("compressionAlgorithm", "ZLIB")
+    desc.addUntracked<int>("compressionLevel", 4)->setComment("ROOT compression level of output file.");
+    desc.addUntracked<std::string>("compressionAlgorithm", "ZSTD")
         ->setComment(
             "Algorithm used to compress data in the ROOT output file, allowed values are ZLIB, LZMA, LZ4, and ZSTD");
     desc.addUntracked<int>("basketSize", 16384)->setComment("Default ROOT basket size in output file.");


### PR DESCRIPTION
#### PR description:

- Default compression changed to ZSTD with compression level 4. This was discussed at the Core meeting based on measurements of file size and event throughput.

#### PR validation:

All framework tests pass.