### PR TITLE
EMTF Unpacker Update to Add HMT and Displaced Muon Information [12_3_X]

### DIFF
--- a/DataFormats/L1TMuon/interface/EMTF/SP.h
+++ b/DataFormats/L1TMuon/interface/EMTF/SP.h
@@ -23,9 +23,12 @@ namespace l1t {
             quality_GMT(-99),
             phi_GMT(-99),
             bx(-99),
+            hmt(-99),
             mode(-99),
             eta_GMT(-99),
             pt_GMT(-99),
+            pt_dxy_GMT(-99),
+            dxy_GMT(-99),
             me1_subsector(-99),
             me1_CSC_ID(-99),
             me1_stub_num(-99),
@@ -40,6 +43,7 @@ namespace l1t {
             me2_delay(-99),
             me3_delay(-99),
             me4_delay(-99),
+            nn_pt_valid(-99),
             pt_LUT_addr(-99),
             format_errors(0),
             dataword(-99){};
@@ -56,9 +60,12 @@ namespace l1t {
       void set_quality_GMT(int bits) { quality_GMT = bits; }
       void set_phi_GMT(int bits) { phi_GMT = bits; }
       void set_bx(int bits) { bx = bits; }
+      void set_hmt(int bits) { hmt = bits; }
       void set_mode(int bits) { mode = bits; }
       void set_eta_GMT(int bits) { eta_GMT = bits; }
       void set_pt_GMT(int bits) { pt_GMT = bits; }
+      void set_pt_dxy_GMT(int bits) { pt_dxy_GMT = bits; }
+      void set_dxy_GMT(int bits) { dxy_GMT = bits; }
       void set_me1_subsector(int bits) { me1_subsector = bits; }
       void set_me1_CSC_ID(int bits) { me1_CSC_ID = bits; }
       void set_me1_stub_num(int bits) { me1_stub_num = bits; }
@@ -73,6 +80,7 @@ namespace l1t {
       void set_me2_delay(int bits) { me2_delay = bits; }
       void set_me3_delay(int bits) { me3_delay = bits; }
       void set_me4_delay(int bits) { me4_delay = bits; }
+      void set_nn_pt_valid(int bits) { nn_pt_valid = bits; }
       void set_pt_LUT_addr(unsigned long bits) { pt_LUT_addr = bits; }
       void add_format_error() { format_errors += 1; }
       void set_dataword(uint64_t bits) { dataword = bits; }
@@ -90,6 +98,8 @@ namespace l1t {
       int Mode() const { return mode; }
       int Eta_GMT() const { return eta_GMT; }
       int Pt_GMT() const { return pt_GMT; }
+      int Pt_dxy_GMT() const { return pt_dxy_GMT; }
+      int Dxy_GMT() const { return dxy_GMT; }
       int ME1_subsector() const { return me1_subsector; }
       int ME1_CSC_ID() const { return me1_CSC_ID; }
       int ME1_stub_num() const { return me1_stub_num; }
@@ -104,9 +114,11 @@ namespace l1t {
       int ME2_delay() const { return me2_delay; }
       int ME3_delay() const { return me3_delay; }
       int ME4_delay() const { return me4_delay; }
+      int NN_pt_valid() const { return nn_pt_valid; }
       unsigned long Pt_LUT_addr() const { return pt_LUT_addr; }
       int Format_errors() const { return format_errors; }
       uint64_t Dataword() const { return dataword; }
+      int HMT() const { return hmt; }
 
     private:
       int hl;
@@ -119,9 +131,12 @@ namespace l1t {
       int quality_GMT;
       int phi_GMT;
       int bx;
+      int hmt;
       int mode;
       int eta_GMT;
       int pt_GMT;
+      int pt_dxy_GMT;
+      int dxy_GMT;
       int me1_subsector;
       int me1_CSC_ID;
       int me1_stub_num;
@@ -136,6 +151,7 @@ namespace l1t {
       int me2_delay;
       int me3_delay;
       int me4_delay;
+      int nn_pt_valid;
       unsigned long pt_LUT_addr;
       int format_errors;
       uint64_t dataword;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -16,6 +16,13 @@ namespace l1t {
         bool unpack(const Block& block,
                     UnpackerCollections* coll) override;  // Apparently it's always good to use override in C++
         // virtual bool packBlock(const Block& block, UnpackerCollections *coll) override;
+
+      private:
+        bool useHMTBits_{false};
+        bool useNNBits_{false};
+
+        int nominalShower_ = 3;
+        int tightShower_ = 4;
       };
 
       // class SPBlockPacker : public Packer { // "SPBlockPacker" inherits from "Packer"
@@ -176,6 +183,14 @@ namespace l1t {
         // payload[0] = bits 0-15, payload[1] = 16-31, payload[3] = 32-47, etc.
         auto payload = block.payload();
 
+        // FW version is computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
+        if (getAlgoVersion() >= 11098){ // FW versions >= 26.10.2021
+          useNNBits_ = true;
+        }
+        if (getAlgoVersion() >= 11306){ // FW versions >= 10.01.2022
+          useHMTBits_ = true;
+        }
+
         // Check Format of Payload
         l1t::emtf::SP SP_;
         for (int err = 0; err < checkFormat(block); err++)
@@ -210,6 +225,10 @@ namespace l1t {
         res_cand = static_cast<EMTFCollections*>(coll)->getRegionalMuonCands();
         RegionalMuonCand mu_(0, 0, 0, 0, 0, 0, 0, tftype::emtf_pos);
 
+        RegionalMuonShowerBxCollection* res_shower;
+        res_shower = static_cast<EMTFCollections*>(coll)->getRegionalMuonShowers();
+        RegionalMuonShower muShower_(false, false, false, false, false, false);
+
         ///////////////////////////////////
         // Unpack the SP Output Data Record
         ///////////////////////////////////
@@ -226,7 +245,12 @@ namespace l1t {
 
         SP_.set_eta_GMT(TwosCompl(9, GetHexBits(SP1c, 0, 8)));
         SP_.set_mode(GetHexBits(SP1c, 9, 12));
-        SP_.set_bx(GetHexBits(SP1c, 13, 14));
+
+        if (useHMTBits_){
+          SP_.set_hmt(GetHexBits(SP1c, 13, 14));
+        } else{
+          SP_.set_bx(GetHexBits(SP1c, 13, 14));
+        }
 
         SP_.set_pt_GMT(GetHexBits(SP1d, 0, 8));
         SP_.set_me1_stub_num(GetHexBits(SP1d, 9, 9));
@@ -246,7 +270,14 @@ namespace l1t {
         SP_.set_me4_delay(GetHexBits(SP2b, 9, 11));
         SP_.set_tbin(GetHexBits(SP2b, 12, 14));
 
-        SP_.set_pt_LUT_addr(GetHexBits(SP2c, 0, 14, SP2d, 0, 14));
+        if (useNNBits_){
+          SP_.set_pt_dxy_GMT(GetHexBits(SP2c, 0, 7));
+          SP_.set_dxy_GMT(GetHexBits(SP2c, 8, 10));
+          SP_.set_nn_pt_valid(GetHexBits(SP2c, 11, 11));
+        } else{
+          SP_.set_pt_LUT_addr(GetHexBits(SP2c, 0, 14, SP2d, 0, 14));
+        }
+
 
         // SP_.set_dataword     ( uint64_t dataword );
 
@@ -271,6 +302,10 @@ namespace l1t {
         mu_.setHwEta(SP_.Eta_GMT());
         mu_.setHwPhi(SP_.Phi_GMT());
         mu_.setHwPt(SP_.Pt_GMT());
+        if (useNNBits_){
+          mu_.setHwPtUnconstrained(SP_.Pt_dxy_GMT());
+          mu_.setHwDXY(SP_.Dxy_GMT());
+        }
         mu_.setTFIdentifiers(Track_.Sector() - 1, (Track_.Endcap() == 1) ? emtf_pos : emtf_neg);
         mu_.setTrackSubAddress(RegionalMuonCand::kTrkNum, Track_.Track_num());
         // Truncated to 11 bits and offset by 25 from global event BX in EMTF firmware
@@ -280,6 +315,11 @@ namespace l1t {
         mu_.setTrackSubAddress(RegionalMuonCand::kBX, EMTF_kBX);
         // mu_.set_dataword   ( SP_.Dataword() );
         // Track_.set_GMT(mu_);
+
+        // Set Regional Muon Showers
+        muShower_.setTFIdentifiers(Track_.Sector() - 1, (Track_.Endcap() == 1) ? emtf_pos : emtf_neg);
+        muShower_.setOneNominalInTime(SP_.HMT() == nominalShower_ ? true : false);
+        muShower_.setOneTightInTime(SP_.HMT() == tightShower_ ? true : false);
 
         ///////////////////////
         // Match hits to tracks
@@ -551,6 +591,9 @@ namespace l1t {
         // TBIN_num can range from 0 through 7, i.e. BX = -3 through +4. - AWB 04.04.16
         res_cand->setBXRange(-3, 4);
         res_cand->push_back(SP_.TBIN() - 3, mu_);
+
+        res_shower->setBXRange(-3, 4);
+        res_shower->push_back(SP_.TBIN() - 3, muShower_);
 
         // Finished with unpacking one SP Output Data Record
         return true;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -21,8 +21,8 @@ namespace l1t {
         bool useHMTBits_{false};
         bool useNNBits_{false};
 
-        int nominalShower_ = 3;
-        int tightShower_ = 4;
+        int nominalShower_ = 2;
+        int tightShower_ = 3;
       };
 
       // class SPBlockPacker : public Packer { // "SPBlockPacker" inherits from "Packer"

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -177,11 +177,11 @@ namespace l1t {
         auto payload = block.payload();
 
         // FW version is computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
-        bool useNNBits_  = getAlgoVersion() >= 11098;  // FW versions >= 26.10.2021
+        bool useNNBits_ = getAlgoVersion() >= 11098;   // FW versions >= 26.10.2021
         bool useHMTBits_ = getAlgoVersion() >= 11306;  // FW versions >= 10.01.2022
 
         static constexpr int nominalShower_ = 2;
-        static constexpr int tightShower_   = 3;
+        static constexpr int tightShower_ = 3;
 
         // Check Format of Payload
         l1t::emtf::SP SP_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -317,9 +317,11 @@ namespace l1t {
         // Track_.set_GMT(mu_);
 
         // Set Regional Muon Showers
-        muShower_.setTFIdentifiers(Track_.Sector() - 1, (Track_.Endcap() == 1) ? emtf_pos : emtf_neg);
-        muShower_.setOneNominalInTime(SP_.HMT() == nominalShower_ ? true : false);
-        muShower_.setOneTightInTime(SP_.HMT() == tightShower_ ? true : false);
+        if (useHMTBits_){
+          muShower_.setTFIdentifiers(Track_.Sector() - 1, (Track_.Endcap() == 1) ? emtf_pos : emtf_neg);
+          muShower_.setOneNominalInTime(SP_.HMT() == nominalShower_ ? true : false);
+          muShower_.setOneTightInTime(SP_.HMT() == tightShower_ ? true : false);
+        }
 
         ///////////////////////
         // Match hits to tracks

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -184,10 +184,10 @@ namespace l1t {
         auto payload = block.payload();
 
         // FW version is computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
-        if (getAlgoVersion() >= 11098){ // FW versions >= 26.10.2021
+        if (getAlgoVersion() >= 11098) {  // FW versions >= 26.10.2021
           useNNBits_ = true;
         }
-        if (getAlgoVersion() >= 11306){ // FW versions >= 10.01.2022
+        if (getAlgoVersion() >= 11306) {  // FW versions >= 10.01.2022
           useHMTBits_ = true;
         }
 
@@ -246,9 +246,9 @@ namespace l1t {
         SP_.set_eta_GMT(TwosCompl(9, GetHexBits(SP1c, 0, 8)));
         SP_.set_mode(GetHexBits(SP1c, 9, 12));
 
-        if (useHMTBits_){
+        if (useHMTBits_) {
           SP_.set_hmt(GetHexBits(SP1c, 13, 14));
-        } else{
+        } else {
           SP_.set_bx(GetHexBits(SP1c, 13, 14));
         }
 
@@ -270,14 +270,13 @@ namespace l1t {
         SP_.set_me4_delay(GetHexBits(SP2b, 9, 11));
         SP_.set_tbin(GetHexBits(SP2b, 12, 14));
 
-        if (useNNBits_){
+        if (useNNBits_) {
           SP_.set_pt_dxy_GMT(GetHexBits(SP2c, 0, 7));
           SP_.set_dxy_GMT(GetHexBits(SP2c, 8, 10));
           SP_.set_nn_pt_valid(GetHexBits(SP2c, 11, 11));
-        } else{
+        } else {
           SP_.set_pt_LUT_addr(GetHexBits(SP2c, 0, 14, SP2d, 0, 14));
         }
-
 
         // SP_.set_dataword     ( uint64_t dataword );
 
@@ -302,7 +301,7 @@ namespace l1t {
         mu_.setHwEta(SP_.Eta_GMT());
         mu_.setHwPhi(SP_.Phi_GMT());
         mu_.setHwPt(SP_.Pt_GMT());
-        if (useNNBits_){
+        if (useNNBits_) {
           mu_.setHwPtUnconstrained(SP_.Pt_dxy_GMT());
           mu_.setHwDXY(SP_.Dxy_GMT());
         }
@@ -317,7 +316,7 @@ namespace l1t {
         // Track_.set_GMT(mu_);
 
         // Set Regional Muon Showers
-        if (useHMTBits_){
+        if (useHMTBits_) {
           muShower_.setTFIdentifiers(Track_.Sector() - 1, (Track_.Endcap() == 1) ? emtf_pos : emtf_neg);
           muShower_.setOneNominalInTime(SP_.HMT() == nominalShower_ ? true : false);
           muShower_.setOneTightInTime(SP_.HMT() == tightShower_ ? true : false);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -16,13 +16,6 @@ namespace l1t {
         bool unpack(const Block& block,
                     UnpackerCollections* coll) override;  // Apparently it's always good to use override in C++
         // virtual bool packBlock(const Block& block, UnpackerCollections *coll) override;
-
-      private:
-        bool useHMTBits_{false};
-        bool useNNBits_{false};
-
-        int nominalShower_ = 2;
-        int tightShower_ = 3;
       };
 
       // class SPBlockPacker : public Packer { // "SPBlockPacker" inherits from "Packer"
@@ -184,12 +177,11 @@ namespace l1t {
         auto payload = block.payload();
 
         // FW version is computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
-        if (getAlgoVersion() >= 11098) {  // FW versions >= 26.10.2021
-          useNNBits_ = true;
-        }
-        if (getAlgoVersion() >= 11306) {  // FW versions >= 10.01.2022
-          useHMTBits_ = true;
-        }
+        bool useNNBits_  = getAlgoVersion() >= 11098;  // FW versions >= 26.10.2021
+        bool useHMTBits_ = getAlgoVersion() >= 11306;  // FW versions >= 10.01.2022
+
+        static constexpr int nominalShower_ = 2;
+        static constexpr int tightShower_   = 3;
 
         // Check Format of Payload
         l1t::emtf::SP SP_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
@@ -39,6 +39,7 @@ namespace l1t {
       // }
 
       event_.put(std::move(regionalMuonCands_));
+      event_.put(std::move(regionalMuonShowers_));
       event_.put(std::move(EMTFDaqOuts_));
       event_.put(std::move(EMTFHits_ZS_));
       event_.put(std::move(EMTFTracks_));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
@@ -6,6 +6,7 @@
 #include <iomanip>   // For things like std::setw
 
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 #include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
@@ -27,6 +28,7 @@ namespace l1t {
       EMTFCollections(edm::Event& e)
           : UnpackerCollections(e),  // What are these? - AWB 27.01.16
             regionalMuonCands_(new RegionalMuonCandBxCollection()),
+            regionalMuonShowers_(new RegionalMuonShowerBxCollection()),
             EMTFDaqOuts_(new EMTFDaqOutCollection()),
             EMTFHits_(new EMTFHitCollection()),
             EMTFHits_ZS_(new EMTFHitCollection()),
@@ -40,6 +42,7 @@ namespace l1t {
       ~EMTFCollections() override;
 
       inline RegionalMuonCandBxCollection* getRegionalMuonCands() { return regionalMuonCands_.get(); }
+      inline RegionalMuonShowerBxCollection* getRegionalMuonShowers() { return regionalMuonShowers_.get(); }
       inline EMTFDaqOutCollection* getEMTFDaqOuts() { return EMTFDaqOuts_.get(); }
       inline EMTFHitCollection* getEMTFHits() { return EMTFHits_.get(); }
       inline EMTFHitCollection* getEMTFHits_ZS() { return EMTFHits_ZS_.get(); }
@@ -52,6 +55,7 @@ namespace l1t {
 
     private:
       std::unique_ptr<RegionalMuonCandBxCollection> regionalMuonCands_;
+      std::unique_ptr<RegionalMuonShowerBxCollection> regionalMuonShowers_;
       std::unique_ptr<EMTFDaqOutCollection> EMTFDaqOuts_;
       std::unique_ptr<EMTFHitCollection> EMTFHits_;
       std::unique_ptr<EMTFHitCollection> EMTFHits_ZS_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
@@ -36,6 +36,7 @@ namespace l1t {
 
     void EMTFSetup::registerProducts(edm::ProducesCollector prod) {
       prod.produces<RegionalMuonCandBxCollection>();
+      prod.produces<RegionalMuonShowerBxCollection>();
       prod.produces<EMTFDaqOutCollection>();
       prod.produces<EMTFHitCollection>();
       prod.produces<EMTFTrackCollection>();
@@ -69,8 +70,9 @@ namespace l1t {
       auto emtf_trailers_unp =
           UnpackerFactory::get()->make("stage2::emtf::TrailersBlockUnpacker");  // Unpack "Event Record Trailer"
 
-      // Currently only the CSC LCT unpacking needs the firmware version, can add others as needed - AWB 09.04.18
+      // Currently only the CSC LCT unpacking and SP unpacking need the firmware version, can add others as needed - AWB 09.04.18 + EY 01.02.22
       emtf_me_unp->setAlgoVersion(fw);
+      emtf_sp_unp->setAlgoVersion(fw);
 
       // Index of res is block->header().getID(), matching block_patterns_ in src/Block.cc
       res[l1t::mtf7::EvHd] = emtf_headers_unp;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
@@ -10,6 +10,7 @@ namespace l1t {
       auto tag = cfg.getParameter<edm::InputTag>("InputLabel");
 
       regionalMuonCandToken_ = cc.consumes<RegionalMuonCandBxCollection>(tag);
+      regionalMuonShowerToken_ = cc.consumes<RegionalMuonShowerBxCollection>(tag);
       EMTFDaqOutToken_ = cc.consumes<EMTFDaqOutCollection>(tag);
       EMTFHitToken_ = cc.consumes<EMTFHitCollection>(tag);
       EMTFTrackToken_ = cc.consumes<EMTFTrackCollection>(tag);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
@@ -2,6 +2,7 @@
 #define EventFilter_L1TRawToDigi_EMTFTokens_h
 
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
 #include "DataFormats/L1TMuon/interface/EMTFDaqOut.h"
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
@@ -20,6 +21,9 @@ namespace l1t {
       inline const edm::EDGetTokenT<RegionalMuonCandBxCollection>& getRegionalMuonCandToken() const {
         return regionalMuonCandToken_;
       }
+      inline const edm::EDGetTokenT<RegionalMuonShowerBxCollection>& getRegionalMuonShowerToken() const {
+        return regionalMuonShowerToken_;
+      }
       inline const edm::EDGetTokenT<EMTFDaqOutCollection>& getEMTFDaqOutToken() const { return EMTFDaqOutToken_; }
       inline const edm::EDGetTokenT<EMTFHitCollection>& getEMTFHitToken() const { return EMTFHitToken_; }
       inline const edm::EDGetTokenT<EMTFTrackCollection>& getEMTFTrackToken() const { return EMTFTrackToken_; }
@@ -31,6 +35,7 @@ namespace l1t {
 
     private:
       edm::EDGetTokenT<RegionalMuonCandBxCollection> regionalMuonCandToken_;
+      edm::EDGetTokenT<RegionalMuonShowerBxCollection> regionalMuonShowerToken_;
       edm::EDGetTokenT<EMTFDaqOutCollection> EMTFDaqOutToken_;
       edm::EDGetTokenT<EMTFHitCollection> EMTFHitToken_;
       edm::EDGetTokenT<EMTFTrackCollection> EMTFTrackToken_;


### PR DESCRIPTION
#### PR description:

This PR updates the EMTF unpacker to add High Multiplicity Trigger (HMT) and Displaced Muon information. The EMTF firmware at P5 is already updated to add these parameters to EMTF DAQ output. 

The main changes are in `EMTFBlockSP` for unpacking the new information. The `EMTFCollections`, `EMTFSetup` `EMTFTokens` and `SP.h` are changed accordingly to include the new Regional Muon Shower object in the EMTF unpacker workflow. 

No changes are expected in performance. 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated with `runTheMatrix.py -l limited -i all --ibeos` and no changes are observed.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of PR https://github.com/cms-sw/cmssw/pull/37194, to include this update in upcoming runs at P5.

<!-- Please replace this text with any link to  -->

