### PR TITLE
introduce SiPhase2BadStrip format for phase-2 simulation

### DIFF
--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="CalibTracker/SiPhase2TrackerESProducers" source_only="1"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiPhase2TrackerObjects"/>
+<use name="CondFormats/SiStripObjects"/>  <!-- needed for the SiStripBadStrip -->
 <use name="DataFormats/SiStripDetId"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2BadStripConfigurableFakeESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2BadStripConfigurableFakeESSource.cc
@@ -1,0 +1,253 @@
+// -*- C++ -*-
+//
+// Package:    CalibTracker/SiPhase2TrackerESProducers
+// Class:      SiPhase2BadStripConfigurableFakeESSource
+//
+/**\class SiPhase2BadStripConfigurableFakeESSource SiPhase2BadStripConfigurableFakeESSource.h CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2BadStripConfigurableFakeESSource.cc
+
+ Description: "fake" SiStripBadStrip ESProducer - configurable list of bad modules
+
+ Implementation:
+     Adapted to Phase-2 from CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
+*/
+
+// system include files
+#include <memory>
+
+// user include files
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+#include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+// neede for the random number generation
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/JamesRandom.h"
+
+class SiPhase2BadStripConfigurableFakeESSource : public edm::ESProducer, public edm::EventSetupRecordIntervalFinder {
+public:
+  SiPhase2BadStripConfigurableFakeESSource(const edm::ParameterSet&);
+  ~SiPhase2BadStripConfigurableFakeESSource() override = default;
+
+  void setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                      const edm::IOVSyncValue& iov,
+                      edm::ValidityInterval& iValidity) override;
+
+  typedef std::unique_ptr<SiStripBadStrip> ReturnType;
+  ReturnType produce(const SiPhase2OuterTrackerBadStripRcd&);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  std::map<unsigned short, unsigned short> clusterizeBadChannels(
+      const std::vector<Phase2TrackerDigi::PackedDigiType>& maskedChannels);
+
+  // configurables
+  bool printDebug_;
+  float badComponentsFraction_;
+
+  // random engine
+  std::unique_ptr<CLHEP::HepRandomEngine> engine_;
+
+  // es tokens
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+};
+
+SiPhase2BadStripConfigurableFakeESSource::SiPhase2BadStripConfigurableFakeESSource(const edm::ParameterSet& iConfig)
+    : engine_(new CLHEP::HepJamesRandom(iConfig.getParameter<unsigned int>("seed"))) {
+  auto cc = setWhatProduced(this);
+  trackTopoToken_ = cc.consumes();
+  geomToken_ = cc.consumes();
+
+  printDebug_ = iConfig.getUntrackedParameter<bool>("printDebug", false);
+  badComponentsFraction_ = iConfig.getParameter<double>("badComponentsFraction");
+
+  if (badComponentsFraction_ > 1. || badComponentsFraction_ < 0.) {
+    throw cms::Exception("Inconsistent configuration")
+        << "[SiPhase2BadStripChannelBuilder::c'tor] the requested fraction of bad components is unphysical. \n";
+  }
+
+  findingRecord<SiPhase2OuterTrackerBadStripRcd>();
+}
+
+void SiPhase2BadStripConfigurableFakeESSource::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+                                                              const edm::IOVSyncValue& iov,
+                                                              edm::ValidityInterval& iValidity) {
+  iValidity = edm::ValidityInterval{iov.beginOfTime(), iov.endOfTime()};
+}
+
+// ------------ method called to produce the data  ------------
+SiPhase2BadStripConfigurableFakeESSource::ReturnType SiPhase2BadStripConfigurableFakeESSource::produce(
+    const SiPhase2OuterTrackerBadStripRcd& iRecord) {
+  using namespace edm::es;
+  using Phase2TrackerGeomDetUnit = PixelGeomDetUnit;
+
+  //TrackerTopology const& tTopo = iRecord.get(trackTopoToken_);
+  TrackerGeometry const& tGeom = iRecord.get(geomToken_);
+
+  auto badStrips = std::make_unique<SiStripBadStrip>();
+
+  // early return with nullptr if fraction is == 0.f
+  if (badComponentsFraction_ == 0.f) {
+    return badStrips;
+  }
+
+  LogDebug("SiPhase2BadStripConfigurableFakeESSource")
+      << " There are " << tGeom.detUnits().size() << " modules in this geometry.";
+
+  int counter{0};
+  for (auto const& det_u : tGeom.detUnits()) {
+    const DetId detid = det_u->geographicalId();
+    uint32_t rawId = detid.rawId();
+    int subid = detid.subdetId();
+    if (detid.det() == DetId::Detector::Tracker) {
+      const Phase2TrackerGeomDetUnit* pixdet = dynamic_cast<const Phase2TrackerGeomDetUnit*>(det_u);
+      assert(pixdet);
+      if (subid == StripSubdetector::TOB || subid == StripSubdetector::TID) {
+        if (tGeom.getDetectorType(rawId) == TrackerGeometry::ModuleType::Ph2PSS ||
+            tGeom.getDetectorType(rawId) == TrackerGeometry::ModuleType::Ph2SS) {
+          const PixelTopology& topol(pixdet->specificTopology());
+
+          const int nrows = topol.nrows();
+          const int ncols = topol.ncolumns();
+
+          LogDebug("SiPhase2BadStripConfigurableFakeESSource")
+              << "DetId: " << rawId << " subdet: " << subid << " nrows: " << nrows << " ncols: " << ncols;
+
+          // auxilliary vector to check if the channels were already used
+          std::vector<Phase2TrackerDigi::PackedDigiType> usedChannels;
+
+          size_t nmaxBadStrips = std::floor(nrows * ncols * badComponentsFraction_);
+
+          while (usedChannels.size() < nmaxBadStrips) {
+            unsigned short badStripRow = std::floor(CLHEP::RandFlat::shoot(engine_.get(), 0, nrows));
+            unsigned short badStripCol = std::floor(CLHEP::RandFlat::shoot(engine_.get(), 0, ncols));
+            const auto& badChannel = Phase2TrackerDigi::pixelToChannel(badStripRow, badStripCol);
+            if (std::find(usedChannels.begin(), usedChannels.end(), badChannel) == usedChannels.end()) {
+              usedChannels.push_back(badChannel);
+            }
+          }
+
+          //usedChannels.push_back(Phase2TrackerDigi::pixelToChannel(0,1)); // useful for testing
+
+          const auto badChannelsGroups = this->clusterizeBadChannels(usedChannels);
+
+          LogDebug("SiPhase2BadStripConfigurableFakeESSource")
+              << rawId << " (" << counter << ") "
+              << " masking " << nmaxBadStrips << " strips, used channels size: " << usedChannels.size()
+              << ", clusters size: " << badChannelsGroups.size();
+
+          std::vector<unsigned int> theSiStripVector;
+
+          // loop over the groups of bad strips
+          for (const auto& [first, consec] : badChannelsGroups) {
+            unsigned int theBadChannelsRange;
+            theBadChannelsRange = badStrips->encodePhase2(first, consec);
+
+            if (printDebug_) {
+              edm::LogInfo("SiPhase2BadStripConfigurableFakeESSource")
+                  << "detid " << rawId << " \t"
+                  << " firstBadStrip " << first << "\t "
+                  << " NconsecutiveBadStrips " << consec << "\t "
+                  << " packed integer " << std::hex << theBadChannelsRange << std::dec;
+            }
+            theSiStripVector.push_back(theBadChannelsRange);
+          }
+
+          SiStripBadStrip::Range range(theSiStripVector.begin(), theSiStripVector.end());
+          if (!badStrips->put(rawId, range))
+            edm::LogError("SiPhase2BadStripConfigurableFakeESSource")
+                << "[SiPhase2BadStripConfigurableFakeESSource::produce] detid already exists";
+
+          counter++;
+
+        }  // if it's a strip module
+      }    // if it's OT
+    }      // if it's Tracker
+  }        // loop on DetIds
+
+  LogDebug("SiPhase2BadStripConfigurableFakeESSource") << "end of the detId loops";
+
+  return badStrips;
+}
+
+// poor-man clusterizing algorithm
+std::map<unsigned short, unsigned short> SiPhase2BadStripConfigurableFakeESSource::clusterizeBadChannels(
+    const std::vector<Phase2TrackerDigi::PackedDigiType>& maskedChannels) {
+  // Here we will store the result
+  std::map<unsigned short, unsigned short> result{};
+  std::map<int, std::string> printresult{};
+
+  // Sort and remove duplicates.
+  std::set data(maskedChannels.begin(), maskedChannels.end());
+
+  // We will start the evaluation at the beginning of our data
+  auto startOfSequence = data.begin();
+
+  // Find all sequences
+  while (startOfSequence != data.end()) {
+    // Find first value that is not greater than one
+    auto endOfSequence =
+        std::adjacent_find(startOfSequence, data.end(), [](const auto& v1, const auto& v2) { return v2 != v1 + 1; });
+    if (endOfSequence != data.end())
+      std::advance(endOfSequence, 1);
+
+    auto consecutiveStrips = std::distance(startOfSequence, endOfSequence);
+    result[*startOfSequence] = consecutiveStrips;
+
+    if (printDebug_) {
+      // Build resulting string
+      std::ostringstream oss{};
+      bool writeDash = false;
+      for (auto it = startOfSequence; it != endOfSequence; ++it) {
+        oss << (writeDash ? "-" : "") << std::to_string(*it);
+        writeDash = true;
+      }
+
+      // Copy result to map
+      for (auto it = startOfSequence; it != endOfSequence; ++it)
+        printresult[*it] = oss.str();
+    }
+
+    // Continue to search for the next sequence
+    startOfSequence = endOfSequence;
+  }
+
+  if (printDebug_) {
+    // Show result on the screen. Or use the map in whichever way you want.
+    for (const auto& [value, text] : printresult)
+      LogDebug("SiPhase2BadStripConfigurableFakeESSource")
+          << std::left << std::setw(2) << value << " -> " << text << "\n";
+  }
+  return result;
+}
+
+void SiPhase2BadStripConfigurableFakeESSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Configurable Fake Phase-2 Outer Tracker Bad Strip ESSource");
+  desc.add<unsigned int>("seed", 1)->setComment("random seed");
+  desc.addUntracked<bool>("printDebug", false)->setComment("maximum amount of print-outs");
+  desc.add<double>("badComponentsFraction", 0.01)->setComment("fraction of bad components to populate the ES");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+#include "FWCore/Framework/interface/SourceFactory.h"
+DEFINE_FWK_EVENTSETUP_SOURCE(SiPhase2BadStripConfigurableFakeESSource);

