### PR TITLE
Add configurable cut on SiStrip max cluster cut (by default <8) in mkFit tracking iterations

### DIFF
--- a/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
+++ b/RecoTracker/MkFit/plugins/MkFitIterationConfigESProducer.cc
@@ -209,18 +209,21 @@ private:
   const edm::ESGetToken<MkFitGeometry, TrackerRecoGeometryRecord> geomToken_;
   const std::string configFile_;
   const float minPtCut_;
+  const unsigned int maxClusterSize_;
 };
 
 MkFitIterationConfigESProducer::MkFitIterationConfigESProducer(const edm::ParameterSet &iConfig)
     : geomToken_{setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName")).consumes()},
       configFile_{iConfig.getParameter<edm::FileInPath>("config").fullPath()},
-      minPtCut_{(float)iConfig.getParameter<double>("minPt")} {}
+      minPtCut_{(float)iConfig.getParameter<double>("minPt")},
+      maxClusterSize_{iConfig.getParameter<unsigned int>("maxClusterSize")} {}
 
 void MkFitIterationConfigESProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<std::string>("ComponentName")->setComment("Product label");
   desc.add<edm::FileInPath>("config")->setComment("Path to the JSON file for the mkFit configuration parameters");
   desc.add<double>("minPt", 0.0)->setComment("min pT cut applied during track building");
+  desc.add<unsigned int>("maxClusterSize", 8)->setComment("Max cluster size of SiStrip hits");
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -231,6 +234,8 @@ std::unique_ptr<mkfit::IterationConfig> MkFitIterationConfigESProducer::produce(
   it_conf->m_params.minPtCut = minPtCut_;
   it_conf->m_backward_params.minPtCut = minPtCut_;
   it_conf->m_partition_seeds = partitionSeeds1;
+  it_conf->m_params.maxClusterSize = maxClusterSize_;
+  it_conf->m_backward_params.maxClusterSize = maxClusterSize_;
   return it_conf;
 }
 

--- a/RecoTracker/MkFitCore/interface/Config.h
+++ b/RecoTracker/MkFitCore/interface/Config.h
@@ -91,15 +91,6 @@ namespace mkfit {
     constexpr float mag_b1 = 7.53701e-06;
     constexpr float mag_a = 2.43878e-11;
 
-    // Config for "fake" hit addition
-    // Only if fake_hit_idx==-1, then count as missing hit for candidate score
-    constexpr int hit_miss_idx_ = -1;        //  hit is missed
-    constexpr int hit_stop_idx_ = -2;        //  track is stopped
-    constexpr int hit_edge_idx_ = -3;        //  track not in sensitive region of detector
-    constexpr int hit_maxcluster_idx_ = -5;  //  hit cluster size > maxClusterSize
-    constexpr int hit_gap_idx_ = -7;         //  track passing through inactive module
-    constexpr int hit_cccfilter_idx_ = -9;   //  hit filtered via CCC (unused)
-
     // Config for SelectHitIndices
     // Use extra arrays to store phi and q of hits.
     // MT: This would in principle allow fast selection of good hits, if

--- a/RecoTracker/MkFitCore/interface/Config.h
+++ b/RecoTracker/MkFitCore/interface/Config.h
@@ -91,6 +91,15 @@ namespace mkfit {
     constexpr float mag_b1 = 7.53701e-06;
     constexpr float mag_a = 2.43878e-11;
 
+    // Config for "fake" hit addition
+    // Only if fake_hit_idx==-1, then count as missing hit for candidate score
+    constexpr int hit_miss_idx_ = -1;        //  hit is missed
+    constexpr int hit_stop_idx_ = -2;        //  track is stopped
+    constexpr int hit_edge_idx_ = -3;        //  track not in sensitive region of detector
+    constexpr int hit_maxcluster_idx_ = -5;  //  hit cluster size > maxClusterSize
+    constexpr int hit_gap_idx_ = -7;         //  track passing through inactive module
+    constexpr int hit_cccfilter_idx_ = -9;   //  hit filtered via CCC (unused)
+
     // Config for SelectHitIndices
     // Use extra arrays to store phi and q of hits.
     // MT: This would in principle allow fast selection of good hits, if

--- a/RecoTracker/MkFitCore/interface/Hit.h
+++ b/RecoTracker/MkFitCore/interface/Hit.h
@@ -206,7 +206,7 @@ namespace mkfit {
         if (cpcm < kMinChargePerCM)
           charge_pcm = 0;
         else
-          charge_pcm = std::min(0xff, ((cpcm - kMinChargePerCM) >> 3) + 1);
+          charge_pcm = std::min((1 << kChargePerCMBits) - 1, ((cpcm - kMinChargePerCM) >> 3) + 1);
       }
       unsigned int get_charge_pcm() const {
         if (charge_pcm == 0)
@@ -222,20 +222,20 @@ namespace mkfit {
     unsigned int spanCols() const { return pdata_.span_cols + 1; }
 
     static unsigned int minChargePerCM() { return kMinChargePerCM; }
-    static unsigned int maxChargePerCM() { return kMinChargePerCM + (0xfe << 3); }
+    static unsigned int maxChargePerCM() { return kMinChargePerCM + (((1 << kChargePerCMBits) - 2) << 3); }
     static unsigned int maxSpan() { return kMaxClusterSize; }
 
     void setupAsPixel(unsigned int id, int rows, int cols) {
       pdata_.detid_in_layer = id;
-      pdata_.charge_pcm = 0xff;
-      pdata_.span_rows = std::min(0x20, rows - 1);
-      pdata_.span_cols = std::min(0x20, cols - 1);
+      pdata_.charge_pcm = (1 << kChargePerCMBits) - 1;
+      pdata_.span_rows = std::min(kMaxClusterSize, rows - 1);
+      pdata_.span_cols = std::min(kMaxClusterSize, cols - 1);
     }
 
     void setupAsStrip(unsigned int id, int cpcm, int rows) {
       pdata_.detid_in_layer = id;
       pdata_.set_charge_pcm(cpcm);
-      pdata_.span_rows = std::min(0x20, rows - 1);
+      pdata_.span_rows = std::min(kMaxClusterSize, rows - 1);
     }
 
   private:

--- a/RecoTracker/MkFitCore/interface/Hit.h
+++ b/RecoTracker/MkFitCore/interface/Hit.h
@@ -188,6 +188,15 @@ namespace mkfit {
     int layer(const MCHitInfoVec& globalMCHitInfo) const { return globalMCHitInfo[mcHitID_].layer(); }
     int mcTrackID(const MCHitInfoVec& globalMCHitInfo) const { return globalMCHitInfo[mcHitID_].mcTrackID(); }
 
+    // Indices for "fake" hit addition
+    // Only if fake_hit_idx==-1, then count as missing hit for candidate score
+    static constexpr int kHitMissIdx = -1;        //  hit is missed
+    static constexpr int kHitStopIdx = -2;        //  track is stopped
+    static constexpr int kHitEdgeIdx = -3;        //  track not in sensitive region of detector
+    static constexpr int kHitMaxClusterIdx = -5;  //  hit cluster size > maxClusterSize
+    static constexpr int kHitInGapIdx = -7;       //  track passing through inactive module
+    static constexpr int kHitCCCFilterIdx = -9;   //  hit filtered via CCC (unused)
+
     static constexpr int kMinChargePerCM = 1620;
     static constexpr int kChargePerCMBits = 8;
     static constexpr int kDetIdInLayerBits = 12;

--- a/RecoTracker/MkFitCore/interface/Hit.h
+++ b/RecoTracker/MkFitCore/interface/Hit.h
@@ -193,8 +193,8 @@ namespace mkfit {
     struct PackedData {
       unsigned int detid_in_layer : 12;
       unsigned int charge_pcm : 8;  // MIMI see set/get funcs; applicable for phase-0/1
-      unsigned int span_rows : 3;
-      unsigned int span_cols : 3;
+      unsigned int span_rows : 5;
+      unsigned int span_cols : 5;
 
       PackedData() : detid_in_layer(0), charge_pcm(0), span_rows(0), span_cols(0) {}
 
@@ -219,19 +219,19 @@ namespace mkfit {
 
     static unsigned int minChargePerCM() { return kMinChargePerCM; }
     static unsigned int maxChargePerCM() { return kMinChargePerCM + (0xfe << 3); }
-    static unsigned int maxSpan() { return 8; }
+    static unsigned int maxSpan() { return 32; }
 
     void setupAsPixel(unsigned int id, int rows, int cols) {
       pdata_.detid_in_layer = id;
       pdata_.charge_pcm = 0xff;
-      pdata_.span_rows = std::min(0x7, rows - 1);
-      pdata_.span_cols = std::min(0x7, cols - 1);
+      pdata_.span_rows = std::min(0x20, rows - 1);
+      pdata_.span_cols = std::min(0x20, cols - 1);
     }
 
     void setupAsStrip(unsigned int id, int cpcm, int rows) {
       pdata_.detid_in_layer = id;
       pdata_.set_charge_pcm(cpcm);
-      pdata_.span_rows = std::min(0x7, rows - 1);
+      pdata_.span_rows = std::min(0x20, rows - 1);
     }
 
   private:

--- a/RecoTracker/MkFitCore/interface/Hit.h
+++ b/RecoTracker/MkFitCore/interface/Hit.h
@@ -192,6 +192,7 @@ namespace mkfit {
     static constexpr int kChargePerCMBits = 8;
     static constexpr int kDetIdInLayerBits = 12;
     static constexpr int kClusterSizeBits = 5;
+    static constexpr int kMaxClusterSize = (1 << kClusterSizeBits) - 1;
 
     struct PackedData {
       unsigned int detid_in_layer : kDetIdInLayerBits;
@@ -222,7 +223,7 @@ namespace mkfit {
 
     static unsigned int minChargePerCM() { return kMinChargePerCM; }
     static unsigned int maxChargePerCM() { return kMinChargePerCM + (0xfe << 3); }
-    static unsigned int maxSpan() { return 32; }
+    static unsigned int maxSpan() { return kMaxClusterSize; }
 
     void setupAsPixel(unsigned int id, int rows, int cols) {
       pdata_.detid_in_layer = id;

--- a/RecoTracker/MkFitCore/interface/Hit.h
+++ b/RecoTracker/MkFitCore/interface/Hit.h
@@ -189,12 +189,15 @@ namespace mkfit {
     int mcTrackID(const MCHitInfoVec& globalMCHitInfo) const { return globalMCHitInfo[mcHitID_].mcTrackID(); }
 
     static constexpr int kMinChargePerCM = 1620;
+    static constexpr int kChargePerCMBits = 8;
+    static constexpr int kDetIdInLayerBits = 12;
+    static constexpr int kClusterSizeBits = 5;
 
     struct PackedData {
-      unsigned int detid_in_layer : 12;
-      unsigned int charge_pcm : 8;  // MIMI see set/get funcs; applicable for phase-0/1
-      unsigned int span_rows : 5;
-      unsigned int span_cols : 5;
+      unsigned int detid_in_layer : kDetIdInLayerBits;
+      unsigned int charge_pcm : kChargePerCMBits;  // MIMI see set/get funcs; applicable for phase-0/1
+      unsigned int span_rows : kClusterSizeBits;
+      unsigned int span_cols : kClusterSizeBits;
 
       PackedData() : detid_in_layer(0), charge_pcm(0), span_rows(0), span_cols(0) {}
 

--- a/RecoTracker/MkFitCore/interface/IterationConfig.h
+++ b/RecoTracker/MkFitCore/interface/IterationConfig.h
@@ -115,6 +115,9 @@ namespace mkfit {
 
     //min pT cut
     float minPtCut = 0.0;
+
+    //max cluster size cut for SiStrip hits
+    unsigned int maxClusterSize = 8;
   };
 
   //==============================================================================

--- a/RecoTracker/MkFitCore/interface/TrackStructures.h
+++ b/RecoTracker/MkFitCore/interface/TrackStructures.h
@@ -473,7 +473,8 @@ namespace mkfit {
     while (--nh >= 0) {
       const HoTNode& hot_node = m_comb_candidate->hot_node(ch);
       int thisL = hot_node.m_hot.layer;
-      if (thisL >= 0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == -9) && thisL != prevL) {
+      if (thisL >= 0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == Hit::kHitCCCFilterIdx) &&
+          thisL != prevL) {
         ++nUL;
         prevL = thisL;
       }
@@ -492,7 +493,7 @@ namespace mkfit {
     while (--nh >= 0) {
       const HoTNode& hot_node = m_comb_candidate->hot_node(ch);
       int thisL = hot_node.m_hot.layer;
-      if (thisL >= 0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == -9)) {
+      if (thisL >= 0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == Hit::kHitCCCFilterIdx)) {
         if (trk_inf[thisL].is_pixel())
           ++pix;
         else if (trk_inf[thisL].is_stereo()) {
@@ -524,7 +525,8 @@ namespace mkfit {
     while (--nh >= 0) {
       const HoTNode& hot_node = m_comb_candidate->hot_node(ch);
       int thisL = hot_node.m_hot.layer;
-      if (thisL >= 0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == -9) && thisL != prevL) {
+      if (thisL >= 0 && (hot_node.m_hot.index >= 0 || hot_node.m_hot.index == Hit::kHitCCCFilterIdx) &&
+          thisL != prevL) {
         if (trk_inf[thisL].is_pixel())
           ++pix;
         else if (trk_inf[thisL].is_stereo())
@@ -552,7 +554,7 @@ namespace mkfit {
   inline void TrackCand::addHitIdx(int hitIdx, int hitLyr, float chi2) {
     lastHitIdx_ = m_comb_candidate->addHit({hitIdx, hitLyr}, chi2, lastHitIdx_);
 
-    if (hitIdx >= 0 || hitIdx == -9) {
+    if (hitIdx >= 0 || hitIdx == Hit::kHitCCCFilterIdx) {
       ++nFoundHits_;
       chi2_ += chi2;
       nInsideMinusOneHits_ += nTailMinusOneHits_;
@@ -561,7 +563,7 @@ namespace mkfit {
     //Note that for tracks passing through an inactive module (hitIdx = -7), we do not count the -7 hit against the track when scoring.
     else {
       ++nMissingHits_;
-      if (hitIdx == -1)
+      if (hitIdx == Hit::kHitMissIdx)
         ++nTailMinusOneHits_;
     }
   }

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -939,6 +939,21 @@ namespace mkfit {
               isCompatible &= passStripChargePCMfromTrack(
                   itrack, layer_of_hits.is_barrel(), charge_pcm[itrack], Hit::minChargePerCM(), propPar, m_msErr);
             }
+            // Select only SiStrip hits with cluster size < maxClusterSize
+            if (!layer_of_hits.is_pixel()) {
+              if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
+                  m_iteration_params->maxClusterSize)
+                isCompatible = false;
+            }
+            // Uncomment to apply analogous cut on cluster size of SiPixel hits
+            //else {
+            //  if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
+            //          m_iteration_params->maxClusterSize ||
+            //      layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanCols() >=
+            //          m_iteration_params->maxClusterSize)
+            //    isCompatible = false;
+            //}
+
             if (isCompatible) {
               oneCandPassCut = true;
               break;
@@ -968,7 +983,7 @@ namespace mkfit {
                                    << "   updated track parameters x=" << m_Par[iC].constAt(0, 0, 0)
                                    << " y=" << m_Par[iC].constAt(0, 1, 0));
 
-        //create candidate with hit in case chi2 < m_iteration_params->chi2Cut_min
+        //create candidate with hit in case chi2 < max_c2
         //fixme: please vectorize me... (not sure it's possible in this case)
         for (int itrack = 0; itrack < N_proc; ++itrack) {
           float max_c2 = getHitSelDynamicChi2Cut(itrack, iP);
@@ -987,6 +1002,21 @@ namespace mkfit {
                 isCompatible &= passStripChargePCMfromTrack(
                     itrack, layer_of_hits.is_barrel(), charge_pcm[itrack], Hit::minChargePerCM(), propPar, m_msErr);
               }
+              // Select only SiStrip hits with cluster size < maxClusterSize
+              if (!layer_of_hits.is_pixel()) {
+                if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
+                    m_iteration_params->maxClusterSize)
+                  isCompatible = false;
+              }
+              // Uncomment to apply analogous cut on cluster size of SiPixel hits
+              //else {
+              //  if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
+              //          m_iteration_params->maxClusterSize ||
+              //      layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanCols() >=
+              //          m_iteration_params->maxClusterSize)
+              //    isCompatible = false;
+              //}
+
               if (isCompatible) {
                 bool hitExists = false;
                 int maxHits = m_NFoundHits(itrack, 0, 0);
@@ -1155,7 +1185,7 @@ namespace mkfit {
                   itrack, layer_of_hits.is_barrel(), charge_pcm[itrack], Hit::minChargePerCM(), propPar, m_msErr);
             }
 
-            // Select only SiStrip hits with cluster size <= m_iteration_params->maxClusterSize
+            // Select only SiStrip hits with cluster size < maxClusterSize
             if (!layer_of_hits.is_pixel()) {
               if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
                   m_iteration_params->maxClusterSize)

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -949,16 +949,6 @@ namespace mkfit {
                 isCompatible = false;
               }
             }
-            // Uncomment to apply analogous cut on cluster size of SiPixel hits
-            //else {
-            //  if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
-            //          m_iteration_params->maxClusterSize ||
-            //      layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanCols() >=
-            //          m_iteration_params->maxClusterSize) {
-            //    isTooLargeCluster[itrack] = true;
-            //    isCompatible = false;
-            //  }
-            //}
 
             if (isCompatible) {
               oneCandPassCut = true;
@@ -1014,14 +1004,6 @@ namespace mkfit {
                     m_iteration_params->maxClusterSize)
                   isCompatible = false;
               }
-              // Uncomment to apply analogous cut on cluster size of SiPixel hits
-              //else {
-              //  if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
-              //          m_iteration_params->maxClusterSize ||
-              //      layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanCols() >=
-              //          m_iteration_params->maxClusterSize)
-              //    isCompatible = false;
-              //}
 
               if (isCompatible) {
                 bool hitExists = false;
@@ -1205,16 +1187,6 @@ namespace mkfit {
                 isCompatible = false;
               }
             }
-            // Uncomment to apply analogous cut on cluster size of SiPixel hits
-            //else {
-            //  if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
-            //          m_iteration_params->maxClusterSize ||
-            //      layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanCols() >=
-            //          m_iteration_params->maxClusterSize) {
-            //    isTooLargeCluster[itrack] = true;
-            //    isCompatible = false;
-            //  }
-            //}
 
             if (isCompatible) {
               CombCandidate &ccand = cloner.combCandWithOriginalIndex(m_SeedIdx(itrack, 0, 0));

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -751,16 +751,16 @@ namespace mkfit {
 
         add_hit(itrack, bestHit[itrack], layer_of_hits.layer_id());
       } else {
-        int fake_hit_idx = Config::hit_miss_idx_;
+        int fake_hit_idx = Hit::kHitMissIdx;
 
         if (m_XWsrResult[itrack].m_wsr == WSR_Edge) {
           // YYYYYY Config::store_missed_layers
-          fake_hit_idx = Config::hit_edge_idx_;
+          fake_hit_idx = Hit::kHitEdgeIdx;
         } else if (num_all_minus_one_hits(itrack)) {
-          fake_hit_idx = Config::hit_stop_idx_;
+          fake_hit_idx = Hit::kHitStopIdx;
         }
 
-        dprint("ADD FAKE HIT FOR TRACK #" << itrack << " withinBounds=" << (fake_hit_idx != Config::hit_edge_idx_)
+        dprint("ADD FAKE HIT FOR TRACK #" << itrack << " withinBounds=" << (fake_hit_idx != Hit::kHitEdgeIdx)
                                           << " r=" << std::hypot(m_Par[iP](itrack, 0, 0), m_Par[iP](itrack, 1, 0)));
 
         m_msErr.setDiagonal3x3(itrack, 666);
@@ -1084,23 +1084,23 @@ namespace mkfit {
 
       int fake_hit_idx = ((num_all_minus_one_hits(itrack) < m_iteration_params->maxHolesPerCand) &&
                           (m_NTailMinusOneHits(itrack, 0, 0) < m_iteration_params->maxConsecHoles))
-                             ? Config::hit_miss_idx_
-                             : Config::hit_stop_idx_;
+                             ? Hit::kHitMissIdx
+                             : Hit::kHitStopIdx;
 
       if (m_XWsrResult[itrack].m_wsr == WSR_Edge) {
         // YYYYYY m_iteration_params->store_missed_layers
-        fake_hit_idx = Config::hit_edge_idx_;
+        fake_hit_idx = Hit::kHitEdgeIdx;
       }
       //now add fake hit for tracks that passsed through inactive modules
       else if (m_XWsrResult[itrack].m_in_gap == true && nHitsAdded[itrack] == 0) {
-        fake_hit_idx = Config::hit_gap_idx_;
+        fake_hit_idx = Hit::kHitInGapIdx;
       }
       //now add fake hit for cases where hit cluster size is larger than maxClusterSize
       else if (isTooLargeCluster[itrack] == true && nHitsAdded[itrack] == 0) {
-        fake_hit_idx = Config::hit_maxcluster_idx_;
+        fake_hit_idx = Hit::kHitMaxClusterIdx;
       }
 
-      dprint("ADD FAKE HIT FOR TRACK #" << itrack << " withinBounds=" << (fake_hit_idx != Config::hit_edge_idx_)
+      dprint("ADD FAKE HIT FOR TRACK #" << itrack << " withinBounds=" << (fake_hit_idx != Hit::kHitEdgeIdx)
                                         << " r=" << std::hypot(m_Par[iP](itrack, 0, 0), m_Par[iP](itrack, 1, 0)));
 
       // QQQ as above, only create and add if score better
@@ -1279,19 +1279,19 @@ namespace mkfit {
       // int fake_hit_idx = num_all_minus_one_hits(itrack) < m_iteration_params->maxHolesPerCand ? -1 : -2;
       int fake_hit_idx = ((num_all_minus_one_hits(itrack) < m_iteration_params->maxHolesPerCand) &&
                           (m_NTailMinusOneHits(itrack, 0, 0) < m_iteration_params->maxConsecHoles))
-                             ? Config::hit_miss_idx_
-                             : Config::hit_stop_idx_;
+                             ? Hit::kHitMissIdx
+                             : Hit::kHitStopIdx;
 
       if (m_XWsrResult[itrack].m_wsr == WSR_Edge) {
-        fake_hit_idx = Config::hit_edge_idx_;
+        fake_hit_idx = Hit::kHitEdgeIdx;
       }
       //now add fake hit for tracks that passsed through inactive modules
       else if (m_XWsrResult[itrack].m_in_gap == true && nHitsAdded[itrack] == 0) {
-        fake_hit_idx = Config::hit_gap_idx_;
+        fake_hit_idx = Hit::kHitInGapIdx;
       }
       //now add fake hit for cases where hit cluster size is larger than maxClusterSize
       else if (isTooLargeCluster[itrack] == true && nHitsAdded[itrack] == 0) {
-        fake_hit_idx = Config::hit_maxcluster_idx_;
+        fake_hit_idx = Hit::kHitMaxClusterIdx;
       }
 
       IdxChi2List tmpList;
@@ -1299,8 +1299,8 @@ namespace mkfit {
       tmpList.hitIdx = fake_hit_idx;
       tmpList.module = -1;
       tmpList.nhits = m_NFoundHits(itrack, 0, 0);
-      tmpList.ntailholes = (fake_hit_idx == Config::hit_miss_idx_ ? m_NTailMinusOneHits(itrack, 0, 0) + 1
-                                                                  : m_NTailMinusOneHits(itrack, 0, 0));
+      tmpList.ntailholes = (fake_hit_idx == Hit::kHitMissIdx ? m_NTailMinusOneHits(itrack, 0, 0) + 1
+                                                             : m_NTailMinusOneHits(itrack, 0, 0));
       tmpList.noverlaps = m_NOverlapHits(itrack, 0, 0);
       tmpList.nholes = num_inside_minus_one_hits(itrack);
       tmpList.pt = std::abs(1.0f / m_Par[iP].At(itrack, 3, 0));

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -1155,13 +1155,19 @@ namespace mkfit {
                   itrack, layer_of_hits.is_barrel(), charge_pcm[itrack], Hit::minChargePerCM(), propPar, m_msErr);
             }
 
-            // Select only SiStrip hits with cluster size <8
+            // Select only SiStrip hits with cluster size <= m_iteration_params->maxClusterSize
             if (!layer_of_hits.is_pixel()) {
-              if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >= 8)
+              if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
+                  m_iteration_params->maxClusterSize)
                 isCompatible = false;
             }
-            //else { // Uncomment to apply analogous cut on pixel cluster size
-            //  if (layer_of_hits.refHit( m_XHitArr.At(itrack, hit_cnt, 0) ).spanRows() >= 8 || layer_of_hits.refHit( m_XHitArr.At(itrack, hit_cnt, 0) ).spanCols() >= 8) isCompatible = false;
+            // Uncomment to apply analogous cut on cluster size of SiPixel hits
+            //else {
+            //  if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >=
+            //          m_iteration_params->maxClusterSize ||
+            //      layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanCols() >=
+            //          m_iteration_params->maxClusterSize)
+            //    isCompatible = false;
             //}
 
             if (isCompatible) {

--- a/RecoTracker/MkFitCore/src/MkFinder.cc
+++ b/RecoTracker/MkFitCore/src/MkFinder.cc
@@ -1155,6 +1155,15 @@ namespace mkfit {
                   itrack, layer_of_hits.is_barrel(), charge_pcm[itrack], Hit::minChargePerCM(), propPar, m_msErr);
             }
 
+            // Select only SiStrip hits with cluster size <8
+            if (!layer_of_hits.is_pixel()) {
+              if (layer_of_hits.refHit(m_XHitArr.At(itrack, hit_cnt, 0)).spanRows() >= 8)
+                isCompatible = false;
+            }
+            //else { // Uncomment to apply analogous cut on pixel cluster size
+            //  if (layer_of_hits.refHit( m_XHitArr.At(itrack, hit_cnt, 0) ).spanRows() >= 8 || layer_of_hits.refHit( m_XHitArr.At(itrack, hit_cnt, 0) ).spanCols() >= 8) isCompatible = false;
+            //}
+
             if (isCompatible) {
               CombCandidate &ccand = cloner.combCandWithOriginalIndex(m_SeedIdx(itrack, 0, 0));
               bool hitExists = false;

--- a/RecoTracker/MkFitCore/standalone/index-desc.txt
+++ b/RecoTracker/MkFitCore/standalone/index-desc.txt
@@ -23,7 +23,7 @@ Idx == -2 : Track has reached maximum number of holes/misses (-1).
 
 Idx == -3 : Track not in sensitive region of detector, does not count towards efficiency.
 
-Idx == -4 : ??
+Idx == -5 : Dummy hit to mark hits with cluster size > maxClusterSize
 
 Idx == -7 : Dummy hit to mark the location of an inactive module
 


### PR DESCRIPTION
### PR description:
This PR introduces a configurable cut on the max hit cluster size (by default < 8) for SiStrip hits in mkFit iterations.
Hits that do not pass such cut are not added to the track nor counted as missing hits in candidate scoring.
This is to be considered as parallel/independent wrt. PR #34618.
Rejecting large clusters allows for a significant reduction of fake tracks, with ~ zero change in efficiency.

### PR validation:
TTbar + PU: http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/maxClusterSize/MTV_TTbarPU50_maxClusterSize7_fakeHitIdx-5
High-pT (1800-2400 GeV) QCD + PU: http://uaf-10.t2.ucsd.edu/~mmasciov/MIC/maxClusterSize/MTV_highPtQCD_wPU_maxClusterSize7_fakeHitIdx-5

Note that the performance in high-pT QCD MC was also evaluated following a report at one past TRK POG meeting, and no regression is visible (see comparisons above).

FYI @mmusich @vmariani 

