### PR TITLE
Update of Exotica HLT validation monitored paths and removal of l1MET from code

### DIFF
--- a/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
@@ -34,7 +34,6 @@
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
-#include "DataFormats/L1Trigger/interface/L1EtMissParticle.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/METReco/interface/CaloMETCollection.h"
 #include "DataFormats/METReco/interface/GenMET.h"
@@ -177,7 +176,6 @@ private:
   StringCutObjectSelector<reco::GenMET> *_genMETSelector;
   StringCutObjectSelector<reco::CaloMET> *_recCaloMETSelector;
   StringCutObjectSelector<reco::CaloMET> *_recCaloMHTSelector;
-  StringCutObjectSelector<l1extra::L1EtMissParticle> *_l1METSelector;
   StringCutObjectSelector<reco::PFTau> *_recPFTauSelector;
   StringCutObjectSelector<reco::Photon> *_recPhotonSelector;
   StringCutObjectSelector<reco::PFJet> *_recPFJetSelector;

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
@@ -4,7 +4,7 @@ CaloHTPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
 #        "HLT_HT900_v",         # Run2
 #        "HLT_HT300_v",         # Run2
-        "HLT_ECALHT800_v",     # Run2 7e33
+#        "HLT_ECALHT800_v",     # Run2 7e33 # Not claimed path for Run3
 #        "HLT_Photon90_CaloIdL_PFHT600_v" # 50ns backup menu
 #        "HLT_HT650_v",           
 #        "HLT_HT410to430_v",        # 2016 menu

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaCaloHT_cff.py
@@ -2,20 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 CaloHTPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_HT900_v",         # Run2
-#        "HLT_HT300_v",         # Run2
-#        "HLT_ECALHT800_v",     # Run2 7e33 # Not claimed path for Run3
-#        "HLT_Photon90_CaloIdL_PFHT600_v" # 50ns backup menu
-#        "HLT_HT650_v",           
-#        "HLT_HT410to430_v",        # 2016 menu
-#        "HLT_HT430to450_v",        # 2016 menu
-#        "HLT_HT450to470_v",        # HT Parking
-#        "HLT_HT470to500_v",        # HT Parking
-#        "HLT_HT500to550_v",        # HT Parking
-#        "HLT_HT550to650_v",        # HT Parking
-        #"DST_HT250_CaloScouting_v", # scouting # moved to DSTJets category
-        #"DST_CaloJet40_CaloScouting_v", # moved to DSTJets category
-        #"DST_L1HTT125ORHTT150ORHTT175_CaloScouting_v" # moved to DSTJets category
+#        "HLT_ECALHT800_v", # Run2 7e33 # Not claimed path for Run3
         ),
     recCaloMHTLabel  = cms.InputTag("recoExoticaValidationCaloHT"),
     recCaloJetLabel  = cms.InputTag("ak4CaloJets"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDSTJets_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDSTJets_cff.py
@@ -2,26 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 DSTJetsPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "DST_CaloJet40_CaloScouting_PFScouting_v",
-#        "DST_CaloJet40_BTagScouting_v",
-#        "DST_L1HTT_CaloScouting_PFScouting_v",
-#        "DST_L1HTT_BTagScouting_v",
-#        "DST_HT250_CaloScouting_v",
-#        "DST_HT410_PFScouting_v",
-#        "DST_HT410_BTagScouting_v",
-#        "DST_HT450_PFScouting_v",
-#        "DST_HT450_BTagScouting_v",
-        # 2016 menu
-#        "DST_HT250_CaloBTagScouting_v",
-#        "DST_L1HTT_CaloBTagScouting_v",
-#        "DST_CaloJet40_CaloBTagScouting_v",
         # For backward compatibility
-#        "DST_HT250_CaloScouting_v", # Not claimed path
-#        "DST_CaloJet40_CaloScouting_v", 
-#        "DST_L1HTT125ORHTT150ORHTT175_CaloScouting_v",
-#        "DST_HT450_PFReco_PFBTagCSVReco_PFScouting_v",
-#        "DST_L1HTT125ORHTT150ORHTT175_PFReco_PFBTagCSVReco_PFScouting_v",
-#        "DST_CaloJet40_PFReco_PFBTagCSVReco_PFScouting_v"
+#        "DST_HT250_CaloScouting_v", # Not claimed path for Run 3
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDSTJets_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDSTJets_cff.py
@@ -16,7 +16,7 @@ DSTJetsPSet = cms.PSet(
 #        "DST_L1HTT_CaloBTagScouting_v",
 #        "DST_CaloJet40_CaloBTagScouting_v",
         # For backward compatibility
-        "DST_HT250_CaloScouting_v", 
+#        "DST_HT250_CaloScouting_v", # Not claimed path
 #        "DST_CaloJet40_CaloScouting_v", 
 #        "DST_L1HTT125ORHTT150ORHTT175_CaloScouting_v",
 #        "DST_HT450_PFReco_PFBTagCSVReco_PFScouting_v",

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDSTMuons_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDSTMuons_cff.py
@@ -2,14 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 DSTMuonsPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "DST_ZeroBias_CaloScouting_PFScouting_v",
-#        "DST_ZeroBias_BTagScouting_v",
-#        "DST_L1DoubleMu_CaloScouting_PFScouting_v",
-#        "DST_L1DoubleMu_BTagScouting_v",
-#        "DST_DoubleMu3_Mass10_CaloScouting_PFScouting_v",
-#        "DST_DoubleMu3_Mass10_BTagScouting_v",
-#        "HLT_DoubleMu3_Mass10_v",
-#        "DST_DoubleMu3_noVtx_CaloScouting_v"
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
@@ -3,18 +3,12 @@ import FWCore.ParameterSet.Config as cms
 DiPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_DoublePhoton85_v",    # Run2 proposal # Claimed path for Run3
-#        "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon22_AND_HE10_R9Id65_Eta2_Mass15_v",
-#        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Eta2_Mass60_v",
-#        "HLT_Photon42_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon25_AND_HE10_R9Id65_Eta2_Mass15_v", #50ns backup menu
-#        "HLT_DoublePhoton60_v",
-#        "HLT_DoublePhoton40_v", # 0T
-#        "HLT_DoublePhoton50_v",  # 0T
         "HLT_DoublePhoton70_v", # Claimed path for Run3
 #        "HLT_DoublePhoton33_CaloIdL_v" # Not claimed path for Run3
-        "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_Mass55_v",
-        "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_v",
-        "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90_v",
-        "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v"
+        "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_Mass55_v", # Claimed path for Run3
+        "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_v", # Claimed path for Run3
+        "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90_v", # Claimed path for Run3
+        "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v" # Claimed path for Run3
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     #recPhotonLabel  = cms.InputTag("gedPhotons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
@@ -2,23 +2,28 @@ import FWCore.ParameterSet.Config as cms
 
 DiPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_DoublePhoton85_v",    # Run2 proposal
+        "HLT_DoublePhoton85_v",    # Run2 proposal # Claimed path for Run3
 #        "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon22_AND_HE10_R9Id65_Eta2_Mass15_v",
 #        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Eta2_Mass60_v",
 #        "HLT_Photon42_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon25_AND_HE10_R9Id65_Eta2_Mass15_v", #50ns backup menu
 #        "HLT_DoublePhoton60_v",
 #        "HLT_DoublePhoton40_v", # 0T
 #        "HLT_DoublePhoton50_v",  # 0T
-        "HLT_DoublePhoton70_v",
-        "HLT_DoublePhoton33_CaloIdL"  
+        "HLT_DoublePhoton70_v", # Claimed path for Run3
+#        "HLT_DoublePhoton33_CaloIdL_v" # Not claimed path for Run3
+        "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_Mass55_v",
+        "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_v",
+        "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90_v",
+        "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v"
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     #recPhotonLabel  = cms.InputTag("gedPhotons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
-    parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
-                                    1100, 1200, 1500
-                                   ),
+    parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
+                                    60, 70, 80, 100, 110, 120, 130, 140, 150,
+                                    160, 170, 180, 190, 200
+                                  ),
     dropPt3 = cms.bool(True),
     )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
