### PR TITLE
Update cmsLHEtoEOSManager.py to use python used by cmsRun

### DIFF
--- a/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
+++ b/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
@@ -1,4 +1,12 @@
-#! /usr/bin/env python3
+#!/bin/sh
+
+""":"
+
+python_cmd="python"
+python3 -c "from FWCore.PythonFramework.CmsRun import CmsRun" 2>/dev/null && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+
+"""
 
 from __future__ import print_function
 print('Starting cmsLHEtoEOSManager.py')


### PR DESCRIPTION
`cmsLHEtoEOSManager.py` is shared by all cmssw releases as it gets deployed under `/cvmfs/cms.cern.ch/share/overrides/bin` (which comes first in PATH after cmsenv). As reported in https://github.com/cms-sw/cmssw/issues/37512, after python2 to python3 migration this script does not work any more in slc6 env ( due to missing python3). The change here proposed to use the `python` used by `cmsRun` . This is the same trick we did for few other shared python tools (https://github.com/cms-sw/cmssw-wm-tools/tree/master/bin).

Fixes https://github.com/cms-sw/cmssw/issues/37512