### PR TITLE
Cosmetic improvement in printout of Payload Inspector plots for DropBoxMetaData

### DIFF
--- a/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
+++ b/CondCore/PhysicsToolsPlugins/interface/DropBoxMetaDataPayloadInspectorHelper.h
@@ -238,13 +238,13 @@ namespace DBoxMetadataHelper {
         toAppend.clear();
         for (unsigned int iPath = 0; iPath < pathsPrep.size(); ++iPath) {
           std::string thisString = pathsPrep[iPath];
-
+          // skip userText since we want to see actual contents, not metadata
           if (thisString.find("userText") == std::string::npos) {
-            // if the line to be added has less than colWidth chars append to current
-            if ((toAppend + thisString).length() < colWidth) {
+            // if the line to be added has less than colWidth chars, and is not a new tag ("inputTag"), append to current
+            if ((toAppend + thisString).length() < colWidth && thisString.find("inputTag") != 0) {
               toAppend += thisString;
             } else {
-              // else if the line exceeds colWidth chars, dump in the vector and resume from scratch
+              // else if the line exceeds colWidth chars or this is a new tag ("inputTag"), dump in the vector and resume from scratch
               output.push_back(toAppend);
               toAppend.clear();
               toAppend += thisString;
@@ -264,10 +264,10 @@ namespace DBoxMetadataHelper {
 
           if (thisString.find("userText") == std::string::npos) {
             // if the line to be added has less than colWidth chars append to current
-            if ((toAppend + thisString).length() < colWidth) {
+            if ((toAppend + thisString).length() < colWidth && thisString.find("inputTag") != 0) {
               toAppend += thisString;
             } else {
-              // else if the line exceeds colWidth chars, dump in the vector and resume from scratch
+              // else if the line exceeds colWidth chars or this is a new tag ("inputTag"), dump in the vector and resume from scratch
               output.push_back(toAppend);
               toAppend.clear();
               toAppend += thisString;
@@ -615,13 +615,13 @@ namespace DBoxMetadataHelper {
       toAppend.clear();
       for (unsigned int iPath = 0; iPath < thePaths.size(); ++iPath) {
         std::string thisString = thePaths[iPath];
-        // if the line to be added has less than colWidth chars append to current
+        // skip userText since we want to compare actual contents, not metadata
         if (thisString.find("userText") == std::string::npos) {
-          // if the line to be added has less than colWidth chars append to current
-          if ((toAppend + thisString).length() < colWidth) {
+          // if the line to be added has less than colWidth chars, and is not a new tag ("inputTag"), append to current
+          if ((toAppend + thisString).length() < colWidth && thisString.find("inputTag") != 0) {
             toAppend += thisString;
           } else {
-            // else if the line exceeds colWidth chars, dump in the vector and resume from scrach
+            // else if the line exceeds colWidth chars or this is a new tag ("inputTag"), dump in the vector and resume from scratch
             output.push_back("#color[" + std::to_string(color) + "]{" + toAppend + "}");
             tmp += toAppend;
             toAppend.clear();


### PR DESCRIPTION
#### PR description:

As continuation to PR #37011, improve legibility of printouts by adding a newline in front of new tag ("inputTag").

#### PR validation:

The correct behaviour is illustrated with the attached plots produced with a modified version of the script test/test_DropBoxMetadata_PayloadInspector.sh (plots with and without these modifications).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
![DropBoxMetadata_Display_new](https://user-images.githubusercontent.com/51359/159305697-f66ff3c2-e830-40d4-b89c-ee4457b7ac5c.png)
![DropBoxMetadata_Display_old](https://user-images.githubusercontent.com/51359/159305703-e53e9b04-02fe-46c8-855e-ba3731b01837.png)

