### PR TITLE
add DB ntuplizer and SiStripCondVisualizer, introduce analysis macros and add unit tests

### DIFF
--- a/CondTools/SiStrip/macros/compareFiles.C
+++ b/CondTools/SiStrip/macros/compareFiles.C
@@ -1,0 +1,401 @@
+#include "TFile.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TKey.h"
+#include "TDirectory.h"
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TObjArray.h"
+#include "TObject.h"
+#include "TClass.h"
+#include <iostream>
+#include <string>
+#include "TPaveText.h"
+
+#include <fstream>  // std::ofstream
+
+//*****************************************************//
+Double_t getMaximum(TObjArray *array)
+//*****************************************************//
+{
+  Double_t theMaximum = (static_cast<TH1 *>(array->At(0)))->GetMaximum();
+  for (Int_t i = 0; i < array->GetSize(); i++) {
+    if ((static_cast<TH1 *>(array->At(i)))->GetMaximum() > theMaximum) {
+      theMaximum = (static_cast<TH1 *>(array->At(i)))->GetMaximum();
+      //cout<<"i= "<<i<<" theMaximum="<<theMaximum<<endl;
+    }
+  }
+  return theMaximum;
+}
+
+/* %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+   MAIN
+   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
+*/
+
+//*****************************************************//
+void compareAll(TString file1, TString file2, TString leg1, TString leg2)
+//*****************************************************//
+{
+  TFile *f1 = TFile::Open(file1);
+  TFile *f2 = TFile::Open(file2);
+
+  f1->cd();
+
+  int i = 0;
+  int j = 0;
+
+  TCanvas dummyC;
+  dummyC.Print("diff.pdf[");
+
+  std::ofstream ofs("check.txt", std::ofstream::out);
+
+  TIter nextkey(gDirectory->GetListOfKeys());
+  while (TKey *key = (TKey *)nextkey()) {
+    //std::cout << "i: " << i << std::endl;
+    ++i;
+    TObject *obj = key->ReadObj();
+    std::string name = obj->GetName();
+    std::cout << "name: " << name << std::endl;
+    if (name.find("Residuals") != string::npos) {
+      std::cout << "skipping:" << name << "folder" << std::endl;
+      continue;
+    }
+    if (obj->IsA()->InheritsFrom("TDirectory")) {
+      f1->cd((name).c_str());
+      TIter nextkey(gDirectory->GetListOfKeys());
+      while (key = (TKey *)nextkey()) {
+        obj = key->ReadObj();
+        if (obj->IsA()->InheritsFrom("TH1")) {
+          TH1 *h = (TH1 *)obj;
+          TString fullpath = name + "/" + h->GetName();
+          //std::cout << "j: " << j << " "<< h->GetName() <<" "<< fullpath << std::endl;
+          ++j;
+          if (TString(h->GetName()).Contains("Charge_Vs_Index"))
+            continue;
+          TCanvas *c1 = new TCanvas(h->GetName(), h->GetName(), 800, 600);
+          c1->cd();
+
+          TPad *pad1;
+          if (obj->IsA()->InheritsFrom("TH2")) {
+            pad1 = new TPad("pad1", "pad1", 0, 0., 0.5, 1.0);
+          } else {
+            pad1 = new TPad("pad1", "pad1", 0, 0.3, 1, 1.0);
+            pad1->SetBottomMargin(0.01);  // Upper and lower plot are joined
+          }
+          //	  pad1->SetGridx();         // Vertical grid
+          pad1->Draw();  // Draw the upper pad: pad1
+          pad1->cd();    // pad1 becomes the current pad
+
+          h->SetMarkerColor(kRed);
+          h->SetStats(kFALSE);
+          h->SetLineColor(kRed);
+          h->SetMarkerStyle(kOpenSquare);
+          h->GetXaxis()->SetLabelOffset(0.2);
+
+          h->GetYaxis()->SetTitleSize(0.05);
+          //h->GetYaxis()->SetTitleFont(43);
+          h->GetYaxis()->SetTitleOffset(0.8);
+
+          TH1 *h2 = (TH1 *)f2->Get(fullpath.Data());
+          h2->SetStats(kFALSE);
+
+          if (h2 == nullptr) {
+            std::cout << "WARNING!!!!!! " << fullpath << " does NOT exist in second file!!!!!" << std::endl;
+            continue;
+          }
+
+          h2->SetMarkerColor(kBlue);
+          h2->SetLineColor(kBlue);
+          h2->SetMarkerStyle(kOpenCircle);
+          h2->GetXaxis()->SetLabelOffset(0.2);
+          h2->GetYaxis()->SetTitleOffset(0.8);
+
+          TObjArray *arrayHistos = new TObjArray();
+          arrayHistos->Expand(2);
+          arrayHistos->Add(h);
+          arrayHistos->Add(h2);
+
+          if (!obj->IsA()->InheritsFrom("TH2")) {
+            Double_t theMaximum = getMaximum(arrayHistos);
+            h->GetYaxis()->SetRangeUser(0., theMaximum * 1.30);
+            h->Draw();
+            h2->Draw("same");
+          } else {
+            c1->cd();
+            pad1->cd();
+            h->SetMarkerSize(0.1);
+            h->Draw("colz");
+
+            TLegend *lego = new TLegend(0.12, 0.80, 0.29, 0.88);
+            lego->SetFillColor(10);
+            lego->SetTextSize(0.042);
+            lego->SetTextFont(42);
+            lego->SetFillColor(10);
+            lego->SetLineColor(10);
+            lego->SetShadowColor(10);
+            lego->AddEntry(h, leg1.Data());
+            lego->Draw();
+
+            c1->cd();
+            TPad *pad2 = new TPad("pad2", "pad2", 0.5, 0., 1.0, 1.0);
+            pad2->Draw();
+            pad2->cd();
+            h2->SetMarkerSize(0.1);
+            h2->Draw("colz");
+
+            TLegend *lego2 = new TLegend(0.12, 0.80, 0.29, 0.88);
+            lego2->SetFillColor(10);
+            lego2->SetTextSize(0.042);
+            lego2->SetTextFont(42);
+            lego2->SetFillColor(10);
+            lego2->SetLineColor(10);
+            lego2->SetShadowColor(10);
+            lego2->AddEntry(h2, leg2.Data());
+            lego2->Draw("same");
+          }
+
+          TString savename = fullpath.ReplaceAll("/", "_");
+          double ksProb = 0;
+
+          // lower plot will be in pad
+          if (!obj->IsA()->InheritsFrom("TH2")) {
+            TLegend *lego = new TLegend(0.12, 0.80, 0.29, 0.88);
+            lego->SetFillColor(10);
+            lego->SetTextSize(0.042);
+            lego->SetTextFont(42);
+            lego->SetFillColor(10);
+            lego->SetLineColor(10);
+            lego->SetShadowColor(10);
+            lego->AddEntry(h, leg1.Data());
+            lego->AddEntry(h2, leg2.Data());
+
+            lego->Draw("same");
+
+            c1->cd();  // Go back to the main canvas before defining pad2
+
+            TPad *pad2 = new TPad("pad2", "pad2", 0, 0.05, 1, 0.3);
+            pad2->SetTopMargin(0.01);
+            pad2->SetBottomMargin(0.35);
+            pad2->SetGridy();  // horizontal grid
+            pad2->Draw();
+            pad2->cd();  // pad2 becomes the current pad
+
+            // Define the ratio plot
+            TH1F *h3 = (TH1F *)h->Clone("h3");
+            h3->SetLineColor(kBlack);
+            h3->SetMarkerColor(kBlack);
+            h3->SetTitle("");
+            h3->SetMinimum(0.55);  // Define Y ..
+            h3->SetMaximum(1.55);  // .. range
+            h3->SetStats(0);       // No statistics on lower plot
+            h3->Divide(h2);
+            h3->SetMarkerStyle(20);
+            h3->Draw("ep");  // Draw the ratio plot
+
+            // Y axis ratio plot settings
+            h3->GetYaxis()->SetTitle("ratio");
+            h3->GetYaxis()->SetNdivisions(505);
+            h3->GetYaxis()->SetTitleSize(20);
+            h3->GetYaxis()->SetTitleFont(43);
+            h3->GetYaxis()->SetTitleOffset(1.2);
+            h3->GetYaxis()->SetLabelFont(43);  // Absolute font size in pixel (precision 3)
+            h3->GetYaxis()->SetLabelSize(15);
+
+            // X axis ratio plot settings
+            h3->GetXaxis()->SetTitleSize(20);
+            h3->GetXaxis()->SetTitleFont(43);
+            h3->GetXaxis()->SetTitleOffset(4.);
+            h3->GetXaxis()->SetLabelFont(43);  // Absolute font size in pixel (precision 3)
+            h3->GetXaxis()->SetLabelSize(15);
+            h3->GetXaxis()->SetLabelOffset(0.02);
+          }
+
+          // avoid spurious false positive due to empty histogram
+          if (h->GetEntries() == 0 && h2->GetEntries() == 0) {
+            ofs << "histogram # " << j << ": " << fullpath << " |has zero entries in both files: " << std::endl;
+            delete c1;
+            delete h;
+            delete h2;
+            continue;
+          }
+          // avoid doing k-test on histograms with different binning
+          if (h->GetXaxis()->GetXmax() != h2->GetXaxis()->GetXmax() ||
+              h->GetXaxis()->GetXmin() != h2->GetXaxis()->GetXmin()) {
+            ofs << "histogram # " << j << ": " << fullpath << " |mismatched bins!!!!!!: " << std::endl;
+            delete c1;
+            delete h;
+            delete h2;
+            continue;
+          }
+
+          ksProb = h->KolmogorovTest(h2);
+          //if(ksProb!=1.){
+          //c1->SaveAs(savename+".pdf");
+          TPaveText ksPt(0, 0.02, 0.35, 0.043, "NDC");
+          ksPt.SetBorderSize(0);
+          ksPt.SetFillColor(0);
+          ksPt.AddText(Form("P(KS)=%g, ered %g eblue %g", ksProb, h->GetEntries(), h2->GetEntries()));
+          if (!obj->IsA()->InheritsFrom("TH2")) {
+            ksPt.SetTextSize(0.1);
+            ksPt.Draw();
+          } else {
+            ksPt.SetTextSize(0.03);
+            ksPt.Draw();
+          }
+          c1->Print("diff.pdf");
+          std::cout << "histogram # " << j << ": " << fullpath << " |kolmogorov: " << ksProb << std::endl;
+          ofs << "histogram # " << j << ": " << fullpath << " |kolmogorov: " << ksProb << std::endl;
+          // }
+
+          delete c1;
+          delete h;
+          delete h2;
+        }
+      }
+    } else if (obj->IsA()->InheritsFrom("TH1")) {
+      obj = key->ReadObj();
+      TH1 *h = (TH1 *)obj;
+      TString fullpath = (TString)h->GetName();
+      //std::cout << "j: " << j << " "<< h->GetName() <<" "<< fullpath << std::endl;
+      ++j;
+      if (obj->IsA()->InheritsFrom("TH2"))
+        continue;
+      TCanvas *c1 = new TCanvas(h->GetName(), h->GetName(), 800, 600);
+      c1->cd();
+      TPad *pad1 = new TPad("pad1", "pad1", 0, 0.3, 1, 1.0);
+      pad1->SetBottomMargin(0.01);  // Upper and lower plot are joined
+      //	  pad1->SetGridx();         // Vertical grid
+      pad1->Draw();  // Draw the upper pad: pad1
+      pad1->cd();    // pad1 becomes the current pad
+
+      h->SetMarkerColor(kRed);
+      h->SetStats(kFALSE);
+      h->SetLineColor(kRed);
+      h->SetMarkerStyle(kOpenSquare);
+      h->GetXaxis()->SetLabelOffset(0.2);
+
+      h->GetYaxis()->SetTitleSize(0.05);
+      //h->GetYaxis()->SetTitleFont(43);
+      h->GetYaxis()->SetTitleOffset(0.8);
+
+      TH1 *h2 = (TH1 *)f2->Get(fullpath.Data());
+      h2->SetStats(kFALSE);
+
+      if (h2 == nullptr) {
+        std::cout << "WARNING!!!!!! " << fullpath << " does NOT exist in second file!!!!!" << std::endl;
+        continue;
+      }
+
+      h2->SetMarkerColor(kBlue);
+      h2->SetLineColor(kBlue);
+      h2->SetMarkerStyle(kOpenCircle);
+      h2->GetXaxis()->SetLabelOffset(0.2);
+      h2->GetYaxis()->SetTitleOffset(0.8);
+
+      TObjArray *arrayHistos = new TObjArray();
+      arrayHistos->Expand(2);
+      arrayHistos->Add(h);
+      arrayHistos->Add(h2);
+
+      Double_t theMaximum = getMaximum(arrayHistos);
+      h->GetYaxis()->SetRangeUser(0., theMaximum * 1.30);
+
+      h->Draw();
+      h2->Draw("same");
+      TString savename = fullpath.ReplaceAll("/", "_");
+      double ksProb = 0;
+
+      TLegend *lego = new TLegend(0.12, 0.80, 0.29, 0.88);
+      lego->SetFillColor(10);
+      lego->SetTextSize(0.042);
+      lego->SetTextFont(42);
+      lego->SetFillColor(10);
+      lego->SetLineColor(10);
+      lego->SetShadowColor(10);
+      lego->AddEntry(h, leg1.Data());
+      lego->AddEntry(h2, leg2.Data());
+
+      lego->Draw("same");
+
+      // lower plot will be in pad
+      c1->cd();  // Go back to the main canvas before defining pad2
+      TPad *pad2 = new TPad("pad2", "pad2", 0, 0.05, 1, 0.3);
+      pad2->SetTopMargin(0.01);
+      pad2->SetBottomMargin(0.35);
+      pad2->SetGridy();  // horizontal grid
+      pad2->Draw();
+      pad2->cd();  // pad2 becomes the current pad
+
+      // Define the ratio plot
+      TH1F *h3 = (TH1F *)h->Clone("h3");
+      h3->SetLineColor(kBlack);
+      h3->SetMarkerColor(kBlack);
+      h3->SetTitle("");
+      h3->SetMinimum(0.55);  // Define Y ..
+      h3->SetMaximum(1.55);  // .. range
+      h3->SetStats(0);       // No statistics on lower plot
+      h3->Divide(h2);
+      h3->SetMarkerStyle(20);
+      h3->Draw("ep");  // Draw the ratio plot
+
+      // Y axis ratio plot settings
+      h3->GetYaxis()->SetTitle("ratio");
+      h3->GetYaxis()->SetNdivisions(505);
+      h3->GetYaxis()->SetTitleSize(20);
+      h3->GetYaxis()->SetTitleFont(43);
+      h3->GetYaxis()->SetTitleOffset(1.2);
+      h3->GetYaxis()->SetLabelFont(43);  // Absolute font size in pixel (precision 3)
+      h3->GetYaxis()->SetLabelSize(15);
+
+      // X axis ratio plot settings
+      h3->GetXaxis()->SetTitleSize(20);
+      h3->GetXaxis()->SetTitleFont(43);
+      h3->GetXaxis()->SetTitleOffset(4.);
+      h3->GetXaxis()->SetLabelFont(43);  // Absolute font size in pixel (precision 3)
+      h3->GetXaxis()->SetLabelSize(15);
+      h3->GetXaxis()->SetLabelOffset(0.02);
+
+      // avoid spurious false positive due to empty histogram
+      if (h->GetEntries() == 0 && h2->GetEntries() == 0) {
+        ofs << "histogram # " << j << ": " << fullpath << " |has zero entries in both files: " << std::endl;
+        delete c1;
+        delete h;
+        delete h2;
+        continue;
+      }
+      // avoid doing k-test on histograms with different binning
+      if (h->GetXaxis()->GetXmax() != h2->GetXaxis()->GetXmax() ||
+          h->GetXaxis()->GetXmin() != h2->GetXaxis()->GetXmin()) {
+        ofs << "histogram # " << j << ": " << fullpath << " |mismatched bins!!!!!!: " << std::endl;
+        delete c1;
+        delete h;
+        delete h2;
+        continue;
+      }
+
+      ksProb = h->KolmogorovTest(h2);
+      //if(ksProb!=1.){
+      //c1->SaveAs(savename+".pdf");
+      TPaveText ksPt(0, 0.02, 0.35, 0.043, "NDC");
+      ksPt.SetBorderSize(0);
+      ksPt.SetFillColor(0);
+      ksPt.AddText(Form("P(KS)=%g, ered %g eblue %g", ksProb, h->GetEntries(), h2->GetEntries()));
+      ksPt.SetTextSize(0.1);
+      ksPt.Draw();
+      c1->Print("diff.pdf");
+      std::cout << "histogram # " << j << ": " << fullpath << " |kolmogorov: " << ksProb << std::endl;
+      ofs << "histogram # " << j << ": " << fullpath << " |kolmogorov: " << ksProb << std::endl;
+      // }
+
+      delete c1;
+      delete h;
+      delete h2;
+    }
+  }  //while
+  f1->Close();
+  f2->Close();
+  dummyC.Print("diff.pdf]");
+
+  ofs.close();
+}

