### PR TITLE
Improve IndexIntoFile for concurrent lumis/runs

### DIFF
--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -626,6 +626,15 @@ namespace edm {
 
       IndexIntoFile const* indexIntoFile() const { return indexIntoFile_; }
 
+      // runOrLumiEntries_ and runOrLumiIndexes_ have the same size. It
+      // is returned by the function size(). There are iterator data members
+      // that are indexes into a container. The iterators also need the size of that
+      // container and the function indexedSize() returns it. For the NoSort and
+      // Sorted derived iterator classes, those indexes point directly into
+      // runOrLumiEntries_ or runOrLumiIndexes_ and therefore return the same
+      // value as size(). The indexes in the EntryOrder iterator class point into
+      // a larger container and indexedSize() is overridden to give the size of
+      // that container.
       int size() const { return size_; }
       virtual int indexedSize() const { return size(); }
 

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -69,13 +69,22 @@ in the iteration (once for each contained contiguous sequence
 of events plus possibly one additional time near the end
 for the run or lumi to be processed and merged, although this
 might or might not occur with the last contiguous sequence
-of events). The iterator automatically skips over
-the duplicate event entries created by this. The client
-needs to check the iterator function named shouldProcessLumi
-or shouldProcessRun to determine whether a lumi or run
-entry should be recognized as a placeholder or it is
-the entry where the products should be read and merged
-for output.
+of events). The iterator is designed to automatically step to
+each event once, even when it points at the same RunOrLumiEntry
+with the same events more than once in the iteration. The client
+does not need to do anything special related to events. On the
+other hand, the client (usually PoolSource, which passes the
+value into the Principal) needs to check the iterator functions
+named shouldProcessLumi or shouldProcessRun to determine whether
+a lumi or run is being encountered more than once. Those functions
+will return true only once. At that time, run or lumi products
+are read, possibly merged, and written to output. When those
+functions return false, transitions still occur but products
+are not read, merged or written. If a module attempts to get
+run or lumi products in those transitions, there will be a
+"ProductNotFound" exception or invalid Handle. In general,
+getting run or lumi products from events does not work with
+the EntryOrder iterator type.
 
 One final comment with regards to IndexIntoFileItr.  This
 is not an STL iterator and it cannot be used with std::

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -49,11 +49,33 @@ There can be multiple run entries in a TTree associated
 with the same run number and ProcessHistoryID in a file.
 There can also be multiple lumi entries associated with
 the same lumi number, run number, and ProcessHistoryID.
-Both sorting orders will make these subgroups contiguous,
+The sorting orders identified as numericalOrder and
+firstAppearanceOrder will make these subgroups contiguous,
 but beyond that is up to the client (normally PoolSource,
 which passes them up to the EventProcessor)
 to deal with merging the multiple run (or lumi) entries
 together.
+
+In entryOrder, the Events are processed in the order they
+appear in the Events TTree. The event entries associated
+with a run might not be contiguous. The event entries associated
+with a lumi might not be contiguous. Even so, the iteration
+order will always follow the pattern run followed by contained
+lumis followed by contained events (note it's possible
+there are no contained events for a lumi or no contained
+lumis for a run). Because the events are not contiguous,
+this leads to run or lumi entries appearing more than once
+in the iteration (once for each contained contiguous sequence
+of events plus possibly one additional time near the end
+for the run or lumi to be processed and merged, although this
+might or might not occur with the last contiguous sequence
+of events). The iterator automatically skips over
+the duplicate event entries created by this. The client
+needs to check the iterator function named shouldProcessLumi
+or shouldProcessRun to determine whether a lumi or run
+entry should be recognized as a placeholder or it is
+the entry where the products should be read and merged
+for output.
 
 One final comment with regards to IndexIntoFileItr.  This
 is not an STL iterator and it cannot be used with std::
@@ -85,14 +107,16 @@ This vector holds one element per entry in the run
 TTree and one element per entry in the lumi TTree.
 When sorted, everything associated with a given run and
 ProcessHistoryID will be contiguous in the vector.
-These groups of elements will be sorted in the order they
-first appear in the input file. Within each of
+These groups of elements will be sorted by an OutputModule
+in the order they first appear when an Event, Lumi or Run
+is written to output (close to input order but because of
+concurrency it might not be exactly the same). Within each of
 these groups the run entries come first in order,
 followed by the elements associated with the lumis.
 The lumis are also contiguous and sorted by first
-appearance in the input file. Within a lumi they
-are sorted by entry order. And each luminosity
-element corresponds to one contiguous sequence
+appearance by the output module in a way similar to runs.
+Within a lumi they are sorted by entry order. And each
+luminosity element corresponds to one contiguous sequence
 of Events in the Events TTree. Before we implemented
 concurrent processing of luminosity blocks that
 was the full story. After that it became more complicated
@@ -112,10 +136,7 @@ is invalid (note the one element with a valid entry might
 or might not be associated with a contiguous block of
 events). In the sort of elements related to a particular
 luminosity block, the entries with invalid entry numbers
-will come before the valid ones. (It has not happened
-yet as I am writing this, but a similar thing will
-likely occur for runs if/when we ever implement concurrent
-runs)
+will come before the valid ones.
 
 There are a number of transient data members also.
 The 3 most important of these are vectors.  To
