### PR TITLE
Offline DQM for new EXO-LLP Run 3 HLT paths

### DIFF
--- a/DQMOffline/Trigger/plugins/METplusTrackMonitor.cc
+++ b/DQMOffline/Trigger/plugins/METplusTrackMonitor.cc
@@ -50,7 +50,6 @@ private:
   edm::EDGetTokenT<trigger::TriggerEvent> theTrigSummary_;
 
   edm::InputTag hltMetTag_;
-  edm::InputTag hltMetCleanTag_;
   edm::InputTag trackLegFilterTag_;
 
   std::vector<double> met_variable_binning_;
@@ -67,7 +66,6 @@ private:
   ObjME metPhiME_;
   ObjME deltaphimetj1ME_;
   ObjME metVsHltMet_;
-  ObjME metVsHltMetClean_;
 
   ObjME muonPtME_variableBinning_;
   ObjME muonPtVsLS_;
@@ -102,7 +100,6 @@ METplusTrackMonitor::METplusTrackMonitor(const edm::ParameterSet& iConfig)
       vtxToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
       theTrigSummary_(consumes<trigger::TriggerEvent>(iConfig.getParameter<edm::InputTag>("trigSummary"))),
       hltMetTag_(iConfig.getParameter<edm::InputTag>("hltMetFilter")),
-      hltMetCleanTag_(iConfig.getParameter<edm::InputTag>("hltMetCleanFilter")),
       trackLegFilterTag_(iConfig.getParameter<edm::InputTag>("trackLegFilter")),
       met_variable_binning_(
           iConfig.getParameter<edm::ParameterSet>("histoPSet").getParameter<std::vector<double> >("metBinning")),
@@ -201,20 +198,6 @@ void METplusTrackMonitor::bookHistograms(DQMStore::IBooker& ibooker,
          met_binning_.xmin,
          met_binning_.xmax);
   setMETitle(metVsHltMet_, "hltMet (online) [GeV]", "CaloMET (offline) [GeV]");
-
-  histname = "metVsHltMetClean";
-  histtitle = "CaloMET vs hltMetClean";
-  bookME(ibooker,
-         metVsHltMetClean_,
-         histname,
-         histtitle,
-         met_binning_.nbins,
-         met_binning_.xmin,
-         met_binning_.xmax,
-         met_binning_.nbins,
-         met_binning_.xmin,
-         met_binning_.xmax);
-  setMETitle(metVsHltMetClean_, "hltMetClean (online) [GeV]", "CaloMET (offline) [GeV]");
 
   // Track leg histograms
 
@@ -343,11 +326,10 @@ void METplusTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup cons
     return;
   }
 
-  trigger::TriggerObject hltMet, hltMetClean;
+  trigger::TriggerObject hltMet;
   bool passesHltMetFilter = getHLTObj(triggerSummary, hltMetTag_, hltMet);
-  bool passesHltMetCleanFilter = getHLTObj(triggerSummary, hltMetCleanTag_, hltMetClean);
 
-  if (!passesHltMetFilter || !passesHltMetCleanFilter)
+  if (!passesHltMetFilter)
     return;
 
   // Filling MET leg histograms (numerator)
@@ -356,7 +338,6 @@ void METplusTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup cons
   deltaphimetj1ME_.numerator->Fill(deltaphi_metjet1);
   metVsLS_.numerator->Fill(ls, met);
   metVsHltMet_.numerator->Fill(hltMet.pt(), met);
-  metVsHltMetClean_.numerator->Fill(hltMetClean.pt(), met);
 
   // Filling track leg histograms (denominator)
   double leadMuonPt = !(muons.empty()) ? muons[0].pt() : -1.0;
@@ -428,7 +409,6 @@ void METplusTrackMonitor::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::InputTag>("trigSummary", edm::InputTag("hltTriggerSummaryAOD"));
   desc.add<edm::InputTag>("hltMetFilter", edm::InputTag("hltMET105", "", "HLT"));
-  desc.add<edm::InputTag>("hltMetCleanFilter", edm::InputTag("hltMETClean65", "", "HLT"));
   desc.add<edm::InputTag>("trackLegFilter", edm::InputTag("hltTrk50Filter", "", "HLT"));
 
   desc.add<std::string>("metSelection", "pt > 0");

--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
@@ -7,46 +7,14 @@ hltDiDispStaMuonCosmicMonitoring = hltDiDispStaMuonMonitoring.clone(
     FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu23NoVtx_2Cha_CosmicSeed/',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*"]) #HLT_ZeroBias_v*
 )
