### PR TITLE
Update all GPU workflows [12.3.x]

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_gpu.py
+++ b/Configuration/PyReleaseValidation/python/relval_gpu.py
@@ -11,50 +11,59 @@ workflows = Matrix()
 
 from Configuration.PyReleaseValidation.relval_upgrade import workflows as _upgrade_workflows
 
-#just define all of them
+# just define all of them
 
-#WFs to run in IB:
-# mc 2018   (Patatrack pixel-only quadruplets: ZMM - on GPU, both CPU and GPU, profiling)
-#           (Patatrack pixel-only triplets: ZMM - on GPU, both CPU and GPU, profiling)
-#           (Patatrack pixel-only quadruplets: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack pixel-only triplets: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack ECAL-only: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack HCAL-only: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack full reco with pixel quadruplets: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack full reco with pixel triplets: TTbar - on GPU, both CPU and GPU, profiling)
-# mc 2021   (Patatrack pixel-only quadruplets: ZMM - on GPU, both CPU and GPU, profiling)
-#           (Patatrack pixel-only triplets: ZMM - on GPU, both CPU and GPU, profiling)
-#           (Patatrack pixel-only quadruplets: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack pixel-only triplets: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack ECAL-only: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack HCAL-only: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack full reco with pixel quadruplets: TTbar - on GPU, both CPU and GPU, profiling)
-#           (Patatrack full reco with pixel triplets: TTbar - on GPU, both CPU and GPU, profiling)
+# WFs to run in IB:
+# mc 2018   Patatrack pixel-only quadruplets: ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:    ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets: TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack ECAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack HCAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets, ECAL, HCAL:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets, ECAL, HCAL:          TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+
+# mc 2021   Patatrack pixel-only quadruplets: ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:    ZMM - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets: TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack ECAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack HCAL-only:              TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only quadruplets, ECAL, HCAL:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           Patatrack pixel-only triplets, ECAL, HCAL:          TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           full reco with Patatrack pixel-only quadruplets:    TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
+#           full reco with Patatrack pixel-only triplets:       TTbar - on GPU (optional), GPU-vs-CPU validation, profiling
 numWFIB = [
-           10842.502, # 10842.503, 10842.504,
-           10842.506, # 10842.507, 10842.508,
-           10824.502, # 10824.503, 10824.504,
-           10824.506, # 10824.507, 10824.508,
-           10824.512, 10824.513, # 10824.514,
-           10824.522, # 10824.523, 10824.524,
-           10824.592, # 10824.593, 10824.594,
-           10824.596, # 10824.597, 10824.598,
-           11650.502, # 11650.503, 11650.504,
-           11650.506, # 11650.507, 11650.508,
-           11634.502, # 11634.503, 11634.504,
-           11634.506, # 11634.507, 11634.508,
-           11634.512, 11634.513, # 11634.514,
-           11634.522, # 11634.523, 11634.524,
-           11634.592, # 11634.593, 11634.594,
-           11634.596, # 11634.597, 11634.598,
+           10842.502, 10842.503, 10842.504,
+           10842.506, 10842.507, 10842.508,
+           10824.502, 10824.503, 10824.504,
+           10824.506, 10824.507, 10824.508,
+           10824.512, 10824.513, 10824.514,
+           10824.522, 10824.523, 10824.524,
+           10824.582, 10824.583, # 10824.524,
+           10824.586, 10824.587, # 10824.528,
+           10824.592, 10824.593,
+           10824.596, 10824.597,
+           11650.502, 11650.503, 11650.504,
+           11650.506, 11650.507, 11650.508,
+           11634.502, 11634.503, 11634.504,
+           11634.506, 11634.507, 11634.508,
+           11634.512, 11634.513, 11634.514,
+           11634.522, 11634.523, 11634.524,
+           11634.582, 11634.583, # 11634.524,
+           11634.586, 11634.587, # 11634.528,
+           11634.592, 11634.593,
+           11634.596, 11634.597,
         ]
 for numWF in numWFIB:
     if not numWF in _upgrade_workflows: continue
     workflows[numWF] = _upgrade_workflows[numWF]
 
