### PR TITLE
HCAL: HCAL TP bug fix for PFA2 scheme

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -446,7 +446,7 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
       unsigned int sample = samples[ibin + i];
 
       if (fix_saturation_ && (sample_saturation.size() > ibin + i))
-        check_sat = (sample_saturation[ibin + i] | (sample > QIE11_MAX_LINEARIZATION_ET));
+        check_sat = (check_sat | sample_saturation[ibin + i] | (sample > QIE11_MAX_LINEARIZATION_ET));
 
       if (sample > QIE11_MAX_LINEARIZATION_ET)
         sample = QIE11_MAX_LINEARIZATION_ET;


### PR DESCRIPTION
#### PR description:

This PR updates the HCAL Trigger Primitive(TP) reconstruction algorithm to fix the bug affecting TPs in PFA2 scheme. While checking the match between TPs from Data and emulation, we found that the current algorithm cannot handle the case in PFA2 when there is a saturation only in SOI while there is no saturation in SOI+1, which produces some TPs saturated in Data, but not saturated in the emulation. There are two plots showing this discrepancy: [ietaViphi](https://user-images.githubusercontent.com/17723379/164754027-584f1ca1-e7a1-46c1-9f98-4d273c9dab5a.png) and [et_corr13](https://user-images.githubusercontent.com/17723379/164754047-7213e4b1-b71c-4ce0-a0e7-23c5cd19b4f8.png). ietaViphi shows the TPs with a disagreement, and et_corr13 compares the data vs emulation for TPs with ieta=-8. We can see there are 2 TPs that are saturated in data but not in emulation. 

#### PR validation:

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport. 
