### PR TITLE
Make both ME1a and ME1b LCT (A/CLCT) sorted into ring 1.

### DIFF
--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -141,6 +141,7 @@ void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
     if (isME1a)
       ring = 1;
     CSCDetId ch_id2(ch_id.endcap(), ch_id.station(), ring, ch_id.chamber(), 0);
+    auto id2 = ch_id2.rawId();// CLCTs should be sorted into the det of the CLCTs.
 
     const auto& clcts_in_det = clcts.get(ch_id2);
 
@@ -156,7 +157,7 @@ void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
         continue;
 
       // store all CLCTs in this chamber
-      chamber_to_clcts_all_[id].push_back(*c);
+      chamber_to_clcts_all_[id2].push_back(*c);
 
       // check that at least 3 comparator digis were matched!
       int nMatches = 0;
@@ -190,13 +191,13 @@ void CSCStubMatcher::matchCLCTsToSimTrack(const CSCCLCTDigiCollection& clcts) {
         edm::LogInfo("CSCStubMatcher") << "clctGOOD";
 
       // store matching CLCTs in this chamber
-      if (std::find(chamber_to_clcts_[id].begin(), chamber_to_clcts_[id].end(), *c) == chamber_to_clcts_[id].end()) {
-        chamber_to_clcts_[id].push_back(*c);
+      if (std::find(chamber_to_clcts_[id2].begin(), chamber_to_clcts_[id2].end(), *c) == chamber_to_clcts_[id2].end()) {
+        chamber_to_clcts_[id2].push_back(*c);
       }
     }
-    if (chamber_to_clcts_[id].size() > 2) {
-      edm::LogInfo("CSCStubMatcher") << "WARNING!!! too many CLCTs " << chamber_to_clcts_[id].size() << " in " << ch_id;
-      for (auto& c : chamber_to_clcts_[id])
+    if (chamber_to_clcts_[id2].size() > 2) {
+      edm::LogInfo("CSCStubMatcher") << "WARNING!!! too many CLCTs " << chamber_to_clcts_[id2].size() << " in " << ch_id2;
+      for (auto& c : chamber_to_clcts_[id2])
         edm::LogInfo("CSCStubMatcher") << "  " << c;
     }
   }
@@ -220,8 +221,9 @@ void CSCStubMatcher::matchALCTsToSimTrack(const CSCALCTDigiCollection& alcts) {
 
     int ring = ch_id.ring();
     if (ring == 4)
-      ring = 1;  //use ME1b id to get CLCTs
+      ring = 1;  //use ME1b id to get ALCTs
     CSCDetId ch_id2(ch_id.endcap(), ch_id.station(), ring, ch_id.chamber(), 0);
+    auto id2 = ch_id2.rawId(); // ALCTs should be sorted into the det of the ALCTs.
 
     const auto& alcts_in_det = alcts.get(ch_id2);
     for (auto a = alcts_in_det.first; a != alcts_in_det.second; ++a) {
@@ -238,7 +240,7 @@ void CSCStubMatcher::matchALCTsToSimTrack(const CSCALCTDigiCollection& alcts) {
       int wg = a->getKeyWG() + 1;  // as ALCT wiregroups numbers start from 0
 
       // store all ALCTs in this chamber
-      chamber_to_alcts_all_[id].push_back(*a);
+      chamber_to_alcts_all_[id2].push_back(*a);
 
       // match by wiregroup with the digis
       if (digi_wgs.find(wg) == digi_wgs.end()) {
@@ -248,13 +250,13 @@ void CSCStubMatcher::matchALCTsToSimTrack(const CSCALCTDigiCollection& alcts) {
         edm::LogInfo("CSCStubMatcher") << "alctGOOD";
 
       // store matching ALCTs in this chamber
-      if (std::find(chamber_to_alcts_[id].begin(), chamber_to_alcts_[id].end(), *a) == chamber_to_alcts_[id].end()) {
-        chamber_to_alcts_[id].push_back(*a);
+      if (std::find(chamber_to_alcts_[id2].begin(), chamber_to_alcts_[id2].end(), *a) == chamber_to_alcts_[id2].end()) {
+        chamber_to_alcts_[id2].push_back(*a);
       }
     }
-    if (chamber_to_alcts_[id].size() > 2) {
-      edm::LogInfo("CSCStubMatcher") << "WARNING!!! too many ALCTs " << chamber_to_alcts_[id].size() << " in " << ch_id;
-      for (auto& a : chamber_to_alcts_[id])
+    if (chamber_to_alcts_[id2].size() > 2) {
+      edm::LogInfo("CSCStubMatcher") << "WARNING!!! too many ALCTs " << chamber_to_alcts_[id2].size() << " in " << ch_id;
+      for (auto& a : chamber_to_alcts_[id2])
         edm::LogInfo("CSCStubMatcher") << "  " << a;
     }
   }
@@ -282,6 +284,7 @@ void CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& l
     if (ring == 4)
       ring = 1;
     CSCDetId ch_id2(ch_id.endcap(), ch_id.station(), ring, ch_id.chamber(), 0);
+    auto id2 = ch_id2.rawId(); // LCTs should be sorted into the det of the LCTs.
 
     const auto& lcts_in_det = lcts.get(ch_id2);
 
@@ -377,8 +380,8 @@ void CSCStubMatcher::matchLCTsToSimTrack(const CSCCorrelatedLCTDigiCollection& l
       if (lct_matched) {
         if (verboseLCT_)
           edm::LogInfo("CSCStubMatcher") << "...was matched";
-        if (std::find(chamber_to_lcts_[id].begin(), chamber_to_lcts_[id].end(), lct) == chamber_to_lcts_[id].end()) {
-          chamber_to_lcts_[id].emplace_back(lct);
+        if (std::find(chamber_to_lcts_[id2].begin(), chamber_to_lcts_[id2].end(), lct) == chamber_to_lcts_[id2].end()) {
+          chamber_to_lcts_[id2].emplace_back(lct);
         }
       }
     }  // lct loop over
@@ -643,9 +646,15 @@ GlobalPoint CSCStubMatcher::getGlobalPosition(unsigned int rawId, const CSCCorre
   CSCDetId cscId(rawId);
   CSCDetId keyId(cscId.endcap(), cscId.station(), cscId.ring(), cscId.chamber(), CSCConstants::KEY_CLCT_LAYER);
   float fractional_strip = lct.getFractionalStrip();
-  // case ME1/a
-  if (cscId.station() == 1 and cscId.ring() == 4 and lct.getStrip() > CSCConstants::MAX_HALF_STRIP_ME1B) {
-    fractional_strip -= CSCConstants::NUM_STRIPS_ME1B;
+  // case ME1/1
+  if (cscId.station() == 1 and (cscId.ring() == 4 || cscId.ring() == 1)) {
+    int ring = 1; // Default to ME1/b
+    if (lct.getStrip() > CSCConstants::MAX_HALF_STRIP_ME1B) {
+      ring = 4; // Change to ME1/a if the HalfStrip Number exceeds the range of ME1/b
+      fractional_strip -= CSCConstants::NUM_STRIPS_ME1B;
+    }
+    CSCDetId cscId_(cscId.endcap(), cscId.station(), ring, cscId.chamber(), cscId.layer());
+    cscId = cscId_;
   }
   // regular cases
   const auto& chamber = cscGeometry_->chamber(cscId);


### PR DESCRIPTION
#### PR description:

This PR changed the ring index of A/C/LCTs in ME1a from 4 to 1, making the ME1a and ME1b be stored at the same container.
The function that calculate the GlobalPoint will take care of the ME1a entries based on the half-strip number of the LCT.


Previously the the CSCStubMatcher will process the A/C/LCTs and sort them by the CSCDetID of the SimHits they are matched to.
Because the DIGI-tier sample does not distinguish ME1a and ME1b for A/C/LCTs, detector information of SimHits has to be used to tell A/C/LCTs from ME1a and ME1b.
But there are cases when both ME1a and ME1b contain the SimHits but LCT is only reconstructed in either. So the LCT would end up in the wrong sorting index (the DetId).
C/LCTs in ME1a and ME1b have different half-strip range, making them easily distinguishable. There is no need to separate ME1a and ME1b in the containers of CSCStubMatcher.

#### PR validation:

Tested on 100k events of private produced muon gun sample.
Here is a plot of ME1b chamber 1 LCT global points. There are distributions outside the block.
[before.pdf](https://github.com/cms-sw/cmssw/files/8208416/before.pdf)
Isolating those entries we found they are from SimHits at the edge.
[before_wing.pdf](https://github.com/cms-sw/cmssw/files/8208584/before_wing.pdf)
If we tell whether a LCT is in ME1a or ME1b by the Half Strip, the problematic entries return consistent GlobalPoint with the SimHits.
[before_correct.pdf](https://github.com/cms-sw/cmssw/files/8208590/before_correct.pdf)
After this correction, the GlobalPoint of LCTs in ME1b chamber 1 becomes:
[Correction.pdf](https://github.com/cms-sw/cmssw/files/8208734/RPhi_ME1b1.pdf)
The ME1a and ME1b LCTs are all in this plot while only the SimHit in ME1b are shown.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A


