### PR TITLE
Fix warning: 'mzbtemp' may be used uninitialized

### DIFF
--- a/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc
@@ -245,7 +245,7 @@ void L1TrackJetProducer::produce(Event &iEvent, const EventSetup &iSetup) {
 void L1TrackJetProducer::L2_cluster(vector<Ptr<L1TTTrackType> > L1TrkPtrs_, vector<int> tdtrk_, MaxZBin &mzb) {
   const int nz = zBins_ + 1;
   MaxZBin all_zBins[nz];
-  MaxZBin mzbtemp;
+  MaxZBin mzbtemp = {};
   for (int z = 0; z < nz; ++z)
     all_zBins[z] = mzbtemp;
 


### PR DESCRIPTION
#### PR description:

This PR fixes the following warning seen in [PPC builds](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_ppc64le_gcc11/CMSSW_12_4_X_2022-03-29-2300/L1Trigger/L1TTrackMatch):
```
/scratch/cmsbuild/jenkins_a/workspace/build-any-ib/w/tmp/BUILDROOT/ec2e2d6b67708ad491c755cf4edb383f/opt/cmssw/slc7_ppc64le_gcc11/cms/cmssw/CMSSW_12_4_X_2022-03-29-2300/src/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc: In member function 'void L1TrackJetProducer::L2_cluster(std::vector<edm::Ptr<TTTrack<edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> > > >, std::vector<int>, MaxZBin&)':
  /scratch/cmsbuild/jenkins_a/workspace/build-any-ib/w/tmp/BUILDROOT/ec2e2d6b67708ad491c755cf4edb383f/opt/cmssw/slc7_ppc64le_gcc11/cms/cmssw/CMSSW_12_4_X_2022-03-29-2300/src/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc:250:18: warning: 'mzbtemp' may be used uninitialized [-Wmaybe-uninitialized]
   250 |     all_zBins[z] = mzbtemp;
      |     ~~~~~~~~~~~~~^~~~~~~~~
/scratch/cmsbuild/jenkins_a/workspace/build-any-ib/w/tmp/BUILDROOT/ec2e2d6b67708ad491c755cf4edb383f/opt/cmssw/slc7_ppc64le_gcc11/cms/cmssw/CMSSW_12_4_X_2022-03-29-2300/src/L1Trigger/L1TTrackMatch/plugins/L1TrackJetProducer.cc:248:11: note: 'mzbtemp' declared here
  248 |   MaxZBin mzbtemp;
      |           ^~~~~~~

```

