### PR TITLE
Fixing the order of unit tests in CondTools/Hcal

### DIFF
--- a/CondTools/Hcal/test/BuildFile.xml
+++ b/CondTools/Hcal/test/BuildFile.xml
@@ -10,7 +10,7 @@
 <library name="PMTParams" file="make_*cc">
 </library>
 
-<bin file="write_HFPhase1PMTParams.cc">
+<bin name="write_HFPhase1PMTParams" file="write_HFPhase1PMTParams.cc">
   <lib name="PMTParams"/>
 </bin>
 
@@ -28,6 +28,7 @@
 </bin>
 
 <bin file="HFPhase1PMTParams_unittest.cc">
+  <flags PRE_TEST = "write_HFPhase1PMTParams"/>
   <flags TEST_RUNNER_ARGS = "/bin/bash CondTools/Hcal/test testHFPhase1PMTParams.sh"/>
   <use name="FWCore/Utilities"/>
 </bin>

--- a/CondTools/Hcal/test/testHFPhase1PMTParams.sh
+++ b/CondTools/Hcal/test/testHFPhase1PMTParams.sh
@@ -3,7 +3,7 @@
 function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING HFPhase1PMTParams generation code ..."
-${CMSSW_BASE}/test/${SCRAM_ARCH}/write_HFPhase1PMTParams 1 HFPhase1PMTParams_V00_mc.bbin || die "Failure running write_HFPhase1PMTParams" $?
+write_HFPhase1PMTParams 1 HFPhase1PMTParams_V00_mc.bbin || die "Failure running write_HFPhase1PMTParams" $?
 
 echo "TESTING HFPhase1PMTParams database creation code ..."
 cmsRun ${LOCAL_TEST_DIR}/HFPhase1PMTParamsDBWriter_cfg.py || die "Failure running HFPhase1PMTParamsDBWriter_cfg.py" $?


### PR DESCRIPTION
#### PR description:

Fixing the order of unit tests in CondTools/Hcal, as the problem with out-of-order test execution was noted after PR #37650 was merged

#### PR validation:

"scram b runtests -j 5" appears to work fine.
