### PR TITLE
run cosmics track refitter in order to fix to Strip Hit residuals

### DIFF
--- a/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
+++ b/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_Cosmic_cff.py
@@ -81,26 +81,39 @@ SiStripMonitorTrack_ckf = SiStripMonitorTrack.clone(
 #     Mod_On = False
 # )
 
+# track refitter 
+from RecoTracker.TrackProducer.TrackRefitterP5_cfi import *
+refitterForCosmictrackfinderP5 = TrackRefitterP5.clone(
+    src = "cosmictrackfinderP5"
+)
+refitterForCtfWithMaterialTracksP5 = TrackRefitterP5.clone(
+    src = "ctfWithMaterialTracksP5"
+)
+refitterForRsWithMaterialTracksP5 = TrackRefitterP5.clone(
+    src = "rsWithMaterialTracksP5"
+)
+
 # TrackerMonitorTrack ####
 # Clone for Cosmic Track Finder
 from DQM.TrackerMonitorTrack.MonitorTrackResiduals_cfi import *
 MonitorTrackResiduals_cosmicTk = MonitorTrackResiduals.clone(
-    trajectoryInput = 'cosmictrackfinderP5',
-    Tracks = 'cosmictrackfinderP5',
+    trajectoryInput = 'refitterForCosmictrackfinderP5',
+    Tracks = 'refitterForCosmictrackfinderP5',
     Mod_On = False,
     VertexCut = False
 )
 # Clone for CKF Tracks
 MonitorTrackResiduals_ckf = MonitorTrackResiduals.clone(
-    trajectoryInput = 'ctfWithMaterialTracksP5',
-    Tracks = 'ctfWithMaterialTracksP5',
+    trajectoryInput = 'refitterForCtfWithMaterialTracksP5',
+    Tracks = 'refitterForCtfWithMaterialTracksP5',
     Mod_On = False,
     VertexCut = False
 )
-# Clone for Road Search  Tracks
+
+# Clone for Road Search Tracks
 # MonitorTrackResiduals_rs = MonitorTrackResiduals.clone(
-#     trajectoryInput = 'rsWithMaterialTracksP5',
-#     Tracks = 'rsWithMaterialTracksP5',
+#     trajectoryInput = 'refitterForRsWithMaterialTracksP5',
+#     Tracks = 'refitterForRsWithMaterialTracksP5',
 #     Mod_On = False,
 #     VertexCut = False
 # )
@@ -133,4 +146,4 @@ SiStripDQMTier0_ckf = cms.Sequence(APVPhases*consecutiveHEs*SiStripMonitorTrack_
 #removed modules using TkDetMap
 #SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*MonitorTrackResiduals_ckf*TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoSiStrip)
 #SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*TrackMon_cosmicTk*TrackMon_ckf*TrackEffMon_ckf*TrackSplitMonitor*dqmInfoSiStrip)
-SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrack_ckf*MonitorTrackResiduals_ckf*dqmInfoSiStrip)
+SiStripDQMTier0 = cms.Sequence(APVPhases*consecutiveHEs*siStripFEDCheck*siStripFEDMonitor*SiStripMonitorDigi*SiStripMonitorCluster*SiStripMonitorTrack_ckf*refitterForCtfWithMaterialTracksP5*MonitorTrackResiduals_ckf*dqmInfoSiStrip)


### PR DESCRIPTION
#### PR description:

Follow-up to PR https://github.com/cms-sw/cmssw/pull/35811.
Noticed that even in the CRAFT'22 DQM (post PR #35811 has been merged) data the Strip End Caps (TID / TEC) residuals are still empty (see e.g.: https://tinyurl.com/yd83lqlz and https://tinyurl.com/y8286jpa).
This has been traced down to the fact that in cosmics, unlike collisions (see:
https://github.com/cms-sw/cmssw/blob/8204ef9abce4ead22a957e14751b38f9f1b05e07/DQM/SiStripMonitorClient/python/SiStripSourceConfigTier0_cff.py#L152-L156
) the bare track collection (without the trajectory in the event) is fed to `TrackerValidationVariables` (making it impossible to get precise residuals in the endcap).
This is fixed in this PR introducing the cosmics track refitter in the DQM configuration.

#### PR validation:

Run: ` runTheMatrix.py -l 138.2 -j 8 --command='-n 1000'`

with the following patch:

```diff
diff --git a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
index bb58285028f..4b9eb6d0e8d 100644
--- a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
+++ b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
@@ -274,14 +274,25 @@ void MonitorTrackResidualsBase<pixel_or_strip>::analyze(const edm::Event &iEvent
 
       auto subdetandlayer = findSubdetAndLayer(RawId, tTopo);
       auto histos = m_SubdetLayerResiduals[subdetandlayer];
+      std::cout << " subdet: " << subdetandlayer.first << " layer: " << subdetandlayer.second << std::endl;
+
       // fill if its error is not zero
       if (it.resXprimeErr != 0 && histos.x.base) {
         histos.x.base->Fill(it.resXprime);
         histos.x.normed->Fill(it.resXprime / it.resXprimeErr);
+
+       if(subdetandlayer.first=="TEC" || subdetandlayer.first=="TID" ){
+         std::cout << "x-residual: " << it.resXprime << " / " << it.resXprimeErr << std::endl;
+       }
         if (!isPixel)
           tkhisto_ResidualsMean->fill(RawId, it.resXprime);
       }
       if (it.resYprimeErr != 0 && histos.y.base) {
+
+       if(subdetandlayer.first=="TEC" || subdetandlayer.first=="TID" ){
+         std::cout << "y-residual:" << it.resYprime << " / " << it.resYprimeErr << std::endl;
+       }
+
         histos.y.base->Fill(it.resYprime);
         histos.y.normed->Fill(it.resYprime / it.resYprimeErr);
       }
```
and now one gets:
```console
Begin processing the 18th record. Run 343498, Event 18792252, LumiSection 1151 on stream 0 at 23-Mar-2022 13:02:01.846 CET
 subdet: TEC layer: 1
x-residual: -0.0151313 / 0.0473088
 subdet: TEC layer: 2
x-residual: 0.0107512 / 0.0143062
 subdet: TEC layer: 3
x-residual: -0.00317227 / 0.00859425
 subdet: TEC layer: 3
x-residual: -0.00389814 / 0.00671078
 subdet: TEC layer: 3
x-residual: 0.00796366 / 0.00832214
 subdet: TEC layer: 4
x-residual: 0.00557164 / 0.0108646
 subdet: TEC layer: 5
x-residual: -0.00106809 / 0.00630571
 subdet: TEC layer: 5
x-residual: 0.00326104 / 0.00766269
 subdet: TEC layer: 6
x-residual: 0.00382722 / 0.010256
 subdet: TEC layer: 6
x-residual: -0.00890858 / 0.00832553
 subdet: TEC layer: 6
x-residual: -0.00241953 / 0.00897227
 subdet: TEC layer: 6
x-residual: -0.00600596 / 0.00603685
 subdet: TEC layer: 6
x-residual: 0.00968534 / 0.00783616
 subdet: TEC layer: 7
x-residual: 0.00883887 / 0.0321769
```
whereas before it was:
```console
Begin processing the 18th record. Run 343498, Event 18792252, LumiSection 1151 on stream 0 at 23-Mar-2022 12:25:17.472 CET
 subdet: TEC layer: 7
x-residual: -998001 / 999
 subdet: TEC layer: 6
x-residual: -998001 / 999
 subdet: TEC layer: 6
x-residual: -998001 / 999
 subdet: TEC layer: 6
x-residual: -998001 / 999
 subdet: TEC layer: 6
x-residual: -998001 / 999
 subdet: TEC layer: 6
x-residual: -998001 / 999
 subdet: TEC layer: 5
x-residual: -998001 / 999
 subdet: TEC layer: 5
x-residual: -998001 / 999
 subdet: TEC layer: 4
x-residual: -998001 / 999
 subdet: TEC layer: 3
x-residual: -998001 / 999
 subdet: TEC layer: 3
x-residual: -998001 / 999
 subdet: TEC layer: 3
x-residual: -998001 / 999
 subdet: TEC layer: 2
x-residual: -998001 / 999
 subdet: TEC layer: 1
x-residual: -998001 / 999
```
Example of obtained plots:

| CMSSW_12_4_X_2022-03-22-1100 as-is | CMSSW_12_4_X_2022-03-22-1100 + this PR |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5082376/159702440-42c561c7-df38-4665-a701-62079eae800f.png) | ![image](https://user-images.githubusercontent.com/5082376/159702311-f5559ea2-fad7-4999-8465-94faeb26ce4d.png) |

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but should be backported for operations.