### PR TITLE
[12_2_X] Merged central modules at L3&L4 in SiPixelLorentzAngle PCL workflow

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -197,21 +197,9 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
 
     if (std::find(treatedIndices.begin(), treatedIndices.end(), i_index) != treatedIndices.end()) {
       hists.detIdsList.at(i_index).push_back(rawId);
-      if (module >= 3 && module <= 6 && (layer == 3 || layer == 4)) {
-        int i_index_merge = (module - 1) / 2 + (layer - 3) * 2 + hists.nlay * hists.nModules_[hists.nlay - 1] +
-                            (int)hists.BPixnewDetIds_.size();
-        hists.detIdsList.at(i_index_merge).push_back(rawId);
-      }
     } else {
       hists.detIdsList.insert(std::pair<uint32_t, std::vector<uint32_t>>(i_index, {rawId}));
       treatedIndices.push_back(i_index);
-
-      if (module >= 3 && module <= 6 && (layer == 3 || layer == 4)) {
-        int i_index_merge = (module - 1) / 2 + (layer - 3) * 2 + hists.nlay * hists.nModules_[hists.nlay - 1] +
-                            (int)hists.BPixnewDetIds_.size();
-        hists.detIdsList.insert(std::pair<uint32_t, std::vector<uint32_t>>(i_index_merge, {rawId}));
-        treatedIndices.push_back(i_index_merge);
-      }
     }
   }
 
@@ -266,29 +254,6 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
 
       hists.h_drift_depth_[i_index]->divide(
           hists.h_drift_depth_adc_[i_index], hists.h_drift_depth_noadc_[i_index], 1., 1., "");
-
-      if ((i_module == 3 || i_module == 5) && (i_layer == 3 || i_layer == 4)) {
-        int i_index_merge = (i_module - 1) / 2 + (i_layer - 3) * 2 + hists.nlay * hists.nModules_[hists.nlay - 1] +
-                            (int)hists.BPixnewDetIds_.size();
-
-        hists.h_drift_depth_[i_index_merge] = iGetter.get(
-            fmt::format("{}/h_drift_depth_layer{}_module{}_and_module{}", prefix_, i_layer, i_module, i_module + 1));
-
-        hists.h_drift_depth_adc_[i_index_merge] = iGetter.get(fmt::format(
-            "{}/h_drift_depth_adc_layer{}_module{}_and_module{}", prefix_, i_layer, i_module, i_module + 1));
-
-        hists.h_drift_depth_adc2_[i_index_merge] = iGetter.get(fmt::format(
-            "{}/h_drift_depth_adc2_layer{}_module{}_and_module{}", prefix_, i_layer, i_module, i_module + 1));
-
-        hists.h_drift_depth_noadc_[i_index_merge] = iGetter.get(fmt::format(
-            "{}/h_drift_depth_noadc_layer{}_module{}_and_module{}", prefix_, i_layer, i_module, i_module + 1));
-
-        hists.h_mean_[i_index_merge] = iGetter.get(
-            fmt::format("{}/h_mean_layer{}_module{}_and_module{}", dqmDir_, i_layer, i_module, i_module + 1));
-
-        hists.h_drift_depth_[i_index_merge]->divide(
-            hists.h_drift_depth_adc_[i_index_merge], hists.h_drift_depth_noadc_[i_index_merge], 1., 1., "");
-      }
     }
   }
 
@@ -354,7 +319,7 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   // retrieve the number of bins from the other monitoring histogram
   const auto& maxSect = hists.h_bySectOccupancy_->getNbinsX();
   const double lo = -0.5;
-  const double hi = maxSect + 0.5;
+  const double hi = maxSect - 0.5;
 
   // this will be booked in the Harvesting folder
   iBooker.setCurrentFolder(fmt::format("{}Harvesting/SectorMonitoring", dqmDir_));
