### PR TITLE
add HLT-EGM customisation for 2018 Data [`12_3_X`]

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -144,12 +144,20 @@ def customiseCTPPSFor2018Input(process):
 
     return process
 
+def customiseEGammaRecoFor2018Input(process):
+    for prod in producers_by_type(process, 'PFECALSuperClusterProducer'):
+        if hasattr(prod, 'regressionConfig'):
+            prod.regressionConfig.regTrainedWithPS = cms.bool(False)
+
+    return process
+
 def customiseFor2018Input(process):
     """Customise the HLT to run on Run 2 data/MC"""
     process = customisePixelGainForRun2Input(process)
     process = customisePixelL1ClusterThresholdForRun2Input(process)
     process = customiseHCALFor2018Input(process)
     process = customiseCTPPSFor2018Input(process)
+    process = customiseEGammaRecoFor2018Input(process)
 
     return process
 


### PR DESCRIPTION
backport of #37606

#### PR description:

This PR updates the function `customiseFor2018Input` used by TSG to characterise the Run-3 HLT menu on 2018 collisions data.

It adds a function named `customiseEGammaRecoFor2018Input`, which currently sets the flag `regTrainedWithPS` to `False` to handle correctly the HLT-EGM energy regression tags of 2018.

#37625 (backport of #37588) changed the value of `regTrainedWithPS` to `true` for Run 3 via the source code. This PR updates the Run-2 customisation such that TSG studies using `customiseFor2018Input` are not affected by that update.

No changes expected. Note that PR tests are completely blind to the modifications in this PR.

#### PR validation:

Relies on the validation done for the original PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#37606

Maintenance of TSG recipes for HLT studies in `12_3_X`.