### PR TITLE
[123X] Add PPS and EGM tags to dataRun3 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,13 +34,13 @@ autoCond = {
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v2',
     # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '123X_dataRun3_HLT_v5',
+    'run3_hlt'                     : '123X_dataRun3_HLT_v7',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v3',
+    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v4',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '123X_dataRun3_Express_v4',
+    'run3_data_express'            : '123X_dataRun3_Express_v5',
     # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '123X_dataRun3_Prompt_v5',
+    'run3_data_prompt'             : '123X_dataRun3_Prompt_v6',
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '123X_dataRun3_v4',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu


### PR DESCRIPTION
#### PR description:

This PR is to include the new 123X online GTs as well as updating 123X_dataRun3_HLT_relval in autoCond.py

The difference with respect to the previous version of the GTs is the inclusion of new PPS and EGM HLT supercluster regression tags (presented here: https://indico.cern.ch/event/1149147/#22-egm-hlt-supercluster-regres).

The differences are listed below:
**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_HLT_v7/123X_dataRun3_HLT_v5

**run3_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_HLT_relval_v4/123X_dataRun3_HLT_relval_v3

**run3_data_express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_Express_v5/123X_dataRun3_Express_v4

**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_Prompt_v6/123X_dataRun3_Prompt_v5


#### PR validation:

The GTs were validated on a [Tier0 replay](https://cms-talk.web.cern.ch/t/replay-testing-cmssw-12-3-0/9158) (Express and Prompt) and a [Fast Track Validation](https://cms-talk.web.cern.ch/t/12-3-0-online-gts/9249) (HLT and Express).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
backport of #37557 
