### PR TITLE
Mark legacy EDModule constructors deprecated

### DIFF
--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -34,7 +34,7 @@ namespace edm {
     friend class WorkerT;
     typedef EDAnalyzer ModuleType;
 
-    EDAnalyzer();
+    CMS_DEPRECATED EDAnalyzer();
     ~EDAnalyzer() override;
 
     std::string workerType() const { return "WorkerT<EDAnalyzer>"; }

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -26,7 +26,13 @@ namespace edm {
     class ModuleHolderT;
   }
 
-  class CMS_DEPRECATED EDAnalyzer : public EDConsumerBase {
+  /**
+   * The legacy EDAnalyzer class is deprecated. We annotate the
+   * constructor only with the CMS_DEPRECATED, because with gcc it
+   * turns out to flag deriving classes more reliably than annotating
+   * the entire class.
+   */
+  class EDAnalyzer : public EDConsumerBase {
   public:
     template <typename T>
     friend class maker::ModuleHolderT;

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -44,7 +44,7 @@ namespace edm {
     friend class WorkerT;
     typedef EDFilter ModuleType;
 
-    EDFilter();
+    CMS_DEPRECATED EDFilter();
     ~EDFilter() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -36,7 +36,13 @@ namespace edm {
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
 
-  class CMS_DEPRECATED EDFilter : public ProducerBase, public EDConsumerBase {
+  /**
+   * The legacy EDFilter class is deprecated. We annotate the
+   * constructor only with the CMS_DEPRECATED, because with gcc it
+   * turns out to flag deriving classes more reliably than annotating
+   * the entire class.
+   */
+  class EDFilter : public ProducerBase, public EDConsumerBase {
   public:
     template <typename T>
     friend class maker::ModuleHolderT;

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -41,7 +41,7 @@ namespace edm {
     friend class WorkerT;
     typedef EDProducer ModuleType;
 
-    EDProducer();
+    CMS_DEPRECATED EDProducer();
     ~EDProducer() override;
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -33,7 +33,13 @@ namespace edm {
     class ModuleHolderT;
   }
 
-  class CMS_DEPRECATED EDProducer : public ProducerBase, public EDConsumerBase {
+  /**
+   * The legacy EDProducer class is deprecated. We annotate the
+   * constructor only with the CMS_DEPRECATED, because with gcc it
+   * turns out to flag deriving classes more reliably than annotating
+   * the entire class.
+   */
+  class EDProducer : public ProducerBase, public EDConsumerBase {
   public:
     template <typename T>
     friend class maker::ModuleHolderT;


### PR DESCRIPTION
#### PR description:

We've noticed on a few occasions that marking the legacy EDModule base classes as `CMS_DEPRECATED` does not cover all the classes that inherit from these base classes. Marking functions deprecated seems to be more reliable to generate warnings, so this PR marks the constructors of the legacy EDModule base classes as `CMS_DEPRECATED`.


#### PR validation:

A legacy EDAnalyzer https://github.com/cms-sw/cmssw/blob/12_4_0_pre2/OnlineDB/SiStripO2O/plugins/SiStripPayloadMapTableCreator.cc that doesn't generate a warning in 12_4_0_pre2, generates a warning with this PR.