### PR TITLE
L1T phase-2: improvements to DT trigger

### DIFF
--- a/L1Trigger/DTTriggerPhase2/interface/GlobalCoordsObtainer.h
+++ b/L1Trigger/DTTriggerPhase2/interface/GlobalCoordsObtainer.h
@@ -1,7 +1,6 @@
 #ifndef L1Trigger_DTTriggerPhase2_GlobalCoordsObtainer_h
 #define L1Trigger_DTTriggerPhase2_GlobalCoordsObtainer_h
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"

--- a/L1Trigger/DTTriggerPhase2/interface/MPCleanHitsFilter.h
+++ b/L1Trigger/DTTriggerPhase2/interface/MPCleanHitsFilter.h
@@ -1,0 +1,51 @@
+#ifndef L1Trigger_DTTriggerPhase2_MPCleanHitsFilter_h
+#define L1Trigger_DTTriggerPhase2_MPCleanHitsFilter_h
+
+#include "L1Trigger/DTTriggerPhase2/interface/MPFilter.h"
+
+#include <iostream>
+#include <fstream>
+
+// ===============================================================================
+// Previous definitions and declarations
+// ===============================================================================
+
+// ===============================================================================
+// Class declarations
+// ===============================================================================
+
+class MPCleanHitsFilter : public MPFilter {
+public:
+  // Constructors and destructor
+  MPCleanHitsFilter(const edm::ParameterSet& pset);
+  ~MPCleanHitsFilter() override;
+
+  // Main methods
+  void initialise(const edm::EventSetup& iEventSetup) override{};
+  void run(edm::Event& iEvent,
+           const edm::EventSetup& iEventSetup,
+           std::vector<cmsdt::metaPrimitive>& inMPath,
+           std::vector<cmsdt::metaPrimitive>& outMPath) override{};
+
+  void run(edm::Event& iEvent,
+           const edm::EventSetup& iEventSetup,
+           MuonPathPtrs& inMPath,
+           MuonPathPtrs& outMPath) override;
+
+  void finish() override{};
+
+  // Other public methods
+  void removeOutliers(MuonPathPtr& mpath);
+
+  double getMeanTime(MuonPathPtr& mpath);
+
+  void setTimeTolerance(int time) { timeTolerance_ = time; }
+  int getTimeTolerance() { return timeTolerance_; }
+
+private:
+  // Private attributes
+  bool debug_;
+  int timeTolerance_;
+};
+
+#endif

--- a/L1Trigger/DTTriggerPhase2/interface/MPFilter.h
+++ b/L1Trigger/DTTriggerPhase2/interface/MPFilter.h
@@ -1,7 +1,6 @@
 #ifndef Phase2L1Trigger_DTTrigger_MPFilter_h
 #define Phase2L1Trigger_DTTrigger_MPFilter_h
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/L1Trigger/DTTriggerPhase2/interface/MPQualityEnhancerFilterBayes.h
+++ b/L1Trigger/DTTriggerPhase2/interface/MPQualityEnhancerFilterBayes.h
@@ -1,0 +1,58 @@
+#ifndef Phase2L1Trigger_DTTrigger_MPQualityEnhancerFilterBayes_h
+#define Phase2L1Trigger_DTTrigger_MPQualityEnhancerFilterBayes_h
+
+#include "L1Trigger/DTTriggerPhase2/interface/MPFilter.h"
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
+
+#include <iostream>
+#include <fstream>
+
+// ===============================================================================
+// Previous definitions and declarations
+// ===============================================================================
+
+// ===============================================================================
+// Class declarations
+// ===============================================================================
+
+class MPQualityEnhancerFilterBayes : public MPFilter {
+public:
+  // Constructors and destructor
+  MPQualityEnhancerFilterBayes(const edm::ParameterSet &pset);
+  ~MPQualityEnhancerFilterBayes() override;
+
+  // Main methods
+  void initialise(const edm::EventSetup &iEventSetup) override;
+  void run(edm::Event &iEvent,
+           const edm::EventSetup &iEventSetup,
+           std::vector<cmsdt::metaPrimitive> &inMPath,
+           std::vector<cmsdt::metaPrimitive> &outMPath) override;
+  void run(edm::Event &iEvent,
+           const edm::EventSetup &iEventSetup,
+           MuonPathPtrs &inMPath,
+           MuonPathPtrs &outMPath) override{};
+
+  void finish() override;
+
+  // Other public methods
+
+  // Public attributes
+  int areCousins(cmsdt::metaPrimitive mp1, cmsdt::metaPrimitive mp2);
+  int shareSL(cmsdt::metaPrimitive mp1, cmsdt::metaPrimitive mp2);
+  bool areSame(cmsdt::metaPrimitive mp1, cmsdt::metaPrimitive mp2);
+  int rango(cmsdt::metaPrimitive mp);
+  int BX(cmsdt::metaPrimitive mp);
+  void printmP(cmsdt::metaPrimitive mP);
+
+private:
+  // Private methods
+  void filterCousins(std::vector<cmsdt::metaPrimitive> &inMPath, std::vector<cmsdt::metaPrimitive> &outMPath);
+  /* void refilteringCousins(std::vector<cmsdt::metaPrimitive> &inMPath, std::vector<cmsdt::metaPrimitive> &outMPath); */
+  /* void filterTanPhi(std::vector<cmsdt::metaPrimitive> &inMPath, std::vector<cmsdt::metaPrimitive> &outMPath); */
+  /* void filterUnique(std::vector<cmsdt::metaPrimitive> &inMPath, std::vector<cmsdt::metaPrimitive> &outMPath); */
+
+  // Private attributes
+  bool debug_;
+};
+
+#endif