@@ -234,7 +255,6 @@ namespace edm {
     static constexpr LuminosityBlockNumber_t invalidLumi = 0U;
     static constexpr EventNumber_t invalidEvent = 0U;
     static constexpr EntryNumber_t invalidEntry = -1LL;
-    static constexpr EntryNumber_t continuedLumi = -2LL;
 
     enum EntryType { kRun, kLumi, kEvent, kEnd };
 
@@ -247,15 +267,15 @@ namespace edm {
     /// This enum is used to specify the order of iteration.
     /// In firstAppearanceOrder there are 3 sort criteria, in order of precedence these are:
     ///
-    ///   1. firstAppearance of the ProcessHistoryID and run number in the file
+    ///   1. firstAppearance of the ProcessHistoryID and run number in the output module
     ///
-    ///   2. firstAppearance of the ProcessHistoryID, run number and lumi number in the file
+    ///   2. firstAppearance of the ProcessHistoryID, run number and lumi number in the output module
     ///
     ///   3. entry number
     ///
     /// In numerical order the criteria are in order of precedence are:
     ///
-    ///   1. processHistoryID index (which are normally in order of appearance in the process)
+    ///   1. processHistoryID index (which are normally in order of appearance in the output module)
     ///
     ///   2. run number
     ///
@@ -264,6 +284,37 @@ namespace edm {
     ///   4. event number
     ///
     ///   5. entry number
+    ///
+    /// In entryOrder the order of iteration is as follows:
+    ///
+    ///   1. Events are processed in the exact order they appear in the
+    ///   input Events TTree. (The main purpose of this order is to allow
+    ///   fast cloning of the input Events TTree to the output Events TTree.)
+    ///
+    ///   2. Runs and Lumis will show up around events so that the pattern
+    ///   run, then contained lumi(s), then contained event(s) is always followed,
+    ////  but because events from a run (or lumi) may not be contiguous a particular
+    ///   run entry or lumi entry may appear multiple times in this ordering. Each
+    ///   Run entry or lumi entry will appear once with the function shouldProcessRun
+    ///   or shouldProcessLumi returning true. The client (usually PoolSource) must
+    ///   notice when these return false and not read or process them multiple times.
+    ///
+    ///   3. All runs and lumis associated with a run should be processed
+    ///   when the last contiguous sequence of events for that run is processed.
+    ///   If a run has no events, then it is interspersed within that sequence
+    ///   of runs according to its run TTree entry number.
+    ///
+    ///   4. Within a run, lumis should be processed when the last contiguous
+    ///   subsequence of events from that lumi is processed. If there are
+    ///   no events from a lumi in the last contiguous sequence of events
+    ///   from the run, then the lumis are interspersed within the sequence
+    ///   of lumis from that run in order of lumi TTree entry number.
+    ///
+    ///   Note that the ordering above will allow the client (usually PoolSource)
+    ///   to merge all run entries associated with a single run and merge all lumi
+    ///   entries associated with a single lumi the first time an input file is
+    ///   read. This is the same as in the other two orderings.
+
     enum SortOrder { numericalOrder, firstAppearanceOrder, entryOrder };
 
     /// Used to start an iteration over the Runs, Lumis, and Events in a file.
@@ -546,7 +597,8 @@ namespace edm {
       virtual RunNumber_t run() const = 0;
       virtual LuminosityBlockNumber_t lumi() const = 0;
       virtual EntryNumber_t entry() const = 0;
-      virtual bool entryContinues() const = 0;
+      virtual bool shouldProcessLumi() const = 0;
+      virtual bool shouldProcessRun() const = 0;
       virtual LuminosityBlockNumber_t peekAheadAtLumi() const = 0;
       virtual EntryNumber_t peekAheadAtEventEntry() const = 0;
       EntryNumber_t firstEventEntryThisRun();
@@ -565,6 +617,7 @@ namespace edm {
 
       IndexIntoFile const* indexIntoFile() const { return indexIntoFile_; }
       int size() const { return size_; }
+      virtual int indexedSize() const { return size(); }
 
       EntryType type() const { return type_; }
       int indexToRun() const { return indexToRun_; }
@@ -627,7 +680,8 @@ namespace edm {
       RunNumber_t run() const override;
       LuminosityBlockNumber_t lumi() const override;
       EntryNumber_t entry() const override;
-      bool entryContinues() const final { return false; };
+      bool shouldProcessLumi() const override { return true; }
+      bool shouldProcessRun() const override { return true; }
       LuminosityBlockNumber_t peekAheadAtLumi() const override;
       EntryNumber_t peekAheadAtEventEntry() const override;
       bool skipLumiInRun() override;
@@ -662,7 +716,8 @@ namespace edm {
       RunNumber_t run() const override;
       LuminosityBlockNumber_t lumi() const override;
       EntryNumber_t entry() const override;
-      bool entryContinues() const final { return false; }
+      bool shouldProcessLumi() const override { return true; }
+      bool shouldProcessRun() const override { return true; }
       LuminosityBlockNumber_t peekAheadAtLumi() const override;
       EntryNumber_t peekAheadAtEventEntry() const override;
       bool skipLumiInRun() override;
@@ -697,16 +752,28 @@ namespace edm {
       RunNumber_t run() const override;
       LuminosityBlockNumber_t lumi() const override;
       EntryNumber_t entry() const override;
-      bool entryContinues() const override;
+      bool shouldProcessLumi() const override;
+      bool shouldProcessRun() const override;
       LuminosityBlockNumber_t peekAheadAtLumi() const override;
       EntryNumber_t peekAheadAtEventEntry() const override;
       bool skipLumiInRun() override;
       bool lumiEntryValid(int index) const override;
+      int indexedSize() const override { return indexedSize_; }
 
     private:
+      // Note the argument to the function runOrLumisEntry is NOT a
+      // direct index into the vector in IndexIntoFile! It returns a
+      // reference to an object from that vector. However, the argument
+      // to runOrLumisEntry is an index into fileOrderRunOrLumiEntry_
+      // which reorders the elements so the iteration is in event TTree
+      // entry order. It also adds in dummy entries to insert
+      // the extra run and lumi transitions required for that ordering.
+
       RunOrLumiEntry const& runOrLumisEntry(EntryNumber_t iEntry) const {
         return indexIntoFile()->runOrLumiEntries()[fileOrderRunOrLumiEntry_[iEntry]];
       }
+      bool shouldProcessRunOrLumi(EntryNumber_t iEntry) const { return shouldProcessRunOrLumi_[iEntry]; }
+      bool shouldProcessEvents(EntryNumber_t iEntry) const { return shouldProcessEvents_[iEntry]; }
       void initializeLumi_() override;
       bool nextEventRange() override;
       bool previousEventRange() override;
@@ -715,7 +782,74 @@ namespace edm {
       bool isSameLumi(int index1, int index2) const override;
       bool isSameRun(int index1, int index2) const override;
       LuminosityBlockNumber_t lumi(int index) const override;
+
+      struct TTreeEntryAndIndex {
+        IndexIntoFile::EntryNumber_t ttreeEntry_;
+        int runOrLumiIndex_;
+      };
+
+      struct EntryOrderInitializationInfo {
+        // Contains information only needed in the constructor of IndexIntoFileItrEntryOrder
+        std::vector<int> firstIndexOfRun_;
+        std::vector<int> firstIndexOfLumi_;
+        std::vector<int> startOfLastContiguousEventsInRun_;
+        std::vector<int> startOfLastContiguousEventsInLumi_;
+
+        // Will contain indexes of lumi entries with events and will be
+        // sorted by first Event TTree entry number.
+        std::vector<TTreeEntryAndIndex> indexesSortedByEventEntry_;
+        std::vector<TTreeEntryAndIndex>::const_iterator iEventSequence_;
+        std::vector<TTreeEntryAndIndex>::const_iterator iEventSequenceEnd_;
+        int eventSequenceIndex_ = 0;
+        RunOrLumiEntry const* eventSequenceRunOrLumiEntry_ = nullptr;
+
+        void nextEventSequence(std::vector<RunOrLumiEntry> const& runOrLumiEntries) {
+          ++iEventSequence_;
+          if (iEventSequence_ < iEventSequenceEnd_) {
+            eventSequenceIndex_ = iEventSequence_->runOrLumiIndex_;
+            eventSequenceRunOrLumiEntry_ = &runOrLumiEntries[eventSequenceIndex_];
+          }
+        }
+
+        // Holds the index to the first entry associated with each run with no events
+        // Sorted by the first run TTree entry number
+        std::vector<TTreeEntryAndIndex> runsWithNoEvents_;
+        std::vector<TTreeEntryAndIndex>::const_iterator nextRunWithNoEvents_;
+        std::vector<TTreeEntryAndIndex>::const_iterator endRunsWithNoEvents_;
+      };
+
+      void addRunsWithNoEvents(EntryOrderInitializationInfo&, EntryNumber_t maxRunTTreeEntry = invalidEntry);
+      void resizeVectors(EntryOrderInitializationInfo&);
+      void gatherNeededInfo(EntryOrderInitializationInfo&);
+      void fillIndexesSortedByEventEntry(EntryOrderInitializationInfo&);
+      void fillIndexesToLastContiguousEvents(EntryOrderInitializationInfo&);
+      void fillLumisWithNoRemainingEvents(std::vector<TTreeEntryAndIndex>& lumisWithNoRemainingEvents,
+                                          int startingIndex,
+                                          EntryNumber_t currentRun,
+                                          RunOrLumiEntry const* eventSequenceRunOrLumiEntry);
+      void addToFileOrder(int index, bool processRunOrLumi, bool processEvents);
+      void handleToEndOfContiguousEventsInRun(EntryOrderInitializationInfo& info, EntryNumber_t currentRun);
+      void handleToEndOfContiguousEventsInLumis(EntryOrderInitializationInfo& info,
+                                                EntryNumber_t currentRun,
+                                                int endOfRunEntries);
+      void setToLowestInLumi(EntryNumber_t& lumiTTreeEntryNumber, EntryOrderInitializationInfo& info, int currentLumi);
+      void handleLumisWithNoEvents(std::vector<TTreeEntryAndIndex>::const_iterator& nextLumiWithNoEvents,
+                                   std::vector<TTreeEntryAndIndex>::const_iterator& endLumisWithNoEvents,
+                                   EntryNumber_t lumiTTreeEntryNumber,
+                                   bool completeAll = false);
+      void handleLumiWithEvents(EntryOrderInitializationInfo& info,
+                                int currentLumi,
+                                EntryNumber_t firstBeginEventsContiguousLumi);
+      void handleLumiEntriesNoRemainingEvents(EntryOrderInitializationInfo& info,
+                                              int& iLumiIndex,
+                                              int currentLumi,
+                                              EntryNumber_t firstBeginEventsContiguousLumi,
+                                              bool completeAll = false);
+
+      int indexedSize_ = 0;
       std::vector<EntryNumber_t> fileOrderRunOrLumiEntry_;
+      std::vector<bool> shouldProcessRunOrLumi_;
+      std::vector<bool> shouldProcessEvents_;
     };
 
     //*****************************************************************************
@@ -745,7 +879,9 @@ namespace edm {
       RunNumber_t run() const { return impl_->run(); }
       LuminosityBlockNumber_t lumi() const { return impl_->lumi(); }
       EntryNumber_t entry() const { return impl_->entry(); }
-      bool entryContinues() const { return impl_->entryContinues(); }
+      bool shouldProcessLumi() const { return impl_->shouldProcessLumi(); }
+      bool shouldProcessRun() const { return impl_->shouldProcessRun(); }
+      bool lumiEntryValid(int index) const { return impl_->lumiEntryValid(index); }
 
       /// Same as lumi() except when the the current type is kRun.
       /// In that case instead of always returning 0 (invalid), it will return the lumi that will be processed next
@@ -839,6 +975,7 @@ namespace edm {
     private:
       //for testing
       friend class ::TestIndexIntoFile;
+      friend class ::TestIndexIntoFile2;
       friend class ::TestIndexIntoFile3;
       friend class ::TestIndexIntoFile4;
       friend class ::TestIndexIntoFile5;
@@ -847,6 +984,7 @@ namespace edm {
       // this class.
       IndexIntoFile const* indexIntoFile() const { return impl_->indexIntoFile(); }
       int size() const { return impl_->size(); }
+      int indexedSize() const { return impl_->indexedSize(); }
       EntryType type() const { return impl_->type(); }
       int indexToRun() const { return impl_->indexToRun(); }
       int indexToLumi() const { return impl_->indexToLumi(); }
@@ -968,6 +1106,9 @@ namespace edm {
     /// because it makes some corrections before sorting.  A std::stable_sort
     /// works in cases where those corrections are not needed.
     void sortVector_Run_Or_Lumi_Entries();
+
+    /// Run this check just after sorting
+    void checkForMissingRunOrLumiEntry() const;
 
     //used internally by addEntry
     void addLumi(int index, RunNumber_t run, LuminosityBlockNumber_t lumi, EntryNumber_t entry);

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -619,7 +619,7 @@ namespace edm {
       EntryNumber_t firstEventEntryThisRun();
       EntryNumber_t firstEventEntryThisLumi();
       virtual bool skipLumiInRun() = 0;
-      virtual bool lumiEntryValid(int index) const = 0;
+      virtual bool lumiIterationStartingIndex(int index) const = 0;
 
       void advanceToNextRun();
       void advanceToNextLumiOrRun();
@@ -710,7 +710,7 @@ namespace edm {
       LuminosityBlockNumber_t peekAheadAtLumi() const override;
       EntryNumber_t peekAheadAtEventEntry() const override;
       bool skipLumiInRun() override;
-      bool lumiEntryValid(int index) const override;
+      bool lumiIterationStartingIndex(int index) const override;
 
     private:
       void initializeLumi_() override;
@@ -746,7 +746,7 @@ namespace edm {
       LuminosityBlockNumber_t peekAheadAtLumi() const override;
       EntryNumber_t peekAheadAtEventEntry() const override;
       bool skipLumiInRun() override;
-      bool lumiEntryValid(int index) const override;
+      bool lumiIterationStartingIndex(int index) const override;
 
     private:
       void initializeLumi_() override;
@@ -782,7 +782,7 @@ namespace edm {
       LuminosityBlockNumber_t peekAheadAtLumi() const override;
       EntryNumber_t peekAheadAtEventEntry() const override;
       bool skipLumiInRun() override;
-      bool lumiEntryValid(int index) const override;
+      bool lumiIterationStartingIndex(int index) const override;
       int indexedSize() const override { return indexedSize_; }
 
     private:
@@ -909,7 +909,7 @@ namespace edm {
       EntryNumber_t entry() const { return impl_->entry(); }
       bool shouldProcessLumi() const { return impl_->shouldProcessLumi(); }
       bool shouldProcessRun() const { return impl_->shouldProcessRun(); }
-      bool lumiEntryValid(int index) const { return impl_->lumiEntryValid(index); }
+      bool lumiIterationStartingIndex(int index) const { return impl_->lumiIterationStartingIndex(index); }
 
       /// Same as lumi() except when the the current type is kRun.
       /// In that case instead of always returning 0 (invalid), it will return the lumi that will be processed next

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -625,6 +625,7 @@ namespace edm {
       bool operator==(IndexIntoFileItrImpl const& right) const;
 
       IndexIntoFile const* indexIntoFile() const { return indexIntoFile_; }
+
       int size() const { return size_; }
       virtual int indexedSize() const { return size(); }
 
@@ -689,8 +690,8 @@ namespace edm {
       RunNumber_t run() const override;
       LuminosityBlockNumber_t lumi() const override;
       EntryNumber_t entry() const override;
-      bool shouldProcessLumi() const override { return true; }
-      bool shouldProcessRun() const override { return true; }
+      bool shouldProcessLumi() const final { return true; }
+      bool shouldProcessRun() const final { return true; }
       LuminosityBlockNumber_t peekAheadAtLumi() const override;
       EntryNumber_t peekAheadAtEventEntry() const override;
       bool skipLumiInRun() override;
@@ -725,8 +726,8 @@ namespace edm {
       RunNumber_t run() const override;
       LuminosityBlockNumber_t lumi() const override;
       EntryNumber_t entry() const override;
-      bool shouldProcessLumi() const override { return true; }
-      bool shouldProcessRun() const override { return true; }
+      bool shouldProcessLumi() const final { return true; }
+      bool shouldProcessRun() const final { return true; }
       LuminosityBlockNumber_t peekAheadAtLumi() const override;
       EntryNumber_t peekAheadAtEventEntry() const override;
       bool skipLumiInRun() override;
@@ -761,8 +762,8 @@ namespace edm {
       RunNumber_t run() const override;
       LuminosityBlockNumber_t lumi() const override;
       EntryNumber_t entry() const override;
-      bool shouldProcessLumi() const override;
-      bool shouldProcessRun() const override;
+      bool shouldProcessLumi() const final;
+      bool shouldProcessRun() const final;
       LuminosityBlockNumber_t peekAheadAtLumi() const override;
       EntryNumber_t peekAheadAtEventEntry() const override;
       bool skipLumiInRun() override;

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -807,7 +807,13 @@ namespace edm {
         int runOrLumiIndex_;
       };
 
-      struct EntryOrderInitializationInfo {
+      class EntryOrderInitializationInfo {
+      public:
+        void resizeVectors(std::vector<RunOrLumiEntry> const&);
+        void gatherNeededInfo(std::vector<RunOrLumiEntry> const&);
+        void fillIndexesSortedByEventEntry(std::vector<RunOrLumiEntry> const&);
+        void fillIndexesToLastContiguousEvents(std::vector<RunOrLumiEntry> const&);
+
         // Contains information only needed in the constructor of IndexIntoFileItrEntryOrder
         std::vector<int> firstIndexOfRun_;
         std::vector<int> firstIndexOfLumi_;
@@ -838,20 +844,17 @@ namespace edm {
       };
 
       void addRunsWithNoEvents(EntryOrderInitializationInfo&, EntryNumber_t maxRunTTreeEntry = invalidEntry);
-      void resizeVectors(EntryOrderInitializationInfo&);
-      void gatherNeededInfo(EntryOrderInitializationInfo&);
-      void fillIndexesSortedByEventEntry(EntryOrderInitializationInfo&);
-      void fillIndexesToLastContiguousEvents(EntryOrderInitializationInfo&);
       void fillLumisWithNoRemainingEvents(std::vector<TTreeEntryAndIndex>& lumisWithNoRemainingEvents,
                                           int startingIndex,
                                           EntryNumber_t currentRun,
-                                          RunOrLumiEntry const* eventSequenceRunOrLumiEntry);
+                                          RunOrLumiEntry const* eventSequenceRunOrLumiEntry) const;
+      void reserveSpaceInVectors(std::vector<EntryNumber_t>::size_type);
       void addToFileOrder(int index, bool processRunOrLumi, bool processEvents);
       void handleToEndOfContiguousEventsInRun(EntryOrderInitializationInfo& info, EntryNumber_t currentRun);
       void handleToEndOfContiguousEventsInLumis(EntryOrderInitializationInfo& info,
                                                 EntryNumber_t currentRun,
                                                 int endOfRunEntries);
-      void setToLowestInLumi(EntryNumber_t& lumiTTreeEntryNumber, EntryOrderInitializationInfo& info, int currentLumi);
+      EntryNumber_t lowestInLumi(EntryOrderInitializationInfo& info, int currentLumi) const;
       void handleLumisWithNoEvents(std::vector<TTreeEntryAndIndex>::const_iterator& nextLumiWithNoEvents,
                                    std::vector<TTreeEntryAndIndex>::const_iterator& endLumisWithNoEvents,
                                    EntryNumber_t lumiTTreeEntryNumber,

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -276,9 +276,15 @@ namespace edm {
     /// This enum is used to specify the order of iteration.
     /// In firstAppearanceOrder there are 3 sort criteria, in order of precedence these are:
     ///
-    ///   1. firstAppearance of the ProcessHistoryID and run number in the output module
+    ///   1. firstAppearance of the ProcessHistoryID and run number in the Events TTree of
+    ///   the file (in cases where there are no Events in a run it depends on the order
+    ///   of the call to writeRun or writeLumi in the preceding step where the IndexIntoFile
+    ///   was created)
     ///
-    ///   2. firstAppearance of the ProcessHistoryID, run number and lumi number in the output module
+    ///   2. firstAppearance of the ProcessHistoryID, run number and lumi number in the Events
+    ///   TTree of the file (in cases where there are no Events in a lumi it depends on the
+    ///   order of the call to writeRun or writeLumi in the preceding step where the IndexIntoFile
+    ///   was created)
     ///
     ///   3. entry number
     ///

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -636,7 +636,7 @@ namespace edm {
       // a larger container and indexedSize() is overridden to give the size of
       // that container.
       int size() const { return size_; }
-      virtual int indexedSize() const { return size(); }
+      virtual int indexedSize() const;
 
       EntryType type() const { return type_; }
       int indexToRun() const { return indexToRun_; }

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -97,49 +97,42 @@ namespace edm {
     }
     previousAddedIndex() = index;
 
-    assert((currentRun() == run && currentIndex() == index) || currentRun() == invalidRun);
-    if (lumi == invalidLumi) {
-      if (currentLumi() != invalidLumi) {
-        throw Exception(errors::LogicError)
-            << "In IndexIntoFile::addEntry. Entries were added in illegal order.\n"
-            << "This means the IndexIntoFile product in the output file will be corrupted.\n"
-            << "The output file will be unusable for most purposes.\n"
-            << "If this occurs after an unrelated exception was thrown in\n"
-            << "endLuminosityBlock or endRun then ignore this exception and fix\n"
-            << "the primary exception. This is an expected side effect.\n"
-            << "Otherwise please report this to the core framework developers\n";
-      }
-      currentIndex() = invalidIndex;
-      currentRun() = invalidRun;
-      currentLumi() = invalidLumi;
-      // assign each run an order value when first seen (using entry but any increasing value would work)
-      std::pair<IndexRunKey, EntryNumber_t> keyAndOrder(IndexRunKey(index, run), entry);
-      runToOrder().insert(keyAndOrder);  // Does nothing if this key was already inserted
+    if (lumi == invalidLumi) {  // adding a run entry
+      std::pair<IndexRunKey, EntryNumber_t> keyAndOrder(IndexRunKey(index, run), runToOrder().size());
+      runToOrder().insert(keyAndOrder);  // does nothing if this key already was inserted
       runOrLumiEntries_.emplace_back(
           runToOrder()[IndexRunKey(index, run)], invalidEntry, entry, index, run, lumi, invalidEntry, invalidEntry);
     } else {
-      if (currentRun() == invalidRun) {
-        currentRun() = run;
-        currentIndex() = index;
-      }
-      if (event == invalidEvent) {
-        if (currentLumi() != lumi and currentLumi() != invalidLumi) {
+      if (event == invalidEvent) {  // adding a lumi entry
+        if ((currentIndex() != index or currentRun() != run or currentLumi() != lumi) and
+            currentLumi() != invalidLumi) {
           //we have overlapping lumis so must inject a placeholder
-          addLumi(index, run, currentLumi(), invalidEntry);
+          addLumi(currentIndex(), currentRun(), currentLumi(), invalidEntry);
         }
-        currentLumi() = invalidLumi;
         addLumi(index, run, lumi, entry);
-      } else {
-        if (currentLumi() != lumi and currentLumi() != invalidLumi) {
+        currentIndex() = invalidIndex;
+        currentRun() = invalidRun;
+        currentLumi() = invalidLumi;
+        std::pair<IndexRunKey, EntryNumber_t> keyAndOrder(IndexRunKey(index, run), runToOrder().size());
+        runToOrder().insert(keyAndOrder);  // does nothing if this key already was inserted
+      } else {                             // adding an event entry
+        if ((currentIndex() != index or currentRun() != run or currentLumi() != lumi) and
+            currentLumi() != invalidLumi) {
           //We have overlapping lumis so need to inject a placeholder
-          addLumi(index, run, currentLumi(), invalidEntry);
+          addLumi(currentIndex(), currentRun(), currentLumi(), invalidEntry);
         }
         setNumberOfEvents(numberOfEvents() + 1);
         if (beginEvents() == invalidEntry) {
+          currentRun() = run;
+          currentIndex() = index;
           currentLumi() = lumi;
           beginEvents() = entry;
           endEvents() = beginEvents() + 1;
+          std::pair<IndexRunKey, EntryNumber_t> keyAndOrder(IndexRunKey(index, run), runToOrder().size());
+          runToOrder().insert(keyAndOrder);  // does nothing if this key already was inserted
         } else {
+          assert(currentIndex() == index);
+          assert(currentRun() == run);
           assert(currentLumi() == lumi);
           assert(entry == endEvents());
           ++endEvents();
@@ -406,6 +399,53 @@ namespace edm {
       item.setOrderPHIDRun(keyAndOrder->second);
     }
     stable_sort_all(runOrLumiEntries_);
+    checkForMissingRunOrLumiEntry();
+  }
+
+  void IndexIntoFile::checkForMissingRunOrLumiEntry() const {
+    bool shouldThrow = false;
+    bool foundValidLumiEntry = true;
+    EntryNumber_t currentRun = invalidEntry;
+    EntryNumber_t currentLumi = invalidEntry;
+    EntryNumber_t previousLumi = invalidEntry;
+
+    for (RunOrLumiEntry const& item : runOrLumiEntries_) {
+      if (item.isRun()) {
+        currentRun = item.orderPHIDRun();
+      } else {  // Lumi
+        if (item.orderPHIDRun() != currentRun) {
+          throw Exception(errors::LogicError)
+              << "In IndexIntoFile::sortVector_Run_Or_Lumi_Entries. Missing Run entry.\n"
+              << "If this occurs after an unrelated exception occurs, please ignore this\n"
+              << "exception and fix the primary exception. This is a possible and expected\n"
+              << "side effect. Otherwise, please report to Framework developers.\n"
+              << "This could indicate a bug in the source or Framework\n";
+        }
+        currentLumi = item.orderPHIDRunLumi();
+        if (currentLumi != previousLumi) {
+          if (!foundValidLumiEntry) {
+            shouldThrow = true;
+          }
+          foundValidLumiEntry = false;
+          previousLumi = currentLumi;
+        }
+        if (item.entry() != invalidEntry) {
+          foundValidLumiEntry = true;
+        }
+      }
+    }
+    if (!foundValidLumiEntry) {
+      shouldThrow = true;
+    }
+
+    if (shouldThrow) {
+      throw Exception(errors::LogicError)
+          << "In IndexIntoFile::sortVector_Run_Or_Lumi_Entries. Missing valid Lumi entry.\n"
+          << "If this occurs after an unrelated exception occurs, please ignore this\n"
+          << "exception and fix the primary exception. This is a possible and expected\n"
+          << "side effect. Otherwise, please report to Framework developers.\n"
+          << "This could indicate a bug in the source or Framework\n";
+    }
   }
 
   void IndexIntoFile::sortEvents() const {
@@ -969,7 +1009,7 @@ namespace edm {
         }
       }
     } else if (type_ == kLumi) {
-      if (indexToLumi_ + 1 == size_) {
+      if (indexToLumi_ + 1 == indexedSize()) {
         if (indexToEvent_ < nEvents_) {
           type_ = kEvent;
         } else {
@@ -1102,7 +1142,7 @@ namespace edm {
     // Find the correct place to start the search
     int newLumi = indexToLumi();
     if (newLumi == invalidIndex) {
-      newLumi = indexToRun() == invalidIndex ? size() - 1 : indexToRun();
+      newLumi = indexToRun() == invalidIndex ? indexedSize() - 1 : indexToRun();
     } else {
       while (getRunOrLumiEntryType(newLumi - 1) == kLumi && isSameLumi(newLumi, newLumi - 1)) {
         --newLumi;
@@ -1125,10 +1165,16 @@ namespace edm {
       return false;
 
     // Finish initializing the iterator
-    while (getRunOrLumiEntryType(newLumi - 1) == kLumi && isSameLumi(newLumi, newLumi - 1) &&
-           lumiEntryValid(newLumi - 1)) {
+    // Go back to the first lumi entry for this lumi
+    while (getRunOrLumiEntryType(newLumi - 1) == kLumi && isSameLumi(newLumi, newLumi - 1)) {
       --newLumi;
     }
+    // Then go forward to the first valid one (or if there are not any valid ones
+    // to the last one, only possible in the entryOrder case)
+    while (not lumiEntryValid(newLumi)) {
+      ++newLumi;
+    }
+
     setIndexToLumi(newLumi);
 
     if (type() != kEnd && isSameRun(newLumi, indexToRun())) {
@@ -1213,7 +1259,7 @@ namespace edm {
   void IndexIntoFile::IndexIntoFileItrImpl::advanceToNextRun() {
     if (type_ == kEnd)
       return;
-    for (int i = 1; indexToRun_ + i < size_; ++i) {
+    for (int i = 1; indexToRun_ + i < indexedSize(); ++i) {
       if (getRunOrLumiEntryType(indexToRun_ + i) == kRun) {
         if (!isSameRun(indexToRun_, indexToRun_ + i)) {
           type_ = kRun;
@@ -1235,7 +1281,7 @@ namespace edm {
     // this run (actually this step is not needed in the
     // context I expect this to be called in, just being careful)
     int startSearch = indexToRun_;
-    for (int i = 1; startSearch + i < size_; ++i) {
+    for (int i = 1; startSearch + i < indexedSize(); ++i) {
       if (getRunOrLumiEntryType(startSearch + i) == kRun && isSameRun(indexToRun_, startSearch + i)) {
         indexToRun_ = startSearch + i;
       } else {
@@ -1251,7 +1297,7 @@ namespace edm {
     startSearch = indexToLumi_;
     if (startSearch == invalidIndex)
       startSearch = indexToRun_;
-    for (int i = 1; startSearch + i < size_; ++i) {
+    for (int i = 1; startSearch + i < indexedSize(); ++i) {
       if (getRunOrLumiEntryType(startSearch + i) == kRun) {
         if (!isSameRun(indexToRun_, startSearch + i)) {
           type_ = kRun;
@@ -1287,9 +1333,9 @@ namespace edm {
     indexToEvent_ = 0;
     nEvents_ = 0;
 
-    for (int i = 1; (i + indexToRun_) < size_; ++i) {
-      EntryType entryType = getRunOrLumiEntryType(indexToRun_ + i);
-      bool sameRun = isSameRun(indexToRun_, indexToRun_ + i);
+    for (int i = indexToRun_ + 1, iEnd = indexedSize(); i < iEnd; ++i) {
+      EntryType entryType = getRunOrLumiEntryType(i);
+      bool sameRun = isSameRun(indexToRun_, i);
 
       if (entryType == kRun) {
         if (sameRun) {
@@ -1298,7 +1344,7 @@ namespace edm {
           break;
         }
       } else {
-        indexToLumi_ = indexToRun_ + i;
+        indexToLumi_ = i;
         initializeLumi();
         return;
       }
@@ -1307,9 +1353,11 @@ namespace edm {
 
   void IndexIntoFile::IndexIntoFileItrImpl::initializeLumi() {
     initializeLumi_();
-    //See if entry number is invalid, this can happen if events from
-    // different lumis overlap when doing concurrent lumi processing
     auto oldLumi = lumi();
+    // Go forward to the first valid lumi entry for this lumi
+    // A lumi entry can be invalid if events from different lumis
+    // overlap when doing concurrent lumi processing and also
+    // when processing lumis with non-contiguous events in EntryOrder.
     while (not lumiEntryValid(indexToLumi_)) {
       ++indexToLumi_;
     }
@@ -1333,6 +1381,7 @@ namespace edm {
   }
 
   void IndexIntoFile::IndexIntoFileItrImpl::getLumisInRun(std::vector<LuminosityBlockNumber_t>& lumis) const {
+    assert(shouldProcessRun());
     lumis.clear();
 
     if (type_ == kEnd)
@@ -1340,7 +1389,7 @@ namespace edm {
 
     LuminosityBlockNumber_t previousLumi = invalidLumi;
 
-    for (int i = 1; (i + indexToRun_) < size_; ++i) {
+    for (int i = 1; (i + indexToRun_) < indexedSize(); ++i) {
       int index = i + indexToRun_;
       EntryType entryType = getRunOrLumiEntryType(index);
 
@@ -1725,8 +1774,9 @@ namespace edm {
     return indexIntoFile()->runOrLumiIndexes()[index].lumi();
   }
 
-  //*************************************
-  IndexIntoFile::IndexIntoFileItrEntryOrder::IndexIntoFileItrEntryOrder(IndexIntoFile const* indexIntoFile,
+  // *************************************
+
+  IndexIntoFile::IndexIntoFileItrEntryOrder::IndexIntoFileItrEntryOrder(IndexIntoFile const* iIndexIntoFile,
                                                                         EntryType entryType,
                                                                         int indexToRun,
                                                                         int indexToLumi,
@@ -1734,55 +1784,37 @@ namespace edm {
                                                                         long long indexToEvent,
                                                                         long long nEvents)
       : IndexIntoFileItrImpl(
-            indexIntoFile, entryType, indexToRun, indexToLumi, indexToEventRange, indexToEvent, nEvents) {
-    auto const& runOrLumiEntries = this->indexIntoFile()->runOrLumiEntries();
-    fileOrderRunOrLumiEntry_.reserve(runOrLumiEntries.size());
-    auto const itBegin = runOrLumiEntries.begin();
-    auto itPresentEntryToRunOrLumis = runOrLumiEntries.begin();
-    auto itRestartSearchAt = runOrLumiEntries.begin();
-    EntryNumber_t endOfContiguousEventEntry = 0;
-    std::vector<bool> usedEntry(runOrLumiEntries.size(), false);
-    auto findFirstOpen = [](auto const& entries) {
-      return std::find(entries.begin(), entries.end(), false) - entries.begin();
-    };
-    while (fileOrderRunOrLumiEntry_.size() != runOrLumiEntries.size()) {
-      assert(itRestartSearchAt != runOrLumiEntries.end());
-      assert(itPresentEntryToRunOrLumis != runOrLumiEntries.end());
+            iIndexIntoFile, entryType, indexToRun, indexToLumi, indexToEventRange, indexToEvent, nEvents) {
+    EntryOrderInitializationInfo info;
+    resizeVectors(info);
 
-      auto const index = itPresentEntryToRunOrLumis - itBegin;
-      if (usedEntry[index]) {
-        ++itPresentEntryToRunOrLumis;
-        continue;
-      }
-      assert(static_cast<std::size_t>(index) < runOrLumiEntries.size());
-      if (itPresentEntryToRunOrLumis->isRun()) {
-        //take Run as it is
-        fileOrderRunOrLumiEntry_.push_back(index);
-        usedEntry[index] = true;
-        itRestartSearchAt = runOrLumiEntries.begin() + findFirstOpen(usedEntry);
-        itPresentEntryToRunOrLumis = itRestartSearchAt;
-        continue;
-      }
-      auto const beginEvents = itPresentEntryToRunOrLumis->beginEvents();
-      if (beginEvents == invalidEntry) {
-        //this is an empty lumi. We want to preserve the order w.r.t previous entries
-        if (std::find(usedEntry.begin(), usedEntry.begin() + index, false) == usedEntry.begin() + index) {
-          fileOrderRunOrLumiEntry_.push_back(index);
-          usedEntry[index] = true;
-          itRestartSearchAt = runOrLumiEntries.begin() + findFirstOpen(usedEntry);
-          itPresentEntryToRunOrLumis = itRestartSearchAt;
-          continue;
-        }
-      } else if (beginEvents == endOfContiguousEventEntry) {
-        fileOrderRunOrLumiEntry_.push_back(index);
-        usedEntry[index] = true;
-        endOfContiguousEventEntry = itPresentEntryToRunOrLumis->endEvents();
-        itRestartSearchAt = runOrLumiEntries.begin() + findFirstOpen(usedEntry);
-        itPresentEntryToRunOrLumis = itRestartSearchAt;
-        continue;
-      }
-      ++itPresentEntryToRunOrLumis;
+    // fill firstIndexOfLumi, firstIndexOfRun, runsWithNoEvents
+    gatherNeededInfo(info);
+
+    fillIndexesSortedByEventEntry(info);
+    fillIndexesToLastContiguousEvents(info);
+
+    EntryNumber_t currentRun = invalidEntry;
+
+    for (info.iEventSequence_ = info.indexesSortedByEventEntry_.cbegin(),
+        info.iEventSequenceEnd_ = info.indexesSortedByEventEntry_.cend();
+         info.iEventSequence_ < info.iEventSequenceEnd_;) {
+      info.eventSequenceIndex_ = info.iEventSequence_->runOrLumiIndex_;
+      info.eventSequenceRunOrLumiEntry_ = &indexIntoFile()->runOrLumiEntries()[info.eventSequenceIndex_];
+
+      assert(info.eventSequenceRunOrLumiEntry_->orderPHIDRun() != currentRun);
+      currentRun = info.eventSequenceRunOrLumiEntry_->orderPHIDRun();
+
+      // Handles the set of events contiguous in the Events TTree from
+      // a single run and all the entries (Run or Lumi) associated with
+      // those events and possibly some runs with no events that precede
+      // the run in the runs TTree.
+      handleToEndOfContiguousEventsInRun(info, currentRun);
     }
+    // This takes care of only Runs with no Events at the end of
+    // the Runs TTree that were not already added.
+    addRunsWithNoEvents(info);
+    indexedSize_ = fileOrderRunOrLumiEntry_.size();
   }
 
   IndexIntoFile::IndexIntoFileItrImpl* IndexIntoFile::IndexIntoFileItrEntryOrder::clone() const {
@@ -1815,32 +1847,40 @@ namespace edm {
     if (type() == kLumi) {
       auto entry = runOrLumisEntry(indexToLumi()).entry();
       if (entry == invalidEntry) {
-        if (indexToLumi() + 1 < size()) {
-          if (runOrLumisEntry(indexToLumi()).lumi() != runOrLumisEntry(indexToLumi() + 1).lumi()) {
-            //find the end of this lumi
-            auto const& runLumiEntry = runOrLumisEntry(indexToLumi());
-            for (auto nextIndex = indexToLumi() + 1; nextIndex < size(); ++nextIndex) {
-              auto const& nextRunLumiEntry = runOrLumisEntry(nextIndex);
-              if (runLumiEntry.lumi() == nextRunLumiEntry.lumi() and runLumiEntry.run() == nextRunLumiEntry.run() and
-                  runLumiEntry.processHistoryIDIndex() == nextRunLumiEntry.processHistoryIDIndex()) {
-                auto nextEntry = nextRunLumiEntry.entry();
-                if (nextEntry != invalidEntry) {
-                  return nextEntry;
-                }
-              }
-            }
-            return continuedLumi;
+        auto const& runLumiEntry = runOrLumisEntry(indexToLumi());
+        for (int index = indexToLumi() + 1; index < indexedSize_; ++index) {
+          auto const& laterRunOrLumiEntry = runOrLumisEntry(index);
+          if (runLumiEntry.lumi() == laterRunOrLumiEntry.lumi() and runLumiEntry.run() == laterRunOrLumiEntry.run() and
+              runLumiEntry.processHistoryIDIndex() == laterRunOrLumiEntry.processHistoryIDIndex() &&
+              laterRunOrLumiEntry.entry() != invalidEntry) {
+            return laterRunOrLumiEntry.entry();
           }
         }
+        // We should always find one and never get here!
+        throw Exception(errors::LogicError) << "In IndexIntoFile::IndexIntoFileItrEntryOrder::entry. Could not\n"
+                                            << "find valid TTree entry number for lumi. This means the IndexIntoFile\n"
+                                            << "product in the output file will be corrupted.\n"
+                                            << "The output file will be unusable for most purposes.\n"
+                                            << "If this occurs after an unrelated exception was thrown,\n"
+                                            << "then ignore this exception and fix the primary exception.\n"
+                                            << "This is an expected side effect.\n"
+                                            << "Otherwise, please report this to the core framework developers\n";
       }
       return entry;
     }
     return runOrLumisEntry(indexToEventRange()).beginEvents() + indexToEvent();
   }
 
-  bool IndexIntoFile::IndexIntoFileItrEntryOrder::entryContinues() const {
-    auto entry = runOrLumisEntry(indexToLumi()).entry();
-    return entry == invalidEntry;
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::shouldProcessLumi() const {
+    assert(type() == kLumi);
+    assert(indexToLumi() != invalidIndex);
+    return shouldProcessRunOrLumi_[indexToLumi()];
+  }
+
+  bool IndexIntoFile::IndexIntoFileItrEntryOrder::shouldProcessRun() const {
+    assert(type() == kRun);
+    assert(indexToRun() != invalidIndex);
+    return shouldProcessRunOrLumi_[indexToRun()];
   }
 
   LuminosityBlockNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::peekAheadAtLumi() const {
@@ -1864,14 +1904,14 @@ namespace edm {
     setIndexToEvent(0);
     setNEvents(0);
 
-    for (int i = 0; indexToLumi() + i < size(); ++i) {
-      if (runOrLumisEntry(indexToLumi() + i).isRun()) {
+    for (int index = indexToLumi(); index < indexedSize_; ++index) {
+      if (runOrLumisEntry(index).isRun()) {
         break;
-      } else if (runOrLumisEntry(indexToLumi() + i).lumi() == runOrLumisEntry(indexToLumi()).lumi()) {
-        if (runOrLumisEntry(indexToLumi() + i).beginEvents() == invalidEntry) {
+      } else if (runOrLumisEntry(index).lumi() == runOrLumisEntry(indexToLumi()).lumi()) {
+        if (runOrLumisEntry(index).beginEvents() == invalidEntry || !shouldProcessEvents(index)) {
           continue;
         }
-        setIndexToEventRange(indexToLumi() + i);
+        setIndexToEventRange(index);
         setIndexToEvent(0);
         setNEvents(runOrLumisEntry(indexToEventRange()).endEvents() -
                    runOrLumisEntry(indexToEventRange()).beginEvents());
@@ -1887,14 +1927,14 @@ namespace edm {
       return false;
 
     // Look for the next event range, same lumi but different entry
-    for (int i = 1; indexToEventRange() + i < size(); ++i) {
-      if (runOrLumisEntry(indexToEventRange() + i).isRun()) {
+    for (int index = indexToEventRange() + 1; index < indexedSize_; ++index) {
+      if (runOrLumisEntry(index).isRun()) {
         return false;  // hit next run
-      } else if (runOrLumisEntry(indexToEventRange() + i).lumi() == runOrLumisEntry(indexToEventRange()).lumi()) {
-        if (runOrLumisEntry(indexToEventRange() + i).beginEvents() == invalidEntry) {
+      } else if (runOrLumisEntry(index).lumi() == runOrLumisEntry(indexToEventRange()).lumi()) {
+        if (runOrLumisEntry(index).beginEvents() == invalidEntry || !shouldProcessEvents(index)) {
           continue;  // same lumi but has no events, keep looking
         }
-        setIndexToEventRange(indexToEventRange() + i);
+        setIndexToEventRange(index);
         setIndexToEvent(0);
         setNEvents(runOrLumisEntry(indexToEventRange()).endEvents() -
                    runOrLumisEntry(indexToEventRange()).beginEvents());
@@ -1908,15 +1948,14 @@ namespace edm {
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::previousEventRange() {
     if (indexToEventRange() == invalidIndex)
       return false;
-    assert(indexToEventRange() < size());
+    assert(indexToEventRange() < indexedSize_);
 
     // Look backward for a previous event range with events, same lumi but different entry
-    for (int i = 1; indexToEventRange() - i > 0; ++i) {
-      int newRange = indexToEventRange() - i;
+    for (int newRange = indexToEventRange() - 1; newRange > 0; --newRange) {
       if (runOrLumisEntry(newRange).isRun()) {
         return false;  // hit run
       } else if (isSameLumi(newRange, indexToEventRange())) {
-        if (runOrLumisEntry(newRange).beginEvents() == invalidEntry) {
+        if (runOrLumisEntry(newRange).beginEvents() == invalidEntry || !shouldProcessEvents(newRange)) {
           continue;  // same lumi but has no events, keep looking
         }
         setIndexToEventRange(newRange);
@@ -1931,7 +1970,7 @@ namespace edm {
   }
 
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::setToLastEventInRange(int index) {
-    if (runOrLumisEntry(index).beginEvents() == invalidEntry) {
+    if (runOrLumisEntry(index).beginEvents() == invalidEntry || !shouldProcessEvents(index)) {
       return false;
     }
     setIndexToEventRange(index);
@@ -1944,7 +1983,7 @@ namespace edm {
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::skipLumiInRun() {
     if (indexToLumi() == invalidIndex)
       return false;
-    for (int i = 1; indexToLumi() + i < size(); ++i) {
+    for (int i = 1; indexToLumi() + i < indexedSize_; ++i) {
       int newLumi = indexToLumi() + i;
       if (runOrLumisEntry(newLumi).isRun()) {
         return false;  // hit next run
@@ -1959,19 +1998,30 @@ namespace edm {
   }
 
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::lumiEntryValid(int index) const {
+    assert(index >= 0 && index < indexedSize_);
     auto entry = runOrLumisEntry(index).entry();
     if (entry == invalidEntry) {
-      if (index + 1 < size()) {
+      // Practically, this function serves its intended purpose, but the behavior is
+      // inconsistent with the name. When we try to initialize indexToLumi_ in
+      // initializeLumi and hit the last lumi without finding any valid ones this
+      // function calls the last one valid even if its entry is invalid.
+      // This is because something needs to be processed for the lumi.
+      // In this case, shouldWeProcessRunOrLumi will return false to let
+      // the code using IndexIntoFile know to not actually try to process
+      // the lumi.
+      if (index + 1 < indexedSize_) {
         if (runOrLumisEntry(index).lumi() != runOrLumisEntry(index + 1).lumi()) {
           return true;
         }
+      } else if (index + 1 == indexedSize_) {
+        return true;
       }
     }
     return entry != invalidEntry;
   }
 
   IndexIntoFile::EntryType IndexIntoFile::IndexIntoFileItrEntryOrder::getRunOrLumiEntryType(int index) const {
-    if (index < 0 || index >= size()) {
+    if (index < 0 || index >= indexedSize_) {
       return kEnd;
     } else if (runOrLumisEntry(index).isRun()) {
       return kRun;
@@ -1980,14 +2030,14 @@ namespace edm {
   }
 
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::isSameLumi(int index1, int index2) const {
-    if (index1 < 0 || index1 >= size() || index2 < 0 || index2 >= size()) {
+    if (index1 < 0 || index1 >= indexedSize_ || index2 < 0 || index2 >= indexedSize_) {
       return false;
     }
     return runOrLumisEntry(index1).lumi() == runOrLumisEntry(index2).lumi();
   }
 
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::isSameRun(int index1, int index2) const {
-    if (index1 < 0 || index1 >= size() || index2 < 0 || index2 >= size()) {
+    if (index1 < 0 || index1 >= indexedSize_ || index2 < 0 || index2 >= indexedSize_) {
       return false;
     }
     return runOrLumisEntry(index1).run() == runOrLumisEntry(index2).run() &&
@@ -1995,10 +2045,391 @@ namespace edm {
   }
 
   LuminosityBlockNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::lumi(int index) const {
-    if (index < 0 || index >= size()) {
+    if (index < 0 || index >= indexedSize_) {
       return invalidLumi;
     }
     return runOrLumisEntry(index).lumi();
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::addRunsWithNoEvents(EntryOrderInitializationInfo& info,
+                                                                      EntryNumber_t maxRunTTreeEntry) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+
+    for (auto& nextRunWithNoEvents = info.nextRunWithNoEvents_;
+         nextRunWithNoEvents != info.endRunsWithNoEvents_ &&
+         (maxRunTTreeEntry == invalidEntry || nextRunWithNoEvents->ttreeEntry_ < maxRunTTreeEntry);
+         ++nextRunWithNoEvents) {
+      int index = nextRunWithNoEvents->runOrLumiIndex_;
+      EntryNumber_t runToAdd = runOrLumiEntries[index].orderPHIDRun();
+      for (int iEnd = static_cast<int>(runOrLumiEntries.size());
+           index < iEnd && runOrLumiEntries[index].orderPHIDRun() == runToAdd;
+           ++index) {
+        // This will add in Run entries and the entries of Lumis in those Runs
+        addToFileOrder(index, true, false);
+      }
+    }
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::resizeVectors(EntryOrderInitializationInfo& info) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+
+    // The value in orderPHIDRun_ is unique to each run and corresponds
+    // to a unique pair of values of run number and ProcessHistoryID.
+    // It's incremented by one each time a new run is added to the
+    // IndexIntoFile so that makes it convenient and efficient for
+    // indexing elements in a vector with an element per run.
+    // It is also convenient to use when comparing two runs
+    // to see if they are the same run.
+    // Analogous things are true for orderPHIDRunLumi_ except
+    // that the lumi number is also used and it identifies lumis
+    // instead of runs in IndexIntoFile.
+
+    EntryNumber_t maxOrderPHIDRun = invalidEntry;
+    EntryNumber_t maxOrderPHIDRunLumi = invalidEntry;
+    unsigned int nSize = 0;
+
+    for (auto const& runOrLumiEntry : runOrLumiEntries) {
+      assert(runOrLumiEntry.orderPHIDRun() >= 0);
+      if (runOrLumiEntry.orderPHIDRun() > maxOrderPHIDRun) {
+        maxOrderPHIDRun = runOrLumiEntry.orderPHIDRun();
+      }
+      if (!runOrLumiEntry.isRun()) {
+        assert(runOrLumiEntry.orderPHIDRunLumi() >= 0);
+        if (runOrLumiEntry.orderPHIDRunLumi() > maxOrderPHIDRunLumi) {
+          maxOrderPHIDRunLumi = runOrLumiEntry.orderPHIDRunLumi();
+        }
+      }
+      if (runOrLumiEntry.beginEvents() != invalidEntry) {
+        // Count entries with events
+        ++nSize;
+      }
+    }
+    info.firstIndexOfRun_.resize(maxOrderPHIDRun + 1, invalidIndex);
+    info.firstIndexOfLumi_.resize(maxOrderPHIDRunLumi + 1, invalidIndex);
+    info.startOfLastContiguousEventsInRun_.resize(maxOrderPHIDRun + 1, invalidIndex);
+    info.startOfLastContiguousEventsInLumi_.resize(maxOrderPHIDRunLumi + 1, invalidIndex);
+    info.indexesSortedByEventEntry_.reserve(nSize);
+
+    // Reserve some space. Most likely this is not big enough, but better than reserving nothing.
+    fileOrderRunOrLumiEntry_.reserve(runOrLumiEntries.size());
+    shouldProcessRunOrLumi_.reserve(runOrLumiEntries.size());
+    shouldProcessEvents_.reserve(runOrLumiEntries.size());
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::gatherNeededInfo(EntryOrderInitializationInfo& info) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+    int iEnd = static_cast<int>(runOrLumiEntries.size());
+
+    EntryNumber_t previousLumi = invalidEntry;
+    EntryNumber_t previousRun = invalidEntry;
+    int index = 0;
+
+    for (auto const& runOrLumiEntry : runOrLumiEntries) {
+      // If first entry for a lumi
+      if (!runOrLumiEntry.isRun() && runOrLumiEntry.orderPHIDRunLumi() != previousLumi) {
+        previousLumi = runOrLumiEntry.orderPHIDRunLumi();
+
+        // Fill map holding the first index into runOrLumiEntries for each lum
+        info.firstIndexOfLumi_[runOrLumiEntry.orderPHIDRunLumi()] = index;
+      }
+
+      // If first entry for a run
+      if (runOrLumiEntry.orderPHIDRun() != previousRun) {
+        previousRun = runOrLumiEntry.orderPHIDRun();
+
+        // Fill map holding the first index into runOrLumiEntries for each run
+        info.firstIndexOfRun_[runOrLumiEntry.orderPHIDRun()] = index;
+
+        // Look ahead to see if the run has events or not
+        bool runHasEvents = false;
+        for (int indexWithinRun = index + 1;
+             indexWithinRun < iEnd && runOrLumiEntries[indexWithinRun].orderPHIDRun() == runOrLumiEntry.orderPHIDRun();
+             ++indexWithinRun) {
+          if (runOrLumiEntries[indexWithinRun].beginEvents() != invalidEntry) {
+            runHasEvents = true;
+            break;
+          }
+        }
+        if (!runHasEvents) {
+          info.runsWithNoEvents_.push_back({runOrLumiEntry.entry(), index});
+        }
+      }
+      ++index;
+    }
+
+    std::sort(info.runsWithNoEvents_.begin(),
+              info.runsWithNoEvents_.end(),
+              [](TTreeEntryAndIndex const& left, TTreeEntryAndIndex const& right) -> bool {
+                return left.ttreeEntry_ < right.ttreeEntry_;
+              });
+
+    info.nextRunWithNoEvents_ = info.runsWithNoEvents_.cbegin();
+    info.endRunsWithNoEvents_ = info.runsWithNoEvents_.cend();
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::fillIndexesSortedByEventEntry(EntryOrderInitializationInfo& info) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+
+    int index = 0;
+    for (auto const& runOrLumiEntry : runOrLumiEntries) {
+      if (runOrLumiEntry.beginEvents() != invalidEntry) {
+        info.indexesSortedByEventEntry_.push_back({runOrLumiEntry.beginEvents(), index});
+      }
+      ++index;
+    }
+
+    std::sort(info.indexesSortedByEventEntry_.begin(),
+              info.indexesSortedByEventEntry_.end(),
+              [](TTreeEntryAndIndex const& left, TTreeEntryAndIndex const& right) -> bool {
+                return left.ttreeEntry_ < right.ttreeEntry_;
+              });
+
+    // The next "for loop" is just a sanity check, it should always pass.
+    int previousIndex = invalidIndex;
+    for (auto const& eventSequence : info.indexesSortedByEventEntry_) {
+      int currentIndex = eventSequence.runOrLumiIndex_;
+      if (previousIndex != invalidIndex) {
+        assert(runOrLumiEntries[previousIndex].endEvents() == runOrLumiEntries[currentIndex].beginEvents());
+      }
+      previousIndex = currentIndex;
+    }
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::fillIndexesToLastContiguousEvents(EntryOrderInitializationInfo& info) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+    EntryNumber_t previousRun = invalidEntry;
+    EntryNumber_t previousLumi = invalidEntry;
+    for (auto const& iter : info.indexesSortedByEventEntry_) {
+      auto currentRun = runOrLumiEntries[iter.runOrLumiIndex_].orderPHIDRun();
+      if (currentRun != previousRun) {
+        info.startOfLastContiguousEventsInRun_[currentRun] = iter.runOrLumiIndex_;
+        previousRun = currentRun;
+      }
+      auto currentLumi = runOrLumiEntries[iter.runOrLumiIndex_].orderPHIDRunLumi();
+      if (currentLumi != previousLumi) {
+        info.startOfLastContiguousEventsInLumi_[currentLumi] = iter.runOrLumiIndex_;
+        previousLumi = currentLumi;
+      }
+    }
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::fillLumisWithNoRemainingEvents(
+      std::vector<TTreeEntryAndIndex>& lumisWithNoRemainingEvents,
+      int startingIndex,
+      EntryNumber_t currentRun,
+      RunOrLumiEntry const* eventSequenceRunOrLumiEntry) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+    int iEnd = static_cast<int>(runOrLumiEntries.size());
+
+    // start at the first entry after the Run entries
+    // iterate over all the lumi entries in this Run
+    // The outer loop iterates over lumis and inner loop iterates over entries in each lumi
+    for (int indexOfLumiEntry = startingIndex;
+         indexOfLumiEntry < iEnd && runOrLumiEntries[indexOfLumiEntry].orderPHIDRun() == currentRun;) {
+      auto currentLumiIndex = indexOfLumiEntry;
+      auto const& currentLumiEntry = runOrLumiEntries[currentLumiIndex];
+      assert(!currentLumiEntry.isRun());
+      auto currentLumi = currentLumiEntry.orderPHIDRunLumi();
+
+      bool foundUnprocessedEvents = false;
+      EntryNumber_t minLumiTTreeEntry = invalidEntry;
+      // iterate over the lumi entries associated with a single lumi
+      for (; indexOfLumiEntry < iEnd && runOrLumiEntries[indexOfLumiEntry].orderPHIDRunLumi() == currentLumi;
+           ++indexOfLumiEntry) {
+        if (runOrLumiEntries[indexOfLumiEntry].beginEvents() >= eventSequenceRunOrLumiEntry->beginEvents()) {
+          foundUnprocessedEvents = true;
+        }
+        // Find the smallest valid Lumi TTree entry for this lumi
+        auto lumiTTreeEntry = runOrLumiEntries[indexOfLumiEntry].entry();
+        if (lumiTTreeEntry != invalidEntry &&
+            (minLumiTTreeEntry == invalidEntry || lumiTTreeEntry < minLumiTTreeEntry)) {
+          minLumiTTreeEntry = lumiTTreeEntry;
+        }
+      }
+      // No event sequences left to process and at least one valid lumi TTree entry.
+      if (!foundUnprocessedEvents && minLumiTTreeEntry != invalidEntry) {
+        lumisWithNoRemainingEvents.push_back({minLumiTTreeEntry, currentLumiIndex});
+      }
+    }
+
+    std::sort(lumisWithNoRemainingEvents.begin(),
+              lumisWithNoRemainingEvents.end(),
+              [](TTreeEntryAndIndex const& left, TTreeEntryAndIndex const& right) -> bool {
+                return left.ttreeEntry_ < right.ttreeEntry_;
+              });
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::addToFileOrder(int index, bool processRunOrLumi, bool processEvents) {
+    fileOrderRunOrLumiEntry_.push_back(index);
+    shouldProcessRunOrLumi_.push_back(processRunOrLumi);
+    shouldProcessEvents_.push_back(processEvents);
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::handleToEndOfContiguousEventsInRun(EntryOrderInitializationInfo& info,
+                                                                                     EntryNumber_t currentRun) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+    int iEnd = static_cast<int>(runOrLumiEntries.size());
+
+    int indexOfRunEntry = info.firstIndexOfRun_[currentRun];
+
+    // Event entries are put in the exact same order as in the Events TTree.
+    // We make some effort to make the Runs and Lumis come out in Run TTree
+    // order and Lumi TTree order, but that is often not possible.
+
+    // If it is the last contiguous sequence of events for the Run, also
+    // add ALL entries corresponding to valid Run or Lumi TTree entries for
+    // this Run. This is the place where the Run and Lumi products will get
+    // processed and merged, ALL of them for this run whether or not they have
+    // events in this particular subsequence of events. This forces all the Run
+    // and Lumi product merging to occur the first time a file is read.
+    if (info.startOfLastContiguousEventsInRun_[currentRun] == info.eventSequenceIndex_) {
+      // Add runs with no events that have an earlier Run TTree entry number
+      addRunsWithNoEvents(info, runOrLumiEntries[indexOfRunEntry].entry());
+
+      // Add all valid run entries associated with the event sequence
+      for (; indexOfRunEntry < iEnd && runOrLumiEntries[indexOfRunEntry].isRun(); ++indexOfRunEntry) {
+        assert(runOrLumiEntries[indexOfRunEntry].orderPHIDRun() == currentRun);
+        addToFileOrder(indexOfRunEntry, true, false);
+      }
+
+      // Add all lumi entries associated with this run
+      handleToEndOfContiguousEventsInLumis(info, currentRun, indexOfRunEntry);
+
+    } else {
+      // Add only the first run entry and flag it to be not processed yet.
+      addToFileOrder(indexOfRunEntry, false, false);
+
+      // Add the minimum number of lumi entries so that the events they reference
+      // will be processed in the correct order, lumis are not to be processed.
+      // The lumis will be added again later to be processed.
+      while (info.iEventSequence_ != info.iEventSequenceEnd_ &&
+             info.eventSequenceRunOrLumiEntry_->orderPHIDRun() == currentRun) {
+        addToFileOrder(info.eventSequenceIndex_, false, true);
+        info.nextEventSequence(runOrLumiEntries);
+      }
+    }
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::handleToEndOfContiguousEventsInLumis(
+      EntryOrderInitializationInfo& info, EntryNumber_t currentRun, int endOfRunEntries) {
+    // Form a list of lumis that have no more events left to be processed and are in the current
+    // run and have at least one valid Lumi TTree entry. Contains the index to the first
+    // lumi entry and its TTree entry number, sorted by earliest lumi TTree entry number.
+    std::vector<TTreeEntryAndIndex> lumisWithNoRemainingEvents;
+    fillLumisWithNoRemainingEvents(
+        lumisWithNoRemainingEvents, endOfRunEntries, currentRun, info.eventSequenceRunOrLumiEntry_);
+    auto nextLumiWithNoEvents = lumisWithNoRemainingEvents.cbegin();
+    auto endLumisWithNoEvents = lumisWithNoRemainingEvents.cend();
+
+    // On each step of this iteration we process all the events in a contiguous sequence of events
+    // from a single lumi (these are events that haven't already been processed and are contained
+    // within the last contiguous sequence of events from the containing run).
+    while (info.iEventSequence_ < info.iEventSequenceEnd_ &&
+           info.eventSequenceRunOrLumiEntry_->orderPHIDRun() == currentRun) {
+      auto currentLumi = info.eventSequenceRunOrLumiEntry_->orderPHIDRunLumi();
+
+      // Last contiguous sequence of events in lumi
+      if (info.startOfLastContiguousEventsInLumi_[currentLumi] == info.eventSequenceIndex_) {
+        auto firstBeginEventsContiguousLumi = info.eventSequenceRunOrLumiEntry_->beginEvents();
+        // Find the first Lumi TTree entry number for this Lumi
+        EntryNumber_t lumiTTreeEntryNumber = invalidEntry;
+        setToLowestInLumi(lumiTTreeEntryNumber, info, currentLumi);
+
+        // In addition, we want lumis before this in the lumi tree if they have no events
+        // left to be processed
+        handleLumisWithNoEvents(nextLumiWithNoEvents, endLumisWithNoEvents, lumiTTreeEntryNumber);
+
+        // Handle the lumi with the next sequence of events to process
+        handleLumiWithEvents(info, currentLumi, firstBeginEventsContiguousLumi);
+
+      } else {
+        // not last contiguous event sequence for lumi
+        while (info.iEventSequence_ < info.iEventSequenceEnd_ &&
+               info.eventSequenceRunOrLumiEntry_->orderPHIDRunLumi() == currentLumi) {
+          addToFileOrder(info.eventSequenceIndex_, false, true);
+          info.nextEventSequence(indexIntoFile()->runOrLumiEntries());
+        }
+      }
+    }
+    handleLumisWithNoEvents(nextLumiWithNoEvents, endLumisWithNoEvents, invalidEntry, true);
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::setToLowestInLumi(EntryNumber_t& lumiTTreeEntryNumber,
+                                                                    EntryOrderInitializationInfo& info,
+                                                                    int currentLumi) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+    int iEnd = static_cast<int>(runOrLumiEntries.size());
+
+    for (int iLumiIndex = info.firstIndexOfLumi_[currentLumi];
+         iLumiIndex < iEnd && runOrLumiEntries[iLumiIndex].orderPHIDRunLumi() == currentLumi;
+         ++iLumiIndex) {
+      lumiTTreeEntryNumber = runOrLumiEntries[iLumiIndex].entry();
+      if (lumiTTreeEntryNumber != invalidEntry) {
+        // First valid one is the lowest because of the sort order of the container
+        break;
+      }
+    }
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::handleLumisWithNoEvents(
+      std::vector<TTreeEntryAndIndex>::const_iterator& nextLumiWithNoEvents,
+      std::vector<TTreeEntryAndIndex>::const_iterator& endLumisWithNoEvents,
+      EntryNumber_t lumiTTreeEntryNumber,
+      bool completeAll) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+    int iEnd = static_cast<int>(runOrLumiEntries.size());
+
+    for (; nextLumiWithNoEvents < endLumisWithNoEvents &&
+           (completeAll || nextLumiWithNoEvents->ttreeEntry_ < lumiTTreeEntryNumber);
+         ++nextLumiWithNoEvents) {
+      int iLumiIndex = nextLumiWithNoEvents->runOrLumiIndex_;
+      auto orderPHIDRunLumi = runOrLumiEntries[iLumiIndex].orderPHIDRunLumi();
+      for (; iLumiIndex < iEnd && runOrLumiEntries[iLumiIndex].orderPHIDRunLumi() == orderPHIDRunLumi; ++iLumiIndex) {
+        if (runOrLumiEntries[iLumiIndex].entry() != invalidEntry) {
+          addToFileOrder(iLumiIndex, true, false);
+        }
+      }
+    }
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::handleLumiWithEvents(EntryOrderInitializationInfo& info,
+                                                                       int currentLumi,
+                                                                       EntryNumber_t firstBeginEventsContiguousLumi) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+    int iLumiIndex = info.firstIndexOfLumi_[currentLumi];
+    while (info.iEventSequence_ < info.iEventSequenceEnd_ &&
+           info.eventSequenceRunOrLumiEntry_->orderPHIDRunLumi() == currentLumi) {
+      // lumi entries for the currentLumi with no remaining Events to process and
+      // with Lumi TTree entry numbers less than the Lumi TTree entry for the next
+      // sequence of Events.
+      handleLumiEntriesNoRemainingEvents(info, iLumiIndex, currentLumi, firstBeginEventsContiguousLumi);
+
+      // Add entry with the next event sequence
+      bool shouldProcessLumi = runOrLumiEntries[info.eventSequenceIndex_].entry() != invalidEntry;
+      addToFileOrder(info.eventSequenceIndex_, shouldProcessLumi, true);
+      info.nextEventSequence(runOrLumiEntries);
+    }
+    handleLumiEntriesNoRemainingEvents(info, iLumiIndex, currentLumi, firstBeginEventsContiguousLumi, true);
+  }
+
+  void IndexIntoFile::IndexIntoFileItrEntryOrder::handleLumiEntriesNoRemainingEvents(
+      EntryOrderInitializationInfo& info,
+      int& iLumiIndex,
+      int currentLumi,
+      EntryNumber_t firstBeginEventsContiguousLumi,
+      bool completeAll) {
+    auto const& runOrLumiEntries = indexIntoFile()->runOrLumiEntries();
+    int iEnd = static_cast<int>(runOrLumiEntries.size());
+
+    for (; iLumiIndex < iEnd && runOrLumiEntries[iLumiIndex].orderPHIDRunLumi() == currentLumi &&
+           (completeAll || runOrLumiEntries[iLumiIndex].entry() < info.eventSequenceRunOrLumiEntry_->entry());
+         ++iLumiIndex) {
+      if (runOrLumiEntries[iLumiIndex].entry() == invalidEntry ||
+          runOrLumiEntries[iLumiIndex].beginEvents() >= firstBeginEventsContiguousLumi) {
+        continue;
+      }
+      addToFileOrder(iLumiIndex, true, false);
+    }
   }
 
   //*************************************

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -58,10 +58,10 @@ namespace edm {
 
   void IndexIntoFile::addLumi(int index, RunNumber_t run, LuminosityBlockNumber_t lumi, EntryNumber_t entry) {
     // assign each lumi an order value sequentially when first seen
-    std::pair<IndexRunLumiKey, EntryNumber_t> keyAndOrder(IndexRunLumiKey(index, run, lumi), lumiToOrder().size());
+    std::pair<IndexRunLumiKey, EntryNumber_t> keyAndOrder{IndexRunLumiKey{index, run, lumi}, lumiToOrder().size()};
     lumiToOrder().insert(keyAndOrder);  // does nothing if this key already was inserted
     runOrLumiEntries_.emplace_back(invalidEntry,
-                                   lumiToOrder()[IndexRunLumiKey(index, run, lumi)],
+                                   lumiToOrder()[IndexRunLumiKey{index, run, lumi}],
                                    entry,
                                    index,
                                    run,
@@ -98,10 +98,10 @@ namespace edm {
     previousAddedIndex() = index;
 
     if (lumi == invalidLumi) {  // adding a run entry
-      std::pair<IndexRunKey, EntryNumber_t> keyAndOrder(IndexRunKey(index, run), runToOrder().size());
+      std::pair<IndexRunKey, EntryNumber_t> keyAndOrder{IndexRunKey{index, run}, runToOrder().size()};
       runToOrder().insert(keyAndOrder);  // does nothing if this key already was inserted
       runOrLumiEntries_.emplace_back(
-          runToOrder()[IndexRunKey(index, run)], invalidEntry, entry, index, run, lumi, invalidEntry, invalidEntry);
+          runToOrder()[IndexRunKey{index, run}], invalidEntry, entry, index, run, lumi, invalidEntry, invalidEntry);
     } else {
       if (event == invalidEvent) {  // adding a lumi entry
         if ((currentIndex() != index or currentRun() != run or currentLumi() != lumi) and
@@ -113,7 +113,7 @@ namespace edm {
         currentIndex() = invalidIndex;
         currentRun() = invalidRun;
         currentLumi() = invalidLumi;
-        std::pair<IndexRunKey, EntryNumber_t> keyAndOrder(IndexRunKey(index, run), runToOrder().size());
+        std::pair<IndexRunKey, EntryNumber_t> keyAndOrder{IndexRunKey{index, run}, runToOrder().size()};
         runToOrder().insert(keyAndOrder);  // does nothing if this key already was inserted
       } else {                             // adding an event entry
         if ((currentIndex() != index or currentRun() != run or currentLumi() != lumi) and
@@ -128,7 +128,7 @@ namespace edm {
           currentLumi() = lumi;
           beginEvents() = entry;
           endEvents() = beginEvents() + 1;
-          std::pair<IndexRunKey, EntryNumber_t> keyAndOrder(IndexRunKey(index, run), runToOrder().size());
+          std::pair<IndexRunKey, EntryNumber_t> keyAndOrder{IndexRunKey{index, run}, runToOrder().size()};
           runToOrder().insert(keyAndOrder);  // does nothing if this key already was inserted
         } else {
           assert(currentIndex() == index);

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -409,6 +409,7 @@ namespace edm {
     EntryNumber_t currentLumi = invalidEntry;
     EntryNumber_t previousLumi = invalidEntry;
 
+    RunOrLumiEntry const* lastEntry = nullptr;
     for (RunOrLumiEntry const& item : runOrLumiEntries_) {
       if (item.isRun()) {
         currentRun = item.orderPHIDRun();
@@ -419,12 +420,14 @@ namespace edm {
               << "If this occurs after an unrelated exception occurs, please ignore this\n"
               << "exception and fix the primary exception. This is a possible and expected\n"
               << "side effect. Otherwise, please report to Framework developers.\n"
-              << "This could indicate a bug in the source or Framework\n";
+              << "This could indicate a bug in the source or Framework\n"
+              << "Run: " << item.run() << " Lumi: " << item.lumi() << " Entry: " << item.entry() << "\n";
         }
         currentLumi = item.orderPHIDRunLumi();
         if (currentLumi != previousLumi) {
           if (!foundValidLumiEntry) {
             shouldThrow = true;
+            break;
           }
           foundValidLumiEntry = false;
           previousLumi = currentLumi;
@@ -433,6 +436,7 @@ namespace edm {
           foundValidLumiEntry = true;
         }
       }
+      lastEntry = &item;
     }
     if (!foundValidLumiEntry) {
       shouldThrow = true;
@@ -444,7 +448,8 @@ namespace edm {
           << "If this occurs after an unrelated exception occurs, please ignore this\n"
           << "exception and fix the primary exception. This is a possible and expected\n"
           << "side effect. Otherwise, please report to Framework developers.\n"
-          << "This could indicate a bug in the source or Framework\n";
+          << "This could indicate a bug in the source or Framework\n"
+          << "Run: " << lastEntry->run() << " Lumi: " << lastEntry->lumi() << " Entry: " << lastEntry->entry() << "\n";
     }
   }
 

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -1376,6 +1376,8 @@ namespace edm {
             nEvents_ == right.nEvents_);
   }
 
+  int IndexIntoFile::IndexIntoFileItrImpl::indexedSize() const { return size(); }
+
   void IndexIntoFile::IndexIntoFileItrImpl::copyPosition(IndexIntoFileItrImpl const& position) {
     type_ = position.type_;
     indexToRun_ = position.indexToRun_;
@@ -1853,7 +1855,7 @@ namespace edm {
       auto entry = runOrLumisEntry(indexToLumi()).entry();
       if (entry == invalidEntry) {
         auto const& runLumiEntry = runOrLumisEntry(indexToLumi());
-        for (int index = indexToLumi() + 1; index < indexedSize_; ++index) {
+        for (int index = indexToLumi() + 1; index < indexedSize(); ++index) {
           auto const& laterRunOrLumiEntry = runOrLumisEntry(index);
           if (runLumiEntry.lumi() == laterRunOrLumiEntry.lumi() and runLumiEntry.run() == laterRunOrLumiEntry.run() and
               runLumiEntry.processHistoryIDIndex() == laterRunOrLumiEntry.processHistoryIDIndex() &&
@@ -1909,7 +1911,7 @@ namespace edm {
     setIndexToEvent(0);
     setNEvents(0);
 
-    for (int index = indexToLumi(); index < indexedSize_; ++index) {
+    for (int index = indexToLumi(); index < indexedSize(); ++index) {
       if (runOrLumisEntry(index).isRun()) {
         break;
       } else if (runOrLumisEntry(index).lumi() == runOrLumisEntry(indexToLumi()).lumi()) {
@@ -1932,7 +1934,7 @@ namespace edm {
       return false;
 
     // Look for the next event range, same lumi but different entry
-    for (int index = indexToEventRange() + 1; index < indexedSize_; ++index) {
+    for (int index = indexToEventRange() + 1; index < indexedSize(); ++index) {
       if (runOrLumisEntry(index).isRun()) {
         return false;  // hit next run
       } else if (runOrLumisEntry(index).lumi() == runOrLumisEntry(indexToEventRange()).lumi()) {
@@ -1953,7 +1955,7 @@ namespace edm {
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::previousEventRange() {
     if (indexToEventRange() == invalidIndex)
       return false;
-    assert(indexToEventRange() < indexedSize_);
+    assert(indexToEventRange() < indexedSize());
 
     // Look backward for a previous event range with events, same lumi but different entry
     for (int newRange = indexToEventRange() - 1; newRange > 0; --newRange) {
@@ -1988,7 +1990,7 @@ namespace edm {
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::skipLumiInRun() {
     if (indexToLumi() == invalidIndex)
       return false;
-    for (int i = 1; indexToLumi() + i < indexedSize_; ++i) {
+    for (int i = 1; indexToLumi() + i < indexedSize(); ++i) {
       int newLumi = indexToLumi() + i;
       if (runOrLumisEntry(newLumi).isRun()) {
         return false;  // hit next run
@@ -2003,7 +2005,7 @@ namespace edm {
   }
 
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::lumiEntryValid(int index) const {
-    assert(index >= 0 && index < indexedSize_);
+    assert(index >= 0 && index < indexedSize());
     auto entry = runOrLumisEntry(index).entry();
     if (entry == invalidEntry) {
       // Practically, this function serves its intended purpose, but the behavior is
@@ -2014,11 +2016,11 @@ namespace edm {
       // In this case, shouldWeProcessRunOrLumi will return false to let
       // the code using IndexIntoFile know to not actually try to process
       // the lumi.
-      if (index + 1 < indexedSize_) {
+      if (index + 1 < indexedSize()) {
         if (runOrLumisEntry(index).lumi() != runOrLumisEntry(index + 1).lumi()) {
           return true;
         }
-      } else if (index + 1 == indexedSize_) {
+      } else if (index + 1 == indexedSize()) {
         return true;
       }
     }
@@ -2026,7 +2028,7 @@ namespace edm {
   }
 
   IndexIntoFile::EntryType IndexIntoFile::IndexIntoFileItrEntryOrder::getRunOrLumiEntryType(int index) const {
-    if (index < 0 || index >= indexedSize_) {
+    if (index < 0 || index >= indexedSize()) {
       return kEnd;
     } else if (runOrLumisEntry(index).isRun()) {
       return kRun;
@@ -2035,14 +2037,14 @@ namespace edm {
   }
 
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::isSameLumi(int index1, int index2) const {
-    if (index1 < 0 || index1 >= indexedSize_ || index2 < 0 || index2 >= indexedSize_) {
+    if (index1 < 0 || index1 >= indexedSize() || index2 < 0 || index2 >= indexedSize()) {
       return false;
     }
     return runOrLumisEntry(index1).lumi() == runOrLumisEntry(index2).lumi();
   }
 
   bool IndexIntoFile::IndexIntoFileItrEntryOrder::isSameRun(int index1, int index2) const {
-    if (index1 < 0 || index1 >= indexedSize_ || index2 < 0 || index2 >= indexedSize_) {
+    if (index1 < 0 || index1 >= indexedSize() || index2 < 0 || index2 >= indexedSize()) {
       return false;
     }
     return runOrLumisEntry(index1).run() == runOrLumisEntry(index2).run() &&
@@ -2050,7 +2052,7 @@ namespace edm {
   }
 
   LuminosityBlockNumber_t IndexIntoFile::IndexIntoFileItrEntryOrder::lumi(int index) const {
-    if (index < 0 || index >= indexedSize_) {
+    if (index < 0 || index >= indexedSize()) {
       return invalidLumi;
     }
     return runOrLumisEntry(index).lumi();

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -1804,6 +1804,12 @@ namespace edm {
 
     EntryNumber_t currentRun = invalidEntry;
 
+    // The main iterator created here (iEventSequence) is incremented
+    // in the function handleToEndOfContiguousEventsInRun and
+    // the functions it calls. The iterator is stored in "info",
+    // which also holds other information related to the iteration.
+    // The information is passed to these functions inside the "info"
+    // object.
     for (info.iEventSequence_ = info.indexesSortedByEventEntry_.cbegin(),
         info.iEventSequenceEnd_ = info.indexesSortedByEventEntry_.cend();
          info.iEventSequence_ < info.iEventSequenceEnd_;) {

--- a/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
@@ -19,6 +19,7 @@ using namespace edm;
 class TestIndexIntoFile2 : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestIndexIntoFile2);
   CPPUNIT_TEST(testAddEntryAndFixAndSort);
+  CPPUNIT_TEST(testAddEntryAndFixAndSort2);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -54,11 +55,20 @@ public:
   void tearDown() {}
 
   void testAddEntryAndFixAndSort();
+  void testAddEntryAndFixAndSort2();
 
   ProcessHistoryID nullPHID;
   ProcessHistoryID fakePHID1;
   ProcessHistoryID fakePHID2;
   ProcessHistoryID fakePHID3;
+
+  bool check(edm::IndexIntoFile::IndexIntoFileItr const& iter,
+             IndexIntoFile::EntryType type,
+             int indexToRun,
+             int indexToLumi,
+             int indexToEventRange,
+             long long indexToEvent,
+             long long nEvents);
 
   // This is a helper class for IndexIntoFile.
   class TestEventFinder : public IndexIntoFile::EventFinder {
@@ -77,6 +87,25 @@ public:
 
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(TestIndexIntoFile2);
+
+bool TestIndexIntoFile2::check(edm::IndexIntoFile::IndexIntoFileItr const& iter,
+                               IndexIntoFile::EntryType type,
+                               int indexToRun,
+                               int indexToLumi,
+                               int indexToEventRange,
+                               long long indexToEvent,
+                               long long nEvents) {
+  bool theyMatch = iter.getEntryType() == type && iter.type() == type && iter.indexToRun() == indexToRun &&
+                   iter.indexToLumi() == indexToLumi && iter.indexToEventRange() == indexToEventRange &&
+                   iter.indexToEvent() == indexToEvent && iter.nEvents() == nEvents;
+  if (!theyMatch) {
+    std::cout << "\nExpected        " << type << "  " << indexToRun << "  " << indexToLumi << "  " << indexToEventRange
+              << "  " << indexToEvent << "  " << nEvents << "\n";
+    std::cout << "Iterator values " << iter.type() << "  " << iter.indexToRun() << "  " << iter.indexToLumi() << "  "
+              << iter.indexToEventRange() << "  " << iter.indexToEvent() << "  " << iter.nEvents() << "\n";
+  }
+  return theyMatch;
+}
 
 void TestIndexIntoFile2::testAddEntryAndFixAndSort() {
   edm::IndexIntoFile indexIntoFile;
@@ -169,10 +198,10 @@ void TestIndexIntoFile2::testAddEntryAndFixAndSort() {
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[3].orderPHIDRun() == 0);
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].orderPHIDRun() == 1);
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].orderPHIDRun() == 1);
-  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].orderPHIDRun() == 3);
-  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].orderPHIDRun() == 3);
-  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].orderPHIDRun() == 3);
-  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].orderPHIDRun() == 3);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].orderPHIDRun() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].orderPHIDRun() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].orderPHIDRun() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].orderPHIDRun() == 2);
 
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
@@ -444,4 +473,375 @@ void TestIndexIntoFile2::testAddEntryAndFixAndSort() {
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiIndexes().capacity() == 0);
   CPPUNIT_ASSERT(indexIntoFile.runOrLumiIndexes().empty());
   CPPUNIT_ASSERT(indexIntoFile.transient_.eventFinder_.get() == 0);
+}
+void TestIndexIntoFile2::testAddEntryAndFixAndSort2() {
+  // Similar to the last test, but this one focuses on the ordering
+  // issues that can occur on boundaries between runs and boundaries
+  // between lumis with concurrent lumis and concurrent runs.
+  edm::IndexIntoFile indexIntoFile;
+
+  indexIntoFile.addEntry(fakePHID1, 11, 1, 0, 0);  // Lumi
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].processHistoryIDIndex() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[0] == fakePHID1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].orderPHIDRunLumi() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].entry() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].run() == 11);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].lumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].beginEvents() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[0].endEvents() == IndexIntoFile::invalidEntry);
+
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 1, 0);  // Event
+  indexIntoFile.addEntry(fakePHID2, 1, 1, 0, 1);  // Lumi
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 3);
+
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].processHistoryIDIndex() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[0] == fakePHID1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].orderPHIDRunLumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].entry() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].run() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].lumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].beginEvents() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[1].endEvents() == 1);
+
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[2].processHistoryIDIndex() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[1] == fakePHID2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[2].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[2].orderPHIDRunLumi() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[2].entry() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[2].run() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[2].lumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[2].beginEvents() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[2].endEvents() == IndexIntoFile::invalidEntry);
+
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 2, 1);  // Event
+  indexIntoFile.addEntry(fakePHID1, 2, 1, 0, 2);  // Lumi
+
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 5);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[3].processHistoryIDIndex() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[0] == fakePHID1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[3].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[3].orderPHIDRunLumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[3].entry() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[3].run() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[3].lumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[3].beginEvents() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[3].endEvents() == 2);
+
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].processHistoryIDIndex() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[0] == fakePHID1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].orderPHIDRunLumi() == 3);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].entry() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].run() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].lumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].beginEvents() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[4].endEvents() == IndexIntoFile::invalidEntry);
+
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 3, 2);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 0, 3);  // Lumi
+
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 7);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].processHistoryIDIndex() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[0] == fakePHID1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].orderPHIDRunLumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].entry() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].run() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].lumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].beginEvents() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[5].endEvents() == 3);
+
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].processHistoryIDIndex() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[0] == fakePHID1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].orderPHIDRunLumi() == 4);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].entry() == 3);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].run() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].lumi() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].beginEvents() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[6].endEvents() == IndexIntoFile::invalidEntry);
+
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 0, 4);  // Lumi
+
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 8);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].processHistoryIDIndex() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[0] == fakePHID1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].orderPHIDRunLumi() == 4);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].entry() == 4);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].run() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].lumi() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].beginEvents() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[7].endEvents() == IndexIntoFile::invalidEntry);
+
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 4, 3);  // Event
+  indexIntoFile.addEntry(fakePHID1, 3, 0, 0, 0);  // Run
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 9);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].processHistoryIDIndex() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[0] == fakePHID1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].orderPHIDRun() == 4);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].entry() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].run() == 3);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].lumi() == IndexIntoFile::invalidLumi);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].beginEvents() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[8].endEvents() == IndexIntoFile::invalidEntry);
+
+  indexIntoFile.addEntry(fakePHID2, 1, 1, 1, 4);  // Event
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 10);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].processHistoryIDIndex() == 0);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[0] == fakePHID1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].orderPHIDRunLumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].entry() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].run() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].lumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].beginEvents() == 3);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[9].endEvents() == 4);
+
+  indexIntoFile.addEntry(fakePHID2, 2, 1, 5, 5);  // Event
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 11);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[10].processHistoryIDIndex() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[1] == fakePHID2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[10].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[10].orderPHIDRunLumi() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[10].entry() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[10].run() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[10].lumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[10].beginEvents() == 4);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[10].endEvents() == 5);
+
+  indexIntoFile.addEntry(fakePHID2, 2, 2, 1, 6);  // Event
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 12);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[11].processHistoryIDIndex() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[1] == fakePHID2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[11].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[11].orderPHIDRunLumi() == 5);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[11].entry() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[11].run() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[11].lumi() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[11].beginEvents() == 5);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[11].endEvents() == 6);
+
+  indexIntoFile.addEntry(fakePHID2, 2, 2, 2, 7);  // Event
+  indexIntoFile.addEntry(fakePHID2, 2, 2, 0, 5);  // Lumi
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 13);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[12].processHistoryIDIndex() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[1] == fakePHID2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[12].orderPHIDRun() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[12].orderPHIDRunLumi() == 6);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[12].entry() == 5);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[12].run() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[12].lumi() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[12].beginEvents() == 6);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[12].endEvents() == 8);
+
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 6);  // Lumi
+  indexIntoFile.addEntry(fakePHID2, 1, 1, 0, 7);  // Lumi
+  indexIntoFile.addEntry(fakePHID2, 2, 1, 0, 8);  // Lumi
+
+  indexIntoFile.addEntry(fakePHID1, 11, 0, 0, 1);  // Run
+  indexIntoFile.addEntry(fakePHID1, 1, 0, 0, 2);   // Run
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[17].orderPHIDRun() == 1);
+  indexIntoFile.addEntry(fakePHID2, 1, 0, 0, 3);  // Run
+
+  indexIntoFile.addEntry(fakePHID2, 2, 0, 0, 4);  // Run
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries().size() == 20);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[19].processHistoryIDIndex() == 1);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs().size() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.processHistoryIDs()[1] == fakePHID2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[19].orderPHIDRun() == 5);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[19].orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[19].entry() == 4);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[19].run() == 2);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[19].lumi() == IndexIntoFile::invalidLumi);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[19].beginEvents() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(indexIntoFile.runOrLumiEntries()[19].endEvents() == IndexIntoFile::invalidEntry);
+
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 5);  // Run
+
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+
+  int index = 0;
+  for (auto const& entry : indexIntoFile.runOrLumiEntries()) {
+    if (index == 0) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 0);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
+      CPPUNIT_ASSERT(entry.entry() == 1);
+    }
+    if (index == 1) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 0);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 0);
+      CPPUNIT_ASSERT(entry.entry() == 0);
+    }
+    if (index == 2) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 1);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
+      CPPUNIT_ASSERT(entry.entry() == 2);
+    }
+    if (index == 3) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 1);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 1);
+      CPPUNIT_ASSERT(entry.entry() == IndexIntoFile::invalidEntry);
+    }
+    if (index == 4) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 1);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 1);
+      CPPUNIT_ASSERT(entry.entry() == IndexIntoFile::invalidEntry);
+    }
+    if (index == 5) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 1);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 1);
+      CPPUNIT_ASSERT(entry.entry() == IndexIntoFile::invalidEntry);
+    }
+    if (index == 6) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 1);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 1);
+      CPPUNIT_ASSERT(entry.entry() == IndexIntoFile::invalidEntry);
+    }
+    if (index == 7) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 1);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 1);
+      CPPUNIT_ASSERT(entry.entry() == 6);
+    }
+    if (index == 8) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 1);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 4);
+      CPPUNIT_ASSERT(entry.entry() == 3);
+    }
+    if (index == 9) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 1);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 4);
+      CPPUNIT_ASSERT(entry.entry() == 4);
+    }
+    if (index == 10) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 2);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
+      CPPUNIT_ASSERT(entry.entry() == 3);
+    }
+    if (index == 11) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 2);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 2);
+      CPPUNIT_ASSERT(entry.entry() == IndexIntoFile::invalidEntry);
+    }
+    if (index == 12) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 2);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 2);
+      CPPUNIT_ASSERT(entry.entry() == 1);
+    }
+    if (index == 13) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 2);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 2);
+      CPPUNIT_ASSERT(entry.entry() == 7);
+    }
+    if (index == 14) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 3);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
+      CPPUNIT_ASSERT(entry.entry() == 5);
+    }
+    if (index == 15) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 3);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 3);
+      CPPUNIT_ASSERT(entry.entry() == 2);
+    }
+    if (index == 16) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 4);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
+      CPPUNIT_ASSERT(entry.entry() == 0);
+    }
+    if (index == 17) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 5);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == IndexIntoFile::invalidEntry);
+      CPPUNIT_ASSERT(entry.entry() == 4);
+    }
+    if (index == 18) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 5);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 5);
+      CPPUNIT_ASSERT(entry.entry() == IndexIntoFile::invalidEntry);
+    }
+    if (index == 19) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 5);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 5);
+      CPPUNIT_ASSERT(entry.entry() == 8);
+    }
+    if (index == 20) {
+      CPPUNIT_ASSERT(entry.orderPHIDRun() == 5);
+      CPPUNIT_ASSERT(entry.orderPHIDRunLumi() == 6);
+      CPPUNIT_ASSERT(entry.entry() == 5);
+    }
+    ++index;
+  }
+  edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+  edm::IndexIntoFile::IndexIntoFileItr iterEntryEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+  int i = 0;
+  for (; iterEntry != iterEntryEnd; ++iterEntry, ++i) {
+    if (i == 0)  // PHID1:Run3
+      CPPUNIT_ASSERT(check(iterEntry, kRun, 0, -1, -1, 0, 0));
+    else if (i == 1)  // PHID1:Run11
+      CPPUNIT_ASSERT(check(iterEntry, kRun, 1, 2, -1, 0, 0));
+    else if (i == 2)
+      CPPUNIT_ASSERT(check(iterEntry, kLumi, 1, 2, -1, 0, 0));
+    else if (i == 3)  // PHID1:Run1
+      CPPUNIT_ASSERT(check(iterEntry, kRun, 3, 4, -1, 0, 0));
+    else if (i == 4)
+      CPPUNIT_ASSERT(check(iterEntry, kLumi, 3, 4, -1, 0, 0));
+    else if (i == 5)
+      CPPUNIT_ASSERT(check(iterEntry, kLumi, 3, 5, -1, 0, 0));
+    else if (i == 6)
+      CPPUNIT_ASSERT(check(iterEntry, kLumi, 3, 10, 6, 0, 1));
+    else if (i == 7)
+      CPPUNIT_ASSERT(check(iterEntry, kEvent, 3, 10, 6, 0, 1));
+    else if (i == 8)
+      CPPUNIT_ASSERT(check(iterEntry, kEvent, 3, 10, 7, 0, 1));
+    else if (i == 9)
+      CPPUNIT_ASSERT(check(iterEntry, kEvent, 3, 10, 8, 0, 1));
+    else if (i == 10)
+      CPPUNIT_ASSERT(check(iterEntry, kEvent, 3, 10, 9, 0, 1));
+    else if (i == 11)  // PHID2:Run1
+      CPPUNIT_ASSERT(check(iterEntry, kRun, 11, 13, 12, 0, 1));
+    else if (i == 12)
+      CPPUNIT_ASSERT(check(iterEntry, kLumi, 11, 13, 12, 0, 1));
+    else if (i == 13)
+      CPPUNIT_ASSERT(check(iterEntry, kLumi, 11, 14, 12, 0, 1));
+    else if (i == 14)
+      CPPUNIT_ASSERT(check(iterEntry, kEvent, 11, 14, 12, 0, 1));
+    else if (i == 15)  // PHID2:Run2
+      CPPUNIT_ASSERT(check(iterEntry, kRun, 15, 17, 16, 0, 1));
+    else if (i == 16)
+      CPPUNIT_ASSERT(check(iterEntry, kLumi, 15, 17, 16, 0, 1));
+    else if (i == 17)
+      CPPUNIT_ASSERT(check(iterEntry, kEvent, 15, 17, 16, 0, 1));
+    else if (i == 18)
+      CPPUNIT_ASSERT(check(iterEntry, kLumi, 15, 18, 18, 0, 2));
+    else if (i == 19)
+      CPPUNIT_ASSERT(check(iterEntry, kEvent, 15, 18, 18, 0, 2));
+    else if (i == 20)
+      CPPUNIT_ASSERT(check(iterEntry, kEvent, 15, 18, 18, 1, 2));
+    else if (i == 21)  // PHID1:Run2
+      CPPUNIT_ASSERT(check(iterEntry, kRun, 19, 20, -1, 0, 0));
+    else if (i == 22)
+      CPPUNIT_ASSERT(check(iterEntry, kLumi, 19, 20, -1, 0, 0));
+    else
+      CPPUNIT_ASSERT(false);
+
+    //CPPUNIT_ASSERT(iterEntry.firstEventEntryThisRun() == IndexIntoFile::invalidEntry);
+    //CPPUNIT_ASSERT(iterEntry.firstEventEntryThisLumi() == IndexIntoFile::invalidEntry);
+  }
+  CPPUNIT_ASSERT(i == 23);
 }

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -24,6 +24,8 @@ class TestIndexIntoFile3 : public CppUnit::TestFixture {
   CPPUNIT_TEST(testOverlappingLumisOutOfOrderEvent);
   CPPUNIT_TEST(testOverlappingLumisWithEndWithEmptyLumi);
   CPPUNIT_TEST(testOverlappingLumisWithLumiEndOrderChanged);
+  CPPUNIT_TEST(testNonContiguousRun);
+  CPPUNIT_TEST(testNonValidLumiInsideValidLumis);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -75,6 +77,8 @@ public:
   void testOverlappingLumisOutOfOrderEvent();
   void testOverlappingLumisWithEndWithEmptyLumi();
   void testOverlappingLumisWithLumiEndOrderChanged();
+  void testNonContiguousRun();
+  void testNonValidLumiInsideValidLumis();
 
   ProcessHistoryID nullPHID;
   ProcessHistoryID fakePHID1;
@@ -225,9 +229,12 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
       CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 2));
       CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
       CPPUNIT_ASSERT(iterFirst.size() == 10);
