### PR TITLE
Better exception messages from ROOT delayed reading

### DIFF
--- a/FWCore/Integration/test/DelayedReaderThrowingSource.cc
+++ b/FWCore/Integration/test/DelayedReaderThrowingSource.cc
@@ -22,7 +22,8 @@ namespace edm {
       ThrowingDelayedReader(
           signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadSource,
           signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadSource)
-          : preEventReadFromSourceSignal_(preEventReadSource), postEventReadFromSourceSignal_(postEventReadSource) {}
+          : preEventReadFromSourceSignal_(preEventReadSource), postEventReadFromSourceSignal_(postEventReadSource),
+              e_(std::make_exception_ptr(cms::Exception("TEST"))) {}
 
       signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal()
           const final {
@@ -35,7 +36,14 @@ namespace edm {
 
     private:
       std::shared_ptr<WrapperBase> getProduct_(BranchID const& k, EDProductGetter const* ep) final {
-        throw cms::Exception("TEST");
+        try {
+          std::rethrow_exception(e_);
+        } catch(cms::Exception const& iE) {
+          //avoid adding to the context for each call
+          auto copyException = iE;
+          copyException.addContext("called ThrowingDelayedReader");
+          throw copyException;
+        }
       }
       void mergeReaders_(DelayedReader*) final{};
       void reset_() final{};
@@ -44,6 +52,7 @@ namespace edm {
           nullptr;
       signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadFromSourceSignal_ =
           nullptr;
+      std::exception_ptr e_;
     };
   }  // namespace
 

--- a/FWCore/Integration/test/DelayedReaderThrowingSource.cc
+++ b/FWCore/Integration/test/DelayedReaderThrowingSource.cc
@@ -22,8 +22,9 @@ namespace edm {
       ThrowingDelayedReader(
           signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadSource,
           signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* postEventReadSource)
-          : preEventReadFromSourceSignal_(preEventReadSource), postEventReadFromSourceSignal_(postEventReadSource),
-              e_(std::make_exception_ptr(cms::Exception("TEST"))) {}
+          : preEventReadFromSourceSignal_(preEventReadSource),
+            postEventReadFromSourceSignal_(postEventReadSource),
+            e_(std::make_exception_ptr(cms::Exception("TEST"))) {}
 
       signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> const* preEventReadFromSourceSignal()
           const final {
@@ -38,7 +39,7 @@ namespace edm {
       std::shared_ptr<WrapperBase> getProduct_(BranchID const& k, EDProductGetter const* ep) final {
         try {
           std::rethrow_exception(e_);
-        } catch(cms::Exception const& iE) {
+        } catch (cms::Exception const& iE) {
           //avoid adding to the context for each call
           auto copyException = iE;
           copyException.addContext("called ThrowingDelayedReader");

--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -43,7 +43,13 @@ namespace edm {
     if (lastException_) {
       try {
         std::rethrow_exception(lastException_);
+      } catch (edm::Exception const& e) {
+        //avoid growing the context each time the exception is rethrown.
+        auto copy = e;
+        copy.addContext("Rethrowing an exception that happened on a different read request.");
+        throw copy;
       } catch (cms::Exception& e) {
+        //If we do anything here to 'copy', we would lose the actual type of the exception.
         e.addContext("Rethrowing an exception that happened on a different read request.");
         throw;
       }


### PR DESCRIPTION
#### PR description:

- For the most common case, have RootDelayedReader copy the held exception type to avoid having all requesting tasks add additional context to the exception.
- Modified test for throwing an exception during delayed reading to have exception handling similar to RootDelayedReader.
 
#### PR validation:

- code compiles
- all framework unit tests pass
- a simple modification to ThrowingDelayedReader reproduced the same over reporting behavior seen by @slava77 . The change here avoided the problem and was applied to RootDelayedReader.

fixes makortel/framework#385