### PR TITLE
Update track analysers used for Alignment input data inspection 

### DIFF
--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -208,15 +208,21 @@ public:
   //_______________________________________________________
   */
   template <class OBJECT_TYPE>
-  int GetIndex(const std::vector<OBJECT_TYPE *> &vec, const std::string &name) {
+  int index(const std::vector<OBJECT_TYPE *> &vec, const std::string &name) {
     for (const auto &iter : vec | boost::adaptors::indexed(0)) {
       if (iter.value() && iter.value()->GetName() == name) {
         return iter.index();
       }
     }
-    edm::LogError("Alignment") << "@SUB=DMRChecker::GetIndex"
+    edm::LogError("Alignment") << "@SUB=DMRChecker::index"
                                << " could not find " << name;
     return -1;
+  }
+
+  template <typename T, typename... Args>
+  T *book(const Args &...args) const {
+    T *t = fs->make<T>(args...);
+    return t;
   }
 
 private:
@@ -460,6 +466,8 @@ private:
   bool firstEvent_;
 
   SiPixelPI::phase phase_;
+  float etaMax_;
+
   const bool isCosmics_;
 
   edm::InputTag TkTag_;
@@ -512,8 +520,9 @@ private:
     }
 
     GlobalPoint zeroPoint(0, 0, 0);
-    edm::LogVerbatim("DMRChecker") << "event #" << ievt << " Event ID = " << event.id()
-                                   << " magnetic field: " << magneticField_->inTesla(zeroPoint) << std::endl;
+    if (DEBUG)
+      edm::LogVerbatim("DMRChecker") << "event #" << ievt << " Event ID = " << event.id()
+                                     << " magnetic field: " << magneticField_->inTesla(zeroPoint) << std::endl;
 
     const reco::TrackCollection tC = *(trackCollection.product());
     itrks += tC.size();
@@ -521,7 +530,8 @@ private:
     runInfoMap_[event.run()].first += 1;
     runInfoMap_[event.run()].second += tC.size();
 
-    edm::LogVerbatim("DMRChecker") << "Reconstructed " << tC.size() << " tracks" << std::endl;
+    if (DEBUG)
+      edm::LogVerbatim("DMRChecker") << "Reconstructed " << tC.size() << " tracks" << std::endl;
 
     edm::Handle<edm::TriggerResults> hltresults = event.getHandle(hltresultsToken_);
     if (hltresults.isValid()) {
@@ -532,7 +542,8 @@ private:
         const string &trigName = triggerNames_.triggerName(itrig);
         bool accept = hltresults->accept(itrig);
         if (accept == 1) {
-          edm::LogVerbatim("DMRChecker") << trigName << " " << accept << " ,track size: " << tC.size() << endl;
+          if (DEBUG)
+            edm::LogVerbatim("DMRChecker") << trigName << " " << accept << " ,track size: " << tC.size() << endl;
           triggerMap_[trigName].first += 1;
           triggerMap_[trigName].second += tC.size();
         }
@@ -688,7 +699,8 @@ private:
                 hBPixResXPull->Fill(pullX);
                 hBPixResYPull->Fill(pullY);
 
-                edm::LogVerbatim("DMRChecker") << "layer: " << layer_num << std::endl;
+                if (DEBUG)
+                  edm::LogVerbatim("DMRChecker") << "layer: " << layer_num << std::endl;
 
                 // update residuals X
                 this->updateOnlineMomenta(resDetailsBPixX_, detid_db, uOrientation * resX * cmToUm, pullX);
@@ -710,8 +722,9 @@ private:
 
                 int packedTopo = disk_num + 3 * (side_num - 1);
 
-                edm::LogVerbatim("DMRChecker") << "side: " << side_num << " disk: " << disk_num
-                                               << " packedTopo: " << packedTopo << " GP.z(): " << GP.z() << std::endl;
+                if (DEBUG)
+                  edm::LogVerbatim("DMRChecker") << "side: " << side_num << " disk: " << disk_num
+                                                 << " packedTopo: " << packedTopo << " GP.z(): " << GP.z() << std::endl;
 
                 hHitCountVsThetaFPix->Fill(GP.theta());
                 hHitCountVsPhiFPix->Fill(GP.phi());
@@ -886,114 +899,117 @@ private:
       }
 
       // Fill 1D track histos
-      static const int etaindex = this->GetIndex(vTrackHistos_, "h_tracketa");
+      static const int etaindex = this->index(vTrackHistos_, "h_tracketa");
       vTrackHistos_[etaindex]->Fill(track.eta());
-      static const int phiindex = this->GetIndex(vTrackHistos_, "h_trackphi");
+      static const int phiindex = this->index(vTrackHistos_, "h_trackphi");
       vTrackHistos_[phiindex]->Fill(track.phi());
-      static const int numOfValidHitsindex = this->GetIndex(vTrackHistos_, "h_trackNumberOfValidHits");
+      static const int numOfValidHitsindex = this->index(vTrackHistos_, "h_trackNumberOfValidHits");
       vTrackHistos_[numOfValidHitsindex]->Fill(track.numberOfValidHits());
-      static const int numOfLostHitsindex = this->GetIndex(vTrackHistos_, "h_trackNumberOfLostHits");
+      static const int numOfLostHitsindex = this->index(vTrackHistos_, "h_trackNumberOfLostHits");
       vTrackHistos_[numOfLostHitsindex]->Fill(track.numberOfLostHits());
 
       GlobalPoint gPoint(track.vx(), track.vy(), track.vz());
       double theLocalMagFieldInInverseGeV = magneticField_->inInverseGeV(gPoint).z();
       double kappa = -track.charge() * theLocalMagFieldInInverseGeV / track.pt();
 
-      static const int kappaindex = this->GetIndex(vTrackHistos_, "h_curvature");
+      static const int kappaindex = this->index(vTrackHistos_, "h_curvature");
       vTrackHistos_[kappaindex]->Fill(kappa);
-      static const int kappaposindex = this->GetIndex(vTrackHistos_, "h_curvature_pos");
+      static const int kappaposindex = this->index(vTrackHistos_, "h_curvature_pos");
       if (track.charge() > 0)
         vTrackHistos_[kappaposindex]->Fill(fabs(kappa));
-      static const int kappanegindex = this->GetIndex(vTrackHistos_, "h_curvature_neg");
+      static const int kappanegindex = this->index(vTrackHistos_, "h_curvature_neg");
       if (track.charge() < 0)
         vTrackHistos_[kappanegindex]->Fill(fabs(kappa));
 
       double chi2Prob = TMath::Prob(track.chi2(), track.ndof());
       double normchi2 = track.normalizedChi2();
 
-      static const int normchi2index = this->GetIndex(vTrackHistos_, "h_normchi2");
+      static const int normchi2index = this->index(vTrackHistos_, "h_normchi2");
       vTrackHistos_[normchi2index]->Fill(normchi2);
-      static const int chi2index = this->GetIndex(vTrackHistos_, "h_chi2");
+      static const int chi2index = this->index(vTrackHistos_, "h_chi2");
       vTrackHistos_[chi2index]->Fill(track.chi2());
-      static const int chi2Probindex = this->GetIndex(vTrackHistos_, "h_chi2Prob");
+      static const int chi2Probindex = this->index(vTrackHistos_, "h_chi2Prob");
       vTrackHistos_[chi2Probindex]->Fill(chi2Prob);
-      static const int ptindex = this->GetIndex(vTrackHistos_, "h_pt");
-      static const int pt2index = this->GetIndex(vTrackHistos_, "h_ptrebin");
+      static const int ptindex = this->index(vTrackHistos_, "h_pt");
+      static const int pt2index = this->index(vTrackHistos_, "h_ptrebin");
       vTrackHistos_[ptindex]->Fill(track.pt());
       vTrackHistos_[pt2index]->Fill(track.pt());
       if (track.ptError() != 0.) {
-        static const int ptResolutionindex = this->GetIndex(vTrackHistos_, "h_ptResolution");
+        static const int ptResolutionindex = this->index(vTrackHistos_, "h_ptResolution");
         vTrackHistos_[ptResolutionindex]->Fill(track.ptError() / track.pt());
       }
       // Fill track profiles
-      static const int d0phiindex = this->GetIndex(vTrackProfiles_, "p_d0_vs_phi");
+      static const int d0phiindex = this->index(vTrackProfiles_, "p_d0_vs_phi");
       vTrackProfiles_[d0phiindex]->Fill(track.phi(), track.d0());
-      static const int dzphiindex = this->GetIndex(vTrackProfiles_, "p_dz_vs_phi");
+      static const int dzphiindex = this->index(vTrackProfiles_, "p_dz_vs_phi");
       vTrackProfiles_[dzphiindex]->Fill(track.phi(), track.dz());
-      static const int d0etaindex = this->GetIndex(vTrackProfiles_, "p_d0_vs_eta");
+      static const int d0etaindex = this->index(vTrackProfiles_, "p_d0_vs_eta");
       vTrackProfiles_[d0etaindex]->Fill(track.eta(), track.d0());
-      static const int dzetaindex = this->GetIndex(vTrackProfiles_, "p_dz_vs_eta");
+      static const int dzetaindex = this->index(vTrackProfiles_, "p_dz_vs_eta");
       vTrackProfiles_[dzetaindex]->Fill(track.eta(), track.dz());
-      static const int chiProbphiindex = this->GetIndex(vTrackProfiles_, "p_chi2Prob_vs_phi");
+      static const int chiProbphiindex = this->index(vTrackProfiles_, "p_chi2Prob_vs_phi");
       vTrackProfiles_[chiProbphiindex]->Fill(track.phi(), chi2Prob);
-      static const int chiProbabsd0index = this->GetIndex(vTrackProfiles_, "p_chi2Prob_vs_d0");
+      static const int chiProbabsd0index = this->index(vTrackProfiles_, "p_chi2Prob_vs_d0");
       vTrackProfiles_[chiProbabsd0index]->Fill(fabs(track.d0()), chi2Prob);
-      static const int chiProbabsdzindex = this->GetIndex(vTrackProfiles_, "p_chi2Prob_vs_dz");
+      static const int chiProbabsdzindex = this->index(vTrackProfiles_, "p_chi2Prob_vs_dz");
       vTrackProfiles_[chiProbabsdzindex]->Fill(track.dz(), chi2Prob);
-      static const int chiphiindex = this->GetIndex(vTrackProfiles_, "p_chi2_vs_phi");
+      static const int chiphiindex = this->index(vTrackProfiles_, "p_chi2_vs_phi");
       vTrackProfiles_[chiphiindex]->Fill(track.phi(), track.chi2());
-      static const int normchiphiindex = this->GetIndex(vTrackProfiles_, "p_normchi2_vs_phi");
+      static const int normchiphiindex = this->index(vTrackProfiles_, "p_normchi2_vs_phi");
       vTrackProfiles_[normchiphiindex]->Fill(track.phi(), normchi2);
-      static const int chietaindex = this->GetIndex(vTrackProfiles_, "p_chi2_vs_eta");
+      static const int chietaindex = this->index(vTrackProfiles_, "p_chi2_vs_eta");
       vTrackProfiles_[chietaindex]->Fill(track.eta(), track.chi2());
-      static const int normchiptindex = this->GetIndex(vTrackProfiles_, "p_normchi2_vs_pt");
+      static const int normchiptindex = this->index(vTrackProfiles_, "p_normchi2_vs_pt");
       vTrackProfiles_[normchiptindex]->Fill(track.pt(), normchi2);
-      static const int normchipindex = this->GetIndex(vTrackProfiles_, "p_normchi2_vs_p");
+      static const int normchipindex = this->index(vTrackProfiles_, "p_normchi2_vs_p");
       vTrackProfiles_[normchipindex]->Fill(track.p(), normchi2);
-      static const int chiProbetaindex = this->GetIndex(vTrackProfiles_, "p_chi2Prob_vs_eta");
+      static const int chiProbetaindex = this->index(vTrackProfiles_, "p_chi2Prob_vs_eta");
       vTrackProfiles_[chiProbetaindex]->Fill(track.eta(), chi2Prob);
-      static const int normchietaindex = this->GetIndex(vTrackProfiles_, "p_normchi2_vs_eta");
+      static const int normchietaindex = this->index(vTrackProfiles_, "p_normchi2_vs_eta");
       vTrackProfiles_[normchietaindex]->Fill(track.eta(), normchi2);
-      static const int kappaphiindex = this->GetIndex(vTrackProfiles_, "p_kappa_vs_phi");
+      static const int kappaphiindex = this->index(vTrackProfiles_, "p_kappa_vs_phi");
       vTrackProfiles_[kappaphiindex]->Fill(track.phi(), kappa);
-      static const int kappaetaindex = this->GetIndex(vTrackProfiles_, "p_kappa_vs_eta");
+      static const int kappaetaindex = this->index(vTrackProfiles_, "p_kappa_vs_eta");
       vTrackProfiles_[kappaetaindex]->Fill(track.eta(), kappa);
-      static const int ptResphiindex = this->GetIndex(vTrackProfiles_, "p_ptResolution_vs_phi");
+      static const int ptResphiindex = this->index(vTrackProfiles_, "p_ptResolution_vs_phi");
       vTrackProfiles_[ptResphiindex]->Fill(track.phi(), track.ptError() / track.pt());
-      static const int ptResetaindex = this->GetIndex(vTrackProfiles_, "p_ptResolution_vs_eta");
+      static const int ptResetaindex = this->index(vTrackProfiles_, "p_ptResolution_vs_eta");
       vTrackProfiles_[ptResetaindex]->Fill(track.eta(), track.ptError() / track.pt());
 
       // Fill 2D track histos
-      static const int d0phiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_d0_vs_phi");
+      static const int etaphiindex_2d = this->index(vTrack2DHistos_, "h2_phi_vs_eta");
+      vTrack2DHistos_[etaphiindex_2d]->Fill(track.eta(), track.phi());
+      static const int d0phiindex_2d = this->index(vTrack2DHistos_, "h2_d0_vs_phi");
       vTrack2DHistos_[d0phiindex_2d]->Fill(track.phi(), track.d0());
-      static const int dzphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_dz_vs_phi");
+      static const int dzphiindex_2d = this->index(vTrack2DHistos_, "h2_dz_vs_phi");
       vTrack2DHistos_[dzphiindex_2d]->Fill(track.phi(), track.dz());
-      static const int d0etaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_d0_vs_eta");
+      static const int d0etaindex_2d = this->index(vTrack2DHistos_, "h2_d0_vs_eta");
       vTrack2DHistos_[d0etaindex_2d]->Fill(track.eta(), track.d0());
-      static const int dzetaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_dz_vs_eta");
+      static const int dzetaindex_2d = this->index(vTrack2DHistos_, "h2_dz_vs_eta");
       vTrack2DHistos_[dzetaindex_2d]->Fill(track.eta(), track.dz());
-      static const int chiphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2_vs_phi");
+      static const int chiphiindex_2d = this->index(vTrack2DHistos_, "h2_chi2_vs_phi");
       vTrack2DHistos_[chiphiindex_2d]->Fill(track.phi(), track.chi2());
-      static const int chiProbphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2Prob_vs_phi");
+      static const int chiProbphiindex_2d = this->index(vTrack2DHistos_, "h2_chi2Prob_vs_phi");
       vTrack2DHistos_[chiProbphiindex_2d]->Fill(track.phi(), chi2Prob);
-      static const int chiProbabsd0index_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2Prob_vs_d0");
+      static const int chiProbabsd0index_2d = this->index(vTrack2DHistos_, "h2_chi2Prob_vs_d0");
       vTrack2DHistos_[chiProbabsd0index_2d]->Fill(fabs(track.d0()), chi2Prob);
-      static const int normchiphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_normchi2_vs_phi");
+      static const int normchiphiindex_2d = this->index(vTrack2DHistos_, "h2_normchi2_vs_phi");
       vTrack2DHistos_[normchiphiindex_2d]->Fill(track.phi(), normchi2);
-      static const int chietaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2_vs_eta");
+      static const int chietaindex_2d = this->index(vTrack2DHistos_, "h2_chi2_vs_eta");
       vTrack2DHistos_[chietaindex_2d]->Fill(track.eta(), track.chi2());
-      static const int chiProbetaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2Prob_vs_eta");
+      static const int chiProbetaindex_2d = this->index(vTrack2DHistos_, "h2_chi2Prob_vs_eta");
       vTrack2DHistos_[chiProbetaindex_2d]->Fill(track.eta(), chi2Prob);
-      static const int normchietaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_normchi2_vs_eta");
+      static const int normchietaindex_2d = this->index(vTrack2DHistos_, "h2_normchi2_vs_eta");
       vTrack2DHistos_[normchietaindex_2d]->Fill(track.eta(), normchi2);
-      static const int kappaphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_kappa_vs_phi");
+      static const int kappaphiindex_2d = this->index(vTrack2DHistos_, "h2_kappa_vs_phi");
       vTrack2DHistos_[kappaphiindex_2d]->Fill(track.phi(), kappa);
-      static const int kappaetaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_kappa_vs_eta");
+      static const int kappaetaindex_2d = this->index(vTrack2DHistos_, "h2_kappa_vs_eta");
       vTrack2DHistos_[kappaetaindex_2d]->Fill(track.eta(), kappa);
-      static const int normchi2kappa_2d = this->GetIndex(vTrack2DHistos_, "h2_normchi2_vs_kappa");
+      static const int normchi2kappa_2d = this->index(vTrack2DHistos_, "h2_normchi2_vs_kappa");
       vTrack2DHistos_[normchi2kappa_2d]->Fill(normchi2, kappa);
 
-      edm::LogVerbatim("DMRChecker") << "filling histos" << std::endl;
+      if (DEBUG)
+        edm::LogVerbatim("DMRChecker") << "filling histos" << std::endl;
 
       //dxy with respect to the beamspot
       reco::BeamSpot beamSpot;
@@ -1019,7 +1035,8 @@ private:
           if (abs(mindxy) > abs(track.dxy(mypoint))) {
             mindxy = track.dxy(mypoint);
             dz = track.dz(mypoint);
-            edm::LogVerbatim("DMRChecker") << "dxy: " << mindxy << " dz: " << dz << std::endl;
+            if (DEBUG)
+              edm::LogVerbatim("DMRChecker") << "dxy: " << mindxy << " dz: " << dz << std::endl;
           }
         }
 
@@ -1037,16 +1054,19 @@ private:
         hdzPV->Fill(100);
       }
 
-      edm::LogVerbatim("DMRChecker") << "end of track loop" << std::endl;
+      if (DEBUG)
+        edm::LogVerbatim("DMRChecker") << "end of track loop" << std::endl;
     }
 
-    edm::LogVerbatim("DMRChecker") << "end of analysis" << std::endl;
+    if (DEBUG)
+      edm::LogVerbatim("DMRChecker") << "end of analysis" << std::endl;
 
     hNtrk->Fill(tC.size());
     hNtrkZoom->Fill(tC.size());
     hNhighPurity->Fill(nHighPurityTracks);
 
-    edm::LogVerbatim("DMRChecker") << "end of analysis" << std::endl;
+    if (DEBUG)
+      edm::LogVerbatim("DMRChecker") << "end of analysis" << std::endl;
   }
 
   //*************************************************************
@@ -1111,106 +1131,109 @@ private:
 
     TH1D::SetDefaultSumw2(kTRUE);
 
+    etaMax_ = 3.;  // assign max value to eta
+
+    // intialize counters
     ievt = 0;
     itrks = 0;
 
-    hrun = fs->make<TH1D>("h_run", "run", 100000, 230000, 240000);
-    hlumi = fs->make<TH1D>("h_lumi", "lumi", 1000, 0, 1000);
+    hrun = book<TH1D>("h_run", "run", 100000, 230000, 240000);
+    hlumi = book<TH1D>("h_lumi", "lumi", 1000, 0, 1000);
 
     // clang-format off
 
