### PR TITLE
[GEM] bugfix - BC and OrbitCounter in AMC13

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMAMC13.h
+++ b/DataFormats/GEMDigi/interface/GEMAMC13.h
@@ -109,6 +109,8 @@ public:
   void addAMCpayload(const GEMAMC& a) { amcs_.push_back(a); }
   void clearAMCpayloads() { amcs_.clear(); }
 
+  static const int lastBC = 3564;
+
 private:
   uint64_t cdfh_;    // CDFHeader
   uint64_t amc13h_;  // AMC13Header

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -40,7 +40,7 @@ public:
     error.badRunType = amc.runType() != 0x1;
     // Last OC in AMC13 is different to TCDS, AMC, and VFAT
     error.badOC = !((uint16_t(amc13->orbitNumber()) == amc.orbitNumber()) ||
-                    (amc13->bunchCrossing() == 0 && amc.orbitNumber() + 1 == (uint16_t(amc13->orbitNumber()))));
+                    (amc13->bunchCrossing() == 0 && uint16_t(amc.orbitNumber() + 1) == uint16_t(amc13->orbitNumber())));
     error.MMCMlocked = !amc.mmcmLocked();
     error.DAQclocklocked = !amc.daqClockLocked();
     error.DAQnotReday = !amc.daqReady();

--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -34,9 +34,13 @@ public:
     amcNum_ = amc.amcNum();
     Errors error{0};
     error.badEC = (amc13->lv1Id() != amc.lv1Id());
-    error.badBC = (amc13->bunchCrossing() != amc.bunchCrossing());
+    // Last BC in AMC13 is different to TCDS, AMC, and VFAT
+    error.badBC = !((amc13->bunchCrossing() == amc.bunchCrossing()) ||
+                    (amc13->bunchCrossing() == 0 && amc.bunchCrossing() == GEMAMC13::lastBC));
     error.badRunType = amc.runType() != 0x1;
-    error.badOC = (uint16_t(amc13->orbitNumber()) != amc.orbitNumber());
+    // Last OC in AMC13 is different to TCDS, AMC, and VFAT
+    error.badOC = !((uint16_t(amc13->orbitNumber()) == amc.orbitNumber()) ||
+                    (amc13->bunchCrossing() == 0 && amc.orbitNumber() + 1 == (uint16_t(amc13->orbitNumber()))));
     error.MMCMlocked = !amc.mmcmLocked();
     error.DAQclocklocked = !amc.daqClockLocked();
     error.DAQnotReday = !amc.daqReady();


### PR DESCRIPTION
#### PR description:
  - the last BC and Orbit counter is different for AMC13 compared to TCDS, AMC, and VFAT
  - due to this difference, we were incorrectly reporting an error at AMC level.
  - this PR fixes this issue.

#### PR validation:
tested with wf1330.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
will need to backport to 12_2 and 12_3