### PR TITLE
Migrate to EventSetup with ESGetToken in GEMCSCSegmentProducer (backport of #36628, 12_2_X)

### DIFF
--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.cc
@@ -9,8 +9,6 @@
 #include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
-
 #include <DataFormats/GEMRecHit/interface/GEMRecHitCollection.h>
 #include <DataFormats/GEMRecHit/interface/GEMCSCSegmentCollection.h>
 #include <DataFormats/GEMRecHit/interface/GEMCSCSegment.h>
@@ -19,9 +17,12 @@
 #include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegment.h>
 
-GEMCSCSegmentProducer::GEMCSCSegmentProducer(const edm::ParameterSet& pas) : iev(0) {
-  csc_token = consumes<CSCSegmentCollection>(pas.getParameter<edm::InputTag>("inputObjectsCSC"));
-  gem_token = consumes<GEMRecHitCollection>(pas.getParameter<edm::InputTag>("inputObjectsGEM"));
+GEMCSCSegmentProducer::GEMCSCSegmentProducer(const edm::ParameterSet& pas)
+    : kCSCGeometryToken_(esConsumes<CSCGeometry, MuonGeometryRecord>()),
+      kGEMGeometryToken_(esConsumes<GEMGeometry, MuonGeometryRecord>()),
+      kCSCSegmentCollectionToken_(consumes<CSCSegmentCollection>(pas.getParameter<edm::InputTag>("inputObjectsCSC"))),
+      kGEMRecHitCollectionToken_(consumes<GEMRecHitCollection>(pas.getParameter<edm::InputTag>("inputObjectsGEM"))),
+      iev(0) {
   segmentBuilder_ = new GEMCSCSegmentBuilder(pas);  // pass on the parameterset
 
   // register what this produces
@@ -37,12 +38,18 @@ void GEMCSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup
   LogDebug("GEMCSCSegment") << "start producing segments for " << ++iev << "th event w/ gem and csc data";
 
   // find the geometry (& conditions?) for this event & cache it in the builder
-  edm::ESHandle<CSCGeometry> cscg;
-  setup.get<MuonGeometryRecord>().get(cscg);
+  const auto cscg = setup.getHandle(kCSCGeometryToken_);
+  if (not cscg.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid CSCGeometry";
+    return;
+  }
   const CSCGeometry* cgeom = &*cscg;
 
-  edm::ESHandle<GEMGeometry> gemg;
-  setup.get<MuonGeometryRecord>().get(gemg);
+  const auto gemg = setup.getHandle(kGEMGeometryToken_);
+  if (not gemg.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid GEMGeometry";
+    return;
+  }
   const GEMGeometry* ggeom = &*gemg;
 
   // cache the geometry in the builder
@@ -52,10 +59,17 @@ void GEMCSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup
   segmentBuilder_->LinkGEMRollsToCSCChamberIndex(ggeom, cgeom);
 
   // get the collection of CSCSegment and GEMRecHits
-  edm::Handle<CSCSegmentCollection> cscSegment;
-  ev.getByToken(csc_token, cscSegment);
-  edm::Handle<GEMRecHitCollection> gemRecHits;
-  ev.getByToken(gem_token, gemRecHits);
+  const auto cscSegment = ev.getHandle(kCSCSegmentCollectionToken_);
+  if (not cscSegment.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid CSCSegmentCollection";
+    return;
+  }
+
+  const auto gemRecHits = ev.getHandle(kGEMRecHitCollectionToken_);
+  if (not gemRecHits.isValid()) {
+    edm::LogError("GEMCSCSegment") << "invalid GEMRecHitCollection";
+    return;
+  }
 
   // create empty collection of GEMCSC Segments
   auto oc = std::make_unique<GEMCSCSegmentCollection>();

--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.h
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegmentProducer.h
@@ -12,11 +12,16 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
+
+#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 
 class GEMCSCSegmentBuilder;
 
@@ -30,10 +35,13 @@ public:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> kCSCGeometryToken_;
+  const edm::ESGetToken<GEMGeometry, MuonGeometryRecord> kGEMGeometryToken_;
+  const edm::EDGetTokenT<CSCSegmentCollection> kCSCSegmentCollectionToken_;
+  const edm::EDGetTokenT<GEMRecHitCollection> kGEMRecHitCollectionToken_;
+
   int iev;  // events through
   GEMCSCSegmentBuilder* segmentBuilder_;
-  edm::EDGetTokenT<CSCSegmentCollection> csc_token;
-  edm::EDGetTokenT<GEMRecHitCollection> gem_token;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:
Backport of #36628. This PR is a technical PR to migrate to using `EventSetup` with `ESGetToken` in `GEMCSCSegmentProducer`.

#### PR validation:
`GEMCSCSegmentProducer` is not included in RECO. So, we can't verify this PR with any wf. So, I added `GEMCSCSegmentProducer` to step3 of 11850.0 for testing and confirmed it works well.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport of #36628. I'm planning a backport of #37178. Then, this fix should precede the backport of #37178 because #37178 uses `GEMCSCSegment`.