-    } else if (i == 1)
+      CPPUNIT_ASSERT(iterFirst.indexedSize() == 10);
+      CPPUNIT_ASSERT(iterFirst.shouldProcessRun());
+    } else if (i == 1) {
       CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 0, 2));
-    else if (i == 2)
+      CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
+    } else if (i == 2)
       CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 1, 0, 2));
     else if (i == 3)
       CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 1, 0, 2));
@@ -366,9 +373,12 @@ void TestIndexIntoFile3::testIterEndWithEvent() {
       CPPUNIT_ASSERT(check(iterNum, kRun, 0, 1, 1, 0, 4));
       CPPUNIT_ASSERT(iterNum.indexIntoFile() == &indexIntoFile);
       CPPUNIT_ASSERT(iterNum.size() == 10);
-    } else if (i == 1)
+      CPPUNIT_ASSERT(iterNum.indexedSize() == 10);
+      CPPUNIT_ASSERT(iterNum.shouldProcessRun());
+    } else if (i == 1) {
       CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 1, 1, 0, 4));
-    else if (i == 2)
+      CPPUNIT_ASSERT(iterNum.shouldProcessLumi());
+    } else if (i == 2)
       CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 2, 1, 0, 4));
     else if (i == 3)
       CPPUNIT_ASSERT(check(iterNum, kLumi, 0, 3, 1, 0, 4));
