### PR TITLE
edmPickEvents improvements

### DIFF
--- a/PhysicsTools/Utilities/scripts/edmPickEvents.py
+++ b/PhysicsTools/Utilities/scripts/edmPickEvents.py
@@ -135,7 +135,7 @@ def getFileNames_dasgoclient(event):
         print(out.decode('utf8'))
         print("--- Standard error---")
         print(err.decode('utf8'))
-        print("--- End --")
+        print("--- End ---")
         exit(1)
     else:
         try:
@@ -147,7 +147,7 @@ def getFileNames_dasgoclient(event):
         except json.decoder.JSONDecodeError:
             print("dasgoclient returned invalid JSON:")
             print(out.decode('utf8'))
-            print("-- End --")
+            print("--- End ---")
             exit(1)
     return files
 

--- a/PhysicsTools/Utilities/scripts/edmPickEvents.py
+++ b/PhysicsTools/Utilities/scripts/edmPickEvents.py
@@ -131,10 +131,10 @@ def getFileNames_dasgoclient(event):
         out, err = proc.communicate()
     exit_code = proc.returncode
     if err or (exit_code != 0):
-        print("DAS query error: return code\n--- Standard output---".format(exit_code))
-        print(out)
+        print("DAS query error: return code {0}\n--- Standard output---".format(exit_code))
+        print(out.decode('utf8'))
         print("--- Standard error---")
-        print(err)
+        print(err.decode('utf8'))
         print("--- End --")
         exit(1)
     else:
@@ -146,7 +146,7 @@ def getFileNames_dasgoclient(event):
                         files.append(fname)
         except json.decoder.JSONDecodeError:
             print("dasgoclient returned invalid JSON:")
-            print(out)
+            print(out.decode('utf8'))
             print("-- End --")
             exit(1)
     return files


### PR DESCRIPTION
#### PR description:

dasgoclient doesn't print all errors to stderr, some go to stdout. Since the errors are not proper JSON, edmPickEvents script will raise JSONDecodeError, but will not show the actual error. The following changes were added to get a better error message:
1) An early detection of failure (test if exit_code != 0) 
2) A failsafe (catching JSONDecodeError)

#### PR validation:

Ran modified code locally. 
Example command: `edmPickEvents.py Cosmics/Run2011A-v1/RAW 160960:277:10001082,160960:277:10001058,160960:277:10001650`

Example output from original code:
```
Traceback (most recent call last):
  File "/build/razumov2/CMSSW_12_3_X_2022-03-10-2300/./edmPickEvents.py", line 334, in <module>
    eventFiles = getFileNames(event, options.das_cli)
  File "/build/razumov2/CMSSW_12_3_X_2022-03-10-2300/./edmPickEvents.py", line 95, in getFileNames
    return getFileNames_dasgoclient(event)
  File "/build/razumov2/CMSSW_12_3_X_2022-03-10-2300/./edmPickEvents.py", line 134, in getFileNames_dasgoclient
    for row in json.loads(res):
  File "/cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc10/external/python3/3.9.6-67e5cf5b4952101922f1d4c8474baa39/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc10/external/python3/3.9.6-67e5cf5b4952101922f1d4c8474baa39/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/cvmfs/cms-ib.cern.ch/week1/slc7_amd64_gcc10/external/python3/3.9.6-67e5cf5b4952101922f1d4c8474baa39/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Example output with proposed changes:
```
DAS query error: return code 18
--- Standard output---
Validation error: unmatched dataset pattern

--- Standard error---

--- End ---
```