### PR TITLE
Update final L1T menu tag for Run 3 start up

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,7 +36,7 @@ autoCond = {
     # GlobalTag for Run3 HLT: it points to the online GT
     'run3_hlt'                     : '123X_dataRun3_HLT_v5',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v2',
+    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v3',
     # GlobalTag for Run3 data relvals (express GT)
     'run3_data_express'            : '123X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals
@@ -44,7 +44,7 @@ autoCond = {
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '123X_dataRun3_v4',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '123X_dataRun3_relval_v2',
+    'run3_data_relval'             : '123X_dataRun3_relval_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -68,19 +68,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v12',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v12',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v13',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v12',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v12',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v12',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v13',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v12',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v13',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '123X_mcRun4_realistic_v9'
+    'phase2_realistic'             : '123X_mcRun4_realistic_v10'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This PR updates the final L1T menu tag for Run 3 start up, as requested in [this CMSTalk post](https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-l1-menu-tag-v1-0-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/8895), for Run3 MC GTs and the Run3 relval GTs used for TSG tests.
The new L1T tag is `L1Menu_Collisions2022_v1_0_0_xml`.

GT differences:

**Run 3 HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_HLT_relval_v2/123X_dataRun3_HLT_relval_v3

**Run 3 data RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_relval_v2/123X_dataRun3_relval_v3

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_design_v12/123X_mcRun3_2021_design_v13

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_v12/123X_mcRun3_2021_realistic_v13

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021cosmics_realistic_deco_v12/123X_mcRun3_2021cosmics_realistic_deco_v13

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_HI_v12/123X_mcRun3_2021_realistic_HI_v13

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2023_realistic_v12/123X_mcRun3_2023_realistic_v13

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2024_realistic_v12/123X_mcRun3_2024_realistic_v13

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun4_realistic_v9/123X_mcRun4_realistic_v10

#### PR validation:
Tested with:
`runTheMatrix.py -l 12034.0,11634.0,7.23,159.0,12434.0,12834.0 --ibeos -j16`

#### Backport:
Not a backport, but a backport to 12_3_X will be provided soon.

FYI @elfontan @Martin-Grunewald 