### PR TITLE
Improve autoAlca dictionaries layout

### DIFF
--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -40,108 +40,48 @@ AlCaRecoMatrix = {"AlCaLumiPixels" : "AlCaPCCZeroBias+AlCaPCCRandom",
                   }
 
 # AlCaReco matrix used in CMSSW releases in 2018
-AlCaRecoMatrix2018 = {"AlCaLumiPixels" : "AlCaPCCZeroBias+AlCaPCCRandom",
-                  "Charmonium"     : "TkAlJpsiMuMu",
-                  "Commissioning"  : "HcalCalIsoTrk+HcalCalIsolatedBunchSelector+TkAlMinBias+SiStripCalMinBias",
-                  "Cosmics"        : "SiPixelCalCosmics+SiStripCalCosmics+TkAlCosmics0T+MuAlGlobalCosmics",
-                  "DoubleEG"       : "EcalCalZElectron+EcalUncalZElectron+HcalCalIterativePhiSym+HcalCalIsoTrkProducerFilter",
-                  "DoubleMuon"     : "TkAlZMuMu+TkAlDiMuonAndVertex+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+HcalCalLowPUHBHEMuonFilter",
-                  # New PD in 2018 to replace SinglePhoton SingleElectron and DoubleEG in 2017
-                  "EGamma"         : "EcalESAlign+EcalUncalWElectron+EcalUncalZElectron+HcalCalIsoTrkProducerFilter+HcalCalIterativePhiSym",
-                  "HLTPhysics"     : "TkAlMinBias+HcalCalIterativePhiSym+HcalCalIsoTrkProducerFilter+HcalCalHO+HcalCalHBHEMuonProducerFilter",
-                  "JetHT"          : "HcalCalIsoTrkProducerFilter+HcalCalIsolatedBunchFilter+TkAlMinBias",
-                  "MinimumBias"    : "SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias",
-                  "MuOnia"         : "TkAlUpsilonMuMu",
-                  "NoBPTX"         : "TkAlCosmicsInCollisions",
-                  "SingleElectron" : "EcalUncalWElectron+EcalUncalZElectron+HcalCalIterativePhiSym+EcalESAlign",
-                  "SingleMuon"     : "SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+HcalCalHO+HcalCalIterativePhiSym+HcalCalHBHEMuonProducerFilter",
-                  "SinglePhoton"   : "HcalCalGammaJet",
-                  "ZeroBias"       : "SiStripCalZeroBias+TkAlMinBias+LumiPixelsMinBias+SiStripCalMinBias+AlCaPCCZeroBiasFromRECO", 
+# First copy the default dict
+AlCaRecoMatrix2018 = AlCaRecoMatrix.copy()
+# Then customize for 2018
+customizationFor2018 = {"ALCALumiPixelsCountsExpress" : "",
+                        "AlcaLumiPixelsExpress"       : "AlCaPCCRandom"
+                       }
+AlCaRecoMatrix2018.update(customizationFor2018)
 
-                  "Express"        : "SiStripCalZeroBias+TkAlMinBias+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+Hotline+LumiPixelsMinBias+SiPixelCalZeroBias",
-                  "ExpressCosmics" : "SiStripPCLHistos+SiStripCalZeroBias+TkAlCosmics0T+SiPixelCalZeroBias",
-                  "ExpressAlignment":"TkAlMinBias",
-                  # Used for new PCC PCL introduced in 2018
-                  "AlcaLumiPixelsExpress":"AlCaPCCRandom",
-                  # These two cannot run on RAW, they are just meant to run on the dedicated AlcaRAW so they do not enter the allForPrompt list
-                  "AlCaPhiSym"     : "",
-                  "AlCaP0"         : "",
-                  # ---------------------------------------------------------------------------------------------------------------------------
-                  "HcalNZS"        : "HcalCalMinBias",
-                  # This is in the AlCaRecoMatrix, but no RelVals are produced
-                  # 'TestEnablesTracker'  : 'TkAlLAS'
-                  # 'TestEnablesEcalHcal' : 'HcalCalPedestal'
-                  "MET" : "HcalCalNoise",
-                  "SingleMu" : "MuAlCalIsolatedMu+MuAlOverlaps+TkAlMuonIsolated+MuAlZMuMu+HcalCalHO",
-                  "DoubleMu" : "MuAlCalIsolatedMu+MuAlOverlaps+TkAlZMuMu",
-                  "DoubleMuParked" : "MuAlCalIsolatedMu+MuAlOverlaps+TkAlZMuMu",
-                  "MuOniaParked" : "TkAlJpsiMuMu+TkAlUpsilonMuMu",
-                  "DoubleElectron" : "EcalCalZElectron+EcalUncalZElectron",
-                  "StreamExpress" : "SiStripCalZeroBias+TkAlMinBias+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+Hotline+LumiPixelsMinBias+SiPixelCalZeroBias+SiPixelCalSingleMuon+PPSCalTrackBasedSel",
-                  "StreamExpressHI" : "SiStripCalZeroBias+TkAlMinBiasHI+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+SiPixelCalZeroBias"
-                  }
 # AlCaReco matrix used in CMSSW releases in 2017