--- a/CondCore/SiPhase2TrackerPlugins/BuildFile.xml
+++ b/CondCore/SiPhase2TrackerPlugins/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="CondCore/ESSources"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiPhase2TrackerObjects"/>
+<use name="CondFormats/SiStripObjects"/>
 <use name="rootrflx"/>
 <flags EDM_PLUGIN="1"/>

--- a/CondCore/SiPhase2TrackerPlugins/src/plugin.cc
+++ b/CondCore/SiPhase2TrackerPlugins/src/plugin.cc
@@ -1,6 +1,7 @@
 #include "CondCore/ESSources/interface/registration_macros.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
 
 #include "CondFormats/DataRecord/interface/TrackerDetToDTCELinkCablingMapRcd.h"
 #include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
@@ -8,3 +9,4 @@
 REGISTER_PLUGIN(TrackerDetToDTCELinkCablingMapRcd, TrackerDetToDTCELinkCablingMap);
 REGISTER_PLUGIN(SiPhase2OuterTrackerLorentzAngleRcd, SiPhase2OuterTrackerLorentzAngle);
 REGISTER_PLUGIN(SiPhase2OuterTrackerLorentzAngleSimRcd, SiPhase2OuterTrackerLorentzAngle);
+REGISTER_PLUGIN(SiPhase2OuterTrackerBadStripRcd, SiStripBadStrip);

