### PR TITLE
Modifying the AlcaPCCIntegrator for processing concurrent lumiblocks

### DIFF
--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -62,6 +62,4 @@ AlCaNoConcurrentLumis = [
     'PromptCalibProdSiPixelAli',       # AlignmentProducerAsAnalyzer, MillePedeFileConverter
     'PromptCalibProdBeamSpotHP',       # AlcaBeamSpotProducer
     'PromptCalibProdBeamSpotHPLowPU',  # AlcaBeamSpotProducer
-    'AlCaPCCRandom',                   # AlcaPCCIntegrator 
-    'AlCaPCCZeroBias'                  # AlcaPCCIntegrator
 ]

--- a/DataFormats/Luminosity/interface/PixelClusterCounts.h
+++ b/DataFormats/Luminosity/interface/PixelClusterCounts.h
@@ -42,6 +42,27 @@ namespace reco {
       }
     }
 
+    void merge(reco::PixelClusterCounts const& pcc) {
+      std::vector<int> const& counts = pcc.readCounts();
+      std::vector<int> const& modIDs = pcc.readModID();
+      std::vector<int> const& events = pcc.readEvents();
+      for (unsigned int i = 0; i < modIDs.size(); i++) {
+        for (unsigned int bxID = 0; bxID < LumiConstants::numBX; ++bxID) {
+          increment(modIDs[i], bxID + 1, counts.at(i * LumiConstants::numBX + bxID));
+        }
+      }
+      for (unsigned int i = 0; i < LumiConstants::numBX; ++i) {
+        m_events[i] += events[i];
+      }
+    }
+
+    void reset() {
+      m_counts.clear();
+      m_ModID.clear();
+      m_events.clear();
+      m_events.resize(LumiConstants::numBX, 0);
+    }
+
     std::vector<int> const& readCounts() const { return (m_counts); }
     std::vector<int> const& readEvents() const { return (m_events); }
     std::vector<int> const& readModID() const { return (m_ModID); }


### PR DESCRIPTION
#### PR description:
The former AlcaPCCIntegrator is not capable of processing concurrent luminosity blocks, since it is an edm::one::EDProducer. The new module is implemented as an edm::global::EDProducer to be able to run on mulitple threads. The output is not modified, and the corresponding workflow remains the same.

Temporary fix and description of the issue: https://github.com/cms-sw/cmssw/pull/37130

#### PR validation:
The modified producer is tested locally.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