-# data 2018 (Patatrack pixel-only: RunHLTPhy2018D, RunJetHT2018D on GPU)
-#           (Patatrack ECAL-only:  RunHLTPhy2018D, RunJetHT2018D on GPU)
-#           (Patatrack HCAL-only:  RunHLTPhy2018D, RunJetHT2018D on GPU)
+# data 2018 Patatrack pixel-only quadruplets:   RunHLTPhy2018D on GPU (optional), RunJetHT2018D on GPU (optional)
+#           Patatrack ECAL-only:                RunHLTPhy2018D on GPU (optional), RunJetHT2018D on GPU (optional)
+#           Patatrack HCAL-only:                RunHLTPhy2018D on GPU (optional), RunJetHT2018D on GPU (optional)
 
 workflows[136.885502] = ['',['RunHLTPhy2018D','HLTDR2_2018','RECODR2_2018reHLT_Patatrack_PixelOnlyGPU','HARVEST2018_pixelTrackingOnly']]
 workflows[136.888502] = ['',['RunJetHT2018D','HLTDR2_2018','RECODR2_2018reHLT_Patatrack_PixelOnlyGPU','HARVEST2018_pixelTrackingOnly']]

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -556,10 +556,13 @@ class PatatrackWorkflow(UpgradeWorkflow):
             else:
               stepDict[stepName][k] = merge([self.__harvest, stepDict[step][k]])
 