-## Efficiency trigger
-hltDispStaMuon23Monitoring = hltDiDispStaMuonMonitoring.clone(
-    FolderName = 'HLT/EXO/DiDispStaMuon/L2Mu23NoVtx_2Cha/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L2Mu23NoVtx_2Cha_v*"]) #HLT_ZeroBias_v*
-)
 
-hltDispStaMuon23CosmicMonitoring = hltDiDispStaMuonMonitoring.clone(
-    FolderName = 'HLT/EXO/DiDispStaMuon/L2Mu23NoVtx_2Cha_CosmicSeed/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L2Mu23NoVtx_2Cha_CosmicSeed_v*"]) #HLT_ZeroBias_v*
+hltDiDispStaMuon10PromptL3Mu0VetoMonitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v*"]) #HLT_ZeroBias_v*
 )
-
-## Backup trigger
-hltDiDispStaMuon25Monitoring = hltDiDispStaMuonMonitoring.clone(
-    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu25NoVtx_2Cha/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu25NoVtx_2Cha_v*"]) #HLT_ZeroBias_v*
-)
-
-hltDiDispStaMuon25CosmicMonitoring = hltDiDispStaMuonMonitoring.clone(
-    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu25NoVtx_2Cha_CosmicSeed/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu25NoVtx_2Cha_CosmicSeed_v*"]) #HLT_ZeroBias_v*
-)
-
-hltDiDispStaMuon30Monitoring = hltDiDispStaMuonMonitoring.clone(
-    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu30NoVtx_2Cha_Eta2p4/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu30NoVtx_2Cha_Eta2p4_v*"]) #HLT_ZeroBias_v*
-)
-
-hltDiDispStaMuon30CosmicMonitoring = hltDiDispStaMuonMonitoring.clone(
-    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu30NoVtx_2Cha_CosmicSeed_Eta2p4/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu30NoVtx_2Cha_CosmicSeed_Eta2p4_v*"]) #HLT_ZeroBias_v*
-)
-
 
 exoHLTdispStaMuonMonitoring = cms.Sequence(
     hltDiDispStaMuonMonitoring
     + hltDiDispStaMuonCosmicMonitoring
-    + hltDispStaMuon23Monitoring
-    + hltDispStaMuon23CosmicMonitoring
-    + hltDiDispStaMuon25Monitoring
-    + hltDiDispStaMuon25CosmicMonitoring
-    + hltDiDispStaMuon30Monitoring
-    + hltDiDispStaMuon30CosmicMonitoring
+    + hltDiDispStaMuon10PromptL3Mu0VetoMonitoring
 )

--- a/DQMOffline/Trigger/python/DisplacedJet_Monitor_cff.py
+++ b/DQMOffline/Trigger/python/DisplacedJet_Monitor_cff.py
@@ -33,25 +33,11 @@ hltHT_HT425_Prommonitoring = hltHTmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT425_v*"])
 )
 
-hltHT_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone(
-    FolderName = 'HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT400_DisplacedDijet40_DisplacedTrack',
-    jetSelection = "pt>40 && eta<2.0",
-    jetSelection_HT  = "pt > 40 && eta < 3.0",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT400_DisplacedDijet40_DisplacedTrack_v*"])
-)
-
 hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone(
     FolderName = 'HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT430_DisplacedDijet40_DisplacedTrack',
     jetSelection = "pt>40 && eta<2.0",
     jetSelection_HT  = "pt > 40 && eta < 3.0",
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet40_DisplacedTrack_v*"])
-)
-
-hltHT_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone(
-    FolderName = 'HLT/EXO/DisplacedJet/HT/HLT_CaloJet_HT430_DisplacedDijet60_DisplacedTrack',
-    jetSelection = "pt>60 && eta<2.0",
-    jetSelection_HT  = "pt > 40 && eta < 3.0",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet60_DisplacedTrack_v*"])
 )
 
 hltHT_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone(
@@ -61,13 +47,6 @@ hltHT_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clo
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT500_DisplacedDijet40_DisplacedTrack_v*"])
 )
 
-hltHT_HT550_DisplacedDijet60_Inclusive_Prommonitoring = hltHTmonitoring.clone(
-    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT550_DisplacedDijet60_Inclusive',
-    jetSelection = "pt>60 && eta<2.0",
-    jetSelection_HT  = "pt > 40 && eta < 3.0",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT550_DisplacedDijet60_Inclusive_v*"])
-)
-
 hltHT_HT650_DisplacedDijet60_Inclusive_Prommonitoring = hltHTmonitoring.clone(
     FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT650_DisplacedDijet60_Inclusive',
     jetSelection = "pt>60 && eta<2.0",
@@ -75,14 +54,32 @@ hltHT_HT650_DisplacedDijet60_Inclusive_Prommonitoring = hltHTmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT650_DisplacedDijet60_Inclusive_v*"])
 )
 
-hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
-    jetSrc = "ak4CaloJets",
-    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT400_DisplacedDijet40_DisplacedTrack',
-    ptcut = 20,
-    ispfjettrg = False,
-    iscalojettrg = True,
-    histoPSet = dict(jetptBinning = [20.,26.,28.,30.,32.,34.,36.,38.,40.,42.,44.,46.,48.,50.,55.,60.,70.,80.,100.,120.,170.,220.,300.,400.]),
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT400_DisplacedDijet40_DisplacedTrack_v*"])
+hltHT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5',
+    jetSelection = "pt>30 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_v*"])
+)
+
+hltHT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose',
+    jetSelection = "pt>30 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_v*"])
+)
+
+hltHT_HT430_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT430_DelayedJet40_SingleDelay1nsTrackless',
+    jetSelection = "pt>40 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DelayedJet40_SingleDelay1nsTrackless_v*"])
+)
+
+hltHT_HT430_DelayedJet40_SingleDelay2nsInclusive_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT430_DelayedJet40_SingleDelay2nsInclusive',
+    jetSelection = "pt>40 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v*"])
 )
 
 hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
@@ -95,16 +92,6 @@ hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitorin
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet40_DisplacedTrack_v*"])
 )
 
-hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
-    jetSrc = "ak4CaloJets",
-    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT430_DisplacedDijet60_DisplacedTrack',
-    ptcut = 20,
-    ispfjettrg = False,
-    iscalojettrg = True,
-    histoPSet = dict(jetptBinning = [20.,26.,30.,35.,40.,45.,50.,52.,53.,54.,56.,58.,60.,62.,64.,66.,68.,70.,72.,75.,80.,100.,120.,170.,220.,300.,400.]),
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet60_DisplacedTrack_v*"])
-)
-
 hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
     jetSrc = "ak4CaloJets",
     FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT500_DisplacedDijet40_DisplacedTrack',
@@ -113,16 +100,6 @@ hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitorin
     iscalojettrg = True,
     histoPSet = dict(jetptBinning = [20.,26.,28.,30.,32.,34.,36.,38.,40.,42.,44.,46.,48.,50.,55.,60.,70.,80.,100.,120.,170.,220.,300.,400.]),
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT500_DisplacedDijet40_DisplacedTrack_v*"])
-)
-
-hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring = hltJetMETmonitoring.clone(
-    jetSrc = "ak4CaloJets",
-    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT550_DisplacedDijet60_Inclusive',
-    ptcut = 20,
-    ispfjettrg = False,
-    iscalojettrg = True,
-    histoPSet = dict(jetptBinning = [20.,26.,30.,35.,40.,45.,50.,52.,53.,54.,56.,58.,60.,62.,64.,66.,68.,70.,72.,75.,80.,100.,120.,170.,220.,300.,400.]),
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT550_DisplacedDijet60_Inclusive_v*"])
 )
 
 hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring = hltJetMETmonitoring.clone(
@@ -135,20 +112,62 @@ hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring = hltJetMETmonitoring.clo
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT650_DisplacedDijet60_Inclusive_v*"])
 )
 
