### PR TITLE
[Draft] [DD4hep] Improvements for DDD big XML file to help Runs 1-2 migration

### DIFF
--- a/DetectorDescription/Core/interface/DDCompactView.h
+++ b/DetectorDescription/Core/interface/DDCompactView.h
@@ -127,16 +127,17 @@ public:
 
   void lockdown();
 
+  DDI::Store<DDName, std::unique_ptr<DDI::Material>> matStore_;
+  DDI::Store<DDName, std::unique_ptr<DDI::Specific>> specStore_;
+
 private:
   void swap(DDCompactView&);
 
   std::unique_ptr<DDCompactViewImpl> rep_;
   std::unique_ptr<DDPosData> worldpos_;
 
-  DDI::Store<DDName, std::unique_ptr<DDI::Material>> matStore_;
   DDI::Store<DDName, std::unique_ptr<DDI::Solid>> solidStore_;
   DDI::Store<DDName, std::unique_ptr<DDI::LogicalPart>> lpStore_;
-  DDI::Store<DDName, std::unique_ptr<DDI::Specific>> specStore_;
   DDI::Store<DDName, std::unique_ptr<DDRotationMatrix>> rotStore_;
 
   Vectors vectors_;

--- a/DetectorDescription/Core/interface/Store.h
+++ b/DetectorDescription/Core/interface/Store.h
@@ -46,6 +46,8 @@ namespace DDI {
 
     auto begin() { return reg_.begin(); }
     auto end() { return reg_.end(); }
+    auto beginConst() const { return reg_.begin(); }
+    auto endConst() const { return reg_.end(); }
     auto size() const { return reg_.size(); }
 
     // empty shell or fetch from registry

--- a/DetectorDescription/OfflineDBLoader/interface/DDCoreToDDXMLOutput.h
+++ b/DetectorDescription/OfflineDBLoader/interface/DDCoreToDDXMLOutput.h
@@ -43,6 +43,7 @@ struct DDCoreToDDXMLOutput {
 
   void element(const TGeoMaterial* element, std::ostream& xos);
   void material(const DDMaterial& material, std::ostream& xos);
+  void material(const DDI::rep_type<DDName, std::unique_ptr<DDI::Material>>& matPair, std::ostream& xos);
   void material(const std::string& matName,
                 double density,
                 const std::vector<cms::DDParsingContext::CompositeMaterial>& matRefs,
@@ -73,6 +74,9 @@ struct DDCoreToDDXMLOutput {
   void specpar(const DDSpecifics& sp, std::ostream& xos);
   void specpar(const std::pair<DDsvalues_type, std::set<const DDPartSelection*>>& pssv, std::ostream& xos);
   void specpar(const std::string& name, const dd4hep::SpecPar& specPar, std::ostream& xos);
+  void specpar(const DDName& name,
+               const std::pair<DDsvalues_type, std::pair<DDName, std::set<const DDPartSelection*>>>& pssv,
+               std::ostream& xos);
 
   static std::string trimShapeName(const std::string& solidName);
   std::string ns_;  // default namespace


### PR DESCRIPTION
Not for merging. This PR is for saving some example code changes that might be helpful for the Runs 1-2 DD4hep migration.

Attempting to process the DDD big XML file (also called the extended geometry description file) with DD4hep can be a helpful step for migration. The big XML file contains the results of the algorithms, so migrating the algorithms can be avoided or postponed. It might even be possible to perform the migration solely on the big XML file and avoid migrating all the XML and algorithms, though there are limitations with such an approach.

This PR is an attempt to allow the DDD big XML file to be processed by DD4hep. It is not complete. Two problems are addressed. First, the SpecPars in the big XML file are given their proper names, which are missing from the standard DDD big XML file. Second, the materials are re-ordered to avoid references being made before definitions. However, a few materials are still out of order. They might be corrected by using newer versions of materials XML files, where these ordering issues have already been fixed. There may be further issues with processing the DDD big XML file with DD4hep yet to be discovered. The task is a work in progress, which may not necessarily be the most promising avenue for performing the migration.

The DDD big XML file for Run 2 2018, for example, is created with this command:
```
cmsRun CondTools/Geometry/test/writehelpers/geometryExtended2018_xmlwriter.py
```