-AlCaRecoMatrix2017 = {"AlCaLumiPixels" : "AlCaPCCZeroBias+AlCaPCCRandom",
-                      "Charmonium"     : "TkAlJpsiMuMu",
-                      "Commissioning"  : "HcalCalIsoTrk+HcalCalIsolatedBunchSelector+TkAlMinBias+SiStripCalMinBias",
-                      "Cosmics"        : "TkAlCosmics0T+MuAlGlobalCosmics",
-                      "DoubleEG"       : "EcalCalZElectron+EcalUncalZElectron+HcalCalIterativePhiSym+HcalCalIsoTrkFilter",
-                      "DoubleMuon"     : "TkAlZMuMu+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu",
-                      "HLTPhysics"     : "TkAlMinBias",
-                      "JetHT"          : "HcalCalIsoTrkFilter+HcalCalIsolatedBunchFilter",
-                      "MinimumBias"    : "SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias",
-                      "MuOnia"         : "TkAlUpsilonMuMu",
-                      "NoBPTX"         : "TkAlCosmicsInCollisions",
-                      "SingleElectron" : "EcalUncalWElectron+EcalUncalZElectron+HcalCalIterativePhiSym+EcalESAlign",
-                      "SingleMuon"     : "TkAlMuonIsolated+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+HcalCalHO+HcalCalIterativePhiSym+HcalCalHBHEMuonFilter+HcalCalHEMuonFilter",
-                      "SinglePhoton"   : "HcalCalGammaJet",
-                      "ZeroBias"       : "SiStripCalZeroBias+TkAlMinBias+LumiPixelsMinBias+SiStripCalMinBias+AlCaPCCZeroBiasFromRECO", 
+# First copy the default dict
+AlCaRecoMatrix2017 = AlCaRecoMatrix.copy()
+# Then customize for 2017
+customizationFor2017 = {"ALCALumiPixelsCountsExpress" : "",
+                        "Cosmics"                     : "TkAlCosmics0T+MuAlGlobalCosmics",
+                        "DoubleEG"                    : "EcalCalZElectron+EcalUncalZElectron+HcalCalIterativePhiSym+HcalCalIsoTrkFilter",
+                        "DoubleMuon"                  : "TkAlZMuMu+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu",
+                        "EGamma"                      : "",
+                        "HLTPhysics"                  : "TkAlMinBias",
+                        "JetHT"                       : "HcalCalIsoTrkFilter+HcalCalIsolatedBunchFilter",
+                        "SingleMuon"                  : "TkAlMuonIsolated+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+HcalCalHO+HcalCalIterativePhiSym+HcalCalHBHEMuonFilter+HcalCalHEMuonFilter",
+                        "DoubleElectron"              : "EcalCalZElectron+EcalUncalZElectron+HcalCalIsoTrkFilter",
+                        "StreamExpress"               : "SiStripCalZeroBias+TkAlMinBias+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+Hotline+LumiPixelsMinBias+SiPixelCalZeroBias"
+                       }
+AlCaRecoMatrix2017.update(customizationFor2017)
 
-                      "Express"  : "SiStripCalZeroBias+TkAlMinBias+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+Hotline+LumiPixelsMinBias+SiPixelCalZeroBias",
-                      "ExpressCosmics" : "SiStripPCLHistos+SiStripCalZeroBias+TkAlCosmics0T+SiPixelCalZeroBias",
-                      "ExpressAlignment":"TkAlMinBias",
-                      # These two cannot run on RAW, they are just meant to run on the dedicated AlcaRAW so they do not enter the allForPrompt list
-                      "AlCaPhiSym"     : "",
-                      "AlCaP0"         : "",
-                      # ---------------------------------------------------------------------------------------------------------------------------
-                      "HcalNZS"        : "HcalCalMinBias",
-                      # This is in the AlCaRecoMatrix, but no RelVals are produced
-                      # 'TestEnablesTracker'  : 'TkAlLAS'
-                      # 'TestEnablesEcalHcal' : 'HcalCalPedestal'
-                      "MET" : "HcalCalNoise",
-                      "SingleMu" : "MuAlCalIsolatedMu+MuAlOverlaps+TkAlMuonIsolated+MuAlZMuMu+HcalCalHO",
-                      "DoubleMu" : "MuAlCalIsolatedMu+MuAlOverlaps+TkAlZMuMu",
-                      "DoubleMuParked" : "MuAlCalIsolatedMu+MuAlOverlaps+TkAlZMuMu",
-                      "MuOniaParked" : "TkAlJpsiMuMu+TkAlUpsilonMuMu",
-                      "DoubleElectron" : "EcalCalZElectron+EcalUncalZElectron+HcalCalIsoTrkFilter",
-                      "StreamExpress" : "SiStripCalZeroBias+TkAlMinBias+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+Hotline+LumiPixelsMinBias+SiPixelCalZeroBias",
-                      "StreamExpressHI" : "SiStripCalZeroBias+TkAlMinBiasHI+SiStripPCLHistos+SiStripCalMinBias+SiStripCalMinBiasAAG+SiPixelCalZeroBias"
-}
-
-# this matrix will be used for the legacy reprocessing of the 2016 2016B-H dataset;
-# with the exception of ZeroBias, it was also used for the 23Sept16 reprocessing of 2016B-G 
-AlCaRecoMatrixRereco = {'AlCaLumiPixels' : 'LumiPixels',
-                        'Charmonium'     : 'TkAlJpsiMuMu',
-                        'Commissioning'  : 'TkAlMinBias+SiStripCalMinBias+HcalCalIsoTrk+HcalCalIsolatedBunchSelector',
-                        'Cosmics'        : 'SiPixelCalCosmics+TkAlCosmics0T+MuAlGlobalCosmics+HcalCalHOCosmics',
-                        'DoubleEG'       : 'EcalUncalZElectron+HcalCalIterativePhiSym+HcalCalIsoTrkFilter',
-                        'DoubleElectron' : 'EcalUncalZElectron+HcalCalIsoTrkFilter',
-                        'DoubleMu'       : 'MuAlCalIsolatedMu+MuAlOverlaps+TkAlZMuMu+MuAlZMuMu+TkAlZMuMu+TkAlJpsiMuMu+TkAlUpsilonMuMu+HcalCalIsoTrkFilter',
-                        'DoubleMuon'     : 'TkAlZMuMu+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu',
-                        'DoubleMuParked' : 'MuAlCalIsolatedMu+MuAlOverlaps+TkAlZMuMu',
-                        'HLTPhysics'     : 'SiStripCalMinBias+TkAlMinBias+HcalCalIsoTrkFilter+HcalCalIterativePhiSym',
-                        'JetHT'          : 'HcalCalDijets+HcalCalIsoTrkFilter+HcalCalIsolatedBunchFilter',
-                        'NoBPTX'         : 'TkAlCosmicsInCollisions',
-                        'MET'            : 'HcalCalNoise',
-                        'MinimumBias'    : 'SiStripCalMinBias+TkAlMinBias',
-                        'MuOnia'         : 'TkAlUpsilonMuMu',
-                        'SingleElectron' : 'EcalUncalWElectron+EcalUncalZElectron+EcalESAlign+HcalCalIterativePhiSym+HcalCalIsoTrkFilter',
-                        'SingleMu'       : 'MuAlCalIsolatedMu+MuAlOverlaps+TkAlMuonIsolated+MuAlZMuMu+HcalCalHO',
-                        'SingleMuon'     : 'SiPixelCalSingleMuonLoose+SiPixelCalSingleMuonTight+TkAlMuonIsolated+MuAlCalIsolatedMu+MuAlOverlaps+MuAlZMuMu+HcalCalIterativePhiSym+HcalCalHO',
-                        'SinglePhoton'   : 'HcalCalGammaJet',
-                        'ZeroBias'       : 'SiStripCalZeroBias+TkAlMinBias+LumiPixelsMinBias+SiStripCalMinBias+SiStripCalMinBiasAfterAbortGap',
-                        'HcalNZS'        : 'HcalCalMinBias'
-                        }
+# This matrix has been used for the legacy reprocessing of the 2016 2016B-H dataset.
+# With the exception of ZeroBias, it was also used for the 23Sept16 reprocessing of 2016B-G
+# First copy the default dict
+AlCaRecoMatrix2016 = AlCaRecoMatrix.copy()
+# Then customize for 2016 re-reco
+customizationFor2016 = {"ALCALumiPixelsCountsExpress" : "",
+                        "AlCaP0"                      : "",
+                        "AlCaPhiSym"                  : "",
+                        "EGamma"                      : "",
+                        "Express"                     : "",
+                        "ExpressAlignment"            : "",
+                        "ExpressCosmics"              : "",
+                        "MuOniaParked"                : "",
+                        "StreamExpress"               : "",
+                        "StreamExpressHI"             : ""
+                       }
+AlCaRecoMatrix2016.update(customizationFor2016)
 
 def buildList(pdList, matrix):
     """Takes a list of primary datasets (PDs) and the AlCaRecoMatrix (a dictinary) and returns a string with all the AlCaRecos for the selected PDs separated by the '+' character without duplicates."""


### PR DESCRIPTION
#### PR description:
Following suggestion in https://github.com/cms-sw/cmssw/pull/37306#discussion_r832377275 this PR restructures the layout of the `AlCaRecoMatrix` dictionaries in `autoAlCa.py`.

`AlCaRecoMatrix` is maintained unchanged, while `AlCaRecoMatrix2017`, `AlCaRecoMatrix2018` and `AlCaRecoMatrixRereco` (now renamed `AlCaRecoMatrix2016`) are copied from `AlCaRecoMatrix` dict and then customized for the specific changes in 2016, 2017 and 2018. 
Special customization dicts are used to define the specific customizations for each year and, as suggested during the review, the `update` method of `dict` is used.

#### PR validation:
Code compiles.

#### Backport:
Not a backport but a backport for 12_3_X might be needed.

FYI @cms-sw/alca-l2 @mmusich 