### PR TITLE
Fixing FastTimerClient Hist Remaking Issue : 12_3_X

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -69,6 +69,8 @@ private:
   MEPSet scalLumiMEPSet_;
   MEPSet pixelLumiMEPSet_;
   MEPSet puMEPSet_;
+
+  bool fillEveryLumiSection_;
 };
 
 FastTimerServiceClient::FastTimerServiceClient(edm::ParameterSet const& config)
@@ -80,7 +82,8 @@ FastTimerServiceClient::FastTimerServiceClient(edm::ParameterSet const& config)
                                          : MEPSet{}),
       pixelLumiMEPSet_(doPlotsVsPixelLumi_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("pixelLumiME"))
                                            : MEPSet{}),
-      puMEPSet_(doPlotsVsPU_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("puME")) : MEPSet{}) {}
+      puMEPSet_(doPlotsVsPU_ ? getHistoPSet(config.getParameter<edm::ParameterSet>("puME")) : MEPSet{}),
+      fillEveryLumiSection_(config.getParameter<bool>("fillEveryLumiSection")) {}
 
 FastTimerServiceClient::~FastTimerServiceClient() = default;
 
@@ -91,7 +94,10 @@ void FastTimerServiceClient::dqmEndJob(DQMStore::IBooker& booker, DQMStore::IGet
 void FastTimerServiceClient::dqmEndLuminosityBlock(DQMStore::IBooker& booker,
                                                    DQMStore::IGetter& getter,
                                                    edm::LuminosityBlock const& lumi,
-                                                   edm::EventSetup const& setup) {}
+                                                   edm::EventSetup const& setup) {
+  if (fillEveryLumiSection_)
+    fillSummaryPlots(booker, getter);
+}
 
 void FastTimerServiceClient::fillSummaryPlots(DQMStore::IBooker& booker, DQMStore::IGetter& getter) {
   if (getter.get(m_dqm_path + "/event time_real")) {
@@ -486,7 +492,7 @@ void FastTimerServiceClient::fillDescriptions(edm::ConfigurationDescriptions& de
   edm::ParameterSetDescription puMEPSet;
   fillPUMePSetDescription(puMEPSet);
   desc.add<edm::ParameterSetDescription>("puME", puMEPSet);
-
+  desc.add<bool>("fillEveryLumiSection", true);
   descriptions.add("fastTimerServiceClient", desc);
 }
 

--- a/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
+++ b/HLTrigger/Timer/plugins/FastTimerServiceClient.cc
@@ -91,9 +91,7 @@ void FastTimerServiceClient::dqmEndJob(DQMStore::IBooker& booker, DQMStore::IGet
 void FastTimerServiceClient::dqmEndLuminosityBlock(DQMStore::IBooker& booker,
                                                    DQMStore::IGetter& getter,
                                                    edm::LuminosityBlock const& lumi,
-                                                   edm::EventSetup const& setup) {
-  fillSummaryPlots(booker, getter);
-}
+                                                   edm::EventSetup const& setup) {}
 
 void FastTimerServiceClient::fillSummaryPlots(DQMStore::IBooker& booker, DQMStore::IGetter& getter) {
   if (getter.get(m_dqm_path + "/event time_real")) {
@@ -251,7 +249,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
     MonitorElement* me;
 
     booker.setCurrentFolder(subsubdir);
-    me = getter.get("module_time_real_average");
+    me = getter.get(subsubdir + "/module_time_real_average");
     if (me) {
       real_average = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);
@@ -266,7 +264,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       }
     }
 
-    me = getter.get("module_time_thread_average");
+    me = getter.get(subsubdir + "/module_time_thread_average");
     if (me) {
       thread_average = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);
@@ -282,7 +280,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       }
     }
 
-    me = getter.get("module_time_real_running");
+    me = getter.get(subsubdir + "/module_time_real_running");
     if (me) {
       real_running = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);
@@ -297,7 +295,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       }
     }
 
-    me = getter.get("module_time_thread_running");
+    me = getter.get(subsubdir + "/module_time_thread_running");
     if (me) {
       thread_running = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);
@@ -313,7 +311,7 @@ void FastTimerServiceClient::fillPathSummaryPlots(DQMStore::IBooker& booker,
       }
     }
 
-    me = getter.get("module_efficiency");
+    me = getter.get(subsubdir + "/module_efficiency");
     if (me) {
       efficiency = me->getTH1F();
       assert(me->getTH1F()->GetXaxis()->GetXmin() == min);


### PR DESCRIPTION
#### PR description:

This is the bug fix backport of https://github.com/cms-sw/cmssw/pull/37402

Before the path of the histogram was not specified when checking it exists leading to the histogram being remade over and over which is a very expensive operation. 

It also adds an option to disable making the histograms every lumisection which is the desired behaviour for everything expect online workflows. 

#### PR validation:

see: https://github.com/cms-sw/cmssw/pull/37402

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

https://github.com/cms-sw/cmssw/pull/37402

This fix is necessary to be able to harvest timing jobs running on multiple lumisections (which is our current workflow when reemulating the L1 running on ZB). Otherwise the job will take hours rather than seconds. 