@@ -1488,6 +1498,16 @@ void TestIndexIntoFile3::testOverlappingLumisOutOfOrderEvent() {
   indexIntoFile.addEntry(fakePHID1, 11, 101, 7, 0);  // Event
   indexIntoFile.addEntry(fakePHID1, 11, 101, 6, 1);  // Event
   indexIntoFile.addEntry(fakePHID1, 11, 101, 5, 2);  // Event
+  // This test is a bit misnamed. The difference between this test and
+  // the preceding one lies in the event entry numbers being swapped
+  // in order. The order below is the expected order (it is NOT out of order).
+  // I don't think the order of entry numbers in the preceding test is
+  // possible, the event entry number is incremented as each event
+  // is written and addEntry is called at that time. The event entry
+  // number should always increment by one at each addEntry call for
+  // an event. Possibly the preceding test should be deleted (although
+  // IndexIntoFile works with that order also even if it will never
+  // occur ...)
   //Dummy Lumi gets added
   indexIntoFile.addEntry(fakePHID1, 11, 102, 5, 3);  // Event
   //Another dummy lumi gets added
@@ -1609,8 +1629,10 @@ void TestIndexIntoFile3::testOverlappingLumisOutOfOrderEvent() {
       switch (i) {
         case 0: {
           CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 3));  // run 11
+          CPPUNIT_ASSERT(iterFirst.processHistoryIDIndex() == 0);
           CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
           CPPUNIT_ASSERT(iterFirst.size() == 10);
+          CPPUNIT_ASSERT(iterFirst.shouldProcessRun());
 
           iterFirst.getLumisInRun(lumis);
           std::vector<LuminosityBlockNumber_t> expected{101, 102};
@@ -1622,11 +1644,13 @@ void TestIndexIntoFile3::testOverlappingLumisOutOfOrderEvent() {
         //values are 'IndexIntoFile::EntryType' 'indexToRun' 'indexToLumi' 'indexToEventRange' 'indexToEvent' 'nEvents'
         case 1: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 0, 3));  // lumi 11/101
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.processHistoryIDIndex() == 0);
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 2: {
           CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 1, 1, 0, 3));  // event 11/101/7