--- a/CondTools/SiStrip/macros/makeNoisePedestalScatterPlot.C
+++ b/CondTools/SiStrip/macros/makeNoisePedestalScatterPlot.C
@@ -1,0 +1,121 @@
+#include "TROOT.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TTree.h"
+#include "TBranch.h"
+#include "TTree.h"
+#include "TChain.h"
+#include "TLegend.h"
+#include "TGaxis.h"
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <map>
+#include <iostream>
+#include <iomanip>  // std::setw
+
+/*--------------------------------------------------------------------*/
+void makeNicePlotStyle(TH1* hist)
+/*--------------------------------------------------------------------*/
+{
+  hist->SetStats(kFALSE);
+  hist->SetLineWidth(2);
+  hist->GetXaxis()->CenterTitle(true);
+  hist->GetYaxis()->CenterTitle(true);
+  hist->GetXaxis()->SetTitleFont(42);
+  hist->GetYaxis()->SetTitleFont(42);
+  hist->GetXaxis()->SetTitleSize(0.05);
+  hist->GetYaxis()->SetTitleSize(0.05);
+  hist->GetXaxis()->SetTitleOffset(0.9);
+  hist->GetYaxis()->SetTitleOffset(1.3);
+  hist->GetXaxis()->SetLabelFont(42);
+  hist->GetYaxis()->SetLabelFont(42);
+  hist->GetYaxis()->SetLabelSize(.05);
+  hist->GetXaxis()->SetLabelSize(.05);
+}
+
+/*--------------------------------------------------------------------*/
+void makeNoisePedestalScatterPlot() {
+  /*--------------------------------------------------------------------*/
+
+  TGaxis::SetMaxDigits(4);
+
+  TFile* file = new TFile("idealNoise.root");
+
+  TH2F* h2_NoiseVsPedestal = (TH2F*)file->Get("h2_NoiseVsPedestal");
+
+  TH2F* h2_NoiseVsPedestalTIB = (TH2F*)file->Get("h2_NoiseVsPedestalTIB");
+  TH2F* h2_NoiseVsPedestalTOB = (TH2F*)file->Get("h2_NoiseVsPedestalTOB");
+  TH2F* h2_NoiseVsPedestalTID = (TH2F*)file->Get("h2_NoiseVsPedestalTID");
+  TH2F* h2_NoiseVsPedestalTEC = (TH2F*)file->Get("h2_NoiseVsPedestalTEC");
+
+  std::map<std::string, TH2F*> scatters;
+
+  scatters["TIB"] = h2_NoiseVsPedestalTIB;
+  scatters["TOB"] = h2_NoiseVsPedestalTOB;
+  scatters["TID"] = h2_NoiseVsPedestalTID;
+  scatters["TEC"] = h2_NoiseVsPedestalTEC;
+
+  std::map<std::string, int> colormap;
+  std::map<std::string, int> markermap;
+  colormap["TIB"] = kRed;
+  markermap["TIB"] = kFullCircle;
+  colormap["TOB"] = kGreen;
+  markermap["TOB"] = kFullTriangleUp;
+  colormap["TID"] = kCyan;
+  markermap["TID"] = kFullSquare;
+  colormap["TEC"] = kBlue;
+  markermap["TEC"] = kFullTriangleDown;
+
+  std::vector<std::string> parts = {"TEC", "TID", "TOB", "TIB"};
+
+  TCanvas* canvas = new TCanvas("c1", "c1", 1000, 800);
+  canvas->cd();
+
+  auto legend2 = new TLegend(0.75, 0.85, 0.95, 0.97);
+  legend2->SetTextSize(0.03);
+  canvas->cd();
+  canvas->cd()->SetTopMargin(0.03);
+  canvas->cd()->SetLeftMargin(0.13);
+  canvas->cd()->SetRightMargin(0.05);
+
+  for (const auto& part : parts) {
+    makeNicePlotStyle(scatters[part]);
+    scatters[part]->SetTitle("");
+    scatters[part]->SetStats(false);
+    scatters[part]->SetMarkerColor(colormap[part]);
+    scatters[part]->SetMarkerStyle(markermap[part]);
+    scatters[part]->SetMarkerSize(0.2);
+
+    auto temp = (TH2F*)(scatters[part]->Clone());
+    temp->SetMarkerSize(1.3);
+
+    if (part == "TEC")
+      scatters[part]->Draw("P");
+    else
+      scatters[part]->Draw("Psame");
+
+    legend2->AddEntry(temp, part.c_str(), "P");
+  }
+
+  legend2->Draw("same");
+
+  canvas->SaveAs("NoiseVsPedestals_subdet.png");
+
+  TCanvas* canvas2 = new TCanvas("c2", "c2", 1000, 800);
+  canvas2->cd();
+  canvas2->cd();
+  canvas2->cd()->SetTopMargin(0.03);
+  canvas2->cd()->SetLeftMargin(0.13);
+  canvas2->cd()->SetRightMargin(0.13);
+
+  makeNicePlotStyle(h2_NoiseVsPedestal);
+  h2_NoiseVsPedestal->SetTitle("");
+  h2_NoiseVsPedestal->SetStats(false);
+  h2_NoiseVsPedestal->Draw("colz");
+
+  canvas2->SaveAs("NoiseVsPedestals.png");
+}

