### PR TITLE
Run4-hgx306 Backport the bugfix to HGCal geometry from the PR's 37330 and 37460

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
+++ b/Geometry/HGCalCommonData/interface/HGCalDDDConstants.h
@@ -84,8 +84,15 @@ public:
   std::pair<float, float> localToGlobal8(
       int lay, int waferU, int waferV, double localX, double localY, bool reco, bool debug) const;
   std::pair<float, float> locateCell(int cell, int lay, int type, bool reco) const;
-  std::pair<float, float> locateCell(
-      int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool debug = false) const;
+  std::pair<float, float> locateCell(int lay,
+                                     int waferU,
+                                     int waferV,
+                                     int cellU,
+                                     int cellV,
+                                     bool reco,
+                                     bool all,
+                                     bool norot = false,
+                                     bool debug = false) const;
   std::pair<float, float> locateCell(const HGCSiliconDetId&, bool debug = false) const;
   std::pair<float, float> locateCell(const HGCScintillatorDetId&, bool debug = false) const;
   std::pair<float, float> locateCellHex(int cell, int wafer, bool reco) const;

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -10,6 +10,7 @@
 #include "Geometry/HGCalCommonData/interface/HGCalGeomParameters.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeomTools.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
+#include "Geometry/HGCalCommonData/interface/HGCalCell.h"
 #include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferIndex.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferMask.h"
