### PR TITLE
Remove deprecation warnings from some `CommonTools` subsystems

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandCollectionExistFilter.cc
+++ b/CommonTools/CandAlgos/plugins/CandCollectionExistFilter.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -7,23 +7,15 @@
 using namespace edm;
 using namespace reco;
 
-class CandCollectionExistFilter : public EDFilter {
+class CandCollectionExistFilter : public edm::stream::EDFilter<> {
 public:
   CandCollectionExistFilter(const ParameterSet& cfg)
       : srcToken_(consumes<CandidateView>(cfg.getParameter<InputTag>("src"))) {}
 
 private:
-  bool filter(Event& evt, const EventSetup&) override {
-    Handle<CandidateView> src;
-    bool exists = true;
-    evt.getByToken(srcToken_, src);
-    if (!src.isValid())
-      exists = false;
-    return exists;
-  }
-  EDGetTokenT<CandidateView> srcToken_;
+  bool filter(Event& evt, const EventSetup&) override { return evt.getHandle(srcToken_).isValid(); }
+  const EDGetTokenT<CandidateView> srcToken_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 DEFINE_FWK_MODULE(CandCollectionExistFilter);

--- a/CommonTools/CandAlgos/plugins/CandReducer.cc
+++ b/CommonTools/CandAlgos/plugins/CandReducer.cc
@@ -16,22 +16,22 @@
  * $Id: CandReducer.cc,v 1.3 2009/09/27 22:26:55 hegner Exp $
  *
  */
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-class CandReducer : public edm::EDProducer {
+class CandReducer : public edm::global::EDProducer<> {
 public:
   /// constructor from parameter set
   explicit CandReducer(const edm::ParameterSet&);
   /// destructor
-  ~CandReducer() override;
+  ~CandReducer() override = default;
 
 private:
   /// process one evevnt
-  void produce(edm::Event& evt, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
   /// label of source candidate collection
-  edm::EDGetTokenT<reco::CandidateView> srcToken_;
+  const edm::EDGetTokenT<reco::CandidateView> srcToken_;
 };
 
 #include "FWCore/Framework/interface/Event.h"
@@ -47,11 +47,8 @@ CandReducer::CandReducer(const edm::ParameterSet& cfg)
   produces<CandidateCollection>();
 }
 
-CandReducer::~CandReducer() {}
-
-void CandReducer::produce(Event& evt, const EventSetup&) {
-  Handle<reco::CandidateView> cands;
-  evt.getByToken(srcToken_, cands);
+void CandReducer::produce(edm::StreamID, edm::Event& evt, edm::EventSetup const&) const {
+  const Handle<reco::CandidateView> cands = evt.getHandle(srcToken_);
   std::unique_ptr<CandidateCollection> comp(new CandidateCollection);
   for (reco::CandidateView::const_iterator c = cands->begin(); c != cands->end(); ++c) {
     std::unique_ptr<Candidate> cand(new LeafCandidate(*c));
@@ -61,5 +58,4 @@ void CandReducer::produce(Event& evt, const EventSetup&) {
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 DEFINE_FWK_MODULE(CandReducer);

--- a/CommonTools/CandAlgos/plugins/ParticleDecayProducer.cc
+++ b/CommonTools/CandAlgos/plugins/ParticleDecayProducer.cc
@@ -6,23 +6,23 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include <vector>
 
-class ParticleDecayProducer : public edm::EDProducer {
+class ParticleDecayProducer : public edm::global::EDProducer<> {
 public:
   explicit ParticleDecayProducer(const edm::ParameterSet&);
-  ~ParticleDecayProducer() override;
+  ~ParticleDecayProducer() override = default;
 
 private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
   edm::EDGetTokenT<reco::CandidateCollection> genCandidatesToken_;
-  int motherPdgId_;
-  std::vector<int> daughtersPdgId_;
-  std::string decayChain_;
+  const int motherPdgId_;
+  const std::vector<int> daughtersPdgId_;
+  const std::string decayChain_;
   std::vector<std::string> valias;
 };
 
@@ -53,13 +53,9 @@ ParticleDecayProducer::ParticleDecayProducer(const edm::ParameterSet& iConfig)
   }
 }
 
-// destructor
-ParticleDecayProducer::~ParticleDecayProducer() {}
-
-void ParticleDecayProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void ParticleDecayProducer::produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
   // get gen particle candidates
-  edm::Handle<CandidateCollection> genCandidatesCollection;
-  iEvent.getByToken(genCandidatesToken_, genCandidatesCollection);
+  const edm::Handle<CandidateCollection> genCandidatesCollection = iEvent.getHandle(genCandidatesToken_);
 
   unique_ptr<CandidateCollection> mothercands(new CandidateCollection);
   unique_ptr<CandidateCollection> daughterscands(new CandidateCollection);
@@ -90,5 +86,4 @@ void ParticleDecayProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 DEFINE_FWK_MODULE(ParticleDecayProducer);

--- a/CommonTools/MVAUtils/interface/TMVAEvaluator.h
+++ b/CommonTools/MVAUtils/interface/TMVAEvaluator.h
@@ -30,12 +30,6 @@ public:
                            const std::vector<std::string>& spectators,
                            bool useAdaBoost = false);
 
-  void initializeGBRForest(const edm::EventSetup& iSetup,
-                           const std::string& label,
-                           const std::vector<std::string>& variables,
-                           const std::vector<std::string>& spectators,
-                           bool useAdaBoost = false);
-
   float evaluateTMVA(const std::map<std::string, float>& inputs, bool useSpectators) const;
   float evaluateGBRForest(const std::map<std::string, float>& inputs) const;
   float evaluate(const std::map<std::string, float>& inputs, bool useSpectators = false) const;

--- a/CommonTools/MVAUtils/plugins/GBRForestWriter.cc
+++ b/CommonTools/MVAUtils/plugins/GBRForestWriter.cc
@@ -7,7 +7,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -21,7 +21,7 @@
 #include <string>
 #include <vector>
 
-class GBRForestWriter : public edm::EDAnalyzer {
+class GBRForestWriter : public edm::one::EDAnalyzer<> {
 public:
   GBRForestWriter(const edm::ParameterSet&);
   ~GBRForestWriter() override;

--- a/CommonTools/MVAUtils/src/TMVAEvaluator.cc
+++ b/CommonTools/MVAUtils/src/TMVAEvaluator.cc
@@ -70,18 +70,6 @@ void TMVAEvaluator::initializeGBRForest(const GBRForest* gbrForest,
   mUseAdaBoost = useAdaBoost;
 }
 
-void TMVAEvaluator::initializeGBRForest(const edm::EventSetup& iSetup,
-                                        const std::string& label,
-                                        const std::vector<std::string>& variables,
-                                        const std::vector<std::string>& spectators,
-                                        bool useAdaBoost) {
-  edm::ESHandle<GBRForest> gbrForestHandle;
-
-  iSetup.get<GBRWrapperRcd>().get(label.c_str(), gbrForestHandle);
-
-  initializeGBRForest(gbrForestHandle.product(), variables, spectators, useAdaBoost);
-}
-
 float TMVAEvaluator::evaluateTMVA(const std::map<std::string, float>& inputs, bool useSpectators) const {
   // default value
   float value = -99.;

--- a/CommonTools/PileupAlgos/plugins/PuppiPhoton.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiPhoton.cc
@@ -13,8 +13,6 @@
 #include "DataFormats/PatCandidates/interface/Photon.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -12,8 +12,6 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/CommonTools/TriggerUtils/test/GenericTriggerEventFlagTest.cc
+++ b/CommonTools/TriggerUtils/test/GenericTriggerEventFlagTest.cc
@@ -15,16 +15,15 @@
   \version  $Id: GenericTriggerEventFlagTest.cc,v 1.2 2012/01/19 20:17:34 vadler Exp $
 */
 
-#include "FWCore/Framework/interface/EDFilter.h"
-
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 
-class GenericTriggerEventFlagTest : public edm::EDFilter {
-  GenericTriggerEventFlag* genericTriggerEventFlag_;
+class GenericTriggerEventFlagTest : public edm::stream::EDFilter<> {
+  GenericTriggerEventFlag genericTriggerEventFlag_;
 
 public:
   explicit GenericTriggerEventFlagTest(const edm::ParameterSet& iConfig);
-  virtual ~GenericTriggerEventFlagTest();
+  virtual ~GenericTriggerEventFlagTest() override = default;
 
 private:
   virtual void beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
@@ -32,17 +31,15 @@ private:
 };
 
 GenericTriggerEventFlagTest::GenericTriggerEventFlagTest(const edm::ParameterSet& iConfig)
-    : genericTriggerEventFlag_(new GenericTriggerEventFlag(iConfig, consumesCollector(), *this)) {}
-
-GenericTriggerEventFlagTest::~GenericTriggerEventFlagTest() { delete genericTriggerEventFlag_; }
+    : genericTriggerEventFlag_(GenericTriggerEventFlag(iConfig, consumesCollector(), *this)) {}
 
 void GenericTriggerEventFlagTest::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  if (genericTriggerEventFlag_->on())
-    genericTriggerEventFlag_->initRun(iRun, iSetup);
+  if (genericTriggerEventFlag_.on())
+    genericTriggerEventFlag_.initRun(iRun, iSetup);
 }
 
 bool GenericTriggerEventFlagTest::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  if (genericTriggerEventFlag_->on() && !genericTriggerEventFlag_->accept(iEvent, iSetup))
+  if (genericTriggerEventFlag_.on() && !genericTriggerEventFlag_.accept(iEvent, iSetup))
     return false;
 
   return true;

--- a/CommonTools/UtilAlgos/plugins/DoubleProducer.cc
+++ b/CommonTools/UtilAlgos/plugins/DoubleProducer.cc
@@ -6,9 +6,9 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
-class DoubleProducer : public edm::EDProducer {
+class DoubleProducer : public edm::stream::EDProducer<> {
 public:
   DoubleProducer(const edm::ParameterSet& cfg);
 

--- a/CommonTools/UtilAlgos/plugins/StopAfterNEvents.cc
+++ b/CommonTools/UtilAlgos/plugins/StopAfterNEvents.cc
@@ -1,10 +1,11 @@
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class StopAfterNEvents : public edm::EDFilter {
+class StopAfterNEvents : public edm::stream::EDFilter<> {
 public:
   StopAfterNEvents(const edm::ParameterSet&);
-  ~StopAfterNEvents() override;
+  ~StopAfterNEvents() override = default;
 
 private:
   bool filter(edm::Event&, edm::EventSetup const&) override;
@@ -21,15 +22,14 @@ using namespace edm;
 StopAfterNEvents::StopAfterNEvents(const ParameterSet& pset)
     : nMax_(pset.getParameter<int>("maxEvents")), n_(0), verbose_(pset.getUntrackedParameter<bool>("verbose", false)) {}
 
-StopAfterNEvents::~StopAfterNEvents() {}
-
 bool StopAfterNEvents::filter(Event&, EventSetup const&) {
   if (n_ < 0)
     return true;
   n_++;
   bool ret = n_ <= nMax_;
   if (verbose_)
-    cout << ">>> filtering event" << n_ << "/" << nMax_ << "(" << (ret ? "true" : "false") << ")" << endl;
+    edm::LogInfo("StopAfterNEvents") << ">>> filtering event" << n_ << "/" << nMax_ << "(" << (ret ? "true" : "false")
+                                     << ")" << endl;
   return ret;
 }
 

--- a/CommonTools/UtilAlgos/test/TestTFileServiceAnalyzer.cc
+++ b/CommonTools/UtilAlgos/test/TestTFileServiceAnalyzer.cc
@@ -1,7 +1,9 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "TH1.h"
 #include "TTree.h"
-class TestTFileServiceAnalyzer : public edm::EDAnalyzer {
+class TestTFileServiceAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// constructor
   TestTFileServiceAnalyzer(const edm::ParameterSet&);
@@ -9,6 +11,7 @@ public:
 private:
   /// process one event
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+
   /// histograms
   TH1F *h_test1, *h_test2;
   /// TTree
@@ -19,15 +22,14 @@ private:
   std::string dir1_, dir2_;
 };
 
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 using namespace edm;
 using namespace std;
 
 TestTFileServiceAnalyzer::TestTFileServiceAnalyzer(const ParameterSet& cfg)
     : dir1_(cfg.getParameter<string>("dir1")), dir2_(cfg.getParameter<string>("dir2")) {
-  Service<TFileService> fs;
+  usesResource(TFileService::kSharedResource);
+  edm::Service<TFileService> fs;
   if (dir1_.empty()) {
     h_test1 = fs->make<TH1F>("test1", "test histogram #1", 100, 0., 100.);
   } else {


### PR DESCRIPTION
#### PR description:

Technical, part of the migrations in https://github.com/cms-sw/cmssw/issues/31061 and https://github.com/cms-sw/cmssw/issues/36404.
Removed some of the CMSDEPRECATED_X warnings in the `CommonTools` subsystems from [CMSSW_12_4_CMSDEPRECATED_X_2022-03-11-2300](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc7_amd64_gcc10/www/fri/12.4.CMSDEPRECATED-fri-23/CMSSW_12_4_CMSDEPRECATED_X_2022-03-11-2300)

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 