--- a/CondTools/SiStrip/macros/noise_analysis.C
+++ b/CondTools/SiStrip/macros/noise_analysis.C
@@ -1,0 +1,450 @@
+#include <iostream>
+#include "TTree.h"
+#include "TMath.h"
+#include <string>
+#include <map>
+#include <vector>
+#include "TFile.h"
+#include "TText.h"
+#include "TGraphErrors.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TUUID.h"
+#include <sstream>
+#include <fstream>
+#include <set>
+#include <algorithm>
+
+using namespace std;
+
+class Mask {
+public:
+  Mask() : container_() {}
+  void add(unsigned int id, int apv) { container_.insert(make_pair(id, apv)); }
+  bool has(unsigned int id, int apv) { return container_.find(make_pair(id, apv)) != container_.end(); }
+
+private:
+  set<pair<unsigned int, int> > container_;
+};
+
+class Entry {
+public:
+  Entry() : entries(0), sum(0), sq_sum(0) {}
+
+  double mean() { return sum / entries; }
+  double std_dev() {
+    double tmean = mean();
+    return TMath::Sqrt((sq_sum - entries * tmean * tmean) / (entries - 1));
+  }
+  double mean_rms() { return std_dev() / TMath::Sqrt(entries); }
+
+  void add(double val) {
+    entries++;
+    sum += val;
+    sq_sum += val * val;
+  }
+
+  void reset() {
+    entries = 0;
+    sum = 0;
+    sq_sum = 0;
+  }
+
+private:
+  long int entries;
+  double sum, sq_sum;
+};
+
+typedef map<double, Entry> EntryMap;
+typedef EntryMap::iterator EntryMapIT;
+
+typedef map<double, TH1F> HMap;
+typedef HMap::iterator HMapIT;
+
+/*void initMap(map<int, map<double, Entry> > &toinit){
+  map<double, Entry> dummy;
+  for(int i=0; i<4; i++)
+    toinit.insert(make_pair<int, map<double, Entry> >(i, dummy));
+    }*/
+
+void loadGraph(EntryMap& input_map, TGraphErrors* graph) {
+  int ipoint = 0;
+  for (EntryMapIT it = input_map.begin(); it != input_map.end(); ++it) {
+    //cout << ipoint << " " << it->first << " " << it->second.mean() << endl;
+    graph->SetPoint(ipoint, it->first, it->second.mean());
+    graph->SetPointError(ipoint, 0., it->second.std_dev());
+    ipoint++;
+  }
+}
+
+TDirectory* makeGraphs(TFile* file, string dirname, EntryMap* input_map) {
+  TDirectory* dir = file->mkdir(dirname.c_str());
+  dir->cd();
+  string regions[4] = {"TIB", "TID", "TOB", "TEC"};
+
+  for (int i = 0; i < 4; i++) {
+    TGraphErrors* graph = new TGraphErrors();
+    graph->SetName(regions[i].c_str());
+    //cout << regions[i] << endl;
+    loadGraph(input_map[i], graph);
+    graph->Write();
+  }
+  return dir;
+}
+
+enum OpMode { STRIP_BASED, APV_BASED, MODULE_BASED };
+
+class Monitor2D {
+public:
+  Monitor2D(OpMode mode, const char* name, int nbinsx, double xmin, double xmax, int nbinsy, double ymin, double ymax)
+      : entryx_(), entryy_(), mode_(mode), obj_(name, "", nbinsx, xmin, xmax, nbinsy, ymin, ymax) {}
+
+  Monitor2D() : entryx_(), entryy_(), mode_(OpMode::STRIP_BASED), obj_() {}
+
+  ~Monitor2D() {}
+
+  void Fill(int apv, int det, double vx, double vy) {
+    switch (mode_) {
+      case (OpMode::APV_BASED):
+        // cout << "time to flush? " << !((apv == prev_apv_ && det == prev_det_) || prev_apv_ == 0) <<
+        // 	" apv: " << apv << " prev_apv: " << prev_apv_ << " det: " << det << " prev_det: " << prev_det_ << endl;
+        if (!((apv == prev_apv_ && det == prev_det_) || prev_apv_ == 0)) {
+          flush();
+        }
+        prev_apv_ = apv;
+        prev_det_ = det;
+        break;
+      case (OpMode::MODULE_BASED):
+        if (!(det == prev_det_ || prev_det_ == 0)) {
+          flush();
+        }
+        prev_det_ = det;
+        break;
+      case (OpMode::STRIP_BASED):
+        flush();
+        break;
+    }
+    entryx_.add(vx);
+    entryy_.add(vy);
+  }
+
+  void flush() {
+    //cout << "Monitor2D::flush" << endl;
+    obj_.Fill(entryx_.mean(), entryy_.mean());
+    entryx_.reset();
+    entryy_.reset();
+  }
+
+  TH2F& hist() {
+    flush();
+    return obj_;
+  }
+
+private:
+  int prev_apv_ = 0, prev_det_ = 0;
+  Entry entryx_, entryy_;
+  OpMode mode_;
+  TH2F obj_;
+};
+
+class Filler {
+public:
+  Filler(string prefix, double hmax = 20) : emap_(), hmap_(), prefix_(prefix), hmax_(hmax) {
+    string names[] = {
+        "UNKNOWN", "IB1", "IB2", "OB1", "OB2", "W1A", "W2A", "W3A", "W1B", "W2B", "W3B", "W4", "W5", "W6", "W7"};
+    for (size_t i = 0; i < 15; i++) {
+      harray_[i] = TH1F((prefix_ + names[i]).c_str(), "", 100, 0, hmax_);
+    }
+  }
+
+  ~Filler(){};
+
+  void add(int idx, double length, int type, double val) {
+    //cout << "Filler::add(" << prefix_ << ", " << op_mode_ << ")"<<endl;
+    EntryMapIT found = emap_[idx].find(length);
+    if (found == emap_[idx].end()) {
+      //cout << "adding new entry in map"<<endl;
+      emap_[idx][length] = Entry();
+      stringstream ss;
+      ss << prefix_ << regions[idx] << "_" << length;
+      hmap_[idx].insert(make_pair(length, TH1F(ss.str().c_str(), "", 100, 0, hmax_)));
+    }
+
+    emap_[idx][length].add(val);
+    hmap_[idx][length].Fill(val);
+    harray_[type].Fill(val);
+  }
+
+  EntryMap* emap() { return emap_; }
+  HMap* hmap() { return hmap_; }
+  void save_harray() {
+    for (size_t i = 0; i < 15; i++)
+      harray_[i].Write();
+  }
+
+private:
+  EntryMap emap_[4];
+  HMap hmap_[4];
+  TH1F harray_[15];
+  string prefix_;
+  const string regions[4] = {"TIB", "TID", "TOB", "TEC"};
+  double hmax_;
+};
+
+class TkMap {
+public:
+  TkMap(string name) : detid_(0), counts_(0), file_(name) {}
+  ~TkMap() { file_.close(); }
+
+  void add(unsigned int det) {
+    if (detid_ && detid_ != det)
+      flush();
+    detid_ = det;
+    counts_++;
+  }
+
+  void flush() {
+    file_ << detid_ << " " << counts_ << endl;
+    counts_ = 0;
+  }
+
+private:
+  unsigned int detid_, counts_;
+  ofstream file_;
+};
+
+void analyze_noise(string input_file,
+                   string output_file,
+                   bool gsim_,
+                   bool g1_,
+                   bool gratio_,
+                   bool gain_ = false,
+                   Mask mask_ = Mask(),
+                   OpMode op_mode_ = OpMode::STRIP_BASED) {
+  //region, strip length, Entries
+  cout << "Running opts: " << endl
+       << "   input:  " << input_file << endl
+       << "   output: " << output_file << endl
+       << "   gsim:   " << gsim_ << endl
+       << "   g1:     " << g1_ << endl
+       << "   gratio  " << gratio_ << endl
+       << "   gain    " << gain_ << endl
+       << "   op_mode:" << op_mode_ << endl;
+  string regions[4] = {"TIB", "TID", "TOB", "TEC"};
+
+  Filler fill_gsim("GSim_");
+  Filler fill_g1("G1_");
+  Filler fill_gratio("GRatio_");
+  Filler fill_gain("GAIN_", 2);
+
+  cout << "Booking 2D plots" << endl;
+  string det_types[] = {
+      "UNKNOWN", "IB1", "IB2", "OB1", "OB2", "W1A", "W2A", "W3A", "W1B", "W2B", "W3B", "W4", "W5", "W6", "W7"};
+  Monitor2D noise_vs_gain[15][6];
+  string base("_noise_vs_gain");
+  for (size_t i = 0; i < 15; i++) {
+    for (size_t j = 0; j < 6; j++) {
+      TUUID id;
+      string idc = id.AsString();
+      noise_vs_gain[i][j] = Monitor2D(op_mode_, idc.c_str(), 100, 0, 2, 124, 0, 31);
+    }
+  }
+
+  cout << "Booking Tracker maps" << endl;
+  TkMap* tkmaps[5];
+  string region_names[] = {"diagonal", "underflow", "below", "above", "overflow", "masked"};
+  for (size_t j = 0; j < 5; j++) {
+    tkmaps[j] = new TkMap(region_names[j + 1] + ".detlist");
+  }
+  cout << "Everything booked " << endl;
+
+  unsigned int detId, ring, istrip, dtype;
+  Int_t layer;
+  float noise, gsim, g1, g2, length;
+  bool isTIB, isTOB, isTEC, isTID;
+
+  TFile* infile = TFile::Open(input_file.c_str());
+  TTree* tree = (TTree*)infile->Get("treeDump/StripDBTree");
+
+  //book branches (I know, hand-made, I hate it)
+  tree->SetBranchAddress("detId", &detId);
+  tree->SetBranchAddress("noise", &noise);
+  tree->SetBranchAddress("istrip", &istrip);
+  tree->SetBranchAddress("detType", &dtype);
+  tree->SetBranchAddress("gsim", &gsim);
+  tree->SetBranchAddress("g1", &g1);
+  tree->SetBranchAddress("g2", &g2);
+  tree->SetBranchAddress("layer", &layer);
+  //tree->SetBranchAddress("ring/i", &ring);
+  tree->SetBranchAddress("length", &length);
+  tree->SetBranchAddress("isTIB", &isTIB);
+  tree->SetBranchAddress("isTOB", &isTOB);
+  tree->SetBranchAddress("isTEC", &isTEC);
+  tree->SetBranchAddress("isTID", &isTID);
+
+  unsigned long int entries = tree->GetEntries();
+  int cent = entries / 10;
+  TH1::AddDirectory(kFALSE);
+
+  unsigned int prev_det = 0, prev_apv = 0;
+  int prev_subdet = -1, prev_type = -1;
+  double prev_length = -1;
+  Entry enoise, eg1, egsim, eg2;
+  bool masked = false;
+  for (unsigned long int ientry = 0; ientry <= entries; ientry++) {
+    if (ientry < entries)
+      tree->GetEntry(ientry);
+    else {
+      //on last event force flushing
+      detId = 0;
+      istrip = prev_apv * 128 + 100;
+    }
+    if (ientry % cent == 0) {
+      cout << "reading entry " << ientry << " of " << entries << " (" << float(ientry) / entries << ")" << endl;
+    }
+    unsigned int idx = 0;
+
+    bool flush = false;
+    switch (op_mode_) {
+      case (OpMode::APV_BASED):
+        flush = (prev_det != 0 && prev_apv != istrip / 128);
+        break;
+      case (OpMode::MODULE_BASED):
+        flush = (prev_det != 0 && prev_det != detId);
+        break;
+      case (OpMode::STRIP_BASED):
+        flush = (ientry != 0);
+        break;
+    }
+
+    if (flush) {
+      //Get Region ID
+      size_t region_ID = 0;  //diagonal by default
+      if (masked) {
+        region_ID = 5;
+      } else if (enoise.mean() < 1)
+        region_ID = 1;
+      else if (enoise.mean() > 30)
+        region_ID = 4;
+      else if (eg1.mean() > 0.2 && (enoise.mean() - 2.5 * eg1.mean()) < 0.5)
+        region_ID = 2;
+      else if (enoise.mean() > 8.333 * eg1.mean())
+        region_ID = 3;
+
+      if (region_ID >= 1)
+        tkmaps[region_ID - 1]->add(prev_det);
+
+      if (gain_) {
+        fill_gain.add(prev_subdet, prev_length, prev_type, eg1.mean());
+        noise_vs_gain[prev_type][region_ID].Fill(prev_apv, prev_det, eg1.mean(), enoise.mean());
+      }
+      if (gsim_) {
+        fill_gsim.add(prev_subdet, prev_length, prev_type, enoise.mean() / egsim.mean());
+      }
+      if (g1_) {
+        fill_g1.add(prev_subdet, prev_length, prev_type, enoise.mean() / eg1.mean());
+      }
+      if (gratio_) {
+        fill_gratio.add(prev_subdet, prev_length, prev_type, (eg1.mean() * eg2.mean() / egsim.mean()) - 1);
+      }
+      enoise.reset();
+      eg1.reset();
+      egsim.reset();
+      eg2.reset();
+    }
+
+    masked = mask_.has(detId, istrip / 128);
+    if (masked && op_mode_ != OpMode::APV_BASED && !gain_)
+      continue;
+    if (ientry < entries) {
+      if (isTOB) {
+        idx = 2;
+      } else if (isTEC) {
+        idx = 3;
+      } else if (isTID) {
+        idx = 1;
+      }
+
+      enoise.add(std::min<float>(noise, 30.5));
+      eg1.add(g1);
+      egsim.add(gsim);
+      eg2.add(g2);
+
+      prev_det = detId;
+      prev_apv = istrip / 128;
+      prev_subdet = idx;
+      prev_length = length;
+      prev_type = dtype;
+    }
+  }
+  cout << "loop done" << endl;
+  TText* info = (TText*)infile->Get("DBTags");
+  cout << "Got DB Info" << endl;
+  //TText* clone_info = (TText*) info->Clone("DBTags");
+  //clone_info->
+
+  cout << "Opening output: " << output_file << endl;
+  TFile* outfile = TFile::Open(output_file.c_str(), "RECREATE");
+
+  if (gain_) {
+    cout << "Saving Gain" << endl;
+    TDirectory* dir = makeGraphs(outfile, "Gain", fill_gain.emap());
+    // HMap* hmap = fill_gain.hmap();
+    // for(int i=0; i<4; i++){
+    // 	for(HMapIT it = hmap[i].begin(); it != hmap[i].end(); ++it){
+    // 		cout << "saving " << it->second.GetName() << endl;
+    // 		it->second.Write();
+    // 	}
+    // }
+    // fill_gain.save_harray();
+    for (size_t i = 0; i < 15; i++) {
+      dir->mkdir(det_types[i].c_str())->cd();
+      for (size_t j = 0; j < 6; j++) {
+        noise_vs_gain[i][j].hist().SetName(region_names[j].c_str());
+        noise_vs_gain[i][j].hist().Write();
+      }
+    }
+  }
+  if (gsim_) {
+    cout << "Saving GSim" << endl;
+    makeGraphs(outfile, "GSim", fill_gsim.emap());
+    HMap* hmap = fill_gsim.hmap();
+    fill_gsim.save_harray();
+    for (int i = 0; i < 4; i++) {
+      for (HMapIT it = hmap[i].begin(); it != hmap[i].end(); ++it) {
+        cout << "saving " << it->second.GetName() << endl;
+        it->second.Write();
+      }
+    }
+  }
+  if (g1_) {
+    cout << "Saving G1" << endl;
+    makeGraphs(outfile, "G1", fill_g1.emap());
+    HMap* hmap = fill_g1.hmap();
+    fill_g1.save_harray();
+    for (int i = 0; i < 4; i++) {
+      for (HMapIT it = hmap[i].begin(); it != hmap[i].end(); ++it) {
+        cout << "saving " << it->second.GetName() << endl;
+        it->second.Write();
+      }
+    }
+  }
+  if (gratio_) {
+    cout << "Saving GRatio" << endl;
+    makeGraphs(outfile, "GRatio", fill_gratio.emap());
+    HMap* hmap = fill_gratio.hmap();
+    fill_gratio.save_harray();
+    for (int i = 0; i < 4; i++) {
+      for (HMapIT it = hmap[i].begin(); it != hmap[i].end(); ++it) {
+        cout << "saving " << it->second.GetName() << endl;
+        it->second.Write();
+      }
+    }
+  }
+  outfile->Write();
+  outfile->Close();
+  infile->Close();
+  for (size_t j = 0; j < 4; j++) {
+    delete tkmaps[j];
+  }
+}

--- a/CondTools/SiStrip/macros/plotHistogramsTogether.C
+++ b/CondTools/SiStrip/macros/plotHistogramsTogether.C
@@ -1,0 +1,215 @@
+/*************************************************
+  Automatically plots histograms from two files
+  onto the same plot and saves them.
+  It looksfor ALL histograms in the first file
+  and plots the corresponding histogram in the 2nd
+  file onto the sample plot.
+  
+  Can be run from a bash prompt as well:
+    root -b -l -q "plotHistogramsTogether.C(\"fileA.root\",\"fileB.root\")"
+    root -b -l -q "plotHistogramsTogether.C(\"fileA.root\",\"fileB.root\",\"Signal\",\"Background\",10,2,1)"
+
+  Michael B. Anderson
+  Sept 5, 2008
+*************************************************/
+
+#include <string.h>
+#include "TFile.h"
+#include "TH1.h"
+#include "TKey.h"
+#include "Riostream.h"
+
+// Accesable everywhere
+TObject *obj;
+TFile *sourceFile1, *sourceFile2;
+TString label1, label2;
+TString outputFolder, outputFilename;
+TCanvas *canvasDefault;
+Float_t scale1, scale2;
+bool showStatsBoxes;
+
+// *******************************************
+// Variables
+TString imageType = "png";
+int outputWidth = 480;
+int outputHeight = 360;
+bool yAxisLogScale = false;
+// End of Variables
+// *******************************************
+
+void recurseOverKeys(TDirectory *target1);
+void plot2Histograms(TH1 *htemp1, TH1 *htemp2, TString filename);
+
+void plotHistogramsTogether(TString fileName1,
+                            TString fileName2,
+                            TString fileLabel1 = "",
+                            TString fileLabel2 = "",
+                            Float_t fileScale1 = 1.0,
+                            Float_t fileScale2 = 1.0,
+                            bool showStats = false) {
+  // If file labels were not given as argument,
+  // use the filename as a label
+  if (fileLabel1 == "") {
+    fileLabel1 = fileName1;
+    fileLabel2 = fileName2;
+    fileLabel1.ReplaceAll(".root", "");
+    fileLabel1.ReplaceAll(".root", "");
+  }
+  label1 = fileLabel1;
+  label2 = fileLabel2;
+
+  // Set the scale of the histograms.
+  // If they are < 0.0, they will be area normalized
+  scale1 = fileScale1;
+  scale2 = fileScale2;
+  showStatsBoxes = showStats;
+
+  sourceFile1 = TFile::Open(fileName1);
+  sourceFile2 = TFile::Open(fileName2);
+
+  outputFolder = "HistogramsTogether/";  // Blank to use current directory,
+                                         // or, for a specific dir type
+                                         // something like "images/"
+
+  gSystem->MakeDirectory(outputFolder);
+
+  canvasDefault = new TCanvas("canvasDefault", "testCanvas", outputWidth, outputHeight);
+
+  // This function will plot all histograms from
+  // file1 against matching histogram from file2
+  recurseOverKeys(sourceFile1);
+
+  sourceFile1->Close();
+  sourceFile2->Close();
+
+  TString currentDir = gSystem->pwd();
+  cout << "Done. See images in:" << endl << currentDir << "/" << outputFolder << endl;
+}
+
+void recurseOverKeys(TDirectory *target1) {
+  // Figure out where we are
+  TString path((char *)strstr(target1->GetPath(), ":"));
+  path.Remove(0, 2);
+
+  sourceFile1->cd(path);
+
+  TDirectory *current_sourcedir = gDirectory;
+
+  TKey *key;
+  TIter nextkey(current_sourcedir->GetListOfKeys());
+
+  while (key = (TKey *)nextkey()) {
+    obj = key->ReadObj();
+
+    // Check if this is a 1D histogram or a directory
+    if (obj->IsA()->InheritsFrom("TH1")) {
+      // **************************
+      // Plot & Save this Histogram
+      TH1 *htemp1, *htemp2;
+
+      htemp1 = (TH1 *)obj;
+      TString histName = htemp1->GetName();
+
+      if (path != "") {
+        sourceFile2->GetObject(path + "/" + histName, htemp2);
+      } else {
+        sourceFile2->GetObject(histName, htemp2);
+      }
+
+      outputFilename = histName;
+      plot2Histograms(htemp1, htemp2, outputFolder + path + "/" + outputFilename + "." + imageType);
+
+    } else if (obj->IsA()->InheritsFrom("TDirectory")) {
+      // it's a subdirectory
+
+      cout << "Found subdirectory " << obj->GetName() << endl;
+      gSystem->MakeDirectory(outputFolder + path + "/" + obj->GetName());
+
+      // obj is now the starting point of another round of merging
+      // obj still knows its depth within the target file via
+      // GetPath(), so we can still figure out where we are in the recursion
+      recurseOverKeys((TDirectory *)obj);
+
+    }  // end of IF a TDriectory
+  }
+}
+
+void plot2Histograms(TH1 *htemp1, TH1 *htemp2, TString filename) {
+  //TString title = htemp1->GetName();
+  TString title = htemp1->GetTitle();
+
+  // Make sure histograms exist
+  if (!htemp2) {
+    cout << "Histogram missing from 2nd file: " << htemp1->GetName() << endl;
+    return;
+  }
+
+  // Scale by given factor.
+  // If given factor is negative, area normalize
+  if (scale1 > 0.0) {
+    htemp1->Scale(scale1);
+  } else {
+    Double_t integral = htemp1->Integral();
+    if (integral > 0.0)
+      htemp1->Scale(1 / integral);
+  }
+  if (scale2 > 0.0) {
+    htemp2->Scale(scale2);
+  } else {
+    Double_t integral = htemp2->Integral();
+    if (integral > 0.0)
+      htemp2->Scale(1 / integral);
+  }
+
+  // Set the histogram colors & lines
+  htemp1->SetLineColor(kRed);
+  htemp2->SetLineColor(kBlue);
+  htemp1->SetLineWidth(1);
+  htemp2->SetLineWidth(2);
+
+  // Turn off stats
+  if (!showStatsBoxes) {
+    gStyle->SetOptStat(0);
+  }
+
+  // Create TStack but we will draw without stacking
+  THStack *tempStack = new THStack();
+  tempStack->Add(htemp1, "sames");
+  tempStack->Add(htemp2, "sames");
+
+  // Draw the histogram and titles
+  tempStack->Draw("hist nostack");
+  tempStack->SetTitle(title);
+  tempStack->GetXaxis()->SetTitle(htemp1->GetXaxis()->GetTitle());
+
+  // Draw the legend
+  TLegend *infoBox = new TLegend(0.75, 0.83, 0.99, 0.99, "");
+  infoBox->AddEntry(htemp1, label1, "L");
+  infoBox->AddEntry(htemp2, label2, "L");
+  infoBox->SetShadowColor(0);  // 0 = transparent
+  infoBox->SetFillColor(kWhite);
+  infoBox->Draw();
+
+  // Place the stats boxes to be non-overlapping
+  if (showStatsBoxes) {
+    canvasDefault->SetRightMargin(0.2);
+    canvasDefault->Update();
+    TPaveStats *st1 = (TPaveStats *)htemp1->GetListOfFunctions()->FindObject("stats");
+    TPaveStats *st2 = (TPaveStats *)htemp2->GetListOfFunctions()->FindObject("stats");
+    st1->SetX1NDC(.79);
+    st1->SetX2NDC(.99);
+    st1->SetY1NDC(.6);
+    st1->SetY2NDC(.8);
+    st2->SetX1NDC(.79);
+    st2->SetX2NDC(.99);
+    st2->SetY1NDC(.38);
+    st2->SetY2NDC(.58);
+    canvasDefault->Modified();
+  }
+
+  // Set log y axis
+  if (yAxisLogScale)
+    canvasDefault->SetLogy(1);
+  // Save the canvas
+  canvasDefault->SaveAs(filename);
+}

