### PR TITLE
Change quality criteria for some supercrystals in the Ecal Endcaps for LED Quality plots [Master]

### DIFF
--- a/DQM/EcalMonitorClient/interface/LedClient.h
+++ b/DQM/EcalMonitorClient/interface/LedClient.h
@@ -27,6 +27,7 @@ namespace ecaldqm {
     double tolerancePNAmp_;
     double tolerancePNRMSRatio_;
     float forwardFactor_;
+    std::vector<uint32_t> SClist_;
   };
 }  // namespace ecaldqm
 


### PR DESCRIPTION
#### PR description:

This PR is done to modify the quality criteria of a few Supercrystals/Towers in DQM LED quality plots of the ECAL Endcaps. This set of supercrystals are known to be problematic by the ECAL LED experts and are being monitored. However it does not affect the quality of physics data and so in order to avoid the DQM displaying them as BAD constantly the quality criteria for them are being changed. The list of supercrystals tower ids are stored in the data file `SClist.dat`

#### PR validation:

This PR was validated by running the Standard Ecal calibration workflow on a test run and observing the DQM output file on an offline DQM test gui to confirm the code changes work as expected. The plots were also approved by the ECAL LED expert.
The PR was also validated by running the DQM relval workflow 136.874 using the runTheMatrix script
`runTheMatrix.py -l 136.874 --ibeos`

