### PR TITLE
Fix resolution validation plots after moving ME1a CLCT from ring 4 to ring 1

### DIFF
--- a/Validation/MuonCSCDigis/src/CSCStubResolutionValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubResolutionValidation.cc
@@ -102,7 +102,8 @@ void CSCStubResolutionValidation::analyze(const edm::Event& e, const edm::EventS
       // calculate deltastrip for ME1/a. Basically, we need to subtract 64 from the CLCT key strip to
       // compare with key strip as obtained through the fit to simhits positions.
       int deltaStrip = 0;
-      if (cscId.station() == 1 and (cscId.ring() == 4 or cscId.ring() == 1) and clct.getKeyStrip() > CSCConstants::MAX_HALF_STRIP_ME1B)
+      if (cscId.station() == 1 and (cscId.ring() == 4 or cscId.ring() == 1) and
+          clct.getKeyStrip() > CSCConstants::MAX_HALF_STRIP_ME1B)
         deltaStrip = CSCConstants::NUM_STRIPS_ME1B;
 
       // fractional strip

--- a/Validation/MuonCSCDigis/src/CSCStubResolutionValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubResolutionValidation.cc
@@ -102,7 +102,7 @@ void CSCStubResolutionValidation::analyze(const edm::Event& e, const edm::EventS
       // calculate deltastrip for ME1/a. Basically, we need to subtract 64 from the CLCT key strip to
       // compare with key strip as obtained through the fit to simhits positions.
       int deltaStrip = 0;
-      if (cscId.station() == 1 and cscId.ring() == 4 and clct.getKeyStrip() > CSCConstants::MAX_HALF_STRIP_ME1B)
+      if (cscId.station() == 1 and (cscId.ring() == 4 or cscId.ring() == 1) and clct.getKeyStrip() > CSCConstants::MAX_HALF_STRIP_ME1B)
         deltaStrip = CSCConstants::NUM_STRIPS_ME1B;
 
       // fractional strip


### PR DESCRIPTION
#### PR description:

This PR fixes the issue brought about by https://github.com/cms-sw/cmssw/issues/37268
Due to the last PR, the CLCTs in ME1a are having detector information of ring == 1 instead of ring == 4.
The CLCT validation will then misinterpret ME1a CLCTs as ME1b ones.

#### PR validation:
