### PR TITLE
Link slimmed muons to lost tracks

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -285,7 +285,7 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
     id = -11;
 
   // assign the proper pdgId for tracks that are reconstructed as a muon
-  const reco::Muon * muon(nullptr);
+  const reco::Muon* muon(nullptr);
   for (auto& mu : *muons) {
     if (reco::TrackRef(mu.innerTrack()) == trk) {
       id = -13 * trk->charge();

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -285,9 +285,11 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
     id = -11;
 
   // assign the proper pdgId for tracks that are reconstructed as a muon
+  const reco::Muon * muon(nullptr);
   for (auto& mu : *muons) {
     if (reco::TrackRef(mu.innerTrack()) == trk) {
       id = -13 * trk->charge();
+      muon = &mu;
       break;
     }
   }
@@ -331,6 +333,9 @@ void pat::PATLostTracks::addPackedCandidate(std::vector<pat::PackedCandidate>& c
     }
   }
   cands.back().setAssociationQuality(pvAssocQuality);
+
+  if (muon)
+    cands.back().setMuonID(muon->isStandAloneMuon(), muon->isGlobalMuon());
 }
 
 std::pair<int, pat::PackedCandidate::PVAssociationQuality> pat::PATLostTracks::associateTrkToVtx(

--- a/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
@@ -69,7 +69,8 @@ pat::PATMuonSlimmer::PATMuonSlimmer(const edm::ParameterSet &iConfig)
       pf2pc_.push_back(consumes<edm::Association<pat::PackedCandidateCollection>>(tag));
   }
   if (linkToLostTrack_) {
-    track2LostTrack_ = consumes<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("lostTracks"));
+    track2LostTrack_ =
+        consumes<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("lostTracks"));
   }
 
   if (modifyMuon_) {
@@ -128,11 +129,11 @@ void pat::PATMuonSlimmer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
     }
   }
   if (linkToLostTrack_) {
-    const auto& trk2LT = iEvent.get(track2LostTrack_);
-    for (const auto& mu : *src) {
-      const auto& track = dynamic_cast<const reco::Muon*>(mu.originalObject())->innerTrack();
+    const auto &trk2LT = iEvent.get(track2LostTrack_);
+    for (const auto &mu : *src) {
+      const auto &track = dynamic_cast<const reco::Muon *>(mu.originalObject())->innerTrack();
       if (track.isNonnull() && trk2LT.contains(track.id())) {
-        const auto& lostTrack = trk2LT[track];
+        const auto &lostTrack = trk2LT[track];
         if (lostTrack.isNonnull())
           mu2pc[mu.refToOrig_] = lostTrack;
       }

--- a/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
@@ -33,7 +33,8 @@ namespace pat {
     const edm::EDGetTokenT<pat::MuonCollection> src_;
     std::vector<edm::EDGetTokenT<reco::PFCandidateCollection>> pf_;
     std::vector<edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>>> pf2pc_;
-    const bool linkToPackedPF_;
+    edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> track2LostTrack_;
+    const bool linkToPackedPF_, linkToLostTrack_;
     const StringCutObjectSelector<pat::Muon> saveTeVMuons_, dropDirectionalIso_, dropPfP4_, slimCaloVars_,
         slimKinkVars_, slimCaloMETCorr_, slimMatches_, segmentsMuonSelection_;
     const bool saveSegments_, modifyMuon_;
@@ -46,6 +47,7 @@ namespace pat {
 pat::PATMuonSlimmer::PATMuonSlimmer(const edm::ParameterSet &iConfig)
     : src_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("src"))),
       linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
+      linkToLostTrack_(iConfig.getParameter<bool>("linkToLostTrack")),
       saveTeVMuons_(iConfig.getParameter<std::string>("saveTeVMuons")),
       dropDirectionalIso_(iConfig.getParameter<std::string>("dropDirectionalIso")),
       dropPfP4_(iConfig.getParameter<std::string>("dropPfP4")),
@@ -65,6 +67,9 @@ pat::PATMuonSlimmer::PATMuonSlimmer(const edm::ParameterSet &iConfig)
       pf_.push_back(consumes<reco::PFCandidateCollection>(tag));
     for (const edm::InputTag &tag : pf2pc)
       pf2pc_.push_back(consumes<edm::Association<pat::PackedCandidateCollection>>(tag));
+  }
+  if (linkToLostTrack_) {
+    track2LostTrack_ = consumes<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("lostTracks"));
   }
 
   if (modifyMuon_) {
@@ -122,6 +127,17 @@ void pat::PATMuonSlimmer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
       }
     }
   }
+  if (linkToLostTrack_) {
+    const auto& trk2LT = iEvent.get(track2LostTrack_);
+    for (const auto& mu : *src) {
+      const auto& track = dynamic_cast<const reco::Muon*>(mu.originalObject())->innerTrack();
+      if (track.isNonnull() && trk2LT.contains(track.id())) {
+        const auto& lostTrack = trk2LT[track];
+        if (lostTrack.isNonnull())
+          mu2pc[mu.refToOrig_] = lostTrack;
+      }
+    }
+  }
 
   std::vector<edm::Handle<edm::Association<reco::TrackExtraCollection>>> trackExtraAssocs(trackExtraAssocs_.size());
   for (unsigned int i = 0; i < trackExtraAssocs_.size(); ++i) {
@@ -141,7 +157,7 @@ void pat::PATMuonSlimmer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
       mu.embedTpfmsMuon();
       mu.embedDytMuon();
     }
-    if (linkToPackedPF_) {
+    if (linkToPackedPF_ || linkToLostTrack_) {
       mu.refToOrig_ = refToPtr(mu2pc[mu.refToOrig_]);
     }
     if (dropDirectionalIso_(mu)) {

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMuons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMuons_cfi.py
@@ -3,8 +3,10 @@ import FWCore.ParameterSet.Config as cms
 slimmedMuons = cms.EDProducer("PATMuonSlimmer",
     src = cms.InputTag("selectedPatMuons"),
     linkToPackedPFCandidates = cms.bool(True),
+    linkToLostTrack = cms.bool(True),
     pfCandidates = cms.VInputTag(cms.InputTag("particleFlow")),
     packedPFCandidates = cms.VInputTag(cms.InputTag("packedPFCandidates")), 
+    lostTracks = cms.InputTag("lostTracks"),
     saveTeVMuons = cms.string("pt > 100"), # you can put a cut to slim selectively, e.g. pt > 10
     dropDirectionalIso = cms.string("0"),
     dropPfP4 = cms.string("1"),


### PR DESCRIPTION
#### PR description:

This PR add the option to link slimmed muons to lost tracks and add the muon ID information to lost tracks.
This is useful to find the corresponding packed candidate associated to the slimmed muon and recover additional muons using the maps produced by PackedCandidateMuonSelectorProducer.

#### PR validation:

Tested with workflow 140.5611 (PbPb 2018 MiniAOD)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
