### PR TITLE
move from `int64_t` to `uint64_t` to avoid bit shifting negative numbers (UB in C++)

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/DeepCoreSeedGenerator.cc
@@ -211,7 +211,7 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
   for (const auto& jet : cores) {  // jet loop
 
     if (jet.pt() > ptMin_) {
-      std::set<long long int> ids;
+      std::set<unsigned long long int> ids;
       const reco::Vertex& jetVertex = vertices[0];
 
       std::vector<GlobalVector> splitClustDirSet =
@@ -329,8 +329,8 @@ void DeepCoreSeedGenerator::produce(edm::Event& iEvent, const edm::EventSetup& i
                 const GlobalVector globSeedDir(
                     GlobalVector::Polar(Geom::Theta<double>(track_theta), Geom::Phi<double>(track_phi), normdirR));
                 LocalVector localSeedDir = globDet->surface().toLocal(globSeedDir);
-                int64_t seedid = (int64_t(xx * 200.) << 0) + (int64_t(yy * 200.) << 16) +
-                                 (int64_t(track_eta * 400.) << 32) + (int64_t(track_phi * 400.) << 48);
+                uint64_t seedid = (uint64_t(xx * 200.) << 0) + (uint64_t(yy * 200.) << 16) +
+                                  (uint64_t(track_eta * 400.) << 32) + (uint64_t(track_phi * 400.) << 48);
                 if (ids.count(seedid) != 0) {
                   continue;
                 }


### PR DESCRIPTION
#### PR description:

In partial response to https://github.com/cms-sw/cmssw/issues/35036#issuecomment-1044139169.
Followed suggestion at https://github.com/cms-sw/cmssw/issues/35036#issuecomment-1021645608 (e.g. `xx`, `yy` , `track_eta` and `track_phi` can be negative, hence when casted to  `int64_t` - and preserving the sign, the bit shift can lead to undefined behaviour), so changed the cast from  `int64_t` to `uint64_t`.
This solution has also been privately discussed with the original author @vberta 

#### PR validation:

`cmssw` compiles, also run a typical battery of ad-hoc relvals with  `seedingDeepCore` enabled:

```console
runTheMatrix.py --what upgrade -l 11634.17,11723.17,11834.17,11923.17 --ibeos
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 