### PR TITLE
[CS9] Remove usage of deprecated SHA1 functions, use EVP_Digest instead

### DIFF
--- a/Utilities/General/test/BuildFile.xml
+++ b/Utilities/General/test/BuildFile.xml
@@ -1,3 +1,12 @@
+<bin file="test_openssl_sha1.cpp" name="test_openssl_sha1">
+  <use name="openssl"/>
+  <flags CXXFLAGS="-Wno-deprecated-declarations"/>
+</bin>
+
+<bin file="test_openssl_evp_digest.cpp" name="test_openssl_evp_digest">
+  <use name="openssl"/>
+</bin>
+
 <bin file="test_precomputed_value_sort.cpp" name="test_precomputed_value_sort">
 </bin>
 

--- a/Utilities/General/test/test_openssl_evp_digest.cpp
+++ b/Utilities/General/test/test_openssl_evp_digest.cpp
@@ -1,0 +1,44 @@
+#include <openssl/evp.h>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+using namespace std;
+int main(){
+   unsigned char hash[EVP_MAX_MD_SIZE];
+   unsigned int md_len = 0;
+# if OPENSSL_API_COMPAT < 0x10100000L
+   OpenSSL_add_all_digests();
+   EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
+#else
+   OPENSSL_init_crypto();
+   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+#endif
+   const EVP_MD *md = EVP_get_digestbyname("SHA1");
+
+   EVP_DigestInit_ex(mdctx, md, NULL);
+   EVP_DigestUpdate(mdctx, "foo", 3);
+   EVP_DigestUpdate(mdctx, "bar", 3);
+   EVP_DigestFinal_ex(mdctx, hash, &md_len);
+# if OPENSSL_API_COMPAT < 0x10100000L
+   EVP_MD_CTX_destroy(mdctx);
+# else
+   EVP_MD_CTX_free(mdctx);
+# endif
+
+   stringstream ss;
+   for(unsigned int i = 0; i < md_len; i++)
+   {
+     ss << hex << setw(2) << setfill('0') << (int)hash[i];
+   }
+   hash[md_len] = 0;
+   string sha_result = "8843d7f92416211de9ebb963ff4ce28125932878";
+   string sha = ss.str();
+   if (sha!=sha_result) {
+     cout <<"Failed: SHA1 Mismatch:"<<sha <<" vs "<<sha_result<<endl;
+      return 1;
+   } 
+   cout <<"Passed: SHA1 match:"<<sha <<" vs "<<sha_result<<endl;
+   return 0;
+}
+

--- a/Utilities/General/test/test_openssl_evp_digest.cpp
+++ b/Utilities/General/test/test_openssl_evp_digest.cpp
@@ -4,41 +4,39 @@
 #include <sstream>
 
 using namespace std;
