### PR TITLE
HCAL finegrain bit fix to account for TDC packing, and SOI alignment

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFinegrainBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFinegrainBit.h
@@ -11,7 +11,7 @@ public:
   // Each bit is replicated for each depth level
   typedef std::array<std::bitset<6>, 2> Tower;
   // Each pair contains uHTR group 0 LUT bits 12-15, TDC, and ADC of the cell in that depth of the trigger tower
-  typedef std::array<std::pair<int, std::pair<int, int>>, 7> TowerTDC;
+  typedef std::array<std::pair<std::pair<int, bool>, std::pair<int, int>>, 7> TowerTDC;
 
   HcalFinegrainBit(int version) : version_(version){};
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFinegrainBit.cc
@@ -53,7 +53,8 @@ std::bitset<6> HcalFinegrainBit::compute(const HcalFinegrainBit::TowerTDC& tower
   int DeepEnergy = 0;
 
   for (size_t i = 0; i < 7; i++) {
-    int bit12_15set = tower[i].first;
+    int bit12_15set = tower[i].first.first;
+    bool is_compressed = tower[i].first.second;
     int bit12 = (bit12_15set & 0b0001);       // low depth 1,2 energy
     int bit13 = (bit12_15set & 0b0010) >> 1;  // high depth 3+ energy
     int bit14 = (bit12_15set & 0b0100) >> 2;  // prompt energy passed
@@ -65,13 +66,23 @@ std::bitset<6> HcalFinegrainBit::compute(const HcalFinegrainBit::TowerTDC& tower
     if (TDC < 50) {  // exclude error code for TDC in HE (unpacked)
       if ((abs(tp_ieta) <= 16) || (i >= 1)) {
         // count delayed / prompt hits either in HB, or in HE (excluding depth 1 due to backgrounds in HE)
-        // TDC values are uncompressed (0-49) at the trigger primitive level. Packing (compressing HB TDC 6:2) happens in packer.
-        if (TDC > tdc_boundary[abs(tp_ieta) - 1][i] && TDC <= tdc_boundary[abs(tp_ieta) - 1][i] + 2 && bit15 == 1)
-          Ndelayed += 1;
-        if (TDC > tdc_boundary[abs(tp_ieta) - 1][i] + 2 && bit15 == 1)
-          NveryDelayed += 1;
-        if (TDC <= tdc_boundary[abs(tp_ieta) - 1][i] && TDC >= 0 && bit14 == 1)
-          Nprompt += 1;
+        // Sim packing into Raw, has uncompressed TDC values (0-49) at the trigger primitive level. Packing (compressing HB TDC 6:2) happens in packer.
+        // Hcal digis have compressed HB TDC (0-3)
+        if (is_compressed == 1) {
+          if (TDC == 1 && bit15 == 1)
+            Ndelayed += 1;
+          if (TDC == 2 && bit15 == 1)
+            NveryDelayed += 1;
+          if (TDC == 0 && bit14 == 1)
+            Nprompt += 1;
+        } else {
+          if (TDC > tdc_boundary[abs(tp_ieta) - 1][i] && TDC <= tdc_boundary[abs(tp_ieta) - 1][i] + 2 && bit15 == 1)
+            Ndelayed += 1;
+          if (TDC > tdc_boundary[abs(tp_ieta) - 1][i] + 2 && bit15 == 1)
+            NveryDelayed += 1;
+          if (TDC <= tdc_boundary[abs(tp_ieta) - 1][i] && TDC >= 0 && bit14 == 1)
+            Nprompt += 1;
+        }
       }
     }
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -498,7 +498,12 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
     }
     // peak-finding is not applied for FG bits
     // compute(msb) returns two bits (MIP). compute(timingTDC,ids) returns 6 bits (1 depth, 1 prompt, 1 delayed 01, 1 delayed 10, 2 reserved)
-    finegrain[ibin] = fg_algo.compute(timingTDC[idx], ids[0]).to_ulong() | fg_algo.compute(msb[idx]).to_ulong() << 4;
+    finegrain[ibin] = fg_algo.compute(timingTDC[idx + filterPresamples], ids[0]).to_ulong() |
+                      fg_algo.compute(msb[idx + filterPresamples]).to_ulong() << 4;
+    if (ibin == tpPresamples && (idx + filterPresamples) != dgPresamples)
+      edm::LogError("HcalTriggerPritimveAlgo")
+          << "TP SOI (tpPresamples = " << tpPresamples
+          << ") is not aligned with digi SOI (dgPresamples = " << dgPresamples << ")";
   }
   outcoder_->compress(output, finegrain, result);
 }
