### PR TITLE
Phase2 digitizer updated to exclude  badchannel in Strip like detectors

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -73,3 +73,9 @@ bool PSPDigitizerAlgorithm::isInBiasRailRegion(const PSimHit& hit) const {
   else
     return false;
 }
+//
+// -- Read Bad Channels from the Condidion DB and kill channels/module accordingly
+//
+void PSPDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) {
+  // this method is dummy at the moment. Will be implemented once we have the corresponding objectcondition DB
+}

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
@@ -17,6 +17,7 @@ public:
   bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) const override;
   bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) const override;
   bool isInBiasRailRegion(const PSimHit& hit) const;
+  void module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) override;
 
 private:
   edm::ESGetToken<SiPhase2OuterTrackerLorentzAngle, SiPhase2OuterTrackerLorentzAngleSimRcd> siPhase2OTLorentzAngleToken_;

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
@@ -18,9 +18,9 @@ void PSSDigitizerAlgorithm::init(const edm::EventSetup& es) {
   if (use_LorentzAngle_DB_)  // Get Lorentz angle from DB record
     siPhase2OTLorentzAngle_ = &es.getData(siPhase2OTLorentzAngleToken_);
 
-  if (use_deadmodule_DB_) // Get Bad Channel (SiStripBadStrip) from DB
-    badChannelPayload_  = &es.getData(badChannelToken_);
-  
+  if (use_deadmodule_DB_)  // Get Bad Channel (SiStripBadStrip) from DB
+    badChannelPayload_ = &es.getData(badChannelToken_);
+
   geom_ = &es.getData(geomToken_);
 }
 PSSDigitizerAlgorithm::PSSDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
@@ -32,7 +32,8 @@ PSSDigitizerAlgorithm::PSSDigitizerAlgorithm(const edm::ParameterSet& conf, edm:
     siPhase2OTLorentzAngleToken_ = iC.esConsumes();
 
   if (use_deadmodule_DB_) {
-    std::string badChannelLabel_ = conf.getParameter<ParameterSet>("SSDigitizerAlgorithm").getUntrackedParameter<std::string>("BadChannelLabel","");
+    std::string badChannelLabel_ = conf.getParameter<ParameterSet>("SSDigitizerAlgorithm")
+                                       .getUntrackedParameter<std::string>("BadChannelLabel", "");
     badChannelToken_ = iC.esConsumes(edm::ESInputTag{"", badChannelLabel_});
   }
 
@@ -69,17 +70,17 @@ void PSSDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomDetUnit* pi
 
   signal_map_type& theSignal = _signal[detId];
   signal_map_type signalNew;
-   
+
   SiStripBadStrip::Range range = badChannelPayload_->getRange(detId);
   for (std::vector<unsigned int>::const_iterator badChannel = range.first; badChannel != range.second; ++badChannel) {
     const auto& firstStrip = badChannelPayload_->decodePhase2(*badChannel).firstStrip;
     const auto& channelRange = badChannelPayload_->decodePhase2(*badChannel).range;
 
-
     for (int index = 0; index < channelRange; index++) {
       for (auto& s : theSignal) {
         auto& channel = s.first;
-        if( channel == firstStrip+index) s.second.set(0.);
+        if (channel == firstStrip + index)
+          s.second.set(0.);
       }
     }
   }

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
@@ -10,12 +10,17 @@
 // Geometry
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
+
 using namespace edm;
 
 void PSSDigitizerAlgorithm::init(const edm::EventSetup& es) {
   if (use_LorentzAngle_DB_)  // Get Lorentz angle from DB record
     siPhase2OTLorentzAngle_ = &es.getData(siPhase2OTLorentzAngleToken_);
 
+  if (use_deadmodule_DB_) // Get Bad Channel (SiStripBadStrip) from DB
+    badChannelPayload_  = &es.getData(badChannelToken_);
+  
   geom_ = &es.getData(geomToken_);
 }
 PSSDigitizerAlgorithm::PSSDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
@@ -25,6 +30,12 @@ PSSDigitizerAlgorithm::PSSDigitizerAlgorithm(const edm::ParameterSet& conf, edm:
       geomToken_(iC.esConsumes()) {
   if (use_LorentzAngle_DB_)
     siPhase2OTLorentzAngleToken_ = iC.esConsumes();
+
+  if (use_deadmodule_DB_) {
+    std::string badChannelLabel_ = conf.getParameter<ParameterSet>("SSDigitizerAlgorithm").getUntrackedParameter<std::string>("BadChannelLabel","");
+    badChannelToken_ = iC.esConsumes(edm::ESInputTag{"", badChannelLabel_});
+  }
+
   pixelFlag_ = false;
   LogDebug("PSSDigitizerAlgorithm") << "Algorithm constructed "
                                     << "Configuration parameters: "
@@ -49,4 +60,27 @@ bool PSSDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo*
                                              float charge,
                                              float thr) const {
   return (charge >= thr);
+}
+//
+// -- Read Bad Channels from the Condidion DB and kill channels/module accordingly
+//
+void PSSDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) {
+  uint32_t detId = pixdet->geographicalId().rawId();
+
+  signal_map_type& theSignal = _signal[detId];
+  signal_map_type signalNew;
+   
+  SiStripBadStrip::Range range = badChannelPayload_->getRange(detId);
+  for (std::vector<unsigned int>::const_iterator badChannel = range.first; badChannel != range.second; ++badChannel) {
+    const auto& firstStrip = badChannelPayload_->decodePhase2(*badChannel).firstStrip;
+    const auto& channelRange = badChannelPayload_->decodePhase2(*badChannel).range;
+
+
+    for (int index = 0; index < channelRange; index++) {
+      for (auto& s : theSignal) {
+        auto& channel = s.first;
+        if( channel == firstStrip+index) s.second.set(0.);
+      }
+    }
+  }
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
@@ -7,7 +7,6 @@
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
 
-
 class PSSDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
 public:
   PSSDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
@@ -5,6 +5,8 @@
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+
 
 class PSSDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
 public:
@@ -16,9 +18,12 @@ public:
 
   bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) const override;
   bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) const override;
