### PR TITLE
Create HLTONLY*EventContent

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -178,6 +178,19 @@ RAWEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
 RAWEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
 #
 #
+# HLTONLY Data Tier definition
+#
+#
+HLTONLYEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *'),
+    splitLevel = cms.untracked.int32(0)
+)
+HLTONLYEventContent.outputCommands.extend(L1TriggerRAW.outputCommands)
+HLTONLYEventContent.outputCommands.extend(HLTriggerRAW.outputCommands)
+HLTONLYEventContent.outputCommands.extend(['drop  FEDRawDataCollection_rawDataCollector_*_*',
+                                           'drop  FEDRawDataCollection_source_*_*'])
+#
+#
 # RECO Data Tier definition
 #
 #
@@ -382,6 +395,12 @@ RAWRECODEBUGHLTEventContent = cms.PSet(
 RAWRECODEBUGHLTEventContent.outputCommands.extend(RAWRECOSIMHLTEventContent.outputCommands)
 RAWRECODEBUGHLTEventContent.outputCommands.extend(SimGeneralFEVTDEBUG.outputCommands)
 RAWRECODEBUGHLTEventContent.outputCommands.extend(SimTrackerDEBUG.outputCommands)
+#
+#
+# HLTONLYSIM Data Tier definition
+#
+#
+HLTONLYSIMEventContent = HLTONLYEventContent.clone()
 #
 #
 # RECOSIM Data Tier definition


### PR DESCRIPTION
#### PR description:

This can be used with the two file solution to allow the HLT only step to not write out the RAW data which improves performance. The following step can then read this output and the original RAW file.

#### PR validation:

The 139.00x RelVals appear to be the only ones that have an HLT only step. I changed their step 2 to only use the HLTONLY content and told step3 to use `--secondfilein` to read the RAW file as well as step2.root. The job ran fine.
