### PR TITLE
pT dependent ROI producers for Muon HLT

### DIFF
--- a/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionByPtBuilder.h
+++ b/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionByPtBuilder.h
@@ -1,5 +1,5 @@
-#ifndef RecoMuon_TrackingTools_MuonTrackingRegionByPtBuilder_H
-#define RecoMuon_TrackingTools_MuonTrackingRegionByPtBuilder_H
+#ifndef RecoMuon_GlobalTrackingTools_MuonTrackingRegionByPtBuilder_h
+#define RecoMuon_GlobalTrackingTools_MuonTrackingRegionByPtBuilder_h
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -30,7 +30,7 @@ public:
   explicit MuonTrackingRegionByPtBuilder(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) { build(par, iC); }
 
   /// Destructor
-  ~MuonTrackingRegionByPtBuilder() override {}
+  ~MuonTrackingRegionByPtBuilder() override = default;
 
   /// Create Region of Interest
   std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event&, const edm::EventSetup&) const override;
@@ -49,8 +49,6 @@ public:
 
   /// Add Fill Descriptions
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  static void fillDescriptionsHLT(edm::ParameterSetDescription& descriptions);
-  static void fillDescriptionsOffline(edm::ParameterSetDescription& descriptions);
 
 private:
   void build(const edm::ParameterSet&, edm::ConsumesCollector&);

--- a/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionByPtBuilder.h
+++ b/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionByPtBuilder.h
@@ -1,0 +1,86 @@
+#ifndef RecoMuon_TrackingTools_MuonTrackingRegionByPtBuilder_H
+#define RecoMuon_TrackingTools_MuonTrackingRegionByPtBuilder_H
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+class MuonServiceProxy;
+class MeasurementTrackerEvent;
+class MagneticField;
+class IdealMagneticFieldRecord;
+class MultipleScatteringParametrisationMaker;
+class TrackerMultipleScatteringRecord;
+
+class MuonTrackingRegionByPtBuilder : public TrackingRegionProducer {
+public:
+  /// Constructor
+  explicit MuonTrackingRegionByPtBuilder(const edm::ParameterSet& par, edm::ConsumesCollector& iC) { build(par, iC); }
+  explicit MuonTrackingRegionByPtBuilder(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) { build(par, iC); }
+
+  /// Destructor
+  ~MuonTrackingRegionByPtBuilder() override {}
+
+  /// Create Region of Interest
+  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event&, const edm::EventSetup&) const override;
+
+  /// Define tracking region
+  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::TrackRef&) const;
+  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track& t) const {
+    return region(t, *theEvent, *theEventSetup);
+  }
+  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track&,
+                                                          const edm::Event&,
+                                                          const edm::EventSetup&) const;
+
+  /// Pass the Event to the algo at each event
+  void setEvent(const edm::Event&, const edm::EventSetup&);
+
+  /// Add Fill Descriptions
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptionsHLT(edm::ParameterSetDescription& descriptions);
+  static void fillDescriptionsOffline(edm::ParameterSetDescription& descriptions);
+
+private:
+  void build(const edm::ParameterSet&, edm::ConsumesCollector&);
+
+  const edm::Event* theEvent;
+  const edm::EventSetup* theEventSetup;
+
+  bool useVertex;
+  bool useFixedZ;
+  bool useFixedPt;
+  bool thePrecise;
+
+  int theMaxRegions;
+
+  double theNsigmaDz;
+
+  double thePtMin;
+  double theDeltaR;
+  double theHalfZ;
+
+  std::vector<double> ptRanges_;
+  std::vector<double> deltaEtas_;
+  std::vector<double> deltaPhis_;
+
+  RectangularEtaPhiTrackingRegion::UseMeasurementTracker theOnDemand;
+  edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerToken;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
+  edm::EDGetTokenT<reco::VertexCollection> vertexCollectionToken;
+  edm::EDGetTokenT<reco::TrackCollection> inputCollectionToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bfieldToken;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> msmakerToken;
+};
+#endif

--- a/RecoMuon/GlobalTrackingTools/plugins/Module.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/Module.cc
@@ -14,3 +14,8 @@ DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, MuonTrackingRegionBuilder, "Muo
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h"
 using MuonTrackingRegionEDProducer = TrackingRegionEDProducerT<MuonTrackingRegionBuilder>;
 DEFINE_FWK_MODULE(MuonTrackingRegionEDProducer);