+  void module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) override;
 
 private:
   edm::ESGetToken<SiPhase2OuterTrackerLorentzAngle, SiPhase2OuterTrackerLorentzAngleSimRcd> siPhase2OTLorentzAngleToken_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  edm::ESGetToken<SiStripBadStrip, SiPhase2OuterTrackerBadStripRcd> badChannelToken_;
+  const SiStripBadStrip* badChannelPayload_;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -23,10 +23,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h"
-//#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
-//#include "CondFormats/SiPixelObjects/interface/PixelROC.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
-//#include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
 
 // Geometry

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -23,10 +23,10 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelLorentzAngle.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
-#include "CondFormats/SiPixelObjects/interface/PixelROC.h"
+//#include "CondFormats/SiPixelObjects/interface/SiPixelQuality.h"
+//#include "CondFormats/SiPixelObjects/interface/PixelROC.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"
-#include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
+//#include "CondFormats/SiPixelObjects/interface/CablingPathToDetUnit.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
 
 // Geometry
@@ -35,7 +35,6 @@
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 
 using namespace edm;
-using namespace sipixelobjects;
 
 namespace ph2tkdigialgo {
   // Mass in MeV
@@ -852,69 +851,6 @@ void Phase2TrackerDigitizerAlgorithm::module_killing_conf(uint32_t detID) {
       s.second.set(0.);
   }
 }