--- a/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
+++ b/CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "FWCore/Utilities/interface/mplVector.h"
 
 /*Record associated to SiPhase2OuterTrackerLorentzAngle Object: the SimRcd is used in simulation only*/
@@ -12,4 +13,8 @@ class SiPhase2OuterTrackerLorentzAngleRcd
 class SiPhase2OuterTrackerLorentzAngleSimRcd
     : public edm::eventsetup::DependentRecordImplementation<SiPhase2OuterTrackerLorentzAngleSimRcd,
                                                             edm::mpl::Vector<TrackerTopologyRcd> > {};
+/*Record associated to SiStripBadStrip Object:*/
+class SiPhase2OuterTrackerBadStripRcd : public edm::eventsetup::DependentRecordImplementation<
+                                            SiPhase2OuterTrackerBadStripRcd,
+                                            edm::mpl::Vector<TrackerTopologyRcd, TrackerDigiGeometryRecord> > {};
 #endif

--- a/CondFormats/DataRecord/src/SiPhase2OuterTrackerCondDataRecords.cc
+++ b/CondFormats/DataRecord/src/SiPhase2OuterTrackerCondDataRecords.cc
@@ -3,3 +3,4 @@
 
 EVENTSETUP_RECORD_REG(SiPhase2OuterTrackerLorentzAngleRcd);
 EVENTSETUP_RECORD_REG(SiPhase2OuterTrackerLorentzAngleSimRcd);
+EVENTSETUP_RECORD_REG(SiPhase2OuterTrackerBadStripRcd);

--- a/CondFormats/SiStripObjects/interface/SiStripBadStrip.h
+++ b/CondFormats/SiStripObjects/interface/SiStripBadStrip.h
@@ -91,6 +91,23 @@ public:
            ((flag & sistrip::FlagBadStripMask_) << sistrip::FlagBadStripShift_);
   }
 
+  // additional methods need for Phase-2
+  inline data decodePhase2(const unsigned int& value) const {
+    data a;
+    a.firstStrip = ((value >> siPhase2strip::FirstBadStripShift_) & siPhase2strip::FirstBadStripMask_);
+    a.range = ((value >> siPhase2strip::RangeBadStripShift_) & siPhase2strip::RangeBadStripMask_);
+    a.flag = ((value >> siPhase2strip::FlagBadStripShift_) & siPhase2strip::FlagBadStripMask_);
+    return a;
+  }
+
+  inline unsigned int encodePhase2(const unsigned short& first,
+                                   const unsigned short& NconsecutiveBadStrips,
+                                   const unsigned short& flag = 0) {
+    return ((first & siPhase2strip::FirstBadStripMask_) << siPhase2strip::FirstBadStripShift_) |
+           ((NconsecutiveBadStrips & siPhase2strip::RangeBadStripMask_) << siPhase2strip::RangeBadStripShift_) |
+           ((flag & siPhase2strip::FlagBadStripMask_) << siPhase2strip::FlagBadStripShift_);
+  }
+
 protected:
   Container v_badstrips;
   Registry indexes;

--- a/CondFormats/SiStripObjects/test/BuildFile.xml
+++ b/CondFormats/SiStripObjects/test/BuildFile.xml
@@ -8,3 +8,8 @@
 
 <bin file="testSerializationSiStripObjects.cpp">
 </bin>
+
+<bin file="test_catch2_*.cpp" name="test_catch2_SiStripBadStrip_Phase2">
+  <use name="DataFormats/SiStripCommon"/>
+  <use name="catch2"/>
+</bin>

--- a/CondFormats/SiStripObjects/test/test_catch2_SiStripBadStripForPhase2.cpp
+++ b/CondFormats/SiStripObjects/test/test_catch2_SiStripBadStripForPhase2.cpp
@@ -1,0 +1,32 @@
+#include "catch.hpp"
+#include <iostream>
+#include <iomanip>  // std::setw
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+
+TEST_CASE("SiStripBadStrip testing", "[SiStripBadStrip]") {
+  //_____________________________________________________________
+  SECTION("Check barrel plotting") {
+    SiStripBadStrip testObject;
+
+    static constexpr unsigned short maxStrips = 0x7FF;
+
+    int counter{0};
+    for (unsigned short fs = 0; fs <= maxStrips; fs++) {
+      for (unsigned short rng = 0; rng <= maxStrips; rng++) {
+        auto encoded = testObject.encodePhase2(fs, rng);
+        auto decoded = testObject.decodePhase2(encoded);
+
+        if (counter < 10) {
+          std::cout << "input: (" << fs << "," << rng << ") | encoded:" << std::setw(10) << encoded << "| decoded : ("
+                    << decoded.firstStrip << "," << decoded.range << ")" << std::endl;
+        }
+
+        assert(decoded.firstStrip == fs);
+        assert(decoded.range == rng);
+
+        counter++;
+      }
+    }
+    REQUIRE(true);
+  }
+}

--- a/CondFormats/SiStripObjects/test/test_catch2_main.cpp
+++ b/CondFormats/SiStripObjects/test/test_catch2_main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
+#include "catch.hpp"

--- a/CondTools/SiPhase2Tracker/plugins/BuildFile.xml
+++ b/CondTools/SiPhase2Tracker/plugins/BuildFile.xml
@@ -6,5 +6,6 @@
 <use name="CondFormats/Common"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiPhase2TrackerObjects"/>
+<use name="CondFormats/SiStripObjects"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <flags EDM_PLUGIN="1"/>