--- a/CondTools/SiStrip/macros/readSiStripDBTrees.C
+++ b/CondTools/SiStrip/macros/readSiStripDBTrees.C
@@ -1,0 +1,503 @@
+#include "TROOT.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TProfile.h"
+#include "TTree.h"
+#include "TBranch.h"
+#include "TTree.h"
+#include "TChain.h"
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <map>
+#include <iostream>
+#include <iomanip>  // std::setw
+
+//**********************************************//
+// Auxilliary class
+//**********************************************//
+class RecordInfo : public TNamed {
+public:
+  RecordInfo(const char* record, const char* tag) : TNamed(record, tag) {}
+
+  void printInfo() const { std::cout << GetName() << " " << GetTitle() << std::endl; }
+
+  const char* getRecord() { return this->GetName(); }
+
+  const char* getIOVSince() { return this->GetTitle(); }
+};
+
+enum ModuleGeometry {
+  UNKNOWNGEOMETRY,
+  IB1,
+  IB2,
+  OB1,
+  OB2,
+  W1A,
+  W2A,
+  W3A,
+  W1B,
+  W2B,
+  W3B,
+  W4,
+  W5,
+  W6,
+  W7,
+  END_OF_GEOMETRIES
+};
+
+enum TrackerRegion {
+  TIB1 = 1,
+  TIB2 = 2,
+  TIB3 = 3,
+  TIB4 = 4,
+  TOB1 = 5,
+  TOB2 = 6,
+  TOB3 = 7,
+  TOB4 = 8,
+  TOB5 = 9,
+  TOB6 = 10,
+  TIDP1 = 11,
+  TIDP2 = 12,
+  TIDP3 = 13,
+  TIDM1 = 14,
+  TIDM2 = 15,
+  TIDM3 = 16,
+  TECP1 = 17,
+  TECP2 = 18,
+  TECP3 = 19,
+  TECP4 = 20,
+  TECP5 = 21,
+  TECP6 = 22,
+  TECP7 = 23,
+  TECP8 = 24,
+  TECP9 = 25,
+  TECM1 = 26,
+  TECM2 = 27,
+  TECM3 = 28,
+  TECM4 = 29,
+  TECM5 = 30,
+  TECM6 = 31,
+  TECM7 = 32,
+  TECM8 = 33,
+  TECM9 = 34,
+  END_OF_REGIONS = 35
+};
+
+/*--------------------------------------------------------------------*/
+TrackerRegion getTheRegionFromTopology(int subdet, int side, int layer)
+/*--------------------------------------------------------------------*/
+{
+  int ret(-99);
+  switch (subdet) {
+    case 3:
+      // this is TIB
+      ret = layer;
+      break;
+    case 4:
+      // this is TID
+      ret = side == 1 ? 10 + std::abs(layer) : 13 + std::abs(layer);
+      break;
+    case 5:
+      // this is TOB
+      ret = layer + 4;
+      break;
+    case 6:
+      // this is TEC
+      ret = side == 1 ? 16 + std::abs(layer) : 25 + std::abs(layer);
+      break;
+    default:
+      std::cout << "getTheRegionFromTopology(): shall never ever be here!" << std::endl;
+      break;
+  }
+  return static_cast<TrackerRegion>(ret);
+}
+
+/*--------------------------------------------------------------------*/
+const char* regionType(int index)
+/*--------------------------------------------------------------------*/
+{
+  auto region = static_cast<std::underlying_type_t<TrackerRegion> >(index);
+
+  switch (region) {
+    case TIB1:
+      return "TIB L1";
+    case TIB2:
+      return "TIB L2";
+    case TIB3:
+      return "TIB L3";
+    case TIB4:
+      return "TIB L4";
+    case TOB1:
+      return "TOB L1";
+    case TOB2:
+      return "TOB L2";
+    case TOB3:
+      return "TOB L3";
+    case TOB4:
+      return "TOB L4";
+    case TOB5:
+      return "TOB L5";
+    case TOB6:
+      return "TOB L6";
+    case TIDP1:
+      return "TID+ D1";
+    case TIDP2:
+      return "TID+ D2";
+    case TIDP3:
+      return "TID+ D3";
+    case TIDM1:
+      return "TID- D1";
+    case TIDM2:
+      return "TID- D2";
+    case TIDM3:
+      return "TID- D3";
+    case TECP1:
+      return "TEC+ D1";
+    case TECP2:
+      return "TEC+ D2";
+    case TECP3:
+      return "TEC+ D3";
+    case TECP4:
+      return "TEC+ D4";
+    case TECP5:
+      return "TEC+ D5";
+    case TECP6:
+      return "TEC+ D6";
+    case TECP7:
+      return "TEC+ D7";
+    case TECP8:
+      return "TEC+ D8";
+    case TECP9:
+      return "TEC+ D9";
+    case TECM1:
+      return "TEC- D1";
+    case TECM2:
+      return "TEC- D2";
+    case TECM3:
+      return "TEC- D3";
+    case TECM4:
+      return "TEC- D4";
+    case TECM5:
+      return "TEC- D5";
+    case TECM6:
+      return "TEC- D6";
+    case TECM7:
+      return "TEC- D7";
+    case TECM8:
+      return "TEC- D8";
+    case TECM9:
+      return "TEC- D9";
+    case END_OF_REGIONS:
+      return "undefined";
+    default:
+      return "should never be here";
+  }
+}
+
+/*--------------------------------------------------------------------*/
+const char* moduleType(int index)
+/*--------------------------------------------------------------------*/
+{
+  auto geometry = static_cast<std::underlying_type_t<ModuleGeometry> >(index);
+
+  switch (geometry) {
+    case UNKNOWNGEOMETRY:
+      return "unknown geometry";
+    case IB1:
+      return "IB1";
+    case IB2:
+      return "IB2";
+    case OB1:
+      return "OB1";
+    case OB2:
+      return "OB2";
+    case W1A:
+      return "W1A";
+    case W2A:
+      return "W2A";
+    case W3A:
+      return "W3A";
+    case W1B:
+      return "W1B";
+    case W2B:
+      return "W2B";
+    case W3B:
+      return "W3B";
+    case W4:
+      return "W4";
+    case W5:
+      return "W5";
+    case W6:
+      return "W6";
+    case W7:
+      return "W7";
+    case END_OF_GEOMETRIES:
+      return "NONE";
+    default:
+      return "should never be here";
+  }
+}
+
+/*--------------------------------------------------------------------*/
+void readNSiStripDBTrees(TString fname)
+/*--------------------------------------------------------------------*/
+{
+  TChain* tree_ = new TChain("treeDump/StripDBTree");
+  tree_->Add(fname);
+
+  uint32_t detId_, ring_, istrip_, det_type_;
+  Int_t layer_, side_, subdetId_;
+  float pedestal_, noise_, gsim_, g1_, g2_, lenght_;
+  bool isTIB_, isTOB_, isTEC_, isTID_, isBad_;
+
+  std::map<int, TH1F*> PedestalPerLayer;
+  std::map<int, TH1F*> idealNoiseRatioPerLayer;
+  std::map<int, TH1F*> NoisePerLayer;
+  std::map<int, TH1F*> g1PerLayer;
+  std::map<int, TH2F*> noiseVsG1PerModuleGeometry;
+  std::map<int, TProfile*> p_noiseVsG1PerModuleGeometry;
+
+  tree_->SetBranchAddress("detId", &detId_);
+  tree_->SetBranchAddress("detType", &det_type_);
+  tree_->SetBranchAddress("noise", &noise_);
+  tree_->SetBranchAddress("pedestal", &pedestal_);
+  tree_->SetBranchAddress("istrip", &istrip_);
+  tree_->SetBranchAddress("gsim", &gsim_);
+  tree_->SetBranchAddress("g1", &g1_);
+  tree_->SetBranchAddress("g2", &g2_);
+  tree_->SetBranchAddress("layer", &layer_);
+  tree_->SetBranchAddress("side", &side_);
+  tree_->SetBranchAddress("subdetId", &subdetId_);
+  tree_->SetBranchAddress("ring", &ring_);
+  tree_->SetBranchAddress("length", &lenght_);
+  tree_->SetBranchAddress("isBad", &isBad_);
+  tree_->SetBranchAddress("isTIB", &isTIB_);
+  tree_->SetBranchAddress("isTOB", &isTOB_);
+  tree_->SetBranchAddress("isTEC", &isTEC_);
+  tree_->SetBranchAddress("isTID", &isTID_);
+
+  int nentries = tree_->GetEntries();
+  std::cout << "Number of entries = " << nentries << std::endl;
+
+  tree_->LoadTree(0);
+  TObjString* s = (TObjString*)tree_->GetTree()->GetUserInfo()->At(0);
+
+  //RecordInfo *header = (RecordInfo*)tree_->GetTree()->GetUserInfo()->FindObject("SiStripPedestalsRcd");
+  //header->printInfo();
+  //std::cout << "printing recordInfo:"<<header->getRecord() << " IOV: "<< header->getIOVSince() << std::endl;
+
+  // print the headers
+
+  std::vector<const char*> records = {
+      "SiStripPedestalsRcd", "SiStripNoisesRcd", "SiStripApvGainRcd", "SiStripApvGain2Rcd", "SiStripQualityRcd"};
+  for (const auto& rec : records) {
+    RecordInfo* header = (RecordInfo*)tree_->GetTree()->GetUserInfo()->FindObject(rec);
+    //header->printInfo();
+    std::cout << "printing recordInfo: " << header->getRecord() << " IOV: " << header->getIOVSince() << std::endl;
+  }
+
+  TH1F* h_avgPedestal =
+      new TH1F("h_avgPedestal_perRegion", "average Pedestal per region;;average Pedestals [ADC counts]", 34, 0., 34.);
+  TH1F* h_avgIdealNoiseRatio =
+      new TH1F("h_avgIdealNoise_perRegion", "average Ideal Noise per region;;averag Ideal Noise ratio", 34, 0., 34.);
+  TH1F* h_avgNoise =
+      new TH1F("h_avgNoise_perRegion", "average Noise per region;; average Noise [ADC counts]", 34, 0., 34.);
+
+  TH1F* h_Pedestal = new TH1F("h_Pedestal", "Pedestal;Pedestals [ADC counts];n. strips", 300, 0., 300.);
+  TH1F* h_idealNoiseRatio = new TH1F("h_IdealNoise", "Ideal Noise;Ideal Noise ratio;n. strips", 500, 0., 10.);
+  TH1F* h_Noise = new TH1F("h_Noise", "Noise;Noise [ADC counts];n. strips", 500, 0., 10.);
+
+  TH2F* h2_NoiseVsPedestal = new TH2F(
+      "h2_NoiseVsPedestal", "Noise Vs Pedestal;Pedestals [ADC counts];Noise [ACD counts]", 350, 0., 350., 120, 0., 12.);
+  TH2F* h2_NoiseVsG1 =
+      new TH2F("h2_NoiseVsG1", "Noise vs G1 Gain;G1 gain;Noise [ACD counts]", 100, 0., 2., 200, 0., 20.);
+
+  TH2F* h2_NoiseVsPedestalTIB = new TH2F("h2_NoiseVsPedestalTIB",
+                                         "Noise Vs Pedestal;Pedestals [ADC counts];Noise [ACD counts]",
+                                         350,
+                                         0.,
+                                         350.,
+                                         120,
+                                         0.,
+                                         12.);
+  TH2F* h2_NoiseVsPedestalTOB = new TH2F("h2_NoiseVsPedestalTOB",
+                                         "Noise Vs Pedestal;Pedestals [ADC counts];Noise [ACD counts]",
+                                         350,
+                                         0.,
+                                         350.,
+                                         120,
+                                         0.,
+                                         12.);
+  TH2F* h2_NoiseVsPedestalTID = new TH2F("h2_NoiseVsPedestalTID",
+                                         "Noise Vs Pedestal;Pedestals [ADC counts];Noise [ACD counts]",
+                                         350,
+                                         0.,
+                                         350.,
+                                         120,
+                                         0.,
+                                         12.);
+  TH2F* h2_NoiseVsPedestalTEC = new TH2F("h2_NoiseVsPedestalTEC",
+                                         "Noise Vs Pedestal;Pedestals [ADC counts];Noise [ACD counts]",
+                                         350,
+                                         0.,
+                                         350.,
+                                         120,
+                                         0.,
+                                         12.);
+
+  TH1F* h_g1 = new TH1F("h_g1", "g1 gain;g1 gain;n. strips", 200, 0., 2.);
+
+  // loop on the tracker regions
+  for (int region = TrackerRegion::TIB1; region != TrackerRegion::END_OF_REGIONS; region++) {
+    auto tag = regionType(region);
+    std::cout << "booking region: " << std::setw(3) << region << " -> " << tag << std::endl;
+    idealNoiseRatioPerLayer[region] = new TH1F(
+        Form("IdealNoise_%s", tag), Form("Ideal Noise %s;Ideal Noise ratio for %s;n. strips", tag, tag), 500, 0., 10.);
+    NoisePerLayer[region] =
+        new TH1F(Form("Noise_%s", tag), Form("Noise %s;Noise for %s [ADC counts];n. strips", tag, tag), 500, 0., 10.);
+    g1PerLayer[region] = new TH1F(Form("g1_%s", tag), Form("g1 %s;g1 for %s;n. strips", tag, tag), 200, 0., 2.);
+    PedestalPerLayer[region] =
+        new TH1F(Form("pedestal_%s", tag), Form("pedestal %s;pedestal for %s;n. strips", tag, tag), 350, 0., 350.);
+
+    h_avgPedestal->GetXaxis()->SetBinLabel(region, tag);
+    h_avgIdealNoiseRatio->GetXaxis()->SetBinLabel(region, tag);
+    h_avgNoise->GetXaxis()->SetBinLabel(region, tag);
+  }
+
+  // loop on the tracker module geometries
+  for (int geometry = ModuleGeometry::IB1; geometry != ModuleGeometry::END_OF_GEOMETRIES; geometry++) {
+    auto tag = moduleType(geometry);
+    noiseVsG1PerModuleGeometry[geometry] = new TH2F(Form("h2_NoiseVsG1_%s", tag),
+                                                    Form("Noise vs G1 Gain for %s;G1 gain;Noise [ACD counts]", tag),
+                                                    100,
+                                                    0.,
+                                                    2.,
+                                                    200,
+                                                    0.,
+                                                    20.);
+    p_noiseVsG1PerModuleGeometry[geometry] = new TProfile(
+        Form("p_NoiseVsG1_%s", tag), Form("Noise vs G1 Gain for %s;G1 gain;Noise [ACD counts]", tag), 100, 0., 2.);
+  }
+
+  uint32_t cachedDetId = -1;
+
+  printf("Progressing Bar              :0%%       20%%       40%%       60%%       80%%       100%%\n");
+  printf("Scanning ntuple              :");
+  int TreeStep = tree_->GetEntries() / 50;
+  if (TreeStep == 0)
+    TreeStep = 1;
+  for (Int_t stripNo = 0; stripNo < nentries; stripNo++) {
+    if (stripNo % TreeStep == 0) {
+      printf(".");
+      fflush(stdout);
+    }
+    Int_t IgetStrip = tree_->GetEntry(stripNo);
+    auto region = getTheRegionFromTopology(subdetId_, side_, layer_);
+
+    h2_NoiseVsPedestal->Fill(pedestal_, noise_);
+    h2_NoiseVsG1->Fill(g1_, noise_);
+
+    switch (subdetId_) {
+      case 3:
+        h2_NoiseVsPedestalTIB->Fill(pedestal_, noise_);
+        break;
+      case 5:
+        h2_NoiseVsPedestalTOB->Fill(pedestal_, noise_);
+        break;
+      case 4:
+        h2_NoiseVsPedestalTID->Fill(pedestal_, noise_);
+        break;
+      case 6:
+        h2_NoiseVsPedestalTEC->Fill(pedestal_, noise_);
+        break;
+      default:
+        std::cout << "shall never be here!" << std::endl;
+    }
+
+    h_Pedestal->Fill(pedestal_);
+    h_idealNoiseRatio->Fill(noise_ / g1_);
+    h_Noise->Fill(noise_);
+    h_g1->Fill(g1_);
+
+    PedestalPerLayer[region]->Fill(pedestal_);
+    idealNoiseRatioPerLayer[region]->Fill(noise_ / g1_);
+    NoisePerLayer[region]->Fill(noise_);
+    g1PerLayer[region]->Fill(g1_);
+
+    noiseVsG1PerModuleGeometry[det_type_]->Fill(g1_, noise_);
+    p_noiseVsG1PerModuleGeometry[det_type_]->Fill(g1_, noise_);
+
+    //std::cout << " strip n."<< stripNo << " detId:"<< detId_ << " strip n.: "<< istrip_ << std::endl;
+    if (detId_ != cachedDetId) {
+      //  std::cout << " strip n."<< stripNo << " detId:"<< detId_ << " strip n.: "<< istrip_
+      //	<< " subdet: " << subdetId_ <<" side: "<< side_ << " layer: "<< layer_ << " (region: " << region << ") =>  " << regionType(region) << " " << moduleType(det_type_) << std::endl;
+      cachedDetId = detId_;
+    }
+  }
+  printf("\n");
+
+  for (int region = TrackerRegion::TIB1; region != TrackerRegion::END_OF_REGIONS; region++) {
+    h_avgIdealNoiseRatio->SetBinContent(region, idealNoiseRatioPerLayer[region]->GetMean());
+    h_avgNoise->SetBinContent(region, NoisePerLayer[region]->GetMean());
+    h_avgPedestal->SetBinContent(region, PedestalPerLayer[region]->GetMean());
+  }
+
+  TFile* outfile = TFile::Open(Form("idealNoise_%s.root", (s->GetString()).Data()), "RECREATE");
+  outfile->cd();
+  h_Pedestal->Write();
+  h_idealNoiseRatio->Write();
+  h_Noise->Write();
+  h2_NoiseVsG1->Write();
+  h2_NoiseVsPedestal->Write();
+  h_g1->Write();
+
+  h_avgPedestal->Write();
+  h_avgIdealNoiseRatio->Write();
+  h_avgNoise->Write();
+
+  TDirectory* byPartition = outfile->mkdir("ByPartition");
+  byPartition->cd();
+  h2_NoiseVsPedestalTIB->Write();
+  h2_NoiseVsPedestalTOB->Write();
+  h2_NoiseVsPedestalTID->Write();
+  h2_NoiseVsPedestalTEC->Write();
+
+  TDirectory* cdIdealNoise = outfile->mkdir("idealNoise");
+  cdIdealNoise->cd();
+  for (int region = TrackerRegion::TIB1; region != TrackerRegion::END_OF_REGIONS; region++) {
+    auto tag = regionType(region);
+    idealNoiseRatioPerLayer[region]->Write();
+  }
+
+  outfile->cd();
+  TDirectory* cdNoise = outfile->mkdir("Noise");
+  cdNoise->cd();
+  for (int region = TrackerRegion::TIB1; region != TrackerRegion::END_OF_REGIONS; region++) {
+    auto tag = regionType(region);
+    NoisePerLayer[region]->Write();
+  }
+
+  outfile->cd();
+  TDirectory* cdG1 = outfile->mkdir("g1");
+  cdG1->cd();
+  for (int region = TrackerRegion::TIB1; region != TrackerRegion::END_OF_REGIONS; region++) {
+    auto tag = regionType(region);
+    g1PerLayer[region]->Write();
+  }
+
+  outfile->cd();
+  TDirectory* cNoiseVsG1 = outfile->mkdir("tickmark_vs_noise");
+  cNoiseVsG1->cd();
+  for (int geometry = ModuleGeometry::IB1; geometry != ModuleGeometry::END_OF_GEOMETRIES; geometry++) {
+    noiseVsG1PerModuleGeometry[geometry]->Write();
+    p_noiseVsG1PerModuleGeometry[geometry]->Write();
+  }
+
+  outfile->Close();
+  tree_->Delete();
+  return;
+}

