### PR TITLE
Phase2-hgx301 Use messagelogger service instead of cout

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
+++ b/Geometry/HGCalCommonData/src/HGCalParametersFromDD.cc
@@ -73,7 +73,7 @@ bool HGCalParametersFromDD::build(const DDCompactView* cpv,
   DDFilteredView fv(*cpv, filter);
   bool ok = fv.firstChild();
   HGCalGeometryMode::WaferMode mode(HGCalGeometryMode::Polyhedra);
-
+  edm::LogVerbatim("HGCalGeom") << "Volume " << name << " GeometryMode ";
   if (ok) {
     DDsvalues_type sv(fv.mergedSpecifics());
     php.mode_ = getGeometryMode("GeometryMode", sv);

--- a/Geometry/HGCalCommonData/test/FastTimeNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/FastTimeNumberingTester.cc
@@ -32,48 +32,45 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/ForwardDetId/interface/FastTimeDetId.h"
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Core/interface/DDExpandedView.h"
 #include "DetectorDescription/Core/interface/DDSpecifics.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/HGCalCommonData/interface/FastTimeDDDConstants.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 class FastTimeNumberingTester : public edm::one::EDAnalyzer<> {
 public:
   explicit FastTimeNumberingTester(const edm::ParameterSet&);
-  ~FastTimeNumberingTester() override;
+  ~FastTimeNumberingTester() override = default;
 
   void beginJob() override {}
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
   void endJob() override {}
 
 private:
-  edm::ESGetToken<FastTimeDDDConstants, IdealGeometryRecord> token_;
+  const edm::ESGetToken<FastTimeDDDConstants, IdealGeometryRecord> token_;
 };
 
 FastTimeNumberingTester::FastTimeNumberingTester(const edm::ParameterSet&)
     : token_{esConsumes<FastTimeDDDConstants, IdealGeometryRecord>(edm::ESInputTag{})} {}
 
-FastTimeNumberingTester::~FastTimeNumberingTester() {}
-
 // ------------ method called to produce the data  ------------
 void FastTimeNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const FastTimeDDDConstants& fTnDC = iSetup.getData(token_);
-  std::cout << "Fast timing device with " << fTnDC.getCells(1) << ":" << fTnDC.getCells(2) << " cells"
-            << " for barrel and endcap\n";
+  edm::LogVerbatim("HGCalGeom") << "Fast timing device with " << fTnDC.getCells(1) << ":" << fTnDC.getCells(2) << " cells for barrel and endcap";
   for (int type = 1; type <= 2; ++type) {
     for (int ix = 0; ix < 400; ++ix) {
       for (int iy = 0; iy < 400; ++iy) {
         if (fTnDC.isValidXY(type, ix, iy)) {
           FastTimeDetId id1(type, ix, iy, 1), id2(type, ix, iy, -1);
-          std::cout << "Valid ID " << id1 << " and " << id2 << std::endl;
+          edm::LogVerbatim("HGCalGeom") << "Valid ID " << id1 << " and " << id2;
         } else {
 #ifdef EDM_ML_DEBUG
-          std::cout << "ix = " << ix << ", iy = " << iy << " is not valid for "
-                    << "FastTime type " << type << std::endl;
+          edm::LogVerbatim("HGCalGeom") << "ix = " << ix << ", iy = " << iy << " is not valid for " << "FastTime type " << type;
 #endif
         }
         iy += 9;

--- a/Geometry/HGCalCommonData/test/FastTimeNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/FastTimeNumberingTester.cc
@@ -61,7 +61,8 @@ FastTimeNumberingTester::FastTimeNumberingTester(const edm::ParameterSet&)
 // ------------ method called to produce the data  ------------
 void FastTimeNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const FastTimeDDDConstants& fTnDC = iSetup.getData(token_);
-  edm::LogVerbatim("HGCalGeom") << "Fast timing device with " << fTnDC.getCells(1) << ":" << fTnDC.getCells(2) << " cells for barrel and endcap";
+  edm::LogVerbatim("HGCalGeom") << "Fast timing device with " << fTnDC.getCells(1) << ":" << fTnDC.getCells(2)
+                                << " cells for barrel and endcap";
   for (int type = 1; type <= 2; ++type) {
     for (int ix = 0; ix < 400; ++ix) {
       for (int iy = 0; iy < 400; ++iy) {
@@ -70,7 +71,8 @@ void FastTimeNumberingTester::analyze(const edm::Event& iEvent, const edm::Event
           edm::LogVerbatim("HGCalGeom") << "Valid ID " << id1 << " and " << id2;
         } else {
 #ifdef EDM_ML_DEBUG
-          edm::LogVerbatim("HGCalGeom") << "ix = " << ix << ", iy = " << iy << " is not valid for " << "FastTime type " << type;
+          edm::LogVerbatim("HGCalGeom") << "ix = " << ix << ", iy = " << iy << " is not valid for "
+                                        << "FastTime type " << type;
 #endif
         }
         iy += 9;

--- a/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
@@ -81,9 +81,13 @@ HGCalNumberingTester::HGCalNumberingTester(const edm::ParameterSet& iC) {
       positionY_[k] /= CLHEP::mm;
     }
   }
-  edm::LogVerbatim("HGCalGeom") << "Test numbering for " << nameDetector_ << " using constants of " << nameSense_ << " at " << positionX_.size() << " local positions " << "for every " << increment_ << " layers for DetType " << detType_ << " and  RecoFlag " << reco_;
+  edm::LogVerbatim("HGCalGeom") << "Test numbering for " << nameDetector_ << " using constants of " << nameSense_
+                                << " at " << positionX_.size() << " local positions "
+                                << "for every " << increment_ << " layers for DetType " << detType_ << " and  RecoFlag "
+                                << reco_;
   for (unsigned int k = 0; k < positionX_.size(); ++k)
-    edm::LogVerbatim("HGCalGeom") << "Position[" << k << "] " << positionX_[k] << " " << unit << ", " << positionY_[k] << " " << unit;
+    edm::LogVerbatim("HGCalGeom") << "Position[" << k << "] " << positionX_[k] << " " << unit << ", " << positionY_[k]
+                                  << " " << unit;
 }
 
 void HGCalNumberingTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -102,13 +106,17 @@ void HGCalNumberingTester::fillDescriptions(edm::ConfigurationDescriptions& desc
 // ------------ method called to produce the data  ------------
 void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const HGCalDDDConstants& hgdc = iSetup.getData(dddToken_);
-  edm::LogVerbatim("HGCalGeom") << nameDetector_ << " Layers = " << hgdc.layers(reco_) << " Sectors = " << hgdc.sectors() << " Minimum Slope = " << hgdc.minSlope();
+  edm::LogVerbatim("HGCalGeom") << nameDetector_ << " Layers = " << hgdc.layers(reco_)
+                                << " Sectors = " << hgdc.sectors() << " Minimum Slope = " << hgdc.minSlope();
   if (detType_ != 0) {
-    edm::LogVerbatim("HGCalGeom") << "Minimum Wafer # " << hgdc.waferMin() << " Mamximum Wafer # " << hgdc.waferMax() << " Wafer counts " << hgdc.waferCount(0) << ":" << hgdc.waferCount(1);
+    edm::LogVerbatim("HGCalGeom") << "Minimum Wafer # " << hgdc.waferMin() << " Mamximum Wafer # " << hgdc.waferMax()
+                                  << " Wafer counts " << hgdc.waferCount(0) << ":" << hgdc.waferCount(1);
     for (unsigned int i = 0; i < hgdc.layers(true); ++i) {
       int lay = i + 1;
       double z = hgdc.waferZ(lay, reco_);
-      edm::LogVerbatim("HGCalGeom") << "Layer " << lay << " Wafers " << hgdc.wafers(lay, 0) << ":" << hgdc.wafers(lay, 1) << ":" << hgdc.wafers(lay, 2) << " Z " << z << " R " << hgdc.rangeR(z, reco_).first << ":" << hgdc.rangeR(z, reco_).second;
+      edm::LogVerbatim("HGCalGeom") << "Layer " << lay << " Wafers " << hgdc.wafers(lay, 0) << ":"
+                                    << hgdc.wafers(lay, 1) << ":" << hgdc.wafers(lay, 2) << " Z " << z << " R "
+                                    << hgdc.rangeR(z, reco_).first << ":" << hgdc.rangeR(z, reco_).second;
     }
   }
   edm::LogVerbatim("HGCalGeom") << std::endl;
@@ -126,12 +134,18 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
         xy = hgdc.locateCell(kxy.second, i + loff, kxy.first, reco_);
         lxy = hgdc.assignCell(xy.first, xy.second, i + loff, 0, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << "," << i + loff << ", " << subsec << "), assignCell o/p (" << kxy.first << ", " << kxy.second << ") locateCell o/p (" << xy.first << ", " << xy.second << ")," << " final (" << lxy.first << ", " << lxy.second << ")" << flg;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << "," << i + loff << ", " << subsec
+                                      << "), assignCell o/p (" << kxy.first << ", " << kxy.second
+                                      << ") locateCell o/p (" << xy.first << ", " << xy.second << "),"
+                                      << " final (" << lxy.first << ", " << lxy.second << ")" << flg;
         kxy = hgdc.assignCell(-localx, -localy, i + loff, subsec, reco_);
         xy = hgdc.locateCell(kxy.second, i + loff, kxy.first, reco_);
         lxy = hgdc.assignCell(xy.first, xy.second, i + loff, 0, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << "," << i + loff << ", " << subsec << "), assignCell o/p (" << kxy.first << ", " << kxy.second << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy.first << ", " << lxy.second << ")" << flg;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << "," << i + loff << ", " << subsec
+                                      << "), assignCell o/p (" << kxy.first << ", " << kxy.second
+                                      << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final ("
+                                      << lxy.first << ", " << lxy.second << ")" << flg;
       } else if (detType_ == 0) {
         std::array<int, 3> kxy, lxy;
         double zpos = hgdc.waferZ(i + loff, reco_);
@@ -139,12 +153,20 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
         xy = hgdc.locateCellTrap(i + loff, kxy[0], kxy[1], reco_);
         lxy = hgdc.assignCellTrap(xy.first, xy.second, zpos, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << "," << zpos << ", " << i + loff << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ") Dist " << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << "," << zpos << ", " << i + loff
+                                      << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2]
+                                      << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0]
+                                      << ":" << lxy[1] << ":" << lxy[2] << ") Dist "
+                                      << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
         kxy = hgdc.assignCellTrap(-localx, -localy, zpos, i + loff, reco_);
         xy = hgdc.locateCellTrap(i + loff, kxy[0], kxy[1], reco_);
         lxy = hgdc.assignCellTrap(xy.first, xy.second, zpos, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << "," << zpos << ", " << i + loff << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ") Dist " << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << "," << zpos << ", " << i + loff
+                                      << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2]
+                                      << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0]
+                                      << ":" << lxy[1] << ":" << lxy[2] << ") Dist "
+                                      << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
       } else {
         std::array<int, 5> kxy, lxy;
         kxy = hgdc.assignCellHex(localx, localy, i + loff, reco_);
@@ -152,12 +174,22 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
         lxy = hgdc.assignCellHex(xy.first, xy.second, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         double zpos = hgdc.waferZ(i + loff, reco_);
-        edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << ", " << i + loff << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":" << kxy[3] << ":" << kxy[4] << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":" << lxy[3] << ":" << lxy[4] << ") Dist " << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << ", " << i + loff
+                                      << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":"
+                                      << kxy[3] << ":" << kxy[4] << ") locateCell o/p (" << xy.first << ", "
+                                      << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":"
+                                      << lxy[3] << ":" << lxy[4] << ") Dist "
+                                      << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg;
         kxy = hgdc.assignCellHex(-localx, -localy, i + loff, reco_);
         xy = hgdc.locateCell(i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true);
         lxy = hgdc.assignCellHex(xy.first, xy.second, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << ", " << i + loff << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":" << kxy[3] << ":" << kxy[4] << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":" << lxy[3] << ":" << lxy[4] << ") Dist " << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << ", " << i + loff
+                                      << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":"
+                                      << kxy[3] << ":" << kxy[4] << ") locateCell o/p (" << xy.first << ", "
+                                      << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":"
+                                      << lxy[3] << ":" << lxy[4] << ") Dist "
+                                      << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg;
       }
       if (k == 0 && i == 0 && detType_ == 1) {
         std::vector<int> ncells = hgdc.numberCells(i + 1, reco_);
@@ -178,7 +210,8 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
     unsigned int kk(0);
     for (auto const& zz : hgdc.getParameter()->zLayerHex_) {
       std::pair<double, double> rr = hgdc.rangeR(zz, true);
-      edm::LogVerbatim("HGCalGeom") << "[" << kk << "]\t z = " << zz << "\t rMin = " << rr.first << "\t rMax = " << rr.second;
+      edm::LogVerbatim("HGCalGeom") << "[" << kk << "]\t z = " << zz << "\t rMin = " << rr.first
+                                    << "\t rMax = " << rr.second;
       ++kk;
     }
   }
@@ -188,7 +221,8 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
     unsigned int kk(0);
     for (auto const& lay : hgdc.getParameter()->layer_) {
       auto rRange = hgdc.getREtaRange(lay);
-      edm::LogVerbatim("HGCalGeom") << "[" << kk << "] Layer " << lay << " R/Eta " << rRange.first << ":" << rRange.second << " nPhi " << hgdc.getPhiBins(lay);
+      edm::LogVerbatim("HGCalGeom") << "[" << kk << "] Layer " << lay << " R/Eta " << rRange.first << ":"
+                                    << rRange.second << " nPhi " << hgdc.getPhiBins(lay);
       ++kk;
     }
   }

--- a/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalNumberingTester.cc
@@ -81,13 +81,9 @@ HGCalNumberingTester::HGCalNumberingTester(const edm::ParameterSet& iC) {
       positionY_[k] /= CLHEP::mm;
     }
   }
-  std::cout << "Test numbering for " << nameDetector_ << " using constants of " << nameSense_ << " at "
-            << positionX_.size() << " local positions "
-            << "for every " << increment_ << " layers for DetType " << detType_ << " and  RecoFlag " << reco_
-            << std::endl;
+  edm::LogVerbatim("HGCalGeom") << "Test numbering for " << nameDetector_ << " using constants of " << nameSense_ << " at " << positionX_.size() << " local positions " << "for every " << increment_ << " layers for DetType " << detType_ << " and  RecoFlag " << reco_;
   for (unsigned int k = 0; k < positionX_.size(); ++k)
-    std::cout << "Position[" << k << "] " << positionX_[k] << " " << unit << ", " << positionY_[k] << " " << unit
-              << std::endl;
+    edm::LogVerbatim("HGCalGeom") << "Position[" << k << "] " << positionX_[k] << " " << unit << ", " << positionY_[k] << " " << unit;
 }
 
 void HGCalNumberingTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -106,20 +102,16 @@ void HGCalNumberingTester::fillDescriptions(edm::ConfigurationDescriptions& desc
 // ------------ method called to produce the data  ------------
 void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const HGCalDDDConstants& hgdc = iSetup.getData(dddToken_);
-  std::cout << nameDetector_ << " Layers = " << hgdc.layers(reco_) << " Sectors = " << hgdc.sectors()
-            << " Minimum Slope = " << hgdc.minSlope() << std::endl;
+  edm::LogVerbatim("HGCalGeom") << nameDetector_ << " Layers = " << hgdc.layers(reco_) << " Sectors = " << hgdc.sectors() << " Minimum Slope = " << hgdc.minSlope();
   if (detType_ != 0) {
-    std::cout << "Minimum Wafer # " << hgdc.waferMin() << " Mamximum Wafer # " << hgdc.waferMax() << " Wafer counts "
-              << hgdc.waferCount(0) << ":" << hgdc.waferCount(1) << std::endl;
+    edm::LogVerbatim("HGCalGeom") << "Minimum Wafer # " << hgdc.waferMin() << " Mamximum Wafer # " << hgdc.waferMax() << " Wafer counts " << hgdc.waferCount(0) << ":" << hgdc.waferCount(1);
     for (unsigned int i = 0; i < hgdc.layers(true); ++i) {
       int lay = i + 1;
       double z = hgdc.waferZ(lay, reco_);
-      std::cout << "Layer " << lay << " Wafers " << hgdc.wafers(lay, 0) << ":" << hgdc.wafers(lay, 1) << ":"
-                << hgdc.wafers(lay, 2) << " Z " << z << " R " << hgdc.rangeR(z, reco_).first << ":"
-                << hgdc.rangeR(z, reco_).second << std::endl;
+      edm::LogVerbatim("HGCalGeom") << "Layer " << lay << " Wafers " << hgdc.wafers(lay, 0) << ":" << hgdc.wafers(lay, 1) << ":" << hgdc.wafers(lay, 2) << " Z " << z << " R " << hgdc.rangeR(z, reco_).first << ":" << hgdc.rangeR(z, reco_).second;
     }
   }
-  std::cout << std::endl << std::endl;
+  edm::LogVerbatim("HGCalGeom") << std::endl;
   std::pair<float, float> xy;
   std::string flg;
   int subsec(0);
@@ -134,17 +126,12 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
         xy = hgdc.locateCell(kxy.second, i + loff, kxy.first, reco_);
         lxy = hgdc.assignCell(xy.first, xy.second, i + loff, 0, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        std::cout << "Input: (" << localx << "," << localy << "," << i + loff << ", " << subsec << "), assignCell o/p ("
-                  << kxy.first << ", " << kxy.second << ") locateCell o/p (" << xy.first << ", " << xy.second << "),"
-                  << " final (" << lxy.first << ", " << lxy.second << ")" << flg << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << "," << i + loff << ", " << subsec << "), assignCell o/p (" << kxy.first << ", " << kxy.second << ") locateCell o/p (" << xy.first << ", " << xy.second << ")," << " final (" << lxy.first << ", " << lxy.second << ")" << flg;
         kxy = hgdc.assignCell(-localx, -localy, i + loff, subsec, reco_);
         xy = hgdc.locateCell(kxy.second, i + loff, kxy.first, reco_);
         lxy = hgdc.assignCell(xy.first, xy.second, i + loff, 0, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        std::cout << "Input: (" << -localx << "," << -localy << "," << i + loff << ", " << subsec
-                  << "), assignCell o/p (" << kxy.first << ", " << kxy.second << ") locateCell o/p (" << xy.first
-                  << ", " << xy.second << "),"
-                  << " final (" << lxy.first << ", " << lxy.second << ")" << flg << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << "," << i + loff << ", " << subsec << "), assignCell o/p (" << kxy.first << ", " << kxy.second << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy.first << ", " << lxy.second << ")" << flg;
       } else if (detType_ == 0) {
         std::array<int, 3> kxy, lxy;
         double zpos = hgdc.waferZ(i + loff, reco_);
@@ -152,20 +139,12 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
         xy = hgdc.locateCellTrap(i + loff, kxy[0], kxy[1], reco_);
         lxy = hgdc.assignCellTrap(xy.first, xy.second, zpos, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        std::cout << "Input: (" << localx << "," << localy << "," << zpos << ", " << i + loff << "), assignCell o/p ("
-                  << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ") locateCell o/p (" << xy.first << ", " << xy.second
-                  << "),"
-                  << " final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ") Dist "
-                  << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << "," << zpos << ", " << i + loff << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ") Dist " << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
         kxy = hgdc.assignCellTrap(-localx, -localy, zpos, i + loff, reco_);
         xy = hgdc.locateCellTrap(i + loff, kxy[0], kxy[1], reco_);
         lxy = hgdc.assignCellTrap(xy.first, xy.second, zpos, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        std::cout << "Input: (" << -localx << "," << -localy << "," << zpos << ", " << i + loff << "), assignCell o/p ("
-                  << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ") locateCell o/p (" << xy.first << ", " << xy.second
-                  << "),"
-                  << " final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ") Dist "
-                  << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << "," << zpos << ", " << i + loff << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ") Dist " << hgdc.distFromEdgeTrap(scl * localx, scl * localy, scl * zpos) << " " << flg;
       } else {
         std::array<int, 5> kxy, lxy;
         kxy = hgdc.assignCellHex(localx, localy, i + loff, reco_);
@@ -173,32 +152,22 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
         lxy = hgdc.assignCellHex(xy.first, xy.second, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
         double zpos = hgdc.waferZ(i + loff, reco_);
-        std::cout << "Input: (" << localx << "," << localy << ", " << i + loff << "), assignCell o/p (" << kxy[0] << ":"
-                  << kxy[1] << ":" << kxy[2] << ":" << kxy[3] << ":" << kxy[4] << ") locateCell o/p (" << xy.first
-                  << ", " << xy.second << "),"
-                  << " final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":" << lxy[3] << ":" << lxy[4]
-                  << ") Dist " << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg
-                  << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << localx << "," << localy << ", " << i + loff << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":" << kxy[3] << ":" << kxy[4] << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":" << lxy[3] << ":" << lxy[4] << ") Dist " << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg;
         kxy = hgdc.assignCellHex(-localx, -localy, i + loff, reco_);
         xy = hgdc.locateCell(i + loff, kxy[0], kxy[1], kxy[3], kxy[4], reco_, true);
         lxy = hgdc.assignCellHex(xy.first, xy.second, i + loff, reco_);
         flg = (kxy == lxy) ? " " : " ***** Error *****";
-        std::cout << "Input: (" << -localx << "," << -localy << ", " << i + loff << "), assignCell o/p (" << kxy[0]
-                  << ":" << kxy[1] << ":" << kxy[2] << ":" << kxy[3] << ":" << kxy[4] << ") locateCell o/p ("
-                  << xy.first << ", " << xy.second << "),"
-                  << " final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":" << lxy[3] << ":" << lxy[4]
-                  << ") Dist " << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg
-                  << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "Input: (" << -localx << "," << -localy << ", " << i + loff << "), assignCell o/p (" << kxy[0] << ":" << kxy[1] << ":" << kxy[2] << ":" << kxy[3] << ":" << kxy[4] << ") locateCell o/p (" << xy.first << ", " << xy.second << "), final (" << lxy[0] << ":" << lxy[1] << ":" << lxy[2] << ":" << lxy[3] << ":" << lxy[4] << ") Dist " << hgdc.distFromEdgeHex(scl * localx, scl * localy, scl * zpos) << " " << flg;
       }
       if (k == 0 && i == 0 && detType_ == 1) {
         std::vector<int> ncells = hgdc.numberCells(i + 1, reco_);
-        std::cout << "Layer " << i + 1 << " with " << ncells.size() << " rows" << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "Layer " << i + 1 << " with " << ncells.size() << " rows";
         int ntot(0);
         for (unsigned int k = 0; k < ncells.size(); ++k) {
           ntot += ncells[k];
-          std::cout << "Row " << k << " with " << ncells[k] << " cells\n";
+          edm::LogVerbatim("HGCalGeom") << "Row " << k << " with " << ncells[k] << " cells";
         }
-        std::cout << "Total Cells " << ntot << ":" << hgdc.maxCells(i + 1, reco_) << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "Total Cells " << ntot << ":" << hgdc.maxCells(i + 1, reco_);
       }
       i += increment_;
     }
@@ -209,7 +178,7 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
     unsigned int kk(0);
     for (auto const& zz : hgdc.getParameter()->zLayerHex_) {
       std::pair<double, double> rr = hgdc.rangeR(zz, true);
-      std::cout << "[" << kk << "]\t z = " << zz << "\t rMin = " << rr.first << "\t rMax = " << rr.second << std::endl;
+      edm::LogVerbatim("HGCalGeom") << "[" << kk << "]\t z = " << zz << "\t rMin = " << rr.first << "\t rMax = " << rr.second;
       ++kk;
     }
   }
@@ -219,8 +188,7 @@ void HGCalNumberingTester::analyze(const edm::Event& iEvent, const edm::EventSet
     unsigned int kk(0);
     for (auto const& lay : hgdc.getParameter()->layer_) {
       auto rRange = hgdc.getREtaRange(lay);
-      std::cout << "[" << kk << "] Layer " << lay << " R/Eta " << rRange.first << ":" << rRange.second << " nPhi "
-                << hgdc.getPhiBins(lay) << std::endl;
+      edm::LogVerbatim("HGCalGeom") << "[" << kk << "] Layer " << lay << " R/Eta " << rRange.first << ":" << rRange.second << " nPhi " << hgdc.getPhiBins(lay);
       ++kk;
     }
   }

--- a/Geometry/HGCalCommonData/test/HGCalParameterTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalParameterTester.cc
@@ -130,8 +130,8 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
   } else if (mode_ == 1) {
     // Wafers of 8-inch format
     edm::LogVerbatim("HGCalGeom") << "DetectorType: " << phgp->detectorType_;
-    edm::LogVerbatim("HGCalGeom") << "Wafer Parameters: " << phgp->waferSize_ << ":" << phgp->waferR_ << ":" << phgp->waferThick_ << ":"
-              << phgp->sensorSeparation_ << ":" << phgp->mouseBite_;
+    edm::LogVerbatim("HGCalGeom") << "Wafer Parameters: " << phgp->waferSize_ << ":" << phgp->waferR_ << ":"
+                                  << phgp->waferThick_ << ":" << phgp->sensorSeparation_ << ":" << phgp->mouseBite_;
     myPrint("waferThickness", phgp->waferThickness_, 10);
     edm::LogVerbatim("HGCalGeom") << "nCells_: " << phgp->nCellsFine_ << ":" << phgp->nCellsCoarse_;
     edm::LogVerbatim("HGCalGeom") << "nSectors_: " << phgp->nSectors_;
@@ -144,15 +144,17 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
     myPrint("CellThickness", phgp->cellThickness_, 10);
     myPrint("radius100to200", phgp->radius100to200_, 10);
     myPrint("radius200to300", phgp->radius200to300_, 10);
-    edm::LogVerbatim("HGCalGeom") << "choiceType " << phgp->choiceType_ << "   nCornerCut " << phgp->nCornerCut_ << "  fracAreaMin "
-              << phgp->fracAreaMin_ << "  zMinForRad " << phgp->zMinForRad_;
+    edm::LogVerbatim("HGCalGeom") << "choiceType " << phgp->choiceType_ << "   nCornerCut " << phgp->nCornerCut_
+                                  << "  fracAreaMin " << phgp->fracAreaMin_ << "  zMinForRad " << phgp->zMinForRad_;
 
     myPrint("CellSize", phgp->cellSize_, 10);
     myPrint("radiusMixBoundary", phgp->radiusMixBoundary_, 10);
     myPrint("LayerCenter", phgp->layerCenter_, 20);
-    edm::LogVerbatim("HGCalGeom") << "Layer Rotation " << phgp->layerRotation_ << "   with " << phgp->layerRotV_.size() << "  parameters";
+    edm::LogVerbatim("HGCalGeom") << "Layer Rotation " << phgp->layerRotation_ << "   with " << phgp->layerRotV_.size()
+                                  << "  parameters";
     for (unsigned int k = 0; k < phgp->layerRotV_.size(); ++k)
-      edm::LogVerbatim("HGCalGeom") << "Element[" << k << "] " << phgp->layerRotV_[k].first << ":" << phgp->layerRotV_[k].second;
+      edm::LogVerbatim("HGCalGeom") << "Element[" << k << "] " << phgp->layerRotV_[k].first << ":"
+                                    << phgp->layerRotV_[k].second;
     myPrint("slopeMin", phgp->slopeMin_, 10);
     myPrint("zFrontMin", phgp->zFrontMin_, 10);
     myPrint("rMinFront", phgp->rMinFront_, 10);
@@ -211,7 +213,11 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
       unsigned int kk(0);
       std::unordered_map<int32_t, HGCalParameters::waferInfo>::const_iterator itr = phgp->waferInfoMap_.begin();
       for (; itr != phgp->waferInfoMap_.end(); ++itr, ++kk)
-        edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << itr->first << "[" << HGCalWaferIndex::waferLayer(itr->first) << ", " << HGCalWaferIndex::waferU(itr->first) << ", " << HGCalWaferIndex::waferV(itr->first) << "] (" << (itr->second).type << ", " << (itr->second).part << ", " << (itr->second).orient << ")";
+        edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << itr->first << "["
+                                      << HGCalWaferIndex::waferLayer(itr->first) << ", "
+                                      << HGCalWaferIndex::waferU(itr->first) << ", "
+                                      << HGCalWaferIndex::waferV(itr->first) << "] (" << (itr->second).type << ", "
+                                      << (itr->second).part << ", " << (itr->second).orient << ")";
     }
   } else {
     // Tpaezoid (scintillator) type
@@ -291,7 +297,12 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
       unsigned int kk(0);
       std::unordered_map<int32_t, HGCalParameters::tileInfo>::const_iterator itr = phgp->tileInfoMap_.begin();
       for (; itr != phgp->tileInfoMap_.end(); ++itr, ++kk)
-        edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << itr->first << "[" << HGCalTileIndex::tileLayer(itr->first) << ", " << HGCalTileIndex::tileRing(itr->first) << ", " << HGCalTileIndex::tilePhi(itr->first) << "] (" << (itr->second).type << ", " << (itr->second).sipm << std::hex << ", " << (itr->second).hex[0] << ", " << (itr->second).hex[1] << ", " << (itr->second).hex[2] << ", " << (itr->second).hex[3] << ")" << std::dec;
+        edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << itr->first << "[" << HGCalTileIndex::tileLayer(itr->first)
+                                      << ", " << HGCalTileIndex::tileRing(itr->first) << ", "
+                                      << HGCalTileIndex::tilePhi(itr->first) << "] (" << (itr->second).type << ", "
+                                      << (itr->second).sipm << std::hex << ", " << (itr->second).hex[0] << ", "
+                                      << (itr->second).hex[1] << ", " << (itr->second).hex[2] << ", "
+                                      << (itr->second).hex[3] << ")" << std::dec;
     }
   }
 
@@ -415,7 +426,8 @@ void HGCalParameterTester::printWaferType(HGCalParameters const* phgp) const {
   if (!kounts.empty()) {
     edm::LogVerbatim("HGCalGeom") << "Summary of waferTypes ==========================";
     for (itr = kounts.begin(); itr != kounts.end(); ++itr)
-      edm::LogVerbatim("HGCalGeom") << "Type (" << (itr->first).first << ":" << (itr->first).second << ") Kount " << itr->second;
+      edm::LogVerbatim("HGCalGeom") << "Type (" << (itr->first).first << ":" << (itr->first).second << ") Kount "
+                                    << itr->second;
   }
 }
 

--- a/Geometry/HGCalCommonData/test/HGCalParameterTester.cc
+++ b/Geometry/HGCalCommonData/test/HGCalParameterTester.cc
@@ -1,10 +1,12 @@
 #include <iostream>
+#include <sstream>
 #include <map>
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
@@ -16,7 +18,7 @@
 class HGCalParameterTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HGCalParameterTester(const edm::ParameterSet&);
-  ~HGCalParameterTester() override {}
+  ~HGCalParameterTester() override = default;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   void beginJob() override {}
@@ -57,16 +59,16 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
   const auto& hgp = iSetup.getData(token_);
   const auto* phgp = &hgp;
 
-  std::cout << phgp->name_ << "\n";
+  edm::LogVerbatim("HGCalGeom") << phgp->name_;
   if (mode_ == 0) {
     // Wafers of 6-inch format
-    std::cout << "DetectorType: " << phgp->detectorType_ << "\n";
-    std::cout << "WaferR_: " << phgp->waferR_ << "\n";
-    std::cout << "nCells_: " << phgp->nCells_ << "\n";
-    std::cout << "nSectors_: " << phgp->nSectors_ << "\n";
-    std::cout << "FirstLayer: " << phgp->firstLayer_ << "\n";
-    std::cout << "FirstMixedLayer: " << phgp->firstMixedLayer_ << "\n";
-    std::cout << "mode_: " << phgp->mode_ << "\n";
+    edm::LogVerbatim("HGCalGeom") << "DetectorType: " << phgp->detectorType_;
+    edm::LogVerbatim("HGCalGeom") << "WaferR_: " << phgp->waferR_;
+    edm::LogVerbatim("HGCalGeom") << "nCells_: " << phgp->nCells_;
+    edm::LogVerbatim("HGCalGeom") << "nSectors_: " << phgp->nSectors_;
+    edm::LogVerbatim("HGCalGeom") << "FirstLayer: " << phgp->firstLayer_;
+    edm::LogVerbatim("HGCalGeom") << "FirstMixedLayer: " << phgp->firstMixedLayer_;
+    edm::LogVerbatim("HGCalGeom") << "mode_: " << phgp->mode_;
 
     myPrint("CellSize", phgp->cellSize_, 10);
     myPrint("slopeMin", phgp->slopeMin_, 10);
@@ -116,9 +118,9 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
     myPrint("depth", phgp->depth_, 18);
     myPrint("depthIndex", phgp->depthIndex_, 18);
     myPrint("depthLayerF", phgp->depthLayerF_, 18);
-    myPrint("waferCopy", phgp->waferCopy_, 8);
-    myPrint("waferTypeL", phgp->waferTypeL_, 20);
-    myPrint("waferTypeT", phgp->waferTypeT_, 20);
+    myPrint("waferCopy", phgp->waferCopy_, 10);
+    myPrint("waferTypeL", phgp->waferTypeL_, 25);
+    myPrint("waferTypeT", phgp->waferTypeT_, 25);
     myPrint("layerGroupM", phgp->layerGroupM_, 18);
     myPrint("layerGroupO", phgp->layerGroupO_, 18);
     printTrform(phgp);
@@ -127,30 +129,30 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
 
   } else if (mode_ == 1) {
     // Wafers of 8-inch format
-    std::cout << "DetectorType: " << phgp->detectorType_ << "\n";
-    std::cout << "Wafer Parameters: " << phgp->waferSize_ << ":" << phgp->waferR_ << ":" << phgp->waferThick_ << ":"
-              << phgp->sensorSeparation_ << ":" << phgp->mouseBite_ << "\n";
+    edm::LogVerbatim("HGCalGeom") << "DetectorType: " << phgp->detectorType_;
+    edm::LogVerbatim("HGCalGeom") << "Wafer Parameters: " << phgp->waferSize_ << ":" << phgp->waferR_ << ":" << phgp->waferThick_ << ":"
+              << phgp->sensorSeparation_ << ":" << phgp->mouseBite_;
     myPrint("waferThickness", phgp->waferThickness_, 10);
-    std::cout << "nCells_: " << phgp->nCellsFine_ << ":" << phgp->nCellsCoarse_ << "\n";
-    std::cout << "nSectors_: " << phgp->nSectors_ << "\n";
-    std::cout << "FirstLayer: " << phgp->firstLayer_ << "\n";
-    std::cout << "FirstMixedLayer: " << phgp->firstMixedLayer_ << "\n";
-    std::cout << "LayerOffset: " << phgp->layerOffset_ << "\n";
-    std::cout << "mode_: " << phgp->mode_ << "\n";
+    edm::LogVerbatim("HGCalGeom") << "nCells_: " << phgp->nCellsFine_ << ":" << phgp->nCellsCoarse_;
+    edm::LogVerbatim("HGCalGeom") << "nSectors_: " << phgp->nSectors_;
+    edm::LogVerbatim("HGCalGeom") << "FirstLayer: " << phgp->firstLayer_;
+    edm::LogVerbatim("HGCalGeom") << "FirstMixedLayer: " << phgp->firstMixedLayer_;
+    edm::LogVerbatim("HGCalGeom") << "LayerOffset: " << phgp->layerOffset_;
+    edm::LogVerbatim("HGCalGeom") << "mode_: " << phgp->mode_;
 
     myPrint("waferUVMaxLayer", phgp->waferUVMaxLayer_, 20);
     myPrint("CellThickness", phgp->cellThickness_, 10);
     myPrint("radius100to200", phgp->radius100to200_, 10);
     myPrint("radius200to300", phgp->radius200to300_, 10);
-    std::cout << "choiceType " << phgp->choiceType_ << "   nCornerCut " << phgp->nCornerCut_ << "  fracAreaMin "
-              << phgp->fracAreaMin_ << "  zMinForRad " << phgp->zMinForRad_ << "\n";
+    edm::LogVerbatim("HGCalGeom") << "choiceType " << phgp->choiceType_ << "   nCornerCut " << phgp->nCornerCut_ << "  fracAreaMin "
+              << phgp->fracAreaMin_ << "  zMinForRad " << phgp->zMinForRad_;
 
     myPrint("CellSize", phgp->cellSize_, 10);
     myPrint("radiusMixBoundary", phgp->radiusMixBoundary_, 10);
     myPrint("LayerCenter", phgp->layerCenter_, 20);
-    std::cout << "Layer Rotation " << phgp->layerRotation_ << "   with " << phgp->layerRotV_.size() << "  parameters\n";
+    edm::LogVerbatim("HGCalGeom") << "Layer Rotation " << phgp->layerRotation_ << "   with " << phgp->layerRotV_.size() << "  parameters";
     for (unsigned int k = 0; k < phgp->layerRotV_.size(); ++k)
-      std::cout << "Element[" << k << "] " << phgp->layerRotV_[k].first << ":" << phgp->layerRotV_[k].second << "\n";
+      edm::LogVerbatim("HGCalGeom") << "Element[" << k << "] " << phgp->layerRotV_[k].first << ":" << phgp->layerRotV_[k].second;
     myPrint("slopeMin", phgp->slopeMin_, 10);
     myPrint("zFrontMin", phgp->zFrontMin_, 10);
     myPrint("rMinFront", phgp->rMinFront_, 10);
@@ -197,35 +199,32 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
     myPrint("depth", phgp->depth_, 18);
     myPrint("depthIndex", phgp->depthIndex_, 18);
     myPrint("depthLayerF", phgp->depthLayerF_, 18);
-    myPrint("waferCopy", phgp->waferCopy_, 8);
-    myPrint("waferTypeL", phgp->waferTypeL_, 20);
+    myPrint("waferCopy", phgp->waferCopy_, 10);
+    myPrint("waferTypeL", phgp->waferTypeL_, 25);
     printTrform(phgp);
     myPrint("levelTop", phgp->levelT_, 10);
     printWaferType(phgp);
 
-    std::cout << "MaskMode: " << phgp->waferMaskMode_ << "\n";
+    edm::LogVerbatim("HGCalGeom") << "MaskMode: " << phgp->waferMaskMode_;
     if (phgp->waferMaskMode_ > 1) {
-      std::cout << "WaferInfo with " << phgp->waferInfoMap_.size() << " elements\n";
+      edm::LogVerbatim("HGCalGeom") << "WaferInfo with " << phgp->waferInfoMap_.size() << " elements";
       unsigned int kk(0);
       std::unordered_map<int32_t, HGCalParameters::waferInfo>::const_iterator itr = phgp->waferInfoMap_.begin();
       for (; itr != phgp->waferInfoMap_.end(); ++itr, ++kk)
-        std::cout << "[" << kk << "] " << itr->first << "[" << HGCalWaferIndex::waferLayer(itr->first) << ", "
-                  << HGCalWaferIndex::waferU(itr->first) << ", " << HGCalWaferIndex::waferV(itr->first) << "] ("
-                  << (itr->second).type << ", " << (itr->second).part << ", " << (itr->second).orient << ")"
-                  << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << itr->first << "[" << HGCalWaferIndex::waferLayer(itr->first) << ", " << HGCalWaferIndex::waferU(itr->first) << ", " << HGCalWaferIndex::waferV(itr->first) << "] (" << (itr->second).type << ", " << (itr->second).part << ", " << (itr->second).orient << ")";
     }
   } else {
     // Tpaezoid (scintillator) type
-    std::cout << "DetectorType: " << phgp->detectorType_ << "\n";
-    std::cout << "nCells_: " << phgp->nCellsFine_ << ":" << phgp->nCellsCoarse_ << "\n";
-    std::cout << "MinTileZize: " << phgp->minTileSize_ << "\n";
-    std::cout << "FirstLayer: " << phgp->firstLayer_ << "\n";
-    std::cout << "FirstMixedLayer: " << phgp->firstMixedLayer_ << "\n";
-    std::cout << "LayerOffset: " << phgp->layerOffset_ << "\n";
-    std::cout << "mode_: " << phgp->mode_ << "\n";
-    std::cout << "waferUVMax: " << phgp->waferUVMax_ << "\n";
-    std::cout << "nSectors_: " << phgp->nSectors_ << "\n";
-    std::cout << "nCells_: " << phgp->nCellsFine_ << ":" << phgp->nCellsCoarse_ << "\n";
+    edm::LogVerbatim("HGCalGeom") << "DetectorType: " << phgp->detectorType_;
+    edm::LogVerbatim("HGCalGeom") << "nCells_: " << phgp->nCellsFine_ << ":" << phgp->nCellsCoarse_;
+    edm::LogVerbatim("HGCalGeom") << "MinTileZize: " << phgp->minTileSize_;
+    edm::LogVerbatim("HGCalGeom") << "FirstLayer: " << phgp->firstLayer_;
+    edm::LogVerbatim("HGCalGeom") << "FirstMixedLayer: " << phgp->firstMixedLayer_;
+    edm::LogVerbatim("HGCalGeom") << "LayerOffset: " << phgp->layerOffset_;
+    edm::LogVerbatim("HGCalGeom") << "mode_: " << phgp->mode_;
+    edm::LogVerbatim("HGCalGeom") << "waferUVMax: " << phgp->waferUVMax_;
+    edm::LogVerbatim("HGCalGeom") << "nSectors_: " << phgp->nSectors_;
+    edm::LogVerbatim("HGCalGeom") << "nCells_: " << phgp->nCellsFine_ << ":" << phgp->nCellsCoarse_;
 
     myPrint("CellSize", phgp->cellSize_, 10);
     myPrint("radiusMixBoundary", phgp->radiusMixBoundary_, 10);
@@ -284,121 +283,128 @@ void HGCalParameterTester::analyze(const edm::Event& iEvent, const edm::EventSet
     myPrint("levelTop", phgp->levelT_, 10);
     printWaferType(phgp);
 
-    std::cout << "MaskMode: " << phgp->waferMaskMode_ << "\n";
+    edm::LogVerbatim("HGCalGeom") << "MaskMode: " << phgp->waferMaskMode_;
     if (phgp->waferMaskMode_ > 1) {
       myPrint("tileRingR", phgp->tileRingR_, 4);
       myPrint("tileRingRange", phgp->tileRingRange_, 8);
-      std::cout << "TileInfo with " << phgp->tileInfoMap_.size() << " elements\n";
+      edm::LogVerbatim("HGCalGeom") << "TileInfo with " << phgp->tileInfoMap_.size() << " elements";
       unsigned int kk(0);
       std::unordered_map<int32_t, HGCalParameters::tileInfo>::const_iterator itr = phgp->tileInfoMap_.begin();
       for (; itr != phgp->tileInfoMap_.end(); ++itr, ++kk)
-        std::cout << "[" << kk << "] " << itr->first << "[" << HGCalTileIndex::tileLayer(itr->first) << ", "
-                  << HGCalTileIndex::tileRing(itr->first) << ", " << HGCalTileIndex::tilePhi(itr->first) << "] ("
-                  << (itr->second).type << ", " << (itr->second).sipm << std::hex << ", " << (itr->second).hex[0]
-                  << ", " << (itr->second).hex[1] << ", " << (itr->second).hex[2] << ", " << (itr->second).hex[3] << ")"
-                  << std::dec << std::endl;
+        edm::LogVerbatim("HGCalGeom") << "[" << kk << "] " << itr->first << "[" << HGCalTileIndex::tileLayer(itr->first) << ", " << HGCalTileIndex::tileRing(itr->first) << ", " << HGCalTileIndex::tilePhi(itr->first) << "] (" << (itr->second).type << ", " << (itr->second).sipm << std::hex << ", " << (itr->second).hex[0] << ", " << (itr->second).hex[1] << ", " << (itr->second).hex[2] << ", " << (itr->second).hex[3] << ")" << std::dec;
     }
   }
 
   auto finish = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = finish - start;
-  std::cout << "Elapsed time: " << elapsed.count() << " s\n";
+  edm::LogVerbatim("HGCalGeom") << "Elapsed time: " << elapsed.count() << " s";
 }
 
 template <typename T>
 void HGCalParameterTester::myPrint(std::string const& s, std::vector<T> const& obj, int n) const {
-  int k(0);
-  std::cout << s << " with " << obj.size() << " elements\n";
+  int k(0), kk(0);
+  edm::LogVerbatim("HGCalGeom") << s << " with " << obj.size() << " elements with n " << n << ": 1000";
+  std::ostringstream st1[1000];
   for (auto const& it : obj) {
-    std::cout << it << ", ";
+    st1[kk] << it << ", ";
     ++k;
     if (k == n) {
-      std::cout << "\n";
+      edm::LogVerbatim("HGCalGeom") << st1[kk].str();
+      ++kk;
       k = 0;
     }
   }
   if (k > 0)
-    std::cout << "\n";
+    edm::LogVerbatim("HGCalGeom") << st1[kk].str();
 }
 
 template <typename T>
 void HGCalParameterTester::myPrint(std::string const& s, std::vector<std::pair<T, T> > const& obj, int n) const {
-  int k(0);
-  std::cout << s << " with " << obj.size() << " elements\n";
+  int k(0), kk(0);
+  edm::LogVerbatim("HGCalGeom") << s << " with " << obj.size() << " elements with n " << n << ":200";
+  std::ostringstream st1[200];
   for (auto const& it : obj) {
-    std::cout << "(" << it.first << ", " << it.second << ") ";
+    st1[kk] << "(" << it.first << ", " << it.second << ") ";
     ++k;
     if (k == n) {
-      std::cout << "\n";
+      edm::LogVerbatim("HGCalGeom") << st1[kk].str();
+      ++kk;
       k = 0;
     }
   }
   if (k > 0)
-    std::cout << "\n";
+    edm::LogVerbatim("HGCalGeom") << st1[kk].str();
 }
 
 void HGCalParameterTester::myPrint(std::string const& s,
                                    std::vector<double> const& obj1,
                                    std::vector<double> const& obj2,
                                    int n) const {
-  int k(0);
-  std::cout << s << " with " << obj1.size() << " elements\n";
+  int k(0), kk(0);
+  std::ostringstream st1[250];
+  edm::LogVerbatim("HGCalGeom") << s << " with " << obj1.size() << " elements with n " << n << ": 250";
   for (unsigned int k1 = 0; k1 < obj1.size(); ++k1) {
-    std::cout << "(" << obj1[k1] << ", " << obj2[k1] << ") ";
+    st1[kk] << "(" << obj1[k1] << ", " << obj2[k1] << ") ";
     ++k;
     if (k == n) {
-      std::cout << "\n";
+      edm::LogVerbatim("HGCalGeom") << st1[kk].str();
+      ++kk;
       k = 0;
     }
   }
   if (k > 0)
-    std::cout << "\n";
+    edm::LogVerbatim("HGCalGeom") << st1[kk].str();
 }
 
 void HGCalParameterTester::myPrint(std::string const& s, HGCalParameters::wafer_map const& obj, int n) const {
-  int k(0);
-  std::cout << s << " with " << obj.size() << " elements\n";
+  int k(0), kk(0);
+  std::ostringstream st1[100];
+  edm::LogVerbatim("HGCalGeom") << s << " with " << obj.size() << " elements with n " << n << ": 100";
   for (auto const& it : obj) {
-    std::cout << it.first << ":" << it.second << ", ";
+    st1[kk] << it.first << ":" << it.second << ", ";
     ++k;
     if (k == n) {
-      std::cout << "\n";
+      edm::LogVerbatim("HGCalGeom") << st1[kk].str();
+      ++kk;
       k = 0;
     }
   }
   if (k > 0)
-    std::cout << "\n";
+    edm::LogVerbatim("HGCalGeom") << st1[kk].str();
 }
 
 void HGCalParameterTester::printTrform(HGCalParameters const* phgp) const {
-  int k(0);
-  std::cout << "TrformIndex with " << phgp->trformIndex_.size() << " elements\n";
+  int k(0), kk(0);
+  std::ostringstream st1[20];
+  edm::LogVerbatim("HGCalGeom") << "TrformIndex with " << phgp->trformIndex_.size() << " elements with n 7:20";
   for (unsigned int i = 0; i < phgp->trformIndex_.size(); ++i) {
     std::array<int, 4> id = phgp->getID(i);
-    std::cout << id[0] << ":" << id[1] << ":" << id[2] << ":" << id[3] << ", ";
+    st1[kk] << id[0] << ":" << id[1] << ":" << id[2] << ":" << id[3] << ", ";
     ++k;
     if (k == 7) {
-      std::cout << "\n";
+      edm::LogVerbatim("HGCalGeom") << st1[kk].str();
+      ++kk;
       k = 0;
     }
   }
   if (k > 0)
-    std::cout << "\n";
+    edm::LogVerbatim("HGCalGeom") << st1[kk].str();
 }
 
 void HGCalParameterTester::printWaferType(HGCalParameters const* phgp) const {
   int k(0);
-  std::cout << "waferTypes with " << phgp->waferTypes_.size() << " elements\n";
+  edm::LogVerbatim("HGCalGeom") << "waferTypes with " << phgp->waferTypes_.size() << " elements";
   std::map<std::pair<int, int>, int> kounts;
   std::map<std::pair<int, int>, int>::iterator itr;
   for (auto const& it : phgp->waferTypes_) {
-    std::cout << " [" << k << "] " << HGCalWaferIndex::waferLayer(it.first);
+    std::ostringstream st1;
+    st1 << " [" << k << "] " << HGCalWaferIndex::waferLayer(it.first);
     if (HGCalWaferIndex::waferFormat(it.first)) {
-      std::cout << ":" << HGCalWaferIndex::waferU(it.first) << ":" << HGCalWaferIndex::waferV(it.first);
+      st1 << ":" << HGCalWaferIndex::waferU(it.first) << ":" << HGCalWaferIndex::waferV(it.first);
     } else {
-      std::cout << ":" << HGCalWaferIndex::waferCopy(it.first);
+      st1 << ":" << HGCalWaferIndex::waferCopy(it.first);
     }
-    std::cout << " ==> (" << (it.second).first << ":" << (it.second).second << ")" << std::endl;
+    edm::LogVerbatim("HGCalGeom") << st1.str() << " ==> (" << (it.second).first << ":" << (it.second).second << ")";
     itr = kounts.find(it.second);
     if (itr == kounts.end())
       kounts[it.second] = 1;
@@ -407,10 +413,9 @@ void HGCalParameterTester::printWaferType(HGCalParameters const* phgp) const {
     ++k;
   }
   if (!kounts.empty()) {
-    std::cout << "Summary of waferTypes ==========================\n";
+    edm::LogVerbatim("HGCalGeom") << "Summary of waferTypes ==========================";
     for (itr = kounts.begin(); itr != kounts.end(); ++itr)
-      std::cout << "Type (" << (itr->first).first << ":" << (itr->first).second << ") Kount " << itr->second
-                << std::endl;
+      edm::LogVerbatim("HGCalGeom") << "Type (" << (itr->first).first << ":" << (itr->first).second << ") Kount " << itr->second;
   }
 }
 

--- a/Geometry/HGCalCommonData/test/HGCalParametersAnalyzer.cc
+++ b/Geometry/HGCalCommonData/test/HGCalParametersAnalyzer.cc
@@ -1,9 +1,11 @@
 #include <iostream>
+#include <sstream>
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/GeometryObjects/interface/PHGCalParameters.h"
 #include "Geometry/Records/interface/PHGCalParametersRcd.h"
@@ -12,12 +14,12 @@ class HGCalParametersAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit HGCalParametersAnalyzer(const edm::ParameterSet&)
       : token_{esConsumes<PHGCalParameters, PHGCalParametersRcd>(edm::ESInputTag{})} {}
-  ~HGCalParametersAnalyzer() override {}
+  ~HGCalParametersAnalyzer() override = default;
 
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
 
 private:
-  edm::ESGetToken<PHGCalParameters, PHGCalParametersRcd> token_;
+  const edm::ESGetToken<PHGCalParameters, PHGCalParametersRcd> token_;
 };
 
 void HGCalParametersAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -26,203 +28,250 @@ void HGCalParametersAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
   const auto& hgp = iSetup.getData(token_);
   const auto* phgp = &hgp;
 
-  std::cout << phgp->name_ << "\n";
+  edm::LogVerbatim("HGCalGeom") << phgp->name_ << "\n";
+  std::ostringstream st1;
   for (auto it : phgp->cellSize_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st1 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st1.str();
 
+  std::ostringstream st2;
   for (auto it : phgp->moduleBlS_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st2 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st2.str();
 
+  std::ostringstream st3;
   for (auto it : phgp->moduleTlS_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st3 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st3.str();
 
+  std::ostringstream st4;
   for (auto it : phgp->moduleHS_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st4 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st4.str();
 
+  std::ostringstream st5;
   for (auto it : phgp->moduleDzS_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st5 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st5.str();
 
+  std::ostringstream st6;
   for (auto it : phgp->moduleAlphaS_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st6 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st6.str();
 
+  std::ostringstream st7;
   for (auto it : phgp->moduleCellS_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st7 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st7.str();
 
+  std::ostringstream st8;
   for (auto it : phgp->moduleBlR_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st8 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st8.str();
 
+  std::ostringstream st9;
   for (auto it : phgp->moduleTlR_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st9 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st9.str();
 
+  std::ostringstream st10;
   for (auto it : phgp->moduleHR_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st10 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st10.str();
 
+  std::ostringstream st11;
   for (auto it : phgp->moduleDzR_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st11 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st11.str();
 
+  std::ostringstream st12;
   for (auto it : phgp->moduleAlphaR_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st12 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st12.str();
 
+  std::ostringstream st13;
   for (auto it : phgp->moduleCellR_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st13 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st13.str();
 
+  std::ostringstream st14;
   for (auto it : phgp->trformTranX_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st14 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st14.str();
 
+  std::ostringstream st15;
   for (auto it : phgp->trformTranY_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st15 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st15.str();
 
+  std::ostringstream st16;
   for (auto it : phgp->trformTranZ_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st16 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st16.str();
 
+  std::ostringstream st17;
   for (auto it : phgp->trformRotXX_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st17 << it << ", ";
 
+  std::ostringstream st18;
   for (auto it : phgp->trformRotYX_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st18 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st18.str();
 
+  std::ostringstream st19;
   for (auto it : phgp->trformRotZX_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st19 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st19.str();
 
+  std::ostringstream st20;
   for (auto it : phgp->trformRotXY_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st20 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st20.str();
 
+  std::ostringstream st21;
   for (auto it : phgp->trformRotYY_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st21 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st21.str();
 
+  std::ostringstream st22;
   for (auto it : phgp->trformRotZY_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st22 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st22.str();
 
+  std::ostringstream st23;
   for (auto it : phgp->trformRotXZ_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st23 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st23.str();
 
+  std::ostringstream st24;
   for (auto it : phgp->trformRotYZ_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st24 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st24.str();
 
+  std::ostringstream st25;
   for (auto it : phgp->trformRotZZ_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st25 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st25.str();
 
+  std::ostringstream st26;
   for (auto it : phgp->zLayerHex_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st26 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st26.str();
 
+  std::ostringstream st27;
   for (auto it : phgp->rMinLayHex_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st27 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st27.str();
 
+  std::ostringstream st28;
   for (auto it : phgp->rMaxLayHex_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st28 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st28.str();
 
+  std::ostringstream st29;
   for (unsigned int k = 0; k < phgp->waferPosX_.size(); ++k)
-    std::cout << "(" << phgp->waferPosX_[k] << ", " << phgp->waferPosY_[k] << ") ";
-  std::cout << "\n";
+    st29 << "(" << phgp->waferPosX_[k] << ", " << phgp->waferPosY_[k] << ") ";
+  edm::LogVerbatim("HGCalGeom") << st29.str();
 
+  std::ostringstream st30;
   for (unsigned int k = 0; k < phgp->cellFineX_.size(); ++k)
-    std::cout << "(" << phgp->cellFineX_[k] << ", " << phgp->cellFineY_[k] << ") ";
-  std::cout << "\n";
+    st30 << "(" << phgp->cellFineX_[k] << ", " << phgp->cellFineY_[k] << ") ";
+  edm::LogVerbatim("HGCalGeom") << st30.str();
 
+  std::ostringstream st31;
   for (unsigned int k = 0; k < phgp->cellCoarseX_.size(); ++k)
-    std::cout << "(" << phgp->cellCoarseX_[k] << ", " << phgp->cellCoarseY_[k] << ") ";
-  std::cout << "\n";
+    st31 << "(" << phgp->cellCoarseX_[k] << ", " << phgp->cellCoarseY_[k] << ") ";
+  edm::LogVerbatim("HGCalGeom") << st31.str();
 
+  std::ostringstream st32;
   for (auto it : phgp->boundR_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st32 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st32.str();
 
+  std::ostringstream st33;
   for (auto it : phgp->moduleLayS_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st33 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st33.str();
 
+  std::ostringstream st34;
   for (auto it : phgp->moduleLayR_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st34 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st34.str();
 
+  std::ostringstream st35;
   for (auto it : phgp->layer_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st35 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st35.str();
 
+  std::ostringstream st36;
   for (auto it : phgp->layerIndex_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st36 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st36.str();
 
+  std::ostringstream st37;
   for (auto it : phgp->layerGroup_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st37 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st37.str();
 
+  std::ostringstream st38;
   for (auto it : phgp->cellFactor_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st38 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st38.str();
 
+  std::ostringstream st39;
   for (auto it : phgp->depth_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st39 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st39.str();
 
+  std::ostringstream st40;
   for (auto it : phgp->depthIndex_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st40 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st40.str();
 
+  std::ostringstream st41;
   for (auto it : phgp->depthLayerF_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st41 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st41.str();
 
+  std::ostringstream st42;
   for (auto it : phgp->waferCopy_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st42 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st42.str();
 
+  std::ostringstream st43;
   for (auto it : phgp->waferTypeL_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st43 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st43.str();
 
+  std::ostringstream st44;
   for (auto it : phgp->waferTypeT_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st44 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st44.str();
 
+  std::ostringstream st45;
   for (auto it : phgp->layerGroupM_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st45 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st45.str();
 
+  std::ostringstream st46;
   for (auto it : phgp->layerGroupO_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st46 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st46.str();
 
+  std::ostringstream st47;
   for (auto it : phgp->trformIndex_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st47 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st47.str();
 
+  std::ostringstream st48;
   for (auto it : phgp->slopeMin_)
-    std::cout << it << ", ";
-  std::cout << "\n";
+    st48 << it << ", ";
+  edm::LogVerbatim("HGCalGeom") << st48.str();
 
-  std::cout << phgp->waferR_ << "\n";
-  std::cout << phgp->nCells_ << "\n";
-  std::cout << phgp->nSectors_ << "\n";
-  std::cout << phgp->mode_ << "\n";
+  edm::LogVerbatim("HGCalGeom") << phgp->waferR_;
+  edm::LogVerbatim("HGCalGeom") << phgp->nCells_;
+  edm::LogVerbatim("HGCalGeom") << phgp->nSectors_;
+  edm::LogVerbatim("HGCalGeom") << phgp->mode_;
 }
 
 DEFINE_FWK_MODULE(HGCalParametersAnalyzer);

--- a/Geometry/HGCalCommonData/test/python/hgcalParameters_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/hgcalParameters_cfg.py
@@ -3,9 +3,13 @@ from Configuration.AlCa.autoCond import autoCond
  
 process = cms.Process("HGCalParametersTest")
 process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if 'MessageLogger' in process.__dict__:
+    process.MessageLogger.HGCalGeom=dict()
+ 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.GlobalTag.globaltag = autoCond['run1_mc']
- 
 process.GlobalTag.toGet = cms.VPSet(cms.PSet(record = cms.string('PHGCalParametersRcd'),
                                               tag = cms.string('HGCALParameters_Geometry_Test01'),
                                               connect = cms.string("sqlite_file:./myfile.db")

--- a/Geometry/HGCalCommonData/test/python/testHGCalParametersDDD_cfg.py
+++ b/Geometry/HGCalCommonData/test/python/testHGCalParametersDDD_cfg.py
@@ -5,7 +5,7 @@ process = cms.Process("HGCalParametersTest",Phase2C11)
 process.load("SimGeneral.HepPDTESSource.pdt_cfi")
 #process.load("Geometry.CMSCommonData.cmsExtendedGeometry2026D83XML_cfi")
 process.load("Geometry.HGCalCommonData.testHGCalV15XML_cfi")
-process.load("Geometry.HGCalCommonData.hgcalParametersInitialization_cfi")
+process.load("Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi")
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 if hasattr(process,'MessageLogger'):


### PR DESCRIPTION
#### PR description:

Use messagelogger service instead of cout in Geometry/HGCalCommonData

#### PR validation:

Use runTheMatrix test workflows and cfg's in the test area

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special