### PR TITLE
Move framework test modules away from legacy types

### DIFF
--- a/FWCore/Framework/test/edproducer_productregistry_callback.cc
+++ b/FWCore/Framework/test/edproducer_productregistry_callback.cc
@@ -16,7 +16,7 @@
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
@@ -52,23 +52,23 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testEDProducerProductRegistryCallback);
 using namespace edm;
 
 namespace {
-  class TestMod : public EDProducer {
+  class TestMod : public global::EDProducer<> {
   public:
     explicit TestMod(ParameterSet const& p);
 
-    void produce(Event& e, EventSetup const&);
+    void produce(StreamID, Event& e, EventSetup const&) const override;
 
     void listen(BranchDescription const&);
   };
 
   TestMod::TestMod(ParameterSet const&) { produces<int>(); }
 
-  void TestMod::produce(Event&, EventSetup const&) {}
+  void TestMod::produce(StreamID, Event&, EventSetup const&) const {}
 
-  class ListenMod : public EDProducer {
+  class ListenMod : public global::EDProducer<> {
   public:
     explicit ListenMod(ParameterSet const&);
-    void produce(Event& e, EventSetup const&);
+    void produce(StreamID, Event& e, EventSetup const&) const override;
     void listen(BranchDescription const&);
   };
 
@@ -76,7 +76,7 @@ namespace {
     callWhenNewProductsRegistered(
         [this](BranchDescription const& branchDescription) { this->listen(branchDescription); });
   }
-  void ListenMod::produce(Event&, EventSetup const&) {}
+  void ListenMod::produce(StreamID, Event&, EventSetup const&) const {}
 
   void ListenMod::listen(BranchDescription const& iDesc) {
     edm::TypeID intType(typeid(int));
@@ -87,10 +87,10 @@ namespace {
     }
   }
 
-  class ListenFloatMod : public EDProducer {
+  class ListenFloatMod : public global::EDProducer<> {
   public:
     explicit ListenFloatMod(ParameterSet const&);
-    void produce(Event& e, EventSetup const&);
+    void produce(StreamID, Event& e, EventSetup const&) const;
     void listen(BranchDescription const&);
   };
 
@@ -98,7 +98,7 @@ namespace {
     callWhenNewProductsRegistered(
         [this](BranchDescription const& branchDescription) { this->listen(branchDescription); });
   }
-  void ListenFloatMod::produce(Event&, EventSetup const&) {}
+  void ListenFloatMod::produce(StreamID, Event&, EventSetup const&) const {}
 
   void ListenFloatMod::listen(BranchDescription const& iDesc) {
     edm::TypeID intType(typeid(int));

--- a/FWCore/Framework/test/maker2_t.cppunit.cc
+++ b/FWCore/Framework/test/maker2_t.cppunit.cc
@@ -6,7 +6,7 @@
 #include "FWCore/Utilities/interface/GetPassID.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/maker/WorkerT.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
@@ -20,16 +20,16 @@
 
 using namespace edm;
 
-class TestMod : public EDProducer {
+class TestMod : public global::EDProducer<> {
 public:
   explicit TestMod(ParameterSet const& p);
 
-  void produce(Event& e, EventSetup const&);
+  void produce(StreamID, Event& e, EventSetup const&) const override;
 };
 
 TestMod::TestMod(ParameterSet const&) { produces<int>(); }
 
-void TestMod::produce(Event&, EventSetup const&) {}
+void TestMod::produce(StreamID, Event&, EventSetup const&) const {}
 
 // ----------------------------------------------
 class testmaker2 : public CppUnit::TestFixture {

--- a/FWCore/Framework/test/stubs/TestBeginEndJobAnalyzer.h
+++ b/FWCore/Framework/test/stubs/TestBeginEndJobAnalyzer.h
@@ -19,23 +19,23 @@
 //
 
 // system include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 // user include files
 
 // forward declarations
-class TestBeginEndJobAnalyzer : public edm::EDAnalyzer {
+class TestBeginEndJobAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit TestBeginEndJobAnalyzer(const edm::ParameterSet&);
   ~TestBeginEndJobAnalyzer();
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  virtual void beginJob() override;
-  virtual void endJob() override;
-  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void beginJob() override;
+  void endJob() override;
+  void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
   struct Control {
     bool beginJobCalled = false;

--- a/FWCore/Framework/test/stubs/TestFailuresAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestFailuresAnalyzer.cc
@@ -55,11 +55,6 @@ TestFailuresAnalyzer::TestFailuresAnalyzer(const edm::ParameterSet& iConfig)
   }
 }
 
-TestFailuresAnalyzer::~TestFailuresAnalyzer() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
-}
-
 //
 // member functions
 //
@@ -80,7 +75,9 @@ void TestFailuresAnalyzer::endJob() {
   }
 }
 
-void TestFailuresAnalyzer::analyze(const edm::Event& e /* iEvent */, const edm::EventSetup& /* iSetup */) {
+void TestFailuresAnalyzer::analyze(edm::StreamID,
+                                   const edm::Event& e /* iEvent */,
+                                   const edm::EventSetup& /* iSetup */) const {
   if (whichFailure_ == kEvent) {
     throw cms::Exception("Test") << " event";
   }

--- a/FWCore/Framework/test/stubs/TestFailuresAnalyzer.h
+++ b/FWCore/Framework/test/stubs/TestFailuresAnalyzer.h
@@ -19,24 +19,23 @@
 //
 
 // system include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 // user include files
 
 // forward declarations
-class TestFailuresAnalyzer : public edm::EDAnalyzer {
+class TestFailuresAnalyzer : public edm::global::EDAnalyzer<> {
 public:
   explicit TestFailuresAnalyzer(const edm::ParameterSet&);
-  ~TestFailuresAnalyzer();
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const final;
 
-  virtual void beginJob();
-  virtual void endJob();
+  void beginJob() final;
+  void endJob() final;
 
 private:
   // ----------member data ---------------------------
-  int whichFailure_;
-  unsigned long long eventToThrow_;
+  const int whichFailure_;
+  const unsigned long long eventToThrow_;
 };
 
 #endif /* test_TestFailuresAnalyzer_h */

--- a/FWCore/Integration/test/HierarchicalEDProducer.cc
+++ b/FWCore/Integration/test/HierarchicalEDProducer.cc
@@ -12,7 +12,7 @@ namespace edmtest {
   HierarchicalEDProducer::~HierarchicalEDProducer() {}
 
   // Functions that gets called by framework every event
-  void HierarchicalEDProducer::produce(edm::Event&, edm::EventSetup const&) {
+  void HierarchicalEDProducer::produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const {
     // nothing to do ... is just a dummy!
   }
 }  // namespace edmtest

--- a/FWCore/Integration/test/HierarchicalEDProducer.h
+++ b/FWCore/Integration/test/HierarchicalEDProducer.h
@@ -9,21 +9,21 @@
  ************************************************************/
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Integration/test/HierarchicalAlgorithms.h"
 
 namespace edmtest {
-  class HierarchicalEDProducer : public edm::EDProducer {
+  class HierarchicalEDProducer : public edm::global::EDProducer<> {
   public:
     explicit HierarchicalEDProducer(edm::ParameterSet const& ps);
 
-    virtual ~HierarchicalEDProducer();
+    ~HierarchicalEDProducer() override;
 
-    virtual void produce(edm::Event& e, edm::EventSetup const& c);
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
 
   private:
-    double radius_;
-    alg_1 outer_alg_;
+    const double radius_;
+    const alg_1 outer_alg_;
   };
 }  // namespace edmtest
 #endif

--- a/FWCore/Integration/test/ProdigalAnalyzer.cc
+++ b/FWCore/Integration/test/ProdigalAnalyzer.cc
@@ -9,7 +9,7 @@
 namespace edmtest {
   ProdigalAnalyzer::ProdigalAnalyzer(edm::ParameterSet const&) { consumes<Prodigal>(edm::InputTag{"maker"}); }
 
-  void ProdigalAnalyzer::analyze(edm::Event const& e, edm::EventSetup const&) {
+  void ProdigalAnalyzer::analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const&) const {
     edm::Handle<Prodigal> h;
     assert(e.getByLabel("maker", h));
     assert(h.provenance()->productProvenance()->parentage().parents().empty());

--- a/FWCore/Integration/test/ProdigalAnalyzer.h
+++ b/FWCore/Integration/test/ProdigalAnalyzer.h
@@ -2,15 +2,14 @@
 #define Integration_ProdigalAnalyzer_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 namespace edmtest {
 
-  class ProdigalAnalyzer : public edm::EDAnalyzer {
+  class ProdigalAnalyzer : public edm::global::EDAnalyzer<> {
   public:
     explicit ProdigalAnalyzer(edm::ParameterSet const& pset);
-    virtual ~ProdigalAnalyzer() {}
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
+    void analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const& c) const final;
   };
 
 }  // namespace edmtest


### PR DESCRIPTION
#### PR description:

Moved additional modules to global or one types.

#### PR validation:

Code compiles and framework unit tests pass.