### PR TITLE
edmPickEvent: print the actual das output instead of json parsing error

### DIFF
--- a/PhysicsTools/Utilities/scripts/edmPickEvents.py
+++ b/PhysicsTools/Utilities/scripts/edmPickEvents.py
@@ -127,12 +127,19 @@ def getFileNames_dasgoclient(event):
     err = proc.stderr.read()
     if  err:
         print("DAS error: %s" % err)
+        print(proc.stdout.read())
+        sys.exit(1)
     else:
-        for row in json.load(proc.stdout):
-            for rec in row.get('file', []):
-                fname = rec.get('name', '')
-                if fname:
-                    files.append(fname)
+        dasout = proc.stdout.read()
+        try:
+            for row in json.loads(dasout):
+                for rec in row.get('file', []):
+                    fname = rec.get('name', '')
+                    if fname:
+                        files.append(fname)
+        except:
+            print(dasout)
+            sys.exit(1)
     return files
 
 def fullCPMpath():

--- a/PhysicsTools/Utilities/test/test_edmPickEvents.sh
+++ b/PhysicsTools/Utilities/test/test_edmPickEvents.sh
@@ -1,9 +1,4 @@
 #!/bin/bash -ex
 #Dataset, Run, Lumi and Events are copied from Workflows 4.22
 
-if ! edmPickEvents.py "/JetHT/Run2018A-PromptReco-v1/MINIAOD" 315489:31:19015199,315489:31:19098714,315489:31:18897114  > run_edmCopyPickMerge.sh ; then
-  cat run_edmCopyPickMerge.sh
-  exit 1
-fi
-chmod +x run_edmCopyPickMerge.sh
-./run_edmCopyPickMerge.sh
+edmPickEvents.py --runInteractive "/JetHT/Run2018A-PromptReco-v1/MINIAOD" 315489:31:19015199,315489:31:19098714,315489:31:18897114

--- a/PhysicsTools/Utilities/test/test_edmPickEvents.sh
+++ b/PhysicsTools/Utilities/test/test_edmPickEvents.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
-#Dataset, Run, Lumi and Events are copied from Workflows 4.22
+#Dataset, Run, Lumi and Events are copied from Workflows 136.8521
 
+export CMS_BOT_USE_DASGOCLIENT=true
 edmPickEvents.py --runInteractive "/JetHT/Run2018A-PromptReco-v1/MINIAOD" 315489:31:19015199,315489:31:19098714,315489:31:18897114


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/pull/37255 should have fixed the edmPickEvent unit test but looks like dasgoclient still fails during IB tests. This PR prints the actual dasgoclient output in case of json parse errors.

Note this change does not fix the unit test itself but just to have more verbose output of edmPickEvent (in case of failures)