### PR TITLE
[12_3_X] simple RECO squence for SPLASH runs

### DIFF
--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -157,6 +157,10 @@ class Reco(Scenario):
 
         eiStep=''
 
+        if 'beamSplashRun' in args:
+          eiStep = ":localreco+hcalOnlyGlobalRecoSequence+caloTowersRec" if args['beamSplashRun'] else ""
+          print("Using RECO%s step for ED clients" % eiStep)     
+
         options.step += 'RAW2DIGI,L1Reco,RECO'+eiStep+',ENDJOB'
 
 

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -47,7 +47,8 @@ except Exception as ex:
 from DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi import GlobalTag
 kwds = {
    'globalTag': GlobalTag.globaltag.value(),
-   'globalTagConnect': GlobalTag.connect.value()
+   'globalTagConnect': GlobalTag.connect.value(),
+   'beamSplashRun' : options.BeamSplashRun,
 }
 
 # explicitly select the input collection, since we get multiple in online

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -47,7 +47,8 @@ except Exception as ex:
 from DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi import GlobalTag
 kwds = {
    'globalTag': GlobalTag.globaltag.value(),
-   'globalTagConnect': GlobalTag.connect.value()
+   'globalTagConnect': GlobalTag.connect.value(),
+   'beamSplashRun' : options.BeamSplashRun,
 }
 
 # explicitly select the input collection, since we get multiple in online

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -81,6 +81,12 @@ options.register('noDB',
                  VarParsing.VarParsing.varType.bool,
                  "Don't upload the BeamSpot conditions to the DB")
 
+options.register('BeamSplashRun',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Set client source settings for beam SPLASH run")
+
 options.parseArguments()
 
 print("Querying DAS for files...")


### PR DESCRIPTION
#### PR description:
For the beam SPLASH runs simplification of RECO sequence is proposed in order to speed up event processing in Event Display DQM clients. As simplified sequence is needed only for SPLASH runs, not for regular 'cosmic' and 'beam operation', the customization in visualizationProcessing function is applied when beamSplashRun option is True.

#### PR validation:
Tested locally, to be tested at P5 in production using on-going runs.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
backport of https://github.com/cms-sw/cmssw/pull/37624
for ongoing operation at P5