### PR TITLE
[12_4_X] simple RECO squence for SPLASH runs

### DIFF
--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -157,7 +157,12 @@ class Reco(Scenario):
 
         eiStep=''
 
+        if 'beamSplashRun' in args:
+          eiStep = ":localreco+hcalOnlyGlobalRecoSequence+caloTowersRec" if args['beamSplashRun'] else ""
+          print("Using RECO%s step for ED clients" % eiStep)     
+
         options.step += 'RAW2DIGI,L1Reco,RECO'+eiStep+',ENDJOB'
+
 
 
         dictIO(options,args)

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -158,10 +158,10 @@ class Reco(Scenario):
         eiStep=''
 
         if 'beamSplashRun' in args:
-          eiStep = ":localreco+hcalOnlyGlobalRecoSequence+caloTowersRec" if args['beamSplashRun'] else ""
-          print("Using RECO%s step for ED clients" % eiStep)     
-
-        options.step += 'RAW2DIGI,L1Reco,RECO'+eiStep+',ENDJOB'
+            options.step += 'RAW2DIGI,L1Reco,RECO'+args['beamSplashRun']+',ENDJOB'
+            print("Using RECO%s step in visualizationProcessing" % args['beamSplashRun'])
+        else :
+            options.step += 'RAW2DIGI,L1Reco,RECO'+eiStep+',ENDJOB'
 
 
 

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -48,7 +48,7 @@ from DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi import GlobalTa
 kwds = {
    'globalTag': GlobalTag.globaltag.value(),
    'globalTagConnect': GlobalTag.connect.value(),
-   'beamSplashRun' : options.BeamSplashRun,
+   'beamSplashRun' : ":localreco+hcalOnlyGlobalRecoSequence+caloTowersRec" if options.BeamSplashRun else "",
 }
 
 # explicitly select the input collection, since we get multiple in online

--- a/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live-secondInstance_cfg.py
@@ -47,7 +47,8 @@ except Exception as ex:
 from DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi import GlobalTag
 kwds = {
    'globalTag': GlobalTag.globaltag.value(),
-   'globalTagConnect': GlobalTag.connect.value()
+   'globalTagConnect': GlobalTag.connect.value(),
+   'beamSplashRun' : options.BeamSplashRun,
 }
 
 # explicitly select the input collection, since we get multiple in online

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -48,7 +48,7 @@ from DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi import GlobalTa
 kwds = {
    'globalTag': GlobalTag.globaltag.value(),
    'globalTagConnect': GlobalTag.connect.value(),
-   'beamSplashRun' : options.BeamSplashRun,
+   'beamSplashRun' : ":localreco+hcalOnlyGlobalRecoSequence+caloTowersRec" if options.BeamSplashRun else "",
 }
 
 # explicitly select the input collection, since we get multiple in online

--- a/DQM/Integration/python/clients/visualization-live_cfg.py
+++ b/DQM/Integration/python/clients/visualization-live_cfg.py
@@ -47,7 +47,8 @@ except Exception as ex:
 from DQM.Integration.config.FrontierCondition_GT_autoExpress_cfi import GlobalTag
 kwds = {
    'globalTag': GlobalTag.globaltag.value(),
-   'globalTagConnect': GlobalTag.connect.value()
+   'globalTagConnect': GlobalTag.connect.value(),
+   'beamSplashRun' : options.BeamSplashRun,
 }
 
 # explicitly select the input collection, since we get multiple in online

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -67,6 +67,12 @@ options.register('eventsPerLumi',
                  VarParsing.VarParsing.varType.int,
                  "This number of last events in each lumisection will be processed.")
 
+options.register('BeamSplashRun',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "Set client source settings for beam SPLASH run")
+
 # This is used only by the online clients themselves. 
 # We need to register it here because otherwise an error occurs saying that there is an unidentified option.
 options.register('unitTest',


### PR DESCRIPTION
#### PR description:

For the beam SPLASH runs simplification of RECO sequence is proposed in order to speed up event processing in Event Display DQM clients. As simplified sequence is needed only for SPLASH runs, not for regular 'cosmic' and 'beam operation', the customization in visualizationProcessing function is applied when beamSplashRun option is True.

#### PR validation:

Tested locally, backport is to be tested at P5 in production using on-going runs.