--- a/CondTools/SiStrip/plugins/SiStripCondVisualizer.cc
+++ b/CondTools/SiStrip/plugins/SiStripCondVisualizer.cc
@@ -1,0 +1,529 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/SiStrip
+// Class:      SiStripNoiseVisualizer
+//
+/**\class SiStripNoiseVisualizer SiStripNoiseVisualizer.cc
+ CondTools/SiStrip/plugins/SiStripNoiseVisualizer.cc
+
+ Description:
+    Creates a ROOT file with per-module profiles of Noise and Pedestals vs strip
+ number
+
+*/
+//
+// Original Author:  Marco Musich
+//         Created:  Thu, 05 Apr 2018 15:32:25 GMT
+//
+//
+
+// system include files
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// user include files
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "CommonTools/UtilAlgos/interface/DetIdSelector.h"
+#include "CondFormats/DataRecord/interface/SiStripApvGainRcd.h"
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
+#include "CondFormats/DataRecord/interface/SiStripPedestalsRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/SiStripObjects/interface/SiStripPedestals.h"
+#include "DataFormats/Common/interface/DetSetNew.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h" /* for STRIPS_PER_APV*/
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#define LOGERROR(x) edm::LogError(x)
+#define LOGWARNING(x) edm::LogWarning(x)
+#define LOGINFO(x) edm::LogInfo(x)
+#define LOGVERBATIM(x) edm::LogVerbatim(x)
+#define LOGDEBUG(x) LogDebug(x)
+
+// ROOT includes
+#include "TNamed.h"
+#include "TObjString.h"
+#include "TText.h"
+#include "TTree.h"
+
+//
+// Auxiliary enum to enumerate the conditions types
+//
+namespace SiStripCondTypes {
+  enum condformat { Noise = 0, Pedestals = 1, G1Gain = 2, G2Gain = 3, Quality = 4, EndOfTypes = 99 };
+  static const std::array<std::string, 5> titles = {{"noise", "pedestals", "G1 gain", "G2 gain", "Quality"}};
+  static const std::array<std::string, 5> units = {{"[ADC counts]", "[ADC counts]", "", "", ""}};
+
+  // some magic from https://stackoverflow.com/questions/47801709/best-way-to-set-a-bitset-with-boolean-values
+  template <typename... Args>
+  std::bitset<sizeof...(Args)> makeBitSet(Args... as) {
+    using unused = bool[];
+    std::bitset<sizeof...(Args)> ret;
+    std::size_t ui{ret.size()};
+    (void)unused{true, (ret.set(--ui, as), true)...};
+    return ret;
+  }
+
+}  // namespace SiStripCondTypes
+
+//
+// class declaration
+//
+
+using HistoMap = std::map<uint32_t, TH1F*>;
+
+class SiStripCondVisualizer : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
+public:
+  explicit SiStripCondVisualizer(const edm::ParameterSet&);
+  ~SiStripCondVisualizer() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override{};
+  bool isDetIdSelected(const uint32_t detid);
+  HistoMap bookModuleHistograms(const TrackerTopology* tTopo, const SiStripCondTypes::condformat& type);
+  std::tuple<std::string, int, int, int> setTopoInfo(uint32_t detId, const TrackerTopology* tTopo);
+  std::string module_location_type(const unsigned int& mod);
+  void fillTheQualityMap(const SiStripQuality* obj, HistoMap& theMap);
+  template <class Payload>
+  void fillTheHistoMap(const Payload* obj, HistoMap& theMap);
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  // ----------member data ---------------------------
+  edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> noiseToken_;
+  edm::ESGetToken<SiStripPedestals, SiStripPedestalsRcd> pedToken_;
+  edm::ESGetToken<SiStripApvGain, SiStripApvGainRcd> g1Token_;
+  edm::ESGetToken<SiStripApvGain, SiStripApvGain2Rcd> g2Token_;
+  edm::ESGetToken<SiStripQuality, SiStripQualityRcd> qualToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+
+  const bool doNoise_;
+  const bool doPeds_;
+  const bool doG1_;
+  const bool doG2_;
+  const bool doBadComps_;
+
+  std::vector<DetIdSelector> detidsels_;
+  edm::Service<TFileService> fs_;
+  SiStripDetInfo detInfo_;
+  std::map<std::string, TFileDirectory> outputFolders_;
+  HistoMap NoiseMap_, PedMap_, G1Map_, G2Map_, QualMap_;
+  std::bitset<5> plottedConditions_;
+};
+
+//
+// constructors and destructor
+//
+SiStripCondVisualizer::SiStripCondVisualizer(const edm::ParameterSet& iConfig)
+    : topoToken_(esConsumes<edm::Transition::BeginRun>()),
+      doNoise_(iConfig.getParameter<bool>("doNoise")),
+      doPeds_(iConfig.getParameter<bool>("doPeds")),
+      doG1_(iConfig.getParameter<bool>("doG1")),
+      doG2_(iConfig.getParameter<bool>("doG2")),
+      doBadComps_(iConfig.getParameter<bool>("doBadComps")),
+      detidsels_() {
+  usesResource(TFileService::kSharedResource);
+  // now do what ever initialization is needed
+  detInfo_ = SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
+
+  plottedConditions_ = SiStripCondTypes::makeBitSet(doNoise_, doPeds_, doG1_, doG2_, doBadComps_);
+
+  // now do the consumes
+  if (doNoise_)
+    noiseToken_ = esConsumes();
+  if (doPeds_)
+    pedToken_ = esConsumes();
+  if (doG1_)
+    g1Token_ = esConsumes();
+  if (doG2_)
+    g2Token_ = esConsumes();
+  if (doBadComps_)
+    qualToken_ = esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("StripQualityLabel")));
+
+  // detid selection
+  std::vector<edm::ParameterSet> selconfigs = iConfig.getParameter<std::vector<edm::ParameterSet>>("selections");
+  for (std::vector<edm::ParameterSet>::const_iterator selconfig = selconfigs.begin(); selconfig != selconfigs.end();
+       ++selconfig) {
+    DetIdSelector selection(*selconfig);
+    detidsels_.push_back(selection);
+  }
+}
+
+//
+// member functions
+//
+
+/*
+ * special case for the SiStripQuality
+ */
+void SiStripCondVisualizer::fillTheQualityMap(const SiStripQuality* obj, HistoMap& theMap) {
+  const auto& badComponentsList = obj->getBadComponentList();
+
+  for (const auto& bc : badComponentsList) {
+    LogDebug("SiStripCondVisualizer") << "Det:" << bc.detid << " location: " << this->module_location_type(bc.detid)
+                                      << " bad APVs:" << bc.BadApvs << " bad Fibers:" << bc.BadFibers
+                                      << " bad Module:" << bc.BadModule;
+  }
+
+  // now get the detids
+  std::vector<uint32_t> activeDetIds;
+  std::transform(badComponentsList.begin(),
+                 badComponentsList.end(),
+                 std::back_inserter(activeDetIds),
+                 [](const SiStripQuality::BadComponent& bc) { return bc.detid; });
+
+  for (const uint32_t& detid : activeDetIds) {
+    if (!this->isDetIdSelected(detid))
+      continue;
+
+    unsigned int nStrip = detInfo_.getNumberOfApvsAndStripLength(detid).first * sistrip::STRIPS_PER_APV;
+
+    for (unsigned int istrip_ = 0; istrip_ < nStrip; ++istrip_) {
+      bool isStripBad = obj->IsStripBad(detid, istrip_);
+      float quant_ = isStripBad ? 1.f : 0.f;
+      if (!theMap.count(detid)) {
+        LOGWARNING("SiStripCondVisualizer")
+            << "@SUB=SiStripCondVisualizer::analyze(): " << detid << " was not found in the quality histogram map!!!";
+      } else {
+        theMap[detid]->SetBinContent(istrip_, quant_);
+      }
+    }  // loop on the strips
+  }    // loop on the active detids
+  return;
+}
+
+/*
+ * Payload functor based method for all the other cases
+ */
+template <class Payload>
+void SiStripCondVisualizer::fillTheHistoMap(const Payload* obj, HistoMap& theMap) {
+  std::function<float(unsigned int, typename Payload::Range)> payloadFunctor = [&obj](unsigned int istrip,
+                                                                                      typename Payload::Range range) {
+    if constexpr (std::is_same_v<Payload, SiStripNoises>) {
+      return obj->getNoise(istrip, range);
+    } else if constexpr (std::is_same_v<Payload, SiStripPedestals>) {
+      return obj->getPed(istrip, range);
+    } else if constexpr (std::is_same_v<Payload, SiStripApvGain>) {
+      return obj->getStripGain(istrip, range);
+    }
+  };
+
+  std::vector<uint32_t> activeDetIds;
+  obj->getDetIds(activeDetIds);
+
+  for (const uint32_t& detid : activeDetIds) {
+    if (!this->isDetIdSelected(detid))
+      continue;
+
+    typename Payload::Range condRange = obj->getRange(detid);
+    unsigned int nStrip = detInfo_.getNumberOfApvsAndStripLength(detid).first * sistrip::STRIPS_PER_APV;
+
+    for (unsigned int istrip_ = 0; istrip_ < nStrip; ++istrip_) {
+      float quant_ = payloadFunctor(istrip_, condRange);
+
+      if (!theMap.count(detid)) {
+        LOGWARNING("SiStripCondVisualizer")
+            << "@SUB=SiStripCondVisualizer::analyze(): " << detid << " was not found in the histogram map!!!";
+      } else {
+        theMap[detid]->SetBinContent(istrip_, quant_);
+      }
+    }  // loop on the strips
+  }    // loop on the active detids
+}
+
+// ------------ method called for each event  ------------
+void SiStripCondVisualizer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+
+  if (doNoise_) {
+    const SiStripNoises* noiseObj = &iSetup.getData(noiseToken_);
+    this->fillTheHistoMap<SiStripNoises>(noiseObj, NoiseMap_);
+  }
+  if (doPeds_) {
+    const SiStripPedestals* pedestalObj = &iSetup.getData(pedToken_);
+    this->fillTheHistoMap<SiStripPedestals>(pedestalObj, PedMap_);
+  }
+  if (doG1_) {
+    const SiStripApvGain* g1Obj = &iSetup.getData(g1Token_);
+    this->fillTheHistoMap<SiStripApvGain>(g1Obj, G1Map_);
+  }
+  if (doG2_) {
+    const SiStripApvGain* g2Obj = &iSetup.getData(g2Token_);
+    this->fillTheHistoMap<SiStripApvGain>(g2Obj, G2Map_);
+  }
+  if (doBadComps_) { /* special case for the SiStripQuality */
+    const SiStripQuality* siStripQualityObj = &iSetup.getData(qualToken_);
+    this->fillTheQualityMap(siStripQualityObj, QualMap_);
+  }
+}
+
+// ------------ method called for each run  ------------
+void SiStripCondVisualizer::beginRun(const edm::Run& iRun, edm::EventSetup const& iSetup) {
+  const TrackerTopology* tTopo_ = &iSetup.getData(topoToken_);
+  const std::map<uint32_t, SiStripDetInfo::DetInfo> DetInfos = detInfo_.getAllData();
+
+  for (const auto& it : DetInfos) {
+    LogDebug("SiStripCondVisualizer") << "detid " << it.first << "isSelected  " << this->isDetIdSelected(it.first);
+
+    if (!this->isDetIdSelected(it.first))
+      continue;
+
+    auto topolInfo = setTopoInfo(it.first, tTopo_);
+    std::string thePart = std::get<0>(topolInfo);
+
+    for (std::size_t i = 0; i < plottedConditions_.size(); ++i) {
+      if (plottedConditions_.test(i)) {
+        const std::string fname = Form("%s_%s", SiStripCondTypes::titles[i].c_str(), thePart.c_str());
+
+        // book the TFileDirectory if it's not already done
+        if (!outputFolders_.count(fname)) {
+          outputFolders_[fname] = fs_->mkdir(fname);
+        }
+      }
+    }  // loop on the bitset of plotted conditions
+  }    // loop on modules
+
+  if (doNoise_) {
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n Before booking NoisMap_.size(): "
+                                     << NoiseMap_.size();
+    NoiseMap_ = bookModuleHistograms(tTopo_, SiStripCondTypes::Noise);
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n After booking NoisMap_.size(): "
+                                     << NoiseMap_.size();
+  }
+  if (doPeds_) {
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n Before booking PedMap_.size(): "
+                                     << PedMap_.size();
+    PedMap_ = bookModuleHistograms(tTopo_, SiStripCondTypes::Pedestals);
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n After booking PedMap_.size(): "
+                                     << PedMap_.size();
+  }
+  if (doG1_) {
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n Before booking G1Map_.size(): "
+                                     << G1Map_.size();
+    G1Map_ = bookModuleHistograms(tTopo_, SiStripCondTypes::G1Gain);
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n After booking G1Map_.size(): "
+                                     << G1Map_.size();
+  }
+  if (doG2_) {
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n Before booking G2Map_.size(): "
+                                     << G2Map_.size();
+    G2Map_ = bookModuleHistograms(tTopo_, SiStripCondTypes::G2Gain);
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n After booking G2Map_.size(): "
+                                     << G2Map_.size();
+  }
+  if (doBadComps_) {
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n Before booking QualMap_.size(): "
+                                     << QualMap_.size();
+    QualMap_ = bookModuleHistograms(tTopo_, SiStripCondTypes::Quality);
+    LOGINFO("SiStripCondVisualizer") << "@SUB=SiStripCondVisualizer::beginRun() \n After booking QualMap_.size(): "
+                                     << QualMap_.size();
+  }
+}
+
+// ------------ method called to determine the topology  ------------
+std::tuple<std::string, int, int, int> SiStripCondVisualizer::setTopoInfo(uint32_t detId,
+                                                                          const TrackerTopology* tTopo) {
+  int subdetId_(-999), layer_(-999), side_(-999);
+  std::string ret = "";
+  std::tuple<std::string, int, int, int> def_tuple{ret, subdetId_, layer_, side_};
+
+  subdetId_ = DetId(detId).subdetId();
+  switch (subdetId_) {
+    case SiStripSubdetector::TIB:  // TIB
+      layer_ = tTopo->tibLayer(detId);
+      side_ = 0;
+      ret += Form("TIB_Layer%i", layer_);
+      break;
+    case SiStripSubdetector::TID:  // TID
+      side_ = tTopo->tidSide(detId);
+      layer_ = tTopo->tidWheel(detId);
+      ret += ("TID_");
+      ret += (side_ == 1) ? Form("P_disk%i", layer_) : Form("M_disk%i", layer_);
+      break;
+    case SiStripSubdetector::TOB:  // TOB
+      layer_ = tTopo->tobLayer(detId);
+      side_ = 0;
+      ret += Form("TOB_Layer%i", layer_);
+      break;
+    case SiStripSubdetector::TEC:  // TEC
+      side_ = tTopo->tecSide(detId);
+      layer_ = tTopo->tecWheel(detId);
+      ret += ("TEC_");
+      ret += (side_ == 1) ? Form("P_disk%i", layer_) : Form("M_disk%i", layer_);
+      break;
+    default:
+      edm::LogError("SiStripCondVisualizer") << "SUB=SiStripCondVisualizer::setTopoInfo() \n unrecognizer partition.";
+      return def_tuple;
+  }
+
+  return std::make_tuple(ret, subdetId_, layer_, side_);
+}
+
+// name of the location of a given module and its type,
+// e.g. TIB_L1s: stereo module at TIB layer 1
+std::string SiStripCondVisualizer::module_location_type(const unsigned int& mod) {
+  const SiStripDetId detid(mod);
+  std::string subdet = "";
+  if (detid.subDetector() == SiStripDetId::TIB)
+    subdet = "TIB";
+  if (detid.subDetector() == SiStripDetId::TOB)
+    subdet = "TOB";
+  if (detid.subDetector() == SiStripDetId::TID)
+    subdet = "TID";
+  if (detid.subDetector() == SiStripDetId::TEC)
+    subdet = "TEC";
+
+  // Barrel
+  int layer = int((mod >> 14) & 0x7);
+  std::string type = (detid.stereo() ? "s" : "a");
+  std::string d_l_t = Form("%s_L%d%s", subdet.c_str(), layer, type.c_str());
+
+  // Endcaps
+  if (subdet == "TID" || subdet == "TEC") {
+    unsigned int sideStartBit_{0};
+    unsigned int wheelStartBit_{0};
+    unsigned int ringStartBit_{0};
+    unsigned int sideMask_{0};
+    unsigned int wheelMask_{0};
+    unsigned int ringMask_{0};
+
+    // TEC
+    if (subdet == "TEC") {
+      sideStartBit_ = 18;
+      wheelStartBit_ = 14;
+      ringStartBit_ = 5;
+      sideMask_ = 0x3;
+      wheelMask_ = 0xF;
+      ringMask_ = 0x7;
+    }
+
+    // TID
+    if (subdet == "TID") {
+      sideStartBit_ = 13;
+      wheelStartBit_ = 11;
+      ringStartBit_ = 9;
+      sideMask_ = 0x3;
+      wheelMask_ = 0x3;
+      ringMask_ = 0x3;
+    }
+
+    // TEC+-, TID+- (see also at the bottom of this file
+    int side = int((mod >> sideStartBit_) & sideMask_);
+    int wheel = int((mod >> wheelStartBit_) & wheelMask_);
+    int ring = int((mod >> ringStartBit_) & ringMask_);
+
+    std::string s_side = (side == 1 ? "Plus" : "Minus");
+
+    d_l_t = Form("%s%s_W%dR%d", subdet.c_str(), s_side.c_str(), wheel, ring);
+  }
+  return d_l_t;
+}
+
+// ------------ method called to determine if the detid is selected
+bool SiStripCondVisualizer::isDetIdSelected(const uint32_t detid) {
+  bool isSelected{false};
+  for (std::vector<DetIdSelector>::const_iterator detidsel = detidsels_.begin(); detidsel != detidsels_.end();
+       ++detidsel) {
+    if (detidsel->isSelected(detid)) {
+      isSelected = true;
+      break;
+    }
+  }
+  return isSelected;
+}
+
+// ------------ method called once to book all the module level histograms
+HistoMap SiStripCondVisualizer::bookModuleHistograms(const TrackerTopology* tTopo_,
+                                                     const SiStripCondTypes::condformat& type) {
+  TH1F::SetDefaultSumw2(kTRUE);
+  HistoMap h;
+
+  const std::map<uint32_t, SiStripDetInfo::DetInfo> DetInfos = detInfo_.getAllData();
+
+  for (const auto& it : DetInfos) {
+    // check if det id is correct and if it is actually cabled in the detector
+    if (it.first == 0 || it.first == 0xFFFFFFFF) {
+      edm::LogError("DetIdNotGood") << "@SUB=analyze"
+                                    << "Wrong det id: " << it.first << "  ... neglecting!";
+      continue;
+    }
+
+    if (!this->isDetIdSelected(it.first))
+      continue;
+
+    auto topolInfo = setTopoInfo(it.first, tTopo_);
+    const std::string thePart = std::get<0>(topolInfo);
+    const std::string fname = Form("%s_%s", SiStripCondTypes::titles[type].c_str(), thePart.c_str());
+
+    unsigned int nStrip = detInfo_.getNumberOfApvsAndStripLength(it.first).first * sistrip::STRIPS_PER_APV;
+
+    h[it.first] =
+        outputFolders_[fname].make<TH1F>(Form("%sProfile_%i", SiStripCondTypes::titles[type].c_str(), it.first),
+                                         Form("%s for module %i (%s);n. strip; %s %s",
+                                              SiStripCondTypes::titles[type].c_str(),
+                                              it.first,
+                                              thePart.c_str(),
+                                              SiStripCondTypes::titles[type].c_str(),
+                                              SiStripCondTypes::units[type].c_str()),
+                                         nStrip,
+                                         -0.5,
+                                         nStrip + 0.5);
+  }
+  return h;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module
+void SiStripCondVisualizer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setComment("Creates a ROOT file with the per-moudle profiles of different SiStrip Database tag contents.");
+  desc.add<bool>("doNoise", false);
+  desc.add<bool>("doPeds", false);
+  desc.add<bool>("doG1", false);
+  desc.add<bool>("doG2", false);
+  desc.add<bool>("doBadComps", false);
+  desc.add<std::string>("StripQualityLabel", "MergedBadComponent");
+
+  // for the DetId selection
+  edm::ParameterSetDescription desc_detIdSelection;
+  desc_detIdSelection.add<unsigned int>("detSelection");
+  desc_detIdSelection.add<std::string>("detLabel");
+  desc_detIdSelection.addUntracked<std::vector<std::string>>("selection");
+  std::vector<edm::ParameterSet> default_detIdSelectionVector;
+  edm::ParameterSet default_detIdSelector;
+  default_detIdSelector.addParameter<unsigned int>("detSelection", 1);
+  default_detIdSelector.addParameter<std::string>("detLabel", "Tracker");
+  default_detIdSelector.addUntrackedParameter<std::vector<std::string>>("selection",
+                                                                        {"0x1e000000-0x16000000",
+                                                                         "0x1e006000-0x18002000",
+                                                                         "0x1e006000-0x18004000",
+                                                                         "0x1e000000-0x1a000000",
+                                                                         "0x1e0c0000-0x1c040000",
+                                                                         "0x1e0c0000-0x1c080000"});
+  default_detIdSelectionVector.push_back(default_detIdSelector);
+  desc.addVPSet("selections", desc_detIdSelection, default_detIdSelectionVector);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(SiStripCondVisualizer);

--- a/CondTools/SiStrip/plugins/SiStripDB2Tree.cc
+++ b/CondTools/SiStrip/plugins/SiStripDB2Tree.cc
@@ -1,0 +1,345 @@
+// -*- C++ -*-
+//
+// Package:    CondTools/SiStrip
+// Class:      SiStripDB2Tree
+//
+/**\class SiStripDB2Tree SiStripDB2Tree.cc CondTools/SiStrip/plugins/SiStripDB2Tree.cc
+
+ Description:
+     Converts several SiStrip Payloads (Noise, Peds, APVGain, etc.) into a TTree
+*/
+//
+// Original Author:  Mauro Verzetti
+// Modified by:      Marco Musich
+//
+
+// system include files
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// user include files
+#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
+#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+#include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "CondFormats/DataRecord/interface/SiStripApvGainRcd.h"
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+#include "CondFormats/DataRecord/interface/SiStripNoisesRcd.h"
+#include "CondFormats/DataRecord/interface/SiStripPedestalsRcd.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
+#include "CondFormats/SiStripObjects/interface/SiStripLatency.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/SiStripObjects/interface/SiStripPedestals.h"
+#include "DataFormats/Common/interface/DetSetNew.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h" /* for STRIPS_PER_APV*/
+#include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#define LOGERROR(x) edm::LogError(x)
+#define LOGINFO(x) edm::LogInfo(x)
+#define LOGDEBUG(x) LogDebug(x)
+
+// ROOT includes
+#include "TNamed.h"
+#include "TObjString.h"
+#include "TText.h"
+#include "TTree.h"
+
+//**********************************************//
+// Auxilliary class
+//**********************************************//
+class RecordInfo : public TNamed {
+public:
+  RecordInfo(const char* record, const char* tag) : TNamed(record, tag) {}
+
+  void printInfo() const { LOGINFO("RecordInfo") << GetName() << " " << GetTitle(); }
+
+  const char* getRecord() { return this->GetName(); }
+  const char* getIOVSince() { return this->GetTitle(); }
+};
+
+class SiStripDB2Tree : public edm::one::EDAnalyzer<edm::one::SharedResources, edm::one::WatchRuns> {
+public:
+  explicit SiStripDB2Tree(const edm::ParameterSet&);
+  ~SiStripDB2Tree() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override{};
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void setTopoInfo(uint32_t detId, const TrackerTopology* tTopo);
+  template <class Rcd>
+  std::pair<const char*, std::string> getRecordInfo(const edm::EventSetup& iSetup) const;
+
+  // ----------member data ---------------------------
+
+  // ES tokens
+  const edm::ESGetToken<SiStripPedestals, SiStripPedestalsRcd> pedToken_;
+  const edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> noiseToken_;
+  const edm::ESGetToken<SiStripApvGain, SiStripApvGainRcd> g1Token_;
+  const edm::ESGetToken<SiStripApvGain, SiStripApvGain2Rcd> g2Token_;
+  const edm::ESGetToken<SiStripQuality, SiStripQualityRcd> qualToken_;
+  const edm::ESGetToken<SiStripApvGain, SiStripApvGainSimRcd> gsimToken_;
+  const edm::ESGetToken<SiStripLatency, SiStripLatencyRcd> latToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+
+  const bool isMC_;
+
+  TTree* tree_;
+  std::string processGT_;
+
+  //branches
+  uint32_t detId_, ring_, istrip_, det_type_;
+  Int_t layer_, side_, subdetId_;
+  float noise_, gsim_, g1_, g2_, lenght_, pedestal_;
+  bool isTIB_, isTOB_, isTEC_, isTID_, isBad_;
+  TText* text_;
+
+  // detInfo
+  SiStripDetInfo detInfo_;
+};
+
+//
+// constructors and destructor
+//
+SiStripDB2Tree::SiStripDB2Tree(const edm::ParameterSet& iConfig)
+    : pedToken_(esConsumes()),
+      noiseToken_(esConsumes()),
+      g1Token_(esConsumes()),
+      g2Token_(esConsumes()),
+      qualToken_(esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("StripQualityLabel")))),
+      gsimToken_(esConsumes()),
+      latToken_(esConsumes()),
+      topoToken_(esConsumes()),
+      isMC_(iConfig.getUntrackedParameter<bool>("isMC", false)),
+      detId_(0),
+      ring_(0),
+      istrip_(0),
+      det_type_(0),
+      layer_(0),
+      side_(0),
+      subdetId_(0),
+      noise_(0),
+      gsim_(0),
+      g1_(0),
+      g2_(0),
+      lenght_(0),
+      isTIB_(false),
+      isTOB_(false),
+      isTEC_(false),
+      isTID_(false) {
+  usesResource(TFileService::kSharedResource);
+
+  edm::Service<TFileService> fs;
+  //now do what ever initialization is needed
+  text_ = fs->make<TText>(0., 0., "");
+  text_->SetName("RunMode");
+  tree_ = fs->make<TTree>("StripDBTree", "Tree with DB SiStrip info");
+
+  tree_->Branch("detId", &detId_, "detId/i");
+  tree_->Branch("detType", &det_type_, "detType/i");
+  tree_->Branch("noise", &noise_, "noise/F");
+  tree_->Branch("pedestal", &pedestal_, "pedestal/F");
+  tree_->Branch("istrip", &istrip_, "istrip/i");
+  tree_->Branch("gsim", &gsim_, "gsim/F");
+  tree_->Branch("g1", &g1_, "g1/F");
+  tree_->Branch("g2", &g2_, "g2/F");
+  tree_->Branch("layer", &layer_, "layer/I");
+  tree_->Branch("side", &side_, "side/I");
+  tree_->Branch("subdetId", &subdetId_, "subdetId/I");
+  tree_->Branch("ring", &ring_, "ring/i");
+  tree_->Branch("length", &lenght_, "length/F");
+  tree_->Branch("isBad", &isBad_, "isBad/O");
+  tree_->Branch("isTIB", &isTIB_, "isTIB/O");
+  tree_->Branch("isTOB", &isTOB_, "isTOB/O");
+  tree_->Branch("isTEC", &isTEC_, "isTEC/O");
+  tree_->Branch("isTID", &isTID_, "isTID/O");
+
+  detInfo_ = SiStripDetInfoFileReader::read(edm::FileInPath(SiStripDetInfoFileReader::kDefaultFile).fullPath());
+}
+
+//
+// member functions
+//
+
+void SiStripDB2Tree::setTopoInfo(uint32_t detId, const TrackerTopology* tTopo) {
+  subdetId_ = DetId(detId).subdetId();
+  switch (subdetId_) {
+    case SiStripSubdetector::TIB:  //TIB
+      isTIB_ = true;
+      isTOB_ = false;
+      isTEC_ = false;
+      isTID_ = false;
+      layer_ = tTopo->tibLayer(detId);
+      side_ = 0;
+      ring_ = 0;
+      break;
+    case SiStripSubdetector::TID:  //TID
+      isTIB_ = false;
+      isTOB_ = false;
+      isTEC_ = false;
+      isTID_ = true;
+      side_ = tTopo->tidSide(detId);
+      layer_ = tTopo->tidWheel(detId);
+      ring_ = 0;
+      break;
+    case SiStripSubdetector::TOB:  //TOB
+      isTIB_ = false;
+      isTOB_ = true;
+      isTEC_ = false;
+      isTID_ = false;
+      layer_ = tTopo->tobLayer(detId);
+      side_ = 0;
+      ring_ = 0;
+      break;
+    case SiStripSubdetector::TEC:  //TEC
+      isTIB_ = false;
+      isTOB_ = false;
+      isTEC_ = true;
+      isTID_ = false;
+      side_ = tTopo->tecSide(detId);
+      layer_ = tTopo->tecWheel(detId);
+      ring_ = 0;
+      break;
+  }
+  return;
+}
+
+// ------------ auxilliary method for record info  ------------
+template <class Rcd>
+std::pair<const char*, std::string> SiStripDB2Tree::getRecordInfo(const edm::EventSetup& iSetup) const {
+  const Rcd& record = iSetup.get<Rcd>();
+  const edm::ValidityInterval& validity = record.validityInterval();
+  const edm::IOVSyncValue first = validity.first();
+  const edm::IOVSyncValue last = validity.last();
+  if (first != edm::IOVSyncValue::beginOfTime() || last != edm::IOVSyncValue::endOfTime()) {
+    LOGINFO("SiStripDB2Tree") << "@SUB=SiStripDB2Tree::getRecordInfo"
+                              << "\nTrying to apply " << record.key().name() << " with multiple IOVs in tag.\n"
+                              << "Validity range is " << first.eventID().run() << " - " << last.eventID().run() << "\n";
+  } else {
+    LOGINFO("SiStripDB2Tree") << "@SUB=SiStripDB2Tree::getRecordInfo"
+                              << "\nTrying to apply " << record.key().name() << "Validity range is "
+                              << first.eventID().run() << " - " << last.eventID().run() << "\n";
+  }
+
+  tree_->GetUserInfo()->Add(new RecordInfo(record.key().name(), std::to_string(first.eventID().run()).c_str()));
+
+  return std::make_pair(record.key().name(), std::to_string(first.eventID().run()));
+}
+
+// ------------ method called for each run  ------------
+void SiStripDB2Tree::beginRun(const edm::Run& iRun, edm::EventSetup const& iSetup) {
+  char c_run[30];
+  sprintf(c_run, "%i", iRun.run());
+  tree_->GetUserInfo()->Add(new TObjString(c_run));
+
+  auto pedHook = this->getRecordInfo<SiStripPedestalsRcd>(iSetup);
+  auto noiseHook = this->getRecordInfo<SiStripNoisesRcd>(iSetup);
+  auto g1Hook = this->getRecordInfo<SiStripApvGainRcd>(iSetup);
+  auto g2Hook = this->getRecordInfo<SiStripApvGain2Rcd>(iSetup);
+  auto qualityHook = this->getRecordInfo<SiStripQualityRcd>(iSetup);
+  if (isMC_) {
+    auto g1SimHook = this->getRecordInfo<SiStripApvGainSimRcd>(iSetup);
+  }
+}
+
+// ------------ method called for each event  ------------
+void SiStripDB2Tree::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // fill header information
+  LogDebug("SiStrip") << edm::getProcessParameterSetContainingModule(moduleDescription()).dump();
+
+  const edm::ParameterSet& globalTagPSet =
+      edm::getProcessParameterSetContainingModule(moduleDescription()).getParameterSet("PoolDBESSource@GlobalTag");
+
+  processGT_ = globalTagPSet.getParameter<std::string>("globaltag");
+
+  RecordInfo* GTheader = new RecordInfo("GlobalTag", processGT_.c_str());
+  tree_->GetUserInfo()->Add(GTheader);
+  GTheader->printInfo();
+
+  // handles
+  const SiStripPedestals* pedestalObj = &iSetup.getData(pedToken_);
+  const SiStripNoises* noiseObj = &iSetup.getData(noiseToken_);
+  const SiStripApvGain* g1Obj = &iSetup.getData(g1Token_);
+  const SiStripApvGain* g2Obj = &iSetup.getData(g2Token_);
+  const SiStripQuality* siStripQualityObj = &iSetup.getData(qualToken_);
+  const SiStripApvGain* gsimObj = nullptr;
+  if (isMC_) {
+    gsimObj = &iSetup.getData(gsimToken_);
+  } else {
+    LOGINFO("SiStripDB2Tree") << "We have determined this Data";
+  }
+
+  bool first = true;
+  const SiStripLatency* latencyObj = &iSetup.getData(latToken_);
+
+  std::vector<uint32_t> activeDetIds;
+  noiseObj->getDetIds(activeDetIds);
+
+  const TrackerTopology* tTopo_ = &iSetup.getData(topoToken_);
+
+  for (uint32_t detid : activeDetIds) {
+    setTopoInfo(detid, tTopo_);
+
+    SiStripNoises::Range noiseRange = noiseObj->getRange(detid);
+    SiStripApvGain::Range gsimRange;
+    if (isMC_ && gsimObj != nullptr) {
+      gsimObj->getRange(detid);
+    }
+    SiStripApvGain::Range g1Range = g1Obj->getRange(detid);
+    SiStripApvGain::Range g2Range = g2Obj->getRange(detid);
+    SiStripPedestals::Range pedestalsRange = pedestalObj->getRange(detid);
+
+    unsigned int nStrip = detInfo_.getNumberOfApvsAndStripLength(detid).first * sistrip::STRIPS_PER_APV;
+    lenght_ = detInfo_.getNumberOfApvsAndStripLength(detid).second;
+    detId_ = detid;
+    det_type_ = static_cast<unsigned int>(SiStripDetId(detid).moduleGeometry());
+    for (istrip_ = 0; istrip_ < nStrip; ++istrip_) {
+      if (first) {
+        first = false;
+        std::string run_op = ((latencyObj->latency(detid, 1) & READMODEMASK) == READMODEMASK) ? "PEAK" : "DECO";
+        text_->SetText(0., 0., run_op.c_str());
+        LOGINFO("SiStripDB2Tree") << "SiStripOperationModeRcd "
+                                  << ". . . " << run_op;
+      }
+      gsim_ = isMC_ ? gsimObj->getStripGain(istrip_, gsimRange) : 1.;
+      g1_ = g1Obj->getStripGain(istrip_, g1Range) ? g1Obj->getStripGain(istrip_, g1Range) : 1.;
+      g2_ = g2Obj->getStripGain(istrip_, g2Range) ? g2Obj->getStripGain(istrip_, g2Range) : 1.;
+      noise_ = noiseObj->getNoise(istrip_, noiseRange);
+      pedestal_ = pedestalObj->getPed(istrip_, pedestalsRange);
+      isBad_ = siStripQualityObj->IsStripBad(siStripQualityObj->getRange(detid), istrip_);
+      tree_->Fill();
+    }
+  }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void SiStripDB2Tree::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.setComment("Creates TTree with SiStrip Database tag content.");
+  desc.add<std::string>("StripQualityLabel", "MergedBadComponent");
+  desc.addUntracked<bool>("isMC", false);
+
+  descriptions.add("SiStripDB2Tree", desc);
+}
+
+//define this as a plug-in
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+DEFINE_FWK_MODULE(SiStripDB2Tree);

