### PR TITLE
bug fix in vertex selection of L2TauTagNNProducer

### DIFF
--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -605,7 +605,7 @@ void L2TauNNProducer::selectGoodTracksAndVertices(const ZVertexSoA& patavtx_soa,
   }
   if (nv > 0) {
     const auto minFOM_fromFrac = (*std::max_element(pTSquaredSum.begin(), pTSquaredSum.end())) * fractionSumPt2_;
-    for (int j = nv - 1; j >= 0 && vtxGood.size()< maxVtx_; --j) {
+    for (int j = nv - 1; j >= 0 && vtxGood.size() < maxVtx_; --j) {
       auto vtx_idx = patavtx_soa.sortInd[j];
       assert(vtx_idx < nv);
       if (nTrkAssociated[vtx_idx] >= 2 && pTSquaredSum[vtx_idx] >= minFOM_fromFrac &&
@@ -668,7 +668,6 @@ void L2TauNNProducer::fillPatatracks(tensorflow::Tensor& cellGridMatrix,
   std::vector<int> vtxGood;
 
   selectGoodTracksAndVertices(patavtx_soa, patatracks_tsoa, trkGood, vtxGood);
-
 
   const int nTaus = allTaus.size();
   for (tau_idx = 0; tau_idx < nTaus; tau_idx++) {
@@ -777,7 +776,6 @@ void L2TauNNProducer::produce(edm::Event& event, const edm::EventSetup& eventset
   caloRecHits.eb = &*ebCal;
   caloRecHits.ee = &*eeCal;
   caloRecHits.geometry = &*geometry;
-
 
   const int nTaus = allTaus.size();
   tensorflow::Tensor cellGridMatrix(tensorflow::DT_FLOAT,

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -400,7 +400,7 @@ void L2TauNNProducer::standardizeTensor(tensorflow::Tensor& tensor) {
 
 void L2TauNNProducer::fillL1TauVars(tensorflow::Tensor& cellGridMatrix, const std::vector<l1t::TauRef>& allTaus) {
   using NNInputs = L2TauTagNNv1::NNInputs;
-  //const int nTaus = static_cast<int>(allTaus.size());
+
   const int nTaus = allTaus.size();
   for (int tau_idx = 0; tau_idx < nTaus; tau_idx++) {
     for (int eta_idx = 0; eta_idx < L2TauTagNNv1::nCellEta; eta_idx++) {
@@ -434,7 +434,7 @@ void L2TauNNProducer::fillCaloRecHits(tensorflow::Tensor& cellGridMatrix,
                                       const std::vector<l1t::TauRef>& allTaus,
                                       const caloRecHitCollections& caloRecHits) {
   using NNInputs = L2TauTagNNv1::NNInputs;
-  //const int nTaus = static_cast<int>(allTaus.size());
+
   const int nTaus = allTaus.size();
   float deta, dphi;
   int eta_idx = 0;
@@ -605,7 +605,7 @@ void L2TauNNProducer::selectGoodTracksAndVertices(const ZVertexSoA& patavtx_soa,
   }
   if (nv > 0) {
     const auto minFOM_fromFrac = (*std::max_element(pTSquaredSum.begin(), pTSquaredSum.end())) * fractionSumPt2_;
-    for (int j = nv - 1; j >= 0; --j) {
+    for (int j = nv - 1; j >= 0 && vtxGood.size()< maxVtx_; --j) {
       auto vtx_idx = patavtx_soa.sortInd[j];
       assert(vtx_idx < nv);
       if (nTrkAssociated[vtx_idx] >= 2 && pTSquaredSum[vtx_idx] >= minFOM_fromFrac &&
@@ -669,7 +669,7 @@ void L2TauNNProducer::fillPatatracks(tensorflow::Tensor& cellGridMatrix,
 
   selectGoodTracksAndVertices(patavtx_soa, patatracks_tsoa, trkGood, vtxGood);
 
-  //const int nTaus = static_cast<int>(allTaus.size());
+
   const int nTaus = allTaus.size();
   for (tau_idx = 0; tau_idx < nTaus; tau_idx++) {
     const float tauEta = allTaus[tau_idx]->eta();
@@ -778,7 +778,7 @@ void L2TauNNProducer::produce(edm::Event& event, const edm::EventSetup& eventset
   caloRecHits.ee = &*eeCal;
   caloRecHits.geometry = &*geometry;
 
-  //const int nTaus = static_cast<int>(allTaus.size());
+
   const int nTaus = allTaus.size();
   tensorflow::Tensor cellGridMatrix(tensorflow::DT_FLOAT,
                                     {nTaus, L2TauTagNNv1::nCellEta, L2TauTagNNv1::nCellPhi, L2TauTagNNv1::nVars});

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -686,7 +686,7 @@ void L2TauNNProducer::fillPatatracks(tensorflow::Tensor& cellGridMatrix,
       const auto nHits = patatracks_tsoa.nHits(it);
       if (nHits <= 0)
         continue;
-      const int patatrackNdof = 2 * nHits - 5;
+      const int patatrackNdof = 2 * std::min(6, nHits) - 5;
 
       const int vtx_idx_assTrk = patavtx_soa.idv[it];
       if (reco::deltaR2(patatrackEta, patatrackPhi, tauEta, tauPhi) < dR2_max) {

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -184,9 +184,9 @@ private:
                       const reco::BeamSpot& beamspot,
                       const MagneticField* magfi);
   void selectGoodTracksAndVertices(const ZVertexSoA& patavtx_soa,
-                                   const pixelTrack::TrackSoA& patatracks_tsoa,
-                                   std::vector<int>& TrkGood,
-                                   std::vector<int>& VtxGood);
+                                      const pixelTrack::TrackSoA& patatracks_tsoa,
+                                      std::vector<int>& TrkGood,
+                                      std::vector<int>& VtxGood);
   std::pair<float, float> impactParameter(int it,
                                           const pixelTrack::TrackSoA& patatracks_tsoa,
                                           float patatrackPhi,
@@ -341,21 +341,21 @@ void L2TauNNProducer::checknan(tensorflow::Tensor& tensor, int debugLevel) {
             edm::LogWarning("InputVar") << "var is nan \nvar name= "
                                         << L2TauTagNNv1::varNameMap.at(static_cast<L2TauTagNNv1::NNInputs>(var_idx))
                                         << "\t var_idx = " << var_idx << "\t eta_idx = " << eta_idx
-                                        << "\t phi_idx = " << phi_idx << "\t tau_idx = " << tau_idx << std::endl;
+                                        << "\t phi_idx = " << phi_idx << "\t tau_idx = " << tau_idx;
             if (debugLevel > 2) {
               edm::LogWarning("InputVar") << "other vars in same cell \n";
               if (var_idx + 1 < tensor_shape.at(3))
                 edm::LogWarning("InputVar") << L2TauTagNNv1::varNameMap.at(static_cast<NNInputs>(var_idx + 1))
-                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 1)) << std::endl;
+                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 1));
               if (var_idx + 2 < tensor_shape.at(3))
                 edm::LogWarning("InputVar") << L2TauTagNNv1::varNameMap.at(static_cast<NNInputs>(var_idx + 2))
-                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 2)) << std::endl;
+                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 2));
               if (var_idx + 3 < tensor_shape.at(3))
                 edm::LogWarning("InputVar") << L2TauTagNNv1::varNameMap.at(static_cast<NNInputs>(var_idx + 3))
-                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 3)) << std::endl;
+                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 3));
               if (var_idx + 4 < tensor_shape.at(3))
                 edm::LogWarning("InputVar") << L2TauTagNNv1::varNameMap.at(static_cast<NNInputs>(var_idx + 4))
-                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 4)) << std::endl;
+                                            << "\t = " << getCell(static_cast<NNInputs>(var_idx + 4));
             }
           }
         }
@@ -568,52 +568,54 @@ void L2TauNNProducer::fillCaloRecHits(tensorflow::Tensor& cellGridMatrix,
 }
 
 void L2TauNNProducer::selectGoodTracksAndVertices(const ZVertexSoA& patavtx_soa,
-                                                  const pixelTrack::TrackSoA& patatracks_tsoa,
-                                                  std::vector<int>& TrkGood,
-                                                  std::vector<int>& VtxGood) {
-  const auto maxTracks = patatracks_tsoa.stride();
-  const int nv = patavtx_soa.nvFinal;
-  auto const* quality = patatracks_tsoa.qualityData();
+                                                     const pixelTrack::TrackSoA& patatracks_tsoa,
+                                                     std::vector<int>& TrkGood,
+                                                     std::vector<int>& VtxGood) {
+   const auto maxTracks = patatracks_tsoa.stride();
+   const int nv = patavtx_soa.nvFinal;
+   auto const* quality = patatracks_tsoa.qualityData();
 
-  // No need to sort either as the algorithms is just using the max (not even the location, just the max value of pt2sum).
-  std::vector<double> pTSquaredSum(nv, 0);
-  std::vector<int> nTrkAssociated(nv, 0);
+   // No need to sort either as the algorithms is just using the max (not even the location, just the max value of pt2sum).
+   std::vector<double> pTSquaredSum(nv,0);
+   std::vector<int> nTrkAssociated(nv,0);
 
-  for (int32_t trk_idx = 0; trk_idx < maxTracks; ++trk_idx) {
-    auto nHits = patatracks_tsoa.nHits(trk_idx);
-    if (nHits == 0) {
-      break;
-    }
-    int vtx_ass_to_track = patavtx_soa.idv[trk_idx];
-    if (vtx_ass_to_track >= 0 && vtx_ass_to_track <= nv) {
-      double patatrackPt = patatracks_tsoa.pt[trk_idx];
-      ++nTrkAssociated.at(vtx_ass_to_track);
-      if (patatrackPt >= trackPtMin_ && patatracks_tsoa.chi2(trk_idx) <= trackChi2Max_) {
-        if (patatrackPt > trackPtMax_) {
-          patatrackPt = trackPtMax_;
-        }
-        pTSquaredSum.at(vtx_ass_to_track) += patatrackPt * patatrackPt;
-      }
-    }
-    auto q = quality[trk_idx];
-    if (q < pixelTrack::Quality::loose)
-      continue;
-    if (nHits < 0)
-      continue;
-    TrkGood.push_back(trk_idx);
-  }
-  if (nv > 0) {
-    const auto minFOM_fromFrac = (*std::max_element(pTSquaredSum.begin(), pTSquaredSum.end())) * fractionSumPt2_;
-    for (int j = nv - 1; j >= 0; --j) {
-      auto vtx_idx = patavtx_soa.sortInd[j];
-      assert(vtx_idx < nv);
-      if (nTrkAssociated.at(vtx_idx) >= 2 && pTSquaredSum[vtx_idx] >= minFOM_fromFrac &&
-          pTSquaredSum[vtx_idx] > minSumPt2_) {
-        VtxGood.push_back(vtx_idx);
-      }
-    }
-  }
+   for (int32_t trk_idx = 0; trk_idx < maxTracks; ++trk_idx) {
+     auto nHits = patatracks_tsoa.nHits(trk_idx);
+     if (nHits == 0){
+       break;
+     }
+      int vtx_ass_to_track = patavtx_soa.idv[trk_idx];
+      if(vtx_ass_to_track>=0 && vtx_ass_to_track<= nv){
+        double patatrackPt = patatracks_tsoa.pt[trk_idx];
+        ++nTrkAssociated.at(vtx_ass_to_track);
+         if (patatrackPt >= trackPtMin_ && patatracks_tsoa.chi2(trk_idx)<=trackChi2Max_){
+           if (patatrackPt > trackPtMax_) {
+             patatrackPt = trackPtMax_;
+           }
+           pTSquaredSum.at(vtx_ass_to_track) += patatrackPt * patatrackPt;
+         }
+       }
+     auto q = quality[trk_idx];
+     if (q < pixelTrack::Quality::loose)
+       continue;
+     if (nHits < 0)
+       continue;
+     TrkGood.push_back(trk_idx);
+
+   }
+   if(nv>0) {
+     const auto minFOM_fromFrac = (*std::max_element(pTSquaredSum.begin(),pTSquaredSum.end()))*fractionSumPt2_;
+     for (int j = nv - 1; j >= 0; --j) {
+       auto vtx_idx = patavtx_soa.sortInd[j];
+       assert(vtx_idx < nv);
+       if(nTrkAssociated.at(vtx_idx)>=2 && pTSquaredSum[vtx_idx] >= minFOM_fromFrac && pTSquaredSum[vtx_idx] > minSumPt2_){
+         VtxGood.push_back(vtx_idx);
+       }
+     }
+   }
 }
+
+
 
 std::pair<float, float> L2TauNNProducer::impactParameter(int it,
                                                          const pixelTrack::TrackSoA& patatracks_tsoa,

--- a/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauTagNNProducer.cc
@@ -832,8 +832,7 @@ void L2TauNNProducer::produce(edm::Event& event, const edm::EventSetup& eventset
     for (size_t tau_pos = 0; tau_pos < nTau; ++tau_pos) {
       const auto tau_idx = TauCollectionMap[inp_idx][tau_pos];
       if (debugLevel_ > 0) {
-        std::cout << event.id().event() << " \t " << (allTaus[tau_idx])->pt() << " \t "
-        //edm::LogInfo("DebugInfo") << event.id().event() << " \t " << (allTaus[tau_idx])->pt() << " \t "
+        edm::LogInfo("DebugInfo") << event.id().event() << " \t " << (allTaus[tau_idx])->pt() << " \t "
                                   << tau_score.at(tau_idx) << std::endl;
       }
       (*tau_tags)[tau_pos] = tau_score.at(tau_idx);


### PR DESCRIPTION
#### PR description:
Doing tests on GPU, some issues in L2NNTag produced outputs have been reported: running twice the L2NNTag producer, it gave different results on the same events/taus. The problem has been addressed to the filling of the CNN inputs : ```PatatrackPtSumWithVertex``` and ```PatatrackSizeWithVertex```. 
The reason is the following: to fill the aforementioned variables while looping on tracks, a match between the vertex associated to the track (*) is required by associating the observable idv (which is the vertex index related to the patatrack) to be the same of the sortInd (**) which is the vertex index sorted by the vertex observable ptv2 .
If you want to give a look to the vertex related observables, they are described [here](https://github.com/cms-sw/cmssw/blob/master/CUDADataFormats/Vertex/interface/ZVertexSoA.h).

This match is not correct: indeed, the idv has to be compared with the vertex index.

(*) all tracks with vertex index -1 are not considered, since this means that they are not associated to any vertex
(**) the sortInd is of a subset of all vertices, since they are required to pass some quality cuts described in the function SelectGoodVertices. Also in this function there is a similar matching requirement and also in that case it has been changed.

In this PR, this bug is fixed.

#### PR validation:

This bug was spotted because while looping multiple times on GPU, results were not consistent among each other.
With the aforementioned change, some preliminar tests on GPU and CPU have been carried on, selecting specific bugged events and from those preliminar tests there are no more differences.

With CPUs there were no difference both before and after the bugfix.  So integrating this PR CPU results should be kept unchanged (in terms of efficiencies and rates).