### PR TITLE
MkFit TrackCandidate error rescale + relaxed selection for overlap hits

### DIFF
--- a/RecoTracker/MkFit/README.md
+++ b/RecoTracker/MkFit/README.md
@@ -51,8 +51,8 @@ $ runTheMatrix.py -l <workflow(s)> --apply 2 --command "--procModifiers tracking
 * *maxHolesPerCand:* maximum number of allowed holes on a candidate
 * *maxConsecHoles:*  maximum number of allowed consecutive holes on a candidate
 * *chi2Cut_min:*     minimum chi2 cut for accepting a new hit
-* *chi2CutOverlap:*  chi2 cut for accepting an overlap hit
-* *pTCutOverlap:*    pT cut below which the overlap hits are not picked up
+* *chi2CutOverlap:*  chi2 cut for accepting an overlap hit (currently NOT used)
+* *pTCutOverlap:*    pT cut below which the overlap hits are not picked up (currently NOT used)
 
 #### Seed cleaning params (based on elliptical dR-dz cut)
 

--- a/RecoTracker/MkFit/README.md
+++ b/RecoTracker/MkFit/README.md
@@ -52,7 +52,7 @@ $ runTheMatrix.py -l <workflow(s)> --apply 2 --command "--procModifiers tracking
 * *maxConsecHoles:*  maximum number of allowed consecutive holes on a candidate
 * *chi2Cut_min:*     minimum chi2 cut for accepting a new hit
 * *chi2CutOverlap:*  chi2 cut for accepting an overlap hit (currently NOT used)
-* *pTCutOverlap:*    pT cut below which the overlap hits are not picked up (currently NOT used)
+* *pTCutOverlap:*    pT cut below which the overlap hits are not picked up
 
 #### Seed cleaning params (based on elliptical dR-dz cut)
 

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -341,6 +341,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     const auto seedIndex = cand.label();
     LogTrace("MkFitOutputConverter") << " from seed " << seedIndex << " seed hits";
 
+    if (mkFitOutput.propagatedToFirstLayer()) fts.rescaleError(100.);
     auto tsosDet =
         mkFitOutput.propagatedToFirstLayer()
             ? convertInnermostState(fts, recHits, propagatorAlong, propagatorOpposite)

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -110,6 +110,8 @@ private:
   const float qualityMaxZ_;
   const float qualityMaxPosErrSq_;
   const bool qualitySignPt_;
+
+  const bool doErrorRescale_;
 };
 
 MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
@@ -134,7 +136,8 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
       qualityMaxRsq_{float(pow(iConfig.getParameter<double>("qualityMaxR"), 2))},
       qualityMaxZ_{float(iConfig.getParameter<double>("qualityMaxZ"))},
       qualityMaxPosErrSq_{float(pow(iConfig.getParameter<double>("qualityMaxPosErr"), 2))},
-      qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")} {}
+      qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")},
+      doErrorRescale_{iConfig.getParameter<bool>("doErrorRescale")} {}
 
 void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -155,6 +158,8 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<double>("qualityMaxZ", 280)->setComment("max(|Z|) for the state position for converted tracks");
   desc.add<double>("qualityMaxPosErr", 100)->setComment("max position error for converted tracks");
   desc.add<bool>("qualitySignPt", true)->setComment("check sign of 1/pt for converted tracks");
+
+  desc.add<bool>("doErrorRescale", true)->setComment("rescale candidate error before final fit");
 
   descriptions.addWithDefaultLabel(desc);
 }
@@ -341,7 +346,9 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     const auto seedIndex = cand.label();
     LogTrace("MkFitOutputConverter") << " from seed " << seedIndex << " seed hits";
 
