### PR TITLE
EL9: Fix OpenSSL warnings

### DIFF
--- a/CondCore/CondDB/BuildFile.xml
+++ b/CondCore/CondDB/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="CondFormats/Serialization"/>
 <use name="CondFormats/Common"/>
 <use name="FWCore/Framework"/>
+<use name="Utilities/OpenSSL"/>
 <use name="boost"/>
 <use name="openssl"/>
 <use name="curl"/>

--- a/DQMServices/FileIO/plugins/BuildFile.xml
+++ b/DQMServices/FileIO/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="EventFilter/Utilities"/>
+<use name="Utilities/OpenSSL"/>
 <use name="stdcxx-fs"/>
 <use name="boost"/>
 <use name="boost_iostreams"/>

--- a/DQMServices/FileIO/plugins/DQMFileSaverOnline.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverOnline.cc
@@ -152,7 +152,7 @@ const std::string DQMFileSaverOnline::fillOrigin(const std::string& filename, co
 
   boost::iostreams::mapped_file_source fp(filename);
 
-  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestInit_ex(mdctx, md, nullptr);
   EVP_DigestUpdate(mdctx, (unsigned char*)fp.data(), fp.size());
   EVP_DigestFinal_ex(mdctx, md5, &md_len);
   EVP_MD_CTX_free(mdctx);

--- a/DQMServices/FileIO/plugins/DQMFileSaverOnline.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverOnline.cc
@@ -8,7 +8,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
-
+#include "Utilities/OpenSSL/interface/openssl_init.h"
 #include "DQMFileSaverOnline.h"
 
 #include <TString.h>
@@ -22,7 +22,6 @@
 #include <utility>
 #include <vector>
 
-#include <openssl/md5.h>
 #include <filesystem>
 #include <boost/iostreams/device/mapped_file.hpp>
 
@@ -145,15 +144,22 @@ const std::string DQMFileSaverOnline::fillOrigin(const std::string& filename, co
   // format.origin (one line):
   //   md5:d566a34b27f48d507150a332b189398b 294835 final_filename.root
 
-  unsigned char md5[MD5_DIGEST_LENGTH];
+  cms::openssl_init();
+  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+  const EVP_MD* md = EVP_get_digestbyname("MD5");
+  unsigned int md_len = 0;
+  unsigned char md5[EVP_MAX_MD_SIZE];
 
   boost::iostreams::mapped_file_source fp(filename);
 
-  MD5((unsigned char*)fp.data(), fp.size(), md5);
+  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestUpdate(mdctx, (unsigned char*)fp.data(), fp.size());
+  EVP_DigestFinal_ex(mdctx, md5, &md_len);
+  EVP_MD_CTX_free(mdctx);
 
   std::ostringstream hash;
-  for (unsigned char& i : md5) {
-    hash << std::hex << std::setfill('0') << std::setw(2) << (int)i;
+  for (unsigned int i = 0; i < md_len; i++) {
+    hash << std::hex << std::setfill('0') << std::setw(2) << (int)md5[i];
   }
 
   std::ostringstream out;

--- a/GeneratorInterface/SherpaInterface/BuildFile.xml
+++ b/GeneratorInterface/SherpaInterface/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="GeneratorInterface/Core"/>
 <use name="GeneratorInterface/ExternalDecays"/>
+<use name="Utilities/OpenSSL"/>
 <use name="clhep"/>
 <use name="sherpa"/>
 <use name="zlib"/>

--- a/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
@@ -1,4 +1,5 @@
 #include "GeneratorInterface/SherpaInterface/interface/SherpackUtilities.h"
+#include "Utilities/OpenSSL/interface/openssl_init.h"
 #include <unistd.h>
 #include <cstdlib>
 namespace spu {
@@ -485,21 +486,26 @@ namespace spu {
   // function for calculating the MD5 checksum of a file
   void md5_File(std::string filename, char *result) {
     char buffer[4096];
-    MD5_CTX md5;
-    MD5_Init(&md5);
+    cms::openssl_init();
+    EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+    const EVP_MD *md = EVP_get_digestbyname("MD5");
+    EVP_DigestInit_ex(mdctx, md, NULL);
 
     //Open File
     int fd = open(filename.c_str(), O_RDONLY);
     int nb_read;
     while ((nb_read = read(fd, buffer, 4096 - 1))) {
-      MD5_Update(&md5, buffer, nb_read);
+      EVP_DigestUpdate(mdctx, buffer, nb_read);
       memset(buffer, 0, 4096);
     }
-    unsigned char tmp[MD5_DIGEST_LENGTH];
-    MD5_Final(tmp, &md5);
+
+    unsigned int md_len = 0;
+    unsigned char tmp[EVP_MAX_MD_SIZE];
+    EVP_DigestFinal_ex(mdctx, tmp, &md_len);
+    EVP_MD_CTX_free(mdctx);
 
     //Convert the result
-    for (int k = 0; k < MD5_DIGEST_LENGTH; ++k) {
+    for (unsigned int k = 0; k < md_len; ++k) {
       sprintf(result + k * 2, "%02x", tmp[k]);
     }
   }

--- a/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
+++ b/GeneratorInterface/SherpaInterface/src/SherpackUtilities.cc
@@ -489,7 +489,7 @@ namespace spu {
     cms::openssl_init();
     EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
     const EVP_MD *md = EVP_get_digestbyname("MD5");
-    EVP_DigestInit_ex(mdctx, md, NULL);
+    EVP_DigestInit_ex(mdctx, md, nullptr);
 
     //Open File
     int fd = open(filename.c_str(), O_RDONLY);

--- a/PhysicsTools/SelectorUtils/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/BuildFile.xml
@@ -16,20 +16,9 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
+<use name="Utilities/OpenSSL"/>
 <use name="rootcore"/>
 <use name="root"/>
-<use name="openssl"/>
 <export>
   <lib name="1"/>
-  <use name="CommonTools/Utils"/>
-  <use name="DataFormats/Candidate"/>
-  <use name="DataFormats/PatCandidates"/>
-  <use name="DataFormats/BeamSpot"/>
-  <use name="DataFormats/Common"/>
-  <use name="DataFormats/Provenance"/>
-  <use name="DataFormats/VertexReco"/>
-  <use name="FWCore/Common"/>
-  <use name="FWCore/ParameterSet"/>
-  <use name="FWCore/Utilities"/>
-  <use name="openssl"/>
 </export>

--- a/PhysicsTools/SelectorUtils/bin/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/bin/BuildFile.xml
@@ -6,10 +6,9 @@
 <use name="FWCore/ParameterSetReader"/>
 <use name="PhysicsTools/FWLite"/>
 <use name="PhysicsTools/SelectorUtils"/>
-<environment>
-  <bin file="testSelection_wplusjets.C">
-  </bin>
+<bin file="testSelection_wplusjets.C">
+</bin>
 
-  <bin file="calculateIdMD5.cc">
-  </bin>
-</environment>
+<bin file="calculateIdMD5.cc">
+  <use name="Utilities/OpenSSL"/>
+</bin>

--- a/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
+++ b/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
@@ -7,7 +7,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"
 
-#include <openssl/md5.h>
+#include "Utilities/OpenSSL/interface/openssl_init.h"
 
 using namespace std;
 
@@ -38,11 +38,19 @@ int main(int argc, char** argv) {
   }
 
   // now setup the md5 and cute accessor functions
-  unsigned char id_md5_[MD5_DIGEST_LENGTH];
-  memset(id_md5_, 0, MD5_DIGEST_LENGTH * sizeof(unsigned char));
-  MD5((const unsigned char*)tracked.c_str(), tracked.size(), id_md5_);
+  cms::openssl_init();
+  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  unsigned int md_len = 0;
+  unsigned char id_md5_[EVP_MAX_MD_SIZE];
+
+  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestUpdate(mdctx, (const unsigned char*)tracked.c_str(), tracked.size());
+  EVP_DigestFinal_ex(mdctx, id_md5_, &md_len);
+  EVP_MD_CTX_free(mdctx);
+
   printf("%s : ", argv[2]);
-  for (unsigned i = 0; i < MD5_DIGEST_LENGTH; ++i) {
+  for (unsigned i = 0; i < md_len; ++i) {
     printf("%02x", id_md5_[i]);
   }
   printf("\n");

--- a/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
+++ b/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
   unsigned int md_len = 0;
   unsigned char id_md5_[EVP_MAX_MD_SIZE];
 
-  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestInit_ex(mdctx, md, nullptr);
   EVP_DigestUpdate(mdctx, (const unsigned char*)tracked.c_str(), tracked.size());
   EVP_DigestFinal_ex(mdctx, id_md5_, &md_len);
   EVP_MD_CTX_free(mdctx);

--- a/Utilities/OpenSSL/test/BuildFile.xml
+++ b/Utilities/OpenSSL/test/BuildFile.xml
@@ -3,5 +3,12 @@
   <flags CXXFLAGS="-Wno-deprecated-declarations"/>
 </bin>
 
+<bin file="test_openssl_md5.cpp" name="test_openssl_md5">
+  <flags CXXFLAGS="-Wno-deprecated-declarations"/>
+</bin>
+
 <bin file="test_openssl_evp_digest.cpp" name="test_openssl_evp_digest">
+</bin>
+
+<bin file="test_openssl_evp_md5.cpp" name="test_openssl_evp_md5">
 </bin>

--- a/Utilities/OpenSSL/test/test_openssl_evp_md5.cpp
+++ b/Utilities/OpenSSL/test/test_openssl_evp_md5.cpp
@@ -1,0 +1,33 @@
+#include "Utilities/OpenSSL/interface/openssl_init.h"
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+using namespace std;
+int main() {
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int md_len = 0;
+  cms::openssl_init();
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+  const EVP_MD *md = EVP_get_digestbyname("MD5");
+
+  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestUpdate(mdctx, "foo-bar-bla", 11);
+  EVP_DigestFinal_ex(mdctx, hash, &md_len);
+  EVP_MD_CTX_free(mdctx);
+
+  char tmp[EVP_MAX_MD_SIZE * 2 + 1];
+  // re-write bytes in hex
+  for (unsigned int i = 0; i < md_len; i++) {
+    ::sprintf(&tmp[i * 2], "%02x", hash[i]);
+  }
+  tmp[md_len * 2] = 0;
+  string sha = tmp;
+  string sha_result = "ad42a5e51344e880010799a7b7c612fc";
+  if (sha != sha_result) {
+    cout << "Failed: SHA1 Mismatch:" << sha << " vs " << sha_result << endl;
+    return 1;
+  }
+  cout << "Passed: SHA1 match:" << sha << " vs " << sha_result << endl;
+  return 0;
+}

--- a/Utilities/OpenSSL/test/test_openssl_md5.cpp
+++ b/Utilities/OpenSSL/test/test_openssl_md5.cpp
@@ -1,0 +1,23 @@
+#include <openssl/md5.h>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+using namespace std;
+int main() {
+  unsigned char hash[MD5_DIGEST_LENGTH];
+  string data("foo-bar-bla");
+  MD5((unsigned char*)data.c_str(), 11, hash);
+  stringstream ss;
+  for (unsigned int i = 0; i < MD5_DIGEST_LENGTH; i++) {
+    ss << hex << setw(2) << setfill('0') << (int)hash[i];
+  }
+  string sha_result = "ad42a5e51344e880010799a7b7c612fc";
+  string sha = ss.str();
+  if (sha != sha_result) {
+    cout << "Failed: SHA1 Mismatch:" << sha << " vs " << sha_result << endl;
+    return 1;
+  }
+  cout << "Passed: SHA1 match:" << sha << " vs " << sha_result << endl;
+  return 0;
+}


### PR DESCRIPTION
These chanegs should fix the remaining OpenSSL warnings
```
PhysicsTools/SelectorUtils/interface/VersionedSelector.h:60:8: warning: 'unsigned char* MD5(const unsigned char*, size_t, unsigned char*)' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
    60 |     MD5((unsigned char*)tracked.c_str(), tracked.size(), id_md5_);
```