### PR TITLE
add HLT customisation for Run-2 CTPPS [`12_3_X`]

### DIFF
--- a/HLTrigger/Configuration/python/CustomConfigs.py
+++ b/HLTrigger/Configuration/python/CustomConfigs.py
@@ -171,8 +171,3 @@ def L1XML(process,xmlFile=None):
     process.ESPreferL1TXML = cms.ESPrefer("L1TUtmTriggerMenuESProducer","L1TriggerMenu")
 
     return process
-
-def CTPPSRun2Geometry(process):
-    if hasattr(process,'ctppsGeometryESModule'):
-        process.ctppsGeometryESModule.isRun2 = True
-    return(process)

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -136,11 +136,20 @@ def customisePixelL1ClusterThresholdForRun2Input(process):
 
     return process
 
+def customiseCTPPSFor2018Input(process):
+    for prod in producers_by_type(process, 'CTPPSGeometryESModule'):
+        prod.isRun2 = True
+    for prod in producers_by_type(process, 'CTPPSPixelRawToDigi'):
+        prod.isRun3 = False
+
+    return process
+
 def customiseFor2018Input(process):
     """Customise the HLT to run on Run 2 data/MC"""
     process = customisePixelGainForRun2Input(process)
     process = customisePixelL1ClusterThresholdForRun2Input(process)
     process = customiseHCALFor2018Input(process)
+    process = customiseCTPPSFor2018Input(process)
 
     return process
 


### PR DESCRIPTION
backport of #37518

#### PR description:

From the original PR:
>This PR updates the customisation used by HLT to run the latest Run-3 menu on Run-2 Data, i.e. `customiseFor2018Input`. The update adds the Run-2 customisation for CTPPS. 
>
>It addresses issue #37483. It likely needs a backport to `12_3_X` to ease HLT development.
>
>The function `CTPPSRun2Geometry` was not used anywhere, so I effectively moved it inside `customiseCTPPSFor2018Input`.
>
>This PR does not affect any central wf, so no differences in the outputs of PR tests are expected.

#### PR validation:

Relies on the validation done for the original PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#37518

Improves a customisation function used offline by HLT for rate/timing measurements.