### PR TITLE
use git init instead of git cms-init which creates a sparse checkout area

### DIFF
--- a/FWCore/Skeletons/test/runtests.sh
+++ b/FWCore/Skeletons/test/runtests.sh
@@ -10,7 +10,7 @@ cd $SCRAM_TEST_NAME
 scram -a $SCRAM_ARCH project $CMSSW_VERSION
 cd $CMSSW_VERSION/src
 eval `scram run -sh`
-git cms-init
+git init
 
 # Copy FWCore/Skeletons in cause unit test is run during PR tests which contains changes for FWCore/Skeletons
 if [ -d $OLD_CMSSW_BASE/src/FWCore/Skeletons ] ; then


### PR DESCRIPTION
Unit test TestFWCoreSkeletons is using `git cms-init` which creates a sparse checkout area and causes the test to fail. Using `git init` should fix this issue.

Although unit tests fails for IBs (  https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc10/CMSSW_12_4_X_2022-03-16-2300/unitTestLogs/FWCore/Skeletons#/  ) but it is not visible via the IB dashboard. This is because the unit tests is internally creating and compiling packages which confuses ourunit test log parser ( https://github.com/cms-sw/cms-bot/blob/master/checkTestLog.py#L107-L108 ) which search for messages like
```
>> Entering Package ...
>> Leaving Package  ...
```
https://github.com/cms-sw/cmsdist/pull/7698 should fix this parsing issue