@@ -477,7 +442,6 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
   for (int i_layer = 1; i_layer <= hists.nlay; i_layer++) {
     for (int i_module = 1; i_module <= hists.nModules_[i_layer - 1]; i_module++) {
       int i_index = i_module + (i_layer - 1) * hists.nModules_[i_layer - 1];
-
       if (hists.h_drift_depth_adc_[i_index] == nullptr)
         continue;
       //loop over bins in depth (z-local-coordinate) (in order to fit slices)
@@ -496,15 +460,6 @@ void SiPixelLorentzAnglePCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQMS
           << res.chi2 << "\t" << res.prob << "\t"
           << "null"
           << "\t" << res.tan_LA << "\t" << res.error_LA;
-
-      if ((i_module == 3 || i_module == 5) && (i_layer == 3 || i_layer == 4)) {
-        int i_index_merge = (i_module - 1) / 2 + (i_layer - 3) * 2 + hists.nlay * hists.nModules_[hists.nlay - 1] +
-                            (int)hists.BPixnewDetIds_.size();
-        for (int i = 1; i <= hist_depth_; i++) {
-          findMean(h_drift_depth_adc_slice_, i, i_index_merge);
-        }
-        const auto& res_combine = fitAndStore(LorentzAngle, i_index_merge, i_layer, i_module);
-      }
     }
   }  // end loop over modules and layers
 
@@ -681,8 +636,7 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
 
   int nentries = hists.h_bySectOccupancy_->getBinContent(i_index);  // number of on track hits in that sector
 
-  bool isNew = ((i_index > hists.nlay * hists.nModules_[hists.nlay - 1]) &&
-                (i_index <= (hists.nlay * hists.nModules_[hists.nlay - 1] + (int)hists.BPixnewDetIds_.size())));
+  bool isNew = (i_index > hists.nlay * hists.nModules_[hists.nlay - 1]);
   int shiftIdx = i_index - hists.nlay * hists.nModules_[hists.nlay - 1] - 1;
 
   LogDebug("SiPixelLorentzAnglePCLHarvester")
@@ -691,13 +645,8 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
   const auto& detIdsToFill =
       isNew ? std::vector<unsigned int>({hists.BPixnewDetIds_[shiftIdx]}) : hists.detIdsList.at(i_index);
 
-  if (i_index <= (hists.nlay * hists.nModules_[hists.nlay - 1] + (int)hists.BPixnewDetIds_.size())) {
-    LogDebug("SiPixelLorentzAnglePCLHarvester")
-        << "index: " << i_index << " i_module: " << i_module << " i_layer: " << i_layer;
-  } else {
-    LogDebug("SiPixelLorentzAnglePCLHarvester") << "index: " << i_index << "combine i_module: " << i_module
-                                                << "and i_module+1" << i_module + 1 << " i_layer: " << i_layer;
-  }
+  LogDebug("SiPixelLorentzAnglePCLHarvester")
+      << "index: " << i_index << " i_module: " << i_module << " i_layer: " << i_layer;
   for (const auto& id : detIdsToFill) {
     LogDebug("SiPixelLorentzAnglePCLHarvester") << id << ",";
   }
