### PR TITLE
[12_3_X] Fix tag names in DQM Fake BeamSpot clients

### DIFF
--- a/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
@@ -5,8 +5,8 @@ import time
 # Define here the BeamSpotOnline record name,
 # it will be used both in FakeBeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineLegacyObjectsRcd'
-BSOnlineTag = 'BeamSpotOnlineLegacy'
-BSOnlineJobName = 'BeamSpotOnlineLegacy'
+BSOnlineTag = 'BeamSpotOnlineFakeLegacy'
+BSOnlineJobName = 'BeamSpotOnlineFakeLegacy'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True
 import sys
@@ -177,8 +177,8 @@ else:
                             ),
 
         # Upload to CondDB
-        connect = cms.string('sqlite_file:BeamSpotOnlineLegacy.db'),
-        preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineLegacy.db'),
+        connect = cms.string('sqlite_file:BeamSpotOnlineFakeLegacy.db'),
+        preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineFakeLegacy.db'),
         runNumber = cms.untracked.uint64(options.runNumber),
         lastLumiFile = cms.untracked.string('last_lumi.txt'),
         latency = cms.untracked.uint32(2),

--- a/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
@@ -4,8 +4,8 @@ import FWCore.ParameterSet.Config as cms
 # Define here the BeamSpotOnline record name,
 # it will be used both in FakeBeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineHLTObjectsRcd'
-BSOnlineTag = 'BeamSpotOnlineHLT'
-BSOnlineJobName = 'BeamSpotOnlineHLT'
+BSOnlineTag = 'BeamSpotOnlineFakeHLT'
+BSOnlineJobName = 'BeamSpotOnlineFakeHLT'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True
 
@@ -148,8 +148,8 @@ else:
                             ),
 
     # Upload to CondDB
-    connect = cms.string('sqlite_file:BeamSpotOnlineHLT.db'),
-    preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineHLT.db'),
+    connect = cms.string('sqlite_file:BeamSpotOnlineFakeHLT.db'),
+    preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineFakeHLT.db'),
 
     runNumber = cms.untracked.uint64(options.runNumber),
     lastLumiFile = cms.untracked.string('last_lumi.txt'),


### PR DESCRIPTION
#### PR description:
Backport of #37376
Following the discussion with BeamSpot/DB/HLT/DAQ experts, in order to stress test the system and prove that the coral patch works we need to re-deploy in production the fake BeamSpot DQM clients that create fake (TRandom) BeamSpot values and upload them to the DB. This will not affect data quality in any way since the fake clients will be deployed **only during cosmics**, when the beamspot is not really used/useful in any case.

In order not to pollute the production tags with "fake" BeamSpot payloads, this PR changes the name of the output tag to which the payloads are uploaded to. The tag name changes are:
 - `BeamSpotOnlineLegacy` --> `BeamSpotOnlineFakeLegacy`
 - `BeamSpotOnlineHLT` --> `BeamSpotOnlineFakeHLT`

#### PR validation:
Code compiles.

#### Backport:
Backport of #37376