### PR TITLE
Make JobReport::reportReadBranches thread safe [CMSSW_12_3]

### DIFF
--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -255,7 +255,7 @@ namespace edm {
       std::map<std::string, long long> readBranches_;
       std::map<std::string, long long> readBranchesSecFile_;
       oneapi::tbb::concurrent_unordered_map<std::string, AtomicLongLong> readBranchesSecSource_;
-      bool printedReadBranches_;
+      std::atomic<bool> printedReadBranches_;
       std::vector<InputFile>::size_type lastOpenedPrimaryInputFile_;
       edm::propagate_const<std::ostream*> ost_;
     };

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -568,9 +568,9 @@ namespace edm {
   }
 
   void JobReport::reportReadBranches() {
-    if (impl_->printedReadBranches_)
+    bool expected = false;
+    if (not impl_->printedReadBranches_.compare_exchange_strong(expected, true))
       return;
-    impl_->printedReadBranches_ = true;
     if (impl_->ost_) {
       std::ostream& ost = *(impl_->ost_);
       ost << "<ReadBranches>\n";


### PR DESCRIPTION
#### PR description:

CRAB jobs have been failing to parse the job report because of this race condition.

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport #37364