### PR TITLE
ECAL - Make EcalConstants constexpr arrays compatible with CUDA code

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalConstants.h
+++ b/DataFormats/EcalDigi/interface/EcalConstants.h
@@ -2,11 +2,26 @@
 #ifndef DataFormats_EcalDigi_EcalConstants_h
 #define DataFormats_EcalDigi_EcalConstants_h
 
+#include "FWCore/Utilities/interface/HostDeviceConstant.h"
+
+// The HOST_DEVICE_CONSTANTs can not reside in the classes directly, which is
+// why they are defined in a namespace and constant pointers to them are used in the classes
+namespace ecalph2 {
+  constexpr unsigned int NGAINS = 2;                     // Number of CATIA gains
+  HOST_DEVICE_CONSTANT float gains[NGAINS] = {10., 1.};  // CATIA gain values
+}  // namespace ecalph2
+
+namespace ecalph1 {
+  constexpr unsigned int NGAINS = 4;                             // Number of MGPA gains including a zero gain that
+                                                                 // could be encoded in the gain id mask
+  HOST_DEVICE_CONSTANT float gains[NGAINS] = {0., 12., 6., 1.};  // MGPA gain values including a zero gain
+}  // namespace ecalph1
+
 class ecalPh2 {
 public:
   static constexpr double Samp_Period = 6.25;               // ADC sampling period in ns
-  static constexpr unsigned int NGAINS = 2;                 // Number of CATIA gains
-  static constexpr float gains[NGAINS] = {10., 1.};         // CATIA gain values
+  static constexpr unsigned int NGAINS = ecalph2::NGAINS;   // Number of CATIA gains
+  static constexpr const float *gains = ecalph2::gains;     // CATIA gain values
   static constexpr unsigned int gainId1 = 1;                // Position of gain 1 in gains array
   static constexpr unsigned int gainId10 = 0;               // Position of gain 10 in gains array
   static constexpr unsigned int sampleSize = 16;            // Number of samples per event
@@ -23,15 +38,14 @@ public:
 
 class ecalPh1 {
 public:
-  static constexpr double Samp_Period = 25.;                 // ADC sampling period in ns
-  static constexpr unsigned int NGAINS = 4;                  // Number of MGPA gains including a zero gain that
-                                                             // could be encoded in the gain id mask
-  static constexpr float gains[NGAINS] = {0., 12., 6., 1.};  // MGPA gain values including a zero gain
-  static constexpr unsigned int sampleSize = 10;             // Number of samples per event
-  static constexpr unsigned int NBITS = 12;                  // Number of available bits
-  static constexpr unsigned int kNOffsets = 2000;            // Number of time offsets generated for APD pulse shape
-                                                             // simulation and reused for every kNOffsets^th channel
-  static constexpr unsigned int kAdcMask = 0xFFF;            // ADC sample mask for unpacking
-  static constexpr unsigned int kGainIdMask = 0x3;           // Gain id mask for unpacking
+  static constexpr double Samp_Period = 25.;               // ADC sampling period in ns
+  static constexpr unsigned int NGAINS = ecalph1::NGAINS;  // Number of MGPA gains including a zero gain
+  static constexpr const float *gains = ecalph1::gains;    // MGPA gain values including a zero gain
+  static constexpr unsigned int sampleSize = 10;           // Number of samples per event
+  static constexpr unsigned int NBITS = 12;                // Number of available bits
+  static constexpr unsigned int kNOffsets = 2000;          // Number of time offsets generated for APD pulse shape
+                                                           // simulation and reused for every kNOffsets^th channel
+  static constexpr unsigned int kAdcMask = 0xFFF;          // ADC sample mask for unpacking
+  static constexpr unsigned int kGainIdMask = 0x3;         // Gain id mask for unpacking
 };
 #endif


### PR DESCRIPTION
#### PR description:

The constexpr arrays defined in EcalConstants.h can not be used in CUDA kernels because they are no scalar types. With the `HOST_DEVICE_CONSTANT` defined in #37159 it is possible to define the arrays in device memory and use the values.

However, using `HOST_DEVICE_CONSTANT` is not possible if the arrays are members of a class and so they are moved to namespaces and constant pointers to the arrays are used in the classes (https://github.com/cms-sw/cmssw/issues/36311#issuecomment-1060844740).

This PR builds on PR #37159 

#### PR validation:

Compiles and passes 11634.512 on a CPU-only machine and on an GPU equipped machine.