--- a/CondTools/SiStrip/test/SiStripCondVisualizer_cfg.py
+++ b/CondTools/SiStrip/test/SiStripCondVisualizer_cfg.py
@@ -1,0 +1,68 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("SiStripCondVisualizer")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.SiStripCondVisualizer=dict()  
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiStripCondVisualizer = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    enableStatistics = cms.untracked.bool(True)
+    )
+
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+
+process.source = cms.Source("EmptyIOVSource",
+                            firstValue = cms.uint64(306054),  
+                            lastValue = cms.uint64(306054),   
+                            timetype = cms.string('runnumber'),
+                            interval = cms.uint64(1)
+                            )
+
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff') 
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_data', '')
+
+# quality producer needed for the bad components dumping
+from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
+siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+    # cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')),  # DCS information
+    cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected
+    cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+    cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+    cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking
+)
+
+siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+siStripQualityESProducer.PrintDebugOutput = cms.bool(True)
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string("conditionsDump.root"))
+
+from CondTools.SiStrip.siStripCondVisualizer_cfi import siStripCondVisualizer
+process.condVisualizer = siStripCondVisualizer.clone(doNoise = True,
+                                                     doPeds = True,
+                                                     doG1 = True,
+                                                     doG2 = True,
+                                                     doBadComps = True,
+                                                     # example of configuration of DetId selector
+                                                     # selections=cms.VPSet(
+                                                     #     cms.PSet(detSelection = cms.uint32(30),detLabel = cms.string("TIB"),selection=cms.untracked.vstring("0x1e000000-0x16000000")),      # TIB
+                                                     #     cms.PSet(detSelection = cms.uint32(41),detLabel = cms.string("TIDMinus"),selection=cms.untracked.vstring("0x1e006000-0x18002000")), # TID minus
+                                                     #     cms.PSet(detSelection = cms.uint32(42),detLabel = cms.string("TIDPlus"),selection=cms.untracked.vstring("0x1e006000-0x18004000")),  # TID plus
+                                                     #     cms.PSet(detSelection = cms.uint32(50),detLabel = cms.string("TOB"),selection=cms.untracked.vstring("0x1e000000-0x1a000000")),      # TOB
+                                                     #     cms.PSet(detSelection = cms.uint32(61),detLabel = cms.string("TECMinus"),selection=cms.untracked.vstring("0x1e0c0000-0x1c040000")), # TEC minus
+                                                     #     cms.PSet(detSelection = cms.uint32(62),detLabel = cms.string("TECPlus"),selection=cms.untracked.vstring("0x1e0c0000-0x1c080000"))   # TEC plus
+                                                     # )
+                                                    )
+process.p = cms.Path(process.condVisualizer)