-    hchi2ndof = fs->make<TH1D>("h_chi2ndof", "chi2/ndf;#chi^{2}/ndf;tracks", 100, 0, 5.);
-    hCharge = fs->make<TH1D>("h_charge", "charge;Charge of the track;tracks", 5, -2.5, 2.5);
-    hNtrk = fs->make<TH1D>("h_Ntrk", "ntracks;Number of Tracks;events", 200, 0., 200.);
-    hNtrkZoom = fs->make<TH1D>("h_NtrkZoom", "Number of tracks; number of tracks;events", 10, 0., 10.);
-    hNhighPurity = fs->make<TH1D>("h_NhighPurity", "n. high purity tracks;Number of high purity tracks;events", 200, 0., 200.);
+    hchi2ndof = book<TH1D>("h_chi2ndof", "chi2/ndf;#chi^{2}/ndf;tracks", 100, 0, 5.);
+    hCharge = book<TH1D>("h_charge", "charge;Charge of the track;tracks", 5, -2.5, 2.5);
+    hNtrk = book<TH1D>("h_Ntrk", "ntracks;Number of Tracks;events", 200, 0., 200.);
+    hNtrkZoom = book<TH1D>("h_NtrkZoom", "Number of tracks; number of tracks;events", 10, 0., 10.);
+    hNhighPurity = book<TH1D>("h_NhighPurity", "n. high purity tracks;Number of high purity tracks;events", 200, 0., 200.);
 
     int nAlgos = reco::TrackBase::algoSize;
-    htrkAlgo = fs->make<TH1I>("h_trkAlgo", "tracking step;iterative tracking step;tracks", nAlgos, -0.5, nAlgos - 0.5);
+    htrkAlgo = book<TH1I>("h_trkAlgo", "tracking step;iterative tracking step;tracks", nAlgos, -0.5, nAlgos - 0.5);
     for (int nbin = 1; nbin <= htrkAlgo->GetNbinsX(); nbin++) {
       htrkAlgo->GetXaxis()->SetBinLabel(nbin, reco::TrackBase::algoNames[nbin - 1].c_str());
     }
 
-    htrkQuality = fs->make<TH1I>("h_trkQuality", "track quality;track quality;tracks", 6, -1, 5);
+    htrkQuality = book<TH1I>("h_trkQuality", "track quality;track quality;tracks", 6, -1, 5);
     std::string qualities[7] = {"undef", "loose", "tight", "highPurity", "confirmed", "goodIterative"};
     for (int nbin = 1; nbin <= htrkQuality->GetNbinsX(); nbin++) {
       htrkQuality->GetXaxis()->SetBinLabel(nbin, qualities[nbin - 1].c_str());
     }
 
-    hP = fs->make<TH1D>("h_P", "Momentum;track momentum [GeV];tracks", 100, 0., 100.);
-    hQoverP = fs->make<TH1D>("h_qoverp", "Track q/p; track q/p [GeV^{-1}];tracks", 100, -1., 1.);
-    hQoverPZoom = fs->make<TH1D>("h_qoverpZoom", "Track q/p; track q/p [GeV^{-1}];tracks", 100, -0.1, 0.1);
-    hPt = fs->make<TH1D>("h_Pt", "Transverse Momentum;track p_{T} [GeV];tracks", 100, 0., 100.);
-    hHit = fs->make<TH1D>("h_nHits", "Number of hits;track n. hits;tracks", 50, -0.5, 49.5);
-    hHit2D = fs->make<TH1D>("h_nHit2D", "Number of 2D hits; number of 2D hits;tracks", 20, 0, 20);
+    hP = book<TH1D>("h_P", "Momentum;track momentum [GeV];tracks", 100, 0., 100.);
+    hQoverP = book<TH1D>("h_qoverp", "Track q/p; track q/p [GeV^{-1}];tracks", 100, -1., 1.);
+    hQoverPZoom = book<TH1D>("h_qoverpZoom", "Track q/p; track q/p [GeV^{-1}];tracks", 100, -0.1, 0.1);
+    hPt = book<TH1D>("h_Pt", "Transverse Momentum;track p_{T} [GeV];tracks", 100, 0., 100.);
+    hHit = book<TH1D>("h_nHits", "Number of hits;track n. hits;tracks", 50, -0.5, 49.5);
+    hHit2D = book<TH1D>("h_nHit2D", "Number of 2D hits; number of 2D hits;tracks", 20, 0, 20);
 
     // Pixel
 