--- a/CondTools/SiPhase2Tracker/plugins/SiPhase2BadStripChannelBuilder.cc
+++ b/CondTools/SiPhase2Tracker/plugins/SiPhase2BadStripChannelBuilder.cc
@@ -1,0 +1,295 @@
+// system include files
+#include <vector>
+#include <memory>
+#include <iostream>
+#include <fstream>
+
+// user include files
+#include "CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandGauss.h"
+
+/** 
+ * enum to decide which algorithm use to populate the conditions
+ */
+namespace {
+  enum badChannelAlgo { NAIVE = 1, RANDOM = 2, NONE = 99 };
+}
+
+class SiPhase2BadStripChannelBuilder : public ConditionDBWriter<SiStripBadStrip> {
+public:
+  explicit SiPhase2BadStripChannelBuilder(const edm::ParameterSet&);
+  ~SiPhase2BadStripChannelBuilder() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  std::unique_ptr<SiStripBadStrip> getNewObject() override;
+
+  void algoBeginRun(const edm::Run& run, const edm::EventSetup& es) override {
+    if (!tTopo_) {
+      tTopo_ = std::make_unique<TrackerTopology>(es.getData(topoToken_));
+      tGeom_ = std::make_unique<TrackerGeometry>(es.getData(geomToken_));
+    }
+  };
+
+  void algoAnalyze(const edm::Event& event, const edm::EventSetup& es) override {
+    edm::Service<edm::RandomNumberGenerator> rng;
+    if (!engine_) {
+      engine_ = &rng->getEngine(event.streamID());
+    }
+  }
+
+  std::map<unsigned short, unsigned short> clusterizeBadChannels(
+      const std::vector<Phase2TrackerDigi::PackedDigiType>& maskedChannels);
+
+  // ----------member data ---------------------------
+  std::unique_ptr<TrackerTopology> tTopo_;
+  std::unique_ptr<TrackerGeometry> tGeom_;
+  CLHEP::HepRandomEngine* engine_;
+
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const bool printdebug_;
+  const unsigned int popConAlgo_;
+  const float badComponentsFraction_;
+  badChannelAlgo theBCAlgo_;
+};
+
+//__________________________________________________________________________________________________
+SiPhase2BadStripChannelBuilder::SiPhase2BadStripChannelBuilder(const edm::ParameterSet& iConfig)
+    : ConditionDBWriter<SiStripBadStrip>(iConfig),
+      topoToken_(esConsumes<edm::Transition::BeginRun>()),
+      geomToken_(esConsumes<edm::Transition::BeginRun>()),
+      printdebug_(iConfig.getUntrackedParameter<bool>("printDebug", false)),
+      popConAlgo_(iConfig.getParameter<unsigned int>("popConAlgo")),
+      badComponentsFraction_(iConfig.getParameter<double>("badComponentsFraction")) {
+  if (badComponentsFraction_ > 1. || badComponentsFraction_ < 0.) {
+    throw cms::Exception("Inconsistent configuration")
+        << "[SiPhase2BadStripChannelBuilder::c'tor] the requested fraction of bad components is unphysical. \n";
+  }
+  theBCAlgo_ = static_cast<badChannelAlgo>(popConAlgo_);
+}
+
+//__________________________________________________________________________________________________
+std::unique_ptr<SiStripBadStrip> SiPhase2BadStripChannelBuilder::getNewObject() {
+  using Phase2TrackerGeomDetUnit = PixelGeomDetUnit;
+  edm::LogInfo("SiPhase2BadStripChannelBuilder") << "... creating dummy SiStripBadStrip Data" << std::endl;
+
+  auto obj = std::make_unique<SiStripBadStrip>();
+
+  // early return with nullptr if fraction is ==0.
+  if (badComponentsFraction_ > 0.) {
+    ;
+  } else {
+    return obj;
+  }
+
+  edm::LogInfo("SiPhase2BadStripChannelBuilder")
+      << " There are " << tGeom_->detUnits().size() << " modules in this geometry." << std::endl;
+
+  for (auto const& det_u : tGeom_->detUnits()) {
+    const DetId detid = det_u->geographicalId();
+    uint32_t rawId = detid.rawId();
+    int subid = detid.subdetId();
+    if (detid.det() == DetId::Detector::Tracker) {
+      const Phase2TrackerGeomDetUnit* pixdet = dynamic_cast<const Phase2TrackerGeomDetUnit*>(det_u);
+      assert(pixdet);
+      LogDebug("SiPhase2BadStripChannelBuilder") << rawId << " is a " << subid << " det" << std::endl;
+      if (subid == StripSubdetector::TOB || subid == StripSubdetector::TID) {
+        if (tGeom_->getDetectorType(rawId) == TrackerGeometry::ModuleType::Ph2PSS ||
+            tGeom_->getDetectorType(rawId) == TrackerGeometry::ModuleType::Ph2SS) {
+          const PixelTopology& topol(pixdet->specificTopology());
+
+          const int nrows = topol.nrows();
+          const int ncols = topol.ncolumns();
+
+          LogDebug("SiPhase2BadStripChannelBuilder")
+              << "DetId: " << rawId << " subdet: " << subid << " nrows: " << nrows << " ncols: " << ncols << std::endl;
+
+          std::vector<unsigned int> theSiStripVector;
+
+          switch (theBCAlgo_) {
+            case NAIVE: {
+              LogDebug("SiPhase2BadStripChannelBuilder") << "using the NAIVE algorithm" << std::endl;
+
+              unsigned short firstBadStrip = std::floor(CLHEP::RandFlat::shoot(engine_, 0, nrows));
+              unsigned short NconsecutiveBadStrips = std::floor(CLHEP::RandFlat::shoot(engine_, 1, 10));
+
+              // if the interval exceeds the end of the module
+              if (firstBadStrip + NconsecutiveBadStrips > nrows) {
+                NconsecutiveBadStrips = nrows - firstBadStrip;
+              }
+
+              unsigned int theBadStripRange;
+              theBadStripRange = obj->encodePhase2(firstBadStrip, NconsecutiveBadStrips);
+
+              if (printdebug_)
+                edm::LogInfo("SiPhase2BadStripChannelBuilder")
+                    << "detid " << rawId << " \t"
+                    << " firstBadStrip " << firstBadStrip << "\t "
+                    << " NconsecutiveBadStrips " << NconsecutiveBadStrips << "\t "
+                    << " packed integer " << std::hex << theBadStripRange << std::dec << std::endl;
+
+              theSiStripVector.push_back(theBadStripRange);
+              break;
+            }
+            case RANDOM: {
+              LogDebug("SiPhase2BadStripChannelBuilder") << "using the RANDOM algorithm" << std::endl;
+
+              // auxilliary vector to check if the channels were already used
+              std::vector<Phase2TrackerDigi::PackedDigiType> usedChannels;
+
+              size_t nmaxBadStrips = std::floor(nrows * ncols * badComponentsFraction_);
+
+              LogDebug("SiPhase2BadStripChannelBuilder")
+                  << __FUNCTION__ << " " << __LINE__ << " will mask: " << nmaxBadStrips << " strips" << std::endl;
+
+              while (usedChannels.size() < nmaxBadStrips) {
+                unsigned short badStripRow = std::floor(CLHEP::RandFlat::shoot(engine_, 0, nrows));
+                unsigned short badStripCol = std::floor(CLHEP::RandFlat::shoot(engine_, 0, ncols));
+                const auto& badChannel = Phase2TrackerDigi::pixelToChannel(badStripRow, badStripCol);
+
+                LogDebug("SiPhase2BadStripChannelBuilder")
+                    << __FUNCTION__ << " " << __LINE__ << ": masking channel " << badChannel << " (" << badStripRow
+                    << "," << badStripCol << ")" << std::endl;
+
+                if (std::find(usedChannels.begin(), usedChannels.end(), badChannel) == usedChannels.end()) {
+                  usedChannels.push_back(badChannel);
+                }
+              }
+
+              const auto badChannelsGroups = this->clusterizeBadChannels(usedChannels);
+              // loop over the groups of bad strips
+              for (const auto& [first, consec] : badChannelsGroups) {
+                unsigned int theBadChannelsRange;
+                theBadChannelsRange = obj->encodePhase2(first, consec);
+
+                if (printdebug_) {
+                  edm::LogInfo("SiPhase2BadStripChannelBuilder")
+                      << "detid " << rawId << " \t"
+                      << " firstBadStrip " << first << "\t "
+                      << " NconsecutiveBadStrips " << consec << "\t "
+                      << " packed integer " << std::hex << theBadChannelsRange << std::dec << std::endl;
+                }
+                theSiStripVector.push_back(theBadChannelsRange);
+              }
+              break;
+            }
+            case NONE:
+              [[fallthrough]];
+            default:
+              throw cms::Exception("Inconsistent configuration") << "Did not specifiy the right algorithm to be run";
+          }
+
+          SiStripBadStrip::Range range(theSiStripVector.begin(), theSiStripVector.end());
+          if (!obj->put(rawId, range))
+            edm::LogError("SiPhase2BadStripChannelBuilder")
+                << "[SiPhase2BadStripChannelBuilder::getNewObject] detid already exists" << std::endl;
+
+        }  // if it's a Strip module
+      }    // if it's OT
+    }      // if it's Tracker
+  }        // loop of geomdets
+
+  //End now write sistripbadChannel data in DB
+  edm::Service<cond::service::PoolDBOutputService> mydbservice;
+
+  if (mydbservice.isAvailable()) {
+    if (mydbservice->isNewTagRequest("SiStripBadStripRcd")) {
+      mydbservice->createOneIOV<SiStripBadStrip>(*obj, mydbservice->beginOfTime(), "SiStripBadStripRcd");
+    } else {
+      mydbservice->appendOneIOV<SiStripBadStrip>(*obj, mydbservice->currentTime(), "SiStripBadStripRcd");
+    }
+  } else {
+    edm::LogError("SiPhase2BadStripChannelBuilder") << "Service is unavailable" << std::endl;
+  }
+
+  tGeom_.release();
+  return obj;
+}
+
+// poor-man clusterizing algorithm
+std::map<unsigned short, unsigned short> SiPhase2BadStripChannelBuilder::clusterizeBadChannels(
+    const std::vector<Phase2TrackerDigi::PackedDigiType>& maskedChannels) {
+  // Here we will store the result
+  std::map<unsigned short, unsigned short> result{};
+  std::map<int, std::string> printresult{};
+
+  // Sort and remove duplicates.
+  std::set data(maskedChannels.begin(), maskedChannels.end());
+
+  // We will start the evaluation at the beginning of our data
+  auto startOfSequence = data.begin();
+
+  // Find all sequences
+  while (startOfSequence != data.end()) {
+    // FInd first value that is not greate than one
+    auto endOfSequence =
+        std::adjacent_find(startOfSequence, data.end(), [](const auto& v1, const auto& v2) { return v2 != v1 + 1; });
+    if (endOfSequence != data.end())
+      std::advance(endOfSequence, 1);
+
+    auto consecutiveStrips = std::distance(startOfSequence, endOfSequence);
+    result[*startOfSequence] = consecutiveStrips;
+
+    if (printdebug_) {
+      // Build resulting string
+      std::ostringstream oss{};
+      bool writeDash = false;
+      for (auto it = startOfSequence; it != endOfSequence; ++it) {
+        oss << (writeDash ? "-" : "") << std::to_string(*it);
+        writeDash = true;
+      }
+
+      // Copy result to map
+      for (auto it = startOfSequence; it != endOfSequence; ++it)
+        printresult[*it] = oss.str();
+    }
+
+    // Continue to search for the next sequence
+    startOfSequence = endOfSequence;
+  }
+
+  if (printdebug_) {
+    // Show result on the screen. Or use the map in whichever way you want.
+    for (const auto& [value, text] : printresult)
+      edm::LogInfo("SiPhase2BadStripChannelBuilder") << std::left << std::setw(2) << value << " -> " << text << "\n";
+  }
+
+  return result;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void SiPhase2BadStripChannelBuilder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Module to build SiStripBadStrip Payloads for the Phase-2 Outer Tracker");
+  ConditionDBWriter::fillPSetDescription(desc);  // inherited from mother class
+  desc.addUntracked<bool>("printDebug", false)->setComment("maximum amount of print-outs");
+  desc.add<unsigned int>("popConAlgo", 1)->setComment("algorithm to populate the payload: 1=NAIVE,2=RANDOM");
+  desc.add<double>("badComponentsFraction", 0.01)->setComment("fraction of bad components to populate the payload");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(SiPhase2BadStripChannelBuilder);

--- a/CondTools/SiPhase2Tracker/plugins/SiPhase2BadStripChannelReader.cc
+++ b/CondTools/SiPhase2Tracker/plugins/SiPhase2BadStripChannelReader.cc
@@ -1,0 +1,94 @@
+// user include files
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+#include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+//
+//
+// class decleration
+//
+class SiPhase2BadStripChannelReader : public edm::global::EDAnalyzer<> {
+public:
+  explicit SiPhase2BadStripChannelReader(const edm::ParameterSet&);
+  ~SiPhase2BadStripChannelReader() override = default;
+  void analyze(edm::StreamID, edm::Event const&, edm::EventSetup const&) const override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  const bool printverbose_;
+  const int printdebug_;
+  const std::string label_;
+  const edm::ESGetToken<SiStripBadStrip, SiPhase2OuterTrackerBadStripRcd> badStripToken_;
+};
+
+SiPhase2BadStripChannelReader::SiPhase2BadStripChannelReader(const edm::ParameterSet& iConfig)
+    : printverbose_(iConfig.getUntrackedParameter<bool>("printVerbose", false)),
+      printdebug_(iConfig.getUntrackedParameter<int>("printDebug", 1)),
+      label_(iConfig.getUntrackedParameter<std::string>("label", "")),
+      badStripToken_(esConsumes(edm::ESInputTag{"", label_})) {}
+
+void SiPhase2BadStripChannelReader::analyze(edm::StreamID,
+                                            edm::Event const& iEvent,
+                                            edm::EventSetup const& iSetup) const {
+  const auto& payload = &iSetup.getData(badStripToken_);
+
+  edm::LogInfo("SiPhase2BadStripChannelReader")
+      << "[SiPhase2BadStripChannelReader::analyze] End Reading SiStriBadStrip with label " << label_ << std::endl;
+
+  const TrackerTopology* ttopo = nullptr;
+
+  std::stringstream ss;
+  if (printverbose_) {
+    payload->printDebug(ss, ttopo);
+  }
+
+  std::vector<uint32_t> detIds;
+  payload->getDetIds(detIds);
+
+  int countMessages{0};
+  for (const auto& d : detIds) {
+    SiStripBadStrip::Range range = payload->getRange(d);
+    for (std::vector<unsigned int>::const_iterator badChannel = range.first; badChannel != range.second; ++badChannel) {
+      const auto& firstStrip = payload->decodePhase2(*badChannel).firstStrip;
+      const auto& range = payload->decodePhase2(*badChannel).range;
+
+      if (printverbose_) {
+        ss << "DetId= " << d << " Channel=" << payload->decodePhase2(*badChannel).firstStrip << ":"
+           << payload->decodePhase2(*badChannel).range << std::endl;
+      }
+
+      if (countMessages < printdebug_) {
+        for (unsigned int index = 0; index < range; index++) {
+          std::pair<int, int> badStrip = Phase2TrackerDigi::channelToPixel(firstStrip + index);
+          ss << "DetId= " << d << " Channel= " << firstStrip + index << " -> strip (row,col)=(" << badStrip.first << ","
+             << badStrip.second << ")" << std::endl;
+        }
+      }  // if doesn't exceed the maximum printout level
+    }    // loop over the range
+    countMessages++;
+  }  // loop over the detids
+
+  edm::LogInfo("SiPhase2BadStripChannelReader") << ss.str() << std::endl;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void SiPhase2BadStripChannelReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Module to read SiStripBadStrip Payloads through SiPhase2OuterTrackerBadStripRcd");
+  desc.addUntracked<bool>("printVerbose", false)->setComment("if active, very verbose output");
+  desc.addUntracked<int>("printDebug", 1)->setComment("tunes the amount of debug level print-outs");
+  desc.addUntracked<std::string>("label", "")->setComment("label from which to read the payload");
+  descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SiPhase2BadStripChannelReader);

--- a/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelBuilder_cfg.py
@@ -1,0 +1,65 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ICALIB")
+
+process.load("Configuration.StandardSequences.Services_cff")
+process.RandomNumberGeneratorService.prod = cms.PSet(
+    initialSeed = cms.untracked.uint32(789341),
+    engineName = cms.untracked.string('TRandom3')
+)
+
+## speciffy detector D49, as the geometry is needed (will take tracker T15)
+process.load("Configuration.Geometry.GeometryExtended2026D49_cff")
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
+
+process.source = cms.Source("EmptyIOVSource",
+    lastValue = cms.uint64(1),
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+    DBParameters = cms.PSet(
+        authenticationPath = cms.untracked.string('')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:SiStripBadStripPhase2_T15_v0.db'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiStripBadStripRcd'),
+        tag = cms.string('SiStripBadStripPhase2_T15')
+    ))
+)
+
+process.prod = cms.EDAnalyzer("SiPhase2BadStripChannelBuilder",                    
+                              Record = cms.string('SiStripBadStripRcd'),
+                              SinceAppendMode = cms.bool(True),
+                              IOVMode = cms.string('Run'),
+                              printDebug = cms.untracked.bool(False),
+                              doStoreOnDB = cms.bool(True),
+                              #popConAlgo = cms.uint32(1), #NAIVE
+                              popConAlgo = cms.uint32(2), #RANDOM
+                              badComponentsFraction = cms.double(0.01)  #1% of bad strips
+                              #badComponentsFraction = cms.double(0.05)  #5% of bad strips
+                              #badComponentsFraction = cms.double(0.1)   #10% of bad strips
+                              )
+
+#process.print = cms.OutputModule("AsciiOutputModule")
+
+process.p = cms.Path(process.prod)
+#process.ep = cms.EndPath(process.print)

