### PR TITLE
Introduce generalized abstraction for Strip Payload Inspector

### DIFF
--- a/CondCore/SiStripPlugins/interface/SiStripCondObjectRepresent.h
+++ b/CondCore/SiStripPlugins/interface/SiStripCondObjectRepresent.h
@@ -1,0 +1,1007 @@
+#ifndef CondCore_SiStripPlugins_SiStripCondObjectRepresent_h
+#define CondCore_SiStripPlugins_SiStripCondObjectRepresent_h
+
+// system includes
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// user includes
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+#include "CommonTools/TrackerMap/interface/TrackerMap.h"
+#include "CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+// ROOT includes
+#include "TCanvas.h"
+#include "TColor.h"
+#include "TGaxis.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TLatex.h"
+#include "TLegend.h"
+#include "TLine.h"
+#include "TPaveLabel.h"
+#include "TProfile.h"
+#include "TROOT.h"
+#include "TStyle.h"
+
+//functions for correct representation of data in summary and plot
+namespace SiStripCondObjectRepresent {
+
+  enum plotType { STANDARD, COMPARISON, DIFF, RATIO, MAP, END_OF_TYPES };
+  enum granularity { PERSTRIP, PERAPV, PERMODULE };
+
+  template <class type>
+  class SiStripCondDataItem {
+  public:
+    SiStripCondDataItem() { init(); }
+
+    virtual ~SiStripCondDataItem() = default;
+
+    void fillAll(unsigned int detid, const std::vector<type> &store) {
+      m_info[detid] = store;
+      m_cached = true;
+      return;
+    }
+
+    void fillByPushBack(unsigned int detid, const type &value) {
+      m_info[detid].push_back(value);
+      m_cached = true;
+    }
+
+    void divide(unsigned int detid, const std::vector<type> &denominator) {
+      if (m_info[detid].size() != denominator.size()) {
+        throw cms::Exception("Unaligned Conditions")
+            << "data size of numerator mismatched the data size of denominator";
+      }
+
+      unsigned int counter = 0;
+      for (const auto &den : denominator) {
+        m_info[detid].at(counter) /= den;
+        counter++;
+      }
+    }
+
+    void subtract(unsigned int detid, const std::vector<type> &subtractor) {
+      if (m_info[detid].size() != subtractor.size()) {
+        throw cms::Exception("Unaligned Conditions")
+            << "data size of numerator mismatched the data size of denominator";
+      }
+
+      unsigned int counter = 0;
+      for (const auto &sub : subtractor) {
+        m_info[detid].at(counter) -= sub;
+        counter++;
+      }
+    }
+
+    std::vector<type> data(unsigned int detid) { return m_info[detid]; }
+
+    std::pair<std::vector<type>, std::vector<type> > demuxedData(unsigned int detid) {
+      if (m_compared) {
+        std::vector<type> v1(m_info[detid].begin(), m_info[detid].begin() + m_info[detid].size() / 2);
+        std::vector<type> v2(m_info[detid].begin() + m_info[detid].size() / 2, m_info[detid].end());
+        assert(v1.size() == v2.size());
+        return std::make_pair(v1, v2);
+      } else {
+        throw cms::Exception("Logic error") << "not being in compared mode, data cannot be demultiplexed";
+      }
+    }
+
+    void fillMonitor1D(const SiStripPI::OpMode &mymode,
+                       SiStripPI::Monitor1D *&mon,
+                       SiStripPI::Entry &entry,
+                       std::vector<type> &values,
+                       const unsigned int prev_det,
+                       unsigned int &prev_apv,
+                       const unsigned int detid) {
+      unsigned int istrip = 0;
+      for (const auto &value : values) {
+        bool flush = false;
+        switch (mymode) {
+          case (SiStripPI::APV_BASED):
+            flush = (prev_det != 0 && prev_apv != istrip / sistrip::STRIPS_PER_APV);
+            break;
+          case (SiStripPI::MODULE_BASED):
+            flush = (prev_det != 0 && prev_det != detid);
+            break;
+          case (SiStripPI::STRIP_BASED):
+            flush = (istrip != 0);
+            break;
+        }
+
+        if (flush) {
+          mon->Fill(prev_apv, prev_det, entry.mean());
+          entry.reset();
+        }
+
+        entry.add(value);
+
+        prev_apv = istrip / sistrip::STRIPS_PER_APV;
+        istrip++;
+      }
+    }
+
+    void setGranularity(bool isPerStrip, bool isPerAPV) {
+      m_servedPerStrip = isPerStrip;
+      m_servedPerAPV = isPerAPV;
+    }
+
+    bool isCached() { return m_cached; }
+
+    void setComparedBit() { m_compared = true; }
+
+    std::vector<unsigned int> detIds(bool verbose) {
+      std::vector<unsigned int> v;
+      for (const auto &element : m_info) {
+        if (verbose) {
+          std::cout << element.first << "\n";
+        }
+        v.push_back(element.first);
+      }
+
+      return v;
+    }
+
+  private:
+    std::map<unsigned int, std::vector<type> > m_info;
+    bool m_servedPerStrip;
+    bool m_servedPerAPV;
+    bool m_cached;
+    bool m_compared;
+
+    void init() {
+      m_servedPerStrip = false;
+      m_servedPerAPV = false;
+      m_info.clear();
+      m_cached = false;
+      m_compared = false;
+    }
+  };
+
+  //used to produce all display objects for payload inspector
+  template <class Item, class type>
+  class SiStripDataContainer {
+  public:
+    SiStripDataContainer(std::shared_ptr<Item> payload, unsigned int run, std::string hash)
+        : payload_(payload),
+          run_(run),
+          hash_(hash),
+          m_trackerTopo(StandaloneTrackerTopology::fromTrackerParametersXMLFile(
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())) {
+      granularity_ = PERSTRIP;
+      PlotMode_ = STANDARD;
+      additionalIOV_ = std::make_pair(-1, "");
+    }
+
+    virtual ~SiStripDataContainer() = default;
+
+    ///////////////// public get functions  /////////////////
+    unsigned int run() { return run_; }
+    std::string hash() { return hash_; }
+    std::string topoMode() { return TopoMode_; }
+    const std::string payloadName() { return payloadType_; }
+    plotType getPlotType() { return PlotMode_; }
+    void setPlotType(plotType myType) { PlotMode_ = myType; }
+    void setPayloadType(std::string myPayloadType) { payloadType_ = myPayloadType; }
+    void setGranularity(granularity myGranularity) {
+      granularity_ = myGranularity;
+
+      switch (myGranularity) {
+        case PERSTRIP:
+          SiStripCondData_.setGranularity(true, false);
+          break;
+        case PERAPV:
+          SiStripCondData_.setGranularity(false, true);
+          break;
+        case PERMODULE:
+          SiStripCondData_.setGranularity(false, false);
+          break;
+        default:
+          edm::LogError("LogicError") << "Unknown granularity type: " << myGranularity;
+      }
+    }
+
+    void setAdditionalIOV(unsigned int run, std::string hash) {
+      additionalIOV_.first = run;
+      additionalIOV_.second = hash;
+    };
+
+    ////NOTE to be implemented in PayloadInspector classes
+    virtual void allValues() {
+      throw cms::Exception("Value definition not found")
+          << "allValues definition not found for " << payloadName() << "\n;";
+    };
+
+    SiStripCondDataItem<type> siStripCondData() { return SiStripCondData_; }
+
+    /***********************************************************************/
+    const char *plotDescriptor()
+    /***********************************************************************/
+    {
+      const char *thePlotType = "";
+      switch (PlotMode_) {
+        case STANDARD:
+          thePlotType = Form("Display - IOV: %i", run_);
+          break;
+        case COMPARISON:
+          thePlotType = "Display";
+          break;
+        case DIFF:
+          thePlotType = Form("#Delta (%i-%i)", run_, additionalIOV_.first);
+          break;
+        case RATIO:
+          thePlotType = Form("Ratio (%i/%i)", run_, additionalIOV_.first);
+          break;
+        case MAP:
+          thePlotType = Form("TrackerMap - %s", hash_.c_str());
+          break;
+        case END_OF_TYPES:
+          edm::LogError("LogicError") << "Unknown plot type: " << PlotMode_;
+          break;
+        default:
+          edm::LogError("LogicError") << "Unknown plot type: " << PlotMode_;
+          break;
+      }
+
+      return thePlotType;
+    }
+
+    // all methods needed for comparison of 2 IOVs
+
+    /***********************************************************************/
+    void compare(SiStripDataContainer *dataCont2)
+    /***********************************************************************/
+    {
+      PlotMode_ = COMPARISON;
+      dataCont2->setPlotType(COMPARISON);
+      SiStripCondData_.setComparedBit();
+
+      setAdditionalIOV(dataCont2->run(), dataCont2->hash());
+
+      if (!SiStripCondData_.isCached())
+        allValues();
+      dataCont2->allValues();
+      auto SiStripCondData2_ = dataCont2->siStripCondData();
+
+      auto listOfDetIds = SiStripCondData_.detIds(false);
+      for (const auto &detId : listOfDetIds) {
+        auto entriesToAdd = SiStripCondData2_.data(detId);
+        for (const auto &entry : entriesToAdd) {
+          SiStripCondData_.fillByPushBack(detId, entry);
+        }
+      }
+    }
+
+    /***********************************************************************/
+    void divide(SiStripDataContainer *dataCont2)
+    /***********************************************************************/
+    {
+      PlotMode_ = RATIO;
+      dataCont2->setPlotType(RATIO);
+
+      setAdditionalIOV(dataCont2->run(), dataCont2->hash());
+
+      if (!SiStripCondData_.isCached())
+        allValues();
+      dataCont2->allValues();
+      auto SiStripCondData2_ = dataCont2->siStripCondData();
+
+      auto listOfDetIds = SiStripCondData_.detIds(false);
+      for (const auto &detId : listOfDetIds) {
+        SiStripCondData_.divide(detId, SiStripCondData2_.data(detId));
+      }
+    }
+
+    /***********************************************************************/
+    void Subtract(SiStripDataContainer *dataCont2)
+    /***********************************************************************/
+    {
+      PlotMode_ = DIFF;
+      dataCont2->setPlotType(DIFF);
+
+      setAdditionalIOV(dataCont2->run(), dataCont2->hash());
+
+      if (!SiStripCondData_.isCached())
+        allValues();
+      dataCont2->allValues();
+      auto SiStripCondData2_ = dataCont2->siStripCondData();
+
+      auto listOfDetIds = SiStripCondData_.detIds(false);
+      for (const auto &detId : listOfDetIds) {
+        SiStripCondData_.subtract(detId, SiStripCondData2_.data(detId));
+      }
+    }
+
+    /***********************************************************************/
+    void printAll()
+    /***********************************************************************/
+    {
+      if (!SiStripCondData_.isCached())
+        allValues();
+      auto listOfDetIds = SiStripCondData_.detIds(false);
+      for (const auto &detId : listOfDetIds) {
+        std::cout << detId << ": ";
+        auto values = SiStripCondData_.data(detId);
+        for (const auto &value : values) {
+          std::cout << value << " ";
+        }
+        std::cout << "\n";
+      }
+    }
+
+    /***********************************************************************/
+    void fillTrackerMap(TrackerMap *&tmap,
+                        std::pair<float, float> &range,
+                        const SiStripPI::estimator &est,
+                        const int nsigmas_of_saturation)
+    /***********************************************************************/
+    {
+      std::string titleMap;
+      if (PlotMode_ != DIFF && PlotMode_ != RATIO) {
+        titleMap =
+            "Tracker Map of " + payloadType_ + " " + estimatorType(est) + " per module (payload : " + hash_ + ")";
+      } else {
+        titleMap = "Tracker Map of " + payloadType_ + " " + Form("%s", plotDescriptor()) + " " + estimatorType(est) +
+                   " per module";
+      }
+
+      tmap = new TrackerMap(payloadType_);
+      tmap->setTitle(titleMap);
+      tmap->setPalette(1);
+
+      // storage of info
+      std::map<unsigned int, float> info_per_detid;
+
+      if (!SiStripCondData_.isCached())
+        allValues();
+      auto listOfDetIds = SiStripCondData_.detIds(false);
+      for (const auto &detId : listOfDetIds) {
+        auto values = SiStripCondData_.data(detId);
+
+        unsigned int nElements = values.size();
+        double mean(0.), rms(0.), min(10000.), max(0.);
+
+        for (const auto &value : values) {
+          mean += value;
+          rms += value * value;
+          if (value < min)
+            min = value;
+          if (value > max)
+            max = value;
+        }
+
+        mean /= nElements;
+        if ((rms / nElements - mean * mean) > 0.) {
+          rms = sqrt(rms / nElements - mean * mean);
+        } else {
+          rms = 0.;
+        }
+
+        switch (est) {
+          case SiStripPI::min:
+            info_per_detid[detId] = min;
+            break;
+          case SiStripPI::max:
+            info_per_detid[detId] = max;
+            break;
+          case SiStripPI::mean:
+            info_per_detid[detId] = mean;
+            break;
+          case SiStripPI::rms:
+            info_per_detid[detId] = rms;
+            break;
+          default:
+            edm::LogWarning("LogicError") << "Unknown estimator: " << est;
+            break;
+        }
+      }
+
+      // loop on the map
+      for (const auto &item : info_per_detid) {
+        tmap->fill(item.first, item.second);
+      }
+
+      range = SiStripPI::getTheRange(info_per_detid, nsigmas_of_saturation);
+    }
+
+    /***********************************************************************/
+    void fillValuePlot(TCanvas &canvas, const SiStripPI::OpMode &op_mode_, int nbins, float min, float max)
+    /***********************************************************************/
+    {
+      auto myMode = op_mode_;
+      // check the consistency first
+
+      if (granularity_ == PERAPV) {
+        switch (op_mode_) {
+          case SiStripPI::STRIP_BASED:
+            edm::LogError("LogicError") << " Cannot display average per " << opType(op_mode_).c_str()
+                                        << " in a conditions served per APV";
+            return;
+          case SiStripPI::APV_BASED:
+            myMode = SiStripPI::STRIP_BASED;
+            break;
+          default:
+            break;
+        }
+      } else if (granularity_ == PERMODULE) {
+        if (op_mode_ == SiStripPI::STRIP_BASED || op_mode_ == SiStripPI::APV_BASED) {
+          edm::LogError("LogicError") << " Cannot display average per " << opType(op_mode_).c_str()
+                                      << " in a conditions served per module";
+          return;
+        }
+      }
+
+      SiStripPI::Monitor1D *f_mon = nullptr;
+      SiStripPI::Monitor1D *l_mon = nullptr;
+
+      f_mon = new SiStripPI::Monitor1D(myMode,
+                                       "first",
+                                       Form("#LT %s #GT per %s;#LT%s per %s#GT %s;n. %ss",
+                                            payloadType_.c_str(),
+                                            opType(op_mode_).c_str(),
+                                            payloadType_.c_str(),
+                                            opType(op_mode_).c_str(),
+                                            (units_[payloadType_]).c_str(),
+                                            opType(op_mode_).c_str()),
+                                       nbins,
+                                       min,
+                                       max);
+
+      if (PlotMode_ == COMPARISON) {
+        l_mon = new SiStripPI::Monitor1D(myMode,
+                                         "last",
+                                         Form("#LT %s #GT per %s;#LT%s per %s#GT %s;n. %ss",
+                                              payloadType_.c_str(),
+                                              opType(op_mode_).c_str(),
+                                              payloadType_.c_str(),
+                                              opType(op_mode_).c_str(),
+                                              (units_[payloadType_]).c_str(),
+                                              opType(op_mode_).c_str()),
+                                         nbins,
+                                         min,
+                                         max);
+      }
+
+      // retrieve the data
+      if (!SiStripCondData_.isCached())
+        allValues();
+      auto listOfDetIds = SiStripCondData_.detIds(false);
+
+      unsigned int prev_det = 0;
+      unsigned int prev_apv = 0;
+      SiStripPI::Entry f_entryContainer;
+      SiStripPI::Entry l_entryContainer;
+
+      std::cout << "mode:" << opType(myMode) << " granularity: " << granularity_
+                << " listOfDetIds.size(): " << listOfDetIds.size() << std::endl;
+
+      for (const auto &detId : listOfDetIds) {
+        if (PlotMode_ == COMPARISON) {
+          auto values = SiStripCondData_.demuxedData(detId);
+          SiStripCondData_.fillMonitor1D(myMode, f_mon, f_entryContainer, values.first, prev_det, prev_apv, detId);
+          SiStripCondData_.fillMonitor1D(myMode, l_mon, l_entryContainer, values.second, prev_det, prev_apv, detId);
+        } else {
+          auto values = SiStripCondData_.data(detId);
+          SiStripCondData_.fillMonitor1D(myMode, f_mon, l_entryContainer, values, prev_det, prev_apv, detId);
+        }
+        prev_det = detId;
+      }
+
+      TH1F *h_first = (TH1F *)(f_mon->getHist()).Clone("h_first");
+      h_first->SetStats(kFALSE);
+      SiStripPI::makeNicePlotStyle(h_first);
+      h_first->GetYaxis()->CenterTitle(true);
+      h_first->GetXaxis()->CenterTitle(true);
+      h_first->SetLineWidth(2);
+      h_first->SetLineColor(kBlack);
+
+      //=========================
+      canvas.cd();
+      canvas.SetBottomMargin(0.11);
+      canvas.SetLeftMargin(0.13);
+      canvas.SetRightMargin(0.05);
+      //canvas.Modified();
+
+      TLegend *legend = new TLegend(0.52, 0.82, 0.95, 0.9);
+      legend->SetTextSize(0.025);
+
+      if (PlotMode_ != COMPARISON) {
+        float theMax = h_first->GetMaximum();
+        h_first->SetMaximum(theMax * 1.30);
+        h_first->Draw();
+
+        legend->AddEntry(h_first, Form("IOV: %i", run_), "L");
+
+      } else {
+        TH1F *h_last = (TH1F *)(l_mon->getHist()).Clone("h_last");
+        h_last->SetStats(kFALSE);
+        SiStripPI::makeNicePlotStyle(h_last);
+        h_last->GetYaxis()->CenterTitle(true);
+        h_last->GetXaxis()->CenterTitle(true);
+        h_last->SetLineWidth(2);
+        h_last->SetLineColor(kBlue);
+
+        std::cout << h_first->GetEntries() << " ---- " << h_last->GetEntries() << std::endl;
+
+        float theMax = (h_first->GetMaximum() > h_last->GetMaximum()) ? h_first->GetMaximum() : h_last->GetMaximum();
+
+        h_first->SetMaximum(theMax * 1.30);
+        h_last->SetMaximum(theMax * 1.30);
+
+        h_first->Draw();
+        h_last->Draw("same");
+
+        legend->SetHeader(Form("%s comparison", payloadType_.c_str()), "C");  // option "C" allows to center the header
+        legend->AddEntry(h_first, Form("IOV: %i", run_), "F");
+        legend->AddEntry(h_last, Form("IOV: %i", (additionalIOV_.first)), "F");
+      }
+
+      legend->Draw("same");
+    }
+
+    /***********************************************************************/
+    void fillSummary(TCanvas &canvas)
+    /***********************************************************************/
+    {
+      std::map<unsigned int, SiStripDetSummary::Values> f_map;
+      std::map<unsigned int, SiStripDetSummary::Values> l_map;
+
+      if (!SiStripCondData_.isCached())
+        allValues();
+      auto listOfDetIds = SiStripCondData_.detIds(false);
+
+      if (PlotMode_ == COMPARISON) {
+        for (const auto &detId : listOfDetIds) {
+          auto values = SiStripCondData_.demuxedData(detId);
+          for (const auto &value : values.first) {
+            summary.add(detId, value);
+          }
+        }
+
+        f_map = summary.getCounts();
+        summary.clear();
+
+        for (const auto &detId : listOfDetIds) {
+          auto values = SiStripCondData_.demuxedData(detId);
+          for (const auto &value : values.second) {
+            summary.add(detId, value);
+          }
+        }
+
+        l_map = summary.getCounts();
+
+      } else {
+        for (const auto &detId : listOfDetIds) {
+          auto values = SiStripCondData_.data(detId);
+          for (const auto &value : values) {
+            summary.add(detId, value);
+          }
+        }
+        f_map = summary.getCounts();
+      }
+
+      if (PlotMode_ == COMPARISON) {
+        std::cout << "f map size: " << f_map.size() << " l map size:" << l_map.size() << std::endl;
+        assert(f_map.size() == l_map.size());
+      }
+      //=========================
+
+      canvas.cd();
+      auto h1 = new TH1F(
+          "byRegion1",
+          Form("SiStrip %s average by region;; average SiStrip %s", payloadType_.c_str(), payloadType_.c_str()),
+          f_map.size(),
+          0.,
+          f_map.size());
+      h1->SetStats(false);
+
+      auto h2 = new TH1F(
+          "byRegion2",
+          Form("SiStrip %s average by region;; average SiStrip %s", payloadType_.c_str(), payloadType_.c_str()),
+          f_map.size(),
+          0.,
+          f_map.size());
+      h2->SetStats(false);
+
+      canvas.SetBottomMargin(0.18);
+      canvas.SetLeftMargin(0.17);
+      canvas.SetRightMargin(0.05);
+      canvas.Modified();
+
+      std::vector<int> boundaries;
+      unsigned int iBin = 0;
+
+      std::string detector;
+      std::string currentDetector;
+
+      for (const auto &element : f_map) {
+        iBin++;
+        int count = element.second.count;
+        double mean = (element.second.mean) / count;
+
+        if (currentDetector.empty())
+          currentDetector = "TIB";
+
+        switch ((element.first) / 1000) {
+          case 1:
+            detector = "TIB";
+            break;
+          case 2:
+            detector = "TOB";
+            break;
+          case 3:
+            detector = "TEC";
+            break;
+          case 4:
+            detector = "TID";
+            break;
+        }
+
+        h1->SetBinContent(iBin, mean);
+        h1->GetXaxis()->SetBinLabel(iBin, SiStripPI::regionType(element.first).second);
+        h1->GetXaxis()->LabelsOption("v");
+
+        if (detector != currentDetector) {
+          boundaries.push_back(iBin);
+          currentDetector = detector;
+        }
+      }
+
+      iBin = 0;
+      if (PlotMode_ == COMPARISON) {
+        for (const auto &element : l_map) {
+          iBin++;
+          int count = element.second.count;
+          double mean = (element.second.mean) / count;
+
+          h2->SetBinContent(iBin, mean);
+          h2->GetXaxis()->SetBinLabel(iBin, SiStripPI::regionType(element.first).second);
+          h2->GetXaxis()->LabelsOption("v");
+        }
+      }
+
+      h1->GetYaxis()->SetRangeUser(0., h1->GetMaximum() * 1.30);
+      h1->SetMarkerStyle(20);
+      h1->SetMarkerSize(1.5);
+      h1->Draw("HIST");
+      h1->Draw("Psame");
+
+      if (PlotMode_ == COMPARISON) {
+        h2->GetYaxis()->SetRangeUser(0., h2->GetMaximum() * 1.30);
+        h2->SetMarkerStyle(25);
+        h2->SetMarkerColor(kBlue);
+        h2->SetLineColor(kBlue);
+        h2->SetMarkerSize(1.5);
+        h2->Draw("HISTsame");
+        h2->Draw("Psame");
+      }
+
+      canvas.Update();
+
+      TLine *l[boundaries.size()];
+      unsigned int i = 0;
+      for (const auto &line : boundaries) {
+        l[i] = new TLine(h1->GetBinLowEdge(line), canvas.GetUymin(), h1->GetBinLowEdge(line), canvas.GetUymax());
+        l[i]->SetLineWidth(1);
+        l[i]->SetLineStyle(9);
+        l[i]->SetLineColor(2);
+        l[i]->Draw("same");
+        i++;
+      }
+
+      TLegend *legend = new TLegend(0.52, 0.82, 0.95, 0.9);
+      legend->SetHeader(hash_.c_str(), "C");  // option "C" allows to center the header
+      legend->AddEntry(h1, Form("IOV: %i", run_), "PL");
+      if (PlotMode_ == COMPARISON) {
+        legend->AddEntry(h2, Form("IOV: %i", additionalIOV_.first), "PL");
+      }
+      legend->SetTextSize(0.025);
+      legend->Draw("same");
+    }
+
+    /***********************************************************************/
+    void fillByPartition(TCanvas &canvas, int nbins, float min, float max)
+    /***********************************************************************/
+    {
+      std::map<std::string, TH1F *> h_parts;
+      std::map<std::string, TH1F *> h_parts2;
+
+      std::map<std::string, int> colormap;
+      std::map<std::string, int> markermap;
+      colormap["TIB"] = kRed;
+      markermap["TIB"] = kFullCircle;
+      colormap["TOB"] = kGreen;
+      markermap["TOB"] = kFullTriangleUp;
+      colormap["TID"] = kBlack;
+      markermap["TID"] = kFullSquare;
+      colormap["TEC"] = kBlue;
+      markermap["TEC"] = kFullTriangleDown;
+
+      std::vector<std::string> parts = {"TEC", "TOB", "TIB", "TID"};
+
+      const char *device;
+      switch (granularity_) {
+        case PERSTRIP:
+          device = "strips";
+          break;
+        case PERAPV:
+          device = "APVs";
+          break;
+        case PERMODULE:
+          device = "modules";
+          break;
+        default:
+          device = "unrecognized device";
+          break;
+      }
+
+      for (const auto &part : parts) {
+        TString globalTitle = Form("%s - %s %s;%s %s;n. %s",
+                                   plotDescriptor(),
+                                   payloadType_.c_str(),
+                                   part.c_str(),
+                                   payloadType_.c_str(),
+                                   (units_[payloadType_]).c_str(),
+                                   device);
+
+        h_parts[part] = new TH1F(Form("h_%s", part.c_str()), globalTitle, nbins, min, max);
+
+        if (PlotMode_ == COMPARISON) {
+          h_parts2[part] = new TH1F(Form("h2_%s", part.c_str()), globalTitle, nbins, min, max);
+        }
+      }
+
+      if (!SiStripCondData_.isCached())
+        allValues();
+      auto listOfDetIds = SiStripCondData_.detIds(false);
+      for (const auto &detId : listOfDetIds) {
+        auto values = SiStripCondData_.data(detId);
+        int subid = DetId(detId).subdetId();
+        unsigned int counter{0};
+        for (const auto &value : values) {
+          counter++;
+          switch (subid) {
+            case StripSubdetector::TIB:
+              if ((PlotMode_ == COMPARISON) && (counter > (values.size() / 2))) {
+                h_parts2["TIB"]->Fill(value);
+              } else {
+                h_parts["TIB"]->Fill(value);
+              }
+              break;
+            case StripSubdetector::TID:
+              if ((PlotMode_ == COMPARISON) && (counter > (values.size() / 2))) {
+                h_parts2["TID"]->Fill(value);
+              } else {
+                h_parts["TID"]->Fill(value);
+              }
+              break;
+            case StripSubdetector::TOB:
+              if ((PlotMode_ == COMPARISON) && (counter > (values.size() / 2))) {
+                h_parts2["TOB"]->Fill(value);
+              } else {
+                h_parts["TOB"]->Fill(value);
+              }
+              break;
+            case StripSubdetector::TEC:
+              if ((PlotMode_ == COMPARISON) && (counter > (values.size() / 2))) {
+                h_parts2["TEC"]->Fill(value);
+              } else {
+                h_parts["TEC"]->Fill(value);
+              }
+              break;
+            default:
+              edm::LogError("LogicError") << "Unknown partition: " << subid;
+              break;
+          }
+        }
+      }
+
+      canvas.Divide(2, 2);
+
+      int index = 0;
+      for (const auto &part : parts) {
+        index++;
+        canvas.cd(index)->SetTopMargin(0.07);
+        canvas.cd(index)->SetLeftMargin(0.13);
+        canvas.cd(index)->SetRightMargin(0.08);
+
+        SiStripPI::makeNicePlotStyle(h_parts[part]);
+        h_parts[part]->SetMinimum(1.);
+        h_parts[part]->SetStats(false);
+        h_parts[part]->SetLineWidth(2);
+
+        if (PlotMode_ != COMPARISON) {
+          h_parts[part]->SetLineColor(colormap[part]);
+          float theMax = h_parts[part]->GetMaximum();
+          h_parts[part]->SetMaximum(theMax * 1.30);
+        } else {
+          h_parts[part]->SetLineColor(kBlack);
+
+          SiStripPI::makeNicePlotStyle(h_parts2[part]);
+          h_parts2[part]->SetMinimum(1.);
+          h_parts2[part]->SetStats(false);
+          h_parts2[part]->SetLineWidth(2);
+          h_parts2[part]->SetLineColor(kBlue);
+
+          float theMax = (h_parts[part]->GetMaximum() > h_parts2[part]->GetMaximum()) ? h_parts[part]->GetMaximum()
+                                                                                      : h_parts2[part]->GetMaximum();
+
+          h_parts[part]->SetMaximum(theMax * 1.30);
+          h_parts2[part]->SetMaximum(theMax * 1.30);
+        }
+
+        h_parts[part]->Draw();
+        if (PlotMode_ == COMPARISON) {
+          h_parts2[part]->Draw("same");
+        }
+
+        TLegend *leg = new TLegend(.60, 0.8, 0.92, 0.93);
+        if (PlotMode_ != COMPARISON) {
+          leg->SetTextSize(0.035);
+          leg->SetHeader(part.c_str(), "C");  // option "C" allows to center the header
+          leg->AddEntry(
+              h_parts[part],
+              Form("#splitline{#mu = %.2f}{r.m.s. = %.2f}", h_parts[part]->GetMean(), h_parts[part]->GetRMS()),
+              "L");
+          leg->Draw("same");
+        } else {
+          leg->AddEntry(h_parts[part], Form("IOV: %i", run_), "L");
+          leg->AddEntry(h_parts2[part], Form("IOV: %i", (additionalIOV_.first)), "L");
+          leg->Draw("same");
+        }
+      }
+    }
+
+    /***********************************************************************/
+    void fillCorrelationByPartition(TCanvas &canvas, int nbins, float min, float max)
+    /***********************************************************************/
+    {
+      SiStripPI::setPaletteStyle(SiStripPI::DEFAULT); /* better looking palette ;)*/
+
+      if (PlotMode_ != COMPARISON) {
+        throw cms::Exception("Logic error") << "not being in compared mode, cannot plot correlations";
+      }
+
+      std::map<std::string, TH2F *> h2_parts;
+
+      std::map<std::string, int> colormap;
+      std::map<std::string, int> markermap;
+      colormap["TIB"] = kRed;
+      markermap["TIB"] = kFullCircle;
+      colormap["TOB"] = kGreen;
+      markermap["TOB"] = kFullTriangleUp;
+      colormap["TID"] = kBlack;
+      markermap["TID"] = kFullSquare;
+      colormap["TEC"] = kBlue;
+      markermap["TEC"] = kFullTriangleDown;
+
+      std::vector<std::string> parts = {"TEC", "TOB", "TIB", "TID"};
+
+      const char *device;
+      switch (granularity_) {
+        case PERSTRIP:
+          device = "strips";
+          break;
+        case PERAPV:
+          device = "APVs";
+          break;
+        case PERMODULE:
+          device = "modules";
+          break;
+        default:
+          device = "unrecognized device";
+          break;
+      }
+
+      for (const auto &part : parts) {
+        TString globalTitle = Form("%s - %s %s;%s %s (#color[4]{%s});%s %s (#color[4]{%s});n. %s",
+                                   "Correlation",  // FIXME: can use the plotDescriptor()
+                                   payloadType_.c_str(),
+                                   part.c_str(),
+                                   payloadType_.c_str(),
+                                   (units_[payloadType_]).c_str(),
+                                   std::to_string(run_).c_str(),
+                                   payloadType_.c_str(),
+                                   (units_[payloadType_]).c_str(),
+                                   std::to_string(additionalIOV_.first).c_str(),
+                                   device);
+
+        h2_parts[part] = new TH2F(Form("h2_%s", part.c_str()), globalTitle, nbins, min, max, nbins, min, max);
+      }
+
+      if (!SiStripCondData_.isCached())
+        allValues();
+      auto listOfDetIds = SiStripCondData_.detIds(false);
+      for (const auto &detId : listOfDetIds) {
+        auto values = SiStripCondData_.demuxedData(detId);
+        int subid = DetId(detId).subdetId();
+        unsigned int counter{0};
+        for (const auto &value : values.first) {
+          switch (subid) {
+            case StripSubdetector::TIB:
+              h2_parts["TIB"]->Fill(value, (values.second)[counter]);
+              break;
+            case StripSubdetector::TID:
+              h2_parts["TID"]->Fill(value, (values.second)[counter]);
+              break;
+            case StripSubdetector::TOB:
+              h2_parts["TOB"]->Fill(value, (values.second)[counter]);
+              break;
+            case StripSubdetector::TEC:
+              h2_parts["TEC"]->Fill(value, (values.second)[counter]);
+              break;
+            default:
+              edm::LogError("LogicError") << "Unknown partition: " << subid;
+              break;
+          }
+          counter++;
+        }
+      }
+
+      canvas.Divide(2, 2);
+
+      int index = 0;
+      for (const auto &part : parts) {
+        index++;
+        canvas.cd(index)->SetTopMargin(0.07);
+        canvas.cd(index)->SetLeftMargin(0.13);
+        canvas.cd(index)->SetRightMargin(0.17);
+
+        SiStripPI::makeNicePlotStyle(h2_parts[part]);
+        h2_parts[part]->GetZaxis()->SetTitleOffset(1.6);
+        h2_parts[part]->GetZaxis()->SetTitleSize(0.04);
+        h2_parts[part]->GetZaxis()->CenterTitle();
+        h2_parts[part]->GetZaxis()->SetMaxDigits(2); /* exponentiate z-axis */
+
+        //h2_parts[part]->SetMarkerColor(colormap[part]);
+        //h2_parts[part]->SetMarkerStyle(markermap[part]);
+        //h2_parts[part]->SetStats(false);
+        //h2_parts[part]->Draw("P");
+        h2_parts[part]->Draw("colz");
+
+        TLegend *leg = new TLegend(.13, 0.87, 0.27, 0.93);
+        leg->SetTextSize(0.045);
+        leg->SetHeader(Form("#bf{%s}", part.c_str()), "C");  // option "C" allows to center the header
+        //leg->AddEntry(h2_parts[part], Form("#DeltaIOV: #splitline{%i}{%i}", run_, additionalIOV_.first),"P");
+        leg->Draw("same");
+      }
+    }
+
+  protected:
+    std::shared_ptr<Item> payload_;
+    std::string payloadType_;
+    SiStripCondDataItem<type> SiStripCondData_;
+
+  private:
+    unsigned int run_;
+    std::string hash_;
+    granularity granularity_;
+    std::string TopoMode_;
+    TrackerTopology m_trackerTopo;
+    SiStripDetSummary summary{&m_trackerTopo};
+    // "Map", "Ratio", or "Diff"
+    plotType PlotMode_;
+    std::pair<int, std::string> additionalIOV_;
+
+    std::map<std::string, std::string> units_ = {{"SiStripPedestals", "[ADC counts]"},
+                                                 {"SiStripApvGain", ""},  //dimensionless TODO: verify
+                                                 {"SiStripNoises", "[ADC counts]"},
+                                                 {"SiStripLorentzAngle", "[1/T}]"},
+                                                 {"SiStripBackPlaneCorrection", ""},
+                                                 {"SiStripBadStrip", ""},  // dimensionless
+                                                 {"SiStripDetVOff", ""}};  // dimensionless
+
+    std::string opType(SiStripPI::OpMode mode) {
+      std::string types[3] = {"Strip", "APV", "Module"};
+      return types[mode];
+    }
+  };
+
+}  // namespace SiStripCondObjectRepresent
+
+#endif

