### PR TITLE
Clean up redundant edm ParameterSet existAs or exist in RecoLocalMuon

### DIFF
--- a/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.cc
+++ b/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.cc
@@ -32,43 +32,39 @@ GEMRecHitProducer::GEMRecHitProducer(const ParameterSet& config)
   // Get masked- and dead-strip information from file
   applyMasking_ = config.getParameter<bool>("applyMasking");
   if (applyMasking_) {
-    if (config.existsAs<edm::FileInPath>("maskFile")) {
       maskSource_ = MaskSource::File;
-      std::ifstream inputFile(config.getParameter<edm::FileInPath>("maskFile").fullPath());
-      if (!inputFile) {
+      std::ifstream inputmaskFile(config.getParameter<edm::FileInPath>("maskFile").fullPath());
+      if (!inputmaskFile) {
         throw cms::Exception("GEMRecHitProducer") << "Masked Strips File cannot not be opened";
       }
       theGEMMaskedStripsObj = std::make_unique<GEMMaskedStrips>();
-      while (inputFile.good()) {
+      while (inputmaskFile.good()) {
         GEMMaskedStrips::MaskItem Item;
-        inputFile >> Item.rawId >> Item.strip;
-        if (inputFile.good())
+        inputmaskFile >> Item.rawId >> Item.strip;
+        if (inputmaskFile.good())
           theGEMMaskedStripsObj->fillMaskVec(Item);
       }
-      inputFile.close();
-    }
+      inputmaskFile.close();
 
-    if (config.existsAs<edm::FileInPath>("deadFile")) {
       deadSource_ = MaskSource::File;
-      std::ifstream inputFile(config.getParameter<edm::FileInPath>("deadFile").fullPath());
-      if (!inputFile) {
+      std::ifstream inputdeadFile(config.getParameter<edm::FileInPath>("deadFile").fullPath());
+      if (!inputdeadFile) {
         throw cms::Exception("GEMRecHitProducer") << "Dead Strips File cannot not be opened";
       }
       theGEMDeadStripsObj = std::make_unique<GEMDeadStrips>();
-      while (inputFile.good()) {
+      while (inputdeadFile.good()) {
         GEMDeadStrips::DeadItem Item;
-        inputFile >> Item.rawId >> Item.strip;
-        if (inputFile.good())
+        inputdeadFile >> Item.rawId >> Item.strip;
+        if (inputdeadFile.good())
           theGEMDeadStripsObj->fillDeadVec(Item);
       }
-      inputFile.close();
-    }
-    if (maskSource_ == MaskSource::EventSetup) {
-      maskedStripsToken_ = esConsumes<GEMMaskedStrips, GEMMaskedStripsRcd, edm::Transition::BeginRun>();
-    }
-    if (deadSource_ == MaskSource::EventSetup) {
-      deadStripsToken_ = esConsumes<GEMDeadStrips, GEMDeadStripsRcd, edm::Transition::BeginRun>();
-    }
+      inputdeadFile.close();
+      if (maskSource_ == MaskSource::EventSetup) {
+        maskedStripsToken_ = esConsumes<GEMMaskedStrips, GEMMaskedStripsRcd, edm::Transition::BeginRun>();
+      }
+      if (deadSource_ == MaskSource::EventSetup) {
+        deadStripsToken_ = esConsumes<GEMDeadStrips, GEMDeadStripsRcd, edm::Transition::BeginRun>();
+      }
   }
 }
 


### PR DESCRIPTION
#### PR description:  
(Technical PR) Optimization of the module configurations: Improve maintainability by cleaning up redundant cases of edm::ParameterSet calls to `existAs` or `exist` for tracked parameters, where redundancy is based on the value being already defined by `fillDescriptions`.
#### Motivation: 
values of tracked parameters should be properly defined in the configuration and be visible in the process configuration provenance; code that checks for the existence of a parameter and sets a hardcoded default would bypass the configuration provenance registration and should be avoided. In general, default parameter values should be provided via `fillDescriptions`, as detailed in [SWGuideConfigValidation](https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideConfigurationValidationAndHelp). Redundant calls to `existAs` or `exist` can be **cleaned up**.

As follow the previous [PR36746](https://github.com/cms-sw/cmssw/pull/36746),  [PR36989](https://github.com/cms-sw/cmssw/pull/36989).

The list of all calls of `existAs` or `exist` are automatically available in the Static Analyzer report. (Bug: CMS code rules)
It is accessible from IB page. https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/
For this task consider only modules or tools used by the modules that define `fillDescriptions`.

In this PR, 1 file was changed.  
RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.cc
 
Here, the "maskFile", "deadFile" parameters are provided in a `fillDescription` .

#### PR validation:
Tested in CMSSW_12_3_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)