### PR TITLE
Skim for Delayed Jets and DTClusters

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXODTCluster_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODTCluster_cff.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+DTClusterHTTrigger = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+DTClusterHTTrigger.TriggerResultsTag = cms.InputTag( "TriggerResults", "", "HLT" )
+DTClusterHTTrigger.HLTPaths = cms.vstring(
+    "*DTCluster*"
+)
+DTClusterHTTrigger.throw = False
+DTClusterHTTrigger.andOr = True
+
+EXODTClusterSkimSequence = cms.Sequence(
+    DTClusterHTTrigger
+)

--- a/Configuration/Skimming/python/PDWG_EXODelayedJet_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODelayedJet_cff.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+DelayedJetHTTrigger = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+DelayedJetHTTrigger.TriggerResultsTag = cms.InputTag( "TriggerResults", "", "HLT" )
+DelayedJetHTTrigger.HLTPaths = cms.vstring(
+    "HLT_HT430_DelayedJet40*"
+)
+DelayedJetHTTrigger.throw = False
+DelayedJetHTTrigger.andOr = True
+
+EXODelayedJetSkimSequence = cms.Sequence(
+    DelayedJetHTTrigger
+)

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -260,6 +260,28 @@ SKIMStreamEXODisplacedJet = cms.FilteredStream(
     dataTier = cms.untracked.string('USER')
     )
 
