### PR TITLE
L1T phase-2: modify HPS taus

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
@@ -67,6 +67,7 @@ namespace l1t {
     float sumNeutralIso() const { return sumNeutralIso_; }
     float sumCombinedIso() const { return sumCombinedIso_; }
     float sumChargedIsoPileup() const { return sumChargedIsoPileup_; }
+    float Z() const { return Z_; }
 
     bool passTightIso() const { return passTightIso_; }
     bool passMediumIso() const { return passMediumIso_; }
@@ -133,6 +134,7 @@ namespace l1t {
     void setSumNeutralIso(float sumNeutralIso) { sumNeutralIso_ = sumNeutralIso; }
     void setSumCombinedIso(float sumCombinedIso) { sumCombinedIso_ = sumCombinedIso; }
     void setSumChargedIsoPileup(float sumChargedIsoPileup) { sumChargedIsoPileup_ = sumChargedIsoPileup; }
+    void setZ(float Z) { Z_ = Z; }
 
     void setPassTightIso(bool passTightIso) { passTightIso_ = passTightIso; }
     void setPassMediumIso(bool passMediumIso) { passMediumIso_ = passMediumIso; }
@@ -197,6 +199,8 @@ namespace l1t {
     bool passMediumRelIso_;
     bool passLooseRelIso_;
     bool passVLooseRelIso_;
+
+    float Z_;
   };
 
 }  // namespace l1t

--- a/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
@@ -67,7 +67,7 @@ namespace l1t {
     float sumNeutralIso() const { return sumNeutralIso_; }
     float sumCombinedIso() const { return sumCombinedIso_; }
     float sumChargedIsoPileup() const { return sumChargedIsoPileup_; }
-    float Z() const { return Z_; }
+    float z() const { return z_; }
 
     bool passTightIso() const { return passTightIso_; }
     bool passMediumIso() const { return passMediumIso_; }
@@ -134,7 +134,7 @@ namespace l1t {
     void setSumNeutralIso(float sumNeutralIso) { sumNeutralIso_ = sumNeutralIso; }
     void setSumCombinedIso(float sumCombinedIso) { sumCombinedIso_ = sumCombinedIso; }
     void setSumChargedIsoPileup(float sumChargedIsoPileup) { sumChargedIsoPileup_ = sumChargedIsoPileup; }
-    void setZ(float Z) { Z_ = Z; }
+    void setZ(float Z) { z_ = Z; }
 
     void setPassTightIso(bool passTightIso) { passTightIso_ = passTightIso; }
     void setPassMediumIso(bool passMediumIso) { passMediumIso_ = passMediumIso; }
@@ -200,7 +200,7 @@ namespace l1t {
     bool passLooseRelIso_;
     bool passVLooseRelIso_;
 
-    float Z_;
+    float z_;
   };
 
 }  // namespace l1t

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -44,9 +44,8 @@
   <class name="edm::RefVector<l1t::PFTauCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTauCollection> >" /> 
 
-  <class name="l1t::HPSPFTau" ClassVersion="14">
-    <version ClassVersion="14" checksum="588131857"/>
-    <version ClassVersion="13" checksum="588108529"/>
+  <class name="l1t::HPSPFTau" ClassVersion="13">
+    <version ClassVersion="13" checksum="588131857"/>
     <version ClassVersion="12" checksum="1127525942"/>
     <version ClassVersion="11" checksum="98678086"/>
   </class>

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -44,7 +44,8 @@
   <class name="edm::RefVector<l1t::PFTauCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTauCollection> >" /> 
 
-  <class name="l1t::HPSPFTau" ClassVersion="12">
+  <class name="l1t::HPSPFTau" ClassVersion="13">
+    <version ClassVersion="13" checksum="588108529"/>
     <version ClassVersion="11" checksum="98678086"/>
     <version ClassVersion="12" checksum="1127525942"/>
   </class>

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -44,10 +44,11 @@
   <class name="edm::RefVector<l1t::PFTauCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTauCollection> >" /> 
 
-  <class name="l1t::HPSPFTau" ClassVersion="13">
+  <class name="l1t::HPSPFTau" ClassVersion="14">
+    <version ClassVersion="14" checksum="588131857"/>
     <version ClassVersion="13" checksum="588108529"/>
-    <version ClassVersion="11" checksum="98678086"/>
     <version ClassVersion="12" checksum="1127525942"/>
+    <version ClassVersion="11" checksum="98678086"/>
   </class>
   <class name="l1t::HPSPFTauCollection"/>
   <class name="edm::Wrapper<l1t::HPSPFTauCollection>"/>

--- a/L1Trigger/Phase2L1Taus/BuildFile.xml
+++ b/L1Trigger/Phase2L1Taus/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="CommonTools/Utils"/>
+<use name="CommonTools/UtilAlgos"/>
 <use name="DataFormats/L1TParticleFlow"/>
 <export>
   <lib name="1"/>

--- a/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.cc
+++ b/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.cc
@@ -220,7 +220,7 @@ void HPSPFTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descript
   desc.add<double>("minSeedJetPt", 30.0);
   desc.add<double>("maxChargedRelIso", 1.0);
   desc.add<double>("minSeedChargedPFCandPt", 5.0);
-  desc.add<edm::InputTag>("srcL1PFCands", edm::InputTag("l1pfCandidates", "PF"));
+  desc.add<edm::InputTag>("srcL1PFCands", edm::InputTag("l1ctLayer1", "PF"));
   desc.add<double>("stripSizeEta", 0.05);
   desc.add<double>("maxLeadChargedPFCandEta", 2.4);
   desc.add<double>("deltaRCleaning", 0.4);

--- a/L1Trigger/Phase2L1Taus/python/HPSPFTauProducerPF_cfi.py
+++ b/L1Trigger/Phase2L1Taus/python/HPSPFTauProducerPF_cfi.py
@@ -2,5 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.Phase2L1Taus.hpspfTauProducer_cfi import hpspfTauProducer as _hpspfTauProducer
 HPSPFTauProducerPF = _hpspfTauProducer.clone(
-  srcL1PFCands = "l1pfCandidates:PF"
+    srcL1PFCands = "l1ctLayer1:PF",
 )

--- a/L1Trigger/Phase2L1Taus/python/HPSPFTauProducerPuppi_cfi.py
+++ b/L1Trigger/Phase2L1Taus/python/HPSPFTauProducerPuppi_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.Phase2L1Taus.hpspfTauProducer_cfi import hpspfTauProducer as _hpspfTauProducer
 HPSPFTauProducerPuppi = _hpspfTauProducer.clone(
-  srcL1PFCands = "l1pfCandidates:Puppi",
+    srcL1PFCands = "l1ctLayer1:Puppi",
   signalQualityCuts = dict(
     chargedHadron = dict(
       maxDz = 1.e+3

--- a/L1Trigger/Phase2L1Taus/src/L1HPSPFTauBuilder.cc
+++ b/L1Trigger/Phase2L1Taus/src/L1HPSPFTauBuilder.cc
@@ -348,83 +348,102 @@ void L1HPSPFTauBuilder::buildL1PFTau() {
       }
     }
   }
-  l1PFTau_.setP4(l1PFTau_p4);
+  if (l1PFTau_.leadChargedPFCand().isNonnull() && l1PFTau_.leadChargedPFCand()->pfTrack().isNonnull()) {
+    l1PFTau_.setZ(l1PFTau_.leadChargedPFCand()->pfTrack()->vertex().z());
 
-  l1PFTau_.setSeedChargedPFCand(l1PFCandSeed_);
-  l1PFTau_.setSeedJet(l1JetSeed_);
+    l1PFTau_.setP4(l1PFTau_p4);
 
-  l1PFTau_.setSignalAllL1PFCandidates(convertToRefVector(signalAllL1PFCandidates_));
-  l1PFTau_.setSignalChargedHadrons(convertToRefVector(signalChargedHadrons_));
-  l1PFTau_.setSignalElectrons(convertToRefVector(signalElectrons_));
-  l1PFTau_.setSignalNeutralHadrons(convertToRefVector(signalNeutralHadrons_));
-  l1PFTau_.setSignalPhotons(convertToRefVector(signalPhotons_));
-  l1PFTau_.setSignalMuons(convertToRefVector(signalMuons_));
+    l1PFTau_.setSeedChargedPFCand(l1PFCandSeed_);
+    l1PFTau_.setSeedJet(l1JetSeed_);
 
-  l1PFTau_.setStripAllL1PFCandidates(convertToRefVector(stripAllL1PFCandidates_));
-  l1PFTau_.setStripElectrons(convertToRefVector(stripElectrons_));
-  l1PFTau_.setStripPhotons(convertToRefVector(stripPhotons_));
+    l1PFTau_.setSignalAllL1PFCandidates(convertToRefVector(signalAllL1PFCandidates_));
+    l1PFTau_.setSignalChargedHadrons(convertToRefVector(signalChargedHadrons_));
+    l1PFTau_.setSignalElectrons(convertToRefVector(signalElectrons_));
+    l1PFTau_.setSignalNeutralHadrons(convertToRefVector(signalNeutralHadrons_));
+    l1PFTau_.setSignalPhotons(convertToRefVector(signalPhotons_));
+    l1PFTau_.setSignalMuons(convertToRefVector(signalMuons_));
 
-  l1PFTau_.setIsoAllL1PFCandidates(convertToRefVector(isoAllL1PFCandidates_));
-  l1PFTau_.setIsoChargedHadrons(convertToRefVector(isoChargedHadrons_));
-  l1PFTau_.setIsoElectrons(convertToRefVector(isoElectrons_));
-  l1PFTau_.setIsoNeutralHadrons(convertToRefVector(isoNeutralHadrons_));
-  l1PFTau_.setIsoPhotons(convertToRefVector(isoPhotons_));
-  l1PFTau_.setIsoMuons(convertToRefVector(isoMuons_));
+    l1PFTau_.setStripAllL1PFCandidates(convertToRefVector(stripAllL1PFCandidates_));
+    l1PFTau_.setStripElectrons(convertToRefVector(stripElectrons_));
+    l1PFTau_.setStripPhotons(convertToRefVector(stripPhotons_));
 
-  l1PFTau_.setSumAllL1PFCandidates(convertToRefVector(sumAllL1PFCandidates_));
-  l1PFTau_.setSumChargedHadrons(convertToRefVector(sumChargedHadrons_));
-  l1PFTau_.setSumElectrons(convertToRefVector(sumElectrons_));
-  l1PFTau_.setSumNeutralHadrons(convertToRefVector(sumNeutralHadrons_));
-  l1PFTau_.setSumPhotons(convertToRefVector(sumPhotons_));
-  l1PFTau_.setSumMuons(convertToRefVector(sumMuons_));
+    l1PFTau_.setIsoAllL1PFCandidates(convertToRefVector(isoAllL1PFCandidates_));
+    l1PFTau_.setIsoChargedHadrons(convertToRefVector(isoChargedHadrons_));
+    l1PFTau_.setIsoElectrons(convertToRefVector(isoElectrons_));
+    l1PFTau_.setIsoNeutralHadrons(convertToRefVector(isoNeutralHadrons_));
+    l1PFTau_.setIsoPhotons(convertToRefVector(isoPhotons_));
+    l1PFTau_.setIsoMuons(convertToRefVector(isoMuons_));
 
-  l1PFTau_.setPrimaryVertex(primaryVertex_);
+    l1PFTau_.setSumAllL1PFCandidates(convertToRefVector(sumAllL1PFCandidates_));
+    l1PFTau_.setSumChargedHadrons(convertToRefVector(sumChargedHadrons_));
+    l1PFTau_.setSumElectrons(convertToRefVector(sumElectrons_));
+    l1PFTau_.setSumNeutralHadrons(convertToRefVector(sumNeutralHadrons_));
+    l1PFTau_.setSumPhotons(convertToRefVector(sumPhotons_));
+    l1PFTau_.setSumMuons(convertToRefVector(sumMuons_));
 
-  if (l1PFTau_.signalChargedHadrons().size() > 1) {
-    if (stripP4_.pt() < 5.)
-      l1PFTau_.setTauType(l1t::HPSPFTau::kThreeProng0Pi0);
-    else
-      l1PFTau_.setTauType(l1t::HPSPFTau::kThreeProng1Pi0);
-  } else {
-    if (stripP4_.pt() < 5.)
-      l1PFTau_.setTauType(l1t::HPSPFTau::kOneProng0Pi0);
-    else
-      l1PFTau_.setTauType(l1t::HPSPFTau::kOneProng1Pi0);
-  }
+    l1PFTau_.setPrimaryVertex(primaryVertex_);
 
-  l1PFTau_.setStripP4(stripP4_);
-
-  l1PFTau_.setSumAllL1PFCandidatesPt(sumAllL1PFCandidatesPt_);
-  l1PFTau_.setSignalConeSize(signalConeSize_);
-  l1PFTau_.setisolationConeSize(isolationConeSize_);
-
-  double sumChargedIso = 0.;
-  double sumNeutralIso = 0.;
-  for (const auto& l1PFCand : isoAllL1PFCandidates_) {
-    if (l1PFCand->charge() != 0) {
-      sumChargedIso += l1PFCand->pt();
-    } else if (l1PFCand->id() == l1t::PFCandidate::Photon) {
-      sumNeutralIso += l1PFCand->pt();
+    if (l1PFTau_.signalChargedHadrons().size() > 1) {
+      if (stripP4_.pt() < 5.)
+        l1PFTau_.setTauType(l1t::HPSPFTau::kThreeProng0Pi0);
+      else
+        l1PFTau_.setTauType(l1t::HPSPFTau::kThreeProng1Pi0);
+    } else {
+      if (stripP4_.pt() < 5.)
+        l1PFTau_.setTauType(l1t::HPSPFTau::kOneProng0Pi0);
+      else
+        l1PFTau_.setTauType(l1t::HPSPFTau::kOneProng1Pi0);
     }
-  }
-  l1PFTau_.setSumChargedIso(sumChargedIso);
-  l1PFTau_.setSumNeutralIso(sumNeutralIso);
-  const double weightNeutralIso = 1.;
-  const double offsetNeutralIso = 0.;
-  l1PFTau_.setSumCombinedIso(sumChargedIso + weightNeutralIso * (sumNeutralIso - offsetNeutralIso));
-  l1PFTau_.setSumChargedIsoPileup(sumChargedIsoPileup_);
 
-  if (l1PFTau_.sumChargedIso() < 20.0) {
-    l1PFTau_.setPassVLooseIso(true);
-  }
-  if (l1PFTau_.sumChargedIso() < 10.0) {
-    l1PFTau_.setPassLooseIso(true);
-  }
-  if (l1PFTau_.sumChargedIso() < 5.0) {
-    l1PFTau_.setPassMediumIso(true);
-  }
-  if (l1PFTau_.sumChargedIso() < 2.5) {
-    l1PFTau_.setPassTightIso(true);
+    l1PFTau_.setStripP4(stripP4_);
+
+    l1PFTau_.setSumAllL1PFCandidatesPt(sumAllL1PFCandidatesPt_);
+    l1PFTau_.setSignalConeSize(signalConeSize_);
+    l1PFTau_.setisolationConeSize(isolationConeSize_);
+
+    double sumChargedIso = 0.;
+    double sumNeutralIso = 0.;
+    for (const auto& l1PFCand : isoAllL1PFCandidates_) {
+      if (l1PFCand->charge() != 0) {
+        sumChargedIso += l1PFCand->pt();
+      } else if (l1PFCand->id() == l1t::PFCandidate::Photon) {
+        sumNeutralIso += l1PFCand->pt();
+      }
+    }
+    l1PFTau_.setSumChargedIso(sumChargedIso);
+    l1PFTau_.setSumNeutralIso(sumNeutralIso);
+    const double weightNeutralIso = 1.;
+    const double offsetNeutralIso = 0.;
+    l1PFTau_.setSumCombinedIso(sumChargedIso + weightNeutralIso * (sumNeutralIso - offsetNeutralIso));
+    l1PFTau_.setSumChargedIsoPileup(sumChargedIsoPileup_);
+
+    if (l1PFTau_.sumChargedIso() < 20.0) {
+      l1PFTau_.setPassVLooseIso(true);
+    }
+    if (l1PFTau_.sumChargedIso() < 10.0) {
+      l1PFTau_.setPassLooseIso(true);
+    }
+    if (l1PFTau_.sumChargedIso() < 5.0) {
+      l1PFTau_.setPassMediumIso(true);
+    }
+    if (l1PFTau_.sumChargedIso() < 2.5) {
+      l1PFTau_.setPassTightIso(true);
+    }
+
+    if (l1PFTau_p4.pt() != 0) {
+      if (l1PFTau_.sumChargedIso() / l1PFTau_p4.pt() < 0.40) {
+        l1PFTau_.setPassVLooseRelIso(true);
+      }
+      if (l1PFTau_.sumChargedIso() / l1PFTau_p4.pt() < 0.20) {
+        l1PFTau_.setPassLooseRelIso(true);
+      }
+      if (l1PFTau_.sumChargedIso() / l1PFTau_p4.pt() < 0.10) {
+        l1PFTau_.setPassMediumRelIso(true);
+      }
+      if (l1PFTau_.sumChargedIso() / l1PFTau_p4.pt() < 0.05) {
+        l1PFTau_.setPassTightRelIso(true);
+      }
+    }
   }
 }
 

--- a/L1Trigger/Phase2L1Taus/test/produceHPSPFTaus_cfg.py
+++ b/L1Trigger/Phase2L1Taus/test/produceHPSPFTaus_cfg.py
@@ -59,40 +59,8 @@ process.productionSequence = cms.Sequence()
 process.load('SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff')
 process.load('CalibCalorimetry.CaloTPG.CaloTPGTranscoder_cfi')
 
-process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
-process.productionSequence += process.hgcalTriggerPrimitives
-
-process.load('SimCalorimetry.EcalEBTrigPrimProducers.ecalEBTriggerPrimitiveDigis_cff')
-process.productionSequence += process.simEcalEBTriggerPrimitiveDigis
-
-process.load("L1Trigger.TrackFindingTracklet.Tracklet_cfi")
-L1TRK_PROC  =  process.TTTracksFromTrackletEmulation
-L1TRK_NAME  = "TTTracksFromTrackletEmulation"
-L1TRK_LABEL = "Level1TTTracks"
-
-process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
-process.productionSequence += process.offlineBeamSpot
-
-process.productionSequence += process.TTTracksFromTrackletEmulation
-
-process.load("SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff")
-process.TTTrackAssociatorFromPixelDigis.TTTracks = cms.VInputTag( cms.InputTag(L1TRK_NAME, L1TRK_LABEL) )
-process.productionSequence += process.TrackTriggerAssociatorTracks
-
-process.load("L1Trigger.L1TTrackMatch.L1TkPrimaryVertexProducer_cfi")
-process.productionSequence += process.L1TkPrimaryVertex
-
 process.load('Configuration.StandardSequences.SimL1Emulator_cff')
 process.productionSequence += process.SimL1Emulator
-
-process.load("L1Trigger.Phase2L1ParticleFlow.pfTracksFromL1Tracks_cfi")
-process.productionSequence += process.pfTracksFromL1Tracks
-
-process.load("L1Trigger.Phase2L1ParticleFlow.l1ParticleFlow_cff")
-process.productionSequence += process.l1ParticleFlow
-
-process.load('L1Trigger.L1CaloTrigger.Phase1L1TJets_cff')
-process.productionSequence += process.Phase1L1TJetsSequence
 
 ############################################################
 # Generator-level (visible) hadronic taus
@@ -156,6 +124,8 @@ process.out = cms.OutputModule("PoolOutputModule",
     ),
     outputCommands = cms.untracked.vstring(
         'drop *_*_*_*',                                 
+        'keep *_l1ctLayer1_PF_*',
+        'keep *_l1ctLayer1_Puppi_*',
         'keep *_l1pfCandidates_PF_*',
         'keep *_l1pfCandidates_Puppi_*',
         'keep *_l1pfProducer*_z0_*',


### PR DESCRIPTION
#### PR description:

This is another PR to port all L1T Phase-2 developments to cms-sw. This PR updates the HPS and Puppi tau constructors. It includes several PRs made locally, the details of which can be found in the twiki https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions and in the cms-l1t-offline branch.