### PR TITLE
Make SwitchProducer work with ConditionalTask

### DIFF
--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -48,6 +48,7 @@
 #include <sstream>
 
 #include "make_shared_noexcept_false.h"
+#include "processEDAliases.h"
 
 namespace edm {
 
@@ -143,201 +144,6 @@ namespace edm {
           }
           throw;
         }
-      }
-    }
-
-    void checkAndInsertAlias(std::string const& friendlyClassName,
-                             std::string const& moduleLabel,
-                             std::string const& productInstanceName,
-                             std::string const& processName,
-                             std::string const& alias,
-                             std::string const& instanceAlias,
-                             ProductRegistry const& preg,
-                             std::multimap<BranchKey, BranchKey>& aliasMap,
-                             std::map<BranchKey, BranchKey>& aliasKeys) {
-      std::string const star("*");
-
-      BranchKey key(friendlyClassName, moduleLabel, productInstanceName, processName);
-      if (preg.productList().find(key) == preg.productList().end()) {
-        // No product was found matching the alias.
-        // We throw an exception only if a module with the specified module label was created in this process.
-        for (auto const& product : preg.productList()) {
-          if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
-            throw Exception(errors::Configuration, "EDAlias does not match data\n")
-                << "There are no products of type '" << friendlyClassName << "'\n"
-                << "with module label '" << moduleLabel << "' and instance name '" << productInstanceName << "'.\n";
-          }
-        }
-      }
-
-      if (auto iter = aliasMap.find(key); iter != aliasMap.end()) {
-        // If the same EDAlias defines multiple products pointing to the same product, throw
-        if (iter->second.moduleLabel() == alias) {
-          throw Exception(errors::Configuration, "EDAlias conflict\n")
-              << "The module label alias '" << alias << "' is used for multiple products of type '" << friendlyClassName
-              << "' with module label '" << moduleLabel << "' and instance name '" << productInstanceName
-              << "'. One alias has the instance name '" << iter->first.productInstanceName()
-              << "' and the other has the instance name '" << instanceAlias << "'.";
-        }
-      }
-
-      std::string const& theInstanceAlias(instanceAlias == star ? productInstanceName : instanceAlias);
-      BranchKey aliasKey(friendlyClassName, alias, theInstanceAlias, processName);
-      if (preg.productList().find(aliasKey) != preg.productList().end()) {
-        throw Exception(errors::Configuration, "EDAlias conflicts with data\n")
-            << "A product of type '" << friendlyClassName << "'\n"
-            << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
-            << "already exists.\n";
-      }
-      auto iter = aliasKeys.find(aliasKey);
-      if (iter != aliasKeys.end()) {
-        // The alias matches a previous one.  If the same alias is used for different product, throw.
-        if (iter->second != key) {
-          throw Exception(errors::Configuration, "EDAlias conflict\n")
-              << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
-              << "are used for multiple products of type '" << friendlyClassName << "'\n"
-              << "One has module label '" << moduleLabel << "' and product instance name '" << productInstanceName
-              << "',\n"
-              << "the other has module label '" << iter->second.moduleLabel() << "' and product instance name '"
-              << iter->second.productInstanceName() << "'.\n";
-        }
-      } else {
-        auto prodIter = preg.productList().find(key);
-        if (prodIter != preg.productList().end()) {
-          if (!prodIter->second.produced()) {
-            throw Exception(errors::Configuration, "EDAlias\n")
-                << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
-                << "are used for a product of type '" << friendlyClassName << "'\n"
-                << "with module label '" << moduleLabel << "' and product instance name '" << productInstanceName
-                << "',\n"
-                << "An EDAlias can only be used for products produced in the current process. This one is not.\n";
-          }
-          aliasMap.insert(std::make_pair(key, aliasKey));
-          aliasKeys.insert(std::make_pair(aliasKey, key));
-        }
-      }
-    }
-
-    void processEDAliases(ParameterSet const& proc_pset, std::string const& processName, ProductRegistry& preg) {
-      std::vector<std::string> aliases = proc_pset.getParameter<std::vector<std::string>>("@all_aliases");
-      if (aliases.empty()) {
-        return;
-      }
-      std::string const star("*");
-      std::string const empty("");
-      ParameterSetDescription desc;
-      desc.add<std::string>("type");
-      desc.add<std::string>("fromProductInstance", star);
-      desc.add<std::string>("toProductInstance", star);
-
-      std::multimap<BranchKey, BranchKey> aliasMap;
-
-      std::map<BranchKey, BranchKey> aliasKeys;  // Used to search for duplicates or clashes.
-
-      // Auxiliary search structure to support wildcard for friendlyClassName
-      std::multimap<std::string, BranchKey> moduleLabelToBranches;
-      for (auto const& prod : preg.productList()) {
-        if (processName == prod.second.processName()) {
-          moduleLabelToBranches.emplace(prod.first.moduleLabel(), prod.first);
-        }
-      }
-
-      // Now, loop over the alias information and store it in aliasMap.
-      for (std::string const& alias : aliases) {
-        ParameterSet const& aliasPSet = proc_pset.getParameterSet(alias);
-        std::vector<std::string> vPSetNames = aliasPSet.getParameterNamesForType<VParameterSet>();
-        for (std::string const& moduleLabel : vPSetNames) {
-          VParameterSet vPSet = aliasPSet.getParameter<VParameterSet>(moduleLabel);
-          for (ParameterSet& pset : vPSet) {
-            desc.validate(pset);
-            std::string friendlyClassName = pset.getParameter<std::string>("type");
-            std::string productInstanceName = pset.getParameter<std::string>("fromProductInstance");
-            std::string instanceAlias = pset.getParameter<std::string>("toProductInstance");
-
-            if (friendlyClassName == star) {
-              bool processHasLabel = false;
-              bool match = false;
-              for (auto it = moduleLabelToBranches.lower_bound(moduleLabel);
-                   it != moduleLabelToBranches.end() && it->first == moduleLabel;
-                   ++it) {
-                processHasLabel = true;
-                if (productInstanceName != star and productInstanceName != it->second.productInstanceName()) {
-                  continue;
-                }
-                match = true;
-
-                checkAndInsertAlias(it->second.friendlyClassName(),
-                                    moduleLabel,
-                                    it->second.productInstanceName(),
-                                    processName,
-                                    alias,
-                                    instanceAlias,
-                                    preg,
-                                    aliasMap,
-                                    aliasKeys);
-              }
-              if (not match and processHasLabel) {
-                // No product was found matching the alias.
-                // We throw an exception only if a module with the specified module label was created in this process.
-                // Note that if that condition is ever relatex, it  might be best to throw an exception with different
-                // message (omitting productInstanceName) in case 'productInstanceName == start'
-                throw Exception(errors::Configuration, "EDAlias parameter set mismatch\n")
-                    << "There are no products with module label '" << moduleLabel << "' and product instance name '"
-                    << productInstanceName << "'.\n";
-              }
-            } else if (productInstanceName == star) {
-              bool match = false;
-              BranchKey lowerBound(friendlyClassName, moduleLabel, empty, empty);
-              for (ProductRegistry::ProductList::const_iterator it = preg.productList().lower_bound(lowerBound);
-                   it != preg.productList().end() && it->first.friendlyClassName() == friendlyClassName &&
-                   it->first.moduleLabel() == moduleLabel;
-                   ++it) {
-                if (it->first.processName() != processName) {
-                  continue;
-                }
-                match = true;
-
-                checkAndInsertAlias(friendlyClassName,
-                                    moduleLabel,
-                                    it->first.productInstanceName(),
-                                    processName,
-                                    alias,
-                                    instanceAlias,
-                                    preg,
-                                    aliasMap,
-                                    aliasKeys);
-              }
-              if (!match) {
-                // No product was found matching the alias.
-                // We throw an exception only if a module with the specified module label was created in this process.
-                for (auto const& product : preg.productList()) {
-                  if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
-                    throw Exception(errors::Configuration, "EDAlias parameter set mismatch\n")
-                        << "There are no products of type '" << friendlyClassName << "'\n"
-                        << "with module label '" << moduleLabel << "'.\n";
-                  }
-                }
-              }
-            } else {
-              checkAndInsertAlias(friendlyClassName,
-                                  moduleLabel,
-                                  productInstanceName,
-                                  processName,
-                                  alias,
-                                  instanceAlias,
-                                  preg,
-                                  aliasMap,
-                                  aliasKeys);
-            }
-          }
-        }
-      }
-
-      // Now add the new alias entries to the product registry.
-      for (auto const& aliasEntry : aliasMap) {
-        ProductRegistry::ProductList::const_iterator it = preg.productList().find(aliasEntry.first);
-        assert(it != preg.productList().end());
-        preg.addLabelAlias(it->second, aliasEntry.second.moduleLabel(), aliasEntry.second.productInstanceName());
       }
     }
 