+from Configuration.Skimming.PDWG_EXODelayedJet_cff import *
+EXODelayedJetPath = cms.Path(EXODelayedJetSkimSequence)
+SKIMStreamEXODelayedJet = cms.FilteredStream(
+    responsible = 'PDWG',
+    name = 'EXODelayedJet',
+    paths = (EXODelayedJetPath),
+    content = skimRawAODContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('AOD')
+    )
+
+from Configuration.Skimming.PDWG_EXODTCluster_cff import *
+EXODTClusterPath = cms.Path(EXODTClusterSkimSequence)
+SKIMStreamEXODTCluster = cms.FilteredStream(
+    responsible = 'PDWG',
+    name = 'EXODTCluster',
+    paths = (EXODTClusterPath),
+    content = skimRawAODContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('AOD')
+    )
+
 from Configuration.Skimming.PDWG_EXODisappTrk_cff import *
 EXODisappTrkPath = cms.Path(EXODisappTrkSkimSequence)
 SKIMStreamEXODisappTrk = cms.FilteredStream(

--- a/Configuration/Skimming/test/test_DTCluster_cfg.py
+++ b/Configuration/Skimming/test/test_DTCluster_cfg.py
@@ -1,0 +1,129 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: skims -s SKIM:EXODTCluster --dasquery=file dataset=/RelValQCD_Pt_1800_2400_14/CMSSW_12_3_0_pre6-123X_mcRun3_2021_realistic_v11-v2/GEN-SIM-RECO -n 10000 --conditions 120X_mcRun3_2021_realistic_v6 --python_filename=EXODTCluster_SKIM.py --processName=SKIMEXODTCluster --era Run3 --no_exec
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('SKIMEXODTCluster',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Skims_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/649f3446-1698-4910-b879-9a6d94d62a9b.root',
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/aa515779-dad9-4994-b7d2-d672a7c8938a.root',
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/b7315dce-732e-4ec7-b137-ee3bafff1cd6.root',
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/df8bd2c1-1e45-479d-9287-2d40fecc25d8.root'
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('skims nevts:10000'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.AODSIMoutput = cms.OutputModule("PoolOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(4),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('AODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(31457280),
+    fileName = cms.untracked.string('file:skims_AOD.root'),
+    outputCommands = process.AODSIMEventContent.outputCommands
+)
+
+
+# Additional output definition
+process.SKIMStreamEXODTCluster = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('EXODTClusterPath')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('AODSIM'),
+        filterName = cms.untracked.string('EXODTCluster')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('EXODTCluster.root'),
+    outputCommands = process.AODSIMEventContent.outputCommands +['keep *_csc2DRecHits_*_*','keep *_dt1DRecHits_*_*']
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '120X_mcRun3_2021_realistic_v6', '')
+
+# Path and EndPath definitions
+process.AODSIMoutput_step = cms.EndPath(process.AODSIMoutput)
+process.SKIMStreamEXODTClusterOutPath = cms.EndPath(process.SKIMStreamEXODTCluster)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.EXODTClusterPath,process.AODSIMoutput_step,process.SKIMStreamEXODTClusterOutPath)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+
+
+# Customisation from command line
+
+#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule
+from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+process = customiseLogErrorHarvesterUsingOutputCommands(process)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/Configuration/Skimming/test/test_DelayedJet_cfg.py
+++ b/Configuration/Skimming/test/test_DelayedJet_cfg.py
@@ -1,0 +1,128 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: skims -s SKIM:EXODelayedJet --dasquery=file dataset=/RelValQCD_Pt_1800_2400_14/CMSSW_12_3_0_pre6-123X_mcRun3_2021_realistic_v11-v2/GEN-SIM-RECO -n 10000 --conditions 120X_mcRun3_2021_realistic_v6 --python_filename=EXODelayedJet_SKIM.py --processName=SKIMEXODelayedJet --no_exec
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('SKIMEXODelayedJet',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Skims_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/649f3446-1698-4910-b879-9a6d94d62a9b.root',
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/aa515779-dad9-4994-b7d2-d672a7c8938a.root',
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/b7315dce-732e-4ec7-b137-ee3bafff1cd6.root',
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/df8bd2c1-1e45-479d-9287-2d40fecc25d8.root'
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('skims nevts:10000'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+ 
+process.AODSIMoutput = cms.OutputModule("PoolOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(4),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('AODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(31457280),
+    fileName = cms.untracked.string('file:skims_AOD.root'),
+    outputCommands = process.AODSIMEventContent.outputCommands
+)
+
+# Additional output definition
+process.SKIMStreamEXODelayedJet = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('EXODelayedJetPath')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('USER'),
+        filterName = cms.untracked.string('EXODelayedJet')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('EXODelayedJet.root'),
+    outputCommands = process.AODSIMEventContent.outputCommands
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '120X_mcRun3_2021_realistic_v6', '')
+
+# Path and EndPath definitions
+process.AODSIMoutput_step = cms.EndPath(process.AODSIMoutput)
+process.SKIMStreamEXODelayedJetOutPath = cms.EndPath(process.SKIMStreamEXODelayedJet)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.EXODelayedJetPath,process.AODSIMoutput_step,process.SKIMStreamEXODelayedJetOutPath)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+
+
+# Customisation from command line
+
+#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule
+from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+process = customiseLogErrorHarvesterUsingOutputCommands(process)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
#### PR description:

This PR adds two RECO level skims that save all standard AOD collections. The delayed jet skim is for use in analyses using jet timing, such as EXO-19-001 (which requires collections only available at AOD). The DT cluster skim is for use in analyses using muon clusters, such as EXO-21-008. The DT cluster skim saves the following collections in addition to AOD:
DTLayerIdDTRecHit1DPairsOwnedRangeMap_dt1DRecHits__RECO
CSCDetIdCSCRecHit2DsOwnedRangeMap_csc2DRecHits__RECO

The delayed jet skim cuts on all tracks satisfying the associated HLT paths under "HLT_HT430_DelayedJet40*":
HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v1
HLT_HT430_DelayedJet40_DoubleDelay1nsInclusive_v1
HLT_HT430_DelayedJet40_SingleDelay1nsTrackless_v1
HLT_HT430_DelayedJet40_DoubleDelay0p5nsTrackless_v1

The DT cluster skim also cuts on tracks satisfying its associated HLT paths under "*DTCluster*":
HLT_L1MET_DTClusterNoMB1S50_v1
HLT_CaloMET60_DTClusterNoMB1S50_v1
HLT_L1MET_DTCluster50_v1
HLT_CaloMET60_DTCluster50_v1

Tested with a high-Pt QCD sample /store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/aa515779-dad9-4994-b7d2-d672a7c8938a.root (2500 events), the skimmed file size for DT clusters was 6.2MB, the skimmed file size for delayed jets was 4.9MB, and the size of the unskimmed AOD file in each case was 551MB.

#### PR validation:

Ran with CMSSW_12_4_0_pre1 and used the config files "test_DTCluster_cfg.py" and "test_DelayedJet_cfg.py", which are both included in the PR.