+          CPPUNIT_ASSERT(iterFirst.processHistoryIDIndex() == 0);
           break;
         }
         case 3: {
@@ -1639,7 +1663,7 @@ void TestIndexIntoFile3::testOverlappingLumisOutOfOrderEvent() {
         }
         case 5: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 2, 0, 1));  // lumi 11/102
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 6: {
@@ -1648,7 +1672,7 @@ void TestIndexIntoFile3::testOverlappingLumisOutOfOrderEvent() {
         }
         case 7: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 3, 0, 1));  // lumi 11/101
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 8: {
@@ -1659,15 +1683,17 @@ void TestIndexIntoFile3::testOverlappingLumisOutOfOrderEvent() {
         }
         case 9: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 1));  // lumi 11/102
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 10: {
           CPPUNIT_ASSERT(check(iterFirst, kEvent, 0, 4, 4, 0, 1));  // event 11/102/4
+          CPPUNIT_ASSERT(iterFirst.processHistoryIDIndex() == 0);
           break;
         }
         case 11: {
           CPPUNIT_ASSERT(check(iterFirst, kRun, 5, 7, -1, 0, 0));  //Run Phid 2 11
+          CPPUNIT_ASSERT(iterFirst.shouldProcessRun());
 
           iterFirst.getLumisInRun(lumis);
           std::vector<LuminosityBlockNumber_t> expected{101, 102};
@@ -1679,22 +1705,29 @@ void TestIndexIntoFile3::testOverlappingLumisOutOfOrderEvent() {
         }
         case 12: {
           CPPUNIT_ASSERT(check(iterFirst, kRun, 6, 7, -1, 0, 0));
+          CPPUNIT_ASSERT(iterFirst.processHistoryIDIndex() == 1);
+          CPPUNIT_ASSERT(iterFirst.shouldProcessRun());
           break;
         }
         case 13: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 7, -1, 0, 0));
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 14: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 8, 9, 0, 1));
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 15: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 6, 9, 9, 0, 1));
+          CPPUNIT_ASSERT(iterFirst.processHistoryIDIndex() == 1);
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 16: {
           CPPUNIT_ASSERT(check(iterFirst, kEvent, 6, 9, 9, 0, 1));
+          CPPUNIT_ASSERT(iterFirst.processHistoryIDIndex() == 1);
           break;
         }
         default:
@@ -1878,6 +1911,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
           CPPUNIT_ASSERT(iterFirst.run() == 1);
           CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
           CPPUNIT_ASSERT(iterFirst.size() == 13);
+          CPPUNIT_ASSERT(iterFirst.shouldProcessRun());
 
           iterFirst.getLumisInRun(lumis);
           std::vector<LuminosityBlockNumber_t> expected{1, 2, 3, 4};
