### PR TITLE
Updating EGM HLT supercluster regression tags for Run 3 in MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,19 +68,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v13',
+    'phase1_2021_design'           : '123X_mcRun3_2021_design_v14',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v13',
+    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v14',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v13',
+    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v14',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v13',
+    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v14',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v13',
+    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v14',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v13',
+    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v15',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '123X_mcRun4_realistic_v10'
+    'phase2_realistic'             : '123X_mcRun4_realistic_v11'
 }
 
 aliases = {

--- a/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/SCEnergyCorrectorSemiParm.cc
@@ -51,7 +51,7 @@ SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm()
       caloGeom_(nullptr),
       isHLT_(false),
       isPhaseII_(false),
-      regTrainedWithPS_(false),
+      regTrainedWithPS_(true),
       applySigmaIetaIphiBug_(false),
       nHitsAboveThresholdEB_(0),
       nHitsAboveThresholdEE_(0),
@@ -67,7 +67,7 @@ SCEnergyCorrectorSemiParm::SCEnergyCorrectorSemiParm(const edm::ParameterSet& iC
 void SCEnergyCorrectorSemiParm::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<bool>("isHLT", false);
   desc.add<bool>("isPhaseII", false);
-  desc.add<bool>("regTrainedWithPS", false);
+  desc.add<bool>("regTrainedWithPS", true);
   desc.add<bool>("applySigmaIetaIphiBug", false);
   desc.add<edm::InputTag>("ecalRecHitsEE", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
   desc.add<edm::InputTag>("ecalRecHitsEB", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));


### PR DESCRIPTION
#### PR description:

Follow-up to https://github.com/cms-sw/cmssw/pull/37491 

Request to update tags is in
https://cms-talk.web.cern.ch/t/mc-gt-updating-egm-hlt-supercluster-regression-tags-for-run-3-in-mc/9343

Adding the EGM HLT supercluster regression tags for Run 3 in MC:
 * 123X_mcRun3_2021_design_v14
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_design_v13/123X_mcRun3_2021_design_v14
 * 123X_mcRun3_2021_realistic_v14
  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_v13/123X_mcRun3_2021_realistic_v14
 * 123X_mcRun3_2021cosmics_realistic_deco_v14
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021cosmics_realistic_deco_v13/123X_mcRun3_2021cosmics_realistic_deco_v14
 * 123X_mcRun3_2021_realistic_HI_v14
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_HI_v13/123X_mcRun3_2021_realistic_HI_v14
 * 123X_mcRun3_2023_realistic_v14
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2023_realistic_v13/123X_mcRun3_2023_realistic_v14
 * 123X_mcRun3_2024_realistic_v15
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2024_realistic_v13/123X_mcRun3_2024_realistic_v15
 * 123X_mcRun4_realistic_v11
 https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun4_realistic_v10/123X_mcRun4_realistic_v11

Diffs in the tags are according to the request:
```
Tag: pfscecal_EBCorrection_online_Run3_120X_v1_mc
Rcd: GBRDWrapperRcd
Label: pfscecal_EBCorrection_online

Tag: pfscecal_EECorrection_online_Run3_120X_v1_mc
Rcd: GBRDWrapperRcd
Label: pfscecal_EECorrection_online

Tag: pfscecal_EBUncertainty_online_Run3_120X_v1_mc
Rcd: GBRDWrapperRcd
Label: pfscecal_EBUncertainty_online

Tag: pfscecal_EEUncertainty_online_Run3_120X_v1_mc
Rcd: GBRDWrapperRcd
Label: pfscecal_EEUncertainty_online
```

#### PR validation:

test parameters:
  - workflows = 12034.0,11634.0,7.23,159.0,12434.0,12834.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport to 12_3_X is expected