--- a/CondTools/SiStrip/test/db_tree_dump.py
+++ b/CondTools/SiStrip/test/db_tree_dump.py
@@ -1,0 +1,157 @@
+#! /bin/env cmsRun
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+from fnmatch import fnmatch
+from pdb import set_trace
+
+#################################################
+options = VarParsing.VarParsing("analysis")
+
+options.register ('outputRootFile',
+                  "",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,         # string, int, or float
+                  "output root file")
+options.register ('records',
+                  [],
+                  VarParsing.VarParsing.multiplicity.list, # singleton or list
+                  VarParsing.VarParsing.varType.string,    # string, int, or float
+                  "record:tag names to be used/changed from GT")
+options.register ('external',
+                  [],
+                  VarParsing.VarParsing.multiplicity.list, # singleton or list
+                  VarParsing.VarParsing.varType.string,    # string, int, or float
+                  "record:fle.db picks the following record from this external file")
+options.register ('runNumber',
+                  1,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,            # string, int, or float
+                  "run number")
+options.register ('runStartTime',
+                  1,
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.int,            # string, int, or float
+                  "run start time")
+options.register ('GlobalTag',
+                  '',
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,         # string, int, or float
+                  "Correct noise for APV gain?")
+
+options.parseArguments()
+
+process = cms.Process("Reader")
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff') 
+
+###################################################################
+# Messages
+###################################################################
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.SiStripDB2Tree=dict()
+process.MessageLogger.RecordInfo=dict()
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    SiStripDB2Tree = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    RecordInfo     = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    enableStatistics = cms.untracked.bool(True)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    #input = cms.untracked.int32(-1) ### shall be -1 for the EmptyIOVSource
+    )
+
+# process.source = cms.Source("EmptyIOVSource",
+#                             firstValue = cms.uint64(options.runNumber),
+#                             lastValue = cms.uint64(options.runNumber),
+#                             timetype = cms.string('runnumber'),
+#                             interval = cms.uint64(1)
+#                             )
+
+process.source = cms.Source("EmptySource",
+                            firstRun = cms.untracked.uint32(options.runNumber),
+                            numberEventsInRun = cms.untracked.uint32(1),
+                            numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+                            firstTime = cms.untracked.uint64(options.runStartTime),
+                            timeBetweenEvents = cms.untracked.uint64(1)
+                            )
+
+connection_map = [
+    ('SiStrip*', 'frontier://PromptProd/CMS_CONDITIONS'),
+    ]
+if options.external:
+    connection_map.extend(
+        (i.split(':')[0], 'sqlite_file:%s' % i.split(':')[1]) for i in options.external
+        )
+
+connection_map.sort(key=lambda x: -1*len(x[0]))
+def best_match(rcd):
+    print(rcd)
+    for pattern, string in connection_map:
+        print(pattern, fnmatch(rcd, pattern))
+        if fnmatch(rcd, pattern):
+            return string
+records = []
+if options.records:
+    for record in options.records:
+        rcd, tag = tuple(record.split(':'))
+        records.append(
+            cms.PSet(
+                record = cms.string(rcd),
+                tag    = cms.string(tag),
+                connect = cms.untracked.string(best_match(rcd))
+                )
+            )
+
+if options.GlobalTag:
+    process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+    from Configuration.AlCa.GlobalTag import GlobalTag
+    process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
+    print("using global tag: %s" % process.GlobalTag.globaltag.value())
+    #process.GlobalTag.DumpStat = cms.untracked.bool(True)  #to dump what records have been accessed
+    process.GlobalTag.toGet = cms.VPSet(*records)
+else:
+    print("overriding using local conditions: %s" %records)
+    process.poolDBESSource = cms.ESSource(
+        "PoolDBESSource",
+        BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+        DBParameters = cms.PSet(
+            messageLevel = cms.untracked.int32(1),  # it used to be 2
+            authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+            ),
+        #DumpStat = cms.untracked.bool(True),
+        timetype = cms.untracked.string('runnumber'),
+        toGet = cms.VPSet(records),
+        connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')
+        )
+
+
+from CalibTracker.SiStripESProducers.SiStripQualityESProducer_cfi import*
+siStripQualityESProducer.ListOfRecordToMerge = cms.VPSet(
+    cms.PSet(record = cms.string("SiStripDetVOffRcd"), tag = cms.string('')),    # DCS information
+    cms.PSet(record = cms.string('SiStripDetCablingRcd'), tag = cms.string('')), # Use Detector cabling information to exclude detectors not connected            
+    cms.PSet(record = cms.string('SiStripBadChannelRcd'), tag = cms.string('')), # Online Bad components
+    cms.PSet(record = cms.string('SiStripBadFiberRcd'), tag = cms.string('')),   # Bad Channel list from the selected IOV as done at PCL
+    cms.PSet(record = cms.string('RunInfoRcd'), tag = cms.string(''))            # List of FEDs exluded during data taking          
+    )
+
+siStripQualityESProducer.ReduceGranularity = cms.bool(False)
+siStripQualityESProducer.ThresholdForReducedGranularity = cms.double(0.3)
+siStripQualityESProducer.appendToDataLabel = 'MergedBadComponent'
+siStripQualityESProducer.PrintDebugOutput = cms.bool(True)
+
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string(options.outputRootFile)
+)
+process.treeDump = cms.EDAnalyzer('SiStripDB2Tree',
+                                  StripQualityLabel = cms.string('MergedBadComponent') 
+                                  )
+process.p = cms.Path(process.treeDump)

