### PR TITLE
Stabilize Fishbone

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -217,7 +217,7 @@ void CAHitNtupletGeneratorKernelsCPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
   {
     std::lock_guard<std::mutex> guard(lock);
     ++iev;
-    kernel_print_found_ntuplets(hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 1000000, iev);
+    kernel_print_found_ntuplets(hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 0, 1000000, iev);
   }
 #endif
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -335,9 +335,15 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
   {
     std::lock_guard<std::mutex> guard(lock);
     ++iev;
+    for (int k = 0; k < 20000; k += 500) {
+      kernel_print_found_ntuplets<<<1, 32, 0, cudaStream>>>(
+          hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), k, k + 500, iev);
+      cudaDeviceSynchronize();
+    }
     kernel_print_found_ntuplets<<<1, 32, 0, cudaStream>>>(
-        hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 1000000, iev);
-    cudaStreamSynchronize(cudaStream);
+        hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 20000, 1000000, iev);
+    cudaDeviceSynchronize();
+    // cudaStreamSynchronize(cudaStream);
   }
 #endif
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -21,6 +21,7 @@ namespace cAHitNtupletGenerator {
     unsigned long long nGoodTracks;
     unsigned long long nUsedHits;
     unsigned long long nDupHits;
+    unsigned long long nFishCells;
     unsigned long long nKilledCells;
     unsigned long long nEmptyCells;
     unsigned long long nZeroTrackCells;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -6,7 +6,7 @@
 #include "CUDADataFormats/Track/interface/PixelTrackHeterogeneous.h"
 #include "GPUCACell.h"
 
-#define DUMP_GPU_TK_TUPLES
+// #define DUMP_GPU_TK_TUPLES
 
 namespace cAHitNtupletGenerator {
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -6,7 +6,7 @@
 #include "CUDADataFormats/Track/interface/PixelTrackHeterogeneous.h"
 #include "GPUCACell.h"
 
-// #define DUMP_GPU_TK_TUPLES
+#define DUMP_GPU_TK_TUPLES
 
 namespace cAHitNtupletGenerator {
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -101,7 +101,7 @@ __global__ void kernel_checkOverflows(HitContainer const *foundNtuplets,
 
   for (int idx = first, nt = (*nCells); idx < nt; idx += gridDim.x * blockDim.x) {
     auto const &thisCell = cells[idx];
-    if (thisCell.hasFishbone())
+    if (thisCell.hasFishbone() && !thisCell.isKilled())
       atomicAdd(&c.nFishCells, 1);
     if (thisCell.outerNeighbors().full())  //++tooManyNeighbors[thisCell.theLayerPairId];
       printf("OuterNeighbors overflow %d in %d\n", idx, thisCell.layerPairId());
@@ -914,9 +914,9 @@ __global__ void kernel_printCounters(cAHitNtupletGenerator::Counters const *coun
          c.nHits,
          c.nCells,
          c.nTuples,
+         c.nFitTracks,
          c.nLooseTracks,
          c.nGoodTracks,
-         c.nFitTracks,
          c.nUsedHits,
          c.nDupHits,
          c.nFishCells,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -101,7 +101,8 @@ __global__ void kernel_checkOverflows(HitContainer const *foundNtuplets,
 
   for (int idx = first, nt = (*nCells); idx < nt; idx += gridDim.x * blockDim.x) {
     auto const &thisCell = cells[idx];
-    if (thisCell.hasFishbone()) atomicAdd(&c.nFishCells, 1);
+    if (thisCell.hasFishbone())
+      atomicAdd(&c.nFishCells, 1);
     if (thisCell.outerNeighbors().full())  //++tooManyNeighbors[thisCell.theLayerPairId];
       printf("OuterNeighbors overflow %d in %d\n", idx, thisCell.layerPairId());
     if (thisCell.tracks().full())  //++tooManyTracks[thisCell.theLayerPairId];
@@ -205,7 +206,7 @@ __global__ void kernel_fastDuplicateRemover(GPUCACell const *__restrict__ cells,
 
     // full crazy combinatorics
     int ntr = thisCell.tracks().size();
-    for (int i = 0; i < ntr-1; ++i) {
+    for (int i = 0; i < ntr - 1; ++i) {
       auto it = thisCell.tracks()[i];
       auto qi = tracks->quality(it);
       if (qi <= reject)
@@ -669,7 +670,7 @@ __global__ void kernel_rejectDuplicate(TkSoA const *__restrict__ ptracks,
     auto score = [&](auto it, auto nl) { return std::abs(tracks.tip(it)); };
 
     // full combinatorics
-    for (auto ip = hitToTuple.begin(idx); ip < hitToTuple.end(idx)-1; ++ip) {
+    for (auto ip = hitToTuple.begin(idx); ip < hitToTuple.end(idx) - 1; ++ip) {
       auto const it = *ip;
       auto qi = quality[it];
       if (qi <= reject)
@@ -863,14 +864,15 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
                                             TkSoA const *__restrict__ ptracks,
                                             Quality const *__restrict__ quality,
                                             CAHitNtupletGeneratorKernelsGPU::HitToTuple const *__restrict__ phitToTuple,
-                                            int32_t maxPrint,
+                                            int32_t firstPrint,
+                                            int32_t lastPrint,
                                             int iev) {
   constexpr auto loose = pixelTrack::Quality::loose;
   auto const &hh = *hhp;
   auto const &foundNtuplets = *ptuples;
   auto const &tracks = *ptracks;
-  int first = blockDim.x * blockIdx.x + threadIdx.x;
-  for (int i = first, np = std::min(maxPrint, foundNtuplets.nOnes()); i < np; i += blockDim.x * gridDim.x) {
+  int first = firstPrint + blockDim.x * blockIdx.x + threadIdx.x;
+  for (int i = first, np = std::min(lastPrint, foundNtuplets.nOnes()); i < np; i += blockDim.x * gridDim.x) {
     auto nh = foundNtuplets.size(i);
     if (nh < 3)
       continue;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -343,18 +343,18 @@ public:
   __device__ __forceinline__ bool unused() const { return 0 == (uint16_t(StatusBit::kUsed) & theStatus_); }
   __device__ __forceinline__ void setStatusBits(StatusBit mask) { theStatus_ |= uint16_t(mask); }
 
-  __device__ __forceinline__ void setFishbone(hindex_type id, float z, Hits const& hh) { 
+  __device__ __forceinline__ void setFishbone(hindex_type id, float z, Hits const& hh) {
     // make it deterministic: use the farther apart (in z)
     auto old = theFishboneId;
-    while (old != atomicCAS(&theFishboneId,old,
-      (invalidHitId == old || std::abs(z-theInnerZ) < std::abs(hh.zGlobal(old)-theInnerZ)) ?
-      id : old)
-    ) old = theFishboneId;
+    while (
+        old !=
+        atomicCAS(&theFishboneId,
+                  old,
+                  (invalidHitId == old || std::abs(z - theInnerZ) < std::abs(hh.zGlobal(old) - theInnerZ)) ? id : old))
+      old = theFishboneId;
   }
   __device__ __forceinline__ auto fishboneId() const { return theFishboneId; }
-  __device__ __forceinline__ bool hasFishbone() const {
-    return theFishboneId != invalidHitId;
-  }
+  __device__ __forceinline__ bool hasFishbone() const { return theFishboneId != invalidHitId; }
 
 private:
   CellNeighbors* theOuterNeighbors;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -350,7 +350,7 @@ public:
         old !=
         atomicCAS(&theFishboneId,
                   old,
-                  (invalidHitId == old || std::abs(z - theInnerZ) < std::abs(hh.zGlobal(old) - theInnerZ)) ? id : old))
+                  (invalidHitId == old || std::abs(z - theInnerZ) > std::abs(hh.zGlobal(old) - theInnerZ)) ? id : old))
       old = theFishboneId;
   }
   __device__ __forceinline__ auto fishboneId() const { return theFishboneId; }

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -75,7 +75,7 @@ namespace gpuPixelDoublets {
           // must be different detectors
           //        if (d[ic]==d[jc]) continue;
           auto cos12 = x[ic] * x[jc] + y[ic] * y[jc] + z[ic] * z[jc];
-          if (d[ic] != d[jc] && cos12 * cos12 >= 0.99999f * (n[ic] * n[jc]) ) {
+          if (d[ic] != d[jc] && cos12 * cos12 >= 0.99999f * (n[ic] * n[jc])) {
             // alligned:  kill farthest (prefer consecutive layers)
             // if same layer prefer farthest (longer level arm) and make space for intermediate hit
             bool sameLayer = l[ic] == l[jc];

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -82,7 +82,7 @@ namespace gpuPixelDoublets {
             if (n[ic] > n[jc]) {
               if (sameLayer) {
                 cj.kill();  // closest
-                ci.setFishbone(cj.inner_hit_id());
+                ci.setFishbone(cj.inner_hit_id(), cj.inner_z(hh), hh);
               } else {
                 ci.kill();  // farthest
                 break;
@@ -92,7 +92,7 @@ namespace gpuPixelDoublets {
                 cj.kill();  // farthest
               } else {
                 ci.kill();  // closest
-                cj.setFishbone(ci.inner_hit_id());
+                cj.setFishbone(ci.inner_hit_id(), ci.inner_z(hh), hh);
                 break;
               }
             }

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -85,7 +85,7 @@ namespace gpuPixelDoublets {
                 ci.setFishbone(cj.inner_hit_id(), cj.inner_z(hh), hh);
               } else {
                 ci.kill();  // farthest
-                break;
+                // break;
               }
             } else {
               if (!sameLayer) {
@@ -93,7 +93,7 @@ namespace gpuPixelDoublets {
               } else {
                 ci.kill();  // closest
                 cj.setFishbone(ci.inner_hit_id(), ci.inner_z(hh), hh);
-                break;
+                // break;
               }
             }
           }

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -85,7 +85,7 @@ namespace gpuPixelDoublets {
                 ci.setFishbone(cj.inner_hit_id(), cj.inner_z(hh), hh);
               } else {
                 ci.kill();  // farthest
-                // break;
+                // break;  // removed to improve reproducibility. keep it for reference and tests
               }
             } else {
               if (!sameLayer) {
@@ -93,7 +93,7 @@ namespace gpuPixelDoublets {
               } else {
                 ci.kill();  // closest
                 cj.setFishbone(ci.inner_hit_id(), ci.inner_z(hh), hh);
-                // break;
+                // break;  // removed to improve reproducibility. keep it for reference    and tests
               }
             }
           }

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -75,7 +75,7 @@ namespace gpuPixelDoublets {
           // must be different detectors
           //        if (d[ic]==d[jc]) continue;
           auto cos12 = x[ic] * x[jc] + y[ic] * y[jc] + z[ic] * z[jc];
-          if (d[ic] != d[jc] && cos12 * cos12 >= 0.99999f * n[ic] * n[jc]) {
+          if (d[ic] != d[jc] && cos12 * cos12 >= 0.99999f * (n[ic] * n[jc]) ) {
             // alligned:  kill farthest (prefer consecutive layers)
             // if same layer prefer farthest (longer level arm) and make space for intermediate hit
             bool sameLayer = l[ic] == l[jc];


### PR DESCRIPTION
The fishbone has been made deterministic and order independent.
The main change is (of course) removing the ```break```  in the combinatorial double loop.

results:
=====

Timing: 
--------

negligible effect.

```
break
T4:
   846.7 ±   0.7 ev/s (4900 events)
   831.0 ±   1.5 ev/s (4900 events)
   816.4 ±   1.3 ev/s (4900 events)
   817.1 ±   1.9 ev/s (4900 events)
 --------------------
   827.8 ±  14.3 ev/s
A10:
  1126.9 ±   7.9 ev/s (4900 events)
  1100.6 ±   7.7 ev/s (4900 events)
  1126.8 ±   7.6 ev/s (4900 events)
  1103.4 ±   6.2 ev/s (4900 events)
 --------------------
  1114.4 ±  14.4 ev/s


no break
T4:
   822.0 ±   2.0 ev/s (4900 events)
   827.6 ±   1.7 ev/s (4900 events)
   822.3 ±   1.6 ev/s (4900 events)
   827.1 ±   2.1 ev/s (4900 events)
 --------------------
   824.7 ±   3.0 ev/s
A10:
  1187.3 ±   2.7 ev/s (4900 events)
  1121.4 ±   7.8 ev/s (4900 events)
  1132.4 ±   2.2 ev/s (4900 events)
  1096.5 ±   7.1 ev/s (4900 events)
 --------------------
  1134.4 ±  38.3 ev/s
```



MTV
-----
slight increase of duplicate (as more fishbone cells are created) for Loose tracks. no effect on HP
http://innocent.home.cern.ch/innocent/RelVal/gpuMTVstableFB/


detailed comparison of reproducibility
--------------------------------------


counters on 1000 TTBAR events
```
break
||Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nLooseTracks  |  nGoodTracks | nUsedHits | nDupHits | nFishCells | nKilledCells | nUsedCells | nZeroTrackCells ||
Counters Raw 1000 11389676 88651895 3908050 1368682 857640 2662036 4878812 3195116 434118 793740 6774466 13927606
Counters Norm 1000 ||  11389.7|  88651.9|  3908.1|  2662.0|  1368.7|  857.6|  4878.8|  3195.1|  0.005|  0.009|  0.076|  0.157||
--
Counters Raw 1000 11389676 88651895 3908121 1368668 857630 2662045 4878809 3195114 434125 793727 6774466 13927643
Counters Norm 1000 ||  11389.7|  88651.9|  3908.1|  2662.0|  1368.7|  857.6|  4878.8|  3195.1|  0.005|  0.009|  0.076|  0.157||


no break
|Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nLooseTracks  |  nGoodTracks | nUsedHits | nDupHits | nFishCells | nKilledCells | nUsedCells | nZeroTrackCells ||
Counters Raw 1000 11389676 88651895 3906666 1368589 857445 2661798 4878546 3194513 436707 794913 6774466 13928968
Counters Norm 1000 ||  11389.7|  88651.9|  3906.7|  2661.8|  1368.6|  857.4|  4878.5|  3194.5|  0.005|  0.009|  0.076|  0.157|
--
Counters Raw 1000 11389676 88651895 3906666 1368607 857464 2661798 4878546 3194513 436707 794913 6774466 13928968
Counters Norm 1000 ||  11389.7|  88651.9|  3906.7|  2661.8|  1368.6|  857.5|  4878.5|  3194.5|  0.005|  0.009|  0.076|  0.157||
--
Counters Raw 1000 11389676 88651895 3906666 1368608 857449 2661798 4878546 3194513 436707 794913 6774466 13928968
Counters Norm 1000 ||  11389.7|  88651.9|  3906.7|  2661.8|  1368.6|  857.4|  4878.5|  3194.5|  0.005|  0.009|  0.076|  0.157||

```


dump of 10 events
```
cat doDumpTK
setenv CUDA_VISIBLE_DEVICES 1
cmsRun gpuDebug.py > & bta.log
cmsRun gpuDebug.py > & btb.log
cmsRun gpuDebug.py > & btc.log

grep TK bta.log | cut -d ' ' -f 3-100 | sort -g -r > bta.txt
grep TK btb.log | cut -d ' ' -f 3-100 | sort -g -r > btb.txt
grep TK btc.log | cut -d ' ' -f 3-100 | sort -g -r > btc.txt
tail -n 4 bt*.log
wc bt*.txt
diff bta.txt btb.txt | egrep "<|>" | wc
diff bta.txt btc.txt | egrep "<|>" | wc
diff btc.txt btb.txt | egrep "<|>" | wc
```

```
no break
[innocent@patatrack02 ttbar2021]$ source doDumpTK
==> ta.log <==
dropped waiting message count 0
||Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nLooseTracks  |  nGoodTracks | nUsedHits | nDupHits | nFishCells | nKilledCells | nUsedCells | nZeroTrackCells ||
Counters Raw 10 121715 1020413 46187 32977 16805 9177 54165 36414 4848 8821 80227 141874
Counters Norm 10 ||  12171.5|  102041.3|  4618.7|  3297.7|  1680.5|  917.7|  5416.5|  3641.4|  0.005|  0.009|  0.079|  0.139||

==> tb.log <==
dropped waiting message count 0
||Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nLooseTracks  |  nGoodTracks | nUsedHits | nDupHits | nFishCells | nKilledCells | nUsedCells | nZeroTrackCells ||
Counters Raw 10 121715 1020413 46187 32977 16806 9178 54165 36414 4848 8821 80227 141874
Counters Norm 10 ||  12171.5|  102041.3|  4618.7|  3297.7|  1680.6|  917.8|  5416.5|  3641.4|  0.005|  0.009|  0.079|  0.139||

==> tc.log <==
dropped waiting message count 0
||Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nLooseTracks  |  nGoodTracks | nUsedHits | nDupHits | nFishCells | nKilledCells | nUsedCells | nZeroTrackCells ||
Counters Raw 10 121715 1020413 46187 32977 16805 9177 54165 36414 4848 8821 80227 141874
Counters Norm 10 ||  12171.5|  102041.3|  4618.7|  3297.7|  1680.5|  917.7|  5416.5|  3641.4|  0.005|  0.009|  0.079|  0.139||
  16807  285717 1975148 ta.txt
  16808  285734 1975272 tb.txt
  16807  285717 1975169 tc.txt
  50422  857168 5925589 total
     71     700    4875
     46     454    3179
     54     513    3563

break
[innocent@patatrack02 ttbar2021]$ source doDumpTK
==> bta.log <==
dropped waiting message count 0
||Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nLooseTracks  |  nGoodTracks | nUsedHits | nDupHits | nFishCells | nKilledCells | nUsedCells | nZeroTrackCells ||
Counters Raw 10 121715 1020413 46199 32978 16813 9178 54169 36415 4813 8806 80227 141851
Counters Norm 10 ||  12171.5|  102041.3|  4619.9|  3297.8|  1681.3|  917.8|  5416.9|  3641.5|  0.005|  0.009|  0.079|  0.139||

==> btb.log <==
dropped waiting message count 0
||Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nLooseTracks  |  nGoodTracks | nUsedHits | nDupHits | nFishCells | nKilledCells | nUsedCells | nZeroTrackCells ||
Counters Raw 10 121715 1020413 46205 32979 16808 9180 54169 36421 4810 8805 80227 141848
Counters Norm 10 ||  12171.5|  102041.3|  4620.5|  3297.9|  1680.8|  918.0|  5416.9|  3642.1|  0.005|  0.009|  0.079|  0.139||

==> btc.log <==
dropped waiting message count 0
||Counters | nEvents | nHits | nCells | nTuples | nFitTacks  |  nLooseTracks  |  nGoodTracks | nUsedHits | nDupHits | nFishCells | nKilledCells | nUsedCells | nZeroTrackCells ||
Counters Raw 10 121715 1020413 46202 32978 16807 9181 54170 36420 4807 8806 80227 141849
Counters Norm 10 ||  12171.5|  102041.3|  4620.2|  3297.8|  1680.7|  918.1|  5417.0|  3642.0|  0.005|  0.009|  0.079|  0.139||
  16815  285853 1976068 bta.txt
  16810  285768 1975451 btb.txt
  16809  285751 1975331 btc.txt
  50434  857372 5926850 total
    204    1955   13446
    251    2393   16459
    248    2373   16396
```


In particular with this PR (no break) comparing 10 events at track level 
NO difference in HP quadruplets, only one HP triplet differs.
the rest are loose triplets (and a couple of loose quadruplets)
REMINDER:
loose tracks are in the collection ONLY to be used for seeding or for algorithms that perform some sort of pre-cleaning
(often a simple association to trimmed-vertices is enough).

Making the various ambiguity solvers deterministic and order independent will be much harder and costly










