### PR TITLE
Make TrackWithVertexSelector able to run without vertex inputTag

### DIFF
--- a/CommonTools/RecoAlgos/src/TrackWithVertexSelector.cc
+++ b/CommonTools/RecoAlgos/src/TrackWithVertexSelector.cc
@@ -35,8 +35,8 @@ TrackWithVertexSelector::~TrackWithVertexSelector() {}
 void TrackWithVertexSelector::init(const edm::Event &event) {
   edm::Handle<reco::VertexCollection> hVtx;
   event.getByToken(vertexToken_, hVtx);
-  vcoll_ = hVtx.product();
-
+  vcoll_ = nVertices_>0 ? hVtx.product() : nullptr;
+  
   edm::Handle<edm::ValueMap<float> > hTimes;
   event.getByToken(timesToken_, hTimes);
   timescoll_ = hTimes.isValid() ? hTimes.product() : nullptr;

--- a/CommonTools/RecoAlgos/src/TrackWithVertexSelector.cc
+++ b/CommonTools/RecoAlgos/src/TrackWithVertexSelector.cc
@@ -35,8 +35,8 @@ TrackWithVertexSelector::~TrackWithVertexSelector() {}
 void TrackWithVertexSelector::init(const edm::Event &event) {
   edm::Handle<reco::VertexCollection> hVtx;
   event.getByToken(vertexToken_, hVtx);
-  vcoll_ = nVertices_>0 ? hVtx.product() : nullptr;
-  
+  vcoll_ = nVertices_ > 0 ? hVtx.product() : nullptr;
+
   edm::Handle<edm::ValueMap<float> > hTimes;
   event.getByToken(timesToken_, hTimes);
   timescoll_ = hTimes.isValid() ? hTimes.product() : nullptr;


### PR DESCRIPTION
Trivial change in `TrackWithVertexSelector.cc` to make it able to run even when there are not vertex collection available.
This might be useful at the HLT.

Please not that `vcoll_` is never called when `nVertices_ == 0`:
```
  if (nVertices_ == 0)
    return true;
  return testVertices(tref, *vcoll_);
```