-// ==========================================================================
-void Phase2TrackerDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) {
-  bool isbad = false;
-  uint32_t detID = pixdet->geographicalId().rawId();
-  int ncol = pixdet->specificTopology().ncolumns();
-  if (ncol < 0)
-    return;
-  std::vector<SiPixelQuality::disabledModuleType> disabledModules = siPixelBadModule_->getBadComponentList();
-
-  SiPixelQuality::disabledModuleType badmodule;
-  for (size_t id = 0; id < disabledModules.size(); id++) {
-    if (detID == disabledModules[id].DetID) {
-      isbad = true;
-      badmodule = disabledModules[id];
-      break;
-    }
-  }
-
-  if (!isbad)
-    return;
-
-  signal_map_type& theSignal = _signal[detID];  // check validity
-  if (badmodule.errorType == 0) {               // this is a whole dead module.
-    for (auto& s : theSignal)
-      s.second.set(0.);  // reset amplitude
-  } else {               // all other module types: half-modules and single ROCs.
-    // Get Bad ROC position:
-    // follow the example of getBadRocPositions in CondFormats/SiPixelObjects/src/SiPixelQuality.cc
-    std::vector<GlobalPixel> badrocpositions;
-    for (size_t j = 0; j < static_cast<size_t>(ncol); j++) {
-      if (siPixelBadModule_->IsRocBad(detID, j)) {
-        std::vector<CablingPathToDetUnit> path = fedCablingMap_->pathToDetUnit(detID);
-        for (auto const& p : path) {
-          const PixelROC* myroc = fedCablingMap_->findItem(p);
-          if (myroc->idInDetUnit() == j) {
-            LocalPixel::RocRowCol local = {39, 25};  //corresponding to center of ROC row, col
-            GlobalPixel global = myroc->toGlobal(LocalPixel(local));
-            badrocpositions.push_back(global);
-            break;
-          }
-        }
-      }
-    }
-
-    for (auto& s : theSignal) {
-      std::pair<int, int> ip;
-      if (pixelFlag_)
-        ip = PixelDigi::channelToPixel(s.first);
-      else
-        ip = Phase2TrackerDigi::channelToPixel(s.first);
-
-      for (auto const& p : badrocpositions) {
-        for (auto& k : badPixels_) {
-          if (p.row == k.getParameter<int>("row") && ip.first == k.getParameter<int>("row") &&
-              std::abs(ip.second - p.col) < k.getParameter<int>("col")) {
-            s.second.set(0.);
-          }
-        }
-      }
-    }
-  }
-}
-
 // For premixing
 void Phase2TrackerDigitizerAlgorithm::loadAccumulator(uint32_t detId, const std::map<int, float>& accumulator) {
   auto& theSignal = _signal[detId];

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -214,8 +214,8 @@ protected:
 
   // remove dead modules using the list in the configuration file PixelDigi_cfi.py
   virtual void module_killing_conf(uint32_t detID);
-  virtual void module_killing_DB(
-      const Phase2TrackerGeomDetUnit* pixdet);  // remove dead modules uisng the list in the DB
+  // remove dead modules uisng the list in the DB    
+  virtual void module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) = 0; 
 
   const SubdetEfficiencies subdetEfficiencies_;
   float calcQ(float x);

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -214,8 +214,8 @@ protected:
 
   // remove dead modules using the list in the configuration file PixelDigi_cfi.py
   virtual void module_killing_conf(uint32_t detID);
-  // remove dead modules uisng the list in the DB    
-  virtual void module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) = 0; 
+  // remove dead modules uisng the list in the DB
+  virtual void module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) = 0;
 
   const SubdetEfficiencies subdetEfficiencies_;
   float calcQ(float x);

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -24,33 +24,8 @@ namespace {
   constexpr double operator""_um_inv(long double length) { return length * 1e4; }
 }  // namespace
 
-void Pixel3DDigitizerAlgorithm::init(const edm::EventSetup& es) {
-  // XXX: Just copied from PixelDigitizer Algorithm
-  //      CHECK if all these is needed
-
-  if (use_ineff_from_db_) {
-    // load gain calibration service fromdb...
-    theSiPixelGainCalibrationService_->setESObjects(es);
-  }
-
-  if (use_deadmodule_DB_) {
-    siPixelBadModule_ = &es.getData(siPixelBadModuleToken_);
-  }
-
-  if (use_LorentzAngle_DB_) {
-    // Get Lorentz angle from DB record
-    siPixelLorentzAngle_ = &es.getData(siPixelLorentzAngleToken_);
-  }
-
-  // gets the map and geometry from the DB (to kill ROCs)
-  fedCablingMap_ = &es.getData(fedCablingMapToken_);
-  geom_ = &es.getData(geomToken_);
-}
-
 Pixel3DDigitizerAlgorithm::Pixel3DDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