@@ -716,8 +665,6 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
     hists.h_bySectDeltaLA_->setBinContent(i_index, deltaLA);
 
     for (const auto& id : detIdsToFill) {
-      if (i_index > (hists.nlay * hists.nModules_[hists.nlay - 1] + (int)hists.BPixnewDetIds_.size()))
-        continue;
       if (!theLAPayload->putLorentzAngle(id, LorentzAnglePerTesla_)) {
         edm::LogError("SiPixelLorentzAnglePCLHarvester") << "[SiPixelLorentzAnglePCLHarvester::fitAndStore]: detid ("
                                                          << i_layer << "," << i_module << ") already exists";
@@ -732,8 +679,6 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
     hists.h_bySectDeltaLA_->setBinContent(i_index, 0.);
 
     for (const auto& id : detIdsToFill) {
-      if (i_index > (hists.nlay * hists.nModules_[hists.nlay - 1] + (int)hists.BPixnewDetIds_.size()))
-        continue;
       LorentzAnglePerTesla_ = currentLorentzAngle->getLorentzAngle(id);
       if (!theLAPayload->putLorentzAngle(id, LorentzAnglePerTesla_)) {
         edm::LogError("SiPixelLorentzAnglePCLHarvester") << "[SiPixelLorentzAnglePCLHarvester::fitAndStore]: detid ("

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -536,6 +536,18 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
                 iHists.h_drift_depth_adc2_.at(i_index)->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
                 iHists.h_drift_depth_noadc_.at(i_index)->Fill(drift, depth, 1.);
                 iHists.h_bySectOccupancy_->Fill(i_index - 1);  // histogram starts at 0
+
+                if (module_ >= 3 && module_ <= 6 && (layer_ == 3 || layer_ == 4)) {
+                  int i_index_merge = (module_ - 1) / 2 + (layer_ - 3) * 2 +
+                                      iHists.nlay * iHists.nModules_[iHists.nlay - 1] +
+                                      (int)iHists.BPixnewDetIds_.size();
+
+                  iHists.h_drift_depth_adc_.at(i_index_merge)->Fill(drift, depth, pixinfo_.adc[j]);
+                  iHists.h_drift_depth_adc2_.at(i_index_merge)->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
+                  iHists.h_drift_depth_noadc_.at(i_index_merge)->Fill(drift, depth, 1.);
+                  iHists.h_bySectOccupancy_->Fill(i_index_merge - 1);
+                }
+
               } else {
                 int new_index = iHists.nModules_[iHists.nlay - 1] +
                                 (iHists.nlay - 1) * iHists.nModules_[iHists.nlay - 1] + 1 + DetId_index;
@@ -693,7 +705,8 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
                                                   edm::Run const& run,
                                                   edm::EventSetup const& iSetup) {
   // book the by partition monitoring
-  const auto maxSect = iHists.nlay * iHists.nModules_[iHists.nlay - 1] + (int)iHists.BPixnewDetIds_.size();
+  const auto maxSect = iHists.nlay * iHists.nModules_[iHists.nlay - 1] + (int)iHists.BPixnewDetIds_.size() +
+                       4;  // add 4 more for combined modules
 
   iBooker.setCurrentFolder(fmt::sprintf("%s/SectorMonitoring", folder_.data()));
   iHists.h_bySectOccupancy_ = iBooker.book1D(
@@ -723,6 +736,26 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
               i_layer,
               i_module);
       iHists.h_mean_[i_index] = iBooker.book1D(name, title, hist_depth_, min_depth_, max_depth_);
+
+      if ((i_module == 3 || i_module == 5) && (i_layer == 3 || i_layer == 4)) {
+        int i_index_merge = (i_module - 1) / 2 + (i_layer - 3) * 2 + iHists.nlay * iHists.nModules_[iHists.nlay - 1] +
+                            (int)iHists.BPixnewDetIds_.size();
+
+        std::string binName = fmt::sprintf("BPix Layer%i Module %i and Module %i", i_layer, i_module, i_module + 1);
+        LogDebug("SiPixelLorentzAnglePCLWorker") << " i_index_merge: " << i_index_merge << " bin name: " << binName
+                                                 << " (i_layer: " << i_layer << " i_module:" << i_module << " and "
+                                                 << " i_module:" << i_module + 1 << ")";
+
+        iHists.h_bySectOccupancy_->setBinLabel(i_index_merge, binName);
+
+        sprintf(name, "h_mean_layer%i_module%i_and_module%i", i_layer, i_module, i_module + 1);
+        sprintf(title,
+                "average drift vs depth layer%i module%i_and_module%i; production depth [#mum]; #LTdrift#GT [#mum]",
+                i_layer,
+                i_module,
+                i_module + 1);
+        iHists.h_mean_[i_index_merge] = iBooker.book1D(name, title, hist_depth_, min_depth_, max_depth_);
+      }
     }
   }
   for (int i = 0; i < (int)iHists.BPixnewDetIds_.size(); i++) {
@@ -765,6 +798,50 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
       sprintf(title, "depth vs drift layer%i module%i; drift [#mum]; production depth [#mum]", i_layer, i_module);
       iHists.h_drift_depth_[i_index] =
           iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+
+      // merge modules 3 and 4 at L3 & L4, merge modules 5 and 6 at L3 & L4
+      if ((i_module == 3 || i_module == 5) && (i_layer == 3 || i_layer == 4)) {
+        unsigned int i_index_merge = (i_module - 1) / 2 + (i_layer - 3) * 2 +
+                                     iHists.nlay * iHists.nModules_[iHists.nlay - 1] +
+                                     (int)iHists.BPixnewDetIds_.size();
+
+        sprintf(name, "h_drift_depth_adc_layer%i_module%i_and_module%i", i_layer, i_module, i_module + 1);
+        sprintf(title,
+                "depth vs drift (ADC) layer%i module%i_and_module%i; drift [#mum]; production depth [#mum]",
+                i_layer,
+                i_module,
+                i_module + 1);
+        iHists.h_drift_depth_adc_[i_index_merge] =
+            iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+
+        sprintf(name, "h_drift_depth_adc2_layer%i_module%i_and_module%i", i_layer, i_module, i_module + 1);
+        sprintf(title,
+                "depth vs drift (ADC^{2}) layer%i module%i_and_module%i; drift [#mum]; production depth [#mum]",
+                i_layer,
+                i_module,
+                i_module + 1);
+        iHists.h_drift_depth_adc2_[i_index_merge] =
+            iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+
+        sprintf(name, "h_drift_depth_noadc_layer%i_module%i_and_module%i", i_layer, i_module, i_module + 1);
+        sprintf(title,
+                "depth vs drift (no ADC) layer%i module%i_and_module%i; drift [#mum]; production depth [#mum]",
+                i_layer,
+                i_module,
+                i_module + 1);
+        iHists.h_drift_depth_noadc_[i_index_merge] =
+            iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+
+        sprintf(name, "h_drift_depth_layer%i_module%i_and_module%i", i_layer, i_module, i_module + 1);
+        sprintf(title,
+                "depth vs drift layer%i module%i_and_module%i; drift [#mum]; production depth [#mum]",
+                i_layer,
+                i_module,
+                i_module + 1);
+
+        iHists.h_drift_depth_[i_index_merge] =
+            iBooker.book2D(name, title, hist_drift_, min_drift_, max_drift_, hist_depth_, min_depth_, max_depth_);
+      }
     }
   }
 


### PR DESCRIPTION
#### PR description:

This PR builds on top of https://github.com/cms-sw/cmssw/pull/36866 to improve low statistics at central modules of L3 and L4 of Phase-I detector.

The details are:
   * Merge info from modules 3 and 4 at L3 and L4
   * Merge info from modules 5 and 6 at L3 and L4

#### PR validation:

Commands:

```console
cmsDriver.py testReAlCa -s ALCA:PromptCalibProdSiPixelLorentzAngle --conditions 121X_dataRun3_Express_TIER0_REPLAY_Run2_v1 --scenario pp --data --era Run2_2018 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 100 --dasquery='file dataset=/StreamExpress/Tier0_REPLAY_2021-SiPixelCalSingleMuon-Express-v1/ALCARECO' --customise_commands='process.ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle.TriggerResultsTag = cms.InputTag ( "TriggerResults","","HLT" ) ; process.ALCARECOCalSignleMuonFilterForSiPixelLorentzAngle.HLTPaths = ["*"]' --nThreads=4
```

```console
cmsDriver.py stepHarvest -s ALCAHARVEST:SiPixelLA --conditions 121X_dataRun3_Express_TIER0_REPLAY_Run2_v1 --scenario pp --data --era Run2_2018 --filein file:PromptCalibProdSiPixelLorentzAngle.root -n -1
```

Test results were uploaded in a private GUI: https://tinyurl.com/ycqk8odf with `ssh -NL 8060:localhost:8060 <USER>@lxplus763.cern.ch`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/37121