### PR TITLE
update modifier to V16

### DIFF
--- a/Validation/HGCalValidation/python/HGCalValidator_cfi.py
+++ b/Validation/HGCalValidation/python/HGCalValidator_cfi.py
@@ -88,3 +88,6 @@ premix_stage2.toModify(hgcalValidator,
 
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 phase2_hgcalV10.toModify(hgcalValidator, totallayers_to_monitor = cms.int32(50))
+
+from Configuration.Eras.Modifier_phase2_hgcalV16_cff import phase2_hgcalV16
+phase2_hgcalV16.toModify(hgcalValidator, totallayers_to_monitor = cms.int32(47))


### PR DESCRIPTION
#### PR description:

With the latest RelVal campaign just announced ([link](https://cms-talk.web.cern.ch/t/new-validation-campaign-12-3-0-pre6-phase2-d88-added/8647)) PdmV is moving rapidly to D88. In this PR we update the modifier in HGCalValidator to be able to correctly run on V16 HGCAL geometry scenario. 

This should effect only the workflows that use the new V16 modifier, removing some empty histograms. 

@rovere @felicepantaleo @pfs @ebrondol @lecriste 