### PR TITLE
HCAL: fix on HCAL TP saturation algorithm to recover a saturation threshold for HE with |ieta| >= 21

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -446,9 +446,7 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
       unsigned int sample = samples[ibin + i];
 
       if (fix_saturation_ && (sample_saturation.size() > ibin + i))
-        check_sat = (sample_saturation[ibin + i] | (sample > QIE11_MAX_LINEARIZATION_ET));
-      else if (sample > QIE11_MAX_LINEARIZATION_ET)
-        sample = QIE11_MAX_LINEARIZATION_ET;
+        check_sat = sample_saturation[ibin + i];
 
       // Usually use a segmentation factor of 1.0 but for ieta >= 21 use 0.5
       double segmentationFactor = 1.0;


### PR DESCRIPTION
#### PR description:

This PR updates the HCAL Trigger Primitive(TP) reconstruction algorithm to fix the effect that TP energy in HE with |ieta| >= 21 saturated at 64 GeV for PFA1/PFA1' pille-up mitigation scheme, while 128 GeV is expected. This effect results from the phi segmentation of towers in this particular region. In |ieta| ≥ 21 with phi segmentation of 10 degrees, TP energy in each time sample in each tower(after sums over depths) is divided by 2 to mimic phi segmentation of 5 degrees in other regions. And because the HCAL TP algorithm checks a saturation of TS in each tower just before this division by 2, the actual saturation check in |ieta| ≥ 21 in HE is at 64 GeV for each TS for now. 

To fix the unexpected low saturation threshold in |ieta| ≥ 21 in HE, the saturation check, which is the second check among 3 saturation checks in the algorithm and turned out to be redundant, is removed. A brief explanation of the old and new algorithm, and the performance test after applying this PR can be found on [Presentation by Taeun Kwon](https://indico.cern.ch/event/1132179/contributions/4764839/attachments/2402243/4108534/Comissioning_1TS_Scheme_4Mar22.pdf).


#### PR validation:

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.
