### PR TITLE
Extend eta range for jets seeding tau reco&ID

### DIFF
--- a/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
@@ -6,6 +6,6 @@ PFRecoTauPFJetInputs = cms.PSet (
     jetConeSize = cms.double(0.5), # for matching between tau and jet
     isolationConeSize = cms.double(0.5), # for the size of the tau isolation
     minJetPt = cms.double(14.0), # do not make taus from jet with pt below that value
-    maxJetAbsEta = cms.double(2.5) # do not make taus from jet more forward/backward than this
+    maxJetAbsEta = cms.double(2.7) # do not make taus from jet more forward/backward than this
 )
 phase2_common.toModify(PFRecoTauPFJetInputs, maxJetAbsEta = cms.double(4.0))


### PR DESCRIPTION
#### PR description:

This PR is to extend eta range for jets seeding tau reco&ID from |eta| of 2.5 to 2.7.
It was found that Phase-2 tracker allows to reconstruct and identify effectively taus up to |eta| of 2.5 instead of 2.3 recommended so far [1]. |Eta| of 2.5 is identical as for electrons which reconstruction also bases on combination of information in tracker and ECAL.
Therefore, we want to extend the eta range enabled for jets seeing tau reco to minimize edge effect when direction of the jet and reconstructed corresponding tau are different. 

Expected changes: small increase of taus at |eta|~2.5.

[1] https://indico.cern.ch/event/1142990/#4-deeptau-developments-for-run sl. 8

#### PR validation:

Tested with10024.0 (TTbar_13+2017+TTbar_13TeV_TuneCUETP8M1_GenSimINPUT+Digi+RecoFakeHLT+HARVESTFakeHLT+ALCA+Nano)

