### PR TITLE
FRDStreamSource Dangling Reference Fix : 12_3_X

### DIFF
--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -22,8 +22,9 @@ FRDStreamSource::FRDStreamSource(edm::ParameterSet const& pset, edm::InputSource
       verifyAdler32_(pset.getUntrackedParameter<bool>("verifyAdler32", true)),
       verifyChecksum_(pset.getUntrackedParameter<bool>("verifyChecksum", true)),
       useL1EventID_(pset.getUntrackedParameter<bool>("useL1EventID", false)) {
-  itFileName_ = fileNames(0).begin();
-  endFileName_ = fileNames(0).end();
+  fileNames_ = fileNames(0),
+  itFileName_ = fileNames_.begin();
+  endFileName_ = fileNames_.end();
   openFile(*itFileName_);
   produces<FEDRawDataCollection>();
 }
@@ -31,6 +32,7 @@ FRDStreamSource::FRDStreamSource(edm::ParameterSet const& pset, edm::InputSource
 bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id,
                                          edm::TimeValue_t& theTime,
                                          edm::EventAuxiliary::ExperimentType& eType) {
+
   if (fin_.peek() == EOF) {
     if (++itFileName_ == endFileName_) {
       fin_.close();

--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -22,8 +22,7 @@ FRDStreamSource::FRDStreamSource(edm::ParameterSet const& pset, edm::InputSource
       verifyAdler32_(pset.getUntrackedParameter<bool>("verifyAdler32", true)),
       verifyChecksum_(pset.getUntrackedParameter<bool>("verifyChecksum", true)),
       useL1EventID_(pset.getUntrackedParameter<bool>("useL1EventID", false)) {
-  fileNames_ = fileNames(0),
-  itFileName_ = fileNames_.begin();
+  fileNames_ = fileNames(0), itFileName_ = fileNames_.begin();
   endFileName_ = fileNames_.end();
   openFile(*itFileName_);
   produces<FEDRawDataCollection>();
@@ -32,7 +31,6 @@ FRDStreamSource::FRDStreamSource(edm::ParameterSet const& pset, edm::InputSource
 bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id,
                                          edm::TimeValue_t& theTime,
                                          edm::EventAuxiliary::ExperimentType& eType) {
-
   if (fin_.peek() == EOF) {
     if (++itFileName_ == endFileName_) {
       fin_.close();

--- a/EventFilter/Utilities/plugins/FRDStreamSource.h
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.h
@@ -34,6 +34,7 @@ private:
 
 private:
   // member data
+  std::vector<std::string> fileNames_;
   std::vector<std::string>::const_iterator itFileName_;
   std::vector<std::string>::const_iterator endFileName_;
   std::ifstream fin_;


### PR DESCRIPTION
#### PR description:

This PR fixes a dangling reference in FRDStreamSource when reading multiple error stream files. The fileNames() function returns std::vectorstd::string which the code sets iterators to which then instantly become invalid as they are dangling.

This keeps an internal copy of the returned std::vector and sets the iterators to that.

#### PR validation:

It now successfully processes events in multiple files rather than spewing random garbage to the terminal.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/37677

It would make life easier for FOG to have this in CMSSW_12_3_X as this will simplify our lives when dealing with error stream events during commissioning. 