--- a/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelReader_cfg.py
+++ b/CondTools/SiPhase2Tracker/test/SiPhase2BadStripChannelReader_cfg.py
@@ -1,0 +1,96 @@
+#! /usr/bin/env cmsRun
+# Author: Marco Musich (Feb 2022)
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("TEST")
+options = VarParsing.VarParsing('analysis')
+options.register('fromESSource',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Populate SiPhase2OuterTrackerBadStripRcd from the ESSource")
+options.parseArguments()
+
+###################################################################
+# Messages
+###################################################################
+process.load('FWCore.MessageService.MessageLogger_cfi')   
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.SiPhase2BadStripChannelReader=dict()  
+process.MessageLogger.SiStripBadStrip=dict()
+process.MessageLogger.SiPhase2BadStripConfigurableFakeESSource=dict()
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable    = cms.untracked.bool(True),
+    enableStatistics = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiPhase2BadStripChannelReader = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    SiStripBadStrip = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    SiPhase2BadStripConfigurableFakeESSource = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+)
+
+###################################################################
+# A data source must always be defined.
+# We don't need it, so here's a dummy one.
+###################################################################
+process.source = cms.Source("EmptyIOVSource",
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    lastValue = cms.uint64(1),
+    interval = cms.uint64(1)
+)
+
+###################################################################
+# Input data
+###################################################################
+if(options.fromESSource): 
+    process.load("Configuration.Geometry.GeometryExtended2026D49_cff")
+    process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+    #process.load("SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff") # already included
+    #process.SiPhase2OTFakeBadStripsESSource.printDebug = cms.untracked.bool(True)    # this makes it verbose 
+    process.SiPhase2OTFakeBadStripsESSource.badComponentsFraction = cms.double(0.05)   # bad components fraction is 5%
+else:
+    tag = 'SiStripBadStripPhase2_T15'
+    suffix = 'v0'
+    inFile = tag+'_'+suffix+'.db'
+    inDB = 'sqlite_file:'+inFile
+    
+    process.load("CondCore.CondDB.CondDB_cfi")
+    # input database (in this case the local sqlite file)
+    process.CondDB.connect = inDB
+    
+    process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+                                          process.CondDB,
+                                          DumpStat=cms.untracked.bool(True),
+                                          toGet = cms.VPSet(cms.PSet(#record = cms.string("SiStripBadStripRcd"),
+                                                                     record = cms.string("SiPhase2OuterTrackerBadStripRcd"),
+                                                                     tag = cms.string(tag))))
+    
+###################################################################
+# check the ES data getter
+###################################################################
+process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
+    toGet = cms.VPSet(cms.PSet(
+        #record = cms.string('SiStripBadStripRcd'),
+        record = cms.string('SiPhase2OuterTrackerBadStripRcd'),
+        data = cms.vstring('SiStripBadStrip')
+    )),
+    verbose = cms.untracked.bool(True)
+)
+
+###################################################################
+# Payload reader
+###################################################################
+import CondTools.SiPhase2Tracker.siPhase2BadStripChannelReader_cfi as _mod
+process.BadStripPayloadReader = _mod.siPhase2BadStripChannelReader.clone(printDebug = 1,
+                                                                         printVerbose = False,
+                                                                         label = "")
+
+###################################################################
+# Path
+###################################################################
+process.p = cms.Path(process.get+process.BadStripPayloadReader)

