### PR TITLE
Add typedefs for association quality and tag template argument types.

### DIFF
--- a/DataFormats/Common/interface/AssociationMap.h
+++ b/DataFormats/Common/interface/AssociationMap.h
@@ -53,6 +53,8 @@ namespace edm {
   public:
     /// self type
     typedef AssociationMap<Tag> self;
+    /// tag/association type
+    typedef Tag tag_type;
     /// index type
     typedef typename Tag::index_type index_type;
     /// insert key type

--- a/DataFormats/Common/interface/OneToManyWithQualityGeneric.h
+++ b/DataFormats/Common/interface/OneToManyWithQualityGeneric.h
@@ -33,6 +33,8 @@ namespace edm {
     typedef KeyRef key_type;
     /// insert val type
     typedef std::pair<ValRef, Q> data_type;
+    /// quality type
+    typedef Q quality_type;
     /// index type
     typedef index index_type;
     /// map type


### PR DESCRIPTION
This PR adds two typedefs needed for creation of JIT-compiled lambdas for quality selection filters in FireworksWeb.
