### PR TITLE
Clean up redundant edm ParameterSet existAs or exist in RecoTauTag

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFTauSelectorDefinition.h
+++ b/RecoTauTag/RecoTau/plugins/PFTauSelectorDefinition.h
@@ -69,9 +69,7 @@ struct PFTauSelectorDefinition {
     }
 
     // Build a string cut if desired
-    if (cfg.exists("cut")) {
-      cut_ = std::make_unique<StringCutObjectSelector<reco::PFTau>>(cfg.getParameter<std::string>("cut"));
-    }
+    cut_ = std::make_unique<StringCutObjectSelector<reco::PFTau>>(cfg.getParameter<std::string>("cut"));
   }
 
   const_iterator begin() const { return selected_.begin(); }


### PR DESCRIPTION
#### PR description:  
(Technical PR) Optimization of the module configurations: Improve maintainability by cleaning up redundant cases of edm::ParameterSet calls to `existAs` or `exist` for tracked parameters, where redundancy is based on the value being already defined by `fillDescriptions`.

As follow the previous [PR36746](https://github.com/cms-sw/cmssw/pull/36746),  [PR36989](https://github.com/cms-sw/cmssw/pull/36989).

The list of all calls of `existAs` or `exist` are automatically available in the Static Analyzer report. (Bug: CMS code rules)
It is accessible from IB page. https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/
For this task consider only modules or tools used by the modules that define `fillDescriptions`.

In this PR, 1 file was changed.  
RecoTauTag/RecoTau/plugins/PFTauSelectorDefinition.h
Here, the "cut" parameter exists in cfipython file.
[cfipython/RecoTauTag/RecoTau/pfTauSelector_cfi.py](https://cmssdt.cern.ch/lxr/source/cfipython/RecoTauTag/RecoTau/pfTauSelector_cfi.py)

#### PR validation:
Tested in CMSSW_12_3_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)