### PR TITLE
B2G HLT DQM cleanup

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -7,17 +7,16 @@ from DQMOffline.Trigger.SoftdropMonitor_cfi import hltSoftdropmonitoring
 from DQMOffline.Trigger.B2GTnPMonitor_cfi import B2GegmGsfElectronIDsForDQM,B2GegHLTDQMOfflineTnPSource
 from DQMOffline.Trigger.TopMonitor_cfi import hltTOPmonitoring
 
-# B2G triggers:
-# HLT_PFHT1050_v*
-# HLT_AK8PFJet500_v*
-# HLT_AK8PFHT750_TrimMass50_v*
-# HLT_AK8PFJet380_TrimMass30_v*
-# HLT_AK8PFHT800_TrimMass50_v*
-# HLT_AK8PFJet400_TrimMass30_v*
-# HLT_AK8PFHT850_TrimMass50_v*
-# HLT_AK8PFJet420_TrimMass30_v*
-# HLT_AK8PFHT900_TrimMass50_v*
-# HLT_AK8PFHT700_TrimR0p1PT0p03Mass50
+### B2G triggers:
+# HLT_AK8PFHT*_TrimMass50
+# HLT_AK8PFJet*_TrimMass30
+# HLT_Mu37_Ele27_CaloIdL_MW
+# HLT_Mu27_Ele37_CaloIdL_MW
+# HLT_Mu37_TkMu27
+#
+# Additionally, we monitor mjj and mSD for PFHT1050 and AK8PFJet500
+
+# HT and AK8jet monitoring
 
 PFHT1050_Mjjmonitoring = hltMjjmonitoring.clone(
     FolderName = 'HLT/B2G/PFHT1050',
@@ -45,26 +44,7 @@ AK8PFJet500_Softdropmonitoring = hltSoftdropmonitoring.clone(
     numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFJet500_v*"])
 )
 
-AK8PFHT750_TrimMass50_HTmonitoring = hltHTmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT750_TrimMass50',
-    jets = "ak8PFJetsPuppi",
-    jetSelection      = "pt > 0 && eta < 2.5",
-    jetSelection_HT = "pt > 200 && eta < 2.5",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT750_TrimMass50_v*"])
-)
-
-AK8PFHT750_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT750_TrimMass50',
-    jets = "ak8PFJetsPuppi",
-    jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT750_TrimMass50_v*"])
-)
-
-AK8PFHT750_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT750_TrimMass50',
-    jetSelection = "pt > 65 && eta < 2.4",
-    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFHT750_TrimMass50_v*"])
-)
+# AK8PFHT800_TrimMass50 monitoring
 
 AK8PFHT800_TrimMass50_HTmonitoring = hltHTmonitoring.clone(
     FolderName = 'HLT/B2G/AK8PFHT800_TrimMass50',
@@ -87,61 +67,7 @@ AK8PFHT800_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT800_TrimMass50_v*"])
 )
 
-AK8PFHT850_TrimMass50_HTmonitoring = hltHTmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT850_TrimMass50',
-    jets = "ak8PFJetsPuppi",
-    jetSelection      = "pt > 0 && eta < 2.5",
-    jetSelection_HT = "pt > 200 && eta < 2.5",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT850_TrimMass50_v*"])
-)
-
-AK8PFHT850_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT850_TrimMass50',
-    jets = "ak8PFJetsPuppi",
-    jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT850_TrimMass50_v*"])
-)
-
-AK8PFHT850_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT850_TrimMass50',
-    jetSelection = "pt > 65 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT850_TrimMass50_v*"])
-)
-
-AK8PFHT900_TrimMass50_HTmonitoring = hltHTmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT900_TrimMass50',
-    jets = "ak8PFJetsPuppi",
-    jetSelection      = "pt > 0 && eta < 2.5",
-    jetSelection_HT = "pt > 200 && eta < 2.5",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT900_TrimMass50_v*"])
-)
-
-AK8PFHT900_TrimMass50_Mjjmonitoring = hltMjjmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT900_TrimMass50',
-    jets = "ak8PFJetsPuppi",
-    jetSelection = "pt > 200 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT900_TrimMass50_v*"])
-)
-
-AK8PFHT900_TrimMass50_Softdropmonitoring = hltSoftdropmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFHT900_TrimMass50',
-    jetSelection = "pt > 65 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFHT900_TrimMass50_v*"])
-)
-
-
-AK8PFJet360_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet360_TrimMass30',
-    ptcut = 360,
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet360_TrimMass30_v*"])
-)
-
-AK8PFJet380_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet380_TrimMass30',
-    ptcut = 380,
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet380_TrimMass30_v*"])
-)
-
+# AK8PFJet400_TrimMass30 monitoring
 
 AK8PFJet400_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
     FolderName = 'HLT/B2G/AK8PFJet400_TrimMass30',
@@ -149,11 +75,20 @@ AK8PFJet400_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_TrimMass30_v*"])
 )
 
-AK8PFJet420_TrimMass30_PromptMonitoring = hltJetMETmonitoring.clone(
-    FolderName = 'HLT/B2G/AK8PFJet420_TrimMass30',
-    ptcut = 420,
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet420_TrimMass30_v*"])
+AK8PFJet400_TrimMass30_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet400_TrimMass30',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFJet400_TrimMass30_v*"])
 )
+
+AK8PFJet400_TrimMass30_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet400_TrimMass30',
+    jetSelection = "pt > 65 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_TrimMass30_v*"])
+)
+
+# Lepton cross trigger monitoring
 
 hltDQMonitorB2G_MuEle = hltTOPmonitoring.clone(
     FolderName = 'HLT/B2G/Dileptonic/HLT_MuXX_EleXX_CaloIdL_MW',
@@ -171,35 +106,20 @@ hltDQMonitorB2G_MuTkMu = hltTOPmonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ['HLT_Mu37_TkMu27_v*'])
 )
 
+
+# the sequence
+
 b2gMonitorHLT = cms.Sequence(
 
     PFHT1050_Mjjmonitoring +
-#    PFHT1050_Softdropmonitoring +
 
     AK8PFJet500_Mjjmonitoring +
-#    AK8PFJet500_Softdropmonitoring +
-
-    AK8PFHT750_TrimMass50_HTmonitoring +
-    AK8PFHT750_TrimMass50_Mjjmonitoring +
-#    AK8PFHT750_TrimMass50_Softdropmonitoring +
 
     AK8PFHT800_TrimMass50_HTmonitoring +
     AK8PFHT800_TrimMass50_Mjjmonitoring +
-#    AK8PFHT800_TrimMass50_Softdropmonitoring +
-
-    AK8PFHT850_TrimMass50_HTmonitoring +
-    AK8PFHT850_TrimMass50_Mjjmonitoring +
-#    AK8PFHT850_TrimMass50_Softdropmonitoring +
-
-    AK8PFHT900_TrimMass50_HTmonitoring +
-    AK8PFHT900_TrimMass50_Mjjmonitoring +
-#    AK8PFHT900_TrimMass50_Softdropmonitoring +
-
-    AK8PFJet360_TrimMass30_PromptMonitoring +
-    AK8PFJet380_TrimMass30_PromptMonitoring +
 
     AK8PFJet400_TrimMass30_PromptMonitoring +
-    AK8PFJet420_TrimMass30_PromptMonitoring +
+    AK8PFJet400_TrimMass30_Mjjmonitoring +
 
     B2GegHLTDQMOfflineTnPSource
 
@@ -216,10 +136,9 @@ b2gMonitorHLT = cms.Sequence(
 b2gHLTDQMSourceWithRECO = cms.Sequence(
     PFHT1050_Softdropmonitoring +
     AK8PFJet500_Softdropmonitoring +
-    AK8PFHT750_TrimMass50_Softdropmonitoring +
     AK8PFHT800_TrimMass50_Softdropmonitoring +
-    AK8PFHT850_TrimMass50_Softdropmonitoring +
-    AK8PFHT900_TrimMass50_Softdropmonitoring
+    AK8PFJet400_TrimMass30_Softdropmonitoring     
+
 )
 
 b2gHLTDQMSourceExtra = cms.Sequence(


### PR DESCRIPTION
#### PR description:

Cleanup of the HLT DQM code of B2Gs HLT paths, as discussed in the last [B2G general meeting](https://indico.cern.ch/event/1149148/) (direct link to slides [here](https://indico.cern.ch/event/1149148/contributions/4825753/attachments/2425807/4153048/220412_B2Ggeneral_DQM.pdf)). The changes were also reported internally to Lisa Benato from the STEAM group and discussed in a recent [STEAM meeting](https://indico.cern.ch/event/1137448/).

Monitoring of multiple TrimMass HLT paths only differing in pt/HT threshold was cut down to only a single threshold for each version. To be consistent with the HT-based version, monitoring of mjj and softdropmass was added for HLT_AK8PFJet400_TrimMass30. 

#### PR validation:

The complete workflow was tested using `runTheMatrix.py -l 11634.0` verifying that the histograms are properly created. The changes were also tested by running the DQM and harvesting steps on different RelVal samples, to check whether the histograms are properly filled. The basic test procedure as instructed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) was run and passed all tests.

I hope the above information is complete, if not I'd be happy to provide anything that might be needed.