-    : Phase2TrackerDigitizerAlgorithm(conf.getParameter<edm::ParameterSet>("AlgorithmCommon"),
-                                      conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm"),
-                                      iC),
+  : PixelDigitizerAlgorithm(conf, iC),
       np_column_radius_(
           (conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("NPColumnRadius")) *
           1.0_um),
@@ -59,16 +34,10 @@ Pixel3DDigitizerAlgorithm::Pixel3DDigitizerAlgorithm(const edm::ParameterSet& co
           1.0_um),
       np_column_gap_(
           (conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("NPColumnGap")) *
-          1.0_um),
-      fedCablingMapToken_(iC.esConsumes()),
-      geomToken_(iC.esConsumes()) {
+          1.0_um) {
+
   // XXX - NEEDED?
   pixelFlag_ = true;
-
-  if (use_deadmodule_DB_)
-    siPixelBadModuleToken_ = iC.esConsumes();
-  if (use_LorentzAngle_DB_)
-    siPixelLorentzAngleToken_ = iC.esConsumes();
 
   edm::LogInfo("Pixel3DDigitizerAlgorithm")
       << "Algorithm constructed \n"

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -25,7 +25,7 @@ namespace {
 }  // namespace
 
 Pixel3DDigitizerAlgorithm::Pixel3DDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
-  : PixelDigitizerAlgorithm(conf, iC),
+    : PixelDigitizerAlgorithm(conf, iC),
       np_column_radius_(
           (conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("NPColumnRadius")) *
           1.0_um),
@@ -35,7 +35,6 @@ Pixel3DDigitizerAlgorithm::Pixel3DDigitizerAlgorithm(const edm::ParameterSet& co
       np_column_gap_(
           (conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("NPColumnGap")) *
           1.0_um) {
-
   // XXX - NEEDED?
   pixelFlag_ = true;
 

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
@@ -18,7 +18,7 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
-#include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
+#include "SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h"
 
 // Data formats
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
@@ -26,13 +26,11 @@
 // system
 #include <functional>
 
-class Pixel3DDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
+class Pixel3DDigitizerAlgorithm : public PixelDigitizerAlgorithm {
 public:
   Pixel3DDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~Pixel3DDigitizerAlgorithm() override;
 
-  // initialization that cannot be done in the constructor
-  void init(const edm::EventSetup& es) override;
   bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) const override;
   std::vector<DigitizerUtility::SignalPoint> drift(
       const PSimHit& hit,

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -258,10 +258,10 @@ void PixelDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomDetUnit* 
   std::vector<SiPixelQuality::disabledModuleType> disabledModules = siPixelBadModule_->getBadComponentList();
 
   SiPixelQuality::disabledModuleType badmodule;
-  for (size_t id = 0; id < disabledModules.size(); id++) {
-    if (detID == disabledModules[id].DetID) {
+  for (const auto& mod : disabledModules) {
+    if (detID == mod.DetID) {
       isbad = true;
-      badmodule = disabledModules[id];
+      badmodule = mod;
       break;
     }
   }

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.cc
@@ -310,4 +310,3 @@ void PixelDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomDetUnit* 
     }
   }
 }
-

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
@@ -52,7 +52,6 @@ public:
   void add_cross_talk(const Phase2TrackerGeomDetUnit* pixdet) override;
   void module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) override;
 
-
   // Addition four xtalk-related parameters to PixelDigitizerAlgorithm specific parameters initialized in Phase2TrackerDigitizerAlgorithm
   double odd_row_interchannelCoupling_next_row_;
   double even_row_interchannelCoupling_next_row_;

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
@@ -50,6 +50,8 @@ public:
   bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) const override;
   bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) const override;
   void add_cross_talk(const Phase2TrackerGeomDetUnit* pixdet) override;
