### PR TITLE
Clean up redundant edm ParameterSet existAs or exist in RecoMET

### DIFF
--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -45,7 +45,7 @@ namespace cms {
       rhoToken_ = consumes<double>(iConfig.getParameter<edm::InputTag>("srcRho"));
     }
 
-    std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
+    std::string alias = iConfig.getParameter<std::string>("alias");
 
     produces<reco::PFMETCollection>().setBranchAlias(alias);
   }


### PR DESCRIPTION
#### PR description:  
(Technical PR) Optimization of the module configurations: Improve maintainability by cleaning up redundant cases of edm::ParameterSet calls to `existAs` or `exist` for tracked parameters, where redundancy is based on the value being already defined by `fillDescriptions`.

#### Motivation: 
values of tracked parameters should be properly defined in the configuration and be visible in the process configuration provenance; code that checks for the existence of a parameter and sets a hardcoded default would bypass the configuration provenance registration and should be avoided. In general, default parameter values should be provided via `fillDescriptions`, as detailed in [SWGuideConfigValidation](https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideConfigurationValidationAndHelp). Redundant calls to `existAs` or `exist` can be **cleaned up**.

As follow the previous [PR36746](https://github.com/cms-sw/cmssw/pull/36746),  [PR36989](https://github.com/cms-sw/cmssw/pull/36989).

The list of all calls of `existAs` or `exist` are automatically available in the Static Analyzer report. (Bug: CMS code rules)
It is accessible from IB page. https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/
For this task consider only modules or tools used by the modules that define `fillDescriptions`.

In this PR, 1 file was changed.  
RecoMET/METProducers/src/PFMETProducer.cc
 
Here, the "alias" parameters are provided in a `fillDescription` .
​[cfipython/RecoMET/METProducers/pfMet_cfi.py](https://cmssdt.cern.ch/lxr/source/cfipython/RecoMET/METProducers/pfMet_cfi.py)

#### PR validation:
Tested in CMSSW_12_3_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)