### PR TITLE
Fix CS8/EL8/CS9 openssl build error

### DIFF
--- a/Utilities/OpenSSL/interface/openssl_init.h
+++ b/Utilities/OpenSSL/interface/openssl_init.h
@@ -2,7 +2,7 @@
 #define UTILITIES_OPENSSL_OPENSSL_INIT_H
 #include <openssl/evp.h>
 
-#if OPENSSL_API_COMPAT < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define EVP_MD_CTX_new EVP_MD_CTX_create
 #define EVP_MD_CTX_free EVP_MD_CTX_destroy
 #endif


### PR DESCRIPTION
use OPENSSL_VERSION_NUMBER instead of OPENSSL_API_COMPAT