### PR TITLE
Add Run3 era for AlCaPhiSymEcal_Nano

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
@@ -7,11 +7,13 @@ Scenario supporting proton collision data taking for AlCaPhiSymEcal stream with 
 """
 
 from Configuration.DataProcessing.Impl.AlCa import AlCa
+from Configuration.Eras.Era_Run3_cff import Run3
 
 class AlCaPhiSymEcal_Nano(AlCa):
     def __init__(self):
         AlCa.__init__(self)
         self.skims=['EcalPhiSymByRun']
+        self.eras=Run3
         self.promptCustoms = [ 'Calibration/EcalCalibAlgos/EcalPhiSymRecoSequence_cff.customise' ]
         self.step = 'RECO:bunchSpacingProducer+ecalMultiFitUncalibRecHitTask+ecalCalibratedRecHitTask'
     """


### PR DESCRIPTION
#### PR description:

Title says it all, this was essentially just forgotten in https://github.com/cms-sw/cmssw/pull/37627 (sorry!)

#### PR validation:

`scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Already included in the backport commit https://github.com/cms-sw/cmssw/pull/37640/commits/23716839a6edfa30372155ab2bd15f2e30886838