@@ -772,7 +578,10 @@ namespace edm {
     std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string>>("@all_modules"));
     std::map<std::string, std::vector<std::pair<std::string, int>>> outputModulePathPositions;
     reduceParameterSet(proc_pset, tns.getEndPaths(), modulesInConfig, usedModuleLabels, outputModulePathPositions);
-    processEDAliases(proc_pset, processConfiguration->processName(), preg);
+    {
+      std::vector<std::string> aliases = proc_pset.getParameter<std::vector<std::string>>("@all_aliases");
+      detail::processEDAliases(aliases, {}, proc_pset, processConfiguration->processName(), preg);
+    }
 
     // At this point all BranchDescriptions are created. Mark now the
     // ones of unscheduled workers to be on-demand.

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -578,21 +578,23 @@ namespace edm {
           auto aliasedToModuleLabels = info.getParameterNames();
           for (auto const& mod : aliasedToModuleLabels) {
             if (not mod.empty() and mod[0] != '@' and conditionalmods.find(mod) != conditionalmods.end()) {
-              auto aliasPSet = proc_pset.getParameter<edm::ParameterSet>(mod);
-              std::string type = star;
-              std::string instance = star;
-              std::string originalInstance = star;
-              if (aliasPSet.exists("type")) {
-                type = aliasPSet.getParameter<std::string>("type");
-              }
-              if (aliasPSet.exists("toProductInstance")) {
-                instance = aliasPSet.getParameter<std::string>("toProductInstance");
-              }
-              if (aliasPSet.exists("fromProductInstance")) {
-                originalInstance = aliasPSet.getParameter<std::string>("fromProductInstance");
-              }
+              auto aliasVPSet = info.getParameter<std::vector<edm::ParameterSet>>(mod);
+              for (auto const& aliasPSet : aliasVPSet) {
+                std::string type = star;
+                std::string instance = star;
+                std::string originalInstance = star;
+                if (aliasPSet.exists("type")) {
+                  type = aliasPSet.getParameter<std::string>("type");
+                }
+                if (aliasPSet.exists("toProductInstance")) {
+                  instance = aliasPSet.getParameter<std::string>("toProductInstance");
+                }
+                if (aliasPSet.exists("fromProductInstance")) {
+                  originalInstance = aliasPSet.getParameter<std::string>("fromProductInstance");
+                }
 
-              aliasMap.emplace(alias, AliasInfo{type, instance, originalInstance, mod});
+                aliasMap.emplace(alias, AliasInfo{type, instance, originalInstance, mod});
+              }
             }
           }
         }

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -28,6 +28,7 @@
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include "LuminosityBlockProcessingStatus.h"
+#include "processEDAliases.h"
 
 #include <algorithm>
 #include <cassert>
@@ -485,6 +486,10 @@ namespace edm {
             }
             if (productFromConditionalModule) {
               itFound = conditionalModules.find(productModuleLabel);
+              //check that the alias-for conditional module has not been used
+              if (itFound == conditionalModules.end()) {
+                continue;
+              }
             }
           } else {
             //need to check the rest of the data product info
@@ -591,6 +596,26 @@ namespace edm {
             }
           }
         }
+      }
+      //find SwitchProducers whose chosen case is an alias
+      {
+        auto const& all_modules = proc_pset.getParameter<std::vector<std::string>>("@all_modules");
+        std::vector<std::string> switchEDAliases;
+        for (auto const& module : all_modules) {
+          auto const& mod_pset = proc_pset.getParameter<edm::ParameterSet>(module);
+          if (mod_pset.getParameter<std::string>("@module_type") == "SwitchProducer") {
+            auto const& chosen_case = mod_pset.getUntrackedParameter<std::string>("@chosen_case");
+            auto range = aliasMap.equal_range(chosen_case);
+            if (range.first != range.second) {
+              switchEDAliases.push_back(chosen_case);
+              for (auto it = range.first; it != range.second; ++it) {
+                aliasMap.emplace(module, it->second);
+              }
+            }
+          }
+        }
+        detail::processEDAliases(
+            switchEDAliases, conditionalmods, proc_pset, processConfiguration->processName(), preg);
       }
       {
         //find branches created by the conditional modules

--- a/FWCore/Framework/src/processEDAliases.cc
+++ b/FWCore/Framework/src/processEDAliases.cc
@@ -46,11 +46,15 @@ namespace edm {
 
       std::string const& theInstanceAlias(instanceAlias == star ? productInstanceName : instanceAlias);
       BranchKey aliasKey(friendlyClassName, alias, theInstanceAlias, processName);
-      if (preg.productList().find(aliasKey) != preg.productList().end()) {
-        throw Exception(errors::Configuration, "EDAlias conflicts with data\n")
-            << "A product of type '" << friendlyClassName << "'\n"
-            << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
-            << "already exists.\n";
+      if (auto it = preg.productList().find(aliasKey); it != preg.productList().end()) {
+        // We might have already inserted an alias that was a chosen case of a SwitchProducer
+        if (not it->second.isAlias()) {
+          throw Exception(errors::Configuration, "EDAlias conflicts with data\n")
+              << "A product of type '" << friendlyClassName << "'\n"
+              << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
+              << "already exists.\n";
+        }
+        return;
       }
       auto iter = aliasKeys.find(aliasKey);
       if (iter != aliasKeys.end()) {

--- a/FWCore/Framework/src/processEDAliases.cc
+++ b/FWCore/Framework/src/processEDAliases.cc
@@ -1,0 +1,218 @@
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/BranchKey.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "processEDAliases.h"
+
+#include <map>
+
+namespace edm {
+  namespace {
+    void checkAndInsertAlias(std::string const& friendlyClassName,
+                             std::string const& moduleLabel,
+                             std::string const& productInstanceName,
+                             std::string const& processName,
+                             std::string const& alias,
+                             std::string const& instanceAlias,
+                             ProductRegistry const& preg,
+                             std::multimap<BranchKey, BranchKey>& aliasMap,
+                             std::map<BranchKey, BranchKey>& aliasKeys) {
+      std::string const star("*");
+
+      BranchKey key(friendlyClassName, moduleLabel, productInstanceName, processName);
+      if (preg.productList().find(key) == preg.productList().end()) {
+        // No product was found matching the alias.
+        // We throw an exception only if a module with the specified module label was created in this process.
+        for (auto const& product : preg.productList()) {
+          if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
+            throw Exception(errors::Configuration, "EDAlias does not match data\n")
+                << "There are no products of type '" << friendlyClassName << "'\n"
+                << "with module label '" << moduleLabel << "' and instance name '" << productInstanceName << "'.\n";
+          }
+        }
+      }
+
+      if (auto iter = aliasMap.find(key); iter != aliasMap.end()) {
+        // If the same EDAlias defines multiple products pointing to the same product, throw
+        if (iter->second.moduleLabel() == alias) {
+          throw Exception(errors::Configuration, "EDAlias conflict\n")
+              << "The module label alias '" << alias << "' is used for multiple products of type '" << friendlyClassName
+              << "' with module label '" << moduleLabel << "' and instance name '" << productInstanceName
+              << "'. One alias has the instance name '" << iter->first.productInstanceName()
+              << "' and the other has the instance name '" << instanceAlias << "'.";
+        }
+      }
+
+      std::string const& theInstanceAlias(instanceAlias == star ? productInstanceName : instanceAlias);
+      BranchKey aliasKey(friendlyClassName, alias, theInstanceAlias, processName);
+      if (preg.productList().find(aliasKey) != preg.productList().end()) {
+        throw Exception(errors::Configuration, "EDAlias conflicts with data\n")
+            << "A product of type '" << friendlyClassName << "'\n"
+            << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
+            << "already exists.\n";
+      }
+      auto iter = aliasKeys.find(aliasKey);
+      if (iter != aliasKeys.end()) {
+        // The alias matches a previous one.  If the same alias is used for different product, throw.
+        if (iter->second != key) {
+          throw Exception(errors::Configuration, "EDAlias conflict\n")
+              << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
+              << "are used for multiple products of type '" << friendlyClassName << "'\n"
+              << "One has module label '" << moduleLabel << "' and product instance name '" << productInstanceName
+              << "',\n"
+              << "the other has module label '" << iter->second.moduleLabel() << "' and product instance name '"
+              << iter->second.productInstanceName() << "'.\n";
+        }
+      } else {
+        auto prodIter = preg.productList().find(key);
+        if (prodIter != preg.productList().end()) {
+          if (!prodIter->second.produced()) {
+            throw Exception(errors::Configuration, "EDAlias\n")
+                << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
+                << "are used for a product of type '" << friendlyClassName << "'\n"
+                << "with module label '" << moduleLabel << "' and product instance name '" << productInstanceName
+                << "',\n"
+                << "An EDAlias can only be used for products produced in the current process. This one is not.\n";
+          }
+          aliasMap.insert(std::make_pair(key, aliasKey));
+          aliasKeys.insert(std::make_pair(aliasKey, key));
+        }
+      }
+    }
+  }  // namespace
+
+  namespace detail {
+    void processEDAliases(std::vector<std::string> const& aliasNamesToProcess,
+                          std::unordered_set<std::string> const& aliasModulesToProcess,
+                          ParameterSet const& proc_pset,
+                          std::string const& processName,
+                          ProductRegistry& preg) {
+      if (aliasNamesToProcess.empty()) {
+        return;
+      }
+      std::string const star("*");
+      std::string const empty("");
+      ParameterSetDescription desc;
+      desc.add<std::string>("type");
+      desc.add<std::string>("fromProductInstance", star);
+      desc.add<std::string>("toProductInstance", star);
+
+      std::multimap<BranchKey, BranchKey> aliasMap;
+
+      std::map<BranchKey, BranchKey> aliasKeys;  // Used to search for duplicates or clashes.
+
+      // Auxiliary search structure to support wildcard for friendlyClassName
+      std::multimap<std::string, BranchKey> moduleLabelToBranches;
+      for (auto const& prod : preg.productList()) {
+        if (processName == prod.second.processName()) {
+          moduleLabelToBranches.emplace(prod.first.moduleLabel(), prod.first);
+        }
+      }
+
+      // Now, loop over the alias information and store it in aliasMap.
+      for (std::string const& alias : aliasNamesToProcess) {
+        ParameterSet const& aliasPSet = proc_pset.getParameterSet(alias);
+        std::vector<std::string> vPSetNames = aliasPSet.getParameterNamesForType<VParameterSet>();
+        for (std::string const& moduleLabel : vPSetNames) {
+          if (not aliasModulesToProcess.empty() and
+              aliasModulesToProcess.find(moduleLabel) == aliasModulesToProcess.end()) {
+            continue;
+          }
+
+          VParameterSet vPSet = aliasPSet.getParameter<VParameterSet>(moduleLabel);
+          for (ParameterSet& pset : vPSet) {
+            desc.validate(pset);
+            std::string friendlyClassName = pset.getParameter<std::string>("type");
+            std::string productInstanceName = pset.getParameter<std::string>("fromProductInstance");
+            std::string instanceAlias = pset.getParameter<std::string>("toProductInstance");
+
+            if (friendlyClassName == star) {
+              bool processHasLabel = false;
+              bool match = false;
+              for (auto it = moduleLabelToBranches.lower_bound(moduleLabel);
+                   it != moduleLabelToBranches.end() && it->first == moduleLabel;
+                   ++it) {
+                processHasLabel = true;
+                if (productInstanceName != star and productInstanceName != it->second.productInstanceName()) {
+                  continue;
+                }
+                match = true;
+
+                checkAndInsertAlias(it->second.friendlyClassName(),
+                                    moduleLabel,
+                                    it->second.productInstanceName(),
+                                    processName,
+                                    alias,
+                                    instanceAlias,
+                                    preg,
+                                    aliasMap,
+                                    aliasKeys);
+              }
+              if (not match and processHasLabel) {
+                // No product was found matching the alias.
+                // We throw an exception only if a module with the specified module label was created in this process.
+                // Note that if that condition is ever relatex, it  might be best to throw an exception with different
+                // message (omitting productInstanceName) in case 'productInstanceName == start'
+                throw Exception(errors::Configuration, "EDAlias parameter set mismatch\n")
+                    << "There are no products with module label '" << moduleLabel << "' and product instance name '"
+                    << productInstanceName << "'.\n";
+              }
+            } else if (productInstanceName == star) {
+              bool match = false;
+              BranchKey lowerBound(friendlyClassName, moduleLabel, empty, empty);
+              for (ProductRegistry::ProductList::const_iterator it = preg.productList().lower_bound(lowerBound);
+                   it != preg.productList().end() && it->first.friendlyClassName() == friendlyClassName &&
+                   it->first.moduleLabel() == moduleLabel;
+                   ++it) {
+                if (it->first.processName() != processName) {
+                  continue;
+                }
+                match = true;
+
+                checkAndInsertAlias(friendlyClassName,
+                                    moduleLabel,
+                                    it->first.productInstanceName(),
+                                    processName,
+                                    alias,
+                                    instanceAlias,
+                                    preg,
+                                    aliasMap,
+                                    aliasKeys);
+              }
+              if (!match) {
+                // No product was found matching the alias.
+                // We throw an exception only if a module with the specified module label was created in this process.
+                for (auto const& product : preg.productList()) {
+                  if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
+                    throw Exception(errors::Configuration, "EDAlias parameter set mismatch\n")
+                        << "There are no products of type '" << friendlyClassName << "'\n"
+                        << "with module label '" << moduleLabel << "'.\n";
+                  }
+                }
+              }
+            } else {
+              checkAndInsertAlias(friendlyClassName,
+                                  moduleLabel,
+                                  productInstanceName,
+                                  processName,
+                                  alias,
+                                  instanceAlias,
+                                  preg,
+                                  aliasMap,
+                                  aliasKeys);
+            }
+          }
+        }
+      }
+
+      // Now add the new alias entries to the product registry.
+      for (auto const& aliasEntry : aliasMap) {
+        // Then check that the alias-for product exists
+        ProductRegistry::ProductList::const_iterator it = preg.productList().find(aliasEntry.first);
+        assert(it != preg.productList().end());
+        preg.addLabelAlias(it->second, aliasEntry.second.moduleLabel(), aliasEntry.second.productInstanceName());
+      }
+    }
+  }  // namespace detail
+}  // namespace edm

--- a/FWCore/Framework/src/processEDAliases.h
+++ b/FWCore/Framework/src/processEDAliases.h
@@ -1,0 +1,27 @@
+#ifndef FWCore_Framework_src_processEDAliases_h
+#define FWCore_Framework_src_processEDAliases_h
+
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <unordered_set>
+#include <string>
+#include <vector>
+
+namespace edm::detail {
+  /**
+   * Process and insert EDAliases to ProductRegistry
+   *
+   * Processes only those EDAliases whose names are given in
+   * aliasNamesToProcess. If aliasModulesToProcess is not empty, only
+   * those alias branches that point to modules named in
+   * aliasModulesToProcess are processed.
+   */
+  void processEDAliases(std::vector<std::string> const& aliasNamesToProcess,
+                        std::unordered_set<std::string> const& aliasModulesToProcess,
+                        ParameterSet const& proc_pset,
+                        std::string const& processName,
+                        ProductRegistry& preg);
+}  // namespace edm::detail
+
+#endif

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -4,6 +4,8 @@ test=testSwitchProducer
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
+# Running on multiple threads and streams to test any behavior that
+# occurs when there are many of them
 NUMTHREADS=4
 
 pushd ${LOCAL_TMP_DIR}
@@ -37,6 +39,29 @@ pushd ${LOCAL_TMP_DIR}
   echo "*************************************************"
   echo "Test provenance of reversely merged output (Task)"
   cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerTaskMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py Task2" $?
+
+
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTask_cfg.py || die "cmsRun ${test}ConditionalTask_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, case test2 disabled"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTask_cfg.py disableTest2 || die "cmsRun ${test}ConditionalTask_cfg.py 2" $?
+
+  echo "*************************************************"
+  echo "Merge outputs (ConditionalTask)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerConditionalTaskMerge1.root inputFiles=file:testSwitchProducerConditionalTask1.root inputFiles=file:testSwitchProducerConditionalTask2.root || die "Merge ConditionalTask1: order 1 2" $?
+  echo "*************************************************"
+  echo "Merge outputs in reverse order (ConditionalTask)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerConditionalTaskMerge2.root inputFiles=file:testSwitchProducerConditionalTask2.root inputFiles=file:testSwitchProducerConditionalTask1.root || die "Merge ConditionalTask2: order 2 1" $?
+
+  echo "*************************************************"
+  echo "Test provenance of merged output (ConditionalTask)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerConditionalTaskMerge1.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py ConditionalTask1" $?
+  echo "*************************************************"
+  echo "Test provenance of reversely merged output (ConditionalTask)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerConditionalTaskMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py ConditionalTask2" $?
 
   
   echo "*************************************************"

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -63,6 +63,14 @@ pushd ${LOCAL_TMP_DIR}
   echo "Test provenance of reversely merged output (ConditionalTask)"
   cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerConditionalTaskMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py ConditionalTask2" $?
 
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, more extensive EDAlias tests"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAlias_cfg.py || die "cmsRun ${test}ConditionalTaskEDAlias_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, more extensive EDAlias tests, case test2 disabled"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAlias_cfg.py disableTest2 || die "cmsRun ${test}ConditionalTaskEDAlias_cfg.py 2" $?
+
   
   echo "*************************************************"
   echo "SwitchProducer in a Path"

--- a/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
@@ -23,15 +23,20 @@ process.out = cms.OutputModule("PoolOutputModule",
     outputCommands = cms.untracked.vstring(
         'keep *_intProducerAlias_*_*',
         'keep *_intProducerDep_*_*',
+        'keep *_intProducerDepAliasDep_*_*',
     )
 )
 
 process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
 process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
+process.intProducer3 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(3))
+process.intProducer4 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(4))
 if enableTest2:
     process.intProducer1.throw = cms.untracked.bool(True)
 else:
     process.intProducer2.throw = cms.untracked.bool(True)
+    process.intProducer3.throw = cms.untracked.bool(True)
+    process.intProducer4.throw = cms.untracked.bool(True)
 
 
 process.intProducerAlias = SwitchProducerTest(
@@ -44,6 +49,19 @@ process.intProducerDep = cms.EDProducer("AddIntsProducer", labels = cms.VInputTa
 if not enableTest2:
     process.intProducerDep.labels = ["intProducer1"]
 
-process.ct = cms.ConditionalTask(process.intProducer1, process.intProducer2)
-process.p = cms.Path(process.intProducerAlias+process.intProducerDep,
+process.intProducerDepAlias = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducerDep", "intProducerAlias")),
+    test2 = cms.EDAlias(intProducer3 = cms.VPSet(cms.PSet(type = cms.string("*"), fromProductInstance = cms.string(""), toProductInstance = cms.string(""))),
+                        intProducer4 = cms.VPSet(cms.PSet(type = cms.string("*"), fromProductInstance = cms.string(""), toProductInstance = cms.string("other"))))
+)
+process.intProducerDepAliasDep = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer3", "intProducer4"))
+if not enableTest2:
+    process.intProducerDepAliasDep.labels = ["intProducerAlias"]
+
+process.ct = cms.ConditionalTask(process.intProducer1, process.intProducer2, process.intProducer3, process.intProducer4)
+process.p = cms.Path(process.intProducerAlias+process.intProducerDep +
+                     process.intProducerDepAlias + process.intProducerDepAliasDep,
                      process.ct)
+
+process.ct2 = cms.ConditionalTask(process.intProducerAlias, process.intProducerDep, process.intProducerDepAlias, process.ct)
+process.p2 = cms.Path(process.intProducerDepAliasDep, process.ct2)

--- a/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+enableTest2 = (sys.argv[-1] != "disableTest2")
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda accelerators: (True, -10),
+                test2 = lambda accelerators: (enableTest2, -9)
+            ), **kargs)
+
+process = cms.Process("PROD1")
+
+process.source = cms.Source("EmptySource")
+if enableTest2:
+    process.source.firstLuminosityBlock = cms.untracked.uint32(2)
+
+process.maxEvents.input = 3
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSwitchProducerConditionalTaskEDAlias%d.root' % (1 if enableTest2 else 2,)),
+    outputCommands = cms.untracked.vstring(
+        'keep *_intProducerAlias_*_*',
+        'keep *_intProducerDep_*_*',
+    )
+)
+
+process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
+process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
+if enableTest2:
+    process.intProducer1.throw = cms.untracked.bool(True)
+else:
+    process.intProducer2.throw = cms.untracked.bool(True)
+
+
+process.intProducerAlias = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer1")),
+    test2 = cms.EDAlias(intProducer2 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string(""), toProductInstance = cms.string("")),
+                                                 cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
+)
+
+process.intProducerDep = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer2"))
+if not enableTest2:
+    process.intProducerDep.labels = ["intProducer1"]
+
+process.ct = cms.ConditionalTask(process.intProducer1, process.intProducer2)
+process.p = cms.Path(process.intProducerAlias+process.intProducerDep,
+                     process.ct)

--- a/FWCore/Integration/test/testSwitchProducerConditionalTask_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTask_cfg.py
@@ -16,12 +16,10 @@ process.source = cms.Source("EmptySource")
 if enableTest2:
     process.source.firstLuminosityBlock = cms.untracked.uint32(2)
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testSwitchProducerTask%d.root' % (1 if enableTest2 else 2,)),
+    fileName = cms.untracked.string('testSwitchProducerConditionalTask%d.root' % (1 if enableTest2 else 2,)),
     outputCommands = cms.untracked.vstring(
         'keep *_intProducer_*_*',
         'keep *_intProducerOther_*_*',
@@ -70,9 +68,8 @@ process.intProducerDep1 = cms.EDProducer("AddIntsProducer", labels = cms.VInputT
 process.intProducerDep2 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer"))
 process.intProducerDep3 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer"))
 
-process.t = cms.Task(process.intProducer, process.intProducerOther, process.intProducerAlias, process.intProducerAlias2,
-                     process.intProducerDep1, process.intProducerDep2, process.intProducerDep3,
-                     process.intProducer1, process.intProducer2, process.intProducer3, process.intProducer4)
-process.p = cms.Path(process.t)
+process.ct = cms.ConditionalTask(process.intProducer, process.intProducerOther, process.intProducerAlias, process.intProducerAlias2,
+                                 process.intProducer1, process.intProducer2, process.intProducer3, process.intProducer4)
+process.p = cms.Path(process.intProducerDep1+process.intProducerDep2+process.intProducerDep3, process.ct)
 
 process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerPath_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerPath_cfg.py
@@ -12,12 +12,6 @@ class SwitchProducerTest(cms.SwitchProducer):
 
 process = cms.Process("PROD1")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1),
-    numberOfConcurrentRuns = cms.untracked.uint32(1),
-    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
-)
-
 process.source = cms.Source("EmptySource")
 if enableTest2:
     process.source.firstLuminosityBlock = cms.untracked.uint32(2)

--- a/FWCore/Integration/test/testSwitchProducerTaskInput_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerTaskInput_cfg.py
@@ -12,12 +12,6 @@ class SwitchProducerTest(cms.SwitchProducer):
 
 process = cms.Process("PROD2")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1),
-    numberOfConcurrentRuns = cms.untracked.uint32(1),
-    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
-)
-
 # Test that having SwitchProducers with same labels as products from
 # earlier processes works
 process.source = cms.Source("PoolSource",

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1298,7 +1298,7 @@ class Process(object):
               l.sort()
               decoratedList.extend(l)
               decoratedList.append("@")
-            iPath.insertInto(processPSet, triggername, decoratedList)
+            iPath.insertInto(processPSet, triggername, decoratedList[:])
         for endpathname in endpaths:
             if endpathname is not endPathWithFinalPathModulesName:
               iEndPath = self.endpaths_()[endpathname]
@@ -1308,7 +1308,7 @@ class Process(object):
             endpathValidator.setLabel(endpathname)
             lister.initialize()
             iEndPath.visit(endpathCompositeVisitor)
-            iEndPath.insertInto(processPSet, endpathname, decoratedList)
+            iEndPath.insertInto(processPSet, endpathname, decoratedList[:])
         processPSet.addVString(False, "@filters_on_endpaths", endpathValidator.filtersOnEndpaths)
           
 
@@ -3692,6 +3692,26 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             self.assertEqual((True,"Foo"), p.values["sp@test1"][1].values["@module_type"])
             self.assertEqual((True,"EDAlias"), p.values["sp@test2"][1].values["@module_edm_type"])
             self.assertEqual((True,"Bar"), p.values["sp@test2"][1].values["a"][1][0].values["type"])
+
+            # ConditionalTask
+            proc = Process("test")
+            proc.spct = SwitchProducerTest(test2 = EDProducer("Foo",
+                                                              a = int32(1),
+                                                              b = PSet(c = int32(2))),
+                                           test1 = EDProducer("Bar",
+                                                              aa = int32(11),
+                                                              bb = PSet(cc = int32(12))),
+                                           test3 = EDAlias(a = VPSet(PSet(type = string("Bar")))))
+            proc.spp = proc.spct.clone()
+            proc.a = EDProducer("A")
+            proc.ct = ConditionalTask(proc.spct)
+            proc.p = Path(proc.a, proc.ct)
+            proc.pp = Path(proc.a + proc.spp)
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual(["a", "spct", "spct@test1", "spct@test2", "spp", "spp@test1", "spp@test2"], p.values["@all_modules"][1])
+            self.assertEqual(["a", "#", "spct", "spct@test1", "spct@test2", "@"], p.values["p"][1])
+            self.assertEqual(["a", "spp", "#", "spp@test1", "spp@test2", "@"], p.values["pp"][1])
 
         def testPrune(self):
             p = Process("test")

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -3613,6 +3613,10 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
                                          test1 = EDProducer("Bar",
                                                             aa = int32(11),
                                                             bb = PSet(cc = int32(12))))
