### PR TITLE
Properly close file using fclose; fixes CS9 compilation warning

### DIFF
--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.cc
@@ -177,8 +177,9 @@ void EcalABAnalyzer::beginJob() {
   if (test == nullptr) {
     doesABTreeExist = false;
     _fitab = true;
-  };
-  delete test;
+  } else {
+    fclose(test);
+  }
 
   TFile* fAB = nullptr;
   TTree* ABInit = nullptr;


### PR DESCRIPTION
This should fix the `cs9` IBs warning
```
 CMSSW_12_4_X_2022-04-06-2300/src/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.cc:181:10: warning: 'void operator delete(void*, std::size_t)' called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
   181 |   delete test;
      |          ^~~~
src/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalABAnalyzer.cc:176:15: note: returned from 'FILE* fopen(const char*, const char*)'
  176 |   test = fopen(nameabinitfile.str().c_str(), "r");
      |          ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```