### PR TITLE
Disable DD4hep Phase2 D88 in short matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
                      28234.0, #2026D60 (exercise HF nose)
                      35034.0, #2026D77 ttbar
                      39434.0, #2026D88 ttbar (2022 new baseline)
-                     39434.911, #2026D88 ttbar DD4hep XML
+                     #39434.911, #2026D88 ttbar DD4hep XML
                      39634.999, #2026D88 ttbar premixing stage1+stage2, PU50
                      39496.0, #CE_E_Front_120um D88
                      39500.0, #CE_H_Coarse_Scint D88 


### PR DESCRIPTION
#### PR description:
Discussed in https://github.com/cms-sw/cmssw/issues/37315
This PR is to disable the DD4hep Phase2 D88 workflow for now, until we understand its behaviour. 

#### PR validation:
None

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No need of backport.
