### PR TITLE
Added the switch for the inclusion of PS energy

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/SCEnergyCorrectorSemiParm.h
@@ -127,6 +127,7 @@ private:
 
   bool isHLT_;
   bool isPhaseII_;
+  bool regTrainedWithPS_;
   bool applySigmaIetaIphiBug_;  //there was a bug in sigmaIetaIphi for the 74X application
   int nHitsAboveThresholdEB_;
   int nHitsAboveThresholdEE_;
@@ -146,6 +147,7 @@ template <edm::Transition esTransition>
 void SCEnergyCorrectorSemiParm::setTokens(const edm::ParameterSet& iConfig, edm::ConsumesCollector cc) {
   isHLT_ = iConfig.getParameter<bool>("isHLT");
   isPhaseII_ = iConfig.getParameter<bool>("isPhaseII");
+  regTrainedWithPS_ = iConfig.getParameter<bool>("regTrainedWithPS");
   applySigmaIetaIphiBug_ = iConfig.getParameter<bool>("applySigmaIetaIphiBug");
   tokenEBRecHits_ = cc.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRecHitsEB"));
   if (not isPhaseII_) {

--- a/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
@@ -51,7 +51,7 @@ SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm()
       caloGeom_(nullptr),
       isHLT_(false),
       isPhaseII_(false),
-      regTrainedWithPS_(true),
+      regTrainedWithPS_(false),
       applySigmaIetaIphiBug_(false),
       nHitsAboveThresholdEB_(0),
       nHitsAboveThresholdEE_(0),
@@ -67,6 +67,7 @@ SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm(const edm::ParameterSet& iC
 void SCEnergyCorrectorSemiParm::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<bool>("isHLT", false);
   desc.add<bool>("isPhaseII", false);
+  desc.add<bool>("regTrainedWithPS", false);
   desc.add<bool>("applySigmaIetaIphiBug", false);
   desc.add<edm::InputTag>("ecalRecHitsEE", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
   desc.add<edm::InputTag>("ecalRecHitsEB", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));

--- a/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
@@ -51,6 +51,7 @@ SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm()
       caloGeom_(nullptr),
       isHLT_(false),
       isPhaseII_(false),
+      regTrainedWithPS_(true),
       applySigmaIetaIphiBug_(false),
       nHitsAboveThresholdEB_(0),
       nHitsAboveThresholdEE_(0),
@@ -140,7 +141,7 @@ std::pair<double, double> SCEnergyCorrectorSemiParm::getCorrections(const reco::
   double sigma = regParam.sigma(regData);
 
   double energyCorr = mean * sc.rawEnergy();
-  if (isHLT_ && sc.seed()->seed().det() == DetId::Ecal && seedId.subdetId() == EcalEndcap) {
+  if (isHLT_ && sc.seed()->seed().det() == DetId::Ecal && seedId.subdetId() == EcalEndcap && !regTrainedWithPS_) {
     energyCorr += sc.preshowerEnergy();
   }
   double resolutionEst = sigma * energyCorr;


### PR DESCRIPTION
#### PR description:

EGamma regression can be trained with and without PS energy taking into consideration. So, we added a switch for this while performing the evaluation in the CMSSW.

***This PR is relevant ONLY for HLT supercluster regression, and that it does not effect the offline egamma regression.***

#### PR validation:

We run the code with the current version of update and it worked as expected.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:


