### PR TITLE
Ed modules migration v1

### DIFF
--- a/DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h
+++ b/DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h
@@ -2,7 +2,6 @@
 #ifndef ElectronDqmAnalyzerBase_h
 #define ElectronDqmAnalyzerBase_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <Rtypes.h>
 #include <string>

--- a/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
@@ -11,7 +11,6 @@
 
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/DQMOffline/EGamma/plugins/ElectronGeneralAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronGeneralAnalyzer.cc
@@ -11,7 +11,6 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/DQMOffline/EGamma/plugins/ElectronTagProbeAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronTagProbeAnalyzer.cc
@@ -13,7 +13,6 @@
 
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
@@ -14,7 +14,7 @@ if cmsEnv.beginTag() == 'Run2_2017':
     process = cms.Process("electronPostValidation",Run2_2017)
 elif cmsEnv.beginTag() == 'Run3':
     from Configuration.Eras.Era_Run3_cff import Run3
-    process = cms.Process('electronValidation', Run3) 
+    process = cms.Process('electronPostValidation', Run3) 
 else:
     from Configuration.Eras.Era_Phase2_cff import Phase2
     process = cms.Process('electronPostValidation',Phase2) 

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
@@ -14,7 +14,7 @@ if cmsEnv.beginTag() == 'Run2_2017':
     process = cms.Process("electronPostValidation",Run2_2017)
 elif cmsEnv.beginTag() == 'Run3':
     from Configuration.Eras.Era_Run3_cff import Run3
-    process = cms.Process('electronValidation', Run3) 
+    process = cms.Process('electronPostValidation', Run3) 
 else:
     from Configuration.Eras.Era_Phase2_cff import Phase2
     process = cms.Process('electronPostValidation',Phase2)

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
@@ -14,7 +14,7 @@ if cmsEnv.beginTag() == 'Run2_2017':
     process = cms.Process("electronPostValidation",Run2_2017)
 elif cmsEnv.beginTag() == 'Run3':
     from Configuration.Eras.Era_Run3_cff import Run3
-    process = cms.Process('electronValidation', Run3) 
+    process = cms.Process('electronPostValidation', Run3) 
 else:
     from Configuration.Eras.Era_Phase2_cff import Phase2
     process = cms.Process('electronPostValidation',Phase2) 

--- a/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
+++ b/Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py
@@ -14,7 +14,7 @@ if cmsEnv.beginTag() == 'Run2_2017':
     process = cms.Process("electronPostValidation",Run2_2017)
 elif cmsEnv.beginTag() == 'Run3':
     from Configuration.Eras.Era_Run3_cff import Run3
-    process = cms.Process('electronValidation', Run3) 
+    process = cms.Process('electronPostValidation', Run3) 
 else:
     from Configuration.Eras.Era_Phase2_cff import Phase2
     process = cms.Process('electronPostValidation',Phase2)


### PR DESCRIPTION
#### PR description:

add some modifications in order to avoid deprecation warnings about EDAnalyzer modules.
Modifications are made on the following files :
DQMOffline/EGamma/interface/ElectronDqmAnalyzerBase.h
DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
DQMOffline/EGamma/plugins/ElectronGeneralAnalyzer.cc
DQMOffline/EGamma/plugins/ElectronTagProbeAnalyzer.cc

Some other small (they do not concern the ED Modules) modifications are made on :
Validation/RecoEgamma/test/ElectronMcFakePostValidation_cfg.py
Validation/RecoEgamma/test/ElectronMcSignalPostValidationMiniAOD_cfg.py
Validation/RecoEgamma/test/ElectronMcSignalPostValidationPt1000_cfg.py
Validation/RecoEgamma/test/ElectronMcSignalPostValidation_cfg.py

#### PR validation:

compilation is OK, basics tests (scram b runtests or local tests) are OK too.
runTheMatrix.py -l limited -i all --ibeos tests are fine (48 47 46 35 17 4 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 failed).
here is the run-log : [runall-report-step123-.log](https://github.com/cms-sw/cmssw/files/8251940/runall-report-step123-.log)

@beaudett