### PR TITLE
HCAL: fix on HCAL TP saturation algorithm to synchronize s/w TP algorithm with f/w

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -446,7 +446,10 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
       unsigned int sample = samples[ibin + i];
 
       if (fix_saturation_ && (sample_saturation.size() > ibin + i))
-        check_sat = sample_saturation[ibin + i];
+        check_sat = (sample_saturation[ibin + i] | (sample > QIE11_MAX_LINEARIZATION_ET));
+
+      if (sample > QIE11_MAX_LINEARIZATION_ET)
+        sample = QIE11_MAX_LINEARIZATION_ET;
 
       // Usually use a segmentation factor of 1.0 but for ieta >= 21 use 0.5
       double segmentationFactor = 1.0;
@@ -490,8 +493,12 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
 
     if (isPeak) {
       output[ibin] = std::min<unsigned int>(sum[idx], QIE11_MAX_LINEARIZATION_ET);
-      if (fix_saturation_ && force_saturation[idx])
+
+      if (fix_saturation_ && force_saturation[idx] && ids.size() == 2)
+        output[ibin] = QIE11_MAX_LINEARIZATION_ET * 0.5;
+      else if (fix_saturation_ && force_saturation[idx])
         output[ibin] = QIE11_MAX_LINEARIZATION_ET;
+
     } else {
       // Not a peak
       output[ibin] = 0;


### PR DESCRIPTION
#### PR description:

This PR updates the HCAL Trigger Primitive(TP) reconstruction algorithm to synchronize s/w TP algorithm with f/w TP algorithm.   Recently, PR updating TP algorithm to recover a saturation threshold for HE with |ieta| >= 21 in PR #37196 was submitted. However, we want the PR #37196 to be reverted since it is not yet implemented in f/w and we need matches between s/w and f/w in production release now. The comparison between recontructed TP energy with MAHI rechit energy was performed and can be found in this [slide](https://github.com/cms-sw/cmssw/files/8422269/Comnissioning_1TS_Scheme_22Apr06.pdf). The problem of the sharp cutoff at 64 GeV in HE(|ieta| >= 21) is well understood now, and TP algorithm will be updated both in f/w and s/w to recover the same TP energy threshold of 128 GeV in HE(|ieta| >= 21) in later PR. 


#### PR validation:

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, but can be backported to CMSSW_12_2_X or CMSSW_12_3_X for matches in TP between s/w and f/w in production release. 
