### PR TITLE
Phase2-hgx302A Use MessageLogger instead of cout in a number of analyzers in HGCalGeometry

### DIFF
--- a/Geometry/HGCalGeometry/test/HGCalSizeTester.cc
+++ b/Geometry/HGCalGeometry/test/HGCalSizeTester.cc
@@ -2,13 +2,13 @@
 #include <string>
 #include <vector>
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
@@ -22,7 +22,7 @@
 class HGCalSizeTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HGCalSizeTester(const edm::ParameterSet&);
-  ~HGCalSizeTester() override;
+  ~HGCalSizeTester() override = default;
 
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
 
@@ -30,15 +30,13 @@ private:
   void doTestWafer(const HGCalGeometry* geom, DetId::Detector det);
   void doTestScint(const HGCalGeometry* geom, DetId::Detector det);
 
-  std::string name;
-  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
+  const std::string name;
+  const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
 };
 
 HGCalSizeTester::HGCalSizeTester(const edm::ParameterSet& iC)
     : name{iC.getParameter<std::string>("detector")},
       geomToken_{esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", name})} {}
-
-HGCalSizeTester::~HGCalSizeTester() {}
 
 void HGCalSizeTester::analyze(const edm::Event&, const edm::EventSetup& iSetup) {
   const auto& geomR = iSetup.getData(geomToken_);
@@ -51,7 +49,7 @@ void HGCalSizeTester::analyze(const edm::Event&, const edm::EventSetup& iSetup) 
       det = DetId::HGCalHSc;
     else
       det = DetId::HGCalEE;
-    std::cout << "Perform test for " << name << " Detector " << det << std::endl;
+    edm::LogVerbatim("HGCalGeomX") << "Perform test for " << name << " Detector " << det;
     if (name == "HGCalHEScintillatorSensitive") {
       doTestScint(geom, det);
     } else {
@@ -62,7 +60,7 @@ void HGCalSizeTester::analyze(const edm::Event&, const edm::EventSetup& iSetup) 
 
 void HGCalSizeTester::doTestWafer(const HGCalGeometry* geom, DetId::Detector det) {
   const std::vector<DetId>& ids = geom->getValidDetIds();
-  std::cout << "doTestWafer:: " << ids.size() << " valid ids for " << geom->cellElement() << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << "doTestWafer:: " << ids.size() << " valid ids for " << geom->cellElement();
   int layers[] = {1, 5, 10};
   int zsides[] = {1, -1};
   int cells[] = {1, 4, 7};
@@ -72,38 +70,29 @@ void HGCalSizeTester::doTestWafer(const HGCalGeometry* geom, DetId::Detector det
       for (int waferU : wafers) {
         for (int waferV : wafers) {
           int type = geom->topology().dddConstants().getTypeHex(layer, waferU, waferV);
-          std::cout << "zside " << zside << " layer " << layer << " wafer " << waferU << ":" << waferV << " type "
-                    << type << std::endl;
+          edm::LogVerbatim("HGCalGeomX") << "zside " << zside << " layer " << layer << " wafer " << waferU << ":" << waferV << " type " << type;
           for (int cellU : cells) {
             for (int cellV : cells) {
-              std::cout << "det " << det << " cell " << cellU << ":" << cellV << std::endl;
+              edm::LogVerbatim("HGCalGeomX") << "det " << det << " cell " << cellU << ":" << cellV;
               DetId id1 = (DetId)(HGCSiliconDetId(det, zside, type, layer, waferU, waferV, cellU, cellV));
-              std::cout << HGCSiliconDetId(id1) << std::endl;
+              edm::LogVerbatim("HGCalGeomX") << HGCSiliconDetId(id1);
               if (geom->topology().valid(id1)) {
                 auto icell1 = geom->getGeometry(id1);
                 GlobalPoint global1 = geom->getPosition(id1);
                 DetId idc1 = geom->getClosestCell(global1);
-                std::cout << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << waferU << ":"
-                          << waferV << ":" << cellU << ":" << cellV << ") Geom " << icell1 << " position ("
-                          << global1.x() << ", " << global1.y() << ", " << global1.z() << ") ids " << std::hex
-                          << id1.rawId() << ":" << idc1.rawId() << std::dec << ":" << HGCSiliconDetId(id1) << ":"
-                          << HGCSiliconDetId(idc1) << " parameter[3] = " << icell1->param()[2] << ":"
-                          << icell1->param()[2];
-                if (id1.rawId() != idc1.rawId())
-                  std::cout << "***** ERROR *****" << std::endl;
-                else
-                  std::cout << std::endl;
+		std::string cherr = (id1.rawId() != idc1.rawId()) ? "***** ERROR *****" : "";
+                edm::LogVerbatim("HGCalGeomX") << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << waferU << ":" << waferV << ":" << cellU << ":" << cellV << ") Geom " << icell1 << " position (" << global1.x() << ", " << global1.y() << ", " << global1.z() << ") ids " << std::hex << id1.rawId() << ":" << idc1.rawId() << std::dec << ":" << HGCSiliconDetId(id1) << ":" << HGCSiliconDetId(idc1) << " parameter[3] = " << icell1->param()[2] << ":" << icell1->param()[2] << cherr;
                 std::vector<GlobalPoint> corners = geom->getNewCorners(idc1);
-                std::cout << corners.size() << " corners";
+		std::ostringstream st1;
+                st1 << corners.size() << " corners";
                 for (auto const& cor : corners)
-                  std::cout << " [" << cor.x() << "," << cor.y() << "," << cor.z() << "]";
-                std::cout << std::endl;
+                  st1 << " [" << cor.x() << "," << cor.y() << "," << cor.z() << "]";
+                edm::LogVerbatim("HGCalGeomX") << st1.str();
                 std::vector<DetId> ids = geom->topology().neighbors(id1);
                 int k(0);
                 for (auto const& id : ids) {
                   GlobalPoint global0 = geom->getPosition(id);
-                  std::cout << "Neighbor[" << k << "] " << HGCSiliconDetId(id) << " position (" << global0.x() << ", "
-                            << global0.y() << ", " << global0.z() << ")" << std::endl;
+                  edm::LogVerbatim("HGCalGeomX") << "Neighbor[" << k << "] " << HGCSiliconDetId(id) << " position (" << global0.x() << ", " << global0.y() << ", " << global0.z() << ")";
                   ++k;
                 }
               }
@@ -117,7 +106,7 @@ void HGCalSizeTester::doTestWafer(const HGCalGeometry* geom, DetId::Detector det
 
 void HGCalSizeTester::doTestScint(const HGCalGeometry* geom, DetId::Detector det) {
   const std::vector<DetId>& ids = geom->getValidDetIds();
-  std::cout << "doTestScint: " << ids.size() << " valid ids for " << geom->cellElement() << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << "doTestScint: " << ids.size() << " valid ids for " << geom->cellElement();
   int layers[] = {9, 15, 22};
   int zsides[] = {1, -1};
   int iphis[] = {1, 51, 101, 151, 201};
@@ -132,26 +121,19 @@ void HGCalSizeTester::doTestScint(const HGCalGeometry* geom, DetId::Detector det
             auto icell1 = geom->getGeometry(id1);
             GlobalPoint global1 = geom->getPosition(id1);
             DetId idc1 = geom->getClosestCell(global1);
-            std::cout << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << ieta << ":" << iphi
-                      << ") Geom " << icell1 << " position (" << global1.x() << ", " << global1.y() << ", "
-                      << global1.z() << ") ids " << std::hex << id1.rawId() << ":" << idc1.rawId() << std::dec << ":"
-                      << HGCScintillatorDetId(id1) << ":" << HGCScintillatorDetId(idc1)
-                      << " parameter[11] = " << icell1->param()[10] << ":" << icell1->param()[10];
-            if (id1.rawId() != idc1.rawId())
-              std::cout << "***** ERROR *****" << std::endl;
-            else
-              std::cout << std::endl;
+	    std::string cherr = (id1.rawId() != idc1.rawId()) ? "***** ERROR *****" : "";
+            edm::LogVerbatim("HGCalGeomX") << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << ieta << ":" << iphi << ") Geom " << icell1 << " position (" << global1.x() << ", " << global1.y() << ", " << global1.z() << ") ids " << std::hex << id1.rawId() << ":" << idc1.rawId() << std::dec << ":" << HGCScintillatorDetId(id1) << ":" << HGCScintillatorDetId(idc1) << " parameter[11] = " << icell1->param()[10] << ":" << icell1->param()[10] << cherr;
             std::vector<GlobalPoint> corners = geom->getNewCorners(idc1);
-            std::cout << corners.size() << " corners";
+	    std::ostringstream st1;
+            st1 << corners.size() << " corners";
             for (auto const& cor : corners)
-              std::cout << " [" << cor.x() << "," << cor.y() << "," << cor.z() << "]";
-            std::cout << std::endl;
+              st1 << " [" << cor.x() << "," << cor.y() << "," << cor.z() << "]";
+            edm::LogVerbatim("HGCalGeomX") << st1.str();
             std::vector<DetId> ids = geom->topology().neighbors(id1);
             int k(0);
             for (auto const& id : ids) {
               GlobalPoint global0 = geom->getPosition(id);
-              std::cout << "Neighbor[" << k << "] " << HGCScintillatorDetId(id) << " position (" << global0.x() << ", "
-                        << global0.y() << ", " << global0.z() << ")" << std::endl;
+              edm::LogVerbatim("HGCalGeomX") << "Neighbor[" << k << "] " << HGCScintillatorDetId(id) << " position (" << global0.x() << ", " << global0.y() << ", " << global0.z() << ")";
               ++k;
             }
           }

--- a/Geometry/HGCalGeometry/test/HGCalSizeTester.cc
+++ b/Geometry/HGCalGeometry/test/HGCalSizeTester.cc
@@ -70,7 +70,8 @@ void HGCalSizeTester::doTestWafer(const HGCalGeometry* geom, DetId::Detector det
       for (int waferU : wafers) {
         for (int waferV : wafers) {
           int type = geom->topology().dddConstants().getTypeHex(layer, waferU, waferV);
-          edm::LogVerbatim("HGCalGeomX") << "zside " << zside << " layer " << layer << " wafer " << waferU << ":" << waferV << " type " << type;
+          edm::LogVerbatim("HGCalGeomX") << "zside " << zside << " layer " << layer << " wafer " << waferU << ":"
+                                         << waferV << " type " << type;
           for (int cellU : cells) {
             for (int cellV : cells) {
               edm::LogVerbatim("HGCalGeomX") << "det " << det << " cell " << cellU << ":" << cellV;
@@ -80,10 +81,15 @@ void HGCalSizeTester::doTestWafer(const HGCalGeometry* geom, DetId::Detector det
                 auto icell1 = geom->getGeometry(id1);
                 GlobalPoint global1 = geom->getPosition(id1);
                 DetId idc1 = geom->getClosestCell(global1);
-		std::string cherr = (id1.rawId() != idc1.rawId()) ? "***** ERROR *****" : "";
-                edm::LogVerbatim("HGCalGeomX") << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << waferU << ":" << waferV << ":" << cellU << ":" << cellV << ") Geom " << icell1 << " position (" << global1.x() << ", " << global1.y() << ", " << global1.z() << ") ids " << std::hex << id1.rawId() << ":" << idc1.rawId() << std::dec << ":" << HGCSiliconDetId(id1) << ":" << HGCSiliconDetId(idc1) << " parameter[3] = " << icell1->param()[2] << ":" << icell1->param()[2] << cherr;
+                std::string cherr = (id1.rawId() != idc1.rawId()) ? "***** ERROR *****" : "";
+                edm::LogVerbatim("HGCalGeomX")
+                    << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << waferU << ":" << waferV
+                    << ":" << cellU << ":" << cellV << ") Geom " << icell1 << " position (" << global1.x() << ", "
+                    << global1.y() << ", " << global1.z() << ") ids " << std::hex << id1.rawId() << ":" << idc1.rawId()
+                    << std::dec << ":" << HGCSiliconDetId(id1) << ":" << HGCSiliconDetId(idc1)
+                    << " parameter[3] = " << icell1->param()[2] << ":" << icell1->param()[2] << cherr;
                 std::vector<GlobalPoint> corners = geom->getNewCorners(idc1);
-		std::ostringstream st1;
+                std::ostringstream st1;
                 st1 << corners.size() << " corners";
                 for (auto const& cor : corners)
                   st1 << " [" << cor.x() << "," << cor.y() << "," << cor.z() << "]";
@@ -92,7 +98,8 @@ void HGCalSizeTester::doTestWafer(const HGCalGeometry* geom, DetId::Detector det
                 int k(0);
                 for (auto const& id : ids) {
                   GlobalPoint global0 = geom->getPosition(id);
-                  edm::LogVerbatim("HGCalGeomX") << "Neighbor[" << k << "] " << HGCSiliconDetId(id) << " position (" << global0.x() << ", " << global0.y() << ", " << global0.z() << ")";
+                  edm::LogVerbatim("HGCalGeomX") << "Neighbor[" << k << "] " << HGCSiliconDetId(id) << " position ("
+                                                 << global0.x() << ", " << global0.y() << ", " << global0.z() << ")";
                   ++k;
                 }
               }
@@ -121,10 +128,15 @@ void HGCalSizeTester::doTestScint(const HGCalGeometry* geom, DetId::Detector det
             auto icell1 = geom->getGeometry(id1);
             GlobalPoint global1 = geom->getPosition(id1);
             DetId idc1 = geom->getClosestCell(global1);
-	    std::string cherr = (id1.rawId() != idc1.rawId()) ? "***** ERROR *****" : "";
-            edm::LogVerbatim("HGCalGeomX") << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << ieta << ":" << iphi << ") Geom " << icell1 << " position (" << global1.x() << ", " << global1.y() << ", " << global1.z() << ") ids " << std::hex << id1.rawId() << ":" << idc1.rawId() << std::dec << ":" << HGCScintillatorDetId(id1) << ":" << HGCScintillatorDetId(idc1) << " parameter[11] = " << icell1->param()[10] << ":" << icell1->param()[10] << cherr;
+            std::string cherr = (id1.rawId() != idc1.rawId()) ? "***** ERROR *****" : "";
+            edm::LogVerbatim("HGCalGeomX")
+                << "DetId (" << det << ":" << zside << ":" << type << ":" << layer << ":" << ieta << ":" << iphi
+                << ") Geom " << icell1 << " position (" << global1.x() << ", " << global1.y() << ", " << global1.z()
+                << ") ids " << std::hex << id1.rawId() << ":" << idc1.rawId() << std::dec << ":"
+                << HGCScintillatorDetId(id1) << ":" << HGCScintillatorDetId(idc1)
+                << " parameter[11] = " << icell1->param()[10] << ":" << icell1->param()[10] << cherr;
             std::vector<GlobalPoint> corners = geom->getNewCorners(idc1);
-	    std::ostringstream st1;
+            std::ostringstream st1;
             st1 << corners.size() << " corners";
             for (auto const& cor : corners)
               st1 << " [" << cor.x() << "," << cor.y() << "," << cor.z() << "]";
@@ -133,7 +145,8 @@ void HGCalSizeTester::doTestScint(const HGCalGeometry* geom, DetId::Detector det
             int k(0);
             for (auto const& id : ids) {
               GlobalPoint global0 = geom->getPosition(id);
-              edm::LogVerbatim("HGCalGeomX") << "Neighbor[" << k << "] " << HGCScintillatorDetId(id) << " position (" << global0.x() << ", " << global0.y() << ", " << global0.z() << ")";
+              edm::LogVerbatim("HGCalGeomX") << "Neighbor[" << k << "] " << HGCScintillatorDetId(id) << " position ("
+                                             << global0.x() << ", " << global0.y() << ", " << global0.z() << ")";
               ++k;
             }
           }

--- a/Geometry/HGCalGeometry/test/HGCalTestNeighbor.cc
+++ b/Geometry/HGCalGeometry/test/HGCalTestNeighbor.cc
@@ -27,7 +27,7 @@
 class HGCalTestNeighbor : public edm::one::EDAnalyzer<> {
 public:
   explicit HGCalTestNeighbor(const edm::ParameterSet&);
-  ~HGCalTestNeighbor() override;
+  ~HGCalTestNeighbor() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
@@ -37,22 +37,19 @@ private:
   void doTestWafer(const HGCalGeometry* geom, DetId::Detector det, const MagneticField* bField);
   void doTestScint(const HGCalGeometry* geom, DetId::Detector det, const MagneticField* bField);
 
-  std::string name_;
-  std::vector<double> px_, py_, pz_;
-  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> fieldToken_;
-  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
+  const std::string name_;
+  const std::vector<double> px_, py_, pz_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> fieldToken_;
+  const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
 };
 
-HGCalTestNeighbor::HGCalTestNeighbor(const edm::ParameterSet& iC) {
-  name_ = iC.getParameter<std::string>("detector");
-  px_ = iC.getParameter<std::vector<double> >("pX");
-  py_ = iC.getParameter<std::vector<double> >("pY");
-  pz_ = iC.getParameter<std::vector<double> >("pZ");
-  fieldToken_ = esConsumes<MagneticField, IdealMagneticFieldRecord>(edm::ESInputTag{});
-  geomToken_ = esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", name_});
-}
-
-HGCalTestNeighbor::~HGCalTestNeighbor() {}
+HGCalTestNeighbor::HGCalTestNeighbor(const edm::ParameterSet& iC) :
+      name_(iC.getParameter<std::string>("detector")),
+      px_(iC.getParameter<std::vector<double> >("pX")),
+      py_(iC.getParameter<std::vector<double> >("pY")),
+      pz_(iC.getParameter<std::vector<double> >("pZ")),
+      fieldToken_(esConsumes<MagneticField, IdealMagneticFieldRecord>(edm::ESInputTag{})),
+      geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", name_})) { }
 
 void HGCalTestNeighbor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -79,8 +76,7 @@ void HGCalTestNeighbor::analyze(const edm::Event&, const edm::EventSetup& iSetup
       subdet = HGCHEB;
     else
       subdet = HGCEE;
-    std::cout << "Perform test for " << name_ << " Detector:Subdetector " << DetId::Forward << ":" << subdet
-              << std::endl;
+    edm::LogVerbatim("HGCalGeomX") << "Perform test for " << name_ << " Detector:Subdetector " << DetId::Forward << ":" << subdet;
     doTest(geom, subdet, bField);
   } else {
     DetId::Detector det;
@@ -90,7 +86,7 @@ void HGCalTestNeighbor::analyze(const edm::Event&, const edm::EventSetup& iSetup
       det = DetId::HGCalHSc;
     else
       det = DetId::HGCalEE;
-    std::cout << "Perform test for " << name_ << " Detector " << det << std::endl;
+    edm::LogVerbatim("HGCalGeomX") << "Perform test for " << name_ << " Detector " << det;
     if (name_ == "HGCalHEScintillatorSensitive") {
       doTestScint(geom, det, bField);
     } else {
@@ -101,7 +97,7 @@ void HGCalTestNeighbor::analyze(const edm::Event&, const edm::EventSetup& iSetup
 
 void HGCalTestNeighbor::doTest(const HGCalGeometry* geom, ForwardSubdetector subdet, const MagneticField* bField) {
   const std::vector<DetId>& ids = geom->getValidDetIds();
-  std::cout << "doTest: " << ids.size() << " valid ids for " << geom->cellElement() << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << "doTest: " << ids.size() << " valid ids for " << geom->cellElement();
 
   int layers[] = {1, 5, 10};
   int zsides[] = {1, -1};
@@ -125,9 +121,7 @@ void HGCalTestNeighbor::doTest(const HGCalGeometry* geom, ForwardSubdetector sub
               GlobalVector p(px_[k], py_[k], zside * pz_[k]);
               DetId id2 = geom->neighborZ(id1, p);
               DetId id3 = geom->neighborZ(id1, bField, 1, p);
-              std::cout << "DetId" << HGCalDetId(id1) << " :" << global1 << " p" << p << " ID2" << HGCalDetId(id2)
-                        << " :" << geom->getPosition(id2) << " ID3" << HGCalDetId(id3) << " :" << geom->getPosition(id3)
-                        << std::endl;
+              edm::LogVerbatim("HGCalGeomX") << "DetId" << HGCalDetId(id1) << " :" << global1 << " p" << p << " ID2" << HGCalDetId(id2) << " :" << geom->getPosition(id2) << " ID3" << HGCalDetId(id3) << " :" << geom->getPosition(id3);
             }
           }
         }
@@ -138,7 +132,7 @@ void HGCalTestNeighbor::doTest(const HGCalGeometry* geom, ForwardSubdetector sub
 
 void HGCalTestNeighbor::doTestWafer(const HGCalGeometry* geom, DetId::Detector det, const MagneticField* bField) {
   const std::vector<DetId>& ids = geom->getValidDetIds();
-  std::cout << "doTestWafer:: " << ids.size() << " valid ids for " << geom->cellElement() << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << "doTestWafer:: " << ids.size() << " valid ids for " << geom->cellElement();
   int layers[] = {1, 5, 10};
   int zsides[] = {1, -1};
   int cells[] = {1, 4, 7};
@@ -158,9 +152,7 @@ void HGCalTestNeighbor::doTestWafer(const HGCalGeometry* geom, DetId::Detector d
                   GlobalVector p(px_[k], py_[k], zside * pz_[k]);
                   DetId id2 = geom->neighborZ(id1, p);
                   DetId id3 = geom->neighborZ(id1, bField, 1, p);
-                  std::cout << "DetId" << HGCSiliconDetId(id1) << " :" << global1 << " p" << p << " ID2"
-                            << HGCSiliconDetId(id2) << " :" << geom->getPosition(id2) << " ID3" << HGCSiliconDetId(id3)
-                            << " :" << geom->getPosition(id3) << std::endl;
+                  edm::LogVerbatim("HGCalGeomX") << "DetId" << HGCSiliconDetId(id1) << " :" << global1 << " p" << p << " ID2" << HGCSiliconDetId(id2) << " :" << geom->getPosition(id2) << " ID3" << HGCSiliconDetId(id3) << " :" << geom->getPosition(id3);
                 }
               }
             }
@@ -173,7 +165,7 @@ void HGCalTestNeighbor::doTestWafer(const HGCalGeometry* geom, DetId::Detector d
 
 void HGCalTestNeighbor::doTestScint(const HGCalGeometry* geom, DetId::Detector det, const MagneticField* bField) {
   const std::vector<DetId>& ids = geom->getValidDetIds();
-  std::cout << "doTestScint: " << ids.size() << " valid ids for " << geom->cellElement() << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << "doTestScint: " << ids.size() << " valid ids for " << geom->cellElement();
   int layers[] = {9, 15, 22};
   int zsides[] = {1, -1};
   int iphis[] = {1, 51, 101, 151, 201};
@@ -191,9 +183,7 @@ void HGCalTestNeighbor::doTestScint(const HGCalGeometry* geom, DetId::Detector d
               GlobalVector p(px_[k], py_[k], zside * pz_[k]);
               DetId id2 = geom->neighborZ(id1, p);
               DetId id3 = geom->neighborZ(id1, bField, 1, p);
-              std::cout << "DetId" << HGCScintillatorDetId(id1) << " :" << global1 << " p" << p << " ID2"
-                        << HGCScintillatorDetId(id2) << " :" << geom->getPosition(id2) << " ID3"
-                        << HGCScintillatorDetId(id3) << " :" << geom->getPosition(id3) << std::endl;
+              edm::LogVerbatim("HGCalGeomX") << "DetId" << HGCScintillatorDetId(id1) << " :" << global1 << " p" << p << " ID2" << HGCScintillatorDetId(id2) << " :" << geom->getPosition(id2) << " ID3" << HGCScintillatorDetId(id3) << " :" << geom->getPosition(id3);
             }
           }
         }

--- a/Geometry/HGCalGeometry/test/HGCalTestNeighbor.cc
+++ b/Geometry/HGCalGeometry/test/HGCalTestNeighbor.cc
@@ -43,13 +43,13 @@ private:
   const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
 };
 
-HGCalTestNeighbor::HGCalTestNeighbor(const edm::ParameterSet& iC) :
-      name_(iC.getParameter<std::string>("detector")),
+HGCalTestNeighbor::HGCalTestNeighbor(const edm::ParameterSet& iC)
+    : name_(iC.getParameter<std::string>("detector")),
       px_(iC.getParameter<std::vector<double> >("pX")),
       py_(iC.getParameter<std::vector<double> >("pY")),
       pz_(iC.getParameter<std::vector<double> >("pZ")),
       fieldToken_(esConsumes<MagneticField, IdealMagneticFieldRecord>(edm::ESInputTag{})),
-      geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", name_})) { }
+      geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", name_})) {}
 
 void HGCalTestNeighbor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -76,7 +76,8 @@ void HGCalTestNeighbor::analyze(const edm::Event&, const edm::EventSetup& iSetup
       subdet = HGCHEB;
     else
       subdet = HGCEE;
-    edm::LogVerbatim("HGCalGeomX") << "Perform test for " << name_ << " Detector:Subdetector " << DetId::Forward << ":" << subdet;
+    edm::LogVerbatim("HGCalGeomX") << "Perform test for " << name_ << " Detector:Subdetector " << DetId::Forward << ":"
+                                   << subdet;
     doTest(geom, subdet, bField);
   } else {
     DetId::Detector det;
@@ -121,7 +122,9 @@ void HGCalTestNeighbor::doTest(const HGCalGeometry* geom, ForwardSubdetector sub
               GlobalVector p(px_[k], py_[k], zside * pz_[k]);
               DetId id2 = geom->neighborZ(id1, p);
               DetId id3 = geom->neighborZ(id1, bField, 1, p);
-              edm::LogVerbatim("HGCalGeomX") << "DetId" << HGCalDetId(id1) << " :" << global1 << " p" << p << " ID2" << HGCalDetId(id2) << " :" << geom->getPosition(id2) << " ID3" << HGCalDetId(id3) << " :" << geom->getPosition(id3);
+              edm::LogVerbatim("HGCalGeomX")
+                  << "DetId" << HGCalDetId(id1) << " :" << global1 << " p" << p << " ID2" << HGCalDetId(id2) << " :"
+                  << geom->getPosition(id2) << " ID3" << HGCalDetId(id3) << " :" << geom->getPosition(id3);
             }
           }
         }
@@ -152,7 +155,9 @@ void HGCalTestNeighbor::doTestWafer(const HGCalGeometry* geom, DetId::Detector d
                   GlobalVector p(px_[k], py_[k], zside * pz_[k]);
                   DetId id2 = geom->neighborZ(id1, p);
                   DetId id3 = geom->neighborZ(id1, bField, 1, p);
-                  edm::LogVerbatim("HGCalGeomX") << "DetId" << HGCSiliconDetId(id1) << " :" << global1 << " p" << p << " ID2" << HGCSiliconDetId(id2) << " :" << geom->getPosition(id2) << " ID3" << HGCSiliconDetId(id3) << " :" << geom->getPosition(id3);
+                  edm::LogVerbatim("HGCalGeomX") << "DetId" << HGCSiliconDetId(id1) << " :" << global1 << " p" << p
+                                                 << " ID2" << HGCSiliconDetId(id2) << " :" << geom->getPosition(id2)
+                                                 << " ID3" << HGCSiliconDetId(id3) << " :" << geom->getPosition(id3);
                 }
               }
             }
@@ -183,7 +188,9 @@ void HGCalTestNeighbor::doTestScint(const HGCalGeometry* geom, DetId::Detector d
               GlobalVector p(px_[k], py_[k], zside * pz_[k]);
               DetId id2 = geom->neighborZ(id1, p);
               DetId id3 = geom->neighborZ(id1, bField, 1, p);
-              edm::LogVerbatim("HGCalGeomX") << "DetId" << HGCScintillatorDetId(id1) << " :" << global1 << " p" << p << " ID2" << HGCScintillatorDetId(id2) << " :" << geom->getPosition(id2) << " ID3" << HGCScintillatorDetId(id3) << " :" << geom->getPosition(id3);
+              edm::LogVerbatim("HGCalGeomX") << "DetId" << HGCScintillatorDetId(id1) << " :" << global1 << " p" << p
+                                             << " ID2" << HGCScintillatorDetId(id2) << " :" << geom->getPosition(id2)
+                                             << " ID3" << HGCScintillatorDetId(id3) << " :" << geom->getPosition(id3);
             }
           }
         }

--- a/Geometry/HGCalGeometry/test/HGCalWaferCell.cc
+++ b/Geometry/HGCalGeometry/test/HGCalWaferCell.cc
@@ -27,11 +27,10 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
@@ -61,7 +60,7 @@ HGCalWaferCell::HGCalWaferCell(const edm::ParameterSet& iC)
       nameDetector_(iC.getParameter<std::string>("NameDevice")),
       debug_(iC.getParameter<bool>("Verbosity")),
       geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})) {
-  std::cout << "Check # of cells for " << nameDetector_ << " using constants of " << nameSense_ << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << "Check # of cells for " << nameDetector_ << " using constants of " << nameSense_;
 }
 
 void HGCalWaferCell::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -81,7 +80,7 @@ void HGCalWaferCell::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   if (hgdc.waferHexagon8()) {
     // Find all valid wafers
     std::vector<DetId> ids = geom->getValidGeomDetIds();
-    std::cout << "\n\nCheck Wafers for " << nameDetector_ << " with " << ids.size() << " wafers\n\n";
+    edm::LogVerbatim("HGCalGeomX") << "\n\nCheck Wafers for " << nameDetector_ << " with " << ids.size() << " wafers\n";
     DetId::Detector det = (nameSense_ == "HGCalHESiliconSensitive") ? DetId::HGCalHSi : DetId::HGCalEE;
     int bad(0);
     std::map<int, int> waferMap;
@@ -96,7 +95,7 @@ void HGCalWaferCell::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       HGCSiliconDetId id(det, 1, type, layer, waferU, waferV, 0, 0);
       int kndx = ((rotn * 10 + part) * 10 + type);
       if (debug_)
-        std::cout << std::hex << id.rawId() << std::dec << " " << id << " Index:" << kndx << std::endl;
+        edm::LogVerbatim("HGCalGeomX") << std::hex << id.rawId() << std::dec << " " << id << " Index:" << kndx;
       if (waferMap.find(kndx) == waferMap.end()) {
         waferMap[kndx] = 1;
       } else {
@@ -105,7 +104,7 @@ void HGCalWaferCell::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       if ((type < 0) || (type > 2) || (part < 0) || (part > 7) || (rotn < 0) || (rotn > 5))
         ++bad;
     }
-    std::cout << bad << " wafers of unknown types among " << hgdc.waferFileSize() << " wafers\n\n";
+    edm::LogVerbatim("HGCalGeomX") << bad << " wafers of unknown types among " << hgdc.waferFileSize() << " wafers\n";
 
     // Now print out the summary
     static const std::vector<int> itype = {0, 1, 2};
@@ -119,13 +118,12 @@ void HGCalWaferCell::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
           int kndx = ((rotn * 10 + part) * 10 + type);
           auto itr = waferMap.find(kndx);
           if (itr != waferMap.end())
-            std::cout << "Type:" << type << " Partial:" << typep[k] << " Orientation:" << rotn << " with "
-                      << (itr->second) << " wafers\n";
+            edm::LogVerbatim("HGCalGeomX") << "Type:" << type << " Partial:" << typep[k] << " Orientation:" << rotn << " with " << (itr->second) << " wafers";
         }
       }
     }
 
-    std::cout << "\n\nSummary of Cells\n================\n";
+    edm::LogVerbatim("HGCalGeomX") << "\n\nSummary of Cells\n================";
     for (const auto& type : itype) {
       int N = (type == 0) ? hgdc.getParameter()->nCellsFine_ : hgdc.getParameter()->nCellsCoarse_;
       for (unsigned int k = 0; k < itypp.size(); ++k) {
@@ -140,12 +138,11 @@ void HGCalWaferCell::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
               }
             }
           }
-          std::cout << "Type:" << type << " Partial:" << typep[k] << " Orientation:" << rotn << " with " << num
-                    << " cells\n";
+          edm::LogVerbatim("HGCalGeomX") << "Type:" << type << " Partial:" << typep[k] << " Orientation:" << rotn << " with " << num << " cells";
         }
       }
     }
-    std::cout << "\n\n\n";
+    edm::LogVerbatim("HGCalGeomX") << "\n\n";
   }
 }
 

--- a/Geometry/HGCalGeometry/test/HGCalWaferCell.cc
+++ b/Geometry/HGCalGeometry/test/HGCalWaferCell.cc
@@ -118,7 +118,8 @@ void HGCalWaferCell::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
           int kndx = ((rotn * 10 + part) * 10 + type);
           auto itr = waferMap.find(kndx);
           if (itr != waferMap.end())
-            edm::LogVerbatim("HGCalGeomX") << "Type:" << type << " Partial:" << typep[k] << " Orientation:" << rotn << " with " << (itr->second) << " wafers";
+            edm::LogVerbatim("HGCalGeomX") << "Type:" << type << " Partial:" << typep[k] << " Orientation:" << rotn
+                                           << " with " << (itr->second) << " wafers";
         }
       }
     }
@@ -138,7 +139,8 @@ void HGCalWaferCell::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
               }
             }
           }
-          edm::LogVerbatim("HGCalGeomX") << "Type:" << type << " Partial:" << typep[k] << " Orientation:" << rotn << " with " << num << " cells";
+          edm::LogVerbatim("HGCalGeomX") << "Type:" << type << " Partial:" << typep[k] << " Orientation:" << rotn
+                                         << " with " << num << " cells";
         }
       }
     }

--- a/Geometry/HGCalGeometry/test/HGCalWaferCheck.cc
+++ b/Geometry/HGCalGeometry/test/HGCalWaferCheck.cc
@@ -58,7 +58,8 @@ HGCalWaferCheck::HGCalWaferCheck(const edm::ParameterSet& iC)
       reco_(iC.getParameter<bool>("Reco")),
       dddToken_(esConsumes<HGCalDDDConstants, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})),
       geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})) {
-  edm::LogVerbatim("HGCalGeomX") << "Test numbering for " << nameDetector_ << " using constants of " << nameSense_ << " for  RecoFlag " << reco_;
+  edm::LogVerbatim("HGCalGeomX") << "Test numbering for " << nameDetector_ << " using constants of " << nameSense_
+                                 << " for  RecoFlag " << reco_;
 }
 
 HGCalWaferCheck::~HGCalWaferCheck() {}
@@ -68,7 +69,9 @@ void HGCalWaferCheck::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   const HGCalDDDConstants& hgdc = iSetup.getData(dddToken_);
   const auto& geomR = iSetup.getData(geomToken_);
   const HGCalGeometry* geom = &geomR;
-  edm::LogVerbatim("HGCalGeomX") << nameDetector_ << " Layers = " << hgdc.layers(reco_) << " Sectors = " << hgdc.sectors() << " Valid Cells " << geomR.getValidDetIds().size() << " Valid Geometry Cells " << geomR.getValidGeomDetIds().size();
+  edm::LogVerbatim("HGCalGeomX") << nameDetector_ << " Layers = " << hgdc.layers(reco_)
+                                 << " Sectors = " << hgdc.sectors() << " Valid Cells " << geomR.getValidDetIds().size()
+                                 << " Valid Geometry Cells " << geomR.getValidGeomDetIds().size();
   if (hgdc.waferHexagon8()) {
     DetId::Detector det = (nameSense_ == "HGCalHESiliconSensitive") ? DetId::HGCalHSi : DetId::HGCalEE;
     for (int layer = 1; layer <= 2; ++layer) {

--- a/Geometry/HGCalGeometry/test/HGCalWaferCheck.cc
+++ b/Geometry/HGCalGeometry/test/HGCalWaferCheck.cc
@@ -27,11 +27,10 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HGCalCommonData/interface/HGCalDDDConstants.h"
@@ -59,8 +58,7 @@ HGCalWaferCheck::HGCalWaferCheck(const edm::ParameterSet& iC)
       reco_(iC.getParameter<bool>("Reco")),
       dddToken_(esConsumes<HGCalDDDConstants, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})),
       geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})) {
-  std::cout << "Test numbering for " << nameDetector_ << " using constants of " << nameSense_ << " for  RecoFlag "
-            << reco_ << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << "Test numbering for " << nameDetector_ << " using constants of " << nameSense_ << " for  RecoFlag " << reco_;
 }
 
 HGCalWaferCheck::~HGCalWaferCheck() {}
@@ -70,9 +68,7 @@ void HGCalWaferCheck::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   const HGCalDDDConstants& hgdc = iSetup.getData(dddToken_);
   const auto& geomR = iSetup.getData(geomToken_);
   const HGCalGeometry* geom = &geomR;
-  std::cout << nameDetector_ << " Layers = " << hgdc.layers(reco_) << " Sectors = " << hgdc.sectors() << " Valid Cells "
-            << geomR.getValidDetIds().size() << " Valid Geometry Cells " << geomR.getValidGeomDetIds().size()
-            << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << nameDetector_ << " Layers = " << hgdc.layers(reco_) << " Sectors = " << hgdc.sectors() << " Valid Cells " << geomR.getValidDetIds().size() << " Valid Geometry Cells " << geomR.getValidGeomDetIds().size();
   if (hgdc.waferHexagon8()) {
     DetId::Detector det = (nameSense_ == "HGCalHESiliconSensitive") ? DetId::HGCalHSi : DetId::HGCalEE;
     for (int layer = 1; layer <= 2; ++layer) {
@@ -82,10 +78,10 @@ void HGCalWaferCheck::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         int cell = (type == 0) ? 12 : 8;
         HGCSiliconDetId id1(det, 1, type, layer, waferU, waferV, cell, cell);
         if (geom->topology().valid(id1))
-          std::cout << " ID: " << id1 << " Position " << geom->getPosition(id1) << std::endl;
+          edm::LogVerbatim("HGCalGeomX") << " ID: " << id1 << " Position " << geom->getPosition(id1);
         HGCSiliconDetId id2(det, -1, type, layer, waferU, waferV, cell, cell);
         if (geom->topology().valid(id2))
-          std::cout << " ID: " << id2 << " Position " << geom->getPosition(id2) << std::endl;
+          edm::LogVerbatim("HGCalGeomX") << " ID: " << id2 << " Position " << geom->getPosition(id2);
       }
       for (int waferV = -12; waferV <= 12; ++waferV) {
         int waferU(0);
@@ -93,10 +89,10 @@ void HGCalWaferCheck::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         int cell = (type == 0) ? 12 : 8;
         HGCSiliconDetId id1(det, 1, type, layer, waferU, waferV, cell, cell);
         if (geom->topology().valid(id1))
-          std::cout << " ID: " << id1 << " Position " << geom->getPosition(id1) << std::endl;
+          edm::LogVerbatim("HGCalGeomX") << " ID: " << id1 << " Position " << geom->getPosition(id1);
         HGCSiliconDetId id2(det, -1, type, layer, waferU, waferV, cell, cell);
         if (geom->topology().valid(id2))
-          std::cout << " ID: " << id2 << " Position " << geom->getPosition(id2) << std::endl;
+          edm::LogVerbatim("HGCalGeomX") << " ID: " << id2 << " Position " << geom->getPosition(id2);
       }
     }
   }

--- a/Geometry/HGCalGeometry/test/HGCalWaferTypeTester.cc
+++ b/Geometry/HGCalGeometry/test/HGCalWaferTypeTester.cc
@@ -30,7 +30,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
@@ -51,18 +51,16 @@ public:
   void endJob() override {}
 
 private:
-  edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
-  std::string nameSense_, nameDetector_;
+  const std::string nameSense_, nameDetector_;
+  const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
 };
 
-HGCalWaferTypeTester::HGCalWaferTypeTester(const edm::ParameterSet& iC) {
-  nameSense_ = iC.getParameter<std::string>("NameSense");
-  nameDetector_ = iC.getParameter<std::string>("NameDevice");
+HGCalWaferTypeTester::HGCalWaferTypeTester(const edm::ParameterSet& iC) :
+      nameSense_(iC.getParameter<std::string>("NameSense")),
+      nameDetector_(iC.getParameter<std::string>("NameDevice")),
+      geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})) {
 
-  geomToken_ = esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_});
-
-  std::cout << "Test wafer types for " << nameDetector_ << " using constants of " << nameSense_ << " for  RecoFlag true"
-            << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << "Test wafer types for " << nameDetector_ << " using constants of " << nameSense_ << " for  RecoFlag true";
 }
 
 void HGCalWaferTypeTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -78,11 +76,11 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
   const HGCalGeometry* geom = &geomR;
   const HGCalDDDConstants& hgdc = geom->topology().dddConstants();
   HGCalGeometryMode::GeometryMode mode = hgdc.geomMode();
-  std::cout << nameDetector_ << "\n Mode = " << mode << std::endl;
+  edm::LogVerbatim("HGCalGeomX") << nameDetector_ << "\n Mode = " << mode;
   if (hgdc.waferHexagon8()) {
     double r = hgdc.waferParameters(true).first;
     double R = hgdc.waferParameters(true).second;
-    std::cout << "Wafer Parameters " << r << ":" << R << std::endl << std::endl;
+    edm::LogVerbatim("HGCalGeomX") << "Wafer Parameters " << r << ":" << R << std::endl;
     // Determine if the 24 points on the perphery of the wafer is within range
     // These are the 6 corners; the middle of the edges and the positions
     // which determines the positions of choptwoMinus and semiMinus
@@ -130,8 +128,7 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
           match = true;
           for (unsigned int i = 0; i < nc; ++i) {
             if ((((pat[indx] / ii) & 1) != 0) && (((ipat / ii) & 1) == 0)) {
-              std::cout << "Fail at " << i << ":" << ii << " Expect " << ((pat[indx] / ii) & 1) << " Found "
-                        << ((ipat / ii) & 1) << std::endl;
+              edm::LogVerbatim("HGCalGeomX") << "Fail at " << i << ":" << ii << " Expect " << ((pat[indx] / ii) & 1) << " Found " << ((ipat / ii) & 1);
               match = false;
               break;
             }
@@ -154,31 +151,24 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
             }
           }
         }
-        std::cout << "Wafer[" << wtype << ", " << hid.layer() << ", " << hid.waferU() << ", " << hid.waferV() << "] "
-                  << " with type: rotation " << type.first << ":" << type.second << " Pattern " << std::hex << pat[indx]
-                  << ":" << ipat << std::dec;
+	std::string cherr = (!match) ? " ***** ERROR *****" : "";
+        edm::LogVerbatim("HGCalGeomX") << "Wafer[" << wtype << ", " << hid.layer() << ", " << hid.waferU() << ", " << hid.waferV() << "]  with type: rotation " << type.first << ":" << type.second << " Pattern " << std::hex << pat[indx] << ":" << ipat << std::dec << cherr;
         if (!match) {
           ++bad;
-          std::cout << " ***** ERROR *****" << std::endl;
           // Need debug information here
           hgdc.waferTypeRotation(hid.layer(), hid.waferU(), hid.waferV(), true);
           HGCalWaferMask::getTypeMode(xyz.x(), xyz.y(), r, R, range.first, range.second, wtype, 0, true);
           for (unsigned int i = 0; i < 24; ++i) {
             double rp = std::sqrt((xyz.x() + dx[i]) * (xyz.x() + dx[i]) + (xyz.y() + dy[i]) * (xyz.y() + dy[i]));
-            std::cout << "Corner[" << i << "] (" << xyz.x() << ":" << xyz.y() << ") (" << (xyz.x() + dx[i]) << ":"
-                      << (xyz.y() + dy[i]) << " ) R " << rp << " Limit " << range.first << ":" << range.second
-                      << std::endl;
+            edm::LogVerbatim("HGCalGeomX") << "Corner[" << i << "] (" << xyz.x() << ":" << xyz.y() << ") (" << (xyz.x() + dx[i]) << ":" << (xyz.y() + dy[i]) << " ) R " << rp << " Limit " << range.first << ":" << range.second;
           }
         } else {
           ++good;
-          std::cout << std::endl;
         }
         ++total;
       }
     }
