### PR TITLE
Properly initialize all member data in L1MuBMTrackSegPhi

### DIFF
--- a/DataFormats/L1TMuon/interface/L1MuBMTrackSegPhi.h
+++ b/DataFormats/L1TMuon/interface/L1MuBMTrackSegPhi.h
@@ -67,7 +67,10 @@ public:
                     bool etaFlag = false);
 
   /// copy constructor
-  L1MuBMTrackSegPhi(const L1MuBMTrackSegPhi&);
+  L1MuBMTrackSegPhi(const L1MuBMTrackSegPhi&) = default;
+
+  /// move constructor
+  L1MuBMTrackSegPhi(L1MuBMTrackSegPhi&&) = default;
 
   /// destructor
   virtual ~L1MuBMTrackSegPhi();
@@ -118,7 +121,10 @@ public:
   inline void setEtaFlag(bool flag) { m_etaFlag = flag; }
 
   /// assignment operator
-  L1MuBMTrackSegPhi& operator=(const L1MuBMTrackSegPhi&);
+  L1MuBMTrackSegPhi& operator=(const L1MuBMTrackSegPhi&) = default;
+
+  /// move assignment operator
+  L1MuBMTrackSegPhi& operator=(L1MuBMTrackSegPhi&&) = default;
 
   /// equal operator
   bool operator==(const L1MuBMTrackSegPhi&) const;

--- a/DataFormats/L1TMuon/src/L1MuBMTrackSegPhi.cc
+++ b/DataFormats/L1TMuon/src/L1MuBMTrackSegPhi.cc
@@ -50,6 +50,7 @@ L1MuBMTrackSegPhi::L1MuBMTrackSegPhi(
       m_phi(phi),
       m_phib(phib),
       m_quality(quality),
+      m_tag(tag),
       m_bx(bx),
       m_etaFlag(etaFlag) {
   /*
@@ -79,15 +80,6 @@ L1MuBMTrackSegPhi::L1MuBMTrackSegPhi(
   }
 */
 }
-
-L1MuBMTrackSegPhi::L1MuBMTrackSegPhi(const L1MuBMTrackSegPhi& id)
-    : m_location(id.m_location),
-      m_phi(id.m_phi),
-      m_phib(id.m_phib),
-      m_quality(id.m_quality),
-      m_tag(id.m_tag),
-      m_bx(id.m_bx),
-      m_etaFlag(id.m_etaFlag) {}
 
 //--------------
 // Destructor --
@@ -123,22 +115,6 @@ double L1MuBMTrackSegPhi::phiValue() const {
 // return phib in radians
 //
 double L1MuBMTrackSegPhi::phibValue() const { return static_cast<double>(m_phib) / 512; }
-
-//
-// Assignment operator
-//
-L1MuBMTrackSegPhi& L1MuBMTrackSegPhi::operator=(const L1MuBMTrackSegPhi& id) {
-  if (this != &id) {
-    m_location = id.m_location;
-    m_phi = id.m_phi;
-    m_phib = id.m_phib;
-    m_quality = id.m_quality;
-    m_tag = id.m_tag;
-    m_bx = id.m_bx;
-    m_etaFlag = id.m_etaFlag;
-  }
-  return *this;
-}
 
 //
 // Equal operator


### PR DESCRIPTION
#### PR description:

- fixed constructor that had missed initializing m_tag
- use compiler default versions of copy/move constructors/assigments.

The missing initialization was caught by the UBSAN report.

#### PR validation:

Code compiles.