--- a/L1Trigger/DTTriggerPhase2/interface/MotherGrouping.h
+++ b/L1Trigger/DTTriggerPhase2/interface/MotherGrouping.h
@@ -1,7 +1,6 @@
 #ifndef Phase2L1Trigger_DTTrigger_MotherGrouping_h
 #define Phase2L1Trigger_DTTrigger_MotherGrouping_h
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/L1Trigger/DTTriggerPhase2/interface/MuonPathAnalyzer.h
+++ b/L1Trigger/DTTriggerPhase2/interface/MuonPathAnalyzer.h
@@ -1,7 +1,6 @@
 #ifndef Phase2L1Trigger_DTTrigger_MuonPathAnalyzer_h
 #define Phase2L1Trigger_DTTrigger_MuonPathAnalyzer_h
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"

--- a/L1Trigger/DTTriggerPhase2/interface/RPCIntegrator.h
+++ b/L1Trigger/DTTriggerPhase2/interface/RPCIntegrator.h
@@ -1,7 +1,6 @@
 #ifndef Phase2L1Trigger_DTTrigger_RPCIntegrator_h
 #define Phase2L1Trigger_DTTrigger_RPCIntegrator_h
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/L1Trigger/DTTriggerPhase2/plugins/CalibratedDigis.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/CalibratedDigis.cc
@@ -32,7 +32,6 @@
 #include "CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CalibMuon/DTDigiSync/interface/DTTTrigSyncFactory.h"
 

--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
@@ -33,6 +33,8 @@
 #include "L1Trigger/DTTriggerPhase2/interface/MPFilter.h"
 #include "L1Trigger/DTTriggerPhase2/interface/MPQualityEnhancerFilter.h"
 #include "L1Trigger/DTTriggerPhase2/interface/MPRedundantFilter.h"
+#include "L1Trigger/DTTriggerPhase2/interface/MPCleanHitsFilter.h"
+#include "L1Trigger/DTTriggerPhase2/interface/MPQualityEnhancerFilterBayes.h"
 #include "L1Trigger/DTTriggerPhase2/interface/GlobalCoordsObtainer.h"
 
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
@@ -104,7 +106,7 @@ public:
   void setMinimumQuality(MP_QUALITY q);
 
   // data-members
-  DTGeometry const* dtGeo_;
+  const DTGeometry* dtGeo_;
   edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomH;
   std::vector<std::pair<int, MuonPath>> primitives_;
 
@@ -122,7 +124,8 @@ private:
   bool do_correlation_;
   int scenario_;
   int df_extended_;
-  std::string geometry_tag_;
+  int max_index_;
+  //  std::string geometry_tag_;
 
   // ParameterSet
   edm::EDGetTokenT<DTDigiCollection> dtDigisToken_;
@@ -133,8 +136,9 @@ private:
   std::unique_ptr<MotherGrouping> grouping_obj_;
   std::unique_ptr<MuonPathAnalyzer> mpathanalyzer_;
   std::unique_ptr<MPFilter> mpathqualityenhancer_;
+  std::unique_ptr<MPFilter> mpathqualityenhancerbayes_;
   std::unique_ptr<MPFilter> mpathredundantfilter_;
-  // std::unique_ptr<MPFilter> mpathhitsfilter_;
+  std::unique_ptr<MPFilter> mpathhitsfilter_;
   std::unique_ptr<MuonPathAssociator> mpathassociator_;
   std::shared_ptr<GlobalCoordsObtainer> globalcoordsobtainer_;
 
@@ -179,6 +183,7 @@ DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset)
   scenario_ = pset.getParameter<int>("scenario");
 
   df_extended_ = pset.getParameter<int>("df_extended");
