### PR TITLE
add HLT-EGM customisation for 2018 Data

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -144,14 +144,23 @@ def customiseCTPPSFor2018Input(process):
 
     return process
 
+def customiseEGammaRecoFor2018Input(process):
+    for prod in producers_by_type(process, 'PFECALSuperClusterProducer'):
+        if hasattr(prod, 'regressionConfig'):
+            prod.regressionConfig.regTrainedWithPS = cms.bool(False)
+
+    return process
+
 def customiseFor2018Input(process):
     """Customise the HLT to run on Run 2 data/MC"""
     process = customisePixelGainForRun2Input(process)
     process = customisePixelL1ClusterThresholdForRun2Input(process)
     process = customiseHCALFor2018Input(process)
     process = customiseCTPPSFor2018Input(process)
+    process = customiseEGammaRecoFor2018Input(process)
 
     return process
+
 
 def customiseFor37231(process):
     """ Customisation to fix the typo of Reccord in PR 37231 (https://github.com/cms-sw/cmssw/pull/37231) """
@@ -185,4 +194,3 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     process = customiseFor37231(process)
 
     return process
-


### PR DESCRIPTION
#### PR description:

This PR updates the function `customiseFor2018Input` used by TSG to characterise the Run-3 HLT menu on 2018 collisions data.

It adds a function named `customiseEGammaRecoFor2018Input`, which currently sets the flag `regTrainedWithPS` to `False` to handle correctly the HLT-EGM energy regression tags of 2018 [*].

https://github.com/cms-sw/cmssw/pull/37588 changed the value of `regTrainedWithPS` to `true` for Run 3 via the source code. This PR updates the Run-2 customisation such that TSG studies using `customiseFor2018Input` are not affected by #37588.

If #37588 is backported to `12_3_X`, this PR will have to be backported as well.

No changes expected. Note that PR tests are completely blind to the modifications in this PR.

[*] If it turns out that the preferred approach is to instead use the Run-3 tags on 2018 data (keeping `regTrainedWithPS=true`), `customiseEGammaRecoFor2018Input` could be updated in the future to overwrite the relevant GT tags instead of changing the value of the `regTrainedWithPS` flag.

FYI: @cms-sw/egamma-pog-l2 

#### PR validation:

Validated with manual tests based on TSG recipes.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

N/A