### PR TITLE
mkFit update to standalone build/test scripts

### DIFF
--- a/RecoTracker/MkFitCore/interface/Hit.h
+++ b/RecoTracker/MkFitCore/interface/Hit.h
@@ -5,6 +5,7 @@
 #include "RecoTracker/MkFitCore/interface/MatrixSTypes.h"
 
 #include <cmath>
+#include <vector>
 #include <string_view>
 
 namespace mkfit {

--- a/RecoTracker/MkFitCore/standalone/README_buildFromCMSSW.txt
+++ b/RecoTracker/MkFitCore/standalone/README_buildFromCMSSW.txt
@@ -1,0 +1,19 @@
+# Procedure to clone just enough of CMSSW to build mkFit for standalone runs.
+# In "git clone" below, substitute the CMSSW branch you want to start from.
+
+git clone --branch master --single-branch --no-checkout --reference /cvmfs/cms-ib.cern.ch/git/cms-sw/cmssw.git git@github.com:cms-sw/cmssw.git mkFitFromCMSSW
+cd mkFitFromCMSSW
+git config core.sparsecheckout true
+echo -e "/.gitignore\n/.clang-tidy\n/.clang-format" > .git/info/sparse-checkout
+echo -e "/RecoTracker/MkFit/\n/RecoTracker/MkFitCMS/\n/RecoTracker/MkFitCore/" >> .git/info/sparse-checkout
+git checkout  # enter detached-head state
+./RecoTracker/MkFitCore/standalone/configure $PWD
+source ./RecoTracker/MkFitCore/standalone/xeon_scripts/init-gcc10-env.sh
+unset INTEL_LICENSE_FILE
+make -j 16 AVX_512:=1 WITH_ROOT=1
+
+# To build with icc, do the above except for make, then:
+# if [ -z ${INTEL_LICENSE_FILE+x} ]; then INTEL_LICENSE_FILE=1; fi
+# source /opt/intel/oneapi/compiler/latest/env/vars.sh
+# source /opt/intel/oneapi/tbb/latest/env/vars.sh
+# make -j 16 AVX_512:=1 WITH_ROOT=1

--- a/RecoTracker/MkFitCore/standalone/README_buildFromCMSSW.txt
+++ b/RecoTracker/MkFitCore/standalone/README_buildFromCMSSW.txt
@@ -13,7 +13,7 @@ unset INTEL_LICENSE_FILE
 make -j 16 AVX_512:=1 WITH_ROOT=1
 
 # To build with icc, do the above except for make, then:
-# if [ -z ${INTEL_LICENSE_FILE+x} ]; then INTEL_LICENSE_FILE=1; fi
+# if [ -z ${INTEL_LICENSE_FILE+x} ]; then export INTEL_LICENSE_FILE=1; fi
 # source /opt/intel/oneapi/compiler/latest/env/vars.sh
 # source /opt/intel/oneapi/tbb/latest/env/vars.sh
 # make -j 16 AVX_512:=1 WITH_ROOT=1

--- a/RecoTracker/MkFitCore/standalone/README_buildFromCMSSW.txt
+++ b/RecoTracker/MkFitCore/standalone/README_buildFromCMSSW.txt
@@ -8,7 +8,7 @@ echo -e "/.gitignore\n/.clang-tidy\n/.clang-format" > .git/info/sparse-checkout
 echo -e "/RecoTracker/MkFit/\n/RecoTracker/MkFitCMS/\n/RecoTracker/MkFitCore/" >> .git/info/sparse-checkout
 git checkout  # enter detached-head state
 ./RecoTracker/MkFitCore/standalone/configure $PWD
-source ./RecoTracker/MkFitCore/standalone/xeon_scripts/init-gcc10-env.sh
+source ./RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh
 unset INTEL_LICENSE_FILE
 make -j 16 AVX_512:=1 WITH_ROOT=1
 

--- a/RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh
+++ b/RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-source /cvmfs/cms.cern.ch/slc7_amd64_gcc820/lcg/root/6.18.04-bcolbf/etc/profile.d/init.sh
-export TBB_GCC=/cvmfs/cms.cern.ch/slc7_amd64_gcc820/external/tbb/2019_U9
-# workaround for https://github.com/cms-sw/cmsdist/issues/5574
-# remove when we switch to a ROOT build where that issues is fixed
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBJPEG_TURBO_ROOT/lib64
-source /opt/intel/bin/compilervars.sh intel64
+source /cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-f52350f4e0b802edeb9a2551a7d00b92/etc/profile.d/init.sh
+export TBB_GCC=/cvmfs/cms.cern.ch/slc7_amd64_gcc10/external/tbb/v2021.4.0-d0152ca29055e3a1bbf629673f6e97c4
+

--- a/RecoTracker/MkFitCore/standalone/xeon_scripts/init-gcc10-env.sh
+++ b/RecoTracker/MkFitCore/standalone/xeon_scripts/init-gcc10-env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-source /cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.20.06-cms/etc/profile.d/init.sh
-export TBB_GCC=/cvmfs/cms.cern.ch/slc7_amd64_gcc10/external/tbb/2020_U2
+source /cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-f52350f4e0b802edeb9a2551a7d00b92/etc/profile.d/init.sh
+export TBB_GCC=/cvmfs/cms.cern.ch/slc7_amd64_gcc10/external/tbb/v2021.4.0-d0152ca29055e3a1bbf629673f6e97c4
 # workaround for https://github.com/cms-sw/cmsdist/issues/5574
 # remove when we switch to a ROOT build where that issues is fixed
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBJPEG_TURBO_ROOT/lib64
+#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBJPEG_TURBO_ROOT/lib64
 ### source /opt/intel/bin/compilervars.sh intel64

--- a/RecoTracker/MkFitCore/standalone/xeon_scripts/init-gcc10-env.sh
+++ b/RecoTracker/MkFitCore/standalone/xeon_scripts/init-gcc10-env.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-source /cvmfs/cms.cern.ch/slc7_amd64_gcc10/lcg/root/6.24.07-f52350f4e0b802edeb9a2551a7d00b92/etc/profile.d/init.sh
-export TBB_GCC=/cvmfs/cms.cern.ch/slc7_amd64_gcc10/external/tbb/v2021.4.0-d0152ca29055e3a1bbf629673f6e97c4
-# workaround for https://github.com/cms-sw/cmsdist/issues/5574
-# remove when we switch to a ROOT build where that issues is fixed
-#export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIBJPEG_TURBO_ROOT/lib64
-### source /opt/intel/bin/compilervars.sh intel64


### PR DESCRIPTION
This is a technical PR, mostly affecting just the standalone setup of mkFit builds
- add a readme file for local standalone test setup
- update the standalone setup script to more recent reference dependencies from cvmfs in init-env.sh
    - also, drop the now superseded gcc10-specific script

Additionally, RecoTracker/MkFitCore/interface/Hit.h was updated to include the `<vector>` header, which appears missing with the updated build setup. The `vector` was used in this file since a while, and the include was apparently entering indirectly previously.

No changes are expected in the standard PR tests.

@srlantz is the original author of the updates