### PR TITLE
Backport muon shower (un)packing and DQM to 12_2_X

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -3,6 +3,8 @@
 
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 #include "L1Trigger/L1TMuon/interface/MicroGMTConfiguration.h"
 
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
@@ -27,14 +29,17 @@ protected:
 private:
   l1t::tftype getTfOrigin(const int tfMuonIndex);
 
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtBMTFToken;
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtOMTFToken;
-  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtEMTFToken;
-  edm::EDGetTokenT<l1t::MuonBxCollection> ugmtMuonToken;
-  std::string monitorDir;
-  bool emul;
-  bool verbose;
+  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtBMTFToken_;
+  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtOMTFToken_;
+  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtEMTFToken_;
+  edm::EDGetTokenT<l1t::MuonBxCollection> ugmtMuonToken_;
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> ugmtEMTFShowerToken_;
+  edm::EDGetTokenT<l1t::MuonShowerBxCollection> ugmtMuonShowerToken_;
+  std::string monitorDir_;
+  bool emul_;
+  bool verbose_;
   bool displacedQuantities_;
+  bool hadronicShowers_;
 
   const float etaScale_;
   const float phiScale_;
@@ -93,6 +98,10 @@ private:
   MonitorElement* ugmtEMTFMuMuDEta;
   MonitorElement* ugmtEMTFMuMuDPhi;
   MonitorElement* ugmtEMTFMuMuDR;
+
+  MonitorElement* ugmtEMTFShowerTypeOccupancyPerSector;
+  MonitorElement* ugmtEMTFShowerTypeOccupancyPerBx;
+  MonitorElement* ugmtEMTFShowerSectorOccupancyPerBx;
 
   MonitorElement* ugmtBOMTFposMuMuDEta;
   MonitorElement* ugmtBOMTFposMuMuDPhi;
@@ -161,6 +170,9 @@ private:
   MonitorElement* ugmtMuonBXvshwIso;
   MonitorElement* ugmtMuonChargevsLink;
 
+  // Output shower plots
+  MonitorElement* ugmtMuonShowerTypeOccupancyPerBx;
+
   // muon correlations
   MonitorElement* ugmtMuMuInvMass;
   MonitorElement* ugmtMuMuInvMassAtVtx;
@@ -200,6 +212,9 @@ private:
   MonitorElement* ugmtMuMuDEtaEneg;
   MonitorElement* ugmtMuMuDPhiEneg;
   MonitorElement* ugmtMuMuDREneg;
+
+  static constexpr unsigned IDX_TIGHT_SHOWER{2};
+  static constexpr unsigned IDX_NOMINAL_SHOWER{1};
 };
 
 #endif

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -7,13 +7,16 @@ l1tStage2uGMT = DQMEDAnalyzer(
     bmtfProducer = cms.InputTag("gmtStage2Digis", "BMTF"),
     omtfProducer = cms.InputTag("gmtStage2Digis", "OMTF"),
     emtfProducer = cms.InputTag("gmtStage2Digis", "EMTF"),
+    emtfShowerProducer = cms.InputTag("gmtStage2Digis", "EMTF"),
     muonProducer = cms.InputTag("gmtStage2Digis", "Muon"),
+    muonShowerProducer = cms.InputTag("gmtStage2Digis", "MuonShower"),
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT"),
     emulator = cms.untracked.bool(False),
     verbose = cms.untracked.bool(False),
-    displacedQuantities = cms.untracked.bool(False)
+    displacedQuantities = cms.untracked.bool(False),
+    hadronicShowers = cms.untracked.bool(False)
 )
 
 ## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tStage2uGMT, displacedQuantities = cms.untracked.bool(True))
+stage2L1Trigger_2021.toModify(l1tStage2uGMT, displacedQuantities = cms.untracked.bool(True), hadronicShowers = cms.untracked.bool(True))

