### PR TITLE
further miscellaneous clean-up / improvements to SiStrip payload inspector

### DIFF
--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -51,7 +51,7 @@ namespace {
       setGranularity(SiStripCondObjectRepresent::PERAPV);
     }
 
-    void allValues() override {
+    void storeAllValues() override {
       std::vector<uint32_t> detid;
       payload_->getDetIds(detid);
 
@@ -222,7 +222,7 @@ namespace {
       SiStripApvGainContainer* f_objContainer =
           new SiStripApvGainContainer(first_payload, std::get<0>(firstiov), std::get<1>(firstiov));
 
-      l_objContainer->Subtract(f_objContainer);
+      l_objContainer->subtract(f_objContainer);
 
       //l_objContainer->printAll();
 

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -44,7 +44,7 @@ namespace {
       setGranularity(SiStripCondObjectRepresent::PERMODULE);
     }
 
-    void allValues() override {
+    void storeAllValues() override {
       auto LAMap_ = payload_->getLorentzAngles();
       for (const auto &element : LAMap_) {
         SiStripCondData_.fillByPushBack(element.first, element.second);

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -646,6 +646,8 @@ namespace {
         : PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Noise values comparison") {}
 
     bool fill() override {
+      TGaxis::SetExponentOffset(-0.1, 0.01, "y");  // X and Y offset for Y axis
+
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = PlotBase::getTag<0>().iovs;
       auto tagname1 = PlotBase::getTag<0>().name;
@@ -670,12 +672,7 @@ namespace {
       auto f_mon = std::unique_ptr<SiStripPI::Monitor1D>(new SiStripPI::Monitor1D(
           op_mode_,
           "f_Noise",
-          Form("#LT Strip Noise #GT per %s for IOV [%s,%s];#LTStrip Noise per %s#GT [ADC counts];n. %ss",
-               opType(op_mode_).c_str(),
-               std::to_string(std::get<0>(firstiov)).c_str(),
-               std::to_string(std::get<0>(lastiov)).c_str(),
-               opType(op_mode_).c_str(),
-               opType(op_mode_).c_str()),
+          Form(";#LTStrip Noise per %s#GT [ADC counts];n. %ss", opType(op_mode_).c_str(), opType(op_mode_).c_str()),
           100,
           0.1,
           10.));
@@ -683,12 +680,7 @@ namespace {
       auto l_mon = std::unique_ptr<SiStripPI::Monitor1D>(new SiStripPI::Monitor1D(
           op_mode_,
           "l_Noise",
-          Form("#LT Strip Noise #GT per %s for IOV [%s,%s];#LTStrip Noise per %s#GT [ADC counts];n. %ss",
-               opType(op_mode_).c_str(),
-               std::to_string(std::get<0>(lastiov)).c_str(),
-               std::to_string(std::get<0>(lastiov)).c_str(),
-               opType(op_mode_).c_str(),
-               opType(op_mode_).c_str()),
+          Form(";#LTStrip Noise per %s#GT [ADC counts];n. %ss", opType(op_mode_).c_str(), opType(op_mode_).c_str()),
           100,
           0.1,
           10.));
@@ -795,31 +787,41 @@ namespace {
       //=========================
       TCanvas canvas("Partition summary", "partition summary", 1200, 1000);
       canvas.cd();
-      canvas.SetBottomMargin(0.11);
+      canvas.SetTopMargin(0.06);
+      canvas.SetBottomMargin(0.10);
       canvas.SetLeftMargin(0.13);
       canvas.SetRightMargin(0.05);
       canvas.Modified();
 
       float theMax = (h_first.GetMaximum() > h_last.GetMaximum()) ? h_first.GetMaximum() : h_last.GetMaximum();
 
-      h_first.SetMaximum(theMax * 1.30);
-      h_last.SetMaximum(theMax * 1.30);
+      h_first.SetMaximum(theMax * 1.20);
+      h_last.SetMaximum(theMax * 1.20);
 
       h_first.Draw();
+      h_last.SetFillColorAlpha(kBlue, 0.15);
       h_last.Draw("same");
 
-      TLegend legend = TLegend(0.13, 0.82, 0.95, 0.9);
+      TLegend legend = TLegend(0.13, 0.83, 0.95, 0.94);
       if (this->m_plotAnnotations.ntags == 2) {
         legend.SetHeader("#bf{Two Tags Comparison}", "C");  // option "C" allows to center the header
         legend.AddEntry(&h_first, (tagname1 + " : " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
         legend.AddEntry(&h_last, (tagname2 + " : " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
       } else {
-        legend.SetHeader(("#bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
-        legend.AddEntry(&h_first, ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
-        legend.AddEntry(&h_last, ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+        legend.SetHeader(("tag: #bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
+        legend.AddEntry(&h_first, ("IOV since: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
+        legend.AddEntry(&h_last, ("IOV since: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
       }
       legend.SetTextSize(0.025);
       legend.Draw("same");
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                       1 - gPad->GetTopMargin() + 0.01,
+                       Form("#LTSiStrip Noise#GT Comparison per %s", opType(op_mode_).c_str()));
 
       std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
@@ -861,6 +863,8 @@ namespace {
     SiStripNoiseValueComparisonBase() : PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Noise values comparison") {}
 
     bool fill() override {
+      TGaxis::SetExponentOffset(-0.1, 0.01, "y");  // X and Y offset for Y axis
+
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = PlotBase::getTag<0>().iovs;
       auto tagname1 = PlotBase::getTag<0>().name;
@@ -882,24 +886,10 @@ namespace {
       std::shared_ptr<SiStripNoises> f_payload = this->fetchPayload(std::get<1>(firstiov));
       std::shared_ptr<SiStripNoises> l_payload = this->fetchPayload(std::get<1>(lastiov));
 
-      auto h_first =
-          std::make_unique<TH1F>("f_Noise",
-                                 Form("Strip noise values comparison [%s,%s];Strip Noise [ADC counts];n. strips",
-                                      std::to_string(std::get<0>(firstiov)).c_str(),
-                                      std::to_string(std::get<0>(lastiov)).c_str()),
-                                 100,
-                                 0.1,
-                                 10.);
+      auto h_first = std::make_unique<TH1F>("f_Noise", ";Strip Noise [ADC counts];n. strips", 100, 0.1, 10.);
       h_first->SetStats(false);
 
-      auto h_last =
-          std::make_unique<TH1F>("l_Noise",
-                                 Form("Strip noise values comparison [%s,%s];Strip Noise [ADC counts];n. strips",
-                                      std::to_string(std::get<0>(firstiov)).c_str(),
-                                      std::to_string(std::get<0>(lastiov)).c_str()),
-                                 100,
-                                 0.1,
-                                 10.);
+      auto h_last = std::make_unique<TH1F>("l_Noise", ";Strip Noise [ADC counts];n. strips", 100, 0.1, 10.);
       h_last->SetStats(false);
 
       std::vector<uint32_t> f_detid;
@@ -928,6 +918,9 @@ namespace {
         }  // loop over strips
       }
 
+      SiStripPI::makeNicePlotStyle(h_first.get());
+      SiStripPI::makeNicePlotStyle(h_last.get());
+
       h_first->GetYaxis()->CenterTitle(true);
       h_last->GetYaxis()->CenterTitle(true);
 
@@ -943,31 +936,39 @@ namespace {
       //=========================
       TCanvas canvas("Partition summary", "partition summary", 1200, 1000);
       canvas.cd();
-      canvas.SetBottomMargin(0.11);
+      canvas.SetTopMargin(0.06);
+      canvas.SetBottomMargin(0.10);
       canvas.SetLeftMargin(0.13);
       canvas.SetRightMargin(0.05);
       canvas.Modified();
 
       float theMax = (h_first->GetMaximum() > h_last->GetMaximum()) ? h_first->GetMaximum() : h_last->GetMaximum();
 
-      h_first->SetMaximum(theMax * 1.30);
-      h_last->SetMaximum(theMax * 1.30);
+      h_first->SetMaximum(theMax * 1.20);
+      h_last->SetMaximum(theMax * 1.20);
 
       h_first->Draw();
+      h_last->SetFillColorAlpha(kBlue, 0.15);
       h_last->Draw("same");
 
-      TLegend legend = TLegend(0.13, 0.82, 0.95, 0.9);
+      TLegend legend = TLegend(0.13, 0.83, 0.95, 0.94);
       if (this->m_plotAnnotations.ntags == 2) {
         legend.SetHeader("#bf{Two Tags Comparison}", "C");  // option "C" allows to center the header
         legend.AddEntry(h_first.get(), (tagname1 + " : " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
         legend.AddEntry(h_last.get(), (tagname2 + " : " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
       } else {
-        legend.SetHeader(("#bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
-        legend.AddEntry(h_first.get(), ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
-        legend.AddEntry(h_last.get(), ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+        legend.SetHeader(("tag: #bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
+        legend.AddEntry(h_first.get(), ("IOV since: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
+        legend.AddEntry(h_last.get(), ("IOV since: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
       }
       legend.SetTextSize(0.025);
       legend.Draw("same");
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.01, "SiStrip Noise Values Comparison");
 
       std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -58,7 +58,7 @@ namespace {
       setGranularity(SiStripCondObjectRepresent::PERSTRIP);
     }
 
-    void allValues() override {
+    void storeAllValues() override {
       std::vector<uint32_t> detid;
       payload_->getDetIds(detid);
 
@@ -138,7 +138,7 @@ namespace {
       SiStripNoiseContainer* f_objContainer =
           new SiStripNoiseContainer(first_payload, std::get<0>(firstiov), std::get<1>(firstiov));
 
-      l_objContainer->Subtract(f_objContainer);
+      l_objContainer->subtract(f_objContainer);
 
       //l_objContainer->printAll();
 
@@ -808,10 +808,16 @@ namespace {
       h_first.Draw();
       h_last.Draw("same");
 
-      TLegend legend = TLegend(0.52, 0.82, 0.95, 0.9);
-      legend.SetHeader("SiStrip Noise comparison", "C");  // option "C" allows to center the header
-      legend.AddEntry(&h_first, ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
-      legend.AddEntry(&h_last, ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+      TLegend legend = TLegend(0.13, 0.82, 0.95, 0.9);
+      if (this->m_plotAnnotations.ntags == 2) {
+        legend.SetHeader("#bf{Two Tags Comparison}", "C");  // option "C" allows to center the header
+        legend.AddEntry(&h_first, (tagname1 + " : " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
+        legend.AddEntry(&h_last, (tagname2 + " : " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+      } else {
+        legend.SetHeader(("#bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
+        legend.AddEntry(&h_first, ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
+        legend.AddEntry(&h_last, ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+      }
       legend.SetTextSize(0.025);
       legend.Draw("same");
 
@@ -950,10 +956,16 @@ namespace {
       h_first->Draw();
       h_last->Draw("same");
 
-      TLegend legend = TLegend(0.52, 0.82, 0.95, 0.9);
-      legend.SetHeader("SiStrip Noise comparison", "C");  // option "C" allows to center the header
-      legend.AddEntry(h_first.get(), ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
-      legend.AddEntry(h_last.get(), ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+      TLegend legend = TLegend(0.13, 0.82, 0.95, 0.9);
+      if (this->m_plotAnnotations.ntags == 2) {
+        legend.SetHeader("#bf{Two Tags Comparison}", "C");  // option "C" allows to center the header
+        legend.AddEntry(h_first.get(), (tagname1 + " : " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
+        legend.AddEntry(h_last.get(), (tagname2 + " : " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+      } else {
+        legend.SetHeader(("#bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
+        legend.AddEntry(h_first.get(), ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
+        legend.AddEntry(h_last.get(), ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+      }
       legend.SetTextSize(0.025);
       legend.Draw("same");
 

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -601,6 +601,8 @@ namespace {
         : PlotImage<SiStripPedestals, nIOVs, ntags>("SiStrip Pedestal values comparison") {}
 
     bool fill() override {
+      TGaxis::SetExponentOffset(-0.1, 0.01, "y");  // X and Y offset for Y axis
+
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = PlotBase::getTag<0>().iovs;
       auto tagname1 = PlotBase::getTag<0>().name;
@@ -625,12 +627,7 @@ namespace {
       auto f_mon = std::unique_ptr<SiStripPI::Monitor1D>(new SiStripPI::Monitor1D(
           op_mode_,
           "f_Pedestal",
-          Form("#LT Strip Pedestal #GT per %s for IOV [%s,%s];#LTStrip Pedestal per %s#GT [ADC counts];n. %ss",
-               opType(op_mode_).c_str(),
-               std::to_string(std::get<0>(firstiov)).c_str(),
-               std::to_string(std::get<0>(lastiov)).c_str(),
-               opType(op_mode_).c_str(),
-               opType(op_mode_).c_str()),
+          Form(";#LTStrip Pedestal per %s#GT [ADC counts];n. %ss", opType(op_mode_).c_str(), opType(op_mode_).c_str()),
           300,
           0.,
           300.));
@@ -638,12 +635,7 @@ namespace {
       auto l_mon = std::unique_ptr<SiStripPI::Monitor1D>(new SiStripPI::Monitor1D(
           op_mode_,
           "l_Pedestal",
-          Form("#LT Strip Pedestal #GT per %s for IOV [%s,%s];#LTStrip Pedestal per %s#GT [ADC counts];n. %ss",
-               opType(op_mode_).c_str(),
-               std::to_string(std::get<0>(lastiov)).c_str(),
-               std::to_string(std::get<0>(lastiov)).c_str(),
-               opType(op_mode_).c_str(),
-               opType(op_mode_).c_str()),
+          Form(";#LTStrip Pedestal per %s#GT [ADC counts];n. %ss", opType(op_mode_).c_str(), opType(op_mode_).c_str()),
           300,
           0.,
           300.));
@@ -749,31 +741,41 @@ namespace {
       //=========================
       TCanvas canvas("Partion summary", "partition summary", 1200, 1000);
       canvas.cd();
-      canvas.SetBottomMargin(0.11);
+      canvas.SetTopMargin(0.06);
+      canvas.SetBottomMargin(0.10);
       canvas.SetLeftMargin(0.13);
       canvas.SetRightMargin(0.05);
       canvas.Modified();
 
       float theMax = (h_first.GetMaximum() > h_last.GetMaximum()) ? h_first.GetMaximum() : h_last.GetMaximum();
 
-      h_first.SetMaximum(theMax * 1.30);
-      h_last.SetMaximum(theMax * 1.30);
+      h_first.SetMaximum(theMax * 1.20);
+      h_last.SetMaximum(theMax * 1.20);
 
       h_first.Draw();
+      h_last.SetFillColorAlpha(kBlue, 0.15);
       h_last.Draw("same");
 
-      TLegend legend = TLegend(0.13, 0.82, 0.95, 0.9);
+      TLegend legend = TLegend(0.13, 0.83, 0.95, 0.94);
       if (this->m_plotAnnotations.ntags == 2) {
         legend.SetHeader("#bf{Two Tags Comparison}", "C");  // option "C" allows to center the header
         legend.AddEntry(&h_first, (tagname1 + " : " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
         legend.AddEntry(&h_last, (tagname2 + " : " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
       } else {
-        legend.SetHeader(("#bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
-        legend.AddEntry(&h_first, ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
-        legend.AddEntry(&h_last, ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+        legend.SetHeader(("tag: #bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
+        legend.AddEntry(&h_first, ("IOV since: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
+        legend.AddEntry(&h_last, ("IOV since: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
       }
       legend.SetTextSize(0.025);
       legend.Draw("same");
+
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
+                       1 - gPad->GetTopMargin() + 0.01,
+                       Form("#LTSiStrip Pedestals#GT Comparison per %s", opType(op_mode_).c_str()));
 
       std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -56,7 +56,7 @@ namespace {
       setGranularity(SiStripCondObjectRepresent::PERSTRIP);
     }
 
-    void allValues() override {
+    void storeAllValues() override {
       std::vector<uint32_t> detid;
       payload_->getDetIds(detid);
 
@@ -136,7 +136,7 @@ namespace {
       SiStripPedestalContainer* f_objContainer =
           new SiStripPedestalContainer(first_payload, std::get<0>(firstiov), std::get<1>(firstiov));
 
-      l_objContainer->Subtract(f_objContainer);
+      l_objContainer->subtract(f_objContainer);
 
       //l_objContainer->printAll();
 
@@ -762,10 +762,16 @@ namespace {
       h_first.Draw();
       h_last.Draw("same");
 
-      TLegend legend = TLegend(0.52, 0.82, 0.95, 0.9);
-      legend.SetHeader("SiStrip Pedestal comparison", "C");  // option "C" allows to center the header
-      legend.AddEntry(&h_first, ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
-      legend.AddEntry(&h_last, ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+      TLegend legend = TLegend(0.13, 0.82, 0.95, 0.9);
+      if (this->m_plotAnnotations.ntags == 2) {
+        legend.SetHeader("#bf{Two Tags Comparison}", "C");  // option "C" allows to center the header
+        legend.AddEntry(&h_first, (tagname1 + " : " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
+        legend.AddEntry(&h_last, (tagname2 + " : " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+      } else {
+        legend.SetHeader(("#bf{" + tagname1 + "}").c_str(), "C");  // option "C" allows to center the header
+        legend.AddEntry(&h_first, ("IOV: " + std::to_string(std::get<0>(firstiov))).c_str(), "F");
+        legend.AddEntry(&h_last, ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "F");
+      }
       legend.SetTextSize(0.025);
       legend.Draw("same");
 

--- a/CondCore/SiStripPlugins/scripts/G2GainsValidator.py
+++ b/CondCore/SiStripPlugins/scripts/G2GainsValidator.py
@@ -1,6 +1,6 @@
 from __future__ import print_function 
 
-import ConfigParser
+import configparser as ConfigParser
 import glob
 import os
 import numpy
@@ -135,6 +135,3 @@ if __name__ == "__main__":
                     command = './testCompare.sh SiStripApvGain_FromParticles_GR10_v1_express '+str(lastG2Payload[0])+' '+str(FCSR+i)+ ' toCompare.db'
                 print(command)
                 getCommandOutput(command)
-
-
-         

--- a/CondCore/SiStripPlugins/scripts/testCompare.sh
+++ b/CondCore/SiStripPlugins/scripts/testCompare.sh
@@ -32,7 +32,7 @@ eval `scram run -sh`;
 # Go back to original working directory
 cd $W_DIR;
 
-plotTypes=(SiStripApvGainsComparator SiStripApvGainsValuesComparator SiStripApvGainsComparatorByRegion SiStripApvGainsRatioComparatorByRegion SiStripApvGainsAvgDeviationRatio1sigmaTrackerMap SiStripApvGainsAvgDeviationRatio2sigmaTrackerMap SiStripApvGainsAvgDeviationRatio3sigmaTrackerMap SiStripApvGainsMaxDeviationRatio1sigmaTrackerMap SiStripApvGainsMaxDeviationRatio2sigmaTrackerMap SiStripApvGainsMaxDeviationRatio3sigmaTrackerMap SiStripApvGainByPartition SiStripApvGainCompareByPartition SiStripApvGainDiffByPartition)
+plotTypes=(SiStripApvGainsComparatorSingleTag SiStripApvGainsValuesComparatorSingleTag SiStripApvGainsComparatorByRegionSingleTag SiStripApvGainsRatioComparatorByRegionSingleTag SiStripApvGainByPartition SiStripApvGainCompareByPartition SiStripApvGainDiffByPartition)
 
 mkdir -p $W_DIR/results_$2-$3
 
@@ -54,4 +54,26 @@ echo "Making plot ${i}"
 	--test;
 
     mv *.png $W_DIR/results_$2-$3/${i}_$1_$2-$3.png
+done
+
+plotTypes2=(SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap)
+
+for i in "${plotTypes2[@]}"
+do
+    for j in 1 2 3
+    do
+	echo "Making plot ${i} with ${j} sigmas"
+	# Run get payload data script
+	getPayloadData.py \
+	    --plugin pluginSiStripApvGain_PayloadInspector \
+	    --plot plot_${i} \
+	    --tag $1 \
+	    --time_type Run \
+	    --iovs  '{"start_iov": "'$STARTIOV'", "end_iov": "'$ENDIOV'"}' \
+	    --input_params '{"nsigma":"'${j}'"}' \
+	    --db sqlite_file:$4 \
+	    --test;
+
+	mv *.png $W_DIR/results_$2-$3/${i}_${j}sigmas_$1_$2-$3.png
+    done
 done


### PR DESCRIPTION
#### PR description:

This is a quick follow-up to https://github.com/cms-sw/cmssw/pull/37265, for a commit that didn't make it in time in that PR.
Just a further clean-up to conform to `cmssw` coding rules and adding improving few plot legends for `SiStripNoises` and `SiStripPedestals` comparisons.

#### PR validation:

Private. Example of plots produced with the extension introduced here with the following commands:

```console
getPayloadData.py --plugin pluginSiStripNoises_PayloadInspector \
   --plot plot_SiStripNoiseValueComparisonSingleTag \
   --tag SiStripNoise_CRAFT_21X_v4_offline \
   --input_params '{}'  \
   --time_type Run \
   --iovs '{"start_iov": "50725", "end_iov": "51415"}'  \
   --db Prod --test;
 
 getPayloadData.py --plugin pluginSiStripPedestals_PayloadInspector \
    --plot plot_SiStripPedestalValueComparisonPerStripSingleTag \
    --tag SiStripPedestals_v2_prompt \
    --input_params '{}' \
    --time_type Run \
    --iovs '{"start_iov": "348767", "end_iov": "348878"}' \
    --db Prod --test ;
```

| SiStrip Noise | SiStrip Peds |
| ------------- | ------------- |
|  ![noisesFurtherPR](https://user-images.githubusercontent.com/5082376/160023015-cdd0688d-7d63-46ce-929e-6b8319b93293.png) |  ![pedestalsFurtherPR](https://user-images.githubusercontent.com/5082376/160023030-b6e69bee-1ce5-408d-b243-60b42148d711.png) |


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