+  void module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) override;
+
 
   // Addition four xtalk-related parameters to PixelDigitizerAlgorithm specific parameters initialized in Phase2TrackerDigitizerAlgorithm
   double odd_row_interchannelCoupling_next_row_;

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
@@ -11,6 +11,8 @@
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerCondDataRecords.h"
+
 using namespace edm;
 
 namespace {
@@ -26,10 +28,12 @@ namespace {
 }  // namespace
 
 void SSDigitizerAlgorithm::init(const edm::EventSetup& es) {
-  if (use_LorentzAngle_DB_) {  // Get Lorentz angle from DB record
+  if (use_LorentzAngle_DB_)   // Get Lorentz angle from DB record
     siPhase2OTLorentzAngle_ = &es.getData(siPhase2OTLorentzAngleToken_);
-  }
-
+ 
+  if (use_deadmodule_DB_) // Get Bad Channel (SiStripBadStrip) from DB 
+    badChannelPayload_  = &es.getData(badChannelToken_);
+  
   geom_ = &es.getData(geomToken_);
 }
 
@@ -44,6 +48,12 @@ SSDigitizerAlgorithm::SSDigitizerAlgorithm(const edm::ParameterSet& conf, edm::C
       geomToken_(iC.esConsumes()) {
   if (use_LorentzAngle_DB_)
     siPhase2OTLorentzAngleToken_ = iC.esConsumes();
+
+  if (use_deadmodule_DB_) {
+    std::string badChannelLabel_ = conf.getParameter<ParameterSet>("SSDigitizerAlgorithm").getUntrackedParameter<std::string>("BadChannelLabel","");
+    badChannelToken_ = iC.esConsumes(edm::ESInputTag{"", badChannelLabel_});
+  }
+
   pixelFlag_ = false;
   LogDebug("SSDigitizerAlgorithm ") << "SSDigitizerAlgorithm constructed "
                                     << "Configuration parameters:"
@@ -179,4 +189,27 @@ bool SSDigitizerAlgorithm::isAboveThreshold(const DigitizerUtility::SimHitInfo* 
                                             float charge,
                                             float thr) const {
   return (charge >= thr);
+}
+//
+// -- Read Bad Channels from the Condidion DB and kill channels/module accordingly
+//
+void SSDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) {
+  uint32_t detId = pixdet->geographicalId().rawId();
+
+  signal_map_type& theSignal = _signal[detId];
+  signal_map_type signalNew;
+   
+  SiStripBadStrip::Range range = badChannelPayload_->getRange(detId);
+  for (std::vector<unsigned int>::const_iterator badChannel = range.first; badChannel != range.second; ++badChannel) {
+    const auto& firstStrip = badChannelPayload_->decodePhase2(*badChannel).firstStrip;
+    const auto& channelRange = badChannelPayload_->decodePhase2(*badChannel).range;
+
+
+    for (int index = 0; index < channelRange; index++) {
+      for (auto& s : theSignal) {
+        auto& channel = s.first;
+        if( channel == firstStrip+index) s.second.set(0.);
+      }
+    }
+  }
 }

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.cc
@@ -28,12 +28,12 @@ namespace {
 }  // namespace
 
 void SSDigitizerAlgorithm::init(const edm::EventSetup& es) {
-  if (use_LorentzAngle_DB_)   // Get Lorentz angle from DB record
+  if (use_LorentzAngle_DB_)  // Get Lorentz angle from DB record
     siPhase2OTLorentzAngle_ = &es.getData(siPhase2OTLorentzAngleToken_);
- 
-  if (use_deadmodule_DB_) // Get Bad Channel (SiStripBadStrip) from DB 
-    badChannelPayload_  = &es.getData(badChannelToken_);
-  
+
+  if (use_deadmodule_DB_)  // Get Bad Channel (SiStripBadStrip) from DB
+    badChannelPayload_ = &es.getData(badChannelToken_);
+
   geom_ = &es.getData(geomToken_);
 }
 
@@ -50,7 +50,8 @@ SSDigitizerAlgorithm::SSDigitizerAlgorithm(const edm::ParameterSet& conf, edm::C
     siPhase2OTLorentzAngleToken_ = iC.esConsumes();
 
   if (use_deadmodule_DB_) {
-    std::string badChannelLabel_ = conf.getParameter<ParameterSet>("SSDigitizerAlgorithm").getUntrackedParameter<std::string>("BadChannelLabel","");
+    std::string badChannelLabel_ = conf.getParameter<ParameterSet>("SSDigitizerAlgorithm")
+                                       .getUntrackedParameter<std::string>("BadChannelLabel", "");
     badChannelToken_ = iC.esConsumes(edm::ESInputTag{"", badChannelLabel_});
   }
 
@@ -198,17 +199,17 @@ void SSDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomDetUnit* pix
 
   signal_map_type& theSignal = _signal[detId];
   signal_map_type signalNew;
-   
+
   SiStripBadStrip::Range range = badChannelPayload_->getRange(detId);
   for (std::vector<unsigned int>::const_iterator badChannel = range.first; badChannel != range.second; ++badChannel) {
     const auto& firstStrip = badChannelPayload_->decodePhase2(*badChannel).firstStrip;
     const auto& channelRange = badChannelPayload_->decodePhase2(*badChannel).range;
 
-
     for (int index = 0; index < channelRange; index++) {
       for (auto& s : theSignal) {
         auto& channel = s.first;
-        if( channel == firstStrip+index) s.second.set(0.);
+        if (channel == firstStrip + index)
+          s.second.set(0.);
       }
     }
   }

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
@@ -5,6 +5,8 @@
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
+
 
 class SSDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
 public:
@@ -25,6 +27,7 @@ private:
   void storeSignalShape();
   bool select_hit_sampledMode(const PSimHit& hit, double tCorr, double& sigScale) const;
   bool select_hit_latchedMode(const PSimHit& hit, double tCorr, double& sigScale) const;
+  void module_killing_DB(const Phase2TrackerGeomDetUnit* pixdet) override;
 
   int hitDetectionMode_;
   std::vector<double> pulseShapeVec_;
@@ -35,5 +38,7 @@ private:
   static constexpr float bx_time{25};
   static constexpr size_t interpolationPoints{1000};
   static constexpr int interpolationStep{10};
+  edm::ESGetToken<SiStripBadStrip, SiPhase2OuterTrackerBadStripRcd> badChannelToken_;
+  const SiStripBadStrip* badChannelPayload_;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
@@ -7,7 +7,6 @@
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
 
-
 class SSDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
 public:
   SSDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -1,4 +1,3 @@
-
 import FWCore.ParameterSet.Config as cms
 
 PixelDigitizerAlgorithmCommon = cms.PSet(


### PR DESCRIPTION
#### PR description:
Implemented code to exclude BadChannels by reading information from the Condition Database for Strip-like detectors, namely PSS and SS types. Also updated the framework to be able to treat BadChannels independently for each type of subdetectors. For Inner Pixel detectors BadChannel implementation is done in PixelDigitizerAlgorithm. 3D-Pixel and Bricked-Pixel algorithms inherit from PixelDigitizerAlgorithm. Also changed the variable/method names dead->bad as the name Bad signifies both dead and noisy

###  Changes expected 
  - Less Digis in PSS and SS detector and accordingly lower Occupancy. The amount what  of loss depend on the fraction of bad channels introduced through the SiPhase2OTFakeBadStripsESSource 
  
### Depends on the PR #37463 (already integrated)

### PR validation:

Validation is done using 

runTheMatrix.py --what upgrade -ne -l 35010.0

The description and the plots are attached below

@emiglior @mmusich 
[Phase2Digitizer_BadChannelStudy_15042022.pdf](https://github.com/cms-sw/cmssw/files/8494633/Phase2Digitizer_BadChannelStudy_15042022.pdf)
