### PR TITLE
Move pixelTracksCPU module definition inside SwitchProducerCUDA

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
@@ -93,17 +93,14 @@ from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
 
 from RecoPixelVertexing.PixelTriplets.pixelTracksCUDA_cfi import pixelTracksCUDA as _pixelTracksCUDA
 
-#Pixel tracks in SoA format on the CPU
-pixelTracksCPU = _pixelTracksCUDA.clone(
-    pixelRecHitSrc = "siPixelRecHitsPreSplitting",
-    idealConditions = False,
-    onGPU = False
-)
-
 # SwitchProducer providing the pixel tracks in SoA format on the CPU
 pixelTracksSoA = SwitchProducerCUDA(
     # build pixel ntuplets and pixel tracks in SoA format on the CPU
-    cpu = pixelTracksCPU
+    cpu = _pixelTracksCUDA.clone(
+        pixelRecHitSrc = "siPixelRecHitsPreSplitting",
+        idealConditions = False,
+        onGPU = False
+    )
 )
 # use quality cuts tuned for Run 2 ideal conditions for all Run 3 workflows
 run3_common.toModify(pixelTracksSoA.cpu,
@@ -132,7 +129,7 @@ from RecoPixelVertexing.PixelTrackFitting.pixelTrackProducerFromSoA_cfi import p
 
 # "Patatrack" sequence running on GPU (or CPU if not available)
 from Configuration.ProcessModifiers.gpu_cff import gpu
-(pixelNtupletFit & gpu).toModify(pixelTracksCPU,
+(pixelNtupletFit & gpu).toModify(pixelTracksSoA.cpu,
     pixelRecHitSrc = "siPixelRecHitsPreSplittingSoA",
 )
 


### PR DESCRIPTION
#### PR description:

While developing #36938 further (what is now in #37563), I came across this one case where a case-EDProducer of a `SwitchProducer` was duplicated between the python module (`PixelTracks_cff`) and `SwitchProducerCUDA` (`pixelTracksSoA`) instead of cloning the module. With my developments the duplication lead to failures in python. ~~This PR clones the module when adding it in `SwitchProducerCUDA`.~~ This PR moves the definition of what was `pixelTracksCPU` module inside the definition of `pixelTracksSoA` `SwitchProducerCUDA`.

#### PR validation:

The `PixelTracks_cff` file passes python with my developments.