+            self.assertEqual(proc.sp.label_(), "sp")
+            self.assertEqual(proc.sp.test1.label_(), "sp@test1")
+            self.assertEqual(proc.sp.test2.label_(), "sp@test2")
+
             proc.a = EDProducer("A")
             proc.s = Sequence(proc.a + proc.sp)
             proc.t = Task(proc.a, proc.sp)
@@ -3990,11 +3994,15 @@ process.schedule = cms.Schedule(*[ process.path1, process.path2 ])""")
             p.f = EDAnalyzer("OurAnalyzer")
             p.g = EDProducer("OurProducer")
             p.h = EDProducer("YourProducer")
-            p.t1 = Task(p.g, p.h)
-            t2 = Task(p.g, p.h)
+            p.i = SwitchProducerTest(
+                test1 = EDProducer("OneProducer"),
+                test2 = EDProducer("TwoProducer")
+            )
+            p.t1 = Task(p.g, p.h, p.i)
+            t2 = Task(p.g, p.h, p.i)
             t3 = Task(p.g, p.h)
             p.t4 = Task(p.h)
-            p.ct1 = ConditionalTask(p.g, p.h)
+            p.ct1 = ConditionalTask(p.g, p.h, p.i)
             ct2 = ConditionalTask(p.g, p.h)
             ct3 = ConditionalTask(p.g, p.h)
             p.ct4 = ConditionalTask(p.h)
@@ -4007,9 +4015,11 @@ process.schedule = cms.Schedule(*[ process.path1, process.path2 ])""")
             p.schedule = Schedule(p.path2, p.path3, p.endpath2, tasks=[t3, p.t4])
             self.assertTrue(hasattr(p, 'f'))
             self.assertTrue(hasattr(p, 'g'))
+            self.assertTrue(hasattr(p, 'i'))
             del p.e
             del p.f
             del p.g
+            del p.i
             self.assertFalse(hasattr(p, 'f'))
             self.assertFalse(hasattr(p, 'g'))
             self.assertEqual(p.t1.dumpPython(), 'cms.Task(process.h)\n')

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -252,6 +252,14 @@ class SwitchProducer(EDProducer):
         self.__setParameters(kargs)
         self._isModified = False
 
+    def setLabel(self, label):
+        super().setLabel(label)
+        # SwitchProducer owns the contained modules, and therefore
+        # need to set / unset the label for them explicitly here
+        for case in self.parameterNames_():
+            producer = self.__dict__[case]
+            producer.setLabel(self.caseLabel_(label, case) if label is not None else None)
+
     @staticmethod
     def getCpu():
         """Returns a function that returns the priority for a CPU "computing device". Intended to be used by deriving classes."""
