### PR TITLE
`HLTDeDxFilter`: prevent variable length array bound evaluates to non-positive value

### DIFF
--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -115,6 +115,11 @@ bool HLTDeDxFilter::hltFilter(edm::Event& iEvent,
 
   bool accept = false;
   int NTracks = 0;
+
+  // early return
+  if (trackCollection.empty())
+    return accept;
+
   //fill local arrays for eta, phi, and pt
   float eta[trackCollection.size()], phi[trackCollection.size()], pt[trackCollection.size()];
   for (unsigned int i = 0; i < trackCollection.size(); i++) {


### PR DESCRIPTION
#### PR description:

In partial response to https://github.com/cms-sw/cmssw/issues/35036#issuecomment-1044139169

#### PR validation:

`cmssw` compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
