### PR TITLE
Add Phase-2 with HLT:75e33 wf

### DIFF
--- a/Configuration/PyReleaseValidation/README.md
+++ b/Configuration/PyReleaseValidation/README.md
@@ -71,6 +71,7 @@ The offsets currently in use are:
 * 0.914: DDD DB
 * 0.101: Phase-2 aging, 1000fb-1
 * 0.103: Phase-2 aging, 3000fb-1
+* 0.111: Phase-2 HLT:75e33
 * 0.201: HGCAL special TICL Pattern recognition Workflows: clue3D
 * 0.202: HGCAL special TICL Pattern recognition Workflows: FastJet
 * 0.9001: Sonic Triton

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3577,7 +3577,17 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--eventcontent':'FEVTDEBUGHLT',
                                       '--geometry' : geom
                                       }
-
+    
+    upgradeStepDict['HLT75e33'][k] = {'-s':'HLT:75e33',
+                                      '--processName':'HLTX',
+                                      '--conditions':gt,
+                                      '--datatier':'FEVTDEBUGHLT',
+                                      '-n':'10',
+                                      '--eventcontent':'FEVTDEBUGHLT',
+                                      '--geometry' : geom,
+                                      '--filein':'file:step3.root'
+                                      }
+    
     upgradeStepDict['Reco'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM',
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-RECO,MINIAODSIM,DQMIO',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1048,6 +1048,23 @@ upgradeWFs['Aging3000'].suffix = 'Aging3000'
 upgradeWFs['Aging3000'].offset = 0.103
 upgradeWFs['Aging3000'].lumi = '3000'
 
+class UpgradeWorkflow_Phase2HLT75e33(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'DigiTrigger' in step: # for Phase-2
+            stepDict[stepName][k] = merge([{'-s': 'DIGI:pdigi_valid,L1TrackTrigger,L1,DIGI2RAW,HLT:75e33'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return fragment=="TTbar_14TeV" and ('2026' in key)
+upgradeWFs['Phase2HLT75e33'] = UpgradeWorkflow_Phase2HLT75e33(
+    steps = [
+        'DigiTrigger',
+    ],
+    PU = [
+        'DigiTrigger',
+    ],
+    suffix = '_HLT75e33',
+    offset = 0.111,
+)
+
 # Specifying explicitly the --filein is not nice but that was the
 # easiest way to "skip" the output of step2 (=premixing stage1) for
 # filein (as it goes to pileup_input). It works (a bit accidentally


### PR DESCRIPTION
#### PR description:
To add Phase-2 wf with HLT 75e33 menu. This is still a draft, to be used with https://github.com/cms-sw/cmssw/pull/37158 and https://github.com/cms-sw/cmssw/pull/37162.

#### PR validation:
`runTheMatrix.py --what upgrade -l 35034.111 -t 8 --wm init`
give expected workflow.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
If merge in 12_4_X, then backport is needed for 12_3_X.