@@ -8,7 +8,7 @@ DiPhotonPSet = cms.PSet(
         "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_Mass55_v", # Claimed path for Run3
         "HLT_Diphoton30_18_R9IdL_AND_HE_AND_IsoCaloId_NoPixelVeto_v", # Claimed path for Run3
         "HLT_Diphoton30_22_R9Id_OR_IsoCaloId_AND_HE_R9Id_Mass90_v", # Claimed path for Run3
-        "HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v" # Claimed path for Run3
+        #"HLT_Diphoton30PV_18PV_R9Id_AND_IsoCaloId_AND_HE_R9Id_PixelVeto_Mass55_v" # Claimed path for Run3 but not existent anymore in CMSSW_12_3_X
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     #recPhotonLabel  = cms.InputTag("gedPhotons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 DisplacedDimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_DoubleMu43NoFiltersNoVtx_v", # 2017 displaced mu-mu (main)
-        "HLT_DoubleMu48NoFiltersNoVtx_v", # 2017 displaced mu-mu (backup)
-        "HLT_DoubleMu33NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (main)
-        "HLT_DoubleMu40NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (backup)
+        "HLT_DoubleMu43NoFiltersNoVtx_v", # 2017 displaced mu-mu (main) # Claimed path for Run3
+        "HLT_DoubleMu48NoFiltersNoVtx_v", # 2017 displaced mu-mu (backup) # Claimed path for Run3
+        "HLT_DoubleMu33NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (main) # Claimed path for Run3
+#        "HLT_DoubleMu40NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (backup) # Not claimed path for Run3
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 DisplacedMuEGPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v", # 2017 displaced e-mu (main)
-        "HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v", # 2017 displaced e-mu (backup)
-        "HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v", # 2017 displaced e-mu, muon with dxy> 0.01cm (main)
-        "HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v", # 2017 displaced e-mu, muon with dxy> 0.01cm (backup)
+        "HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v", # 2017 displaced e-mu (main) # Claimed path for Run3
+        "HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v", # 2017 displaced e-mu (backup) # Claimed path for Run3
+        "HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v", # 2017 displaced e-mu, muon with dxy> 0.01cm (main) # Claimed path for Run3
+        "HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v", # 2017 displaced e-mu, muon with dxy> 0.01cm (backup) # Claimed path for Run3
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     recMuonLabel  = cms.InputTag("muons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaEleMu_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaEleMu_cff.py
@@ -2,11 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 EleMuPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_Mu30_Ele30_CaloIdL_GsfTrkIdVL_v"
-        "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v",
-        "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v",
-        "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v",
-        "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v"
+        "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v", # Claimed path for Run3
+        "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v", # Claimed path for Run3
+        "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v", # Claimed path for Run3
+        "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v" # Claimed path for Run3
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     recMuonLabel  = cms.InputTag("muons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaEleMu_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaEleMu_cff.py
@@ -3,6 +3,10 @@ import FWCore.ParameterSet.Config as cms
 EleMuPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
 #        "HLT_Mu30_Ele30_CaloIdL_GsfTrkIdVL_v"
+        "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ_v",
+        "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_v",
+        "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v",
+        "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v"
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     recMuonLabel  = cms.InputTag("muons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHTDisplacedJets_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHTDisplacedJets_cff.py
@@ -2,46 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 HTDisplacedJetsPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_HT200_v",
-#        "HLT_HT275_v",
-#        "HLT_HT325_v",
         "HLT_HT425_v", # Claimed path for Run3
-#        "HLT_HT575_v",
-        
-#        "HLT_HT650_DisplacedDijet80_Inclusive_v",
-#        "HLT_HT750_DisplacedDijet80_Inclusive_v",
-#        "HLT_HT350_DisplacedDijet80_DisplacedTrack_v",
-#        "HLT_HT350_DisplacedDijet80_Tight_DisplacedTrack_v",
-        # 2016 menu
-#        "HLT_HT550_DisplacedDijet80_Inclusive_v",
-#        "HLT_HT350_DisplacedDijet40_Inclusive_v",
-#        "HLT_HT200_DisplacedDijet40_DisplacedTrack_v",
-        # 5e33, 7e33 menus
-#        "HLT_HT500_DisplacedDijet40_Inclusive_v",
-#        "HLT_HT550_DisplacedDijet40_Inclusive_v",
-#        "HLT_HT350_DisplacedDijet40_DisplacedTrack_v",
-        #"HLT_HT350_DisplacedDijet80_DisplacedTrack_v",
-#        "HLT_VBF_DisplacedJet40_DisplacedTrack_v",
-#        "HLT_VBF_DisplacedJet40_Hadronic_v",
-#        "HLT_VBF_DisplacedJet40_TightID_DisplacedTrack_v",
-#        "HLT_VBF_DisplacedJet40_TightID_Hadronic_v",
-        # 1.4e34 menus
-#        "HLT_VBF_DisplacedJet40_VTightID_Hadronic_v",
-#        "HLT_VBF_DisplacedJet40_VVTightID_DisplacedTrack_v",
-#        "HLT_VBF_DisplacedJet40_VVTightID_Hadronic_v",
-#        "HLT_VBF_DisplacedJet40_VTightID_DisplacedTrack_v",
-        # Loose Threshold path for Run3s.
-#        "HLT_VBF_DisplacedJet40_DisplacedTrack_2TrackIP2DSig5_v",
-#        "HLT_HT400_DisplacedDijet40_Inclusive_v",
-#        "HLT_HT250_DisplacedDijet40_DisplacedTrack_v",
-#        "HLT_VBF_DisplacedJet40_Hadronic_2PromptTrack_v",
         #2017 
         "HLT_HT430_DisplacedDijet40_DisplacedTrack_v", # Claimed path for Run3
         "HLT_HT430_DisplacedDijet60_DisplacedTrack_v", # Claimed path for Run3
-#        "HLT_HT430_DisplacedDijet80_DisplacedTrack_v",
         "HLT_HT650_DisplacedDijet60_Inclusive_v", # Claimed path for Run3
-        "HLT_HT400_DisplacedDijet40_DisplacedTrack_v",
-        "HLT_HT550_DisplacedDijet60_Inclusive_v"
+        "HLT_HT400_DisplacedDijet40_DisplacedTrack_v", # Claimed path for Run3
+        "HLT_HT550_DisplacedDijet60_Inclusive_v" # Claimed path for Run3
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHTDisplacedJets_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHTDisplacedJets_cff.py
@@ -5,7 +5,7 @@ HTDisplacedJetsPSet = cms.PSet(
 #        "HLT_HT200_v",
 #        "HLT_HT275_v",
 #        "HLT_HT325_v",
-        "HLT_HT425_v",
+        "HLT_HT425_v", # Claimed path for Run3
 #        "HLT_HT575_v",
         
 #        "HLT_HT650_DisplacedDijet80_Inclusive_v",
@@ -30,16 +30,18 @@ HTDisplacedJetsPSet = cms.PSet(
 #        "HLT_VBF_DisplacedJet40_VVTightID_DisplacedTrack_v",
 #        "HLT_VBF_DisplacedJet40_VVTightID_Hadronic_v",
 #        "HLT_VBF_DisplacedJet40_VTightID_DisplacedTrack_v",
-        # Loose Threshold paths.
+        # Loose Threshold path for Run3s.
 #        "HLT_VBF_DisplacedJet40_DisplacedTrack_2TrackIP2DSig5_v",
 #        "HLT_HT400_DisplacedDijet40_Inclusive_v",
 #        "HLT_HT250_DisplacedDijet40_DisplacedTrack_v",
 #        "HLT_VBF_DisplacedJet40_Hadronic_2PromptTrack_v",
         #2017 
-        "HLT_HT430_DisplacedDijet40_DisplacedTrack_v",
-        "HLT_HT430_DisplacedDijet60_DisplacedTrack_v",
+        "HLT_HT430_DisplacedDijet40_DisplacedTrack_v", # Claimed path for Run3
+        "HLT_HT430_DisplacedDijet60_DisplacedTrack_v", # Claimed path for Run3
 #        "HLT_HT430_DisplacedDijet80_DisplacedTrack_v",
-        "HLT_HT650_DisplacedDijet60_Inclusive_v"
+        "HLT_HT650_DisplacedDijet60_Inclusive_v", # Claimed path for Run3
+        "HLT_HT400_DisplacedDijet40_DisplacedTrack_v",
+        "HLT_HT550_DisplacedDijet60_Inclusive_v"
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),
@@ -50,10 +52,11 @@ HTDisplacedJetsPSet = cms.PSet(
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble(0, 50, 100, 150,
                                    200, 220, 240, 260, 280, 300,
-                                   320, 340, 360, 380, 400,
-                                   420, 440, 460, 480, 500,
-                                   520, 540, 560, 580, 600,
-                                   620, 640, 660, 680, 700,
-                                   750, 800, 850, 900, 950, 1000,
-                                   1100, 1200, 1300, 1400, 1500)
+                                   320, 340, 360, 380, 400, 420,
+                                   440, 460, 480, 500, 520, 540,
+                                   560, 580, 600, 650, 700, 750,
+                                   800, 850, 900, 1100, 1300, 1500),
+    parametersTurnOnSumEt = cms.vdouble(    0,  100,  200,  300,  400,  500,  600,  700,  800,  900,
+                                         1000, 1100, 1200, 1300, 1400, 1500
+                                       )
 )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtDielectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtDielectron_cff.py
@@ -2,11 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 HighPtDielectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_DoubleEle25_CaloIdL_GsfTrkIdVL_v", # 0T only
-#        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_MW_v", # Run2
-#        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_v",    # Run1 & Run2
-#        "HLT_DoubleEle33_CaloIdL_MW_v",            # 2016 menu # Not claimed path for Run3
-#        "HLT_DoubleEle33_CaloIdL_v"                # 2016 menu
+#        "HLT_DoubleEle33_CaloIdL_MW_v", # 2016 menu # Not claimed path for Run3
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtDielectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtDielectron_cff.py
@@ -5,7 +5,7 @@ HighPtDielectronPSet = cms.PSet(
 #        "HLT_DoubleEle25_CaloIdL_GsfTrkIdVL_v", # 0T only
 #        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_MW_v", # Run2
 #        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_v",    # Run1 & Run2
-        "HLT_DoubleEle33_CaloIdL_MW_v",            # 2016 menu
+#        "HLT_DoubleEle33_CaloIdL_MW_v",            # 2016 menu # Not claimed path for Run3
 #        "HLT_DoubleEle33_CaloIdL_v"                # 2016 menu
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtDimuon_cff.py
@@ -2,12 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 HighPtDimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_Mu30_TkMu11_v", # Run2
-#        "HLT_Mu40_TkMu11_v", # Run2, backup
-#        "HLT_Mu27_TkMu8_v", # Run2, control
-#        "HLT_Mu17_Mu8_v"   # Run2 & Run1
-        #"HLT_Mu17_TkMu8_v", # Run1
-        #"HLT_Mu22_TkMu8_v"  # Run1
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
@@ -4,7 +4,6 @@ HighPtElectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
 #        "HLT_Ele145_CaloIdVT_GsfTrkIdT_v", # Not claimed path for Run3
 #        "HLT_Ele200_CaloIdVT_GsfTrkIdT_v", # Not claimed path for Run3
-#        "HLT_Ele105_CaloIdVT_GsfTrkIdT_v", # Run2 proposal
         "HLT_Ele115_CaloIdVT_GsfTrkIdT_v"  # 50ns backup menu # Claimed path for Run3
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 HighPtElectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_Ele145_CaloIdVT_GsfTrkIdT_v",
-        "HLT_Ele200_CaloIdVT_GsfTrkIdT_v",
+#        "HLT_Ele145_CaloIdVT_GsfTrkIdT_v", # Not claimed path for Run3
+#        "HLT_Ele200_CaloIdVT_GsfTrkIdT_v", # Not claimed path for Run3
 #        "HLT_Ele105_CaloIdVT_GsfTrkIdT_v", # Run2 proposal
-        "HLT_Ele115_CaloIdVT_GsfTrkIdT_v"  # 50ns backup menu
+        "HLT_Ele115_CaloIdVT_GsfTrkIdT_v"  # 50ns backup menu # Claimed path for Run3
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
@@ -3,18 +3,13 @@ import FWCore.ParameterSet.Config as cms
 HighPtPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_Photon175_v",  # Run2 proposal # Claimed path for Run3
-#        "HLT_Photon165_HE10_v",  # Run2 proposal
-#        "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon31_AND_HE10_R9Id65_Mass10_v",  # Run2 proposal
-#        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Mass60_v",  # Run2 proposal
-#        "HLT_Photon90_CaloIdL_PFHT500_v", #50ns backup menu
 #        "HLT_Photon150_v", # 0T # Not claimed path for Run3
-        #"HLT_Photon135_v"  # Run1 (frozenHLT)
         "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350MinPFJet15_v", # 2017 # Claimed path for Run3
 #        "HLT_Photon33_v", # 2017 # Not claimed path for Run3
 #        "HLT_Photon60_R9Id90_CaloIdL_IsoL_v", # 2017 # Not claimed path for Run3
 #        "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_v" # 2017 # Not claimed path for Run3
-        "HLT_Photon110EB_TightID_TightIso_v", 
-        "HLT_Photon200_v"
+        "HLT_Photon110EB_TightID_TightIso_v", # Claimed path for Run3 
+        "HLT_Photon200_v" # Claimed path for Run3
         ),
     recPhotonLabel  = cms.InputTag("gedPhotons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
@@ -2,25 +2,27 @@ import FWCore.ParameterSet.Config as cms
 
 HighPtPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_Photon175_v",  # Run2 proposal
+        "HLT_Photon175_v",  # Run2 proposal # Claimed path for Run3
 #        "HLT_Photon165_HE10_v",  # Run2 proposal
 #        "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon31_AND_HE10_R9Id65_Mass10_v",  # Run2 proposal
 #        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Mass60_v",  # Run2 proposal
 #        "HLT_Photon90_CaloIdL_PFHT500_v", #50ns backup menu
-        "HLT_Photon150_v", # 0T
+#        "HLT_Photon150_v", # 0T # Not claimed path for Run3
         #"HLT_Photon135_v"  # Run1 (frozenHLT)
-        "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350MinPFJet15_v", # 2017
-        "HLT_Photon33_v", # 2017
-        "HLT_Photon60_R9Id90_CaloIdL_IsoL_v", # 2017
-        "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_v" # 2017
+        "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350MinPFJet15_v", # 2017 # Claimed path for Run3
+#        "HLT_Photon33_v", # 2017 # Not claimed path for Run3
+#        "HLT_Photon60_R9Id90_CaloIdL_IsoL_v", # 2017 # Not claimed path for Run3
+#        "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_v" # 2017 # Not claimed path for Run3
+        "HLT_Photon110EB_TightID_TightIso_v", 
+        "HLT_Photon200_v"
         ),
     recPhotonLabel  = cms.InputTag("gedPhotons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
-    parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 
-                                    250, 300, 400, 500, 600, 700, 800, 900, 1000,
-                                    1100, 1200, 1500
+    parametersTurnOn = cms.vdouble( 0, 25, 50, 75, 100, 125, 150, 175, 200, 225,
+                                    250, 275, 300, 400, 500, 600, 700, 800, 900, 1000
                                    ),
+    dropPt2 = cms.bool(True),
     dropPt3 = cms.bool(True),
     )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaJetNoBptx_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaJetNoBptx_cff.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 JetNoBptxPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_UncorrectedJetE30_NoBPTX_v", # 2017 proposal
-        "HLT_UncorrectedJetE30_NoBPTX3BX_v",
-        "HLT_UncorrectedJetE60_NoBPTX3BX_v",
-        "HLT_UncorrectedJetE70_NoBPTX3BX_v",
+        "HLT_UncorrectedJetE30_NoBPTX_v", # 2017 proposal # Claimed path for Run3
+        "HLT_UncorrectedJetE30_NoBPTX3BX_v", # Claimed path for Run3
+        "HLT_UncorrectedJetE60_NoBPTX3BX_v", # Claimed path for Run3
+        "HLT_UncorrectedJetE70_NoBPTX3BX_v", # Claimed path for Run3
         ),
     recCaloJetLabel    = cms.InputTag("ak4CaloJets"),
 

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDielectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDielectron_cff.py
@@ -2,14 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 LowPtDielectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_MW_v", # Run2
-#        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_v",    # Run1 & Run2
 #        "HLT_DoubleEle33_CaloIdL_MW_v",            # 2016 menu # Not claimed path for Run3
-#        "HLT_DoubleEle33_CaloIdL_v"                # 2016 menu
-        "HLT_DoubleEle25_CaloIdL_MW_v",
-        "HLT_DoubleEle27_CaloIdL_MW_v",
-        "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v",
-        "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v"
+        "HLT_DoubleEle25_CaloIdL_MW_v", # Claimed path for Run3
+        "HLT_DoubleEle27_CaloIdL_MW_v", # Claimed path for Run3
+        "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v", # Claimed path for Run3
+        "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v" # Claimed path for Run3
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDielectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDielectron_cff.py
@@ -4,8 +4,12 @@ LowPtDielectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
 #        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_MW_v", # Run2
 #        "HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_v",    # Run1 & Run2
-        "HLT_DoubleEle33_CaloIdL_MW_v",            # 2016 menu
+#        "HLT_DoubleEle33_CaloIdL_MW_v",            # 2016 menu # Not claimed path for Run3
 #        "HLT_DoubleEle33_CaloIdL_v"                # 2016 menu
+        "HLT_DoubleEle25_CaloIdL_MW_v",
+        "HLT_DoubleEle27_CaloIdL_MW_v",
+        "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v",
+        "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v"
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDimuon_cff.py
@@ -8,6 +8,9 @@ LowPtDimuonPSet = cms.PSet(
         #"HLT_Mu17_Mu8_v",    # Run1
         #"HLT_Mu17_TkMu8_v",  # Run1
         #"HLT_Mu22_TkMu8_v"   # Run1
+        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v",
+        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v",
+        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v"
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtDimuon_cff.py
@@ -2,15 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 LowPtDimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_Mu30_TkMu11_v",  # Run2
-#        "HLT_Mu17_TkMu8_DZ_v",# Run2
-#        "HLT_Mu17_Mu8_DZ_v"  # Run2
-        #"HLT_Mu17_Mu8_v",    # Run1
-        #"HLT_Mu17_TkMu8_v",  # Run1
-        #"HLT_Mu22_TkMu8_v"   # Run1
-        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v",
-        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v",
-        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v"
+        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8_v", # Claimed path for Run3
+        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass8_v", # Claimed path for Run3
+        "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v" # Claimed path for Run3
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtElectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtElectron_cff.py
@@ -2,12 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 LowPtElectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_Ele27_WP85_Gsf_v" # Run2 proposal
-        #"HLT_Ele27_WP80_v"    # Run1 
-        "HLT_Ele28_WPTight_Gsf_v",
-        "HLT_Ele32_WPTight_Gsf_L1DoubleEG_v",
-        "HLT_Ele32_WPTight_Gsf_v",
-        "HLT_Ele35_WPTight_Gsf_v"
+        "HLT_Ele28_WPTight_Gsf_v", # Claimed path for Run3
+        "HLT_Ele32_WPTight_Gsf_L1DoubleEG_v", # Claimed path for Run3
+        "HLT_Ele32_WPTight_Gsf_v", # Claimed path for Run3
+        "HLT_Ele35_WPTight_Gsf_v" # Claimed path for Run3
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtElectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtElectron_cff.py
@@ -4,15 +4,18 @@ LowPtElectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
 #        "HLT_Ele27_WP85_Gsf_v" # Run2 proposal
         #"HLT_Ele27_WP80_v"    # Run1 
+        "HLT_Ele28_WPTight_Gsf_v",
+        "HLT_Ele32_WPTight_Gsf_L1DoubleEG_v",
+        "HLT_Ele32_WPTight_Gsf_v",
+        "HLT_Ele35_WPTight_Gsf_v"
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
-    #parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
-    #                                60, 70, 80, 100, 120, 140, 160, 180, 200
     parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
                                     60, 70, 80, 100
                                    ),
+    dropPt2 = cms.bool(True),
     dropPt3 = cms.bool(True),
     )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtTrimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtTrimuon_cff.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 LowPtTrimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
 #        "HLT_TrkMu15_DoubleTrkMu5NoFiltersNoVtx_v", #signal
-        "HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v",
-        "HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v", #signal
+#        "HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v", # Not claimed path for Run3
+#        "HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v", #signal # Not claimed path for Run3
 #        "HLT_Dimuon0_Jpsi_Muon_v",                  # control
 #        "HLT_Mu17_TkMu8_DZ",                        # backup
 #        "HLT_Mu17_Mu8_DZ"                           # backup

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtTrimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtTrimuon_cff.py
@@ -2,12 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 LowPtTrimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_TrkMu15_DoubleTrkMu5NoFiltersNoVtx_v", #signal
-#        "HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v", # Not claimed path for Run3
-#        "HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v", #signal # Not claimed path for Run3
-#        "HLT_Dimuon0_Jpsi_Muon_v",                  # control
-#        "HLT_Mu17_TkMu8_DZ",                        # backup
-#        "HLT_Mu17_Mu8_DZ"                           # backup
     ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
@@ -2,11 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 METplusTrackPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        #"HLT_MET75_IsoTrk50_v",       # 2015-6 proposal
-        #"HLT_MET90_IsoTrk50_v",       # 2015-6 proposal
-        #"HLT_MET60_IsoTrk35_Loose_v", # 2016-6 proposal
-        "HLT_MET105_IsoTrk50_v",       # 2017 proposal # Claimed path for Run3
-        "HLT_MET120_IsoTrk50_v"        # 2017 proposal # Claimed path for Run3
+        "HLT_MET105_IsoTrk50_v", # 2017 proposal # Claimed path for Run3
+        "HLT_MET120_IsoTrk50_v"  # 2017 proposal # Claimed path for Run3
     ),
     recPFMETLabel = cms.InputTag("pfMet"),
     #recMETLabel   = cms.InputTag("hltPFMETProducer"),
@@ -14,8 +11,8 @@ METplusTrackPSet = cms.PSet(
     recMuonLabel  = cms.InputTag("muons"),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     #recTrackLabel = cms.InputTag("generalTracks"),
-    #hltMETLabel   = cms.InputTag("hltMetClean"),                    
-    #l1METLabel    = cms.InputTag("l1extraParticles","MET"),   
+    #hltMETLabel   = cms.InputTag("hltMetClean"),
+    #l1METLabel    = cms.InputTag("l1extraParticles","MET"),                    
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
@@ -5,8 +5,8 @@ METplusTrackPSet = cms.PSet(
         #"HLT_MET75_IsoTrk50_v",       # 2015-6 proposal
         #"HLT_MET90_IsoTrk50_v",       # 2015-6 proposal
         #"HLT_MET60_IsoTrk35_Loose_v", # 2016-6 proposal
-        "HLT_MET105_IsoTrk50_v",       # 2017 proposal
-        "HLT_MET120_IsoTrk50_v"        # 2017 proposal
+        "HLT_MET105_IsoTrk50_v",       # 2017 proposal # Claimed path for Run3
+        "HLT_MET120_IsoTrk50_v"        # 2017 proposal # Claimed path for Run3
     ),
     recPFMETLabel = cms.InputTag("pfMet"),
     #recMETLabel   = cms.InputTag("hltPFMETProducer"),
@@ -15,7 +15,7 @@ METplusTrackPSet = cms.PSet(
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     #recTrackLabel = cms.InputTag("generalTracks"),
     #hltMETLabel   = cms.InputTag("hltMetClean"),                    
-    l1METLabel    = cms.InputTag("l1extraParticles","MET"),   
+    #l1METLabel    = cms.InputTag("l1extraParticles","MET"),   
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
@@ -12,7 +12,6 @@ METplusTrackPSet = cms.PSet(
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     #recTrackLabel = cms.InputTag("generalTracks"),
     #hltMETLabel   = cms.InputTag("hltMetClean"),
-    #l1METLabel    = cms.InputTag("l1extraParticles","MET"),                    
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojetBackup_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojetBackup_cff.py
@@ -9,9 +9,11 @@ MonojetBackupPSet = cms.PSet(
         #"HLT_PFCenJet140_PFMETNoMu140_PFMHTNoMu140_v",
         #"HLT_PFCenJet150_PFMETNoMu150_PFMHTNoMu150_v",
         #"HLT_CaloJet500_NoID_v",
-        "HLT_CaloJet500_NoJetID_v",
+        "HLT_CaloJet500_NoJetID_v", # Claimed path for Run3
         #"HLT_MonoCentralPFJet80_PFMETnoMu105_NHEF0p95_v" # Run1
-        "HLT_CaloJet550_NoJetID_v"
+        "HLT_CaloJet550_NoJetID_v", # Claimed path for Run3
+        "HLT_PFJet500_v",
+        "HLT_PFJet550_v"
         ),
     recPFJetLabel    = cms.InputTag("ak4PFJets"),
     recPFMETLabel    = cms.InputTag("pfMet"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojetBackup_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojetBackup_cff.py
@@ -2,18 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 MonojetBackupPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        #"HLT_PFJet260_v", # Run2
-        #"HLT_PFJetCen80_PFMETNoMu100_v",
-        #"HLT_PFJetCen80_PFMHTNoPuNoMu100_v",
-        #"HLT_PFCenJet140_PFMETNoMu100_PFMHTNoMu140_v",
-        #"HLT_PFCenJet140_PFMETNoMu140_PFMHTNoMu140_v",
-        #"HLT_PFCenJet150_PFMETNoMu150_PFMHTNoMu150_v",
-        #"HLT_CaloJet500_NoID_v",
         "HLT_CaloJet500_NoJetID_v", # Claimed path for Run3
-        #"HLT_MonoCentralPFJet80_PFMETnoMu105_NHEF0p95_v" # Run1
         "HLT_CaloJet550_NoJetID_v", # Claimed path for Run3
-        "HLT_PFJet500_v",
-        "HLT_PFJet550_v"
+        "HLT_PFJet500_v", # Claimed path for Run3
+        "HLT_PFJet550_v" # Claimed path for Run3
         ),
     recPFJetLabel    = cms.InputTag("ak4PFJets"),
     recPFMETLabel    = cms.InputTag("pfMet"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
@@ -2,17 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 MonojetPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v",
         "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v", # Claimed path for Run3
-#        "HLT_MET200_v",
 #        "HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v", # Not claimed path for Run3
-#        "HLT_MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_IDTight_v",
-        #2016 menu
-#        "HLT_PFMETNoMu100_PFMHTNoMu100_IDTight_v",
         "HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_v", # Claimed path for Run3
-#        "HLT_MonoCentralPFJet80_PFMETNoMu100_PFMHTNoMu100_IDTight_v",
 #        "HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight_v", # Not claimed path for Run3
-        #2017 menu
 #        "HLT_PFMET110_PFMHT110_IDTight_v", # Not claimed path for Run3
         "HLT_PFMET120_PFMHT120_IDTight_v", # Claimed path for Run3
 #        "HLT_PFMET130_PFMHT130_IDTight_v", # Not claimed path for Run3
@@ -31,12 +24,6 @@ MonojetPSet = cms.PSet(
         "HLT_PFHT700_PFMET95_PFMHT95_IDTight_v", # Claimed path for Run3
         "HLT_PFHT800_PFMET75_PFMHT75_IDTight_v", # Claimed path for Run3
         "HLT_PFHT800_PFMET85_PFMHT85_IDTight_v", # Claimed path for Run3
-        # For backward compatibility
-#        "HLT_PFMETNoMu90_JetIdCleaned_PFMHTNoMu90_IDTight_v",
-#        "HLT_PFMETNoMu120_JetIdCleaned_PFMHTNoMu120_IDTight_v",
-#        "HLT_MET200_JetIdCleaned_v",
-#        "HLT_MonoCentralPFJet80_PFMETNoMu120_JetIdCleaned_PFMHTNoMu120_IDTight_v",
-#        "HLT_MonoCentralPFJet80_PFMETNoMu90_JetIdCleaned_PFMHTNoMu90_IDTight_v"
     ),
 
     recCaloJetLabel    = cms.InputTag("ak4CaloJets"),
@@ -54,11 +41,10 @@ MonojetPSet = cms.PSet(
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble( 0, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150,
-                                    160, 170, 180, 190, 200,
-                                    220, 240, 260, 280, 300,
-                                    320, 340, 360, 380, 400,
-                                    420, 440, 460, 480, 500,600,700,800,900,1100,1200,
-                                    1400,1500),
+                                    160, 170, 180, 190, 200, 220, 240, 260, 280, 300,
+                                    320, 340, 360, 380, 400, 420, 440, 460, 480, 500,
+                                    600, 700, 800, 900, 1100, 1200, 1400,1500
+                                  ),
 
     parametersTurnOnSumEt = cms.vdouble(    0,  100,  200,  300,  400,  500,  600,  700,  800,  900,
                                          1000, 1100, 1200, 1300, 1400, 1500

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
@@ -3,34 +3,34 @@ import FWCore.ParameterSet.Config as cms
 MonojetPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
 #        "HLT_PFMETNoMu90_PFMHTNoMu90_IDTight_v",
-        "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v",
+        "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v", # Claimed path for Run3
 #        "HLT_MET200_v",
-        "HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v",
+#        "HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v", # Not claimed path for Run3
 #        "HLT_MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_IDTight_v",
         #2016 menu
 #        "HLT_PFMETNoMu100_PFMHTNoMu100_IDTight_v",
-        "HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_v",
+        "HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_v", # Claimed path for Run3
 #        "HLT_MonoCentralPFJet80_PFMETNoMu100_PFMHTNoMu100_IDTight_v",
-        "HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight_v",
+#        "HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight_v", # Not claimed path for Run3
         #2017 menu
-        "HLT_PFMET110_PFMHT110_IDTight_v",
-        "HLT_PFMET120_PFMHT120_IDTight_v",
-        "HLT_PFMET130_PFMHT130_IDTight_v",
-        "HLT_PFMET140_PFMHT140_IDTight_v",
-        "HLT_PFMETTypeOne110_PFMHT110_IDTight_v",
-        "HLT_PFMETTypeOne120_PFMHT120_IDTight_v",
-        "HLT_PFMETTypeOne130_PFMHT130_IDTight_v",
-        "HLT_PFMETTypeOne140_PFMHT140_IDTight_v",
-        "HLT_PFMETNoMu130_PFMHTNoMu130_IDTight_v",
-        "HLT_PFMETNoMu140_PFMHTNoMu140_IDTight_v",
-        "HLT_MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_IDTight_v",
-        "HLT_MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_IDTight_v",
-        "HLT_PFHT500_PFMET100_PFMHT100_IDTight_v",
-        "HLT_PFHT500_PFMET110_PFMHT110_IDTight_v",
-        "HLT_PFHT700_PFMET85_PFMHT85_IDTight_v",
-        "HLT_PFHT700_PFMET95_PFMHT95_IDTight_v",
-        "HLT_PFHT800_PFMET75_PFMHT75_IDTight_v",
-        "HLT_PFHT800_PFMET85_PFMHT85_IDTight_v",
+#        "HLT_PFMET110_PFMHT110_IDTight_v", # Not claimed path for Run3
+        "HLT_PFMET120_PFMHT120_IDTight_v", # Claimed path for Run3
+#        "HLT_PFMET130_PFMHT130_IDTight_v", # Not claimed path for Run3
+#        "HLT_PFMET140_PFMHT140_IDTight_v", # Not claimed path for Run3
+#        "HLT_PFMETTypeOne110_PFMHT110_IDTight_v", # Not claimed path for Run3
+#        "HLT_PFMETTypeOne120_PFMHT120_IDTight_v", # Not claimed path for Run3
+#        "HLT_PFMETTypeOne130_PFMHT130_IDTight_v", # Not claimed path for Run3
+#        "HLT_PFMETTypeOne140_PFMHT140_IDTight_v", # Not claimed path for Run3
+        "HLT_PFMETNoMu130_PFMHTNoMu130_IDTight_v", # Claimed path for Run3
+        "HLT_PFMETNoMu140_PFMHTNoMu140_IDTight_v", # Claimed path for Run3
+#        "HLT_MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_IDTight_v", # Not claimed path for Run3
+#        "HLT_MonoCentralPFJet80_PFMETNoMu140_PFMHTNoMu140_IDTight_v", # Not claimed path for Run3
+        "HLT_PFHT500_PFMET100_PFMHT100_IDTight_v", # Claimed path for Run3
+        "HLT_PFHT500_PFMET110_PFMHT110_IDTight_v", # Claimed path for Run3
+        "HLT_PFHT700_PFMET85_PFMHT85_IDTight_v", # Claimed path for Run3
+        "HLT_PFHT700_PFMET95_PFMHT95_IDTight_v", # Claimed path for Run3
+        "HLT_PFHT800_PFMET75_PFMHT75_IDTight_v", # Claimed path for Run3
+        "HLT_PFHT800_PFMET85_PFMHT85_IDTight_v", # Claimed path for Run3
         # For backward compatibility
 #        "HLT_PFMETNoMu90_JetIdCleaned_PFMHTNoMu90_IDTight_v",
 #        "HLT_PFMETNoMu120_JetIdCleaned_PFMHTNoMu120_IDTight_v",
@@ -55,10 +55,10 @@ MonojetPSet = cms.PSet(
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble( 0, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150,
                                     160, 170, 180, 190, 200,
-                                    220, 240, 260, 280, 300, 
+                                    220, 240, 260, 280, 300,
                                     320, 340, 360, 380, 400,
                                     420, 440, 460, 480, 500,600,700,800,900,1100,1200,
-                                    1400,1600,1800,2000,2200,2400,2600,2800,3000),
+                                    1400,1500),
 
     parametersTurnOnSumEt = cms.vdouble(    0,  100,  200,  300,  400,  500,  600,  700,  800,  900,
                                          1000, 1100, 1200, 1300, 1400, 1500

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
@@ -2,19 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 MuonNoBptxPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v", # 2017 proposal
-        "HLT_L2Mu10_NoVertex_NoBPTX_v",
-        "HLT_L2Mu10_NoVertex_NoBPTX3BX_v",
-        "HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX_v"
+        "HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v", # 2017 proposal # Claimed path for Run3
+        "HLT_L2Mu10_NoVertex_NoBPTX_v", # Claimed path for Run3
+        "HLT_L2Mu10_NoVertex_NoBPTX3BX_v", # Claimed path for Run3
+        "HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX_v" # Claimed path for Run3
         ),
     #recMuonLabel  = cms.InputTag("muons"),
     recMuonTrkLabel  = cms.InputTag("displacedStandAloneMuons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
-    #parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
-    #                                1100, 1200, 1500
-    #                               ),
     parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50,
                                     60, 70, 80, 100
                                    ),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
@@ -19,7 +19,9 @@ PFHTPSet = cms.PSet(
         #"DST_HT450_PFReco_PFBTagCSVReco_PFScouting_v", # Moved to DSTJets category
         #"DST_L1HTT125ORHTT150ORHTT175_PFReco_PFBTagCSVReco_PFScouting_v", # Moved to DSTJets category
         #"DST_CaloJet40_PFReco_PFBTagCSVReco_PFScouting_v" # Moved to DSTJets category
-        "HLT_PFHT350MinPFJet15_v" #2017
+#        "HLT_PFHT350MinPFJet15_v" #2017 # Not claimed path for Run3
+        "HLT_PFHT1050_v",
+        "HLT_PFHT250_v"
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),
@@ -30,5 +32,8 @@ PFHTPSet = cms.PSet(
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble(0, 50, 100, 150, 200, 250, 300, 350, 400, 450, 470, 
                                    500, 550, 600, 650, 700, 800, 900, 1000
-                                   )
+                                   ),
+    parametersTurnOnSumEt = cms.vdouble(    0,  100,  200,  300,  400,  500,  600,  700,  800,  900,
+                                         1000, 1100, 1200, 1300, 1400, 1600, 1800, 2000
+                                       )
 )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPFHT_cff.py
@@ -2,26 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 PFHTPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_PFHT650_WideJetMJJ900DEtaJJ1p5_v",
-#        "HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v",
-#        "HLT_PFHT750_4Jet_v",
-#        "HLT_PFHT550_4JetPt50_v",
-#        "HLT_PFHT650_4JetPt50_v",
-#        "HLT_PFHT750_4JetPt50_v",
-#        "HLT_PFHT650_4Jet_v", # Run2
-#        "HLT_PFHT550_4Jet_v", # Run2
-#        "HLT_PFHT800_v",
-#        "HLT_PFHT650_v",
-#        "HLT_PFHT800_4JetPt50_v",
-#        "HLT_PFHT750_4JetPt70_v",
-#        "HLT_PFHT850_4JetPt50_v",
-#        "HLT_PFHT750_4JetPt80_v",
-        #"DST_HT450_PFReco_PFBTagCSVReco_PFScouting_v", # Moved to DSTJets category
-        #"DST_L1HTT125ORHTT150ORHTT175_PFReco_PFBTagCSVReco_PFScouting_v", # Moved to DSTJets category
-        #"DST_CaloJet40_PFReco_PFBTagCSVReco_PFScouting_v" # Moved to DSTJets category
 #        "HLT_PFHT350MinPFJet15_v" #2017 # Not claimed path for Run3
-        "HLT_PFHT1050_v",
-        "HLT_PFHT250_v"
+        "HLT_PFHT1050_v", # Claimed path for Run3
+        "HLT_PFHT250_v" # Claimed path for Run3
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPhotonMET_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPhotonMET_cff.py
@@ -2,9 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 PhotonMETPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_Photon135_PFMET100_v",
-#        "HLT_Photon135_PFMET100_JetIdCleaned_v", # For backward compatibility
-#        "HLT_Photon125_v" # 0T
         ),
     recPFMETLabel  = cms.InputTag("pfMet"),
     recPhotonLabel  = cms.InputTag("gedPhotons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
@@ -2,19 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 PureMETPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_PFMET170_NotCleaned_v",
-#        "HLT_PFMET170_v",
-#        "HLT_PFMET170_HBHECleaned_v",
-#        "HLT_PFMET170_NoiseCleaned_v",  # Run2
-#        "HLT_MET200_v",
-#        "HLT_MET100_v",    # 0T
-#        "HLT_MET150_v",    # 0T
-
-        # For backward compatibility
-#        "HLT_PFMET170_JetIdCleaned_v",  
-#        "HLT_MET200_JetIdCleaned_v",
-#        "HLT_MET100_JetIdCleaned_v",    # 0T
-#        "HLT_MET150_JetIdCleaned_v"     # 0T
         ),
     recPFMETLabel  = cms.InputTag("pfMet"),
     recCaloMETLabel = cms.InputTag("caloMet"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaSingleMuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaSingleMuon_cff.py
@@ -2,13 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 SingleMuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_Mu45_eta2p1_v", # Run 2 
         "HLT_Mu50_v", # Run 2 # Claimed path for Run3
-#        "HLT_TkMu50_v", # 2016 menu
-        #50ns backup menu
         "HLT_Mu55_v", # Claimed path for Run3
-#        "HLT_Mu50_eta2p1_v"
-        "HLT_IsoMu24_v"
+        "HLT_IsoMu24_v" # Claimed path for Run3
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaSingleMuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaSingleMuon_cff.py
@@ -3,17 +3,18 @@ import FWCore.ParameterSet.Config as cms
 SingleMuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
 #        "HLT_Mu45_eta2p1_v", # Run 2 
-        "HLT_Mu50_v", # Run 2
+        "HLT_Mu50_v", # Run 2 # Claimed path for Run3
 #        "HLT_TkMu50_v", # 2016 menu
         #50ns backup menu
-        "HLT_Mu55_v",
+        "HLT_Mu55_v", # Claimed path for Run3
 #        "HLT_Mu50_eta2p1_v"
+        "HLT_IsoMu24_v"
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
-    parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 25, 30, 35, 40, 
+    parametersTurnOn = cms.vdouble( 0, 5, 10, 15, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 
                                     42, 44, 46, 48, 50, 52, 54, 56, 58, 60,
                                     70, 80, 90, 100
                                    ),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaTracklessJets_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaTracklessJets_cff.py
@@ -2,12 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 TracklessJetsPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-#        "HLT_SingleCentralPFJet170_CFMax0p1_v",
-#        "HLT_DiCentralPFJet170_CFMax0p1_v",
-#        "HLT_DiCentralPFJet220_CFMax0p3_v",
-#        "HLT_DiCentralPFJet330_CFMax0p5_v",
-#        "HLT_DiCentralPFJet170_v",
-#        "HLT_DiCentralPFJet430_v"
         ),
     recPFJetLabel   = cms.InputTag("ak4PFJets"),
     recCaloJetLabel = cms.InputTag("ak4CaloJets"),

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -62,7 +62,7 @@ from HLTriggerOffline.Exotica.hltExoticaValidator_cfi import hltExoticaValidator
 #------------------------------------------------------------
 #--- IMPORTANT: Update this collection whenever you introduce a new object
 #               in the code (from EVTColContainer::getTypeString)
-def make_exo_postprocessor(analysis_name, plot_types=["TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4", "EffEta", "EffPhi", "EffDxy"], object_types=["Mu","refittedStandAloneMuons","Track","Ele","Photon","PFTau","PFJet","MET","PFMET","PFMHT","GenMET","CaloJet","CaloMET","CaloMHT","l1MET"], extra_str_templates=[]):
+def make_exo_postprocessor(analysis_name, plot_types=["TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4", "EffEta", "EffPhi", "EffDxy"], object_types=["Mu","refittedStandAloneMuons","Track","Ele","Photon","PFTau","PFJet","MET","PFMET","PFMHT","GenMET","CaloJet","CaloMET","CaloMHT"], extra_str_templates=[]):
     postprocessor = hltExoticaPostProcessor.clone()
     postprocessor.subDirs = ["HLT/Exotica/" + analysis_name]
     efficiency_strings = [] # List of plots to look for. This is quite a bit larger than the number of plots that will be made.

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -187,9 +187,6 @@ hltExoticaValidator = DQMEDAnalyzer(
     hltMET_genCut   = cms.string("pt > 75"),
     hltMET_recCut   = cms.string("pt > 75"),  
    
-    l1MET_genCut    = cms.string("pt > 75"),
-    l1MET_recCut    = cms.string("pt > 75"),  
-   
     # The specific parameters per analysis: the name of the parameter set has to be 
     # the same as the defined ones in the 'analysis' datamember. Each analysis is a PSet
     # with the mandatory attributes:
@@ -232,6 +229,3 @@ hltExoticaValidator = DQMEDAnalyzer(
     DSTMuons         = DSTMuonsPSet,
     TracklessJets    = TracklessJetsPSet
 )
-
-from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-stage2L1Trigger.toModify(hltExoticaValidator, METplusTrack = dict(l1METLabel = None))

--- a/HLTriggerOffline/Exotica/src/EVTColContainer.cc
+++ b/HLTriggerOffline/Exotica/src/EVTColContainer.cc
@@ -20,8 +20,6 @@
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
-#include "DataFormats/L1Trigger/interface/L1EtMissParticle.h"
-#include "DataFormats/L1Trigger/interface/L1EtMissParticleFwd.h"
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/METReco/interface/CaloMETFwd.h"
 #include "DataFormats/METReco/interface/GenMET.h"
@@ -57,7 +55,6 @@ struct EVTColContainer {
     GENMET = 390001,
     CALOMET = 390002,
     HLTMET = 390003,
-    L1MET = 390004,
     PFJET = 211,
     CALOJET = 111,
     CALOMHT = 400002,
@@ -78,7 +75,6 @@ struct EVTColContainer {
   const std::vector<reco::GenMET> *genMETs;
   const std::vector<reco::CaloMET> *caloMETs;
   const std::vector<reco::CaloMET> *caloMHTs;
-  const std::vector<l1extra::L1EtMissParticle> *l1METs;
   const std::vector<reco::PFTau> *pfTaus;
   const std::vector<reco::PFJet> *pfJets;
   const std::vector<reco::CaloJet> *caloJets;
@@ -99,7 +95,6 @@ struct EVTColContainer {
         genMETs(nullptr),
         caloMETs(nullptr),
         caloMHTs(nullptr),
-        l1METs(nullptr),
         pfTaus(nullptr),
         pfJets(nullptr),
         caloJets(nullptr),
@@ -124,7 +119,6 @@ struct EVTColContainer {
     genMETs = nullptr;
     caloMETs = nullptr;
     caloMHTs = nullptr;
-    l1METs = nullptr;
     pfTaus = nullptr;
     pfJets = nullptr;
     caloJets = nullptr;
@@ -173,10 +167,6 @@ struct EVTColContainer {
     caloMHTs = v;
     ++nInitialized;
   }
-  void set(const l1extra::L1EtMissParticleCollection *v) {
-    l1METs = v;
-    ++nInitialized;
-  }
   void set(const reco::PFTauCollection *v) {
     pfTaus = v;
     ++nInitialized;
@@ -215,8 +205,6 @@ struct EVTColContainer {
       size = caloMETs->size();
     } else if (objtype == EVTColContainer::CALOMHT && caloMHTs != nullptr) {
       size = caloMHTs->size();
-    } else if (objtype == EVTColContainer::L1MET && l1METs != nullptr) {
-      size = l1METs->size();
     } else if (objtype == EVTColContainer::PFTAU && pfTaus != nullptr) {
       size = pfTaus->size();
     } else if (objtype == EVTColContainer::PFJET && pfJets != nullptr) {
@@ -254,8 +242,6 @@ struct EVTColContainer {
       objTypestr = "CaloMET";
     } else if (objtype == EVTColContainer::CALOMHT) {
       objTypestr = "CaloMHT";
-    } else if (objtype == EVTColContainer::L1MET) {
-      objTypestr = "l1MET";
     } else if (objtype == EVTColContainer::PFTAU) {
       objTypestr = "PFTau";
     } else if (objtype == EVTColContainer::PFJET) {

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -52,7 +52,6 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet &pset,
       _genMETSelector(nullptr),
       _recCaloMETSelector(nullptr),
       _recCaloMHTSelector(nullptr),
-      _l1METSelector(nullptr),
       _recPFTauSelector(nullptr),
       _recPhotonSelector(nullptr),
       _recPFJetSelector(nullptr),
@@ -174,8 +173,6 @@ HLTExoticaSubAnalysis::~HLTExoticaSubAnalysis() {
   _recCaloMETSelector = nullptr;
   delete _recCaloMHTSelector;
   _recCaloMHTSelector = nullptr;
-  delete _l1METSelector;
-  _l1METSelector = nullptr;
   delete _recPFTauSelector;
   _recPFTauSelector = nullptr;
   delete _recPFJetSelector;
@@ -768,7 +765,6 @@ const std::vector<unsigned int> HLTExoticaSubAnalysis::getObjectsType(const std:
                                                  EVTColContainer::GENMET,
                                                  EVTColContainer::CALOMET,
                                                  EVTColContainer::CALOMHT,
-                                                 EVTColContainer::L1MET,
                                                  EVTColContainer::PFTAU,
                                                  EVTColContainer::PFJET,
                                                  EVTColContainer::CALOJET};
@@ -840,10 +836,6 @@ void HLTExoticaSubAnalysis::getNamesOfObjects(const edm::ParameterSet &anpset) {
   if (anpset.exists("hltMETLabel")) {
     _recLabels[EVTColContainer::CALOMET] = anpset.getParameter<edm::InputTag>("hltMETLabel");
     _genSelectorMap[EVTColContainer::CALOMET] = nullptr;
-  }
-  if (anpset.exists("l1METLabel")) {
-    _recLabels[EVTColContainer::L1MET] = anpset.getParameter<edm::InputTag>("l1METLabel");
-    _genSelectorMap[EVTColContainer::L1MET] = nullptr;
   }
   if (anpset.exists("recPFTauLabel")) {
     _recLabels[EVTColContainer::PFTAU] = anpset.getParameter<edm::InputTag>("recPFTauLabel");
@@ -927,11 +919,6 @@ void HLTExoticaSubAnalysis::registerConsumes(edm::ConsumesCollector &iC) {
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::CALOMHT) {
       edm::EDGetTokenT<reco::CaloMETCollection> particularToken = iC.consumes<reco::CaloMETCollection>(it->second);
-      edm::EDGetToken token(particularToken);
-      _tokens[it->first] = token;
-    } else if (it->first == EVTColContainer::L1MET) {
-      edm::EDGetTokenT<l1extra::L1EtMissParticleCollection> particularToken =
-          iC.consumes<l1extra::L1EtMissParticleCollection>(it->second);
       edm::EDGetToken token(particularToken);
       _tokens[it->first] = token;
     } else if (it->first == EVTColContainer::PFTAU) {
@@ -1040,11 +1027,6 @@ void HLTExoticaSubAnalysis::getHandlesToObjects(const edm::Event &iEvent, EVTCol
       iEvent.getByToken(it->second, theHandle);
       if (theHandle.isValid())
         col->setCaloMHT(theHandle.product());
-    } else if (it->first == EVTColContainer::L1MET) {
-      edm::Handle<l1extra::L1EtMissParticleCollection> theHandle;
-      iEvent.getByToken(it->second, theHandle);
-      if (theHandle.isValid())
-        col->set(theHandle.product());
     } else if (it->first == EVTColContainer::PFTAU) {
       edm::Handle<reco::PFTauCollection> theHandle;
       iEvent.getByToken(it->second, theHandle);
@@ -1167,8 +1149,6 @@ void HLTExoticaSubAnalysis::initSelector(const unsigned int &objtype) {
     _recCaloMETSelector = new StringCutObjectSelector<reco::CaloMET>(_recCut[objtype]);
   } else if (objtype == EVTColContainer::CALOMHT && _recCaloMHTSelector == nullptr) {
     _recCaloMHTSelector = new StringCutObjectSelector<reco::CaloMET>(_recCut[objtype]);
-  } else if (objtype == EVTColContainer::L1MET && _l1METSelector == nullptr) {
-    _l1METSelector = new StringCutObjectSelector<l1extra::L1EtMissParticle>(_recCut[objtype]);
   } else if (objtype == EVTColContainer::PFTAU && _recPFTauSelector == nullptr) {
     _recPFTauSelector = new StringCutObjectSelector<reco::PFTau>(_recCut[objtype]);
   } else if (objtype == EVTColContainer::PFJET && _recPFJetSelector == nullptr) {
@@ -1298,16 +1278,6 @@ void HLTExoticaSubAnalysis::insertCandidates(const unsigned int &objType,
         matches->push_back(m);
         if (i == 0)
           theSumEt[objType] = cols->caloMHTs->at(i).sumEt();
-      }
-    }
-  } else if (objType == EVTColContainer::L1MET) {
-    for (size_t i = 0; i < cols->l1METs->size(); i++) {
-      LogDebug("ExoticaValidation") << "Inserting L1MET " << i;
-      if (_l1METSelector->operator()(cols->l1METs->at(i))) {
-        reco::LeafCandidate m(0, cols->l1METs->at(i).p4(), cols->l1METs->at(i).vertex(), objType, 0, true);
-        matches->push_back(m);
-        if (i == 0)
-          theSumEt[objType] = cols->l1METs->at(i).etTotal();
       }
     }
   } else if (objType == EVTColContainer::PFTAU) {


### PR DESCRIPTION
#### PR description:

Updated the Exotica HLT validation monitored paths based on more recent information from EXO/LLP claimed HLT paths for Run 3 as described in [EXOTICATriggerValidation](https://twiki.cern.ch/twiki/bin/view/CMS/EXOTICATriggerValidation#Updates_on_the_Exotica_HLT_valid) , and modified some of the generated histograms binning to fit the updated paths. Deleted very outdated paths that were commented to clean the code. Histograms related to paths not claimed are not created anymore, and histograms related to paths that were claimed but were not being monitored will be added.

Completely removed variable l1MET from the code, as it was not used in the validation (since it was not being produced as described in #36916), and, after the changes in #36916, configuration file [hltExoticaValidator_cfg.py](https://github.com/cms-sw/cmssw/blob/master/HLTriggerOffline/Exotica/test/hltExoticaValidator_cfg.py) could not be executed due to the usage of a non existing label `l1METLabel` in [hltExoticaMETplusTrack_cff.py](https://github.com/cms-sw/cmssw/blob/master/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py).

#### PR validation:

Checked removed and added paths histograms using RelVal datasets, and everything is as expected.

When commented label `l1METLabel` in [hltExoticaMETplusTrack_cff.py](https://github.com/cms-sw/cmssw/blob/master/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py), the configuration file [hltExoticaValidator_cfg.py](https://github.com/cms-sw/cmssw/blob/master/HLTriggerOffline/Exotica/test/hltExoticaValidator_cfg.py) worked normally again, but the execution of command `runTheMatrix.py -l limited -i all --ibeos -t 8` for validation, exhibited several failing workflows as shown in [1]. Upon removing l1MET from code, execution of `runTheMatrix.py -l limited -i all --ibeos -t 8` exhibit a failure in workflow 2018.1 with ret= 35072 (is this a memory issue only?) [2]. After running command `runTheMatrix.py -l 2018.1 -t 8`, got no failures [3].