### PR TITLE
L1 Phase-2: update L1TParticleFlow dataformats 

### DIFF
--- a/DataFormats/L1TParticleFlow/BuildFile.xml
+++ b/DataFormats/L1TParticleFlow/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="DataFormats/L1TCorrelator"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/JetReco"/>
+<use name="DataFormats/L1TMuonPhase2"/>
 <use name="rootrflx"/>
 
 <export>

--- a/DataFormats/L1TParticleFlow/interface/PFCandidate.h
+++ b/DataFormats/L1TParticleFlow/interface/PFCandidate.h
@@ -3,15 +3,16 @@
 
 #include <vector>
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
-#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1TMuonPhase2/interface/SAMuon.h"
 #include "DataFormats/L1TParticleFlow/interface/PFCluster.h"
 #include "DataFormats/L1TParticleFlow/interface/PFTrack.h"
+#include "DataFormats/L1TParticleFlow/interface/RegionalOutput.h"
 
 namespace l1t {
 
   class PFCandidate : public L1Candidate {
   public:
-    typedef edm::Ptr<l1t::Muon> MuonRef;
+    typedef l1t::SAMuonRef MuonRef;
     enum ParticleType { ChargedHadron = 0, Electron = 1, NeutralHadron = 2, Photon = 3, Muon = 4 };
 
     PFCandidate() {}
@@ -45,11 +46,35 @@ namespace l1t {
     /// PUPPI weight (-1 if not available)
     float puppiWeight() const { return puppiWeight_; }
 
+    void setZ0(float z0) { setVertex(reco::Particle::Point(0, 0, z0)); }
+    void setDxy(float dxy) { dxy_ = dxy; }
+
+    float z0() const { return vz(); }
+    float dxy() const { return dxy_; }
+
+    int16_t hwZ0() const { return hwZ0_; }
+    int16_t hwDxy() const { return hwDxy_; }
+    uint16_t hwTkQuality() const { return hwTkQuality_; }
+    uint16_t hwPuppiWeight() const { return hwPuppiWeight_; }
+    uint16_t hwEmID() const { return hwEmID_; }
+    uint64_t encodedPuppi64() const { return encodedPuppi64_; }
+
+    void setHwZ0(int16_t hwZ0) { hwZ0_ = hwZ0; }
+    void setHwDxy(int16_t hwDxy) { hwDxy_ = hwDxy; }
+    void setHwTkQuality(uint16_t hwTkQuality) { hwTkQuality_ = hwTkQuality; }
+    void setHwPuppiWeight(uint16_t hwPuppiWeight) { hwPuppiWeight_ = hwPuppiWeight; }
+    void setHwEmID(uint16_t hwEmID) { hwEmID_ = hwEmID; }
+    void setEncodedPuppi64(uint64_t encodedPuppi64) { encodedPuppi64_ = encodedPuppi64; }
+
   private:
     PFClusterRef clusterRef_;
     PFTrackRef trackRef_;
     MuonRef muonRef_;
-    float puppiWeight_;
+    float dxy_, puppiWeight_;
+
+    int16_t hwZ0_, hwDxy_;
+    uint16_t hwTkQuality_, hwPuppiWeight_, hwEmID_;
+    uint64_t encodedPuppi64_;
 
     void setPdgIdFromParticleType(int charge, ParticleType kind);
   };
@@ -57,5 +82,6 @@ namespace l1t {
   typedef std::vector<l1t::PFCandidate> PFCandidateCollection;
   typedef edm::Ref<l1t::PFCandidateCollection> PFCandidateRef;
   typedef edm::RefVector<l1t::PFCandidateCollection> PFCandidateRefVector;
+  typedef l1t::RegionalOutput<l1t::PFCandidateCollection> PFCandidateRegionalOutput;
 }  // namespace l1t
 #endif

--- a/DataFormats/L1TParticleFlow/interface/PFCluster.h
+++ b/DataFormats/L1TParticleFlow/interface/PFCluster.h
@@ -58,6 +58,7 @@ namespace l1t {
 
     bool isEM() const { return hwQual(); }
     void setIsEM(bool isEM) { setHwQual(isEM); }
+    unsigned int hwEmID() const { return hwQual(); }
 
     float egVsPionMVAOut() const { return egVsPionMVAOut_; }
     void setEgVsPionMVAOut(float egVsPionMVAOut) { egVsPionMVAOut_ = egVsPionMVAOut; }

--- a/DataFormats/L1TParticleFlow/interface/PFJet.h
+++ b/DataFormats/L1TParticleFlow/interface/PFJet.h
@@ -36,9 +36,14 @@ namespace l1t {
     using reco::LeafCandidate::daughter;  // avoid hiding the base
     edm::Ptr<l1t::L1Candidate> daughterPtr(size_type i) const { return constituents_[i]; }
 
+    // Get and set the encodedJet_ bits. The Jet is encoded in 128 bits as a 2-element array of uint64_t
+    std::array<uint64_t, 2> encodedJet() { return encodedJet_; }
+    void setEncodedJet(std::array<uint64_t, 2> jet) { encodedJet_ = jet; }
+
   private:
     float rawPt_;
     Constituents constituents_;
+    std::array<uint64_t, 2> encodedJet_ = {{0, 0}};
   };
 
   typedef std::vector<l1t::PFJet> PFJetCollection;

--- a/DataFormats/L1TParticleFlow/interface/PFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/PFTau.h
@@ -41,14 +41,32 @@ namespace l1t {
     float chargedIso() const { return iso_; }
     float fullIso() const { return fullIso_; }
     int id() const { return id_; }
+
+    void setZ0(float z0) { setVertex(reco::Particle::Point(0, 0, z0)); }
+    void setDxy(float dxy) { dxy_ = dxy; }
+
+    float z0() const { return vz(); }
+    float dxy() const { return dxy_; }
+
+    bool passMass() const { return (mass() < 2 + pt() / 40); }
     bool passLooseNN() const {
       return iso_ * (PFTAU_NN_OFFSET + PFTAU_NN_SLOPE * (min(pt(), PFTAU_NN_PT_CUTOFF))) * PFTAU_NN_OVERALL_SCALE >
              PFTAU_NN_LOOSE_CUT;
+    }
+    bool passLooseNNMass() const {
+      if (!passMass())
+        return false;
+      return passLooseNN();
     }
     bool passLoosePF() const { return fullIso_ < PFTAU_PF_LOOSE_CUT; }
     bool passTightNN() const {
       return iso_ * (PFTAU_NN_OFFSET + PFTAU_NN_SLOPE * (min(pt(), PFTAU_NN_PT_CUTOFF))) * PFTAU_NN_OVERALL_SCALE >
              PFTAU_NN_TIGHT_CUT;
+    }
+    bool passTightNNMass() const {
+      if (!passMass())
+        return false;
+      return passTightNN();
     }
     bool passTightPF() const { return fullIso_ < PFTAU_PF_TIGHT_CUT; }
 
@@ -56,6 +74,7 @@ namespace l1t {
     float iso_;
     float fullIso_;
     int id_;
+    float dxy_;
   };
 
   typedef std::vector<l1t::PFTau> PFTauCollection;

--- a/DataFormats/L1TParticleFlow/interface/PFTrack.h
+++ b/DataFormats/L1TParticleFlow/interface/PFTrack.h
@@ -36,7 +36,8 @@ namespace l1t {
           trkPtError_(trkPtError),
           caloPtError_(caloPtError),
           isMuon_(isMuon),
-          nPar_(nPar) {
+          nPar_(nPar),
+          trackWord_(*tkPtr) {
       setCharge(charge);
       setVertex(vtx);
     }
@@ -72,6 +73,9 @@ namespace l1t {
     float normalizedChi2() const { return track()->chi2Red(); }
     float chi2() const { return track()->chi2(); }
 
+    const TTTrack_TrackWord& trackWord() const { return trackWord_; }
+    TTTrack_TrackWord& trackWord() { return trackWord_; }
+
   private:
     TrackRef trackRef_;
     float caloEta_, caloPhi_;
@@ -79,6 +83,7 @@ namespace l1t {
     float caloPtError_;
     bool isMuon_;
     unsigned int nPar_;
+    TTTrack_TrackWord trackWord_;
   };
 
   typedef std::vector<l1t::PFTrack> PFTrackCollection;

--- a/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
+++ b/DataFormats/L1TParticleFlow/interface/RegionalOutput.h
@@ -1,0 +1,144 @@
+#ifndef DataFormats_L1TParticleFlow_RegionalOutput_h
+#define DataFormats_L1TParticleFlow_RegionalOutput_h
+
+#include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include <vector>
+
+namespace l1t {
+  template <typename T>
+  class RegionalOutput {
+  public:
+    typedef typename T::value_type value_type;
+    typedef edm::Ref<T> ref;
+    typedef edm::RefProd<T> refprod;
+
+    class iterator {
+    public:
+      typedef typename T::value_type value_type;
+      typedef ptrdiff_t difference_type;
+      iterator(const RegionalOutput<T>& src, unsigned int idx) : src_(&src), idx_(idx) {}
+      iterator(iterator const& it) : src_(it.src_), idx_(it.idx_) {}
+      iterator() : src_(nullptr), idx_(0) {}
+      iterator& operator++() {
+        ++idx_;
+        return *this;
+      }
+      iterator operator++(int) {
+        iterator ci = *this;
+        ++idx_;
+        return ci;
+      }
+      iterator& operator--() {
+        --idx_;
+        return *this;
+      }
+      iterator operator--(int) {
+        iterator ci = *this;
+        --idx_;
+        return ci;
+      }
+      difference_type operator-(iterator const& o) const { return idx_ - o.idx_; }
+      iterator operator+(difference_type n) const { return iterator(src_, idx_ + n); }
+      iterator operator-(difference_type n) const { return iterator(src_, idx_ - n); }
+      bool operator<(iterator const& o) const { return idx_ < o.idx_; }
+      bool operator==(iterator const& ci) const { return idx_ == ci.idx_; }
+      bool operator!=(iterator const& ci) const { return idx_ != ci.idx_; }
+      value_type const& operator*() const { return src_->objAt(idx_); }
+      value_type const* operator->() const { return &src_->objAt(idx_); }
+      iterator& operator+=(difference_type d) {
+        idx_ += d;
+        return *this;
+      }
+      iterator& operator-=(difference_type d) {
+        idx_ -= d;
+        return *this;
+      }
+      value_type const& operator[](difference_type d) const { return src_->objAt(idx_ + d); }
+      // interface to get EDM refs & related stuff
+      edm::Ref<T> ref() const { return src_->refAt(idx_); }
+      edm::ProductID id() const { return src_->id(); }
+      unsigned int idx() const { return idx_; }
+      unsigned int key() const { return idx_; }
+
+    private:
+      const RegionalOutput<T>* src_;
+      unsigned int idx_;
+    };
+    typedef iterator const_iterator;
+
+    class Region {
+    public:
+      typedef typename T::value_type value_type;
+      typedef typename RegionalOutput<T>::iterator iterator;
+      typedef typename RegionalOutput<T>::const_iterator const_iterator;
+
+      const value_type& operator[](unsigned int idx) const { return src_->objAt(ibegin_ + idx); }
+      const value_type& front() const { return src_->objAt(ibegin_); }
+      const value_type& back() const { return src_->objAt(iend_ - 1); }
+      iterator begin() const { return iterator(*src_, ibegin_); }
+      iterator end() const { return iterator(*src_, iend_); }
+      unsigned int size() const { return iend_ - ibegin_; }
+      bool empty() const { return (iend_ == ibegin_); }
+      // interface to get EDM refs & related stuff
+      ref refAt(unsigned int idx) const { return src_->refAt(ibegin_ + idx); }
+      edm::ProductID id() const { return src_->id(); }
+
+    private:
+      const RegionalOutput<T>* src_;
+      unsigned int ibegin_, iend_;
+      friend class RegionalOutput<T>;
+      Region(const RegionalOutput<T>* src, unsigned int ibegin, unsigned int iend)
+          : src_(src), ibegin_(ibegin), iend_(iend) {}
+    };
+
+    RegionalOutput() : refprod_(), values_(), regions_(), etas_(), phis_() {}
+    RegionalOutput(const edm::RefProd<T>& prod) : refprod_(prod), values_(), regions_(), etas_(), phis_() {}
+
+    void addRegion(const std::vector<int>& indices, const float eta, const float phi) {
+      regions_.emplace_back((regions_.empty() ? 0 : regions_.back()) + indices.size());
+      values_.insert(values_.end(), indices.begin(), indices.end());
+      etas_.push_back(eta);
+      phis_.push_back(phi);
+    }
+
+    edm::ProductID id() const { return refprod_.id(); }
+    unsigned int size() const { return values_.size(); }
+    unsigned int nRegions() const { return regions_.size(); }
+    bool empty() const { return values_.empty(); }
+    void clear() {
+      values_.clear();
+      regions_.clear();
+      etas_.clear();
+      phis_.clear();
+    }
+    void shrink_to_fit() {
+      values_.shrink_to_fit();
+      regions_.shrink_to_fit();
+      etas_.shrink_to_fit();
+      phis_.shrink_to_fit();
+    }
+
+    const_iterator begin() const { return const_iterator(this, 0); }
+    const_iterator end() const { return const_iterator(this, values_.size()); }
+
+    Region region(unsigned int ireg) const { return Region(this, ireg == 0 ? 0 : regions_[ireg - 1], regions_[ireg]); }
+    const float eta(unsigned int ireg) const { return etas_[ireg]; }
+    const float phi(unsigned int ireg) const { return phis_[ireg]; }
+
+    ref refAt(unsigned int idx) const { return ref(refprod_, values_[idx]); }
+    const value_type& objAt(unsigned int idx) const { return (*refprod_)[values_[idx]]; }
+
+    //Used by ROOT storage
+    CMS_CLASS_VERSION(10)
+
+  protected:
+    refprod refprod_;
+    std::vector<unsigned int> values_;   // list of indices to objects in each region, flattened.
+    std::vector<unsigned int> regions_;  // for each region, store the index of one-past the last object in values
+    std::vector<float> etas_;            // floatEtaCenter of each PFregion
+    std::vector<float> phis_;            // floatPhiCenter of each PFregion
+  };
+}  // namespace l1t
+#endif

--- a/DataFormats/L1TParticleFlow/src/PFCandidate.cc
+++ b/DataFormats/L1TParticleFlow/src/PFCandidate.cc
@@ -2,7 +2,15 @@
 
 l1t::PFCandidate::PFCandidate(
     ParticleType kind, int charge, const PolarLorentzVector& p, float puppiWeight, int hwpt, int hweta, int hwphi)
-    : L1Candidate(p, hwpt, hweta, hwphi, /*hwQuality=*/int(kind)), puppiWeight_(puppiWeight) {
+    : L1Candidate(p, hwpt, hweta, hwphi, /*hwQuality=*/int(kind)),
+      dxy_(0),
+      puppiWeight_(puppiWeight),
+      hwZ0_(0),
+      hwDxy_(0),
+      hwTkQuality_(0),
+      hwPuppiWeight_(0),
+      hwEmID_(0),
+      encodedPuppi64_(0) {
   setCharge(charge);
   setPdgIdFromParticleType(charge, kind);
 }

--- a/DataFormats/L1TParticleFlow/src/PFCluster.cc
+++ b/DataFormats/L1TParticleFlow/src/PFCluster.cc
@@ -5,7 +5,7 @@ void l1t::PFCluster::calibratePt(float newpt, float preserveEmEt) {
   ptError_ *= newpt / pt();
   setP4(PolarLorentzVector(newpt, eta(), phi(), mass()));
   if (preserveEmEt) {
-    float hNew = std::max<float>(pt() - currEmEt, 0);
+    float hNew = pt() - currEmEt;
     hOverE_ = (currEmEt > 0 ? hNew / currEmEt : -1);
   }
 }

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -9,7 +9,8 @@
   <class name="edm::RefVector<l1t::PFClusterCollection>" /> 
 
   <class name="l1t::PFTrack::TrackRef" />
-  <class name="l1t::PFTrack"  ClassVersion="3">
+  <class name="l1t::PFTrack"  ClassVersion="4">
+        <version ClassVersion="4" checksum="1055891431"/>
         <version ClassVersion="3" checksum="2332162612"/>
   </class>
   <class name="l1t::PFTrackCollection" />
@@ -18,7 +19,8 @@
   <class name="edm::RefVector<l1t::PFTrackCollection>" /> 
   <class name="std::vector<edm::Ref<l1t::PFTrackCollection> >" />
 
-  <class name="l1t::PFCandidate"  ClassVersion="3">
+  <class name="l1t::PFCandidate"  ClassVersion="4">
+        <version ClassVersion="4" checksum="2195440462"/>
         <version ClassVersion="3" checksum="4253860178"/>
   </class>
   <class name="l1t::PFCandidateCollection" />
@@ -26,7 +28,8 @@
   <class name="edm::Ref<l1t::PFCandidateCollection>" />
   <class name="edm::RefVector<l1t::PFCandidateCollection>" />
 
-  <class name="l1t::PFJet"  ClassVersion="3">
+  <class name="l1t::PFJet"  ClassVersion="4">
+        <version ClassVersion="4" checksum="1424452548"/>
         <version ClassVersion="3" checksum="133342988"/>
   </class>
   <class name="l1t::PFJetCollection" />
@@ -35,7 +38,8 @@
   <class name="edm::RefVector<l1t::PFJetCollection>" />
   <class name="std::vector<edm::Ref<std::vector<l1t::PFJet>,l1t::PFJet,edm::refhelper::FindUsingAdvance<std::vector<l1t::PFJet>,l1t::PFJet> > >" />
 
-  <class name="l1t::PFTau"  ClassVersion="3">
+  <class name="l1t::PFTau"  ClassVersion="4">
+        <version ClassVersion="4" checksum="2045755946"/>
         <version ClassVersion="3" checksum="1410157160"/>
   </class>
   <class name="l1t::PFTauCollection" />


### PR DESCRIPTION
#### PR description:

This is another PR to port all L1T Phase-2 developments to cms-sw. This PR targets the dataformats of the objects relevant to PF at L1. It includes several PRs made locally, the details of which can be found in the twiki https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions and in the cms-l1t-offline branch.