### PR TITLE
Fixing FastTimerClient Hist Remaking Issue : 12_4_X

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -69,6 +69,8 @@ private:
   MEPSet scalLumiMEPSet_;
   MEPSet pixelLumiMEPSet_;
   MEPSet puMEPSet_;
+
+  bool fillEveryLumiSection_;
 };
 
 FastTimerServiceClient::FastTimerServiceClient(edm::ParameterSet const& config)
@@ -80,7 +82,8 @@ FastTimerServiceClient::FastTimerServiceClient(edm::ParameterSet const& config)
                                          : MEPSet{}),
       pixelLumiMEPSet_(doPlotsVsPixelLumi_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("pixelLumiME"))
                                            : MEPSet{}),
-      puMEPSet_(doPlotsVsPU_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("puME")) : MEPSet{}) {}
+      puMEPSet_(doPlotsVsPU_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("puME")) : MEPSet{}),
+      fillEveryLumiSection_(config.getParameter<bool>("fillEveryLumiSection")) {}
 
 FastTimerServiceClient::~FastTimerServiceClient() = default;
 
@@ -91,7 +94,10 @@ void FastTimerServiceClient::dqmEndJob(DQMStore::IBooker& booker, DQMStore::IGet
 void FastTimerServiceClient::dqmEndLuminosityBlock(DQMStore::IBooker& booker,
                                                    DQMStore::IGetter& getter,
                                                    edm::LuminosityBlock const& lumi,
-                                                   edm::EventSetup const& setup) {}
+                                                   edm::EventSetup const& setup) {
+  if (fillEveryLumiSection_)
+    fillSummaryPlots(booker, getter);
+}
 
 void FastTimerServiceClient::fillSummaryPlots(DQMStore::IBooker& booker, DQMStore::IGetter& getter) {
   if (getter.get(m_dqm_path + "/event time_real")) {
@@ -486,7 +492,7 @@ void FastTimerServiceClient::fillDescriptions(edm::ConfigurationDescriptions& de
   edm::ParameterSetDescription puMEPSet;
   fillPUMePSetDescription(puMEPSet);
   desc.add<edm::ParameterSetDescription>("puME", puMEPSet);
-
+  desc.add<bool>("fillEveryLumiSection", true);
   descriptions.add("fastTimerServiceClient", desc);
 }
 

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -91,9 +91,7 @@ void FastTimerServiceClient::dqmEndJob(DQMStore::IBooker& booker, DQMStore::IGet
 void FastTimerServiceClient::dqmEndLuminosityBlock(DQMStore::IBooker& booker,
                                                    DQMStore::IGetter& getter,
                                                    edm::LuminosityBlock const& lumi,
-                                                   edm::EventSetup const& setup) {
-  fillSummaryPlots(booker, getter);
-}
+                                                   edm::EventSetup const& setup) {}
 
 void FastTimerServiceClient::fillSummaryPlots(DQMStore::IBooker& booker, DQMStore::IGetter& getter) {
   if (getter.get(m_dqm_path + "/event time_real")) {
@@ -251,7 +249,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
     MonitorElement* me;
 
     booker.setCurrentFolder(subsubdir);
-    me = getter.get("module_time_real_average");
+    me = getter.get(subsubdir + "/module_time_real_average");
     if (me) {
       real_average = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);
@@ -266,7 +264,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       }
     }
 
-    me = getter.get("module_time_thread_average");
+    me = getter.get(subsubdir + "/module_time_thread_average");
     if (me) {
       thread_average = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);
@@ -282,7 +280,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       }
     }
 
-    me = getter.get("module_time_real_running");
+    me = getter.get(subsubdir + "/module_time_real_running");
     if (me) {
       real_running = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);
@@ -297,7 +295,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       }
     }
 
-    me = getter.get("module_time_thread_running");
+    me = getter.get(subsubdir + "/module_time_thread_running");
     if (me) {
       thread_running = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);
@@ -313,7 +311,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       }
     }
 
-    me = getter.get("module_efficiency");
+    me = getter.get(subsubdir + "/module_efficiency");
     if (me) {
       efficiency = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);


### PR DESCRIPTION
#### PR description:

This PR is a bug fix doing two things
1) properly checking if a histogram already exists so there is no needless remaking (the path was missing before so the hist was not found)
2) ~removing the per lumisection making of the histograms, its just the same histograms being reset to exactly the same content each time~
update: 2) after review has been changed to keep this behavior as default as it is needed by the online DQM and it is now controlled by  a parameter which defaults to keep the old behaviour. 

point 1) is absolutely necessary. 2) is just nice but can be removed if needed.

This is an important fix as we can not harvest timing results over many lumisections without it. This is because its very very slow to change a histogram labels which this does when it thinks it has created a new histogram. 

It superseeds: https://github.com/cms-sw/cmssw/pull/36313

#### PR validation:
The histograms are identical before and after this PR with the exception that the number of entries now accurately reflects the number of times SetBinContent should be called  (before it was that number times the number of LS +1)


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

We'll need this in 12_3_0, its causing a real problem when running on reemulated L1 samples (which have lots of LS to gain stats). 