@@ -913,6 +918,12 @@ void HcalTriggerPrimitiveAlgo::addUpgradeTDCFG(const HcalTrigTowerDetId& id, con
   incoder_->adc2Linear(frame, samples1);                                  // use linearization LUT
   std::vector<unsigned short> bits12_15 = incoder_->group0FGbits(frame);  // get 4 energy bits (12-15) from group 0 LUT
 
+  bool is_compressed = false;
+  if (detId.subdet() == HcalBarrel) {
+    is_compressed = (frame.flavor() == 3);  
+    // 0 if frame.flavor is 0 (uncompressed), 1 if frame.flavor is 3 (compressed)
+  }
+
   auto it = fgUpgradeTDCMap_.find(id);
   if (it == fgUpgradeTDCMap_.end()) {
     FGUpgradeTDCContainer element;
@@ -920,7 +931,8 @@ void HcalTriggerPrimitiveAlgo::addUpgradeTDCFG(const HcalTrigTowerDetId& id, con
     it = fgUpgradeTDCMap_.insert(std::make_pair(id, element)).first;
   }
   for (int i = 0; i < frame.samples(); i++) {
-    it->second[i][detId.depth() - 1] = std::make_pair(bits12_15[i], std::make_pair(frame[i].tdc(), samples1[i]));
+    it->second[i][detId.depth() - 1] =
+        std::make_pair(std::make_pair(bits12_15[i], is_compressed), std::make_pair(frame[i].tdc(), samples1[i]));
   }
 }
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -920,7 +920,7 @@ void HcalTriggerPrimitiveAlgo::addUpgradeTDCFG(const HcalTrigTowerDetId& id, con
 
   bool is_compressed = false;
   if (detId.subdet() == HcalBarrel) {
-    is_compressed = (frame.flavor() == 3);  
+    is_compressed = (frame.flavor() == 3);
     // 0 if frame.flavor is 0 (uncompressed), 1 if frame.flavor is 3 (compressed)
   }
 


### PR DESCRIPTION
#### PR description:

`HcalFinegrainBit.cc` is run in cases where HB TDC is compressed and uncompressed. This PR handles both cases. In `HcalTriggerPrimitiveAlgo.cc`, `frame.flavor()` is used to define `is_compressed` which is passed to `HcalFinegrainBit.cc`. This determines if the input TDC values are uncompressed (`flavor=0, is_compressed=0`) or compressed (`flavor=3, is_compressed=1`). Depending on the TDC packing, either a comparison to `tdc_boundary` is made (uncompressed), or a direct comparison to TDC 0, 1, 2 is made. 

Additional edits in `HcalTriggerPrimitiveAlgo.cc` are made to handle the matching of TP SOI and digi SOI in a more robust way. This ensures that with changes in conditions or filterPresamples, the TDC from the QIE11 dataframe SOI is selected for the fine grain bit algorithm SOI (ensuring ibin = 2 corresponds to idx = 5). 

#### PR validation:

`runTheMatrix.py` passed. Tested in CMSSW_12_4_X_2022-03-31-1100.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Will be backported to 12_3_X, as the L1 LLP trigger emulator was merged in 123X (PR #36919) and relies upon the fine grain bits. 