+
+#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionByPtBuilder.h"
+DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, MuonTrackingRegionByPtBuilder, "MuonTrackingRegionByPtBuilder");
+using MuonTrackingRegionByPtEDProducer = TrackingRegionEDProducerT<MuonTrackingRegionByPtBuilder>;
+DEFINE_FWK_MODULE(MuonTrackingRegionByPtEDProducer);

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionByPtBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionByPtBuilder.cc
@@ -69,7 +69,7 @@ void MuonTrackingRegionByPtBuilder::build(const edm::ParameterSet& par, edm::Con
   // Flag to use precise??
   thePrecise = par.getParameter<bool>("precise");
 
-  // perigee reference point ToDo: Check this
+  // perigee reference point
   theOnDemand = RectangularEtaPhiTrackingRegion::intToUseMeasurementTracker(par.getParameter<int>("OnDemand"));
   if (theOnDemand != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
     theMeasurementTrackerToken =

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionByPtBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionByPtBuilder.cc
@@ -1,0 +1,244 @@
+#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionByPtBuilder.h"
+
+//-------------------------------
+// Collaborating Class Headers --
+//-------------------------------
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
+
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
+
+//
+// constructor
+//
+void MuonTrackingRegionByPtBuilder::build(const edm::ParameterSet& par, edm::ConsumesCollector& iC) {
+  // Adjust errors on dz
+  theNsigmaDz = par.getParameter<double>("Rescale_Dz");
+
+  // Flag to switch to use Vertices instead of BeamSpot
+  useVertex = par.getParameter<bool>("UseVertex");
+
+  // Flag to use fixed limits for Eta, Phi, Z, pT
+  useFixedZ = par.getParameter<bool>("Z_fixed");
+  useFixedPt = par.getParameter<bool>("Pt_fixed");
+
+  // Minimum value for pT
+  thePtMin = par.getParameter<double>("Pt_min");
+
+  // The static region size along the Z direction
+  theHalfZ = par.getParameter<double>("DeltaZ");
+
+  // The transverse distance of the region from the BS/PV
+  theDeltaR = par.getParameter<double>("DeltaR");
+
+  // Parameterized ROIs depending on the pt
+  ptRanges_ = par.getParameter<std::vector<double>>("ptRanges");
+  if (ptRanges_.size() < 2) {
+    edm::LogError("MuonTrackingRegionByPtBuilder")
+        << "Size of ptRanges does not be less than 2." << std::endl;
+  }
+
+  deltaEtas_ = par.getParameter<std::vector<double>>("deltaEtas");
+  if (deltaEtas_.size() != ptRanges_.size() - 1) {
+    edm::LogError("MuonTrackingRegionByPtBuilder")
+        << "Size of deltaEtas does not match number of pt bins." << std::endl;
+  }
+
+  deltaPhis_ = par.getParameter<std::vector<double>>("deltaPhis");
+  if (deltaPhis_.size() != ptRanges_.size() - 1) {
+    edm::LogError("MuonTrackingRegionByPtBuilder")
+        << "Size of deltaPhis does not match number of pt bins." << std::endl;
+  }
+
+  // Maximum number of regions to build when looping over Muons
+  theMaxRegions = par.getParameter<int>("maxRegions");
+
+  // Flag to use precise??
+  thePrecise = par.getParameter<bool>("precise");
+
+  // perigee reference point ToDo: Check this
+  theOnDemand = RectangularEtaPhiTrackingRegion::intToUseMeasurementTracker(par.getParameter<int>("OnDemand"));
+  if (theOnDemand != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+    theMeasurementTrackerToken =
+        iC.consumes<MeasurementTrackerEvent>(par.getParameter<edm::InputTag>("MeasurementTrackerName"));
+  }
+
+  // Vertex collection and Beam Spot
+  beamSpotToken = iC.consumes<reco::BeamSpot>(par.getParameter<edm::InputTag>("beamSpot"));
+  vertexCollectionToken = iC.consumes<reco::VertexCollection>(par.getParameter<edm::InputTag>("vertexCollection"));
+
+  // Input muon collection
+  inputCollectionToken = iC.consumes<reco::TrackCollection>(par.getParameter<edm::InputTag>("input"));
+
+  bfieldToken = iC.esConsumes();
+  if (thePrecise) {
+    msmakerToken = iC.esConsumes();
+  }
+}
+
+//
+// Member function to be compatible with TrackingRegionProducerFactory: create many ROI for many tracks
+//
+std::vector<std::unique_ptr<TrackingRegion>> MuonTrackingRegionByPtBuilder::regions(const edm::Event& ev,
+                                                                                const edm::EventSetup& es) const {
+  std::vector<std::unique_ptr<TrackingRegion>> result;
+
+  edm::Handle<reco::TrackCollection> tracks;
+  ev.getByToken(inputCollectionToken, tracks);
+
+  int nRegions = 0;
+  for (auto it = tracks->cbegin(), ed = tracks->cend(); it != ed && nRegions < theMaxRegions; ++it) {
+    result.push_back(region(*it, ev, es));
+    nRegions++;
+  }
+
+  return result;
+}
+
+//
+// Call region on Track from TrackRef
+//
+std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionByPtBuilder::region(const reco::TrackRef& track) const {
+  return region(*track);
+}
+
+//
+// ToDo: Not sure if this is needed?
+//
+void MuonTrackingRegionByPtBuilder::setEvent(const edm::Event& event, const edm::EventSetup& es) {
+  theEvent = &event;
+  theEventSetup = &es;
+}
+
+//
+//	Main member function called to create the ROI
+//
+std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionByPtBuilder::region(const reco::Track& staTrack,
+                                                                                   const edm::Event& ev,
+                                                                                   const edm::EventSetup& es) const {
+  // get track momentum/direction at vertex
+  const math::XYZVector& mom = staTrack.momentum();
+  GlobalVector dirVector(mom.x(), mom.y(), mom.z());
+  double pt = staTrack.pt();
+
+  // Fix for StandAlone tracks with low momentum
+  const math::XYZVector& innerMomentum = staTrack.innerMomentum();
+  GlobalVector forSmallMomentum(innerMomentum.x(), innerMomentum.y(), innerMomentum.z());
+  if (staTrack.p() <= 1.5) {
+    pt = std::abs(forSmallMomentum.perp());
+  }
+
+  // initial vertex position - in the following it is replaced with beamspot/vertexing
+  GlobalPoint vertexPos(0.0, 0.0, 0.0);
+  // standard 15.9, if useVertex than use error from  vertex
+  double deltaZ = theHalfZ;
+
+  // retrieve beam spot information
+  edm::Handle<reco::BeamSpot> bs;
+  bool bsHandleFlag = ev.getByToken(beamSpotToken, bs);
+
+  // check the validity, otherwise vertexing
+  if (bsHandleFlag && bs.isValid() && !useVertex) {
+    vertexPos = GlobalPoint(bs->x0(), bs->y0(), bs->z0());
+    deltaZ = useFixedZ ? theHalfZ : bs->sigmaZ() * theNsigmaDz;
+  } else {
+    // get originZPos from list of reconstructed vertices (first or all)
+    edm::Handle<reco::VertexCollection> vertexCollection;
+    bool vtxHandleFlag = ev.getByToken(vertexCollectionToken, vertexCollection);
+    // check if there exists at least one reconstructed vertex
+    if (vtxHandleFlag && !vertexCollection->empty()) {
+      // use the first vertex in the collection and assume it is the primary event vertex
+      reco::VertexCollection::const_iterator vtx = vertexCollection->begin();
+      if (!vtx->isFake() && vtx->isValid()) {
+        vertexPos = GlobalPoint(vtx->x(), vtx->y(), vtx->z());
+        deltaZ = useFixedZ ? theHalfZ : vtx->zError() * theNsigmaDz;
+      }
+    }
+  }
+
+  // set delta eta and delta phi depending on the pt
+  auto region_dEta = deltaEtas_.at(0);
+  auto region_dPhi = deltaPhis_.at(0);
+  if (pt < ptRanges_.back()) {
+    auto lowEdge = std::upper_bound(ptRanges_.begin(), ptRanges_.end(), pt);
+    region_dEta = deltaEtas_.at(lowEdge - ptRanges_.begin() - 1);
+    region_dPhi = deltaPhis_.at(lowEdge - ptRanges_.begin() - 1);
+  }
+
+  float deltaR = theDeltaR;
+  double minPt = useFixedPt ? thePtMin : std::max(thePtMin, pt * 0.6);
+
+  const MeasurementTrackerEvent* measurementTracker = nullptr;
+  if (!theMeasurementTrackerToken.isUninitialized()) {
+    edm::Handle<MeasurementTrackerEvent> hmte;
+    ev.getByToken(theMeasurementTrackerToken, hmte);
+    measurementTracker = hmte.product();
+  }
+
+  const auto& bfield = es.getData(bfieldToken);
+  const MultipleScatteringParametrisationMaker* msmaker = nullptr;
+  if (thePrecise) {
+    msmaker = &es.getData(msmakerToken);
+  }
+
+  auto region = std::make_unique<RectangularEtaPhiTrackingRegion>(dirVector,
+                                                                  vertexPos,
+                                                                  minPt,
+                                                                  deltaR,
+                                                                  deltaZ,
+                                                                  region_dEta,
+                                                                  region_dPhi,
+                                                                  bfield,
+                                                                  msmaker,
+                                                                  thePrecise,
+                                                                  theOnDemand,
+                                                                  measurementTracker);
+
+  LogDebug("MuonTrackingRegionByPtBuilder") << "the region parameters are:\n"
+                                        << "\n dirVector: " << dirVector << "\n vertexPos: " << vertexPos
+                                        << "\n minPt: " << minPt << "\n deltaR:" << deltaR << "\n deltaZ:" << deltaZ
+                                        << "\n region_dEta:" << region_dEta << "\n region_dPhi:" << region_dPhi
+                                        << "\n on demand parameter: " << static_cast<int>(theOnDemand);
+
+  return region;
+}
+
+void MuonTrackingRegionByPtBuilder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("DeltaR", 0.2);
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag(""));
+  desc.add<int>("OnDemand", -1);
+  desc.add<edm::InputTag>("vertexCollection", edm::InputTag(""));
+  desc.add<edm::InputTag>("MeasurementTrackerName", edm::InputTag(""));
+  desc.add<bool>("UseVertex", false);
+  desc.add<double>("Rescale_Dz", 3.0);
+  desc.add<bool>("Pt_fixed", false);
+  desc.add<bool>("Z_fixed", true);
+  desc.add<double>("Pt_min", 1.5);
+  desc.add<double>("DeltaZ", 15.9);
+  desc.add<std::vector<double>>("ptRanges", {0., 1.e9});
+  desc.add<std::vector<double>>("deltaEtas", {0.2});
+  desc.add<std::vector<double>>("deltaPhis", {0.15});
+  desc.add<int>("maxRegions", 1);
+  desc.add<bool>("precise", true);
+  desc.add<edm::InputTag>("input", edm::InputTag(""));
+  descriptions.add("MuonTrackingRegionByPtBuilder", desc);
+
+  descriptions.setComment(
+      "Build a TrackingRegion around a standalone muon. Options to define region around beamspot or primary vertex and "
+      "dynamic regions are included.");
+}

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionByPtBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionByPtBuilder.cc
@@ -48,8 +48,7 @@ void MuonTrackingRegionByPtBuilder::build(const edm::ParameterSet& par, edm::Con
   // Parameterized ROIs depending on the pt
   ptRanges_ = par.getParameter<std::vector<double>>("ptRanges");
   if (ptRanges_.size() < 2) {
-    edm::LogError("MuonTrackingRegionByPtBuilder")
-        << "Size of ptRanges does not be less than 2." << std::endl;
+    edm::LogError("MuonTrackingRegionByPtBuilder") << "Size of ptRanges does not be less than 2." << std::endl;
   }
 
   deltaEtas_ = par.getParameter<std::vector<double>>("deltaEtas");
@@ -94,7 +93,7 @@ void MuonTrackingRegionByPtBuilder::build(const edm::ParameterSet& par, edm::Con
 // Member function to be compatible with TrackingRegionProducerFactory: create many ROI for many tracks
 //
 std::vector<std::unique_ptr<TrackingRegion>> MuonTrackingRegionByPtBuilder::regions(const edm::Event& ev,
-                                                                                const edm::EventSetup& es) const {
+                                                                                    const edm::EventSetup& es) const {
   std::vector<std::unique_ptr<TrackingRegion>> result;
 
   edm::Handle<reco::TrackCollection> tracks;
@@ -112,7 +111,8 @@ std::vector<std::unique_ptr<TrackingRegion>> MuonTrackingRegionByPtBuilder::regi
 //
 // Call region on Track from TrackRef
 //
-std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionByPtBuilder::region(const reco::TrackRef& track) const {
+std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionByPtBuilder::region(
+    const reco::TrackRef& track) const {
   return region(*track);
 }
 
@@ -127,9 +127,8 @@ void MuonTrackingRegionByPtBuilder::setEvent(const edm::Event& event, const edm:
 //
 //	Main member function called to create the ROI
 //
-std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionByPtBuilder::region(const reco::Track& staTrack,
-                                                                                   const edm::Event& ev,
-                                                                                   const edm::EventSetup& es) const {
+std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionByPtBuilder::region(
+    const reco::Track& staTrack, const edm::Event& ev, const edm::EventSetup& es) const {
   // get track momentum/direction at vertex
   const math::XYZVector& mom = staTrack.momentum();
   GlobalVector dirVector(mom.x(), mom.y(), mom.z());
@@ -208,11 +207,11 @@ std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionByPtBuilder::
                                                                   theOnDemand,
                                                                   measurementTracker);
 
-  LogDebug("MuonTrackingRegionByPtBuilder") << "the region parameters are:\n"
-                                        << "\n dirVector: " << dirVector << "\n vertexPos: " << vertexPos
-                                        << "\n minPt: " << minPt << "\n deltaR:" << deltaR << "\n deltaZ:" << deltaZ
-                                        << "\n region_dEta:" << region_dEta << "\n region_dPhi:" << region_dPhi
-                                        << "\n on demand parameter: " << static_cast<int>(theOnDemand);
+  LogDebug("MuonTrackingRegionByPtBuilder")
+      << "the region parameters are:\n"
+      << "\n dirVector: " << dirVector << "\n vertexPos: " << vertexPos << "\n minPt: " << minPt
+      << "\n deltaR:" << deltaR << "\n deltaZ:" << deltaZ << "\n region_dEta:" << region_dEta
+      << "\n region_dPhi:" << region_dPhi << "\n on demand parameter: " << static_cast<int>(theOnDemand);
 
   return region;
 }

--- a/RecoTracker/TkTrackingRegions/plugins/BuildFile.xml
+++ b/RecoTracker/TkTrackingRegions/plugins/BuildFile.xml
@@ -1,9 +1,13 @@
 <library file="*.cc" name="RecoTrackerTkTrackingRegionsPlugins">
   <use name="CondFormats/SiPixelObjects"/>
   <use name="DataFormats/Candidate"/>
+  <use name="DataFormats/L1Trigger"/>
+  <use name="DataFormats/MuonDetId"/>
   <use name="Geometry/Records"/>
   <use name="Geometry/TrackerGeometryBuilder"/>
   <use name="MagneticField/Records"/>
   <use name="RecoTracker/TkTrackingRegions"/>
+  <use name="RecoMuon/TrackingTools"/>
+  <use name="clhep"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoTracker/TkTrackingRegions/plugins/L1MuonSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/L1MuonSeededTrackingRegionsProducer.h
@@ -1,0 +1,412 @@
+#ifndef L1MuonSeededTrackingRegionsProducer_h
+#define L1MuonSeededTrackingRegionsProducer_h
+
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "RecoTracker/Record/interface/TrackerMultipleScatteringRecord.h"
+#include "RecoTracker/TkMSParametrization/interface/MultipleScatteringParametrisationMaker.h"
+#include "CLHEP/Vector/ThreeVector.h"
+
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+
+/** class L1MuonSeededTrackingRegionsProducer
+ *
+ * eta-phi TrackingRegions producer in directions defined by L1 muon objects of interest
+ * from a collection defined by the "input" parameter.
+ *
+ * Four operational modes are supported ("mode" parameter):
+ *
+ *   BeamSpotFixed:
+ *     origin is defined by the beam spot
+ *     z-half-length is defined by a fixed zErrorBeamSpot parameter
+ *   BeamSpotSigma:
+ *     origin is defined by the beam spot
+ *     z-half-length is defined by nSigmaZBeamSpot * beamSpot.sigmaZ
+ *   VerticesFixed:
+ *     origins are defined by vertices from VertexCollection (use maximum MaxNVertices of them)
+ *     z-half-length is defined by a fixed zErrorVetex parameter
+ *   VerticesSigma:
+ *     origins are defined by vertices from VertexCollection (use maximum MaxNVertices of them)
+ *     z-half-length is defined by nSigmaZVertex * vetex.zError
+ *
+ *   If, while using one of the "Vertices" modes, there's no vertices in an event, we fall back into
+ *   either BeamSpotSigma or BeamSpotFixed mode, depending on the positiveness of nSigmaZBeamSpot.
+ *
+ *   \author M. Oh.
+ *       based on RecoTracker/TkTrackingRegions/plugins/CandidateSeededTrackingRegionsProducer.h
+ */
+class L1MuonSeededTrackingRegionsProducer : public TrackingRegionProducer {
+public:
+  typedef enum { BEAM_SPOT_FIXED, BEAM_SPOT_SIGMA, VERTICES_FIXED, VERTICES_SIGMA } Mode;
+
+  explicit L1MuonSeededTrackingRegionsProducer(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
+      : token_field(iC.esConsumes()),
+        l1MinPt_(iConfig.getParameter<double>("L1MinPt")),
+        l1MaxEta_(iConfig.getParameter<double>("L1MaxEta")),
+        l1MinQuality_(iConfig.getParameter<unsigned int>("L1MinQuality")),
+        minPtBarrel_(iConfig.getParameter<double>("SetMinPtBarrelTo")),
+        minPtEndcap_(iConfig.getParameter<double>("SetMinPtEndcapTo")),
+        centralBxOnly_(iConfig.getParameter<bool>("CentralBxOnly")),
+        propagatorName_(iConfig.getParameter<std::string>("Propagator")) {
+    edm::ParameterSet regPSet = iConfig.getParameter<edm::ParameterSet>("RegionPSet");
+
+    // operation mode
+    std::string modeString = regPSet.getParameter<std::string>("mode");
+    if (modeString == "BeamSpotFixed")
+      m_mode = BEAM_SPOT_FIXED;
+    else if (modeString == "BeamSpotSigma")
+      m_mode = BEAM_SPOT_SIGMA;
+    else if (modeString == "VerticesFixed")
+      m_mode = VERTICES_FIXED;
+    else if (modeString == "VerticesSigma")
+      m_mode = VERTICES_SIGMA;
+    else
+      edm::LogError("L1MuonSeededTrackingRegionsProducer") << "Unknown mode string: " << modeString;
+
+    // basic inputs
+    token_input = iC.consumes<l1t::MuonBxCollection>(regPSet.getParameter<edm::InputTag>("input"));
+    m_maxNRegions = regPSet.getParameter<int>("maxNRegions");
+    token_beamSpot = iC.consumes<reco::BeamSpot>(regPSet.getParameter<edm::InputTag>("beamSpot"));
+    m_maxNVertices = 1;
+    if (m_mode == VERTICES_FIXED || m_mode == VERTICES_SIGMA) {
+      token_vertex = iC.consumes<reco::VertexCollection>(regPSet.getParameter<edm::InputTag>("vertexCollection"));
+      m_maxNVertices = regPSet.getParameter<int>("maxNVertices");
+    }
+
+    // RectangularEtaPhiTrackingRegion parameters:
+    m_ptMin = regPSet.getParameter<double>("ptMin");
+    m_originRadius = regPSet.getParameter<double>("originRadius");
+    m_zErrorBeamSpot = regPSet.getParameter<double>("zErrorBeamSpot");
+    m_ptRanges = regPSet.getParameter<std::vector<double>>("ptRanges");
+    if (m_ptRanges.size() < 2) {
+      edm::LogError("L1MuonSeededTrackingRegionsProducer")
+          << "Size of ptRanges does not be less than 2" << std::endl;
+    }
+    m_deltaEtas = regPSet.getParameter<std::vector<double>>("deltaEtas");
+    if (m_deltaEtas.size() != m_ptRanges.size() - 1) {
+      edm::LogError("L1MuonSeededTrackingRegionsProducer")
+          << "Size of deltaEtas does not match number of pt bins." << std::endl;
+    }
+    m_deltaPhis = regPSet.getParameter<std::vector<double>>("deltaPhis");
+    if (m_deltaPhis.size() != m_ptRanges.size() - 1) {
+      edm::LogError("L1MuonSeededTrackingRegionsProducer")
+          << "Size of deltaPhis does not match number of pt bins." << std::endl;
+    }
+
+    m_precise = regPSet.getParameter<bool>("precise");
+    m_whereToUseMeasurementTracker = RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(
+        regPSet.getParameter<std::string>("whereToUseMeasurementTracker"));
+    if (m_whereToUseMeasurementTracker != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+      token_measurementTracker =
+          iC.consumes<MeasurementTrackerEvent>(regPSet.getParameter<edm::InputTag>("measurementTrackerName"));
+    }
+    m_searchOpt = false;
+    if (regPSet.exists("searchOpt"))
+      m_searchOpt = regPSet.getParameter<bool>("searchOpt");
+
+    // mode-dependent z-halflength of tracking regions
+    if (m_mode == VERTICES_SIGMA)
+      m_nSigmaZVertex = regPSet.getParameter<double>("nSigmaZVertex");
+    if (m_mode == VERTICES_FIXED)
+      m_zErrorVetex = regPSet.getParameter<double>("zErrorVetex");
+    m_nSigmaZBeamSpot = -1.;
+    if (m_mode == BEAM_SPOT_SIGMA) {
+      m_nSigmaZBeamSpot = regPSet.getParameter<double>("nSigmaZBeamSpot");
+      if (m_nSigmaZBeamSpot < 0.)
+        edm::LogError("L1MuonSeededTrackingRegionsProducer")
+            << "nSigmaZBeamSpot must be positive for BeamSpotSigma mode!";
+    }
+    if (m_precise) {
+      token_msmaker = iC.esConsumes();
+    }
+
+    // MuonServiceProxy
+    edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
+    service_ = std::make_unique<MuonServiceProxy>(serviceParameters, std::move(iC));
+  }
+
+  ~L1MuonSeededTrackingRegionsProducer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+
+    // L1 muon selection parameters
+    desc.add<std::string>("Propagator", "");
+    desc.add<double>("L1MinPt", -1.);
+    desc.add<double>("L1MaxEta", 5.0);
+    desc.add<unsigned int>("L1MinQuality", 0);
+    desc.add<double>("SetMinPtBarrelTo", 3.5);
+    desc.add<double>("SetMinPtEndcapTo", 1.0);
+    desc.add<bool>("CentralBxOnly", true);
+
+    // Tracking region parameters
+    edm::ParameterSetDescription descRegion;
+    descRegion.add<std::string>("mode", "BeamSpotSigma");
+    descRegion.add<edm::InputTag>("input", edm::InputTag(""));
+    descRegion.add<int>("maxNRegions", 10);
+    descRegion.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"));
+    descRegion.add<edm::InputTag>("vertexCollection", edm::InputTag("notUsed"));
+    descRegion.add<int>("maxNVertices", 1);
+    descRegion.add<double>("ptMin", 0.0);
+    descRegion.add<double>("originRadius", 0.2);
+    descRegion.add<double>("zErrorBeamSpot", 24.2);
+    descRegion.add<std::vector<double>>("ptRanges", {0., 1.e9});
+    descRegion.add<std::vector<double>>("deltaEtas", {0.35});
+    descRegion.add<std::vector<double>>("deltaPhis", {0.2});
+    descRegion.add<bool>("precise", true);
+    descRegion.add<double>("nSigmaZVertex", 3.);
+    descRegion.add<double>("zErrorVetex", 0.2);
+    descRegion.add<double>("nSigmaZBeamSpot", 4.);
+    descRegion.add<std::string>("whereToUseMeasurementTracker", "Never");
+    descRegion.add<edm::InputTag>("measurementTrackerName", edm::InputTag(""));
+    descRegion.add<bool>("searchOpt", false);
+    desc.add<edm::ParameterSetDescription>("RegionPSet", descRegion);
+
+    // MuonServiceProxy for the propagation
+    edm::ParameterSetDescription psd0;
+    psd0.addUntracked<std::vector<std::string>>("Propagators", {"SteppingHelixPropagatorAny"});
+    psd0.add<bool>("RPCLayers", false);
+    psd0.addUntracked<bool>("UseMuonNavigation", false);
+    desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
+
+    descriptions.add("hltIterL3MuonPixelTracksTrackingRegions", desc);
+  }
+
+  std::vector<std::unique_ptr<TrackingRegion>> regions(const edm::Event& iEvent,
+                                                       const edm::EventSetup& iSetup) const override {
+    std::vector<std::unique_ptr<TrackingRegion>> result;
+
+    // pick up the candidate objects of interest
+    edm::Handle<l1t::MuonBxCollection> muColl;
+    iEvent.getByToken(token_input, muColl);
+    if (muColl->size() == 0)
+      return result;
+
+    // always need the beam spot (as a fall back strategy for vertex modes)
+    edm::Handle<reco::BeamSpot> bs;
+    iEvent.getByToken(token_beamSpot, bs);
+    if (!bs.isValid())
+      return result;
+
+    // this is a default origin for all modes
+    GlobalPoint default_origin(bs->x0(), bs->y0(), bs->z0());
+
+    // vector of origin & halfLength pairs:
+    std::vector<std::pair<GlobalPoint, float>> origins;
+
+    // fill the origins and halfLengths depending on the mode
+    if (m_mode == BEAM_SPOT_FIXED || m_mode == BEAM_SPOT_SIGMA) {
+      origins.push_back(std::make_pair(
+          default_origin, (m_mode == BEAM_SPOT_FIXED) ? m_zErrorBeamSpot : m_nSigmaZBeamSpot * bs->sigmaZ()));
+    } else if (m_mode == VERTICES_FIXED || m_mode == VERTICES_SIGMA) {
+      edm::Handle<reco::VertexCollection> vertices;
+      iEvent.getByToken(token_vertex, vertices);
+      int n_vert = 0;
+      for (reco::VertexCollection::const_iterator v = vertices->begin();
+           v != vertices->end() && n_vert < m_maxNVertices;
+           ++v) {
+        if (v->isFake() || !v->isValid())
+          continue;
+
+        origins.push_back(std::make_pair(GlobalPoint(v->x(), v->y(), v->z()),
+                                         (m_mode == VERTICES_FIXED) ? m_zErrorVetex : m_nSigmaZVertex * v->zError()));
+        ++n_vert;
+      }
+      // no-vertex fall-back case:
+      if (origins.empty()) {
+        origins.push_back(std::make_pair(
+            default_origin, (m_nSigmaZBeamSpot > 0.) ? m_nSigmaZBeamSpot * bs->z0Error() : m_zErrorBeamSpot));
+      }
+    }
+
+    const MeasurementTrackerEvent* measurementTracker = nullptr;
+    if (!token_measurementTracker.isUninitialized()) {
+      edm::Handle<MeasurementTrackerEvent> hmte;
+      iEvent.getByToken(token_measurementTracker, hmte);
+      measurementTracker = hmte.product();
+    }
+
+    const auto& field = iSetup.getData(token_field);
+    const MultipleScatteringParametrisationMaker* msmaker = nullptr;
+    if (m_precise) {
+      msmaker = &iSetup.getData(token_msmaker);
+    }
+
+    // create tracking regions (maximum MaxNRegions of them) in directions of the
+    // objects of interest (we expect that the collection was sorted in decreasing pt order)
+    int n_regions = 0;
+    for (int ibx = muColl->getFirstBX(); ibx <= muColl->getLastBX() && n_regions < m_maxNRegions; ++ibx) {
+      if (centralBxOnly_ && (ibx != 0))
+        continue;
+
+      for (auto it = muColl->begin(ibx); it != muColl->end(ibx) && n_regions < m_maxNRegions; it++) {
+        unsigned int quality = it->hwQual();
+        if (quality <= l1MinQuality_)
+          continue;
+
+        float pt = it->pt();
+        float eta = it->eta();
+        if (pt < l1MinPt_ || std::abs(eta) > l1MaxEta_)
+          continue;
+
+        float theta = 2 * atan(exp(-eta));
+        float phi = it->phi();
+
+        int valid_charge = it->hwChargeValid();
+        int charge = it->charge();
+        if (!valid_charge)
+          charge = 0;
+
+        int link = 36 + (int)(it->tfMuonIndex() / 3.);
+        bool barrel = true;
+        if ((link >= 36 && link <= 41) || (link >= 66 && link <= 71))
+          barrel = false;
+
+        // propagate L1 FTS to BS
+        service_->update(iSetup);
+        const DetLayer* detLayer = nullptr;
+        float radius = 0.;
+
+        CLHEP::Hep3Vector vec(0., 1., 0.);
+        vec.setTheta(theta);
+        vec.setPhi(phi);
+
+        DetId theid;
+        // Get the det layer on which the state should be put
+        if (barrel) {
+          // MB2
+          theid = DTChamberId(0, 2, 0);
+          detLayer = service_->detLayerGeometry()->idToLayer(theid);
+
+          const BoundSurface* sur = &(detLayer->surface());
+          const BoundCylinder* bc = dynamic_cast<const BoundCylinder*>(sur);
+
+          radius = std::abs(bc->radius() / sin(theta));
+
+          if (pt < minPtBarrel_)
+            pt = minPtBarrel_;
+        } else {
+          // ME2
+          theid = theta < Geom::pi() / 2. ? CSCDetId(1, 2, 0, 0, 0) : CSCDetId(2, 2, 0, 0, 0);
+
+          detLayer = service_->detLayerGeometry()->idToLayer(theid);
+
+          radius = std::abs(detLayer->position().z() / cos(theta));
+
+          if (pt < minPtEndcap_)
+            pt = minPtEndcap_;
+        }
+        vec.setMag(radius);
+        GlobalPoint pos(vec.x(), vec.y(), vec.z());
+        GlobalVector mom(pt * cos(phi), pt * sin(phi), pt * cos(theta) / sin(theta));
+        GlobalTrajectoryParameters param(pos, mom, charge, &*service_->magneticField());
+
+        AlgebraicSymMatrix55 mat;
+        mat[0][0] = (0.25 / pt) * (0.25 / pt);  // sigma^2(charge/abs_momentum)
+        if (!barrel)
+          mat[0][0] = (0.4 / pt) * (0.4 / pt);
+
+        //Assign q/pt = 0 +- 1/pt if charge has been declared invalid
+        if (!valid_charge)
+          mat[0][0] = (1. / pt) * (1. / pt);
+
+        mat[1][1] = 0.05 * 0.05;  // sigma^2(lambda)
+        mat[2][2] = 0.2 * 0.2;    // sigma^2(phi)
+        mat[3][3] = 20. * 20.;    // sigma^2(x_transverse))
+        mat[4][4] = 20. * 20.;    // sigma^2(y_transverse))
+
+        CurvilinearTrajectoryError error(mat);
+
+        const FreeTrajectoryState state(param, error);
+
+        FreeTrajectoryState state_bs = service_->propagator(propagatorName_)->propagate(state, *bs.product());
+
+        GlobalVector direction(state_bs.momentum().x(), state_bs.momentum().y(), state_bs.momentum().z());
+
+        // set deltaEta and deltaPhi from L1 muon pt
+        auto deltaEta = m_deltaEtas.at(0);
+        auto deltaPhi = m_deltaPhis.at(0);
+        if (it->pt() < m_ptRanges.back()) {
+          auto lowEdge = std::upper_bound(m_ptRanges.begin(), m_ptRanges.end(), it->pt());
+          deltaEta = m_deltaEtas.at(lowEdge - m_ptRanges.begin() - 1);
+          deltaPhi = m_deltaPhis.at(lowEdge - m_ptRanges.begin() - 1);
+        }
+
+        for (size_t j = 0; j < origins.size() && n_regions < m_maxNRegions; ++j) {
+          result.push_back(std::make_unique<RectangularEtaPhiTrackingRegion>(direction,
+                                                                             origins[j].first,
+                                                                             m_ptMin,
+                                                                             m_originRadius,
+                                                                             origins[j].second,
+                                                                             deltaEta,  // m_deltaEta,
+                                                                             deltaPhi,  // m_deltaPhi,
+                                                                             field,
+                                                                             msmaker,
+                                                                             m_precise,
+                                                                             m_whereToUseMeasurementTracker,
+                                                                             measurementTracker,
+                                                                             m_searchOpt));
+          ++n_regions;
+        }
+      }
+    }
+    edm::LogInfo("L1MuonSeededTrackingRegionsProducer") << "produced " << n_regions << " regions";
+
+    return result;
+  }
+
+private:
+  Mode m_mode;
+
+  int m_maxNRegions;
+  edm::EDGetTokenT<reco::VertexCollection> token_vertex;
+  edm::EDGetTokenT<reco::BeamSpot> token_beamSpot;
+  edm::EDGetTokenT<l1t::MuonBxCollection> token_input;
+  int m_maxNVertices;
+
+  float m_ptMin;
+  float m_originRadius;
+  float m_zErrorBeamSpot;
+  std::vector<double> m_ptRanges;
+  std::vector<double> m_deltaEtas;
+  std::vector<double> m_deltaPhis;
+  bool m_precise;
+  edm::EDGetTokenT<MeasurementTrackerEvent> token_measurementTracker;
+  RectangularEtaPhiTrackingRegion::UseMeasurementTracker m_whereToUseMeasurementTracker;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> token_field;
+  edm::ESGetToken<MultipleScatteringParametrisationMaker, TrackerMultipleScatteringRecord> token_msmaker;
+  bool m_searchOpt;
+
+  float m_nSigmaZVertex;
+  float m_zErrorVetex;
+  float m_nSigmaZBeamSpot;
+
+  const double l1MinPt_;
+  const double l1MaxEta_;
+  const unsigned l1MinQuality_;
+  const double minPtBarrel_;
+  const double minPtEndcap_;
+  bool centralBxOnly_;
+
+  std::string propagatorName_;
+  std::unique_ptr<MuonServiceProxy> service_;
+};
+
+#endif

--- a/RecoTracker/TkTrackingRegions/plugins/L1MuonSeededTrackingRegionsProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/L1MuonSeededTrackingRegionsProducer.h
@@ -96,8 +96,7 @@ public:
     m_zErrorBeamSpot = regPSet.getParameter<double>("zErrorBeamSpot");
     m_ptRanges = regPSet.getParameter<std::vector<double>>("ptRanges");
     if (m_ptRanges.size() < 2) {
-      edm::LogError("L1MuonSeededTrackingRegionsProducer")
-          << "Size of ptRanges does not be less than 2" << std::endl;
+      edm::LogError("L1MuonSeededTrackingRegionsProducer") << "Size of ptRanges does not be less than 2" << std::endl;
     }
     m_deltaEtas = regPSet.getParameter<std::vector<double>>("deltaEtas");
     if (m_deltaEtas.size() != m_ptRanges.size() - 1) {

--- a/RecoTracker/TkTrackingRegions/plugins/SealModule.cc
+++ b/RecoTracker/TkTrackingRegions/plugins/SealModule.cc
@@ -7,6 +7,7 @@
 #include "RecoTracker/TkTrackingRegions/plugins/PointSeededTrackingRegionsProducer.h"
 #include "RecoTracker/TkTrackingRegions/plugins/CandidateSeededTrackingRegionsProducer.h"
 #include "RecoTracker/TkTrackingRegions/plugins/CandidatePointSeededTrackingRegionsProducer.h"
+#include "RecoTracker/TkTrackingRegions/plugins/L1MuonSeededTrackingRegionsProducer.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "GlobalTrackingRegionWithVerticesProducer.h"
 #include "GlobalTrackingRegionProducer.h"
@@ -28,6 +29,9 @@ DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory,
 DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory,
                   CandidatePointSeededTrackingRegionsProducer,
                   "CandidatePointSeededTrackingRegionsProducer");
+DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory,
+                  L1MuonSeededTrackingRegionsProducer,
+                  "L1MuonSeededTrackingRegionsProducer");
 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h"
 using GlobalTrackingRegionEDProducer = TrackingRegionEDProducerT<GlobalTrackingRegionProducer>;
@@ -48,6 +52,9 @@ DEFINE_FWK_MODULE(CandidateSeededTrackingRegionsEDProducer);
 using CandidatePointSeededTrackingRegionsEDProducer =
     TrackingRegionEDProducerT<CandidatePointSeededTrackingRegionsProducer>;
 DEFINE_FWK_MODULE(CandidatePointSeededTrackingRegionsEDProducer);
+
+using L1MuonSeededTrackingRegionsEDProducer = TrackingRegionEDProducerT<L1MuonSeededTrackingRegionsProducer>;
+DEFINE_FWK_MODULE(L1MuonSeededTrackingRegionsEDProducer);
 
 using AreaSeededTrackingRegionsEDProducer = TrackingRegionEDProducerT<AreaSeededTrackingRegionsProducer>;
 DEFINE_FWK_MODULE(AreaSeededTrackingRegionsEDProducer);


### PR DESCRIPTION
This PR adds two new tracking region producers with pt parametrized ROI sizes for the inside-out track reconstruction in Muon HLT. These modules are minimally changed from the existing modules:

- `RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionByPtBuilder.h` is updated from `RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h`
- `RecoTracker/TkTrackingRegions/plugins/L1MuonSeededTrackingRegionsProducer.h` is updated from `RecoTracker/TkTrackingRegions/plugins/CandidateSeededTrackingRegionsProducer.h`

Initial performance study was presented at the TSG meeting by @wonpoint4: https://indico.cern.ch/event/1131517/contributions/4751084/attachments/2396360/4097442/220223_TSG_MuonROI_wonjun.pdf

- Significant efficiency gain at low pT, e.g. 75% to 95% at 4 GeV, with a cost of up to around 10 ms timing increase and O(10%) of rate increase for low-pT muon triggers (no significant impact on the total rates).
- The final ROI parameter tuning (python configuration level changes) to balance between efficiency and timing/rates is ongoing.

FYI: @JanFSchulte @wonpoint4