### PR TITLE
Remove duplicate pixels

### DIFF
--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -60,6 +60,7 @@ public:
     constexpr int row() const { return row_; }
     constexpr int col() const { return col_; }
     constexpr PixelPos operator+(const Shift& shift) const { return PixelPos(row() + shift.dx(), col() + shift.dy()); }
+    constexpr bool operator==(const PixelPos& pos) const { return (row() == pos.row() && col() == pos.col()); }
 
   private:
     int row_;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -63,6 +63,7 @@ PixelThresholdClusterizer::PixelThresholdClusterizer(edm::ParameterSet const& co
       doSplitClusters(conf.getParameter<bool>("SplitClusters")) {
   theBuffer.setSize(theNumOfRows, theNumOfCols);
   theFakePixels.clear();
+  thePixelOccurrence.clear();
 }
 /////////////////////////////////////////////////////////////////////////////
 PixelThresholdClusterizer::~PixelThresholdClusterizer() {}
@@ -111,6 +112,8 @@ bool PixelThresholdClusterizer::setup(const PixelGeomDetUnit* pixDet) {
   }
 
   theFakePixels.resize(nrows * ncols, false);
+
+  thePixelOccurrence.resize(nrows * ncols, 0);
 
   return true;
 }
@@ -185,6 +188,8 @@ void PixelThresholdClusterizer::clusterizeDetUnitT(const T& input,
   clear_buffer(begin, end);
 
   theFakePixels.clear();
+
+  thePixelOccurrence.clear();
 }
 
 //----------------------------------------------------------------------------
@@ -291,12 +296,28 @@ void PixelThresholdClusterizer::copy_to_buffer(DigiIterator begin, DigiIterator 
     */
 
     if (adc >= thePixelThreshold) {
-      theBuffer.set_adc(row, col, adc);
-      // VV: add pixel to the fake list. Only when running on digi collection
-      if (di->flag() != 0)
-        theFakePixels[row * theNumOfCols + col] = true;
-      if (adc >= theSeedThreshold)
-        theSeeds.push_back(SiPixelCluster::PixelPos(row, col));
+      thePixelOccurrence[theBuffer.index(row, col)]++;                     // increment the occurrence counter
+      uint8_t occurrence = thePixelOccurrence[theBuffer.index(row, col)];  // get the occurrence counter
+
+      switch (occurrence) {
+        // the 1st occurrence (standard treatment)
+        case 1:
+          theBuffer.set_adc(row, col, adc);
+          // VV: add pixel to the fake list. Only when running on digi collection
+          if (di->flag() != 0)
+            theFakePixels[row * theNumOfCols + col] = true;
+          if (adc >= theSeedThreshold)
+            theSeeds.push_back(SiPixelCluster::PixelPos(row, col));
+          break;
+
+        // the 2nd occurrence (duplicate pixel: reset the buffer to 0 and remove from the list of seed pixels)
+        case 2:
+          theBuffer.set_adc(row, col, 0);
+          std::remove(theSeeds.begin(), theSeeds.end(), SiPixelCluster::PixelPos(row, col));
+          break;
+
+          // in case a pixel appears more than twice, nothing needs to be done because it was already removed at the 2nd occurrence
+      }
     }
   }
   assert(i == (end - begin));

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -295,29 +295,29 @@ void PixelThresholdClusterizer::copy_to_buffer(DigiIterator begin, DigiIterator 
        of view of the final cluster charge since these are typically >= 20000.
     */
 
-    if (adc >= thePixelThreshold) {
-      thePixelOccurrence[theBuffer.index(row, col)]++;                     // increment the occurrence counter
-      uint8_t occurrence = thePixelOccurrence[theBuffer.index(row, col)];  // get the occurrence counter
+    thePixelOccurrence[theBuffer.index(row, col)]++;                     // increment the occurrence counter
+    uint8_t occurrence = thePixelOccurrence[theBuffer.index(row, col)];  // get the occurrence counter
 
-      switch (occurrence) {
-        // the 1st occurrence (standard treatment)
-        case 1:
+    switch (occurrence) {
+      // the 1st occurrence (standard treatment)
+      case 1:
+        if (adc >= thePixelThreshold) {
           theBuffer.set_adc(row, col, adc);
           // VV: add pixel to the fake list. Only when running on digi collection
           if (di->flag() != 0)
             theFakePixels[row * theNumOfCols + col] = true;
           if (adc >= theSeedThreshold)
             theSeeds.push_back(SiPixelCluster::PixelPos(row, col));
-          break;
+        }
+        break;
 
-        // the 2nd occurrence (duplicate pixel: reset the buffer to 0 and remove from the list of seed pixels)
-        case 2:
-          theBuffer.set_adc(row, col, 0);
-          std::remove(theSeeds.begin(), theSeeds.end(), SiPixelCluster::PixelPos(row, col));
-          break;
+      // the 2nd occurrence (duplicate pixel: reset the buffer to 0 and remove from the list of seed pixels)
+      case 2:
+        theBuffer.set_adc(row, col, 0);
+        std::remove(theSeeds.begin(), theSeeds.end(), SiPixelCluster::PixelPos(row, col));
+        break;
 
-          // in case a pixel appears more than twice, nothing needs to be done because it was already removed at the 2nd occurrence
-      }
+        // in case a pixel appears more than twice, nothing needs to be done because it was already removed at the 2nd occurrence
     }
   }
   assert(i == (end - begin));

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.h
@@ -92,6 +92,8 @@ protected:
 
   std::vector<bool> theFakePixels;  // fake pixels introduced to guide clustering
 
+  std::vector<uint8_t> thePixelOccurrence;  // the number of times each pixel occurs (for tracking duplicate pixels)
+
   //! Clustering-related quantities:
   float thePixelThresholdInNoiseUnits;    // Pixel threshold in units of noise
   float theSeedThresholdInNoiseUnits;     // Pixel cluster seed in units of noise


### PR DESCRIPTION
#### PR description:

This PR completely removes all duplicate pixels from the clustering step. This is an alternative to https://github.com/cms-sw/cmssw/pull/37496 where charges from duplicate pixels are summed up.

No changes are expected in MC samples because duplicate pixels are not expected to appear in simulation. Nevertheless, as discussed below in https://github.com/cms-sw/cmssw/pull/37559#issuecomment-1099529597 and follow-up comments, it was observed that duplicate pixels actually do appear in Phase 2 MC workflows. If the intention was to add up charges from such duplicate pixels, this is not done even in the current clusterizer code and instead only the last occurrence of a duplicate pixel is taken. Hence, this issue will have to be addressed on the Phase 2 pixel digitizer side.

In the data there could be some tiny differences in case some duplicate pixels appear.

#### PR validation:

Code compiles :)
