### PR TITLE
small fix to enable CSC unpacker in L1T DQM sequence

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -55,7 +55,7 @@ process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 
 # remove unneeded unpackers
 process.RawToDigi.remove(process.ecalPreshowerDigis)
-process.RawToDigi.remove(process.muonCSCDigis)
+#process.RawToDigi.remove(process.muonCSCDigis)
 process.RawToDigi.remove(process.muonDTDigis)
 process.RawToDigi.remove(process.muonRPCDigis)
 process.RawToDigi.remove(process.siPixelDigis)


### PR DESCRIPTION
#### PR description:

This is a small fix for [issue 37584](https://github.com/cms-sw/cmssw/issues/37584).
The CSC shower DQM, enabled since [PR 37544](https://github.com/cms-sw/cmssw/pull/37544), takes muonCSCDigis as input, while it is not enabled in L1T DQM sequence by default.
Enable CSC unpacker here to avoid errors.

In discussion with L1T SW expert to see if this fix complies with CMSSW rules/conventions. A more appropriate fix will be made if needed.

#### PR validation:

The relevant sequence `l1tstage2_dqm_sourceclient-live_cfg.py` runs fine. 
Matrix test not performed as it is a very simple change.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A

