### PR TITLE
[12.2.X] Change to `SiStripCluster` DataFormat: use `auto` for return types

### DIFF
--- a/DataFormats/SiStripCluster/interface/SiStripCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripCluster.h
@@ -40,13 +40,6 @@ public:
     amplitudes_.insert(amplitudes_.end(), begin, end);
   }
 
-  /** The number of the first strip in the cluster.
-   *  The high bit of firstStrip_ indicates whether the cluster is a candidate for being merged.
-   */
-  uint16_t firstStrip() const { return firstStrip_ & stripIndexMask; }
-
-  uint16_t endStrip() const { return firstStrip() + size(); }
-
   /** The amplitudes of the strips forming the cluster.
    *  The amplitudes are on consecutive strips; if a strip is missing
    *  the amplitude is set to zero.
@@ -58,14 +51,20 @@ public:
    *  You can find the special meanings of values { 0, 254, 255} in section 3.4.1 of
    *  http://www.te.rl.ac.uk/esdg/cms-fed/firmware/Documents/FE_FPGA_Technical_Description.pdf
    */
-  uint8_t const* begin() const { return amplitudes_.data(); }
-  uint8_t const* end() const { return begin() + size(); }
-  uint8_t size() const { return amplitudes_.size(); }
-  uint8_t operator[](int i) const { return *(begin() + i); }
-  bool empty() const { return 0 == size(); }
+  auto size() const { return amplitudes_.size(); }
+  auto const* begin() const { return amplitudes_.data(); }
+  auto const* end() const { return begin() + size(); }
+  auto operator[](int i) const { return *(begin() + i); }
+  bool empty() const { return amplitudes_.empty(); }
   bool full() const { return false; }
 
   SiStripCluster const& amplitudes() const { return *this; }
+
+  /** The number of the first strip in the cluster.
+   *  The high bit of firstStrip_ indicates whether the cluster is a candidate for being merged.
+   */
+  uint16_t firstStrip() const { return firstStrip_ & stripIndexMask; }
+  uint16_t endStrip() const { return firstStrip() + size(); }
 
   /** The barycenter of the cluster, not corrected for Lorentz shift;
    *  should not be used as position estimate for tracking.


### PR DESCRIPTION
#### PR description:

Verbatim backport of #36852, needed for Run-3 POG preparatory MC running in CMSSW_12_2_X.
See issues in production at [unified](https://cms-unified.web.cern.ch/cms-unified/showlog/?search=task_EGM-Run3Winter22GS-00023#IO).

#### PR validation:

How to reproduce:
   * use PSet from [unified](https://cms-unified.web.cern.ch/cms-unified/joblogs/cmsunified_task_EGM-Run3Winter22GS-00023__v1_T_220315_155813_5930/139/EGM-Run3Winter22GS-00023_0/2f049003-cce8-4986-a4c7-2907fcdf43df-175-2-logArchive/job/WMTaskSpace/cmsRun2/), and run it in `CMSSW_12_2_1` (it is also available at [this gist of mine](https://gist.githubusercontent.com/mmusich/43bde22e3c467952950652ddd576fba0/raw/3184897a33d31cb4885b69b697123e31fd35506f/issueWithStripsReproducer_cfg.py)).
   * using this commit it should not fail anymore.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #36852

FYI: @kskovpen 