+hltJet_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_v*"])
+)
+
+hltJet_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_v*"])
+)
+
+hltJet_HT430_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT430_DelayedJet40_SingleDelay1nsTrackless',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DelayedJet40_SingleDelay1nsTrackless_v*"])
+)
+
+hltJet_HT430_DelayedJet40_SingleDelay2nsInclusive_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT430_DelayedJet40_SingleDelay2nsInclusive',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v*"])
+)
+
 exoHLTDisplacedJetmonitoring = cms.Sequence(
  hltHT_HT425_Prommonitoring
-+hltHT_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring
 +hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring
-+hltHT_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring
 +hltHT_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring
-+hltHT_HT550_DisplacedDijet60_Inclusive_Prommonitoring
 +hltHT_HT650_DisplacedDijet60_Inclusive_Prommonitoring
-+hltJet_HT400_DisplacedDijet40_DisplacedTrack_Prommonitoring
++hltHT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_Prommonitoring
++hltHT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_Prommonitoring
++hltHT_HT430_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring
++hltHT_HT430_DelayedJet40_SingleDelay2nsInclusive_Prommonitoring
 +hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring
-+hltJet_HT430_DisplacedDijet60_DisplacedTrack_Prommonitoring
 +hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring
-+hltJet_HT550_DisplacedDijet60_Inclusive_Prommonitoring
 +hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring
++hltJet_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_Prommonitoring
++hltJet_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_Prommonitoring
++hltJet_HT430_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring
++hltJet_HT430_DelayedJet40_SingleDelay2nsInclusive_Prommonitoring
 )
 
 

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_Client_cff.py
@@ -92,7 +92,7 @@ DiDispStaMuonEfficiency = DQMEDHarvester("DQMGenericClient",
 
 
 METplusTrackEfficiency = DQMEDHarvester("DQMGenericClient",
-    subDirs = cms.untracked.vstring("HLT/EXO/MET/MET105_IsoTrk50/", "HLT/EXO/MET/MET120_IsoTrk50/"),
+    subDirs = cms.untracked.vstring("HLT/EXO/MET/*"),
     verbose = cms.untracked.uint32(0), # Set to 2 for all messages
     resolution = cms.vstring(),
     efficiency = cms.vstring(

--- a/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/ExoticaMonitoring_cff.py
@@ -15,7 +15,7 @@ exoticaMonitorHLT = cms.Sequence(
   + exoHLTdispStaMuonMonitoring
   + exoHLTPhotonmonitoring
   + exoHLTHTmonitoring
-# + exoHLTMETplusTrackMonitoring    # disabled pending the review of METplusTrackMonitor.cc
+  + exoHLTMETplusTrackMonitoring
   + exoHLTMuonmonitoring
   + exoHLTDisplacedJetmonitoring
 )

--- a/DQMOffline/Trigger/python/METMonitor_cff.py
+++ b/DQMOffline/Trigger/python/METMonitor_cff.py
@@ -266,7 +266,7 @@ PFMETTypeOne200_HBHE_BeamHaloCleaned_METmonitoring = hltMETmonitoring.clone(
 )
 # HLT_L1MET_DTClusterNoMB1S50_v
 L1MET_DTClusterNoMB1S50_METmonitoring = hltMETmonitoring.clone(
-    FolderName = 'HLT/MET/L1MET_DTClusterNoMB1S50/',
+    FolderName = 'HLT/EXO/MET/L1MET_DTClusterNoMB1S50/',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L1MET_DTClusterNoMB1S50_v*"])
 )
 

--- a/DQMOffline/Trigger/python/METMonitor_cff.py
+++ b/DQMOffline/Trigger/python/METMonitor_cff.py
@@ -264,6 +264,12 @@ PFMETTypeOne200_HBHE_BeamHaloCleaned_METmonitoring = hltMETmonitoring.clone(
     FolderName = 'HLT/JME/MET/PFMETTypeOne200_HBHE_BeamHaloCleaned/',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETTypeOne200_HBHE_BeamHaloCleaned_v*"])
 )
+# HLT_L1MET_DTClusterNoMB1S50_v
+L1MET_DTClusterNoMB1S50_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/MET/L1MET_DTClusterNoMB1S50/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L1MET_DTClusterNoMB1S50_v*"])
+)
+
 exoHLTMETmonitoring = cms.Sequence(
     PFMET110_PFMHT110_IDTight_METmonitoring
     + PFMET120_PFMHT120_IDTight_METmonitoring
@@ -313,4 +319,5 @@ exoHLTMETmonitoring = cms.Sequence(
     + PFMET250_HBHECleaned_METmonitoring
     + PFMET300_HBHECleaned_METmonitoring
     + PFMETTypeOne200_HBHE_BeamHaloCleaned_METmonitoring  
+    + L1MET_DTClusterNoMB1S50_METmonitoring
 )

--- a/DQMOffline/Trigger/python/METplusTrackMonitor_cff.py
+++ b/DQMOffline/Trigger/python/METplusTrackMonitor_cff.py
@@ -4,20 +4,34 @@ from DQMOffline.Trigger.METplusTrackMonitor_cfi import hltMETplusTrackMonitoring
 
 # HLT_MET105_IsoTrk50
 MET105_IsoTrk50monitoring = hltMETplusTrackMonitoring.clone(
-    FolderName = 'HLT/MET/MET105_IsoTrk50/',
+    FolderName = 'HLT/EXO/MET/MET105_IsoTrk50/',
     hltMetFilter = 'hltMET105::HLT',
-    hltMetCleanFilter = 'hltMETClean65::HLT'
+    hltMetCleanFilter = 'hltMETClean65::HLT',
+    met       = "caloMet",
 )
 MET105_IsoTrk50monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MET105_IsoTrk50_v*")
-# HLT_MET120_IsoTrk50
-MET120_IsoTrk50monitoring = hltMETplusTrackMonitoring.clone(
-    FolderName = 'HLT/MET/MET120_IsoTrk50/',
-    hltMetFilter = 'hltMET120::HLT',
-    hltMetCleanFilter = 'hltMETClean65::HLT'
+
+# HLT_PFMET105_IsoTrk50
+PFMET105_IsoTrk50monitoring = hltMETplusTrackMonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMET105_IsoTrk50/',
+    hltMetFilter = 'hltPFMET105::HLT',
+    hltMetCleanFilter = 'hltMETClean65::HLT',
+    met       = "caloMet",
 )
-MET120_IsoTrk50monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MET120_IsoTrk50_v*")
+PFMET105_IsoTrk50monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET105_IsoTrk50_v*")
+
+# HLT_PFMET110_PFJet100
+PFMET110_PFJet100monitoring = hltMETplusTrackMonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMET110_PFJet100/',
+    hltMetFilter = 'hltPFMET110::HLT',
+    hltMetCleanFilter = 'hltMETClean65::HLT', #NEED TO CHECK
+    met       = "caloMet",
+)
+PFMET110_PFJet100monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET110_PFJet100_v*")
+
 exoHLTMETplusTrackMonitoring = cms.Sequence(
     MET105_IsoTrk50monitoring
-    + MET120_IsoTrk50monitoring
+    + PFMET105_IsoTrk50monitoring
+    + PFMET110_PFJet100monitoring
 )
 

--- a/DQMOffline/Trigger/python/METplusTrackMonitor_cff.py
+++ b/DQMOffline/Trigger/python/METplusTrackMonitor_cff.py
@@ -6,7 +6,6 @@ from DQMOffline.Trigger.METplusTrackMonitor_cfi import hltMETplusTrackMonitoring
 MET105_IsoTrk50monitoring = hltMETplusTrackMonitoring.clone(
     FolderName = 'HLT/EXO/MET/MET105_IsoTrk50/',
     hltMetFilter = 'hltMET105::HLT',
-    hltMetCleanFilter = 'hltMETClean65::HLT',
     met       = "caloMet",
 )
 MET105_IsoTrk50monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_MET105_IsoTrk50_v*")
@@ -15,7 +14,6 @@ MET105_IsoTrk50monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT
 PFMET105_IsoTrk50monitoring = hltMETplusTrackMonitoring.clone(
     FolderName = 'HLT/EXO/MET/PFMET105_IsoTrk50/',
     hltMetFilter = 'hltPFMET105::HLT',
-    hltMetCleanFilter = 'hltMETClean65::HLT',
     met       = "caloMet",
 )
 PFMET105_IsoTrk50monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET105_IsoTrk50_v*")
@@ -24,7 +22,6 @@ PFMET105_IsoTrk50monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("H
 PFMET110_PFJet100monitoring = hltMETplusTrackMonitoring.clone(
     FolderName = 'HLT/EXO/MET/PFMET110_PFJet100/',
     hltMetFilter = 'hltPFMET110::HLT',
-    hltMetCleanFilter = 'hltMETClean65::HLT', #NEED TO CHECK
     met       = "caloMet",
 )
 PFMET110_PFJet100monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET110_PFJet100_v*")

--- a/DQMOffline/Trigger/python/METplusTrackMonitor_cfi.py
+++ b/DQMOffline/Trigger/python/METplusTrackMonitor_cfi.py
@@ -11,7 +11,7 @@ for ibin in range(nBinsLogX_METplusTrack + 1):
    binsLogX_METplusTrack.append( pow(10, powerLo_METplusTrack + ibin * binPowerWidth_METplusTrack) )
 
 hltMETplusTrackMonitoring = metPlusTrackMonitoring.clone(
-  FolderName = 'HLT/MET/MET105_IsoTrk50/',
+  FolderName = 'HLT/EXO/MET/MET105_IsoTrk50/',
   histoPSet = dict(
           lsPSet = dict(
                     nbins = 250 ,

--- a/DQMOffline/Trigger/python/MuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/MuonMonitor_cff.py
@@ -4,25 +4,25 @@ from DQMOffline.Trigger.MuonMonitor_cfi import hltMuonmonitoring
 
 
 TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/TrkMu12_DoubleTrkMu5NoFiltersNoVtx/'
+    FolderName = 'HLT/EXO/Muon/TrkMu12_DoubleTrkMu5NoFiltersNoVtx/'
 )
 TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*")
 TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet40_v*","HLT_PFJet60_v*","HLT_PFJet80_v*") 
 
 TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/TrkMu16_DoubleTrkMu6NoFiltersNoVtx/'
+    FolderName = 'HLT/EXO/Muon/TrkMu16_DoubleTrkMu6NoFiltersNoVtx/'
 )
 TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v*")
 TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*") 
 
 TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/TrkMu17_DoubleTrkMu8NoFiltersNoVtx/'
+    FolderName = 'HLT/EXO/Muon/TrkMu17_DoubleTrkMu8NoFiltersNoVtx/'
 )
 TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v*")
 TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*")
 
 DoubleMu43NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/DoubleMu43NoFiltersNoVtx/',
+    FolderName = 'HLT/EXO/Muon/DoubleMu43NoFiltersNoVtx/',
     nmuons = 2
 )
 DoubleMu43NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu43NoFiltersNoVtx_v*")
@@ -31,7 +31,7 @@ DoubleMu43NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vs
 
 
 DoubleMu40NoFiltersNoVtxDisplaced_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/DoubleMu40NoFiltersNoVtxDisplaced/',
+    FolderName = 'HLT/EXO/Muon/DoubleMu40NoFiltersNoVtxDisplaced/',
     nmuons = 2
 )
 DoubleMu40NoFiltersNoVtxDisplaced_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu40NoFiltersNoVtxDisplaced_v*")
@@ -39,7 +39,7 @@ DoubleMu40NoFiltersNoVtxDisplaced_monitoring.denGenericTriggerEventPSet.hltPaths
 
 #--------------------------------------------------
 DoubleL2Mu23NoVtx_2Cha_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/DoubleL2Mu23NoVtx_2Cha/',
+    FolderName = 'HLT/EXO/Muon/DoubleL2Mu23NoVtx_2Cha/',
     nmuons = 2
 )
 DoubleL2Mu23NoVtx_2Cha_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_v*")
