### PR TITLE
[L1-O2O] ESGetToken migration L1CondDBPayloadWriter and O2O unit tests

### DIFF
--- a/CondTools/L1Trigger/interface/WriterProxy.h
+++ b/CondTools/L1Trigger/interface/WriterProxy.h
@@ -14,8 +14,6 @@
 
 #include <string>
 
-using namespace edm;
-
 namespace l1t {
 
   /* This is class that is used to save data to DB. Saving requires that we should know types at compile time.
@@ -46,17 +44,14 @@ namespace l1t {
  * should instaciate a new version of this class and register it in plugin system.
  */
   template <class Record, class Type>
-    class WriterProxyT : public WriterProxy {
-
+  class WriterProxyT : public WriterProxy {
   private:
     edm::ESGetToken<Type, Record> rcdToken;
 
   public:
     ~WriterProxyT() override {}
 
-    void setToken(edm::ConsumesCollector cc) override {
-      rcdToken = cc.esConsumes();
-    }
+    void setToken(edm::ConsumesCollector cc) override { rcdToken = cc.esConsumes(); }
 
     /* This method requires that Record and Type supports copy constructor */
     std::string save(const edm::EventSetup& setup) const override {
@@ -68,7 +63,6 @@ namespace l1t {
       } catch (l1t::DataAlreadyPresentException& ex) {
         return std::string();
       }
-
       // If handle is invalid, then data is already in DB
 
       edm::Service<cond::service::PoolDBOutputService> poolDb;
@@ -77,14 +71,13 @@ namespace l1t {
       }
       poolDb->forceInit();
       cond::persistency::Session session = poolDb->session();
-      cond::persistency::TransactionScope tr(session.transaction());
-      // if throw transaction will unroll
-      ///	    tr.start(false);
+      if (not session.transaction().isActive())
+        session.transaction().start(false);  // true: read only, false: read-write
 
       std::shared_ptr<Type> pointer = std::make_shared<Type>(*(handle.product()));
       std::string payloadToken = session.storePayload(*pointer);
-      ///	    tr.commit();
-      tr.close();
+
+      session.transaction().commit();
       return payloadToken;
     }
   };

--- a/CondTools/L1TriggerExt/interface/DataWriterExt.h
+++ b/CondTools/L1TriggerExt/interface/DataWriterExt.h
@@ -69,9 +69,7 @@ namespace l1t {
 
     bool fillLastTriggerKeyList(L1TriggerKeyListExt& output);
 
-    WriterProxy* getWriter() {
-      return writer.get();
-    }
+    WriterProxy* getWriter() { return writer.get(); }
 
   private:
     WriterProxyPtr writer;
@@ -88,12 +86,12 @@ namespace l1t {
 
     poolDb->forceInit();
     cond::persistency::Session session = poolDb->session();
-    ///  session.transaction().start(true);
+    session.transaction().start(true);
 
     // Get object from CondDB
     std::shared_ptr<T> ref = session.fetchPayload<T>(payloadToken);
     outputObject = *ref;
-    ///  session.transaction().commit ();
+    session.transaction().commit();
   }
 
 }  // namespace l1t

--- a/CondTools/L1TriggerExt/interface/DataWriterExt.h
+++ b/CondTools/L1TriggerExt/interface/DataWriterExt.h
@@ -32,15 +32,19 @@ namespace l1t {
  * REGISTER_PLUGIN(record, type) from registration_macros.h found in PluginSystem.
  */
 
+  typedef std::unique_ptr<WriterProxy> WriterProxyPtr;
+
   class DataWriterExt {
   public:
     DataWriterExt();
+    DataWriterExt(const std::string&);
     ~DataWriterExt();
 
     // Payload and IOV writing functions.
 
     // Get payload from EventSetup and write to DB with no IOV
     // recordType = "record@type", return value is payload token
+    std::string writePayload(const edm::EventSetup& setup);
     std::string writePayload(const edm::EventSetup& setup, const std::string& recordType);
 
     // Use PoolDBOutputService to append IOV with sinceRun to IOV sequence
@@ -64,6 +68,13 @@ namespace l1t {
     std::string lastPayloadToken(const std::string& recordName);
 
     bool fillLastTriggerKeyList(L1TriggerKeyListExt& output);
+
+    WriterProxy* getWriter() {
+      return writer.get();
+    }
+
+  private:
+    WriterProxyPtr writer;
 
   protected:
   };

--- a/CondTools/L1TriggerExt/interface/DataWriterExt.h
+++ b/CondTools/L1TriggerExt/interface/DataWriterExt.h
@@ -69,10 +69,10 @@ namespace l1t {
 
     bool fillLastTriggerKeyList(L1TriggerKeyListExt& output);
 
-    WriterProxy* getWriter() { return writer.get(); }
+    WriterProxy* getWriter() { return writer_.get(); }
 
   private:
-    WriterProxyPtr writer;
+    WriterProxyPtr writer_;
 
   protected:
   };

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
@@ -56,14 +56,13 @@ L1CondDBPayloadWriterExt::L1CondDBPayloadWriterExt(const edm::ParameterSet& iCon
       m_overwriteKeys(iConfig.getParameter<bool>("overwriteKeys")),
       m_logTransactions(iConfig.getParameter<bool>("logTransactions")),
       m_newL1TriggerKeyListExt(iConfig.getParameter<bool>("newL1TriggerKeyListExt")),
-      theL1TriggerKeyExtToken_(esConsumes())
-{
+      theL1TriggerKeyExtToken_(esConsumes()) {
   auto cc = consumesCollector();
-  for (auto sysWriter : iConfig.getParameter<std::vector<std::string>>("sysWriters")) {
+  for (const auto& sysWriter : iConfig.getParameter<std::vector<std::string>>("sysWriters")) {
     //construct writer
     DataWriterExtPtr writer = std::make_unique<l1t::DataWriterExt>(sysWriter);
-    writer->getWriter()->setToken( cc );
-    m_rcdToWriterMap[ sysWriter ] = std::move(writer); //the sysWriter holds info in 'rcd@prod' format
+    writer->getWriter()->setToken(cc);
+    m_rcdToWriterMap[sysWriter] = std::move(writer);  //the sysWriter holds info in 'rcd@prod' format
   }
 }
 
@@ -79,7 +78,6 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
   // Get L1TriggerKeyListExt and make a copy
   L1TriggerKeyListExt oldKeyList;
   l1t::DataWriterExt& m_writer = *m_rcdToWriterMap.at("L1TriggerKeyExtRcd@L1TriggerKeyExt");
-
 
   if (!m_newL1TriggerKeyListExt) {
     if (!m_writer.fillLastTriggerKeyList(oldKeyList)) {

--- a/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1CondDBPayloadWriterExt.cc
@@ -79,11 +79,8 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
   L1TriggerKeyListExt oldKeyList;
   l1t::DataWriterExt& m_writer = *m_rcdToWriterMap.at("L1TriggerKeyExtRcd@L1TriggerKeyExt");
 
-  if (!m_newL1TriggerKeyListExt) {
-    if (!m_writer.fillLastTriggerKeyList(oldKeyList)) {
-      edm::LogError("L1-O2O") << "Problem getting last L1TriggerKeyListExt";
-    }
-  }
+  if (not(m_newL1TriggerKeyListExt or m_writer.fillLastTriggerKeyList(oldKeyList)))
+    edm::LogError("L1-O2O") << "Problem getting last L1TriggerKeyListExt";
 
   L1TriggerKeyListExt* keyList = nullptr;
 
@@ -105,84 +102,98 @@ void L1CondDBPayloadWriterExt::analyze(const edm::Event& iEvent, const edm::Even
     edm::LogVerbatim("L1-O2O") << ex.what();
   }
 
-  if (triggerKeyOK && m_writeL1TriggerKeyExt) {
-    edm::LogVerbatim("L1-O2O") << "Object key for L1TriggerKeyExtRcd@L1TriggerKeyExt: " << key.tscKey();
+  if (triggerKeyOK and m_writeL1TriggerKeyExt) {
+    edm::LogVerbatim("L1-O2O") << "Object key for L1TriggerKeyExtRcd@L1TriggerKeyExt: " << key.tscKey()
+                               << " (about to run writePayload)";
     token = m_writer.writePayload(iSetup);
   }
 
-  // If L1TriggerKeyExt is invalid, then all configuration data is already in DB
-  bool throwException = false;
-
-  if (!token.empty() || !m_writeL1TriggerKeyExt) {
-    // Record token in L1TriggerKeyListExt
-    if (m_writeL1TriggerKeyExt) {
-      keyList = new L1TriggerKeyListExt(oldKeyList);
-      if (!(keyList->addKey(key.tscKey(), token, m_overwriteKeys))) {
-        throw cond::Exception("L1CondDBPayloadWriter: TSC key " + key.tscKey() + " already in L1TriggerKeyListExt");
-      }
-    }
-
-    if (m_writeConfigData) {
-      // Loop over record@type in L1TriggerKeyExt
-      L1TriggerKeyExt::RecordToKey::const_iterator it = key.recordToKeyMap().begin();
-      L1TriggerKeyExt::RecordToKey::const_iterator end = key.recordToKeyMap().end();
-
-      for (; it != end; ++it) {
-        // Do nothing if object key is null.
-        if (it->second == L1TriggerKeyExt::kNullKey) {
-          edm::LogVerbatim("L1-O2O") << "L1CondDBPayloadWriter: null object key for " << it->first
-                                     << "; skipping this record.";
-        } else {
-          // Check key is new before writing
-          if (oldKeyList.token(it->first, it->second).empty() || m_overwriteKeys) {
-            // Write data to ORCON with no IOV
-            if (!oldKeyList.token(it->first, it->second).empty()) {
-              edm::LogVerbatim("L1-O2O") << "*** Overwriting payload: object key for " << it->first << ": "
-                                         << it->second;
-            } else {
-              edm::LogVerbatim("L1-O2O") << "object key for " << it->first << ": " << it->second;
-            }
-
-            try {
-              token = m_rcdToWriterMap.at(it->first)->writePayload(iSetup);
-            } catch (l1t::DataInvalidException& ex) {
-              edm::LogVerbatim("L1-O2O") << ex.what() << " Skipping to next record.";
-
-              throwException = true;
-
-              continue;
-            }
-
-            if (!token.empty()) {
-              // Record token in L1TriggerKeyListExt
-              if (!keyList) {
-                keyList = new L1TriggerKeyListExt(oldKeyList);
-              }
-
-              if (!(keyList->addKey(it->first, it->second, token, m_overwriteKeys))) {
-                // This should never happen because of the check
-                // above, but just in case....
-                throw cond::Exception("L1CondDBPayloadWriter: subsystem key " + it->second + " for " + it->first +
-                                      " already in L1TriggerKeyListExt");
-              }
-            }
-          } else {
-            edm::LogVerbatim("L1-O2O") << "L1CondDBPayloadWriter: object key " << it->second << " for " << it->first
-                                       << " already in L1TriggerKeyListExt";
-          }
-        }
-      }
-    }
+  // If L1TriggerKeyExt is invalid (empty), then all configuration data is already in DB
+  // m_writeL1TriggerKeyExt the naming is misleading,
+  // the bool is used to say to the module whether it runs or not to update a L1TriggerKeyExtRcd
+  // (so if no payload for L1TriggerKeyExtRcd AND you run for updating L1TriggerKeyExtRcd ==> you have nothing to update)
+  if (token.empty() and m_writeL1TriggerKeyExt) {
+    edm::LogInfo("L1CondDBPayloadWriterExt::analyze") << " token = " << token;
+    return;
   }
 
-  if (keyList) {
+  // Record token in L1TriggerKeyListExt
+  if (m_writeL1TriggerKeyExt) {
+    keyList = new L1TriggerKeyListExt(oldKeyList);
+    if (not keyList->addKey(key.tscKey(), token, m_overwriteKeys))
+      throw cond::Exception("L1CondDBPayloadWriter: TSC key " + key.tscKey() + " already in L1TriggerKeyListExt");
+  }
+
+  if (not m_writeConfigData) {
     // Write L1TriggerKeyListExt to ORCON
-    m_writer.writeKeyList(keyList, 0, m_logTransactions);
+    if (keyList)
+      m_writer.writeKeyList(keyList, 0, m_logTransactions);
+    return;
   }
 
-  if (throwException) {
+  // Loop over record@type in L1TriggerKeyExt
+  // (as before make writers, try to write payload and if needed handle exceptions)
+
+  // this is not needed maps have implemented begin and end methods for their iterators
+  // L1TriggerKeyExt::RecordToKey::const_iterator it = key.recordToKeyMap().begin();
+  // L1TriggerKeyExt::RecordToKey::const_iterator end = key.recordToKeyMap().end();
+  // for (; it != end; ++it) {
+
+  bool throwException = false;
+  for (const auto& it : key.recordToKeyMap()) {
+    // If there isn't any WriterProxyT constructed for this rcd, continue
+    // (the missing rcds are left out for a reason - those are static that throw exceptions that cannot be handled in 12_3)
+    if (m_rcdToWriterMap.find(it.first) == m_rcdToWriterMap.end())
+      continue;
+
+    // Do nothing if object key is null.
+    // (Panos) this might not be working as the "empty" keys are L1TriggerKeyExt::kEmptyKey (std::string(""))
+    if (it.second == L1TriggerKeyExt::kNullKey) {
+      edm::LogVerbatim("L1-O2O") << "L1CondDBPayloadWriter: null object key for " << it.first
+                                 << "; skipping this record.";
+      continue;
+    }
+
+    // Check key is new before writing
+    if (oldKeyList.token(it.first, it.second).empty() || m_overwriteKeys) {
+      // Write data to ORCON with no IOV
+      if (!oldKeyList.token(it.first, it.second).empty()) {
+        edm::LogVerbatim("L1-O2O") << "*** Overwriting payload: object key for " << it.first << ": " << it.second;
+      } else {
+        edm::LogVerbatim("L1-O2O") << "object key for " << it.first << ": " << it.second;
+      }
+
+      try {
+        edm::LogVerbatim("L1-O2O") << "about to run writePayload for " << it.first;
+        token = m_rcdToWriterMap.at(it.first)->writePayload(iSetup);
+      } catch (l1t::DataInvalidException& ex) {
+        edm::LogVerbatim("L1-O2O") << ex.what() << " Skipping to next record.";
+        throwException = true;
+        continue;
+      }
+
+      if (!token.empty()) {
+        // Record token in L1TriggerKeyListExt
+        if (!keyList)
+          keyList = new L1TriggerKeyListExt(oldKeyList);
+        // The following should never happen because of the check
+        // above, but just in case....
+        if (!(keyList->addKey(it.first, it.second, token, m_overwriteKeys)))
+          throw cond::Exception("L1CondDBPayloadWriter")
+              << "subsystem key " << it.second << " for " << it.first << " already in L1TriggerKeyListExt";
+      }
+
+    } else
+      edm::LogVerbatim("L1-O2O") << "L1CondDBPayloadWriter: object key " << it.second << " for " << it.first
+                                 << " already in L1TriggerKeyListExt";
+
+  }  // for rcds from keys
+
+  if (keyList)  // Write L1TriggerKeyListExt to ORCON
+    m_writer.writeKeyList(keyList, 0, m_logTransactions);
+
+  if (throwException)
     throw l1t::DataInvalidException("Payload problem found.");
-  }
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cfi.py
@@ -12,11 +12,11 @@ L1CondDBPayloadWriterExt = cms.EDAnalyzer(
         "L1TCaloParamsO2ORcd@CaloParams",
         "L1TGlobalPrescalesVetosFractO2ORcd@L1TGlobalPrescalesVetosFract",
         "L1TMuonBarrelParamsO2ORcd@L1TMuonBarrelParams",
-#        "L1TMuonEndCapForestO2ORcd@L1TMuonEndCapForest",
+        "L1TMuonEndCapForestO2ORcd@L1TMuonEndCapForest",
         "L1TMuonEndCapParamsO2ORcd@L1TMuonEndCapParams",
         "L1TMuonGlobalParamsO2ORcd@L1TMuonGlobalParams",
         "L1TMuonOverlapFwVersionO2ORcd@L1TMuonOverlapFwVersion",
-#        "L1TMuonOverlapParamsO2ORcd@L1TMuonOverlapParams",
+        "L1TMuonOverlapParamsO2ORcd@L1TMuonOverlapParams",
         "L1TUtmTriggerMenuO2ORcd@L1TUtmTriggerMenu"
     )
 )

--- a/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cfi.py
@@ -8,15 +8,16 @@ L1CondDBPayloadWriterExt = cms.EDAnalyzer(
     logTransactions = cms.bool(False),
     newL1TriggerKeyListExt = cms.bool(False),
     sysWriters = cms.vstring(
-       "L1TCaloParamsO2ORcd@CaloParams",
-       "L1TGlobalPrescalesVetosFractO2ORcd@L1TGlobalPrescalesVetosFract",
-       "L1TMuonBarrelParamsO2ORcd@L1TMuonBarrelParams",
-       "L1TMuonEndCapForestO2ORcd@L1TMuonEndCapForest",
-       "L1TMuonEndCapParamsO2ORcd@L1TMuonEndCapParams",
-       "L1TMuonGlobalParamsO2ORcd@L1TMuonGlobalParams",
-       "L1TMuonOverlapFwVersionO2ORcd@L1TMuonOverlapFwVersion",
-       "L1TMuonOverlapParamsO2ORcd@L1TMuonOverlapParams",
-       "L1TUtmTriggerMenuO2ORcd@L1TUtmTriggerMenu"
+        "L1TriggerKeyExtRcd@L1TriggerKeyExt",
+        "L1TCaloParamsO2ORcd@CaloParams",
+        "L1TGlobalPrescalesVetosFractO2ORcd@L1TGlobalPrescalesVetosFract",
+        "L1TMuonBarrelParamsO2ORcd@L1TMuonBarrelParams",
+#        "L1TMuonEndCapForestO2ORcd@L1TMuonEndCapForest",
+        "L1TMuonEndCapParamsO2ORcd@L1TMuonEndCapParams",
+        "L1TMuonGlobalParamsO2ORcd@L1TMuonGlobalParams",
+        "L1TMuonOverlapFwVersionO2ORcd@L1TMuonOverlapFwVersion",
+#        "L1TMuonOverlapParamsO2ORcd@L1TMuonOverlapParams",
+        "L1TUtmTriggerMenuO2ORcd@L1TUtmTriggerMenu"
     )
 )
 

--- a/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cfi.py
+++ b/CondTools/L1TriggerExt/python/L1CondDBPayloadWriterExt_cfi.py
@@ -1,11 +1,23 @@
 import FWCore.ParameterSet.Config as cms
 
-L1CondDBPayloadWriterExt = cms.EDAnalyzer("L1CondDBPayloadWriterExt",
-                                       writeL1TriggerKeyExt = cms.bool(True),
-                                       writeConfigData = cms.bool(True),
-                                       overwriteKeys = cms.bool(False),
-                                       logTransactions = cms.bool(False),
-                                       newL1TriggerKeyListExt = cms.bool(False)
-                                       )
+L1CondDBPayloadWriterExt = cms.EDAnalyzer(
+    "L1CondDBPayloadWriterExt",
+    writeL1TriggerKeyExt = cms.bool(True),
+    writeConfigData = cms.bool(True),
+    overwriteKeys = cms.bool(False),
+    logTransactions = cms.bool(False),
+    newL1TriggerKeyListExt = cms.bool(False),
+    sysWriters = cms.vstring(
+       "L1TCaloParamsO2ORcd@CaloParams",
+       "L1TGlobalPrescalesVetosFractO2ORcd@L1TGlobalPrescalesVetosFract",
+       "L1TMuonBarrelParamsO2ORcd@L1TMuonBarrelParams",
+       "L1TMuonEndCapForestO2ORcd@L1TMuonEndCapForest",
+       "L1TMuonEndCapParamsO2ORcd@L1TMuonEndCapParams",
+       "L1TMuonGlobalParamsO2ORcd@L1TMuonGlobalParams",
+       "L1TMuonOverlapFwVersionO2ORcd@L1TMuonOverlapFwVersion",
+       "L1TMuonOverlapParamsO2ORcd@L1TMuonOverlapParams",
+       "L1TUtmTriggerMenuO2ORcd@L1TUtmTriggerMenu"
+    )
+)
 
 

--- a/CondTools/L1TriggerExt/src/DataWriterExt.cc
+++ b/CondTools/L1TriggerExt/src/DataWriterExt.cc
@@ -7,17 +7,52 @@
 #include "CondCore/CondDB/interface/Serialization.h"
 
 #include <utility>
+#include <typeinfo>
 
 namespace l1t {
-  DataWriterExt::DataWriterExt() {}
-  DataWriterExt::~DataWriterExt() {}
 
-  std::string DataWriterExt::writePayload(const edm::EventSetup& setup, const std::string& recordType) {
+  // Default Constructor
+  DataWriterExt::DataWriterExt() {}
+
+  // Constructor Needed for Writers with Rcds dependednt on Online Producers
+  // they need to be constructed at "construction time" to register what they produce
+  DataWriterExt::DataWriterExt(const std::string& recordType) {
     WriterFactory* factory = WriterFactory::get();
-    std::unique_ptr<WriterProxy> writer(factory->create(recordType + "@Writer"));
+    writer = factory->create(recordType + "@Writer");
     if (writer.get() == nullptr) {
       throw cond::Exception("DataWriter: could not create WriterProxy with name " + recordType + "@Writer");
     }
+    edm::LogVerbatim("L1-O2O DataWriterExt::DataWriterExt") << "Created new " << typeid(writer).name()
+                                                            << "  | address " << writer.get()
+                                                            << "  | rcd " << recordType;
+  }
+  DataWriterExt::~DataWriterExt() {}
+
+  std::string DataWriterExt::writePayload(const edm::EventSetup& setup) {
+    edm::LogVerbatim("L1-O2O DataWriterExt::writePayload")
+      << "Will use stored writer at " << writer.get();
+
+    edm::Service<cond::service::PoolDBOutputService> poolDb;
+    if (!poolDb.isAvailable()) {
+      throw cond::Exception("DataWriter: PoolDBOutputService not available.");
+    }
+
+    // 2010-02-16: Move session and transaction to WriterProxy::save().  Otherwise, if another transaction is
+    // started while WriterProxy::save() is called (e.g. in a ESProducer like L1ConfigOnlineProdBase), the
+    // transaction here will become read-only.
+    std::string payloadToken = writer->save(setup);
+    edm::LogVerbatim("L1-O2O") << typeid(*writer).name() << " PAYLOAD TOKEN " << payloadToken;
+
+    return payloadToken;
+  }
+
+  std::string DataWriterExt::writePayload(const edm::EventSetup& setup, const std::string& recordType) {
+    WriterFactory* factory = WriterFactory::get();
+    WriterProxyPtr writer_(factory->create(recordType + "@Writer"));
+    if (writer_.get() == nullptr) {
+      throw cond::Exception("DataWriter: could not create WriterProxy with name " + recordType + "@Writer");
+    }
+    writer = std::move(writer_);
 
     edm::Service<cond::service::PoolDBOutputService> poolDb;
     if (!poolDb.isAvailable()) {
@@ -38,7 +73,7 @@ namespace l1t {
     //  std::string payloadToken = writer->save( setup, session ) ;
     std::string payloadToken = writer->save(setup);
 
-    edm::LogVerbatim("L1-O2O") << recordType << " PAYLOAD TOKEN " << payloadToken;
+    edm::LogVerbatim("L1-O2O") << typeid(*writer).name() << " PAYLOAD TOKEN " << payloadToken;
 
     ////  tr.close();
     //   tr.commit ();

--- a/CondTools/L1TriggerExt/test/L1ConfigWritePayloadOnlineExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWritePayloadOnlineExt_cfg.py
@@ -89,6 +89,11 @@ options.register('unsafe',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "Comma-separated list of systems that we do not care about anymore")
+options.register('dropFromJob',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Comma-separated list of systems for which we must not create WriterProxy")
 
 options.parseArguments()
 
@@ -112,6 +117,7 @@ process.load("CondTools.L1TriggerExt.L1ConfigTSCPayloadsExt_cff")
 from CondTools.L1TriggerExt.L1ConfigTSCPayloadsExt_cff import setTSCPayloadsDB, liftPayloadSafetyFor
 setTSCPayloadsDB( process, options.onlineDBConnect, options.onlineDBAuth, options.protoDBConnect, options.protoDBAuth )
 liftPayloadSafetyFor( process, options.unsafe.split(',') )
+print( "Lifted transaction safe for:", options.unsafe.split(',') )
 
 # Define CondDB tags
 from CondTools.L1TriggerExt.L1CondEnumExt_cfi import L1CondEnumExt
@@ -170,4 +176,25 @@ else:
                                 lastValue = cms.uint64(4294967295),
                                 interval = cms.uint64(1) )
                             
+systems = process.L1CondDBPayloadWriterExt.sysWriters
+if "uGMT" in options.dropFromJob:
+    systems.remove("L1TMuonGlobalParamsO2ORcd@L1TMuonGlobalParams")
+if "EMTF" in options.dropFromJob:
+    systems.remove("L1TMuonEndCapParamsO2ORcd@L1TMuonEndCapParams")
+    ## still need a method to handle exceptions for existing payloads in the CondDB
+    #systems.remove("L1TMuonEndCapForestO2ORcd@L1TMuonEndCapForest")
+if "OMTF" in options.dropFromJob:
+    systems.remove("L1TMuonOverlapFwVersionO2ORcd@L1TMuonOverlapFwVersion")
+    ## still need a method to handle exceptions for existing payloads in the CondDB
+    #systems.remove("L1TMuonOverlapParamsO2ORcd@L1TMuonOverlapParams")
+if "BMTF" in options.dropFromJob:
+    systems.remove("L1TMuonBarrelParamsO2ORcd@L1TMuonBarrelParams")
+if "CALO" in options.dropFromJob:
+    systems.remove("L1TCaloParamsO2ORcd@CaloParams")
+if "uGT" in options.dropFromJob:
+    systems.remove("L1TUtmTriggerMenuO2ORcd@L1TUtmTriggerMenu")
+if "uGTrs" in options.dropFromJob:
+    systems.remove("L1TGlobalPrescalesVetosFractO2ORcd@L1TGlobalPrescalesVetosFract")
+print( "Will create only the following writers:", process.L1CondDBPayloadWriterExt.sysWriters )
+
 process.p = cms.Path(process.L1CondDBPayloadWriterExt)

--- a/CondTools/L1TriggerExt/test/L1ConfigWritePayloadOnlineExt_cfg.py
+++ b/CondTools/L1TriggerExt/test/L1ConfigWritePayloadOnlineExt_cfg.py
@@ -177,16 +177,17 @@ else:
                                 interval = cms.uint64(1) )
                             
 systems = process.L1CondDBPayloadWriterExt.sysWriters
+## still need a method to handle exceptions for existing payloads in the CondDB
+systems.remove("L1TMuonEndCapForestO2ORcd@L1TMuonEndCapForest")
+systems.remove("L1TMuonOverlapParamsO2ORcd@L1TMuonOverlapParams")
 if "uGMT" in options.dropFromJob:
     systems.remove("L1TMuonGlobalParamsO2ORcd@L1TMuonGlobalParams")
 if "EMTF" in options.dropFromJob:
     systems.remove("L1TMuonEndCapParamsO2ORcd@L1TMuonEndCapParams")
     ## still need a method to handle exceptions for existing payloads in the CondDB
-    #systems.remove("L1TMuonEndCapForestO2ORcd@L1TMuonEndCapForest")
 if "OMTF" in options.dropFromJob:
     systems.remove("L1TMuonOverlapFwVersionO2ORcd@L1TMuonOverlapFwVersion")
     ## still need a method to handle exceptions for existing payloads in the CondDB
-    #systems.remove("L1TMuonOverlapParamsO2ORcd@L1TMuonOverlapParams")
 if "BMTF" in options.dropFromJob:
     systems.remove("L1TMuonBarrelParamsO2ORcd@L1TMuonBarrelParams")
 if "CALO" in options.dropFromJob:

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TGlobalPrescalesVetosOnlineProd.cc
@@ -658,7 +658,8 @@ std::unique_ptr<const L1TGlobalPrescalesVetosFract> L1TGlobalPrescalesVetosOnlin
 
   auto payload = std::make_unique<const L1TGlobalPrescalesVetosFract>(*data_.getWriteInstance());
 
-  edm::LogInfo("L1-O2O: L1TCaloParamsOnlineProd") << "SummaryForFunctionManager: uGTrs | OK      | All looks good";
+  edm::LogInfo("L1-O2O: L1TGlobalPrescalesVetosOnlineProd")
+      << "SummaryForFunctionManager: uGTrs | OK      | All looks good";
 
   return payload;
 }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
@@ -150,7 +150,8 @@ std::unique_ptr<const L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObj
 
   auto retval = std::make_unique<const L1TMuonBarrelParams>(m_params_helper);
 
-  edm::LogInfo("L1-O2O: L1TCaloParamsOnlineProd") << "SummaryForFunctionManager: BMTF  | OK      | All looks good";
+  edm::LogInfo("L1-O2O: L1TMuonBarrelParamsOnlineProd")
+      << "SummaryForFunctionManager: BMTF  | OK      | All looks good";
   return retval;
 }
 

--- a/L1TriggerConfig/L1TConfigProducers/test/BuildFile.xml
+++ b/L1TriggerConfig/L1TConfigProducers/test/BuildFile.xml
@@ -1,0 +1,7 @@
+<architecture name="(slc|cc).*_amd64_.*">
+  <ifcxx11_abi value="1">
+    <flags SETENV="LD_PRELOAD=$(CMS_ORACLEOCCI_LIB)"/>
+  </ifcxx11_abi>
+  <test name="L1O2O_L1TMenu" command="runL1-O2O-scramTests.sh -k uGT,uGTrs -d uGMT,EMTF,OMTF,BMTF,CALO 400000 l1_trg_cosmics2022/v43 l1_trg_rs_cosmics2020/v23"/>
+  <test name="L1O2O_L1TSubs" command="runL1-O2O-scramTests.sh -k uGMT,EMTF,OMTF,BMTF,CALO -d uGT,uGTrs -t L1TMuonEndCapForest:Stage2v1_hlt 500000 l1_trg_collisions2021/v6 l1_trg_rs_collisions2021/v22"/>
+</architecture>

--- a/L1TriggerConfig/L1TConfigProducers/test/BuildFile.xml
+++ b/L1TriggerConfig/L1TConfigProducers/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<architecture name="(slc|cc).*_amd64_.*">
+<architecture name="_amd64_">
   <ifcxx11_abi value="1">
     <flags SETENV="LD_PRELOAD=$(CMS_ORACLEOCCI_LIB)"/>
   </ifcxx11_abi>

--- a/L1TriggerConfig/L1TConfigProducers/test/runL1-O2O-iov.sh
+++ b/L1TriggerConfig/L1TConfigProducers/test/runL1-O2O-iov.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+#set -x
+
+xflag=0
+CMS_OPTIONS=""
+KEY_CONTENT=""
+TAG_UPDATE=""
+UNSAFE=""
+
+while getopts 'xfk:t:u:h' OPTION
+  do
+  case $OPTION in
+      x) xflag=1
+          ;;
+      f) CMS_OPTIONS=$CMS_OPTIONS" forceUpdate=1"
+          ;;
+      k) KEY_CONTENT=$KEY_CONTENT" subsystemLabels=$OPTARG"
+          ;;
+      t) if [ -z $TAG_UPDATE ] ; then TAG_UPDATE="tagUpdate="; else TAG_UPDATE=$TAG_UPDATE","; fi
+         TAG_UPDATE=$TAG_UPDATE$OPTARG
+          ;;
+      u) if [ -z $UNSAFE ] ; then UNSAFE="unsafe="; else UNSAFE=$UNSAFE","; fi
+         UNSAFE=$UNSAFE$OPTARG
+          ;;
+      h) echo "Usage: [-xf] runnum tsckey"
+          echo "  -x: write to ORCON instead of sqlite file"
+          echo "  -f: force IOV update"
+          echo "  -k: limit update to the specific systems (default are all, which is equivalent to -k uGT,uGTrs,GMT,EMTF,OMTF,BMTF,CALO)"
+          echo "  -t: override tag name as TYPE:NEW_TAG_BASE (e.g. -t L1TCaloParams:Stage2v1)"
+          echo "  -u: lift transaction safety: carry on even problems are encountered (e.g. -u EMTF,OMTF,CALO)"
+          exit
+          ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+runnum=$1
+tsckey=$2
+rskey=$3
+
+#CMSSW_BASE=${RELEASEDIR}
+#CMSSW_BASE=${JOBDIR}/${RELEASE} #for local CMSSW checkout
+echo CMSSW_BASE = $CMSSW_BASE
+
+export TNS_ADMIN=/etc
+
+echo "INFO: ADDITIONAL CMS OPTIONS:  " $CMS_OPTIONS $KEY_CONTENT $TAG_UPDATE
+
+ONLINEDB_OPTIONS="onlineDBConnect=oracle://cms_omds_adg/CMS_TRG_R onlineDBAuth=./"
+#ONLINEDB_OPTIONS="onlineDBAuth=./"
+PROTODB_OPTIONS="protoDBConnect=oracle://cms_orcon_adg/CMS_CONDITIONS protoDBAuth=./"
+
+echo "Writing to sqlite_file:l1config.db instead of ORCON."
+INDB_OPTIONS="inputDBConnect=sqlite_file:l1config.db inputDBAuth=./" 
+OUTDB_OPTIONS="outputDBConnect=sqlite_file:l1config.db outputDBAuth=./"
+COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=sqlite_file:l1config.db"
+
+# echo "Writing to cms_orcoff_prep instead of ORCON"
+# INDB_OPTIONS="inputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS inputDBAuth=/data/O2O/L1T/"
+# OUTDB_OPTIONS="outputDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS outputDBAuth=/data/O2O/L1T/"
+# COPY_OPTIONS="copyNonO2OPayloads=1 copyDBConnect=oracle://cms_orcoff_prep/CMS_CONDITIONS copyDBAuth=/data/O2O/L1T/"
+
+
+
+if cmsRun -e ${CMSSW_BASE}/src/CondTools/L1TriggerExt/test/l1o2otestanalyzer_cfg.py ${INDB_OPTIONS} printL1TriggerKeyListExt=1 ${TAG_UPDATE} | grep "${tsckey}:${rskey}" ; then echo "TSC payloads present"
+else
+    echo "TSC payloads absent; writing $KEY_CONTENT now"
+    cmsRun -e ${CMSSW_BASE}/src/CondTools/L1TriggerExt/test/L1ConfigWritePayloadOnlineExt_cfg.py tscKey=${tsckey} rsKey=${rskey} ${ONLINEDB_OPTIONS} ${PROTODB_OPTIONS} ${OUTDB_OPTIONS} ${COPY_OPTIONS} ${KEY_CONTENT} ${TAG_UPDATE} ${UNSAFE} logTransactions=0 print | tee -a lastLogForFM.txt
+    #cmsRun ./L1ConfigWritePayloadOnlineExt_cfg.py tscKey=${tsckey} rsKey=${rskey} ${OUTDB_OPTIONS1} ${COPY_OPTIONS} ${KEY_CONTENT} ${TAG_UPDATE} ${UNSAFE} logTransactions=0 print | tee -a lastLogForFM.txt
+    o2ocode=${PIPESTATUS[0]}
+#    o2ocode=$?
+    if [ ${o2ocode} -ne 0 ]
+    then
+	echo "L1-O2O-ERROR: could not write TSC payloads"
+	echo "L1-O2O-ERROR: could not write TSC payloads" 1>&2
+	exit ${o2ocode}
+    fi
+fi
+
+cmsRun $CMSSW_BASE/src/CondTools/L1TriggerExt/test/L1ConfigWriteIOVOnlineExt_cfg.py ${CMS_OPTIONS} tscKey=${tsckey} rsKey=${rskey} runNumber=${runnum} ${OUTDB_OPTIONS} ${TAG_UPDATE} logTransactions=0 print | grep -Ev "CORAL.*Info|CORAL.*Debug" | tee -a lastLogForFM.txt
+o2ocode=${PIPESTATUS[0]}
+
+if [ ${o2ocode} -eq 0 ]
+then
+    echo
+    echo "`date` : checking O2O"
+    if cmsRun $CMSSW_BASE/src/CondTools/L1TriggerExt/test/l1o2otestanalyzer_cfg.py ${INDB_OPTIONS} printL1TriggerKeyExt=1 runNumber=${runnum} ${TAG_UPDATE} | grep ${tsckey} ; then echo "L1-O2O-INFO: IOV OK"
+    else
+	echo "L1-O2O-ERROR: IOV NOT OK"
+	echo "L1-O2O-ERROR: IOV NOT OK" 1>&2
+	exit 199
+    fi
+else
+    if [ ${o2ocode} -eq 66 ]
+    then
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check authentication token .cms_cond/db.key"
+	echo "L1-O2O-ERROR: unable to connect to OMDS or ORCON.  Check authentication token .cms_cond/db.key" 1>&2
+    else
+        if [ ${o2ocode} -eq 65 ]
+        then
+            echo "L1-O2O-ERROR: problem writing object to ORCON."
+            echo "L1-O2O-ERROR: problem writing object to ORCON." 1>&2
+        fi
+    fi
+    exit ${o2ocode}
+fi
+
+
+


### PR DESCRIPTION
#### PR description:

This PR implements WriterProxy from CondTools/L1TriggerExt to inherit from edm::EDConsumerBase as it's required for running esConsumes() to register ESGetToken objects when is called by CondDBPayloadWriter

#### PR validation:

This pkg is part of the L1 O2O and there is not any central wf to be tested
Tested Locally and from custom patch on machine conddb-1 writing to sqlite file and Prep respectively
The local replica of the p5 script is commited together in this PR ( runL1-O2O-iov.sh )
if this PR is a backport please specify the original PR and why you need to backport that PR:

