### PR TITLE
[10.6.X] fix the cms EDModule type of `GenParticleMatchMerger`

### DIFF
--- a/SimTracker/TrackAssociation/python/allTrackMCMatch_cfi.py
+++ b/SimTracker/TrackAssociation/python/allTrackMCMatch_cfi.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-allTrackMCMatch = cms.EDFilter("GenParticleMatchMerger",
-    src = cms.VInputTag(cms.InputTag("trackMCMatch"), cms.InputTag("standAloneMuonsMCMatch"), cms.InputTag("globalMuonsMCMatch"))
-)
+allTrackMCMatch = cms.EDProducer("GenParticleMatchMerger",
+                                 src = cms.VInputTag(cms.InputTag("trackMCMatch"),
+                                                     cms.InputTag("standAloneMuonsMCMatch"),
+                                                     cms.InputTag("globalMuonsMCMatch")))
 
 

--- a/SimTracker/TrackAssociation/python/globalMuonsMCMatch_cfi.py
+++ b/SimTracker/TrackAssociation/python/globalMuonsMCMatch_cfi.py
@@ -4,7 +4,8 @@ globalMuonsMCMatch = cms.EDProducer("MCTrackMatcher",
     trackingParticles = cms.InputTag("mix","MergedTrackTruth"),
     tracks = cms.InputTag("globalMuons"),
     genParticles = cms.InputTag("genParticles"),
-    associator = cms.InputTag('trackAssociatorByHits')
+    associator = cms.string('trackAssociatorByHits'),
+    throwOnMissingTPCollection = cms.bool(True)
 )
 
 

--- a/SimTracker/TrackAssociation/python/standAloneMuonsMCMatch_cfi.py
+++ b/SimTracker/TrackAssociation/python/standAloneMuonsMCMatch_cfi.py
@@ -4,7 +4,8 @@ standAloneMuonsMCMatch = cms.EDProducer("MCTrackMatcher",
     trackingParticles = cms.InputTag("mix","MergedTrackTruth"),
     tracks = cms.InputTag("standAloneMuons"),
     genParticles = cms.InputTag("genParticles"),
-    associator = cms.InputTag('trackAssociatorByHits')
+    associator = cms.string('trackAssociatorByHits'),
+    throwOnMissingTPCollection = cms.bool(True)
 )
 
 

--- a/SimTracker/TrackAssociation/python/trackMCMatch_cfi.py
+++ b/SimTracker/TrackAssociation/python/trackMCMatch_cfi.py
@@ -4,7 +4,7 @@ trackMCMatch = cms.EDProducer("MCTrackMatcher",
     trackingParticles = cms.InputTag("mix","MergedTrackTruth"),
     tracks = cms.InputTag("generalTracks"),
     genParticles = cms.InputTag("genParticles"),
-    associator = cms.string('TrackAssociatorByHits'),
+    associator = cms.string('trackAssociatorByHits'),
     throwOnMissingTPCollection = cms.bool(True)
 )
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/37613

#### PR description:

It appears that `CollectionAdder` 

https://github.com/cms-sw/cmssw/blob/837fd56eb63cfeab570ff8b23d5fdca1716febd0/CommonTools/UtilAlgos/interface/CollectionAdder.h#L17

which is the underlying module type of https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/PhysicsTools/HepMCCandAlgos/plugins/GenParticleMatchMerger.cc#L4

is an `EDProducer`, but it was declared in the configuration as an `EDFilter`:

https://github.com/cms-sw/cmssw/blob/837fd56eb63cfeab570ff8b23d5fdca1716febd0/SimTracker/TrackAssociation/python/allTrackMCMatch_cfi.py#L3

leading to runtime errors of the type:

```console
----- Begin Fatal Exception 19-Apr-2022 00:54:18 CEST-----------------------
An exception of category 'Configuration' occurred while
   [0] Constructing the EventProcessor
   [1] Validating configuration of module: class=GenParticleMatchMerger label='allTrackMCMatch'
Exception Message:
The base type in the python configuration is EDFilter, but the base type
for the module's C++ class is EDProducer. Please fix the configuration.
It must use the same base type as the C++ class.
----- End Fatal Exception -------------------------------------------------
```
this is trivially fixed here.
In addition in commit [f68a4df](https://github.com/cms-sw/cmssw/pull/37613/commits/f68a4df4191d9d33a85339a1a899b31294cd1a57), I take care of some other mismatched types in the configuration.
The parameter `associator` of `MCTrackMatcher` should be a `cms.string` and not a `cms.InputTag`:

https://github.com/cms-sw/cmssw/blob/9583b99e8c31f33b8924a18bbb08568f6386f03b/SimTracker/TrackAssociation/plugins/MCTrackMatcher.cc#L44

Finally in the same commit, the value of the variable  `associator` in `Tracker/TrackAssociation/python/trackMCMatch_cfi.py` is corrected such that it is `trackAssociatorByHits` and not `TrackAssociatorByHits`

#### PR validation:

Private scripts.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

verbatim backport of https://github.com/cms-sw/cmssw/pull/37613, useful for Ultra-Legacy analysis

cc: @tvami 