### PR TITLE
Link cmsRunGP with libtcmalloc.so so that heap profiling can be run.

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -76,7 +76,7 @@
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>
-  <use name="jemalloc"/>
+  <use name="tcmalloc"/>
   <use name="gperf"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>


### PR DESCRIPTION
cmsRunTC links to libtcmalloc_minimal.so so it cannot be used for gperftools heap profiling. Instead of linking libtcmalloc.so to cmsRunTC, link it to cmsRunGP which can then be used for heap profiling.

Tested locally.