@@ -47,14 +47,14 @@ DoubleL2Mu23NoVtx_2Cha_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstr
 
 
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/DoubleL2Mu23NoVtx_2Cha_CosmicSeed/',
+    FolderName = 'HLT/EXO/Muon/DoubleL2Mu23NoVtx_2Cha_CosmicSeed/',
     nmuons = 2
 )
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*")
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 #--------------------------------------------------
 DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto/',
+    FolderName = 'HLT/EXO/Muon/DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto/',
     nmuons = 2
 )
 DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v*")
@@ -62,7 +62,7 @@ DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring.denGenericTriggerEventPSet.hlt
 
 #--------------------------------------------------
 DoubleL3Mu10NoVtx_Displaced_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/DoubleL3Mu10NoVtx_Displaced/',
+    FolderName = 'HLT/EXO/Muon/DoubleL3Mu10NoVtx_Displaced/',
     nmuons = 2
 )
 DoubleL3Mu10NoVtx_Displaced_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL3Mu10NoVtx_Displaced_v*")
@@ -71,7 +71,7 @@ DoubleL3Mu10NoVtx_Displaced_monitoring.denGenericTriggerEventPSet.hltPaths = cms
 #--------------------------------------------------
 
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtx_Photon43_CaloIdL/',
+    FolderName = 'HLT/EXO/Muon/Mu43NoFiltersNoVtx_Photon43_CaloIdL/',
     nmuons = 1,
     nelectrons = 1
 )