--- a/CondTools/SiPhase2Tracker/test/test_CondToolsSiPhase2Tracker.sh
+++ b/CondTools/SiPhase2Tracker/test/test_CondToolsSiPhase2Tracker.sh
@@ -2,10 +2,16 @@
 TEST_DIR=$CMSSW_BASE/src/CondTools/SiPhase2Tracker/test
 echo "test dir: $TEST_DIR"
 
-printf "testing writing Phase2 Lorentz Angle \n\n"
+printf "testing writing Phase2 Outer Tracker Lorentz Angle \n\n"
 ## need to be in order (don't read before writing)
 cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleWriter_cfg.py
 cmsRun ${TEST_DIR}/SiPhase2OuterTrackerLorentzAngleReader_cfg.py
+
+printf "testing writing Phase2 Outer Tracker Bad Strips \n\n"
+## need to be in order (don't read before writing)
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelBuilder_cfg.py
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py
+cmsRun ${TEST_DIR}/SiPhase2BadStripChannelReader_cfg.py fromESSource=True
 
 printf "testing writing Phase2 Tracker Cabling Map (test) \n\n"
 ## need to be in order (don't read before writing)

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D49_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D49_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D49.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D60_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D60_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D60.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D68_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D68_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D68.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D70_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D70_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D70.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D76_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D76_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D76.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D77_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D77_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D77.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D78_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D78_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D78.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D79_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D79_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D79.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D80_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D80_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D80.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D81_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D81_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D81.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D82_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D82_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D82.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D83_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D83_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D83.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D84_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D84_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D84.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D85_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D85_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D85.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D86_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D86_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D86.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D87_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D87_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D87.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D88_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D88_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D88.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D89_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D89_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D89.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D90_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D90_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D90.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D91_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D91_cff.py
@@ -7,6 +7,7 @@ from Configuration.Geometry.GeometryDD4hep_cff import *
 DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D91.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D49_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D49_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D49XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D53_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D53_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D53XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D60_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D60_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D68_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D68_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D68XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D70_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D70_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D70XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D76_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D76_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D76XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D77_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D77_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D77XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D78_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D78_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D78XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D79_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D79_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D79XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D80_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D80_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D80XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D81_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D81_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D81XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D82_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D82_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D82XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D83_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D83_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D83XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D84_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D84_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D84XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D85_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D85_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D85XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D86_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D86_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D86XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D87_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D87_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D87XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D88_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D88_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D88XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D89_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D89_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D89XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D90_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D90_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D90XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D91_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D91_cff.py
