### PR TITLE
[HGCal] Bug fix in Validation

### DIFF
--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -3,6 +3,9 @@ from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabelsMerge
 from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
 
+tracksterLabels = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMerge]
+tracksterLabels.extend(['ticlSimTracksters', 'ticlSimTracksters_fromCPs'])
+
 prefix = 'HGCAL/HGCalValidator/'
 maxlayerzm =  50# last layer of BH -z
 maxlayerzp =  100# last layer of BH +z
@@ -37,8 +40,7 @@ eff_simclusters.extend(["fake_phi_layer{:02d} 'LayerCluster Fake Rate vs #phi La
 eff_simclusters.extend(["merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer{:02d} in z-' NumMerge_LayerCluster_in_SimCluster_Eta_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_eta_layer{:02d} 'LayerCluster Merge Rate vs #eta Layer{:02d} in z+' NumMerge_LayerCluster_in_SimCluster_Eta_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 eff_simclusters.extend(["merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z-' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "merge_phi_layer{:02d} 'LayerCluster Merge Rate vs #phi Layer{:02d} in z+' NumMerge_LayerCluster_in_SimCluster_Phi_perlayer{:02d} Denom_LayerCluster_in_SimCluster_Phi_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ])
 
-subdirsSim = [prefix + hgcalValidator.label_SimClusters._InputTag__moduleLabel + '/ticlTracksters'+iteration+'/' for iteration in ticlIterLabelsMerge]
-subdirsSim.extend([prefix + hgcalValidator.label_SimClusters._InputTag__moduleLabel + '/ticlSimTracksters'])
+subdirsSim = [prefix + hgcalValidator.label_SimClusters._InputTag__moduleLabel + '/'+iteration+'/' for iteration in tracksterLabels]
 postProcessorHGCALsimclusters = DQMEDHarvester('DQMGenericClient',
     subDirs = cms.untracked.vstring(subdirsSim),
     efficiency = cms.vstring(eff_simclusters),
@@ -66,12 +68,10 @@ for elem in simDict:
             eff_tracksters.extend([m+"_"+v+simDict[elem]+" 'Trackster "+metrics[m][0]+" vs "+variables[v][0]+"' Num"+metrics[m][1]+"Trackster_"+V+simDict[elem]+" Denom_Trackster_"+V+simDict[elem]+fakerate])
 
 tsToCP_linking = hgcalValidator.label_TSToCPLinking.value()
-subdirsTracksters = [prefix+'ticlSimTracksters/'+tsToCP_linking, prefix+'ticlSimTracksters_fromCPs/'+tsToCP_linking]
-subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToCP_linking for iteration in ticlIterLabelsMerge)
+subdirsTracksters = [prefix+iteration+'/'+tsToCP_linking for iteration in tracksterLabels]
 
 tsToSTS_patternRec = hgcalValidator.label_TSToSTSPR.value()
-subdirsTracksters.extend([prefix+'ticlSimTracksters/'+tsToSTS_patternRec, prefix+'ticlSimTracksters_fromCPs/'+tsToSTS_patternRec])
-subdirsTracksters.extend(prefix+'ticlTracksters'+iteration+'/'+tsToSTS_patternRec for iteration in ticlIterLabelsMerge)
+subdirsTracksters.extend(prefix+iteration+'/'+tsToSTS_patternRec for iteration in tracksterLabels)
 
 postProcessorHGCALTracksters = DQMEDHarvester('DQMGenericClient',
   subDirs = cms.untracked.vstring(subdirsTracksters),

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -5,7 +5,7 @@ import os
 import argparse
 from time import time
 
-from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabelsMerge
+from Validation.HGCalValidation.PostProcessorHGCAL_cfi import tracksterLabels as trackstersIters
 
 from Validation.RecoTrack.plotting.validation import SeparateValidation, SimpleValidation, SimpleSample
 from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
@@ -13,8 +13,6 @@ import Validation.HGCalValidation.hgcalPlots as hgcalPlots
 import Validation.RecoTrack.plotting.plotting as plotting
 
 simClustersIters = [hgcalValidator.label_SimClustersLevel._InputTag__moduleLabel, "ticlSimTracksters"]
-trackstersIters = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMerge]
-trackstersIters.extend(["ticlSimTracksters", "ticlSimTracksters_fromCPs"])
 
 hitCalLabel = 'hitCalibration'
 hitValLabel = 'hitValidation'

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -2616,10 +2616,10 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
           }
           const auto elemId = (valType == 0) ? hitid : lcId;
           const auto elemFr = (valType == 0) ? it_haf.second : lcFraction;
-          //Since the current hit from sim cluster has a reconstructed hit with the same detid,
-          //make a map that will connect a detid with:
-          //1. the CaloParticles that have a SimCluster with sim hits in that cell via caloparticle id.
-          //2. the sum of all SimHits fractions that contributes to that detid.
+          //Since the current hit from SimCluster has a reconstructed hit {with the same detid, belonging to the corresponding SimTrackster},
+          //make a map that will connect a {detid,lcID} with:
+          //1. the SimTracksters that have a SimCluster with {sim hits in, LCs containing} that cell via SimTrackster id.
+          //2. the sum of all {SimHits, LCs} fractions that contributes to that detid.
           //So, keep in mind that in case of multiple CaloParticles contributing in the same cell
           //the fraction is the sum over all calo particles. So, something like:
           //detid: (caloparticle 1, sum of hits fractions in that detid over all cp) , (caloparticle 2, sum of hits fractions in that detid over all cp), (caloparticle 3, sum of hits fractions in that detid over all cp) ...

--- a/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
+++ b/Validation/HGCalValidation/src/HGVHistoProducerAlgo.cc
@@ -2606,12 +2606,15 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
         //V9:maps the layers in -z: 0->51 and in +z: 52->103
         //V10:maps the layers in -z: 0->49 and in +z: 50->99
         const auto itcheck = hitMap.find(hitid);
-        //Checks whether the current hit belonging to sim cluster has a reconstructed hit.
+        //Check whether the current hit belonging to sim cluster has a reconstructed hit
         if ((valType == 0 && itcheck != hitMap.end()) || (valType > 0 && int(lcId) >= 0)) {
+          float lcFraction = 0;
+          if (valType > 0) {
+            const auto iLC = std::find(simTSs[iSTS].vertices().begin(), simTSs[iSTS].vertices().end(), lcId);
+            lcFraction =
+                1.f / simTSs[iSTS].vertex_multiplicity(std::distance(std::begin(simTSs[iSTS].vertices()), iLC));
+          }
           const auto elemId = (valType == 0) ? hitid : lcId;
-          const auto iLC = std::find(simTSs[iSTS].vertices().begin(), simTSs[iSTS].vertices().end(), lcId);
-          const auto lcFraction =
-              1.f / simTSs[iSTS].vertex_multiplicity(std::distance(std::begin(simTSs[iSTS].vertices()), iLC));
           const auto elemFr = (valType == 0) ? it_haf.second : lcFraction;
           //Since the current hit from sim cluster has a reconstructed hit with the same detid,
           //make a map that will connect a detid with:
@@ -2641,7 +2644,7 @@ void HGVHistoProducerAlgo::tracksters_to_SimTracksters(
           //fill the cPOnLayer[caloparticle][layer] object with energy (sum of all rechits energy times fraction
           //of the relevant simhit) and keep the hit (detid and fraction) that contributed.
           cPOnLayer[cpId].energy += it_haf.second * hitEn;
-          sCOnLayer[cpId][iSim].energy += lcFraction * hitEn;
+          sCOnLayer[cpId][iSim].energy += elemFr * hitEn;
           // Need to compress the hits and fractions in order to have a
           // reasonable score between CP and LC. Imagine, for example, that a
           // CP has detID X used by 2 SimClusters with different fractions. If


### PR DESCRIPTION
#### PR description:

This PR fixes a [bug](#36991) introduced by #36712, and removes some code duplication.
No changes are expected in the output, except for a new set of validation plots in the `SimCluster` subfolder of the HGCal validation, named `ticlSimTracksters_fromCPs`.  

#### PR validation:

```runTheMatrix -l limited```