### PR TITLE
Introduce `PtMaxTrackCountFilter`

### DIFF
--- a/CommonTools/RecoAlgos/plugins/PtMaxTrackCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMaxTrackCountFilter.cc
@@ -1,0 +1,27 @@
+/* \class PtMaxTrackCountFilter
+ *
+ * Filters events if at least N tracks below
+ * a pt cut are present.
+ *
+ * \author: Marco Musich
+ *
+ */
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "CommonTools/UtilAlgos/interface/ObjectCountFilter.h"
+#include "CommonTools/UtilAlgos/interface/PtMaxSelector.h"
+
+typedef ObjectCountFilter<reco::TrackCollection, PtMaxSelector>::type PtMaxTrackCountFilter;
+
+template <>
+void PtMaxTrackCountFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("tracks"));
+  desc.add<unsigned int>("minNumber", 1);
+  desc.add<double>("ptMax", 999.);
+  desc.add<std::string>("cut", "");
+  descriptions.add("ptMaxTrackCountFilter", desc);
+}
+
+DEFINE_FWK_MODULE(PtMaxTrackCountFilter);

--- a/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/PtMinTrackCountFilter.cc
@@ -18,6 +18,7 @@ template <>
 void PtMinTrackCountFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("tracks"));
+  desc.add<unsigned int>("minNumber", 1);
   desc.add<double>("ptMin", 0.);
   desc.add<std::string>("cut", "");
   descriptions.add("ptMinTrackCountFilter", desc);

--- a/CommonTools/UtilAlgos/interface/PtMaxSelector.h
+++ b/CommonTools/UtilAlgos/interface/PtMaxSelector.h
@@ -1,0 +1,23 @@
+#ifndef UtilAlgos_PtMaxSelector_h
+#define UtilAlgos_PtMaxSelector_h
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/Utils/interface/PtMaxSelector.h"
+
+namespace reco {
+  namespace modules {
+
+    template <>
+    struct ParameterAdapter<PtMaxSelector> {
+      static PtMaxSelector make(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC) {
+        return PtMaxSelector(cfg.getParameter<double>("ptMax"));
+      }
+
+      static void fillPSetDescription(edm::ParameterSetDescription& desc) { desc.add<double>("ptMax", 0.); }
+    };
+
+  }  // namespace modules
+}  // namespace reco
+
+#endif

--- a/CommonTools/Utils/interface/PtMaxSelector.h
+++ b/CommonTools/Utils/interface/PtMaxSelector.h
@@ -1,0 +1,21 @@
+#ifndef RecoAlgos_PtMaxSelector_h
+#define RecoAlgos_PtMaxSelector_h
+/* \class PtMaxSelector
+ *
+ * \author Luca Lista, INFN
+ *
+ * $Id: PtMaxSelector.h,v 1.6 2007/06/18 18:33:54 llista Exp $
+ */
+
+struct PtMaxSelector {
+  PtMaxSelector(double ptMax) : ptMax_(ptMax) {}
+  template <typename T>
+  bool operator()(const T& t) const {
+    return t.pt() < ptMax_;
+  }
+
+private:
+  double ptMax_;
+};
+
+#endif


### PR DESCRIPTION
#### PR description:

To study cosmic commissioning events (especially to check detector noise), it is sometimes convenient to isolate low pT tracks.
As far as I could see, there's no such filter to retain only events with at least a track below a certain threshold. This is added here.
In addition I profit to fix the `fillDescriptions`  method of [PtMinTrackCountFilter.cc](https://github.com/cms-sw/cmssw/compare/master...mmusich:PtMinTrackCountFilter?expand=1#diff-d632b65943b2e5288d54a8e4c534126f0c96dc867790e617e87fa48cdf50eac7) which has been introduced in PR https://github.com/cms-sw/cmssw/pull/29604/ (this is done in commit: a3e107893bcd74b54f27b62e549c9365c479deac, without it, using the filter results in failure validating the configuration).

#### PR validation:

Private, tested adding:

```python
from CommonTools.RecoAlgos.ptMaxTrackCountFilter_cfi import ptMaxTrackCountFilter
process.myfilter = ptMaxTrackCountFilter.clone(src = cms.InputTag('ctfWithMaterialTracksP5'),
                                               ptMax = cms.double(3.))
```

to configuration file and tested it works correctly.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A