-
+# Pixel-only quadruplets workflow running on CPU
+#  - HLT on CPU
+#  - Pixel-only reconstruction on CPU, with DQM and validation
+#  - harvesting
 upgradeWFs['PatatrackPixelOnlyCPU'] = PatatrackWorkflow(
     digi = {
-        # there is no customisation for enabling the Patatrack pixel quadruplets running only on the CPU
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
@@ -572,8 +575,13 @@ upgradeWFs['PatatrackPixelOnlyCPU'] = PatatrackWorkflow(
     offset = 0.501,
 )
 
+# Pixel-only quadruplets workflow running on CPU or GPU
+#  - HLT on GPU (optional)
+#  - Pixel-only reconstruction on GPU (optional), with DQM and validation
+#  - harvesting
 upgradeWFs['PatatrackPixelOnlyGPU'] = PatatrackWorkflow(
     digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
         '--procModifiers': 'gpu'
     },
     reco = {
@@ -587,10 +595,34 @@ upgradeWFs['PatatrackPixelOnlyGPU'] = PatatrackWorkflow(
     offset = 0.502,
 )
 
-# add here a .503 workflow for GPU vs CPU validation
+# Pixel-only quadruplets workflow running on CPU and GPU
+#  - HLT on GPU (required)
+#  - Pixel-only reconstruction on both CPU and GPU, with DQM and validation for GPU-vs-CPU comparisons
+#  - harvesting
+upgradeWFs['PatatrackPixelOnlyGPUValidation'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'gpu'
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'pixelNtupletFit,gpuValidation'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'
+    },
+    suffix = 'Patatrack_PixelOnlyGPU_Validation',
+    offset = 0.503,
+)
 
+# Pixel-only quadruplets workflow running on CPU or GPU, trimmed down for benchmarking
+#  - HLT on GPU (optional)
+#  - Pixel-only reconstruction on GPU (optional)
 upgradeWFs['PatatrackPixelOnlyGPUProfiling'] = PatatrackWorkflow(
     digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
         '--procModifiers': 'gpu'
     },
     reco = {
@@ -603,9 +635,13 @@ upgradeWFs['PatatrackPixelOnlyGPUProfiling'] = PatatrackWorkflow(
     offset = 0.504,
 )
 
+# Pixel-only triplets workflow running on CPU
+#  - HLT on CPU
+#  - Pixel-only reconstruction on CPU, with DQM and validation
+#  - harvesting
 upgradeWFs['PatatrackPixelOnlyTripletsCPU'] = PatatrackWorkflow(
     digi = {
-        # there is no customisation for enabling the Patatrack pixel triplets running only on the CPU
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
@@ -619,10 +655,14 @@ upgradeWFs['PatatrackPixelOnlyTripletsCPU'] = PatatrackWorkflow(
     offset = 0.505,
 )
 
+# Pixel-only triplets workflow running on CPU or GPU
+#  - HLT on GPU (optional)
+#  - Pixel-only reconstruction on GPU (optional), with DQM and validation
+#  - harvesting
 upgradeWFs['PatatrackPixelOnlyTripletsGPU'] = PatatrackWorkflow(
     digi = {
-        '--procModifiers': 'gpu',
-        '--customise': 'HLTrigger/Configuration/customizeHLTforPatatrack.enablePatatrackPixelTriplets'
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--procModifiers': 'gpu'
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
@@ -636,12 +676,36 @@ upgradeWFs['PatatrackPixelOnlyTripletsGPU'] = PatatrackWorkflow(
     offset = 0.506,
 )
 
-# add here a .507 workflow for GPU vs CPU validation
+# Pixel-only triplets workflow running on CPU and GPU
+#  - HLT on GPU (required)
+#  - Pixel-only reconstruction on both CPU and GPU, with DQM and validation for GPU-vs-CPU comparisons
+#  - harvesting
+upgradeWFs['PatatrackPixelOnlyTripletsGPUValidation'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'gpu'
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly,VALIDATION:@pixelTrackingOnlyValidation,DQM:@pixelTrackingOnlyDQM',
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'pixelNtupletFit,gpuValidation',
+        '--customise': 'RecoPixelVertexing/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM'
+    },
+    suffix = 'Patatrack_PixelOnlyTripletsGPU_Validation',
+    offset = 0.507,
+)
 
+# Pixel-only triplets workflow running on CPU or GPU, trimmed down for benchmarking
+#  - HLT on GPU (optional)
+#  - Pixel-only reconstruction on GPU (optional)
 upgradeWFs['PatatrackPixelOnlyTripletsGPUProfiling'] = PatatrackWorkflow(
     digi = {
-        '--procModifiers': 'gpu',
-        '--customise': 'HLTrigger/Configuration/customizeHLTforPatatrack.enablePatatrackPixelTriplets'
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--procModifiers': 'gpu'
     },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_pixelOnly,RECO:reconstruction_pixelTrackingOnly',
@@ -653,7 +717,14 @@ upgradeWFs['PatatrackPixelOnlyTripletsGPUProfiling'] = PatatrackWorkflow(
     offset = 0.508,
 )
 
+# ECAL-only workflow running on CPU
+#  - HLT on CPU
+#  - ECAL-only reconstruction on CPU, with DQM and validation
+#  - harvesting
 upgradeWFs['PatatrackECALOnlyCPU'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+    },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_ecalOnly,RECO:reconstruction_ecalOnly,VALIDATION:@ecalOnlyValidation,DQM:@ecalOnly',
     },
@@ -664,8 +735,13 @@ upgradeWFs['PatatrackECALOnlyCPU'] = PatatrackWorkflow(
     offset = 0.511,
 )
 
+# ECAL-only workflow running on CPU or GPU
+#  - HLT on GPU (optional)
+#  - ECAL-only reconstruction on GPU (optional), with DQM and validation
+#  - harvesting
 upgradeWFs['PatatrackECALOnlyGPU'] = PatatrackWorkflow(
     digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
         '--procModifiers': 'gpu'
     },
     reco = {
@@ -679,8 +755,13 @@ upgradeWFs['PatatrackECALOnlyGPU'] = PatatrackWorkflow(
     offset = 0.512,
 )
 
+# ECAL-only workflow running on CPU and GPU
+#  - HLT on GPU (required)
+#  - ECAL-only reconstruction on both CPU and GPU, with DQM and validation for GPU-vs-CPU comparisons
+#  - harvesting
 upgradeWFs['PatatrackECALOnlyGPUValidation'] = PatatrackWorkflow(
     digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
         '--accelerators': 'gpu-nvidia',
         '--procModifiers': 'gpu'
     },
@@ -696,8 +777,12 @@ upgradeWFs['PatatrackECALOnlyGPUValidation'] = PatatrackWorkflow(
     offset = 0.513,
 )
 
+# ECAL-only workflow running on CPU or GPU, trimmed down for benchmarking
+#  - HLT on GPU (optional)
+#  - ECAL-only reconstruction on GPU (optional)
 upgradeWFs['PatatrackECALOnlyGPUProfiling'] = PatatrackWorkflow(
     digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
         '--procModifiers': 'gpu'
     },
     reco = {
@@ -710,7 +795,14 @@ upgradeWFs['PatatrackECALOnlyGPUProfiling'] = PatatrackWorkflow(
     offset = 0.514,
 )
 
+# HCAL-only workflow running on CPU
+#  - HLT on CPU
+#  - HCAL-only reconstruction on CPU, with DQM and validation
+#  - harvesting
 upgradeWFs['PatatrackHCALOnlyCPU'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+    },
     reco = {
         '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation,DQM:@hcalOnly+@hcal2Only',
     },
@@ -721,8 +813,13 @@ upgradeWFs['PatatrackHCALOnlyCPU'] = PatatrackWorkflow(
     offset = 0.521,
 )
 
+# HCAL-only workflow running on CPU or GPU
+#  - HLT on GPU (optional)
+#  - HCAL-only reconstruction on GPU (optional), with DQM and validation
+#  - harvesting
 upgradeWFs['PatatrackHCALOnlyGPU'] = PatatrackWorkflow(
     digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
         '--procModifiers': 'gpu'
     },
     reco = {
@@ -736,10 +833,34 @@ upgradeWFs['PatatrackHCALOnlyGPU'] = PatatrackWorkflow(
     offset = 0.522,
 )
 
-# add here a .523 workflow for GPU vs CPU validation
+# HCAL-only workflow running on CPU and GPU
+#  - HLT on GPU (required)
+#  - HCAL-only reconstruction on both CPU and GPU, with DQM and validation for GPU-vs-CPU comparisons
+#  - harvesting
+upgradeWFs['PatatrackHCALOnlyGPUValidation'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'gpu'
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_hcalOnly,RECO:reconstruction_hcalOnly,VALIDATION:@hcalOnlyValidation,DQM:@hcalOnly+@hcal2Only',
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'gpuValidation'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@hcalOnlyValidation+@hcal'
+    },
+    suffix = 'Patatrack_HCALOnlyGPU_Validation',
+    offset = 0.523,
+)
 
+# HCAL-only workflow running on CPU or GPU, trimmed down for benchmarking
+#  - HLT on GPU (optional)
+#  - HCAL-only reconstruction on GPU (optional)
 upgradeWFs['PatatrackHCALOnlyGPUProfiling'] = PatatrackWorkflow(
     digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
         '--procModifiers': 'gpu'
     },
     reco = {
@@ -752,9 +873,145 @@ upgradeWFs['PatatrackHCALOnlyGPUProfiling'] = PatatrackWorkflow(
     offset = 0.524,
 )
 
-upgradeWFs['PatatrackCPU'] = PatatrackWorkflow(
+# Workflow running the Pixel quadruplets, ECAL and HCAL reconstruction on CPU
+#  - HLT on CPU
+#  - reconstruction on CPU, with DQM and validation
+#  - harvesting
+upgradeWFs['PatatrackAllCPU'] = PatatrackWorkflow(
     digi = {
-        # there is no customisation for enabling the Patatrack pixel quadruplets running only on the CPU
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly+RawToDigi_ecalOnly+RawToDigi_hcalOnly,RECO:reconstruction_pixelTrackingOnly+reconstruction_ecalOnly+reconstruction_hcalOnly,VALIDATION:@pixelTrackingOnlyValidation+@ecalOnlyValidation+@hcalOnlyValidation,DQM:@pixelTrackingOnlyDQM+@ecalOnly+@hcalOnly+@hcal2Only',
+        '--procModifiers': 'pixelNtupletFit'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@ecalOnlyValidation+@ecal+@hcalOnlyValidation+@hcalOnly+@hcal2Only'
+    },
+    suffix = 'Patatrack_AllCPU',
+    offset = 0.581,
+)
+
+# Workflow running the Pixel quadruplets, ECAL and HCAL reconstruction on CPU or GPU
+#  - HLT on GPU (optional)
+#  - reconstruction on GPU (optional), with DQM and validation
+#  - harvesting
+upgradeWFs['PatatrackAllGPU'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--procModifiers': 'gpu'
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly+RawToDigi_ecalOnly+RawToDigi_hcalOnly,RECO:reconstruction_pixelTrackingOnly+reconstruction_ecalOnly+reconstruction_hcalOnly,VALIDATION:@pixelTrackingOnlyValidation+@ecalOnlyValidation+@hcalOnlyValidation,DQM:@pixelTrackingOnlyDQM+@ecalOnly+@hcalOnly+@hcal2Only',
+        '--procModifiers': 'pixelNtupletFit,gpu'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@ecalOnlyValidation+@ecal+@hcalOnlyValidation+@hcalOnly+@hcal2Only'
+    },
+    suffix = 'Patatrack_AllGPU',
+    offset = 0.582,
+)
+
+# Workflow running the Pixel quadruplets, ECAL and HCAL reconstruction on CPU and GPU
+#  - HLT on GPU (required)
+#  - reconstruction on CPU and GPU, with DQM and validation for GPU-vs-CPU comparisons
+#  - harvesting
+upgradeWFs['PatatrackAllGPUValidation'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'gpu'
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly+RawToDigi_ecalOnly+RawToDigi_hcalOnly,RECO:reconstruction_pixelTrackingOnly+reconstruction_ecalOnly+reconstruction_hcalOnly,VALIDATION:@pixelTrackingOnlyValidation+@ecalOnlyValidation+@hcalOnlyValidation,DQM:@pixelTrackingOnlyDQM+@ecalOnly+@hcalOnly+@hcal2Only',
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'pixelNtupletFit,gpuValidation'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@ecalOnlyValidation+@ecal+@hcalOnlyValidation+@hcalOnly+@hcal2Only'
+    },
+    suffix = 'Patatrack_AllGPU_Validation',
+    offset = 0.583,
+)
+
+# Workflow running the Pixel quadruplets, ECAL and HCAL reconstruction on CPU or GPU, trimmed down for benchmarking
+#  - HLT on GPU (optional)
+#  - minimal reconstruction on GPU (optional)
+# FIXME workflow 0.584 to be implemented
+
+# Workflow running the Pixel triplets, ECAL and HCAL reconstruction on CPU
+#  - HLT on CPU
+#  - reconstruction on CPU, with DQM and validation
+#  - harvesting
+upgradeWFs['PatatrackAllTripletsCPU'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly+RawToDigi_ecalOnly+RawToDigi_hcalOnly,RECO:reconstruction_pixelTrackingOnly+reconstruction_ecalOnly+reconstruction_hcalOnly,VALIDATION:@pixelTrackingOnlyValidation+@ecalOnlyValidation+@hcalOnlyValidation,DQM:@pixelTrackingOnlyDQM+@ecalOnly+@hcalOnly+@hcal2Only',
+        '--procModifiers': 'pixelNtupletFit'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@ecalOnlyValidation+@ecal+@hcalOnlyValidation+@hcalOnly+@hcal2Only'
+    },
+    suffix = 'Patatrack_AllTripletsCPU',
+    offset = 0.585,
+)
+
+# Workflow running the Pixel triplets, ECAL and HCAL reconstruction on CPU or GPU
+#  - HLT on GPU (optional)
+#  - reconstruction on GPU (optional), with DQM and validation
+#  - harvesting
+upgradeWFs['PatatrackAllTripletsGPU'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--procModifiers': 'gpu'
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly+RawToDigi_ecalOnly+RawToDigi_hcalOnly,RECO:reconstruction_pixelTrackingOnly+reconstruction_ecalOnly+reconstruction_hcalOnly,VALIDATION:@pixelTrackingOnlyValidation+@ecalOnlyValidation+@hcalOnlyValidation,DQM:@pixelTrackingOnlyDQM+@ecalOnly+@hcalOnly+@hcal2Only',
+        '--procModifiers': 'pixelNtupletFit,gpu'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@ecalOnlyValidation+@ecal+@hcalOnlyValidation+@hcalOnly+@hcal2Only'
+    },
+    suffix = 'Patatrack_AllTripletsGPU',
+    offset = 0.586,
+)
+
+# Workflow running the Pixel triplets, ECAL and HCAL reconstruction on CPU and GPU
+#  - HLT on GPU (required)
+#  - reconstruction on CPU and GPU, with DQM and validation for GPU-vs-CPU comparisons
+#  - harvesting
+upgradeWFs['PatatrackAllTripletsGPUValidation'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'gpu'
+    },
+    reco = {
+        '-s': 'RAW2DIGI:RawToDigi_pixelOnly+RawToDigi_ecalOnly+RawToDigi_hcalOnly,RECO:reconstruction_pixelTrackingOnly+reconstruction_ecalOnly+reconstruction_hcalOnly,VALIDATION:@pixelTrackingOnlyValidation+@ecalOnlyValidation+@hcalOnlyValidation,DQM:@pixelTrackingOnlyDQM+@ecalOnly+@hcalOnly+@hcal2Only',
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'pixelNtupletFit,gpuValidation'
+    },
+    harvest = {
+        '-s': 'HARVESTING:@trackingOnlyValidation+@pixelTrackingOnlyDQM+@ecalOnlyValidation+@ecal+@hcalOnlyValidation+@hcalOnly+@hcal2Only'
+    },
+    suffix = 'Patatrack_AllTripletsGPU_Validation',
+    offset = 0.587,
+)
+
+# Workflow running the Pixel triplets, ECAL and HCAL reconstruction on CPU or GPU, trimmed down for benchmarking
+#  - HLT on GPU (optional)
+#  - minimal reconstruction on GPU (optional)
+# FIXME workflow 0.588 to be implemented
+
+# Workflow running the Pixel quadruplets, ECAL and HCAL reconstruction on CPU, together with the full offline reconstruction
+#  - HLT on CPU
+#  - reconstruction on CPU, with DQM and validation
+#  - harvesting
+upgradeWFs['PatatrackFullRecoCPU'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
     },
     reco = {
         # skip the @pixelTrackingOnlyValidation which cannot run together with the full reconstruction
@@ -762,13 +1019,19 @@ upgradeWFs['PatatrackCPU'] = PatatrackWorkflow(
         '--procModifiers': 'pixelNtupletFit'
     },
     harvest = {
+        # skip the @pixelTrackingOnlyDQM harvesting
     },
-    suffix = 'Patatrack_CPU',
+    suffix = 'Patatrack_FullRecoCPU',
     offset = 0.591,
 )
 
-upgradeWFs['PatatrackGPU'] = PatatrackWorkflow(
+# Workflow running the Pixel quadruplets, ECAL and HCAL reconstruction on GPU (optional), together with the full offline reconstruction on CPU
+#  - HLT on GPU (optional)
+#  - reconstruction on GPU (optional), with DQM and validation
+#  - harvesting
+upgradeWFs['PatatrackFullRecoGPU'] = PatatrackWorkflow(
     digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
         '--procModifiers': 'gpu'
     },
     reco = {
@@ -777,14 +1040,42 @@ upgradeWFs['PatatrackGPU'] = PatatrackWorkflow(
         '--procModifiers': 'pixelNtupletFit,gpu'
     },
     harvest = {
+        # skip the @pixelTrackingOnlyDQM harvesting
     },
-    suffix = 'Patatrack_GPU',
+    suffix = 'Patatrack_FullRecoGPU',
     offset = 0.592,
 )
 
-upgradeWFs['PatatrackTripletsCPU'] = PatatrackWorkflow(
+# Workflow running the Pixel quadruplets, ECAL and HCAL reconstruction on CPU and GPU, together with the full offline reconstruction on CPU
+#  - HLT on GPU (required)
+#  - reconstruction on CPU and GPU, with DQM and validation for GPU-vs-CPU comparisons
+#  - harvesting
+upgradeWFs['PatatrackFullRecoGPUValidation'] = PatatrackWorkflow(
     digi = {
-        # there is no customisation for enabling the Patatrack pixel triplets running only on the CPU
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'gpu'
+    },
+    reco = {
+        # skip the @pixelTrackingOnlyValidation which cannot run together with the full reconstruction
+        '-s': 'RAW2DIGI:RawToDigi+RawToDigi_pixelOnly,L1Reco,RECO:reconstruction+reconstruction_pixelTrackingOnly,RECOSIM,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@pixelTrackingOnlyDQM',
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'pixelNtupletFit,gpuValidation'
+    },
+    harvest = {
+        # skip the @pixelTrackingOnlyDQM harvesting
+    },
+    suffix = 'Patatrack_FullRecoGPU_Validation',
+    offset = 0.593,
+)
+
+# Workflow running the Pixel triplets, ECAL and HCAL reconstruction on CPU, together with the full offline reconstruction
+#  - HLT on CPU
+#  - reconstruction on CPU, with DQM and validation
+#  - harvesting
+upgradeWFs['PatatrackFullRecoTripletsCPU'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
     },
     reco = {
         # skip the @pixelTrackingOnlyValidation which cannot run together with the full reconstruction
@@ -793,15 +1084,20 @@ upgradeWFs['PatatrackTripletsCPU'] = PatatrackWorkflow(
         '--customise' : 'RecoPixelVertexing/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets'
     },
     harvest = {
+        # skip the @pixelTrackingOnlyDQM harvesting
     },
-    suffix = 'Patatrack_TripletsCPU',
+    suffix = 'Patatrack_FullRecoTripletsCPU',
     offset = 0.595,
 )
 
-upgradeWFs['PatatrackTripletsGPU'] = PatatrackWorkflow(
+# Workflow running the Pixel triplets, ECAL and HCAL reconstruction on GPU (optional), together with the full offline reconstruction on CPU
+#  - HLT on GPU (optional)
+#  - reconstruction on GPU (optional), with DQM and validation
+#  - harvesting
+upgradeWFs['PatatrackFullRecoTripletsGPU'] = PatatrackWorkflow(
     digi = {
-        '--procModifiers': 'gpu',
-        '--customise': 'HLTrigger/Configuration/customizeHLTforPatatrack.enablePatatrackPixelTriplets'
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--procModifiers': 'gpu'
     },
     reco = {
         # skip the @pixelTrackingOnlyValidation which cannot run together with the full reconstruction
@@ -810,10 +1106,36 @@ upgradeWFs['PatatrackTripletsGPU'] = PatatrackWorkflow(
         '--customise': 'RecoPixelVertexing/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets'
     },
     harvest = {
+        # skip the @pixelTrackingOnlyDQM harvesting
     },
-    suffix = 'Patatrack_TripletsGPU',
+    suffix = 'Patatrack_FullRecoTripletsGPU',
     offset = 0.596,
 )
+
+# Workflow running the Pixel triplets, ECAL and HCAL reconstruction on CPU and GPU, together with the full offline reconstruction on CPU
+#  - HLT on GPU (required)
+#  - reconstruction on CPU and GPU, with DQM and validation for GPU-vs-CPU comparisons
+#  - harvesting
+upgradeWFs['PatatrackFullRecoTripletsGPUValidation'] = PatatrackWorkflow(
+    digi = {
+        # the HLT menu is already set up for using GPUs if available and if the "gpu" modifier is enabled
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'gpu'
+    },
+    reco = {
+        # skip the @pixelTrackingOnlyValidation which cannot run together with the full reconstruction
+        '-s': 'RAW2DIGI:RawToDigi+RawToDigi_pixelOnly,L1Reco,RECO:reconstruction+reconstruction_pixelTrackingOnly,RECOSIM,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM+@pixelTrackingOnlyDQM',
+        '--accelerators': 'gpu-nvidia',
+        '--procModifiers': 'pixelNtupletFit,gpuValidation',
+        '--customise' : 'RecoPixelVertexing/Configuration/customizePixelTracksForTriplets.customizePixelTracksForTriplets'
+    },
+    harvest = {
+        # skip the @pixelTrackingOnlyDQM harvesting
+    },
+    suffix = 'Patatrack_FullRecoTripletsGPU_Validation',
+    offset = 0.597,
+)
+
 
 # end of Patatrack workflows
 


### PR DESCRIPTION
#### PR description:

Add Pixel-only and HCAL-only validation workflows:
  - Pixel only, on CPU and GPU, with GPU-vs-CPU validation: `#.503` (quadruplets), `#.507` (triplets)
  - HCAL only, on CPU and GPU, with GPU-vs-CPU validation: `#.523`

Enable the existing Pixel-only and HCAL-only profiling workflows:
  - Pixel only, on GPU (optionally): `#.504` (quadruplets), `#.508` (triplets)
  - HCAL only, on GPU (optionally): `#.524`

Add a single workflow running all GPU-enabled reconstruction (Pixel, ECAL, HCAL):
  - all, on CPU: `#.581` (quadruplets) and `#.585` (triplets)
  - all, on GPU (optionally): `#.582` (pixel quadruplets) and `#.586` (triplets)
  - all, on CPU and GPU, with GPU-vs-CPU validation: `#.583` (quadruplets) and `#.587` (triplets)

Do not customise the HLT, as it already makes full use of GPU reconstruction when the "gpu" modifier is enabled.
Add a short description before each workflow.

#### PR validation:

All new or updated GPU workflows ran successfully in `CMSSW_12_4_X_2022-03-23-2300`:
#### Pixel-only
```
$ runTheMatrix.py -w gpu -j 4 -t 4 -l 11634.501,11634.502,11634.503,11634.504,11634.505,11634.506,11634.507,11634.508
11634.501_TTbar_14TeV+2021_Patatrack_PixelOnlyCPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:38:32 2022-date Thu Mar 31 09:35:53 2022; exit: 0 0 0 0
11634.502_TTbar_14TeV+2021_Patatrack_PixelOnlyGPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:38:34 2022-date Thu Mar 31 09:35:53 2022; exit: 0 0 0 0
11634.503_TTbar_14TeV+2021_Patatrack_PixelOnlyGPU_Validation+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:38:34 2022-date Thu Mar 31 09:35:54 2022; exit: 0 0 0 0
11634.504_TTbar_14TeV+2021_Patatrack_PixelOnlyGPU_Profiling+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano Step0-PASSED Step1-PASSED Step2-PASSED  - time date Thu Mar 31 09:38:08 2022-date Thu Mar 31 09:35:54 2022; exit: 0 0 0
11634.505_TTbar_14TeV+2021_Patatrack_PixelOnlyTripletsCPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:40:50 2022-date Thu Mar 31 09:38:08 2022; exit: 0 0 0 0
11634.506_TTbar_14TeV+2021_Patatrack_PixelOnlyTripletsGPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:41:11 2022-date Thu Mar 31 09:38:32 2022; exit: 0 0 0 0
11634.507_TTbar_14TeV+2021_Patatrack_PixelOnlyTripletsGPU_Validation+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:41:11 2022-date Thu Mar 31 09:38:34 2022; exit: 0 0 0 0
11634.508_TTbar_14TeV+2021_Patatrack_PixelOnlyTripletsGPU_Profiling+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano Step0-PASSED Step1-PASSED Step2-PASSED  - time date Thu Mar 31 09:40:46 2022-date Thu Mar 31 09:38:34 2022; exit: 0 0 0
8 8 8 8 tests passed, 0 0 0 0 failed
```

#### ECAL-only
```
$ runTheMatrix.py -w gpu -j 4 -t 4 -l 11634.511,11634.512,11634.513,11634.514
11634.511_TTbar_14TeV+2021_Patatrack_ECALOnlyCPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:43:11 2022-date Thu Mar 31 09:40:46 2022; exit: 0 0 0 0
11634.512_TTbar_14TeV+2021_Patatrack_ECALOnlyGPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:43:20 2022-date Thu Mar 31 09:40:51 2022; exit: 0 0 0 0
11634.513_TTbar_14TeV+2021_Patatrack_ECALOnlyGPU_Validation+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:43:41 2022-date Thu Mar 31 09:41:12 2022; exit: 0 0 0 0
11634.514_TTbar_14TeV+2021_Patatrack_ECALOnlyGPU_Profiling+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano Step0-PASSED Step1-PASSED Step2-PASSED  - time date Thu Mar 31 09:43:18 2022-date Thu Mar 31 09:41:13 2022; exit: 0 0 0
4 4 4 4 tests passed, 0 0 0 0 failed
```

#### HCAL-only
```
$ runTheMatrix.py -w gpu -j 4 -t 4 -l 11634.521,11634.522,11634.523,11634.524
11634.521_TTbar_14TeV+2021_Patatrack_HCALOnlyCPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:45:34 2022-date Thu Mar 31 09:43:11 2022; exit: 0 0 0 0
11634.522_TTbar_14TeV+2021_Patatrack_HCALOnlyGPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:45:45 2022-date Thu Mar 31 09:43:18 2022; exit: 0 0 0 0
11634.523_TTbar_14TeV+2021_Patatrack_HCALOnlyGPU_Validation+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:45:48 2022-date Thu Mar 31 09:43:21 2022; exit: 0 0 0 0
11634.524_TTbar_14TeV+2021_Patatrack_HCALOnlyGPU_Profiling+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano Step0-PASSED Step1-PASSED Step2-PASSED  - time date Thu Mar 31 09:45:44 2022-date Thu Mar 31 09:43:42 2022; exit: 0 0 0
4 4 4 4 tests passed, 0 0 0 0 failed
```

#### All GPU sequences
```
$ runTheMatrix.py -w gpu -j 4 -t 4 -l 11634.581,11634.582,11634.583,11634.585,11634.586,11634.587
11634.581_TTbar_14TeV+2021_Patatrack_AllCPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 10:30:52 2022-date Thu Mar 31 10:28:11 2022; exit: 0 0 0 0
11634.582_TTbar_14TeV+2021_Patatrack_AllGPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 10:30:52 2022-date Thu Mar 31 10:28:12 2022; exit: 0 0 0 0
11634.583_TTbar_14TeV+2021_Patatrack_AllGPU_Validation+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 10:30:54 2022-date Thu Mar 31 10:28:12 2022; exit: 0 0 0 0
11634.585_TTbar_14TeV+2021_Patatrack_AllTripletsCPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 10:30:52 2022-date Thu Mar 31 10:28:13 2022; exit: 0 0 0 0
11634.586_TTbar_14TeV+2021_Patatrack_AllTripletsGPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 10:33:26 2022-date Thu Mar 31 10:30:53 2022; exit: 0 0 0 0
11634.587_TTbar_14TeV+2021_Patatrack_AllTripletsGPU_Validation+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 10:33:26 2022-date Thu Mar 31 10:30:53 2022; exit: 0 0 0 0
6 6 6 6 tests passed, 0 0 0 0 failed
```

#### Full offline reconstruction with all GPU sequences
```
$ runTheMatrix.py -w gpu -j 4 -t 4 -l 11634.591,11634.592,11634.593,11634.595,11634.596,11634.597
11634.591_TTbar_14TeV+2021_Patatrack_FullRecoCPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:53:14 2022-date Thu Mar 31 09:48:31 2022; exit: 0 0 0 0
11634.592_TTbar_14TeV+2021_Patatrack_FullRecoGPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:53:13 2022-date Thu Mar 31 09:48:32 2022; exit: 0 0 0 0
11634.593_TTbar_14TeV+2021_Patatrack_FullRecoGPU_Validation+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:55:43 2022-date Thu Mar 31 09:51:49 2022; exit: 0 0 0 0
11634.595_TTbar_14TeV+2021_Patatrack_FullRecoTripletsCPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:55:42 2022-date Thu Mar 31 09:51:49 2022; exit: 0 0 0 0
11634.596_TTbar_14TeV+2021_Patatrack_FullRecoTripletsGPU+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:57:05 2022-date Thu Mar 31 09:53:13 2022; exit: 0 0 0 0
11634.597_TTbar_14TeV+2021_Patatrack_FullRecoTripletsGPU_Validation+TTbar_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 31 09:57:05 2022-date Thu Mar 31 09:53:14 2022; exit: 0 0 0 0
6 6 6 6 tests passed, 0 0 0 0 failed
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #37411.