@@ -80,7 +80,7 @@ Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring.denGenericTriggerEventPSet.hltPat
 
 
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg/',
+    FolderName = 'HLT/EXO/Muon/Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg/',
     nmuons = 1,
     nelectrons = 1,
     eleSelection = 'pt > 43'
@@ -89,7 +89,7 @@ Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.numGenericTriggerEventPSet.
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg/',
+    FolderName = 'HLT/EXO/Muon/Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg/',
     nmuons = 1,
     nelectrons = 1,
     muonSelection = 'pt > 43'
@@ -99,7 +99,7 @@ Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet
 
 
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL/',
+    FolderName = 'HLT/EXO/Muon/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL/',
     nmuons = 1,
     nelectrons = 1
 )
@@ -108,7 +108,7 @@ Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring.denGenericTriggerEventPS
 
 
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg/',
+    FolderName = 'HLT/EXO/Muon/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg/',
     nmuons = 1,
     nelectrons = 1,
     eleSelection = 'pt > 38'
@@ -117,7 +117,7 @@ Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.numGenericTriggerE
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg/',
+    FolderName = 'HLT/EXO/Muon/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg/',
     nmuons = 1,
     nelectrons = 1,
     muonSelection = 'pt > 38'
@@ -128,7 +128,7 @@ Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.denGenericTrigger
 #####
 
 Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId/',
