### PR TITLE
Update autoCond.py to include GTs with fixed L1 Menu for Run3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -35,12 +35,16 @@ autoCond = {
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 HLT: it points to the online GT
     'run3_hlt'                     : '123X_dataRun3_HLT_v5',
+    # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
+    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v1',
     # GlobalTag for Run3 data relvals (express GT)
     'run3_data_express'            : '123X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals
     'run3_data_prompt'             : '123X_dataRun3_Prompt_v5',
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '123X_dataRun3_v4',
+    # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
+    'run3_data_relval'             : '123X_dataRun3_relval_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

This PR is to include two new GTs to autoCond.py: `run3_hlt_relval` and `run3_data_relval`. These GTs will be included in relval workflows for Run3 with fixed L1T Menu and were requested by TSG. They are based on the HLT and offline data GTs with a difference of the L1Menu tags as can be seen below.

The relval workflows to use these GTs will be added at a later step.

The difference in the Run3 relval GTs wrt the HLT and offline Queues:

**run3_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_HLT_relval_v1/123X_dataRun3_HLT_v5

**run3_data_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_relval_v1/123X_dataRun3_v4

FYI: @Martin-Grunewald 

#### PR validation:

The GTs included in autoCond are not in any relval workflow to be tested yet.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N.A.
