### PR TITLE
[12.2.X] Introduce alignment campaign-like unit test for `pede`

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -1,3 +1,11 @@
 <test name="test_PrepareInputDb" command="mps_prepare_input_db.py -g auto:run2_data -r 1 -o ${LOCALTOP}/tmp/test_input.db"/>
 <test name="test_MpsWorkFlow" command="test_mps-workflow.sh"/>
 <test name="test_CreateFileLists" command="mps_create_file_lists.py --test-mode --force -i /OVERRIDDEN/IN/TESTMODE -o ${LOCALTOP}/tmp/mps_create_file_lists -n 200000 --iov 42 --iov 174"/>
+<test name="test-pede" command="pede -t">
+  <use name="millepede"/>
+  <flags USE_UNITTEST_DIR="1"/>
+</test>
+<bin name="testPedeCampaign" file="TestDriver.cpp">
+  <flags TEST_RUNNER_ARGS="/bin/bash Alignment/MillePedeAlignmentAlgorithm/test test_pede.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>

--- a/Alignment/MillePedeAlignmentAlgorithm/test/TestDriver.cpp
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/TestDriver.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.py
@@ -1,0 +1,100 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("Alignment")
+
+process.Tracer = cms.Service("Tracer")
+
+setupGlobaltag = "121X_mcRun3_2021_realistic_forpp900GeV_v6"
+setupCollection = "ALCARECOTkAlCosmicsCosmicTF0T"
+setupCosmicsDecoMode = True
+setupCosmicsZeroTesla = False
+setupPrimaryWidth     = -1.0
+setupJson             = "placeholder_json"
+setupRunStartGeometry = 1
+setupAlgoMode = "pede"
+setupMonitorFile      = "millePedeMonitorISN.root"
+setupBinaryFile       = "milleBinaryISN.dat"
+readFiles = cms.untracked.vstring()
+
+import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.GeneralSetup as generalSetup
+generalSetup.setup(process, setupGlobaltag, setupCosmicsZeroTesla)
+
+
+################################################################################
+# setup alignment producer
+################################################################################
+import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.ConfigureAlignmentProducer as confAliProducer
+
+confAliProducer.setConfiguration(process,
+    collection   = setupCollection,
+    mode         = setupAlgoMode,
+    monitorFile  = setupMonitorFile,
+    binaryFile   = setupBinaryFile,
+    primaryWidth = setupPrimaryWidth,
+    cosmicsZeroTesla = setupCosmicsZeroTesla)
+
+
+################################################################################
+# Overwrite some conditions in global tag
+################################################################################
+import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.SetCondition as tagwriter
+
+################################################################################
+# insert Startgeometry 
+################################################################################
+# You can use tagwriter.setCondition() to overwrite conditions in globaltag
+
+################################################################################
+# insert Alignables 
+################################################################################
+process.AlignmentProducer.ParameterBuilder.parameterTypes = ["SelectorRigid,RigidBody"]
+
+################################################################################
+# Define the high-level structure alignables
+################################################################################
+process.AlignmentProducer.ParameterBuilder.SelectorRigid = cms.PSet(
+    alignParams = cms.vstring(
+        "TrackerP1PXBHalfBarrel,111111",
+        "TrackerP1PXECHalfCylinder,111111",
+        "TrackerTIBHalfBarrel,111111",
+        "TrackerTOBHalfBarrel,rrrrrr",
+        "TrackerTIDEndcap,111111",
+        "TrackerTECEndcap,111111",
+    )
+)
+
+################################################################################
+# insert Pedesettings 
+################################################################################
+import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.helper as helper
+helper.set_pede_option(process, "skipemptycons")
+
+################################################################################
+# Mille-procedure
+################################################################################
+if setupAlgoMode == "mille":
+    import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.MilleSetup as mille
+    mille.setup(process,
+                input_files        = readFiles,
+                collection         = setupCollection,
+                json_file          = setupJson,
+                cosmics_zero_tesla = setupCosmicsZeroTesla,
+                cosmics_deco_mode  = setupCosmicsDecoMode)
+
+################################################################################
+# Pede-procedure
+################################################################################
+else:
+    merge_binary_files = [
+                'milleBinary001.dat',
+                'milleBinary002.dat',
+                'milleBinary003.dat']
+    merge_tree_files   = [
+                'treeFile001.root',
+                'treeFile002.root',
+                'treeFile003.root']
+
+    import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.PedeSetup as pede
+    pede.setup(process,
+               binary_files = merge_binary_files,
+               tree_files = merge_tree_files,
+               run_start_geometry = setupRunStartGeometry)

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+
+if [ "${SCRAM_TEST_NAME}" != "" ] ; then
+  mkdir ${SCRAM_TEST_NAME}
+  cd ${SCRAM_TEST_NAME}
+fi
+
+if test -f "milleBinary00*"; then
+    echo "cleaning the local test area"
+    rm -fr milleBinary00* 
+    rm -fr pedeSteer* 
+fi
+
+pwd
+echo " testing Aligment/MillePedeAlignmentAlgorithm"
+
+REMOTE="/store/group/alca_global/tkal_millepede_tests/"
+TESTPACKAGE="test_pede_package.tar"
+COMMMAND=`xrdfs cms-xrd-global.cern.ch locate ${REMOTE}${TESTPACKAGE}`
+STATUS=$?
+echo "xrdfs command status = "$STATUS
+if [ $STATUS -eq 0 ]; then
+    echo "Using file ${TESTPACKAGE}. Running in ${LOCAL_TEST_DIR}."
+    xrdcp root://cms-xrd-global.cern.ch/${REMOTE}${TESTPACKAGE} ${LOCAL_TEST_DIR}
+    tar -xvf ${LOCAL_TEST_DIR}/${TESTPACKAGE} 
+    gunzip milleBinary00*    
+    (cmsRun ${LOCAL_TEST_DIR}/test_pede.py) || die 'failed running test_pede.py' $?
+    echo -e "\n MillePede Exit Status: "`cat millepede.end`
+else 
+  die "SKIPPING test, file ${TESTPACKAGE} not found" 0
+fi


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/37211

#### PR description:

As discussed here https://github.com/cms-sw/cmsdist/pull/7660#issuecomment-1059375497 introduce a pede execution based off a real (small-scale) MC alignment campaign (cosmics-only). The needed input files to steer the execution are at: `/store/group/alca_global/tkal_millepede_tests/`

#### PR validation:

run `scram b runtests_testPedeCampaign`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/37211
