### PR TITLE
Always have l1t::EtSum::type_ be initialized

### DIFF
--- a/DataFormats/L1Trigger/interface/EtSum.h
+++ b/DataFormats/L1Trigger/interface/EtSum.h
@@ -46,10 +46,13 @@ namespace l1t {
       kAsymEt,
       kAsymHt,
       kAsymEtHF,
-      kAsymHtHF
+      kAsymHtHF,
+      kUninitialized
     };
 
-    EtSum() {}
+    EtSum() : type_{kUninitialized} {}
+    explicit EtSum(EtSumType type) : type_{type} {}
+
     EtSum(const LorentzVector& p4, EtSumType type, int pt = 0, int eta = 0, int phi = 0, int qual = 0);
 
     EtSum(const PolarLorentzVector& p4, EtSumType type, int pt = 0, int eta = 0, int phi = 0, int qual = 0);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/EtSumUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/EtSumUnpacker.cc
@@ -39,18 +39,16 @@ namespace l1t {
         int totht = candbit[1] & 0xFFF;
         int overflowtotht = (candbit[1] >> 12) & 0x1;
 
-        l1t::EtSum et = l1t::EtSum();
+        l1t::EtSum et{l1t::EtSum::kTotalEt};
         et.setHwPt(totet);
-        et.setType(l1t::EtSum::kTotalEt);
         int flagtotet = et.hwQual();
         flagtotet |= overflowtotet;
         et.setHwQual(flagtotet);
         LogDebug("L1T") << "ET: pT " << et.hwPt() << "is overflow " << overflowtotet << std::endl;
         res_->set(bx, 2, et);
 
-        l1t::EtSum ht = l1t::EtSum();
+        l1t::EtSum ht{l1t::EtSum::kTotalHt};
         ht.setHwPt(totht);
-        ht.setType(l1t::EtSum::kTotalHt);
         int flagtotht = ht.hwQual();
         flagtotht |= overflowtotht;
         ht.setHwQual(flagtotht);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/HFRingUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/HFRingUnpacker.cc
@@ -65,10 +65,9 @@ namespace l1t {
         LogDebug("L1T") << "hfrs pT " << hfrs.hwPt();
         resHFRingSums_->push_back(bx, hfrs);
 
-        l1t::EtSum mht = l1t::EtSum();
+        l1t::EtSum mht{l1t::EtSum::kMissingHt};
         mht.setHwPt(htmiss);
         mht.setHwPhi(htmissphi);
-        mht.setType(l1t::EtSum::kMissingHt);
         int flaghtmiss = mht.hwQual();
         flaghtmiss |= overflowhtmiss;
         mht.setHwQual(flaghtmiss);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyEtSumUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyEtSumUnpacker.cc
@@ -43,28 +43,25 @@ namespace l1t {
           int overflowtotht = (candbit[2] >> 12) & 0x1;
           int etmissphi = candbit[3] & 0x7F;
 
-          l1t::EtSum et = l1t::EtSum();
+          l1t::EtSum et{l1t::EtSum::kTotalEt};
           et.setHwPt(totet);
-          et.setType(l1t::EtSum::kTotalEt);
           int flagtotet = et.hwQual();
           flagtotet |= overflowtotet;
           et.setHwQual(flagtotet);
           LogDebug("L1T") << "ET: pT " << et.hwPt() << "is overflow " << overflowtotet << std::endl;
           res_->push_back(bx, et);
 
-          l1t::EtSum ht = l1t::EtSum();
+          l1t::EtSum ht{l1t::EtSum::kTotalHt};
           ht.setHwPt(totht);
-          ht.setType(l1t::EtSum::kTotalHt);
           int flagtotht = ht.hwQual();
           flagtotht |= overflowtotht;
           ht.setHwQual(flagtotht);
           LogDebug("L1T") << "HT: pT " << ht.hwPt() << "is overflow " << overflowtotht << std::endl;
           res_->push_back(bx, ht);
 
-          l1t::EtSum met = l1t::EtSum();
+          l1t::EtSum met{l1t::EtSum::kMissingEt};
           met.setHwPt(etmiss);
           met.setHwPhi(etmissphi);
-          met.setType(l1t::EtSum::kMissingEt);
           int flagetmiss = met.hwQual();
           flagetmiss |= overflowetmiss;
           met.setHwQual(flagetmiss);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyHFRingUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/LegacyHFRingUnpacker.cc
@@ -59,10 +59,9 @@ namespace l1t {
           LogDebug("L1T") << "hfrs pT " << hfrs.hwPt();
           resHFRingSums_->push_back(bx, hfrs);
 
-          l1t::EtSum mht = l1t::EtSum();
+          l1t::EtSum mht{l1t::EtSum::kMissingHt};
           mht.setHwPt(htmiss);
           mht.setHwPhi(htmissphi);
-          mht.setType(l1t::EtSum::kMissingHt);
           int flaghtmiss = mht.hwQual();
           flaghtmiss |= overflowhtmiss;
           mht.setHwQual(flaghtmiss);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissEtUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissEtUnpacker.cc
@@ -38,10 +38,9 @@ namespace l1t {
         int overflowetmiss = (candbit[0] >> 12) & 0x1;
         int etmissphi = candbit[1] & 0x7F;
 
-        l1t::EtSum met = l1t::EtSum();
+        l1t::EtSum met{l1t::EtSum::kMissingEt};
         met.setHwPt(etmiss);
         met.setHwPhi(etmissphi);
-        met.setType(l1t::EtSum::kMissingEt);
         int flagetmiss = met.hwQual();
         flagetmiss |= overflowetmiss;
         met.setHwQual(flagetmiss);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissHtUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage1/MissHtUnpacker.cc
@@ -38,10 +38,9 @@ namespace l1t {
         int htmiss = (candbit[0] >> 5) & 0x7F;
         int overflowhtmiss = (candbit[0] >> 12) & 0x1;
 
-        l1t::EtSum mht = l1t::EtSum();
+        l1t::EtSum mht{l1t::EtSum::kMissingHt};
         mht.setHwPt(htmiss);
         mht.setHwPhi(htmissphi);
-        mht.setType(l1t::EtSum::kMissingHt);
         int flaghtmiss = mht.hwQual();
         flaghtmiss |= overflowhtmiss;
         mht.setHwQual(flaghtmiss);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker.cc
@@ -42,10 +42,8 @@ namespace l1t {
 
         uint32_t raw_data = block.payload().at(iFrame);
 
-        l1t::EtSum et = l1t::EtSum();
-
+        l1t::EtSum et{l1t::EtSum::kTotalEt};
         et.setHwPt(raw_data & 0xFFF);
-        et.setType(l1t::EtSum::kTotalEt);
         et.setP4(l1t::CaloTools::p4Demux(&et));
 
         LogDebug("L1T") << "ET: pT " << et.hwPt() << " bx " << bx;
@@ -54,10 +52,9 @@ namespace l1t {
 
         // ET EM
 
-        l1t::EtSum etem = l1t::EtSum();
+        l1t::EtSum etem{l1t::EtSum::kTotalEtEm};
 
         etem.setHwPt((raw_data >> 12) & 0xFFF);
-        etem.setType(l1t::EtSum::kTotalEtEm);
         etem.setP4(l1t::CaloTools::p4Demux(&etem));
 
         LogDebug("L1T") << "ETEM: pT " << etem.hwPt() << " bx " << bx;
@@ -66,9 +63,8 @@ namespace l1t {
 
         // MBHFPT0
 
-        l1t::EtSum mbp0 = l1t::EtSum();
+        l1t::EtSum mbp0{l1t::EtSum::kMinBiasHFP0};
         mbp0.setHwPt((raw_data >> 28) & 0xf);
-        mbp0.setType(l1t::EtSum::kMinBiasHFP0);
 
         res_->push_back(bx, mbp0);
 
@@ -76,10 +72,8 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 1];
 
-        l1t::EtSum ht = l1t::EtSum();
-
+        l1t::EtSum ht{l1t::EtSum::kTotalHt};
         ht.setHwPt(raw_data & 0xFFF);
-        ht.setType(l1t::EtSum::kTotalHt);
         ht.setP4(l1t::CaloTools::p4Demux(&ht));
 
         LogDebug("L1T") << "HT: pT " << ht.hwPt();
@@ -88,9 +82,8 @@ namespace l1t {
 
         //MBHFMT0
 
-        l1t::EtSum mbm0 = l1t::EtSum();
+        l1t::EtSum mbm0{l1t::EtSum::kMinBiasHFM0};
         mbm0.setHwPt((raw_data >> 28) & 0xf);
-        mbm0.setType(l1t::EtSum::kMinBiasHFM0);
 
         res_->push_back(bx, mbm0);
 
@@ -98,11 +91,10 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 2];
 
-        l1t::EtSum met = l1t::EtSum();
+        l1t::EtSum met{l1t::EtSum::kMissingEt};
 
         met.setHwPt(raw_data & 0xFFF);
         met.setHwPhi((raw_data >> 12) & 0xFF);
-        met.setType(l1t::EtSum::kMissingEt);
         met.setP4(l1t::CaloTools::p4Demux(&met));
 
         LogDebug("L1T") << "MET: phi " << met.hwPhi() << " pT " << met.hwPt() << " bx " << bx;
@@ -111,9 +103,8 @@ namespace l1t {
 
         // MBHFPT1
 
-        l1t::EtSum mbp1 = l1t::EtSum();
+        l1t::EtSum mbp1{l1t::EtSum::kMinBiasHFP1};
         mbp1.setHwPt((raw_data >> 28) & 0xf);
-        mbp1.setType(l1t::EtSum::kMinBiasHFP1);
 
         res_->push_back(bx, mbp1);
 
@@ -121,11 +112,10 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 3];
 
-        l1t::EtSum mht = l1t::EtSum();
+        l1t::EtSum mht{l1t::EtSum::kMissingHt};
 
         mht.setHwPt(raw_data & 0xFFF);
         mht.setHwPhi((raw_data >> 12) & 0xFF);
-        mht.setType(l1t::EtSum::kMissingHt);
         mht.setP4(l1t::CaloTools::p4Demux(&mht));
 
         LogDebug("L1T") << "MHT: phi " << mht.hwPhi() << " pT " << mht.hwPt() << " bx " << bx;
@@ -134,9 +124,8 @@ namespace l1t {
 
         // MBHFMT1
 
-        l1t::EtSum mbm1 = l1t::EtSum();
+        l1t::EtSum mbm1{l1t::EtSum::kMinBiasHFM1};
         mbm1.setHwPt((raw_data >> 28) & 0xf);
-        mbm1.setType(l1t::EtSum::kMinBiasHFM1);
 
         res_->push_back(bx, mbm1);
 
@@ -144,11 +133,10 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 4];
 
-        l1t::EtSum methf = l1t::EtSum();
+        l1t::EtSum methf{l1t::EtSum::kMissingEtHF};
 
         methf.setHwPt(raw_data & 0xFFF);
         methf.setHwPhi((raw_data >> 12) & 0xFF);
-        methf.setType(l1t::EtSum::kMissingEtHF);
         methf.setP4(l1t::CaloTools::p4Demux(&methf));
 
         LogDebug("L1T") << "METHF: phi " << methf.hwPhi() << " pT " << methf.hwPt() << " bx " << bx;
@@ -159,11 +147,9 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 5];
 
-        l1t::EtSum mhthf = l1t::EtSum();
-
+        l1t::EtSum mhthf{l1t::EtSum::kMissingHtHF};
         mhthf.setHwPt(raw_data & 0xFFF);
         mhthf.setHwPhi((raw_data >> 12) & 0xFF);
-        mhthf.setType(l1t::EtSum::kMissingHtHF);
         mhthf.setP4(l1t::CaloTools::p4Demux(&mhthf));
 
         LogDebug("L1T") << "MHThf: phi " << mhthf.hwPhi() << " pT " << mhthf.hwPt() << " bx " << bx;
@@ -174,9 +160,8 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 1];
 
-        l1t::EtSum towCount = l1t::EtSum();
+        l1t::EtSum towCount{l1t::EtSum::kTowerCount};
         towCount.setHwPt((raw_data >> 12) & 0x1FFF);
-        towCount.setType((l1t::EtSum::kTowerCount));
         towCount.setP4(l1t::CaloTools::p4Demux(&towCount));
 
         res_->push_back(bx, towCount);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker_0x10010057.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EtSumUnpacker_0x10010057.cc
@@ -42,10 +42,9 @@ namespace l1t {
 
         uint32_t raw_data = block.payload().at(iFrame);
 
-        l1t::EtSum et = l1t::EtSum();
+        l1t::EtSum et{l1t::EtSum::kTotalEt};
 
         et.setHwPt(raw_data & 0xFFF);
-        et.setType(l1t::EtSum::kTotalEt);
         et.setP4(l1t::CaloTools::p4Demux(&et));
 
         LogDebug("L1T") << "ET: pT " << et.hwPt() << " bx " << bx;
@@ -54,10 +53,9 @@ namespace l1t {
 
         // ET EM
 
-        l1t::EtSum etem = l1t::EtSum();
+        l1t::EtSum etem{l1t::EtSum::kTotalEtEm};
 
         etem.setHwPt((raw_data >> 12) & 0xFFF);
-        etem.setType(l1t::EtSum::kTotalEtEm);
         etem.setP4(l1t::CaloTools::p4Demux(&etem));
 
         LogDebug("L1T") << "ETEM: pT " << etem.hwPt() << " bx " << bx;
@@ -66,9 +64,8 @@ namespace l1t {
 
         // MBHFPT0
 
-        l1t::EtSum mbp0 = l1t::EtSum();
+        l1t::EtSum mbp0{l1t::EtSum::kMinBiasHFP0};
         mbp0.setHwPt((raw_data >> 28) & 0xf);
-        mbp0.setType(l1t::EtSum::kMinBiasHFP0);
 
         res_->push_back(bx, mbp0);
 
@@ -76,10 +73,9 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 1];
 
-        l1t::EtSum ht = l1t::EtSum();
+        l1t::EtSum ht{l1t::EtSum::kTotalHt};
 
         ht.setHwPt(raw_data & 0xFFF);
-        ht.setType(l1t::EtSum::kTotalHt);
         ht.setP4(l1t::CaloTools::p4Demux(&ht));
 
         LogDebug("L1T") << "HT: pT " << ht.hwPt();
@@ -88,9 +84,8 @@ namespace l1t {
 
         //MBHFMT0
 
-        l1t::EtSum mbm0 = l1t::EtSum();
+        l1t::EtSum mbm0{l1t::EtSum::kMinBiasHFM0};
         mbm0.setHwPt((raw_data >> 28) & 0xf);
-        mbm0.setType(l1t::EtSum::kMinBiasHFM0);
 
         res_->push_back(bx, mbm0);
 
@@ -98,11 +93,10 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 2];
 
-        l1t::EtSum met = l1t::EtSum();
+        l1t::EtSum met{l1t::EtSum::kMissingEt};
 
         met.setHwPt(raw_data & 0xFFF);
         met.setHwPhi((raw_data >> 12) & 0xFF);
-        met.setType(l1t::EtSum::kMissingEt);
         met.setP4(l1t::CaloTools::p4Demux(&met));
 
         LogDebug("L1T") << "MET: phi " << met.hwPhi() << " pT " << met.hwPt() << " bx " << bx;
@@ -111,17 +105,15 @@ namespace l1t {
 
         // MBHFPT1
 
-        l1t::EtSum mbp1 = l1t::EtSum();
+        l1t::EtSum mbp1{l1t::EtSum::kMinBiasHFP1};
         mbp1.setHwPt((raw_data >> 28) & 0xf);
-        mbp1.setType(l1t::EtSum::kMinBiasHFP1);
 
         res_->push_back(bx, mbp1);
 
         // ET ASYMM
 
-        l1t::EtSum etAsym = l1t::EtSum();
+        l1t::EtSum etAsym{l1t::EtSum::kAsymEt};
         etAsym.setHwPt((raw_data >> 20) & 0xFF);
-        etAsym.setType(l1t::EtSum::kAsymEt);
 
         res_->push_back(bx, etAsym);
 
@@ -129,11 +121,10 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 3];
 
-        l1t::EtSum mht = l1t::EtSum();
+        l1t::EtSum mht{l1t::EtSum::kMissingHt};
 
         mht.setHwPt(raw_data & 0xFFF);
         mht.setHwPhi((raw_data >> 12) & 0xFF);
-        mht.setType(l1t::EtSum::kMissingHt);
         mht.setP4(l1t::CaloTools::p4Demux(&mht));
 
         LogDebug("L1T") << "MHT: phi " << mht.hwPhi() << " pT " << mht.hwPt() << " bx " << bx;
@@ -142,17 +133,15 @@ namespace l1t {
 
         // MBHFMT1
 
-        l1t::EtSum mbm1 = l1t::EtSum();
+        l1t::EtSum mbm1{l1t::EtSum::kMinBiasHFM1};
         mbm1.setHwPt((raw_data >> 28) & 0xf);
-        mbm1.setType(l1t::EtSum::kMinBiasHFM1);
 
         res_->push_back(bx, mbm1);
 
         // HT ASYMM
 
-        l1t::EtSum htAsym = l1t::EtSum();
+        l1t::EtSum htAsym{l1t::EtSum::kAsymHt};
         htAsym.setHwPt((raw_data >> 20) & 0xFF);
-        htAsym.setType(l1t::EtSum::kAsymHt);
 
         res_->push_back(bx, htAsym);
 
@@ -160,11 +149,10 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 4];
 
-        l1t::EtSum methf = l1t::EtSum();
+        l1t::EtSum methf{l1t::EtSum::kMissingEtHF};
 
         methf.setHwPt(raw_data & 0xFFF);
         methf.setHwPhi((raw_data >> 12) & 0xFF);
-        methf.setType(l1t::EtSum::kMissingEtHF);
         methf.setP4(l1t::CaloTools::p4Demux(&methf));
 
         LogDebug("L1T") << "METHF: phi " << methf.hwPhi() << " pT " << methf.hwPt() << " bx " << bx;
@@ -173,9 +161,8 @@ namespace l1t {
 
         // ETHF ASYMM
 
-        l1t::EtSum etHFAsym = l1t::EtSum();
+        l1t::EtSum etHFAsym{l1t::EtSum::kAsymEtHF};
         etHFAsym.setHwPt((raw_data >> 20) & 0xFF);
-        etHFAsym.setType(l1t::EtSum::kAsymEtHF);
 
         res_->push_back(bx, etHFAsym);
 
@@ -187,11 +174,10 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 5];
 
-        l1t::EtSum mhthf = l1t::EtSum();
+        l1t::EtSum mhthf{l1t::EtSum::kMissingHtHF};
 
         mhthf.setHwPt(raw_data & 0xFFF);
         mhthf.setHwPhi((raw_data >> 12) & 0xFF);
-        mhthf.setType(l1t::EtSum::kMissingHtHF);
         mhthf.setP4(l1t::CaloTools::p4Demux(&mhthf));
 
         LogDebug("L1T") << "MHThf: phi " << mhthf.hwPhi() << " pT " << mhthf.hwPt() << " bx " << bx;
@@ -200,9 +186,8 @@ namespace l1t {
 
         // HTHF ASYMM
 
-        l1t::EtSum htHFAsym = l1t::EtSum();
+        l1t::EtSum htHFAsym{l1t::EtSum::kAsymHtHF};
         htHFAsym.setHwPt((raw_data >> 20) & 0xFF);
-        htHFAsym.setType(l1t::EtSum::kAsymHtHF);
 
         res_->push_back(bx, htHFAsym);
 
@@ -210,9 +195,8 @@ namespace l1t {
 
         uint32_t centUN = ((raw_data >> 28) & 0xF);
 
-        l1t::EtSum cent = l1t::EtSum();
+        l1t::EtSum cent{l1t::EtSum::kCentrality};
         cent.setHwPt((centUN << 4) | centLN);
-        cent.setType(l1t::EtSum::kCentrality);
 
         res_->push_back(bx, cent);
 
@@ -220,9 +204,8 @@ namespace l1t {
 
         raw_data = block.payload()[iFrame + 1];
 
-        l1t::EtSum towCount = l1t::EtSum();
+        l1t::EtSum towCount{l1t::EtSum::kTowerCount};
         towCount.setHwPt((raw_data >> 12) & 0x1FFF);
-        towCount.setType((l1t::EtSum::kTowerCount));
         towCount.setP4(l1t::CaloTools::p4Demux(&towCount));
 
         res_->push_back(bx, towCount);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010010.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010010.cc
@@ -309,30 +309,25 @@ namespace l1t {
         //      ===== Aux =====
         raw_data = block.payload()[faux];
 
-        // create a sum object for each type of HF sum
-        l1t::EtSum mbp0 = l1t::EtSum();
-        l1t::EtSum mbm0 = l1t::EtSum();
-        l1t::EtSum mbm1 = l1t::EtSum();
-        l1t::EtSum mbp1 = l1t::EtSum();
-
         // readout the sums only if the correct block is  being processed (first frame of AUX)
         switch (block.header().getID()) {
           case 121:  // this should correspond to the first link
+          {
             // read 4 bits starting at position 24 (24 -> 28)
+            l1t::EtSum mbp0{l1t::EtSum::kMinBiasHFP0};
             mbp0.setHwPt((raw_data >> 24) & 0xF);
-            mbp0.setType(l1t::EtSum::kMinBiasHFP0);
 
             // read 4 bits starting at position 16 (16 -> 20)
+            l1t::EtSum mbm0{l1t::EtSum::kMinBiasHFM0};
             mbm0.setHwPt((raw_data >> 16) & 0xF);
-            mbm0.setType(l1t::EtSum::kMinBiasHFM0);
 
             // read 4 bits starting at position 8 (8 -> 12)
+            l1t::EtSum mbp1{l1t::EtSum::kMinBiasHFP1};
             mbp1.setHwPt((raw_data >> 8) & 0xF);
-            mbp1.setType(l1t::EtSum::kMinBiasHFP1);
 
             // read the first 4 bits by masking with 0xF
+            l1t::EtSum mbm1{l1t::EtSum::kMinBiasHFM1};
             mbm1.setHwPt(raw_data & 0xF);
-            mbm1.setType(l1t::EtSum::kMinBiasHFM1);
 
             LogDebug("L1T") << "mbp0 HF sum: " << mbp0.hwPt();
             LogDebug("L1T") << "mbm0 HF sum: " << mbm0.hwPt();
@@ -344,6 +339,7 @@ namespace l1t {
             res2_->push_back(0, mbp1);
             res2_->push_back(0, mbm1);
             break;
+          }
           default:
             break;
         }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010033.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MPUnpacker_0x10010033.cc
@@ -88,7 +88,6 @@ namespace l1t {
       raw_data = block.payload()[fet + 1];
 
       l1t::EtSum etNoHF = l1t::EtSum();
-      l1t::EtSum etEm = l1t::EtSum();
 
       switch (block.header().getID()) {
         case 123:  // 61
@@ -125,7 +124,7 @@ namespace l1t {
 
       // ET EM
       if (block.header().getID() == 123 || block.header().getID() == 125) {
-        etEm.setType(l1t::EtSum::kTotalEtEm);
+        l1t::EtSum etEm{l1t::EtSum::kTotalEtEm};
         etEm.setHwPt(static_cast<int32_t>(uint32_t((raw_data >> 16) & 0xFFFF)));
         res2_->push_back(0, etEm);
       }
@@ -314,30 +313,26 @@ namespace l1t {
       raw_data = block.payload()[faux];
 
       // create a sum object for each type of HF sum
-      l1t::EtSum mbp0 = l1t::EtSum();
-      l1t::EtSum mbm0 = l1t::EtSum();
-      l1t::EtSum mbm1 = l1t::EtSum();
-      l1t::EtSum mbp1 = l1t::EtSum();
-      l1t::EtSum towCount = l1t::EtSum();
 
       // readout the sums only if the correct block is  being processed (first frame of AUX)
       switch (block.header().getID()) {
         case 121:  // this should correspond to the first link
+        {
           // read 4 bits starting at position 24 (24 -> 28)
+          l1t::EtSum mbp0{l1t::EtSum::kMinBiasHFP0};
           mbp0.setHwPt((raw_data >> 24) & 0xF);
-          mbp0.setType(l1t::EtSum::kMinBiasHFP0);
 
           // read 4 bits starting at position 16 (16 -> 20)
+          l1t::EtSum mbm0{l1t::EtSum::kMinBiasHFM0};
           mbm0.setHwPt((raw_data >> 16) & 0xF);
-          mbm0.setType(l1t::EtSum::kMinBiasHFM0);
 
           // read 4 bits starting at position 8 (8 -> 12)
+          l1t::EtSum mbp1{l1t::EtSum::kMinBiasHFP1};
           mbp1.setHwPt((raw_data >> 8) & 0xF);
-          mbp1.setType(l1t::EtSum::kMinBiasHFP1);
 
           // read the first 4 bits by masking with 0xF
+          l1t::EtSum mbm1{l1t::EtSum::kMinBiasHFM1};
           mbm1.setHwPt(raw_data & 0xF);
-          mbm1.setType(l1t::EtSum::kMinBiasHFM1);
 
           LogDebug("L1T") << "mbp0 HF sum: " << mbp0.hwPt();
           LogDebug("L1T") << "mbm0 HF sum: " << mbm0.hwPt();
@@ -349,11 +344,13 @@ namespace l1t {
           res2_->push_back(0, mbp1);
           res2_->push_back(0, mbm1);
           break;
-        case 127:
+        }
+        case 127: {
+          l1t::EtSum towCount{l1t::EtSum::kTowerCount};
           towCount.setHwPt(raw_data & 0x1FFF);
-          towCount.setType(l1t::EtSum::kTowerCount);
           res2_->push_back(0, towCount);
           break;
+        }
         default:
           break;
       }

--- a/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloLayer2Comp.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TStage2CaloLayer2Comp.cc
@@ -648,11 +648,9 @@ bool L1TStage2CaloLayer2Comp::compareSums(const edm::Handle<l1t::EtSumBxCollecti
     return false;
   }
 
-  l1t::EtSum dataSum;
-  l1t::EtSum emulSum;
   for (unsigned int i = 0; i < emulCol->size(currBx); i++) {
-    emulSum = emulCol->at(currBx, i);
-    dataSum = dataCol->at(currBx, l1t::CaloTools::emul_to_data_sum_index_map[i]);
+    l1t::EtSum const &emulSum = emulCol->at(currBx, i);
+    l1t::EtSum const &dataSum = dataCol->at(currBx, l1t::CaloTools::emul_to_data_sum_index_map[i]);
 
     if (emulSum.getType() != dataSum.getType()) {
       edm::LogProblem("l1tcalol2ebec") << "EtSum type problem (data emul): " << dataSum.getType() << " "


### PR DESCRIPTION
#### PR description:

- Added new `kUninitialized` value to enum and used in default constructor
- Added new constructor to guarantee type is set
- Used new constructor in all places it seemed to make sense

This was found by the UBSAN checker.

#### PR validation:

Code compiles. This should not change any behavior (unless the behavior was caused by undefined behavior) of the code.