-    if (mkFitOutput.propagatedToFirstLayer())
+    // Rescale candidate error if candidate is already propagated to first layer, to be consistent with TransientInitialStateEstimator::innerState used in CkfTrackCandidateMakerBase
+    // Error is only rescaled for candidates propagated to first layer; otherwise, candidates undergo backwardFit where error is already rescaled
+    if (mkFitOutput.propagatedToFirstLayer() && doErrorRescale_)
       fts.rescaleError(100.);
     auto tsosDet =
         mkFitOutput.propagatedToFirstLayer()

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -346,8 +346,10 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     const auto seedIndex = cand.label();
     LogTrace("MkFitOutputConverter") << " from seed " << seedIndex << " seed hits";
 
-    // Rescale candidate error if candidate is already propagated to first layer, to be consistent with TransientInitialStateEstimator::innerState used in CkfTrackCandidateMakerBase
-    // Error is only rescaled for candidates propagated to first layer; otherwise, candidates undergo backwardFit where error is already rescaled
+    // Rescale candidate error if candidate is already propagated to first layer,
+    // to be consistent with TransientInitialStateEstimator::innerState used in CkfTrackCandidateMakerBase
+    // Error is only rescaled for candidates propagated to first layer;
+    // otherwise, candidates undergo backwardFit where error is already rescaled
     if (mkFitOutput.propagatedToFirstLayer() && doErrorRescale_)
       fts.rescaleError(100.);
     auto tsosDet =

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -341,7 +341,8 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
     const auto seedIndex = cand.label();
     LogTrace("MkFitOutputConverter") << " from seed " << seedIndex << " seed hits";
 
-    if (mkFitOutput.propagatedToFirstLayer()) fts.rescaleError(100.);
+    if (mkFitOutput.propagatedToFirstLayer())
+      fts.rescaleError(100.);
     auto tsosDet =
         mkFitOutput.propagatedToFirstLayer()
             ? convertInnermostState(fts, recHits, propagatorAlong, propagatorOpposite)

