### PR TITLE
[Backport] New set of files coherent with the new v1_0_0 L1Menu

### DIFF
--- a/L1Trigger/Configuration/python/customiseUtils.py
+++ b/L1Trigger/Configuration/python/customiseUtils.py
@@ -76,7 +76,7 @@ def L1TGlobalDigisSummary(process):
 def L1TGlobalMenuXML(process):
     process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
     process.load('L1Trigger.L1TGlobal.TriggerMenu_cff')
-    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2016_v2c.xml')
+    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2022_v1_0_0.xml')
     return process
 
 def L1TGlobalSimDigisSummary(process):

--- a/L1Trigger/L1TGlobal/python/PrescalesVetosFract_cff.py
+++ b/L1Trigger/L1TGlobal/python/PrescalesVetosFract_cff.py
@@ -16,9 +16,9 @@ L1TGlobalPrescalesVetosFract = cms.ESProducer("L1TGlobalPrescalesVetosFractESPro
     TriggerMenuLuminosity = cms.string('startup'),
     Verbosity = cms.int32(0),
     AlgoBxMaskDefault = cms.int32(1),
-    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_v11.xml'),
-    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_V1.xml'),
-    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_v17.xml'),
-    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_v1.xml'),
+    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_L1MenuCollisions2022_v1_0_0'),
+    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_L1MenuCollisions2022_v1_0_0'),
+    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_L1MenuCollisions2022_v1_0_0'),
+    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_L1MenuCollisions2022_v1_0_0'),
 
 )

--- a/L1Trigger/L1TGlobal/python/PrescalesVetos_cff.py
+++ b/L1Trigger/L1TGlobal/python/PrescalesVetos_cff.py
@@ -15,10 +15,10 @@ L1TGlobalPrescalesVetos = cms.ESProducer("L1TGlobalPrescalesVetosESProducer",
     TriggerMenuLuminosity = cms.string('startup'),
     Verbosity = cms.int32(0),
     AlgoBxMaskDefault = cms.int32(1),
-    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_v11.xml'),
-    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_V1.xml'),
-    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_v17.xml'),
-    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_v1.xml'),
+    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_L1MenuCollisions2022_v1_0_0'),
+    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_L1MenuCollisions2022_v1_0_0'),
+    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_L1MenuCollisions2022_v1_0_0'),
+    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_L1MenuCollisions2022_v1_0_0'),
 
 )
 

--- a/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
+++ b/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
@@ -210,7 +210,7 @@ process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
 
 process.load("L1Trigger.L1TGlobal.TriggerMenu_cff")
 
-xmlMenu="L1Menu_Collisions2022_v0_1_2.xml"
+xmlMenu="L1Menu_Collisions2022_v1_0_0.xml"
 process.TriggerMenu.L1TriggerMenuFile = cms.string(xmlMenu)
 process.ESPreferL1TXML = cms.ESPrefer("L1TUtmTriggerMenuESProducer","TriggerMenu")
 


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/37453 to **CMSSW_12_3_0**.

A full set of xml files for the L1 emulation of prescales and masks coherent with the updated L1 menu for Run 3 has been created and pushed to [L1Trigger-L1TGlobal](https://github.com/cms-data/L1Trigger-L1TGlobal) ([PR#9](https://github.com/cms-data/L1Trigger-L1TGlobal/pull/9)). A backport of these files has been requested in the github issue https://github.com/cms-data/L1Trigger-L1TGlobal/issues/10. Changes will be backported to **CMSSW_12_3_0** in https://github.com/cms-sw/cmsdist/pull/7770 after the tests.

#### PR validation:
Basic tests performed successfully starting from CMSSW_12_3_X_2022-04-07-1100.
> cmsrel CMSSW_12_3_X_2022-04-07-1100
> cd CMSSW_12_3_X_2022-04-07-1100/src
> cmsenv
> git cms-addpkg L1Trigger/Configuration
> git cms-addpkg L1Trigger/L1TGlobal
> git cherry-pick 36263094dc3c4615ca636402333d485859005ab6
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests
> scram build code-checks
> scram build code-format