### PR TITLE
BeamSpot DQM clients modified to log to onlineDB only when beam status from TCDS is STABLE (backport for 12_3_X)

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -122,7 +122,8 @@ BeamMonitor::BeamMonitor(const ParameterSet& ps)
       resetHistos_(false),
       StartAverage_(false),
       firstAverageFit_(0),
-      countGapLumi_(0) {
+      countGapLumi_(0),
+      logToDb_(false) {
   monitorName_ = ps.getUntrackedParameter<string>("monitorName", "YourSubsystemName");
   recordName_ = ps.getUntrackedParameter<string>("recordName");
   bsSrc_ = consumes<reco::BeamSpot>(ps.getUntrackedParameter<InputTag>("beamSpot"));
@@ -163,6 +164,8 @@ BeamMonitor::BeamMonitor(const ParameterSet& ps)
   lastlumi_ = 0;
   nextlumi_ = 0;
   processed_ = false;
+
+  tcdsToken_ = consumes<TCDSRecord>(ps.getParameter<InputTag>("tcdsRecord"));
 }
 
 //--------------------------------------------------------
@@ -212,7 +215,7 @@ namespace {
 }  // namespace
 
 void BeamMonitor::dqmBeginRun(edm::Run const&, edm::EventSetup const&) {
-  if (useLockRecords_ && onlineDbService_.isAvailable()) {
+  if (useLockRecords_ && onlineDbService_.isAvailable() && logToDb_) {
     onlineDbService_->lockRecords();
   }
   nAnalyzedLS_ = 0;
@@ -533,7 +536,7 @@ void BeamMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const Eve
   // start DB logger
   DBloggerReturn_ = 0;
   nAnalyzedLS_++;
-  if (onlineDbService_.isAvailable()) {
+  if (onlineDbService_.isAvailable() && logToDb_) {
     onlineDbService_->logger().start();
     onlineDbService_->logger().logInfo() << "BeamMonitor::beginLuminosityBlock - LS: " << lumiSeg.luminosityBlock()
                                          << " - Run: " << lumiSeg.getRun().run();
@@ -661,6 +664,12 @@ void BeamMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const Eve
 
 // ----------------------------------------------------------
 void BeamMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
+  Handle<TCDSRecord> tcdsData;
+  iEvent.getByToken(tcdsToken_, tcdsData);
+  int beamMode = tcdsData->getBST().getBeamMode();
+  if (beamMode == BSTRecord::BeamMode::STABLE)
+    logToDb_ = true;
+
   const int nthlumi = iEvent.luminosityBlock();
   if (onlineMode_ && (nthlumi < nextlumi_)) {
     edm::LogInfo("BeamMonitor") << "analyze::  Spilt event from previous lumi section!" << std::endl;
@@ -809,7 +818,7 @@ void BeamMonitor::endLuminosityBlock(const LuminosityBlock& lumiSeg, const Event
   tmpTime = refBStime[1] = refPVtime[1] = fendtime;
 
   // end DB logger
-  if (onlineDbService_.isAvailable()) {
+  if (onlineDbService_.isAvailable() && logToDb_) {
     onlineDbService_->logger().logInfo() << "BeamMonitor::endLuminosityBlock";
     onlineDbService_->logger().end(DBloggerReturn_);
   }
@@ -1401,7 +1410,8 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
       edm::LogInfo("BeamMonitor") << BSOnline << std::endl;
 
       // Create the payload for BeamSpotOnlineObjects object
-      if (onlineDbService_.isAvailable() && (nAnalyzedLS_ < nLS_for_upload_ || nAnalyzedLS_ % nLS_for_upload_ == 0)) {
+      if (onlineDbService_.isAvailable() && (nAnalyzedLS_ < nLS_for_upload_ || nAnalyzedLS_ % nLS_for_upload_ == 0) &&
+          logToDb_) {
         edm::LogInfo("BeamMonitor") << "FitAndFill::[PayloadCreation] onlineDbService available \n" << std::endl;
         onlineDbService_->logger().logInfo() << "BeamMonitor::FitAndFill - Lumi of the current fit: " << currentlumi;
         onlineDbService_->logger().logInfo()
@@ -1454,7 +1464,7 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
       edm::LogInfo("BeamMonitor") << "FitAndFill::   [BeamMonitor] Output beam spot for DIP \n" << endl;
       edm::LogInfo("BeamMonitor") << bs << endl;
 
-      if (onlineDbService_.isAvailable()) {
+      if (onlineDbService_.isAvailable() && logToDb_) {
         onlineDbService_->logger().logInfo() << "BeamMonitor::FitAndFill - Beam fit fails!!!";
         onlineDbService_->logger().logInfo() << "BeamMonitor::FitAndFill - Output beam spot for DIP";
         onlineDbService_->logger().logInfo() << "\n" << bs;
@@ -1481,7 +1491,7 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
     edm::LogInfo("BeamMonitor") << "FitAndFill::  [BeamMonitor] Output fake beam spot for DIP \n" << endl;
     edm::LogInfo("BeamMonitor") << bs << endl;
 
-    if (onlineDbService_.isAvailable()) {
+    if (onlineDbService_.isAvailable() && logToDb_) {
       onlineDbService_->logger().logInfo() << "BeamMonitor::FitAndFill - No fitting";
       onlineDbService_->logger().logInfo() << "BeamMonitor::FitAndFill - Output fake beam spot for DIP";
       onlineDbService_->logger().logInfo() << "\n" << bs;
@@ -1585,7 +1595,7 @@ void BeamMonitor::dqmEndRun(const Run& r, const EventSetup& context) {
   mapLSPVStoreSize.clear();
   mapLSCF.clear();
 
-  if (useLockRecords_ && onlineDbService_.isAvailable()) {
+  if (useLockRecords_ && onlineDbService_.isAvailable() && logToDb_) {
     onlineDbService_->releaseLocks();
   }
 }

--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -664,9 +664,8 @@ void BeamMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const Eve
 
 // ----------------------------------------------------------
 void BeamMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
-  Handle<TCDSRecord> tcdsData;
-  iEvent.getByToken(tcdsToken_, tcdsData);
-  int beamMode = tcdsData->getBST().getBeamMode();
+  const TCDSRecord& tcdsData = iEvent.get(tcdsToken_);
+  int beamMode = tcdsData.getBST().getBeamMode();
   if (beamMode == BSTRecord::BeamMode::STABLE)
     logToDb_ = true;
 

--- a/DQM/BeamMonitor/plugins/BeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.h
@@ -25,6 +25,8 @@
 #include "RecoVertex/BeamSpotProducer/interface/BSTrkParameters.h"
 #include "RecoVertex/BeamSpotProducer/interface/BeamFitter.h"
 #include "CondCore/DBOutputService/interface/OnlineDBOutputService.h"
+#include "DataFormats/TCDS/interface/BSTRecord.h"
+#include "DataFormats/TCDS/interface/TCDSRecord.h"
 #include <fstream>
 
 //
@@ -122,6 +124,9 @@ private:
 
   int nAnalyzedLS_;
   int nLS_for_upload_;
+
+  edm::EDGetTokenT<TCDSRecord> tcdsToken_;
+  bool logToDb_;
   // ----------member data ---------------------------
 
   //   std::vector<BSTrkParameters> fBSvector;

--- a/DQM/BeamMonitor/plugins/BuildFile.xml
+++ b/DQM/BeamMonitor/plugins/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="DataFormats/Scalers"/>
 <use name="DataFormats/OnlineMetaData"/>
 <use name="DataFormats/TrackReco"/>
+<use name="DataFormats/TCDS"/>
 <use name="FWCore/Framework"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="CondFormats/DataRecord"/>

--- a/DQM/BeamMonitor/python/BeamMonitor_Cosmics_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_Cosmics_cff.py
@@ -13,6 +13,7 @@ dqmBeamMonitor = DQMEDAnalyzer("BeamMonitor",
                               recordName = cms.untracked.string('BeamSpotOnlineHLTObjectsRcd'),
                               useLockRecords = cms.untracked.bool(False),
                               nLSForUpload = cms.untracked.int32(5),
+                              tcdsRecord = cms.InputTag('tcdsDigis','tcdsRecord'),
                               BeamFitter = cms.PSet(
         			Debug = cms.untracked.bool(False),
         			TrackCollection = cms.untracked.InputTag('ctfWithMaterialTracksP5'), ## ctfWithMaterialTracksP5 for CRAFT

--- a/DQM/BeamMonitor/python/BeamMonitor_MC_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_MC_cff.py
@@ -14,6 +14,7 @@ dqmBeamMonitor = cms.DQMEDAnalyzer("BeamMonitor",
                               recordName = cms.untracked.string('BeamSpotOnlineHLTObjectsRcd'),
                               useLockRecords = cms.untracked.bool(False),
                               nLSForUpload = cms.untracked.int32(5),
+                              tcdsRecord = cms.InputTag('tcdsDigis','tcdsRecord'),
                               BeamFitter = cms.PSet(
         			Debug = cms.untracked.bool(False),
         			TrackCollection = cms.untracked.InputTag('generalTracks'), ## ctfWithMaterialTracksP5 for CRAFT

--- a/DQM/BeamMonitor/python/BeamMonitor_PixelLess_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_PixelLess_cff.py
@@ -12,6 +12,7 @@ dqmBeamMonitor_pixelless = DQMEDAnalyzer("BeamMonitor",
                               recordName = cms.untracked.string('BeamSpotOnlineHLTObjectsRcd'),
                               useLockRecords = cms.untracked.bool(False),
                               nLSForUpload = cms.untracked.int32(5),
+                              tcdsRecord = cms.InputTag('tcdsDigis','tcdsRecord'),
                               BeamFitter = cms.PSet(
         			Debug = cms.untracked.bool(False),
         			TrackCollection = cms.untracked.InputTag('ctfPixelLess'),

--- a/DQM/BeamMonitor/python/BeamMonitor_Pixel_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_Pixel_cff.py
@@ -17,6 +17,7 @@ dqmBeamMonitor = DQMEDAnalyzer("BeamMonitor",
                               jetTrigger  = cms.untracked.vstring(),
                               hltResults = cms.InputTag("TriggerResults","","HLT"),
                               nLSForUpload = cms.untracked.int32(5),
+                              tcdsRecord = cms.InputTag('tcdsDigis','tcdsRecord'),
                               BeamFitter = cms.PSet(
                                 Debug = cms.untracked.bool(False),
                                 TrackCollection = cms.untracked.InputTag('pixelTracks'),

--- a/DQM/BeamMonitor/python/BeamMonitor_cff.py
+++ b/DQM/BeamMonitor/python/BeamMonitor_cff.py
@@ -16,6 +16,7 @@ dqmBeamMonitor = DQMEDAnalyzer("BeamMonitor",
                               useLockRecords = cms.untracked.bool(False),
                               hltResults = cms.InputTag("TriggerResults::HLT"),
                               nLSForUpload = cms.untracked.int32(5),
+                              tcdsRecord = cms.InputTag('tcdsDigis','tcdsRecord'),
                               BeamFitter = cms.PSet(
                                 Debug = cms.untracked.bool(False),
                                 TrackCollection = cms.untracked.InputTag('generalTracks'),

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -284,6 +284,10 @@ if ( process.runType.getRunType() == process.runType.cosmic_run or
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
 
+# Digitisation: produce the TCDS digis containing BST record
+from EventFilter.OnlineMetaDataRawToDigi.tcdsRawToDigi_cfi import *
+process.tcdsDigis = tcdsRawToDigi.clone()
+
 #------------------------
 # Set rawDataRepacker (HI and live) or rawDataCollector (for all the rest)
 if (process.runType.getRunType() == process.runType.hi_run and live):
@@ -305,6 +309,7 @@ process.muonRPCDigis.InputLabel          = rawDataInputTag
 process.scalersRawToDigi.scalersInputTag = rawDataInputTag
 process.siPixelDigis.cpu.InputLabel      = rawDataInputTag
 process.siStripDigis.ProductLabel        = rawDataInputTag
+process.tcdsDigis.InputLabel             = rawDataInputTag
 
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
@@ -427,6 +432,7 @@ print("Configured frontierKey", options.runUniqueKey)
 # Final path
 if (not process.runType.getRunType() == process.runType.hi_run):
     process.p = cms.Path(process.scalersRawToDigi
+                       * process.tcdsDigis
                        * process.onlineMetaDataDigis
                        * process.dqmTKStatus
                        * process.hltTriggerTypeFilter
@@ -436,6 +442,7 @@ if (not process.runType.getRunType() == process.runType.hi_run):
                        * process.BeamSpotProblemModule)
 else:
     process.p = cms.Path(process.scalersRawToDigi
+                       * process.tcdsDigis
                        * process.onlineMetaDataDigis
                        * process.dqmTKStatus
                        * process.hltTriggerTypeFilter

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -118,6 +118,19 @@ process.monitor = cms.Sequence(process.dqmBeamMonitor)
 from DQM.Integration.config.online_customizations_cfi import *
 process = customise(process)
 
+# Digitisation: produce the TCDS digis containing BST record
+from EventFilter.OnlineMetaDataRawToDigi.tcdsRawToDigi_cfi import *
+process.tcdsDigis = tcdsRawToDigi.clone()
+
+#------------------------
+# Set rawDataRepacker (HI and live) or rawDataCollector (for all the rest)
+if (process.runType.getRunType() == process.runType.hi_run and live):
+    rawDataInputTag = "rawDataRepacker"
+else:
+    rawDataInputTag = "rawDataCollector"
+
+process.tcdsDigis.InputLabel = rawDataInputTag
+
 #-----------------------------------------------------------
 # Swap offline <-> online BeamSpot as in Express and HLT
 import RecoVertex.BeamSpotProducer.onlineBeamSpotESProducer_cfi as _mod
@@ -226,6 +239,7 @@ if (process.runType.getRunType() == process.runType.pp_run or
     print("Configured frontierKey", options.runUniqueKey)
 
     process.p = cms.Path( process.hltTriggerTypeFilter
+                        * process.tcdsDigis
                         * process.dqmcommon
                         * process.offlineBeamSpot
                         * process.monitor )


### PR DESCRIPTION
Following discussion with @ggovi BeamSpot DQM clients have been modified in such a way that they log to onlineDB only when the beam mode from TCDS is STABLE. This prevents the generation of dummy logs containing only "fit failed" reports during, e.g., cosmics data taking.

Code in this PR compile and the following local tests were successful

-scram b code-format
-scram b code-checks
-scramv1 b runtests

This PR is a backport of https://github.com/cms-sw/cmssw/pull/37614

FYI: @gennai @francescobrivio