### PR TITLE
Change tracks to optional requirement in HLTDisplacedEgammaFilter

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTDisplacedEgammaFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTDisplacedEgammaFilter.h
@@ -46,6 +46,7 @@ private:
   double sMaj_max;
   double seedTimeMin;
   double seedTimeMax;
+  bool useTrackVeto;
 
   edm::InputTag inputTrk;
   edm::EDGetTokenT<reco::TrackCollection> inputTrkToken_;


### PR DESCRIPTION
#### PR description:

The track requirement in the HLTDisplacedEgamma filter is made optional. I want to make use of this filter to set cuts on the smin, smaj and time variables. These can be done based on ECal rechit info only and no track requirement. Implementation ignores track-based restriction, when the input tag for the track collection is empty.

#### PR validation:

The config was privately tested and verified to work properly.

