### PR TITLE
fix thinnedAssociationsHelperPtr scope error

### DIFF
--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -370,7 +370,7 @@ namespace edm {
       metaDataTree->SetBranchAddress(poolNames::branchIDListBranchName().c_str(), &branchIDListsPtr);
     }
 
-    ThinnedAssociationsHelper* thinnedAssociationsHelperPtr; // must remain in scope through getEntry()
+    ThinnedAssociationsHelper* thinnedAssociationsHelperPtr;  // must remain in scope through getEntry()
     if (inputType != InputType::SecondarySource) {
       fileThinnedAssociationsHelper_ =
           std::make_unique<ThinnedAssociationsHelper>();  // propagate_const<T> has no reset() function

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -370,10 +370,11 @@ namespace edm {
       metaDataTree->SetBranchAddress(poolNames::branchIDListBranchName().c_str(), &branchIDListsPtr);
     }
 
+    ThinnedAssociationsHelper* thinnedAssociationsHelperPtr; // must remain in scope through getEntry()
     if (inputType != InputType::SecondarySource) {
       fileThinnedAssociationsHelper_ =
           std::make_unique<ThinnedAssociationsHelper>();  // propagate_const<T> has no reset() function
-      ThinnedAssociationsHelper* thinnedAssociationsHelperPtr = fileThinnedAssociationsHelper_.get();
+      thinnedAssociationsHelperPtr = fileThinnedAssociationsHelper_.get();
       if (metaDataTree->FindBranch(poolNames::thinnedAssociationsHelperBranchName().c_str()) != nullptr) {
         metaDataTree->SetBranchAddress(poolNames::thinnedAssociationsHelperBranchName().c_str(),
                                        &thinnedAssociationsHelperPtr);


### PR DESCRIPTION
#### PR description:

`thinnedAssociationsHelperPtr`, defined here:

https://github.com/cms-sw/cmssw/blob/6abbda549d88a3999eaf90f941c1d93b997240cf/IOPool/Input/src/RootFile.cc#L373-L381

goes out of scope before it is used (implicitly) here:

https://github.com/cms-sw/cmssw/blob/6abbda549d88a3999eaf90f941c1d93b997240cf/IOPool/Input/src/RootFile.cc#L402-L403

This corrects the bug by moving `thinnedAssociationsHelperPtr` so that it remains in scope through its use by `roottree::getEntry()`.  This was found via a custom build with select portions of ROOT compiled with ASAN (while chasing a different problem).

#### PR validation:

Compiles, confirmed in custom build that it corrects the scope problem found by ASAN, trivial technical fix.