### PR TITLE
Fixes to the tauID configuration tool

### DIFF
--- a/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
+++ b/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
@@ -34,6 +34,15 @@ class adaptToRunAtMiniAOD(object):
 			self.process.makePatTausTask,
 			self.process.selectedPatTaus
 		)
+		#Add Run-2 tauIDs for boostedTaus
+		if self.runBoosted:
+			self.process.PFTauMVAIsoTask = cms.Task(
+				self.process.hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw,
+				self.process.hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT,
+				self.process.hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw,
+				self.process.hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLT
+			)
+			self.process.PFTauTask.add(self.process.PFTauMVAIsoTask)
 		self.miniAODTausTask = configtools.cloneProcessingSnippetTask(
 			self.process,self.process.miniAODTausTask,postfix=self.postfix)
 		setattr(self.process,'miniAODTausSequence'+self.postfix,cms.Sequence(self.miniAODTausTask))
@@ -227,13 +236,49 @@ class adaptToRunAtMiniAOD(object):
 				 provenanceConfigLabel = cms.string('IDWPdefinitions'),
 				 idLabel = cms.string('ByTightMuonRejectionSimple')
                  ))
+		#Add Run-2 tauIDs still used for boostedTaus
+		if self.runBoosted:
+			from PhysicsTools.PatAlgos.producersLayer1.tauProducer_cfi import containerID
+			containerID(_patTauProducer.tauIDSources,
+				"hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT"+self.postfix,
+				"rawValues", [
+				["byIsolationMVArun2DBoldDMwLTraw", "discriminator"]
+			])
+			containerID(_patTauProducer.tauIDSources,
+				"hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT"+self.postfix,
+				"workingPoints", [
+				["byVVLooseIsolationMVArun2DBoldDMwLT", "_VVLoose"],
+				["byVLooseIsolationMVArun2DBoldDMwLT", "_VLoose"],
+				["byLooseIsolationMVArun2DBoldDMwLT", "_Loose"],
+				["byMediumIsolationMVArun2DBoldDMwLT", "_Medium"],
+				["byTightIsolationMVArun2DBoldDMwLT", "_Tight"],
+				["byVTightIsolationMVArun2DBoldDMwLT", "_VTight"],
+				["byVVTightIsolationMVArun2DBoldDMwLT", "_VVTight"]
+			])
+			containerID(_patTauProducer.tauIDSources,
+				"hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLT"+self.postfix,
+				"rawValues", [
+				["byIsolationMVArun2DBnewDMwLTraw", "discriminator"]
+			])
+			containerID(_patTauProducer.tauIDSources,
+				"hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLT"+self.postfix,
+				"workingPoints", [
+				["byVVLooseIsolationMVArun2DBnewDMwLT", "_VVLoose"],
+				["byVLooseIsolationMVArun2DBnewDMwLT", "_VLoose"],
+				["byLooseIsolationMVArun2DBnewDMwLT", "_Loose"],
+				["byMediumIsolationMVArun2DBnewDMwLT", "_Medium"],
+				["byTightIsolationMVArun2DBnewDMwLT", "_Tight"],
+				["byVTightIsolationMVArun2DBnewDMwLT", "_VTight"],
+				["byVVTightIsolationMVArun2DBnewDMwLT", "_VVTight"]
+			])
 
 		# Run TauIDs (anti-e && deepTau) on top of selectedPatTaus
 		_updatedTauName = 'selectedPatTausNewIDs'+self.postfix
 		_noUpdatedTauName = 'selectedPatTausNoNewIDs'+self.postfix
-		toKeep = ['againstEle2018']
-		if not self.runBoosted:
-			toKeep.append('deepTau2017v2p1')
+		toKeep = ['deepTau2017v2p1']
+		#For boosted do not run deepTauIDs, but add still used Run-2 anti-e MVA
+		if self.runBoosted:
+			toKeep = ['againstEle2018']
 		import RecoTauTag.RecoTau.tools.runTauIdMVA as tauIdConfig
 		tauIdEmbedder = tauIdConfig.TauIDEmbedder(
 			self.process, debug = False,

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -1007,8 +1007,18 @@ class TauIDEmbedder(object):
                 getattr(self.process, self.updatedTauName).tauIDSources,
                 tauIDSources)
             getattr(self.process, self.updatedTauName).tauIDSources = tauIDSources
-        setattr(self.process,"rerunMvaIsolationTask"+self.postfix,_rerunMvaIsolationTask)
-        setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,_rerunMvaIsolationSequence)
+        if not hasattr(self.process,"rerunMvaIsolationTask"+self.postfix):
+            setattr(self.process,"rerunMvaIsolationTask"+self.postfix,_rerunMvaIsolationTask)
+        else:
+            _updatedRerunMvaIsolationTask = getattr(self.process,"rerunMvaIsolationTask"+self.postfix)
+            _updatedRerunMvaIsolationTask.add(_rerunMvaIsolationTask)
+            setattr(self.process,"rerunMvaIsolationTask"+self.postfix,_updatedRerunMvaIsolationTask)
+        if not hasattr(self.process,"rerunMvaIsolationSequence"+self.postfix):
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,_rerunMvaIsolationSequence)
+        else:
+            _updatedRerunMvaIsolationSequence = getattr(self.process,"rerunMvaIsolationSequence"+self.postfix)
+            _updatedRerunMvaIsolationSequence += _rerunMvaIsolationSequence
+            setattr(self.process,"rerunMvaIsolationSequence"+self.postfix,_updatedRerunMvaIsolationSequence)
 
 
     def processDeepProducer(self, producer_name, tauIDSources, workingPoints_):


### PR DESCRIPTION
#### PR description:

This is a technical PR which fixes two small issues in tauID configuration tools:
* Modification of [RecoTauTag/RecoTau/python/tools/runTauIdMVA.py](https://github.com/cms-sw/cmssw/compare/master...mbluj:CMSSW_12_4_X_tauToolFixes?expand=1#diff-3c94bf99fbc35756eae7c627998054f6752b0dc17386bb8ebf5caf00c2c05218) is to correctly deal with cases when the tool is used two times in the same "process"; The change does not affect workflows in which the tool is used (mini and nanoAOD)
* Modification of [adaptToRunAtMiniAOD.py](https://github.com/cms-sw/cmssw/compare/master...mbluj:CMSSW_12_4_X_tauToolFixes?expand=1#diff-3599b5508af9a9f45a93a2f76c540b6cb530519be084e01c87fadead12f1b759) adds BDT-based tauIDs to boostedTau workflow on top of miniAOD. These tauIDs were removed in  #37091 from configuration from which this workflow is derived. The boostedTau-at-mini workflow is not run as a part of official workflows thus the change does not affect them.

#### PR validation:

Validated in workflows using the modified tools - miniAOD and nanoAOD production, and tau-at-miniAOD workflows.