+    FolderName = 'HLT/EXO/Muon/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId/',
     nmuons = 1,
     nelectrons = 1
 )
@@ -137,7 +137,7 @@ Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring.denGenericTriggerEv
 
 
 Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg/',
+    FolderName = 'HLT/EXO/Muon/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg/',
     nmuons = 1,
     nelectrons = 1,
     eleSelection = 'pt > 38'
@@ -146,7 +146,7 @@ Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring.numGenericTri
 Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg/',
+    FolderName = 'HLT/EXO/Muon/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg/',
     nmuons = 1,
     nelectrons = 1,
     muonSelection = 'pt > 38'

--- a/DQMOffline/Trigger/python/MuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/MuonMonitor_cff.py
@@ -29,20 +29,6 @@ DoubleMu43NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vs
 DoubleMu43NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 
-DoubleMu48NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/DoubleMu48NoFiltersNoVtx/',
-    nmuons = 2
-)
-DoubleMu48NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu48NoFiltersNoVtx_v*")
-DoubleMu48NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
-
-DoubleMu33NoFiltersNoVtxDisplaced_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/DoubleMu33NoFiltersNoVtxDisplaced/',
-    nmuons = 2
-)
-DoubleMu33NoFiltersNoVtxDisplaced_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu33NoFiltersNoVtxDisplaced_v*")
-DoubleMu33NoFiltersNoVtxDisplaced_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 DoubleMu40NoFiltersNoVtxDisplaced_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/DoubleMu40NoFiltersNoVtxDisplaced/',
@@ -66,6 +52,22 @@ DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring = hltMuonmonitoring.clone(
 )
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*")
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+#--------------------------------------------------
+DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto/',
+    nmuons = 2
+)
+DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v*")
+DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+
+#--------------------------------------------------
+DoubleL3Mu10NoVtx_Displaced_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/DoubleL3Mu10NoVtx_Displaced/',
+    nmuons = 2
+)
+DoubleL3Mu10NoVtx_Displaced_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL3Mu10NoVtx_Displaced_v*")
+DoubleL3Mu10NoVtx_Displaced_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+
 #--------------------------------------------------
 
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring = hltMuonmonitoring.clone(
@@ -96,32 +98,6 @@ Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu48NoFiltersNoVtx_Photon48_CaloIdL/',
-    nmuons = 1,
-    nelectrons = 1
-)
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v*")
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg/',
-    nmuons = 1,
-    nelectrons = 1,
-    eleSelection = 'pt > 48'
-)
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v*")
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg/',
-    nmuons = 1,
-    nelectrons = 1,
-    muonSelection = 'pt > 48'
-)
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v*")
-Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL/',
     nmuons = 1,
@@ -149,55 +125,55 @@ Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring = hltMuonmonitori
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*")
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL/',
+#####
+
+Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId/',
     nmuons = 1,
     nelectrons = 1
 )
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v*")
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*")
+Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg/',
+
+Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg/',
     nmuons = 1,
     nelectrons = 1,
-    eleSelection = 'pt > 43'
+    eleSelection = 'pt > 38'
 )
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v*")
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*")
+Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
-
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg/',
+Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg/',
     nmuons = 1,
     nelectrons = 1,