--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -1,24 +1,29 @@
 #ifndef CONDCORE_SISTRIPPLUGINS_SISTRIPPAYLOADINSPECTORHELPER_H
 #define CONDCORE_SISTRIPPLUGINS_SISTRIPPAYLOADINSPECTORHELPER_H
 
-#include <vector>
+// system includes
 #include <numeric>
 #include <string>
+#include <vector>
+
+// user includes
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+#include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
+#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h" /* for STRIPS_PER_APV*/
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+// ROOT includes
 #include "TH1.h"
 #include "TH2.h"
 #include "TPaveText.h"
 #include "TStyle.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
-#include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
-#include "CondFormats/SiStripObjects/interface/SiStripDetSummary.h"
-#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
-#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
-
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace SiStripPI {
 
@@ -566,7 +571,7 @@ namespace SiStripPI {
       int nAPVs = detInfo.getNumberOfApvsAndStripLength(det.first).first;
       // one fiber connects to 2 APVs
       int nFibers = nAPVs / 2;
-      int nStrips = (128 * detInfo.getNumberOfApvsAndStripLength(det.first).first);
+      int nStrips = (sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(det.first).first);
       NTkComponents[0]++;
       NTkComponents[1] += nFibers;
       NTkComponents[2] += nAPVs;
@@ -719,7 +724,7 @@ namespace SiStripPI {
         percentage += range;
       }
       if (percentage != 0)
-        percentage /= 128. * detInfo.getNumberOfApvsAndStripLength(detid).first;
+        percentage /= sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(detid).first;
       if (percentage > 1)
         edm::LogError("SiStripBadStrip_PayloadInspector")
             << "PROBLEM detid " << detid << " value " << percentage << std::endl;

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -21,6 +21,7 @@
 
 // auxilliary functions
 #include "CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h"
+#include "CondCore/SiStripPlugins/interface/SiStripCondObjectRepresent.h"
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 
 #include <memory>
@@ -41,6 +42,199 @@
 namespace {
 
   using namespace cond::payloadInspector;
+
+  class SiStripApvGainContainer : public SiStripCondObjectRepresent::SiStripDataContainer<SiStripApvGain, float> {
+  public:
+    SiStripApvGainContainer(std::shared_ptr<SiStripApvGain> payload, unsigned int run, std::string hash)
+        : SiStripCondObjectRepresent::SiStripDataContainer<SiStripApvGain, float>(payload, run, hash) {
+      payloadType_ = "SiStripApvGain";
+      setGranularity(SiStripCondObjectRepresent::PERAPV);
+    }
+
+    void allValues() override {
+      std::vector<uint32_t> detid;
+      payload_->getDetIds(detid);
+
+      for (const auto& d : detid) {
+        SiStripApvGain::Range range = payload_->getRange(d);
+        for (int it = 0; it < range.second - range.first; it++) {
+          // to be used to fill the histogram
+          SiStripCondData_.fillByPushBack(d, payload_->getApvGain(it, range));
+        }
+      }
+    }
+  };
+
+  /************************************************
+    testing the machinery
+  ************************************************/
+  class SiStripApvGainTest : public cond::payloadInspector::Histogram1D<SiStripApvGain, SINGLE_IOV> {
+  public:
+    SiStripApvGainTest()
+        : cond::payloadInspector::Histogram1D<SiStripApvGain, SINGLE_IOV>(
+              "SiStrip ApvGain values", "SiStrip ApvGain values", 1, 0.0, 1.) {}
+
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      for (auto const& iov : tag.iovs) {
+        std::shared_ptr<SiStripApvGain> payload = Base::fetchPayload(std::get<1>(iov));
+        if (payload.get()) {
+          SiStripApvGainContainer* objContainer =
+              new SiStripApvGainContainer(payload, std::get<0>(iov), std::get<1>(iov));
+          objContainer->printAll();
+
+        }  // payload
+      }    // iovs
+      return true;
+    }  // fill
+  };
+
+  class SiStripApvGainByPartition : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  public:
+    SiStripApvGainByPartition() : cond::payloadInspector::PlotImage<SiStripApvGain>("SiStrip ApvGains By Partition") {
+      setSingleIov(true);
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      auto iov = iovs.front();
+      std::shared_ptr<SiStripApvGain> payload = fetchPayload(std::get<1>(iov));
+      if (payload.get()) {
+        SiStripApvGainContainer* objContainer =
+            new SiStripApvGainContainer(payload, std::get<0>(iov), std::get<1>(iov));
+        //objContainer->printAll();
+
+        TCanvas canvas("Partition summary", "partition summary", 1400, 1000);
+        objContainer->fillByPartition(canvas, 100, 0., 2.);
+
+        std::string fileName(m_imageFileName);
+        canvas.SaveAs(fileName.c_str());
+
+      }  // payload
+      return true;
+    }  // fill
+  };
+
+  class SiStripApvGainCompareByPartition : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  public:
+    SiStripApvGainCompareByPartition()
+        : cond::payloadInspector::PlotImage<SiStripApvGain>("SiStrip Compare ApvGains By Partition") {
+      setSingleIov(false);
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+
+      // make absolute sure the IOVs are sortd by since
+      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
+        return std::get<0>(t1) < std::get<0>(t2);
+      });
+
+      auto firstiov = sorted_iovs.front();
+      auto lastiov = sorted_iovs.back();
+
+      std::shared_ptr<SiStripApvGain> last_payload = fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripApvGain> first_payload = fetchPayload(std::get<1>(firstiov));
+
+      SiStripApvGainContainer* l_objContainer =
+          new SiStripApvGainContainer(last_payload, std::get<0>(lastiov), std::get<1>(lastiov));
+      SiStripApvGainContainer* f_objContainer =
+          new SiStripApvGainContainer(first_payload, std::get<0>(firstiov), std::get<1>(firstiov));
+
+      l_objContainer->compare(f_objContainer);
+
+      //l_objContainer->printAll();
+
+      TCanvas canvas("Partition summary", "partition summary", 1400, 1000);
+      l_objContainer->fillByPartition(canvas, 100, 0.5, 1.5);
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }  // fill
+  };
+
+  class SiStripApvGainRatioByPartition : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  public:
+    SiStripApvGainRatioByPartition()
+        : cond::payloadInspector::PlotImage<SiStripApvGain>("SiStrip Ratio ApvGains By Partition") {
+      setSingleIov(false);
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+
+      // make absolute sure the IOVs are sortd by since
+      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
+        return std::get<0>(t1) < std::get<0>(t2);
+      });
+
+      auto firstiov = sorted_iovs.front();
+      auto lastiov = sorted_iovs.back();
+
+      std::shared_ptr<SiStripApvGain> last_payload = fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripApvGain> first_payload = fetchPayload(std::get<1>(firstiov));
+
+      SiStripApvGainContainer* l_objContainer =
+          new SiStripApvGainContainer(last_payload, std::get<0>(lastiov), std::get<1>(lastiov));
+      SiStripApvGainContainer* f_objContainer =
+          new SiStripApvGainContainer(first_payload, std::get<0>(firstiov), std::get<1>(firstiov));
+
+      l_objContainer->divide(f_objContainer);
+
+      //l_objContainer->printAll();
+
+      TCanvas canvas("Partition summary", "partition summary", 1400, 1000);
+      l_objContainer->fillByPartition(canvas, 200, 0., 2.);
+      for (int i = 1; i <= 4; i++)
+        canvas.cd(i)->SetLogy();
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }  // fill
+  };
+
+  class SiStripApvGainDiffByPartition : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  public:
+    SiStripApvGainDiffByPartition()
+        : cond::payloadInspector::PlotImage<SiStripApvGain>("SiStrip Diff ApvGains By Partition") {
+      setSingleIov(false);
+    }
+
+    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+
+      // make absolute sure the IOVs are sortd by since
+      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
+        return std::get<0>(t1) < std::get<0>(t2);
+      });
+
+      auto firstiov = sorted_iovs.front();
+      auto lastiov = sorted_iovs.back();
+
+      std::shared_ptr<SiStripApvGain> last_payload = fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripApvGain> first_payload = fetchPayload(std::get<1>(firstiov));
+
+      SiStripApvGainContainer* l_objContainer =
+          new SiStripApvGainContainer(last_payload, std::get<0>(lastiov), std::get<1>(lastiov));
+      SiStripApvGainContainer* f_objContainer =
+          new SiStripApvGainContainer(first_payload, std::get<0>(firstiov), std::get<1>(firstiov));
+
+      l_objContainer->Subtract(f_objContainer);
+
+      //l_objContainer->printAll();
+
+      TCanvas canvas("Partition summary", "partition summary", 1400, 1000);
+      l_objContainer->fillByPartition(canvas, 100, -0.1, 0.1);
+
+      std::string fileName(m_imageFileName);
+      canvas.SaveAs(fileName.c_str());
+
+      return true;
+    }  // fill
+  };
 
   /************************************************
     1d histogram of SiStripApvGains of 1 IOV 
@@ -2073,6 +2267,11 @@ namespace {
 // Register the classes as boost python plugin
 PAYLOAD_INSPECTOR_MODULE(SiStripApvGain) {
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsValue);
+  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainTest);
+  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainByPartition);
+  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainCompareByPartition);
+  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainRatioByPartition);
+  PAYLOAD_INSPECTOR_CLASS(SiStripApvGainDiffByPartition);
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsTest);
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsByRegion);
   PAYLOAD_INSPECTOR_CLASS(SiStripApvGainsComparatorSingleTag);

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -165,7 +165,8 @@ namespace {
           badStripsPerDetId[d] += payload->decode(*badStrip).range;
           //ss << "DetId="<< d << " Strip=" << payload->decode(*badStrip).firstStrip <<":"<< payload->decode(*badStrip).range << " flag="<< payload->decode(*badStrip).flag << std::endl;
         }
-        float fraction = badStripsPerDetId[d] / (128. * detInfo.getNumberOfApvsAndStripLength(d).first);
+        float fraction =
+            badStripsPerDetId[d] / (sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(d).first);
         tmap->fill(d, fraction);
       }  // loop over detIds
 
@@ -227,7 +228,8 @@ namespace {
         for (std::vector<unsigned int>::const_iterator badStrip = range.first; badStrip != range.second; ++badStrip) {
           badStripsPerDetId[d] += payload->decode(*badStrip).range;
         }
-        float fraction = badStripsPerDetId[d] / (128. * detInfo.getNumberOfApvsAndStripLength(d).first);
+        float fraction =
+            badStripsPerDetId[d] / (sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(d).first);
         if (fraction > 0.) {
           myMap.fill(d, fraction);
         }
@@ -276,7 +278,7 @@ namespace {
       float numerator(0.), denominator(0.);
       std::vector<uint32_t> all_detids = detInfo.getAllDetIds();
       for (const auto& det : all_detids) {
-        denominator += 128. * detInfo.getNumberOfApvsAndStripLength(det).first;
+        denominator += sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(det).first;
         if (badStripsPerDetId.count(det) != 0)
           numerator += badStripsPerDetId[det];
       }
@@ -321,7 +323,7 @@ namespace {
         int subid = DetId(det).subdetId();
         if (subid != StripSubdetector::TIB)
           continue;
-        denominator += 128. * detInfo.getNumberOfApvsAndStripLength(det).first;
+        denominator += sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(det).first;
         if (badStripsPerDetId.count(det) != 0)
           numerator += badStripsPerDetId[det];
       }
@@ -366,7 +368,7 @@ namespace {
         int subid = DetId(det).subdetId();
         if (subid != StripSubdetector::TOB)
           continue;
-        denominator += 128. * detInfo.getNumberOfApvsAndStripLength(det).first;
+        denominator += sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(det).first;
         if (badStripsPerDetId.count(det) != 0)
           numerator += badStripsPerDetId[det];
       }
@@ -411,7 +413,7 @@ namespace {
         int subid = DetId(det).subdetId();
         if (subid != StripSubdetector::TID)
           continue;
-        denominator += 128. * detInfo.getNumberOfApvsAndStripLength(det).first;
+        denominator += sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(det).first;
         if (badStripsPerDetId.count(det) != 0)
           numerator += badStripsPerDetId[det];
       }
@@ -456,7 +458,7 @@ namespace {
         int subid = DetId(det).subdetId();
         if (subid != StripSubdetector::TEC)
           continue;
-        denominator += 128. * detInfo.getNumberOfApvsAndStripLength(det).first;
+        denominator += sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(det).first;
         if (badStripsPerDetId.count(det) != 0)
           numerator += badStripsPerDetId[det];
       }
@@ -880,7 +882,7 @@ namespace {
           LastFractionPerDetId[d] += last_payload->decode(*badStrip).range;
         }
         // normalize to the number of strips per module
-        LastFractionPerDetId[d] /= (128. * detInfo.getNumberOfApvsAndStripLength(d).first);
+        LastFractionPerDetId[d] /= (sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(d).first);
       }  // loop over detIds
 
       std::vector<uint32_t> detid2;
@@ -894,7 +896,7 @@ namespace {
           FirstFractionPerDetId[d] += first_payload->decode(*badStrip).range;
         }
         // normalize to the number of strips per module
-        FirstFractionPerDetId[d] /= (128. * detInfo.getNumberOfApvsAndStripLength(d).first);
+        FirstFractionPerDetId[d] /= (sistrip::STRIPS_PER_APV * detInfo.getNumberOfApvsAndStripLength(d).first);
       }  // loop over detIds
 
       std::vector<uint32_t> allDetIds = detInfo.getAllDetIds();

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -272,6 +272,14 @@ namespace {
       auto iov = tag.iovs.front();
       std::shared_ptr<SiStripDetVOff> payload = fetchPayload(std::get<1>(iov));
 
+      unsigned long IOV = std::get<0>(iov);
+      int run = 0;
+      if (IOV < 4294967296) {
+        run = std::get<0>(iov);
+      } else {  // time type IOV
+        run = IOV >> 32;
+      }
+
       std::vector<uint32_t> detid;
       payload->getDetIds(detid);
 
@@ -304,6 +312,9 @@ namespace {
 
       h_HV->SetStats(false);
       h_LV->SetStats(false);
+
+      h_HV->SetTitle(nullptr);
+      h_LV->SetTitle(nullptr);
 
       canvas.SetBottomMargin(0.18);
       canvas.SetLeftMargin(0.10);
@@ -393,6 +404,22 @@ namespace {
       legend.AddEntry(h_LV.get(), ("LV channels: " + std::to_string(payload->getLVoffCounts())).c_str(), "PL");
       legend.SetTextSize(0.025);
       legend.Draw("same");
+
+      TLatex t1;
+      t1.SetNDC();
+      t1.SetTextAlign(26);
+      t1.SetTextSize(0.05);
+      if (IOV < 4294967296)
+        t1.DrawLatex(0.5, 0.96, Form("SiStrip DetVOff, IOV %i", run));
+      else {  // time type IOV
+        time_t t = run;
+        char buf[256];
+        struct tm lt;
+        localtime_r(&t, &lt);
+        strftime(buf, sizeof(buf), "%F %R:%S", &lt);
+        buf[sizeof(buf) - 1] = 0;
+        t1.DrawLatex(0.5, 0.96, Form("SiStrip DetVOff, IOV %s", buf));
+      }
 
       // Remove the current axis
       h_HV.get()->GetYaxis()->SetLabelOffset(999);

--- a/CondCore/SiStripPlugins/scripts/G2GainsValidator.py
+++ b/CondCore/SiStripPlugins/scripts/G2GainsValidator.py
@@ -1,0 +1,140 @@
+from __future__ import print_function 
+
+import ConfigParser
+import glob
+import os
+import numpy
+import re
+import ROOT
+import string
+import subprocess
+import sys
+import optparse
+import time
+import json
+import datetime
+from datetime import datetime
+import CondCore.Utilities.conddblib as conddb
+
+##############################################
+def getCommandOutput(command):
+##############################################
+    """This function executes `command` and returns it output.
+    Arguments:
+    - `command`: Shell command to be invoked by this function.
+    """
+    child = os.popen(command)
+    data = child.read()
+    err = child.close()
+    if err:
+        print ('%s failed w/ exit code %d' % (command, err))
+    return data
+
+##############################################
+def getFCSR():
+##############################################
+    out = subprocess.check_output(["curl", "-k", "-s", "https://cmsweb.cern.ch/t0wmadatasvc/prod/firstconditionsaferun"])
+    response = json.loads(out)["result"][0]
+    return int(response)
+
+##############################################
+def getPromptGT():
+##############################################
+    out = subprocess.check_output(["curl", "-k", "-s", "https://cmsweb.cern.ch/t0wmadatasvc/prod/reco_config"])
+    response = json.loads(out)["result"][0]['global_tag']
+    return response
+
+##############################################
+def getExpressGT():
+##############################################
+    out = subprocess.check_output(["curl", "-k", "-s", "https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config"])
+    response = json.loads(out)["result"][0]['global_tag']
+    return response
+
+##############################################
+if __name__ == "__main__":
+##############################################
+
+    parser = optparse.OptionParser(usage = 'Usage: %prog [options] <file> [<file> ...]\n')
+     
+    parser.add_option('-t', '--validationTag',
+                      dest = 'validationTag',
+                      default = "SiStripApvGainAfterAbortGap_PCL_multirun_v0_prompt",
+                      help = 'validation tag',
+                      )
+     
+    parser.add_option('-s', '--since',
+                      dest = 'since',
+                      default = -1,
+                      help = 'sinces to copy from validation tag',
+                      )
+     
+    (options, arguments) = parser.parse_args()
+
+
+    FCSR = getFCSR()
+    promptGT  = getPromptGT()
+    expressGT = getExpressGT() 
+    print ("Current FCSR:",FCSR,"| Express Global Tag",expressGT,"| Prompt Global Tag",promptGT)
+
+    con = conddb.connect(url = conddb.make_url("pro"))
+    session = con.session()
+    IOV     = session.get_dbtype(conddb.IOV)
+    TAG     = session.get_dbtype(conddb.Tag)
+    GT      = session.get_dbtype(conddb.GlobalTag)
+    GTMAP   = session.get_dbtype(conddb.GlobalTagMap)
+    RUNINFO = session.get_dbtype(conddb.RunInfo)
+
+    myGTMap = session.query(GTMAP.record, GTMAP.label, GTMAP.tag_name).\
+        filter(GTMAP.global_tag_name == str(expressGT)).\
+        order_by(GTMAP.record, GTMAP.label).\
+        all()
+
+    ## connect to prep DB and get the list of IOVs to look at
+    con2 = conddb.connect(url = conddb.make_url("dev"))
+    session2 = con2.session()
+    validationTagIOVs = session2.query(IOV.since,IOV.payload_hash,IOV.insertion_time).filter(IOV.tag_name == options.validationTag).all()
+
+    ### fill the list of IOVs to be validated
+    IOVsToValidate=[]
+    if(options.since==-1):
+        IOVsToValidate.append(validationTagIOVs[-1][0])
+        print("changing the default validation tag since to:",IOVsToValidate[0])
+        
+    else:
+        for entry in validationTagIOVs:
+            if(options.since!=1 and int(entry[0])>=int(options.since)):
+                print("appending to the validation list:",entry[0],entry[1],entry[2])
+                IOVsToValidate.append(entry[0])
+            
+    for element in myGTMap:
+    #print element
+        Record = element[0]
+        Label  = element[1]
+        Tag = element[2]
+        if(Record=="SiStripApvGain2Rcd"):
+            TagIOVs = session.query(IOV.since,IOV.payload_hash,IOV.insertion_time).filter(IOV.tag_name == Tag).all()
+            lastG2Payload = TagIOVs[-1]
+            print("last payload has IOV since:",lastG2Payload[0],"payload hash:",lastG2Payload[1],"insertion time:",lastG2Payload[2])
+            command = 'conddb_import -c sqlite_file:toCompare.db -f frontier://FrontierProd/CMS_CONDITIONS -i '+str(Tag) +' -t '+str(Tag)+' -b '+str(lastG2Payload[0])
+            print(command)
+            getCommandOutput(command)
+
+            for i,theValidationTagSince in enumerate(IOVsToValidate):
+
+                command = 'conddb_import -c sqlite_file:toCompare.db -f frontier://FrontierPrep/CMS_CONDITIONS -i '+str(options.validationTag) +' -t '+str(Tag)+' -b '+str(theValidationTagSince)
+                if(theValidationTagSince < lastG2Payload[0]):
+                    print("the last available IOV in the validation tag is older than the current last express IOV, taking FCSR as a since!")
+                    command = 'conddb_import -c sqlite_file:toCompare.db -f frontier://FrontierPrep/CMS_CONDITIONS -i '+str(options.validationTag) +' -t '+str(Tag)+' -b '+str(FCSR+i)
+
+                print(command)
+                getCommandOutput(command)
+
+                command = './testCompare.sh SiStripApvGain_FromParticles_GR10_v1_express '+str(lastG2Payload[0])+' '+str(theValidationTagSince)+ ' toCompare.db'
+                if(theValidationTagSince < lastG2Payload[0]):
+                    command = './testCompare.sh SiStripApvGain_FromParticles_GR10_v1_express '+str(lastG2Payload[0])+' '+str(FCSR+i)+ ' toCompare.db'
+                print(command)
+                getCommandOutput(command)
+
+
+         

--- a/CondCore/SiStripPlugins/scripts/testCompare.sh
+++ b/CondCore/SiStripPlugins/scripts/testCompare.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+display_usage() { 
+    echo "This script must be run giving the following arguments." 
+    echo -e "./testCompare.sh <name of tag> <first IOV> <last IOV> <sqlite file> \n\n"
+    echo -e "example: \n ./testCompare.sh SiStripApvGain_FromParticles_GR10_v1_express 300577 302322 toCompare.db \n" 
+} 
+
+# if less than two arguments supplied, display usage 
+	if [  $# -le 3 ] 
+	then 
+		display_usage
+		exit 1
+	fi 
+ 
+# check whether user had supplied -h or --help . If yes display usage 
+	if [[ ( $# == "--help") ||  $# == "-h" ]] 
+	then 
+		display_usage
+		exit 0
+	fi 
+
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+STARTIOV=$2
+ENDIOV=$3
+
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+
+plotTypes=(SiStripApvGainsComparator SiStripApvGainsValuesComparator SiStripApvGainsComparatorByRegion SiStripApvGainsRatioComparatorByRegion SiStripApvGainsAvgDeviationRatio1sigmaTrackerMap SiStripApvGainsAvgDeviationRatio2sigmaTrackerMap SiStripApvGainsAvgDeviationRatio3sigmaTrackerMap SiStripApvGainsMaxDeviationRatio1sigmaTrackerMap SiStripApvGainsMaxDeviationRatio2sigmaTrackerMap SiStripApvGainsMaxDeviationRatio3sigmaTrackerMap SiStripApvGainByPartition SiStripApvGainCompareByPartition SiStripApvGainDiffByPartition)
+
+mkdir -p $W_DIR/results_$2-$3
+
+if [ -f *.png ]; then    
+    rm *.png
+fi
+
+for i in "${plotTypes[@]}" 
+do
+echo "Making plot ${i}"
+# Run get payload data script
+    getPayloadData.py \
+	--plugin pluginSiStripApvGain_PayloadInspector \
+	--plot plot_${i} \
+	--tag $1 \
+	--time_type Run \
+	--iovs  '{"start_iov": "'$STARTIOV'", "end_iov": "'$ENDIOV'"}' \
+	--db sqlite_file:$4 \
+	--test;
+
+    mv *.png $W_DIR/results_$2-$3/${i}_$1_$2-$3.png
+done

--- a/CondCore/SiStripPlugins/test/consistencyCheck.sh
+++ b/CondCore/SiStripPlugins/test/consistencyCheck.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Save current working dir so img can be outputted there later
+W_DIR=$(pwd);
+# Set SCRAM architecture var
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory
+cd $W_DIR;
+# Run get payload data script
+
+if [ ! -d $W_DIR/results ]; then
+    mkdir $W_DIR/results
+fi
+ 
+# reference
+getPayloadData.py \
+    --plugin pluginSiStripNoises_PayloadInspector \
+    --plot plot_SiStripNoiseValueComparisonPerAPV \
+    --tag SiStripNoise_GR10_v1_hlt \
+    --time_type Run \
+    --iovs '{"start_iov": "312968", "end_iov": "313120"}' \
+    --db Prod \
+    --test;
+	
+mv *.png $W_DIR/results/SiStripNoisesPerAPVValues_ref.png
+
+# target
+getPayloadData.py \
+    --plugin pluginSiStripNoises_PayloadInspector \
+    --plot plot_SiStripNoiseConsistencyCheck \
+    --tag SiStripNoise_GR10_v1_hlt \
+    --time_type Run \
+    --iovs '{"start_iov": "312968", "end_iov": "313120"}' \
+    --db Prod \
+    --test;
+	
+mv *.png $W_DIR/results/SiStripNoisesPerAPVValues_tar.png
+
+# LA test
+getPayloadData.py \
+    --plugin pluginSiStripLorentzAngle_PayloadInspector \
+    --plot plot_SiStripLorentzAngleTest \
+    --tag SiStripLorentzAngleDeco_GR10_v1_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "132646", "end_iov": "132646"}' \
+    --db Prod \
+    --test;
+	
+mv *.png $W_DIR/results/SiStripLorentzAngleTest.png
+
+getPayloadData.py \
+    --plugin pluginSiStripLorentzAngle_PayloadInspector \
+    --plot plot_SiStripLorentzAngleCompareByRegion \
+    --tag SiStripLorentzAngleDeco_GR10_v1_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "132646", "end_iov": "254501"}' \
+    --db Prod \
+    --test;
+	
+mv *.png $W_DIR/results/SiStripLorentzAngleComparebyRegion.png

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -108,6 +108,14 @@ getPayloadData.py \
     --db Prod \
     --test ;
 
+getPayloadData.py \
+    --plugin pluginSiStripDetVOff_PayloadInspector \
+    --plot plot_SiStripDetVOffByRegion \
+    --tag SiStripDetVOff_v6_prompt \
+    --time_type Run --iovs '{"start_iov": "6607932533539533824", "end_iov": "6607932533539533824"}' \
+    --db Prod \
+    --test;
+
 ######################
 # Test dumping of switched off modules
 ######################
@@ -139,4 +147,4 @@ getPayloadData.py \
     --time_type Run \
     --iovs '{"start_iov": "1", "end_iov": "1"}' \
     --db Prod \
-    --test;
+    --test ;

--- a/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testNoisePayloadInspector.sh
@@ -47,6 +47,17 @@ getPayloadData.py --plugin pluginSiStripNoises_PayloadInspector \
     --input_params '{"DetIds":"470065830,369121594,369124670,470177668"}' \
     --test ;
 
+####################
+# Correlations
+####################
+getPayloadData.py --plugin pluginSiStripNoises_PayloadInspector \
+    --plot plot_SiStripNoiseCorrelationByPartition \
+    --tag SiStripNoise_v2_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "348767", "end_iov": "348878"}' \
+    --db Prod \
+    --test ;
+
 estimators=(Mean Min Max RMS)
 plotTypes=(Strip APV Module)
 partition=(TIB TOB TEC TID)

--- a/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
+++ b/CondCore/SiStripPlugins/test/testPedestalsPayloadInspector.sh
@@ -48,6 +48,18 @@ getPayloadData.py \
     --input_params '{"DetIds":"470065830,369121594,369124670,470177668"}' \
     --test ;
 
+####################
+# Correlations
+####################
+getPayloadData.py \
+    --plugin pluginSiStripPedestals_PayloadInspector \
+    --plot plot_SiStripPedestalCorrelationByPartition \
+    --tag SiStripPedestals_v2_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "348767", "end_iov": "348878"}' \
+    --db Prod \
+    --test ;
+
 estimators=(Mean Min Max RMS)
 plotTypes=(Strip APV Module)
 

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -96,6 +96,10 @@ int main(int argc, char** argv) {
   histoNoiseForDetId.process(connectionString, PI::mk_input(tag, start, start));
   edm::LogPrint("testSiStripPayloadInspector") << histoNoiseForDetId.data() << std::endl;
 
+  SiStripNoiseCorrelationByPartition histoNoiseCorrelationByPartition;
+  histoNoiseCorrelationByPartition.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testSiStripPayloadInspector") << histoNoiseCorrelationByPartition.data() << std::endl;
+
   // Pedestals
 
   tag = "SiStripPedestals_v2_prompt";
@@ -118,6 +122,10 @@ int main(int argc, char** argv) {
   histoPedestalForDetId.setInputParamValues(inputs);
   histoPedestalForDetId.process(connectionString, PI::mk_input(tag, start, start));
   edm::LogPrint("testSiStripPayloadInspector") << histoPedestalForDetId.data() << std::endl;
+
+  SiStripPedestalCorrelationByPartition histoPedestalCorrelationByPartition;
+  histoPedestalCorrelationByPartition.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testSiStripPayloadInspector") << histoPedestalCorrelationByPartition.data() << std::endl;
 
   //Latency
 

--- a/CondFormats/SiStripObjects/interface/SiStripDetSummary.h
+++ b/CondFormats/SiStripObjects/interface/SiStripDetSummary.h
@@ -61,6 +61,8 @@ public:
    */
   void print(std::stringstream& ss, const bool mean = true) const;
 
+  inline void clear() { valueMap_.clear(); }
+
   struct Values {
     Values() : mean(0.), rms(0.), count(0) {}
     double mean;


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to introduce a generalized abstraction for Strip Payload inspector `SiStripCondObjectRepresent` and use it to make detailed comparison and correlation plots for the Strip payload inspector.

#### PR validation:

Relies on augmented unit tests and extended private validation. 
Example of plots obtainable with the new additions.

   * Strip Noise:

![image](https://user-images.githubusercontent.com/5082376/158883860-1f02b8d1-3862-44d0-98b3-a329f590af3e.png)

   * Strip Pedestals:

![image](https://user-images.githubusercontent.com/5082376/158883902-bcc3ce65-4676-46d6-b68f-a3e8c426af8c.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A