### PR TITLE
Semi-random initial value in the L1 trigger prescale counter

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -183,10 +183,10 @@ namespace l1t {
         if (ps > 1) {
           auto nps = semirandom - floor(semirandom / ps) * ps;
           // if nps=0 or a wrong value (<0,>ps) use PS value (standard method)
-          if (nps > 0 || nps <= ps)
+          if (nps > 0 and nps <= ps)
             ps = nps;
           else {
-            if (nps != 0)  // complain only if nps <0 or nps >PS
+          if (nps != 0)  // complain only if nps <0 or nps >PS
               edm::LogWarning("L1TGlobal::semirandomNumber")
                   << "\n The inital prescale counter obtained by L1TGlobal::semirandomNumber is wrong."
                   << "\n This is probably do to the floating-point precision. Using the PS value." << semirandom

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -167,36 +167,7 @@ namespace l1t {
 
     //initializer prescale counter using a semi-random value between [1, prescale value]
     static const std::vector<double> semirandomNumber(const edm::Event& iEvent,
-                                                      const std::vector<double>& prescaleFactorsAlgoTrig) {
-      auto out = prescaleFactorsAlgoTrig;
-      // pick a random number from a combination of run, lumi, event numbers
-      std::srand(iEvent.id().run());
-      std::srand(std::rand() + iEvent.id().luminosityBlock());
-      // this causes different (semi)random number number for different streams
-      // reminder: different streams have different initial event number
-      std::srand(std::rand() + iEvent.id().event());
-      // very large (semi)random number
-      double const semirandom = std::rand();
-      for (auto& ps : out) {
-        // if the ps is smaller than 1 (e.g. ps=0, ps=1), it is not changed
-        // else, replace ps with a semirandom integer in the [1,ps] range
-        if (ps > 1) {
-          auto nps = semirandom - floor(semirandom / ps) * ps;
-          // if nps=0 or a wrong value (<0,>ps) use PS value (standard method)
-          if (nps > 0 and nps <= ps)
-            ps = nps;
-          else {
-            if (nps != 0)  // complain only if nps <0 or nps >PS
-              edm::LogWarning("L1TGlobal::semirandomNumber")
-                  << "\n The inital prescale counter obtained by L1TGlobal::semirandomNumber is wrong."
-                  << "\n This is probably do to the floating-point precision. Using the PS value."
-                  << "\n semirandom = " << semirandom << "\n PS = " << ps << "\n nps = " << nps
-                  << " <-- it should be in the range [0 , " << ps << "]" << std::endl;
-          }
-        }
-      }
-      return out;
-    }
+                                                      const std::vector<double>& prescaleFactorsAlgoTrig);
 
     /*  Drop individual EtSums for Now
     /// pointer to ETM data list

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -186,10 +186,10 @@ namespace l1t {
           if (nps > 0 and nps <= ps)
             ps = nps;
           else {
-          if (nps != 0)  // complain only if nps <0 or nps >PS
+            if (nps != 0)  // complain only if nps <0 or nps >PS
               edm::LogWarning("L1TGlobal::semirandomNumber")
                   << "\n The inital prescale counter obtained by L1TGlobal::semirandomNumber is wrong."
-                  << "\n This is probably do to the floating-point precision. Using the PS value." << semirandom
+                  << "\n This is probably do to the floating-point precision. Using the PS value."
                   << "\n semirandom = " << semirandom << "\n PS = " << ps << "\n nps = " << nps
                   << " <-- it should be in the range [0 , " << ps << "]" << std::endl;
           }

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -69,6 +69,7 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   // switch for muon showers in Run-3
   desc.add<bool>("useMuonShowers", false);
   desc.add<bool>("resetPSCountersEachLumiSec", true);
+  desc.add<bool>("semiRandomInitialPSCounters", false);
   // These parameters have well defined  default values and are not currently
   // part of the L1T/HLT interface.  They can be cleaned up or updated at will:
   desc.add<bool>("ProduceL1GtDaqRecord", true);
@@ -116,6 +117,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
       m_requireMenuToMatchAlgoBlkInput(parSet.getParameter<bool>("RequireMenuToMatchAlgoBlkInput")),
       m_algoblkInputTag(parSet.getParameter<edm::InputTag>("AlgoBlkInputTag")),
       m_resetPSCountersEachLumiSec(parSet.getParameter<bool>("resetPSCountersEachLumiSec")),
+      m_semiRandomInitialPSCounters(parSet.getParameter<bool>("semiRandomInitialPSCounters")),
       m_useMuonShowers(parSet.getParameter<bool>("useMuonShowers")) {
   m_egInputToken = consumes<BXVector<EGamma>>(m_egInputTag);
   m_tauInputToken = consumes<BXVector<Tau>>(m_tauInputTag);
@@ -197,6 +199,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
   m_uGtBrd = std::make_unique<GlobalBoard>();
   m_uGtBrd->setVerbosity(m_verbosity);
   m_uGtBrd->setResetPSCountersEachLumiSec(m_resetPSCountersEachLumiSec);
+  m_uGtBrd->setSemiRandomInitialPSCounters(m_semiRandomInitialPSCounters);
 
   // initialize cached IDs
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -188,6 +188,8 @@ private:
 
   //disables reseting the prescale counters each lumisection (needed for offline)
   bool m_resetPSCountersEachLumiSec;
+  // start the PS counter from a random value between [1,PS] instead of PS
+  bool m_semiRandomInitialPSCounters;
   // switch to load muon showers in the global board
   bool m_useMuonShowers;
 };

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -971,14 +971,13 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
   // prescale counters are reset at the beginning of the luminosity segment
   if (m_firstEv) {
     // prescale counters: numberPhysTriggers counters per bunch cross
-    m_prescaleCounterAlgoTrig.reserve(numberPhysTriggers * totalBxInEvent);
+    m_prescaleCounterAlgoTrig.reserve(totalBxInEvent);
+
+    auto const& prescaleCountersAlgoTrig =
+        m_semiRandomInitialPSCounters ? semirandomNumber(iEvent, prescaleFactorsAlgoTrig) : prescaleFactorsAlgoTrig;
 
     for (int iBxInEvent = 0; iBxInEvent <= totalBxInEvent; ++iBxInEvent) {
-      if (m_semiRandomInitialPSCounters) {
-        m_prescaleCounterAlgoTrig.push_back(semirandomNumber(iEvent, prescaleFactorsAlgoTrig));
-      } else {
-        m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);
-      }
+      m_prescaleCounterAlgoTrig.push_back(prescaleCountersAlgoTrig);
     }
     m_firstEv = false;
     m_currentLumi = iEvent.luminosityBlock();

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -1170,7 +1170,7 @@ void l1t::GlobalBoard::printGmtData(const int iBxInEvent) const {
 
 //initializer prescale counter using a semi-random value between [1, prescale value]
 const std::vector<double> l1t::GlobalBoard::semirandomNumber(const edm::Event& iEvent,
-                                                  const std::vector<double>& prescaleFactorsAlgoTrig) {
+                                                             const std::vector<double>& prescaleFactorsAlgoTrig) {
   auto out = prescaleFactorsAlgoTrig;
   // pick a random number from a combination of run, lumi, event numbers
   std::srand(iEvent.id().run());

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -1167,3 +1167,36 @@ void l1t::GlobalBoard::printGmtData(const int iBxInEvent) const {
 
   LogTrace("L1TGlobal") << std::endl;
 }
+
+//initializer prescale counter using a semi-random value between [1, prescale value]
+const std::vector<double> l1t::GlobalBoard::semirandomNumber(const edm::Event& iEvent,
+                                                  const std::vector<double>& prescaleFactorsAlgoTrig) {
+  auto out = prescaleFactorsAlgoTrig;
+  // pick a random number from a combination of run, lumi, event numbers
+  std::srand(iEvent.id().run());
+  std::srand(std::rand() + iEvent.id().luminosityBlock());
+  // this causes different (semi)random number number for different streams
+  // reminder: different streams have different initial event number
+  std::srand(std::rand() + iEvent.id().event());
+  // very large (semi)random number
+  double const semirandom = std::rand();
+  for (auto& ps : out) {
+    // if the ps is smaller than 1 (e.g. ps=0, ps=1), it is not changed
+    // else, replace ps with a semirandom integer in the [1,ps] range
+    if (ps > 1) {
+      auto nps = semirandom - floor(semirandom / ps) * ps;
+      // if nps=0 or a wrong value (<0,>ps) use PS value (standard method)
+      if (nps > 0 and nps <= ps)
+        ps = nps;
+      else {
+        if (nps != 0)  // complain only if nps <0 or nps >PS
+          edm::LogWarning("L1TGlobal::semirandomNumber")
+              << "\n The inital prescale counter obtained by L1TGlobal::semirandomNumber is wrong."
+              << "\n This is probably do to the floating-point precision. Using the PS value."
+              << "\n semirandom = " << semirandom << "\n PS = " << ps << "\n nps = " << nps
+              << " <-- it should be in the range [0 , " << ps << "]" << std::endl;
+      }
+    }
+  }
+  return out;
+}

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -974,7 +974,11 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
     m_prescaleCounterAlgoTrig.reserve(numberPhysTriggers * totalBxInEvent);
 
     for (int iBxInEvent = 0; iBxInEvent <= totalBxInEvent; ++iBxInEvent) {
-      m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);
+      if (m_semiRandomInitialPSCounters) {
+        m_prescaleCounterAlgoTrig.push_back(semirandomNumber(iEvent, prescaleFactorsAlgoTrig));
+      } else {
+        m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);
+      }
     }
     m_firstEv = false;
     m_currentLumi = iEvent.luminosityBlock();
@@ -984,7 +988,11 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
   if (m_firstEvLumiSegment || (m_currentLumi != iEvent.luminosityBlock() && m_resetPSCountersEachLumiSec)) {
     m_prescaleCounterAlgoTrig.clear();
     for (int iBxInEvent = 0; iBxInEvent <= totalBxInEvent; ++iBxInEvent) {
-      m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);
+      if (m_semiRandomInitialPSCounters) {
+        m_prescaleCounterAlgoTrig.push_back(semirandomNumber(iEvent, prescaleFactorsAlgoTrig));
+      } else {
+        m_prescaleCounterAlgoTrig.push_back(prescaleFactorsAlgoTrig);
+      }
     }
     m_firstEvLumiSegment = false;
     m_currentLumi = iEvent.luminosityBlock();


### PR DESCRIPTION
#### PR description:

The standard behavior of the L1 trigger prescaler is to start a counter from the prescale value (eg. 1000) and then reduce it of one unit every time the corresponding L1 trigger is accepted. Once the counter reach 0, the L1 trigger is consider to pass also the L1 prescale, and the counter goes back to the prescale value.
The counter is reset at the beginning of each lumisection (unless you enable https://github.com/cms-sw/cmssw/pull/37395)

This PR adds the option to set the initial prescale value of the PS counter from PS to a semirandom value taken in the range [0, PS]. This option is required to avoid that running on a heavily prescaled sample (eg. ZeroBias) the PS counter never reach 0 and therefore no events pass the prescaler. Starting on a random value, the average rate will be closer to the actual rate that we would see in the actual datataking (at P5 the L1 trigger evaluate a huge number of events per LS).

The "semi-random" refers to the `std::srand` function which gives a reproducible sequence of random numbers.
However the reproducibility is not preserved when running with multithreading because I use also the event number as input of the random number generator.
The current L1 trigger precaler does not preserve the reproducibility when multi-threading is on.

This PR is somehow related to https://github.com/cms-sw/cmssw/pull/37395. 

#### PR validation:

Running the prescaler on 3151 events (two LS: 1584 events + 1567 events) on ZeroBias with a prescale of 100 using 16 threads.

Default configuration: 8 events passed
Including this PR (default): 6 events passed
Including this PR (semiRandomInitialPSCounters on): 30 events passed
________________________________________________________
Second test (same configurations)

Default configuration: 4 events passed
Including this PR (default): 5 events passed
Including this PR (semiRandomInitialPSCounters on): 31 events passed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Yes, I'd like to have a backport to 12_3_X - although it is not strictly necessary - as it will be used for the first stable beam and therefore for the first HLT menu.
We use this PR for the HLT rate estimate based on the L1 skim of the ZeroBias dataset.

