### PR TITLE
Change prescaled dedx calculation to exclude pixels for Run3

### DIFF
--- a/RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h
+++ b/RecoTracker/DeDx/interface/GenericTruncatedAverageDeDxEstimator.h
@@ -9,27 +9,31 @@
 class GenericTruncatedAverageDeDxEstimator : public BaseDeDxEstimator {
 public:
   GenericTruncatedAverageDeDxEstimator(const edm::ParameterSet& iConfig) {
-    m_fraction = iConfig.getParameter<double>("fraction");
-    m_expo = iConfig.getParameter<double>("exponent");
+    fraction_ = iConfig.getParameter<double>("fraction");
+    expo_ = iConfig.getParameter<double>("exponent");
+    truncate_ = iConfig.getParameter<bool>("truncate");
   }
 
   std::pair<float, float> dedx(const reco::DeDxHitCollection& Hits) override {
     int first = 0, last = Hits.size();
-    if (m_fraction > 0) {  // truncate high charge ones
-      last -= int(Hits.size() * m_fraction);
-    } else {
-      first += int(Hits.size() * (-m_fraction));
+    if (truncate_) {
+      if (fraction_ > 0) {  // truncate high charge ones
+        last -= int(Hits.size() * fraction_);
+      } else if (fraction_ < 0) {
+        first += int(Hits.size() * (-fraction_));
+      }
     }
     double sumdedx = 0;
     for (int i = first; i < last; i++) {
-      sumdedx += pow(Hits[i].charge(), m_expo);
+      sumdedx += pow(Hits[i].charge(), expo_);
     }
-    double avrdedx = (last - first) ? pow(sumdedx / (last - first), 1.0 / m_expo) : 0.0;
+    double avrdedx = (last - first) ? pow(sumdedx / (last - first), 1.0 / expo_) : 0.0;
     return std::make_pair(avrdedx, -1);
   }
 
 private:
-  float m_fraction, m_expo;
+  float fraction_, expo_;
+  bool truncate_;
 };
 
 #endif

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -41,6 +41,7 @@ void DeDxEstimatorProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<string>("ProbabilityMode", "Accumulation");
   desc.add<double>("fraction", 0.4);
   desc.add<double>("exponent", -2.0);
+  desc.add<bool>("truncate", true);
 
   descriptions.add("DeDxEstimatorProducer", desc);
 }

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -84,11 +84,6 @@ fastSim.toReplaceWith(doAlldEdXEstimatorsTask, cms.Task(dedxHarmonic2, dedxPixel
 # use only the strips for Run-3
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
 run3_common.toModify(dedxHitInfo,
-    lowPtTracksEstimatorParameters = cms.PSet(
-        fraction = cms.double(0),
-        exponent = cms.double(-2.0),
-        truncate = cms.bool(False)
-    ),
+    lowPtTracksEstimatorParameters = dict(fraction = 0., exponent = -2.0,truncate = False),
     usePixelForPrescales = False
 )
-

--- a/RecoTracker/DeDx/python/dedxEstimators_cff.py
+++ b/RecoTracker/DeDx/python/dedxEstimators_cff.py
@@ -22,8 +22,10 @@ dedxHitInfo = cms.EDProducer("DeDxHitInfoProducer",
     lowPtTracksEstimatorParameters = cms.PSet( # generalized truncated average
         fraction = cms.double(-0.15), # negative = throw away the 15% with lowest charge
         exponent = cms.double(-2.0),
+        truncate = cms.bool(True),
     ),
     lowPtTracksDeDxThreshold = cms.double(3.5), # threshold on tracks
+    usePixelForPrescales = cms.bool(True)
 )
 
 import RecoTracker.DeDx.DeDxEstimatorProducer_cfi as _mod
@@ -78,3 +80,15 @@ doAlldEdXEstimatorsTask = cms.Task(dedxTruncated40 , dedxHarmonic2 , dedxPixelHa
 doAlldEdXEstimators = cms.Sequence(doAlldEdXEstimatorsTask)
 
 fastSim.toReplaceWith(doAlldEdXEstimatorsTask, cms.Task(dedxHarmonic2, dedxPixelHarmonic2))
+
+# use only the strips for Run-3
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(dedxHitInfo,
+    lowPtTracksEstimatorParameters = cms.PSet(
+        fraction = cms.double(0),
+        exponent = cms.double(-2.0),
+        truncate = cms.bool(False)
+    ),
+    usePixelForPrescales = False
+)
+


### PR DESCRIPTION
#### PR description:

See in a talk https://indico.cern.ch/event/1142346/#5-news-from-jhu

For calibration purposes, low pT tracks are stored with a prescale factor 
 * the value of the prescale depends on the (scaled) charges (Ih)
 * the current approach combines both the pixel and the strips charges 

Problem:
 * Due to radiation damage the charge is decreasing, 
 * The strips have a 2nd gain calibration to correct for this, but there is no correction for the pixels
 * Fraction of tracks in the different prescale categories changes!

Proposal
 * For Run3, we propose to change the definition of Ih used for this prescale decision to be based on strips hits only, thus having the fraction of tracks in the different prescale categories (100 and 2000) to remain constant in time.
 * In this case the truncation of the lower charge is also not needed

#### PR validation:

```
voms-proxy-init -voms cms -rfc
echo '{"346512" : [[250, 300]]}' > step1_lumiRanges.log
(dasgoclient --limit 0 --query 'lumi,file dataset=/MinimumBias/Commissioning2021-v1/RAW run=346512' --format json | das-selected-lumis.py 250,300 ) | sort -u > step1_dasquery.log
cmsDriver.py step2 --conditions auto:run3_data_prompt -s RAW2DIGI,L1Reco,RECO,PAT --datatier MINIAOD --eventcontent MINIAOD --data --process reRECO --scenario pp --era Run3 --customise Configuration/DataProcessing/RecoTLR.customisePrompt --triggerResultsProcess RECO -n 100 --filein filelist:step1_dasquery.log --lumiToProcess step1_lumiRanges.log --fileout file:step2.root
```
runs.

And also
```
cmsDriver.py step2 --conditions auto:run3_data_prompt -s RAW2DIGI,L1Reco,RECO --datatier AOD --eventcontent AOD --data --process reRECO --scenario pp --era Run3 --customise Configuration/DataProcessing/RecoTLR.customisePrompt --triggerResultsProcess RECO -n 100 --filein filelist:step1_dasquery.log --lumiToProcess step1_lumiRanges.log --fileout file:step2.root
```
shows the plot in the PDF in https://indico.cern.ch/event/1142346/#5-news-from-jhu


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
