### PR TITLE
Migrate to D88 wfs and clean up

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -33,7 +33,7 @@ numWFIB.extend([38234.0]) #2026D85
 numWFIB.extend([38634.0]) #2026D86
 numWFIB.extend([39034.0]) #2026D87
 numWFIB.extend([39434.0,39434.911,39434.103]) #2026D88 DDD XML, DD4hep XML, aging
-numWFIB.extend([39461.97]) #2026D88 premixing stage1 (NuGun+PU)
+numWFIB.extend([39661.97]) #2026D88 premixing stage1 (NuGun+PU)
 numWFIB.extend([39434.5,39434.9,39434.501,39434.502]) #2026D88 pixelTrackingOnly, vector hits, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
 numWFIB.extend([39634.99,39634.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([39434.21,39634.21,39634.9921]) #2026D88 prodlike, prodlike PU, prodlike premix stage1+stage2

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -15,18 +15,13 @@ from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgra
 #2026 WFs to run in IB (TTbar)
 numWFIB = []
 numWFIB.extend([23234.0]) #2026D49
-numWFIB.extend([23461.97]) #2026D49 premixing stage1 (NuGun+PU)
 numWFIB.extend([23434.99,23434.999]) #2026D49 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([23234.21,23434.21,23434.9921]) #2026D49 prodlike, prodlike PU, prodlike premix stage1+stage2
-numWFIB.extend([23234.103]) #2026D49 aging
-numWFIB.extend([23234.9]) #2026D49 vector hits
 numWFIB.extend([28234.0]) #2026D60
 numWFIB.extend([31434.0]) #2026D68
 numWFIB.extend([32234.0]) #2026D70
 numWFIB.extend([34634.0]) #2026D76
-numWFIB.extend([35034.0,35034.911]) #2026D77,DD4hep
-numWFIB.extend([35234.99,35234.999]) #2026D77 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
-numWFIB.extend([35034.21,35234.21,35234.9921]) #2026D77 prodlike, prodlike PU, prodlike premix stage1+stage2
+numWFIB.extend([35034.0]) #2026D77
 numWFIB.extend([35434.0]) #2026D78
 numWFIB.extend([35834.0]) #2026D79
 numWFIB.extend([36234.0]) #2026D80
@@ -37,15 +32,17 @@ numWFIB.extend([37834.0]) #2026D84
 numWFIB.extend([38234.0]) #2026D85
 numWFIB.extend([38634.0]) #2026D86
 numWFIB.extend([39034.0]) #2026D87
-numWFIB.extend([39434.0,39434.5,39434.501,39434.502,39434.911]) #2026D88, pixelTrackingOnly, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU, DD4hep
+numWFIB.extend([39434.0,39434.911,39434.103]) #2026D88 DDD XML, DD4hep XML, aging
+numWFIB.extend([39461.97]) #2026D88 premixing stage1 (NuGun+PU)
+numWFIB.extend([39434.5,39434.9,39434.501,39434.502]) #2026D88 pixelTrackingOnly, vector hits, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
 numWFIB.extend([39634.99,39634.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([39434.21,39634.21,39634.9921]) #2026D88 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([39834.0]) #2026D89
 numWFIB.extend([40234.0]) #2026D90
 numWFIB.extend([40634.0]) #2026D91
 
-#additional sample for short matrix
-#CloseByPGun
+#Additional sample for short matrix and IB
+#CloseByPGun for HGCAL
 numWFIB.extend([39496.0]) #CE_E_Front_120um D88
 numWFIB.extend([39500.0]) #CE_H_Coarse_Scint D88
 

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -24,8 +24,6 @@ numWFIB.extend([28234.0]) #2026D60
 numWFIB.extend([31434.0]) #2026D68
 numWFIB.extend([32234.0]) #2026D70
 numWFIB.extend([34634.0]) #2026D76
-numWFIB.extend([34834.99,34834.999]) #2026D76 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
-numWFIB.extend([34634.21,34834.21,34834.9921]) #2026D76 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([35034.0,35034.911]) #2026D77,DD4hep
 numWFIB.extend([35234.99,35234.999]) #2026D77 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([35034.21,35234.21,35234.9921]) #2026D77 prodlike, prodlike PU, prodlike premix stage1+stage2
@@ -39,9 +37,9 @@ numWFIB.extend([37834.0]) #2026D84
 numWFIB.extend([38234.0]) #2026D85
 numWFIB.extend([38634.0]) #2026D86
 numWFIB.extend([39034.0]) #2026D87
-numWFIB.extend([39434.0,39434.21,39434.5,39434.501,39434.502,39434.911]) #2026D88, prodlike, pixelTrackingOnly, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU, DD4hep
-#numWFIB.extend([39634.99,39634.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
-#numWFIB.extend([39634.21,39634.9921]) #2026D88 prodlike PU, prodlike premix stage1+stage2
+numWFIB.extend([39434.0,39434.5,39434.501,39434.502,39434.911]) #2026D88, pixelTrackingOnly, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU, DD4hep
+numWFIB.extend([39634.99,39634.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
+numWFIB.extend([39434.21,39634.21,39634.9921]) #2026D88 prodlike, prodlike PU, prodlike premix stage1+stage2
 numWFIB.extend([39834.0]) #2026D89
 numWFIB.extend([40234.0]) #2026D90
 numWFIB.extend([40634.0]) #2026D91

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3469,7 +3469,7 @@ defaultDataSets['2024']='CMSSW_12_0_0_pre4-120X_mcRun3_2024_realistic_v2-v'
 defaultDataSets['2026D49']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D49noPU-v'
 defaultDataSets['2026D76']='CMSSW_12_0_0_pre4-113X_mcRun4_realistic_v7_2026D76noPU-v'
 defaultDataSets['2026D77']='CMSSW_12_1_0_pre2-113X_mcRun4_realistic_v7_2026D77noPU-v'
-#defaultDataSets['2026D88']='CMSSW_12_2_0_pre3-122X_mcRun4_realistic_v4_2026D88noPU-v'
+defaultDataSets['2026D88']='CMSSW_12_3_0_pre5-123X_mcRun4_realistic_v4_2026D88noPU-v'
 
 puDataSets = {}
 for key, value in defaultDataSets.items(): puDataSets[key+'PU'] = value

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -98,11 +98,10 @@ if __name__ == '__main__':
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
                      28234.0, #2026D60 (exercise HF nose)
-                     35034.0, #2026D77 ttbar (2021 new baseline)
-                     35234.999, #2026D77 ttbar premixing stage1+stage2, PU50 (to be removed when migration to D88 is complete)
-                     38634.0, #2026D86 ttbar (to be removed when migration to D88 is complete)
-                     39434.0, #2026D88 ttbar
-                     #39634.999, #2026D88 ttbar premixing stage1+stage2, PU50
+                     35034.0, #2026D77 ttbar
+                     39434.0, #2026D88 ttbar (2022 new baseline)
+                     39434.911 #2026D88 ttbar DD4hep XML
+                     39634.999, #2026D88 ttbar premixing stage1+stage2, PU50
                      39496.0, #CE_E_Front_120um D88
                      39500.0, #CE_H_Coarse_Scint D88 
                      25202.0, #2016 ttbar UP15 PU

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
                      28234.0, #2026D60 (exercise HF nose)
                      35034.0, #2026D77 ttbar
                      39434.0, #2026D88 ttbar (2022 new baseline)
-                     39434.911 #2026D88 ttbar DD4hep XML
+                     39434.911, #2026D88 ttbar DD4hep XML
                      39634.999, #2026D88 ttbar premixing stage1+stage2, PU50
                      39496.0, #CE_E_Front_120um D88
                      39500.0, #CE_H_Coarse_Scint D88 


### PR DESCRIPTION
#### PR description:
This PR follows the green light of D88 validation report at PPD General ([March 17](https://indico.cern.ch/event/1139390/))

The PU workflow of D88 is added to IB. In addition, DD4hep wf of D88 is added to the short matrix, and there is a clean up in the list of the short matrix and IB workflows.

#### PR validation:
-

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport, and no need of backport.