### PR TITLE
Set concurrent lumis/IOVs in ConfigBuilder if their value is different from default regardless of the number of threads

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2286,13 +2286,6 @@ class ConfigBuilder(object):
             if overrideConcurrentIOVs:
                 self.pythonCfgCode +="process.options.eventSetup.numberOfConcurrentIOVs = "+self._options.nConcurrentIOVs+"\n"
                 self.process.options.eventSetup.numberOfConcurrentIOVs = int(self._options.nConcurrentIOVs)
-        if self._options.nConcurrentLumis != "1":
-            # nConcurrentLumis == 0 implies that framework decides the
-            # value based on the number of streams, and the number of
-            # threads/streams can be set afterwards. The safest check
-            # is then to set assertLegacySafe == True only when
-            # explicitly asked to use 1 concurrent lumi.
-            self.pythonCfgCode +="if hasattr(process, 'DQMStore'): process.DQMStore.assertLegacySafe=cms.untracked.bool(False)\n"
 
         if self._options.accelerators is not None:
             accelerators = self._options.accelerators.split(',')

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2268,19 +2268,31 @@ class ConfigBuilder(object):
         self.pythonCfgCode+="from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask\n"
         self.pythonCfgCode+="associatePatAlgosToolsTask(process)\n"
 
-        if self._options.nThreads != "1":
+        overrideThreads = (self._options.nThreads != "1")
+        overrideConcurrentLumis = (self._options.nConcurrentLumis != defaultOptions.nConcurrentLumis)
+        overrideConcurrentIOVs = (self._options.nConcurrentIOVs != defaultOptions.nConcurrentIOVs)
+
+        if overrideThreads or overrideConcurrentLumis or overrideConcurrentIOVs:
             self.pythonCfgCode +="\n"
             self.pythonCfgCode +="#Setup FWK for multithreaded\n"
-            self.pythonCfgCode +="process.options.numberOfThreads = "+self._options.nThreads+"\n"
-            self.pythonCfgCode +="process.options.numberOfStreams = "+self._options.nStreams+"\n"
-            self.pythonCfgCode +="process.options.numberOfConcurrentLuminosityBlocks = "+self._options.nConcurrentLumis+"\n"
-            self.pythonCfgCode +="process.options.eventSetup.numberOfConcurrentIOVs = "+self._options.nConcurrentIOVs+"\n"
-            if int(self._options.nConcurrentLumis) > 1:
-              self.pythonCfgCode +="if hasattr(process, 'DQMStore'): process.DQMStore.assertLegacySafe=cms.untracked.bool(False)\n"
-            self.process.options.numberOfThreads = int(self._options.nThreads)
-            self.process.options.numberOfStreams = int(self._options.nStreams)
-            self.process.options.numberOfConcurrentLuminosityBlocks = int(self._options.nConcurrentLumis)
-            self.process.options.eventSetup.numberOfConcurrentIOVs = int(self._options.nConcurrentIOVs)
+            if overrideThreads:
+                self.pythonCfgCode +="process.options.numberOfThreads = "+self._options.nThreads+"\n"
+                self.pythonCfgCode +="process.options.numberOfStreams = "+self._options.nStreams+"\n"
+                self.process.options.numberOfThreads = int(self._options.nThreads)
+                self.process.options.numberOfStreams = int(self._options.nStreams)
+            if overrideConcurrentLumis:
+                self.pythonCfgCode +="process.options.numberOfConcurrentLuminosityBlocks = "+self._options.nConcurrentLumis+"\n"
+                self.process.options.numberOfConcurrentLuminosityBlocks = int(self._options.nConcurrentLumis)
+            if overrideConcurrentIOVs:
+                self.pythonCfgCode +="process.options.eventSetup.numberOfConcurrentIOVs = "+self._options.nConcurrentIOVs+"\n"
+                self.process.options.eventSetup.numberOfConcurrentIOVs = int(self._options.nConcurrentIOVs)
+        if self._options.nConcurrentLumis != "1":
+            # nConcurrentLumis == 0 implies that framework decides the
+            # value based on the number of streams, and the number of
+            # threads/streams can be set afterwards. The safest check
+            # is then to set assertLegacySafe == True only when
+            # explicitly asked to use 1 concurrent lumi.
+            self.pythonCfgCode +="if hasattr(process, 'DQMStore'): process.DQMStore.assertLegacySafe=cms.untracked.bool(False)\n"
 
         if self._options.accelerators is not None:
             accelerators = self._options.accelerators.split(',')


### PR DESCRIPTION
#### PR description:

As discussed in Mattermost https://mattermost.web.cern.ch/cms-o-and-c/pl/sw55fqpr7pna8x581q453wcsne and reported in #37385, it can happen that the job configuration is generated with cmsDriver without specifying the number of threads (i.e. that is 1), and ends up being used with number of threads being overridden. If the number of concurrent lumis/IOVs is set different from the default in such case, that setting would be lost.

This PR overrides the `process.options.numberOfConcurrentLuminosityBlocks` and `process.options.eventSetup.numberOfConcurrentIOVs` when they have been changed from their defaults, regardless of the number of threads.

#### PR validation:

Checked with `limited,5.2,140.0,521.0,7.0,300.0,140.0,5.5,511.0,281.0,8.1,534.0,281.0,132.0,280.0,120.0` with `runTheMatrix.py` both `-t 2` option and without that the special cases that "need" to be explicitly set to use 1 concurrent lumi get that override in both cases. (I used the same set of workflows as in #35302)