@@ -213,7 +214,7 @@ bool HGCalDDDConstants::cellInLayer(int waferU, int waferV, int cellU, int cellV
   const auto& indx = getIndex(lay, true);
   if (indx.first >= 0) {
     if (waferHexagon8() || waferHexagon6()) {
-      const auto& xy = ((waferHexagon8()) ? locateCell(lay, waferU, waferV, cellU, cellV, reco, true, true)
+      const auto& xy = ((waferHexagon8()) ? locateCell(lay, waferU, waferV, cellU, cellV, reco, true, false, false)
                                           : locateCell(cellU, lay, waferU, reco));
       double rpos = sqrt(xy.first * xy.first + xy.second * xy.second);
       return ((rpos >= hgpar_->rMinLayHex_[indx.first]) && (rpos <= hgpar_->rMaxLayHex_[indx.first]));
@@ -621,7 +622,7 @@ std::pair<float, float> HGCalDDDConstants::localToGlobal8(
   bool rotx =
       ((!hgpar_->layerType_.empty()) && (hgpar_->layerType_[lay - hgpar_->firstLayer_] == HGCalTypes::WaferCenterR));
   if (debug)
-    edm::LogVerbatim("HGCalGeom") << "LocalToGlobal " << lay << ":" << (lay - hgpar_->firstLayer_) << ":" << rotx
+    edm::LogVerbatim("HGCalGeom") << "LocalToGlobal8 " << lay << ":" << (lay - hgpar_->firstLayer_) << ":" << rotx
                                   << " Local (" << x << ":" << y << ") Reco " << reco;
   if (!reco) {
     x *= HGCalParameters::k_ScaleToDDD;
@@ -631,7 +632,7 @@ std::pair<float, float> HGCalDDDConstants::localToGlobal8(
   x += xy.first;
   y += xy.second;
   if (debug)
-    edm::LogVerbatim("HGCalGeom") << "With wafer " << x << ":" << y << " by addong " << xy.first << ":" << xy.second;
+    edm::LogVerbatim("HGCalGeom") << "With wafer " << x << ":" << y << " by adding " << xy.first << ":" << xy.second;
   return (rotx ? getXY(lay, x, y, false) : std::make_pair(x, y));
 }
 
@@ -667,21 +668,20 @@ std::pair<float, float> HGCalDDDConstants::locateCell(int cell, int lay, int typ
 }
 
 std::pair<float, float> HGCalDDDConstants::locateCell(
-    int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool debug) const {
+    int lay, int waferU, int waferV, int cellU, int cellV, bool reco, bool all, bool norot, bool debug) const {
   double x(0), y(0);
   int indx = HGCalWaferIndex::waferIndex(lay, waferU, waferV);
   auto itr = hgpar_->typesInLayers_.find(indx);
   int type = ((itr == hgpar_->typesInLayers_.end()) ? 2 : hgpar_->waferTypeL_[itr->second]);
-  bool rotx =
-      ((!hgpar_->layerType_.empty()) && (hgpar_->layerType_[lay - hgpar_->firstLayer_] == HGCalTypes::WaferCenterR));
-#ifdef EDM_ML_DEBUG
+  bool rotx = (norot) ? false
+                      : ((!hgpar_->layerType_.empty()) &&
+                         (hgpar_->layerType_[lay - hgpar_->firstLayer_] == HGCalTypes::WaferCenterR));
   if (debug) {
     edm::LogVerbatim("HGCalGeom") << "LocateCell " << lay << ":" << (lay - hgpar_->firstLayer_) << ":" << rotx << ":"
                                   << waferU << ":" << waferV << ":" << indx << ":"
                                   << (itr == hgpar_->typesInLayers_.end()) << ":" << type << " Flags " << reco << ":"
                                   << all;
   }
-#endif
   int kndx = cellV * 100 + cellU;
   if (type == 0) {
     auto ktr = hgpar_->cellFineIndex_.find(kndx);
@@ -689,22 +689,18 @@ std::pair<float, float> HGCalDDDConstants::locateCell(
       x = hgpar_->cellFineX_[ktr->second];
       y = hgpar_->cellFineY_[ktr->second];
     }
-#ifdef EDM_ML_DEBUG
     if (debug)
       edm::LogVerbatim("HGCalGeom") << "Fine " << cellU << ":" << cellV << ":" << kndx << ":" << x << ":" << y << ":"
                                     << (ktr != hgpar_->cellFineIndex_.end());
-#endif
   } else {
     auto ktr = hgpar_->cellCoarseIndex_.find(kndx);
     if (ktr != hgpar_->cellCoarseIndex_.end()) {
       x = hgpar_->cellCoarseX_[ktr->second];
       y = hgpar_->cellCoarseY_[ktr->second];
     }
-#ifdef EDM_ML_DEBUG
     if (debug)
       edm::LogVerbatim("HGCalGeom") << "Coarse " << cellU << ":" << cellV << ":" << kndx << ":" << x << ":" << y << ":"
                                     << (ktr != hgpar_->cellCoarseIndex_.end());
-#endif
   }
   if (!reco) {
     x *= HGCalParameters::k_ScaleToDDD;
@@ -714,10 +710,8 @@ std::pair<float, float> HGCalDDDConstants::locateCell(
     const auto& xy = waferPositionNoRot(lay, waferU, waferV, reco, debug);
     x += xy.first;
     y += xy.second;
-#ifdef EDM_ML_DEBUG
     if (debug)
-      edm::LogVerbatim("HGCalGeom") << "With wafer " << x << ":" << y << " by addong " << xy.first << ":" << xy.second;
-#endif
+      edm::LogVerbatim("HGCalGeom") << "With wafer " << x << ":" << y << " by adding " << xy.first << ":" << xy.second;
   }
   return (rotx ? getXY(lay, x, y, false) : std::make_pair(x, y));
 }

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -10,7 +10,6 @@
 #include "Geometry/HGCalCommonData/interface/HGCalGeomParameters.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeomTools.h"
 #include "Geometry/HGCalCommonData/interface/HGCalGeometryMode.h"
-#include "Geometry/HGCalCommonData/interface/HGCalCell.h"
 #include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferIndex.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferMask.h"

--- a/Geometry/HGCalGeometry/interface/HGCalGeometry.h
+++ b/Geometry/HGCalGeometry/interface/HGCalGeometry.h
@@ -50,7 +50,7 @@ public:
 
   HGCalGeometry(const HGCalTopology& topology);
 
-  ~HGCalGeometry() override;
+  ~HGCalGeometry() override = default;
 
   void localCorners(Pt3DVec& lc, const CCGFloat* pv, unsigned int i, Pt3D& ref);
 
@@ -70,7 +70,7 @@ public:
                   CaloSubdetectorGeometry::DimVec& dimVector,
                   CaloSubdetectorGeometry::IVec& dinsVector) const override;
 
-  GlobalPoint getPosition(const DetId& id) const;
+  GlobalPoint getPosition(const DetId& id, bool debug = false) const;
   GlobalPoint getWaferPosition(const DetId& id) const;
 
   /// Returns area of a cell
@@ -79,7 +79,7 @@ public:
   /// Returns the corner points of this cell's volume.
   CornersVec getCorners(const DetId& id) const;
   CornersVec get8Corners(const DetId& id) const;
-  CornersVec getNewCorners(const DetId& id) const;
+  CornersVec getNewCorners(const DetId& id, bool debug = false) const;
 
   // Get neighbor in z along a direction
   DetId neighborZ(const DetId& idin, const GlobalVector& p) const;

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -23,6 +23,8 @@ typedef std::vector<float> ParmVec;
 
 //#define EDM_ML_DEBUG
 
+const bool debugLocate = false;
+
 HGCalGeometry::HGCalGeometry(const HGCalTopology& topology_)
     : m_topology(topology_),
       m_validGeomIds(topology_.totalGeomModules()),
@@ -39,8 +41,6 @@ HGCalGeometry::HGCalGeometry(const HGCalTopology& topology_)
   edm::LogVerbatim("HGCalGeom") << "Expected total # of Geometry Modules " << m_topology.totalGeomModules();
 #endif
 }
-
-HGCalGeometry::~HGCalGeometry() {}
 
 void HGCalGeometry::fillNamedParams(DDFilteredView fv) {}
 
@@ -183,7 +183,7 @@ std::shared_ptr<const CaloCellGeometry> HGCalGeometry::getGeometry(const DetId& 
     return nullptr;  // nothing to get
   DetId geomId = getGeometryDetId(detId);
   const uint32_t cellIndex(m_topology.detId2denseGeomId(geomId));
-  const GlobalPoint pos = (detId != geomId) ? getPosition(detId) : GlobalPoint();
+  const GlobalPoint pos = (detId != geomId) ? getPosition(detId, false) : GlobalPoint();
   return cellGeomPtr(cellIndex, pos);
 }
 
@@ -195,7 +195,7 @@ bool HGCalGeometry::present(const DetId& detId) const {
   return (nullptr != getGeometryRawPtr(index));
 }
 
-GlobalPoint HGCalGeometry::getPosition(const DetId& detid) const {
+GlobalPoint HGCalGeometry::getPosition(const DetId& detid, bool debug) const {
   unsigned int cellIndex = indexFor(detid);
   GlobalPoint glob;
   unsigned int maxSize = (m_topology.tileTrapezoid() ? m_cellVec2.size() : m_cellVec.size());
@@ -206,32 +206,30 @@ GlobalPoint HGCalGeometry::getPosition(const DetId& detid) const {
       xy = m_topology.dddConstants().locateCellHex(id.iCell1, id.iSec1, true);
       const HepGeom::Point3D<float> lcoord(xy.first, xy.second, 0);
       glob = m_cellVec[cellIndex].getPosition(lcoord);
-#ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "getPosition:: index " << cellIndex << " Local " << lcoord.x() << ":"
-                                    << lcoord.y() << " ID " << id.iCell1 << ":" << id.iSec1 << " Global " << glob;
-#endif
+      if (debug)
+        edm::LogVerbatim("HGCalGeom") << "getPosition:: index " << cellIndex << " Local " << lcoord.x() << ":"
+                                      << lcoord.y() << " ID " << id.iCell1 << ":" << id.iSec1 << " Global " << glob;
     } else if (m_topology.tileTrapezoid()) {
       const HepGeom::Point3D<float> lcoord(0, 0, 0);
       glob = m_cellVec2[cellIndex].getPosition(lcoord);
-#ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "getPositionTrap:: index " << cellIndex << " Local " << lcoord.x() << ":"
-                                    << lcoord.y() << " ID " << id.iLay << ":" << id.iSec1 << ":" << id.iCell1
-                                    << " Global " << glob;
-#endif
+      if (debug)
+        edm::LogVerbatim("HGCalGeom") << "getPositionTrap:: index " << cellIndex << " Local " << lcoord.x() << ":"
+                                      << lcoord.y() << " ID " << id.iLay << ":" << id.iSec1 << ":" << id.iCell1
+                                      << " Global " << glob;
     } else {
-#ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "getPosition for " << HGCSiliconDetId(detid) << " Layer " << id.iLay << " Wafer "
-                                    << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":" << id.iCell2;
-#endif
-      xy = m_topology.dddConstants().locateCell(id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, true);
+      if (debug)
+        edm::LogVerbatim("HGCalGeom") << "getPosition for " << HGCSiliconDetId(detid) << " Layer " << id.iLay
+                                      << " Wafer " << id.iSec1 << ":" << id.iSec2 << " Cell " << id.iCell1 << ":"
+                                      << id.iCell2;
+      xy = m_topology.dddConstants().locateCell(
+          id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, true, false, debug);
       double xx = id.zSide * xy.first;
       double zz = id.zSide * m_topology.dddConstants().waferZ(id.iLay, true);
       glob = GlobalPoint(xx, xy.second, zz);
-#ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("HGCalGeom") << "getPositionWafer:: index " << cellIndex << " Local " << xy.first << ":"
-                                    << xy.second << " ID " << id.iLay << ":" << id.iSec1 << ":" << id.iSec2 << ":"
-                                    << id.iCell1 << ":" << id.iCell2 << " Global " << glob;
-#endif
+      if (debug)
+        edm::LogVerbatim("HGCalGeom") << "getPositionWafer:: index " << cellIndex << " Local " << xy.first << ":"
+                                      << xy.second << " ID " << id.iLay << ":" << id.iSec1 << ":" << id.iSec2 << ":"
+                                      << id.iCell1 << ":" << id.iCell2 << " Global " << glob;
     }
   }
   return glob;
@@ -276,7 +274,7 @@ HGCalGeometry::CornersVec HGCalGeometry::getCorners(const DetId& detid) const {
   unsigned int cellIndex = indexFor(detid);
   HGCalTopology::DecodedDetId id = m_topology.decode(detid);
   if (cellIndex < m_cellVec2.size() && m_det == DetId::HGCalHSc) {
-    GlobalPoint v = getPosition(detid);
+    GlobalPoint v = getPosition(detid, false);
     int type = std::min(id.iType, 1);
     std::pair<double, double> rr = m_topology.dddConstants().cellSizeTrap(type, id.iSec1);
     float dr = k_half * (rr.second - rr.first);
@@ -307,7 +305,8 @@ HGCalGeometry::CornersVec HGCalGeometry::getCorners(const DetId& detid) const {
         co[i] = m_cellVec[cellIndex].getPosition(lcoord);
       }
     } else {
-      xy = m_topology.dddConstants().locateCell(id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false);
+      xy = m_topology.dddConstants().locateCell(
+          id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debugLocate);
       float zz = m_topology.dddConstants().waferZ(id.iLay, true);
       float dx = k_fac2 * m_cellVec[cellIndex].param()[FlatHexagon::k_r];
       float dy = k_fac1 * m_cellVec[cellIndex].param()[FlatHexagon::k_R];
@@ -332,7 +331,7 @@ HGCalGeometry::CornersVec HGCalGeometry::get8Corners(const DetId& detid) const {
   unsigned int cellIndex = indexFor(detid);
   HGCalTopology::DecodedDetId id = m_topology.decode(detid);
   if (cellIndex < m_cellVec2.size() && m_det == DetId::HGCalHSc) {
-    GlobalPoint v = getPosition(detid);
+    GlobalPoint v = getPosition(detid, false);
     int type = std::min(id.iType, 1);
     std::pair<double, double> rr = m_topology.dddConstants().cellSizeTrap(type, id.iSec1);
     float dr = k_half * (rr.second - rr.first);
@@ -363,7 +362,8 @@ HGCalGeometry::CornersVec HGCalGeometry::get8Corners(const DetId& detid) const {
         co[i] = m_cellVec[cellIndex].getPosition(lcoord);
       }
     } else {
-      xy = m_topology.dddConstants().locateCell(id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false);
+      xy = m_topology.dddConstants().locateCell(
+          id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debugLocate);
       dx = k_fac2 * m_cellVec[cellIndex].param()[FlatHexagon::k_r];
       float dy = k_fac1 * m_cellVec[cellIndex].param()[FlatHexagon::k_R];
       float dz = -id.zSide * m_cellVec[cellIndex].param()[FlatHexagon::k_dZ];
@@ -379,13 +379,16 @@ HGCalGeometry::CornersVec HGCalGeometry::get8Corners(const DetId& detid) const {
   return co;
 }
 
-HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid) const {
+HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid, bool debug) const {
   unsigned int ncorner = (m_det == DetId::HGCalHSc) ? 5 : 7;
   HGCalGeometry::CornersVec co(ncorner, GlobalPoint(0, 0, 0));
   unsigned int cellIndex = indexFor(detid);
   HGCalTopology::DecodedDetId id = m_topology.decode(detid);
+  if (debug)
+    edm::LogVerbatim("HGCalGeom") << "NewCorners for Layer " << id.iLay << " Wafer " << id.iSec1 << ":" << id.iSec2
+                                  << " Cell " << id.iCell1 << ":" << id.iCell2;
   if (cellIndex < m_cellVec2.size() && m_det == DetId::HGCalHSc) {
-    GlobalPoint v = getPosition(detid);
+    GlobalPoint v = getPosition(detid, false);
     int type = std::min(id.iType, 1);
     std::pair<double, double> rr = m_topology.dddConstants().cellSizeTrap(type, id.iSec1);
     float dr = k_half * (rr.second - rr.first);
@@ -407,6 +410,11 @@ HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid) const
     float dz = -id.zSide * m_cellVec[cellIndex].param()[FlatHexagon::k_dZ];
     static const int signx[] = {1, -1, -2, -1, 1, 2};
     static const int signy[] = {1, 1, 0, -1, -1, 0};
+#ifdef EDM_ML_DEBUG
+    if (debug)
+      edm::LogVerbatim("HGCalGeom") << "kfac " << k_fac1 << ":" << k_fac2 << " dx:dy:dz " << dx << ":" << dy << ":"
+                                    << dz;
+#endif
     if (m_topology.waferHexagon6()) {
       xy = m_topology.dddConstants().locateCellHex(id.iCell1, id.iSec1, true);
       for (unsigned int i = 0; i < ncorner - 1; ++i) {
@@ -414,11 +422,18 @@ HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid) const
         co[i] = m_cellVec[cellIndex].getPosition(lcoord);
       }
     } else {
-      xy = m_topology.dddConstants().locateCell(id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false);
+      xy = m_topology.dddConstants().locateCell(
+          id.iLay, id.iSec1, id.iSec2, id.iCell1, id.iCell2, true, false, true, debug);
       float zz = m_topology.dddConstants().waferZ(id.iLay, true);
       for (unsigned int i = 0; i < ncorner; ++i) {
-        auto xyglob = m_topology.dddConstants().localToGlobal8(
-            id.iLay, id.iSec1, id.iSec2, (xy.first + signx[i] * dx), (xy.second + signy[i] * dy), true, false);
+        double xloc = xy.first + signx[i] * dx;
+        double yloc = xy.second + signy[i] * dy;
+#ifdef EDM_ML_DEBUG
+        if (debug)
+          edm::LogVerbatim("HGCalGeom") << "Corner " << i << " x " << xy.first << ":" << xloc << " y " << xy.second
+                                        << ":" << yloc << " z " << zz << ":" << id.zSide * (zz + dz);
+#endif
+        auto xyglob = m_topology.dddConstants().localToGlobal8(id.iLay, id.iSec1, id.iSec2, xloc, yloc, true, debug);
         double xx = id.zSide * xyglob.first;
         co[i] = GlobalPoint(xx, xyglob.second, id.zSide * (zz + dz));
       }
@@ -440,7 +455,7 @@ DetId HGCalGeometry::neighborZ(const DetId& idin, const GlobalVector& momentum) 
 #endif
   if ((lay >= m_topology.dddConstants().firstLayer()) && (lay <= m_topology.dddConstants().lastLayer(true)) &&
       (momentum.z() != 0.0)) {
-    GlobalPoint v = getPosition(idin);
+    GlobalPoint v = getPosition(idin, false);
     double z = id.zSide * m_topology.dddConstants().waferZ(lay, true);
     double grad = (z - v.z()) / momentum.z();
     GlobalPoint p(v.x() + grad * momentum.x(), v.y() + grad * momentum.y(), z);
@@ -471,7 +486,7 @@ DetId HGCalGeometry::neighborZ(const DetId& idin,
 #endif
   if ((lay >= m_topology.dddConstants().firstLayer()) && (lay <= m_topology.dddConstants().lastLayer(true)) &&
       (momentum.z() != 0.0)) {
-    GlobalPoint v = getPosition(idin);
+    GlobalPoint v = getPosition(idin, false);
     double z = id.zSide * m_topology.dddConstants().waferZ(lay, true);
     FreeTrajectoryState fts(v, momentum, charge, bField);
     Plane::PlanePointer nPlane = Plane::build(Plane::PositionType(0, 0, z), Plane::RotationType());

--- a/Geometry/HGCalGeometry/test/HGCalGeometryNewCornersTest.cc
+++ b/Geometry/HGCalGeometry/test/HGCalGeometryNewCornersTest.cc
@@ -1,0 +1,96 @@
+#include <cmath>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+#include "DataFormats/Math/interface/angle_units.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+
+using namespace angle_units::operators;
+
+class HGCalGeometryNewCornersTest : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+public:
+  explicit HGCalGeometryNewCornersTest(const edm::ParameterSet&);
+  ~HGCalGeometryNewCornersTest() override = default;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {}
+  void endRun(edm::Run const&, edm::EventSetup const&) override {}
+
+private:
+  const std::string nameDetector_;
+  const edm::ESGetToken<HGCalGeometry, IdealGeometryRecord> geomToken_;
+  const std::vector<int> layers_;
+  const std::vector<int> waferU_, waferV_, types_;
+  const bool debug_;
+};
+
+HGCalGeometryNewCornersTest::HGCalGeometryNewCornersTest(const edm::ParameterSet& iC)
+    : nameDetector_(iC.getParameter<std::string>("detectorName")),
+      geomToken_(esConsumes<HGCalGeometry, IdealGeometryRecord, edm::Transition::BeginRun>(
+          edm::ESInputTag{"", nameDetector_})),
+      layers_(iC.getParameter<std::vector<int>>("layers")),
+      waferU_(iC.getParameter<std::vector<int>>("waferUs")),
+      waferV_(iC.getParameter<std::vector<int>>("waferVs")),
+      types_(iC.getParameter<std::vector<int>>("types")),
+      debug_(iC.getParameter<bool>("debugFlag")) {}
+
+void HGCalGeometryNewCornersTest::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  std::vector<int> layer = {27, 28, 29, 30, 31, 32};
+  std::vector<int> waferU = {-2, -3, 1, -8, 2, 8};
+  std::vector<int> waferV = {0, -2, 3, 0, 9, 0};
+  std::vector<int> type = {0, 0, 0, 2, 2, 2};
+  desc.add<std::string>("detectorName", "HGCalHESiliconSensitive");
+  desc.add<std::vector<int>>("layers", layer);
+  desc.add<std::vector<int>>("waferUs", waferU);
+  desc.add<std::vector<int>>("waferVs", waferV);
+  desc.add<std::vector<int>>("types", type);
+  desc.add<bool>("debugFlag", false);
+  descriptions.add("hgcalGeometryNewCornersTest", desc);
+}
+
+void HGCalGeometryNewCornersTest::beginRun(const edm::Run&, const edm::EventSetup& iSetup) {
+  const auto& geomR = iSetup.getData(geomToken_);
+  const HGCalGeometry* geom = &geomR;
+  DetId::Detector det = (nameDetector_ == "HGCalEESensitive") ? DetId::HGCalEE : DetId::HGCalHSi;
+  int layerF = *(layers_.begin());
+  int layerL = *(--layers_.end());
+  int layerOff = geom->topology().dddConstants().getLayerOffset();
+  edm::LogVerbatim("HGCalGeom") << nameDetector_ << " with layers in the range " << layerF << ":" << layerL
+                                << " Offset " << layerOff << " and for " << waferU_.size() << " wafers and cells";
+
+  for (unsigned int k = 0; k < waferU_.size(); ++k) {
+    for (auto lay : layers_) {
+      HGCSiliconDetId detId(det, 1, types_[k], lay - layerOff, waferU_[k], waferV_[k], 0, 0);
+      GlobalPoint global = geom->getPosition(DetId(detId), debug_);
+      double phi2 = global.phi();
+      auto xy = geom->topology().dddConstants().waferPosition(lay - layerOff, waferU_[k], waferV_[k], debug_);
+      double phi1 = std::atan2(xy.second, xy.first);
+      edm::LogVerbatim("HGCalGeom") << "Layer: " << lay << " U " << waferU_[k] << " V " << waferV_[k] << " Position ("
+                                    << xy.first << ", " << xy.second << ") phi " << convertRadToDeg(phi1);
+      edm::LogVerbatim("HGCalGeom") << detId << " Position " << global << " phi " << convertRadToDeg(phi2);
+      std::vector<GlobalPoint> corners = geom->getNewCorners(DetId(detId), debug_);
+      std::ostringstream st1;
+      for (auto const& it : corners)
+        st1 << it << ", ";
+      edm::LogVerbatim("HGCalGeom") << "Corners: " << st1.str();
+    }
+  }
+}
+
+//define this as a plug-in
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HGCalGeometryNewCornersTest);

--- a/Geometry/HGCalGeometry/test/python/testHGCalGeometryNewCorners_cfg.py
+++ b/Geometry/HGCalGeometry/test/python/testHGCalGeometryNewCorners_cfg.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11I13M9_cff import Phase2C11I13M9
+process = cms.Process('PROD',Phase2C11I13M9)
+process.load('Configuration.Geometry.GeometryExtended2026D86Reco_cff')
+
+process.load("SimGeneral.HepPDTESSource.pdt_cfi")
+process.load('Geometry.HGCalGeometry.hgcalGeometryNewCornersTest_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+if hasattr(process,'MessageLogger'):
+    process.MessageLogger.HGCalGeom=dict()
+
+process.load("IOMC.RandomEngine.IOMC_cff")
+process.RandomNumberGeneratorService.generator.initialSeed = 456789
+
+process.source = cms.Source("EmptySource")
+
+process.generator = cms.EDProducer("FlatRandomEGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32(14),
+        MinEta = cms.double(-3.5),
+        MaxEta = cms.double(3.5),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinE   = cms.double(9.99),
+        MaxE   = cms.double(10.01)
+    ),
+    AddAntiParticle = cms.bool(False),
+    Verbosity       = cms.untracked.int32(0),
+    firstRun        = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.p1 = cms.Path(process.generator*process.hgcalGeometryNewCornersTest)


### PR DESCRIPTION
#### PR description:

Backport the bugfix to HGCal geometry from the PR's 37330 and 37460 which calculates the corners of the cells in the rotated layers correctly

#### PR validation:

Use the runTheMatrix test workflows and some code in the test area of Geometry/HGCa;Geometry

.#### if this PR is a backport please specify the original PR and why you need to backport that PR:

The PR #37330 is merged with the master. The PR #37460 only takes care of comments suggested by Andreas while merging #37330