### PR TITLE
Backport to `12_3_X` of Patatrack pixel-reco updates (pT-clamping in vertex sorting + stabilized Fishbone)

### DIFF
--- a/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
+++ b/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
@@ -45,6 +45,9 @@ public:
 
   eigenSoA::ScalarSoA<int8_t, S> nLayers;
 
+  constexpr int nTracks() const { return nTracks_;}
+  constexpr void setNTracks(int n) { nTracks_=n;}
+
   constexpr int nHits(int i) const { return detIndices.size(i); }
 
   constexpr bool isTriplet(int i) const { return nLayers(i) == 3; }
@@ -80,6 +83,10 @@ public:
 
   HitContainer hitIndices;
   HitContainer detIndices;
+
+private: 
+  int nTracks_;
+
 };
 
 namespace pixelTrack {

--- a/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
+++ b/CUDADataFormats/Track/interface/TrackSoAHeterogeneousT.h
@@ -45,8 +45,8 @@ public:
 
   eigenSoA::ScalarSoA<int8_t, S> nLayers;
 
-  constexpr int nTracks() const { return nTracks_;}
-  constexpr void setNTracks(int n) { nTracks_=n;}
+  constexpr int nTracks() const { return nTracks_; }
+  constexpr void setNTracks(int n) { nTracks_ = n; }
 
   constexpr int nHits(int i) const { return detIndices.size(i); }
 
@@ -84,9 +84,8 @@ public:
   HitContainer hitIndices;
   HitContainer detIndices;
 
-private: 
+private:
   int nTracks_;
-
 };
 
 namespace pixelTrack {

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
@@ -154,16 +154,15 @@ void PixelTrackProducerFromSoA::produce(edm::StreamID streamID,
   auto const *quality = tsoa.qualityData();
   auto const &fit = tsoa.stateAtBS;
   auto const &hitIndices = tsoa.hitIndices;
-  auto maxTracks = tsoa.stride();
+  auto nTracks = tsoa.nTracks();
 
-  tracks.reserve(maxTracks);
+  tracks.reserve(nTracks);
 
   int32_t nt = 0;
 
-  for (int32_t it = 0; it < maxTracks; ++it) {
+  for (int32_t it = 0; it < nTracks; ++it) {
     auto nHits = tsoa.nHits(it);
-    if (nHits == 0)
-      break;  // this is a guard: maybe we need to move to nTracks...
+    assert(nHits >= 3);
     indToEdm.push_back(-1);
     auto q = quality[it];
     if (q < minQuality_)

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
@@ -17,7 +17,7 @@
 #include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
 
 // Switch on to enable checks and printout for found tracks
-#undef PIXEL_DEBUG_PRODUCE
+// #define PIXEL_DEBUG_PRODUCE
 
 class PixelTrackSoAFromCUDA : public edm::stream::EDProducer<edm::ExternalWork> {
 public:
@@ -63,7 +63,9 @@ void PixelTrackSoAFromCUDA::produce(edm::Event& iEvent, edm::EventSetup const& i
 #ifdef PIXEL_DEBUG_PRODUCE
   auto const& tsoa = *soa_;
   auto maxTracks = tsoa.stride();
-  std::cout << "size of SoA" << sizeof(tsoa) << " stride " << maxTracks << std::endl;
+  auto nTracks = tsoa.nTracks();
+  std::cout << "size of SoA " << sizeof(tsoa) << " stride " << maxTracks << std::endl;
+  std::cout << "found " << nTracks << " tracks in cpu SoA at " << &tsoa << std::endl;
 
   int32_t nt = 0;
   for (int32_t it = 0; it < maxTracks; ++it) {
@@ -73,7 +75,7 @@ void PixelTrackSoAFromCUDA::produce(edm::Event& iEvent, edm::EventSetup const& i
       break;  // this is a guard: maybe we need to move to nTracks...
     nt++;
   }
-  std::cout << "found " << nt << " tracks in cpu SoA at " << &tsoa << std::endl;
+  assert(nTracks == nt);
 #endif
 
   // DO NOT  make a copy  (actually TWO....)

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -217,7 +217,7 @@ void CAHitNtupletGeneratorKernelsCPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
   {
     std::lock_guard<std::mutex> guard(lock);
     ++iev;
-    kernel_print_found_ntuplets(hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 1000000, iev);
+    kernel_print_found_ntuplets(hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 0, 1000000, iev);
   }
 #endif
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -129,7 +129,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   cms::cuda::finalizeBulk(device_hitTuple_apc_, tuples_d);
 
   kernel_fillHitDetIndices(tuples_d, hh.view(), detId_d);
-  kernel_fillNLayers(tracks_d,device_hitTuple_apc_);
+  kernel_fillNLayers(tracks_d, device_hitTuple_apc_);
 
   // remove duplicates (tracks that share a doublet)
   kernel_earlyDuplicateRemover(device_theCells_.get(), device_nCells_, tracks_d, quality_d, params_.dupPassThrough_);
@@ -210,7 +210,6 @@ void CAHitNtupletGeneratorKernelsCPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
     kernel_doStatsForHitInTracks(device_hitToTuple_.get(), counters_);
     kernel_doStatsForTracks(tuples_d, quality_d, counters_);
   }
-
 
 #ifdef DUMP_GPU_TK_TUPLES
   static std::atomic<int> iev(0);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -211,9 +211,14 @@ void CAHitNtupletGeneratorKernelsCPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
     kernel_doStatsForTracks(tuples_d, quality_d, counters_);
   }
 
+
 #ifdef DUMP_GPU_TK_TUPLES
   static std::atomic<int> iev(0);
-  ++iev;
-  kernel_print_found_ntuplets(hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 100, iev);
+  static std::mutex lock;
+  {
+    std::lock_guard<std::mutex> guard(lock);
+    ++iev;
+    kernel_print_found_ntuplets(hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 1000000, iev);
+  }
 #endif
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cc
@@ -129,7 +129,7 @@ void CAHitNtupletGeneratorKernelsCPU::launchKernels(HitsOnCPU const &hh, TkSoA *
   cms::cuda::finalizeBulk(device_hitTuple_apc_, tuples_d);
 
   kernel_fillHitDetIndices(tuples_d, hh.view(), detId_d);
-  kernel_fillNLayers(tracks_d);
+  kernel_fillNLayers(tracks_d,device_hitTuple_apc_);
 
   // remove duplicates (tracks that share a doublet)
   kernel_earlyDuplicateRemover(device_theCells_.get(), device_nCells_, tracks_d, quality_d, params_.dupPassThrough_);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -336,7 +336,7 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
     std::lock_guard<std::mutex> guard(lock);  
     ++iev;
     kernel_print_found_ntuplets<<<1, 32, 0, cudaStream>>>(
-        hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 100, iev);
+        hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 1000000, iev);
     cudaStreamSynchronize(cudaStream);
   }
 #endif

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -91,7 +91,7 @@ void CAHitNtupletGeneratorKernelsGPU::launchKernels(HitsOnCPU const &hh, TkSoA *
 
   kernel_fillHitDetIndices<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tuples_d, hh.view(), detId_d);
   cudaCheck(cudaGetLastError());
-  kernel_fillNLayers<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tracks_d);
+  kernel_fillNLayers<<<numberOfBlocks, blockSize, 0, cudaStream>>>(tracks_d, device_hitTuple_apc_);
   cudaCheck(cudaGetLastError());
 
   // remove duplicates (tracks that share a doublet)

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -335,9 +335,15 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
   {
     std::lock_guard<std::mutex> guard(lock);
     ++iev;
+    for (int k = 0; k < 20000; k += 500) {
+      kernel_print_found_ntuplets<<<1, 32, 0, cudaStream>>>(
+          hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), k, k + 500, iev);
+      cudaDeviceSynchronize();
+    }
     kernel_print_found_ntuplets<<<1, 32, 0, cudaStream>>>(
-        hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 1000000, iev);
-    cudaStreamSynchronize(cudaStream);
+        hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 20000, 1000000, iev);
+    cudaDeviceSynchronize();
+    // cudaStreamSynchronize(cudaStream);
   }
 #endif
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.cu
@@ -333,7 +333,7 @@ void CAHitNtupletGeneratorKernelsGPU::classifyTuples(HitsOnCPU const &hh, TkSoA 
   static std::atomic<int> iev(0);
   static std::mutex lock;
   {
-    std::lock_guard<std::mutex> guard(lock);  
+    std::lock_guard<std::mutex> guard(lock);
     ++iev;
     kernel_print_found_ntuplets<<<1, 32, 0, cudaStream>>>(
         hh.view(), tuples_d, tracks_d, quality_d, device_hitToTuple_.get(), 1000000, iev);

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -21,6 +21,7 @@ namespace cAHitNtupletGenerator {
     unsigned long long nGoodTracks;
     unsigned long long nUsedHits;
     unsigned long long nDupHits;
+    unsigned long long nFishCells;
     unsigned long long nKilledCells;
     unsigned long long nEmptyCells;
     unsigned long long nZeroTrackCells;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -6,7 +6,7 @@
 #include "CUDADataFormats/Track/interface/PixelTrackHeterogeneous.h"
 #include "GPUCACell.h"
 
-#define DUMP_GPU_TK_TUPLES
+// #define DUMP_GPU_TK_TUPLES
 
 namespace cAHitNtupletGenerator {
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernels.h
@@ -6,7 +6,7 @@
 #include "CUDADataFormats/Track/interface/PixelTrackHeterogeneous.h"
 #include "GPUCACell.h"
 
-// #define DUMP_GPU_TK_TUPLES
+#define DUMP_GPU_TK_TUPLES
 
 namespace cAHitNtupletGenerator {
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -561,10 +561,11 @@ __global__ void kernel_fillNLayers(TkSoA *__restrict__ ptracks, cms::cuda::Atomi
   auto &tracks = *ptracks;
   auto first = blockIdx.x * blockDim.x + threadIdx.x;
   auto ntracks = apc->get().m;
-  if (0==first) tracks.setNTracks(ntracks);
+  if (0 == first)
+    tracks.setNTracks(ntracks);
   for (int idx = first, nt = ntracks; idx < nt; idx += gridDim.x * blockDim.x) {
     auto nHits = tracks.nHits(idx);
-    assert (nHits >=3);
+    assert(nHits >= 3);
     tracks.nLayers(idx) = tracks.computeNumberOfLayers(idx);
   }
 }
@@ -872,7 +873,8 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
     auto nh = foundNtuplets.size(i);
     if (nh < 3)
       continue;
-    if (quality[i] < loose) continue;
+    if (quality[i] < loose)
+      continue;
     printf("TK: %d %d %d %d %f %f %f %f %f %f %f %.3f %.3f %.3f %.3f %.3f %.3f\n",
            10000 * iev + i,
            int(quality[i]),
@@ -891,7 +893,7 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
            hh.zGlobal(*(foundNtuplets.begin(i) + 2)),
            nh > 3 ? hh.zGlobal(int(*(foundNtuplets.begin(i) + 3))) : 0,
            nh > 4 ? hh.zGlobal(int(*(foundNtuplets.begin(i) + 4))) : 0,
-           nh > 5 ? hh.zGlobal(int(*(foundNtuplets.begin(i) + nh-1))) : 0);
+           nh > 5 ? hh.zGlobal(int(*(foundNtuplets.begin(i) + nh - 1))) : 0);
   }
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -101,7 +101,7 @@ __global__ void kernel_checkOverflows(HitContainer const *foundNtuplets,
 
   for (int idx = first, nt = (*nCells); idx < nt; idx += gridDim.x * blockDim.x) {
     auto const &thisCell = cells[idx];
-    if (thisCell.hasFishbone())
+    if (thisCell.hasFishbone() && !thisCell.isKilled())
       atomicAdd(&c.nFishCells, 1);
     if (thisCell.outerNeighbors().full())  //++tooManyNeighbors[thisCell.theLayerPairId];
       printf("OuterNeighbors overflow %d in %d\n", idx, thisCell.layerPairId());
@@ -914,9 +914,9 @@ __global__ void kernel_printCounters(cAHitNtupletGenerator::Counters const *coun
          c.nHits,
          c.nCells,
          c.nTuples,
+         c.nFitTracks,
          c.nLooseTracks,
          c.nGoodTracks,
-         c.nFitTracks,
          c.nUsedHits,
          c.nDupHits,
          c.nFishCells,

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -101,7 +101,8 @@ __global__ void kernel_checkOverflows(HitContainer const *foundNtuplets,
 
   for (int idx = first, nt = (*nCells); idx < nt; idx += gridDim.x * blockDim.x) {
     auto const &thisCell = cells[idx];
-    if (thisCell.hasFishbone()) atomicAdd(&c.nFishCells, 1);
+    if (thisCell.hasFishbone())
+      atomicAdd(&c.nFishCells, 1);
     if (thisCell.outerNeighbors().full())  //++tooManyNeighbors[thisCell.theLayerPairId];
       printf("OuterNeighbors overflow %d in %d\n", idx, thisCell.layerPairId());
     if (thisCell.tracks().full())  //++tooManyTracks[thisCell.theLayerPairId];
@@ -205,7 +206,7 @@ __global__ void kernel_fastDuplicateRemover(GPUCACell const *__restrict__ cells,
 
     // full crazy combinatorics
     int ntr = thisCell.tracks().size();
-    for (int i = 0; i < ntr-1; ++i) {
+    for (int i = 0; i < ntr - 1; ++i) {
       auto it = thisCell.tracks()[i];
       auto qi = tracks->quality(it);
       if (qi <= reject)
@@ -669,7 +670,7 @@ __global__ void kernel_rejectDuplicate(TkSoA const *__restrict__ ptracks,
     auto score = [&](auto it, auto nl) { return std::abs(tracks.tip(it)); };
 
     // full combinatorics
-    for (auto ip = hitToTuple.begin(idx); ip < hitToTuple.end(idx)-1; ++ip) {
+    for (auto ip = hitToTuple.begin(idx); ip < hitToTuple.end(idx) - 1; ++ip) {
       auto const it = *ip;
       auto qi = quality[it];
       if (qi <= reject)
@@ -863,14 +864,15 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
                                             TkSoA const *__restrict__ ptracks,
                                             Quality const *__restrict__ quality,
                                             CAHitNtupletGeneratorKernelsGPU::HitToTuple const *__restrict__ phitToTuple,
-                                            int32_t maxPrint,
+                                            int32_t firstPrint,
+                                            int32_t lastPrint,
                                             int iev) {
   constexpr auto loose = pixelTrack::Quality::loose;
   auto const &hh = *hhp;
   auto const &foundNtuplets = *ptuples;
   auto const &tracks = *ptracks;
-  int first = blockDim.x * blockIdx.x + threadIdx.x;
-  for (int i = first, np = std::min(maxPrint, foundNtuplets.nOnes()); i < np; i += blockDim.x * gridDim.x) {
+  int first = firstPrint + blockDim.x * blockIdx.x + threadIdx.x;
+  for (int i = first, np = std::min(lastPrint, foundNtuplets.nOnes()); i < np; i += blockDim.x * gridDim.x) {
     auto nh = foundNtuplets.size(i);
     if (nh < 3)
       continue;

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -863,6 +863,7 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
                                             int32_t maxPrint,
                                             int iev) {
   constexpr auto loose = pixelTrack::Quality::loose;
+  auto const &hh = *hhp;
   auto const &foundNtuplets = *ptuples;
   auto const &tracks = *ptracks;
   int first = blockDim.x * blockIdx.x + threadIdx.x;
@@ -871,7 +872,7 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
     if (nh < 3)
       continue;
     if (quality[i] < loose) continue;
-    printf("TK: %d %d %d %d %f %f %f %f %f %f %f %d %d %d %d %d %d\n",
+    printf("TK: %d %d %d %d %f %f %f %f %f %f %f %.3f %.3f %.3f %.3f %.3f %.3f\n",
            10000 * iev + i,
            int(quality[i]),
            nh,
@@ -884,12 +885,12 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
            tracks.zip(i),
            //           asinhf(fit_results[i].par(3)),
            tracks.chi2(i),
-           *foundNtuplets.begin(i),
-           *(foundNtuplets.begin(i) + 1),
-           *(foundNtuplets.begin(i) + 2),
-           nh > 3 ? int(*(foundNtuplets.begin(i) + 3)) : -1,
-           nh > 4 ? int(*(foundNtuplets.begin(i) + 4)) : -1,
-           nh > 5 ? int(*(foundNtuplets.begin(i) + nh-1)) : -1);
+           hh.zGlobal(*foundNtuplets.begin(i)),
+           hh.zGlobal(*(foundNtuplets.begin(i) + 1)),
+           hh.zGlobal(*(foundNtuplets.begin(i) + 2)),
+           nh > 3 ? hh.zGlobal(int(*(foundNtuplets.begin(i) + 3))) : 0,
+           nh > 4 ? hh.zGlobal(int(*(foundNtuplets.begin(i) + 4))) : 0,
+           nh > 5 ? hh.zGlobal(int(*(foundNtuplets.begin(i) + nh-1))) : 0);
   }
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -862,6 +862,7 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
                                             CAHitNtupletGeneratorKernelsGPU::HitToTuple const *__restrict__ phitToTuple,
                                             int32_t maxPrint,
                                             int iev) {
+  constexpr auto loose = pixelTrack::Quality::loose;
   auto const &foundNtuplets = *ptuples;
   auto const &tracks = *ptracks;
   int first = blockDim.x * blockIdx.x + threadIdx.x;
@@ -869,10 +870,12 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
     auto nh = foundNtuplets.size(i);
     if (nh < 3)
       continue;
-    printf("TK: %d %d %d %f %f %f %f %f %f %f %d %d %d %d %d\n",
+    if (quality[i] < loose) continue;
+    printf("TK: %d %d %d %d %f %f %f %f %f %f %f %d %d %d %d %d %d\n",
            10000 * iev + i,
            int(quality[i]),
            nh,
+           tracks.nLayers(i),
            tracks.charge(i),
            tracks.pt(i),
            tracks.eta(i),
@@ -885,7 +888,8 @@ __global__ void kernel_print_found_ntuplets(TrackingRecHit2DSOAView const *__res
            *(foundNtuplets.begin(i) + 1),
            *(foundNtuplets.begin(i) + 2),
            nh > 3 ? int(*(foundNtuplets.begin(i) + 3)) : -1,
-           nh > 4 ? int(*(foundNtuplets.begin(i) + 4)) : -1);
+           nh > 4 ? int(*(foundNtuplets.begin(i) + 4)) : -1,
+           nh > 5 ? int(*(foundNtuplets.begin(i) + nh-1)) : -1);
   }
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -83,10 +83,11 @@ CAHitNtupletGeneratorOnGPU::CAHitNtupletGeneratorOnGPU(const edm::ParameterSet& 
                cfg.getParameter<double>("dcaCutOuterTriplet"),
                makeQualityCuts(cfg.getParameterSet("trackQualityCuts"))) {
 #ifdef DUMP_GPU_TK_TUPLES
-  printf("TK: %s %s % %s %s %s %s %s %s %s %s %s %s %s %s %s\n",
+  printf("TK: %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n",
          "tid",
          "qual",
          "nh",
+         "nl",
          "charge",
          "pt",
          "eta",
@@ -98,7 +99,8 @@ CAHitNtupletGeneratorOnGPU::CAHitNtupletGeneratorOnGPU(const edm::ParameterSet& 
          "h2",
          "h3",
          "h4",
-         "h5");
+         "h5",
+         "hn");
 #endif
 
   if (m_params.onGPU_) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -343,18 +343,18 @@ public:
   __device__ __forceinline__ bool unused() const { return 0 == (uint16_t(StatusBit::kUsed) & theStatus_); }
   __device__ __forceinline__ void setStatusBits(StatusBit mask) { theStatus_ |= uint16_t(mask); }
 
-  __device__ __forceinline__ void setFishbone(hindex_type id, float z, Hits const& hh) { 
+  __device__ __forceinline__ void setFishbone(hindex_type id, float z, Hits const& hh) {
     // make it deterministic: use the farther apart (in z)
     auto old = theFishboneId;
-    while (old != atomicCAS(&theFishboneId,old,
-      (invalidHitId == old || std::abs(z-theInnerZ) < std::abs(hh.zGlobal(old)-theInnerZ)) ?
-      id : old)
-    ) old = theFishboneId;
+    while (
+        old !=
+        atomicCAS(&theFishboneId,
+                  old,
+                  (invalidHitId == old || std::abs(z - theInnerZ) < std::abs(hh.zGlobal(old) - theInnerZ)) ? id : old))
+      old = theFishboneId;
   }
   __device__ __forceinline__ auto fishboneId() const { return theFishboneId; }
-  __device__ __forceinline__ bool hasFishbone() const {
-    return theFishboneId != invalidHitId;
-  }
+  __device__ __forceinline__ bool hasFishbone() const { return theFishboneId != invalidHitId; }
 
 private:
   CellNeighbors* theOuterNeighbors;

--- a/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/GPUCACell.h
@@ -350,7 +350,7 @@ public:
         old !=
         atomicCAS(&theFishboneId,
                   old,
-                  (invalidHitId == old || std::abs(z - theInnerZ) < std::abs(hh.zGlobal(old) - theInnerZ)) ? id : old))
+                  (invalidHitId == old || std::abs(z - theInnerZ) > std::abs(hh.zGlobal(old) - theInnerZ)) ? id : old))
       old = theFishboneId;
   }
   __device__ __forceinline__ auto fishboneId() const { return theFishboneId; }

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -75,7 +75,7 @@ namespace gpuPixelDoublets {
           // must be different detectors
           //        if (d[ic]==d[jc]) continue;
           auto cos12 = x[ic] * x[jc] + y[ic] * y[jc] + z[ic] * z[jc];
-          if (d[ic] != d[jc] && cos12 * cos12 >= 0.99999f * (n[ic] * n[jc]) ) {
+          if (d[ic] != d[jc] && cos12 * cos12 >= 0.99999f * (n[ic] * n[jc])) {
             // alligned:  kill farthest (prefer consecutive layers)
             // if same layer prefer farthest (longer level arm) and make space for intermediate hit
             bool sameLayer = l[ic] == l[jc];

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -82,7 +82,7 @@ namespace gpuPixelDoublets {
             if (n[ic] > n[jc]) {
               if (sameLayer) {
                 cj.kill();  // closest
-                ci.setFishbone(cj.inner_hit_id());
+                ci.setFishbone(cj.inner_hit_id(), cj.inner_z(hh), hh);
               } else {
                 ci.kill();  // farthest
                 break;
@@ -92,7 +92,7 @@ namespace gpuPixelDoublets {
                 cj.kill();  // farthest
               } else {
                 ci.kill();  // closest
-                cj.setFishbone(ci.inner_hit_id());
+                cj.setFishbone(ci.inner_hit_id(), ci.inner_z(hh), hh);
                 break;
               }
             }

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -85,7 +85,7 @@ namespace gpuPixelDoublets {
                 ci.setFishbone(cj.inner_hit_id(), cj.inner_z(hh), hh);
               } else {
                 ci.kill();  // farthest
-                break;
+                // break;
               }
             } else {
               if (!sameLayer) {
@@ -93,7 +93,7 @@ namespace gpuPixelDoublets {
               } else {
                 ci.kill();  // closest
                 cj.setFishbone(ci.inner_hit_id(), ci.inner_z(hh), hh);
-                break;
+                // break;
               }
             }
           }

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -85,7 +85,7 @@ namespace gpuPixelDoublets {
                 ci.setFishbone(cj.inner_hit_id(), cj.inner_z(hh), hh);
               } else {
                 ci.kill();  // farthest
-                // break;
+                // break;  // removed to improve reproducibility. keep it for reference and tests
               }
             } else {
               if (!sameLayer) {
@@ -93,7 +93,7 @@ namespace gpuPixelDoublets {
               } else {
                 ci.kill();  // closest
                 cj.setFishbone(ci.inner_hit_id(), ci.inner_z(hh), hh);
-                // break;
+                // break;  // removed to improve reproducibility. keep it for reference    and tests
               }
             }
           }

--- a/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/gpuFishbone.h
@@ -75,7 +75,7 @@ namespace gpuPixelDoublets {
           // must be different detectors
           //        if (d[ic]==d[jc]) continue;
           auto cos12 = x[ic] * x[jc] + y[ic] * y[jc] + z[ic] * z[jc];
-          if (d[ic] != d[jc] && cos12 * cos12 >= 0.99999f * n[ic] * n[jc]) {
+          if (d[ic] != d[jc] && cos12 * cos12 >= 0.99999f * (n[ic] * n[jc]) ) {
             // alligned:  kill farthest (prefer consecutive layers)
             // if same layer prefer farthest (longer level arm) and make space for intermediate hit
             bool sameLayer = l[ic] == l[jc];

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerCUDA.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/PixelVertexProducerCUDA.cc
@@ -58,7 +58,7 @@ PixelVertexProducerCUDA::PixelVertexProducerCUDA(const edm::ParameterSet& conf)
                conf.getParameter<double>("errmax"),
                conf.getParameter<double>("chi2max")),
       ptMin_(conf.getParameter<double>("PtMin")),  // 0.5 GeV
-      ptMax_(conf.getParameter<double>("PtMax"))  // 75. GeV
+      ptMax_(conf.getParameter<double>("PtMax"))   // 75. GeV
 {
   if (onGPU_) {
     tokenGPUTrack_ =

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.cc
@@ -28,7 +28,7 @@ namespace gpuVertexFinder {
     auto first = blockIdx.x * blockDim.x + threadIdx.x;
     for (int idx = first, nt = tracks.nTracks(); idx < nt; idx += gridDim.x * blockDim.x) {
       auto nHits = tracks.nHits(idx);
-      assert(nHits >3);
+      assert(nHits >= 3);
 
       // initialize soa...
       soa->idv[idx] = -1;
@@ -44,7 +44,7 @@ namespace gpuVertexFinder {
         continue;
 
       // clamp pt
-      pt = std::min(pt,ptMax);
+      pt = std::min(pt, ptMax);
 
       auto& data = *pws;
       auto it = atomicAdd(&data.ntrks, 1);
@@ -121,11 +121,11 @@ namespace gpuVertexFinder {
     init<<<1, 1, 0, stream>>>(soa, ws_d.get());
     auto blockSize = 128;
     auto numberOfBlocks = (TkSoA::stride() + blockSize - 1) / blockSize;
-    loadTracks<<<numberOfBlocks, blockSize, 0, stream>>>(tksoa, soa, ws_d.get(), ptMin,ptMax);
+    loadTracks<<<numberOfBlocks, blockSize, 0, stream>>>(tksoa, soa, ws_d.get(), ptMin, ptMax);
     cudaCheck(cudaGetLastError());
 #else
     init(soa, ws_d.get());
-    loadTracks(tksoa, soa, ws_d.get(), ptMin,ptMax);
+    loadTracks(tksoa, soa, ws_d.get(), ptMin, ptMax);
 #endif
 
 #ifdef __CUDACC__

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.cc
@@ -26,10 +26,9 @@ namespace gpuVertexFinder {
     auto const* quality = tracks.qualityData();
 
     auto first = blockIdx.x * blockDim.x + threadIdx.x;
-    for (int idx = first, nt = TkSoA::stride(); idx < nt; idx += gridDim.x * blockDim.x) {
+    for (int idx = first, nt = tracks.nTracks(); idx < nt; idx += gridDim.x * blockDim.x) {
       auto nHits = tracks.nHits(idx);
-      if (nHits == 0)
-        break;  // this is a guard: maybe we need to move to nTracks...
+      assert(nHits >3);
 
       // initialize soa...
       soa->idv[idx] = -1;

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.h
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/gpuVertexFinder.h
@@ -64,8 +64,8 @@ namespace gpuVertexFinder {
 
     ~Producer() = default;
 
-    ZVertexHeterogeneous makeAsync(cudaStream_t stream, TkSoA const* tksoa, float ptMin) const;
-    ZVertexHeterogeneous make(TkSoA const* tksoa, float ptMin) const;
+    ZVertexHeterogeneous makeAsync(cudaStream_t stream, TkSoA const* tksoa, float ptMin, float ptMax) const;
+    ZVertexHeterogeneous make(TkSoA const* tksoa, float ptMin, float ptMax) const;
 
   private:
     const bool oneKernel_;


### PR DESCRIPTION
backport of #37281
backport of #37398

#### PR description:

I open the backport of #37281 and #37398 to `12_3_X` as per TSG's request (see https://github.com/cms-sw/cmssw/pull/37281#issuecomment-1080639025; cc: @silviodonato @Martin-Grunewald).

Those PRs change the outputs of the HLT pixel reconstruction, and TSG would like to have these updates in `12_3_X` (release cycle to be used at HLT at the start of Run 3).

Below, a copy of the description of the original PRs by @VinInn.

Description of #37281 ("Patatrack: introduce pt-clamping in vertex sorting, add #tracks in track SOA"):
>This PR introduces some long standing improvements in Patatrack that can be useful to POG and PAG using directly SOA products.
>
>  1. Track Pt-clamping is introduced in vertex sorting.
>      This is supposed to mitigate the effect of spurious tracks with large pt due to miss-measurement, resolution or inaccurate calibration/alignment.
>
>The effect has been tested in Z->tau-tau events that are supposed to be among those who most suffer from signal-vertex miss-identification.
>The effect is small if not negligible. see: http://innocent.home.cern.ch/innocent/RelVal/ztt_clamp/plots_selectedPixelVertices/pvtagging.pdf
>where we compare clamping at 20, 75 (the default) and 1000 GeV.
>This is not unexpected given the resolution of HP quadruplets, those used to build vertices, that reaches ~30% at ~70 GeV.
>It may be different with initial calibrations or large inefficiency.
>
>Results for ttbar can be found in
>http://innocent.home.cern.ch/innocent/RelVal/gpuMTVclamp/plots_selectedPixelVertices/pvtagging.pdf
>
>  2. The number of tracks is stored in the track SOA.
>      This should make the use of the SOA more user-friendly.
>
>Default has changed, so expect small regressions.

Excerpt of the description of #37398 ("Stabilize Fishbone"):
>The fishbone has been made deterministic and order independent.
>The main change is (of course) removing the `break` in the combinatorial double loop.
>
>results:
> Timing: negligible effect.
>
> MTV: slight increase of duplicate (as more fishbone cells are created) for Loose tracks. no effect on HP
> http://innocent.home.cern.ch/innocent/RelVal/gpuMTVstableFB/
>
> detailed comparison of reproducibility
> [..]
> In particular with this PR (no break) comparing 10 events at track level
> NO difference in HP quadruplets, only one HP triplet differs.
> the rest are loose triplets (and a couple of loose quadruplets)
> REMINDER:
> loose tracks are in the collection ONLY to be used for seeding or for algorithms that perform some sort of pre-cleaning
> (often a simple association to trimmed-vertices is enough).
>
> Making the various ambiguity solvers deterministic and order independent will be much harder and costly

#### PR validation:

Relies on the validation done for the original PRs.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#37281
#37398