@@ -5,6 +5,7 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D91XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalV15ParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -196,6 +196,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -232,6 +233,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -268,6 +270,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -303,6 +306,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -339,6 +343,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -374,6 +379,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -409,6 +415,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -444,6 +451,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -479,6 +487,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -514,6 +523,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -549,6 +559,7 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',

--- a/DataFormats/SiStripCommon/interface/ConstantsForCondObjects.h
+++ b/DataFormats/SiStripCommon/interface/ConstantsForCondObjects.h
@@ -21,4 +21,14 @@ namespace sistrip {
   static const uint32_t LowThStripShift_ = 0;
 }  // namespace sistrip
 
+namespace siPhase2strip {
+  static const uint32_t FirstBadStripMask_ = 0x7FF;
+  static const uint32_t RangeBadStripMask_ = 0x7FF;
+  static const uint32_t FlagBadStripMask_ = 0xFFF;
+
+  static const uint32_t FirstBadStripShift_ = 21;
+  static const uint32_t RangeBadStripShift_ = 10;
+  static const uint32_t FlagBadStripShift_ = 0;
+}  // namespace siPhase2strip
+
 #endif  // DataFormats_SiStripCommon_ConstantsForCondObjects_H

--- a/SLHCUpgradeSimulations/Geometry/python/fakePhase2OuterTrackerConditions_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakePhase2OuterTrackerConditions_cff.py
@@ -1,24 +1,35 @@
 import FWCore.ParameterSet.Config as cms
 
