### PR TITLE
[OT inefficiency] add 0% bad strip scenario to customization function and generate new RelVal workflows

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -37,6 +37,7 @@ numWFIB.extend([39661.97]) #2026D88 premixing stage1 (NuGun+PU)
 numWFIB.extend([39434.5,39434.9,39434.501,39434.502]) #2026D88 pixelTrackingOnly, vector hits, Patatrack local reconstruction on CPU, Patatrack local reconstruction on GPU
 numWFIB.extend([39634.99,39634.999]) #2026D88 premixing combined stage1+stage2 (ttbar+PU200, ttbar+PU50 for PR test)
 numWFIB.extend([39434.21,39634.21,39634.9921]) #2026D88 prodlike, prodlike PU, prodlike premix stage1+stage2
+numWFIB.extend([39634.114]) #2026D88 PU, with 10% OT ineffiency
 numWFIB.extend([39834.0]) #2026D89
 numWFIB.extend([40234.0]) #2026D90
 numWFIB.extend([40634.0]) #2026D91

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1370,6 +1370,49 @@ upgradeWFs['Aging3000'].suffix = 'Aging3000'
 upgradeWFs['Aging3000'].offset = 0.103
 upgradeWFs['Aging3000'].lumi = '3000'
 
+#
+# Simulates Bias Rail in Phase-2 OT PS modules and X% random bad Strips
+# in PS-s and SS sensors
+#
+class UpgradeWorkflow_OTInefficiency(UpgradeWorkflow):
+    def setup_(self, step, stepName, stepDict, k, properties):
+        if 'Digi' in step:
+            stepDict[stepName][k] = merge([{'--customise': 'SimTracker/SiPhase2Digitizer/customizeForOTInefficiency.customizeSiPhase2OTInefficiency'+self.percent+'Percent'}, stepDict[step][k]])
+    def condition(self, fragment, stepList, key, hasHarvest):
+        return fragment=="TTbar_14TeV" and '2026' in key
+# define several of them
+upgradeWFs['OTInefficiency'] = UpgradeWorkflow_OTInefficiency(
+    steps =  [
+        'Digi',
+        'DigiTrigger',
+    ],
+    PU =  [
+        'Digi',
+        'DigiTrigger',
+    ],
+    suffix = '_OTInefficiency',
+    offset = 0.111,
+)
+upgradeWFs['OTInefficiency'].percent = 'Zero'
+
+# 1% bad strips
+upgradeWFs['OTInefficiency1PC'] = deepcopy(upgradeWFs['OTInefficiency'])
+upgradeWFs['OTInefficiency1PC'].suffix = '_OTInefficiency1PC'
+upgradeWFs['OTInefficiency1PC'].offset = 0.112
+upgradeWFs['OTInefficiency1PC'].percent = 'One'
+
+# 5% bad strips
+upgradeWFs['OTInefficiency5PC'] = deepcopy(upgradeWFs['OTInefficiency'])
+upgradeWFs['OTInefficiency5PC'].suffix = '_OTInefficiency5PC'
+upgradeWFs['OTInefficiency5PC'].offset = 0.113
+upgradeWFs['OTInefficiency5PC'].percent = 'Five'
+
+# 10% bad strips
+upgradeWFs['OTInefficiency10PC'] = deepcopy(upgradeWFs['OTInefficiency'])
+upgradeWFs['OTInefficiency10PC'].suffix = '_OTInefficiency10PC'
+upgradeWFs['OTInefficiency10PC'].offset = 0.114
+upgradeWFs['OTInefficiency10PC'].percent = 'Ten'
+
 # Specifying explicitly the --filein is not nice but that was the
 # easiest way to "skip" the output of step2 (=premixing stage1) for
 # filein (as it goes to pileup_input). It works (a bit accidentally

--- a/SimTracker/SiPhase2Digitizer/python/customizeForOTInefficiency.py
+++ b/SimTracker/SiPhase2Digitizer/python/customizeForOTInefficiency.py
@@ -36,6 +36,15 @@ def _commonCustomizeForInefficiency(process):
     return process
 
 #
+# activate bias rail inefficiency only
+#
+def customizeSiPhase2OTInefficiencyZeroPercent(process):
+
+    _commonCustomizeForInefficiency(process)
+
+    return process
+
+#
 # activate bias rail inefficiency and 1% random bad strips
 #
 def customizeSiPhase2OTInefficiencyOnePercent(process):


### PR DESCRIPTION
#### PR description:

This is a follow-up to PR https://github.com/cms-sw/cmssw/pull/37463, introducing a customization function for the scenario in which there is no simulation of the bad strips in the Outer Tracker, but only the inefficiency due to the bias rail in the macro-pixel sensors.
I profit of this PR to add also to the matrix a battery of relvals to exercise the various scenarios.

#### PR validation:

