### PR TITLE
Fixed dead assign in CalibTracker/SiStripHitEfficiency and CalibFormats/SiStripObjects

### DIFF
--- a/CalibFormats/SiStripObjects/src/SiStripQuality.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripQuality.cc
@@ -337,7 +337,6 @@ void SiStripQuality::ReduceGranularity(double threshold) {
     BadStripPerApv[3] = 0;
     BadStripPerApv[4] = 0;
     BadStripPerApv[5] = 0;
-    ipos = 0;
 
     SiStripBadStrip::Range sqrange =
         SiStripBadStrip::Range(getDataVectorBegin() + rp->ibegin, getDataVectorBegin() + rp->iend);

--- a/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
+++ b/CalibTracker/SiStripHitEfficiency/src/HitEff.cc
@@ -708,7 +708,6 @@ void HitEff::analyze(const edm::Event& e, const edm::EventSetup& es) {
                     FinalCluster[i] = VCluster_info.at(0)[i];
                   }
                 }
-                nClusters = 0;
                 VCluster_info.clear();
               }
 


### PR DESCRIPTION
Fixed dead assign from llvm-analysis : https://cmssdt.cern.ch/SDT/jenkins-artifacts/pull-request-integration/PR-65994f/23822/llvm-analysis/

#### PR description:
Upon request of @tvami, fixed two dead assign that were raised by llvm-analysis of PR #37530. No changes expected to output.

#### PR validation:

Passed `scram b runtests` and `runTheMatrix.py -l limited -i all --ibeos` (47 46 45 34 17 4 1 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 0 failed)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not applicable