### PR TITLE
minor changes to SiPixelLorentzAnglePCL modules

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLWorker.cc
@@ -523,7 +523,7 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
                 if (ylim1 < ypixhigh)
                   ypixhigh = ylim1;
               }
-              float ypixavg = 0.5 * (ypixlow + ypixhigh);
+              float ypixavg = 0.5f * (ypixlow + ypixhigh);
 
               float dx = (pixinfo_.x[j] - xlim1) * cmToum;  // dx: in the unit of micrometer
               float dy = (ypixavg - ylim1) * cmToum;        // dy: in the unit of micrometer
@@ -532,24 +532,24 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
 
               if (isNewMod == false) {
                 int i_index = module_ + (layer_ - 1) * iHists.nModules_[layer_ - 1];
-                iHists.h_drift_depth_adc_.at(i_index)->Fill(drift, depth, pixinfo_.adc[j]);
-                iHists.h_drift_depth_adc2_.at(i_index)->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
-                iHists.h_drift_depth_noadc_.at(i_index)->Fill(drift, depth, 1.);
+                iHists.h_drift_depth_adc_[i_index]->Fill(drift, depth, pixinfo_.adc[j]);
+                iHists.h_drift_depth_adc2_[i_index]->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
+                iHists.h_drift_depth_noadc_[i_index]->Fill(drift, depth, 1.);
                 iHists.h_bySectOccupancy_->Fill(i_index - 1);  // histogram starts at 0
 
                 if (tracker->getDetectorType(subDetID) == TrackerGeometry::ModuleType::Ph1PXB) {
                   if ((module_ == 3 || module_ == 5) && (layer_ == 3 || layer_ == 4)) {
                     int i_index_merge = i_index + 1;
-                    iHists.h_drift_depth_adc_.at(i_index_merge)->Fill(drift, depth, pixinfo_.adc[j]);
-                    iHists.h_drift_depth_adc2_.at(i_index_merge)->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
-                    iHists.h_drift_depth_noadc_.at(i_index_merge)->Fill(drift, depth, 1.);
+                    iHists.h_drift_depth_adc_[i_index_merge]->Fill(drift, depth, pixinfo_.adc[j]);
+                    iHists.h_drift_depth_adc2_[i_index_merge]->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
+                    iHists.h_drift_depth_noadc_[i_index_merge]->Fill(drift, depth, 1.);
                     iHists.h_bySectOccupancy_->Fill(i_index_merge - 1);
                   }
                   if ((module_ == 4 || module_ == 6) && (layer_ == 3 || layer_ == 4)) {
                     int i_index_merge = i_index - 1;
-                    iHists.h_drift_depth_adc_.at(i_index_merge)->Fill(drift, depth, pixinfo_.adc[j]);
-                    iHists.h_drift_depth_adc2_.at(i_index_merge)->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
-                    iHists.h_drift_depth_noadc_.at(i_index_merge)->Fill(drift, depth, 1.);
+                    iHists.h_drift_depth_adc_[i_index_merge]->Fill(drift, depth, pixinfo_.adc[j]);
+                    iHists.h_drift_depth_adc2_[i_index_merge]->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
+                    iHists.h_drift_depth_noadc_[i_index_merge]->Fill(drift, depth, 1.);
                     iHists.h_bySectOccupancy_->Fill(i_index_merge - 1);
                   }
                 }
@@ -558,9 +558,9 @@ void SiPixelLorentzAnglePCLWorker::analyze(edm::Event const& iEvent, edm::EventS
                 int new_index = iHists.nModules_[iHists.nlay - 1] +
                                 (iHists.nlay - 1) * iHists.nModules_[iHists.nlay - 1] + 1 + DetId_index;
 
-                iHists.h_drift_depth_adc_.at(new_index)->Fill(drift, depth, pixinfo_.adc[j]);
-                iHists.h_drift_depth_adc2_.at(new_index)->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
-                iHists.h_drift_depth_noadc_.at(new_index)->Fill(drift, depth, 1.);
+                iHists.h_drift_depth_adc_[new_index]->Fill(drift, depth, pixinfo_.adc[j]);
+                iHists.h_drift_depth_adc2_[new_index]->Fill(drift, depth, pixinfo_.adc[j] * pixinfo_.adc[j]);
+                iHists.h_drift_depth_noadc_[new_index]->Fill(drift, depth, 1.);
                 iHists.h_bySectOccupancy_->Fill(new_index - 1);  // histogram starts at 0
               }
             }
@@ -729,7 +729,7 @@ void SiPixelLorentzAnglePCLWorker::bookHistograms(DQMStore::IBooker& iBooker,
   for (int i_layer = 1; i_layer <= iHists.nlay; i_layer++) {
     for (int i_module = 1; i_module <= iHists.nModules_[i_layer - 1]; i_module++) {
       unsigned int i_index = i_module + (i_layer - 1) * iHists.nModules_[i_layer - 1];
-      std::string binName = fmt::sprintf("BPix Layer%i Module %i", i_layer, i_module);
+      std::string binName = fmt::sprintf("BPix Lay%i Mod%i", i_layer, i_module);
       LogDebug("SiPixelLorentzAnglePCLWorker") << " i_index: " << i_index << " bin name: " << binName
                                                << " (i_layer: " << i_layer << " i_module:" << i_module << ")";
 
@@ -883,7 +883,7 @@ void SiPixelLorentzAnglePCLWorker::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<edm::InputTag>("src", edm::InputTag("TrackRefitter"))->setComment("input track collections");
   desc.add<double>("ptMin", 3.)->setComment("minimum pt on tracks");
   desc.add<double>("normChi2Max", 2.)->setComment("maximum reduced chi squared");
-  desc.add<std::vector<int>>("clustSizeYMin", {4, 4, 3, 2})
+  desc.add<std::vector<int>>("clustSizeYMin", {4, 3, 3, 2})
       ->setComment("minimum cluster size on Y axis for all Barrel Layers");
   desc.add<int>("clustSizeXMax", 5)->setComment("maximum cluster size on X axis");
   desc.add<double>("residualMax", 0.005)->setComment("maximum residual");


### PR DESCRIPTION
#### PR description:

The goal of this PR is to introduce few minor improvements to the SiPixelLorentzAnglePCL modules:
   * loosen the cluster size cut on BPix L2 from 4 to 3, as per presentation at [AlCa/DB meeting Mar 28<sup>th</sup>](https://indico.cern.ch/event/1143221/contributions/4799559/attachments/2416002/4135528/LA_AlCa_20220328.pdf#page=14); 
   * zero the errors in several per sector monitor elements (to ease comparison using DQM GUI);
   * avoid bounds checks in array access to speed-up computations;
   * shorten per-sector bin names;
   * reset ME `h_drift_depth_adc_slice_` after computation is done;

#### PR validation:

Private tests to be completed.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 

cc:
@wweiphy 