### PR TITLE
[Fireworks master] Correctly handle string type in FWParameterSetterBase::makeSetterFor()

### DIFF
--- a/Fireworks/Core/src/FWParameterSetterBase.cc
+++ b/Fireworks/Core/src/FWParameterSetterBase.cc
@@ -100,20 +100,20 @@ std::shared_ptr<FWParameterSetterBase> FWParameterSetterBase::makeSetterFor(FWPa
     //        different type of FW*Parameter.
     if (name == "FWGenericParameter<bool>")
       name = "FWBoolParameterSetter";
-    else if (name == "FWGenericParameter<std::string>")
-      name = "FWStringParameterSetter";
-    else if (name == "FWGenericParameter<std::basic_string<char> >")
-      name = "FWStringParameterSetter";
     else if (name == "FWGenericParameterWithRange<double>")
       name = "FWDoubleParameterSetter";
     else if (name == "FWGenericParameterWithRange<long int>")
       name = "FWLongParameterSetter";
     else if (name == "FWGenericParameterWithRange<long>")
       name = "FWLongParameterSetter";
-    else
+    else if (paramClass.friendlyClassName() == "StringFWGenericParameter")
+      name = "FWStringParameterSetter";
+    else {
       name += "Setter";
-
+      fwLog(fwlog::kWarning) << "can't find setter type for "<< iParam->name() << ", guessing to " << name << "\n";
+    }
     edm::TypeWithDict setterClass(edm::TypeWithDict::byName(name));
+
     if (setterClass == edm::TypeWithDict()) {
       fwLog(fwlog::kError) << " the type " << name << " has no dictionary" << std::endl;
     }

--- a/Fireworks/Core/src/FWParameterSetterBase.cc
+++ b/Fireworks/Core/src/FWParameterSetterBase.cc
@@ -110,7 +110,7 @@ std::shared_ptr<FWParameterSetterBase> FWParameterSetterBase::makeSetterFor(FWPa
       name = "FWStringParameterSetter";
     else {
       name += "Setter";
-      fwLog(fwlog::kWarning) << "can't find setter type for "<< iParam->name() << ", guessing to " << name << "\n";
+      fwLog(fwlog::kWarning) << "can't find setter type for " << iParam->name() << ", guessing to " << name << "\n";
     }
     edm::TypeWithDict setterClass(edm::TypeWithDict::byName(name));
 


### PR DESCRIPTION
Port of #37349 from 12_2_X to master.