### PR TITLE
Update DQM (offline + HLTEvF) HLT track monitoring for Run3 era

### DIFF
--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_Client_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_Client_cff.py
@@ -6,7 +6,8 @@ from DQMOffline.Trigger.TrackingMonitoring_Client_cff import *
 trackingEffFromHitPatternHLT = trackingEffFromHitPattern.clone(
 subDirs = (
    "HLT/Tracking/pixelTracks/HitEffFromHitPattern*",
-   "HLT/Tracking/iter2Merged/HitEffFromHitPattern*"
+   "HLT/Tracking/iter2Merged/HitEffFromHitPattern*",
+   "HLT/Tracking/tracks/HitEffFromHitPattern*"
 )
 )
 # Sequence
@@ -26,3 +27,13 @@ subDirs = (
 trackingForElectronsMonitorClientHLT = cms.Sequence(
     trackingForElectronsEffFromHitPatternHLT
 )
+
+def _modifyForRun3Default(efffromhitpattern):
+    efffromhitpattern.subDirs = ["HLT/Tracking/pixelTracks/HitEffFromHitPattern*", "HLT/Tracking/tracks/HitEffFromHitPattern*"]
+
+def _modifyForRun3EGM(efffromhitpattern):
+    efffromhitpattern.subDirs = ["HLT/EGM/Tracking/GSF/HitEffFromHitPattern*"]
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(trackingEffFromHitPatternHLT, _modifyForRun3Default)
+run3_common.toModify(trackingForElectronsEffFromHitPatternHLT, _modifyForRun3EGM)

--- a/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
+++ b/DQM/HLTEvF/python/HLTTrackingMonitoring_cff.py
@@ -20,3 +20,7 @@ egmTrackingMonitorHLTsequence = cms.Sequence(
     * pixelTracksForElectronsTracksMonitoringHLT
     * iterHLTTracksForElectronsMonitoringHLT
 )
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toReplaceWith(trackingMonitoringHLTsequence, cms.Sequence(pixelTracksMonitoringHLT * iterHLTTracksMonitoringHLT))
+run3_common.toReplaceWith(egmTrackingMonitorHLTsequence, cms.Sequence(gsfTracksMonitoringHLT))

--- a/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_Client_cff.py
@@ -66,3 +66,13 @@ TrackToTrackEfficiencies = DQMEDHarvester("DQMGenericClient",
 trackEfficiencyMonitoringClientHLT = cms.Sequence(
     TrackToTrackEfficiencies
 )
+
+def _modifyForRun3Default(efffromhitpattern):
+    efffromhitpattern.subDirs = ["HLT/Tracking/pixelTracks/HitEffFromHitPattern*", "HLT/Tracking/tracks/HitEffFromHitPattern*"]
+
+def _modifyForRun3EGM(efffromhitpattern):
+    efffromhitpattern.subDirs = ["HLT/EGM/Tracking/GSF/HitEffFromHitPattern*"]
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(trackingEffFromHitPatternHLT, _modifyForRun3Default)
+run3_common.toModify(trackingForElectronsEffFromHitPatternHLT, _modifyForRun3EGM)

--- a/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/TrackingMonitoring_cff.py
@@ -116,7 +116,7 @@ trackingMonitorHLT = cms.Sequence(
 trackingMonitorHLTall = cms.Sequence(
     pixelTracksMonitoringHLT
     + iter0TracksMonitoringHLT
-    + iter2HPTracksMonitoringHLT
+    + iter0HPTracksMonitoringHLT
     + iter1TracksMonitoringHLT
     + iter1HPTracksMonitoringHLT
     + iter2TracksMonitoringHLT
@@ -199,6 +199,10 @@ egmTrackingMonitorHLT = cms.Sequence(
     + iterHLTTracksForElectronsMonitoringHLT
 )
 
-
 trkHLTDQMSourceExtra = cms.Sequence(
 )
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toReplaceWith(trackingMonitorHLT, cms.Sequence(pixelTracksMonitoringHLT + iterHLTTracksMonitoringHLT))
+run3_common.toReplaceWith(trackingMonitorHLTall, cms.Sequence(pixelTracksMonitoringHLT + iter0TracksMonitoringHLT + iterHLTTracksMonitoringHLT))
+run3_common.toReplaceWith(egmTrackingMonitorHLT, cms.Sequence(gsfTracksMonitoringHLT))


### PR DESCRIPTION
### PR description:

Along the line of PR #37090, this PR updates DQM HLT track monitoring for Run3, removing deprecated collections.
After confirming with @RSalvatico and @ram1123 (for EGM), this PR also updates EGM track monitoring with the same purpose.

FYI: @mmusich, @vmariani, @AdrianoDee, @kjpena, @slezki

### PR validation:

PR is technical, with no change in physics: only collections monitored in DQM are updated for Run3.