### PR TITLE
AllStepsToTree option switched ON

### DIFF
--- a/Validation/Geometry/test/runP_Tracker.py
+++ b/Validation/Geometry/test/runP_Tracker.py
@@ -126,7 +126,7 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
     MaterialBudgetAction = cms.PSet(
         HistosFile = cms.string('matbdg_%s_%s.root' % (options.label,
                                                        options.geom)),
-        AllStepsToTree = cms.bool(False),
+        AllStepsToTree = cms.bool(True),
         HistogramList = cms.string('Tracker'),
         SelectedVolumes = cms.vstring(_components),
         TreeFile = cms.string('matbdg_tree_%s_%s.root' % (options.label,


### PR DESCRIPTION
#### PR description:

~/CMSSW_12_3_X_2022-03-23-1100/src/Validation/Geometry/test/runP_Tracker.py is updated;

- AllStepsToTree option has been fixed by "Fix AllStepsToTree option to runP_Tracker.py script #37095"; this pull request puts AllStepsToTree option in use in runP_Tracker.py.
- This PR depends on "Fix AllStepsToTree option to runP_Tracker.py script #37095", and will depend on any PR's or externals that report a present/future problem/issue/improvement on the AllStepsToTree option.
- AllStepsToTree option switched ON is necessary for MaterialBudget.py to generate a number of non-empty plots  (see PR validation below).
- https://github.com/cms-sw/cmssw/pull/37095



#### PR validation:

Tracker Material Budget Validation was run with CMSSW_12_3_X_2022-03-23-1100 (https://twiki.cern.ch/twiki/bin/viewauth/CMS/TrackerMaterialBudgetValidation - TWiki needs to be updated), "Validation plots: single geometry configuration" were produced (.png and .pdf files that illustrate the tracker material budget, measured in fractional radiation lengths x or hadronic interaction lengths l, plotted as a function of eta, or phi, or R, or eta and phi, etc.).

- Some "Validation plots: single geometry configuration" cannot be produced (MaterialBudget.py produces empty plots) when AllStepsToTree option is switched OFF in tested versions of CMSSW_12 - AllStepsToTree option switched ON is necessary.
- Relevant TWiki page (needs to be updated): https://twiki.cern.ch/twiki/bin/viewauth/CMS/TrackerMaterialBudgetValidation 

log in to [user@lxplus7.cern.ch](mailto:user@lxplus7.cern.ch) (follow the usual steps on Terminal, see example at the end)
COPY-PASTE into terminal: {
tcsh
setenv SCRAM_ARCH slc7_amd64_gcc10 
scram project CMSSW_12_3_X_2022-03-23-1100
cd CMSSW_12_3_X_2022-03-23-1100/src
cmsenv
git cms-addpkg Validation/Geometry
scram b disable-biglib
cmsenv
scram b -j8
cd Validation/Geometry/test
cmsRun single_neutrino_cfg.py
python3 runP_Tracker.py geom=Extended2017Plan1 label=Tracker > matbudget.out
cmsenv
mkdir Images
python3 MaterialBudget.py -s -d Tracker -g "Extended2017Plan1" # 's' means single and d means 'detector'
} END COPY-PASTE into terminal.

Instructions to log in to user@lxplus7.cern.ch
1. Enter the following line in your Terminal:
- $ ssh -XY username@lxplus.cern.ch
- or:
- $ ssh -XY username@lxplus7.cern.ch
2. Enter your CERN password when prompted to do so,
3. Your terminal should now begin with (you have successfully logged in) :
- [username@lxplus7## ~]$



#### if this PR is a backport please specify the original PR and why you need to backport that PR:

- https://github.com/cms-sw/cmssw/pull/37095

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
