### PR TITLE
Removing assert to address the issue #35668

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitSoAFromLegacy.cc
@@ -217,7 +217,7 @@ void SiPixelRecHitSoAFromLegacy::produce(edm::StreamID streamID, edm::Event& iEv
         clus.push_back(ic);
         ++ndigi;
       }
-      assert(clust.originalId() == ic);  // make sure hits and clus are in sync
+
       if (convert2Legacy_)
         clusterRef.emplace_back(edmNew::makeRefTo(hclusters, &clust));
       ic++;


### PR DESCRIPTION
#### PR description:

This PR comments the assert statement in order to address the issue https://github.com/cms-sw/cmssw/issues/35668.

The assert statement checks if the clusters on one detId are stored by increasing clust.originalId(). That is true for Legacy clusters coming from the Legacy Clusterizer, however if the Legacy clusters are output by SiPixelDigisClustersFromSoA that is no more true and the assert fails.

#### PR validation:

Run wfs 11634.501, 11634.502 (on CPU and GPU), 11634.506 and 
hltGetConfiguration /dev/CMSSW_12_3_0/GRun --globaltag 122X_mcRun3_2021_realistic_v5 --mc --customise HLTrigger/Configuration/customizeHLTforPatatrack.customiseCommon,HLTrigger/Configuration/customizeHLTforPatatrack.customisePixelLocalReconstruction --input file:/eos/cms/store/relval/CMSSW_12_3_0_pre2/RelValQCD_FlatPt_15_3000HS_14/GEN-SIM-DIGI-RAW/122X_mcRun3_2021_realistic_v5-v1/2580000/9681546e-e170-41e0-aca3-280a014ba2cc.root --era Run3 --output minimal --max-events 1 > hlt.py

All work fine.