-    hBPixResXPrime = fs->make<TH1D>("h_BPixResXPrime", "BPix track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
-    hFPixResXPrime = fs->make<TH1D>("h_FPixResXPrime", "FPix track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
-    hFPixZPlusResXPrime = fs->make<TH1D>("h_FPixZPlusResXPrime", "FPix (Z+) track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
-    hFPixZMinusResXPrime = fs->make<TH1D>("h_FPixZMinusResXPrime", "FPix (Z-) track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
+    hBPixResXPrime = book<TH1D>("h_BPixResXPrime", "BPix track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
+    hFPixResXPrime = book<TH1D>("h_FPixResXPrime", "FPix track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
+    hFPixZPlusResXPrime = book<TH1D>("h_FPixZPlusResXPrime", "FPix (Z+) track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
+    hFPixZMinusResXPrime = book<TH1D>("h_FPixZMinusResXPrime", "FPix (Z-) track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
 
-    hBPixResYPrime = fs->make<TH1D>("h_BPixResYPrime", "BPix track Y-residuals;res_{Y'} [#mum];hits", 100, -1000., 1000.);
-    hFPixResYPrime = fs->make<TH1D>("h_FPixResYPrime", "FPix track Y-residuals;res_{Y'} [#mum];hits", 100, -1000., 1000.);
-    hFPixZPlusResYPrime = fs->make<TH1D>("h_FPixZPlusResYPrime", "FPix (Z+) track Y-residuals;res_{Y'} [#mum];hits", 100, -1000., 1000.);
-    hFPixZMinusResYPrime = fs->make<TH1D>("h_FPixZMinusResYPrime", "FPix (Z-) track Y-residuals;res_{Y'} [#mum];hits", 100, -1000., 1000.);
+    hBPixResYPrime = book<TH1D>("h_BPixResYPrime", "BPix track Y-residuals;res_{Y'} [#mum];hits", 100, -1000., 1000.);
+    hFPixResYPrime = book<TH1D>("h_FPixResYPrime", "FPix track Y-residuals;res_{Y'} [#mum];hits", 100, -1000., 1000.);
+    hFPixZPlusResYPrime = book<TH1D>("h_FPixZPlusResYPrime", "FPix (Z+) track Y-residuals;res_{Y'} [#mum];hits", 100, -1000., 1000.);
+    hFPixZMinusResYPrime = book<TH1D>("h_FPixZMinusResYPrime", "FPix (Z-) track Y-residuals;res_{Y'} [#mum];hits", 100, -1000., 1000.);
 
-    hBPixResXPull = fs->make<TH1D>("h_BPixResXPull", "BPix track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
-    hFPixResXPull = fs->make<TH1D>("h_FPixResXPull", "FPix track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
-    hFPixZPlusResXPull = fs->make<TH1D>("h_FPixZPlusResXPull", "FPix (Z+) track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
-    hFPixZMinusResXPull = fs->make<TH1D>("h_FPixZMinusResXPull", "FPix (Z-) track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
+    hBPixResXPull = book<TH1D>("h_BPixResXPull", "BPix track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
+    hFPixResXPull = book<TH1D>("h_FPixResXPull", "FPix track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
+    hFPixZPlusResXPull = book<TH1D>("h_FPixZPlusResXPull", "FPix (Z+) track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
+    hFPixZMinusResXPull = book<TH1D>("h_FPixZMinusResXPull", "FPix (Z-) track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
 
-    hBPixResYPull = fs->make<TH1D>("h_BPixResYPull", "BPix track Y-pulls;res_{Y'}/#sigma_{res_{Y'}};hits", 100, -5., 5.);
-    hFPixResYPull = fs->make<TH1D>("h_FPixResYPull", "FPix track Y-pulls;res_{Y'}/#sigma_{res_{Y'}};hits", 100, -5., 5.);
-    hFPixZPlusResYPull = fs->make<TH1D>("h_FPixZPlusResYPull", "FPix (Z+) track Y-pulls;res_{Y'}/#sigma_{res_{Y'}};hits", 100, -5., 5.);
-    hFPixZMinusResYPull = fs->make<TH1D>("h_FPixZMinusResYPull", "FPix (Z-) track Y-pulls;res_{Y'}/#sigma_{res_{Y'}};hits", 100, -5., 5.);
+    hBPixResYPull = book<TH1D>("h_BPixResYPull", "BPix track Y-pulls;res_{Y'}/#sigma_{res_{Y'}};hits", 100, -5., 5.);
+    hFPixResYPull = book<TH1D>("h_FPixResYPull", "FPix track Y-pulls;res_{Y'}/#sigma_{res_{Y'}};hits", 100, -5., 5.);
+    hFPixZPlusResYPull = book<TH1D>("h_FPixZPlusResYPull", "FPix (Z+) track Y-pulls;res_{Y'}/#sigma_{res_{Y'}};hits", 100, -5., 5.);
+    hFPixZMinusResYPull = book<TH1D>("h_FPixZMinusResYPull", "FPix (Z-) track Y-pulls;res_{Y'}/#sigma_{res_{Y'}};hits", 100, -5., 5.);
 
     // Strips
 
-    hTIBResXPrime = fs->make<TH1D>("h_TIBResXPrime", "TIB track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
-    hTOBResXPrime = fs->make<TH1D>("h_TOBResXPrime", "TOB track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
-    hTIDResXPrime = fs->make<TH1D>("h_TIDResXPrime", "TID track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
-    hTECResXPrime = fs->make<TH1D>("h_TECResXPrime", "TEC track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
+    hTIBResXPrime = book<TH1D>("h_TIBResXPrime", "TIB track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
+    hTOBResXPrime = book<TH1D>("h_TOBResXPrime", "TOB track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
+    hTIDResXPrime = book<TH1D>("h_TIDResXPrime", "TID track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
+    hTECResXPrime = book<TH1D>("h_TECResXPrime", "TEC track X-residuals;res_{X'} [#mum];hits", 100, -1000., 1000.);
 
-    hTIBResXPull = fs->make<TH1D>("h_TIBResXPull", "TIB track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
-    hTOBResXPull = fs->make<TH1D>("h_TOBResXPull", "TOB track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
-    hTIDResXPull = fs->make<TH1D>("h_TIDResXPull", "TID track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
-    hTECResXPull = fs->make<TH1D>("h_TECResXPull", "TEC track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
+    hTIBResXPull = book<TH1D>("h_TIBResXPull", "TIB track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
+    hTOBResXPull = book<TH1D>("h_TOBResXPull", "TOB track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
+    hTIDResXPull = book<TH1D>("h_TIDResXPull", "TID track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
+    hTECResXPull = book<TH1D>("h_TECResXPull", "TEC track X-pulls;res_{X'}/#sigma_{res_{X'}};hits", 100, -5., 5.);
 
     // hit counts
 
-    hHitCountVsZBPix = fs->make<TH1D>("h_HitCountVsZBpix", "Number of BPix hits vs z;hit global z;hits", 60, -30, 30);
-    hHitCountVsZFPix = fs->make<TH1D>("h_HitCountVsZFpix", "Number of FPix hits vs z;hit global z;hits", 100, -100, 100);
+    hHitCountVsZBPix = book<TH1D>("h_HitCountVsZBpix", "Number of BPix hits vs z;hit global z;hits", 60, -30, 30);
+    hHitCountVsZFPix = book<TH1D>("h_HitCountVsZFpix", "Number of FPix hits vs z;hit global z;hits", 100, -100, 100);
 
-    hHitCountVsXBPix = fs->make<TH1D>("h_HitCountVsXBpix", "Number of BPix hits vs x;hit global x;hits", 20, -20, 20);
-    hHitCountVsXFPix = fs->make<TH1D>("h_HitCountVsXFpix", "Number of FPix hits vs x;hit global x;hits", 20, -20, 20);
+    hHitCountVsXBPix = book<TH1D>("h_HitCountVsXBpix", "Number of BPix hits vs x;hit global x;hits", 20, -20, 20);
+    hHitCountVsXFPix = book<TH1D>("h_HitCountVsXFpix", "Number of FPix hits vs x;hit global x;hits", 20, -20, 20);
 
-    hHitCountVsYBPix = fs->make<TH1D>("h_HitCountVsYBpix", "Number of BPix hits vs y;hit global y;hits", 20, -20, 20);
-    hHitCountVsYFPix = fs->make<TH1D>("h_HitCountVsYFpix", "Number of FPix hits vs y;hit global y;hits", 20, -20, 20);
+    hHitCountVsYBPix = book<TH1D>("h_HitCountVsYBpix", "Number of BPix hits vs y;hit global y;hits", 20, -20, 20);
+    hHitCountVsYFPix = book<TH1D>("h_HitCountVsYFpix", "Number of FPix hits vs y;hit global y;hits", 20, -20, 20);
 
-    hHitCountVsThetaBPix = fs->make<TH1D>("h_HitCountVsThetaBpix", "Number of BPix hits vs #theta;hit global #theta;hits", 20, 0., M_PI);
-    hHitCountVsPhiBPix = fs->make<TH1D>("h_HitCountVsPhiBpix", "Number of BPix hits vs #phi;hit global #phi;hits", 20, -M_PI, M_PI);
+    hHitCountVsThetaBPix = book<TH1D>("h_HitCountVsThetaBpix", "Number of BPix hits vs #theta;hit global #theta;hits", 20, 0., M_PI);
+    hHitCountVsPhiBPix = book<TH1D>("h_HitCountVsPhiBpix", "Number of BPix hits vs #phi;hit global #phi;hits", 20, -M_PI, M_PI);
 
-    hHitCountVsThetaFPix = fs->make<TH1D>("h_HitCountVsThetaFpix", "Number of FPix hits vs #theta;hit global #theta;hits", 40, 0., M_PI);
-    hHitCountVsPhiFPix = fs->make<TH1D>("h_HitCountVsPhiFpix", "Number of FPix hits vs #phi;hit global #phi;hits", 20, -M_PI, M_PI);
+    hHitCountVsThetaFPix = book<TH1D>("h_HitCountVsThetaFpix", "Number of FPix hits vs #theta;hit global #theta;hits", 40, 0., M_PI);
+    hHitCountVsPhiFPix = book<TH1D>("h_HitCountVsPhiFpix", "Number of FPix hits vs #phi;hit global #phi;hits", 20, -M_PI, M_PI);
 
     // two sides of FPix
 
-    hHitCountVsZFPixPlus = fs->make<TH1D>("h_HitCountVsZFPixPlus", "Number of FPix(Z+) hits vs z;hit global z;hits", 60, 15., 60);
-    hHitCountVsZFPixMinus = fs->make<TH1D>("h_HitCountVsZFPixMinus", "Number of FPix(Z-) hits vs z;hit global z;hits", 100, -60., -15.);
+    hHitCountVsZFPixPlus = book<TH1D>("h_HitCountVsZFPixPlus", "Number of FPix(Z+) hits vs z;hit global z;hits", 60, 15., 60);
+    hHitCountVsZFPixMinus = book<TH1D>("h_HitCountVsZFPixMinus", "Number of FPix(Z-) hits vs z;hit global z;hits", 100, -60., -15.);
 
-    hHitCountVsXFPixPlus = fs->make<TH1D>("h_HitCountVsXFPixPlus", "Number of FPix(Z+) hits vs x;hit global x;hits", 20, -20, 20);
-    hHitCountVsXFPixMinus = fs->make<TH1D>("h_HitCountVsXFPixMinus", "Number of FPix(Z-) hits vs x;hit global x;hits", 20, -20, 20);
+    hHitCountVsXFPixPlus = book<TH1D>("h_HitCountVsXFPixPlus", "Number of FPix(Z+) hits vs x;hit global x;hits", 20, -20, 20);
+    hHitCountVsXFPixMinus = book<TH1D>("h_HitCountVsXFPixMinus", "Number of FPix(Z-) hits vs x;hit global x;hits", 20, -20, 20);
 
-    hHitCountVsYFPixPlus = fs->make<TH1D>("h_HitCountVsYFPixPlus", "Number of FPix(Z+) hits vs y;hit global y;hits", 20, -20, 20);
-    hHitCountVsYFPixMinus = fs->make<TH1D>("h_HitCountVsYFPixMinus", "Number of FPix(Z-) hits vs y;hit global y;hits", 20, -20, 20);
+    hHitCountVsYFPixPlus = book<TH1D>("h_HitCountVsYFPixPlus", "Number of FPix(Z+) hits vs y;hit global y;hits", 20, -20, 20);
+    hHitCountVsYFPixMinus = book<TH1D>("h_HitCountVsYFPixMinus", "Number of FPix(Z-) hits vs y;hit global y;hits", 20, -20, 20);
 
-    hHitCountVsThetaFPixPlus = fs->make<TH1D>("h_HitCountVsThetaFPixPlus", "Number of FPix(Z+) hits vs #theta;hit global #theta;hits", 20, 0., M_PI);
-    hHitCountVsPhiFPixPlus = fs->make<TH1D>("h_HitCountVsPhiFPixPlus","Number of FPix(Z+) hits vs #phi;hit global #phi;hits",20,-M_PI,M_PI);
+    hHitCountVsThetaFPixPlus = book<TH1D>("h_HitCountVsThetaFPixPlus", "Number of FPix(Z+) hits vs #theta;hit global #theta;hits", 20, 0., M_PI);
+    hHitCountVsPhiFPixPlus = book<TH1D>("h_HitCountVsPhiFPixPlus","Number of FPix(Z+) hits vs #phi;hit global #phi;hits",20,-M_PI,M_PI);
 
-    hHitCountVsThetaFPixMinus = fs->make<TH1D>("h_HitCountVsThetaFPixMinus", "Number of FPix(Z+) hits vs #theta;hit global #theta;hits", 40, 0., M_PI);
-    hHitCountVsPhiFPixMinus = fs->make<TH1D>("h_HitCountVsPhiFPixMinus","Number of FPix(Z+) hits vs #phi;hit global #phi;hits",20,-M_PI,M_PI);
+    hHitCountVsThetaFPixMinus = book<TH1D>("h_HitCountVsThetaFPixMinus", "Number of FPix(Z+) hits vs #theta;hit global #theta;hits", 40, 0., M_PI);
+    hHitCountVsPhiFPixMinus = book<TH1D>("h_HitCountVsPhiFPixMinus","Number of FPix(Z+) hits vs #phi;hit global #phi;hits",20,-M_PI,M_PI);
 
     TFileDirectory ByLayerResiduals = fs->mkdir("ByLayerResiduals");
     barrelLayersResidualsX = bookResidualsHistogram(ByLayerResiduals, 4, "X", "Res", "BPix");
@@ -1224,136 +1247,137 @@ private:
     barrelLayersPullsY = bookResidualsHistogram(ByLayerPulls, 4, "Y", "Pull", "BPix");
     endcapDisksPullsY = bookResidualsHistogram(ByLayerPulls, 6, "Y", "Pull", "FPix");
 
-    hEta = fs->make<TH1D>("h_Eta", "Track pseudorapidity; track #eta;tracks", 100, -M_PI, M_PI);
-    hPhi = fs->make<TH1D>("h_Phi", "Track azimuth; track #phi;tracks", 100, -M_PI, M_PI);
+    hEta = book<TH1D>("h_Eta", "Track pseudorapidity; track #eta;tracks", 100, -etaMax_, etaMax_);
+    hPhi = book<TH1D>("h_Phi", "Track azimuth; track #phi;tracks", 100, -M_PI, M_PI);
 
-    hPhiBarrel = fs->make<TH1D>("h_PhiBarrel", "hPhiBarrel (0<|#eta|<0.8);track #Phi;tracks", 100, -M_PI, M_PI);
-    hPhiOverlapPlus = fs->make<TH1D>("h_PhiOverlapPlus", "hPhiOverlapPlus (0.8<#eta<1.4);track #phi;tracks", 100, -M_PI, M_PI);
-    hPhiOverlapMinus = fs->make<TH1D>("h_PhiOverlapMinus", "hPhiOverlapMinus (-1.4<#eta<-0.8);track #phi;tracks", 100, -M_PI, M_PI);
-    hPhiEndcapPlus = fs->make<TH1D>("h_PhiEndcapPlus", "hPhiEndcapPlus (#eta>1.4);track #phi;track", 100, -M_PI, M_PI);
-    hPhiEndcapMinus = fs->make<TH1D>("h_PhiEndcapMinus", "hPhiEndcapMinus (#eta<1.4);track #phi;tracks", 100, -M_PI, M_PI);
+    hPhiBarrel = book<TH1D>("h_PhiBarrel", "hPhiBarrel (0<|#eta|<0.8);track #Phi;tracks", 100, -M_PI, M_PI);
+    hPhiOverlapPlus = book<TH1D>("h_PhiOverlapPlus", "hPhiOverlapPlus (0.8<#eta<1.4);track #phi;tracks", 100, -M_PI, M_PI);
+    hPhiOverlapMinus = book<TH1D>("h_PhiOverlapMinus", "hPhiOverlapMinus (-1.4<#eta<-0.8);track #phi;tracks", 100, -M_PI, M_PI);
+    hPhiEndcapPlus = book<TH1D>("h_PhiEndcapPlus", "hPhiEndcapPlus (#eta>1.4);track #phi;track", 100, -M_PI, M_PI);
+    hPhiEndcapMinus = book<TH1D>("h_PhiEndcapMinus", "hPhiEndcapMinus (#eta<1.4);track #phi;tracks", 100, -M_PI, M_PI);
 
     if (!isCosmics_) {
-      hPhp = fs->make<TH1D>("h_P_hp", "Momentum (high purity);track momentum [GeV];tracks", 100, 0., 100.);
-      hPthp = fs->make<TH1D>("h_Pt_hp", "Transverse Momentum (high purity);track p_{T} [GeV];tracks", 100, 0., 100.);
-      hHithp = fs->make<TH1D>("h_nHit_hp", "Number of hits (high purity);track n. hits;tracks", 30, 0, 30);
-      hEtahp = fs->make<TH1D>("h_Eta_hp", "Track pseudorapidity (high purity); track #eta;tracks", 100, -M_PI, M_PI);
-      hPhihp = fs->make<TH1D>("h_Phi_hp", "Track azimuth (high purity); track #phi;tracks", 100, -M_PI, M_PI);
-      hchi2ndofhp = fs->make<TH1D>("h_chi2ndof_hp", "chi2/ndf (high purity);#chi^{2}/ndf;tracks", 100, 0, 5.);
-      hchi2Probhp = fs->make<TH1D>("hchi2_Prob_hp", "#chi^{2} probability (high purity);#chi^{2}prob_{Track};Number of Tracks", 100, 0.0, 1.);
+      hPhp = book<TH1D>("h_P_hp", "Momentum (high purity);track momentum [GeV];tracks", 100, 0., 100.);
+      hPthp = book<TH1D>("h_Pt_hp", "Transverse Momentum (high purity);track p_{T} [GeV];tracks", 100, 0., 100.);
+      hHithp = book<TH1D>("h_nHit_hp", "Number of hits (high purity);track n. hits;tracks", 30, 0, 30);
+      hEtahp = book<TH1D>("h_Eta_hp", "Track pseudorapidity (high purity); track #eta;tracks", 100, -etaMax_, etaMax_);
+      hPhihp = book<TH1D>("h_Phi_hp", "Track azimuth (high purity); track #phi;tracks", 100, -M_PI, M_PI);
+      hchi2ndofhp = book<TH1D>("h_chi2ndof_hp", "chi2/ndf (high purity);#chi^{2}/ndf;tracks", 100, 0, 5.);
+      hchi2Probhp = book<TH1D>("hchi2_Prob_hp", "#chi^{2} probability (high purity);#chi^{2}prob_{Track};Number of Tracks", 100, 0.0, 1.);
 
-      hvx = fs->make<TH1D>("h_vx", "Track v_{x} ; track v_{x} [cm];tracks", 100, -1.5, 1.5);
-      hvy = fs->make<TH1D>("h_vy", "Track v_{y} ; track v_{y} [cm];tracks", 100, -1.5, 1.5);
-      hvz = fs->make<TH1D>("h_vz", "Track v_{z} ; track v_{z} [cm];tracks", 100, -20., 20.);
-      hd0 = fs->make<TH1D>("h_d0", "Track d_{0} ; track d_{0} [cm];tracks", 100, -1., 1.);
-      hdxy = fs->make<TH1D>("h_dxy", "Track d_{xy}; track d_{xy} [cm]; tracks", 100, -0.5, 0.5);
-      hdz = fs->make<TH1D>("h_dz", "Track d_{z} ; track d_{z} [cm]; tracks", 100, -20, 20);
+      hvx = book<TH1D>("h_vx", "Track v_{x} ; track v_{x} [cm];tracks", 100, -1.5, 1.5);
+      hvy = book<TH1D>("h_vy", "Track v_{y} ; track v_{y} [cm];tracks", 100, -1.5, 1.5);
+      hvz = book<TH1D>("h_vz", "Track v_{z} ; track v_{z} [cm];tracks", 100, -20., 20.);
+      hd0 = book<TH1D>("h_d0", "Track d_{0} ; track d_{0} [cm];tracks", 100, -1., 1.);
+      hdxy = book<TH1D>("h_dxy", "Track d_{xy}; track d_{xy} [cm]; tracks", 100, -0.5, 0.5);
+      hdz = book<TH1D>("h_dz", "Track d_{z} ; track d_{z} [cm]; tracks", 100, -20, 20);
 
-      hd0PVvsphi = fs->make<TH2D>("h2_d0PVvsphi", "hd0PVvsphi;track #phi;track d_{0}(PV) [cm]", 160, -M_PI, M_PI, 100, -1., 1.);
-      hd0PVvseta = fs->make<TH2D>("h2_d0PVvseta", "hdPV0vseta;track #eta;track d_{0}(PV) [cm]", 160, -2.5, 2.5, 100, -1., 1.);
-      hd0PVvspt = fs->make<TH2D>("h2_d0PVvspt", "hdPV0vspt;track p_{T};d_{0}(PV) [cm]", 50, 0., 100., 100, -1, 1.);
+      hd0PVvsphi = book<TH2D>("h2_d0PVvsphi", "hd0PVvsphi;track #phi;track d_{0}(PV) [cm]", 160, -M_PI, M_PI, 100, -1., 1.);
+      hd0PVvseta = book<TH2D>("h2_d0PVvseta", "hdPV0vseta;track #eta;track d_{0}(PV) [cm]", 160, -etaMax_, etaMax_, 100, -1., 1.);
+      hd0PVvspt = book<TH2D>("h2_d0PVvspt", "hdPV0vspt;track p_{T};d_{0}(PV) [cm]", 50, 0., 100., 100, -1, 1.);
 
-      hdxyBS = fs->make<TH1D>("h_dxyBS", "hdxyBS; track d_{xy}(BS) [cm];tracks", 100, -0.1, 0.1);
-      hd0BS = fs->make<TH1D>("h_d0BS", "hd0BS ; track d_{0}(BS) [cm];tracks", 100, -0.1, 0.1);
-      hdzBS = fs->make<TH1D>("h_dzBS", "hdzBS ; track d_{z}(BS) [cm];tracks", 100, -12, 12);
-      hdxyPV = fs->make<TH1D>("h_dxyPV", "hdxyPV; track d_{xy}(PV) [cm];tracks", 100, -0.1, 0.1);
-      hd0PV = fs->make<TH1D>("h_d0PV", "hd0PV ; track d_{0}(PV) [cm];tracks", 100, -0.15, 0.15);
-      hdzPV = fs->make<TH1D>("h_dzPV", "hdzPV ; track d_{z}(PV) [cm];tracks", 100, -0.1, 0.1);
+      hdxyBS = book<TH1D>("h_dxyBS", "hdxyBS; track d_{xy}(BS) [cm];tracks", 100, -0.1, 0.1);
+      hd0BS = book<TH1D>("h_d0BS", "hd0BS ; track d_{0}(BS) [cm];tracks", 100, -0.1, 0.1);
+      hdzBS = book<TH1D>("h_dzBS", "hdzBS ; track d_{z}(BS) [cm];tracks", 100, -12, 12);
+      hdxyPV = book<TH1D>("h_dxyPV", "hdxyPV; track d_{xy}(PV) [cm];tracks", 100, -0.1, 0.1);
+      hd0PV = book<TH1D>("h_d0PV", "hd0PV ; track d_{0}(PV) [cm];tracks", 100, -0.15, 0.15);
+      hdzPV = book<TH1D>("h_dzPV", "hdzPV ; track d_{z}(PV) [cm];tracks", 100, -0.1, 0.1);
 
-      hnhTIB = fs->make<TH1D>("h_nHitTIB", "nhTIB;# hits in TIB; tracks", 20, 0., 20.);
-      hnhTID = fs->make<TH1D>("h_nHitTID", "nhTID;# hits in TID; tracks", 20, 0., 20.);
-      hnhTOB = fs->make<TH1D>("h_nHitTOB", "nhTOB;# hits in TOB; tracks", 20, 0., 20.);
-      hnhTEC = fs->make<TH1D>("h_nHitTEC", "nhTEC;# hits in TEC; tracks", 20, 0., 20.);
+      hnhTIB = book<TH1D>("h_nHitTIB", "nhTIB;# hits in TIB; tracks", 20, 0., 20.);
+      hnhTID = book<TH1D>("h_nHitTID", "nhTID;# hits in TID; tracks", 20, 0., 20.);
+      hnhTOB = book<TH1D>("h_nHitTOB", "nhTOB;# hits in TOB; tracks", 20, 0., 20.);
+      hnhTEC = book<TH1D>("h_nHitTEC", "nhTEC;# hits in TEC; tracks", 20, 0., 20.);
 
     } else {
-      hvx = fs->make<TH1D>("h_vx", "Track v_{x};track v_{x} [cm];tracks", 100, -100., 100.);
-      hvy = fs->make<TH1D>("h_vy", "Track v_{y};track v_{y} [cm];tracks", 100, -100., 100.);
-      hvz = fs->make<TH1D>("h_vz", "Track v_{z};track v_{z} [cm];track", 100, -100., 100.);
-      hd0 = fs->make<TH1D>("h_d0", "Track d_{0};track d_{0} [cm];track", 100, -100., 100.);
-      hdxy = fs->make<TH1D>("h_dxy", "Track d_{xy};track d_{xy} [cm];tracks", 100, -100, 100);
-      hdz = fs->make<TH1D>("h_dz", "Track d_{z};track d_{z} [cm];tracks", 100, -200, 200);
+      hvx = book<TH1D>("h_vx", "Track v_{x};track v_{x} [cm];tracks", 100, -100., 100.);
+      hvy = book<TH1D>("h_vy", "Track v_{y};track v_{y} [cm];tracks", 100, -100., 100.);
+      hvz = book<TH1D>("h_vz", "Track v_{z};track v_{z} [cm];track", 100, -100., 100.);
+      hd0 = book<TH1D>("h_d0", "Track d_{0};track d_{0} [cm];track", 100, -100., 100.);
+      hdxy = book<TH1D>("h_dxy", "Track d_{xy};track d_{xy} [cm];tracks", 100, -100, 100);
+      hdz = book<TH1D>("h_dz", "Track d_{z};track d_{z} [cm];tracks", 100, -200, 200);
 
-      hd0vsphi = fs->make<TH2D>("h2_d0vsphi", "Track d_{0} vs #phi; track #phi;track d_{0} [cm]", 160, -3.20, 3.20, 100, -100., 100.);
-      hd0vseta = fs->make<TH2D>("h2_d0vseta", "Track d_{0} vs #eta; track #eta;track d_{0} [cm]", 160, -3.20, 3.20, 100, -100., 100.);
-      hd0vspt = fs->make<TH2D>("h2_d0vspt", "Track d_{0} vs p_{T};track p_{T};track d_{0} [cm]", 50, 0., 100., 100, -100, 100);
+      hd0vsphi = book<TH2D>("h2_d0vsphi", "Track d_{0} vs #phi; track #phi;track d_{0} [cm]", 160, -M_PI, M_PI, 100, -100., 100.);
+      hd0vseta = book<TH2D>("h2_d0vseta", "Track d_{0} vs #eta; track #eta;track d_{0} [cm]", 160, -etaMax_, etaMax_, 100, -100., 100.);
+      hd0vspt = book<TH2D>("h2_d0vspt", "Track d_{0} vs p_{T};track p_{T};track d_{0} [cm]", 50, 0., 100., 100, -100, 100);
 
-      hdxyBS = fs->make<TH1D>("h_dxyBS", "Track d_{xy}(BS);d_{xy}(BS) [cm];tracks", 100, -100., 100.);
-      hd0BS = fs->make<TH1D>("h_d0BS", "Track d_{0}(BS);d_{0}(BS) [cm];tracks", 100, -100., 100.);
-      hdzBS = fs->make<TH1D>("h_dzBS", "Track d_{z}(BS);d_{z}(BS) [cm];tracks", 100, -100., 100.);
-      hdxyPV = fs->make<TH1D>("h_dxyPV", "Track d_{xy}(PV); d_{xy}(PV) [cm];tracks", 100, -100., 100.);
-      hd0PV = fs->make<TH1D>("h_d0PV", "Track d_{0}(PV); d_{0}(PV) [cm];tracks", 100, -100., 100.);
-      hdzPV = fs->make<TH1D>("h_dzPV", "Track d_{z}(PV); d_{z}(PV) [cm];tracks", 100, -100., 100.);
+      hdxyBS = book<TH1D>("h_dxyBS", "Track d_{xy}(BS);d_{xy}(BS) [cm];tracks", 100, -100., 100.);
+      hd0BS = book<TH1D>("h_d0BS", "Track d_{0}(BS);d_{0}(BS) [cm];tracks", 100, -100., 100.);
+      hdzBS = book<TH1D>("h_dzBS", "Track d_{z}(BS);d_{z}(BS) [cm];tracks", 100, -100., 100.);
+      hdxyPV = book<TH1D>("h_dxyPV", "Track d_{xy}(PV); d_{xy}(PV) [cm];tracks", 100, -100., 100.);
+      hd0PV = book<TH1D>("h_d0PV", "Track d_{0}(PV); d_{0}(PV) [cm];tracks", 100, -100., 100.);
+      hdzPV = book<TH1D>("h_dzPV", "Track d_{z}(PV); d_{z}(PV) [cm];tracks", 100, -100., 100.);
 
-      hnhTIB = fs->make<TH1D>("h_nHitTIB", "nhTIB;# hits in TIB; tracks", 30, 0., 30.);
-      hnhTID = fs->make<TH1D>("h_nHitTID", "nhTID;# hits in TID; tracks", 30, 0., 30.);
-      hnhTOB = fs->make<TH1D>("h_nHitTOB", "nhTOB;# hits in TOB; tracks", 30, 0., 30.);
-      hnhTEC = fs->make<TH1D>("h_nHitTEC", "nhTEC;# hits in TEC; tracks", 30, 0., 30.);
+      hnhTIB = book<TH1D>("h_nHitTIB", "nhTIB;# hits in TIB; tracks", 30, 0., 30.);
+      hnhTID = book<TH1D>("h_nHitTID", "nhTID;# hits in TID; tracks", 30, 0., 30.);
+      hnhTOB = book<TH1D>("h_nHitTOB", "nhTOB;# hits in TOB; tracks", 30, 0., 30.);
+      hnhTEC = book<TH1D>("h_nHitTEC", "nhTEC;# hits in TEC; tracks", 30, 0., 30.);
     }
 
-    hnhpxb = fs->make<TH1D>("h_nHitPXB", "nhpxb;# hits in Pixel Barrel; tracks", 10, 0., 10.);
-    hnhpxe = fs->make<TH1D>("h_nHitPXE", "nhpxe;# hits in Pixel Endcap; tracks", 10, 0., 10.);
+    hnhpxb = book<TH1D>("h_nHitPXB", "nhpxb;# hits in Pixel Barrel; tracks", 10, 0., 10.);
+    hnhpxe = book<TH1D>("h_nHitPXE", "nhpxe;# hits in Pixel Endcap; tracks", 10, 0., 10.);
 
-    hHitComposition = fs->make<TH1D>("h_hitcomposition", "track hit composition;;# hits", 6, -0.5, 5.5);
-    pNBpixHitsVsVx = fs->make<TProfile>("p_NpixHits_vs_Vx", "n. Barrel Pixel hits vs. v_{x};v_{x} (cm);n. BPix hits", 20, -20, 20);
-    pNBpixHitsVsVy = fs->make<TProfile>("p_NpixHits_vs_Vy", "n. Barrel Pixel hits vs. v_{y};v_{y} (cm);n. BPix hits", 20, -20, 20);
-    pNBpixHitsVsVz = fs->make<TProfile>("p_NpixHits_vs_Vz", "n. Barrel Pixel hits vs. v_{z};v_{z} (cm);n. BPix hits", 20, -100, 100);
+    hHitComposition = book<TH1D>("h_hitcomposition", "track hit composition;;# hits", 6, -0.5, 5.5);
+    pNBpixHitsVsVx = book<TProfile>("p_NpixHits_vs_Vx", "n. Barrel Pixel hits vs. v_{x};v_{x} (cm);n. BPix hits", 20, -20, 20);
+    pNBpixHitsVsVy = book<TProfile>("p_NpixHits_vs_Vy", "n. Barrel Pixel hits vs. v_{y};v_{y} (cm);n. BPix hits", 20, -20, 20);
+    pNBpixHitsVsVz = book<TProfile>("p_NpixHits_vs_Vz", "n. Barrel Pixel hits vs. v_{z};v_{z} (cm);n. BPix hits", 20, -100, 100);
 
     std::string dets[6] = {"PXB", "PXF", "TIB", "TID", "TOB", "TEC"};
     for (int i = 1; i <= hHitComposition->GetNbinsX(); i++) {
       hHitComposition->GetXaxis()->SetBinLabel(i, dets[i - 1].c_str());
     }
 
-    vTrackHistos_.push_back(fs->make<TH1F>("h_tracketa", "Track #eta;#eta_{Track};Number of Tracks", 90, -3., 3.));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_trackphi", "Track #phi;#phi_{Track};Number of Tracks", 90, -M_PI, M_PI));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_trackNumberOfValidHits", "Track # of valid hits;# of valid hits _{Track};Number of Tracks", 40, 0., 40.));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_trackNumberOfLostHits", "Track # of lost hits;# of lost hits _{Track};Number of Tracks", 10, 0., 10.));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_curvature", "Curvature #kappa;#kappa_{Track};Number of Tracks", 100, -.05, .05));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_curvature_pos", "Curvature |#kappa| Positive Tracks;|#kappa_{pos Track}|;Number of Tracks", 100, .0, .05));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_curvature_neg", "Curvature |#kappa| Negative Tracks;|#kappa_{neg Track}|;Number of Tracks", 100, .0, .05));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_diff_curvature", "Curvature |#kappa| Tracks Difference;|#kappa_{Track}|;# Pos Tracks - # Neg Tracks", 100,.0,.05));
+    vTrackHistos_.push_back(book<TH1F>("h_tracketa", "Track #eta;#eta_{Track};Number of Tracks", 90, -etaMax_, etaMax_));
+    vTrackHistos_.push_back(book<TH1F>("h_trackphi", "Track #phi;#phi_{Track};Number of Tracks", 90, -M_PI, M_PI));
+    vTrackHistos_.push_back(book<TH1F>("h_trackNumberOfValidHits", "Track # of valid hits;# of valid hits _{Track};Number of Tracks", 40, 0., 40.));
+    vTrackHistos_.push_back(book<TH1F>("h_trackNumberOfLostHits", "Track # of lost hits;# of lost hits _{Track};Number of Tracks", 10, 0., 10.));
+    vTrackHistos_.push_back(book<TH1F>("h_curvature", "Curvature #kappa;#kappa_{Track};Number of Tracks", 100, -.05, .05));
+    vTrackHistos_.push_back(book<TH1F>("h_curvature_pos", "Curvature |#kappa| Positive Tracks;|#kappa_{pos Track}|;Number of Tracks", 100, .0, .05));
+    vTrackHistos_.push_back(book<TH1F>("h_curvature_neg", "Curvature |#kappa| Negative Tracks;|#kappa_{neg Track}|;Number of Tracks", 100, .0, .05));
+    vTrackHistos_.push_back(book<TH1F>("h_diff_curvature", "Curvature |#kappa| Tracks Difference;|#kappa_{Track}|;# Pos Tracks - # Neg Tracks", 100,.0,.05));
 
-    vTrackHistos_.push_back(fs->make<TH1F>("h_chi2", "Track #chi^{2};#chi^{2}_{Track};Number of Tracks", 500, -0.01, 500.));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_chi2Prob", "#chi^{2} probability;Track Prob(#chi^{2},ndof);Number of Tracks", 100, 0.0, 1.));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_normchi2", "#chi^{2}/ndof;#chi^{2}/ndof;Number of Tracks", 100, -0.01, 10.));
+    vTrackHistos_.push_back(book<TH1F>("h_chi2", "Track #chi^{2};#chi^{2}_{Track};Number of Tracks", 500, -0.01, 500.));
+    vTrackHistos_.push_back(book<TH1F>("h_chi2Prob", "#chi^{2} probability;Track Prob(#chi^{2},ndof);Number of Tracks", 100, 0.0, 1.));
+    vTrackHistos_.push_back(book<TH1F>("h_normchi2", "#chi^{2}/ndof;#chi^{2}/ndof;Number of Tracks", 100, -0.01, 10.));
 
     //variable binning for chi2/ndof vs. pT
     double xBins[19] = {0., 0.15, 0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 7., 10., 15., 25., 40., 100., 200.};
-    vTrackHistos_.push_back(fs->make<TH1F>("h_pt", "Track p_{T};p_{T}^{track} [GeV];Number of Tracks", 250, 0., 250));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_ptrebin", "Track p_{T};p_{T}^{track} [GeV];Number of Tracks", 18, xBins));
+    vTrackHistos_.push_back(book<TH1F>("h_pt", "Track p_{T};p_{T}^{track} [GeV];Number of Tracks", 250, 0., 250));
+    vTrackHistos_.push_back(book<TH1F>("h_ptrebin", "Track p_{T};p_{T}^{track} [GeV];Number of Tracks", 18, xBins));
 
-    vTrackHistos_.push_back(fs->make<TH1F>("h_ptResolution", "#delta_{p_{T}}/p_{T}^{track};#delta_{p_{T}}/p_{T}^{track};Number of Tracks", 100, 0., 0.5));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_d0_vs_phi", "Transverse Impact Parameter vs. #phi;#phi_{Track};#LT d_{0} #GT [cm]", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_dz_vs_phi", "Longitudinal Impact Parameter vs. #phi;#phi_{Track};#LT d_{z} #GT [cm]", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_d0_vs_eta", "Transverse Impact Parameter vs. #eta;#eta_{Track};#LT d_{0} #GT [cm]", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_dz_vs_eta", "Longitudinal Impact Parameter vs. #eta;#eta_{Track};#LT d_{z} #GT [cm]", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_chi2_vs_phi", "#chi^{2} vs. #phi;#phi_{Track};#LT #chi^{2} #GT", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_chi2Prob_vs_phi","#chi^{2} probablility vs. #phi;#phi_{Track};#LT #chi^{2} probability#GT",100,-M_PI,M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_chi2Prob_vs_d0", "#chi^{2} probablility vs. |d_{0}|;|d_{0}|[cm];#LT #chi^{2} probability#GT", 100, 0, 80));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_chi2Prob_vs_dz", "#chi^{2} probablility vs. dz;d_{z} [cm];#LT #chi^{2} probability#GT", 100, -30, 30));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_normchi2_vs_phi", "#chi^{2}/ndof vs. #phi;#phi_{Track};#LT #chi^{2}/ndof #GT", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_chi2_vs_eta", "#chi^{2} vs. #eta;#eta_{Track};#LT #chi^{2} #GT", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_normchi2_vs_pt", "norm #chi^{2} vs. p_{T}_{Track}; p_{T}_{Track};#LT #chi^{2}/ndof #GT", 18, xBins));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_normchi2_vs_p", "#chi^{2}/ndof vs. p_{Track};p_{Track};#LT #chi^{2}/ndof #GT", 18, xBins));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_chi2Prob_vs_eta","#chi^{2} probability vs. #eta;#eta_{Track};#LT #chi^{2} probability #GT",100,-M_PI,M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_normchi2_vs_eta", "#chi^{2}/ndof vs. #eta;#eta_{Track};#LT #chi^{2}/ndof #GT", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_kappa_vs_phi", "#kappa vs. #phi;#phi_{Track};#kappa", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_kappa_vs_eta", "#kappa vs. #eta;#eta_{Track};#kappa", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_ptResolution_vs_phi","#delta_{p_{T}}/p_{T}^{track};#phi^{track};#delta_{p_{T}}/p_{T}^{track}",100,-M_PI,M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>("p_ptResolution_vs_eta","#delta_{p_{T}}/p_{T}^{track};#eta^{track};#delta_{p_{T}}/p_{T}^{track}",100,-M_PI,M_PI));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_d0_vs_phi","Transverse Impact Parameter vs. #phi;#phi_{Track};d_{0} [cm]", 100, -M_PI, M_PI, 100, -1., 1.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_dz_vs_phi","Longitudinal Impact Parameter vs. #phi;#phi_{Track};d_{z} [cm]",100,-M_PI,M_PI,100,-100.,100.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_d0_vs_eta","Transverse Impact Parameter vs. #eta;#eta_{Track};d_{0} [cm]", 100, -M_PI, M_PI, 100, -1., 1.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_dz_vs_eta","Longitudinal Impact Parameter vs. #eta;#eta_{Track};d_{z} [cm]",100,-M_PI,M_PI, 100,-100.,100.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_chi2_vs_phi", "#chi^{2} vs. #phi;#phi_{Track};#chi^{2}", 100, -M_PI, M_PI, 500, 0., 500.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_chi2Prob_vs_phi","#chi^{2} probability vs. #phi;#phi_{Track};#chi^{2} probability",100,-M_PI,M_PI,100,0.,1.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_chi2Prob_vs_d0","#chi^{2} probability vs. |d_{0}|;|d_{0}| [cm];#chi^{2} probability",100,0,80,100,0.,1.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_normchi2_vs_phi", "#chi^{2}/ndof vs. #phi;#phi_{Track};#chi^{2}/ndof", 100, -M_PI, M_PI, 100, 0., 10.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_chi2_vs_eta", "#chi^{2} vs. #eta;#eta_{Track};#chi^{2}", 100, -M_PI, M_PI, 500, 0., 500.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_chi2Prob_vs_eta","#chi^{2} probaility vs. #eta;#eta_{Track};#chi^{2} probability",100,-M_PI,M_PI,100,0.,1.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_normchi2_vs_eta", "#chi^{2}/ndof vs. #eta;#eta_{Track};#chi^{2}/ndof", 100, -M_PI, M_PI, 100, 0., 10.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_kappa_vs_phi", "#kappa vs. #phi;#phi_{Track};#kappa", 100, -M_PI, M_PI, 100, .0, .05));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_kappa_vs_eta", "#kappa vs. #eta;#eta_{Track};#kappa", 100, -M_PI, M_PI, 100, .0, .05));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_normchi2_vs_kappa", "#kappa vs. #chi^{2}/ndof;#chi^{2}/ndof;#kappa", 100, 0., 10, 100, -.03, .03));
+    vTrackHistos_.push_back(book<TH1F>("h_ptResolution", "#delta_{p_{T}}/p_{T}^{track};#delta_{p_{T}}/p_{T}^{track};Number of Tracks", 100, 0., 0.5));
+    vTrackProfiles_.push_back(book<TProfile>("p_d0_vs_phi", "Transverse Impact Parameter vs. #phi;#phi_{Track};#LT d_{0} #GT [cm]", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_dz_vs_phi", "Longitudinal Impact Parameter vs. #phi;#phi_{Track};#LT d_{z} #GT [cm]", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_d0_vs_eta", "Transverse Impact Parameter vs. #eta;#eta_{Track};#LT d_{0} #GT [cm]", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_dz_vs_eta", "Longitudinal Impact Parameter vs. #eta;#eta_{Track};#LT d_{z} #GT [cm]", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2_vs_phi", "#chi^{2} vs. #phi;#phi_{Track};#LT #chi^{2} #GT", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2Prob_vs_phi","#chi^{2} probablility vs. #phi;#phi_{Track};#LT #chi^{2} probability#GT",100,-M_PI,M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2Prob_vs_d0", "#chi^{2} probablility vs. |d_{0}|;|d_{0}|[cm];#LT #chi^{2} probability#GT", 100, 0, 80));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2Prob_vs_dz", "#chi^{2} probablility vs. dz;d_{z} [cm];#LT #chi^{2} probability#GT", 100, -30, 30));
+    vTrackProfiles_.push_back(book<TProfile>("p_normchi2_vs_phi", "#chi^{2}/ndof vs. #phi;#phi_{Track};#LT #chi^{2}/ndof #GT", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2_vs_eta", "#chi^{2} vs. #eta;#eta_{Track};#LT #chi^{2} #GT", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_normchi2_vs_pt", "norm #chi^{2} vs. p_{T}_{Track}; p_{T}_{Track};#LT #chi^{2}/ndof #GT", 18, xBins));
+    vTrackProfiles_.push_back(book<TProfile>("p_normchi2_vs_p", "#chi^{2}/ndof vs. p_{Track};p_{Track};#LT #chi^{2}/ndof #GT", 18, xBins));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2Prob_vs_eta","#chi^{2} probability vs. #eta;#eta_{Track};#LT #chi^{2} probability #GT",100,-etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_normchi2_vs_eta", "#chi^{2}/ndof vs. #eta;#eta_{Track};#LT #chi^{2}/ndof #GT", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_kappa_vs_phi", "#kappa vs. #phi;#phi_{Track};#kappa", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_kappa_vs_eta", "#kappa vs. #eta;#eta_{Track};#kappa", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_ptResolution_vs_phi","#delta_{p_{T}}/p_{T}^{track};#phi^{track};#delta_{p_{T}}/p_{T}^{track}", 100,-M_PI,M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_ptResolution_vs_eta","#delta_{p_{T}}/p_{T}^{track};#eta^{track};#delta_{p_{T}}/p_{T}^{track}", 100, -etaMax_, etaMax_));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_d0_vs_phi","Transverse Impact Parameter vs. #phi;#phi_{Track};d_{0} [cm]", 100, -M_PI, M_PI, 100, -1., 1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_phi_vs_eta", "Track #phi vs. #eta;#eta_{Track};#phi_{Track}",50, -etaMax_, etaMax_, 50, -M_PI, M_PI));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_dz_vs_phi","Longitudinal Impact Parameter vs. #phi;#phi_{Track};d_{z} [cm]",100,-M_PI,M_PI,100,-100.,100.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_d0_vs_eta","Transverse Impact Parameter vs. #eta;#eta_{Track};d_{0} [cm]", 100, -etaMax_, etaMax_, 100, -1., 1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_dz_vs_eta","Longitudinal Impact Parameter vs. #eta;#eta_{Track};d_{z} [cm]",100, -etaMax_, etaMax_, 100,-100.,100.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2_vs_phi", "#chi^{2} vs. #phi;#phi_{Track};#chi^{2}", 100, -M_PI, M_PI, 500, 0., 500.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2Prob_vs_phi","#chi^{2} probability vs. #phi;#phi_{Track};#chi^{2} probability",100,-M_PI,M_PI,100,0.,1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2Prob_vs_d0","#chi^{2} probability vs. |d_{0}|;|d_{0}| [cm];#chi^{2} probability",100,0,80,100,0.,1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_normchi2_vs_phi", "#chi^{2}/ndof vs. #phi;#phi_{Track};#chi^{2}/ndof", 100, -M_PI, M_PI, 100, 0., 10.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2_vs_eta", "#chi^{2} vs. #eta;#eta_{Track};#chi^{2}", 100, -etaMax_, etaMax_, 500, 0., 500.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2Prob_vs_eta","#chi^{2} probaility vs. #eta;#eta_{Track};#chi^{2} probability",100,-M_PI,M_PI,100,0.,1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_normchi2_vs_eta", "#chi^{2}/ndof vs. #eta;#eta_{Track};#chi^{2}/ndof", 100, -etaMax_, etaMax_, 100, 0., 10.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_kappa_vs_phi", "#kappa vs. #phi;#phi_{Track};#kappa", 100, -M_PI, M_PI, 100, .0, .05));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_kappa_vs_eta", "#kappa vs. #eta;#eta_{Track};#kappa", 100, -etaMax_, etaMax_, 100, .0, .05));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_normchi2_vs_kappa", "#kappa vs. #chi^{2}/ndof;#chi^{2}/ndof;#kappa", 100, 0., 10, 100, -.03, .03));
 
     // clang-format on
 
@@ -1375,10 +1399,10 @@ private:
     edm::LogPrint("DMRChecker") << "firing triggers: " << nFiringTriggers << std::endl;
     edm::LogPrint("DMRChecker") << "*******************************" << std::endl;
 
-    tksByTrigger_ = fs->make<TH1D>(
-        "tksByTrigger", "tracks by HLT path;;% of # traks", nFiringTriggers, -0.5, nFiringTriggers - 0.5);
-    evtsByTrigger_ = fs->make<TH1D>(
-        "evtsByTrigger", "events by HLT path;;% of # events", nFiringTriggers, -0.5, nFiringTriggers - 0.5);
+    tksByTrigger_ =
+        book<TH1D>("tksByTrigger", "tracks by HLT path;;% of # traks", nFiringTriggers, -0.5, nFiringTriggers - 0.5);
+    evtsByTrigger_ =
+        book<TH1D>("evtsByTrigger", "events by HLT path;;% of # events", nFiringTriggers, -0.5, nFiringTriggers - 0.5);
 
     if (DEBUG)
       edm::LogPrint("DMRChecker") << __FILE__ << "@" << __FUNCTION__ << " L-" << __LINE__ << std::endl;
@@ -1425,46 +1449,46 @@ private:
     edm::LogPrint("DMRChecker") << "considered runs: " << nRuns << std::endl;
     edm::LogPrint("DMRChecker") << "*******************************" << std::endl;
 
-    modeByRun_ = fs->make<TH1D>("modeByRun",
-                                "Strip APV mode by run number;;APV mode (-1=deco,+1=peak)",
-                                runRange,
-                                theRuns_.front() - 0.5,
-                                theRuns_.back() + 0.5);
-    fieldByRun_ = fs->make<TH1D>("fieldByRun",
-                                 "CMS B-field intensity by run number;;B-field intensity [T]",
-                                 runRange,
-                                 theRuns_.front() - 0.5,
-                                 theRuns_.back() + 0.5);
+    modeByRun_ = book<TH1D>("modeByRun",
+                            "Strip APV mode by run number;;APV mode (-1=deco,+1=peak)",
+                            runRange,
+                            theRuns_.front() - 0.5,
+                            theRuns_.back() + 0.5);
+    fieldByRun_ = book<TH1D>("fieldByRun",
+                             "CMS B-field intensity by run number;;B-field intensity [T]",
+                             runRange,
+                             theRuns_.front() - 0.5,
+                             theRuns_.back() + 0.5);
 
-    tracksByRun_ = fs->make<TH1D>("tracksByRun",
-                                  "n. AlCaReco Tracks by run number;;n. of tracks",
+    tracksByRun_ = book<TH1D>("tracksByRun",
+                              "n. AlCaReco Tracks by run number;;n. of tracks",
+                              runRange,
+                              theRuns_.front() - 0.5,
+                              theRuns_.back() + 0.5);
+    hitsByRun_ = book<TH1D>(
+        "histByRun", "n. of hits by run number;;n. of hits", runRange, theRuns_.front() - 0.5, theRuns_.back() + 0.5);
+
+    trackRatesByRun_ = book<TH1D>("trackRatesByRun",
+                                  "rate of AlCaReco Tracks by run number;;n. of tracks/s",
                                   runRange,
                                   theRuns_.front() - 0.5,
                                   theRuns_.back() + 0.5);
-    hitsByRun_ = fs->make<TH1D>(
-        "histByRun", "n. of hits by run number;;n. of hits", runRange, theRuns_.front() - 0.5, theRuns_.back() + 0.5);
+    eventRatesByRun_ = book<TH1D>("eventRatesByRun",
+                                  "rate of AlCaReco Events by run number;;n. of events/s",
+                                  runRange,
+                                  theRuns_.front() - 0.5,
+                                  theRuns_.back() + 0.5);
 
-    trackRatesByRun_ = fs->make<TH1D>("trackRatesByRun",
-                                      "rate of AlCaReco Tracks by run number;;n. of tracks/s",
-                                      runRange,
-                                      theRuns_.front() - 0.5,
-                                      theRuns_.back() + 0.5);
-    eventRatesByRun_ = fs->make<TH1D>("eventRatesByRun",
-                                      "rate of AlCaReco Events by run number;;n. of events/s",
-                                      runRange,
-                                      theRuns_.front() - 0.5,
-                                      theRuns_.back() + 0.5);
-
-    hitsinBPixByRun_ = fs->make<TH1D>("histinBPixByRun",
-                                      "n. of hits in BPix by run number;;n. of BPix hits",
-                                      runRange,
-                                      theRuns_.front() - 0.5,
-                                      theRuns_.back() + 0.5);
-    hitsinFPixByRun_ = fs->make<TH1D>("histinFPixByRun",
-                                      "n. of hits in FPix by run number;;n. of FPix hits",
-                                      runRange,
-                                      theRuns_.front() - 0.5,
-                                      theRuns_.back() + 0.5);
+    hitsinBPixByRun_ = book<TH1D>("histinBPixByRun",
+                                  "n. of hits in BPix by run number;;n. of BPix hits",
+                                  runRange,
+                                  theRuns_.front() - 0.5,
+                                  theRuns_.back() + 0.5);
+    hitsinFPixByRun_ = book<TH1D>("histinFPixByRun",
+                                  "n. of hits in FPix by run number;;n. of FPix hits",
+                                  runRange,
+                                  theRuns_.front() - 0.5,
+                                  theRuns_.back() + 0.5);
 
     for (const auto &the_r : theRuns_) {
       if (conditionsMap_.find(the_r)->second.first != 0) {

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -699,6 +699,10 @@ private:
   void beginRun(edm::Run const &run, edm::EventSetup const &setup) override
   //*************************************************************
   {
+    // initialize runInfoMap_
+    runInfoMap_[run.run()].first = 0;
+    runInfoMap_[run.run()].second = 0;
+
     // Magnetic Field setup
     magneticField_ = setup.getHandle(magFieldToken_);
     float B_ = magneticField_.product()->inTesla(GlobalPoint(0, 0, 0)).mag();
@@ -709,7 +713,7 @@ private:
     }
 
     //SiStrip Latency
-    edm::ESHandle<SiStripLatency> apvlat = setup.getHandle(latencyToken_);
+    const SiStripLatency *apvlat = &setup.getData(latencyToken_);
     if (apvlat->singleReadOutMode() == 1) {
       mode = 1;  // peak mode
     } else if (apvlat->singleReadOutMode() == 0) {

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -131,15 +131,21 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions &);
 
   template <class OBJECT_TYPE>
-  int GetIndex(const std::vector<OBJECT_TYPE *> &vec, const TString &name) {
+  int index(const std::vector<OBJECT_TYPE *> &vec, const TString &name) {
     for (const auto &iter : vec | boost::adaptors::indexed(0)) {
       if (iter.value() && iter.value()->GetName() == name) {
         return iter.index();
       }
     }
-    edm::LogError("GeneralPurposeTrackAnalyzer") << "@SUB=GeneralPurposeTrackAnalyzer::GetIndex"
+    edm::LogError("GeneralPurposeTrackAnalyzer") << "@SUB=GeneralPurposeTrackAnalyzer::index"
                                                  << " could not find " << name;
     return -1;
+  }
+
+  template <typename T, typename... Args>
+  T *book(const Args &...args) const {
+    T *t = fs->make<T>(args...);
+    return t;
   }
 
 private:
@@ -529,111 +535,113 @@ private:
       }
 
       // Fill 1D track histos
-      static const int etaindex = this->GetIndex(vTrackHistos_, "h_tracketa");
+      static const int etaindex = this->index(vTrackHistos_, "h_tracketa");
       vTrackHistos_[etaindex]->Fill(track->eta());
-      static const int phiindex = this->GetIndex(vTrackHistos_, "h_trackphi");
+      static const int phiindex = this->index(vTrackHistos_, "h_trackphi");
       vTrackHistos_[phiindex]->Fill(track->phi());
-      static const int numOfValidHitsindex = this->GetIndex(vTrackHistos_, "h_trackNumberOfValidHits");
+      static const int numOfValidHitsindex = this->index(vTrackHistos_, "h_trackNumberOfValidHits");
       vTrackHistos_[numOfValidHitsindex]->Fill(track->numberOfValidHits());
-      static const int numOfLostHitsindex = this->GetIndex(vTrackHistos_, "h_trackNumberOfLostHits");
+      static const int numOfLostHitsindex = this->index(vTrackHistos_, "h_trackNumberOfLostHits");
       vTrackHistos_[numOfLostHitsindex]->Fill(track->numberOfLostHits());
 
       GlobalPoint gPoint(track->vx(), track->vy(), track->vz());
       double theLocalMagFieldInInverseGeV = magneticField_->inInverseGeV(gPoint).z();
       double kappa = -track->charge() * theLocalMagFieldInInverseGeV / track->pt();
 
-      static const int kappaindex = this->GetIndex(vTrackHistos_, "h_curvature");
+      static const int kappaindex = this->index(vTrackHistos_, "h_curvature");
       vTrackHistos_[kappaindex]->Fill(kappa);
-      static const int kappaposindex = this->GetIndex(vTrackHistos_, "h_curvature_pos");
+      static const int kappaposindex = this->index(vTrackHistos_, "h_curvature_pos");
       if (track->charge() > 0)
         vTrackHistos_[kappaposindex]->Fill(fabs(kappa));
-      static const int kappanegindex = this->GetIndex(vTrackHistos_, "h_curvature_neg");
+      static const int kappanegindex = this->index(vTrackHistos_, "h_curvature_neg");
       if (track->charge() < 0)
         vTrackHistos_[kappanegindex]->Fill(fabs(kappa));
 
       double chi2Prob = TMath::Prob(track->chi2(), track->ndof());
       double normchi2 = track->normalizedChi2();
 
-      static const int normchi2index = this->GetIndex(vTrackHistos_, "h_normchi2");
+      static const int normchi2index = this->index(vTrackHistos_, "h_normchi2");
       vTrackHistos_[normchi2index]->Fill(normchi2);
-      static const int chi2index = this->GetIndex(vTrackHistos_, "h_chi2");
+      static const int chi2index = this->index(vTrackHistos_, "h_chi2");
       vTrackHistos_[chi2index]->Fill(track->chi2());
-      static const int chi2Probindex = this->GetIndex(vTrackHistos_, "h_chi2Prob");
+      static const int chi2Probindex = this->index(vTrackHistos_, "h_chi2Prob");
       vTrackHistos_[chi2Probindex]->Fill(chi2Prob);
-      static const int ptindex = this->GetIndex(vTrackHistos_, "h_pt");
-      static const int pt2index = this->GetIndex(vTrackHistos_, "h_ptrebin");
+      static const int ptindex = this->index(vTrackHistos_, "h_pt");
+      static const int pt2index = this->index(vTrackHistos_, "h_ptrebin");
       vTrackHistos_[ptindex]->Fill(track->pt());
       vTrackHistos_[pt2index]->Fill(track->pt());
       if (track->ptError() != 0.) {
-        static const int ptResolutionindex = this->GetIndex(vTrackHistos_, "h_ptResolution");
+        static const int ptResolutionindex = this->index(vTrackHistos_, "h_ptResolution");
         vTrackHistos_[ptResolutionindex]->Fill(track->ptError() / track->pt());
       }
       // Fill track profiles
-      static const int d0phiindex = this->GetIndex(vTrackProfiles_, "p_d0_vs_phi");
+      static const int d0phiindex = this->index(vTrackProfiles_, "p_d0_vs_phi");
       vTrackProfiles_[d0phiindex]->Fill(track->phi(), track->d0());
-      static const int dzphiindex = this->GetIndex(vTrackProfiles_, "p_dz_vs_phi");
+      static const int dzphiindex = this->index(vTrackProfiles_, "p_dz_vs_phi");
       vTrackProfiles_[dzphiindex]->Fill(track->phi(), track->dz());
-      static const int d0etaindex = this->GetIndex(vTrackProfiles_, "p_d0_vs_eta");
+      static const int d0etaindex = this->index(vTrackProfiles_, "p_d0_vs_eta");
       vTrackProfiles_[d0etaindex]->Fill(track->eta(), track->d0());
-      static const int dzetaindex = this->GetIndex(vTrackProfiles_, "p_dz_vs_eta");
+      static const int dzetaindex = this->index(vTrackProfiles_, "p_dz_vs_eta");
       vTrackProfiles_[dzetaindex]->Fill(track->eta(), track->dz());
-      static const int chiProbphiindex = this->GetIndex(vTrackProfiles_, "p_chi2Prob_vs_phi");
+      static const int chiProbphiindex = this->index(vTrackProfiles_, "p_chi2Prob_vs_phi");
       vTrackProfiles_[chiProbphiindex]->Fill(track->phi(), chi2Prob);
-      static const int chiProbabsd0index = this->GetIndex(vTrackProfiles_, "p_chi2Prob_vs_d0");
+      static const int chiProbabsd0index = this->index(vTrackProfiles_, "p_chi2Prob_vs_d0");
       vTrackProfiles_[chiProbabsd0index]->Fill(fabs(track->d0()), chi2Prob);
-      static const int chiProbabsdzindex = this->GetIndex(vTrackProfiles_, "p_chi2Prob_vs_dz");
+      static const int chiProbabsdzindex = this->index(vTrackProfiles_, "p_chi2Prob_vs_dz");
       vTrackProfiles_[chiProbabsdzindex]->Fill(track->dz(), chi2Prob);
-      static const int chiphiindex = this->GetIndex(vTrackProfiles_, "p_chi2_vs_phi");
+      static const int chiphiindex = this->index(vTrackProfiles_, "p_chi2_vs_phi");
       vTrackProfiles_[chiphiindex]->Fill(track->phi(), track->chi2());
-      static const int normchiphiindex = this->GetIndex(vTrackProfiles_, "p_normchi2_vs_phi");
+      static const int normchiphiindex = this->index(vTrackProfiles_, "p_normchi2_vs_phi");
       vTrackProfiles_[normchiphiindex]->Fill(track->phi(), normchi2);
-      static const int chietaindex = this->GetIndex(vTrackProfiles_, "p_chi2_vs_eta");
+      static const int chietaindex = this->index(vTrackProfiles_, "p_chi2_vs_eta");
       vTrackProfiles_[chietaindex]->Fill(track->eta(), track->chi2());
-      static const int normchiptindex = this->GetIndex(vTrackProfiles_, "p_normchi2_vs_pt");
+      static const int normchiptindex = this->index(vTrackProfiles_, "p_normchi2_vs_pt");
       vTrackProfiles_[normchiptindex]->Fill(track->pt(), normchi2);
-      static const int normchipindex = this->GetIndex(vTrackProfiles_, "p_normchi2_vs_p");
+      static const int normchipindex = this->index(vTrackProfiles_, "p_normchi2_vs_p");
       vTrackProfiles_[normchipindex]->Fill(track->p(), normchi2);
-      static const int chiProbetaindex = this->GetIndex(vTrackProfiles_, "p_chi2Prob_vs_eta");
+      static const int chiProbetaindex = this->index(vTrackProfiles_, "p_chi2Prob_vs_eta");
       vTrackProfiles_[chiProbetaindex]->Fill(track->eta(), chi2Prob);
-      static const int normchietaindex = this->GetIndex(vTrackProfiles_, "p_normchi2_vs_eta");
+      static const int normchietaindex = this->index(vTrackProfiles_, "p_normchi2_vs_eta");
       vTrackProfiles_[normchietaindex]->Fill(track->eta(), normchi2);
-      static const int kappaphiindex = this->GetIndex(vTrackProfiles_, "p_kappa_vs_phi");
+      static const int kappaphiindex = this->index(vTrackProfiles_, "p_kappa_vs_phi");
       vTrackProfiles_[kappaphiindex]->Fill(track->phi(), kappa);
-      static const int kappaetaindex = this->GetIndex(vTrackProfiles_, "p_kappa_vs_eta");
+      static const int kappaetaindex = this->index(vTrackProfiles_, "p_kappa_vs_eta");
       vTrackProfiles_[kappaetaindex]->Fill(track->eta(), kappa);
-      static const int ptResphiindex = this->GetIndex(vTrackProfiles_, "p_ptResolution_vs_phi");
+      static const int ptResphiindex = this->index(vTrackProfiles_, "p_ptResolution_vs_phi");
       vTrackProfiles_[ptResphiindex]->Fill(track->phi(), track->ptError() / track->pt());
-      static const int ptResetaindex = this->GetIndex(vTrackProfiles_, "p_ptResolution_vs_eta");
+      static const int ptResetaindex = this->index(vTrackProfiles_, "p_ptResolution_vs_eta");
       vTrackProfiles_[ptResetaindex]->Fill(track->eta(), track->ptError() / track->pt());
 
       // Fill 2D track histos
-      static const int d0phiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_d0_vs_phi");
+      static const int etaphiindex_2d = this->index(vTrack2DHistos_, "h2_phi_vs_eta");
+      vTrack2DHistos_[etaphiindex_2d]->Fill(track->eta(), track->phi());
+      static const int d0phiindex_2d = this->index(vTrack2DHistos_, "h2_d0_vs_phi");
       vTrack2DHistos_[d0phiindex_2d]->Fill(track->phi(), track->d0());
-      static const int dzphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_dz_vs_phi");
+      static const int dzphiindex_2d = this->index(vTrack2DHistos_, "h2_dz_vs_phi");
       vTrack2DHistos_[dzphiindex_2d]->Fill(track->phi(), track->dz());
-      static const int d0etaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_d0_vs_eta");
+      static const int d0etaindex_2d = this->index(vTrack2DHistos_, "h2_d0_vs_eta");
       vTrack2DHistos_[d0etaindex_2d]->Fill(track->eta(), track->d0());
-      static const int dzetaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_dz_vs_eta");
+      static const int dzetaindex_2d = this->index(vTrack2DHistos_, "h2_dz_vs_eta");
       vTrack2DHistos_[dzetaindex_2d]->Fill(track->eta(), track->dz());
-      static const int chiphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2_vs_phi");
+      static const int chiphiindex_2d = this->index(vTrack2DHistos_, "h2_chi2_vs_phi");
       vTrack2DHistos_[chiphiindex_2d]->Fill(track->phi(), track->chi2());
-      static const int chiProbphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2Prob_vs_phi");
+      static const int chiProbphiindex_2d = this->index(vTrack2DHistos_, "h2_chi2Prob_vs_phi");
       vTrack2DHistos_[chiProbphiindex_2d]->Fill(track->phi(), chi2Prob);
-      static const int chiProbabsd0index_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2Prob_vs_d0");
+      static const int chiProbabsd0index_2d = this->index(vTrack2DHistos_, "h2_chi2Prob_vs_d0");
       vTrack2DHistos_[chiProbabsd0index_2d]->Fill(fabs(track->d0()), chi2Prob);
-      static const int normchiphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_normchi2_vs_phi");
+      static const int normchiphiindex_2d = this->index(vTrack2DHistos_, "h2_normchi2_vs_phi");
       vTrack2DHistos_[normchiphiindex_2d]->Fill(track->phi(), normchi2);
-      static const int chietaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2_vs_eta");
+      static const int chietaindex_2d = this->index(vTrack2DHistos_, "h2_chi2_vs_eta");
       vTrack2DHistos_[chietaindex_2d]->Fill(track->eta(), track->chi2());
-      static const int chiProbetaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_chi2Prob_vs_eta");
+      static const int chiProbetaindex_2d = this->index(vTrack2DHistos_, "h2_chi2Prob_vs_eta");
       vTrack2DHistos_[chiProbetaindex_2d]->Fill(track->eta(), chi2Prob);
-      static const int normchietaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_normchi2_vs_eta");
+      static const int normchietaindex_2d = this->index(vTrack2DHistos_, "h2_normchi2_vs_eta");
       vTrack2DHistos_[normchietaindex_2d]->Fill(track->eta(), normchi2);
-      static const int kappaphiindex_2d = this->GetIndex(vTrack2DHistos_, "h2_kappa_vs_phi");
+      static const int kappaphiindex_2d = this->index(vTrack2DHistos_, "h2_kappa_vs_phi");
       vTrack2DHistos_[kappaphiindex_2d]->Fill(track->phi(), kappa);
-      static const int kappaetaindex_2d = this->GetIndex(vTrack2DHistos_, "h2_kappa_vs_eta");
+      static const int kappaetaindex_2d = this->index(vTrack2DHistos_, "h2_kappa_vs_eta");
       vTrack2DHistos_[kappaetaindex_2d]->Fill(track->eta(), kappa);
-      static const int normchi2kappa_2d = this->GetIndex(vTrack2DHistos_, "h2_normchi2_vs_kappa");
+      static const int normchi2kappa_2d = this->index(vTrack2DHistos_, "h2_normchi2_vs_kappa");
       vTrack2DHistos_[normchi2kappa_2d]->Fill(normchi2, kappa);
 
       //dxy with respect to the beamspot
@@ -752,155 +760,152 @@ private:
     ievt = 0;
     itrks = 0;
 
-    hrun = fs->make<TH1D>("h_run", "run", 100000, 230000, 240000);
-    hlumi = fs->make<TH1D>("h_lumi", "lumi", 1000, 0, 1000);
+    hrun = book<TH1D>("h_run", "run", 100000, 230000, 240000);
+    hlumi = book<TH1D>("h_lumi", "lumi", 1000, 0, 1000);
 
-    hchi2ndof = fs->make<TH1D>("h_chi2ndof", "chi2/ndf;#chi^{2}/ndf;tracks", 100, 0, 5.);
-    hCharge = fs->make<TH1D>("h_charge", "charge;Charge of the track;tracks", 5, -2.5, 2.5);
-    hNtrk = fs->make<TH1D>("h_Ntrk", "ntracks;Number of Tracks;events", 200, 0., 200.);
-    hNtrkZoom = fs->make<TH1D>("h_NtrkZoom", "Number of tracks; number of tracks;events", 10, 0., 10.);
+    hchi2ndof = book<TH1D>("h_chi2ndof", "chi2/ndf;#chi^{2}/ndf;tracks", 100, 0, 5.);
+    hCharge = book<TH1D>("h_charge", "charge;Charge of the track;tracks", 5, -2.5, 2.5);
+    hNtrk = book<TH1D>("h_Ntrk", "ntracks;Number of Tracks;events", 200, 0., 200.);
+    hNtrkZoom = book<TH1D>("h_NtrkZoom", "Number of tracks; number of tracks;events", 10, 0., 10.);
     hNhighPurity =
-        fs->make<TH1D>("h_NhighPurity", "n. high purity tracks;Number of high purity tracks;events", 200, 0., 200.);
+        book<TH1D>("h_NhighPurity", "n. high purity tracks;Number of high purity tracks;events", 200, 0., 200.);
 
-    htrkAlgo = fs->make<TH1I>("h_trkAlgo",
-                              "tracking step;iterative tracking step;tracks",
-                              reco::TrackBase::algoSize,
-                              0.,
-                              double(reco::TrackBase::algoSize));
+    htrkAlgo = book<TH1I>("h_trkAlgo",
+                          "tracking step;iterative tracking step;tracks",
+                          reco::TrackBase::algoSize,
+                          0.,
+                          double(reco::TrackBase::algoSize));
 
-    htrkOriAlgo = fs->make<TH1I>("h_trkOriAlgo",
-                                 "original tracking step;original iterative tracking step;tracks",
-                                 reco::TrackBase::algoSize,
-                                 0.,
-                                 double(reco::TrackBase::algoSize));
+    htrkOriAlgo = book<TH1I>("h_trkOriAlgo",
+                             "original tracking step;original iterative tracking step;tracks",
+                             reco::TrackBase::algoSize,
+                             0.,
+                             double(reco::TrackBase::algoSize));
 
     for (size_t ibin = 0; ibin < reco::TrackBase::algoSize - 1; ibin++) {
       htrkAlgo->GetXaxis()->SetBinLabel(ibin + 1, (reco::TrackBase::algoNames[ibin]).c_str());
       htrkOriAlgo->GetXaxis()->SetBinLabel(ibin + 1, (reco::TrackBase::algoNames[ibin]).c_str());
     }
 
-    htrkQuality = fs->make<TH1I>("h_trkQuality", "track quality;track quality;tracks", 6, -1, 5);
+    htrkQuality = book<TH1I>("h_trkQuality", "track quality;track quality;tracks", 6, -1, 5);
     std::string qualities[7] = {"undef", "loose", "tight", "highPurity", "confirmed", "goodIterative"};
     for (int nbin = 1; nbin <= htrkQuality->GetNbinsX(); nbin++) {
       htrkQuality->GetXaxis()->SetBinLabel(nbin, (qualities[nbin - 1]).c_str());
     }
 
-    hP = fs->make<TH1D>("h_P", "Momentum;track momentum [GeV];tracks", 100, 0., 100.);
-    hQoverP = fs->make<TH1D>("h_qoverp", "Track q/p; track q/p [GeV^{-1}];tracks", 100, -1., 1.);
-    hQoverPZoom = fs->make<TH1D>("h_qoverpZoom", "Track q/p; track q/p [GeV^{-1}];tracks", 100, -0.1, 0.1);
-    hPt = fs->make<TH1D>("h_Pt", "Transverse Momentum;track p_{T} [GeV];tracks", 100, 0., 100.);
-    hHit = fs->make<TH1D>("h_nHits", "Number of hits;track n. hits;tracks", 50, -0.5, 49.5);
-    hHit2D = fs->make<TH1D>("h_nHit2D", "Number of 2D hits; number of 2D hits;tracks", 20, 0, 20);
+    hP = book<TH1D>("h_P", "Momentum;track momentum [GeV];tracks", 100, 0., 100.);
+    hQoverP = book<TH1D>("h_qoverp", "Track q/p; track q/p [GeV^{-1}];tracks", 100, -1., 1.);
+    hQoverPZoom = book<TH1D>("h_qoverpZoom", "Track q/p; track q/p [GeV^{-1}];tracks", 100, -0.1, 0.1);
+    hPt = book<TH1D>("h_Pt", "Transverse Momentum;track p_{T} [GeV];tracks", 100, 0., 100.);
+    hHit = book<TH1D>("h_nHits", "Number of hits;track n. hits;tracks", 50, -0.5, 49.5);
+    hHit2D = book<TH1D>("h_nHit2D", "Number of 2D hits; number of 2D hits;tracks", 20, 0, 20);
 
-    hHitCountVsZBPix = fs->make<TH1D>("h_HitCountVsZBpix", "Number of BPix hits vs z;hit global z;hits", 60, -30, 30);
-    hHitCountVsZFPix =
-        fs->make<TH1D>("h_HitCountVsZFpix", "Number of FPix hits vs z;hit global z;hits", 100, -100, 100);
+    hHitCountVsZBPix = book<TH1D>("h_HitCountVsZBpix", "Number of BPix hits vs z;hit global z;hits", 60, -30, 30);
+    hHitCountVsZFPix = book<TH1D>("h_HitCountVsZFpix", "Number of FPix hits vs z;hit global z;hits", 100, -100, 100);
 
-    hHitCountVsXBPix = fs->make<TH1D>("h_HitCountVsXBpix", "Number of BPix hits vs x;hit global x;hits", 20, -20, 20);
-    hHitCountVsXFPix = fs->make<TH1D>("h_HitCountVsXFpix", "Number of FPix hits vs x;hit global x;hits", 20, -20, 20);
+    hHitCountVsXBPix = book<TH1D>("h_HitCountVsXBpix", "Number of BPix hits vs x;hit global x;hits", 20, -20, 20);
+    hHitCountVsXFPix = book<TH1D>("h_HitCountVsXFpix", "Number of FPix hits vs x;hit global x;hits", 20, -20, 20);
 
-    hHitCountVsYBPix = fs->make<TH1D>("h_HitCountVsYBpix", "Number of BPix hits vs y;hit global y;hits", 20, -20, 20);
-    hHitCountVsYFPix = fs->make<TH1D>("h_HitCountVsYFpix", "Number of FPix hits vs y;hit global y;hits", 20, -20, 20);
+    hHitCountVsYBPix = book<TH1D>("h_HitCountVsYBpix", "Number of BPix hits vs y;hit global y;hits", 20, -20, 20);
+    hHitCountVsYFPix = book<TH1D>("h_HitCountVsYFpix", "Number of FPix hits vs y;hit global y;hits", 20, -20, 20);
 
     hHitCountVsThetaBPix =
-        fs->make<TH1D>("h_HitCountVsThetaBpix", "Number of BPix hits vs #theta;hit global #theta;hits", 20, 0., M_PI);
+        book<TH1D>("h_HitCountVsThetaBpix", "Number of BPix hits vs #theta;hit global #theta;hits", 20, 0., M_PI);
     hHitCountVsPhiBPix =
-        fs->make<TH1D>("h_HitCountVsPhiBpix", "Number of BPix hits vs #phi;hit global #phi;hits", 20, -M_PI, M_PI);
+        book<TH1D>("h_HitCountVsPhiBpix", "Number of BPix hits vs #phi;hit global #phi;hits", 20, -M_PI, M_PI);
 
     hHitCountVsThetaFPix =
-        fs->make<TH1D>("h_HitCountVsThetaFpix", "Number of FPix hits vs #theta;hit global #theta;hits", 40, 0., M_PI);
+        book<TH1D>("h_HitCountVsThetaFpix", "Number of FPix hits vs #theta;hit global #theta;hits", 40, 0., M_PI);
     hHitCountVsPhiFPix =
-        fs->make<TH1D>("h_HitCountVsPhiFpix", "Number of FPix hits vs #phi;hit global #phi;hits", 20, -M_PI, M_PI);
+        book<TH1D>("h_HitCountVsPhiFpix", "Number of FPix hits vs #phi;hit global #phi;hits", 20, -M_PI, M_PI);
 
-    hEta = fs->make<TH1D>("h_Eta", "Track pseudorapidity; track #eta;tracks", 100, -etaMax_, etaMax_);
-    hPhi = fs->make<TH1D>("h_Phi", "Track azimuth; track #phi;tracks", 100, -M_PI, M_PI);
+    hEta = book<TH1D>("h_Eta", "Track pseudorapidity; track #eta;tracks", 100, -etaMax_, etaMax_);
+    hPhi = book<TH1D>("h_Phi", "Track azimuth; track #phi;tracks", 100, -M_PI, M_PI);
 
-    hPhiBarrel = fs->make<TH1D>("h_PhiBarrel", "hPhiBarrel (0<|#eta|<0.8);track #Phi;tracks", 100, -M_PI, M_PI);
+    hPhiBarrel = book<TH1D>("h_PhiBarrel", "hPhiBarrel (0<|#eta|<0.8);track #Phi;tracks", 100, -M_PI, M_PI);
     hPhiOverlapPlus =
-        fs->make<TH1D>("h_PhiOverlapPlus", "hPhiOverlapPlus (0.8<#eta<1.4);track #phi;tracks", 100, -M_PI, M_PI);
+        book<TH1D>("h_PhiOverlapPlus", "hPhiOverlapPlus (0.8<#eta<1.4);track #phi;tracks", 100, -M_PI, M_PI);
     hPhiOverlapMinus =
-        fs->make<TH1D>("h_PhiOverlapMinus", "hPhiOverlapMinus (-1.4<#eta<-0.8);track #phi;tracks", 100, -M_PI, M_PI);
-    hPhiEndcapPlus = fs->make<TH1D>("h_PhiEndcapPlus", "hPhiEndcapPlus (#eta>1.4);track #phi;track", 100, -M_PI, M_PI);
-    hPhiEndcapMinus =
-        fs->make<TH1D>("h_PhiEndcapMinus", "hPhiEndcapMinus (#eta<1.4);track #phi;tracks", 100, -M_PI, M_PI);
+        book<TH1D>("h_PhiOverlapMinus", "hPhiOverlapMinus (-1.4<#eta<-0.8);track #phi;tracks", 100, -M_PI, M_PI);
+    hPhiEndcapPlus = book<TH1D>("h_PhiEndcapPlus", "hPhiEndcapPlus (#eta>1.4);track #phi;track", 100, -M_PI, M_PI);
+    hPhiEndcapMinus = book<TH1D>("h_PhiEndcapMinus", "hPhiEndcapMinus (#eta<1.4);track #phi;tracks", 100, -M_PI, M_PI);
 
     if (!isCosmics_) {
-      hPhp = fs->make<TH1D>("h_P_hp", "Momentum (high purity);track momentum [GeV];tracks", 100, 0., 100.);
-      hPthp = fs->make<TH1D>("h_Pt_hp", "Transverse Momentum (high purity);track p_{T} [GeV];tracks", 100, 0., 100.);
-      hHithp = fs->make<TH1D>("h_nHit_hp", "Number of hits (high purity);track n. hits;tracks", 30, 0, 30);
-      hEtahp =
-          fs->make<TH1D>("h_Eta_hp", "Track pseudorapidity (high purity); track #eta;tracks", 100, -etaMax_, etaMax_);
-      hPhihp = fs->make<TH1D>("h_Phi_hp", "Track azimuth (high purity); track #phi;tracks", 100, -M_PI, M_PI);
-      hchi2ndofhp = fs->make<TH1D>("h_chi2ndof_hp", "chi2/ndf (high purity);#chi^{2}/ndf;tracks", 100, 0, 5.);
-      hchi2Probhp = fs->make<TH1D>(
+      hPhp = book<TH1D>("h_P_hp", "Momentum (high purity);track momentum [GeV];tracks", 100, 0., 100.);
+      hPthp = book<TH1D>("h_Pt_hp", "Transverse Momentum (high purity);track p_{T} [GeV];tracks", 100, 0., 100.);
+      hHithp = book<TH1D>("h_nHit_hp", "Number of hits (high purity);track n. hits;tracks", 30, 0, 30);
+      hEtahp = book<TH1D>("h_Eta_hp", "Track pseudorapidity (high purity); track #eta;tracks", 100, -etaMax_, etaMax_);
+      hPhihp = book<TH1D>("h_Phi_hp", "Track azimuth (high purity); track #phi;tracks", 100, -M_PI, M_PI);
+      hchi2ndofhp = book<TH1D>("h_chi2ndof_hp", "chi2/ndf (high purity);#chi^{2}/ndf;tracks", 100, 0, 5.);
+      hchi2Probhp = book<TH1D>(
           "h_chi2_Prob_hp", "#chi^{2} probability (high purity);#chi^{2}prob_{Track};Number of Tracks", 100, 0.0, 1.);
 
-      hvx = fs->make<TH1D>("h_vx", "Track v_{x} ; track v_{x} [cm];tracks", 100, -1.5, 1.5);
-      hvy = fs->make<TH1D>("h_vy", "Track v_{y} ; track v_{y} [cm];tracks", 100, -1.5, 1.5);
-      hvz = fs->make<TH1D>("h_vz", "Track v_{z} ; track v_{z} [cm];tracks", 100, -20., 20.);
-      hd0 = fs->make<TH1D>("h_d0", "Track d_{0} ; track d_{0} [cm];tracks", 100, -1., 1.);
-      hdxy = fs->make<TH1D>("h_dxy", "Track d_{xy}; track d_{xy} [cm]; tracks", 100, -0.5, 0.5);
-      hdz = fs->make<TH1D>("h_dz", "Track d_{z} ; track d_{z} [cm]; tracks", 100, -20, 20);
+      hvx = book<TH1D>("h_vx", "Track v_{x} ; track v_{x} [cm];tracks", 100, -1.5, 1.5);
+      hvy = book<TH1D>("h_vy", "Track v_{y} ; track v_{y} [cm];tracks", 100, -1.5, 1.5);
+      hvz = book<TH1D>("h_vz", "Track v_{z} ; track v_{z} [cm];tracks", 100, -20., 20.);
+      hd0 = book<TH1D>("h_d0", "Track d_{0} ; track d_{0} [cm];tracks", 100, -1., 1.);
+      hdxy = book<TH1D>("h_dxy", "Track d_{xy}; track d_{xy} [cm]; tracks", 100, -0.5, 0.5);
+      hdz = book<TH1D>("h_dz", "Track d_{z} ; track d_{z} [cm]; tracks", 100, -20, 20);
 
       hd0PVvsphi =
-          fs->make<TH2D>("h2_d0PVvsphi", "hd0PVvsphi;track #phi;track d_{0}(PV) [cm]", 160, -M_PI, M_PI, 100, -1., 1.);
+          book<TH2D>("h2_d0PVvsphi", "hd0PVvsphi;track #phi;track d_{0}(PV) [cm]", 160, -M_PI, M_PI, 100, -1., 1.);
       hd0PVvseta =
-          fs->make<TH2D>("h2_d0PVvseta", "hdPV0vseta;track #eta;track d_{0}(PV) [cm]", 160, -2.5, 2.5, 100, -1., 1.);
-      hd0PVvspt = fs->make<TH2D>("h2_d0PVvspt", "hdPV0vspt;track p_{T};d_{0}(PV) [cm]", 50, 0., 100., 100, -1, 1.);
+          book<TH2D>("h2_d0PVvseta", "hdPV0vseta;track #eta;track d_{0}(PV) [cm]", 160, -2.5, 2.5, 100, -1., 1.);
+      hd0PVvspt = book<TH2D>("h2_d0PVvspt", "hdPV0vspt;track p_{T};d_{0}(PV) [cm]", 50, 0., 100., 100, -1, 1.);
 
-      hdxyBS = fs->make<TH1D>("h_dxyBS", "hdxyBS; track d_{xy}(BS) [cm];tracks", 100, -0.1, 0.1);
-      hd0BS = fs->make<TH1D>("h_d0BS", "hd0BS ; track d_{0}(BS) [cm];tracks", 100, -0.1, 0.1);
-      hdzBS = fs->make<TH1D>("h_dzBS", "hdzBS ; track d_{z}(BS) [cm];tracks", 100, -12, 12);
-      hdxyPV = fs->make<TH1D>("h_dxyPV", "hdxyPV; track d_{xy}(PV) [cm];tracks", 100, -0.1, 0.1);
-      hd0PV = fs->make<TH1D>("h_d0PV", "hd0PV ; track d_{0}(PV) [cm];tracks", 100, -0.15, 0.15);
-      hdzPV = fs->make<TH1D>("h_dzPV", "hdzPV ; track d_{z}(PV) [cm];tracks", 100, -0.1, 0.1);
+      hdxyBS = book<TH1D>("h_dxyBS", "hdxyBS; track d_{xy}(BS) [cm];tracks", 100, -0.1, 0.1);
+      hd0BS = book<TH1D>("h_d0BS", "hd0BS ; track d_{0}(BS) [cm];tracks", 100, -0.1, 0.1);
+      hdzBS = book<TH1D>("h_dzBS", "hdzBS ; track d_{z}(BS) [cm];tracks", 100, -12, 12);
+      hdxyPV = book<TH1D>("h_dxyPV", "hdxyPV; track d_{xy}(PV) [cm];tracks", 100, -0.1, 0.1);
+      hd0PV = book<TH1D>("h_d0PV", "hd0PV ; track d_{0}(PV) [cm];tracks", 100, -0.15, 0.15);
+      hdzPV = book<TH1D>("h_dzPV", "hdzPV ; track d_{z}(PV) [cm];tracks", 100, -0.1, 0.1);
 
-      hnhTIB = fs->make<TH1D>("h_nHitTIB", "nhTIB;# hits in TIB; tracks", 20, 0., 20.);
-      hnhTID = fs->make<TH1D>("h_nHitTID", "nhTID;# hits in TID; tracks", 20, 0., 20.);
-      hnhTOB = fs->make<TH1D>("h_nHitTOB", "nhTOB;# hits in TOB; tracks", 20, 0., 20.);
-      hnhTEC = fs->make<TH1D>("h_nHitTEC", "nhTEC;# hits in TEC; tracks", 20, 0., 20.);
+      hnhTIB = book<TH1D>("h_nHitTIB", "nhTIB;# hits in TIB; tracks", 20, 0., 20.);
+      hnhTID = book<TH1D>("h_nHitTID", "nhTID;# hits in TID; tracks", 20, 0., 20.);
+      hnhTOB = book<TH1D>("h_nHitTOB", "nhTOB;# hits in TOB; tracks", 20, 0., 20.);
+      hnhTEC = book<TH1D>("h_nHitTEC", "nhTEC;# hits in TEC; tracks", 20, 0., 20.);
 
     } else {
-      hvx = fs->make<TH1D>("h_vx", "Track v_{x};track v_{x} [cm];tracks", 100, -100., 100.);
-      hvy = fs->make<TH1D>("h_vy", "Track v_{y};track v_{y} [cm];tracks", 100, -100., 100.);
-      hvz = fs->make<TH1D>("h_vz", "Track v_{z};track v_{z} [cm];track", 100, -100., 100.);
-      hd0 = fs->make<TH1D>("h_d0", "Track d_{0};track d_{0} [cm];track", 100, -100., 100.);
-      hdxy = fs->make<TH1D>("h_dxy", "Track d_{xy};track d_{xy} [cm];tracks", 100, -100, 100);
-      hdz = fs->make<TH1D>("h_dz", "Track d_{z};track d_{z} [cm];tracks", 100, -200, 200);
+      hvx = book<TH1D>("h_vx", "Track v_{x};track v_{x} [cm];tracks", 100, -100., 100.);
+      hvy = book<TH1D>("h_vy", "Track v_{y};track v_{y} [cm];tracks", 100, -100., 100.);
+      hvz = book<TH1D>("h_vz", "Track v_{z};track v_{z} [cm];track", 100, -100., 100.);
+      hd0 = book<TH1D>("h_d0", "Track d_{0};track d_{0} [cm];track", 100, -100., 100.);
+      hdxy = book<TH1D>("h_dxy", "Track d_{xy};track d_{xy} [cm];tracks", 100, -100, 100);
+      hdz = book<TH1D>("h_dz", "Track d_{z};track d_{z} [cm];tracks", 100, -200, 200);
 
-      hd0vsphi = fs->make<TH2D>(
+      hd0vsphi = book<TH2D>(
           "h2_d0vsphi", "Track d_{0} vs #phi; track #phi;track d_{0} [cm]", 160, -3.20, 3.20, 100, -100., 100.);
-      hd0vseta = fs->make<TH2D>(
+      hd0vseta = book<TH2D>(
           "h2_d0vseta", "Track d_{0} vs #eta; track #eta;track d_{0} [cm]", 160, -3.20, 3.20, 100, -100., 100.);
-      hd0vspt = fs->make<TH2D>(
-          "h2_d0vspt", "Track d_{0} vs p_{T};track p_{T};track d_{0} [cm]", 50, 0., 100., 100, -100, 100);
+      hd0vspt =
+          book<TH2D>("h2_d0vspt", "Track d_{0} vs p_{T};track p_{T};track d_{0} [cm]", 50, 0., 100., 100, -100, 100);
 
-      hdxyBS = fs->make<TH1D>("h_dxyBS", "Track d_{xy}(BS);d_{xy}(BS) [cm];tracks", 100, -100., 100.);
-      hd0BS = fs->make<TH1D>("h_d0BS", "Track d_{0}(BS);d_{0}(BS) [cm];tracks", 100, -100., 100.);
-      hdzBS = fs->make<TH1D>("h_dzBS", "Track d_{z}(BS);d_{z}(BS) [cm];tracks", 100, -100., 100.);
-      hdxyPV = fs->make<TH1D>("h_dxyPV", "Track d_{xy}(PV); d_{xy}(PV) [cm];tracks", 100, -100., 100.);
-      hd0PV = fs->make<TH1D>("h_d0PV", "Track d_{0}(PV); d_{0}(PV) [cm];tracks", 100, -100., 100.);
-      hdzPV = fs->make<TH1D>("h_dzPV", "Track d_{z}(PV); d_{z}(PV) [cm];tracks", 100, -100., 100.);
+      hdxyBS = book<TH1D>("h_dxyBS", "Track d_{xy}(BS);d_{xy}(BS) [cm];tracks", 100, -100., 100.);
+      hd0BS = book<TH1D>("h_d0BS", "Track d_{0}(BS);d_{0}(BS) [cm];tracks", 100, -100., 100.);
+      hdzBS = book<TH1D>("h_dzBS", "Track d_{z}(BS);d_{z}(BS) [cm];tracks", 100, -100., 100.);
+      hdxyPV = book<TH1D>("h_dxyPV", "Track d_{xy}(PV); d_{xy}(PV) [cm];tracks", 100, -100., 100.);
+      hd0PV = book<TH1D>("h_d0PV", "Track d_{0}(PV); d_{0}(PV) [cm];tracks", 100, -100., 100.);
+      hdzPV = book<TH1D>("h_dzPV", "Track d_{z}(PV); d_{z}(PV) [cm];tracks", 100, -100., 100.);
 
-      hnhTIB = fs->make<TH1D>("h_nHitTIB", "nhTIB;# hits in TIB; tracks", 30, 0., 30.);
-      hnhTID = fs->make<TH1D>("h_nHitTID", "nhTID;# hits in TID; tracks", 30, 0., 30.);
-      hnhTOB = fs->make<TH1D>("h_nHitTOB", "nhTOB;# hits in TOB; tracks", 30, 0., 30.);
-      hnhTEC = fs->make<TH1D>("h_nHitTEC", "nhTEC;# hits in TEC; tracks", 30, 0., 30.);
+      hnhTIB = book<TH1D>("h_nHitTIB", "nhTIB;# hits in TIB; tracks", 30, 0., 30.);
+      hnhTID = book<TH1D>("h_nHitTID", "nhTID;# hits in TID; tracks", 30, 0., 30.);
+      hnhTOB = book<TH1D>("h_nHitTOB", "nhTOB;# hits in TOB; tracks", 30, 0., 30.);
+      hnhTEC = book<TH1D>("h_nHitTEC", "nhTEC;# hits in TEC; tracks", 30, 0., 30.);
     }
 
-    hnhpxb = fs->make<TH1D>("h_nHitPXB", "nhpxb;# hits in Pixel Barrel; tracks", 10, 0., 10.);
-    hnhpxe = fs->make<TH1D>("h_nHitPXE", "nhpxe;# hits in Pixel Endcap; tracks", 10, 0., 10.);
+    hnhpxb = book<TH1D>("h_nHitPXB", "nhpxb;# hits in Pixel Barrel; tracks", 10, 0., 10.);
+    hnhpxe = book<TH1D>("h_nHitPXE", "nhpxe;# hits in Pixel Endcap; tracks", 10, 0., 10.);
 
-    hHitComposition = fs->make<TH1D>("h_hitcomposition", "track hit composition;;# hits", 6, -0.5, 5.5);
+    hHitComposition = book<TH1D>("h_hitcomposition", "track hit composition;;# hits", 6, -0.5, 5.5);
 
     pNBpixHitsVsVx =
-        fs->make<TProfile>("p_NpixHits_vs_Vx", "n. Barrel Pixel hits vs. v_{x};v_{x} (cm);n. BPix hits", 20, -20, 20);
+        book<TProfile>("p_NpixHits_vs_Vx", "n. Barrel Pixel hits vs. v_{x};v_{x} (cm);n. BPix hits", 20, -20, 20);
 
     pNBpixHitsVsVy =
-        fs->make<TProfile>("p_NpixHits_vs_Vy", "n. Barrel Pixel hits vs. v_{y};v_{y} (cm);n. BPix hits", 20, -20, 20);
+        book<TProfile>("p_NpixHits_vs_Vy", "n. Barrel Pixel hits vs. v_{y};v_{y} (cm);n. BPix hits", 20, -20, 20);
 
     pNBpixHitsVsVz =
-        fs->make<TProfile>("p_NpixHits_vs_Vz", "n. Barrel Pixel hits vs. v_{z};v_{z} (cm);n. BPix hits", 20, -100, 100);
+        book<TProfile>("p_NpixHits_vs_Vz", "n. Barrel Pixel hits vs. v_{z};v_{z} (cm);n. BPix hits", 20, -100, 100);
 
     std::string dets[6] = {"PXB", "PXF", "TIB", "TID", "TOB", "TEC"};
 
@@ -908,167 +913,63 @@ private:
       hHitComposition->GetXaxis()->SetBinLabel(i, (dets[i - 1]).c_str());
     }
 
-    vTrackHistos_.push_back(
-        fs->make<TH1F>("h_tracketa", "Track #eta;#eta_{Track};Number of Tracks", 90, -etaMax_, etaMax_));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_trackphi", "Track #phi;#phi_{Track};Number of Tracks", 90, -M_PI, M_PI));
-    vTrackHistos_.push_back(fs->make<TH1F>(
-        "h_trackNumberOfValidHits", "Track # of valid hits;# of valid hits _{Track};Number of Tracks", 40, 0., 40.));
-    vTrackHistos_.push_back(fs->make<TH1F>(
-        "h_trackNumberOfLostHits", "Track # of lost hits;# of lost hits _{Track};Number of Tracks", 10, 0., 10.));
-    vTrackHistos_.push_back(
-        fs->make<TH1F>("h_curvature", "Curvature #kappa;#kappa_{Track};Number of Tracks", 100, -.05, .05));
-    vTrackHistos_.push_back(fs->make<TH1F>(
-        "h_curvature_pos", "Curvature |#kappa| Positive Tracks;|#kappa_{pos Track}|;Number of Tracks", 100, .0, .05));
-    vTrackHistos_.push_back(fs->make<TH1F>(
-        "h_curvature_neg", "Curvature |#kappa| Negative Tracks;|#kappa_{neg Track}|;Number of Tracks", 100, .0, .05));
-    vTrackHistos_.push_back(
-        fs->make<TH1F>("h_diff_curvature",
-                       "Curvature |#kappa| Tracks Difference;|#kappa_{Track}|;# Pos Tracks - # Neg Tracks",
-                       100,
-                       .0,
-                       .05));
+    // vector of track histograms
 
-    vTrackHistos_.push_back(
-        fs->make<TH1F>("h_chi2", "Track #chi^{2};#chi^{2}_{Track};Number of Tracks", 500, -0.01, 500.));
-    vTrackHistos_.push_back(
-        fs->make<TH1F>("h_chi2Prob", "#chi^{2} probability;Track Prob(#chi^{2},ndof);Number of Tracks", 100, 0.0, 1.));
-    vTrackHistos_.push_back(
-        fs->make<TH1F>("h_normchi2", "#chi^{2}/ndof;#chi^{2}/ndof;Number of Tracks", 100, -0.01, 10.));
+    // clang-format off
+
+    vTrackHistos_.push_back(book<TH1F>("h_tracketa", "Track #eta;#eta_{Track};Number of Tracks", 90, -etaMax_, etaMax_));
+    vTrackHistos_.push_back(book<TH1F>("h_trackphi", "Track #phi;#phi_{Track};Number of Tracks", 90, -M_PI, M_PI));
+    vTrackHistos_.push_back(book<TH1F>("h_trackNumberOfValidHits", "Track # of valid hits;# of valid hits _{Track};Number of Tracks", 40, 0., 40.));
+    vTrackHistos_.push_back(book<TH1F>("h_trackNumberOfLostHits", "Track # of lost hits;# of lost hits _{Track};Number of Tracks", 10, 0., 10.));
+    vTrackHistos_.push_back(book<TH1F>("h_curvature", "Curvature #kappa;#kappa_{Track};Number of Tracks", 100, -.05, .05));
+    vTrackHistos_.push_back(book<TH1F>("h_curvature_pos", "Curvature |#kappa| Positive Tracks;|#kappa_{pos Track}|;Number of Tracks", 100, .0, .05));
+    vTrackHistos_.push_back(book<TH1F>("h_curvature_neg", "Curvature |#kappa| Negative Tracks;|#kappa_{neg Track}|;Number of Tracks", 100, .0, .05));
+    vTrackHistos_.push_back(book<TH1F>("h_diff_curvature","Curvature |#kappa| Tracks Difference;|#kappa_{Track}|;# Pos Tracks - # Neg Tracks",100, .0, .05));
+    vTrackHistos_.push_back(book<TH1F>("h_chi2", "Track #chi^{2};#chi^{2}_{Track};Number of Tracks", 500, -0.01, 500.));
+    vTrackHistos_.push_back(book<TH1F>("h_chi2Prob", "#chi^{2} probability;Track Prob(#chi^{2},ndof);Number of Tracks", 100, 0.0, 1.));
+    vTrackHistos_.push_back(book<TH1F>("h_normchi2", "#chi^{2}/ndof;#chi^{2}/ndof;Number of Tracks", 100, -0.01, 10.));
     //variable binning for chi2/ndof vs. pT
     double xBins[19] = {0., 0.15, 0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5, 5., 7., 10., 15., 25., 40., 100., 200.};
-    vTrackHistos_.push_back(fs->make<TH1F>("h_pt", "Track p_{T};p_{T}^{track} [GeV];Number of Tracks", 250, 0., 250));
-    vTrackHistos_.push_back(fs->make<TH1F>("h_ptrebin", "Track p_{T};p_{T}^{track} [GeV];Number of Tracks", 18, xBins));
-    vTrackHistos_.push_back(fs->make<TH1F>(
-        "h_ptResolution", "#delta_{p_{T}}/p_{T}^{track};#delta_{p_{T}}/p_{T}^{track};Number of Tracks", 100, 0., 0.5));
-    vTrackProfiles_.push_back(fs->make<TProfile>(
-        "p_d0_vs_phi", "Transverse Impact Parameter vs. #phi;#phi_{Track};#LT d_{0} #GT [cm]", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>(
-        "p_dz_vs_phi", "Longitudinal Impact Parameter vs. #phi;#phi_{Track};#LT d_{z} #GT [cm]", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(fs->make<TProfile>(
-        "p_d0_vs_eta", "Transverse Impact Parameter vs. #eta;#eta_{Track};#LT d_{0} #GT [cm]", 100, -etaMax_, etaMax_));
-    vTrackProfiles_.push_back(
-        fs->make<TProfile>("p_dz_vs_eta",
-                           "Longitudinal Impact Parameter vs. #eta;#eta_{Track};#LT d_{z} #GT [cm]",
-                           100,
-                           -etaMax_,
-                           etaMax_));
-    vTrackProfiles_.push_back(
-        fs->make<TProfile>("p_chi2_vs_phi", "#chi^{2} vs. #phi;#phi_{Track};#LT #chi^{2} #GT", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(
-        fs->make<TProfile>("p_chi2Prob_vs_phi",
-                           "#chi^{2} probablility vs. #phi;#phi_{Track};#LT #chi^{2} probability#GT",
-                           100,
-                           -M_PI,
-                           M_PI));
+    vTrackHistos_.push_back(book<TH1F>("h_pt", "Track p_{T};p_{T}^{track} [GeV];Number of Tracks", 250, 0., 250));
+    vTrackHistos_.push_back(book<TH1F>("h_ptrebin", "Track p_{T};p_{T}^{track} [GeV];Number of Tracks", 18, xBins));
+    vTrackHistos_.push_back(book<TH1F>("h_ptResolution", "#delta_{p_{T}}/p_{T}^{track};#delta_{p_{T}}/p_{T}^{track};Number of Tracks", 100, 0., 0.5));
 
-    vTrackProfiles_.push_back(fs->make<TProfile>(
-        "p_chi2Prob_vs_d0", "#chi^{2} probablility vs. |d_{0}|;|d_{0}|[cm];#LT #chi^{2} probability#GT", 100, 0, 80));
-    vTrackProfiles_.push_back(fs->make<TProfile>(
-        "p_chi2Prob_vs_dz", "#chi^{2} probablility vs. dz;d_{z} [cm];#LT #chi^{2} probability#GT", 100, -30, 30));
-    vTrackProfiles_.push_back(fs->make<TProfile>(
-        "p_normchi2_vs_phi", "#chi^{2}/ndof vs. #phi;#phi_{Track};#LT #chi^{2}/ndof #GT", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(
-        fs->make<TProfile>("p_chi2_vs_eta", "#chi^{2} vs. #eta;#eta_{Track};#LT #chi^{2} #GT", 100, -etaMax_, etaMax_));
-    vTrackProfiles_.push_back(fs->make<TProfile>(
-        "p_normchi2_vs_pt", "norm #chi^{2} vs. p_{T}_{Track}; p_{T}_{Track};#LT #chi^{2}/ndof #GT", 18, xBins));
-    vTrackProfiles_.push_back(fs->make<TProfile>(
-        "p_normchi2_vs_p", "#chi^{2}/ndof vs. p_{Track};p_{Track};#LT #chi^{2}/ndof #GT", 18, xBins));
-    vTrackProfiles_.push_back(
-        fs->make<TProfile>("p_chi2Prob_vs_eta",
-                           "#chi^{2} probability vs. #eta;#eta_{Track};#LT #chi^{2} probability #GT",
-                           100,
-                           -etaMax_,
-                           etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_d0_vs_phi", "Transverse Impact Parameter vs. #phi;#phi_{Track};#LT d_{0} #GT [cm]", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_dz_vs_phi", "Longitudinal Impact Parameter vs. #phi;#phi_{Track};#LT d_{z} #GT [cm]", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_d0_vs_eta", "Transverse Impact Parameter vs. #eta;#eta_{Track};#LT d_{0} #GT [cm]", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_dz_vs_eta", "Longitudinal Impact Parameter vs. #eta;#eta_{Track};#LT d_{z} #GT [cm]", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2_vs_phi", "#chi^{2} vs. #phi;#phi_{Track};#LT #chi^{2} #GT", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2Prob_vs_phi", "#chi^{2} probablility vs. #phi;#phi_{Track};#LT #chi^{2} probability#GT", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2Prob_vs_d0", "#chi^{2} probablility vs. |d_{0}|;|d_{0}|[cm];#LT #chi^{2} probability#GT", 100, 0, 80));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2Prob_vs_dz", "#chi^{2} probablility vs. dz;d_{z} [cm];#LT #chi^{2} probability#GT", 100, -30, 30));
+    vTrackProfiles_.push_back(book<TProfile>("p_normchi2_vs_phi", "#chi^{2}/ndof vs. #phi;#phi_{Track};#LT #chi^{2}/ndof #GT", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2_vs_eta", "#chi^{2} vs. #eta;#eta_{Track};#LT #chi^{2} #GT", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_normchi2_vs_pt", "norm #chi^{2} vs. p_{T}_{Track}; p_{T}_{Track};#LT #chi^{2}/ndof #GT", 18, xBins));
+    vTrackProfiles_.push_back(book<TProfile>("p_normchi2_vs_p", "#chi^{2}/ndof vs. p_{Track};p_{Track};#LT #chi^{2}/ndof #GT", 18, xBins));
+    vTrackProfiles_.push_back(book<TProfile>("p_chi2Prob_vs_eta","#chi^{2} probability vs. #eta;#eta_{Track};#LT #chi^{2} probability #GT",100,-etaMax_,etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_normchi2_vs_eta", "#chi^{2}/ndof vs. #eta;#eta_{Track};#LT #chi^{2}/ndof #GT", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_kappa_vs_phi", "#kappa vs. #phi;#phi_{Track};#kappa", 100, -M_PI, M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_kappa_vs_eta", "#kappa vs. #eta;#eta_{Track};#kappa", 100, -etaMax_, etaMax_));
+    vTrackProfiles_.push_back(book<TProfile>("p_ptResolution_vs_phi","#delta_{p_{T}}/p_{T}^{track};#phi^{track};#delta_{p_{T}}/p_{T}^{track}",100,-M_PI,M_PI));
+    vTrackProfiles_.push_back(book<TProfile>("p_ptResolution_vs_eta","#delta_{p_{T}}/p_{T}^{track};#eta^{track};#delta_{p_{T}}/p_{T}^{track}",100,-etaMax_,etaMax_));
 
-    vTrackProfiles_.push_back(fs->make<TProfile>(
-        "p_normchi2_vs_eta", "#chi^{2}/ndof vs. #eta;#eta_{Track};#LT #chi^{2}/ndof #GT", 100, -etaMax_, etaMax_));
-    vTrackProfiles_.push_back(
-        fs->make<TProfile>("p_kappa_vs_phi", "#kappa vs. #phi;#phi_{Track};#kappa", 100, -M_PI, M_PI));
-    vTrackProfiles_.push_back(
-        fs->make<TProfile>("p_kappa_vs_eta", "#kappa vs. #eta;#eta_{Track};#kappa", 100, -etaMax_, etaMax_));
-    vTrackProfiles_.push_back(
-        fs->make<TProfile>("p_ptResolution_vs_phi",
-                           "#delta_{p_{T}}/p_{T}^{track};#phi^{track};#delta_{p_{T}}/p_{T}^{track}",
-                           100,
-                           -M_PI,
-                           M_PI));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_phi_vs_eta", "Track #phi vs. #eta;#eta_{Track};#phi_{Track}",50, -etaMax_, etaMax_, 50, -M_PI, M_PI));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_d0_vs_phi", "Transverse Impact Parameter vs. #phi;#phi_{Track};d_{0} [cm]", 100, -M_PI, M_PI, 100, -1., 1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_dz_vs_phi", "Longitudinal Impact Parameter vs. #phi;#phi_{Track};d_{z} [cm]",100, -M_PI, M_PI, 100, -100., 100.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_d0_vs_eta", "Transverse Impact Parameter vs. #eta;#eta_{Track};d_{0} [cm]", 100, -etaMax_, etaMax_, 100, -1., 1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_dz_vs_eta", "Longitudinal Impact Parameter vs. #eta;#eta_{Track};d_{z} [cm]", 100, -etaMax_, etaMax_, 100, -100., 100.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2_vs_phi", "#chi^{2} vs. #phi;#phi_{Track};#chi^{2}", 100, -M_PI, M_PI, 500, 0., 500.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2Prob_vs_phi", "#chi^{2} probability vs. #phi;#phi_{Track};#chi^{2} probability", 100, -M_PI, M_PI, 100, 0., 1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2Prob_vs_d0", "#chi^{2} probability vs. |d_{0}|;|d_{0}| [cm];#chi^{2} probability", 100, 0, 80, 100, 0., 1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_normchi2_vs_phi", "#chi^{2}/ndof vs. #phi;#phi_{Track};#chi^{2}/ndof", 100, -M_PI, M_PI, 100, 0., 10.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2_vs_eta", "#chi^{2} vs. #eta;#eta_{Track};#chi^{2}", 100, -etaMax_, etaMax_, 500, 0., 500.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_chi2Prob_vs_eta", "#chi^{2} probaility vs. #eta;#eta_{Track};#chi^{2} probability", 100, -etaMax_, etaMax_, 100, 0., 1.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_normchi2_vs_eta", "#chi^{2}/ndof vs. #eta;#eta_{Track};#chi^{2}/ndof", 100, -etaMax_, etaMax_, 100, 0., 10.));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_kappa_vs_phi", "#kappa vs. #phi;#phi_{Track};#kappa", 100, -M_PI, M_PI, 100, .0, .05));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_kappa_vs_eta", "#kappa vs. #eta;#eta_{Track};#kappa", 100, -etaMax_, etaMax_, 100, .0, .05));
+    vTrack2DHistos_.push_back(book<TH2F>("h2_normchi2_vs_kappa", "#kappa vs. #chi^{2}/ndof;#chi^{2}/ndof;#kappa", 100, 0., 10, 100, -.03, .03));
 
-    vTrackProfiles_.push_back(
-        fs->make<TProfile>("p_ptResolution_vs_eta",
-                           "#delta_{p_{T}}/p_{T}^{track};#eta^{track};#delta_{p_{T}}/p_{T}^{track}",
-                           100,
-                           -etaMax_,
-                           etaMax_));
-
-    vTrack2DHistos_.push_back(fs->make<TH2F>(
-        "h2_d0_vs_phi", "Transverse Impact Parameter vs. #phi;#phi_{Track};d_{0} [cm]", 100, -M_PI, M_PI, 100, -1., 1.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_dz_vs_phi",
-                                             "Longitudinal Impact Parameter vs. #phi;#phi_{Track};d_{z} [cm]",
-                                             100,
-                                             -M_PI,
-                                             M_PI,
-                                             100,
-                                             -100.,
-                                             100.));
-
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_d0_vs_eta",
-                                             "Transverse Impact Parameter vs. #eta;#eta_{Track};d_{0} [cm]",
-                                             100,
-                                             -etaMax_,
-                                             etaMax_,
-                                             100,
-                                             -1.,
-                                             1.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_dz_vs_eta",
-                                             "Longitudinal Impact Parameter vs. #eta;#eta_{Track};d_{z} [cm]",
-                                             100,
-                                             -etaMax_,
-                                             etaMax_,
-                                             100,
-                                             -100.,
-                                             100.));
-
-    vTrack2DHistos_.push_back(
-        fs->make<TH2F>("h2_chi2_vs_phi", "#chi^{2} vs. #phi;#phi_{Track};#chi^{2}", 100, -M_PI, M_PI, 500, 0., 500.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_chi2Prob_vs_phi",
-                                             "#chi^{2} probability vs. #phi;#phi_{Track};#chi^{2} probability",
-                                             100,
-                                             -M_PI,
-                                             M_PI,
-                                             100,
-                                             0.,
-                                             1.));
-
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_chi2Prob_vs_d0",
-                                             "#chi^{2} probability vs. |d_{0}|;|d_{0}| [cm];#chi^{2} probability",
-                                             100,
-                                             0,
-                                             80,
-                                             100,
-                                             0.,
-                                             1.));
-
-    vTrack2DHistos_.push_back(fs->make<TH2F>(
-        "h2_normchi2_vs_phi", "#chi^{2}/ndof vs. #phi;#phi_{Track};#chi^{2}/ndof", 100, -M_PI, M_PI, 100, 0., 10.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>(
-        "h2_chi2_vs_eta", "#chi^{2} vs. #eta;#eta_{Track};#chi^{2}", 100, -etaMax_, etaMax_, 500, 0., 500.));
-    vTrack2DHistos_.push_back(fs->make<TH2F>("h2_chi2Prob_vs_eta",
-                                             "#chi^{2} probaility vs. #eta;#eta_{Track};#chi^{2} probability",
-                                             100,
-                                             -etaMax_,
-                                             etaMax_,
-                                             100,
-                                             0.,
-                                             1.));
-
-    vTrack2DHistos_.push_back(fs->make<TH2F>(
-        "h2_normchi2_vs_eta", "#chi^{2}/ndof vs. #eta;#eta_{Track};#chi^{2}/ndof", 100, -etaMax_, etaMax_, 100, 0., 10.));
-    vTrack2DHistos_.push_back(
-        fs->make<TH2F>("h2_kappa_vs_phi", "#kappa vs. #phi;#phi_{Track};#kappa", 100, -M_PI, M_PI, 100, .0, .05));
-    vTrack2DHistos_.push_back(
-        fs->make<TH2F>("h2_kappa_vs_eta", "#kappa vs. #eta;#eta_{Track};#kappa", 100, -etaMax_, etaMax_, 100, .0, .05));
-    vTrack2DHistos_.push_back(fs->make<TH2F>(
-        "h2_normchi2_vs_kappa", "#kappa vs. #chi^{2}/ndof;#chi^{2}/ndof;#kappa", 100, 0., 10, 100, -.03, .03));
+    // clang-format on
 
     firstEvent_ = true;
 
@@ -1087,10 +988,10 @@ private:
     edm::LogPrint("GeneralPurposeTrackAnalyzer") << "firing triggers: " << nFiringTriggers << std::endl;
     edm::LogPrint("GeneralPurposeTrackAnalyzer") << "*******************************" << std::endl;
 
-    tksByTrigger_ = fs->make<TH1D>(
-        "tksByTrigger", "tracks by HLT path;;% of # traks", nFiringTriggers, -0.5, nFiringTriggers - 0.5);
-    evtsByTrigger_ = fs->make<TH1D>(
-        "evtsByTrigger", "events by HLT path;;% of # events", nFiringTriggers, -0.5, nFiringTriggers - 0.5);
+    tksByTrigger_ =
+        book<TH1D>("tksByTrigger", "tracks by HLT path;;% of # traks", nFiringTriggers, -0.5, nFiringTriggers - 0.5);
+    evtsByTrigger_ =
+        book<TH1D>("evtsByTrigger", "events by HLT path;;% of # events", nFiringTriggers, -0.5, nFiringTriggers - 0.5);
 
     int i = 0;
     for (const auto &it : triggerMap_) {
@@ -1131,17 +1032,17 @@ private:
     edm::LogPrint("GeneralPurposeTrackAnalyzer") << "considered runs: " << nRuns << std::endl;
     edm::LogPrint("GeneralPurposeTrackAnalyzer") << "*******************************" << std::endl;
 
-    modeByRun_ = fs->make<TH1D>("modeByRun",
-                                "Strip APV mode by run number;;APV mode (-1=deco,+1=peak)",
-                                runRange,
-                                theRuns_.front() - 0.5,
-                                theRuns_.back() + 0.5);
+    modeByRun_ = book<TH1D>("modeByRun",
+                            "Strip APV mode by run number;;APV mode (-1=deco,+1=peak)",
+                            runRange,
+                            theRuns_.front() - 0.5,
+                            theRuns_.back() + 0.5);
 
-    fieldByRun_ = fs->make<TH1D>("fieldByRun",
-                                 "CMS B-field intensity by run number;;B-field intensity [T]",
-                                 runRange,
-                                 theRuns_.front() - 0.5,
-                                 theRuns_.back() + 0.5);
+    fieldByRun_ = book<TH1D>("fieldByRun",
+                             "CMS B-field intensity by run number;;B-field intensity [T]",
+                             runRange,
+                             theRuns_.front() - 0.5,
+                             theRuns_.back() + 0.5);
 
     for (const auto &the_r : theRuns_) {
       if (conditionsMap_.find(the_r)->second.first != 0) {

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -12,4 +12,8 @@
     <use name="Alignment/OfflineValidation"/>
   </bin>
 
+  <bin name="testTrackAnalysis" file="testTrackAnalyzers.cc">
+    <use name="FWCore/TestProcessor"/>
+    <use name="catch2"/>
+  </bin>
 </environment>

--- a/Alignment/OfflineValidation/test/inspectData_cfg.py
+++ b/Alignment/OfflineValidation/test/inspectData_cfg.py
@@ -1,29 +1,34 @@
 import glob
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.VarParsing as VarParsing
-options = VarParsing.VarParsing()
 
 ###################################################################
 # Setup 'standard' options
 ###################################################################
-
-options.register('OutFileName',
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('outFileName',
                  "test.root", # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.string, # string, int, or float
                  "name of the output file (test.root is default)")
 
-options.register('myGT',
-                 "auto:phase1_2021_cosmics_0T", # default value
+options.register('trackCollection',
+                 "ctfWithMaterialTracksP5", #ALCARECOTkAlCosmicsCTF0T
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.string, # string, int, or float
+                 "name of the input track collection")
+
+options.register('globalTag',
+                 "auto:run3_data_prompt", # default value
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.string, # string, int, or float
                  "name of the input Global Tag")
 
-options.register('myDataset',
-                 "myDataset_v1",
+options.register('inputData',
+                 "/eos/cms/store/express/Commissioning2022/ExpressCosmics/FEVT/Express-v1/000/350/010/00000/*",
                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                  VarParsing.VarParsing.varType.string, # string, int, or float
-                 "name of the input dataset")
+                 "eos directory to read  from")
 
 options.register('maxEvents',
                  -1,
@@ -39,11 +44,20 @@ process = cms.Process("AlCaRECOAnalysis")
 # Message logger service
 ###################################################################
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-process.MessageLogger.cerr = cms.untracked.PSet(enable = cms.untracked.bool(False))
-process.MessageLogger.cout = cms.untracked.PSet(INFO = cms.untracked.PSet(
-    reportEvery = cms.untracked.int32(1000) # every 100th only
-    #    limit = cms.untracked.int32(10)       # or limit to 10 printouts...
-    ))
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.DMRChecker=dict()  
+process.MessageLogger.GeneralPurposeTrackAnalyzer=dict()
+process.MessageLogger.cout = cms.untracked.PSet(
+    enable = cms.untracked.bool(True),
+    threshold = cms.untracked.string("INFO"),
+    default   = cms.untracked.PSet(limit = cms.untracked.int32(0)),                       
+    FwkReport = cms.untracked.PSet(limit = cms.untracked.int32(-1),
+                                   reportEvery = cms.untracked.int32(1000)
+                                   ),                                                      
+    DMRChecker = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    GeneralPurposeTrackAnalyzer = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    #enableStatistics = cms.untracked.bool(True)
+    )
 
 ###################################################################
 # Geometry producer and standard includes
@@ -60,45 +74,24 @@ process.load("CondCore.CondDB.CondDB_cfi")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag,options.myGT, '')
-
-# process.GlobalTag.toGet = cms.VPSet(
-#     cms.PSet(record = cms.string("SiPixelTemplateDBObjectRcd"),
-#              label = cms.untracked.string("0T"),
-#              #tag = cms.string("SiPixelTemplateDBObject_phase1_0T_mc_BoR3_v1"),
-#              tag = cms.string("SiPixelTemplateDBObject_phase1_0T_mc_BoR3_v1_bugfix"),
-#              connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-#              ),
-#     cms.PSet(record = cms.string("SiPixelGenErrorDBObjectRcd"),
-#              #tag = cms.string("SiPixelGenErrorDBObject_phase1_0T_mc_BoR3_v1"),
-#              tag = cms.string("SiPixelGenErrorDBObject_phase1_0T_mc_BoR3_v1_bugfix"),
-#              connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-#              ),
-# )
-
+process.GlobalTag = GlobalTag(process.GlobalTag,options.globalTag, '')
 
 ###################################################################
 # Source
 ###################################################################
-
 readFiles = cms.untracked.vstring()
 process.source = cms.Source("PoolSource",fileNames = readFiles)
 the_files=[]
-file_list = glob.glob("/eos/cms/store/mc/Run3Winter20CosmicDR/TKCosmics_0T/ALCARECO/TkAlCosmics0T-0T_110X_mcRun3_2021cosmics_realistic_deco_v4-v1/40000/*")
+#file_list = glob.glob(options.inputData)
+file_list = glob.glob("/eos/cms/store/express/Commissioning2022/ExpressCosmics/FEVT/Express-v1/000/350/010/00000/*")
 for f in file_list:
     the_files.append(f.replace("/eos/cms",""))
 
-readFiles.extend(the_files)
-    
+#readFiles.extend(the_files)
+readFiles.extend(["/store/express/Commissioning2022/ExpressCosmics/FEVT/Express-v1/000/350/010/00000/e0edb947-f8c4-4e6a-b856-ab64117fc6ee.root"]) 
+
 print(the_files)
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(options.maxEvents))
-
-# readFiles.extend(['/store/mc/Run3Winter20CosmicDR/TKCosmics_0T/ALCARECO/TkAlCosmics0T-0T_110X_mcRun3_2021cosmics_realistic_deco_v4-v1/40000/4AC4A0B1-12CD-CC4C-AA44-BF94D02DA323.root',
-#                   '/store/mc/Run3Winter20CosmicDR/TKCosmics_0T/ALCARECO/TkAlCosmics0T-0T_110X_mcRun3_2021cosmics_realistic_deco_v4-v1/40000/44D2D421-9B16-FA47-9C53-B8B93A7F2077.root',
-#                   '/store/mc/Run3Winter20CosmicDR/TKCosmics_0T/ALCARECO/TkAlCosmics0T-0T_110X_mcRun3_2021cosmics_realistic_deco_v4-v1/40000/525F1D6D-9271-FF41-B05E-C99FFCB029D9.root',
-#                   '/store/mc/Run3Winter20CosmicDR/TKCosmics_0T/ALCARECO/TkAlCosmics0T-0T_110X_mcRun3_2021cosmics_realistic_deco_v4-v1/40000/39381C24-97B6-E641-B4AB-7D1B1D25A782.root',
-#                   '/store/mc/Run3Winter20CosmicDR/TKCosmics_0T/ALCARECO/TkAlCosmics0T-0T_110X_mcRun3_2021cosmics_realistic_deco_v4-v1/40000/08901961-CFB6-4A43-98FC-D1817EF76D13.root'])
-
 
 ###################################################################
 # momentum constraint for 0T
@@ -106,7 +99,7 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(options.maxEv
 process.load("RecoTracker.TrackProducer.MomentumConstraintProducer_cff")
 import RecoTracker.TrackProducer.MomentumConstraintProducer_cff
 process.AliMomConstraint = RecoTracker.TrackProducer.MomentumConstraintProducer_cff.MyMomConstraint.clone()
-process.AliMomConstraint.src = 'ALCARECOTkAlCosmicsCTF0T'
+process.AliMomConstraint.src = options.trackCollection
 process.AliMomConstraint.fixedMomentum = 5.0
 process.AliMomConstraint.fixedMomentumError = 0.005
 
@@ -114,11 +107,10 @@ process.AliMomConstraint.fixedMomentumError = 0.005
 # Alignment Track Selector
 ###################################################################
 import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
-
 process.MuSkimSelector = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
     applyBasicCuts = True,                                                                            
     filter = True,
-    src = 'ALCARECOTkAlCosmicsCTF0T',
+    src = options.trackCollection,
     ptMin = 17.,
     pMin = 17.,
     etaMin = -2.5,
@@ -128,8 +120,7 @@ process.MuSkimSelector = Alignment.CommonAlignmentProducer.AlignmentTrackSelecto
     dzMin = -25.,
     dzMax = 25.,
     nHitMin = 6,
-    nHitMin2D = 0,
-    )
+    nHitMin2D = 0)
 
 ###################################################################
 # The TrackRefitter
@@ -137,40 +128,45 @@ process.MuSkimSelector = Alignment.CommonAlignmentProducer.AlignmentTrackSelecto
 process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
 import RecoTracker.TrackProducer.TrackRefitters_cff
 process.TrackRefitter1 = process.TrackRefitterP5.clone(
-    src =  'ALCARECOTkAlCosmicsCTF0T', #'AliMomConstraint',
+    src =  options.trackCollection, #'AliMomConstraint',
     TrajectoryInEvent = True,
-    TTRHBuilder = "WithTrackAngle",  #"WithAngleAndTemplate",
+    TTRHBuilder = "WithAngleAndTemplate", #"WithTrackAngle"
     NavigationSchool = "",
     #constraint = 'momentum', ### SPECIFIC FOR CRUZET
     #srcConstr='AliMomConstraint' ### SPECIFIC FOR CRUZET$works only with tag V02-10-02 TrackingTools/PatternTools / or CMSSW >=31X
     )
 
 ###################################################################
+# the pT filter
+###################################################################
+from CommonTools.RecoAlgos.ptMaxTrackCountFilter_cfi import ptMaxTrackCountFilter
+process.myfilter = ptMaxTrackCountFilter.clone(src = cms.InputTag(options.trackCollection),
+                                               ptMax = cms.double(3.))
+
+###################################################################
 # The analysis module
 ###################################################################
 process.myanalysis = cms.EDAnalyzer("GeneralPurposeTrackAnalyzer",
                                     TkTag  = cms.InputTag('TrackRefitter1'),
-                                    isCosmics = cms.bool(True)
-                                    )
+                                    isCosmics = cms.bool(True))
 
 process.fastdmr = cms.EDAnalyzer("DMRChecker",
                                  TkTag  = cms.InputTag('TrackRefitter1'),
-                                 isCosmics = cms.bool(True)
-                                 )
+                                 isCosmics = cms.bool(True))
 
 ###################################################################
 # Output name
 ###################################################################
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string(options.OutFileName)
-                                   )
+                                   fileName = cms.string(options.outFileName))
 
 ###################################################################
 # Path
 ###################################################################
-process.p1 = cms.Path(process.offlineBeamSpot*
-                      #process.AliMomConstraint*
-                      process.TrackRefitter1*
-                      process.myanalysis*
-                      process.fastdmr
+process.p1 = cms.Path(process.myfilter
+                      *process.offlineBeamSpot
+                      #*process.AliMomConstraint
+                      *process.TrackRefitter1
+                      *process.myanalysis
+                      *process.fastdmr
                       )

--- a/Alignment/OfflineValidation/test/testTrackAnalyzers.cc
+++ b/Alignment/OfflineValidation/test/testTrackAnalyzers.cc
@@ -1,0 +1,78 @@
+#include "FWCore/TestProcessor/interface/TestProcessor.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+TEST_CASE("GeneralPurposeTrackAnalyzer tests", "[GeneralPurposeTrackAnalyzer]") {
+  //The python configuration
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+from Alignment.OfflineValidation.GeneralPurposeTrackAnalyzer_cfi import GeneralPurposeTrackAnalyzer
+process = TestProcess()
+process.trackAnalyzer = GeneralPurposeTrackAnalyzer
+process.moduleToTest(process.trackAnalyzer)
+process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('TFileService',fileName=cms.string('tesTrackAnalyzer1.root')))
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+  SECTION("base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  // SECTION("No event data") {
+  //   edm::test::TestProcessor tester(config);
+  //   REQUIRE_NOTHROW(tester.test());
+  // }
+
+  // SECTION("beginJob and endJob only") {
+  //   edm::test::TestProcessor tester(config);
+  //   REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  // }
+
+  // SECTION("Run with no LuminosityBlocks") {
+  //   edm::test::TestProcessor tester(config);
+  //   REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  // }
+
+  // SECTION("LuminosityBlock with no Events") {
+  //   edm::test::TestProcessor tester(config);
+  //   REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  // }
+}
+
+TEST_CASE("DMRChecker tests", "[DMRChecker]") {
+  //The python configuration
+  const std::string baseConfig{
+      R"_(from FWCore.TestProcessor.TestProcess import *
+from Alignment.OfflineValidation.DMRChecker_cfi import DMRChecker
+process = TestProcess()
+process.dmrAnalyzer = DMRChecker
+process.moduleToTest(process.dmrAnalyzer)
+process.add_(cms.Service('MessageLogger'))
+process.add_(cms.Service('TFileService',fileName=cms.string('tesTrackAnalyzer2.root')))
+)_"};
+
+  edm::test::TestProcessor::Config config{baseConfig};
+  SECTION("base configuration is OK") { REQUIRE_NOTHROW(edm::test::TestProcessor(config)); }
+
+  // SECTION("No event data") {
+  //   edm::test::TestProcessor tester(config);
+  //   REQUIRE_NOTHROW(tester.test());
+  // }
+
+  // SECTION("beginJob and endJob only") {
+  //   edm::test::TestProcessor tester(config);
+  //   REQUIRE_NOTHROW(tester.testBeginAndEndJobOnly());
+  // }
+
+  // SECTION("Run with no LuminosityBlocks") {
+  //   edm::test::TestProcessor tester(config);
+  //   REQUIRE_NOTHROW(tester.testRunWithNoLuminosityBlocks());
+  // }
+
+  // SECTION("LuminosityBlock with no Events") {
+  //   edm::test::TestProcessor tester(config);
+  //   REQUIRE_NOTHROW(tester.testLuminosityBlockWithNoEvents());
+  // }
+}

--- a/Alignment/OfflineValidation/test/test_all.sh
+++ b/Alignment/OfflineValidation/test/test_all.sh
@@ -2,14 +2,14 @@
 
 function die { echo $1: status $2 ; exit $2; }
 
-echo "TESTING Alignment/OfflineValidation ..."
-cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_OfflineValidation_cfg.py" $?
-
 if test -f "validation_config.ini"; then
     rm -f validation_config.ini
 fi
 
+echo "TESTING Alignment/OfflineValidation ..."
+cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_OfflineValidation_cfg.py" $?
 cmsRun ${LOCAL_TEST_DIR}/DiMuonVertexValidation_cfg.py maxEvents=10 || die "Failure running DiMuonVertexValidation_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/inspectData_cfg.py unitTest=True || die "Failure running inspectData_cfg.py" $?
 
 ## copy into local sqlite file the ideal alignment
 echo "COPYING locally Ideal Alignment ..."


### PR DESCRIPTION
#### PR description:

Title says it all, update a couple of analyzers that are used to check the input data for the global tracker alignment procedure.
I profit of this to make an addition to the unit tests of this package to have them tested, together with a stub of catch2 tests.
I also employ the filter that was introduced in https://github.com/cms-sw/cmssw/pull/37500 to isolate low pT tracks. 
This is exercised in the unit tests.

#### PR validation:

Private, relies also on the augmented unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A