### PR TITLE
[12_4_X] Fix writing of int8_t flat table columns in nanoAOD flat ntuples

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
+++ b/PhysicsTools/NanoAOD/plugins/TableOutputBranches.cc
@@ -20,7 +20,7 @@ void TableOutputBranches::defineBranchesFromFirstEvent(const nanoaod::FlatTable 
         m_intBranches.emplace_back(var, tab.columnDoc(i), "I");
         break;
       case nanoaod::FlatTable::ColumnType::Int8:
-        m_int8Branches.emplace_back(var, tab.columnDoc(i), "b");
+        m_int8Branches.emplace_back(var, tab.columnDoc(i), "B");
         break;
       case nanoaod::FlatTable::ColumnType::UInt8:
         m_uint8Branches.emplace_back(var, tab.columnDoc(i), "b");
@@ -59,7 +59,7 @@ void TableOutputBranches::branch(TTree &tree) {
   }
   std::string varsize = m_singleton ? "" : "[n" + m_baseName + "]";
   for (std::vector<NamedBranchPtr> *branches :
-       {&m_floatBranches, &m_intBranches, &m_uint8Branches, &m_uint32Branches, &m_doubleBranches}) {
+       {&m_floatBranches, &m_intBranches, &m_int8Branches, &m_uint8Branches, &m_uint32Branches, &m_doubleBranches}) {
     for (auto &pair : *branches) {
       std::string branchName = makeBranchName(m_baseName, pair.name);
       pair.branch =
@@ -99,6 +99,8 @@ void TableOutputBranches::fill(const edm::OccurrenceForOutput &iWhatever, TTree 
     fillColumn<float>(pair, tab);
   for (auto &pair : m_intBranches)
     fillColumn<int>(pair, tab);
+  for (auto &pair : m_int8Branches)
+    fillColumn<int8_t>(pair, tab);
   for (auto &pair : m_uint8Branches)
     fillColumn<uint8_t>(pair, tab);
   for (auto &pair : m_uint32Branches)


### PR DESCRIPTION
#### PR description:

This PR addresses an issue with the `NanoAODOutputModule`, that fails writing `int8_t` columns from `nanoaod::flatTable` objets when generating flat nanoADO trees.

#### PR validation:

The PR was tested using a dedicated Muon "ALCANANO" presented [at  cross-POG on March 9th](https://indico.cern.ch/event/1129877/#4-muon-and-alcareco), checking that `nanoaod::flatTable` `int8_t` columns now appear in the output flat tree.

The workflows used in [PR 34169](https://github.com/cms-sw/cmssw/pull/34169) were also checked to run successfully.