### PR TITLE
get rid of CMSDEPRECATED_X warnings in `HeavyFlavorAnalysis/SpecificDecay`

### DIFF
--- a/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHHistoSpecificDecay.cc
+++ b/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHHistoSpecificDecay.cc
@@ -1,30 +1,20 @@
-
-#include "HeavyFlavorAnalysis/SpecificDecay/plugins/BPHHistoSpecificDecay.h"
-
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHParticleMasses.h"
-
-#include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
-
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
-
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHParticleMasses.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/plugins/BPHHistoSpecificDecay.h"
 #include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
+
+#include "TFile.h"
+#include "TH1.h"
 #include "TMath.h"
-#include "Math/VectorUtil.h"
+#include "TTree.h"
 #include "TVector3.h"
 
-#include <TH1.h>
-#include <TTree.h>
-#include <TFile.h>
-
+#include "Math/VectorUtil.h"
 #include <set>
 #include <string>
 #include <iostream>
@@ -1302,10 +1292,6 @@ void BPHHistoSpecificDecay::analyze(const edm::Event& ev, const edm::EventSetup&
   runNumber = ev.id().run();
   lumiSection = ev.id().luminosityBlock();
   eventNumber = ev.id().event();
-
-  // get magnetic field
-  edm::ESHandle<MagneticField> magneticField;
-  es.get<IdealMagneticFieldRecord>().get(magneticField);
 
   // get object collections
   // collections are got through "BPHTokenWrapper" interface to allow

--- a/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHHistoSpecificDecay.h
+++ b/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHHistoSpecificDecay.h
@@ -1,17 +1,15 @@
 #ifndef HeavyFlavorAnalysis_SpecificDecay_BPHHistoSpecificDecay_h
 #define HeavyFlavorAnalysis_SpecificDecay_BPHHistoSpecificDecay_h
 
-#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHAnalyzerTokenWrapper.h"
-#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
-
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/Common/interface/Ref.h"
-
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHAnalyzerTokenWrapper.h"
 
 #include <string>
 
@@ -38,7 +36,7 @@ public:
 
   class CandidateSelect {
   public:
-    virtual ~CandidateSelect() {}
+    virtual ~CandidateSelect() = default;
     virtual bool accept(const pat::CompositeCandidate& cand, const reco::Vertex* pv = nullptr) const = 0;
   };
 

--- a/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHWriteSpecificDecay.cc
+++ b/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHWriteSpecificDecay.cc
@@ -1,47 +1,37 @@
-#include "HeavyFlavorAnalysis/SpecificDecay/plugins/BPHWriteSpecificDecay.h"
-
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHRecoBuilder.h"
-#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHRecoSelect.h"
-#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHRecoCandidate.h"
-#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHPlusMinusCandidate.h"
-#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHMomentumSelect.h"
-#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHVertexSelect.h"
-#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHTrackReference.h"
-
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHMuonPtSelect.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHMuonEtaSelect.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHParticlePtSelect.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHParticleNeutralVeto.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHMassSelect.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHChi2Select.h"
-
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHOniaToMuMuBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHKx0ToKPiBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHPhiToKKBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBuToJPsiKBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBsToJPsiPhiBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBdToJPsiKxBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHK0sToPiPiBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHLambda0ToPPiBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHParticleMasses.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBdToJPsiKsBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHLbToJPsiL0Builder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBcToJPsiPiBuilder.h"
-#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHX3872ToJPsiPiPiBuilder.h"
-
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/PatCandidates/interface/GenericParticle.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-
-#include "DataFormats/PatCandidates/interface/GenericParticle.h"
-#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
-
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHMomentumSelect.h"
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHPlusMinusCandidate.h"
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHRecoBuilder.h"
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHRecoCandidate.h"
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHRecoSelect.h"
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHTrackReference.h"
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHVertexSelect.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBcToJPsiPiBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBdToJPsiKsBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBdToJPsiKxBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBsToJPsiPhiBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHBuToJPsiKBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHChi2Select.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHK0sToPiPiBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHKx0ToKPiBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHLambda0ToPPiBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHLbToJPsiL0Builder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHMassSelect.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHMuonEtaSelect.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHMuonPtSelect.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHOniaToMuMuBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHParticleMasses.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHParticleNeutralVeto.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHParticlePtSelect.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHPhiToKKBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/interface/BPHX3872ToJPsiPiPiBuilder.h"
+#include "HeavyFlavorAnalysis/SpecificDecay/plugins/BPHWriteSpecificDecay.h"
+#include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistance.h"
 
 #include <set>
 #include <string>
@@ -53,7 +43,7 @@ using namespace std;
 // is equivalent to
 // ( xyz = ps.getParameter< string >( "xyx" ) )
 
-BPHWriteSpecificDecay::BPHWriteSpecificDecay(const edm::ParameterSet& ps) {
+BPHWriteSpecificDecay::BPHWriteSpecificDecay(const edm::ParameterSet& ps) : bFieldToken(esConsumes()) {
   usePV = (!SET_PAR(string, pVertexLabel, ps).empty());
   usePM = (!SET_PAR(string, patMuonLabel, ps).empty());
   useCC = (!SET_PAR(string, ccCandsLabel, ps).empty());
@@ -212,8 +202,6 @@ BPHWriteSpecificDecay::BPHWriteSpecificDecay(const edm::ParameterSet& ps) {
     produces<pat::CompositeCandidateCollection>(x3872Name);
 }
 
-BPHWriteSpecificDecay::~BPHWriteSpecificDecay() {}
-
 void BPHWriteSpecificDecay::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<string>("pVertexLabel", "");
@@ -320,8 +308,7 @@ void BPHWriteSpecificDecay::fill(edm::Event& ev, const edm::EventSetup& es) {
   ccRefMap.clear();
 
   // get magnetic field
-  edm::ESHandle<MagneticField> magneticField;
-  es.get<IdealMagneticFieldRecord>().get(magneticField);
+  const MagneticField* magneticField = &es.getData(bFieldToken);
 
   // get object collections
   // collections are got through "BPHTokenWrapper" interface to allow

--- a/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHWriteSpecificDecay.h
+++ b/HeavyFlavorAnalysis/SpecificDecay/plugins/BPHWriteSpecificDecay.h
@@ -1,26 +1,23 @@
 #ifndef HeavyFlavorAnalysis_SpecificDecay_BPHWriteSpecificDecay_h
 #define HeavyFlavorAnalysis_SpecificDecay_BPHWriteSpecificDecay_h
 
-#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHAnalyzerTokenWrapper.h"
-
+#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/PatCandidates/interface/GenericParticle.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHAnalyzerTokenWrapper.h"
 #include "HeavyFlavorAnalysis/RecoDecay/interface/BPHPlusMinusCandidate.h"
 #include "HeavyFlavorAnalysis/RecoDecay/interface/BPHRecoCandidate.h"
 #include "HeavyFlavorAnalysis/RecoDecay/interface/BPHTrackReference.h"
-
-#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
 #include "HeavyFlavorAnalysis/RecoDecay/interface/BPHVertexCompositePtrCandidate.h"
-
-#include "DataFormats/Common/interface/Ref.h"
-#include "DataFormats/PatCandidates/interface/Muon.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/PatCandidates/interface/GenericParticle.h"
-#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
-
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoVertex/KinematicFitPrimitives/interface/RefCountedKinematicParticle.h"
 #include "RecoVertex/KinematicFitPrimitives/interface/RefCountedKinematicVertex.h"
 
@@ -34,7 +31,7 @@ class BPHRecoCandidate;
 class BPHWriteSpecificDecay : public BPHAnalyzerWrapper<BPHModuleWrapper::one_producer> {
 public:
   explicit BPHWriteSpecificDecay(const edm::ParameterSet& ps);
-  ~BPHWriteSpecificDecay() override;
+  ~BPHWriteSpecificDecay() override = default;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -44,6 +41,7 @@ public:
   void endJob() override;
 
 private:
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bFieldToken;
   std::string pVertexLabel;
   std::string patMuonLabel;
   std::string ccCandsLabel;


### PR DESCRIPTION
#### PR description:

Title says it all, part of https://github.com/cms-sw/cmssw/issues/31061.
Removed all of the `CMSDEPRECATED_X` warnings in the `HeavyFlavorAnalysis/SpecificDecay` subsystem from [CMSSW_12_4_CMSDEPRECATED_X_2022-04-04-2300](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc10/CMSSW_12_4_CMSDEPRECATED_X_2022-04-04-2300/HeavyFlavorAnalysis/SpecificDecay).
Profited to clean-up a bit the includes and destructors in the touched classes.

#### PR validation:

`cmssw` compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 