### PR TITLE
Updating Muon MVA ID working point tight (Backport)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1051,7 +1051,7 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     float mvaID = 0.0;
     constexpr int MVAsentinelValue = -99;
     constexpr float mvaIDmediumCut = 0.08;
-    constexpr float mvaIDtightCut = 0.49;
+    constexpr float mvaIDtightCut = 0.12;
     if (computeMuonIDMVA_) {
       if (muon.isLooseMuon()) {
         mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];
@@ -1060,7 +1060,7 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       }
       muon.setMvaIDValue(mvaID);
       muon.setSelector(reco::Muon::MvaIDwpMedium, muon.mvaIDValue() > mvaIDmediumCut);
-      muon.setSelector(reco::Muon::MvaIDwpTight, muon.mvaIDValue() > mvaIDtightCut);
+      muon.setSelector(reco::Muon::MvaIDwpTight, muon.mvaIDValue() > mvaIDtightCut and dz < 0.5 and dxy < 0.2);
     }
 
     //SOFT MVA

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -1053,6 +1053,8 @@ void PATMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     constexpr float mvaIDmediumCut = 0.08;
     constexpr float mvaIDtightCut = 0.12;
     if (computeMuonIDMVA_) {
+	  const double dz = std::abs(muon.muonBestTrack()->dz(primaryVertex.position()));
+	  const double dxy = std::abs(muon.muonBestTrack()->dxy(primaryVertex.position()));
       if (muon.isLooseMuon()) {
         mvaID = globalCache()->muonMvaIDEstimator().computeMVAID(muon)[1];
       } else {


### PR DESCRIPTION
#### Backport from [PR 37250](https://github.com/cms-sw/cmssw/pull/37250)

#### PR description:
We have updated the Muon MVA ID model and we need to change the cut of the  WP Tight, Cuts in IP are also added to the Tight working point.

- Related [PR](https://github.com/cms-sw/cmssw/pull/36179).
- This MVA  has been presented in several Muon POG meetings: https://indico.cern.ch/event/1135971/contributions/4766180/attachments/2402974/4109990/muonMVAupdate_7mar2022.pdf
- The analysis is documented in this Analysis Note: https://gitlab.cern.ch/tdr/notes/AN-21-107
- Twiki: https://twiki.cern.ch/twiki/bin/view/CMS/LeptonMVAID
- Cadiline: https://cms.cern.ch/iCMS/analysisadmin/cadilines?line=MUO-22-001 
- Related PR: to include the MVA model in data repository, in .onnx format -> https://github.com/cms-data/RecoMuon-MuonIdentification/pull/8

#### PR validation:
We execute the basic tests suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) 