### PR TITLE
HLT release validation for new EXO-LLP Run 3 paths

### DIFF
--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
@@ -3,9 +3,10 @@ import FWCore.ParameterSet.Config as cms
 DisplacedDimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_DoubleMu43NoFiltersNoVtx_v", # 2017 displaced mu-mu (main) # Claimed path for Run3
-        "HLT_DoubleMu48NoFiltersNoVtx_v", # 2017 displaced mu-mu (backup) # Claimed path for Run3
-        "HLT_DoubleMu33NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (main) # Claimed path for Run3
+#        "HLT_DoubleMu48NoFiltersNoVtx_v", # 2017 displaced mu-mu (backup) # Claimed path for Run3, but a backup so no need to monitor it closely here
+#        "HLT_DoubleMu33NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (main) # Claimed path for Run3, but being superseeded by HLT_DoubleL3Mu10NoVtx_Displaced_v)
 #        "HLT_DoubleMu40NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (backup) # Not claimed path for Run3
+        "HLT_DoubleL3Mu10NoVtx_Displaced_v", #New Run3 path
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedL2Dimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedL2Dimuon_cff.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+DisplacedL2DimuonPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v", #Claimed for Run 3
+        "HLT_DoubleL2Mu23NoVtx_2Cha_v", #Claimed for Run 3
+        "HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v", #New for Run 3
+        ),
+    recMuonLabel  = cms.InputTag("muons"),
+    recMuonTrkLabel  = cms.InputTag("displacedStandAloneMuons"),
+
+    # -- Analysis specific cuts
+    minCandidates = cms.uint32(2),
+    # -- Analysis specific binnings
+    parametersDxy      = cms.vdouble(50, -50, 50),
+    parametersTurnOn = cms.vdouble(
+                                    0, 10, 20, 30, 40, 50,
+                                    100, 150, 200, 250, 300, 350, 400, 450, 500, 550, 600
+                                   ),
+    dropPt3 = cms.bool(True),
+
+    )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
@@ -3,9 +3,10 @@ import FWCore.ParameterSet.Config as cms
 DisplacedMuEGPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v", # 2017 displaced e-mu (main) # Claimed path for Run3
-        "HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v", # 2017 displaced e-mu (backup) # Claimed path for Run3
+#        "HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v", # 2017 displaced e-mu (backup) # Claimed path for Run3, but a backup so no need to monitor it closely here
         "HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v", # 2017 displaced e-mu, muon with dxy> 0.01cm (main) # Claimed path for Run3
