### PR TITLE
Tighten check for the number of weights in GenWeightValidation

### DIFF
--- a/Validation/EventGenerator/plugins/GenWeightValidation.cc
+++ b/Validation/EventGenerator/plugins/GenWeightValidation.cc
@@ -122,17 +122,18 @@ void GenWeightValidation::dqmBeginRun(const edm::Run&, const edm::EventSetup&) {
 void GenWeightValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   weights_ = wmanager_.weightsCollection(iEvent);
 
-  if (weights_.at(idxGenEvtInfo_).empty())
-    return;  // no weights in GenEventInfo
+  unsigned weightsSize = weights_.at(idxGenEvtInfo_).size();
+  if (weightsSize < 2)
+    return;  // no baseline weight in GenEventInfo
 
   weight_ = weights_.at(idxGenEvtInfo_)[0] / std::abs(weights_.at(idxGenEvtInfo_)[0]);
   nEvt_->Fill(0.5, weight_);
-  nlogWgt_->Fill(std::log10(weights_.at(idxGenEvtInfo_).size()), weight_);
+  nlogWgt_->Fill(std::log10(weightsSize), weight_);
 
-  for (unsigned idx = 0; idx < weights_.at(idxGenEvtInfo_).size(); idx++)
+  for (unsigned idx = 0; idx < weightsSize; idx++)
     wgtVal_->Fill(weights_.at(idxGenEvtInfo_)[idx] / weights_.at(idxGenEvtInfo_)[1], weight_);
 
-  if ((int)weights_.at(idxGenEvtInfo_).size() <= idxMax_)
+  if ((int)weightsSize <= idxMax_)
     return;  // no PS weights in GenEventInfo
 
   edm::Handle<reco::GenParticleCollection> ptcls;


### PR DESCRIPTION
#### PR description:

Following a couple of issues reported after the merging of #36994:
- Non reproducibility of DQM histos filled in GenWeightValidation, which suggests some uninitialized or wrongly defined input value, see https://github.com/cms-sw/cmssw/pull/36994#pullrequestreview-904019313 and following discussion in the thread
- out-of-bounds memory read coming from `GenWeightValidation::analyze`, as reported by ASAN, see https://github.com/cms-sw/cmssw/pull/36994#issuecomment-1062980362

@SanghyunKo suggested in https://github.com/cms-sw/cmssw/pull/36994#discussion_r822464150 a quite reasonable fix for them.

To speed up the integration in view of the 12_3_0pre6 deadline, I implement here the fix of @SanghyunKo, while waiting for some possible further feedback

Of course, if @SanghyunKo or anyone else finds a more appropriate solution, this PR can be closed and we can move to the new one.

#### PR validation:

- It builds
- The fix is quite logical, and needed in any case