-##
-## Fake Sim Outer Tracker Lorentz Angle
-##
-
-SiPhase2OTFakeLorentzAngleESSource = cms.ESSource('SiPhase2OuterTrackerFakeLorentzAngleESSource',
-                                                  LAValue = cms.double(0.07),
-                                                  recordName = cms.string("LorentzAngle")
-                                                  )
-
-es_prefer_fake_LA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","SiPhase2OTFakeLorentzAngleESSource")
+# The Outer Tracker Lorentz Angle are now taken from Global Tag
 
 ##
 ## Fake Sim Outer Tracker Lorentz Angle
 ##
 
-SiPhase2OTFakeSimLorentzAngleESSource = cms.ESSource('SiPhase2OuterTrackerFakeLorentzAngleESSource',
-                                                     LAValue = cms.double(0.07),
-                                                     recordName = cms.string("SimLorentzAngle")
-                                                     )
+# SiPhase2OTFakeLorentzAngleESSource = cms.ESSource('SiPhase2OuterTrackerFakeLorentzAngleESSource',
+#                                                   LAValue = cms.double(0.07),
+#                                                   recordName = cms.string("LorentzAngle"))
 
-es_prefer_fake_simLA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","SiPhase2OTFakeSimLorentzAngleESSource")
+# es_prefer_fake_LA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","SiPhase2OTFakeLorentzAngleESSource")
 
+##
+## Fake Sim Outer Tracker Lorentz Angle
+##
+
+# SiPhase2OTFakeSimLorentzAngleESSource = cms.ESSource('SiPhase2OuterTrackerFakeLorentzAngleESSource',
+#                                                      LAValue = cms.double(0.07),
+#                                                      recordName = cms.string("SimLorentzAngle"))
+
+# es_prefer_fake_simLA = cms.ESPrefer("SiPhase2OuterTrackerFakeLorentzAngleESSource","SiPhase2OTFakeSimLorentzAngleESSource")
+
+##
+## Fake Sim Outer Tracker Lorentz Angle
+##
+
+from CalibTracker.SiPhase2TrackerESProducers.siPhase2BadStripConfigurableFakeESSource_cfi import siPhase2BadStripConfigurableFakeESSource
+SiPhase2OTFakeBadStripsESSource = siPhase2BadStripConfigurableFakeESSource.clone(seed = 1,
+                                                                                 printDebug = False,
+                                                                                 badComponentsFraction = 0.,
+                                                                                 appendToDataLabel = '')
+
+es_prefer_fake_BadStrips = cms.ESPrefer("SiPhase2BadStripConfigurableFakeESSource","SiPhase2OTFakeBadStripsESSource")


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to adapt the current `SiStripBadStrip` infrastructure to accomodate the needs to simulate bad strips in the PS-s and SS modules of the Phase-2 Outer Tracker.
   * The existing `CondFormat` `SiStripBadStrip` is mostly fine to be used as a container of the bad strip data, though the `decode` and `encode` functions needed to be specialized as the total amount of strips in a phase-2 module (maximally = 2 cols*1016 rows) exceeds the total maximal amount of strips in the Phase-0 Strip tracker modules (6 APV * 128 = 728).
   * A new set of packing constants is introduced at `DataFormats/SiStripCommon/interface/ConstantsForCondObjects.h` and used in the `decodePhase2` and `encodePhase2` methods of `SiStripBadStrip`.
   * A new (dependent) record to hold the bad strip data is introduced (`SiPhase2OuterTrackerBadStripRcd`), together with a novel `ESSource` (`SiPhase2BadStripConfigurableFakeESSource.cc`) that delivers in said record, randomly generated `SiStripBadStrip` data with a configurable fraction of bad components (flatly distributed over all the detector).
   * This `ESource` is included in all existing Phase-2 geometries via the configuration fragment `fakePhase2OuterTrackerConditions_cff`, loaded in the various geometries, and it is at the moment configured in such a way that no bad components are simulated.
   * I add to this PR also sqlite file DB writers and readers in the `CondTools/SiPhase2Tracker` package, together with unit tests to test the payload writing and reading.
   
This PR is technical and no regressions to existing workflows are expected.

#### PR validation:

Performed following tests:
   * `cmssw` compiles;
   * `scram b runtests`  runs fine;
   * `runTheMatrix.py -l limited --ibeos` runs fine;
   * privately generated samples with the different bad components fractions have been used to develop the corresponding changes in the Phase-2 Tracker digitizer to actually simulate the killing of the bad components. Such changes will be proposed as a separate PR by @suchandradutta once this one is merged.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

cc: @emiglior @suchandradutta @tsusa 
