### PR TITLE
Adding option to disable resetting L1 PS counters on ls change [`12_3_X`]

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -193,7 +193,7 @@ namespace l1t {
     void setBxFirst(int bx);
     void setBxLast(int bx);
 
-    void setResetPSCountersEachLumiSec(bool val){m_resetPSCountersEachLumiSec=val;}
+    void setResetPSCountersEachLumiSec(bool val) { m_resetPSCountersEachLumiSec = val; }
 
   public:
     inline void setVerbosity(const int verbosity) { m_verbosity = verbosity; }

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -193,6 +193,8 @@ namespace l1t {
     void setBxFirst(int bx);
     void setBxLast(int bx);
 
+    void setResetPSCountersEachLumiSec(bool val){m_resetPSCountersEachLumiSec=val;}
+
   public:
     inline void setVerbosity(const int verbosity) { m_verbosity = verbosity; }
 
@@ -263,6 +265,9 @@ namespace l1t {
     // Information about board
     int m_uGtBoardNumber;
     bool m_uGtFinalBoard;
+
+    //whether we reset the prescales each lumi or not
+    bool m_resetPSCountersEachLumiSec = true;
   };
 
 }  // namespace l1t

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -68,7 +68,7 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
 
   // switch for muon showers in Run-3
   desc.add<bool>("useMuonShowers", false);
-
+  desc.add<bool>("resetPSCountersEachLumiSec",true);
   // These parameters have well defined  default values and are not currently
   // part of the L1T/HLT interface.  They can be cleaned up or updated at will:
   desc.add<bool>("ProduceL1GtDaqRecord", true);
@@ -115,6 +115,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
       m_getPrescaleColumnFromData(parSet.getParameter<bool>("GetPrescaleColumnFromData")),
       m_requireMenuToMatchAlgoBlkInput(parSet.getParameter<bool>("RequireMenuToMatchAlgoBlkInput")),
       m_algoblkInputTag(parSet.getParameter<edm::InputTag>("AlgoBlkInputTag")),
+      m_resetPSCountersEachLumiSec(parSet.getParameter<bool>("resetPSCountersEachLumiSec")),
       m_useMuonShowers(parSet.getParameter<bool>("useMuonShowers")) {
   m_egInputToken = consumes<BXVector<EGamma>>(m_egInputTag);
   m_tauInputToken = consumes<BXVector<Tau>>(m_tauInputTag);
@@ -195,6 +196,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
   // create new uGt Board
   m_uGtBrd = std::make_unique<GlobalBoard>();
   m_uGtBrd->setVerbosity(m_verbosity);
+  m_uGtBrd->setResetPSCountersEachLumiSec(m_resetPSCountersEachLumiSec);
 
   // initialize cached IDs
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -68,7 +68,7 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
 
   // switch for muon showers in Run-3
   desc.add<bool>("useMuonShowers", false);
-  desc.add<bool>("resetPSCountersEachLumiSec",true);
+  desc.add<bool>("resetPSCountersEachLumiSec", true);
   // These parameters have well defined  default values and are not currently
   // part of the L1T/HLT interface.  They can be cleaned up or updated at will:
   desc.add<bool>("ProduceL1GtDaqRecord", true);

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -186,6 +186,8 @@ private:
   edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_l1GtMenuToken;
   edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd> m_l1GtPrescaleVetosToken;
 
+  //disables reseting the prescale counters each lumisection (needed for offline)
+  bool m_resetPSCountersEachLumiSec;
   // switch to load muon showers in the global board
   bool m_useMuonShowers;
 };

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -981,7 +981,7 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
   }
 
   // update and clear prescales at the beginning of the luminosity segment
-  if (m_firstEvLumiSegment || (m_currentLumi != iEvent.luminosityBlock() && m_resetPSCountersEachLumiSec) ) { 
+  if (m_firstEvLumiSegment || (m_currentLumi != iEvent.luminosityBlock() && m_resetPSCountersEachLumiSec)) {
     m_prescaleCounterAlgoTrig.clear();
     for (int iBxInEvent = 0; iBxInEvent <= totalBxInEvent; ++iBxInEvent) {
       m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -981,12 +981,11 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
   }
 
   // update and clear prescales at the beginning of the luminosity segment
-  if (m_firstEvLumiSegment || m_currentLumi != iEvent.luminosityBlock()) {
+  if (m_firstEvLumiSegment || (m_currentLumi != iEvent.luminosityBlock() && m_resetPSCountersEachLumiSec) ) { 
     m_prescaleCounterAlgoTrig.clear();
     for (int iBxInEvent = 0; iBxInEvent <= totalBxInEvent; ++iBxInEvent) {
       m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);
     }
-
     m_firstEvLumiSegment = false;
     m_currentLumi = iEvent.luminosityBlock();
   }


### PR DESCRIPTION
backport of #37395

#### PR description:

Backport of #37395. This PR is needed by TSG for HLT-rate studies in `12_3_X`. It simply adds an option to a producer without changing its defaults.

Description of the original PR by @Sam-Harper (cc: @silviodonato @Martin-Grunewald):
>This PR adds an option to disable resetting the prescale counters of the L1 trigger on lumi section change. This is needed for offline L1 reemulations where we only have ~23000 events per lumisection available (often much much less due to multithreading/job splitting) and this reset comes too soon and causes triggers to have a much higher effective prescale or not fire at all. This is based on the excellent debugging and investigations by @sanuvarghese
>
>Also could experts just confirm why the L1 resets counters every lumisection? I'm just curious to why.
>
>Finally as spotted by both Sanu and myself, we note that this code can not work with fractional prescales. What is the plan here?

#### PR validation:

Relies on the validation done for the original PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#37395

Purpose: HLT development in `12_3_X`.