### PR TITLE
Moving esConsumes statement from the analyze method into the constructor

### DIFF
--- a/CondTools/Hcal/interface/BoostIODBReader.h
+++ b/CondTools/Hcal/interface/BoostIODBReader.h
@@ -51,16 +51,16 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   std::string outputFile_;
+  edm::ESGetToken<DataType, RecordType> tok_;
 };
 
 template <class DataType, class RecordType>
 BoostIODBReader<DataType, RecordType>::BoostIODBReader(const edm::ParameterSet& ps)
-    : outputFile_(ps.getParameter<std::string>("outputFile")) {}
+    : outputFile_(ps.getParameter<std::string>("outputFile")), tok_(esConsumes<DataType, RecordType>()) {}
 
 template <class DataType, class RecordType>
 void BoostIODBReader<DataType, RecordType>::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESGetToken<DataType, RecordType> tok = esConsumes<DataType, RecordType>();
-  const DataType* p = &iSetup.getData(tok);
+  const DataType* p = &iSetup.getData(tok_);
 
   std::ofstream of(outputFile_.c_str(), std::ios_base::binary);
   if (!of.is_open())

--- a/CondTools/Hcal/interface/BoostIODBReader.h
+++ b/CondTools/Hcal/interface/BoostIODBReader.h
@@ -50,8 +50,8 @@ public:
 private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  std::string outputFile_;
-  edm::ESGetToken<DataType, RecordType> tok_;
+  const std::string outputFile_;
+  const edm::ESGetToken<DataType, RecordType> tok_;
 };
 
 template <class DataType, class RecordType>

--- a/CondTools/Hcal/test/BuildFile.xml
+++ b/CondTools/Hcal/test/BuildFile.xml
@@ -27,6 +27,11 @@
   <lib name="PMTParams"/>
 </bin>
 
+<bin file="HFPhase1PMTParams_unittest.cc">
+  <flags TEST_RUNNER_ARGS = "/bin/bash CondTools/Hcal/test testHFPhase1PMTParams.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>
+
 <library file="HcalConditionsTest.cc" name="testCondToolsConTHcal">
  <flags EDM_PLUGIN="1"/>
 </library>

--- a/CondTools/Hcal/test/HFPhase1PMTParams_unittest.cc
+++ b/CondTools/Hcal/test/HFPhase1PMTParams_unittest.cc
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/CondTools/Hcal/test/testHFPhase1PMTParams.sh
+++ b/CondTools/Hcal/test/testHFPhase1PMTParams.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING HFPhase1PMTParams generation code ..."
+${CMSSW_BASE}/test/${SCRAM_ARCH}/write_HFPhase1PMTParams 1 HFPhase1PMTParams_V00_mc.bbin || die "Failure running write_HFPhase1PMTParams" $?
+
+echo "TESTING HFPhase1PMTParams database creation code ..."
+cmsRun ${LOCAL_TEST_DIR}/HFPhase1PMTParamsDBWriter_cfg.py || die "Failure running HFPhase1PMTParamsDBWriter_cfg.py" $?
+
+echo "TESTING HFPhase1PMTParams database reading code ..."
+cmsRun ${LOCAL_TEST_DIR}/HFPhase1PMTParamsDBReader_cfg.py || die "Failure running HFPhase1PMTParamsDBReader_cfg.py" $?
+
+echo "TESTING that we can restore HFPhase1PMTParams from the database ..."
+diff HFPhase1PMTParams_V00_mc.bbin dbread.bbin || die "Database contents differ from the original" $?


### PR DESCRIPTION
#### PR description:

Moving esConsumes statement from the "analyze" method into the constructor.

#### PR validation:

Checked that the database read/write sequence for HFPhase1PMTParams objects works as described in CondTools/Hcal/test/readme_HFPhase1PMTParams.txt

This code is not used by any workflows (calibration tables preparation only), so default matrix tests were not run.
