### PR TITLE
Update of L3MuonCandidateProducerFromMuons to work also with displaced

### DIFF
--- a/RecoMuon/L3MuonProducer/python/l3MuonCandidateProducerFromMuons_cfi.py
+++ b/RecoMuon/L3MuonProducer/python/l3MuonCandidateProducerFromMuons_cfi.py
@@ -1,5 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-l3MuonCandidateProducerFromMuons = cms.EDProducer("L3MuonCandidateProducerFromMuons",
-    InputObjects = cms.InputTag("L2Muons")
-)

--- a/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.h
+++ b/RecoMuon/L3MuonProducer/src/L3MuonCandidateProducerFromMuons.h
@@ -29,13 +29,17 @@ public:
   /// destructor
   ~L3MuonCandidateProducerFromMuons() override;
 
+  /// descriptions
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
   /// produce candidates
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
   // L3/GLB Collection Label
-  edm::InputTag m_L3CollectionLabel;
-  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+  edm::InputTag const m_L3CollectionLabel;
+  edm::EDGetTokenT<reco::MuonCollection> const m_muonToken;
+  bool const m_displacedReco;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

This PR implements a small change in the `L3MuonCandidateProducerFromMuons` module. A summary of this PR can be found on this [slides](https://github.com/cms-sw/cmssw/files/8521728/HLT-Muon-Displaced.pdf).

When this module was used with displaced muons a degradation in efficiency and resolution was observed. The reason was that this module was taking the innerTrack of the muon by default for momentum estimation. For displaced muons its better to take the globalTrack as shown in the attached slides (better efficiency and resolution).

We propose to add a flag to turn on the displaced reconstruction. This flag is set false by default to not interfere with the prompt reconstruction.

#### PR validation:

This PR passed the `scram b runtests` and code quality checks.