### PR TITLE
Fix edmPickEvents.py unit test

### DIFF
--- a/PhysicsTools/Utilities/scripts/edmPickEvents.py
+++ b/PhysicsTools/Utilities/scripts/edmPickEvents.py
@@ -83,16 +83,16 @@ class Event (dict):
 ## Subroutines ##
 #################
 
-def getFileNames(event, client=None, timeout=15):
+def getFileNames(event, client=None):
     """Return files for given DAS query"""
     if  client == 'das_client':
         return getFileNames_das_client(event)
     elif client == 'dasgoclient':
-        return getFileNames_dasgoclient(event, timeout)
+        return getFileNames_dasgoclient(event)
     # default action
     for path in os.getenv('PATH').split(':'):
         if  os.path.isfile(os.path.join(path, 'dasgoclient')):
-            return getFileNames_dasgoclient(event, timeout)
+            return getFileNames_dasgoclient(event)
     return getFileNames_das_client(event)
 
 def getFileNames_das_client(event):
@@ -118,39 +118,21 @@ def getFileNames_das_client(event):
 
     return files
 
-def getFileNames_dasgoclient(event, timeout=15):
+def getFileNames_dasgoclient(event):
     """Return files for given DAS query via dasgoclient"""
     query = "file dataset=%(dataset)s run=%(run)i lumi=%(lumi)i" % event
     cmd = ['dasgoclient', '-query', query, '-json']
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     files = []
-    try:
-        out, err = proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        print("DAS query timeout")
-        out, err = proc.communicate()
-    exit_code = proc.returncode
-    if err or (exit_code != 0):
-        print("DAS command:",cmd)
-        print("DAS query error: return code {0}\n--- Standard output---".format(exit_code))
-        print(out.decode('utf8'))
-        print("--- Standard error---")
-        print(err.decode('utf8'))
-        print("--- End ---")
-        exit(1)
+    err = proc.stderr.read()
+    if  err:
+        print("DAS error: %s" % err)
     else:
-        try:
-            for row in json.loads(out):
-                for rec in row.get('file', []):
-                    fname = rec.get('name', '')
-                    if fname:
-                        files.append(fname)
-        except json.decoder.JSONDecodeError:
-            print("dasgoclient returned invalid JSON:")
-            print(out.decode('utf8'))
-            print("--- End ---")
-            exit(1)
+        for row in json.load(proc.stdout):
+            for rec in row.get('file', []):
+                fname = rec.get('name', '')
+                if fname:
+                    files.append(fname)
     return files
 
 def fullCPMpath():
@@ -270,9 +252,6 @@ https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookPickEvents ''')
     parser.add_option ('--das-client', dest='das_cli', type='string',
                        default=das_cli,
                        help="Specify das client to use (default '%s')" % das_cli )
-    parser.add_option ('--das-client-timeout', dest='dasClientTimeout', type='int',
-                       default=15,
-                       help = 'Timeout in seconds after which das client command should be timed out.')
     (options, args) = parser.parse_args()
 
 
@@ -349,7 +328,7 @@ https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookPickEvents ''')
         files = []
         eventPurgeList = []
         for event in eventList:
-            eventFiles = getFileNames(event, options.das_cli, options.dasClientTimeout)
+            eventFiles = getFileNames(event, options.das_cli)
             if eventFiles == ['[]']: # event not contained in the input dataset
                 print("** WARNING: ** According to a DAS query, run = %i; lumi = %i; event = %i not contained in %s.  Skipping."%(event.run,event.lumi,event.event,event.dataset))
                 eventPurgeList.append( event )

--- a/PhysicsTools/Utilities/test/test_edmPickEvents.sh
+++ b/PhysicsTools/Utilities/test/test_edmPickEvents.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 #Dataset, Run, Lumi and Events are copied from Workflows 4.22
 
-if ! edmPickEvents.py "/Cosmics/Run2011A-v1/RAW" 160960:277:10001082,160960:277:10001058,160960:277:10001650 > run_edmCopyPickMerge.sh ; then
+if ! edmPickEvents.py "/JetHT/Run2018A-PromptReco-v1/MINIAOD" 315489:31:19015199,315489:31:19098714,315489:31:18897114  > run_edmCopyPickMerge.sh ; then
   cat run_edmCopyPickMerge.sh
   exit 1
 fi

--- a/PhysicsTools/Utilities/test/test_edmPickEvents.sh
+++ b/PhysicsTools/Utilities/test/test_edmPickEvents.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -ex
 #Dataset, Run, Lumi and Events are copied from Workflows 4.22
 
-edmPickEvents.py  "/Cosmics/Run2011A-v1/RAW" 160960:277:10001082,160960:277:10001058,160960:277:10001650 > run_edmCopyPickMerge.sh
+if ! edmPickEvents.py --das-client-timeout 300 "/Cosmics/Run2011A-v1/RAW" 160960:277:10001082,160960:277:10001058,160960:277:10001650 > run_edmCopyPickMerge.sh ; then
+  cat run_edmCopyPickMerge.sh
+  exit 1
+fi
 chmod +x run_edmCopyPickMerge.sh
 ./run_edmCopyPickMerge.sh

--- a/PhysicsTools/Utilities/test/test_edmPickEvents.sh
+++ b/PhysicsTools/Utilities/test/test_edmPickEvents.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 #Dataset, Run, Lumi and Events are copied from Workflows 4.22
 
-if ! edmPickEvents.py --das-client-timeout 300 "/Cosmics/Run2011A-v1/RAW" 160960:277:10001082,160960:277:10001058,160960:277:10001650 > run_edmCopyPickMerge.sh ; then
+if ! edmPickEvents.py "/Cosmics/Run2011A-v1/RAW" 160960:277:10001082,160960:277:10001058,160960:277:10001650 > run_edmCopyPickMerge.sh ; then
   cat run_edmCopyPickMerge.sh
   exit 1
 fi


### PR DESCRIPTION
#37208 PR added a timeout of 15 sec for `edmPickEvents.py` . The unit test query takes more than 15s that is why it is now very frequently failing. I have reverted the change in #37208 and updated the unit test script to properly dump the output if  `edmPickEvents.py` fails. 

I also have updated the dataset used for querying das. Now unit test uses the dataset used by workflow `136.8521` . This allows unit test to make use of already cached das results and open already existing data file from ibeos cache