-        "HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v", # 2017 displaced e-mu, muon with dxy> 0.01cm (backup) # Claimed path for Run3
+#        "HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v", # 2017 displaced e-mu, muon with dxy> 0.01cm (backup) # Claimed path for Run3, but a backup so no need to monitor it closely here
+        "HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v", # New Run3 path
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     recMuonLabel  = cms.InputTag("muons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHTDisplacedJets_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHTDisplacedJets_cff.py
@@ -5,10 +5,14 @@ HTDisplacedJetsPSet = cms.PSet(
         "HLT_HT425_v", # Claimed path for Run3
         #2017 
         "HLT_HT430_DisplacedDijet40_DisplacedTrack_v", # Claimed path for Run3
-        "HLT_HT430_DisplacedDijet60_DisplacedTrack_v", # Claimed path for Run3
+#        "HLT_HT430_DisplacedDijet60_DisplacedTrack_v", # Claimed path for Run3, but a backup so no need to monitor it closely here
         "HLT_HT650_DisplacedDijet60_Inclusive_v", # Claimed path for Run3
-        "HLT_HT400_DisplacedDijet40_DisplacedTrack_v", # Claimed path for Run3
-        "HLT_HT550_DisplacedDijet60_Inclusive_v" # Claimed path for Run3
+#        "HLT_HT400_DisplacedDijet40_DisplacedTrack_v", # Claimed path for Run3, but a control path so no need to monitor it closely here
+#        "HLT_HT550_DisplacedDijet60_Inclusive_v" # Claimed path for Run3, but a control path so no need to monitor it closely here
+        "HLT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_v", # New path for Run 3
+        "HLT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_v", # New path for Run 3
+        "HLT_HT430_DelayedJet40_SingleDelay1nsTrackless_v", # New path for Run 3
+        "HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v", # New path for Run 3
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaJetNoBptx_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaJetNoBptx_cff.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 JetNoBptxPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_UncorrectedJetE30_NoBPTX_v", # 2017 proposal # Claimed path for Run3
-        "HLT_UncorrectedJetE30_NoBPTX3BX_v", # Claimed path for Run3
+#        "HLT_UncorrectedJetE30_NoBPTX_v", # 2017 proposal # Claimed path for Run3, but a control path so no need to monitor it closely here
+#        "HLT_UncorrectedJetE30_NoBPTX3BX_v", # Claimed path for Run3, but a control path so no need to monitor it closely here
         "HLT_UncorrectedJetE60_NoBPTX3BX_v", # Claimed path for Run3
-        "HLT_UncorrectedJetE70_NoBPTX3BX_v", # Claimed path for Run3
+#        "HLT_UncorrectedJetE70_NoBPTX3BX_v", # Claimed path for Run3, but a backup so no need to monitor it closely here
         ),
     recCaloJetLabel    = cms.InputTag("ak4CaloJets"),
 

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
@@ -3,7 +3,9 @@ import FWCore.ParameterSet.Config as cms
 METplusTrackPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_MET105_IsoTrk50_v", # 2017 proposal # Claimed path for Run3
-        "HLT_MET120_IsoTrk50_v"  # 2017 proposal # Claimed path for Run3
+#        "HLT_MET120_IsoTrk50_v"  # 2017 proposal # Claimed path for Run3, but a backup so no need to monitor it closely here
+        "HLT_PFMET105_IsoTrk50_v", # New Run 3 path
+        "HLT_PFMET110_PFJet100_v", # New Run 3 path
     ),
     recPFMETLabel = cms.InputTag("pfMet"),
     #recMETLabel   = cms.InputTag("hltPFMETProducer"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 MuonNoBptxPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v", # 2017 proposal # Claimed path for Run3
-        "HLT_L2Mu10_NoVertex_NoBPTX_v", # Claimed path for Run3
-        "HLT_L2Mu10_NoVertex_NoBPTX3BX_v", # Claimed path for Run3
+#        "HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v", # 2017 proposal # Claimed path for Run3, but a backup so no need to monitor it closely here
+#        "HLT_L2Mu10_NoVertex_NoBPTX_v", # Claimed path for Run3, but a control path so no need to monitor it closely here
+#        "HLT_L2Mu10_NoVertex_NoBPTX3BX_v", # Claimed path for Run3, but a control path so no need to monitor it closely here
         "HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX_v" # Claimed path for Run3
         ),
     #recMuonLabel  = cms.InputTag("muons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 PureMETPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
+        "HLT_L1MET_DTClusterNoMB1S50_v", #New Run 3 path
         ),
     recPFMETLabel  = cms.InputTag("pfMet"),
     recCaloMETLabel = cms.InputTag("caloMet"),

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -102,6 +102,7 @@ hltExoticaPostJetNoBptx = make_exo_postprocessor("JetNoBptx")
 hltExoticaPostMuonNoBptx = make_exo_postprocessor("MuonNoBptx")
 hltExoticaPostDisplacedMuEG = make_exo_postprocessor("DisplacedMuEG")
 hltExoticaPostDisplacedDimuon = make_exo_postprocessor("DisplacedDimuon")
+hltExoticaPostDisplacedL2Dimuon = make_exo_postprocessor("DisplacedL2Dimuon")
 hltExoticaPostMonojet = make_exo_postprocessor("Monojet")
 hltExoticaPostMonojetBackup = make_exo_postprocessor("MonojetBackup")
 hltExoticaPostPureMET = make_exo_postprocessor("PureMET")
