### PR TITLE
Add TICL from Reco customise

### DIFF
--- a/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
+++ b/RecoHGCal/Configuration/python/RecoHGCal_EventContent_cff.py
@@ -47,6 +47,7 @@ def customiseHGCalOnlyEventContent(process):
                                             'keep SimVertexs_g4SimHits_*_*',
                                             'keep *_layerClusterSimClusterAssociationProducer_*_*',
                                             'keep *_layerClusterCaloParticleAssociationProducer_*_*',
+                                            'keep *_randomEngineStateProducer_*_*',
                                             ])
 
     if hasattr(process, 'FEVTDEBUGEventContent'):

--- a/RecoHGCal/TICL/python/customiseTICLFromReco.py
+++ b/RecoHGCal/TICL/python/customiseTICLFromReco.py
@@ -1,5 +1,6 @@
 # Reconstruction
 from RecoHGCal.TICL.iterativeTICL_cff import *
+from RecoLocalCalo.HGCalRecProducers.hgcalLayerClusters_cff import hgcalLayerClusters
 # Validation
 from Validation.HGCalValidation.HGCalValidator_cfi import *
 from RecoLocalCalo.HGCalRecProducers.hgcalRecHitMapProducer_cfi import hgcalRecHitMapProducer
@@ -16,7 +17,8 @@ def customiseTICLFromReco(process):
 # TensorFlow ESSource
     process.TFESSource = cms.Task(process.trackdnn_source)
 # Reconstruction
-    process.TICL = cms.Path(process.TFESSource,
+    process.TICL = cms.Path(process.hgcalLayerClusters,
+                            process.TFESSource,
                             process.ticlLayerTileTask,
                             process.ticlIterationsTask,
                             process.ticlTracksterMergeTask)

--- a/RecoHGCal/TICL/python/customiseTICLFromReco.py
+++ b/RecoHGCal/TICL/python/customiseTICLFromReco.py
@@ -1,0 +1,46 @@
+# Reconstruction
+from RecoHGCal.TICL.iterativeTICL_cff import *
+# Validation
+from Validation.HGCalValidation.HGCalValidator_cfi import *
+from RecoLocalCalo.HGCalRecProducers.hgcalRecHitMapProducer_cfi import hgcalRecHitMapProducer
+
+# Load DNN ESSource
+from RecoTracker.IterativeTracking.iterativeTk_cff import trackdnn_source
+
+# Automatic addition of the customisation function from RecoHGCal.Configuration.RecoHGCal_EventContent_cff
+from RecoHGCal.Configuration.RecoHGCal_EventContent_cff import customiseHGCalOnlyEventContent
+
+
+
+def customiseTICLFromReco(process):
+# TensorFlow ESSource
+    process.TFESSource = cms.Task(process.trackdnn_source)
+# Reconstruction
+    process.TICL = cms.Path(process.TFESSource,
+                            process.ticlLayerTileTask,
+                            process.ticlIterationsTask,
+                            process.ticlTracksterMergeTask)
+# Validation
+    process.TICL_ValidationProducers = cms.Task(process.hgcalRecHitMapProducer,
+                                                process.lcAssocByEnergyScoreProducer,
+                                                process.layerClusterCaloParticleAssociationProducer,
+                                                process.scAssocByEnergyScoreProducer,
+                                                process.layerClusterSimClusterAssociationProducer,
+                                               )
+    process.TICL_Validator = cms.Task(process.hgcalValidator)
+    process.TICL_Validation = cms.Path(process.TICL_ValidationProducers,
+                                       process.TICL_Validator
+                                      )
+# Path and EndPath definitions
+    process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
+    process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+    process.schedule = cms.Schedule(process.TICL,
+                                    process.TICL_Validation,
+                                    process.FEVTDEBUGHLToutput_step,
+                                    process.DQMoutput_step)
+#call to customisation function customiseHGCalOnlyEventContent imported from RecoHGCal.Configuration.RecoHGCal_EventContent_cff
+    process = customiseHGCalOnlyEventContent(process)
+
+    return process


### PR DESCRIPTION
#### PR description:

Add a `customise` function to be able to quickly run HGCAL TICL-reconstruction from the RECO data-tier. This will cut down the development cycle by a considerable amount. Also, save the output using a dedicated, slimmed, HGCAL-only event content to save space.

#### PR validation:

Local testing works just fine.