+  max_index_ = pset.getParameter<int>("max_primitives") - 1;
 
   dtDigisToken_ = consumes<DTDigiCollection>(pset.getParameter<edm::InputTag>("digiTag"));
 
@@ -187,9 +192,6 @@ DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset)
 
   // Choosing grouping scheme:
   algo_ = pset.getParameter<int>("algo");
-
-  // Local to global coordinates approach
-  geometry_tag_ = pset.getUntrackedParameter<std::string>("geometry_tag", "");
 
   edm::ConsumesCollector consumesColl(consumesCollector());
   globalcoordsobtainer_ = std::make_shared<GlobalCoordsObtainer>(pset);
@@ -221,7 +223,9 @@ DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset)
   superCelltimewidth_ = pset.getParameter<double>("superCelltimewidth");
 
   mpathqualityenhancer_ = std::make_unique<MPQualityEnhancerFilter>(pset);
+  mpathqualityenhancerbayes_ = std::make_unique<MPQualityEnhancerFilterBayes>(pset);
   mpathredundantfilter_ = std::make_unique<MPRedundantFilter>(pset);
+  mpathhitsfilter_ = std::make_unique<MPCleanHitsFilter>(pset);
   mpathassociator_ = std::make_unique<MuonPathAssociator>(pset, consumesColl, globalcoordsobtainer_);
   rpc_integrator_ = std::make_unique<RPCIntegrator>(pset, consumesColl);
 
@@ -239,15 +243,17 @@ void DTTrigPhase2Prod::beginRun(edm::Run const& iRun, const edm::EventSetup& iEv
   if (debug_)
     LogDebug("DTTrigPhase2Prod") << "beginRun: getting DT geometry";
 
-  grouping_obj_->initialise(iEventSetup);          // Grouping object initialisation
-  mpathanalyzer_->initialise(iEventSetup);         // Analyzer object initialisation
-  mpathqualityenhancer_->initialise(iEventSetup);  // Filter object initialisation
-  mpathredundantfilter_->initialise(iEventSetup);  // Filter object initialisation
-  mpathassociator_->initialise(iEventSetup);       // Associator object initialisation
+  grouping_obj_->initialise(iEventSetup);               // Grouping object initialisation
+  mpathanalyzer_->initialise(iEventSetup);              // Analyzer object initialisation
+  mpathqualityenhancer_->initialise(iEventSetup);       // Filter object initialisation
+  mpathredundantfilter_->initialise(iEventSetup);       // Filter object initialisation
+  mpathqualityenhancerbayes_->initialise(iEventSetup);  // Filter object initialisation
+  mpathhitsfilter_->initialise(iEventSetup);
+  mpathassociator_->initialise(iEventSetup);  // Associator object initialisation
 
-  edm::ESHandle<DTGeometry> geom;
-  iEventSetup.get<MuonGeometryRecord>().get(geometry_tag_, geom);
-  dtGeo_ = &(*geom);
+  if (auto geom = iEventSetup.getHandle(dtGeomH)) {
+    dtGeo_ = &(*geom);
+  }
 }
 
 void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
