### PR TITLE
Associated PF for Egamma in 2018 PbPb miniAOD

### DIFF
--- a/CommonTools/ParticleFlow/python/pfEGammaToCandidateRemapper_cfi.py
+++ b/CommonTools/ParticleFlow/python/pfEGammaToCandidateRemapper_cfi.py
@@ -7,3 +7,5 @@ pfEGammaToCandidateRemapper = cms.EDProducer("PFEGammaToCandidateRemapper",
     photon2pf = cms.InputTag("particleBasedIsolation","gedPhotons"), 
     pf2pf = cms.InputTag("FILLME")
 )
+
+pfEGammaToCandidateRemapperCleaned = pfEGammaToCandidateRemapper.clone(pf2pf = "cleanedParticleFlow")

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -7,6 +7,7 @@ from PhysicsTools.PatAlgos.slimming.offlineSlimmedPrimaryVertices_cfi import *
 from PhysicsTools.PatAlgos.slimming.offlineSlimmedPrimaryVertices4D_cfi import *
 from PhysicsTools.PatAlgos.slimming.offlineSlimmedPrimaryVerticesWithBS_cfi import *
 from CommonTools.RecoAlgos.primaryVertexAssociation_cfi import *
+from CommonTools.ParticleFlow.pfEGammaToCandidateRemapper_cfi import *
 from PhysicsTools.PatAlgos.slimming.genParticles_cff import *
 from PhysicsTools.PatAlgos.slimming.genParticleAssociation_cff import *
 from PhysicsTools.PatAlgos.slimming.selectedPatTrigger_cfi import *

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -92,6 +92,7 @@ pp_on_AA.toReplaceWith(
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 run2_miniAOD_pp_on_AA_103X.toReplaceWith(slimmingTask,cms.Task(primaryVertexAssociationCleaned,slimmingTask.copy()))
 run2_miniAOD_pp_on_AA_103X.toReplaceWith(slimmingTask,cms.Task(primaryVertexWithBSAssociationCleaned,slimmingTask.copy()))
+run2_miniAOD_pp_on_AA_103X.toReplaceWith(slimmingTask,cms.Task(pfEGammaToCandidateRemapperCleaned,slimmingTask.copy()))
 
 from RecoHI.HiTracking.miniAODVertexRecovery_cff import offlinePrimaryVerticesRecovery, offlineSlimmedPrimaryVerticesRecovery
 pp_on_AA.toReplaceWith(

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -105,13 +105,9 @@ pp_on_AA.toModify(
     hiPhotonIsolationMapOutput = "photonIsolationHIProducerppGED"
 )
 
-from RecoHI.HiJetAlgos.HiBadParticleCleaner_cfi import cleanedParticleFlow
-from CommonTools.ParticleFlow.pfEGammaToCandidateRemapper_cfi import pfEGammaToCandidateRemapper as pfEGammaToCandidateRemapperCleaned
-pfEGammaToCandidateRemapperCleaned.pf2pf = cms.InputTag("cleanedParticleFlow")
-
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 run2_miniAOD_pp_on_AA_103X.toModify(
     reducedEgamma,
-    photonsPFValMap = cms.InputTag("pfEGammaToCandidateRemapperCleaned:photons"),
-    gsfElectronsPFValMap = cms.InputTag("pfEGammaToCandidateRemapperCleaned:electrons")
+    photonsPFValMap = "pfEGammaToCandidateRemapperCleaned:photons",
+    gsfElectronsPFValMap = "pfEGammaToCandidateRemapperCleaned:electrons"
 )

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -104,3 +104,14 @@ pp_on_AA.toModify(
     hiPhotonIsolationMapInput = "photonIsolationHIProducerppGED",
     hiPhotonIsolationMapOutput = "photonIsolationHIProducerppGED"
 )
+
+from RecoHI.HiJetAlgos.HiBadParticleCleaner_cfi import cleanedParticleFlow
+from CommonTools.ParticleFlow.pfEGammaToCandidateRemapper_cfi import pfEGammaToCandidateRemapper as pfEGammaToCandidateRemapperCleaned
+pfEGammaToCandidateRemapperCleaned.pf2pf = cms.InputTag("cleanedParticleFlow")
+
+from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
+run2_miniAOD_pp_on_AA_103X.toModify(
+    reducedEgamma,
+    photonsPFValMap = cms.InputTag("pfEGammaToCandidateRemapperCleaned:photons"),
+    gsfElectronsPFValMap = cms.InputTag("pfEGammaToCandidateRemapperCleaned:electrons")
+)

--- a/RecoHI/HiJetAlgos/plugins/HiBadParticleCleaner.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiBadParticleCleaner.cc
@@ -94,7 +94,7 @@ void HiBadParticleCleaner::produce(edm::StreamID, edm::Event& iEvent, const edm:
 
   size_t n = pfCandidates->size();
   std::vector<int> oldToNew(n);
-  int iPF = -1;
+  size_t iPF = -1;
   for (const reco::PFCandidate& pfCandidate : *pfCandidates) {
     iPF++;
     if (pfCandidate.particleId() == reco::PFCandidate::ParticleType::mu)  // muon cleaning

--- a/RecoHI/HiJetAlgos/plugins/HiBadParticleCleaner.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiBadParticleCleaner.cc
@@ -92,7 +92,7 @@ void HiBadParticleCleaner::produce(edm::StreamID, edm::Event& iEvent, const edm:
 
   bool foundBadCandidate = false;
 
-  int n = pfCandidates->size();
+  size_t n = pfCandidates->size();
   std::vector<int> oldToNew(n);
   int iPF = -1;
   for (const reco::PFCandidate& pfCandidate : *pfCandidates) {

--- a/RecoHI/HiJetAlgos/plugins/HiBadParticleCleaner.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiBadParticleCleaner.cc
@@ -32,7 +32,7 @@ private:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   // ----------member data ---------------------------
 
-  edm::EDGetTokenT<edm::View<reco::PFCandidate> > tokenPFCandidates_;
+  edm::EDGetTokenT<edm::View<reco::PFCandidate>> tokenPFCandidates_;
   edm::EDGetTokenT<reco::VertexCollection> tokenPV_;
 
   const double minMuonPt_;
@@ -51,7 +51,7 @@ private:
 // constructors and destructor
 //
 HiBadParticleCleaner::HiBadParticleCleaner(const edm::ParameterSet& iConfig)
-    : tokenPFCandidates_(consumes<edm::View<reco::PFCandidate> >(iConfig.getParameter<edm::InputTag>("PFCandidates"))),
+    : tokenPFCandidates_(consumes<edm::View<reco::PFCandidate>>(iConfig.getParameter<edm::InputTag>("PFCandidates"))),
       tokenPV_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("offlinePV"))),
       minMuonPt_(iConfig.getParameter<double>("minMuonPt")),
       minChargedHadronPt_(iConfig.getParameter<double>("minChargedHadronPt")),
@@ -133,7 +133,7 @@ void HiBadParticleCleaner::produce(edm::StreamID, edm::Event& iEvent, const edm:
 
           if (sig3d > maxSigLoose_) {
             pBadCandidateCollection->push_back(pfCandidate);
-            oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+            oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
             foundBadCandidate = true;
             continue;
           }
@@ -141,14 +141,14 @@ void HiBadParticleCleaner::produce(edm::StreamID, edm::Event& iEvent, const edm:
           if (track->pt() < pfCandidate.pt() / 1.5 || track->pt() > pfCandidate.pt() * 1.5) {
             foundBadCandidate = true;
             pBadCandidateCollection->push_back(pfCandidate);
-            oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+            oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
             continue;
           }
           if (track->originalAlgo() == reco::TrackBase::muonSeededStepOutIn &&
               track->hitPattern().trackerLayersWithMeasurement() < minTrackerLayersForMuonTight_) {
             foundBadCandidate = true;
             pBadCandidateCollection->push_back(pfCandidate);
-            oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+            oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
             continue;
           }
         }
@@ -164,7 +164,7 @@ void HiBadParticleCleaner::produce(edm::StreamID, edm::Event& iEvent, const edm:
         if ((nHits < minTrackNHits_ && nPixelHits < minPixelNHits_) || nHits == 3) {
           foundBadCandidate = true;
           pBadCandidateCollection->push_back(pfCandidate);
-          oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+          oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
           continue;
         }
 
@@ -185,14 +185,14 @@ void HiBadParticleCleaner::produce(edm::StreamID, edm::Event& iEvent, const edm:
         if (sig3d > maxSigLoose_) {
           foundBadCandidate = true;
           pBadCandidateCollection->push_back(pfCandidate);
-          oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+          oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
           continue;
         }
 
         if (sig3d > maxSigTight_ && nHits < minTrackNHits_) {
           foundBadCandidate = true;
           pBadCandidateCollection->push_back(pfCandidate);
-          oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+          oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
           continue;
         }
 
@@ -203,14 +203,14 @@ void HiBadParticleCleaner::produce(edm::StreamID, edm::Event& iEvent, const edm:
           if (sig3d > maxSigLoose_) {
             foundBadCandidate = true;
             pBadCandidateCollection->push_back(pfCandidate);
-            oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+            oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
             continue;
           }
 
           if (nHits < minTrackNHits_) {
             foundBadCandidate = true;
             pBadCandidateCollection->push_back(pfCandidate);
-            oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+            oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
             continue;
           }
         }
@@ -221,21 +221,21 @@ void HiBadParticleCleaner::produce(edm::StreamID, edm::Event& iEvent, const edm:
           if (sig3d > maxSigTight_) {
             foundBadCandidate = true;
             pBadCandidateCollection->push_back(pfCandidate);
-            oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+            oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
             continue;
           }
 
           if (nHits < minTrackNHits_) {
             foundBadCandidate = true;
             pBadCandidateCollection->push_back(pfCandidate);
-            oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+            oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
             continue;
           }
 
           if (nPixelHits < minPixelNHits_) {
             foundBadCandidate = true;
             pBadCandidateCollection->push_back(pfCandidate);
-            oldToNew[iPF] = -1*(pBadCandidateCollection->size());
+            oldToNew[iPF] = -1 * (pBadCandidateCollection->size());
             continue;
           }
         }


### PR DESCRIPTION
**Description**

PF candidate association is necessary for a GED electron/photon to avoid double counting energy in PF isolation.

In AOD, the association is stored in `particleBasedIsolation` object. In miniAOD, association is accessible via `associatedPackedPFCandidates()` of a pat electron/photon (e.g. [here](https://github.com/cms-sw/cmssw/blob/4883b2eac701c829419f974811c1cd2f6550bd56/DataFormats/PatCandidates/interface/Photon.h#L314)), the AOD-2-miniAOD process transfers the association between objects.

Currently, the transfer does not work correctly for 2018 PbPb data, i.e. `run2_miniAOD_pp_on_AA_103X` process. This is understood as packedPFcandidates in this workflow is made from an intermediate, "cleaned" PF collection (introduced via [PR](https://github.com/cms-sw/cmssw/pull/31668)) and while references in `particleBasedIsolation` are still the ones from original PF collection. The `associatedPackedPFCandidates` collection created in current workflow is not correct.

This PR fixes the problem by producing a map between original (old) and the cleaned (new) PF candidate references and updating the references in `particleBasedIsolation` from old to new ones.

**Validation**
Tests pass wf 140.5611 and give correct output.

@mandrenguyen