### PR TITLE
Phase2-hgx309A Add a method to extract orientation indexfrom placement index of HGCal cells/wafers

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalCell.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCell.h
@@ -49,6 +49,7 @@ public:
   std::pair<double, double> cellUV2XY2(int32_t u, int32_t v, int32_t placementIndex, int32_t type);
   std::pair<int32_t, int32_t> cellUV2Cell(int32_t u, int32_t v, int32_t placementIndex, int32_t type);
   static int32_t cellPlacementIndex(int32_t iz, int32_t fwdBack, int32_t orient);
+  static std::pair<int32_t, int32_t> cellOrient (int32_t placementIndex);
   static std::pair<int32_t, int32_t> cellType(int32_t u, int32_t v, int32_t ncell, int32_t placementIndex);
 
 private:

--- a/Geometry/HGCalCommonData/interface/HGCalCell.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCell.h
@@ -49,7 +49,7 @@ public:
   std::pair<double, double> cellUV2XY2(int32_t u, int32_t v, int32_t placementIndex, int32_t type);
   std::pair<int32_t, int32_t> cellUV2Cell(int32_t u, int32_t v, int32_t placementIndex, int32_t type);
   static int32_t cellPlacementIndex(int32_t iz, int32_t fwdBack, int32_t orient);
-  static std::pair<int32_t, int32_t> cellOrient (int32_t placementIndex);
+  static std::pair<int32_t, int32_t> cellOrient(int32_t placementIndex);
   static std::pair<int32_t, int32_t> cellType(int32_t u, int32_t v, int32_t ncell, int32_t placementIndex);
 
 private:

--- a/Geometry/HGCalCommonData/src/HGCalCell.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCell.cc
@@ -232,12 +232,12 @@ int HGCalCell::cellPlacementIndex(int32_t iz, int32_t fwdBack, int32_t orient) {
   return indx;
 }
 
-std::pair<int32_t, int32_t> HGCalCell::cellOrient (int32_t placementIndex) {
-  int32_t orient = (placementIndex >= HGCalCell::cellPlacementExtra) ? (placementIndex - HGCalCell::cellPlacementExtra) : placementIndex;
+std::pair<int32_t, int32_t> HGCalCell::cellOrient(int32_t placementIndex) {
+  int32_t orient = (placementIndex >= HGCalCell::cellPlacementExtra) ? (placementIndex - HGCalCell::cellPlacementExtra)
+                                                                     : placementIndex;
   int32_t fwdBack = (placementIndex >= HGCalCell::cellPlacementExtra) ? 1 : -1;
   return std::make_pair(orient, fwdBack);
 }
-
 
 std::pair<int32_t, int32_t> HGCalCell::cellType(int32_t u, int32_t v, int32_t ncell, int32_t placementIndex) {
   int cell(0), cellx(0), cellt(HGCalCell::fullCell);

--- a/Geometry/HGCalCommonData/src/HGCalCell.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCell.cc
@@ -232,6 +232,13 @@ int HGCalCell::cellPlacementIndex(int32_t iz, int32_t fwdBack, int32_t orient) {
   return indx;
 }
 
+std::pair<int32_t, int32_t> HGCalCell::cellOrient (int32_t placementIndex) {
+  int32_t orient = (placementIndex >= HGCalCell::cellPlacementExtra) ? (placementIndex - HGCalCell::cellPlacementExtra) : placementIndex;
+  int32_t fwdBack = (placementIndex >= HGCalCell::cellPlacementExtra) ? 1 : -1;
+  return std::make_pair(orient, fwdBack);
+}
+
+
 std::pair<int32_t, int32_t> HGCalCell::cellType(int32_t u, int32_t v, int32_t ncell, int32_t placementIndex) {
   int cell(0), cellx(0), cellt(HGCalCell::fullCell);
   if (placementIndex >= HGCalCell::cellPlacementExtra) {


### PR DESCRIPTION
#### PR description:

Add a method to extract orientation indexfrom placement index of HGCal cells/wafers

#### PR validation:

Use the runTheMatrix test workflows 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special