### PR TITLE
Fixing missing Buildfile dependencies on hepmc

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/BuildFile.xml
+++ b/FastSimulation/SimplifiedGeometryPropagator/BuildFile.xml
@@ -15,6 +15,7 @@
 <use name="pythia8"/>
 <use name="HepPDT"/>
 <use name="clhep"/>
+<use name="hepmc"/>
 <use name="rootcore"/>
 <use name="geant4core"/>
 <export>

--- a/Fireworks/Core/BuildFile.xml
+++ b/Fireworks/Core/BuildFile.xml
@@ -37,6 +37,7 @@
 <use name="rootrgl"/>
 <use name="rootglew"/>
 <use name="rootgui"/>
+<use name="hepmc"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/AMPTInterface/BuildFile.xml
+++ b/GeneratorInterface/AMPTInterface/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="boost"/>
+<use name="hepmc"/>
 <use name="GeneratorInterface/Core"/>
 <use name="FWCore/Framework"/>
 <use name="SimDataFormats/GeneratorProducts"/>

--- a/GeneratorInterface/BeamHaloGenerator/BuildFile.xml
+++ b/GeneratorInterface/BeamHaloGenerator/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="boost"/>
+<use name="hepmc"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="SimDataFormats/GeneratorProducts"/>

--- a/GeneratorInterface/Core/BuildFile.xml
+++ b/GeneratorInterface/Core/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="GeneratorInterface/LHEInterface"/>
 <use name="heppdt"/>
 <use name="boost"/>
+<use name="hepmc"/>
 <use name="clhep"/>
 <use name="lhapdf"/>
 <use name="f77compiler"/>

--- a/GeneratorInterface/CosmicMuonGenerator/BuildFile.xml
+++ b/GeneratorInterface/CosmicMuonGenerator/BuildFile.xml
@@ -4,4 +4,5 @@
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="clhep"/>
 <use name="root"/>
+<use name="hepmc"/>
 <flags EDM_PLUGIN="1"/>

--- a/GeneratorInterface/ExhumeInterface/BuildFile.xml
+++ b/GeneratorInterface/ExhumeInterface/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="clhep"/>
 <use name="f77compiler"/>
 <use name="heppdt"/>
+<use name="hepmc"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/Herwig6Interface/BuildFile.xml
+++ b/GeneratorInterface/Herwig6Interface/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="herwig"/>
 <use name="fastjet"/>
 <use name="jimmy"/>
+<use name="hepmc"/>
 <architecture name="osx">
   <use name="jimmy_headers"/>
   <flags NO_EXPORT="jimmy"/>

--- a/GeneratorInterface/HijingInterface/BuildFile.xml
+++ b/GeneratorInterface/HijingInterface/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="GeneratorInterface/ExternalDecays"/>
 <use name="f77compiler"/>
+<use name="hepmc"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/Hydjet2Interface/BuildFile.xml
+++ b/GeneratorInterface/Hydjet2Interface/BuildFile.xml
@@ -15,6 +15,7 @@
 <use name="hydjet2"/>
 <use name="rootmath"/>
 <use name="rootcore"/>
+<use name="hepmc"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/HydjetInterface/BuildFile.xml
+++ b/GeneratorInterface/HydjetInterface/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="GeneratorInterface/ExternalDecays"/>
 <use   name="f77compiler"/>
 <use   name="hydjet"/>
+<use name="hepmc"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/GeneratorInterface/PartonShowerVeto/BuildFile.xml
+++ b/GeneratorInterface/PartonShowerVeto/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="pythia8"/>
 <use name="pythia6"/>
 <use name="f77compiler"/>
+<use name="hepmc"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/PomwigInterface/BuildFile.xml
+++ b/GeneratorInterface/PomwigInterface/BuildFile.xml
@@ -6,6 +6,7 @@
 <use name="clhep"/>
 <use name="heppdt"/>
 <use name="f77compiler"/>
+<use name="hepmc"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/PyquenInterface/BuildFile.xml
+++ b/GeneratorInterface/PyquenInterface/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="GeneratorInterface/Pythia6Interface"/>
 <use name="GeneratorInterface/ExternalDecays"/>
 <use name="pyquen"/>
+<use name="hepmc"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/Pythia6Interface/BuildFile.xml
+++ b/GeneratorInterface/Pythia6Interface/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="clhep"/>
 <use name="pythia6"/>
 <use name="f77compiler"/>
+<use name="hepmc"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/ReggeGribovPartonMCInterface/BuildFile.xml
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="GeneratorInterface/ExternalDecays"/>
 <use name="f77compiler"/>
+<use name="hepmc"/>
 <flags CPPDEFINES="__SIBYLL__"/>
 <flags CPPDEFINES="__QGSJET01__"/>
 <flags CPPDEFINES="__QGSJETII04__"/>

--- a/HLTriggerOffline/Egamma/BuildFile.xml
+++ b/HLTriggerOffline/Egamma/BuildFile.xml
@@ -6,4 +6,5 @@
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="boost"/>
+<use name="hepmc"/>
 <flags EDM_PLUGIN="1"/>

--- a/IOMC/EventVertexGenerators/BuildFile.xml
+++ b/IOMC/EventVertexGenerators/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="FWCore/Utilities"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="clhep"/>
+<use name="hepmc"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/BeamSpotObjects"/>
 <use name="CondFormats/PPSObjects"/>


### PR DESCRIPTION
Ensure that any package using hepmc in its interface or src declares that dependency in its build file.