--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -93,7 +93,7 @@ namespace mkfit {
     int maxConsecHoles = 1;
     float chi2Cut_min = 15.0;
     float chi2CutOverlap = 3.5;
-    float pTCutOverlap = 1.0;
+    float pTCutOverlap = 0.0;
 
     //seed cleaning params
     float c_ptthr_hpt = 2.0;

--- a/RecoTracker/MkFitCore/src/CandCloner.cc
+++ b/RecoTracker/MkFitCore/src/CandCloner.cc
@@ -191,9 +191,9 @@ namespace mkfit {
           if (n_pushed >= mp_iteration_params->maxCandsPerSeed)
             break;
 
-          // set the overlap if we have a true hit and pT > pTCutOverlap
+          // set the overlap if we have a true hit (and possibly pT > pTCutOverlap)
           HitMatch *hm;
-          if (tc.pT() > mp_iteration_params->pTCutOverlap && h2a.hitIdx >= 0 &&
+	  if (tc.pT() > 0.0 && h2a.hitIdx >= 0 && // To select tracks with a different pT cut, can use: mp_iteration_params->pTCutOverlap
               (hm = ccand[h2a.trkIdx].findOverlap(h2a.hitIdx, h2a.module))) {
             tc.addHitIdx(hm->m_hit_idx, m_layer, hm->m_chi2);
             tc.incOverlapCount();

--- a/RecoTracker/MkFitCore/src/CandCloner.cc
+++ b/RecoTracker/MkFitCore/src/CandCloner.cc
@@ -193,8 +193,10 @@ namespace mkfit {
 
           // set the overlap if we have a true hit (and possibly pT > pTCutOverlap)
           HitMatch *hm;
-	  if (tc.pT() > 0.0 && h2a.hitIdx >= 0 && // To select tracks with a different pT cut, can use: mp_iteration_params->pTCutOverlap
-              (hm = ccand[h2a.trkIdx].findOverlap(h2a.hitIdx, h2a.module))) {
+          if (tc.pT() > 0.0 && h2a.hitIdx >= 0 &&
+              (hm = ccand[h2a.trkIdx].findOverlap(
+                   h2a.hitIdx,
+                   h2a.module))) {  // To select tracks with a different pT cut, can use: mp_iteration_params->pTCutOverlap
             tc.addHitIdx(hm->m_hit_idx, m_layer, hm->m_chi2);
             tc.incOverlapCount();
           }

--- a/RecoTracker/MkFitCore/src/CandCloner.cc
+++ b/RecoTracker/MkFitCore/src/CandCloner.cc
@@ -191,7 +191,7 @@ namespace mkfit {
           if (n_pushed >= mp_iteration_params->maxCandsPerSeed)
             break;
 
-          // set the overlap if we have a true hit and pT > pTCutOverlap (=0 by default)
+          // set the overlap if we have a true hit and pT > pTCutOverlap
           HitMatch *hm;
           if (tc.pT() > mp_iteration_params->pTCutOverlap && h2a.hitIdx >= 0 &&
               (hm = ccand[h2a.trkIdx].findOverlap(h2a.hitIdx, h2a.module))) {

--- a/RecoTracker/MkFitCore/src/CandCloner.cc
+++ b/RecoTracker/MkFitCore/src/CandCloner.cc
@@ -191,12 +191,10 @@ namespace mkfit {
           if (n_pushed >= mp_iteration_params->maxCandsPerSeed)
             break;
 
-          // set the overlap if we have a true hit (and possibly pT > pTCutOverlap)
+          // set the overlap if we have a true hit and pT > pTCutOverlap (=0 by default)
           HitMatch *hm;
-          if (tc.pT() > 0.0 && h2a.hitIdx >= 0 &&
-              (hm = ccand[h2a.trkIdx].findOverlap(
-                   h2a.hitIdx,
-                   h2a.module))) {  // To select tracks with a different pT cut, can use: mp_iteration_params->pTCutOverlap
+          if (tc.pT() > mp_iteration_params->pTCutOverlap && h2a.hitIdx >= 0 &&
+              (hm = ccand[h2a.trkIdx].findOverlap(h2a.hitIdx, h2a.module))) {
             tc.addHitIdx(hm->m_hit_idx, m_layer, hm->m_chi2);
             tc.incOverlapCount();
           }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -1074,7 +1074,7 @@ namespace mkfit {
                 newcand.setScore(getScoreCand(newcand, true /*penalizeTailMissHits*/, true /*inFindCandidates*/));
                 newcand.setOriginIndex(m_CandIdx(itrack, 0, 0));
 
-                if (chi2 < m_iteration_params->chi2CutOverlap) {
+                if (chi2 < max_c2) { // to apply a fixed cut instead: m_iteration_params->chi2CutOverlap 
                   CombCandidate &ccand = *newcand.combCandidate();
                   ccand[m_CandIdx(itrack, 0, 0)].considerHitForOverlap(
                       hit_idx, layer_of_hits.refHit(hit_idx).detIDinLayer(), chi2);
@@ -1232,7 +1232,7 @@ namespace mkfit {
               const int hit_idx = m_XHitArr.At(itrack, hit_cnt, 0);
 
               // Register hit for overlap consideration, here we apply chi2 cut
-              if (chi2 < m_iteration_params->chi2CutOverlap) {
+              if (chi2 < max_c2) { // to apply a fixed cut instead: m_iteration_params->chi2CutOverlap 
                 ccand[m_CandIdx(itrack, 0, 0)].considerHitForOverlap(
                     hit_idx, layer_of_hits.refHit(hit_idx).detIDinLayer(), chi2);
               }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -1074,7 +1074,8 @@ namespace mkfit {
                 newcand.setScore(getScoreCand(newcand, true /*penalizeTailMissHits*/, true /*inFindCandidates*/));
                 newcand.setOriginIndex(m_CandIdx(itrack, 0, 0));
 
-                if (chi2 < max_c2) {  // to apply a fixed cut instead: m_iteration_params->chi2CutOverlap
+                // To apply a fixed cut instead of dynamic cut for overlap: m_iteration_params->chi2CutOverlap
+                if (chi2 < max_c2) {
                   CombCandidate &ccand = *newcand.combCandidate();
                   ccand[m_CandIdx(itrack, 0, 0)].considerHitForOverlap(
                       hit_idx, layer_of_hits.refHit(hit_idx).detIDinLayer(), chi2);
@@ -1231,8 +1232,9 @@ namespace mkfit {
               nHitsAdded[itrack]++;
               const int hit_idx = m_XHitArr.At(itrack, hit_cnt, 0);
 
-              // Register hit for overlap consideration, here we apply chi2 cut
-              if (chi2 < max_c2) {  // to apply a fixed cut instead: m_iteration_params->chi2CutOverlap
+              // Register hit for overlap consideration, if chi2 cut is passed
+              // To apply a fixed cut instead of dynamic cut for overlap: m_iteration_params->chi2CutOverlap
+              if (chi2 < max_c2) {
                 ccand[m_CandIdx(itrack, 0, 0)].considerHitForOverlap(
                     hit_idx, layer_of_hits.refHit(hit_idx).detIDinLayer(), chi2);
               }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -1074,7 +1074,7 @@ namespace mkfit {
                 newcand.setScore(getScoreCand(newcand, true /*penalizeTailMissHits*/, true /*inFindCandidates*/));
                 newcand.setOriginIndex(m_CandIdx(itrack, 0, 0));
 
-                if (chi2 < max_c2) { // to apply a fixed cut instead: m_iteration_params->chi2CutOverlap 
+                if (chi2 < max_c2) {  // to apply a fixed cut instead: m_iteration_params->chi2CutOverlap
                   CombCandidate &ccand = *newcand.combCandidate();
                   ccand[m_CandIdx(itrack, 0, 0)].considerHitForOverlap(
                       hit_idx, layer_of_hits.refHit(hit_idx).detIDinLayer(), chi2);
@@ -1232,7 +1232,7 @@ namespace mkfit {
               const int hit_idx = m_XHitArr.At(itrack, hit_cnt, 0);
 
               // Register hit for overlap consideration, here we apply chi2 cut
-              if (chi2 < max_c2) { // to apply a fixed cut instead: m_iteration_params->chi2CutOverlap 
+              if (chi2 < max_c2) {  // to apply a fixed cut instead: m_iteration_params->chi2CutOverlap
                 ccand[m_CandIdx(itrack, 0, 0)].considerHitForOverlap(
                     hit_idx, layer_of_hits.refHit(hit_idx).detIDinLayer(), chi2);
               }


### PR DESCRIPTION
### PR description:

This PR introduces two updates for mkFit tracking iterations:
(1) rescale covariance of TrackCandidate's before CMSSW final fit (where the rescaling option is configurable);
(2) relax selection of overlap hits.

It requires cms-data/RecoTracker-MkFit#9.

### PR validation:

Rescaling the covariance of TrackCandidate's allows to better match CKF performance in terms of residuals, with a consequent decrease in duplicate tracks (from the duplicate merging/cleaning across mkFit and CKF iterations). E.g.:
http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/rescaleError100/MTV_TTbarPU50_rescaleError100_defaultIters_mkFitOnly/plots_highPurity/effandfakePtEtaPhi.pdf

Similarly to CKF tracks, a few % bias in track pT is introduced, due to a known feature related the description of the detector material in endcaps. E.g.:
http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/rescaleError100/MTV_TTbarPU50_rescaleError100_defaultIters_vsCKF/plots_highPurity/residualPt.pdf

Relaxing the selection of overlap hits allows to increase the track hit multiplicity, with a reduction of fake tracks:
http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/rescaleError100/MTV_TTbarPU50_rescaleError100_extractedGeoms_overlapHitCuts_mkFitOnly/

For more details, please refer to presentations at TRK POG:
(1) https://indico.cern.ch/event/1133724/#4-mkfit-status-report
(2) https://indico.cern.ch/event/1142469/#5-mkfit-status-report

FYI @mmusich @vmariani 