@@ -1890,7 +1924,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         case 1: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 0, 2));  // lumi 1/1
           CPPUNIT_ASSERT(iterFirst.lumi() == 1);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 2: {
@@ -1904,7 +1938,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         case 4: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 2, 0, 2));  // lumi 1/2
           CPPUNIT_ASSERT(iterFirst.lumi() == 2);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 5: {
@@ -1917,8 +1951,8 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         }
         case 7: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 3, 0, 1));  // lumi 1/1
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           CPPUNIT_ASSERT(iterFirst.lumi() == 1);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
           break;
         }
         case 8: {
@@ -1930,7 +1964,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         case 9: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 1));  // lumi 1/2
           CPPUNIT_ASSERT(iterFirst.lumi() == 2);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 10: {
@@ -1940,7 +1974,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         case 11: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 6, 5, 0, 2));  // lumi 1/1   5
           CPPUNIT_ASSERT(iterFirst.lumi() == 1);
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 12: {
@@ -1954,7 +1988,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         case 14: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 8, 7, 0, 1));  // lumi 1/2
           CPPUNIT_ASSERT(iterFirst.lumi() == 2);
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 15: {
@@ -1969,7 +2003,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         case 17: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 9, 9, 0, 4));  // lumi 1/3
           CPPUNIT_ASSERT(iterFirst.lumi() == 3);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 18: {
@@ -1991,7 +2025,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         case 22: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 10, 10, 0, 3));  // lumi 1/4
           CPPUNIT_ASSERT(iterFirst.lumi() == 4);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 23: {
@@ -2009,7 +2043,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         case 26: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 11, 11, 0, 1));  // lumi 1/3
           CPPUNIT_ASSERT(iterFirst.lumi() == 3);
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 27: {
@@ -2019,7 +2053,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithEndWithEmptyLumi() {
         case 28: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 12, 12, 0, 2));  // lumi 1/4
           CPPUNIT_ASSERT(iterFirst.lumi() == 4);
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 29: {
@@ -2209,6 +2243,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
       switch (i) {
         case 0: {
           CPPUNIT_ASSERT(check(iterFirst, kRun, 0, 1, 1, 0, 2));  // run 1
+          CPPUNIT_ASSERT(iterFirst.shouldProcessRun());
           CPPUNIT_ASSERT(iterFirst.run() == 1);
           CPPUNIT_ASSERT(iterFirst.indexIntoFile() == &indexIntoFile);
           CPPUNIT_ASSERT(iterFirst.size() == 11);
@@ -2224,7 +2259,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 1: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 1, 1, 0, 2));  // lumi 1/1
           CPPUNIT_ASSERT(iterFirst.lumi() == 1);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 2: {
@@ -2238,7 +2273,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 4: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 2, 2, 0, 2));  // lumi 1/2
           CPPUNIT_ASSERT(iterFirst.lumi() == 2);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 5: {
@@ -2252,7 +2287,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 7: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 3, 3, 0, 1));  // lumi 1/1
           CPPUNIT_ASSERT(iterFirst.lumi() == 1);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 8: {
@@ -2264,7 +2299,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 9: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 4, 4, 0, 1));  // lumi 1/2
           CPPUNIT_ASSERT(iterFirst.lumi() == 2);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 10: {
@@ -2274,7 +2309,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 11: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 5, 5, 0, 1));  // lumi 1/1   5
           CPPUNIT_ASSERT(iterFirst.lumi() == 1);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 12: {
@@ -2284,7 +2319,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 13: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 6, 6, 0, 2));  // lumi 1/2
           CPPUNIT_ASSERT(iterFirst.lumi() == 2);
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 14: {
@@ -2299,7 +2334,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 16: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 7, 7, 0, 1));  // lumi 1/1
           CPPUNIT_ASSERT(iterFirst.lumi() == 1);
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 17: {
@@ -2309,7 +2344,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 18: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 8, 8, 0, 4));  // lumi 1/3
           CPPUNIT_ASSERT(iterFirst.lumi() == 3);
