### PR TITLE
Add min pT filter in mkFit iterations during track building

### DIFF
--- a/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedQuadStep_cff.py
@@ -212,6 +212,7 @@ trackingMkFitDetachedQuadStep.toReplaceWith(detachedQuadStepTrackCandidates, mkF
     mkFitSeeds = 'detachedQuadStepTrackCandidatesMkFitSeeds',
     tracks = 'detachedQuadStepTrackCandidatesMkFit',
 ))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(detachedQuadStepTrackCandidatesMkFitConfig, minPt=0.9)
 
 #For FastSim phase1 tracking 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi

--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -242,6 +242,7 @@ trackingMkFitDetachedTripletStep.toReplaceWith(detachedTripletStepTrackCandidate
     mkFitSeeds = 'detachedTripletStepTrackCandidatesMkFitSeeds',
     tracks = 'detachedTripletStepTrackCandidatesMkFit',
 ))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(detachedTripletStepTrackCandidatesMkFitConfig, minPt=0.9)
 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 _fastSim_detachedTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(

--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -242,6 +242,7 @@ trackingMkFitHighPtTripletStep.toReplaceWith(highPtTripletStepTrackCandidates, m
     mkFitSeeds = 'highPtTripletStepTrackCandidatesMkFitSeeds',
     tracks = 'highPtTripletStepTrackCandidatesMkFit',
 ))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(highPtTripletStepTrackCandidatesMkFitConfig, minPt=0.7)
 
 # For Phase2PU140
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits as _trajectoryCleanerBySharedHits

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -257,6 +257,7 @@ trackingMkFitInitialStep.toReplaceWith(initialStepTrackCandidates, mkFitOutputCo
     mkFitSeeds = 'initialStepTrackCandidatesMkFitSeeds',
     tracks = 'initialStepTrackCandidatesMkFit',
 ))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(initialStepTrackCandidatesMkFitConfig, minPt=0.6)
 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(initialStepTrackCandidates,

--- a/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtQuadStep_cff.py
@@ -202,6 +202,7 @@ trackingMkFitLowPtQuadStep.toReplaceWith(lowPtQuadStepTrackCandidates, mkFitOutp
     mkFitSeeds = 'lowPtQuadStepTrackCandidatesMkFitSeeds',
     tracks = 'lowPtQuadStepTrackCandidatesMkFit',
 ))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(lowPtQuadStepTrackCandidatesMkFitConfig, minPt=0.49)
 
 #For FastSim phase1 tracking
 import FastSimulation.Tracking.TrackCandidateProducer_cfi

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -270,6 +270,7 @@ trackingMkFitLowPtTripletStep.toReplaceWith(lowPtTripletStepTrackCandidates, mkF
     mkFitSeeds = 'lowPtTripletStepTrackCandidatesMkFitSeeds',
     tracks = 'lowPtTripletStepTrackCandidatesMkFit',
 ))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(lowPtTripletStepTrackCandidatesMkFitConfig, minPt=0.49)
 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(lowPtTripletStepTrackCandidates,

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -318,6 +318,7 @@ trackingMkFitMixedTripletStep.toReplaceWith(mixedTripletStepTrackCandidates, mkF
     mkFitSeeds = 'mixedTripletStepTrackCandidatesMkFitSeeds',
     tracks = 'mixedTripletStepTrackCandidatesMkFit',
 ))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(mixedTripletStepTrackCandidatesMkFitConfig, minPt=0.4)
 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(mixedTripletStepTrackCandidates,

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -322,6 +322,7 @@ trackingMkFitPixelLessStep.toReplaceWith(pixelLessStepTrackCandidates, mkFitOutp
     mkFitSeeds = 'pixelLessStepTrackCandidatesMkFitSeeds',
     tracks = 'pixelLessStepTrackCandidatesMkFit',
 ))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(pixelLessStepTrackCandidatesMkFitConfig, minPt=2.0)
 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(pixelLessStepTrackCandidates,

--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -305,6 +305,7 @@ trackingMkFitTobTecStep.toReplaceWith(tobTecStepTrackCandidates, mkFitOutputConv
     mkFitSeeds = 'tobTecStepTrackCandidatesMkFitSeeds',
     tracks = 'tobTecStepTrackCandidatesMkFit',
 ))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(tobTecStepTrackCandidatesMkFitConfig, minPt=2.0)
 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 fastSim.toReplaceWith(tobTecStepTrackCandidates,

--- a/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
@@ -218,16 +218,19 @@ public:
 private:
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> geomToken_;
   const std::string configFile_;
+  const float minPtCut_;
 };
 
 MkFitIterationConfigESProducer::MkFitIterationConfigESProducer(const edm::ParameterSet &iConfig)
     : geomToken_{setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName")).consumes()},
-      configFile_{iConfig.getParameter<edm::FileInPath>("config").fullPath()} {}
+      configFile_{iConfig.getParameter<edm::FileInPath>("config").fullPath()},
+      minPtCut_{(float)iConfig.getParameter<double>("minPt")} {}
 
 void MkFitIterationConfigESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("ComponentName")->setComment("Product label");
   desc.add<edm::FileInPath>("config")->setComment("Path to the JSON file for the mkFit configuration parameters");
+  desc.add<double>("minPt", 0.0)->setComment("min pT cut applied during track building");
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -235,6 +238,8 @@ std::unique_ptr<mkfit::IterationConfig> MkFitIterationConfigESProducer::produce(
     const TrackerRecoGeometryRecord &iRecord) {
   mkfit::ConfigJson cj;
   auto it_conf = cj.load_File(configFile_);
+  it_conf->m_params.minPtCut = minPtCut_;
+  it_conf->m_backward_params.minPtCut = minPtCut_;
   it_conf->m_partition_seeds = partitionSeeds1;
   return it_conf;
 }

--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -112,6 +112,9 @@ namespace mkfit {
     float drth_central = 0.001;
     float drth_obarrel = 0.001;
     float drth_forward = 0.001;
+
+    //min pT cut
+    float minPtCut = 0.0;
   };
 
   //==============================================================================

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -614,6 +614,9 @@ namespace mkfit {
 
     seed_cand_vec.clear();
 
+    auto &iter_params = (iteration_dir == SteeringParams::IT_BkwSearch) ? m_job->m_iter_config.m_backward_params
+                                                                        : m_job->m_iter_config.m_params;
+
     for (int iseed = start_seed; iseed < end_seed; ++iseed) {
       CombCandidate &ccand = m_event_of_comb_cands[iseed];
 
@@ -624,6 +627,11 @@ namespace mkfit {
         bool active = false;
         for (int ic = 0; ic < (int)ccand.size(); ++ic) {
           if (ccand[ic].getLastHitIdx() != -2) {
+            // Stop candidates with pT<X GeV
+            if (ccand[ic].pT() < iter_params.minPtCut) {
+              ccand[ic].addHitIdx(-2, layer, 0.0f);
+              continue;
+            }
             // Check if the candidate is close to it's max_r, pi/2 - 0.2 rad (11.5 deg)
             if (iteration_dir == SteeringParams::IT_FwdSearch && ccand[ic].pT() < 1.2) {
               const float dphi = std::abs(ccand[ic].posPhi() - ccand[ic].momPhi());


### PR DESCRIPTION
### PR description:

As per title, this PR adds configurable min pT filter in mkFit iterations during track building, aimed at addressing issue trackreco/cmssw#83, relevant for HI tracking (following https://indico.cern.ch/event/1133724/#5-mkfit-usage-for-heavy-ion-tr).
Corresponding pp_on_XeXe_2017 and pp_on_AA modifiers with the same min pT cuts as CKF are also added.
Performance in default Run-3 configuration is unchanged (zero difference).

### PR validation:

TTbar + PU: http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/minPtCut/MTV_TTbarPU50_minPtIterConfig_forPR/
-> Zero difference is observed for standard pp tracking.

FYI @mmusich @vmariani 