### PR TITLE
Add LHCTransport to Run3 GEN content

### DIFF
--- a/GeneratorInterface/Configuration/python/GeneratorInterface_EventContent_cff.py
+++ b/GeneratorInterface/Configuration/python/GeneratorInterface_EventContent_cff.py
@@ -19,6 +19,7 @@ GeneratorInterfaceRAW = cms.PSet(
         'keep GenLumiInfoProduct_generator_*_*',
         'keep GenEventInfoProduct_generator_*_*',
         'keep edmHepMCProduct_generatorSmeared_*_*',
+        'keep edmHepMCProduct_LHCTransport_*_*',
         'keep GenFilterInfo_*_*_*',
         'keep *_genParticles_*_*'
     )
@@ -34,6 +35,7 @@ GeneratorInterfaceRECO = cms.PSet(
         'keep GenLumiInfoProduct_generator_*_*',
         'keep GenEventInfoProduct_generator_*_*',
         'keep edmHepMCProduct_generatorSmeared_*_*',
+        'keep edmHepMCProduct_LHCTransport_*_*',
         'keep GenFilterInfo_*_*_*',
         'keep *_genParticles_*_*'
     )
@@ -52,9 +54,3 @@ GeneratorInterfaceAOD = cms.PSet(
         'keep *_genParticles_*_*'
     )
 )
-
-from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(GeneratorInterfaceRAW,
-                     outputCommands = GeneratorInterfaceRAW.outputCommands+['keep edmHepMCProduct_LHCTransport_*_*'])
-run3_common.toModify(GeneratorInterfaceRECO,
-                     outputCommands = GeneratorInterfaceRECO.outputCommands+['keep edmHepMCProduct_LHCTransport_*_*'])

--- a/GeneratorInterface/Configuration/python/GeneratorInterface_EventContent_cff.py
+++ b/GeneratorInterface/Configuration/python/GeneratorInterface_EventContent_cff.py
@@ -52,3 +52,9 @@ GeneratorInterfaceAOD = cms.PSet(
         'keep *_genParticles_*_*'
     )
 )
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(GeneratorInterfaceRAW,
+                     outputCommands = GeneratorInterfaceRAW.outputCommands+['keep edmHepMCProduct_LHCTransport_*_*'])
+run3_common.toModify(GeneratorInterfaceRECO,
+                     outputCommands = GeneratorInterfaceRECO.outputCommands+['keep edmHepMCProduct_LHCTransport_*_*'])


### PR DESCRIPTION
#### PR description:
As reported in https://github.com/cms-sw/cmssw/issues/37469
We can't split GEN and SIM for Run-3 because of missing 
`edm::HepMCProduct "LHCTransport" "" "GEN"`

This PR adds it as default collection of GENRAW and GENRECO.

#### PR validation:
Test with 2 steps, GEN and SIM, separately wotks:
`cmsDriver.py TTbar_14TeV_TuneCP5_cfi  -s GEN,SIM -n 10 --conditions auto:phase1_2021_realistic --beamspot Run3RoundOptics25ns13TeVLowSigmaZ --datatier GEN-SIM --eventcontent RAWSIM --geometry DB:Extended --era Run3 --python step1_TTbar_14TeV_GEN.py --no_exec --fileout file:step1.root  --nThreads 8`

`cmsDriver.py step2  -s SIM --conditions auto:phase1_2021_realistic --datatier GEN-SIM -n -1 --eventcontent FEVTDEBUGHLT --geometry DB:Extended --era Run3 --python step2_SIM_2021.py --no_exec --filein  file:step1.root  --fileout file:step2.root  --nThreads 8`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No need of backport if we don't need to split them in the release before 12_4.
