### PR TITLE
Add PFTauDiscriminator based on IP

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
@@ -11,9 +11,8 @@ class PFRecoTauDiscriminationByIPCut final : public PFTauDiscriminationProducerB
 public:
   explicit PFRecoTauDiscriminationByIPCut(const edm::ParameterSet& iConfig)
       : PFTauDiscriminationProducerBase(iConfig),
-        tausTIPToken_(consumes<PFTauTIPAssociationByRef>(iConfig.getParameter<edm::InputTag>("tausTIP"))),
-        tauTIPSelectorString_(iConfig.getParameter<std::string>("cut")),
-        tauTIPSelector_(tauTIPSelectorString_) {}
+        tausTIPToken_(consumes(iConfig.getParameter<edm::InputTag>("tausTIP"))),
+        tauTIPSelector_(iConfig.getParameter<std::string>("cut")) {}
   ~PFRecoTauDiscriminationByIPCut() override {}
   void beginEvent(const edm::Event&, const edm::EventSetup&) override;
   double discriminate(const PFTauRef& pfTau) const override;
@@ -25,7 +24,6 @@ private:
   edm::EDGetTokenT<PFTauTIPAssociationByRef> tausTIPToken_;
   edm::Handle<PFTauTIPAssociationByRef> tausTIP_;
 
-  const std::string tauTIPSelectorString_;
   const StringCutObjectSelector<reco::PFTauTransverseImpactParameter> tauTIPSelector_;
 };
 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
@@ -1,0 +1,60 @@
+#include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
+#include <FWCore/ParameterSet/interface/ConfigurationDescriptions.h>
+#include <FWCore/ParameterSet/interface/ParameterSetDescription.h>
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/TauReco/interface/PFTauFwd.h"
+#include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
+#include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterAssociation.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+/* 
+ * class PFRecoTauDiscriminationByIPCut
+ */
+
+using namespace reco;
+
+class PFRecoTauDiscriminationByIPCut : public PFTauDiscriminationProducerBase {
+public:
+  explicit PFRecoTauDiscriminationByIPCut(const edm::ParameterSet& iConfig)
+      : PFTauDiscriminationProducerBase(iConfig),
+        tausTIPToken_(consumes<PFTauTIPAssociationByRef>(iConfig.getParameter<edm::InputTag>("tausTIP"))),
+        tauTIPSelectorString_(iConfig.getParameter<std::string>("cut")),
+        tauTIPSelector_(tauTIPSelectorString_) {}
+  ~PFRecoTauDiscriminationByIPCut() override {}
+  void beginEvent(const edm::Event&, const edm::EventSetup&) override;
+  double discriminate(const PFTauRef& pfTau) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  typedef edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> >
+      PFTauTIPAssociationByRef;
+  edm::EDGetTokenT<PFTauTIPAssociationByRef> tausTIPToken_;
+  edm::Handle<PFTauTIPAssociationByRef> tausTIP_;
+
+  const std::string tauTIPSelectorString_;
+  const StringCutObjectSelector<reco::PFTauTransverseImpactParameter> tauTIPSelector_;
+};
+
+double PFRecoTauDiscriminationByIPCut::discriminate(const PFTauRef& thePFTauRef) const {
+  return tauTIPSelector_(*(*tausTIP_)[thePFTauRef]) ? 1. : 0.;
+}
+
+void PFRecoTauDiscriminationByIPCut::beginEvent(const edm::Event& event, const edm::EventSetup& eventSetup) {
+  event.getByToken(tausTIPToken_, tausTIP_);
+}
+
+void PFRecoTauDiscriminationByIPCut::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("tausTIP", edm::InputTag("hltTauIPCollection"));
+  desc.add<std::string>("cut", "abs(dxy) > -999.");
+  {
+    edm::ParameterSetDescription psd0;
+    psd0.add<std::string>("BooleanOperator", "and");
+    desc.add<edm::ParameterSetDescription>("Prediscriminants", psd0);
+  }
+  desc.add<edm::InputTag>("PFTauProducer", edm::InputTag("pfRecoTauProducer"));
+  descriptions.addWithDefaultLabel(desc);
+}
+
+DEFINE_FWK_MODULE(PFRecoTauDiscriminationByIPCut);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
@@ -1,11 +1,4 @@
 #include "RecoTauTag/RecoTau/interface/TauDiscriminationProducerBase.h"
-#include <FWCore/ParameterSet/interface/ConfigurationDescriptions.h>
-#include <FWCore/ParameterSet/interface/ParameterSetDescription.h>
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "DataFormats/TauReco/interface/PFTau.h"
-#include "DataFormats/TauReco/interface/PFTauFwd.h"
-#include "DataFormats/TauReco/interface/PFTauDiscriminator.h"
 #include "DataFormats/TauReco/interface/PFTauTransverseImpactParameterAssociation.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 /* 

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
@@ -7,7 +7,7 @@
 
 using namespace reco;
 
-class PFRecoTauDiscriminationByIPCut : public PFTauDiscriminationProducerBase {
+class PFRecoTauDiscriminationByIPCut final : public PFTauDiscriminationProducerBase {
 public:
   explicit PFRecoTauDiscriminationByIPCut(const edm::ParameterSet& iConfig)
       : PFTauDiscriminationProducerBase(iConfig),

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIPCut.cc
@@ -41,12 +41,7 @@ void PFRecoTauDiscriminationByIPCut::fillDescriptions(edm::ConfigurationDescript
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("tausTIP", edm::InputTag("hltTauIPCollection"));
   desc.add<std::string>("cut", "abs(dxy) > -999.");
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.add<std::string>("BooleanOperator", "and");
-    desc.add<edm::ParameterSetDescription>("Prediscriminants", psd0);
-  }
-  desc.add<edm::InputTag>("PFTauProducer", edm::InputTag("pfRecoTauProducer"));
+  fillProducerDescriptions(desc);  // inherited from the base
   descriptions.addWithDefaultLabel(desc);
 }
 


### PR DESCRIPTION
#### PR description:

The main purpose is to use this producer for the displaced tau triggers in Run3.

#### PR validation:

Code checks and runTheMatrix tests have been performed on top of CMSSW_12_4_0_pre2

The producer can be tested via:
```
cp /afs/cern.ch/user/a/azotz/public/displacedTaus/* .
cmsRun customise_hlt_12_3_0.py
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport, but a backport to 12_3_X is planned