### PR TITLE
L1T ASAN heap-buffer-overflow fix resulting from PR #36919 (12_4_X)

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Packer.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Packer.cc
@@ -108,11 +108,11 @@ namespace l1t {
             HcalTrigTowerDetId id(cEta, cPhi);
             const auto tp = hcalTPGs->find(id);
 
-            int fg_bits = 0;
-            for (int index = 0; index < 6; index++)
-              fg_bits += tp->SOI_fineGrain(index) << index;
-
             if (tp != hcalTPGs->end()) {
+              uint32_t fg_bits = 0;
+              for (int index = 0; index < 6; index++)
+                fg_bits |= tp->SOI_fineGrain(index) << index;
+
               ctp7Data.setET(cType, negativeEta, iEta, iPhi, tp->SOI_compressedEt());
               ctp7Data.setFB(cType, negativeEta, iEta, iPhi, fg_bits);
             }


### PR DESCRIPTION
#### PR description:

Fixing the heap-buffer-overflow in `l1t::stage2::CaloLayer1Packer::makeHCalTPGs()` resulting from PR #36919, and identified in Issue #37012. One file is changed: `CaloLayer1Packer.cc`, moving the loop that sets `fg_bits` to inside the conditional to ensure that this is only done when `id` is found. `fg_bits` is declared as a uint_32, and the bit setting is done via |= (more robust than the initial implementation).

#### PR validation:

Passed `runTheMatrix.py` in `CMSSW_12_4_X_2022-03-14-2300`.

In `CMSSW_12_4_ASAN_X_2022-03-14-1100`, step2 heap-buffer-overflow is resolved, tested with `runTheMatrix.py -l 39834.0`.

This is a forward PR to current master (12_4_X), instead of PR #37253 by request. Would eventually like to be included in 12_3_X via backport. 