-          CPPUNIT_ASSERT(iterFirst.entryContinues());
+          CPPUNIT_ASSERT(!iterFirst.shouldProcessLumi());
           break;
         }
         case 19: {
@@ -2331,7 +2366,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 23: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 9, 9, 0, 5));  // lumi 1/4
           CPPUNIT_ASSERT(iterFirst.lumi() == 4);
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 24: {
@@ -2357,7 +2392,7 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
         case 29: {
           CPPUNIT_ASSERT(check(iterFirst, kLumi, 0, 10, 10, 0, 1));  // lumi 1/3
           CPPUNIT_ASSERT(iterFirst.lumi() == 3);
-          CPPUNIT_ASSERT(not iterFirst.entryContinues());
+          CPPUNIT_ASSERT(iterFirst.shouldProcessLumi());
           break;
         }
         case 30: {
@@ -2370,5 +2405,348 @@ void TestIndexIntoFile3::testOverlappingLumisWithLumiEndOrderChanged() {
       }
     }
     CPPUNIT_ASSERT(i == 31);
+  }
+}
+
+void TestIndexIntoFile3::testNonContiguousRun() {
+  edm::IndexIntoFile indexIntoFile;
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 1, 0);  // Event
+  indexIntoFile.addEntry(fakePHID1, 2, 1, 1, 1);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 2, 2);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 0);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 0, 0, 0);  // Run
+  indexIntoFile.addEntry(fakePHID1, 2, 1, 0, 1);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 1);  // Run
+
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 3, 3);  // Event
+  indexIntoFile.addEntry(fakePHID1, 2, 1, 2, 4);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 4, 5);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 2);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 0, 0, 2);  // Run
+  indexIntoFile.addEntry(fakePHID1, 2, 1, 0, 3);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 3);  // Run
+
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iter = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+    int i = 0;
+    for (i = 0; iter != iterEnd; ++iter, ++i) {
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iter, kRun, 0, 1, 1, 0, 1));  // run 1
+          CPPUNIT_ASSERT(iter.size() == 12);
+          CPPUNIT_ASSERT(iter.indexedSize() == 16);
+          CPPUNIT_ASSERT(!iter.shouldProcessRun());
+          CPPUNIT_ASSERT(iter.entry() == 0);
+          break;
+        }
+        case 1: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 0, 1, 1, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(!iter.shouldProcessLumi());
+          // entry has special code in it to look for other entries if the
+          // current RunOrLumiEntry has an invalid TTree entry number.
+          CPPUNIT_ASSERT(iter.entry() == 0);
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 0, 1, 1, 0, 1));  // event 1:1:1
+          CPPUNIT_ASSERT(iter.entry() == 0);
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iter, kRun, 2, 3, 3, 0, 1));  // run 2
+          CPPUNIT_ASSERT(!iter.shouldProcessRun());
+          CPPUNIT_ASSERT(iter.entry() == 1);
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 2, 3, 3, 0, 1));  // lumi 2:1
+          CPPUNIT_ASSERT(!iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 1);
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 2, 3, 3, 0, 1));  // event 2:1:1
+          CPPUNIT_ASSERT(iter.entry() == 1);
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iter, kRun, 4, 5, 5, 0, 1));  // run 1
+          CPPUNIT_ASSERT(!iter.shouldProcessRun());
+          CPPUNIT_ASSERT(iter.entry() == 0);
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 4, 5, 5, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(!iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 0);
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 4, 6, 5, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(!iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 0);
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 4, 6, 5, 0, 1));  // event 1:1:2
+          CPPUNIT_ASSERT(iter.entry() == 2);
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 4, 6, 6, 0, 1));  // event 1:1:3
+          CPPUNIT_ASSERT(iter.entry() == 3);
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iter, kRun, 7, 10, 9, 0, 1));  // run 2
+          CPPUNIT_ASSERT(iter.shouldProcessRun());
+          CPPUNIT_ASSERT(iter.entry() == 1);
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iter, kRun, 8, 10, 9, 0, 1));  // run 2
+          CPPUNIT_ASSERT(iter.shouldProcessRun());
+          CPPUNIT_ASSERT(iter.entry() == 3);
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 8, 10, 9, 0, 1));  // lumi 2:1
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 1);
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 8, 11, 9, 0, 1));  // lumi 2:1
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 3);
+          break;
+        }
+        case 15: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 8, 11, 9, 0, 1));  // event 2:1:2
+          CPPUNIT_ASSERT(iter.entry() == 4);
+          break;
+        }
+        case 16: {
+          CPPUNIT_ASSERT(check(iter, kRun, 12, 14, 15, 0, 1));  // run 1
+          CPPUNIT_ASSERT(iter.shouldProcessRun());
+          CPPUNIT_ASSERT(iter.entry() == 0);
+          break;
+        }
+        case 17: {
+          CPPUNIT_ASSERT(check(iter, kRun, 13, 14, 15, 0, 1));  // run 1
+          CPPUNIT_ASSERT(iter.shouldProcessRun());
+          CPPUNIT_ASSERT(iter.entry() == 2);
+          break;
+        }
+        case 18: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 13, 14, 15, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 0);
+          break;
+        }
+        case 19: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 13, 15, 15, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 2);
+          break;
+        }
+        case 20: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 13, 15, 15, 0, 1));  // event 1:1:4
+          CPPUNIT_ASSERT(iter.entry() == 5);
+          break;
+        }
+        default:
+          CPPUNIT_ASSERT(false);
+      }
+    }
+    CPPUNIT_ASSERT(i == 21);
+  }
+}
+
+void TestIndexIntoFile3::testNonValidLumiInsideValidLumis() {
+  edm::IndexIntoFile indexIntoFile;
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 1, 0);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 0, 0);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 2, 1);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 1);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 0, 2);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 3, 2);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 2, 0, 3);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 4, 3);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 4);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 2, 1, 1, 4);  // Event
+  indexIntoFile.addEntry(fakePHID1, 2, 1, 0, 5);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 0);  // Run
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 5, 5);  // Event
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 6);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 0, 0, 1);  // Run
+
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iter = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    edm::IndexIntoFile::IndexIntoFileItr iterEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+    int i = 0;
+    for (i = 0; iter != iterEnd; ++iter, ++i) {
+      switch (i) {
+        case 0: {
+          CPPUNIT_ASSERT(check(iter, kRun, 0, 2, 1, 0, 1));  // run 1
+          CPPUNIT_ASSERT(iter.size() == 11);
+          CPPUNIT_ASSERT(iter.indexedSize() == 14);
+          CPPUNIT_ASSERT(!iter.shouldProcessRun());
+          break;
+        }
+        case 1: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 0, 2, 1, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(!iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.lumiEntryValid(2));
+          break;
+        }
+        case 2: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 0, 3, 1, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(!iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(!iter.lumiEntryValid(3));
+          break;
+        }
+        case 3: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 0, 4, 1, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(!iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.lumiEntryValid(4));
+          break;
+        }
+        case 4: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 0, 4, 1, 0, 1));  // event 1:1:1
+          CPPUNIT_ASSERT(iter.entry() == 0);
+          break;
+        }
+        case 5: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 0, 4, 2, 0, 1));  // event 1:1:2
+          CPPUNIT_ASSERT(iter.entry() == 1);
+          break;
+        }
+        case 6: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 0, 4, 3, 0, 1));  // event 1:1:3
+          CPPUNIT_ASSERT(iter.entry() == 2);
+          break;
+        }
+        case 7: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 0, 4, 4, 0, 1));  // event 1:1:4
+          CPPUNIT_ASSERT(iter.entry() == 3);
+          break;
+        }
+        case 8: {
+          CPPUNIT_ASSERT(check(iter, kRun, 5, 6, 6, 0, 1));  // run 2
+          CPPUNIT_ASSERT(iter.shouldProcessRun());
+          break;
+        }
+        case 9: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 5, 6, 6, 0, 1));  // lumi 2:1
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          break;
+        }
+        case 10: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 5, 6, 6, 0, 1));  // event 2:1:1
+          CPPUNIT_ASSERT(iter.entry() == 4);
+          break;
+        }
+        case 11: {
+          CPPUNIT_ASSERT(check(iter, kRun, 7, 8, -1, 0, 0));  // run 1
+          CPPUNIT_ASSERT(iter.shouldProcessRun());
+          break;
+        }
+        case 12: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 7, 8, -1, 0, 0));  // lumi 1:2
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          break;
+        }
+        case 13: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 7, 9, -1, 0, 0));  // lumi 1:2
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          break;
+        }
+        case 14: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 7, 10, -1, 0, 0));  // lumi 1:2
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          break;
+        }
+        case 15: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 7, 11, 13, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 1);
+          break;
+        }
+        case 16: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 7, 12, 13, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 4);
+          break;
+        }
+        case 17: {
+          CPPUNIT_ASSERT(check(iter, kLumi, 7, 13, 13, 0, 1));  // lumi 1:1
+          CPPUNIT_ASSERT(iter.shouldProcessLumi());
+          CPPUNIT_ASSERT(iter.entry() == 6);
+          break;
+        }
+        case 18: {
+          CPPUNIT_ASSERT(check(iter, kEvent, 7, 13, 13, 0, 1));  // event 1:1:5
+          CPPUNIT_ASSERT(iter.entry() == 5);
+          break;
+        }
+      }
+    }
+    CPPUNIT_ASSERT(i == 19);
+
+    skipEventBackward(iter);
+    checkSkipped(0, 1, 1, 5);
+    CPPUNIT_ASSERT(check(iter, kRun, 7, 11, 13, 0, 1));
+
+    skipEventBackward(iter);
+    checkSkipped(0, 2, 1, 4);
+    CPPUNIT_ASSERT(check(iter, kRun, 5, 6, 6, 0, 1));
+
+    skipEventBackward(iter);
+    checkSkipped(0, 1, 1, 3);
+    CPPUNIT_ASSERT(check(iter, kRun, 0, 2, 4, 0, 1));
+
+    skipEventBackward(iter);
+    checkSkipped(0, 1, 1, 2);
+    CPPUNIT_ASSERT(check(iter, kRun, 0, 2, 3, 0, 1));
+
+    skipEventBackward(iter);
+    checkSkipped(0, 1, 1, 1);
+    CPPUNIT_ASSERT(check(iter, kRun, 0, 2, 2, 0, 1));
+
+    skipEventBackward(iter);
+    checkSkipped(0, 1, 1, 0);
+    CPPUNIT_ASSERT(check(iter, kRun, 0, 2, 1, 0, 1));
+
+    skipEventBackward(iter);
+    checkSkipped(-1, 0, 0, -1);
+    CPPUNIT_ASSERT(check(iter, kRun, 0, 2, 1, 0, 1));
+
+    iter.advanceToNextRun();
+    CPPUNIT_ASSERT(check(iter, kRun, 5, 6, 6, 0, 1));  // run 2
+    iter.advanceToNextRun();
+    CPPUNIT_ASSERT(check(iter, kRun, 7, 8, -1, 0, 0));  // run 1
+    iter.advanceToNextRun();
+    CPPUNIT_ASSERT(check(iter, kEnd, -1, -1, -1, 0, 0));
+
+    iter = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    iter.advanceToNextLumiOrRun();
+    CPPUNIT_ASSERT(check(iter, kLumi, 0, 2, 1, 0, 1));  // lumi 1:1
+    iter.advanceToNextLumiOrRun();
+    CPPUNIT_ASSERT(check(iter, kRun, 5, 6, 6, 0, 1));  // run 2
+    iter.advanceToNextLumiOrRun();
+    CPPUNIT_ASSERT(check(iter, kLumi, 5, 6, 6, 0, 1));  // lumi 2:1
+    iter.advanceToNextLumiOrRun();
+    CPPUNIT_ASSERT(check(iter, kRun, 7, 8, -1, 0, 0));  // run 1
+    iter.advanceToNextLumiOrRun();
+    CPPUNIT_ASSERT(check(iter, kLumi, 7, 8, -1, 0, 0));  // lumi 1:2
+    iter.advanceToNextLumiOrRun();
+    CPPUNIT_ASSERT(check(iter, kLumi, 7, 11, 13, 0, 1));  // lumi 1:1
+    iter.advanceToNextLumiOrRun();
+    CPPUNIT_ASSERT(check(iter, kEnd, -1, -1, -1, 0, 0));
   }
 }

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -2601,19 +2601,19 @@ void TestIndexIntoFile3::testNonValidLumiInsideValidLumis() {
         case 1: {
           CPPUNIT_ASSERT(check(iter, kLumi, 0, 2, 1, 0, 1));  // lumi 1:1
           CPPUNIT_ASSERT(!iter.shouldProcessLumi());
-          CPPUNIT_ASSERT(iter.lumiEntryValid(2));
+          CPPUNIT_ASSERT(iter.lumiIterationStartingIndex(2));
           break;
         }
         case 2: {
           CPPUNIT_ASSERT(check(iter, kLumi, 0, 3, 1, 0, 1));  // lumi 1:1
           CPPUNIT_ASSERT(!iter.shouldProcessLumi());
-          CPPUNIT_ASSERT(!iter.lumiEntryValid(3));
+          CPPUNIT_ASSERT(!iter.lumiIterationStartingIndex(3));
           break;
         }
         case 3: {
           CPPUNIT_ASSERT(check(iter, kLumi, 0, 4, 1, 0, 1));  // lumi 1:1
           CPPUNIT_ASSERT(!iter.shouldProcessLumi());
-          CPPUNIT_ASSERT(iter.lumiEntryValid(4));
+          CPPUNIT_ASSERT(iter.lumiIterationStartingIndex(4));
           break;
         }
         case 4: {

--- a/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
@@ -25,6 +25,9 @@ class TestIndexIntoFile : public CppUnit::TestFixture {
   CPPUNIT_TEST(testSkip);
   CPPUNIT_TEST(testSkip2);
   CPPUNIT_TEST(testSkip3);
+  CPPUNIT_TEST(testEndWithRun);
+  CPPUNIT_TEST(testRunsNoEvents);
+  CPPUNIT_TEST(testLumisNoEvents);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -77,7 +80,10 @@ public:
   void testSkip();
   void testSkip2();
   void testSkip3();
+  void testEndWithRun();
   void testReduce();
+  void testRunsNoEvents();
+  void testLumisNoEvents();
 
   ProcessHistoryID nullPHID;
   ProcessHistoryID fakePHID1;
@@ -115,9 +121,9 @@ void TestIndexIntoFile::check(edm::IndexIntoFile::IndexIntoFileItr const& iter,
                    iter.indexToEvent() == indexToEvent && iter.nEvents() == nEvents;
   if (!theyMatch) {
     std::cout << "\nExpected        " << type << "  " << indexToRun << "  " << indexToLumi << "  " << indexToEventRange
-              << "  " << indexToEvent << "  " << nEvents << "\n";
+              << "  " << indexToEvent << "  " << nEvents << std::endl;
     std::cout << "Iterator values " << iter.type() << "  " << iter.indexToRun() << "  " << iter.indexToLumi() << "  "
-              << iter.indexToEventRange() << "  " << iter.indexToEvent() << "  " << iter.nEvents() << "\n";
+              << iter.indexToEventRange() << "  " << iter.indexToEvent() << "  " << iter.nEvents() << std::endl;
   }
   CPPUNIT_ASSERT(theyMatch);
 }
@@ -534,6 +540,9 @@ void TestIndexIntoFile::testIterLastLumiRangeNoEvents() {
       CPPUNIT_ASSERT(false);
   }
   CPPUNIT_ASSERT(i == 11);
+
+  skipEventBackward(iterEntry);
+  checkSkipped(0, 2, 101, 2);
 }
 
 void TestIndexIntoFile::testSkip() {
@@ -790,7 +799,513 @@ void TestIndexIntoFile::testSkip3() {
   }
 }
 
+void TestIndexIntoFile::testEndWithRun() {
+  edm::IndexIntoFile indexIntoFile;
+  indexIntoFile.addEntry(fakePHID1, 1, 0, 0, 0);  // Run
+
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+
+  edm::IndexIntoFile::IndexIntoFileItr iterFirst = indexIntoFile.begin(IndexIntoFile::firstAppearanceOrder);
+  check(iterFirst, kRun, 0, -1, -1, 0, 0);
+  ++iterFirst;
+  check(iterFirst, kEnd, -1, -1, -1, 0, 0);
+
+  edm::IndexIntoFile::IndexIntoFileItr iterNum = indexIntoFile.begin(IndexIntoFile::numericalOrder);
+  check(iterNum, kRun, 0, -1, -1, 0, 0);
+  ++iterNum;
+  check(iterNum, kEnd, -1, -1, -1, 0, 0);
+
+  {
+    edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+    check(iterEntry, kRun, 0, -1, -1, 0, 0);
+    ++iterEntry;
+    check(iterEntry, kEnd, -1, -1, -1, 0, 0);
+  }
+}
+
 void TestIndexIntoFile::testReduce() {
   // This test is implemented in FWCore/Integration/test/ProcessHistory_t.cpp
   // because of dependency issues.
+}
+
+void TestIndexIntoFile::testRunsNoEvents() {
+  edm::IndexIntoFile indexIntoFile;
+  indexIntoFile.addEntry(fakePHID1, 8, 1, 0, 0);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 5, 1, 0, 1);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 2);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 3, 1, 1, 0);  // Event
+  indexIntoFile.addEntry(fakePHID1, 3, 1, 0, 3);  // Lumi
+
+  indexIntoFile.addEntry(fakePHID1, 4, 1, 1, 1);   // Event
+  indexIntoFile.addEntry(fakePHID1, 4, 1, 0, 4);   // Lumi
+  indexIntoFile.addEntry(fakePHID1, 7, 1, 0, 5);   // Lumi
+  indexIntoFile.addEntry(fakePHID1, 7, 2, 0, 6);   // Lumi
+  indexIntoFile.addEntry(fakePHID1, 7, 3, 1, 2);   // Event
+  indexIntoFile.addEntry(fakePHID1, 7, 3, 0, 7);   // Lumi
+  indexIntoFile.addEntry(fakePHID1, 7, 4, 0, 8);   // Lumi
+  indexIntoFile.addEntry(fakePHID1, 7, 5, 0, 9);   // Lumi
+  indexIntoFile.addEntry(fakePHID1, 7, 6, 1, 3);   // Event
+  indexIntoFile.addEntry(fakePHID1, 7, 6, 0, 10);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 7, 7, 1, 4);   // Event
+  indexIntoFile.addEntry(fakePHID1, 7, 7, 0, 11);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 7, 8, 0, 12);  // Lumi
+  indexIntoFile.addEntry(fakePHID1, 7, 9, 0, 13);  // Lumi
+
+  indexIntoFile.addEntry(fakePHID1, 1, 0, 0, 0);  // Run
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 1);  // Run
+  indexIntoFile.addEntry(fakePHID1, 3, 0, 0, 2);  // Run
+  indexIntoFile.addEntry(fakePHID1, 4, 0, 0, 3);  // Run
+  indexIntoFile.addEntry(fakePHID1, 5, 0, 0, 4);  // Run
+  indexIntoFile.addEntry(fakePHID1, 6, 0, 0, 5);  // Run
+  indexIntoFile.addEntry(fakePHID1, 7, 0, 0, 6);  // Run
+  indexIntoFile.addEntry(fakePHID1, 8, 0, 0, 7);  // Run
+  indexIntoFile.addEntry(fakePHID1, 9, 0, 0, 8);  // Run
+
+  indexIntoFile.addEntry(fakePHID1, 8, 0, 0, 9);   // Run
+  indexIntoFile.addEntry(fakePHID1, 5, 0, 0, 10);  // Run
+  indexIntoFile.addEntry(fakePHID1, 4, 0, 0, 11);  // Run
+  indexIntoFile.addEntry(fakePHID1, 4, 0, 0, 12);  // Run
+  indexIntoFile.addEntry(fakePHID1, 4, 0, 0, 13);  // Run
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 14);  // Run
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 15);  // Run
+
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+
+  edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+  edm::IndexIntoFile::IndexIntoFileItr iterEntryEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+  int i = 0;
+  for (; iterEntry != iterEntryEnd; ++iterEntry, ++i) {
+    if (i == 0) {
+      check(iterEntry, kRun, 0, 1, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 1 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessRun());
+    } else if (i == 1) {
+      check(iterEntry, kLumi, 0, 1, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 1 && iterEntry.lumi() == 1);
+    } else if (i == 2) {
+      check(iterEntry, kRun, 2, -1, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 3) {
+      check(iterEntry, kRun, 3, -1, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 4) {
+      check(iterEntry, kRun, 4, -1, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 5) {
+      check(iterEntry, kRun, 5, 6, 6, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 3 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 6) {
+      check(iterEntry, kLumi, 5, 6, 6, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 3 && iterEntry.lumi() == 1);
+    } else if (i == 7) {
+      check(iterEntry, kEvent, 5, 6, 6, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 3 && iterEntry.lumi() == 1);
+    } else if (i == 8) {
+      check(iterEntry, kRun, 7, 11, 11, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 4 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 9) {
+      check(iterEntry, kRun, 8, 11, 11, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 4 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 10) {
+      check(iterEntry, kRun, 9, 11, 11, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 4 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 11) {
+      check(iterEntry, kRun, 10, 11, 11, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 4 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 12) {
+      check(iterEntry, kLumi, 10, 11, 11, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 4 && iterEntry.lumi() == 1);
+    } else if (i == 13) {
+      check(iterEntry, kEvent, 10, 11, 11, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 4 && iterEntry.lumi() == 1);
+    } else if (i == 14) {
+      check(iterEntry, kRun, 12, 14, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 5 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 15) {
+      check(iterEntry, kRun, 13, 14, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 5 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 16) {
+      check(iterEntry, kLumi, 13, 14, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 5 && iterEntry.lumi() == 1);
+    } else if (i == 17) {
+      check(iterEntry, kRun, 15, -1, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 6 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 18) {
+      check(iterEntry, kRun, 16, 17, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 19) {
+      check(iterEntry, kLumi, 16, 17, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 1);
+    } else if (i == 20) {
+      check(iterEntry, kLumi, 16, 18, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 2);
+    } else if (i == 21) {
+      check(iterEntry, kLumi, 16, 19, 19, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 3);
+    } else if (i == 22) {
+      check(iterEntry, kEvent, 16, 19, 19, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 3);
+    } else if (i == 23) {
+      check(iterEntry, kLumi, 16, 20, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 4);
+    } else if (i == 24) {
+      check(iterEntry, kLumi, 16, 21, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 5);
+    } else if (i == 25) {
+      check(iterEntry, kLumi, 16, 22, 22, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 6);
+    } else if (i == 26) {
+      check(iterEntry, kEvent, 16, 22, 22, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 6);
+    } else if (i == 27) {
+      check(iterEntry, kLumi, 16, 23, 23, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 7);
+    } else if (i == 28) {
+      check(iterEntry, kEvent, 16, 23, 23, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 7);
+    } else if (i == 29) {
+      check(iterEntry, kLumi, 16, 24, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 8);
+    } else if (i == 30) {
+      check(iterEntry, kLumi, 16, 25, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 7 && iterEntry.lumi() == 9);
+    } else if (i == 31) {
+      check(iterEntry, kRun, 26, 28, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 8 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 32) {
+      check(iterEntry, kRun, 27, 28, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 8 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else if (i == 33) {
+      check(iterEntry, kLumi, 27, 28, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 8 && iterEntry.lumi() == 1);
+    } else if (i == 34) {
+      check(iterEntry, kRun, 29, -1, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 9 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+    } else
+      CPPUNIT_ASSERT(false);
+  }
+  CPPUNIT_ASSERT(i == 35);
+}
+
+void TestIndexIntoFile::testLumisNoEvents() {
+  edm::IndexIntoFile indexIntoFile;
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 1, 0);  // Event 2:7:1
+  indexIntoFile.addEntry(fakePHID1, 2, 8, 1, 1);  // Event 2:8:1
+
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 1, 2);  // Event 1:1:1
+  indexIntoFile.addEntry(fakePHID1, 1, 1, 0, 0);  // Lumi  1:1
+  indexIntoFile.addEntry(fakePHID1, 1, 0, 0, 0);  // Run   1
+
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 2, 3);  // Event 2:7:2
+
+  indexIntoFile.addEntry(fakePHID1, 2, 1, 1, 4);  // Event 2:1:1
+  indexIntoFile.addEntry(fakePHID1, 2, 1, 0, 1);  // Lumi  2:1
+  indexIntoFile.addEntry(fakePHID1, 2, 2, 0, 2);  // Lumi  2:2
+  indexIntoFile.addEntry(fakePHID1, 2, 3, 0, 3);  // Lumi  2:3
+  indexIntoFile.addEntry(fakePHID1, 2, 4, 0, 4);  // Lumi  2:4
+  indexIntoFile.addEntry(fakePHID1, 2, 5, 1, 5);  // Event 2:5:1
+  indexIntoFile.addEntry(fakePHID1, 2, 5, 0, 5);  // Lumi  2:5
+  indexIntoFile.addEntry(fakePHID1, 2, 6, 0, 6);  // Lumi  2:6
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 3, 6);  // Event 2:7:3
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 0, 7);  // Lumi  2:7
+  indexIntoFile.addEntry(fakePHID1, 2, 8, 1, 7);  // Event 2:8:1
+  indexIntoFile.addEntry(fakePHID1, 2, 8, 0, 8);  // Lumi  2:8
+  indexIntoFile.addEntry(fakePHID1, 2, 9, 0, 9);  // Lumi  2:9
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 1);  // Run   2
+
+  indexIntoFile.addEntry(fakePHID1, 3, 1, 1, 8);   // Event 3:1:1
+  indexIntoFile.addEntry(fakePHID1, 3, 1, 0, 10);  // Lumi  3:1
+  indexIntoFile.addEntry(fakePHID1, 3, 0, 0, 2);   // Run   3
+
+  indexIntoFile.addEntry(fakePHID1, 2, 4, 1, 9);    // Event 2:4:1
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 4, 10);   // Event 2:7:4
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 5, 11);   // Event 2:7:5
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 0, 11);   // Lumi  2:7
+  indexIntoFile.addEntry(fakePHID1, 2, 3, 1, 12);   // Event 2:3:1
+  indexIntoFile.addEntry(fakePHID1, 2, 3, 0, 12);   // Lumi  2:3
+  indexIntoFile.addEntry(fakePHID1, 2, 4, 2, 13);   // Event 2:4:1
+  indexIntoFile.addEntry(fakePHID1, 2, 4, 0, 13);   // Lumi  2:4
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 6, 14);   // Event 2:7:6
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 0, 14);   // Lumi  2:7
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 7, 15);   // Event 2:7:7
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 8, 16);   // Event 2:7:8
+  indexIntoFile.addEntry(fakePHID1, 2, 3, 0, 15);   // Lumi  2:3
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 9, 17);   // Event 2:7:9
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 10, 18);  // Event 2:7:10
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 0, 16);   // Lumi  2:7
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 0, 17);   // Lumi  2:7
+  indexIntoFile.addEntry(fakePHID1, 2, 7, 0, 18);   // Lumi  2:7
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 3);    // Run   2
+  indexIntoFile.addEntry(fakePHID1, 2, 0, 0, 4);    // Run   2
+  indexIntoFile.sortVector_Run_Or_Lumi_Entries();
+
+  edm::IndexIntoFile::IndexIntoFileItr iterEntry = indexIntoFile.begin(IndexIntoFile::entryOrder);
+  edm::IndexIntoFile::IndexIntoFileItr iterEntryEnd = indexIntoFile.end(IndexIntoFile::entryOrder);
+  int i = 0;
+  for (; iterEntry != iterEntryEnd; ++iterEntry, ++i) {
+    if (i == 0) {
+      check(iterEntry, kRun, 0, 1, 1, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessRun());
+      CPPUNIT_ASSERT(iterEntry.entry() == 1);
+    } else if (i == 1) {
+      check(iterEntry, kLumi, 0, 1, 1, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 7);
+    } else if (i == 2) {
+      check(iterEntry, kEvent, 0, 1, 1, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 0);
+    } else if (i == 3) {
+      check(iterEntry, kLumi, 0, 2, 2, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 8);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 8);
+    } else if (i == 4) {
+      check(iterEntry, kEvent, 0, 2, 2, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 8);
+      CPPUNIT_ASSERT(iterEntry.entry() == 1);
+    } else if (i == 5) {
+      check(iterEntry, kRun, 3, 4, 4, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 1 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessRun());
+      CPPUNIT_ASSERT(iterEntry.entry() == 0);
+    } else if (i == 6) {
+      check(iterEntry, kLumi, 3, 4, 4, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 1 && iterEntry.lumi() == 1);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 0);
+    } else if (i == 7) {
+      check(iterEntry, kEvent, 3, 4, 4, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 1 && iterEntry.lumi() == 1);
+      CPPUNIT_ASSERT(iterEntry.entry() == 2);
+    } else if (i == 8) {
+      check(iterEntry, kRun, 5, 6, 6, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessRun());
+      CPPUNIT_ASSERT(iterEntry.entry() == 1);
+    } else if (i == 9) {
+      check(iterEntry, kLumi, 5, 6, 6, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 7);
+    } else if (i == 10) {
+      check(iterEntry, kEvent, 5, 6, 6, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 3);
+    } else if (i == 11) {
+      check(iterEntry, kLumi, 5, 7, 7, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 1);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 1);
+    } else if (i == 12) {
+      check(iterEntry, kEvent, 5, 7, 7, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 1);
+      CPPUNIT_ASSERT(iterEntry.entry() == 4);
+    } else if (i == 13) {
+      check(iterEntry, kLumi, 5, 8, 8, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 5);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 5);
+    } else if (i == 14) {
+      check(iterEntry, kEvent, 5, 8, 8, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 5);
+      CPPUNIT_ASSERT(iterEntry.entry() == 5);
+    } else if (i == 15) {
+      check(iterEntry, kLumi, 5, 9, 9, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 7);
+    } else if (i == 16) {
+      check(iterEntry, kEvent, 5, 9, 9, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 6);
+    } else if (i == 17) {
+      check(iterEntry, kLumi, 5, 10, 10, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 8);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 8);
+    } else if (i == 18) {
+      check(iterEntry, kEvent, 5, 10, 10, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 8);
+      CPPUNIT_ASSERT(iterEntry.entry() == 7);
+    } else if (i == 19) {
+      check(iterEntry, kRun, 11, 12, 12, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 3 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessRun());
+      CPPUNIT_ASSERT(iterEntry.entry() == 2);
+    } else if (i == 20) {
+      check(iterEntry, kLumi, 11, 12, 12, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 3 && iterEntry.lumi() == 1);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 10);
+    } else if (i == 21) {
+      check(iterEntry, kEvent, 11, 12, 12, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 3 && iterEntry.lumi() == 1);
+      CPPUNIT_ASSERT(iterEntry.entry() == 8);
+    } else if (i == 22) {
+      check(iterEntry, kRun, 13, 16, 16, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessRun());
+      CPPUNIT_ASSERT(iterEntry.entry() == 1);
+    } else if (i == 23) {
+      check(iterEntry, kRun, 14, 16, 16, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessRun());
+      CPPUNIT_ASSERT(iterEntry.entry() == 3);
+    } else if (i == 24) {
+      check(iterEntry, kRun, 15, 16, 16, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == IndexIntoFile::invalidLumi);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessRun());
+      CPPUNIT_ASSERT(iterEntry.entry() == 4);
+    } else if (i == 25) {
+      check(iterEntry, kLumi, 15, 16, 16, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 4);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 4);
+    } else if (i == 26) {
+      check(iterEntry, kEvent, 15, 16, 16, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 4);
+      CPPUNIT_ASSERT(iterEntry.entry() == 9);
+    } else if (i == 27) {
+      check(iterEntry, kLumi, 15, 17, 17, 0, 2);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 11);
+    } else if (i == 28) {
+      check(iterEntry, kEvent, 15, 17, 17, 0, 2);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 10);
+    } else if (i == 29) {
+      check(iterEntry, kEvent, 15, 17, 17, 1, 2);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 11);
+    } else if (i == 30) {
+      check(iterEntry, kLumi, 15, 18, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 1);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 1);
+    } else if (i == 31) {
+      check(iterEntry, kLumi, 15, 19, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 2);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 2);
+    } else if (i == 32) {
+      check(iterEntry, kLumi, 15, 20, 21, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 3);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 3);
+    } else if (i == 33) {
+      check(iterEntry, kLumi, 15, 21, 21, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 3);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 12);
+    } else if (i == 34) {
+      check(iterEntry, kLumi, 15, 22, 21, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 3);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 15);
+    } else if (i == 35) {
+      check(iterEntry, kEvent, 15, 22, 21, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 3);
+      CPPUNIT_ASSERT(iterEntry.entry() == 12);
+    } else if (i == 36) {
+      check(iterEntry, kLumi, 15, 23, 24, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 4);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 4);
+    } else if (i == 37) {
+      check(iterEntry, kLumi, 15, 24, 24, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 4);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 13);
+    } else if (i == 38) {
+      check(iterEntry, kEvent, 15, 24, 24, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 4);
+      CPPUNIT_ASSERT(iterEntry.entry() == 13);
+    } else if (i == 39) {
+      check(iterEntry, kLumi, 15, 25, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 5);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 5);
+    } else if (i == 40) {
+      check(iterEntry, kLumi, 15, 26, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 6);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 6);
+    } else if (i == 41) {
+      check(iterEntry, kLumi, 15, 27, 29, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 7);
+    } else if (i == 42) {
+      check(iterEntry, kLumi, 15, 28, 29, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 11);
+    } else if (i == 43) {
+      check(iterEntry, kLumi, 15, 29, 29, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 14);
+    } else if (i == 44) {
+      check(iterEntry, kLumi, 15, 30, 29, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(!iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 16);
+    } else if (i == 45) {
+      check(iterEntry, kLumi, 15, 31, 29, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 16);
+    } else if (i == 46) {
+      check(iterEntry, kLumi, 15, 32, 29, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 17);
+    } else if (i == 47) {
+      check(iterEntry, kLumi, 15, 33, 29, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 18);
+    } else if (i == 48) {
+      check(iterEntry, kEvent, 15, 33, 29, 0, 1);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 14);
+    } else if (i == 49) {
+      check(iterEntry, kEvent, 15, 33, 30, 0, 2);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 15);
+    } else if (i == 50) {
+      check(iterEntry, kEvent, 15, 33, 30, 1, 2);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 16);
+    } else if (i == 51) {
+      check(iterEntry, kEvent, 15, 33, 31, 0, 2);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 17);
+    } else if (i == 52) {
+      check(iterEntry, kEvent, 15, 33, 31, 1, 2);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 7);
+      CPPUNIT_ASSERT(iterEntry.entry() == 18);
+    } else if (i == 53) {
+      check(iterEntry, kLumi, 15, 34, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 8);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 8);
+    } else if (i == 54) {
+      check(iterEntry, kLumi, 15, 35, -1, 0, 0);
+      CPPUNIT_ASSERT(iterEntry.run() == 2 && iterEntry.lumi() == 9);
+      CPPUNIT_ASSERT(iterEntry.shouldProcessLumi());
+      CPPUNIT_ASSERT(iterEntry.entry() == 9);
+    } else
+      CPPUNIT_ASSERT(false);
+  }
+  CPPUNIT_ASSERT(iterEntry.entry() == IndexIntoFile::invalidEntry);
+  CPPUNIT_ASSERT(i == 55);
+
+  skipEventBackward(iterEntry);
+  checkSkipped(0, 2, 7, 18);
+  check(iterEntry, kRun, 13, 27, 31, 1, 2);
 }

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -32,6 +32,7 @@ namespace edm {
   public:
     typedef LuminosityBlockAuxiliary Auxiliary;
     typedef Principal Base;
+
     LuminosityBlockPrincipal(std::shared_ptr<ProductRegistry const> reg,
                              ProcessConfiguration const& pc,
                              HistoryAppender* historyAppender,
@@ -47,8 +48,6 @@ namespace edm {
     RunPrincipal& runPrincipal() { return *runPrincipal_; }
 
     void setRunPrincipal(std::shared_ptr<RunPrincipal> rp) { runPrincipal_ = rp; }
-
-    void setWillBeContinued(bool iContinued) { willBeContinued_ = iContinued; }
 
     LuminosityBlockIndex index() const { return index_; }
 
@@ -73,8 +72,9 @@ namespace edm {
 
     void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const;
 
-    ///The source is replaying overlapping LuminosityBlocks and this is not the last part for this LumiosityBlock
-    bool willBeContinued() const { return willBeContinued_; }
+    enum ContinueState { kUninitialized, kWillBeContinued, kProcessLumi };
+    ContinueState continueState() const { return continueState_; }
+    void setContinueState(ContinueState value) { continueState_ = value; }
 
   private:
     unsigned int transitionIndex_() const override;
@@ -85,7 +85,7 @@ namespace edm {
 
     LuminosityBlockIndex index_;
 
-    bool willBeContinued_ = false;
+    ContinueState continueState_ = kUninitialized;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -72,9 +72,9 @@ namespace edm {
 
     void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp) const;
 
-    enum ContinueState { kUninitialized, kWillBeContinued, kProcessLumi };
-    ContinueState continueState() const { return continueState_; }
-    void setContinueState(ContinueState value) { continueState_ = value; }
+    enum ShouldWriteLumi { kUninitialized, kNo, kYes };
+    ShouldWriteLumi shouldWriteLumi() const { return shouldWriteLumi_; }
+    void setShouldWriteLumi(ShouldWriteLumi value) { shouldWriteLumi_ = value; }
 
   private:
     unsigned int transitionIndex_() const override;
@@ -85,7 +85,7 @@ namespace edm {
 
     LuminosityBlockIndex index_;
 
-    ContinueState continueState_ = kUninitialized;
+    ShouldWriteLumi shouldWriteLumi_ = kUninitialized;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -82,9 +82,9 @@ namespace edm {
 
     void preReadFile();
 
-    enum ContinueState { kUninitialized, kWillBeContinued, kProcessRun };
-    ContinueState continueState() const { return continueState_; }
-    void setContinueState(ContinueState value) { continueState_ = value; }
+    enum ShouldWriteRun { kUninitialized, kNo, kYes };
+    ShouldWriteRun shouldWriteRun() const { return shouldWriteRun_; }
+    void setShouldWriteRun(ShouldWriteRun value) { shouldWriteRun_ = value; }
 
   private:
     unsigned int transitionIndex_() const override;
@@ -98,7 +98,7 @@ namespace edm {
     // per concurrent run. In all other cases, this should just be null.
     edm::propagate_const<std::unique_ptr<MergeableRunProductMetadata>> mergeableRunProductMetadataPtr_;
 
-    ContinueState continueState_ = kUninitialized;
+    ShouldWriteRun shouldWriteRun_ = kUninitialized;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -82,6 +82,10 @@ namespace edm {
 
     void preReadFile();
 
+    enum ContinueState { kUninitialized, kWillBeContinued, kProcessRun };
+    ContinueState continueState() const { return continueState_; }
+    void setContinueState(ContinueState value) { continueState_ = value; }
+
   private:
     unsigned int transitionIndex_() const override;
 
@@ -93,6 +97,8 @@ namespace edm {
     // there should be one MergeableRunProductMetadata object created
     // per concurrent run. In all other cases, this should just be null.
     edm::propagate_const<std::unique_ptr<MergeableRunProductMetadata>> mergeableRunProductMetadataPtr_;
+
+    ContinueState continueState_ = kUninitialized;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1233,7 +1233,7 @@ namespace edm {
 
       if (globalBeginSucceeded) {
         RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
-        if (runPrincipal.continueState() != RunPrincipal::kWillBeContinued) {
+        if (runPrincipal.shouldWriteRun() != RunPrincipal::kNo) {
           FinalWaitingTask t;
           MergeableRunProductMetadata* mergeableRunProductMetadata = runPrincipal.mergeableRunProductMetadata();
           mergeableRunProductMetadata->preWriteRun();
@@ -1784,7 +1784,7 @@ namespace edm {
 
   void EventProcessor::writeLumiAsync(WaitingTaskHolder task, LuminosityBlockPrincipal& lumiPrincipal) {
     using namespace edm::waiting_task;
-    if (lumiPrincipal.continueState() != LuminosityBlockPrincipal::kWillBeContinued) {
+    if (lumiPrincipal.shouldWriteLumi() != LuminosityBlockPrincipal::kNo) {
       chain::first([&](auto nextTask) {
         ServiceRegistry::Operate op(serviceToken_);
 
@@ -1803,7 +1803,7 @@ namespace edm {
     for (auto& s : subProcesses_) {
       s.deleteLumiFromCache(*iStatus.lumiPrincipal());
     }
-    iStatus.lumiPrincipal()->setContinueState(LuminosityBlockPrincipal::kUninitialized);
+    iStatus.lumiPrincipal()->setShouldWriteLumi(LuminosityBlockPrincipal::kUninitialized);
     iStatus.lumiPrincipal()->clearPrincipal();
     //FDEBUG(1) << "\tdeleteLumiFromCache " << run << "/" << lumi << "\n";
   }

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -16,7 +16,6 @@ namespace edm {
   void LuminosityBlockPrincipal::fillLuminosityBlockPrincipal(ProcessHistory const* processHistory,
                                                               DelayedReader* reader) {
     fillPrincipal(aux_.processHistoryID(), processHistory, reader);
-    willBeContinued_ = false;
   }
 
   void LuminosityBlockPrincipal::put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const {

--- a/FWCore/Integration/test/run_RunMerge.sh
+++ b/FWCore/Integration/test/run_RunMerge.sh
@@ -91,6 +91,15 @@ pushd ${LOCAL_TMP_DIR}
   echo ${test}COPY1------------------------------------------------------------
   cmsRun -p ${LOCAL_TEST_DIR}/${test}COPY1_cfg.py || die "cmsRun ${test}COPY1_cfg.py" $?
 
+  echo ${test}MERGE6------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}MERGE6_cfg.py || die "cmsRun ${test}MERGE6_cfg.py" $?
+
+  echo ${test}NoRunLumiSort------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}NoRunLumiSort_cfg.py || die "cmsRun ${test}NoRunLumiSort_cfg.py" $?
+
+  echo ${test}TEST6------------------------------------------------------------
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}TEST6_cfg.py || die "cmsRun ${test}TEST6_cfg.py" $?
+
   echo ${test}PickEvents------------------------------------------------------------
   cmsRun -p ${LOCAL_TEST_DIR}/${test}PickEvents_cfg.py || die "cmsRun ${test}PickEvents_cfg.py" $?
 

--- a/FWCore/Integration/test/testRunMergeMERGE6_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE6_cfg.py
@@ -1,0 +1,106 @@
+# The purpose of this configuration is to prepare
+# input for a test of the noRunLumiSort configuration
+# parameter that has non-contiguous sequences of
+# events from the same run (and the same lumi).
+
+# It is expected there are 6 warnings that
+# print out while this runs related to merging.
+# The test should pass with these warnings.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MERGE")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMerge1.root',
+        'file:testRunMerge2.root',
+        'file:testRunMerge3.root'
+    ),
+    inputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_A_*_*',
+        'drop *_B_*_*',
+        'drop *_C_*_*',
+        'drop *_D_*_*',
+        'drop *_E_*_*',
+        'drop *_F_*_*',
+        'drop *_G_*_*',
+        'drop *_H_*_*',
+        'drop *_I_*_*',
+        'drop *_J_*_*',
+        'drop *_K_*_*',
+        'drop *_L_*_*',
+        'drop *_tryNoPut_*_*',
+        'drop *_aliasForThingToBeDropped2_*_*',
+        'drop *_dependsOnThingToBeDropped1_*_*',
+        'drop *_makeThingToBeDropped_*_*',
+        'drop edmtestThingWithMerge_makeThingToBeDropped1_*_*',
+        'drop edmtestThing_*_*_*'
+    )
+)
+
+process.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+    #   0's are just placeholders, if the value is a "0" the check is not made.
+
+    expectedBeginRunProd = cms.untracked.vint32(
+        0,   20004,  10003,   # File boundary before this causing merge
+        0,   10002,  10003,
+        0,   10002,  10004
+    ),
+    expectedEndRunProd = cms.untracked.vint32(
+        0, 200004, 100003,   # File boundary before this causing merge
+        0, 100002, 100003,
+        0, 100002, 100004
+    ),
+    expectedBeginLumiProd = cms.untracked.vint32(
+        0,       204,    103,   # File boundary before this causing merge
+        0,       102,    103,
+        0,       102,    104
+    ),
+    expectedEndLumiProd = cms.untracked.vint32(
+        0,     2004,   1003,   # File boundary before this causing merge
+        0,     1002,   1003,
+        0,     1002,   1004
+    ),
+    expectedBeginRunNew = cms.untracked.vint32(
+        0,   10002,  10003,
+        0,   10002,  10003,
+        0,   10002,  10003
+    ),
+    expectedEndRunNew = cms.untracked.vint32(
+        0,   100002,  100003,
+        0,   100002,  100003,
+        0,   100002,  100003
+    ),
+    expectedBeginLumiNew = cms.untracked.vint32(
+        0,   102,  103,
+        0,   102,  103,
+        0,   102,  103
+    ),
+    expectedEndLumiNew = cms.untracked.vint32(
+        0,   1002,  1003,
+        0,   1002,  1003,
+        0,   1002,  1003
+    )
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeMERGE6.root')
+)
+
+process.path1 = cms.Path(process.thingWithMergeProducer + process.test)
+process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testRunMergeNoRunLumiSort_cfg.py
+++ b/FWCore/Integration/test/testRunMergeNoRunLumiSort_cfg.py
@@ -1,0 +1,116 @@
+# A test of the noRunLumiSort configuration parameter
+# where the input has non-contiguous event sequences
+# from the same run.
+
+# It is expected there are 8 warnings and 8 errors that
+# print out while this runs related to merging.
+# The test should pass with these errors and warnings.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("NORUNLUMISORT")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMergeMERGE6.root', 
+        'file:testRunMergeMERGE6.root'
+    ),
+    duplicateCheckMode = cms.untracked.string('checkEachRealDataFile'),
+    noRunLumiSort = cms.untracked.bool(True)
+)
+
+process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
+    verbose = cms.untracked.bool(True),
+    expectedRunLumiEvents = cms.untracked.vuint32(
+1, 0, 0,
+1, 1, 0,
+1, 1, 11,
+1, 1, 12,
+1, 1, 13,
+1, 1, 14,
+1, 1, 15,
+1, 1, 16,
+1, 1, 17,
+1, 1, 18,
+1, 1, 19,
+1, 1, 20,
+1, 1, 21,
+1, 1, 22,
+1, 1, 23,
+1, 1, 24,
+1, 1, 25,
+1, 1, 0,
+1, 0, 0,
+2, 0, 0,
+2, 1, 0,
+2, 1, 1,
+2, 1, 2,
+2, 1, 3,
+2, 1, 4,
+2, 1, 5,
+2, 1, 0,
+2, 0, 0,
+1, 0, 0,
+1, 1, 0,
+1, 1, 1,
+1, 1, 2,
+1, 1, 3,
+1, 1, 4,
+1, 1, 5,
+1, 1, 6,
+1, 1, 7,
+1, 1, 8,
+1, 1, 9,
+1, 1, 10
+)
+)
+process.test2.expectedRunLumiEvents.extend([
+1, 1, 11,
+1, 1, 12,
+1, 1, 13,
+1, 1, 14,
+1, 1, 15,
+1, 1, 16,
+1, 1, 17,
+1, 1, 18,
+1, 1, 19,
+1, 1, 20,
+1, 1, 21,
+1, 1, 22,
+1, 1, 23,
+1, 1, 24,
+1, 1, 25,
+1, 1, 0,
+1, 0, 0,
+2, 0, 0,
+2, 1, 0,
+2, 1, 1,
+2, 1, 2,
+2, 1, 3,
+2, 1, 4,
+2, 1, 5,
+2, 1, 0,
+2, 0, 0,
+1, 0, 0,
+1, 1, 0,
+1, 1, 1,
+1, 1, 2,
+1, 1, 3,
+1, 1, 4,
+1, 1, 5,
+1, 1, 6,
+1, 1, 7,
+1, 1, 8,
+1, 1, 9,
+1, 1, 10,
+1, 1, 0,
+1, 0, 0,
+])
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeNoRunLumiSort.root')
+)
+
+process.path1 = cms.Path(process.test2)
+
+process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testRunMergeTEST6_cfg.py
+++ b/FWCore/Integration/test/testRunMergeTEST6_cfg.py
@@ -1,0 +1,159 @@
+# A test of the noRunLumiSort configuration parameter
+# where the input has non-contiguous event sequences
+# from the same run. This configuration reads a file
+# created using that parameter and checks that the
+# run product and lumi product merging that occurred
+# was done properly.
+
+# It is expected there are 8 warnings that
+# print out while this runs related to merging.
+# The test should pass with these warnings.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testRunMergeNoRunLumiSort.root'
+    ),
+    duplicateCheckMode = cms.untracked.string('noDuplicateCheck')
+)
+
+process.test = cms.EDAnalyzer("TestMergeResults",
+                            
+    #   Check to see that the value we read matches what we know
+    #   was written. Expected values listed below come in sets of three
+    #      value expected in Thing
+    #      value expected in ThingWithMerge
+    #      value expected in ThingWithIsEqual
+    #   Each set of 3 is tested at endRun for the expected
+    #   run values or at endLuminosityBlock for the expected
+    #   lumi values. And then the next set of three values
+    #   is tested at the next endRun or endLuminosityBlock.
+    #   When the sequence of parameter values is exhausted it stops checking
+    #   0's are just placeholders, if the value is a "0" the check is not made.
+
+    expectedBeginRunProd = cms.untracked.vint32(
+        0,   60012,  10003,
+        0,   20004,  10003
+    ),
+                            
+    expectedEndRunProd = cms.untracked.vint32(
+        0, 600012, 100003,
+        0, 200004, 100003
+    ),
+
+    expectedBeginLumiProd = cms.untracked.vint32(
+        0,       612,    103,
+        0,       204,    103
+    ),
+
+    expectedEndLumiProd = cms.untracked.vint32(
+        0,     6012,   1003,
+        0,     2004,   1003
+    ),
+
+    expectedBeginRunNew = cms.untracked.vint32(
+        10001,   40008,  10003,
+        10001,   20004,  10003
+    ),
+
+    expectedEndRunNew = cms.untracked.vint32(
+        100001, 400008, 100003,
+        100001, 200004, 100003
+    ),
+
+    expectedBeginLumiNew = cms.untracked.vint32(
+        101,       408,    103,
+        101,       204,    103
+    ),
+
+    expectedEndLumiNew = cms.untracked.vint32(
+        1001,     4008,   1003,
+        1001,     2004,   1003
+    )
+)
+
+process.test2 = cms.EDAnalyzer('RunLumiEventAnalyzer',
+    verbose = cms.untracked.bool(True),
+    expectedRunLumiEvents = cms.untracked.vuint32(
+1, 0, 0,
+1, 1, 0,
+1, 1, 11,
+1, 1, 12,
+1, 1, 13,
+1, 1, 14,
+1, 1, 15,
+1, 1, 16,
+1, 1, 17,
+1, 1, 18,
+1, 1, 19,
+1, 1, 20,
+1, 1, 21,
+1, 1, 22,
+1, 1, 23,
+1, 1, 24,
+1, 1, 25,
+1, 1, 1,
+1, 1, 2,
+1, 1, 3,
+1, 1, 4,
+1, 1, 5,
+1, 1, 6,
+1, 1, 7,
+1, 1, 8,
+1, 1, 9,
+1, 1, 10,
+1, 1, 11,
+1, 1, 12,
+1, 1, 13,
+1, 1, 14,
+1, 1, 15,
+1, 1, 16,
+1, 1, 17,
+1, 1, 18,
+1, 1, 19,
+1, 1, 20,
+1, 1, 21,
+1, 1, 22,
+1, 1, 23,
+1, 1, 24,
+1, 1, 25,
+1, 1, 1,
+1, 1, 2,
+1, 1, 3,
+1, 1, 4,
+1, 1, 5,
+1, 1, 6,
+1, 1, 7,
+1, 1, 8,
+1, 1, 9,
+1, 1, 10,
+1, 1, 0,
+1, 0, 0
+)
+)
+process.test2.expectedRunLumiEvents.extend([
+2, 0, 0,
+2, 1, 0,
+2, 1, 1,
+2, 1, 2,
+2, 1, 3,
+2, 1, 4,
+2, 1, 5,
+2, 1, 1,
+2, 1, 2,
+2, 1, 3,
+2, 1, 4,
+2, 1, 5,
+2, 1, 0,
+2, 0, 0
+])
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testRunMergeTEST6.root')
+)
+
+process.path1 = cms.Path(process.test * process.test2)
+process.e = cms.EndPath(process.out)

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -181,8 +181,8 @@ namespace edm {
   }
 
   void PoolSource::readRun_(RunPrincipal& runPrincipal) {
-    primaryFileSequence_->readRun_(runPrincipal);
-    if (secondaryFileSequence_ && !branchIDsToReplace_[InRun].empty()) {
+    bool shouldWeProcessRun = primaryFileSequence_->readRun_(runPrincipal);
+    if (secondaryFileSequence_ && shouldWeProcessRun && !branchIDsToReplace_[InRun].empty()) {
       bool found = secondaryFileSequence_->skipToItem(runPrincipal.run(), 0U, 0U);
       if (found) {
         std::shared_ptr<RunAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readRunAuxiliary_();
@@ -203,8 +203,8 @@ namespace edm {
   }
 
   void PoolSource::readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) {
-    primaryFileSequence_->readLuminosityBlock_(lumiPrincipal);
-    if (secondaryFileSequence_ && !branchIDsToReplace_[InLumi].empty()) {
+    bool shouldWeProcessLumi = primaryFileSequence_->readLuminosityBlock_(lumiPrincipal);
+    if (secondaryFileSequence_ && shouldWeProcessLumi && !branchIDsToReplace_[InLumi].empty()) {
       bool found = secondaryFileSequence_->skipToItem(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), 0U);
       if (found) {
         std::shared_ptr<LuminosityBlockAuxiliary> secondaryAuxiliary =

--- a/IOPool/Input/src/RepeatingCachedRootSource.cc
+++ b/IOPool/Input/src/RepeatingCachedRootSource.cc
@@ -363,7 +363,7 @@ RepeatingCachedRootSource::ItemType RepeatingCachedRootSource::getNextItemType()
 }
 
 void RepeatingCachedRootSource::readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) {
-  return rootFile_->readLuminosityBlock_(lumiPrincipal);
+  rootFile_->readLuminosityBlock_(lumiPrincipal);
 }
 
 std::shared_ptr<LuminosityBlockAuxiliary> RepeatingCachedRootSource::readLuminosityBlockAuxiliary_() {

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1746,11 +1746,11 @@ namespace edm {
       runPrincipal.fillRunPrincipal(*processHistoryRegistry_, runTree_.resetAndGetRootDelayedReader());
       // Read in all the products now.
       runPrincipal.readAllFromSourceAndMergeImmediately(mergeableRunProductMetadata);
-      runPrincipal.setContinueState(RunPrincipal::kProcessRun);
+      runPrincipal.setShouldWriteRun(RunPrincipal::kYes);
     } else {
       runPrincipal.fillRunPrincipal(*processHistoryRegistry_, nullptr);
-      if (runPrincipal.continueState() != RunPrincipal::kProcessRun) {
-        runPrincipal.setContinueState(RunPrincipal::kWillBeContinued);
+      if (runPrincipal.shouldWriteRun() != RunPrincipal::kYes) {
+        runPrincipal.setShouldWriteRun(RunPrincipal::kNo);
       }
     }
     return shouldProcessRun;
@@ -1812,12 +1812,12 @@ namespace edm {
       lumiPrincipal.fillLuminosityBlockPrincipal(history, lumiTree_.resetAndGetRootDelayedReader());
       // Read in all the products now.
       lumiPrincipal.readAllFromSourceAndMergeImmediately();
-      lumiPrincipal.setContinueState(LuminosityBlockPrincipal::kProcessLumi);
+      lumiPrincipal.setShouldWriteLumi(LuminosityBlockPrincipal::kYes);
     } else {
       auto history = processHistoryRegistry_->getMapped(lumiPrincipal.aux().processHistoryID());
       lumiPrincipal.fillLuminosityBlockPrincipal(history, nullptr);
-      if (lumiPrincipal.continueState() != LuminosityBlockPrincipal::kProcessLumi) {
-        lumiPrincipal.setContinueState(LuminosityBlockPrincipal::kWillBeContinued);
+      if (lumiPrincipal.shouldWriteLumi() != LuminosityBlockPrincipal::kYes) {
+        lumiPrincipal.setShouldWriteLumi(LuminosityBlockPrincipal::kNo);
       }
     }
     ++indexIntoFileIter_;

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -231,9 +231,9 @@ namespace edm {
     bool nextProcessBlock_(ProcessBlockPrincipal&);
     void readProcessBlock_(ProcessBlockPrincipal&);
 
-    void readRun_(RunPrincipal& runPrincipal);
+    bool readRun_(RunPrincipal& runPrincipal);
     void readFakeRun_(RunPrincipal& runPrincipal);
-    void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
+    bool readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
     std::string const& file() const { return file_; }
     std::shared_ptr<ProductRegistry const> productRegistry() const { return productRegistry_; }
     // IndexIntoFile::EntryNumber_t const& entryNumber() const {return indexIntoFileIter().entry();}

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -60,9 +60,9 @@ namespace edm {
     return rootFile()->readLuminosityBlockAuxiliary_();
   }
 
-  void RootInputFileSequence::readRun_(RunPrincipal& runPrincipal) {
+  bool RootInputFileSequence::readRun_(RunPrincipal& runPrincipal) {
     assert(rootFile());
-    rootFile()->readRun_(runPrincipal);
+    return rootFile()->readRun_(runPrincipal);
   }
 
   void RootInputFileSequence::fillProcessBlockHelper_() {
@@ -80,9 +80,9 @@ namespace edm {
     rootFile()->readProcessBlock_(processBlockPrincipal);
   }
 
-  void RootInputFileSequence::readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) {
+  bool RootInputFileSequence::readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) {
     assert(rootFile());
-    rootFile()->readLuminosityBlock_(lumiPrincipal);
+    return rootFile()->readLuminosityBlock_(lumiPrincipal);
   }
 
   // readEvent() is responsible for setting up the EventPrincipal.

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -40,9 +40,9 @@ namespace edm {
     bool containedInCurrentFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const;
     bool readEvent(EventPrincipal& cache);
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
-    void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
+    bool readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_();
-    void readRun_(RunPrincipal& runPrincipal);
+    bool readRun_(RunPrincipal& runPrincipal);
     void fillProcessBlockHelper_();
     bool nextProcessBlock_(ProcessBlockPrincipal&);
     void readProcessBlock_(ProcessBlockPrincipal&);

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -36,6 +36,14 @@ namespace edm {
         usingGoToEvent_(false),
         enablePrefetching_(false),
         enforceGUIDInFileName_(pset.getUntrackedParameter<bool>("enforceGUIDInFileName")) {
+    if (noRunLumiSort_ && (remainingEvents() >= 0 || remainingLuminosityBlocks() >= 0)) {
+      // There would need to be some Framework development work to allow stopping
+      // early with noRunLumiSort set true related to closing lumis and runs that
+      // were supposed to be continued but were not... We cannot have events written
+      // to output with no run or lumi written to output.
+      throw Exception(errors::Configuration,
+                      "Illegal to configure noRunLumiSort and limit the number of events or luminosityBlocks");
+    }
     // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
     Service<SiteLocalConfig> pSLC;
     if (pSLC.isAvailable()) {


### PR DESCRIPTION
#### PR description:

Modifies the class IndexIntoFile, so that it can handle concurrent runs and better handle concurrent lumis. This PR does not include the implementation of concurrent runs. That will be submitted in a separate PR in the future. There should not be any further changes needed in IndexIntoFile.h or IndexIntoFile.cc in that future PR.

This PR includes heavy edits to the code that supports the "noRunLumiSort" ordering in IndexIntoFile (mostly in the nested class IndexIntoFile::IndexIntoFileItrEntryOrder). That ordering is currently used in some contexts to support file merging with files that have been created with concurrent lumis. That ordering allows fast cloning even when concurrent lumis have scrambled the event order in the files at lumi boundaries. Before concurrent lumis, events from a luminosity block would all be written contiguously into the output file. With concurrent lumis, events from a following lumi can be written before all the events from the preceding lumi are written. This is because the time to process an event can vary. The same thing will also happen when concurrent runs are implemented at run boundaries.

This also modifies the code in IndexIntoFile used by output modules to build the new IndexIntoFile written into a new output file.

There are some minimal changes outside IndexIntoFile needed to deal with the changes in the IndexIntoFile interface and behavior.

One might or might not consider this to be a bug fix. The existing version of the code should be working properly in the contexts where it is currently used. No one has reported any problems and the problem should be obvious if it occurs. On the other hand, it is currently possible to create files where the events in a run are not contiguous by file merging. This is similar to what will also happen with concurrent runs. If one is reading with "noRunLumiSort" mode, then these noncontiguous events from different runs can cause an assert failure in the Framework. We might consider backporting this change to  12_2_X and 12_3_X. Before those release series, "noRunLumiSort" mode did not exist and there was not a problem. One might hesitate to backport this PR because it touches a significant number of lines of critical code. The potential for a new bug is a risk. My inclination would be to not backport it unless problems actually occur, although I will backport it if asked. I am not aware of any conflicts between this PR and those earlier releases.

#### PR validation:

New unit tests are added in FWCore/Integration/test and DataFormats/Provenance/test to cover these changes.
