### PR TITLE
Fix typos in MessageLogger tests

### DIFF
--- a/FWCore/MessageService/bin/Standalone.cpp
+++ b/FWCore/MessageService/bin/Standalone.cpp
@@ -9,6 +9,7 @@
 
 ----------------------------------------------------------------------*/
 
+#include <cmath>
 #include <exception>
 #include <iostream>
 #include <iomanip>
@@ -41,7 +42,7 @@ void DoMyStuff() {
   // be substantially more complex. This example is about as simple
   // as can be.
 
-  double d = 3.14159265357989;
+  double d = M_PI;
   edm::LogWarning("cat_A") << "Test of std::setprecision(p):"
                            << " Pi with precision 12 is " << std::setprecision(12) << d;
 

--- a/FWCore/MessageService/test/UnitTestClient_C.cc
+++ b/FWCore/MessageService/test/UnitTestClient_C.cc
@@ -1,10 +1,11 @@
+#include <cmath>
+#include <iomanip>
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-
-#include <iomanip>
 
 namespace edmtest {
 
@@ -21,7 +22,7 @@ namespace edmtest {
     edm::LogWarning("cat_A") << "Test of std::setw(n) and std::setfill('c'):"
                              << "The following should read ++abcdefg $$$12:" << std::setfill('+') << std::setw(9)
                              << "abcdefg" << std::setw(5) << std::setfill('$') << 12;
-    double d = 3.14159265357989;
+    double d = M_PI;
     edm::LogWarning("cat_A") << "Test of std::setprecision(p):"
                              << "Pi with precision 12 is" << std::setprecision(12) << d;
     edm::LogWarning("cat_A") << "Test of spacing:"

--- a/FWCore/MessageService/test/UnitTestClient_C.cc
+++ b/FWCore/MessageService/test/UnitTestClient_C.cc
@@ -18,22 +18,22 @@ namespace edmtest {
 
   void UnitTestClient_C::analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const {
     int i = 145;
-    edm::LogWarning("cat_A") << "Test of std::hex:" << i << std::hex << "in hex is" << i;
-    edm::LogWarning("cat_A") << "Test of std::setw(n) and std::setfill('c'):"
-                             << "The following should read ++abcdefg $$$12:" << std::setfill('+') << std::setw(9)
+    edm::LogWarning("cat_A") << "Test of std::hex: " << i << std::hex << " in hex is " << i;
+    edm::LogWarning("cat_A") << "Test of std::setw(n) and std::setfill('c'): "
+                             << "The following should read ++abcdefg $$$12: " << std::setfill('+') << std::setw(9)
                              << "abcdefg" << std::setw(5) << std::setfill('$') << 12;
     double d = M_PI;
-    edm::LogWarning("cat_A") << "Test of std::setprecision(p):"
-                             << "Pi with precision 12 is" << std::setprecision(12) << d;
-    edm::LogWarning("cat_A") << "Test of spacing:"
-                             << "The following should read a b c dd:"
+    edm::LogWarning("cat_A") << "Test of std::setprecision(p): "
+                             << "Pi with precision 12 is " << std::setprecision(12) << d;
+    edm::LogWarning("cat_A") << "Test of spacing: "
+                             << "The following should read a b c dd: "
                              << "a" << std::setfill('+') << "b" << std::hex << "c" << std::setw(2) << "dd";
 
     edm::LogWarning("cat_A").format("Test of format hex: {0} in hex is {0:x}", i);
     edm::LogWarning("cat_A")
-        .format("Test of format fill and width:")
+        .format("Test of format fill and width: ")
         .format("The following should read ++abcdefg $$$12: {:+>9} {:$>5}", "abcdefg", 12);
-    edm::LogWarning("cat_A").format("Test of format precision:Pi with precision 12 is {:.12g}", d);
+    edm::LogWarning("cat_A").format("Test of format precision: Pi with precision 12 is {:.12g}", d);
     edm::LogWarning("cat_A").format(
         "Test of format spacing: The following should read a b cc: {} {:+>} {:>2}", "a", "b", "cc");
   }

--- a/FWCore/MessageService/test/UnitTestClient_G.cc
+++ b/FWCore/MessageService/test/UnitTestClient_G.cc
@@ -1,11 +1,12 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDAnalyzer.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/StreamID.h"
-
+#include <cmath>
 #include <iomanip>
 #include <iostream>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 
 namespace edmtest {
 
@@ -21,7 +22,7 @@ namespace edmtest {
       std::cerr << "??? It appears that Message Processing is not Set Up???\n\n";
     }
 
-    double d = 3.14159265357989;
+    double d = M_PI;
     edm::LogWarning("cat_A") << "Test of std::setprecision(p):"
                              << " Pi with precision 12 is " << std::setprecision(12) << d;
 

--- a/FWCore/MessageService/test/unit_test_outputs/infos.log
+++ b/FWCore/MessageService/test/unit_test_outputs/infos.log
@@ -1,6 +1,6 @@
 Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at {Timestamp} 
 %MSG-w cat_A:  UnitTestClient_G:sendSomeMessages Run: 1 Event: 1
-Test of std::setprecision(p): Pi with precision 12 is 3.14159265358
+Test of std::setprecision(p): Pi with precision 12 is 3.14159265359
 %MSG
 %MSG-i cat_B:  UnitTestClient_G:sendSomeMessages Run: 1 Event: 1
 		Emit Info level message 1

--- a/FWCore/MessageService/test/unit_test_outputs/u10_warnings.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u10_warnings.log
@@ -5,7 +5,7 @@ Test of std::hex:145in hex is91
 Test of std::setw(n) and std::setfill('c'):The following should read ++abcdefg $$$12:++abcdefg$$$12
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of std::setprecision(p):Pi with precision 12 is3.14159265358
+Test of std::setprecision(p):Pi with precision 12 is3.14159265359
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of spacing:The following should read a b c dd:abcdd
@@ -17,7 +17,7 @@ Test of format hex: 145 in hex is 91
 Test of format fill and width:The following should read ++abcdefg $$$12: ++abcdefg $$$12
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of format precision:Pi with precision 12 is 3.14159265358
+Test of format precision:Pi with precision 12 is 3.14159265359
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of format spacing: The following should read a b cc: a b cc

--- a/FWCore/MessageService/test/unit_test_outputs/u10_warnings.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u10_warnings.log
@@ -1,23 +1,23 @@
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of std::hex:145in hex is91
+Test of std::hex: 145 in hex is 91
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of std::setw(n) and std::setfill('c'):The following should read ++abcdefg $$$12:++abcdefg$$$12
+Test of std::setw(n) and std::setfill('c'): The following should read ++abcdefg $$$12: ++abcdefg$$$12
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of std::setprecision(p):Pi with precision 12 is3.14159265359
+Test of std::setprecision(p): Pi with precision 12 is 3.14159265359
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of spacing:The following should read a b c dd:abcdd
+Test of spacing: The following should read a b c dd: abcdd
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of format hex: 145 in hex is 91
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of format fill and width:The following should read ++abcdefg $$$12: ++abcdefg $$$12
+Test of format fill and width: The following should read ++abcdefg $$$12: ++abcdefg $$$12
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of format precision:Pi with precision 12 is 3.14159265359
+Test of format precision: Pi with precision 12 is 3.14159265359
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of format spacing: The following should read a b cc: a b cc

--- a/FWCore/MessageService/test/unit_test_outputs/u20_cerr.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u20_cerr.log
@@ -1,6 +1,6 @@
 Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at {Timestamp} 
 %MSG-w cat_A:  UnitTestClient_G:sendSomeMessages Run: 1 Event: 1
-Test of std::setprecision(p): Pi with precision 12 is 3.14159265358
+Test of std::setprecision(p): Pi with precision 12 is 3.14159265359
 %MSG
 %MSG-w cat_C:  UnitTestClient_G:sendSomeMessages Run: 1 Event: 1
 		Emit Warning level message 1

--- a/FWCore/MessageService/test/unit_test_outputs/u6_warnings.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u6_warnings.log
@@ -5,7 +5,7 @@ Test of std::hex:145in hex is91
 Test of std::setw(n) and std::setfill('c'):The following should read ++abcdefg $$$12:++abcdefg$$$12
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of std::setprecision(p):Pi with precision 12 is3.14159265358
+Test of std::setprecision(p):Pi with precision 12 is3.14159265359
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of spacing:The following should read a b c dd:abcdd
@@ -17,7 +17,7 @@ Test of format hex: 145 in hex is 91
 Test of format fill and width:The following should read ++abcdefg $$$12: ++abcdefg $$$12
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of format precision:Pi with precision 12 is 3.14159265358
+Test of format precision:Pi with precision 12 is 3.14159265359
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of format spacing: The following should read a b cc: a b cc

--- a/FWCore/MessageService/test/unit_test_outputs/u6_warnings.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u6_warnings.log
@@ -1,23 +1,23 @@
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of std::hex:145in hex is91
+Test of std::hex: 145 in hex is 91
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of std::setw(n) and std::setfill('c'):The following should read ++abcdefg $$$12:++abcdefg$$$12
+Test of std::setw(n) and std::setfill('c'): The following should read ++abcdefg $$$12: ++abcdefg$$$12
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of std::setprecision(p):Pi with precision 12 is3.14159265359
+Test of std::setprecision(p): Pi with precision 12 is 3.14159265359
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of spacing:The following should read a b c dd:abcdd
+Test of spacing: The following should read a b c dd: abcdd
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of format hex: 145 in hex is 91
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of format fill and width:The following should read ++abcdefg $$$12: ++abcdefg $$$12
+Test of format fill and width: The following should read ++abcdefg $$$12: ++abcdefg $$$12
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
-Test of format precision:Pi with precision 12 is 3.14159265359
+Test of format precision: Pi with precision 12 is 3.14159265359
 %MSG
 %MSG-w cat_A:  UnitTestClient_C:sendSomeMessages Run: 1 Event: 1
 Test of format spacing: The following should read a b cc: a b cc

--- a/FWCore/MessageService/test/unit_test_outputs/warnings.log
+++ b/FWCore/MessageService/test/unit_test_outputs/warnings.log
@@ -1,5 +1,5 @@
 %MSG-w cat_A:  UnitTestClient_G:sendSomeMessages Run: 1 Event: 1
-Test of std::setprecision(p): Pi with precision 12 is 3.14159265358
+Test of std::setprecision(p): Pi with precision 12 is 3.14159265359
 %MSG
 %MSG-w cat_C:  UnitTestClient_G:sendSomeMessages Run: 1 Event: 1
 		Emit Warning level message 1


### PR DESCRIPTION
#### PR description:

Fix wrongs values and missing spaces  in the MessageLogger tests.

#### PR validation:

None.
