### PR TITLE
Fix deprecation warnings in SimG4CMS

### DIFF
--- a/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
@@ -25,7 +25,8 @@ uint32_t PPSDiamondOrganization::unitID(const G4Step* aStep) {
   for (int ii = 0; ii < touch->GetHistoryDepth(); ii++) {
     physVol = touch->GetVolume(ii);
 
-    if (G4StrUtil::contains(physVol->GetName(), "CTPPS_Diamond_Segment") || G4StrUtil::contains(physVol->GetName(), "CTPPS_UFSD_Segment")) {
+    if (G4StrUtil::contains(physVol->GetName(), "CTPPS_Diamond_Segment") ||
+        G4StrUtil::contains(physVol->GetName(), "CTPPS_UFSD_Segment")) {
       theDetector_ = physVol->GetCopyNo() % 100;
       thePlane_ = physVol->GetCopyNo() / 100;
       LogDebug("PPSSimDiamond") << "\n---------------------CTPPS_Diamond_Segment-------------------------------------"

--- a/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
@@ -14,9 +14,9 @@
 #include <iostream>
 
 #if G4VERSION_NUMBER >= 1100
-#define STRING_CONTAINS(a,b) G4StrUtil::contains(a,b)
+#define STRING_CONTAINS(a, b) G4StrUtil::contains(a, b)
 #else
-#define STRING_CONTAINS(a,b) a.contains(b)
+#define STRING_CONTAINS(a, b) a.contains(b)
 #endif
 
 //******************************************************************** Constructor and destructor

--- a/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
@@ -25,7 +25,7 @@ uint32_t PPSDiamondOrganization::unitID(const G4Step* aStep) {
   for (int ii = 0; ii < touch->GetHistoryDepth(); ii++) {
     physVol = touch->GetVolume(ii);
 
-    if (physVol->GetName().contains("CTPPS_Diamond_Segment") || physVol->GetName().contains("CTPPS_UFSD_Segment")) {
+    if (G4StrUtil::contains(physVol->GetName(), "CTPPS_Diamond_Segment") || G4StrUtil::contains(physVol->GetName(), "CTPPS_UFSD_Segment")) {
       theDetector_ = physVol->GetCopyNo() % 100;
       thePlane_ = physVol->GetCopyNo() / 100;
       LogDebug("PPSSimDiamond") << "\n---------------------CTPPS_Diamond_Segment-------------------------------------"
@@ -35,7 +35,7 @@ uint32_t PPSDiamondOrganization::unitID(const G4Step* aStep) {
       LogDebug("PPSSimDiamond") << "\t\t\t\t\tdetector= " << theDetector_ << " plane= " << thePlane_ << " ii = " << ii;
     }
 
-    else if (physVol->GetName().contains("Primary_Vacuum")) {
+    else if (G4StrUtil::contains(physVol->GetName(), "Primary_Vacuum")) {
       int cpy_no = physVol->GetCopyNo();
       theArm_ = (cpy_no / 100) % 10;
       theStation_ = (cpy_no / 10) % 10;

--- a/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
@@ -8,9 +8,16 @@
 #include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
 #include "G4VPhysicalVolume.hh"
 #include "G4VTouchable.hh"
+#include "G4Version.hh"
 #include "G4Step.hh"
 
 #include <iostream>
+
+#if G4VERSION_NUMBER >= 1100
+#define STRING_CONTAINS(a,b) G4StrUtil::contains(a,b)
+#else
+#define STRING_CONTAINS(a,b) a.contains(b)
+#endif
 
 //******************************************************************** Constructor and destructor
 
@@ -25,8 +32,8 @@ uint32_t PPSDiamondOrganization::unitID(const G4Step* aStep) {
   for (int ii = 0; ii < touch->GetHistoryDepth(); ii++) {
     physVol = touch->GetVolume(ii);
 
-    if (G4StrUtil::contains(physVol->GetName(), "CTPPS_Diamond_Segment") ||
-        G4StrUtil::contains(physVol->GetName(), "CTPPS_UFSD_Segment")) {
+    if (STRING_CONTAINS(physVol->GetName(), "CTPPS_Diamond_Segment") ||
+        STRING_CONTAINS(physVol->GetName(), "CTPPS_UFSD_Segment")) {
       theDetector_ = physVol->GetCopyNo() % 100;
       thePlane_ = physVol->GetCopyNo() / 100;
       LogDebug("PPSSimDiamond") << "\n---------------------CTPPS_Diamond_Segment-------------------------------------"
@@ -36,7 +43,7 @@ uint32_t PPSDiamondOrganization::unitID(const G4Step* aStep) {
       LogDebug("PPSSimDiamond") << "\t\t\t\t\tdetector= " << theDetector_ << " plane= " << thePlane_ << " ii = " << ii;
     }
 
-    else if (G4StrUtil::contains(physVol->GetName(), "Primary_Vacuum")) {
+    else if (STRING_CONTAINS(physVol->GetName(), "Primary_Vacuum")) {
       int cpy_no = physVol->GetCopyNo();
       theArm_ = (cpy_no / 100) % 10;
       theStation_ = (cpy_no / 10) % 10;

--- a/SimG4CMS/PPS/src/PPSPixelOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSPixelOrganization.cc
@@ -16,9 +16,9 @@
 #include "G4Version.hh"
 
 #if G4VERSION_NUMBER >= 1100
-#define STRING_CONTAINS(a,b) G4StrUtil::contains(a,b)
+#define STRING_CONTAINS(a, b) G4StrUtil::contains(a, b)
 #else
-#define STRING_CONTAINS(a,b) a.contains(b)
+#define STRING_CONTAINS(a, b) a.contains(b)
 #endif
 
 //

--- a/SimG4CMS/PPS/src/PPSPixelOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSPixelOrganization.cc
@@ -39,10 +39,10 @@ uint32_t PPSPixelOrganization ::unitID(const G4Step* aStep) {
     edm::LogInfo("PPSSim") << "physVol=" << physVol->GetName() << ", level=" << ii
                            << ", physVol->GetCopyNo()=" << physVol->GetCopyNo();
 
-    if (physVol->GetName().contains("Envelop")) {
+    if (G4StrUtil::contains(physVol->GetName(), "Envelop")) {
       currentPlane_ = physVol->GetCopyNo() - 1;
       foundEnvelop = true;
-    } else if (physVol->GetName().contains("RP_box_primary_vacuum")) {
+    } else if (G4StrUtil::contains(physVol->GetName(), "RP_box_primary_vacuum")) {
       int cpy_no = physVol->GetCopyNo();
       currentArm_ = (cpy_no / 100) % 10;
       currentStation_ = (cpy_no / 10) % 10;

--- a/SimG4CMS/PPS/src/PPSPixelOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSPixelOrganization.cc
@@ -13,6 +13,13 @@
 #include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
 #include "G4VPhysicalVolume.hh"
 #include "G4VTouchable.hh"
+#include "G4Version.hh"
+
+#if G4VERSION_NUMBER >= 1100
+#define STRING_CONTAINS(a,b) G4StrUtil::contains(a,b)
+#else
+#define STRING_CONTAINS(a,b) a.contains(b)
+#endif
 
 //
 // constructors and destructor
@@ -39,10 +46,10 @@ uint32_t PPSPixelOrganization ::unitID(const G4Step* aStep) {
     edm::LogInfo("PPSSim") << "physVol=" << physVol->GetName() << ", level=" << ii
                            << ", physVol->GetCopyNo()=" << physVol->GetCopyNo();
 
-    if (G4StrUtil::contains(physVol->GetName(), "Envelop")) {
+    if (STRING_CONTAINS(physVol->GetName(), "Envelop")) {
       currentPlane_ = physVol->GetCopyNo() - 1;
       foundEnvelop = true;
-    } else if (G4StrUtil::contains(physVol->GetName(), "RP_box_primary_vacuum")) {
+    } else if (STRING_CONTAINS(physVol->GetName(), "RP_box_primary_vacuum")) {
       int cpy_no = physVol->GetCopyNo();
       currentArm_ = (cpy_no / 100) % 10;
       currentStation_ = (cpy_no / 10) % 10;

--- a/SimG4CMS/PPS/src/PPSStripOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSStripOrganization.cc
@@ -5,7 +5,15 @@
 
 #include "G4VPhysicalVolume.hh"
 #include "G4VTouchable.hh"
+#include "G4Version.hh"
 #include "G4Step.hh"
+
+#if G4VERSION_NUMBER >= 1100
+#define STRING_CONTAINS(a,b) G4StrUtil::contains(a,b)
+#else
+#define STRING_CONTAINS(a,b) a.contains(b)
+#endif
+
 
 #include <iostream>
 
@@ -20,9 +28,9 @@ uint32_t PPSStripOrganization::unitID(const G4Step* aStep) {
 
   for (int ii = 0; ii < touch->GetHistoryDepth(); ii++) {
     physVol = touch->GetVolume(ii);
-    if (G4StrUtil::contains(physVol->GetName(), "RP_Silicon_Detector")) {
+    if (STRING_CONTAINS(physVol->GetName(), "RP_Silicon_Detector")) {
       detector = physVol->GetCopyNo();
-    } else if (G4StrUtil::contains(physVol->GetName(), "RP_box_primary_vacuum")) {
+    } else if (STRING_CONTAINS(physVol->GetName(), "RP_box_primary_vacuum")) {
       int cpy_no = physVol->GetCopyNo();
       arm = (cpy_no / 100) % 10;
       station = (cpy_no / 10) % 10;

--- a/SimG4CMS/PPS/src/PPSStripOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSStripOrganization.cc
@@ -20,9 +20,9 @@ uint32_t PPSStripOrganization::unitID(const G4Step* aStep) {
 
   for (int ii = 0; ii < touch->GetHistoryDepth(); ii++) {
     physVol = touch->GetVolume(ii);
-    if (physVol->GetName().contains("RP_Silicon_Detector")) {
+    if (G4StrUtil::contains(physVol->GetName(), "RP_Silicon_Detector")) {
       detector = physVol->GetCopyNo();
-    } else if (physVol->GetName().contains("RP_box_primary_vacuum")) {
+    } else if (G4StrUtil::contains(physVol->GetName(), "RP_box_primary_vacuum")) {
       int cpy_no = physVol->GetCopyNo();
       arm = (cpy_no / 100) % 10;
       station = (cpy_no / 10) % 10;

--- a/SimG4CMS/PPS/src/PPSStripOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSStripOrganization.cc
@@ -9,11 +9,10 @@
 #include "G4Step.hh"
 
 #if G4VERSION_NUMBER >= 1100
-#define STRING_CONTAINS(a,b) G4StrUtil::contains(a,b)
+#define STRING_CONTAINS(a, b) G4StrUtil::contains(a, b)
 #else
-#define STRING_CONTAINS(a,b) a.contains(b)
+#define STRING_CONTAINS(a, b) a.contains(b)
 #endif
-
 
 #include <iostream>
 


### PR DESCRIPTION
#### PR description:

This PR replaces calls to deprecated `G4bool G4String::contains()` function with calls to `G4StrUtil::contains` seen in GEANT4 IBs, [e.g.](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc10/CMSSW_12_4_GEANT4_X_2022-03-29-2300/SimG4CMS/PPS).

```
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/src/PPSDiamondOrganization.cc: In member function 'virtual uint32_t PPSDiamondOrganization::unitID(const G4Step*)':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/src/PPSDiamondOrganization.cc:28:60: warning: 'G4bool G4String::contains(const string&) const' is deprecated: Use G4StrUtil::contains instead [-Wdeprecated-declarations]
    28 |     if (physVol->GetName().contains("CTPPS_Diamond_Segment") || physVol->GetName().contains("CTPPS_UFSD_Segment")) {
      |                                                            ^
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc10/external/geant4/11.0.1-e5c3ab95d266b6a852f7454bdb6f9423/include/Geant4/G4String.hh:316,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc10/external/geant4/11.0.1-e5c3ab95d266b6a852f7454bdb6f9423/include/Geant4/globals.hh:50,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/interface/PPSDiamondOrganization.h:7,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/src/PPSDiamondOrganization.cc:7:
/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc10/external/geant4/11.0.1-e5c3ab95d266b6a852f7454bdb6f9423/include/Geant4/G4String.icc:96:15: note: declared here
   96 | inline G4bool G4String::contains(const std::string& str) const
      |               ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/src/PPSDiamondOrganization.cc:28:113: warning: 'G4bool G4String::contains(const string&) const' is deprecated: Use G4StrUtil::contains instead [-Wdeprecated-declarations]
    28 |     if (physVol->GetName().contains("CTPPS_Diamond_Segment") || physVol->GetName().contains("CTPPS_UFSD_Segment")) {
      |                                                                                                                 ^
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc10/external/geant4/11.0.1-e5c3ab95d266b6a852f7454bdb6f9423/include/Geant4/G4String.hh:316,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc10/external/geant4/11.0.1-e5c3ab95d266b6a852f7454bdb6f9423/include/Geant4/globals.hh:50,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/interface/PPSDiamondOrganization.h:7,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/src/PPSDiamondOrganization.cc:7:
/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc10/external/geant4/11.0.1-e5c3ab95d266b6a852f7454bdb6f9423/include/Geant4/G4String.icc:96:15: note: declared here
   96 | inline G4bool G4String::contains(const std::string& str) const
      |               ^~~~~~~~
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/src/PPSDiamondOrganization.cc:38:58: warning: 'G4bool G4String::contains(const string&) const' is deprecated: Use G4StrUtil::contains instead [-Wdeprecated-declarations]
    38 |     else if (physVol->GetName().contains("Primary_Vacuum")) {
      |                                                          ^
In file included from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc10/external/geant4/11.0.1-e5c3ab95d266b6a852f7454bdb6f9423/include/Geant4/G4String.hh:316,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc10/external/geant4/11.0.1-e5c3ab95d266b6a852f7454bdb6f9423/include/Geant4/globals.hh:50,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/interface/PPSDiamondOrganization.h:7,
                 from /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9f1dcd8695f4af40540dda788c6080c9/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_GEANT4_X_2022-03-29-2300/src/SimG4CMS/PPS/src/PPSDiamondOrganization.cc:7:
/data/cmsbld/jenkins/workspace/build-any-ib/w/slc7_amd64_gcc10/external/geant4/11.0.1-e5c3ab95d266b6a852f7454bdb6f9423/include/Geant4/G4String.icc:96:15: note: declared here
   96 | inline G4bool G4String::contains(const std::string& str) const
      |               ^~~~~~~~
```