### PR TITLE
handle inverted filters in `TriggerObjectStandAlone`

### DIFF
--- a/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
+++ b/DataFormats/PatCandidates/src/TriggerObjectStandAlone.cc
@@ -413,12 +413,10 @@ std::vector<std::string> const *TriggerObjectStandAlone::allLabels(edm::Paramete
     const unsigned int n(triggerNames.size());
     std::set<std::string> saveTags;
     for (unsigned int i = 0; i != n; ++i) {
-      if (pset->existsAs<vector<string> >(triggerNames.triggerName(i), true)) {
-        auto modules = pset->getParameter<vector<string> >(triggerNames.triggerName(i));
-        for (size_t m = 0; m < modules.size(); m++) {
-          auto module = modules[m];
-          auto moduleStrip = module.front() != '-' ? module : module.substr(1);
-
+      if (pset->existsAs<vector<string>>(triggerNames.triggerName(i), true)) {
+        auto const &modules = pset->getParameter<vector<string>>(triggerNames.triggerName(i));
+        for (auto const &module : modules) {
+          auto const moduleStrip = module.front() != '-' and module.front() != '!' ? module : module.substr(1);
           if (pset->exists(moduleStrip)) {
             const auto &modulePSet = pset->getParameterSet(moduleStrip);
             if (modulePSet.existsAs<bool>("saveTags", true) and modulePSet.getParameter<bool>("saveTags")) {
@@ -430,7 +428,7 @@ std::vector<std::string> const *TriggerObjectStandAlone::allLabels(edm::Paramete
     }
     std::vector<std::string> allModules(saveTags.begin(), saveTags.end());
     std::pair<AllLabelsMap::iterator, bool> ret =
-        allLabelsMap.insert(std::pair<edm::ParameterSetID, std::vector<std::string> >(psetid, allModules));
+        allLabelsMap.insert(std::pair<edm::ParameterSetID, std::vector<std::string>>(psetid, allModules));
     return &(ret.first->second);
   }
   return nullptr;


### PR DESCRIPTION
#### PR description:

This PR improves `TriggerObjectStandAlone` to handle cases where inverted filters (e.g. `~process.fooFilter`, which returns the opposite of `process.fooFilter`) are used in the configuration file.

Addresses https://github.com/cms-sw/cmssw/pull/37152#issuecomment-1060012129 by @perrotta, and possibly solves https://github.com/cms-sw/cmssw/issues/37157.

Note: I don't know `TriggerObjectStandAlone` well, and I would encourage PAT experts to have a look at the suggested fix.

FYI: @Martin-Grunewald 

#### PR validation:

Ran `runTheMatrix.py -l 11634.0`, and checked that the warnings in question disappeared.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A