@@ -136,6 +137,7 @@ hltExoticaPostProcessors = cms.Sequence(
     # Displaced paths
     hltExoticaPostDisplacedMuEG +
     hltExoticaPostDisplacedDimuon +
+    hltExoticaPostDisplacedL2Dimuon +
     # Others
     hltExoticaPostMonojet +
     hltExoticaPostMonojetBackup +

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -29,6 +29,7 @@ from HLTriggerOffline.Exotica.analyses.hltExoticaJetNoBptx_cff         import Je
 from HLTriggerOffline.Exotica.analyses.hltExoticaMuonNoBptx_cff        import MuonNoBptxPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedMuEG_cff     import DisplacedMuEGPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedDimuon_cff   import DisplacedDimuonPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedL2Dimuon_cff import DisplacedL2DimuonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaPureMET_cff           import PureMETPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaMETplusTrack_cff      import METplusTrackPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaMonojet_cff           import MonojetPSet
@@ -68,6 +69,7 @@ hltExoticaValidator = DQMEDAnalyzer(
         "CaloHT",
         "DisplacedMuEG",
         "DisplacedDimuon",
+        "DisplacedL2Dimuon",
         "PureMET",
         "METplusTrack",
         "Monojet",
@@ -216,6 +218,7 @@ hltExoticaValidator = DQMEDAnalyzer(
     MuonNoBptx       = MuonNoBptxPSet,
     DisplacedMuEG    = DisplacedMuEGPSet,
     DisplacedDimuon  = DisplacedDimuonPSet,
+    DisplacedL2Dimuon = DisplacedL2DimuonPSet,
     PureMET          = PureMETPSet,                                 
     METplusTrack     = METplusTrackPSet,                                 
     Monojet          = MonojetPSet,


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

This PR updates the exotica HLT release validation (in HLTriggerOffline/Exotica) to include the validation of the new long-lived particle (LLP) paths that went into v1 of the Run 3 HLT menu [1]. Complying with the request from STEAM to limit the number of histograms produced, the general philosophy going into these changes was to monitor only the signal paths, and not the backup or control paths. So, these paths have been added to the monitoring:

```
HLT_HT430_DelayedJet40_SingleDelay1nsTrackless_v
HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v
HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v
HLT_DoubleL2Mu23NoVtx_2Cha_v
HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v
HLT_DoubleL3Mu10NoVtx_Displaced_v
HLT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_v
HLT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_v
HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v
HLT_PFMET105_IsoTrk50_v
HLT_PFMET110_PFJet100_v
HLT_L1MET_DTClusterNoMB1S50_v
```

And these have been removed:
```
HLT_DoubleMu33NoFiltersNoVtxDisplaced_v
HLT_DoubleMu48NoFiltersNoVtx_v
HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v
HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v
HLT_UncorrectedJetE30_NoBPTX_v
HLT_UncorrectedJetE30_NoBPTX3BX_v
HLT_UncorrectedJetE70_NoBPTX3BX_v
HLT_L2Mu10_NoVertex_NoBPTX_v
HLT_L2Mu10_NoVertex_NoBPTX3BX_v
HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v
HLT_HT400_DisplacedDijet40_DisplacedTrack_v
HLT_HT430_DisplacedDijet60_DisplacedTrack_v
HLT_HT550_DisplacedDijet60_Inclusive_v
```



#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Using a TTbar relval [2], I have checked that the correct histograms are produced when running
```
cmsRun HLTriggerOffline/Exotica/test/hltExoticaValidator_cfg.py
cmsRun HLTriggerOffline/Exotica/test/hltExoticaPostProcessor_cfg.py
```

I have also successfully tested this PR with 
```
runTheMatrix.py -l limited -i all --ibeos
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport

<!-- Please replace this text with any link to  -->


[1] https://its.cern.ch/jira/browse/CMSHLT-2211
[2] /RelValTTbar_14TeV/CMSSW_12_3_0_pre6-123X_mcRun4_realistic_v8_2026D88noPU-v1/GEN-SIM-RECO