@@ -350,6 +356,8 @@ void DTTrigPhase2Prod::produce(Event& iEvent, const EventSetup& iEventSetup) {
   MuonPathPtrs filteredmuonpaths;
   if (algo_ == Standard) {
     mpathredundantfilter_->run(iEvent, iEventSetup, muonpaths, filteredmuonpaths);
+  } else {
+    mpathhitsfilter_->run(iEvent, iEventSetup, muonpaths, filteredmuonpaths);
   }
 
   if (dump_) {
@@ -711,7 +719,9 @@ void DTTrigPhase2Prod::endRun(edm::Run const& iRun, const edm::EventSetup& iEven
   grouping_obj_->finish();
   mpathanalyzer_->finish();
   mpathqualityenhancer_->finish();
+  mpathqualityenhancerbayes_->finish();
   mpathredundantfilter_->finish();
+  mpathhitsfilter_->finish();
   mpathassociator_->finish();
   rpc_integrator_->finish();
 };
@@ -773,7 +783,8 @@ void DTTrigPhase2Prod::assignIndex(std::vector<metaPrimitive>& inMPaths) {
   for (auto& prims : primsPerBX) {
     assignIndexPerBX(prims.second);
     for (const auto& primitive : prims.second)
-      inMPaths.push_back(primitive);
+      if (primitive.index <= max_index_)
+        inMPaths.push_back(primitive);
   }
 }
 

--- a/L1Trigger/DTTriggerPhase2/python/CalibratedDigis_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/CalibratedDigis_cfi.py
@@ -23,7 +23,7 @@ CalibratedDigis = cms.EDProducer("CalibratedDigis",
                                  timeOffset = cms.int32(0),
                                  flat_calib = cms.int32(0),
                                  scenario = cms.untracked.int32(0),
-                                 dtDigiTag = cms.InputTag("muonDTDigis")
+                                 dtDigiTag = cms.InputTag("simMuonDTDigis")
                                  )
 
 

--- a/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -27,6 +27,7 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                scenario = cms.int32(0), #0 for mc, 1 for data, 2 for slice test
                                                df_extended = cms.int32(0), # DF: 0 for standard, 1 for extended, 2 for both 
                                                filter_cousins = cms.untracked.bool(True),
+                                               max_primitives = cms.int32(999),
 
                                                ttrig_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/wire_rawId_ttrig.txt'),
                                                z_filename = cms.FileInPath('L1Trigger/DTTriggerPhase2/data/wire_rawId_z.txt'),

--- a/L1Trigger/DTTriggerPhase2/src/MPCleanHitsFilter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPCleanHitsFilter.cc
@@ -1,0 +1,56 @@
+#include "L1Trigger/DTTriggerPhase2/interface/MPCleanHitsFilter.h"
+
+using namespace edm;
+using namespace std;
+
+// ============================================================================
+// Constructors and destructor
+// ============================================================================
+MPCleanHitsFilter::MPCleanHitsFilter(const ParameterSet &pset) : MPFilter(pset) {
+  // Obtention of parameters
+  debug_ = pset.getUntrackedParameter<bool>("debug");
+
+  timeTolerance_ = pset.exists("timeTolerance") ? pset.getParameter<int>("timeTolerance") : 999999;
+  // probably something close to the max time drift (400ns/2) is a reasonable value
+}
+void MPCleanHitsFilter::run(edm::Event &iEvent,
+                            const edm::EventSetup &iEventSetup,
+                            MuonPathPtrs &inMPaths,
+                            MuonPathPtrs &outMPaths) {
+  int counter = 0;
+  for (const auto &mpath : inMPaths) {
+    ++counter;
+    auto mpAux = std::make_shared<MuonPath>(*mpath);
+    removeOutliers(mpAux);  // remove hits that are more than 1 bX from the meantime.
+
+    outMPaths.emplace_back(mpAux);
+  }
+}
+
+void MPCleanHitsFilter::removeOutliers(MuonPathPtr &mpath) {
+  int MeanTime = getMeanTime(mpath);
+  for (int i = 0; i < mpath->nprimitives(); i++) {
+    if (!mpath->primitive(i)->isValidTime())
+      continue;
+    if (std::abs(mpath->primitive(i)->tdcTimeStamp() - MeanTime) > timeTolerance_) {
+      mpath->primitive(i)->setTDCTimeStamp(-1);  //invalidate hit
+      mpath->primitive(i)->setChannelId(-1);     //invalidate hit
+    }
+  }
+}
+
+double MPCleanHitsFilter::getMeanTime(MuonPathPtr &mpath) {
+  float meantime = 0.;
+  float count = 0.;
+  for (int i = 0; i < mpath->nprimitives(); i++) {
+    if (mpath->primitive(i) == nullptr)
+      continue;
+    if (!mpath->primitive(i)->isValidTime())
+      continue;
+    meantime += mpath->primitive(i)->tdcTimeStamp();
+    count++;
+  }
+  return meantime / count;
+}
+
+MPCleanHitsFilter::~MPCleanHitsFilter() {}

--- a/L1Trigger/DTTriggerPhase2/src/MPQualityEnhancerFilter.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPQualityEnhancerFilter.cc
@@ -148,7 +148,7 @@ void MPQualityEnhancerFilter::filterCousins(std::vector<metaPrimitive> &inMPaths
 void MPQualityEnhancerFilter::refilteringCousins(std::vector<metaPrimitive> &inMPaths,
                                                  std::vector<metaPrimitive> &outMPaths) {
   if (debug_)
-    std::cout << "filtering: starting cousins refiltering" << std::endl;
+    LogDebug("MPQualityEnhancerFilter") << "filtering: starting cousins refiltering\n";
   int bestI = -1;
   double bestChi2 = 9999;
   bool oneOf4 = false;

--- a/L1Trigger/DTTriggerPhase2/src/MPQualityEnhancerFilterBayes.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MPQualityEnhancerFilterBayes.cc
@@ -1,0 +1,319 @@
+#include "L1Trigger/DTTriggerPhase2/interface/MPQualityEnhancerFilterBayes.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+using namespace edm;
+using namespace std;
+using namespace cmsdt;
+;
+
+// ============================================================================
+// Constructors and destructor
+// ============================================================================
+MPQualityEnhancerFilterBayes::MPQualityEnhancerFilterBayes(const ParameterSet &pset) : MPFilter(pset) {
+  // Obtention of parameters
+  debug_ = pset.getUntrackedParameter<bool>("debug");
+}
+
+MPQualityEnhancerFilterBayes::~MPQualityEnhancerFilterBayes() {}
+
+// ============================================================================
+// Main methods (initialise, run, finish)
+// ============================================================================
+void MPQualityEnhancerFilterBayes::initialise(const edm::EventSetup &iEventSetup) {}
+
+void MPQualityEnhancerFilterBayes::run(edm::Event &iEvent,
+                                       const edm::EventSetup &iEventSetup,
+                                       std::vector<metaPrimitive> &inMPaths,
+                                       std::vector<metaPrimitive> &outMPaths) {
+  // std::vector<metaPrimitive> buff;
+  // std::vector<metaPrimitive> buff2;
+
+  filterCousins(inMPaths, outMPaths);
+  if (debug_) {
+    LogDebug("MPQualityEnhancerFilterBayes") << "Ended Cousins Filter. The final primitives before Refiltering are: ";
+    for (unsigned int i = 0; i < outMPaths.size(); i++) {
+      printmP(outMPaths[i]);
+    }
+    LogDebug("MPQualityEnhancerFilterBayes") << "Total Primitives = " << outMPaths.size();
+  }
+  // refilteringCousins(buff, buff2);
+  // if (debug_) {
+  //   LogDebug("MPQualityEnhancerFilterBayes") << "Ended Cousins Refilter. The final primitives before UniqueFilter are: ";
+  //   for (unsigned int i = 0; i < buff2.size(); i++) {
+  //     printmP(buff2[i]);
+  //   }
+  //   LogDebug("MPQualityEnhancerFilterBayes") << "Total Primitives = " << buff2.size();
+  // }
+  // filterUnique(buff2, outMPaths);
+
+  // buff.clear();
+  // buff2.clear();
+}
+
+void MPQualityEnhancerFilterBayes::finish(){};
+
+///////////////////////////
+///  OTHER METHODS
+int MPQualityEnhancerFilterBayes::areCousins(metaPrimitive mp, metaPrimitive second_mp) {
+  DTSuperLayerId mpId(mp.rawId);
+  DTSuperLayerId second_mpId(second_mp.rawId);
+
+  cout << "Comparing mp:" << endl;
+  cout << "ID: wheel " << mpId.wheel() << ", station " << mpId.station() << ", sector " << mpId.sector() << endl;
+  cout << "ID: wheel " << second_mpId.wheel() << ", station " << second_mpId.station() << ", sector "
+       << second_mpId.sector() << endl;
+
+  cout << mp.wi1 << "(" << mp.tdc1 << ")"
+       << " " << mp.wi2 << "(" << mp.tdc2 << ")"
+       << " " << mp.wi3 << "(" << mp.tdc3 << ")"
+       << " " << mp.wi4 << "(" << mp.tdc4 << ")"
+       << " " << mp.wi5 << "(" << mp.tdc5 << ")"
+       << " " << mp.wi6 << "(" << mp.tdc6 << ")"
+       << " " << mp.wi7 << "(" << mp.tdc7 << ")"
+       << " " << mp.wi8 << "(" << mp.tdc8 << ")"
+       << " " << endl;
+  cout << second_mp.wi1 << "(" << second_mp.tdc1 << ")"
+       << " " << second_mp.wi2 << "(" << second_mp.tdc2 << ")"
+       << " " << second_mp.wi3 << "(" << second_mp.tdc3 << ")"
+       << " " << second_mp.wi4 << "(" << second_mp.tdc4 << ")"
+       << " " << second_mp.wi5 << "(" << second_mp.tdc5 << ")"
+       << " " << second_mp.wi6 << "(" << second_mp.tdc6 << ")"
+       << " " << second_mp.wi7 << "(" << second_mp.tdc7 << ")"
+       << " " << second_mp.wi8 << "(" << second_mp.tdc8 << ")"
+       << " " << endl;
+
+  int output = 0;
+  //  if (mp.rawId != second_mp.rawId){
+  // metaPrimitives must be in the same chamber to be cousins
+  if (mpId.wheel() != second_mpId.wheel() || mpId.station() != second_mpId.station() ||
+      mpId.sector() != second_mpId.sector()) {
+    cout << "Not in the same chamber" << endl;
+    return output;
+  }
+
+  if (mp.wi1 == second_mp.wi1 and mp.tdc1 == second_mp.tdc1 and mp.wi1 != -1 and mp.tdc1 != -1)
+    output = 1;
+  if (mp.wi2 == second_mp.wi2 and mp.tdc2 == second_mp.tdc2 and mp.wi2 != -1 and mp.tdc2 != -1)
+    output = 2;
+  if (mp.wi3 == second_mp.wi3 and mp.tdc3 == second_mp.tdc3 and mp.wi3 != -1 and mp.tdc3 != -1)
+    output = 3;
+  if (mp.wi4 == second_mp.wi4 and mp.tdc4 == second_mp.tdc4 and mp.wi4 != -1 and mp.tdc4 != -1)
+    output = 4;
+  if (mp.wi5 == second_mp.wi5 and mp.tdc5 == second_mp.tdc5 and mp.wi5 != -1 and mp.tdc5 != -1)
+    output = 5;
+  if (mp.wi6 == second_mp.wi6 and mp.tdc6 == second_mp.tdc6 and mp.wi6 != -1 and mp.tdc6 != -1)
+    output = 6;
+  if (mp.wi7 == second_mp.wi7 and mp.tdc7 == second_mp.tdc7 and mp.wi7 != -1 and mp.tdc7 != -1)
+    output = 7;
+  if (mp.wi8 == second_mp.wi8 and mp.tdc8 == second_mp.tdc8 and mp.wi8 != -1 and mp.tdc8 != -1)
+    output = 8;
+
+  cout << output << endl;
+  return output;
+}
+
+///////////////////////////
+///  OTHER METHODS
+bool MPQualityEnhancerFilterBayes::areSame(metaPrimitive mp, metaPrimitive second_mp) {
+  if (mp.rawId != second_mp.rawId)
+    return false;
+  if (mp.wi1 != second_mp.wi1 or mp.tdc1 != second_mp.tdc1)
+    return false;
+  if (mp.wi2 != second_mp.wi2 or mp.tdc2 != second_mp.tdc2)
+    return false;
+  if (mp.wi3 != second_mp.wi3 or mp.tdc3 != second_mp.tdc3)
+    return false;
+  if (mp.wi4 != second_mp.wi4 or mp.tdc4 != second_mp.tdc4)
+    return false;
+  if (mp.wi5 != second_mp.wi5 or mp.tdc5 != second_mp.tdc5)
+    return false;
+  if (mp.wi6 != second_mp.wi6 or mp.tdc6 != second_mp.tdc6)
+    return false;
+  if (mp.wi7 != second_mp.wi7 or mp.tdc7 != second_mp.tdc7)
+    return false;
+  if (mp.wi8 != second_mp.wi8 or mp.tdc8 != second_mp.tdc8)
+    return false;
+  return true;
+}
+
+int MPQualityEnhancerFilterBayes::shareSL(metaPrimitive mp, metaPrimitive second_mp) {
+  DTSuperLayerId mpId(mp.rawId);
+  DTSuperLayerId second_mpId(second_mp.rawId);
+
+  int output = 0;
+  if (mpId.wheel() != second_mpId.wheel() || mpId.station() != second_mpId.station() ||
+      mpId.sector() != second_mpId.sector()) {
+    return output;
+  }
+
+  int SL1 = 0;
+  int SL3 = 0;
+
+  int SL1_shared = 0;
+  int SL3_shared = 0;
+
+  if (mp.wi1 != -1 and mp.tdc1 != -1) {
+    ++SL1;
+    if (mp.wi1 == second_mp.wi1 and mp.tdc1 == second_mp.tdc1) {
+      ++SL1_shared;
+    }
+  }
+  if (mp.wi2 != -1 and mp.tdc2 != -1) {
+    ++SL1;
+    if (mp.wi2 == second_mp.wi2 and mp.tdc2 == second_mp.tdc2) {
+      ++SL1_shared;
+    }
+  }
+  if (mp.wi3 != -1 and mp.tdc3 != -1) {
+    ++SL1;
+    if (mp.wi3 == second_mp.wi3 and mp.tdc3 == second_mp.tdc3) {
+      ++SL1_shared;
+    }
+  }
+  if (mp.wi4 != -1 and mp.tdc4 != -1) {
+    ++SL1;
+    if (mp.wi4 == second_mp.wi4 and mp.tdc4 == second_mp.tdc4) {
+      ++SL1_shared;
+    }
+  }
+
+  if (mp.wi5 != -1 and mp.tdc5 != -1) {
+    ++SL3;
+    if (mp.wi5 == second_mp.wi5 and mp.tdc5 == second_mp.tdc5) {
+      ++SL3_shared;
+    }
+  }
+  if (mp.wi6 != -1 and mp.tdc6 != -1) {
+    ++SL3;
+    if (mp.wi6 == second_mp.wi6 and mp.tdc6 == second_mp.tdc6) {
+      ++SL3_shared;
+    }
+  }
+  if (mp.wi7 != -1 and mp.tdc7 != -1) {
+    ++SL3;
+    if (mp.wi7 == second_mp.wi7 and mp.tdc7 == second_mp.tdc7) {
+      ++SL3_shared;
+    }
+  }
+  if (mp.wi8 != -1 and mp.tdc8 != -1) {
+    ++SL3;
+    if (mp.wi8 == second_mp.wi8 and mp.tdc8 == second_mp.tdc8) {
+      ++SL3_shared;
+    }
+  }
+
+  // If the two mp share all hits in a SL, we consider that they share that SL
+  if (SL1_shared == SL1 || SL3_shared == SL3)
+    output = 1;
+
+  return output;
+}
+
+int MPQualityEnhancerFilterBayes::BX(metaPrimitive mp) {
+  int bx;
+  bx = (int)round(mp.t0 / (float)LHC_CLK_FREQ);
+  return bx;
+}
+
+// Is this really needed?
+int MPQualityEnhancerFilterBayes::rango(metaPrimitive mp) {
+  // Correlated
+  if (mp.quality > 5)
+    return 2;
+  // uncorrelated
+  else
+    return 1;
+}
+
+void MPQualityEnhancerFilterBayes::filterCousins(std::vector<metaPrimitive> &inMPaths,
+                                                 std::vector<metaPrimitive> &outMPaths) {
+  // int primo_index = 0;
+  // bool oneof4 = false; // quality >= 6, for the moment. So, correlated primitives
+  // int bestI = -1;
+  // double bestChi2 = 9999;
+
+  // At the beginning, we want to keep all mpaths
+  bool keep_this[inMPaths.size()];
+  for (unsigned int k = 0; k < inMPaths.size(); k++) {
+    keep_this[k] = true;
+  }
+
+  // If we have just one mpath, save it
+  if (inMPaths.size() == 1) {
+    if (debug_) {
+      printmP(inMPaths[0]);
+    }
+    outMPaths.push_back(inMPaths[0]);
+  }
+  // More than one mpath
+  else if (inMPaths.size() > 1) {
+    for (int i = 0; i < int(inMPaths.size()); i++) {
+      if (debug_) {
+        printmP(inMPaths[i]);
+      }
+      // If we have already decided to reject the candidate, skip it
+      if (keep_this[i] == false)
+        continue;
+      for (int j = i + 1; j < int(inMPaths.size()); j++) {
+        // If we have already decided to reject the candidate, skip it
+        if (keep_this[j] == false)
+          continue;
+        // Case they are the same, keep the first one
+        if (areSame(inMPaths[i], inMPaths[j]) == true)
+          keep_this[i] = false;
+        // Case they are cousins, keep the best one
+        if (areCousins(inMPaths[i], inMPaths[j]) != 0) {
+          cout << "They are cousins" << endl;
+
+          // In case both are correlated, they have to share a full SL
+          if (inMPaths[i].quality > 5 && inMPaths[j].quality > 5 && shareSL(inMPaths[i], inMPaths[j]) == 0) {
+            cout << "But don't share a whole SL" << endl;
+            continue;
+          }
+
+          // Compare only if rango is the same (both correlated or both not-correlated)
+          // if (rango(inMPaths[i]) != rango(inMPaths[j])) continue;
+
+          // If rango is the same, keep higher quality one
+          // Still, keep lower-quality one if it has lower Chi2
+          // and if its BX is different to the higher-quality one
+          if (inMPaths[i].quality > inMPaths[j].quality) {
+            if ((inMPaths[i].chi2 < inMPaths[j].chi2) || BX(inMPaths[i]) == BX(inMPaths[j]))
+              keep_this[j] = false;
+          } else if (inMPaths[i].quality < inMPaths[j].quality) {
+            if ((inMPaths[i].chi2 > inMPaths[j].chi2) || BX(inMPaths[i]) == BX(inMPaths[j]))
+              keep_this[i] = false;
+          } else {  // if they have same quality
+            // If quality is 8, keep both
+            // if (inMPaths[i].quality >= 8) continue;
+            // Otherwise, keep the one with better Chi2
+            // and also the one with worse Chi2 if its BX is different
+            // else{
+            if (inMPaths[i].chi2 > inMPaths[j].chi2 && BX(inMPaths[i]) == BX(inMPaths[j]))
+              keep_this[i] = false;
+            else if (inMPaths[i].chi2 < inMPaths[j].chi2 && BX(inMPaths[i]) == BX(inMPaths[j]))
+              keep_this[j] = false;
+            else
+              continue;
+            //}
+          }
+        }
+      }
+    }
+    // Finally, fill the output with accepted candidates
+    for (int i = 0; i < int(inMPaths.size()); i++)
+      if (keep_this[i] == true)
+        outMPaths.push_back(inMPaths[i]);
+  }
+}
+
+void MPQualityEnhancerFilterBayes::printmP(metaPrimitive mP) {
+  DTSuperLayerId slId(mP.rawId);
+  LogDebug("MPQualityEnhancerFilterBayes")
+      << slId << "\t"
+      << " " << setw(2) << left << mP.wi1 << " " << setw(2) << left << mP.wi2 << " " << setw(2) << left << mP.wi3 << " "
+      << setw(2) << left << mP.wi4 << " " << setw(5) << left << mP.tdc1 << " " << setw(5) << left << mP.tdc2 << " "
+      << setw(5) << left << mP.tdc3 << " " << setw(5) << left << mP.tdc4 << " " << setw(10) << right << mP.x << " "
+      << setw(9) << left << mP.tanPhi << " " << setw(5) << left << mP.t0 << " " << setw(13) << left << mP.chi2
+      << " r:" << rango(mP);
+}

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathAnalyticAnalyzer.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathAnalyticAnalyzer.cc
@@ -77,8 +77,7 @@ void MuonPathAnalyticAnalyzer::initialise(const edm::EventSetup &iEventSetup) {
   if (debug_)
     LogDebug("MuonPathAnalyticAnalyzer") << "MuonPathAnalyticAnalyzer::initialiase";
 
-  edm::ESHandle<DTGeometry> geom;
-  iEventSetup.get<MuonGeometryRecord>().get(geometry_tag_, geom);
+  auto geom = iEventSetup.getHandle(dtGeomH);
   dtGeo_ = &(*geom);
 }
 

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathAnalyzerInChamber.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathAnalyzerInChamber.cc
@@ -56,8 +56,8 @@ void MuonPathAnalyzerInChamber::initialise(const edm::EventSetup &iEventSetup) {
   if (debug_)
     LogDebug("MuonPathAnalyzerInChamber") << "MuonPathAnalyzerInChamber::initialiase";
 
-  const MuonGeometryRecord &geom = iEventSetup.get<MuonGeometryRecord>();
-  dtGeo_ = &geom.get(dtGeomH);
+  auto geom = iEventSetup.getHandle(dtGeomH);
+  dtGeo_ = geom.product();
 }
 
 void MuonPathAnalyzerInChamber::run(edm::Event &iEvent,

--- a/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc
+++ b/L1Trigger/DTTriggerPhase2/src/MuonPathAssociator.cc
@@ -58,8 +58,7 @@ void MuonPathAssociator::initialise(const edm::EventSetup &iEventSetup) {
   if (debug_)
     LogDebug("MuonPathAssociator") << "MuonPathAssociator::initialiase";
 
-  edm::ESHandle<DTGeometry> geom;
-  iEventSetup.get<MuonGeometryRecord>().get(geometry_tag_, geom);
+  auto geom = iEventSetup.getHandle(dtGeomH_);
   dtGeo_ = &(*geom);
 }
 

--- a/L1Trigger/DTTriggerPhase2/src/RPCIntegrator.cc
+++ b/L1Trigger/DTTriggerPhase2/src/RPCIntegrator.cc
@@ -36,8 +36,14 @@ void RPCIntegrator::initialise(const edm::EventSetup& iEventSetup, double shift_
     LogDebug("RPCIntegrator") << "Getting RPC geometry";
 
   const MuonGeometryRecord& geom = iEventSetup.get<MuonGeometryRecord>();
-  dtGeo_ = &geom.get(dtGeomH_);
-  rpcGeo_ = &geom.get(rpcGeomH_);
+  if (auto handle = iEventSetup.getHandle(dtGeomH_)) {
+    dtGeo_ = handle.product();
+  }
+
+  if (auto handle = iEventSetup.getHandle(rpcGeomH_)) {
+    rpcGeo_ = handle.product();
+  }
+
   shift_back_ = shift_back_fromDT;
 }
 

--- a/L1Trigger/DTTriggerPhase2/src/RPCIntegrator.cc
+++ b/L1Trigger/DTTriggerPhase2/src/RPCIntegrator.cc
@@ -35,7 +35,6 @@ void RPCIntegrator::initialise(const edm::EventSetup& iEventSetup, double shift_
   if (m_debug_)
     LogDebug("RPCIntegrator") << "Getting RPC geometry";
 
-  const MuonGeometryRecord& geom = iEventSetup.get<MuonGeometryRecord>();
   if (auto handle = iEventSetup.getHandle(dtGeomH_)) {
     dtGeo_ = handle.product();
   }


### PR DESCRIPTION
#### PR description:

This is another  PR to port all L1T Phase-2 developments to cms-sw. This PR targets the DT code. It includes several PRs made locally, the details of which can be found in the twiki https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions and in the cms-l1t-offline branch.