-int main(){
-   unsigned char hash[EVP_MAX_MD_SIZE];
-   unsigned int md_len = 0;
-# if OPENSSL_API_COMPAT < 0x10100000L
-   OpenSSL_add_all_digests();
-   EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
+int main() {
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int md_len = 0;
+#if OPENSSL_API_COMPAT < 0x10100000L
+  OpenSSL_add_all_digests();
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_create();
 #else
-   OPENSSL_init_crypto();
-   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+  OPENSSL_init_crypto();
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
 #endif
-   const EVP_MD *md = EVP_get_digestbyname("SHA1");
+  const EVP_MD *md = EVP_get_digestbyname("SHA1");
 
-   EVP_DigestInit_ex(mdctx, md, NULL);
-   EVP_DigestUpdate(mdctx, "foo", 3);
-   EVP_DigestUpdate(mdctx, "bar", 3);
-   EVP_DigestFinal_ex(mdctx, hash, &md_len);
-# if OPENSSL_API_COMPAT < 0x10100000L
-   EVP_MD_CTX_destroy(mdctx);
-# else
-   EVP_MD_CTX_free(mdctx);
-# endif
+  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestUpdate(mdctx, "foo", 3);
+  EVP_DigestUpdate(mdctx, "bar", 3);
+  EVP_DigestFinal_ex(mdctx, hash, &md_len);
+#if OPENSSL_API_COMPAT < 0x10100000L
+  EVP_MD_CTX_destroy(mdctx);
+#else
+  EVP_MD_CTX_free(mdctx);
+#endif
 
-   stringstream ss;
-   for(unsigned int i = 0; i < md_len; i++)
-   {
-     ss << hex << setw(2) << setfill('0') << (int)hash[i];
-   }
-   hash[md_len] = 0;
-   string sha_result = "8843d7f92416211de9ebb963ff4ce28125932878";
-   string sha = ss.str();
-   if (sha!=sha_result) {
-     cout <<"Failed: SHA1 Mismatch:"<<sha <<" vs "<<sha_result<<endl;
-      return 1;
-   } 
-   cout <<"Passed: SHA1 match:"<<sha <<" vs "<<sha_result<<endl;
-   return 0;
+  stringstream ss;
+  for (unsigned int i = 0; i < md_len; i++) {
+    ss << hex << setw(2) << setfill('0') << (int)hash[i];
+  }
+  hash[md_len] = 0;
+  string sha_result = "8843d7f92416211de9ebb963ff4ce28125932878";
+  string sha = ss.str();
+  if (sha != sha_result) {
+    cout << "Failed: SHA1 Mismatch:" << sha << " vs " << sha_result << endl;
+    return 1;
+  }
+  cout << "Passed: SHA1 match:" << sha << " vs " << sha_result << endl;
+  return 0;
 }
-

--- a/Utilities/General/test/test_openssl_sha1.cpp
+++ b/Utilities/General/test/test_openssl_sha1.cpp
@@ -1,0 +1,29 @@
+#include <openssl/sha.h>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+using namespace std;
+int main(){
+   SHA_CTX ctx;
+   SHA1_Init(&ctx);
+   SHA1_Update(&ctx, "foo", 3);
+   SHA1_Update(&ctx, "bar", 3);
+   unsigned char hash[SHA_DIGEST_LENGTH];
+   SHA1_Final(hash, &ctx);
+
+   stringstream ss;
+   for(unsigned int i = 0; i < SHA_DIGEST_LENGTH; i++)
+   {
+     ss << hex << setw(2) << setfill('0') << (int)hash[i];
+   }
+   string sha_result = "8843d7f92416211de9ebb963ff4ce28125932878";
+   string sha = ss.str();
+   if (sha!=sha_result) {
+     cout <<"Failed: SHA1 Mismatch:"<<sha <<" vs "<<sha_result<<endl;
+      return 1;
+   } 
+   cout <<"Passed: SHA1 match:"<<sha <<" vs "<<sha_result<<endl;
+   return 0;
+}
+

--- a/Utilities/General/test/test_openssl_sha1.cpp
+++ b/Utilities/General/test/test_openssl_sha1.cpp
@@ -4,26 +4,24 @@
 #include <sstream>
 
 using namespace std;
-int main(){
-   SHA_CTX ctx;
-   SHA1_Init(&ctx);
-   SHA1_Update(&ctx, "foo", 3);
-   SHA1_Update(&ctx, "bar", 3);
-   unsigned char hash[SHA_DIGEST_LENGTH];
-   SHA1_Final(hash, &ctx);
+int main() {
+  SHA_CTX ctx;
+  SHA1_Init(&ctx);
+  SHA1_Update(&ctx, "foo", 3);
+  SHA1_Update(&ctx, "bar", 3);
+  unsigned char hash[SHA_DIGEST_LENGTH];
+  SHA1_Final(hash, &ctx);
 
-   stringstream ss;
-   for(unsigned int i = 0; i < SHA_DIGEST_LENGTH; i++)
-   {
-     ss << hex << setw(2) << setfill('0') << (int)hash[i];
-   }
-   string sha_result = "8843d7f92416211de9ebb963ff4ce28125932878";
-   string sha = ss.str();
-   if (sha!=sha_result) {
-     cout <<"Failed: SHA1 Mismatch:"<<sha <<" vs "<<sha_result<<endl;
-      return 1;
-   } 
-   cout <<"Passed: SHA1 match:"<<sha <<" vs "<<sha_result<<endl;
-   return 0;
+  stringstream ss;
+  for (unsigned int i = 0; i < SHA_DIGEST_LENGTH; i++) {
+    ss << hex << setw(2) << setfill('0') << (int)hash[i];
+  }
+  string sha_result = "8843d7f92416211de9ebb963ff4ce28125932878";
+  string sha = ss.str();
+  if (sha != sha_result) {
+    cout << "Failed: SHA1 Mismatch:" << sha << " vs " << sha_result << endl;
+    return 1;
+  }
+  cout << "Passed: SHA1 match:" << sha << " vs " << sha_result << endl;
+  return 0;
 }
-


### PR DESCRIPTION
For CS9 IB, where `OpenSSL` version `3.0`, we have a lot of warning about deprecated use of `SHA1_*` functions [a]. OpenSSL recommends to use `EVP_Digest*` instead [b]. 

This PR updates OnlineDB/SiStripO2O package (where we have 88 warnings in cs9 Ibs) to use `EVP_Digest*` . Also unit tests are added to test old `SHA1_*` and new `EVP_Digest*`.

[a] https://www.openssl.org/docs/manmaster/man3/SHA1_Init.html

[b]
```
All of the functions described on this page except for SHA1(), SHA224(), SHA256(), SHA384() and SHA512() are
deprecated. Applications should instead use EVP_DigestInit_ex(3), EVP_DigestUpdate(3) , EVP_DigestFinal_ex(3)
or the quick one-shot function EVP_Q_digest(3)
```