### PR TITLE
Utilities/StaticAnaylzers: Add check to postprocess-scan-build.py for empty cells to avoid index out of range error.

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/postprocess-scan-build.py
+++ b/Utilities/StaticAnalyzers/scripts/postprocess-scan-build.py
@@ -23,27 +23,29 @@ rowsbody = tables[2].find('tbody')
 rows = rowsbody.find_all('tr')
 for row in rows:
     cells = row.find_all('td')
-    key = str(cells[2])+str(cells[3])+str(cells[4])
-    if key in seen.keys():
-        seen[key] = seen[key]+1
-        href = cells[6].find('a', href=True)
-        if href:
-            report = href['href'].split("#")[0]
-            report_file = os.path.join(report_dir, report)
-            if report.startswith("report-") and os.path.exists(report_file):
-                os.remove(report_file)
-        row.decompose()
-    else:
-        seen[key] = 1
+    if cells:
+      key = str(cells[2])+str(cells[3])+str(cells[4])
+      if key in seen.keys():
+          seen[key] = seen[key]+1
+          href = cells[6].find('a', href=True)
+          if href:
+              report = href['href'].split("#")[0]
+              report_file = os.path.join(report_dir, report)
+              if report.startswith("report-") and os.path.exists(report_file):
+                  os.remove(report_file)
+          row.decompose()
+      else:
+          seen[key] = 1
 
 
 rowsbody = tables[2].find('tbody')
 rows = rowsbody.find_all('tr')
 for row in rows:
     cells = row.find_all('td')
-    key = str(cells[2])+str(cells[3])+str(cells[4])
-    tag = soup.new_tag('td')
-    tag.string = '{}'.format(seen[key])
-    tag['class'] = 'Q'
-    row.insert(3, tag)
+    if cells:
+      key = str(cells[2])+str(cells[3])+str(cells[4])
+      tag = soup.new_tag('td')
+      tag.string = '{}'.format(seen[key])
+      tag['class'] = 'Q'
+      row.insert(3, tag)
 print(soup.prettify(formatter=None))


### PR DESCRIPTION

#### PR description:

Fix for  error producing empty index.html for static analyzer report.

```
postprocess-scan-build.py index.html 
Traceback (most recent call last):
  File "/build/gartung/CMSSW_12_4_X_2022-04-05-1100/bin/slc7_amd64_gcc10/postprocess-scan-build.py", line 26, in <module>
    key = str(cells[2])+str(cells[3])+str(cells[4])
IndexError: list index out of range
```

#### PR validation:

Tested locally

