### PR TITLE
Customize for OT inefficiency

### DIFF
--- a/CondTools/SiPhase2Tracker/plugins/SiPhase2BadStripChannelBuilder.cc
+++ b/CondTools/SiPhase2Tracker/plugins/SiPhase2BadStripChannelBuilder.cc
@@ -97,9 +97,7 @@ std::unique_ptr<SiStripBadStrip> SiPhase2BadStripChannelBuilder::getNewObject() 
   auto obj = std::make_unique<SiStripBadStrip>();
 
   // early return with nullptr if fraction is ==0.
-  if (badComponentsFraction_ > 0.) {
-    ;
-  } else {
+  if (badComponentsFraction_ == 0.f) {
     return obj;
   }
 

--- a/SimTracker/SiPhase2Digitizer/python/customizeForOTInefficiency.py
+++ b/SimTracker/SiPhase2Digitizer/python/customizeForOTInefficiency.py
@@ -1,0 +1,75 @@
+import FWCore.ParameterSet.Config as cms
+
+def _commonCustomizeForInefficiency(process):
+    ## for standard mixing
+    if hasattr(process,'mix') and hasattr(process.mix,'digitizers') and hasattr(process.mix.digitizers,'pixel'): 
+        if hasattr(process.mix.digitizers.pixel,'PSPDigitizerAlgorithm'):
+            print("# Activating Bias Rail Inefficiency in macro-pixels")
+            process.mix.digitizers.pixel.PSPDigitizerAlgorithm.AddBiasRailInefficiency = cms.bool(True)
+
+        if hasattr(process.mix.digitizers.pixel,'PSSDigitizerAlgorithm'):
+            print("# Activating bad strip simulation for s-sensors in PS modules from DB")
+            process.mix.digitizers.pixel.PSSDigitizerAlgorithm.KillModules = cms.bool(True)
+            process.mix.digitizers.pixel.PSSDigitizerAlgorithm.DeadModules_DB = cms.bool(True)
+
+        if hasattr(process.mix.digitizers.pixel,'SSDigitizerAlgorithm'):
+            print("# Activating bad strip simulation for SS modules from DB")
+            process.mix.digitizers.pixel.SSDigitizerAlgorithm.KillModules = cms.bool(True)
+            process.mix.digitizers.pixel.SSDigitizerAlgorithm.DeadModules_DB = cms.bool(True)
+
+    ## for pre-mixing
+    if hasattr(process, "mixData") and hasattr(process.mixData, "workers") and hasattr(process.mixData.workers, "pixel"):
+        if hasattr(process.mixData.workers.pixel,'PSPDigitizerAlgorithm'):
+            print("# Activating Bias Rail Inefficiency in macro-pixels")
+            process.mixData.workers.pixel.PSPDigitizerAlgorithm.AddBiasRailInefficiency = cms.bool(True)
+
+        if hasattr(process.mixData.workers.pixel,'PSSDigitizerAlgorithm'):
+            print("# Activating bad strip simulation for s-sensors in PS modules from DB")
+            process.mixData.workers.pixel.PSSDigitizerAlgorithm.KillModules = cms.bool(True)
+            process.mixData.workers.pixel.PSSDigitizerAlgorithm.DeadModules_DB = cms.bool(True)
+
+        if hasattr(process.mixData.workers.pixel,'SSDigitizerAlgorithm'):
+            print("# Activating bad strip simulation for SS modules from DB")
+            process.mixData.workers.pixel.SSDigitizerAlgorithm.KillModules = cms.bool(True)
+            process.mixData.workers.pixel.SSDigitizerAlgorithm.DeadModules_DB = cms.bool(True)
+
+    return process
+
+#
+# activate bias rail inefficiency and 1% random bad strips
+#
+def customizeSiPhase2OTInefficiencyOnePercent(process):
+
+    _commonCustomizeForInefficiency(process)
+
+    if hasattr(process,'SiPhase2OTFakeBadStripsESSource') :
+        print("# Adding 1% of randomly generated bad strips")
+        process.SiPhase2OTFakeBadStripsESSource.badComponentsFraction = 0.01 # 1% bad components
+
+    return process
+
+#
+# activate bias rail inefficiency and 5% random bad strips
+#
+def customizeSiPhase2OTInefficiencyFivePercent(process):
+
+    _commonCustomizeForInefficiency(process)
+
+    if hasattr(process,'SiPhase2OTFakeBadStripsESSource') :
+        print("# Adding 5% of randomly generated bad strips")
+        process.SiPhase2OTFakeBadStripsESSource.badComponentsFraction = 0.05 # 5% bad components
+
+    return process
+
+#
+# activate bias rail inefficiency and 10% random bad strips
+#
+def customizeSiPhase2OTInefficiencyTenPercent(process):
+
+    _commonCustomizeForInefficiency(process)
+ 
+    if hasattr(process,'SiPhase2OTFakeBadStripsESSource') :
+        print("# Adding 10% of randomly generated bad strips")
+        process.SiPhase2OTFakeBadStripsESSource.badComponentsFraction = 0.1 # 10% bad components
+
+    return process


### PR DESCRIPTION
#### PR description:

This is a first follow-up to PR https://github.com/cms-sw/cmssw/pull/37397.
It consists of two commits:
   * 1c7926639d95113e92ba39bb20ee9d0d1aea2347 simplifies the logic in `SiPhase2BadStripChannelBuilder` as requested at https://github.com/cms-sw/cmssw/pull/37397#discussion_r842459081
   * 4c880cec81067564200b1129e4125e00ba03386a add file with customization functions for OT Inefficiencies, with different choices for the random fraction of bad strips
   
#### PR validation:

Tested e.g. with: 
```console
runTheMatrix.py -l 35434.0 --command='--customise SimTracker/SiPhase2Digitizer/customizeForOTInefficiency.customizeSiPhase2OTInefficiencyOnePercent'
```
and checked that the right switches get activated.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

cc:
@suchandradutta @emiglior 