### PR TITLE
Add std::move to std::vector member of Run3ScoutingMuon

### DIFF
--- a/DataFormats/Scouting/interface/Run3ScoutingMuon.h
+++ b/DataFormats/Scouting/interface/Run3ScoutingMuon.h
@@ -120,7 +120,7 @@ public:
         trk_vy_(trk_vy),
         trk_vz_(trk_vz),
         vtxIndx_(std::move(vtxIndx)),
-        trk_hitPattern_(trk_hitPattern) {}
+        trk_hitPattern_(std::move(trk_hitPattern)) {}
   //default constructor
   Run3ScoutingMuon()
       : pt_(0),


### PR DESCRIPTION
### PR description:

Add std::move to std::vector member of Run3ScoutingMuon, as per comment https://github.com/cms-sw/cmssw/pull/37149#discussion_r821716772