--- a/DQM/L1TMonitor/src/L1TStage2Shower.cc
+++ b/DQM/L1TMonitor/src/L1TStage2Shower.cc
@@ -166,8 +166,8 @@ void L1TStage2Shower::analyze(const edm::Event& e, const edm::EventSetup& c) {
     if (not Shower.isValid())
       continue;
     if (Shower.isOneNominalInTime() or Shower.isTwoLooseInTime() or Shower.isOneTightInTime()) {
-      int endcap = Shower.endcap();
-      int sector = Shower.sector();
+      int endcap = Shower.trackFinderType() == l1t::tftype::emtf_pos ? 1 : -1;
+      int sector = Shower.processor() + 1;
       if (Shower.isOneTightInTime())
         emtfShowerTypeOccupancy->Fill(sector, (endcap == 1) ? 7.5 : 0.5);
       if (Shower.isTwoLooseInTime())

--- a/DataFormats/L1TMuon/interface/RegionalMuonShower.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonShower.h
@@ -5,6 +5,8 @@
 #include "DataFormats/L1Trigger/interface/BXVector.h"
 #include "DataFormats/L1Trigger/interface/L1TObjComparison.h"
 
+#include "RegionalMuonCandFwd.h"  // For tftype.
+
 namespace l1t {
 
   class RegionalMuonShower;
@@ -31,9 +33,8 @@ namespace l1t {
     void setTwoLooseOutOfTime(const bool bit) { isTwoLooseOutOfTime_ = bit; }
     void setTwoLooseInTime(const bool bit) { isTwoLooseInTime_ = bit; }
 
-    void setEndcap(const int endcap) { endcap_ = endcap; }
-    void setSector(const unsigned sector) { sector_ = sector; }
-    void setLink(const int link) { link_ = link; };
+    /// Set the processor ID, track-finder type. From these two, the link is set
+    void setTFIdentifiers(int processor, tftype trackFinder);
 
     bool isValid() const;
     bool isOneNominalInTime() const { return isOneNominalInTime_; }
@@ -43,10 +44,12 @@ namespace l1t {
     bool isTwoLooseInTime() const { return isTwoLooseInTime_; }
     bool isTwoLooseOutOfTime() const { return isTwoLooseOutOfTime_; }
 
-    int endcap() const { return endcap_; }
-    int sector() const { return sector_; }
     /// Get link on which the MicroGMT receives the candidate
-    int link() const { return link_; }
+    const int link() const { return link_; };
+    /// Get processor ID on which the candidate was found (0..5 for OMTF/EMTF; 0..11 for BMTF)
+    const int processor() const { return processor_; };
+    /// Get track-finder which found the muon (bmtf, emtf_pos/emtf_neg or omtf_pos/omtf_neg)
+    const tftype trackFinderType() const { return trackFinder_; };
 
     bool operator==(const l1t::RegionalMuonShower& rhs) const;
     inline bool operator!=(const l1t::RegionalMuonShower& rhs) const { return !(operator==(rhs)); };
@@ -60,9 +63,9 @@ namespace l1t {
     bool isOneTightOutOfTime_;
     bool isTwoLooseInTime_;
     bool isTwoLooseOutOfTime_;
-    int endcap_;       //    +/-1.  For ME+ and ME-.
-    unsigned sector_;  //  1 -  6.
     int link_;
+    int processor_;
+    tftype trackFinder_;
   };
 
 }  // namespace l1t

--- a/DataFormats/L1TMuon/src/RegionalMuonShower.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonShower.cc
@@ -12,11 +12,32 @@ l1t::RegionalMuonShower::RegionalMuonShower(bool oneNominalInTime,
       isOneTightOutOfTime_(oneTightOutOfTime),
       isTwoLooseInTime_(twoLooseInTime),
       isTwoLooseOutOfTime_(twoLooseOutOfTime),
-      endcap_(0),
-      sector_(0),
-      link_(0) {}
+      link_(0),
+      processor_(0) {}
 
 l1t::RegionalMuonShower::~RegionalMuonShower() {}
+
+void l1t::RegionalMuonShower::setTFIdentifiers(int processor, tftype trackFinder) {
+  trackFinder_ = trackFinder;
+  processor_ = processor;
+
+  switch (trackFinder_) {
+    case tftype::emtf_pos:
+      link_ = processor_ + 36;  // range 36...41
+      break;
+    case tftype::omtf_pos:
+      link_ = processor_ + 42;  // range 42...47
+      break;
+    case tftype::bmtf:
+      link_ = processor_ + 48;  // range 48...59
+      break;
+    case tftype::omtf_neg:
+      link_ = processor_ + 60;  // range 60...65
+      break;
+    case tftype::emtf_neg:
+      link_ = processor_ + 66;  // range 66...71
+  }
+}
 
 bool l1t::RegionalMuonShower::isValid() const {
   return (isOneNominalInTime_ or isTwoLooseInTime_ or isOneTightInTime_);

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -13,7 +13,8 @@
   <class name="l1t::RegionalMuonCandBxCollection"/>
   <class name="edm::Wrapper<l1t::RegionalMuonCandBxCollection>"/>
 
-  <class name="l1t::RegionalMuonShower" ClassVersion="11">
+  <class name="l1t::RegionalMuonShower" ClassVersion="12">
+    <version ClassVersion="12" checksum="1591048325"/>
     <version ClassVersion="11" checksum="376206249"/>
     <version ClassVersion="10" checksum="3501434665"/>
   </class>

--- a/DataFormats/L1Trigger/interface/MuonShower.h
+++ b/DataFormats/L1Trigger/interface/MuonShower.h
@@ -54,13 +54,15 @@ namespace l1t {
       The 2 loose showers case would be mapped onto musOutOfTime0 and musOutOfTime1 later during Run-3
     */
 
-    void setMus0(const bool bit) { mus0_ = bit; }
-    void setMus1(const bool bit) { mus1_ = bit; }
+    void setOneNominalInTime(const bool bit) { oneNominalInTime_ = bit; }
+    void setOneTightInTime(const bool bit) { oneTightInTime_ = bit; }
+    void setMus0(const bool bit) { oneNominalInTime_ = bit; }
+    void setMus1(const bool bit) { oneTightInTime_ = bit; }
     void setMusOutOfTime0(const bool bit) { musOutOfTime0_ = bit; }
     void setMusOutOfTime1(const bool bit) { musOutOfTime1_ = bit; }
 
-    bool mus0() const { return mus0_; }
-    bool mus1() const { return mus1_; }
+    bool mus0() const { return oneNominalInTime_; }
+    bool mus1() const { return oneTightInTime_; }
     bool musOutOfTime0() const { return musOutOfTime0_; }
     bool musOutOfTime1() const { return musOutOfTime1_; }
 
@@ -69,8 +71,8 @@ namespace l1t {
 
     // useful members for trigger performance studies
     // needed at startup Run-3
-    bool isOneNominalInTime() const { return mus0_; }
-    bool isOneTightInTime() const { return mus1_; }
+    bool isOneNominalInTime() const { return oneNominalInTime_; }
+    bool isOneTightInTime() const { return oneTightInTime_; }
     // to be developed during Run-3
     bool isTwoLooseInTime() const { return false; }
     // these options require more study
@@ -84,8 +86,8 @@ namespace l1t {
   private:
     // Run-3 definitions as provided in DN-20-033
     // in time and out-of-time qualities. only 2 bits each.
-    bool mus0_;
-    bool mus1_;
+    bool oneNominalInTime_;
+    bool oneTightInTime_;
     bool musOutOfTime0_;
     bool musOutOfTime1_;
   };

--- a/DataFormats/L1Trigger/src/MuonShower.cc
+++ b/DataFormats/L1Trigger/src/MuonShower.cc
@@ -9,16 +9,18 @@ l1t::MuonShower::MuonShower(bool oneNominalInTime,
     : L1Candidate(math::PtEtaPhiMLorentzVector{0., 0., 0., 0.}, 0., 0., 0., 0, 0),
       // in this object it makes more sense to the different shower types to
       // the 4 bits, so that the object easily interfaces with the uGT emulator
-      mus0_(oneNominalInTime),
-      mus1_(oneTightInTime),
+      oneNominalInTime_(oneNominalInTime),
+      oneTightInTime_(oneTightInTime),
       musOutOfTime0_(false),
       musOutOfTime1_(false) {}
 
 l1t::MuonShower::~MuonShower() {}
 
-bool l1t::MuonShower::isValid() const { return mus0_ or mus1_ or musOutOfTime0_ or musOutOfTime1_; }
+bool l1t::MuonShower::isValid() const {
+  return oneNominalInTime_ or oneTightInTime_ or musOutOfTime0_ or musOutOfTime1_;
+}
 
 bool l1t::MuonShower::operator==(const l1t::MuonShower& rhs) const {
-  return (mus0_ == rhs.mus0() and mus1_ == rhs.mus1() and musOutOfTime0_ == rhs.musOutOfTime0() and
-          musOutOfTime1_ == rhs.musOutOfTime1());
+  return (oneNominalInTime_ == rhs.isOneNominalInTime() and oneTightInTime_ == rhs.isOneTightInTime() and
+          musOutOfTime0_ == rhs.musOutOfTime0() and musOutOfTime1_ == rhs.musOutOfTime1());
 }

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -103,7 +103,8 @@
   <class name="l1t::MuonVectorRef"/>
   <class name="edm::Wrapper<l1t::MuonVectorRef>"/>
 
-  <class name="l1t::MuonShower" ClassVersion="11">
+  <class name="l1t::MuonShower" ClassVersion="12">
+   <version ClassVersion="12" checksum="2452991184"/>
    <version ClassVersion="11" checksum="3610959089"/>
    <version ClassVersion="10" checksum="3869296059"/>
   </class>

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CommonTokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CommonTokens.h
@@ -6,6 +6,7 @@
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "EventFilter/L1TRawToDigi/interface/PackerTokens.h"
@@ -19,6 +20,7 @@ namespace l1t {
       inline const edm::EDGetTokenT<JetBxCollection>& getJetToken() const { return jetToken_; };
       inline const edm::EDGetTokenT<TauBxCollection>& getTauToken() const { return tauToken_; };
       inline const edm::EDGetTokenT<MuonBxCollection>& getMuonToken() const { return muonToken_; };
+      inline const edm::EDGetTokenT<MuonShowerBxCollection>& getMuonShowerToken() const { return muonShowerToken_; };
 
     protected:
       edm::EDGetTokenT<EGammaBxCollection> egammaToken_;
@@ -26,6 +28,7 @@ namespace l1t {
       edm::EDGetTokenT<JetBxCollection> jetToken_;
       edm::EDGetTokenT<TauBxCollection> tauToken_;
       edm::EDGetTokenT<MuonBxCollection> muonToken_;
+      edm::EDGetTokenT<MuonShowerBxCollection> muonShowerToken_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
@@ -19,6 +19,12 @@ namespace l1t {
       event_.put(std::move(imdMuonsEMTFPos_), "imdMuonsEMTFPos");
       event_.put(std::move(imdMuonsOMTFNeg_), "imdMuonsOMTFNeg");
       event_.put(std::move(imdMuonsOMTFPos_), "imdMuonsOMTFPos");
+
+      event_.put(std::move(regionalMuonShowersEMTF_), "EMTF");
+      event_.put(std::move(muonShowers_[0]), "MuonShower");
+      for (int i = 1; i < 6; ++i) {
+        event_.put(std::move(muonShowers_[i]), "MuonShowerCopy" + std::to_string(i));
+      }
     }
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.cc
@@ -11,7 +11,7 @@ namespace l1t {
       event_.put(std::move(regionalMuonCandsOMTF_), "OMTF");
       event_.put(std::move(regionalMuonCandsEMTF_), "EMTF");
       event_.put(std::move(muons_[0]), "Muon");
-      for (int i = 1; i < 6; ++i) {
+      for (size_t i = 1; i < NUM_OUTPUT_COPIES; ++i) {
         event_.put(std::move(muons_[i]), "MuonCopy" + std::to_string(i));
       }
       event_.put(std::move(imdMuonsBMTF_), "imdMuonsBMTF");
@@ -22,7 +22,7 @@ namespace l1t {
 
       event_.put(std::move(regionalMuonShowersEMTF_), "EMTF");
       event_.put(std::move(muonShowers_[0]), "MuonShower");
-      for (int i = 1; i < 6; ++i) {
+      for (size_t i = 1; i < NUM_OUTPUT_COPIES; ++i) {
         event_.put(std::move(muonShowers_[i]), "MuonShowerCopy" + std::to_string(i));
       }
     }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
@@ -59,6 +59,8 @@ namespace l1t {
         return muonShowers_[copy].get();
       };
 
+      static constexpr size_t NUM_OUTPUT_COPIES{6};
+
     private:
       std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCandsBMTF_;
       std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCandsOMTF_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTCollections.h
@@ -4,6 +4,9 @@
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
 #include "L1TObjectCollections.h"
 
 #include <array>
@@ -27,9 +30,15 @@ namespace l1t {
             imdMuonsEMTFNeg_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)),
             imdMuonsEMTFPos_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)),
             imdMuonsOMTFNeg_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)),
-            imdMuonsOMTFPos_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)) {
+            imdMuonsOMTFPos_(std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx)),
+
+            regionalMuonShowersEMTF_(std::make_unique<RegionalMuonShowerBxCollection>(0, iFirstBx, iLastBx)),
+            muonShowers_() {
         std::generate(muons_.begin(), muons_.end(), [&oFirstBx, &oLastBx] {
           return std::make_unique<MuonBxCollection>(0, oFirstBx, oLastBx);
+        });
+        std::generate(muonShowers_.begin(), muonShowers_.end(), [&oFirstBx, &oLastBx] {
+          return std::make_unique<MuonShowerBxCollection>(0, oFirstBx, oLastBx);
         });
       };
 
@@ -45,6 +54,11 @@ namespace l1t {
       inline MuonBxCollection* getImdMuonsOMTFNeg() { return imdMuonsOMTFNeg_.get(); };
       inline MuonBxCollection* getImdMuonsOMTFPos() { return imdMuonsOMTFPos_.get(); };
 
+      inline RegionalMuonShowerBxCollection* getRegionalMuonShowersEMTF() { return regionalMuonShowersEMTF_.get(); };
+      inline MuonShowerBxCollection* getMuonShowers(const unsigned int copy) override {
+        return muonShowers_[copy].get();
+      };
+
     private:
       std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCandsBMTF_;
       std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCandsOMTF_;
@@ -55,6 +69,9 @@ namespace l1t {
       std::unique_ptr<MuonBxCollection> imdMuonsEMTFPos_;
       std::unique_ptr<MuonBxCollection> imdMuonsOMTFNeg_;
       std::unique_ptr<MuonBxCollection> imdMuonsOMTFPos_;
+
+      std::unique_ptr<RegionalMuonShowerBxCollection> regionalMuonShowersEMTF_;
+      std::array<std::unique_ptr<MuonShowerBxCollection>, 6> muonShowers_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -73,7 +73,7 @@ namespace l1t {
       prod.produces<RegionalMuonCandBxCollection>("OMTF");
       prod.produces<RegionalMuonCandBxCollection>("EMTF");
       prod.produces<MuonBxCollection>("Muon");
-      for (int i = 1; i < 6; ++i) {
+      for (size_t i = 1; i < GMTCollections::NUM_OUTPUT_COPIES; ++i) {
         prod.produces<MuonBxCollection>("MuonCopy" + std::to_string(i));
       }
       prod.produces<MuonBxCollection>("imdMuonsBMTF");
@@ -84,7 +84,7 @@ namespace l1t {
 
       prod.produces<RegionalMuonShowerBxCollection>("EMTF");
       prod.produces<MuonShowerBxCollection>("MuonShower");
-      for (int i = 1; i < 6; ++i) {
+      for (size_t i = 1; i < GMTCollections::NUM_OUTPUT_COPIES; ++i) {
         prod.produces<MuonShowerBxCollection>("MuonShowerCopy" + std::to_string(i));
       }
     }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTSetup.cc
@@ -5,11 +5,11 @@
 #include "EventFilter/L1TRawToDigi/plugins/PackingSetupFactory.h"
 #include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
 
-#include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h"
 #include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h"
+#include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h"
 #include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.h"
-#include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h"
 #include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h"
+#include "EventFilter/L1TRawToDigi/plugins/implementations_stage2/IntermediateMuonUnpacker.h"
 
 #include "GMTSetup.h"
 
@@ -36,6 +36,8 @@ namespace l1t {
           ->setComment("uGMT intermediate muon from neg. OMTF side after first sorting stage");
       desc.addOptional<edm::InputTag>("ImdInputLabelOMTFPos")
           ->setComment("uGMT intermediate muon from pos. OMTF side after first sorting stage");
+      desc.addOptional<edm::InputTag>("ShowerInputLabel")->setComment("for Run3");
+      desc.addOptional<edm::InputTag>("EMTFShowerInputLabel")->setComment("for Run3");
     }
 
     PackerMap GMTSetup::getPackers(int fed, unsigned int fw) {
@@ -43,6 +45,9 @@ namespace l1t {
       if (fed == 1402) {
         auto gmt_in_packer = static_pointer_cast<l1t::stage2::RegionalMuonGMTPacker>(
             PackerFactory::get()->make("stage2::RegionalMuonGMTPacker"));
+        if (fw >= 0x7000000) {
+          gmt_in_packer->setUseEmtfShowers();
+        }
         if (fw >= 0x6010000) {
           gmt_in_packer->setUseEmtfDisplacementInfo();
         }
@@ -76,6 +81,12 @@ namespace l1t {
       prod.produces<MuonBxCollection>("imdMuonsEMTFPos");
       prod.produces<MuonBxCollection>("imdMuonsOMTFNeg");
       prod.produces<MuonBxCollection>("imdMuonsOMTFPos");
+
+      prod.produces<RegionalMuonShowerBxCollection>("EMTF");
+      prod.produces<MuonShowerBxCollection>("MuonShower");
+      for (int i = 1; i < 6; ++i) {
+        prod.produces<MuonShowerBxCollection>("MuonShowerCopy" + std::to_string(i));
+      }
     }
 
     std::unique_ptr<UnpackerCollections> GMTSetup::getCollections(edm::Event& e) {
@@ -89,6 +100,9 @@ namespace l1t {
       // input muons on links 36-71
       auto gmt_in_unp = static_pointer_cast<l1t::stage2::RegionalMuonGMTUnpacker>(
           UnpackerFactory::get()->make("stage2::RegionalMuonGMTUnpacker"));
+      if (fw >= 0x7000000) {
+        gmt_in_unp->setUseEmtfShowers();
+      }
       if (fw >= 0x6010000) {
         gmt_in_unp->setUseEmtfDisplacementInfo();
       }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTTokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTTokens.cc
@@ -26,6 +26,12 @@ namespace l1t {
       imdMuonTokenEMTFPos_ = cc.consumes<MuonBxCollection>(imdEmtfPosTag);
       imdMuonTokenOMTFNeg_ = cc.consumes<MuonBxCollection>(imdOmtfNegTag);
       imdMuonTokenOMTFPos_ = cc.consumes<MuonBxCollection>(imdOmtfPosTag);
+
+      auto emtfShowerTag = cfg.getParameter<edm::InputTag>("EMTFShowerInputLabel");
+      auto showerTag = cfg.getParameter<edm::InputTag>("ShowerInputLabel");
+
+      regionalMuonShowerTokenEMTF_ = cc.consumes<RegionalMuonShowerBxCollection>(emtfShowerTag);
+      muonShowerToken_ = cc.consumes<MuonShowerBxCollection>(showerTag);
     }
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTTokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GMTTokens.h
@@ -2,6 +2,7 @@
 #define GMTTokens_h
 
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 
 #include "CommonTokens.h"
@@ -27,6 +28,10 @@ namespace l1t {
       inline const edm::EDGetTokenT<MuonBxCollection>& getImdMuonTokenOMTFNeg() const { return imdMuonTokenOMTFNeg_; };
       inline const edm::EDGetTokenT<MuonBxCollection>& getImdMuonTokenOMTFPos() const { return imdMuonTokenOMTFPos_; };
 
+      inline const edm::EDGetTokenT<RegionalMuonShowerBxCollection>& getRegionalMuonShowerTokenEMTF() const {
+        return regionalMuonShowerTokenEMTF_;
+      };
+
     private:
       edm::EDGetTokenT<RegionalMuonCandBxCollection> regionalMuonCandTokenBMTF_;
       edm::EDGetTokenT<RegionalMuonCandBxCollection> regionalMuonCandTokenOMTF_;
@@ -36,6 +41,8 @@ namespace l1t {
       edm::EDGetTokenT<MuonBxCollection> imdMuonTokenEMTFPos_;
       edm::EDGetTokenT<MuonBxCollection> imdMuonTokenOMTFNeg_;
       edm::EDGetTokenT<MuonBxCollection> imdMuonTokenOMTFPos_;
+
+      edm::EDGetTokenT<RegionalMuonShowerBxCollection> regionalMuonShowerTokenEMTF_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.cc
@@ -6,13 +6,14 @@ namespace l1t {
   namespace stage2 {
     GTCollections::~GTCollections() {
       event_.put(std::move(muons_[0]), "Muon");
+      event_.put(std::move(muonShowers_[0]), "MuonShower");
       event_.put(std::move(egammas_[0]), "EGamma");
       event_.put(std::move(etsums_[0]), "EtSum");
       event_.put(std::move(jets_[0]), "Jet");
       event_.put(std::move(taus_[0]), "Tau");
-
       for (int i = 1; i < 6; ++i) {
         event_.put(std::move(muons_[i]), "Muon" + std::to_string(i + 1));
+        event_.put(std::move(muonShowers_[i]), "MuonShower" + std::to_string(i + 1));
         event_.put(std::move(egammas_[i]), "EGamma" + std::to_string(i + 1));
         event_.put(std::move(etsums_[i]), "EtSum" + std::to_string(i + 1));
         event_.put(std::move(jets_[i]), "Jet" + std::to_string(i + 1));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTCollections.h
@@ -20,6 +20,8 @@ namespace l1t {
       GTCollections(edm::Event& e)
           : L1TObjectCollections(e), algBlk_(new GlobalAlgBlkBxCollection()), extBlk_(new GlobalExtBlkBxCollection()) {
         std::generate(muons_.begin(), muons_.end(), [] { return std::make_unique<MuonBxCollection>(); });
+        std::generate(
+            muonShowers_.begin(), muonShowers_.end(), [] { return std::make_unique<MuonShowerBxCollection>(); });
         std::generate(egammas_.begin(), egammas_.end(), [] { return std::make_unique<EGammaBxCollection>(); });
         std::generate(etsums_.begin(), etsums_.end(), [] { return std::make_unique<EtSumBxCollection>(); });
         std::generate(jets_.begin(), jets_.end(), [] { return std::make_unique<JetBxCollection>(); });
@@ -29,6 +31,9 @@ namespace l1t {
       ~GTCollections() override;
 
       inline MuonBxCollection* getMuons(const unsigned int copy) override { return muons_[copy].get(); };
+      inline MuonShowerBxCollection* getMuonShowers(const unsigned int copy) override {
+        return muonShowers_[copy].get();
+      };
       inline EGammaBxCollection* getEGammas(const unsigned int copy) override { return egammas_[copy].get(); };
       inline EtSumBxCollection* getEtSums(const unsigned int copy) override { return etsums_[copy].get(); };
       inline JetBxCollection* getJets(const unsigned int copy) override { return jets_[copy].get(); };
@@ -39,6 +44,7 @@ namespace l1t {
 
     private:
       std::array<std::unique_ptr<MuonBxCollection>, 6> muons_;
+      std::array<std::unique_ptr<MuonShowerBxCollection>, 6> muonShowers_;
       std::array<std::unique_ptr<EGammaBxCollection>, 6> egammas_;
       std::array<std::unique_ptr<EtSumBxCollection>, 6> etsums_;
       std::array<std::unique_ptr<JetBxCollection>, 6> jets_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTSetup.cc
@@ -21,6 +21,7 @@ namespace l1t {
       desc.addOptional<edm::InputTag>("GtInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("ExtInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("MuonInputTag")->setComment("for stage2");
+      desc.addOptional<edm::InputTag>("ShowerInputTag")->setComment("for Run3");
       desc.addOptional<edm::InputTag>("EGammaInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("JetInputTag")->setComment("for stage2");
       desc.addOptional<edm::InputTag>("TauInputTag")->setComment("for stage2");
@@ -50,6 +51,7 @@ namespace l1t {
 
     void GTSetup::registerProducts(edm::ProducesCollector prod) {
       prod.produces<MuonBxCollection>("Muon");
+      prod.produces<MuonShowerBxCollection>("MuonShower");
       prod.produces<EGammaBxCollection>("EGamma");
       prod.produces<EtSumBxCollection>("EtSum");
       prod.produces<JetBxCollection>("Jet");
@@ -58,6 +60,7 @@ namespace l1t {
       prod.produces<GlobalExtBlkBxCollection>();
       for (int i = 2; i < 7; ++i) {  // Collections from boards 2-6
         prod.produces<MuonBxCollection>("Muon" + std::to_string(i));
+        prod.produces<MuonShowerBxCollection>("MuonShower" + std::to_string(i));
         prod.produces<EGammaBxCollection>("EGamma" + std::to_string(i));
         prod.produces<EtSumBxCollection>("EtSum" + std::to_string(i));
         prod.produces<JetBxCollection>("Jet" + std::to_string(i));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTTokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/GTTokens.cc
@@ -14,10 +14,12 @@ namespace l1t {
       auto tautag = cfg.getParameter<edm::InputTag>("TauInputTag");
       auto etsumtag = cfg.getParameter<edm::InputTag>("EtSumInputTag");
       auto muontag = cfg.getParameter<edm::InputTag>("MuonInputTag");
+      auto muonshowertag = cfg.getParameter<edm::InputTag>("ShowerInputLabel");
 
       //cout << "DEBUG:  GmtInputTag" <<  muontag << "\n";
 
       muonToken_ = cc.consumes<MuonBxCollection>(muontag);
+      muonShowerToken_ = cc.consumes<MuonShowerBxCollection>(muonshowertag);
       egammaToken_ = cc.consumes<EGammaBxCollection>(egammatag);
       etSumToken_ = cc.consumes<EtSumBxCollection>(etsumtag);
       jetToken_ = cc.consumes<JetBxCollection>(jettag);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
@@ -6,6 +6,7 @@
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 
@@ -19,6 +20,7 @@ namespace l1t {
       ~L1TObjectCollections() override;
 
       virtual MuonBxCollection* getMuons(const unsigned int copy) { return nullptr; }
+      virtual MuonShowerBxCollection* getMuonShowers(const unsigned int copy) { return nullptr; }
       virtual EGammaBxCollection* getEGammas(const unsigned int copy) { return nullptr; }  //= 0;
       virtual EtSumBxCollection* getEtSums(const unsigned int copy) { return nullptr; }
       virtual JetBxCollection* getJets(const unsigned int copy) { return nullptr; }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
@@ -9,7 +9,7 @@ namespace l1t {
       GMTOutputObjectMap gmtObjMap;
       std::pair<int, int> muonBx = getMuons(gmtObjMap, event, static_cast<const CommonTokens*>(toks)->getMuonToken());
       std::pair<int, int> muonShowerBx{0, 0};
-      if (fedId_ == 1402 && fwId_ >= 0x7000000) {
+      if ((fedId_ == 1402 && fwId_ >= 0x7000000) || (fedId_ == 1404 && fwId_ >= 0x00010f01)) {
         muonShowerBx = getMuonShowers(gmtObjMap, event, static_cast<const CommonTokens*>(toks)->getMuonShowerToken());
       }
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.cc
@@ -6,14 +6,16 @@
 namespace l1t {
   namespace stage2 {
     Blocks MuonPacker::pack(const edm::Event& event, const PackerTokens* toks) {
-      edm::Handle<MuonBxCollection> muons;
-      event.getByToken(static_cast<const CommonTokens*>(toks)->getMuonToken(), muons);
+      GMTOutputObjectMap gmtObjMap;
+      std::pair<int, int> muonBx = getMuons(gmtObjMap, event, static_cast<const CommonTokens*>(toks)->getMuonToken());
+      std::pair<int, int> muonShowerBx{0, 0};
+      if (fedId_ == 1402 && fwId_ >= 0x7000000) {
+        muonShowerBx = getMuonShowers(gmtObjMap, event, static_cast<const CommonTokens*>(toks)->getMuonShowerToken());
+      }
 
       PayloadMap payloadMap;
 
-      for (int bx = muons->getFirstBX(); bx <= muons->getLastBX(); ++bx) {
-        packBx(payloadMap, muons, bx);
-      }
+      packBx(gmtObjMap, muonBx.first, muonBx.second, muonShowerBx.first, muonShowerBx.second, payloadMap);
 
       Blocks blocks;
       // push everything in the blocks vector
@@ -23,58 +25,98 @@ namespace l1t {
       return blocks;
     }
 
-    void MuonPacker::packBx(PayloadMap& payloadMap, const edm::Handle<MuonBxCollection>& muons, int bx) {
-      // the first word in every BX and every block id is 0
-      for (unsigned int blkId = b1_; blkId < b1_ + 7; blkId += 2) {
-        payloadMap[blkId].push_back(0);
+    std::pair<int, int> MuonPacker::getMuonShowers(GMTOutputObjectMap& objMap,
+                                                   const edm::Event& event,
+                                                   const edm::EDGetTokenT<MuonShowerBxCollection>& showerToken) {
+      edm::Handle<MuonShowerBxCollection> muonShowers;
+      event.getByToken(showerToken, muonShowers);
+      for (int bx = muonShowers->getFirstBX(); bx <= muonShowers->getLastBX(); ++bx) {
+        if (muonShowers->size(bx) > 0) {
+          objMap[bx].shower = muonShowers->at(bx, 0);  // At most one shower per BX.
+        }
       }
+      return std::make_pair(muonShowers->getFirstBX(), muonShowers->getLastBX());
+    }
 
-      unsigned int blkId = b1_;
-      auto mu{muons->begin(bx)};
-      uint32_t mu1_shared_word{0};
-      uint32_t mu2_shared_word{0};
-      uint32_t mu1_msw{0};
-      uint32_t mu2_msw{0};
-      uint32_t mu1_lsw{0};
-      uint32_t mu2_lsw{0};
-      // Slightly convoluted logic to account for the Run-3 muon readout record:
-      // To make space for displacement information we moved the raw
-      // (i.e. non-extrapolated) eta value to the second "spare" word
-      // in the block which we call "shared word". So the logic below
-      // needs to be aware if it is operating on the first or second
-      // muon in the block in order to place the eta value in the right
-      // place in the shared word. Additionally the logic needs to
-      // wait for the second muon in the block before filling the
-      // payload map because the shared word goes in first.
-      for (int muCtr = 1; muCtr <= 8; ++muCtr) {
-        if (mu != muons->end(bx)) {
-          MuonRawDigiTranslator::generatePackedDataWords(
-              *mu, mu2_shared_word, mu2_lsw, mu2_msw, fedId_, fwId_, 2 - (muCtr % 2));
-          ++mu;
+    std::pair<int, int> MuonPacker::getMuons(GMTOutputObjectMap& objMap,
+                                             const edm::Event& event,
+                                             const edm::EDGetTokenT<MuonBxCollection>& muonToken) {
+      edm::Handle<MuonBxCollection> muons;
+      event.getByToken(muonToken, muons);
+      for (int bx = muons->getFirstBX(); bx <= muons->getLastBX(); ++bx) {
+        objMap[bx] = GMTObjects();
+        for (auto mu = muons->begin(bx); mu != muons->end(bx); ++mu) {
+          objMap[bx].mus.push_back(*mu);
+        }
+      }
+      return std::make_pair(muons->getFirstBX(), muons->getLastBX());
+    }
+
+    void MuonPacker::packBx(const GMTOutputObjectMap& objMap,
+                            const int firstMuonBx,
+                            const int lastMuonBx,
+                            const int firstMuonShowerBx,
+                            const int lastMuonShowerBx,
+                            PayloadMap& payloadMap) {
+      const auto firstBx{std::min(firstMuonShowerBx, firstMuonBx)};
+      const auto lastBx{std::max(lastMuonShowerBx, lastMuonBx)};
+
+      for (int bx{firstBx}; bx < lastBx + 1; ++bx) {
+        // the first word in every BX and every block id is 0
+        for (unsigned int blkId = b1_; blkId < b1_ + 7; blkId += 2) {
+          payloadMap[blkId].push_back(0);
         }
 
-        // If we're remaining in the current block the muon we just packed is the first one in the block.
-        // If not we add both muons to the payload map and go to the next block.
-        if (muCtr % 2 == 1) {
-          mu1_shared_word = mu2_shared_word;
-          mu1_lsw = mu2_lsw;
-          mu1_msw = mu2_msw;
-        } else {
-          payloadMap[blkId].push_back(mu1_shared_word | mu2_shared_word);
-          payloadMap[blkId].push_back(mu1_lsw);
-          payloadMap[blkId].push_back(mu1_msw);
-          payloadMap[blkId].push_back(mu2_lsw);
-          payloadMap[blkId].push_back(mu2_msw);
+        unsigned int blkId = b1_;
+        uint32_t mu1_shared_word{0};
+        uint32_t mu2_shared_word{0};
+        uint32_t mu1_msw{0};
+        uint32_t mu2_msw{0};
+        uint32_t mu1_lsw{0};
+        uint32_t mu2_lsw{0};
+        auto mu{objMap.at(bx).mus.begin()};  // Need to get the first muon of that bx from the object map
+        std::array<uint32_t, 4> showerWords{
+            MuonRawDigiTranslator::getPackedShowerDataWords(objMap.at(bx).shower, fedId_, fwId_)};
+        // Slightly convoluted logic to account for the Run-3 muon readout record:
+        // To make space for displacement information we moved the raw
+        // (i.e. non-extrapolated) eta value to the second "spare" word
+        // in the block which we call "shared word". So the logic below
+        // needs to be aware if it is operating on the first or second
+        // muon in the block in order to place the eta value in the right
+        // place in the shared word. Additionally the logic needs to
+        // wait for the second muon in the block before filling the
+        // payload map because the shared word goes in first.
+        for (int muCtr = 1; muCtr <= 8; ++muCtr) {
+          if (mu != objMap.at(bx).mus.end()) {
+            MuonRawDigiTranslator::generatePackedMuonDataWords(
+                *mu, mu2_shared_word, mu2_lsw, mu2_msw, fedId_, fwId_, 2 - (muCtr % 2));
+            ++mu;
+          }
 
-          blkId += 2;
+          // If we're remaining in the current block the muon we just packed is the first one in the block.
+          // If not we add both muons to the payload map and go to the next block.
+          if (muCtr % 2 == 1) {
+            mu1_shared_word = mu2_shared_word;
+            mu1_lsw = mu2_lsw;
+            mu1_msw = mu2_msw;
+            mu1_msw |= showerWords.at(muCtr / 2);  // Shower bits are added only to the first muon of the link.
+          } else {
+            payloadMap[blkId].push_back(mu1_shared_word | mu2_shared_word);
+            payloadMap[blkId].push_back(mu1_lsw);
+            payloadMap[blkId].push_back(mu1_msw);
+            payloadMap[blkId].push_back(mu2_lsw);
+            payloadMap[blkId].push_back(mu2_msw);
 
-          mu1_shared_word = 0;
-          mu1_lsw = 0;
-          mu1_msw = 0;
+            blkId += 2;
+
+            mu1_shared_word = 0;
+            mu1_lsw = 0;
+            mu1_msw = 0;
+          }
+          mu2_shared_word = 0;
+          mu2_lsw = 0;
+          mu2_msw = 0;
         }
-        mu2_shared_word = 0;
-        mu2_lsw = 0;
-        mu2_msw = 0;
       }
     }
   }  // namespace stage2

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonPacker.h
@@ -18,9 +18,25 @@ namespace l1t {
       inline void setFed(unsigned fedId) { fedId_ = fedId; };
 
     private:
+      struct GMTObjects {
+        std::vector<Muon> mus;
+        MuonShower shower;
+      };
+      typedef std::map<size_t, GMTObjects> GMTOutputObjectMap;  // Map of BX --> objects
       typedef std::map<unsigned int, std::vector<uint32_t>> PayloadMap;
 
-      void packBx(PayloadMap& payloadMap, const edm::Handle<MuonBxCollection>& muons, int bx);
+      std::pair<int, int> getMuonShowers(GMTOutputObjectMap& objMap,
+                                         const edm::Event& event,
+                                         const edm::EDGetTokenT<MuonShowerBxCollection>& showerToken);
+      std::pair<int, int> getMuons(GMTOutputObjectMap& objMap,
+                                   const edm::Event& event,
+                                   const edm::EDGetTokenT<MuonBxCollection>& muonToken);
+      void packBx(const GMTOutputObjectMap& objMap,
+                  int firstMuonBx,
+                  int lastMuonBx,
+                  int firstMuonShowerBx,
+                  int lastMuonShowerBx,
+                  PayloadMap& payloadMap);
 
       unsigned fwId_{0};
       unsigned fedId_{0};

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -71,7 +71,7 @@ namespace l1t {
         // Output links are odd and input links are even.
         int link_offset{0};  // This is correct for the uGT unpacker
         if (fed_ == 1402) {  // For uGMT we have to adjust the block/link ID
-          --link_offset;
+          link_offset = 1;
         }
         unsigned linkID{(blockID - link_offset) / 2};
 
@@ -82,6 +82,7 @@ namespace l1t {
         MuonShower shower;
         if (!muonShowerCollection_->isEmpty(bx)) {
           shower = muonShowerCollection_->at(bx, 0);
+          muonShowerCollection_->erase(bx, 0);
         }
         if (linkID == 0) {  // OneNominal shower
           shower.setOneNominalInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -8,7 +8,7 @@
 
 namespace l1t {
   namespace stage2 {
-    MuonUnpacker::MuonUnpacker() : res_(nullptr), muonCopy_(0) {}
+    MuonUnpacker::MuonUnpacker() : muonCollection_(nullptr), muonShowerCollection_(nullptr), muonCopy_(0) {}
 
     bool MuonUnpacker::unpack(const Block& block, UnpackerCollections* coll) {
       LogDebug("L1T") << "Block ID  = " << block.header().getID() << " size = " << block.header().getSize();
@@ -33,8 +33,12 @@ namespace l1t {
       getBXRange(nBX, firstBX, lastBX);
 
       // Set the muon collection and the BX range
-      res_ = static_cast<L1TObjectCollections*>(coll)->getMuons(muonCopy_);
-      res_->setBXRange(firstBX, lastBX);
+      muonCollection_ = static_cast<L1TObjectCollections*>(coll)->getMuons(muonCopy_);
+      muonCollection_->setBXRange(firstBX, lastBX);
+      // Set the muon shower collection and the BX range
+      muonShowerCollection_ = static_cast<L1TObjectCollections*>(coll)->getMuonShowers(muonCopy_);
+      muonShowerCollection_->setBXRange(firstBX, lastBX);
+
       LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;
 
       // Get the BX blocks and unpack them
@@ -48,15 +52,47 @@ namespace l1t {
               << " in BX header is outside of the BX range [" << firstBX << "," << lastBX
               << "] defined in the block header.";
         }
-        unpackBx(bx, bxBlock.payload());
+        unpackBx(bx, bxBlock.payload(), block.header().getID());
       }
       return true;
     }
 
-    void MuonUnpacker::unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int startIdx) {
+    void MuonUnpacker::unpackBx(int bx,
+                                const std::vector<uint32_t>& payload,
+                                unsigned int blockID,
+                                unsigned int startIdx) {
       unsigned int i = startIdx + 2;  // Only words 2-5 are "standard" muon words.
       // Check if there are enough words left in the payload
       if (startIdx + nWords_ <= payload.size()) {
+        // Unpacking showers.
+        // The shower from uGMT is transmitted via four links, each link
+        // carrying on of the bits of the shower. We therefore have to
+        // determine which link we're looking at and act accordingly.
+        // Output links are odd and input links are even.
+        int link_offset{0};  // This is correct for the uGT unpacker
+        if (fed_ == 1402) {  // For uGMT we have to adjust the block/link ID
+          --link_offset;
+        }
+        unsigned linkID{(blockID - link_offset) / 2};
+
+        // Try to get the shower for this BX and if it doesn't exist create an
+        // empty one and push it in.
+        // Note: We can't just create it for the first linkID, because in
+        // prinicple there could be a case where that is removed by the ZS.
+        MuonShower shower;
+        if (!muonShowerCollection_->isEmpty(bx)) {
+          shower = muonShowerCollection_->at(bx, 0);
+        }
+        if (linkID == 0) {  // OneNominal shower
+          shower.setOneNominalInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));
+        } else if (linkID == 1) {  // OneTight shower
+          shower.setOneTightInTime(l1t::MuonRawDigiTranslator::showerFired(payload[i + 1], fed_, getAlgoVersion()));
+        }
+
+        if (shower.isValid()) {
+          muonShowerCollection_->push_back(bx, shower);
+        }
+
         for (unsigned nWord = 2; nWord < nWords_; nWord += 2) {  // Only words 2-5 are "standard" muon words.
           uint32_t raw_data_spare = payload[startIdx + 1];
           uint32_t raw_data_00_31 = payload[i++];
@@ -78,7 +114,7 @@ namespace l1t {
                           << " iso " << mu.hwIso() << " qual " << mu.hwQual() << " charge " << mu.hwCharge()
                           << " charge valid " << mu.hwChargeValid();
 
-          res_->push_back(bx, mu);
+          muonCollection_->push_back(bx, mu);
         }
       } else {
         edm::LogWarning("L1T") << "Only " << payload.size() - i << " 32 bit words in this BX but " << nWords_

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.h
@@ -24,11 +24,12 @@ namespace l1t {
       static constexpr unsigned nWords_ = 6;  // every link transmits 6 words (3 muons) per bx
       static constexpr unsigned bxzs_enable_shift_ = 1;
 
-      MuonBxCollection* res_;
+      MuonBxCollection* muonCollection_;
+      MuonShowerBxCollection* muonShowerCollection_;
       int fed_;
       unsigned int muonCopy_;
 
-      void unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int startIdx = 0);
+      void unpackBx(int bx, const std::vector<uint32_t>& payload, unsigned int blockID, unsigned int startIdx = 0);
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.cc
@@ -1,3 +1,4 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"
 
@@ -8,62 +9,121 @@
 namespace l1t {
   namespace stage2 {
     Blocks RegionalMuonGMTPacker::pack(const edm::Event& event, const PackerTokens* toks) {
+      GMTObjectMap bmtfObjMap;
+      GMTObjectMap omtfObjMap;
+      GMTObjectMap emtfObjMap;
       auto bmtfToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonCandTokenBMTF();
       auto omtfToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonCandTokenOMTF();
       auto emtfToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonCandTokenEMTF();
 
+      // First we put the muons in our object map.
+      std::pair<int, int> bmtfMuonBx = getMuons(bmtfObjMap, event, bmtfToken);
+      std::pair<int, int> omtfMuonBx = getMuons(omtfObjMap, event, omtfToken);
+      std::pair<int, int> emtfMuonBx = getMuons(emtfObjMap, event, emtfToken);
+
+      // Then the showers (We don't expect to have shower data from BMTF and OMTF -- at the moment, at least)
+      std::pair<int, int> emtfMuonShowerBx{0, 0};
+      if (useEmtfShowers_) {
+        auto emtfShowerToken = static_cast<const GMTTokens*>(toks)->getRegionalMuonShowerTokenEMTF();
+        emtfMuonShowerBx = getMuonShowers(emtfObjMap, event, emtfShowerToken);
+      }
+
       Blocks blocks;
 
-      // pack the muons for each TF in blocks
-      packTF(event, bmtfToken, blocks);
-      packTF(event, omtfToken, blocks);
-      packTF(event, emtfToken, blocks);
+      // Pack the muons and showers for each TF in blocks
+      packTF(bmtfObjMap, bmtfMuonBx.first, bmtfMuonBx.second, 0, 0, blocks);
+      packTF(omtfObjMap, omtfMuonBx.first, omtfMuonBx.second, 0, 0, blocks);
+      packTF(emtfObjMap, emtfMuonBx.first, emtfMuonBx.second, emtfMuonShowerBx.first, emtfMuonShowerBx.second, blocks);
 
       return blocks;
     }
 
-    void RegionalMuonGMTPacker::packTF(const edm::Event& event,
-                                       const edm::EDGetTokenT<RegionalMuonCandBxCollection>& tfToken,
-                                       Blocks& blocks) {
+    std::pair<int, int> RegionalMuonGMTPacker::getMuonShowers(
+        GMTObjectMap& objMap,
+        const edm::Event& event,
+        const edm::EDGetTokenT<RegionalMuonShowerBxCollection>& tfShowerToken) {
+      edm::Handle<RegionalMuonShowerBxCollection> muonShowers;
+      event.getByToken(tfShowerToken, muonShowers);
+      for (int bx = muonShowers->getFirstBX(); bx <= muonShowers->getLastBX(); ++bx) {
+        for (auto muShower = muonShowers->begin(bx); muShower != muonShowers->end(bx); ++muShower) {
+          objMap[bx][muShower->link()].shower = *muShower;
+        }
+      }
+      return std::make_pair(muonShowers->getFirstBX(), muonShowers->getLastBX());
+    }
+
+    std::pair<int, int> RegionalMuonGMTPacker::getMuons(GMTObjectMap& objMap,
+                                                        const edm::Event& event,
+                                                        const edm::EDGetTokenT<RegionalMuonCandBxCollection>& tfToken) {
       edm::Handle<RegionalMuonCandBxCollection> muons;
       event.getByToken(tfToken, muons);
+      for (int bx = muons->getFirstBX(); bx <= muons->getLastBX(); ++bx) {
+        for (auto mu = muons->begin(bx); mu != muons->end(bx); ++mu) {
+          objMap[bx][mu->link()].mus.push_back(*mu);
+        }
+      }
+      return std::make_pair(muons->getFirstBX(), muons->getLastBX());
+    }
 
-      constexpr unsigned wordsPerBx = 6;  // number of 32 bit words per BX
+    void RegionalMuonGMTPacker::packTF(const GMTObjectMap& objMap,
+                                       const int firstMuonBx,
+                                       const int lastMuonBx,
+                                       const int firstMuonShowerBx,
+                                       const int lastMuonShowerBx,
+                                       Blocks& blocks) {
+      const auto firstBx{std::min(firstMuonShowerBx, firstMuonBx)};
+      const auto lastBx{std::max(lastMuonShowerBx, lastMuonBx)};
+      const auto nBx{lastBx - firstBx + 1};
 
       PayloadMap payloadMap;
 
-      const auto nBx = muons->getLastBX() - muons->getFirstBX() + 1;
       unsigned bxCtr = 0;
-      for (int i = muons->getFirstBX(); i <= muons->getLastBX(); ++i, ++bxCtr) {
-        for (auto mu = muons->begin(i); mu != muons->end(i); ++mu) {
-          const auto linkTimes2 = mu->link() * 2;
+      for (int bx{firstBx}; bx < lastBx + 1; ++bx, ++bxCtr) {
+        if (objMap.count(bx) > 0) {
+          for (const auto& linkMap : objMap.at(bx)) {
+            const auto linkTimes2{linkMap.first * 2};
+            const auto gmtObjects{linkMap.second};
 
-          // If the map key is new reserve the payload size.
-          if (payloadMap.count(linkTimes2) == 0) {
-            payloadMap[linkTimes2].reserve(wordsPerBx * nBx);
-            // If there was no muon on the link of this muon in previous
-            // BX the payload up to this BX must be filled with zeros.
-            if (bxCtr > 0) {
-              while (payloadMap[linkTimes2].size() < bxCtr * wordsPerBx) {
-                payloadMap[linkTimes2].push_back(0);
+            // If the payload map key is new reserve the payload size.
+            if (payloadMap.count(linkTimes2) == 0) {
+              payloadMap[linkTimes2].reserve(wordsPerBx_ * nBx);
+              // If there was no muon on the link of this muon in previous
+              // BX the payload up to this BX must be filled with zeros.
+              if (bxCtr > 0) {
+                while (payloadMap[linkTimes2].size() < bxCtr * wordsPerBx_) {
+                  payloadMap[linkTimes2].push_back(0);
+                }
               }
             }
+
+            if (gmtObjects.mus.size() > 3) {
+              edm::LogError("L1T") << "Muon collection for link " << linkMap.first << " has " << gmtObjects.mus.size()
+                                   << " entries, but 3 is the maximum!";
+            }
+
+            std::array<uint32_t, 6> buf{};  // Making sure contents of buf are initialised to 0.
+            size_t frameIdx{0};
+            for (const auto& mu : gmtObjects.mus) {
+              // Fill the muon in the payload for this link.
+              uint32_t msw{0};
+              uint32_t lsw{0};
+
+              RegionalMuonRawDigiTranslator::generatePackedDataWords(mu, lsw, msw, isKbmtf_, useEmtfDisplacementInfo_);
+
+              buf.at(frameIdx++) = lsw;
+              buf.at(frameIdx++) = msw;
+            }
+            // Add shower bits to the payload buffer.
+            RegionalMuonRawDigiTranslator::generatePackedShowerPayload(gmtObjects.shower, buf, useEmtfShowers_);
+
+            payloadMap[linkTimes2].insert(
+                payloadMap[linkTimes2].end(), std::move_iterator(buf.begin()), std::move_iterator(buf.end()));
           }
-
-          // Fill the muon in the payload for this link.
-          uint32_t msw = 0;
-          uint32_t lsw = 0;
-
-          RegionalMuonRawDigiTranslator::generatePackedDataWords(*mu, lsw, msw, isKbmtf_, useEmtfDisplacementInfo_);
-
-          payloadMap[linkTimes2].push_back(lsw);
-          payloadMap[linkTimes2].push_back(msw);
         }
-
-        // padding to 3 muons per block id (link) per BX
-        // This can be empty muons as well.
+        // We now loop over all channels in the payload map and make sure that they are filled up to the current BX
+        // If they are not, we fill them with zeros
         for (auto& kv : payloadMap) {
-          while (kv.second.size() < (bxCtr + 1) * wordsPerBx) {
+          while (kv.second.size() < (bxCtr + 1) * wordsPerBx_) {
             kv.second.push_back(0);
           }
         }
@@ -74,6 +134,7 @@ namespace l1t {
         blocks.push_back(Block(kv.first, kv.second));
       }
     }
+
   }  // namespace stage2
 }  // namespace l1t
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTPacker.h
@@ -6,6 +6,7 @@
 #include "EventFilter/L1TRawToDigi/interface/PackerTokens.h"
 #include "EventFilter/L1TRawToDigi/interface/Block.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 #include "FWCore/Framework/interface/Event.h"
 
 namespace l1t {
@@ -15,13 +16,33 @@ namespace l1t {
       Blocks pack(const edm::Event&, const PackerTokens*) override;
       void setIsKbmtf() { isKbmtf_ = true; };
       void setUseEmtfDisplacementInfo() { useEmtfDisplacementInfo_ = true; };
+      void setUseEmtfShowers() { useEmtfShowers_ = true; };
 
     private:
+      struct GMTObjects {
+        std::vector<RegionalMuonCand> mus;
+        RegionalMuonShower shower;
+      };
+      typedef std::map<size_t, std::map<size_t, GMTObjects>> GMTObjectMap;  // Map of BX --> linkID --> objects
       typedef std::map<unsigned int, std::vector<uint32_t>> PayloadMap;
-      void packTF(const edm::Event&, const edm::EDGetTokenT<RegionalMuonCandBxCollection>&, Blocks&);
+      void packTF(const GMTObjectMap& objMap,
+                  int firstMuonBx,
+                  int lastMuonBx,
+                  int firstMuonShowerBx,
+                  int lastMuonShowerBx,
+                  Blocks&);
+      std::pair<int, int> getMuons(GMTObjectMap& objMap,
+                                   const edm::Event& event,
+                                   const edm::EDGetTokenT<RegionalMuonCandBxCollection>& tfToken);
+      std::pair<int, int> getMuonShowers(GMTObjectMap& objMap,
+                                         const edm::Event& event,
+                                         const edm::EDGetTokenT<RegionalMuonShowerBxCollection>& tfShowerToken);
+
+      static constexpr size_t wordsPerBx_ = 6;  // number of 32 bit words per BX
 
       bool isKbmtf_{false};
       bool useEmtfDisplacementInfo_{false};
+      bool useEmtfShowers_{false};
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -33,14 +33,19 @@ namespace l1t {
       // decide which collection to use according to the link ID
       unsigned int linkId = blockId / 2;
       int processor;
-      RegionalMuonCandBxCollection* res;
+      RegionalMuonCandBxCollection* regionalMuonCollection;
+      RegionalMuonShowerBxCollection* regionalMuonShowerCollection;
       tftype trackFinder;
       if (linkId > 47 && linkId < 60) {
-        res = static_cast<GMTCollections*>(coll)->getRegionalMuonCandsBMTF();
+        regionalMuonCollection = static_cast<GMTCollections*>(coll)->getRegionalMuonCandsBMTF();
+        regionalMuonShowerCollection =
+            new RegionalMuonShowerBxCollection();  // To avoid warning re uninitialised collection
         trackFinder = tftype::bmtf;
         processor = linkId - 48;
       } else if (linkId > 41 && linkId < 66) {
-        res = static_cast<GMTCollections*>(coll)->getRegionalMuonCandsOMTF();
+        regionalMuonCollection = static_cast<GMTCollections*>(coll)->getRegionalMuonCandsOMTF();
+        regionalMuonShowerCollection =
+            new RegionalMuonShowerBxCollection();  // To avoid warning re uninitialised collection
         if (linkId < 48) {
           trackFinder = tftype::omtf_pos;
           processor = linkId - 42;
@@ -49,7 +54,8 @@ namespace l1t {
           processor = linkId - 60;
         }
       } else if (linkId > 35 && linkId < 72) {
-        res = static_cast<GMTCollections*>(coll)->getRegionalMuonCandsEMTF();
+        regionalMuonCollection = static_cast<GMTCollections*>(coll)->getRegionalMuonCandsEMTF();
+        regionalMuonShowerCollection = static_cast<GMTCollections*>(coll)->getRegionalMuonShowersEMTF();
         if (linkId < 42) {
           trackFinder = tftype::emtf_pos;
           processor = linkId - 36;
@@ -61,7 +67,8 @@ namespace l1t {
         edm::LogError("L1T") << "No TF muon expected for link " << linkId;
         return false;
       }
-      res->setBXRange(firstBX, lastBX);
+      regionalMuonCollection->setBXRange(firstBX, lastBX);
+      regionalMuonShowerCollection->setBXRange(firstBX, lastBX);
 
       LogDebug("L1T") << "nBX = " << nBX << " first BX = " << firstBX << " lastBX = " << lastBX;
 
@@ -108,7 +115,13 @@ namespace l1t {
                             << mu.hwPt() << " qual " << mu.hwQual() << " sign " << mu.hwSign() << " sign valid "
                             << mu.hwSignValid() << " unconstrained pT " << mu.hwPtUnconstrained();
 
-            res->push_back(bx, mu);
+            regionalMuonCollection->push_back(bx, mu);
+          }
+          // Fill RegionalMuonShower objects. For this we need to look at all six words together.
+          RegionalMuonShower muShower;
+          if (RegionalMuonRawDigiTranslator::fillRegionalMuonShower(
+                  muShower, bxPayload, processor, trackFinder, useEmtfShowers_)) {
+            regionalMuonShowerCollection->push_back(bx, muShower);
           }
         } else {
           unsigned int nWords =

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.h
@@ -12,6 +12,7 @@ namespace l1t {
       bool unpack(const Block& block, UnpackerCollections* coll) override;
       void setIsKbmtf() { isKbmtf_ = true; }
       void setUseEmtfDisplacementInfo() { useEmtfDisplacementInfo_ = true; }
+      void setUseEmtfShowers() { useEmtfShowers_ = true; }
 
     private:
       static constexpr unsigned nWords_ = 6;  // every link transmits 6 words (3 muons) per bx
@@ -19,6 +20,7 @@ namespace l1t {
 
       bool isKbmtf_{false};
       bool useEmtfDisplacementInfo_{false};
+      bool useEmtfShowers_{false};
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
@@ -12,6 +12,8 @@ gmtStage2Raw = cms.EDProducer(
     ImdInputLabelEMTFPos = cms.InputTag("simGmtStage2Digis", "imdMuonsEMTFPos"),
     ImdInputLabelOMTFNeg = cms.InputTag("simGmtStage2Digis", "imdMuonsOMTFNeg"),
     ImdInputLabelOMTFPos = cms.InputTag("simGmtStage2Digis", "imdMuonsOMTFPos"),
+    EMTFShowerInputLabel = cms.InputTag("simEmtfShowers", "EMTF"),
+    ShowerInputLabel = cms.InputTag("simGmtShowerDigis"),
     FedId = cms.int32(1402),
     FWId = cms.uint32(0x3000000), # First used uGMT firmware version
     lenSlinkHeader = cms.untracked.int32(8),
@@ -32,4 +34,4 @@ stage2L1Trigger_2018.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simBm
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x6010000))
+stage2L1Trigger_2021.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x7000000))

--- a/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
@@ -7,6 +7,7 @@ gtStage2Raw = cms.EDProducer(
     GtInputTag = cms.InputTag("simGtStage2Digis"),
     ExtInputTag = cms.InputTag("simGtExtFakeStage2Digis"),
     MuonInputTag   = cms.InputTag("simGmtStage2Digis"),
+    ShowerInputLabel = cms.InputTag("simGmtShowerDigis"),
     EGammaInputTag = cms.InputTag("simCaloStage2Digis"),
     TauInputTag    = cms.InputTag("simCaloStage2Digis"),
     JetInputTag    = cms.InputTag("simCaloStage2Digis"),
@@ -31,4 +32,4 @@ stage2L1Trigger_2018.toModify(gtStage2Raw, FWId = cms.uint32(0x10F2)) # FW w/ ne
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x1130)) # FW w/ displaced muon info.
+stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x10f01)) # FW w/ displaced muon info and hadronic showers.

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -18,6 +18,7 @@ namespace l1t {
                          int muInBx);
     static void fillMuon(Muon& mu, uint32_t raw_data_spare, uint64_t dataword, int fed, unsigned int fw, int muInBx);
     static void fillIntermediateMuon(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63, unsigned int fw);
+    static bool showerFired(uint32_t shower_word, int fedId, unsigned int fwId);
     static void generatePackedMuonDataWords(const Muon& mu,
                                             uint32_t& raw_data_spare,
                                             uint32_t& raw_data_00_31,

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -2,6 +2,9 @@
 #define MuonRawDigiTranslator_h
 
 #include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+
+#include <array>
 
 namespace l1t {
   class MuonRawDigiTranslator {
@@ -15,16 +18,17 @@ namespace l1t {
                          int muInBx);
     static void fillMuon(Muon& mu, uint32_t raw_data_spare, uint64_t dataword, int fed, unsigned int fw, int muInBx);
     static void fillIntermediateMuon(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63, unsigned int fw);
-    static void generatePackedDataWords(const Muon& mu,
-                                        uint32_t& raw_data_spare,
-                                        uint32_t& raw_data_00_31,
-                                        uint32_t& raw_data_32_63,
-                                        int fedId,
-                                        int fwId,
-                                        int muInBx);
+    static void generatePackedMuonDataWords(const Muon& mu,
+                                            uint32_t& raw_data_spare,
+                                            uint32_t& raw_data_00_31,
+                                            uint32_t& raw_data_32_63,
+                                            int fedId,
+                                            int fwId,
+                                            int muInBx);
     static void generate64bitDataWord(
         const Muon& mu, uint32_t& raw_data_spare, uint64_t& dataword, int fedId, int fwId, int muInBx);
-    static int calcHwEta(const uint32_t& raw, const unsigned absEtaShift, const unsigned etaSignShift);
+    static std::array<uint32_t, 4> getPackedShowerDataWords(const MuonShower& shower, int fedId, unsigned int fwId);
+    static int calcHwEta(const uint32_t& raw, unsigned absEtaShift, unsigned etaSignShift);
 
     static constexpr unsigned ptMask_ = 0x1FF;
     static constexpr unsigned ptShift_ = 10;
@@ -49,6 +53,7 @@ namespace l1t {
     static constexpr unsigned ptUnconstrainedMask_ = 0xFF;
     static constexpr unsigned ptUnconstrainedShift_ = 21;
     static constexpr unsigned ptUnconstrainedIntermedidateShift_ = 0;
+    static constexpr unsigned showerShift_ = 29;      // For Run-3
     static constexpr unsigned absEtaMu1Shift_ = 13;   // For Run-3
     static constexpr unsigned etaMu1SignShift_ = 21;  // For Run-3
     static constexpr unsigned absEtaMu2Shift_ = 22;   // For Run-3
@@ -65,14 +70,14 @@ namespace l1t {
                                        int muInBx,
                                        bool wasSpecialMWGR = false);
     static void fillIntermediateMuonQuantitiesRun3(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63);
-    static void generatePackedDataWordsRun3(const Muon& mu,
-                                            int abs_eta,
-                                            int abs_eta_at_vtx,
-                                            uint32_t& raw_data_spare,
-                                            uint32_t& raw_data_00_31,
-                                            uint32_t& raw_data_32_63,
-                                            int muInBx,
-                                            bool wasSpecialMWGR = false);
+    static void generatePackedMuonDataWordsRun3(const Muon& mu,
+                                                int abs_eta,
+                                                int abs_eta_at_vtx,
+                                                uint32_t& raw_data_spare,
+                                                uint32_t& raw_data_00_31,
+                                                uint32_t& raw_data_32_63,
+                                                int muInBx,
+                                                bool wasSpecialMWGR = false);
   };
 }  // namespace l1t
 

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -52,8 +52,8 @@ namespace l1t {
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;
     static constexpr unsigned emtfShowerMask_ = 0x1;
-    static constexpr unsigned emtfShowerInTimeFrame_ = 0;
-    static constexpr unsigned emtfShowerOOTFrame_ = 2;
+    static constexpr unsigned emtfShowerInTimeFrame_ = 1;
+    static constexpr unsigned emtfShowerOOTFrame_ = 3;
     static constexpr unsigned emtfShowerOneNominalShift_ = 18;
     static constexpr unsigned emtfShowerOneTightShift_ = 19;
 

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -51,7 +51,7 @@ namespace l1t {
     static constexpr unsigned emtfPtUnconstrainedShift_ = 20;
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;
-    static constexpr unsigned emtfShowerMask_ = 0x3;
+    static constexpr unsigned emtfShowerMask_ = 0x1;
     static constexpr unsigned emtfShowerInTimeFrame_ = 0;
     static constexpr unsigned emtfShowerOOTFrame_ = 2;
     static constexpr unsigned emtfShowerOneNominalShift_ = 18;

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -51,14 +51,11 @@ namespace l1t {
     static constexpr unsigned emtfPtUnconstrainedShift_ = 20;
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;
-    static constexpr unsigned emtfShowerOneNominalFrame_ = 0;
-    static constexpr unsigned emtfShowerOneNominalMask_ = 0x3;
-    static constexpr unsigned emtfShowerOneNominalInTimeShift_ = 18;
-    static constexpr unsigned emtfShowerOneNominalOutOfTimeShift_ = 19;
-    static constexpr unsigned emtfShowerTwoLooseFrame_ = 2;
-    static constexpr unsigned emtfShowerTwoLooseMask_ = 0x3;
-    static constexpr unsigned emtfShowerTwoLooseInTimeShift_ = 18;
-    static constexpr unsigned emtfShowerTwoLooseOutOfTimeShift_ = 19;
+    static constexpr unsigned emtfShowerMask_ = 0x3;
+    static constexpr unsigned emtfShowerInTimeFrame_ = 0;
+    static constexpr unsigned emtfShowerOOTFrame_ = 2;
+    static constexpr unsigned emtfShowerOneNominalShift_ = 18;
+    static constexpr unsigned emtfShowerOneTightShift_ = 19;
 
     // relative shifts within track address
     static constexpr unsigned bmtfTrAddrSegSelMask_ = 0xF;

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -2,6 +2,7 @@
 #define RegionalMuonRawDigiTranslator_h
 
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 
 namespace l1t {
   class RegionalMuonRawDigiTranslator {
@@ -15,11 +16,16 @@ namespace l1t {
                                      bool useEmtfDisplacementInfo);
     static void fillRegionalMuonCand(
         RegionalMuonCand& mu, uint64_t dataword, int proc, tftype tf, bool isKbmtf, bool useEmtfDisplacementInfo);
+    static bool fillRegionalMuonShower(
+        RegionalMuonShower& muShower, std::vector<uint32_t> bxPayload, int proc, tftype tf, bool useEmtfShowers);
     static void generatePackedDataWords(const RegionalMuonCand& mu,
                                         uint32_t& raw_data_00_31,
                                         uint32_t& raw_data_32_63,
                                         bool isKbmtf,
                                         bool useEmtfDisplacementInfo);
+    static void generatePackedShowerPayload(const RegionalMuonShower& shower,
+                                            std::array<uint32_t, 6>& payload,
+                                            bool useEmtfShowers);
     static uint64_t generate64bitDataWord(const RegionalMuonCand& mu, bool isKbmtf, bool useEmtfDisplacementInfo);
     static int generateRawTrkAddress(const RegionalMuonCand&, bool isKalman);
 
@@ -45,6 +51,15 @@ namespace l1t {
     static constexpr unsigned emtfPtUnconstrainedShift_ = 20;
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;
     static constexpr unsigned trackAddressShift_ = 2;
+    static constexpr unsigned emtfShowerOneNominalFrame_ = 0;
+    static constexpr unsigned emtfShowerOneNominalMask_ = 0x3;
+    static constexpr unsigned emtfShowerOneNominalInTimeShift_ = 18;
+    static constexpr unsigned emtfShowerOneNominalOutOfTimeShift_ = 19;
+    static constexpr unsigned emtfShowerTwoLooseFrame_ = 2;
+    static constexpr unsigned emtfShowerTwoLooseMask_ = 0x3;
+    static constexpr unsigned emtfShowerTwoLooseInTimeShift_ = 18;
+    static constexpr unsigned emtfShowerTwoLooseOutOfTimeShift_ = 19;
+
     // relative shifts within track address
     static constexpr unsigned bmtfTrAddrSegSelMask_ = 0xF;
     static constexpr unsigned bmtfTrAddrSegSelShift_ = 21;

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -108,7 +108,7 @@ _run3_Shower_SimL1TMuonTask.add(simGmtShowerDigis)
 from L1Trigger.L1TMuonBarrel.simKBmtfStubs_cfi import *
 from L1Trigger.L1TMuonBarrel.simKBmtfDigis_cfi import *
 from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger
-phase2_trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simTwinMuxDigis, simBmtfDigis, simKBmtfStubs, simKBmtfDigis, simEmtfDigis, simOmtfDigis, simGmtCaloSumDigis, simGmtStage2Digis))
+phase2_trigger.toReplaceWith(SimL1TMuonTask, cms.Task(SimL1TMuonCommonTask, simTwinMuxDigis, simBmtfDigis, simKBmtfStubs, simKBmtfDigis, simEmtfDigis, simOmtfDigis, simGmtCaloSumDigis, simGmtStage2Digis, simEmtfShowers, simGmtShowerDigis))
 
 ## GEM TPs
 from L1Trigger.L1TGEM.simGEMDigis_cff import *

--- a/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/MuonRawDigiTranslator.cc
@@ -263,17 +263,20 @@ void l1t::MuonRawDigiTranslator::generate64bitDataWord(
   dataword = (((uint64_t)msw) << 32) + lsw;
 }
 
+bool l1t::MuonRawDigiTranslator::showerFired(uint32_t shower_word, int fedId, unsigned int fwId) {
+  if ((fedId == 1402 && fwId >= 0x7000000) || (fedId == 1404 && fwId >= 0x00010f01)) {
+    return ((shower_word >> showerShift_) & 1) == 1;
+  }
+  return false;
+}
+
 std::array<uint32_t, 4> l1t::MuonRawDigiTranslator::getPackedShowerDataWords(const MuonShower& shower,
                                                                              const int fedId,
                                                                              const unsigned int fwId) {
   std::array<uint32_t, 4> res{};
-  if (fedId == 1402 && fwId < 0x7000000) {
-    return res;
-  } else {
+  if ((fedId == 1402 && fwId >= 0x7000000) || (fedId == 1404 && fwId >= 0x00010f01)) {
     res.at(0) = shower.isOneNominalInTime() ? (1 << showerShift_) : 0;
-    res.at(1) = shower.isOneNominalOutOfTime() ? (1 << showerShift_) : 0;
-    res.at(2) = shower.isTwoLooseInTime() ? (1 << showerShift_) : 0;
-    res.at(3) = shower.isTwoLooseOutOfTime() ? (1 << showerShift_) : 0;
+    res.at(1) = shower.isOneTightInTime() ? (1 << showerShift_) : 0;
   }
   return res;
 }

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -127,7 +127,7 @@ bool l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonShower(
     muShower.setOneTightInTime(((bxPayload[emtfShowerInTimeFrame_] >> emtfShowerOneTightShift_) & 1) == 1);
     muShower.setOneTightOutOfTime(((bxPayload[emtfShowerOOTFrame_] >> emtfShowerOneTightShift_) & 1) == 1);
 
-    return true;
+    return muShower.isValid();
   } else {
     return false;
   }

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -134,7 +134,7 @@ bool l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonShower(
 void l1t::RegionalMuonRawDigiTranslator::generatePackedShowerPayload(const RegionalMuonShower& shower,
                                                                      std::array<uint32_t, 6>& payload,
                                                                      const bool useEmtfShowers) {
-  if (!useEmtfShowers) {
+  if (!useEmtfShowers || !shower.isValid()) {
     return;
   }
   // First we check whether we're going to overwrite something in the payload.

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -76,12 +76,13 @@ void l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonCand(RegionalMuonCand& 
     mu.setTrackSubAddress(RegionalMuonCand::kME3Ch, (rawTrackAddress >> emtfTrAddrMe3ChShift_) & emtfTrAddrMe3ChMask_);
     mu.setTrackSubAddress(RegionalMuonCand::kME4Seg, (rawTrackAddress >> emtfTrAddrMe4SegShift_) & 0x1);
     mu.setTrackSubAddress(RegionalMuonCand::kME4Ch, (rawTrackAddress >> emtfTrAddrMe4ChShift_) & emtfTrAddrMe4ChMask_);
-    mu.setTrackSubAddress(RegionalMuonCand::kTrkNum,
-                          (rawTrackAddress >> emtfTrAddrTrkNumShift_) & emtfTrAddrTrkNumMask_);
-    mu.setTrackSubAddress(RegionalMuonCand::kBX, (rawTrackAddress >> emtfTrAddrBxShift_) & emtfTrAddrBxMask_);
     if (useEmtfDisplacementInfo) {  // In Run-3 we receive displaced muon information from EMTF
       mu.setHwPtUnconstrained((raw_data_32_63 >> emtfPtUnconstrainedShift_) & ptUnconstrainedMask_);
       mu.setHwDXY((raw_data_32_63 >> emtfDxyShift_) & dxyMask_);
+    } else {
+      mu.setTrackSubAddress(RegionalMuonCand::kTrkNum,
+                            (rawTrackAddress >> emtfTrAddrTrkNumShift_) & emtfTrAddrTrkNumMask_);
+      mu.setTrackSubAddress(RegionalMuonCand::kBX, (rawTrackAddress >> emtfTrAddrBxShift_) & emtfTrAddrBxMask_);
     }
   } else if (tf == omtf_neg || tf == omtf_pos) {
     mu.setTrackSubAddress(RegionalMuonCand::kLayers,
@@ -142,7 +143,8 @@ void l1t::RegionalMuonRawDigiTranslator::generatePackedShowerPayload(const Regio
       (((payload.at(emtfShowerOOTFrame_) >> emtfShowerOneNominalShift_) & emtfShowerMask_) != 0) ||
       (((payload.at(emtfShowerOOTFrame_) >> emtfShowerOneTightShift_) & emtfShowerMask_) != 0)) {
     edm::LogError("L1T") << "Check constants for RegionalMuonShower fields! It looks like we're in danger of "
-                            "overwriting muon data in the packer!";
+                            "overwriting muon data in the packer! InTimeFrame is "
+                         << payload.at(emtfShowerInTimeFrame_) << ", OOTFrame is " << payload.at(emtfShowerOOTFrame_);
     return;
   }
   payload.at(emtfShowerInTimeFrame_) |= (shower.isOneNominalInTime() & 1) << emtfShowerOneNominalShift_ |
@@ -234,9 +236,7 @@ int l1t::RegionalMuonRawDigiTranslator::generateRawTrkAddress(const RegionalMuon
                    (mu.trackSubAddress(RegionalMuonCand::kME3Seg) & 0x1) << emtfTrAddrMe3SegShift_ |
                    (mu.trackSubAddress(RegionalMuonCand::kME3Ch) & emtfTrAddrMe3ChMask_) << emtfTrAddrMe3ChShift_ |
                    (mu.trackSubAddress(RegionalMuonCand::kME4Seg) & 0x1) << emtfTrAddrMe4SegShift_ |
-                   (mu.trackSubAddress(RegionalMuonCand::kME4Ch) & emtfTrAddrMe4ChMask_) << emtfTrAddrMe4ChShift_ |
-                   (mu.trackSubAddress(RegionalMuonCand::kTrkNum) & emtfTrAddrTrkNumMask_) << emtfTrAddrTrkNumShift_ |
-                   (mu.trackSubAddress(RegionalMuonCand::kBX) & emtfTrAddrBxMask_) << emtfTrAddrBxShift_;
+                   (mu.trackSubAddress(RegionalMuonCand::kME4Ch) & emtfTrAddrMe4ChMask_) << emtfTrAddrMe4ChShift_;
 
     } else {
       edm::LogWarning("L1T") << "EMTF muon track address map contains " << mu.trackAddress().size()

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -79,6 +79,8 @@ void l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonCand(RegionalMuonCand& 
     if (useEmtfDisplacementInfo) {  // In Run-3 we receive displaced muon information from EMTF
       mu.setHwPtUnconstrained((raw_data_32_63 >> emtfPtUnconstrainedShift_) & ptUnconstrainedMask_);
       mu.setHwDXY((raw_data_32_63 >> emtfDxyShift_) & dxyMask_);
+      mu.setTrackSubAddress(RegionalMuonCand::kTrkNum, 0);
+      mu.setTrackSubAddress(RegionalMuonCand::kBX, 0);
     } else {
       mu.setTrackSubAddress(RegionalMuonCand::kTrkNum,
                             (rawTrackAddress >> emtfTrAddrTrkNumShift_) & emtfTrAddrTrkNumMask_);

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -137,8 +137,10 @@ void l1t::RegionalMuonRawDigiTranslator::generatePackedShowerPayload(const Regio
     return;
   }
   // First we check whether we're going to overwrite something in the payload.
-  if (((payload.at(emtfShowerInTimeFrame_) & emtfShowerMask_) != 0) ||
-      ((payload.at(emtfShowerOOTFrame_) & emtfShowerMask_) != 0)) {
+  if ((((payload.at(emtfShowerInTimeFrame_) >> emtfShowerOneNominalShift_) & emtfShowerMask_) != 0) ||
+      (((payload.at(emtfShowerInTimeFrame_) >> emtfShowerOneTightShift_) & emtfShowerMask_) != 0) ||
+      (((payload.at(emtfShowerOOTFrame_) >> emtfShowerOneNominalShift_) & emtfShowerMask_) != 0) ||
+      (((payload.at(emtfShowerOOTFrame_) >> emtfShowerOneTightShift_) & emtfShowerMask_) != 0)) {
     edm::LogError("L1T") << "Check constants for RegionalMuonShower fields! It looks like we're in danger of "
                             "overwriting muon data in the packer!";
     return;

--- a/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
+++ b/L1Trigger/L1TMuon/src/RegionalMuonRawDigiTranslator.cc
@@ -119,13 +119,10 @@ bool l1t::RegionalMuonRawDigiTranslator::fillRegionalMuonShower(
   if (useEmtfShowers && (tf == emtf_pos || tf == emtf_neg)) {
     muShower.setTFIdentifiers(proc, tf);
 
-    muShower.setOneNominalInTime(((bxPayload[emtfShowerOneNominalFrame_] >> emtfShowerOneNominalInTimeShift_) & 1) ==
-                                 1);
-    muShower.setOneNominalOutOfTime(
-        ((bxPayload[emtfShowerOneNominalFrame_] >> emtfShowerOneNominalOutOfTimeShift_) & 1) == 1);
-    muShower.setTwoLooseInTime(((bxPayload[emtfShowerTwoLooseFrame_] >> emtfShowerTwoLooseInTimeShift_) & 1) == 1);
-    muShower.setTwoLooseOutOfTime(((bxPayload[emtfShowerTwoLooseFrame_] >> emtfShowerTwoLooseOutOfTimeShift_) & 1) ==
-                                  1);
+    muShower.setOneNominalInTime(((bxPayload[emtfShowerInTimeFrame_] >> emtfShowerOneNominalShift_) & 1) == 1);
+    muShower.setOneNominalOutOfTime(((bxPayload[emtfShowerOOTFrame_] >> emtfShowerOneNominalShift_) & 1) == 1);
+    muShower.setOneTightInTime(((bxPayload[emtfShowerInTimeFrame_] >> emtfShowerOneTightShift_) & 1) == 1);
+    muShower.setOneTightOutOfTime(((bxPayload[emtfShowerOOTFrame_] >> emtfShowerOneTightShift_) & 1) == 1);
 
     return true;
   } else {
@@ -140,16 +137,16 @@ void l1t::RegionalMuonRawDigiTranslator::generatePackedShowerPayload(const Regio
     return;
   }
   // First we check whether we're going to overwrite something in the payload.
-  if (((payload.at(emtfShowerOneNominalFrame_) & emtfShowerOneNominalMask_) != 0) ||
-      ((payload.at(emtfShowerTwoLooseFrame_) & emtfShowerTwoLooseMask_) != 0)) {
+  if (((payload.at(emtfShowerInTimeFrame_) & emtfShowerMask_) != 0) ||
+      ((payload.at(emtfShowerOOTFrame_) & emtfShowerMask_) != 0)) {
     edm::LogError("L1T") << "Check constants for RegionalMuonShower fields! It looks like we're in danger of "
                             "overwriting muon data in the packer!";
     return;
   }
-  payload.at(emtfShowerOneNominalFrame_) |= (shower.isOneNominalInTime() & 1) << emtfShowerOneNominalInTimeShift_ |
-                                            (shower.isOneNominalOutOfTime() & 1) << emtfShowerOneNominalOutOfTimeShift_;
-  payload.at(emtfShowerTwoLooseFrame_) |= (shower.isTwoLooseInTime() & 1) << emtfShowerTwoLooseInTimeShift_ |
-                                          (shower.isTwoLooseOutOfTime() & 1) << emtfShowerTwoLooseOutOfTimeShift_;
+  payload.at(emtfShowerInTimeFrame_) |= (shower.isOneNominalInTime() & 1) << emtfShowerOneNominalShift_ |
+                                        (shower.isOneTightInTime() & 1) << emtfShowerOneTightShift_;
+  payload.at(emtfShowerOOTFrame_) |= (shower.isOneNominalOutOfTime() & 1) << emtfShowerOneNominalShift_ |
+                                     (shower.isOneTightOutOfTime() & 1) << emtfShowerOneTightShift_;
 }
 
 void l1t::RegionalMuonRawDigiTranslator::generatePackedDataWords(const RegionalMuonCand& mu,

--- a/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
+++ b/L1Trigger/L1TMuonEndCap/interface/SectorProcessorShower.h
@@ -15,6 +15,8 @@
 #include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 #include "L1Trigger/L1TMuonEndCap/interface/Common.h"
 
+#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+
 #include <vector>
 
 class SectorProcessorShower {

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessorShower.cc
@@ -67,10 +67,8 @@ void SectorProcessorShower::process(const CSCShowerDigiCollection& in_showers,
   if (accept) {
     // shower output
     l1t::RegionalMuonShower out_shower(hasOneNominalInTime, false, hasTwoLooseInTime, false, hasOneTightInTime, false);
-    // convert [1,2] to [1, -1]
-    const int endcap(endcap_ == 1 ? 1 : -1);
-    out_shower.setEndcap(endcap);
-    out_shower.setSector(sector_);
+    l1t::tftype tftype = (endcap_ == 1) ? l1t::tftype::emtf_pos : l1t::tftype::emtf_neg;
+    out_shower.setTFIdentifiers(sector_, tftype);
     out_showers.push_back(0, out_shower);
   }
 }


### PR DESCRIPTION
#### PR description:

This is a backport PR comprising multiple original ones. It contains unpackers and packers for hadronic showers at the uGMT inputs and outputs as well as the DQM for muon showers. 

Ideally this should be used in the P5 DQM as soon as possible, could you let me know if this isn't the correct branch to target for this?

attn: @vukasinmilosevic 

#### PR validation:

Ran `runTheMatrix.py -l limited -i all --ibeos` as well as `scram b runtests` after rebasing/cherry-picking.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Original PRs:
* #35627
* #36462
* #36877
* #36920

I would like to have these changes available in the DQM at P5. They are not required for T0 or HLT. 