--- a/CondTools/SiStrip/test/db_tree_dump_wrapper.py
+++ b/CondTools/SiStrip/test/db_tree_dump_wrapper.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import calendar
+import optparse
+import importlib
+import sqlalchemy
+import subprocess
+import CondCore.Utilities.conddblib as conddb
+
+##############################################
+def execme(command, dryrun=False):
+##############################################
+    '''Wrapper for executing commands.
+    '''
+    if dryrun:
+        print(command)
+    else:
+        print(" * Executing: %s ..." % (command))
+        os.system(command)
+        print(" * Executed!")
+
+##############################################
+def main():
+##############################################
+
+    defaultGT='auto:run3_data_prompt'
+    #defaultGT='123X_dataRun3_Prompt_v5'
+    defaultRun=346512
+    
+    parser = optparse.OptionParser(usage = 'Usage: %prog [options] <file> [<file> ...]\n')
+    
+    parser.add_option('-G', '--inputGT',
+                      dest = 'inputGT',
+                      default = defaultGT,
+                      help = 'Global Tag to get conditions',
+                      )
+
+    parser.add_option('-r', '--inputRun',
+                      dest = 'inputRun',
+                      default = defaultRun,
+                      help = 'run to be used',
+                      )
+
+    (options, arguments) = parser.parse_args()
+
+    print("Input configuration")
+    print("globalTag: ",options.inputGT)
+    print("runNumber: ",options.inputRun)
+    
+    con = conddb.connect(url = conddb.make_url())
+    session = con.session()
+    RunInfo = session.get_dbtype(conddb.RunInfo)
+    
+    bestRun = session.query(RunInfo.run_number,RunInfo.start_time, RunInfo.end_time).filter(RunInfo.run_number >= options.inputRun).first()
+    if bestRun is None:
+        raise Exception("Run %s can't be matched with an existing run in the database." %options.runNumber)
+    
+    start= bestRun[1]
+    stop = bestRun[2]
+    
+    bestRunStartTime = calendar.timegm( bestRun[1].utctimetuple() ) << 32
+    bestRunStopTime  = calendar.timegm( bestRun[2].utctimetuple() ) << 32
+    
+    print("run start time:",start,"(",bestRunStartTime,")")
+    print("run stop time: ",stop,"(",bestRunStopTime,")")
+    
+    gtstring=str(options.inputGT)
+    if('auto' in gtstring):
+        from Configuration.AlCa import autoCond
+        key=gtstring.replace('auto:','')
+        print("An autoCond Global Tag was used, will use key %s" % key)
+        gtstring=autoCond.autoCond[key]
+        print("Will use the resolved key %s" % gtstring)
+
+    command='cmsRun db_tree_dump.py outputRootFile=sistrip_db_tree_'+gtstring+'_'+str(options.inputRun)+'.root GlobalTag='+options.inputGT+' runNumber='+str(options.inputRun)+' runStartTime='+str(bestRunStartTime)
+    
+    execme(command)
+
+if __name__ == "__main__":        
+    main()

--- a/CondTools/SiStrip/test/testBuildersReaders.sh
+++ b/CondTools/SiStrip/test/testBuildersReaders.sh
@@ -77,3 +77,9 @@ sqlite3 gainManipulations.db "select * from IOV"
 
 (cmsRun ${LOCAL_TEST_DIR}/SiStripApvGainRescaler_cfg.py additionalConds=sqlite_file:${PWD}/gainManipulations.db) || die "Failure using cmsRun SiStripApvGainRescaler_cfg.py)" $?
 echo -e " Done with the gain rescaler \n\n"
+
+## do the visualization code
+
+(cmsRun "${LOCAL_TEST_DIR}/"SiStripCondVisualizer_cfg.py) || die "Failure using cmsRun SiStripCondVisualizer_cfg.py" $?
+(python3 "${LOCAL_TEST_DIR}/"db_tree_dump_wrapper.py) || die "Failure running python3 db_tree_dump_wrapper.py" $?
+echo -e " Done with the visualization \n\n"


### PR DESCRIPTION
#### PR description:

Title says it all, adds to `CondTools/SiStrip`:
   * a module to dump several strip conditions in a tree format for easier post-processing
   * the ROOT macros to perform said analysis
   * a module to populate per-DetId profiles of conditions, with the possibility to select on given module groups
   
Corresponding configuration files and unit tests are added.    

#### PR validation:

Relies on the augmented unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
