### PR TITLE
Migrate deprecated EDModule for CondFormats/DTObjects

### DIFF
--- a/CondFormats/DTObjects/test/stubs/DTConfigPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTConfigPrint.cc
@@ -30,8 +30,6 @@ namespace edmtest {
 
   DTConfigPrint::DTConfigPrint(int i) {}
 
-  DTConfigPrint::~DTConfigPrint() {}
-
   void DTConfigPrint::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.

--- a/CondFormats/DTObjects/test/stubs/DTConfigPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTConfigPrint.h
@@ -5,7 +5,7 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -21,12 +21,12 @@ Toy EDAnalyzer for testing purposes only.
 #include <string>
 
 namespace edmtest {
-  class DTConfigPrint : public edm::EDAnalyzer {
+  class DTConfigPrint : public edm::one::EDAnalyzer<> {
   public:
     explicit DTConfigPrint(edm::ParameterSet const& p);
     explicit DTConfigPrint(int i);
-    virtual ~DTConfigPrint();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    ~DTConfigPrint() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     std::string connect;

--- a/CondFormats/DTObjects/test/stubs/DTConfigWrite.cc
+++ b/CondFormats/DTObjects/test/stubs/DTConfigWrite.cc
@@ -28,8 +28,6 @@ namespace edmtest {
 
   DTConfigWrite::DTConfigWrite(int i) {}
 
-  DTConfigWrite::~DTConfigWrite() {}
-
   void DTConfigWrite::analyze(const edm::Event& e, const edm::EventSetup& context) {
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;

--- a/CondFormats/DTObjects/test/stubs/DTConfigWrite.h
+++ b/CondFormats/DTObjects/test/stubs/DTConfigWrite.h
@@ -5,20 +5,20 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace edmtest {
-  class DTConfigWrite : public edm::EDAnalyzer {
+  class DTConfigWrite : public edm::one::EDAnalyzer<> {
   public:
     explicit DTConfigWrite(edm::ParameterSet const& p);
     explicit DTConfigWrite(int i);
-    virtual ~DTConfigWrite();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
-    virtual void endJob();
+    ~DTConfigWrite() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void endJob() override;
 
   private:
   };

--- a/CondFormats/DTObjects/test/stubs/DTDeadPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTDeadPrint.cc
@@ -20,8 +20,6 @@ namespace edmtest {
 
   DTDeadPrint::DTDeadPrint(int i) {}
 
-  DTDeadPrint::~DTDeadPrint() {}
-
   void DTDeadPrint::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.

--- a/CondFormats/DTObjects/test/stubs/DTDeadPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTDeadPrint.h
@@ -5,7 +5,7 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,12 +15,12 @@ Toy EDAnalyzer for testing purposes only.
 #include "CondFormats/DataRecord/interface/DTDeadFlagRcd.h"
 
 namespace edmtest {
-  class DTDeadPrint : public edm::EDAnalyzer {
+  class DTDeadPrint : public edm::one::EDAnalyzer<> {
   public:
     explicit DTDeadPrint(edm::ParameterSet const& p);
     explicit DTDeadPrint(int i);
-    virtual ~DTDeadPrint();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    ~DTDeadPrint() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     edm::ESGetToken<DTDeadFlag, DTDeadFlagRcd> es_token;

--- a/CondFormats/DTObjects/test/stubs/DTDeadUpdate.h
+++ b/CondFormats/DTObjects/test/stubs/DTDeadUpdate.h
@@ -5,7 +5,7 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,13 +15,13 @@ Toy EDAnalyzer for testing purposes only.
 #include "CondFormats/DataRecord/interface/DTDeadFlagRcd.h"
 
 namespace edmtest {
-  class DTDeadUpdate : public edm::EDAnalyzer {
+  class DTDeadUpdate : public edm::one::EDAnalyzer<> {
   public:
     explicit DTDeadUpdate(edm::ParameterSet const& p);
     explicit DTDeadUpdate(int i);
-    virtual ~DTDeadUpdate();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
-    virtual void endJob();
+    ~DTDeadUpdate() override;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void endJob() override;
 
   private:
     void fill_dead_HV(const char* file, DTDeadFlag* deadList);

--- a/CondFormats/DTObjects/test/stubs/DTDeadWrite.cc
+++ b/CondFormats/DTObjects/test/stubs/DTDeadWrite.cc
@@ -24,8 +24,6 @@ namespace edmtest {
 
   DTDeadWrite::DTDeadWrite(int i) {}
 
-  DTDeadWrite::~DTDeadWrite() {}
-
   void DTDeadWrite::analyze(const edm::Event& e, const edm::EventSetup& context) {
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;

--- a/CondFormats/DTObjects/test/stubs/DTDeadWrite.h
+++ b/CondFormats/DTObjects/test/stubs/DTDeadWrite.h
@@ -5,7 +5,7 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -14,13 +14,13 @@ Toy EDAnalyzer for testing purposes only.
 class DTDeadFlag;
 
 namespace edmtest {
-  class DTDeadWrite : public edm::EDAnalyzer {
+  class DTDeadWrite : public edm::one::EDAnalyzer<> {
   public:
     explicit DTDeadWrite(edm::ParameterSet const& p);
     explicit DTDeadWrite(int i);
-    virtual ~DTDeadWrite();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
-    virtual void endJob();
+    ~DTDeadWrite() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void endJob() override;
 
   private:
     void fill_dead_HV(const char* file, DTDeadFlag* deadList);

--- a/CondFormats/DTObjects/test/stubs/DTFullMapPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTFullMapPrint.cc
@@ -21,8 +21,6 @@ namespace edmtest {
 
   DTFullMapPrint::DTFullMapPrint(int i) {}
 
-  DTFullMapPrint::~DTFullMapPrint() {}
-
   void DTFullMapPrint::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.

--- a/CondFormats/DTObjects/test/stubs/DTFullMapPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTFullMapPrint.h
@@ -5,7 +5,7 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,12 +15,12 @@ Toy EDAnalyzer for testing purposes only.
 #include "CondFormats/DataRecord/interface/DTReadOutMappingRcd.h"
 
 namespace edmtest {
-  class DTFullMapPrint : public edm::EDAnalyzer {
+  class DTFullMapPrint : public edm::one::EDAnalyzer<> {
   public:
     explicit DTFullMapPrint(edm::ParameterSet const& p);
     explicit DTFullMapPrint(int i);
-    virtual ~DTFullMapPrint();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    ~DTFullMapPrint() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     edm::ESGetToken<DTReadOutMapping, DTReadOutMappingRcd> es_token;

--- a/CondFormats/DTObjects/test/stubs/DTMapPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTMapPrint.cc
@@ -20,8 +20,6 @@ namespace edmtest {
 
   DTMapPrint::DTMapPrint(int i) {}
 
-  DTMapPrint::~DTMapPrint() {}
-
   void DTMapPrint::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.

--- a/CondFormats/DTObjects/test/stubs/DTMapPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTMapPrint.h
@@ -5,7 +5,7 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,12 +15,12 @@ Toy EDAnalyzer for testing purposes only.
 #include "CondFormats/DataRecord/interface/DTReadOutMappingRcd.h"
 
 namespace edmtest {
-  class DTMapPrint : public edm::EDAnalyzer {
+  class DTMapPrint : public edm::one::EDAnalyzer<> {
   public:
     explicit DTMapPrint(edm::ParameterSet const& p);
     explicit DTMapPrint(int i);
-    virtual ~DTMapPrint();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    ~DTMapPrint() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     edm::ESGetToken<DTReadOutMapping, DTReadOutMappingRcd> es_token;

--- a/CondFormats/DTObjects/test/stubs/DTMapWrite.cc
+++ b/CondFormats/DTObjects/test/stubs/DTMapWrite.cc
@@ -28,8 +28,6 @@ namespace edmtest {
 
   DTMapWrite::DTMapWrite(int i) {}
 
-  DTMapWrite::~DTMapWrite() {}
-
   void DTMapWrite::analyze(const edm::Event& e, const edm::EventSetup& context) {
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;

--- a/CondFormats/DTObjects/test/stubs/DTMapWrite.h
+++ b/CondFormats/DTObjects/test/stubs/DTMapWrite.h
@@ -5,20 +5,20 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace edmtest {
-  class DTMapWrite : public edm::EDAnalyzer {
+  class DTMapWrite : public edm::one::EDAnalyzer<> {
   public:
     explicit DTMapWrite(edm::ParameterSet const& p);
     explicit DTMapWrite(int i);
-    virtual ~DTMapWrite();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
-    virtual void endJob();
+    ~DTMapWrite() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void endJob() override;
 
   private:
   };

--- a/CondFormats/DTObjects/test/stubs/DTRangeT0Print.cc
+++ b/CondFormats/DTObjects/test/stubs/DTRangeT0Print.cc
@@ -20,8 +20,6 @@ namespace edmtest {
 
   DTRangeT0Print::DTRangeT0Print(int i) {}
 
-  DTRangeT0Print::~DTRangeT0Print() {}
-
   void DTRangeT0Print::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.

--- a/CondFormats/DTObjects/test/stubs/DTRangeT0Print.h
+++ b/CondFormats/DTObjects/test/stubs/DTRangeT0Print.h
@@ -5,7 +5,7 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,12 +15,12 @@ Toy EDAnalyzer for testing purposes only.
 #include "CondFormats/DataRecord/interface/DTRangeT0Rcd.h"
 
 namespace edmtest {
-  class DTRangeT0Print : public edm::EDAnalyzer {
+  class DTRangeT0Print : public edm::one::EDAnalyzer<> {
   public:
     explicit DTRangeT0Print(edm::ParameterSet const& p);
     explicit DTRangeT0Print(int i);
-    virtual ~DTRangeT0Print();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    ~DTRangeT0Print() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     edm::ESGetToken<DTRangeT0, DTRangeT0Rcd> es_token;

--- a/CondFormats/DTObjects/test/stubs/DTRangeT0Write.cc
+++ b/CondFormats/DTObjects/test/stubs/DTRangeT0Write.cc
@@ -28,8 +28,6 @@ namespace edmtest {
 
   DTRangeT0Write::DTRangeT0Write(int i) {}
 
-  DTRangeT0Write::~DTRangeT0Write() {}
-
   void DTRangeT0Write::analyze(const edm::Event& e, const edm::EventSetup& context) {
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;

--- a/CondFormats/DTObjects/test/stubs/DTRangeT0Write.h
+++ b/CondFormats/DTObjects/test/stubs/DTRangeT0Write.h
@@ -5,20 +5,20 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace edmtest {
-  class DTRangeT0Write : public edm::EDAnalyzer {
+  class DTRangeT0Write : public edm::one::EDAnalyzer<> {
   public:
     explicit DTRangeT0Write(edm::ParameterSet const& p);
     explicit DTRangeT0Write(int i);
-    virtual ~DTRangeT0Write();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
-    virtual void endJob();
+    ~DTRangeT0Write() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void endJob() override;
 
   private:
   };

--- a/CondFormats/DTObjects/test/stubs/DTT0Print.cc
+++ b/CondFormats/DTObjects/test/stubs/DTT0Print.cc
@@ -20,8 +20,6 @@ namespace edmtest {
 
   DTT0Print::DTT0Print(int i) {}
 
-  DTT0Print::~DTT0Print() {}
-
   void DTT0Print::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.

--- a/CondFormats/DTObjects/test/stubs/DTT0Print.h
+++ b/CondFormats/DTObjects/test/stubs/DTT0Print.h
@@ -5,7 +5,7 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,12 +15,12 @@ Toy EDAnalyzer for testing purposes only.
 #include "CondFormats/DataRecord/interface/DTT0Rcd.h"
 
 namespace edmtest {
-  class DTT0Print : public edm::EDAnalyzer {
+  class DTT0Print : public edm::one::EDAnalyzer<> {
   public:
     explicit DTT0Print(edm::ParameterSet const& p);
     explicit DTT0Print(int i);
-    virtual ~DTT0Print();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    ~DTT0Print() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     edm::ESGetToken<DTT0, DTT0Rcd> es_token;

--- a/CondFormats/DTObjects/test/stubs/DTT0Write.cc
+++ b/CondFormats/DTObjects/test/stubs/DTT0Write.cc
@@ -28,8 +28,6 @@ namespace edmtest {
 
   DTT0Write::DTT0Write(int i) {}
 
-  DTT0Write::~DTT0Write() {}
-
   void DTT0Write::analyze(const edm::Event& e, const edm::EventSetup& context) {
     std::cout << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     std::cout << " ---EVENT NUMBER " << e.id().event() << std::endl;

--- a/CondFormats/DTObjects/test/stubs/DTT0Write.h
+++ b/CondFormats/DTObjects/test/stubs/DTT0Write.h
@@ -5,20 +5,20 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace edmtest {
-  class DTT0Write : public edm::EDAnalyzer {
+  class DTT0Write : public edm::one::EDAnalyzer<> {
   public:
     explicit DTT0Write(edm::ParameterSet const& p);
     explicit DTT0Write(int i);
-    virtual ~DTT0Write();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
-    virtual void endJob();
+    ~DTT0Write() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
+    void endJob() override;
 
   private:
   };

--- a/CondFormats/DTObjects/test/stubs/DTTtrigPrint.cc
+++ b/CondFormats/DTObjects/test/stubs/DTTtrigPrint.cc
@@ -20,8 +20,6 @@ namespace edmtest {
 
   DTTtrigPrint::DTTtrigPrint(int i) {}
 
-  DTTtrigPrint::~DTTtrigPrint() {}
-
   void DTTtrigPrint::analyze(const edm::Event& e, const edm::EventSetup& context) {
     using namespace edm::eventsetup;
     // Context is not used.

--- a/CondFormats/DTObjects/test/stubs/DTTtrigPrint.h
+++ b/CondFormats/DTObjects/test/stubs/DTTtrigPrint.h
@@ -5,7 +5,7 @@ Toy EDAnalyzer for testing purposes only.
 
 ----------------------------------------------------------------------*/
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -15,12 +15,12 @@ Toy EDAnalyzer for testing purposes only.
 #include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 namespace edmtest {
-  class DTTtrigPrint : public edm::EDAnalyzer {
+  class DTTtrigPrint : public edm::one::EDAnalyzer<> {
   public:
     explicit DTTtrigPrint(edm::ParameterSet const& p);
     explicit DTTtrigPrint(int i);
-    virtual ~DTTtrigPrint();
-    virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
+    ~DTTtrigPrint() override = default;
+    void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
   private:
     edm::ESGetToken<DTTtrig, DTTtrigRcd> es_token;


### PR DESCRIPTION
#### PR description:

Migrates the deprecated EDAnalyzer for CondFormats/DTObjects to the new One version as described in https://github.com/cms-sw/cmssw/issues/36404. This is the last part for DT of [this spreadsheet](https://docs.google.com/spreadsheets/d/18hTA-VwyNAQcclQM-vgXFJRqxPegDLJC4sZqAQAAuAk/edit#gid=0).

#### PR validation:

Code compiles. code-checks & code-format

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport and no backports foreseen.