@@ -288,6 +296,8 @@ class SwitchProducer(EDProducer):
             message += self.dumpPython() + '\n'
             raise ValueError(message)
         self.__dict__[name]=value
+        if self.hasLabel_():
+            value.setLabel(self.caseLabel_(self.label_(), name))
         self._Parameterizable__parameterNames.append(name)
         self._isModified = True
 
@@ -318,6 +328,8 @@ class SwitchProducer(EDProducer):
                 raise TypeError(name+" can only be set to a cms.EDProducer or cms.EDAlias")
             # We should always receive an cms.EDProducer
             self.__dict__[name] = value
+            if self.hasLabel_():
+                value.setLabel(self.caseLabel_(self.label_(), name))
             self._isModified = True
 
     def clone(self, **params):
@@ -386,8 +398,8 @@ class SwitchProducer(EDProducer):
         newpset.addString(True, "@module_label", self.moduleLabel_(myname))
         newpset.addString(True, "@module_type", "SwitchProducer")
         newpset.addString(True, "@module_edm_type", "EDProducer")
-        newpset.addVString(True, "@all_cases", [myname+"@"+p for p in self.parameterNames_()])
-        newpset.addString(False, "@chosen_case", myname+"@"+self._chooseCase(accelerators))
+        newpset.addVString(True, "@all_cases", [self.caseLabel_(myname, p) for p in self.parameterNames_()])
+        newpset.addString(False, "@chosen_case", self.caseLabel_(myname, self._chooseCase(accelerators)))
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
 
     def _placeImpl(self,name,proc):
@@ -550,6 +562,24 @@ if __name__ == "__main__":
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESProducer("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESPrefer("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = SwitchProducerTest(test1 = EDProducer("Foo"))))
+
+            # Label
+            sp.setLabel("sp")
+            self.assertEqual(sp.label_(), "sp")
+            self.assertEqual(sp.test1.label_(), "sp@test1")
+            self.assertEqual(sp.test2.label_(), "sp@test2")
+            sp.test3 = EDProducer("Xyzzy")
+            self.assertEqual(sp.test3.label_(), "sp@test3")
+            sp.test1 = EDProducer("Fred")
+            self.assertEqual(sp.test1.label_(), "sp@test1")
+            del sp.test1
+            sp.test1 = EDProducer("Wilma")
+            self.assertEqual(sp.test1.label_(), "sp@test1")
+            sp.setLabel(None)
+            sp.setLabel("other")
+            self.assertEqual(sp.label_(), "other")
+            self.assertEqual(sp.test1.label_(), "other@test1")
+            self.assertEqual(sp.test2.label_(), "other@test2")
 
             # Case decision
             accelerators = ["test1", "test2", "test3"]

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -380,6 +380,14 @@ class SwitchProducer(EDProducer):
         return myname
     def caseLabel_(self, name, case):
         return name+"@"+case
+    def modulesForConditionalTask_(self):
+        # Need the contained modules (not EDAliases) for ConditionalTask
+        ret = []
+        for case in self.parameterNames_():
+            caseobj = self.__dict__[case]
+            if not isinstance(caseobj, EDAlias):
+                ret.append(caseobj)
+        return ret
     def appendToProcessDescLists_(self, modules, aliases, myname):
         # This way we can insert the chosen EDProducer to @all_modules
         # so that we get easily a worker for it

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -924,6 +924,12 @@ class ModuleNodeOnConditionalTaskVisitor(object):
     def enter(self,visitee):
         if isinstance(visitee, ConditionalTask):
             self._levelInTasks += 1
+        # This block gets the modules contained by SwitchProducer. It
+        # needs to be before the "levelInTasks == 0" check because the
+        # contained modules need to be treated like in ConditionalTask
+        # also when the SwitchProducer itself is in the Path.
+        if hasattr(visitee, "modulesForConditionalTask_"):
+            self.l.extend(visitee.modulesForConditionalTask_())
         if self._levelInTasks == 0:
             return
         if visitee.isLeaf():


### PR DESCRIPTION
#### PR description:

Further testing of `ConditionalTask` (https://github.com/cms-sw/cmssw/pull/37305) for HLT revealed that it and `SwitchProducer` mechanism didn't work together at all (as discussed in https://github.com/cms-sw/cmssw/issues/36938#issuecomment-1090262706 onwards). This PR makes the `SwitchProducer` to work with `ConditionalTask` with the following changes
* `SwitchProducer` case module objects get now their module labels set (previously they were not).
  * This change lead to #37562. I checked all other uses of `SwitchProducerCUDA` and the case modules were always either defined inline or cloned from other module objects
* In python, if `SwitchProducer` is on a `ConditionalTask` or in a `Path`, the case modules get treated as if they were in an anonymous `ConditionalTask` associated with the `ConditionalTask`/`Path`
* `SwitchProducer` with an `EDAlias` as a chosen case required adding those `EDAlias`es into the `ProductRegistry` so that the `callWhenNewProductsRegistered()` callbacks in `SwitchProducer` get called, that lead to data product consumption being properly registered, that is needed for the module dependence checks in `StreamSchedule::tryToPlaceConditionalModules()`
  * This step required moving `processEDAliases()` function out from `Schedule.cc`
* The tests I added for `SwitchProducer` with `EDAlias` also revealed that the `EDAlias` treatment was generally broken for `ConditionalTask`. 

#### PR validation:

Framework unit tests run. The HLT test in https://github.com/cms-sw/cmssw/issues/36938#issuecomment-1090262706 runs as well.