### PR TITLE
[MkFit] use CMS_UNROLL_LOOP_COUNT and constexpr if to improve optimization

### DIFF
--- a/RecoTracker/MkFitCore/src/PropagationMPlex.cc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.cc
@@ -1,3 +1,5 @@
+#include "FWCore/Utilities/interface/CMSUnrollLoop.h"
+
 #include "MaterialEffects.h"
 #include "PropagationMPlex.h"
 
@@ -331,6 +333,7 @@ namespace mkfit {
       float pxin = cosP / ipt;
       float pyin = sinP / ipt;
 
+      CMS_UNROLL_LOOP_COUNT(Config::Niter)
       for (int i = 0; i < Config::Niter; ++i) {
         dprint_np(n,
                   std::endl
@@ -343,7 +346,7 @@ namespace mkfit {
         const float ialpha = (r - r0) * ipt / k;
         //alpha+=ialpha;
 
-        if (Config::useTrigApprox) {
+        if constexpr (Config::useTrigApprox) {
           sincos4(ialpha * 0.5f, sinah, cosah);
         } else {
           cosah = std::cos(ialpha * 0.5f);
@@ -754,7 +757,7 @@ namespace mkfit {
       const float deltaZ = zout - zin;
       const float alpha = deltaZ * tanT * ipt * kinv;
 
-      if (Config::useTrigApprox) {
+      if constexpr (Config::useTrigApprox) {
         sincos4(alpha * 0.5f, sinahTmp, cosahTmp);
       } else {
         cosahTmp = std::cos(alpha * 0.5f);

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.icc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.icc
@@ -70,6 +70,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
     float dDdipt = 0.;
     float dDdphi = 0.;
 
+    CMS_UNROLL_LOOP_COUNT(Config::Niter)
     for (int i = 0; i < Config::Niter; ++i) {
       //compute distance and path for the current iteration
       r0 = hipo(outPar(n, 0, 0), outPar(n, 1, 0));
@@ -93,7 +94,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
       }
       D += id;
 
-      if (Config::useTrigApprox) {
+      if constexpr (Config::useTrigApprox) {
         sincos4(id * ipt * kinv * 0.5f, sinah, cosah);
       } else {
         cosah = std::cos(id * ipt * kinv * 0.5f);
@@ -162,7 +163,7 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
     const float dadipt = (ipt * dDdipt + D) * kinv;
     const float dadphi = dDdphi * ipt * kinv;
 
-    if (Config::useTrigApprox) {
+    if constexpr (Config::useTrigApprox) {
       sincos4(alpha, sina, cosa);
     } else {
       cosa = std::cos(alpha);


### PR DESCRIPTION
#### PR description:

Based on compiler diagnostic feedback, this PR adds CMS_UNROLL_LOOP_COUNT to the inner loops of the propagation code and "if constexpr" in locations that chooses between standard trigonometric operations and small angle approximations.  This should improve vectorization options with compilers that don't have access to vector versions of libm.

#### PR validation:

Compiles, verified with compiler diagnostics that the loops are unrolled as intended, otherwise trivial technical change.