### PR TITLE
Add new scenario for ECAL ALCANANO and update the unit test

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+_AlCaPhiSymEcal_Nano_
+
+Scenario supporting proton collision data taking for AlCaPhiSymEcal stream with ALCANANO output
+
+"""
+
+from Configuration.DataProcessing.Impl.AlCa import AlCa
+
+class AlCaPhiSymEcal_Nano(AlCa):
+    def __init__(self):
+        AlCa.__init__(self)
+        self.skims=['EcalPhiSymByRun']
+        self.promptCustoms = [ 'Calibration/EcalCalibAlgos/EcalPhiSymRecoSequence_cff.customise' ]
+        self.step = 'RECO:bunchSpacingProducer+ecalMultiFitUncalibRecHitTask+ecalCalibratedRecHitTask'
+    """
+    _AlCaPhiSymEcal_Nano_
+
+    Implement configuration building for data processing for proton
+    collision data taking for AlCaPhiSymEcal stream with ALCANANO output
+
+    """

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -38,7 +38,7 @@ do
 done
 
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"


### PR DESCRIPTION
#### PR description:

By doing the T0 replay
https://github.com/dmwm/T0/pull/4664/
I realized that the relvals run
```
steps['RECOALCAECALPHISYMDR3']=merge([{'--scenario':'pp',
                                       '--era':'Run3',
                                       '--conditions':'auto:run3_data_prompt',
                                       '--datatier':'RECO',
                                       '--eventcontent':'RECO',
                                       '-n':'-1',
                                       '-s':'RECO:bunchSpacingProducer+ecalMultiFitUncalibRecHitTask+ecalCalibratedRecHitTask',
                                       '--customise':'Calibration/EcalCalibAlgos/EcalPhiSymRecoSequence_cff'},dataReco])
```
and the customization in T0 happens through scenarios, so this PR adds the needed scenario.

#### PR validation:

`scram b runtests` runs and produces a config that for example contains the `ecalMultiFitUncalibRecHitTask` task.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Needs to be backported to 12_3_X for https://github.com/dmwm/T0/pull/4664/ to work