Run successfully: `runTheMatrix.py --what upgrade -l 23234.111,23234.112,23234.113,23234.114` (when merged together with  https://github.com/cms-sw/cmssw/pull/37576)
Also ` runTheMatrix.py --what upgrade --show | grep OT` gives:
```
23234.111 2026D49_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
23234.112 2026D49_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
23234.113 2026D49_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
23234.114 2026D49_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
23434.111 2026D49PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
23434.112 2026D49PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
23434.113 2026D49PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
23434.114 2026D49PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
28234.111 2026D60_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
28234.112 2026D60_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
28234.113 2026D60_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
28234.114 2026D60_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
28434.111 2026D60PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
28434.112 2026D60PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
28434.113 2026D60PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
28434.114 2026D60PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
31434.111 2026D68_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
31434.112 2026D68_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
31434.113 2026D68_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
31434.114 2026D68_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
31634.111 2026D68PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
31634.112 2026D68PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
31634.113 2026D68PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
31634.114 2026D68PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
32234.111 2026D70_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
32234.112 2026D70_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
32234.113 2026D70_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
32234.114 2026D70_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
32434.111 2026D70PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
32434.112 2026D70PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
32434.113 2026D70PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
32434.114 2026D70PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
34634.111 2026D76_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
34634.112 2026D76_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
34634.113 2026D76_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
34634.114 2026D76_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
34834.111 2026D76PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
34834.112 2026D76PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
34834.113 2026D76PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
34834.114 2026D76PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
35034.111 2026D77_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35034.112 2026D77_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35034.113 2026D77_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35034.114 2026D77_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35234.111 2026D77PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
35234.112 2026D77PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
35234.113 2026D77PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
35234.114 2026D77PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
35434.111 2026D78_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35434.112 2026D78_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35434.113 2026D78_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35434.114 2026D78_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35634.111 2026D78PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
35634.112 2026D78PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
35634.113 2026D78PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
35634.114 2026D78PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
35834.111 2026D79_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35834.112 2026D79_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35834.113 2026D79_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
35834.114 2026D79_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
36034.111 2026D79PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36034.112 2026D79PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36034.113 2026D79PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36034.114 2026D79PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36234.111 2026D80_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
36234.112 2026D80_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
36234.113 2026D80_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
36234.114 2026D80_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
36434.111 2026D80PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36434.112 2026D80PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36434.113 2026D80PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36434.114 2026D80PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36634.111 2026D81_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
36634.112 2026D81_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
36634.113 2026D81_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
36634.114 2026D81_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
36834.111 2026D81PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36834.112 2026D81PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36834.113 2026D81PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
36834.114 2026D81PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
37034.111 2026D82_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37034.112 2026D82_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37034.113 2026D82_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37034.114 2026D82_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37234.111 2026D82PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
37234.112 2026D82PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
37234.113 2026D82PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
37234.114 2026D82PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
37434.111 2026D83_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37434.112 2026D83_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37434.113 2026D83_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37434.114 2026D83_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37634.111 2026D83PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
37634.112 2026D83PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
37634.113 2026D83PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
37634.114 2026D83PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
37834.111 2026D84_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37834.112 2026D84_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37834.113 2026D84_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
37834.114 2026D84_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
38034.111 2026D84PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38034.112 2026D84PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38034.113 2026D84PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38034.114 2026D84PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38234.111 2026D85_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
38234.112 2026D85_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
38234.113 2026D85_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
38234.114 2026D85_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
38434.111 2026D85PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38434.112 2026D85PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38434.113 2026D85PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38434.114 2026D85PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38634.111 2026D86_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
38634.112 2026D86_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
38634.113 2026D86_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
38634.114 2026D86_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
38834.111 2026D86PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38834.112 2026D86PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38834.113 2026D86PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
38834.114 2026D86PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
39034.111 2026D87_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39034.112 2026D87_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39034.113 2026D87_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39034.114 2026D87_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39234.111 2026D87PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
39234.112 2026D87PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
39234.113 2026D87PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
39234.114 2026D87PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
39434.111 2026D88_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39434.112 2026D88_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39434.113 2026D88_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39434.114 2026D88_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39634.111 2026D88PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
39634.112 2026D88PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
39634.113 2026D88PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
39634.114 2026D88PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
39834.111 2026D89_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39834.112 2026D89_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39834.113 2026D89_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
39834.114 2026D89_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
40034.111 2026D89PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40034.112 2026D89PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40034.113 2026D89PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40034.114 2026D89PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40234.111 2026D90_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
40234.112 2026D90_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
40234.113 2026D90_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
40234.114 2026D90_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
40434.111 2026D90PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40434.112 2026D90PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40434.113 2026D90PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40434.114 2026D90PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40634.111 2026D91_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
40634.112 2026D91_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
40634.113 2026D91_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
40634.114 2026D91_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
40834.111 2026D91PU_OTInefficiency+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40834.112 2026D91PU_OTInefficiency1PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40834.113 2026D91PU_OTInefficiency5PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
40834.114 2026D91PU_OTInefficiency10PC+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTriggerPU+RecoGlobalPU+HARVESTGlobalPU 
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

cc: @emiglior @suchandradutta 