### PR TITLE
Change the way to match "mg_reweighting" in production of NanoAOD MC samples

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -830,7 +830,7 @@ public:
             }
           } else if (std::regex_search(lines[iLine], groups, weightgroupRwgt)) {
             std::string groupname = groups.str(1);
-            if (groupname == "mg_reweighting") {
+            if (groupname.find("mg_reweighting") != std::string::npos) {
               if (lheDebug)
                 std::cout << ">>> Looks like a LHE weights for reweighting" << std::endl;
               for (++iLine; iLine < nLines; ++iLine) {


### PR DESCRIPTION
#### PR description:

Solve the problem that NanoAOD cannot store the ReweightingWeight of MC samples generated with MG5.

#### PR validation:

Validated in this [link](https://cms-talk.web.cern.ch/t/problems-with-lhereweightingweight-in-new-ul-aqgc-samples/8861) and in the private UL samples.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special.