### PR TITLE
Adding MacroPixel inefficiency in Tracker Phase2Digitizer

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -61,12 +61,14 @@ bool PSPDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo*
 //  Check whether the Hit is in the Inefficient Bias Rail Region
 //
 bool PSPDigitizerAlgorithm::isInBiasRailRegion(const PSimHit& hit) const {
-  static const float implant = 0.1467;  // Implant length (1.467 mm)
-  static const float bRail = 0.00375;   // Bias Rail region which causes inefficiency (37.5micron)
-  float block_len = 16 * implant + 15.5 * bRail;
+  constexpr float implant    = 0.1467;  // Implant length (1.467 mm)
+  constexpr float bRail      = 0.00375;   // Bias Rail region which causes inefficiency (37.5micron)
+  // Do coordinate transformation of the local Y from module middle point considering 32 implants and 31 inter-impant regions with bias rail
+  constexpr float block_len  = 16 * implant + 15.5 * bRail;
+  constexpr float block_unit = implant + bRail;
   float yin = hit.entryPoint().y() + block_len;
   float yout = hit.exitPoint().y() + block_len;
-  if (std::fmod(yin, (implant + bRail)) > implant || std::fmod(yout, (implant + bRail)) > implant)
+  if (std::fmod(yin, block_unit) > implant || std::fmod(yout, block_unit) > implant)
     return true;
   else
     return false;

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -61,10 +61,10 @@ bool PSPDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo*
 //  Check whether the Hit is in the Inefficient Bias Rail Region
 //
 bool PSPDigitizerAlgorithm::isInBiasRailRegion(const PSimHit& hit) const {
-  constexpr float implant    = 0.1467;  // Implant length (1.467 mm)
-  constexpr float bRail      = 0.00375;   // Bias Rail region which causes inefficiency (37.5micron)
+  constexpr float implant = 0.1467;  // Implant length (1.467 mm)
+  constexpr float bRail = 0.00375;   // Bias Rail region which causes inefficiency (37.5micron)
   // Do coordinate transformation of the local Y from module middle point considering 32 implants and 31 inter-impant regions with bias rail
-  constexpr float block_len  = 16 * implant + 15.5 * bRail;
+  constexpr float block_len = 16 * implant + 15.5 * bRail;
   constexpr float block_unit = implant + bRail;
   float yin = hit.entryPoint().y() + block_len;
   float yout = hit.exitPoint().y() + block_len;

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
@@ -16,9 +16,11 @@ public:
 
   bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) const override;
   bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) const override;
+  bool isInBiasRailRegion(const PSimHit& hit) const;
 
 private:
   edm::ESGetToken<SiPhase2OuterTrackerLorentzAngle, SiPhase2OuterTrackerLorentzAngleSimRcd> siPhase2OTLorentzAngleToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  bool addBiasRailInefficiency_{false};
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -127,7 +127,8 @@ phase2TrackerDigitizer = cms.PSet(
       EfficiencyFactors_Barrel = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999 ),
       EfficiencyFactors_Endcap = cms.vdouble(0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 0.999, 
       0.999, 0.999 ),#Efficiencies kept as Side2Disk1,Side1Disk1 and so on
-      CellsToKill = cms.VPSet()
+      CellsToKill = cms.VPSet(),
+      AddBiasRailInefficiency= cms.bool(False)
     ),
 #Strip in PS module
     PSSDigitizerAlgorithm = cms.PSet(


### PR DESCRIPTION
#### PR description:

Adding macropixel inefficiency due to bias rail in  the Phase2Digitizer framework in PSPDigitizerAlgorithm 
  - expect to see digi losses in the PSP modules 
  - other PRs or externals it depends upon : none
 

#### PR validation:
The validation is done using 

runTheMatrix.py --what upgrade -ne -l 39010.0

The description and the plots are attached below

[Phase2Digitizer_BiasRailInEfficiency_07032022.pdf](https://github.com/cms-sw/cmssw/files/8205691/Phase2Digitizer_BiasRailInEfficiency_07032022.pdf)

#### if this PR is a backport please specify the original PR and why you need to backport that PR: Not backported

@emiglior @mmusich @tsusa 
