### PR TITLE
Enable concurrent IOVs by default in ConfigBuilder

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -88,7 +88,7 @@ defaultOptions.timeoutOutput = False
 defaultOptions.nThreads = '1'
 defaultOptions.nStreams = '0'
 defaultOptions.nConcurrentLumis = '0'
-defaultOptions.nConcurrentIOVs = '1'
+defaultOptions.nConcurrentIOVs = '0'
 defaultOptions.accelerators = None
 
 # some helper routines


### PR DESCRIPTION
#### PR description:

While investigating https://github.com/cms-sw/cmssw/issues/37385 / https://github.com/cms-sw/cmssw/pull/37417 I noticed the default value in ConfigBuilder for the number of concurrent IOVs was still 1. I was supposed to change this to 0 at the time as https://github.com/cms-sw/cmssw/pull/35302 that followed the default value logic addition to `cmsRun` directly in https://github.com/cms-sw/cmssw/pull/34231. This PR sets the default value to 0, which means that the number of concurrent IOVs is set to be the same as the number of concurrent lumis.

For future reference, the main concern at the time was the memory usage of the additional per-lumi EventSetup products, which was concluded to be small in https://github.com/cms-sw/cmssw/issues/33436.

#### PR validation:

Limited matrix (plus some more) runs multithreaded