### PR TITLE
Cleanup redundant edm ParameterSet existAs in RecoBTag

### DIFF
--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -260,8 +260,7 @@ TemplatedSecondaryVertexProducer<IPTI, VTX>::TemplatedSecondaryVertexProducer(co
       constraint == CONSTRAINT_BEAMSPOT || constraint == CONSTRAINT_PV_PRIMARIES_IN_FIT)
     token_BeamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpotTag"));
   useExternalSV = false;
-  if (params.existsAs<bool>("useExternalSV"))
-    useExternalSV = params.getParameter<bool>("useExternalSV");
+  useExternalSV = params.getParameter<bool>("useExternalSV");
   if (useExternalSV) {
     token_extSVCollection = consumes<edm::View<VTX> >(params.getParameter<edm::InputTag>("extSVCollection"));
     extSVDeltaRToJet = params.getParameter<double>("extSVDeltaRToJet");

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -259,7 +259,6 @@ TemplatedSecondaryVertexProducer<IPTI, VTX>::TemplatedSecondaryVertexProducer(co
   if (constraint == CONSTRAINT_PV_BEAMSPOT_SIZE || constraint == CONSTRAINT_PV_BS_Z_ERRORS_SCALED ||
       constraint == CONSTRAINT_BEAMSPOT || constraint == CONSTRAINT_PV_PRIMARIES_IN_FIT)
     token_BeamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpotTag"));
-  useExternalSV = false;
   useExternalSV = params.getParameter<bool>("useExternalSV");
   if (useExternalSV) {
     token_extSVCollection = consumes<edm::View<VTX> >(params.getParameter<edm::InputTag>("extSVCollection"));


### PR DESCRIPTION
#### PR description:  
(Technical PR) Optimization of the module configurations: Improve maintainability by cleaning up redundant cases of edm::ParameterSet calls to `existAs` or `exist` for tracked parameters, where redundancy is based on the value being already defined by `fillDescriptions`.

As follow the previous [PR36746](https://github.com/cms-sw/cmssw/pull/36746),  [PR36989](https://github.com/cms-sw/cmssw/pull/36989), [PR37313](https://github.com/cms-sw/cmssw/pull/37313), and [PR37314](https://github.com/cms-sw/cmssw/pull/37314).

The list of all calls of `existAs` or `exist` are automatically available in the Static Analyzer report. (Bug: CMS code rules)
It is accessible from IB page. https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/
For this task consider only modules or tools used by the modules that define `fillDescriptions`.

In this PR, 1 file was changed.  
[RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc](https://github.com/cms-sw/cmssw/compare/master...jeongeun:btagupdate124X?expand=1#diff-78b40ba71dc4f20ef7cfc6ee839ae485d85f0758a4d578a33de6dd97852201ac)
 
Here, the "useExternalSV" parameter was provided in a `fillDescription` .
RecoBTag/SecondaryVertex/python/secondaryVertexTagInfos_cfi.py

#### PR validation:
Tested in CMSSW_12_4_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)