### PR TITLE
Avoid DQMIO file GUID collisions

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -38,6 +38,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/Utilities/interface/Digest.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
@@ -334,8 +335,10 @@ void DQMRootOutputModule::openFile(edm::FileBlock const&) {
 
   edm::Service<edm::JobReport> jr;
   cms::Digest branchHash;
-  std::string guid{m_file->GetUUID().AsString()};
+  std::string guid{edm::createGlobalIdentifier()};
   std::transform(guid.begin(), guid.end(), guid.begin(), (int (*)(int))std::toupper);
+
+  m_file->WriteObject(&guid, kCmsGuid);
   m_jrToken = jr->outputFileOpened(m_fileName,
                                    m_logicalFileName,
                                    std::string(),

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -553,7 +553,8 @@ std::shared_ptr<edm::FileBlock> DQMRootSource::readFile_() {
 
     std::unique_ptr<std::string> guid{file->Get<std::string>(kCmsGuid)};
     if (not guid) {
-      guid = std::make_unique<std::string>();
+      guid = std::make_unique<std::string>(file->GetUUID().AsString());
+      std::transform(guid->begin(), guid->end(), guid->begin(), (int (*)(int))std::toupper);
     }
 
     edm::Service<edm::JobReport> jr;

--- a/DQMServices/FwkIO/plugins/format.h
+++ b/DQMServices/FwkIO/plugins/format.h
@@ -65,6 +65,9 @@ static const char* const kTypeBranch = "Type";
 static const char* const kFirstIndex = "FirstIndex";
 static const char* const kLastIndex = "LastIndex";
 
+//File GUID
+static const char* const kCmsGuid = "cms::edm::GUID";
+
 //Meta data info
 static const char* const kMetaDataDirectoryAbsolute = "/MetaData";
 static const char* const kMetaDataDirectory = kMetaDataDirectoryAbsolute + 1;

--- a/DQMServices/FwkIO/test/check_guid_file1.py
+++ b/DQMServices/FwkIO/test/check_guid_file1.py
@@ -6,8 +6,10 @@ import ROOT
 fname_root = "dqm_file1.root"
 fname_report = "dqm_file1_jobreport.xml"
 
+kCmsGuid = "cms::edm::GUID"
+
 f = ROOT.TFile.Open(fname_root)
-guid_file = f.GetUUID().AsString().upper()
+guid_file = getattr(f, kCmsGuid)
 f.Close()
 
 guid_report = None


### PR DESCRIPTION
#### PR description:

As covered in #37240, the algorithm ROOT uses for `TUUID` can result in high filename collisions rates, which has been causing operational problems for the tier0.  Most framework uses of GUIDs were switched to using random GUIDs due to UUID collisions in containers.  This PR makes the same switch for DQMIO, and also restores the registration of DQMIO input files to the FJR.

#### PR validation:

Passes tests.  There's more validation I'd like to do, but I'm pushing this out now as there's high demand for a fix for this issue.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.  Backports to 12_3_0 and 12_2_0 will follow shortly.