### PR TITLE
[RFC] Migrate L1CondDBPayloadWriterExt to esConsumes

### DIFF
--- a/CondTools/L1Trigger/plugins/L1CondDBPayloadWriter.cc
+++ b/CondTools/L1Trigger/plugins/L1CondDBPayloadWriter.cc
@@ -74,22 +74,20 @@ void L1CondDBPayloadWriter::analyze(const edm::Event& iEvent, const edm::EventSe
 
   // Write L1TriggerKey to ORCON with no IOV
   std::string token;
-  ESHandle<L1TriggerKey> key;
 
   // Before calling writePayload(), check if TSC key is already in
   // L1TriggerKeyList.  writePayload() will not catch this situation in
   // the case of dummy configurations.
   bool triggerKeyOK = true;
-  try {
-    // Get L1TriggerKey
-    key = iSetup.getHandle(l1TriggerKeyToken_);
-
+  // Get L1TriggerKey
+  ESHandle<L1TriggerKey> key = iSetup.getHandle(l1TriggerKeyToken_);
+  if (key.isValid()) {
     if (!m_overwriteKeys) {
       triggerKeyOK = oldKeyList.token(key->tscKey()).empty();
     }
-  } catch (l1t::DataAlreadyPresentException& ex) {
+  } else {
     triggerKeyOK = false;
-    edm::LogVerbatim("L1-O2O") << ex.what();
+    edm::LogVerbatim("L1-O2O") << "L1TriggerKey was already inserted";
   }
 
   if (triggerKeyOK && m_writeL1TriggerKey) {

--- a/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.cc
+++ b/CondTools/L1Trigger/plugins/L1SubsystemKeysOnlineProd.cc
@@ -147,7 +147,8 @@ L1SubsystemKeysOnlineProd::ReturnType L1SubsystemKeysOnlineProd::produce(const L
     pL1TriggerKey->setSubsystemKey(L1TriggerKey::kTSP0, tsp0Key);
     edm::LogVerbatim("L1-O2O") << "TSP0_KEY " << tsp0Key;
   } else {
-    throw l1t::DataAlreadyPresentException("L1TriggerKey for TSC key " + m_tscKey + " already in CondDB.");
+    // use nullptr to signal that the L1TriggerKey already exists in CondDB
+    return {};
   }
 
   return pL1TriggerKey;

--- a/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
+++ b/CondTools/L1Trigger/plugins/L1TriggerKeyOnlineProd.cc
@@ -68,22 +68,18 @@ L1TriggerKeyOnlineProd::~L1TriggerKeyOnlineProd() {
 // ------------ method called to produce the data  ------------
 L1TriggerKeyOnlineProd::ReturnType L1TriggerKeyOnlineProd::produce(const L1TriggerKeyRcd& iRecord) {
   // Start with "SubsystemKeysOnly"
-  edm::ESHandle<L1TriggerKey> subsystemKeys;
-  try {
-    subsystemKeys = iRecord.getHandle(l1TriggerKeyToken_);
-  } catch (l1t::DataAlreadyPresentException& ex) {
-    throw ex;
+  edm::ESHandle<L1TriggerKey> subsystemKeys = iRecord.getHandle(l1TriggerKeyToken_);
+  if (not subsystemKeys.isValid()) {
+    return {};
   }
 
   std::unique_ptr<L1TriggerKey> pL1TriggerKey = std::make_unique<L1TriggerKey>(*subsystemKeys);
 
   // Collate object keys
   for (const auto& l1token : l1TriggerKeyTokenVec_) {
-    edm::ESHandle<L1TriggerKey> objectKeys;
-    try {
-      objectKeys = iRecord.getHandle(l1token);
-    } catch (l1t::DataAlreadyPresentException& ex) {
-      throw ex;
+    edm::ESHandle<L1TriggerKey> objectKeys = iRecord.getHandle(l1token);
+    if (not objectKeys.isValid()) {
+      return {};
     }
 
     pL1TriggerKey->add(objectKeys->recordToKeyMap());

--- a/CondTools/L1Trigger/src/L1ObjectKeysOnlineProdBase.cc
+++ b/CondTools/L1Trigger/src/L1ObjectKeysOnlineProdBase.cc
@@ -71,11 +71,9 @@ L1ObjectKeysOnlineProdBase::~L1ObjectKeysOnlineProdBase() {
 L1ObjectKeysOnlineProdBase::ReturnType L1ObjectKeysOnlineProdBase::produce(const L1TriggerKeyRcd& iRecord) {
   // Get L1TriggerKey with label "SubsystemKeysOnly".  Re-throw exception if
   // not present.
-  edm::ESHandle<L1TriggerKey> subsystemKeys;
-  try {
-    subsystemKeys = iRecord.getHandle(l1TriggerKeyToken_);
-  } catch (l1t::DataAlreadyPresentException& ex) {
-    throw ex;
+  edm::ESHandle<L1TriggerKey> subsystemKeys = iRecord.getHandle(l1TriggerKeyToken_);
+  if (not subsystemKeys.isValid()) {
+    return {};
   }
 
   // Copy L1TriggerKey to new object.

--- a/CondTools/L1TriggerExt/interface/DataWriterExt.h
+++ b/CondTools/L1TriggerExt/interface/DataWriterExt.h
@@ -20,6 +20,8 @@
 
 #include <string>
 #include <map>
+#include <optional>
+#include <unordered_map>
 
 namespace l1t {
 
@@ -34,14 +36,18 @@ namespace l1t {
 
   class DataWriterExt {
   public:
+    // non-consumes interface, to be removed
     DataWriterExt();
+    // interface with consumes
+    DataWriterExt(std::vector<std::string> const& recordTypes, edm::ConsumesCollector cc);
     ~DataWriterExt();
 
     // Payload and IOV writing functions.
 
     // Get payload from EventSetup and write to DB with no IOV
     // recordType = "record@type", return value is payload token
-    std::string writePayload(const edm::EventSetup& setup, const std::string& recordType);
+    // returned optional is nullopt if the recordType is not given in the constructor
+    std::optional<std::string> writePayload(const edm::EventSetup& setup, const std::string& recordType);
 
     // Use PoolDBOutputService to append IOV with sinceRun to IOV sequence
     // for given ESRecord.  PoolDBOutputService knows the corresponding IOV tag.
@@ -65,7 +71,8 @@ namespace l1t {
 
     bool fillLastTriggerKeyList(L1TriggerKeyListExt& output);
 
-  protected:
+  private:
+    std::unordered_map<std::string, std::unique_ptr<WriterProxy>> writers_;
   };
 
   template <class T>

--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -149,9 +149,8 @@ std::unique_ptr<const TData> L1ConfigOnlineProdBaseExt<TRcd, TData>::produce(con
       throw l1t::DataInvalidException("Unable to generate " + dataType + " for key " + key + ".");
     }
   } else {
-    std::string dataType = edm::typelookup::className<TData>();
-
-    throw l1t::DataAlreadyPresentException(dataType + " for key " + key + " already in CondDB.");
+    // use nullptr to signal that the L1TriggerKey already exists in CondDB
+    return {};
   }
 
   return pData;
@@ -169,9 +168,7 @@ bool L1ConfigOnlineProdBaseExt<TRcd, TData>::getObjectKey(const TRcd& record, st
   // If L1TriggerKeyExt is invalid, then all configuration objects are
   // already in ORCON.
   // edm::ESHandle<L1TriggerKeyExt> key_token;
-  try {
-    keyRcd.get(key_token);
-  } catch (l1t::DataAlreadyPresentException& ex) {
+  if (not keyRcd.getHandle(key_token).isValid()) {
     objectKey = std::string();
     return false;
   }

--- a/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1SubsystemKeysOnlineProdExt.cc
@@ -152,8 +152,8 @@ L1SubsystemKeysOnlineProdExt::ReturnType L1SubsystemKeysOnlineProdExt::produce(c
     edm::LogVerbatim("L1-O2O") << "TWINMUX_RS_KEY:	" << TWINMUXrsKey;
 
   } else {
-    throw l1t::DataAlreadyPresentException("L1TriggerKeyExt for TSC key " + m_tscKey + " and RS key " + m_rsKey +
-                                           " already in CondDB.");
+    // use nullptr to signal that the L1TriggerKey already exists in CondDB
+    return {};
   }
 
   return pL1TriggerKey;

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
@@ -32,14 +32,12 @@ L1TriggerKeyOnlineProdExt::~L1TriggerKeyOnlineProdExt() {
 // ------------ method called to produce the data  ------------
 L1TriggerKeyOnlineProdExt::ReturnType L1TriggerKeyOnlineProdExt::produce(const L1TriggerKeyExtRcd& iRecord) {
   // Start with "SubsystemKeysOnly"
-  L1TriggerKeyExt subsystemKeys;
-  try {
-    subsystemKeys = iRecord.get(L1TriggerKeyExt_token);
-  } catch (l1t::DataAlreadyPresentException& ex) {
-    throw ex;
+  edm::ESHandle<L1TriggerKeyExt> subsystemKeys = iRecord.getHandle(L1TriggerKeyExt_token);
+  if (not subsystemKeys.isValid()) {
+    return {};
   }
 
-  auto pL1TriggerKey = std::make_unique<L1TriggerKeyExt>(subsystemKeys);
+  auto pL1TriggerKey = std::make_unique<L1TriggerKeyExt>(*subsystemKeys);
 
   // Collate object keys
   for (auto const& token : m_subsystemTokens) {

--- a/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
+++ b/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
@@ -21,15 +21,13 @@ L1ObjectKeysOnlineProdBaseExt::~L1ObjectKeysOnlineProdBaseExt() {
 L1ObjectKeysOnlineProdBaseExt::ReturnType L1ObjectKeysOnlineProdBaseExt::produce(const L1TriggerKeyExtRcd& iRecord) {
   // Get L1TriggerKeyExt with label "SubsystemKeysOnly".  Re-throw exception if
   // not present.
-  L1TriggerKeyExt subsystemKeys;
-  try {
-    subsystemKeys = iRecord.get(L1TriggerKeyExt_token);
-  } catch (l1t::DataAlreadyPresentException& ex) {
-    throw ex;
+  edm::ESHandle<L1TriggerKeyExt> subsystemKeys = iRecord.getHandle(L1TriggerKeyExt_token);
+  if (not subsystemKeys.isValid()) {
+    return {};
   }
 
   // Copy L1TriggerKeyExt to new object.
-  auto pL1TriggerKey = std::make_unique<L1TriggerKeyExt>(subsystemKeys);
+  auto pL1TriggerKey = std::make_unique<L1TriggerKeyExt>(*subsystemKeys);
 
   // Get object keys.
   fillObjectKeys(pL1TriggerKey.get());


### PR DESCRIPTION
#### PR description:

This PR **is not intended to be merged** as such. It is intended as an illustration of design choices alternative to https://github.com/cms-sw/cmssw/pull/37602 that may be useful (or not) in later improvements of the code, that I and @Dr15Jones hacked together in parallel to the recent updates in #37602 (in part to gain better understanding of the code). The main differences wrt. #37602 
* The map of strings to writer objects is within `DataWriterExt` instead of `L1CondDBPayloadWriterExt`
* It makes an attempt to handle the "data product already exists in the target DB" case (that is currently broken)
  * I believe the data product existence check could be achieved in simpler means, the approach chosen here was to minimize structural changes (given the time pressure).

#### PR validation:

Code compiles.