### PR TITLE
[Core][RH8] Fix unit test to use python3

### DIFF
--- a/IOPool/Common/test/run_TestEdmConfigDump.sh
+++ b/IOPool/Common/test/run_TestEdmConfigDump.sh
@@ -6,7 +6,7 @@ pushd ${LOCAL_TMP_DIR}
 
   cmsRun ${LOCAL_TEST_DIR}/testEdmConfigDump_cfg.py > testEdmConfigDump.log || die "cmsRun testEdmConfigDump_cfg.py" $?
   edmProvDump testEdmProvDump.root > provdump.log
-  python ${LOCAL_TEST_DIR}/removeChangingParts.py provdump.log > provdump1.log
+  python3 ${LOCAL_TEST_DIR}/removeChangingParts.py provdump.log > provdump1.log
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/provdump.log provdump1.log  || die "comparing provdump.log" $?
 
 popd


### PR DESCRIPTION
This should fix the unit test for RHEL8 IBs where we do not have python (python2) installed