-    muonSelection = 'pt > 43'
+    muonSelection = 'pt > 38'
 )
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v*")
-Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*")
+Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+
 
 exoHLTMuonmonitoring = cms.Sequence(
     TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring 
     + TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring
     + TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring
     + DoubleMu43NoFiltersNoVtx_monitoring
-    + DoubleMu48NoFiltersNoVtx_monitoring
-    + DoubleMu33NoFiltersNoVtxDisplaced_monitoring
     + DoubleMu40NoFiltersNoVtxDisplaced_monitoring
     + Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring
-    + Mu48NoFiltersNoVtx_Photon48_CaloIdL_monitoring
     + Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring
-    + Mu48NoFiltersNoVtx_Photon48_CaloIdL_MuLeg_monitoring
     + Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring
-    + Mu48NoFiltersNoVtx_Photon48_CaloIdL_EleLeg_monitoring
     + Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring
-    + Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_monitoring
     + Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring
-    + Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_MuLeg_monitoring
     + Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring
-    + Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_EleLeg_monitoring
+    + Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring
+    + Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring
+    + Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring
     + DoubleL2Mu23NoVtx_2Cha_monitoring
     + DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring
+    + DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring
+    + DoubleL3Mu10NoVtx_Displaced_monitoring
 )
 
 

--- a/DQMOffline/Trigger/python/NoBPTXMonitor_cff.py
+++ b/DQMOffline/Trigger/python/NoBPTXMonitor_cff.py
@@ -2,24 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMOffline.Trigger.NoBPTXMonitor_cfi import hltNoBPTXmonitoring
 
-hltNoBPTXJetE70Monitoring = hltNoBPTXmonitoring.clone(
-    FolderName = 'HLT/EXO/NoBPTX/JetE70/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_UncorrectedJetE70_NoBPTX3BX_v*"]) #HLT_ZeroBias_v*
-)
-
 hltNoBPTXL2Mu40Monitoring = hltNoBPTXmonitoring.clone(
     FolderName = 'HLT/EXO/NoBPTX/L2Mu40/',
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX_v*"]) #HLT_ZeroBias_v*
 )
 
-hltNoBPTXL2Mu45Monitoring = hltNoBPTXmonitoring.clone(
-    FolderName = 'HLT/EXO/NoBPTX/L2Mu45/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v*"]) #HLT_ZeroBias_v*
-)
-
 exoHLTNoBPTXmonitoring = cms.Sequence(
     hltNoBPTXmonitoring
-    + hltNoBPTXJetE70Monitoring
     + hltNoBPTXL2Mu40Monitoring
-    + hltNoBPTXL2Mu45Monitoring
 )


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

This PR updates the HLT offline DQM (in DQMOffline/Trigger) to include the new long-lived particle (LLP) paths that went into v1 of the Run 3 HLT menu [1]. Complying with the request from STEAM to limit the number of histograms produced, the general philosophy going into these changes was to monitor only the signal paths, and not the backup or control paths. So, these paths have been added to the monitoring:

```
HLT_HT430_DelayedJet40_SingleDelay1nsTrackless_v
HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v
HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v
HLT_DoubleL2Mu23NoVtx_2Cha_v
HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v
HLT_DoubleL3Mu10NoVtx_Displaced_v
HLT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_v
HLT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_v
HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v
HLT_PFMET105_IsoTrk50_v
HLT_PFMET110_PFJet100_v
HLT_L1MET_DTClusterNoMB1S50_v
```

and these paths have been removed:
```
HLT_DoubleMu33NoFiltersNoVtxDisplaced_v
HLT_DoubleMu48NoFiltersNoVtx_v
HLT_Mu48NoFiltersNoVtx_Photon48_CaloIdL_v
HLT_Mu43NoFiltersNoVtxDisplaced_Photon43_CaloIdL_v
HLT_UncorrectedJetE70_NoBPTX3BX_v
HLT_L2Mu45_NoVertex_3Sta_NoBPTX3BX_v
HLT_HT400_DisplacedDijet40_DisplacedTrack_v
HLT_HT430_DisplacedDijet60_DisplacedTrack_v
HLT_HT550_DisplacedDijet60_Inclusive_v
HLT_MET120_IsoTrk50_v
```

This PR has a similar philosophy as [2].

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Using the 11634.0 ttbar workflow, I have tested that the correct histograms are produced and filled in the harvested DQM file.

I have also successfully tested this PR with 
```
runTheMatrix.py -l limited -i all --ibeos
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Not a backport


[1] https://its.cern.ch/jira/browse/CMSHLT-2211
[2] https://github.com/cms-sw/cmssw/pull/37298