-    std::cout << "\n\nExamined " << ids.size() << ":" << all << " wafers " << total << " partial wafers of which "
-              << good << " are good and " << bad << " are bad" << std::endl
-              << std::endl;
+    edm::LogVerbatim("HGCalGeomX") << "\n\nExamined " << ids.size() << ":" << all << " wafers " << total << " partial wafers of which " << good << " are good and " << bad << " are bad\n";
   }
 }
 

--- a/Geometry/HGCalGeometry/test/HGCalWaferTypeTester.cc
+++ b/Geometry/HGCalGeometry/test/HGCalWaferTypeTester.cc
@@ -55,12 +55,12 @@ private:
   const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
 };
 
-HGCalWaferTypeTester::HGCalWaferTypeTester(const edm::ParameterSet& iC) :
-      nameSense_(iC.getParameter<std::string>("NameSense")),
+HGCalWaferTypeTester::HGCalWaferTypeTester(const edm::ParameterSet& iC)
+    : nameSense_(iC.getParameter<std::string>("NameSense")),
       nameDetector_(iC.getParameter<std::string>("NameDevice")),
       geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord>(edm::ESInputTag{"", nameSense_})) {
-
-  edm::LogVerbatim("HGCalGeomX") << "Test wafer types for " << nameDetector_ << " using constants of " << nameSense_ << " for  RecoFlag true";
+  edm::LogVerbatim("HGCalGeomX") << "Test wafer types for " << nameDetector_ << " using constants of " << nameSense_
+                                 << " for  RecoFlag true";
 }
 
 void HGCalWaferTypeTester::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -128,7 +128,8 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
           match = true;
           for (unsigned int i = 0; i < nc; ++i) {
             if ((((pat[indx] / ii) & 1) != 0) && (((ipat / ii) & 1) == 0)) {
-              edm::LogVerbatim("HGCalGeomX") << "Fail at " << i << ":" << ii << " Expect " << ((pat[indx] / ii) & 1) << " Found " << ((ipat / ii) & 1);
+              edm::LogVerbatim("HGCalGeomX") << "Fail at " << i << ":" << ii << " Expect " << ((pat[indx] / ii) & 1)
+                                             << " Found " << ((ipat / ii) & 1);
               match = false;
               break;
             }
@@ -151,8 +152,10 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
             }
           }
         }
-	std::string cherr = (!match) ? " ***** ERROR *****" : "";
-        edm::LogVerbatim("HGCalGeomX") << "Wafer[" << wtype << ", " << hid.layer() << ", " << hid.waferU() << ", " << hid.waferV() << "]  with type: rotation " << type.first << ":" << type.second << " Pattern " << std::hex << pat[indx] << ":" << ipat << std::dec << cherr;
+        std::string cherr = (!match) ? " ***** ERROR *****" : "";
+        edm::LogVerbatim("HGCalGeomX") << "Wafer[" << wtype << ", " << hid.layer() << ", " << hid.waferU() << ", "
+                                       << hid.waferV() << "]  with type: rotation " << type.first << ":" << type.second
+                                       << " Pattern " << std::hex << pat[indx] << ":" << ipat << std::dec << cherr;
         if (!match) {
           ++bad;
           // Need debug information here
@@ -160,7 +163,9 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
           HGCalWaferMask::getTypeMode(xyz.x(), xyz.y(), r, R, range.first, range.second, wtype, 0, true);
           for (unsigned int i = 0; i < 24; ++i) {
             double rp = std::sqrt((xyz.x() + dx[i]) * (xyz.x() + dx[i]) + (xyz.y() + dy[i]) * (xyz.y() + dy[i]));
-            edm::LogVerbatim("HGCalGeomX") << "Corner[" << i << "] (" << xyz.x() << ":" << xyz.y() << ") (" << (xyz.x() + dx[i]) << ":" << (xyz.y() + dy[i]) << " ) R " << rp << " Limit " << range.first << ":" << range.second;
+            edm::LogVerbatim("HGCalGeomX")
+                << "Corner[" << i << "] (" << xyz.x() << ":" << xyz.y() << ") (" << (xyz.x() + dx[i]) << ":"
+                << (xyz.y() + dy[i]) << " ) R " << rp << " Limit " << range.first << ":" << range.second;
           }
         } else {
           ++good;
@@ -168,7 +173,8 @@ void HGCalWaferTypeTester::analyze(const edm::Event& iEvent, const edm::EventSet
         ++total;
       }
     }
-    edm::LogVerbatim("HGCalGeomX") << "\n\nExamined " << ids.size() << ":" << all << " wafers " << total << " partial wafers of which " << good << " are good and " << bad << " are bad\n";
+    edm::LogVerbatim("HGCalGeomX") << "\n\nExamined " << ids.size() << ":" << all << " wafers " << total
+                                   << " partial wafers of which " << good << " are good and " << bad << " are bad\n";
   }
 }
 

--- a/Geometry/HGCalGeometry/test/python/testHGCalNeighbor_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalNeighbor_cfg.py
@@ -15,6 +15,7 @@ process.GlobalTag.globaltag = autoCond['phase2_realistic']
 
 if hasattr(process,'MessageLogger'):
     process.MessageLogger.HGCalGeom=dict()
+    process.MessageLogger.HGCalGeomX=dict()
 
 process.load("IOMC.RandomEngine.IOMC_cff")
 process.RandomNumberGeneratorService.generator.initialSeed = 456789

--- a/Geometry/HGCalGeometry/test/python/testHGCalSize_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalSize_cfg.py
@@ -12,6 +12,7 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 
 if hasattr(process,'MessageLogger'):
     process.MessageLogger.HGCalGeom=dict()
+    process.MessageLogger.HGCalGeomX=dict()
 
 process.load("IOMC.RandomEngine.IOMC_cff")
 process.RandomNumberGeneratorService.generator.initialSeed = 456789

--- a/Geometry/HGCalGeometry/test/python/testHGCalWafer_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalWafer_cfg.py
@@ -8,6 +8,7 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 
 if hasattr(process,'MessageLogger'):
     process.MessageLogger.HGCalGeom=dict()
+    process.MessageLogger.HGCalGeomX=dict()
 
 process.load("IOMC.RandomEngine.IOMC_cff")
 process.RandomNumberGeneratorService.generator.initialSeed = 456789


### PR DESCRIPTION
#### PR description:

Use MessageLogger instead of cout in a number of analyzers in HGCalGeometry

#### PR validation:

Use runTheMatrix test workflows 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special