### PR TITLE
LLP GenFilter based on transverse displacement and pdgId - backport #37669

### DIFF
--- a/GeneratorInterface/GenFilters/interface/MCLongLivedParticles.h
+++ b/GeneratorInterface/GenFilters/interface/MCLongLivedParticles.h
@@ -7,7 +7,9 @@
 // 
 /* 
 
- Description: filter events based on the Pythia ProcessID and the Pt_hat
+ Description: 
+Filter particles based on their minimum and/or maximum displacement on the transverse plane and optionally on their pdgIds
+To run independently of pdgIds, do not insert the particleIDs entry in filter declaration
 
  Implementation: inherits from generic EDFilter
      
@@ -31,11 +33,16 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Pythia8/Pythia.h"
 
 
 //
 // class decleration
 //
+
+namespace edm {
+  class HepMCProduct;
+}
 
 class MCLongLivedParticles : public edm::EDFilter {
 public:
@@ -46,8 +53,11 @@ public:
   bool filter(edm::Event&, const edm::EventSetup&) override;
 private:
   // ----------member data ---------------------------
-  
-  float theCut;
+  const edm::EDGetTokenT<edm::HepMCProduct> token_;
+  std::vector<int> particleIDs;  //possible now to chose on which pdgIds the filter is applied - if ParticleIDs.size()==0 runs on all particles in  the event as the preovious filter version
+ 
+  float theUpperCut; // Maximum displacement accepted
+  float theLowerCut; //Minimum displacement accepted 
   edm::InputTag hepMCProductTag_;
 };
 #endif

--- a/GeneratorInterface/GenFilters/interface/MCLongLivedParticles.h
+++ b/GeneratorInterface/GenFilters/interface/MCLongLivedParticles.h
@@ -1,28 +1,17 @@
-#ifndef MCLongLivedParticles_h
-#define MCLongLivedParticles_h
 // -*- C++ -*-
 //
 // Package:    MCLongLivedParticles
 // Class:      MCLongLivedParticles
 // 
-/* 
+ 
 
- Description: 
-Filter particles based on their minimum and/or maximum displacement on the transverse plane and optionally on their pdgIds
-To run independently of pdgIds, do not insert the particleIDs entry in filter declaration
+// Description: 
+//Filter particles based on their minimum and/or maximum displacement on the transverse plane and optionally on their pdgIds
+//To run independently of pdgIds, run with particleIDs_(0) entry in filter declaration
 
- Implementation: inherits from generic EDFilter
+// Implementation: inherits from generic EDFilter
      
-*/
-//
-// Original Author:  Filip Moortgat
-//         Created:  Mon Sept 11 10:57:54 CET 2006
-//
-//
-
-
 // system include files
-#include <memory>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -46,17 +35,18 @@ namespace edm {
 class MCLongLivedParticles : public edm::EDFilter {
 public:
   explicit MCLongLivedParticles(const edm::ParameterSet&);
-  ~MCLongLivedParticles() override;
-  
+  ~MCLongLivedParticles() override = default;
+ 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions); 
 
   bool filter(edm::Event&, const edm::EventSetup&) override;
 private:
   // ----------member data ---------------------------
-  const edm::EDGetTokenT<edm::HepMCProduct> token_;
-  std::vector<int> particleIDs;  //possible now to chose on which pdgIds the filter is applied - if ParticleIDs.size()==0 runs on all particles in  the event as the preovious filter version
-  float theCut; 
-  float theUpperCut; // Maximum displacement accepted
-  float theLowerCut; //Minimum displacement accepted 
   edm::InputTag hepMCProductTag_;
+  const edm::EDGetTokenT<edm::HepMCProduct> token_;
+  //possible now to chose on which pdgIds the filter is applied - if ParticleIDs.size()==0 runs on all particles in  the event as the preovious filter version
+  std::vector<int> particleIDs_; 
+  float theCut; 
+  float theUpperCut_; // Maximum displacement accepted
+  float theLowerCut_; //Minimum displacement accepted 
 };
-#endif

--- a/GeneratorInterface/GenFilters/interface/MCLongLivedParticles.h
+++ b/GeneratorInterface/GenFilters/interface/MCLongLivedParticles.h
@@ -33,7 +33,6 @@ To run independently of pdgIds, do not insert the particleIDs entry in filter de
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "Pythia8/Pythia.h"
 
 
 //
@@ -55,7 +54,7 @@ private:
   // ----------member data ---------------------------
   const edm::EDGetTokenT<edm::HepMCProduct> token_;
   std::vector<int> particleIDs;  //possible now to chose on which pdgIds the filter is applied - if ParticleIDs.size()==0 runs on all particles in  the event as the preovious filter version
- 
+  float theCut; 
   float theUpperCut; // Maximum displacement accepted
   float theLowerCut; //Minimum displacement accepted 
   edm::InputTag hepMCProductTag_;

--- a/GeneratorInterface/GenFilters/src/MCLongLivedParticles.cc
+++ b/GeneratorInterface/GenFilters/src/MCLongLivedParticles.cc
@@ -11,22 +11,20 @@ using namespace std;
 //To run independently of pdgId, do not insert the particleIDs entry in filter declaration
 
 MCLongLivedParticles::MCLongLivedParticles(const edm::ParameterSet& iConfig) :
-  //hepMCProductTag is left untracked for backwards compatibility
+  //Parameters left untracked to have flexibility in filter initialization and ensure backwards compatibility
+  //(specify or not the input tag and cuts so that the filter acts as 
+  //its previous version or  as the new one, depending on which parameters have been initialized)
   hepMCProductTag_(iConfig.getUntrackedParameter<edm::InputTag>("hepMCProductTag",edm::InputTag("generator","unsmeared"))),
   token_(consumes<edm::HepMCProduct>(hepMCProductTag_)),
-  particleIDs_(iConfig.getParameter<std::vector<int>>("ParticleIDs")),
-  //theCut is left untracked for backwards compatibility
+  particleIDs_(iConfig.getUntrackedParameter<std::vector<int>>("ParticleIDs",std::vector<int>{0})),
   theCut(iConfig.getUntrackedParameter<double>("LengCut",10.)), // for backwards compatibility
-  theUpperCut_(iConfig.getParameter<double>("LengMax")),
-  theLowerCut_(iConfig.getParameter<double>("LengMin"))
+  theUpperCut_(iConfig.getUntrackedParameter<double>("LengMax",-1)),
+  theLowerCut_(iConfig.getUntrackedParameter<double>("LengMin",-1))
 {}
 
 
 void MCLongLivedParticles::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::vector<int>>("ParticleIDs", std::vector<int>{0});
-  desc.add<double>("LengMax", -1.);
-  desc.add<double>("LengMin", -1.);
 }
 
 

--- a/GeneratorInterface/GenFilters/src/MCLongLivedParticles.cc
+++ b/GeneratorInterface/GenFilters/src/MCLongLivedParticles.cc
@@ -7,12 +7,17 @@
 using namespace edm;
 using namespace std;
 
+//Filter particles based on their minimum and/or maximum displacement on the transverse plane and optionally on their pdgIds
+//To run independently of pdgId, do not insert the particleIDs entry in filter declaration
 
 MCLongLivedParticles::MCLongLivedParticles(const edm::ParameterSet& iConfig) :
-  hepMCProductTag_(iConfig.getUntrackedParameter<edm::InputTag>("hepMCProductTag",edm::InputTag("generator","unsmeared"))) {
+  token_(consumes<edm::HepMCProduct>(edm::InputTag(iConfig.getUntrackedParameter("moduleLabel",std::string("generator")),"unsmeared"))),
+  particleIDs(iConfig.getUntrackedParameter("ParticleIDs",std::vector<int>{0})),
+  //hepMCProductTag_(iConfig.getUntrackedParameter<edm::InputTag>("hepMCProductTag",edm::InputTag("generator","unsmeared"))) {}
    //here do whatever other initialization is needed
-  theCut = iConfig.getUntrackedParameter<double>("LengCut",10.);
-}
+  theUpperCut(iConfig.getUntrackedParameter<double>("LengMax",-1.)),
+  theLowerCut(iConfig.getUntrackedParameter<double>("LengMin",-1.))
+{}
 
 
 MCLongLivedParticles::~MCLongLivedParticles()
@@ -32,32 +37,53 @@ bool MCLongLivedParticles::filter(edm::Event& iEvent, const edm::EventSetup& iSe
   
   Handle<HepMCProduct> evt;
   
-  iEvent.getByLabel(hepMCProductTag_, evt);
-  
+  iEvent.getByToken(token_, evt);
+    
   bool pass = false;
+  bool matchedID = true;
+
+  float theUpperCut2 = theUpperCut*theUpperCut;
+  float theLowerCut2 = theLowerCut*theLowerCut;
   
   const HepMC::GenEvent * generated_event = evt->GetEvent();
   HepMC::GenEvent::particle_const_iterator p;
   
   for (p = generated_event->particles_begin(); p != generated_event->particles_end(); p++)
     { 
+      //if a list of pdgId is provided, loop only on particles with those pdgId 
+      if (particleIDs.at(0)!=0){
+        matchedID = false;
+        for (unsigned int idx=0; idx < particleIDs.size(); idx++){
+          if (abs((*p)->pdg_id())==abs(particleIDs.at(idx))){ //compares absolute values of pdgIds
+            matchedID = true;
+            break;
+          }
+        }                
+      } 
+      
+    
+      if (matchedID){ 
 
-      if(((*p)->production_vertex() != nullptr) && ((*p)->end_vertex()!=nullptr))
-	{
-	  float dist = sqrt((((*p)->production_vertex())->position().x()-((*p)->end_vertex())->position().x())*(((*p)->production_vertex())->position().x()-((*p)->end_vertex())->position().x())+
-			    (((*p)->production_vertex())->position().y()-((*p)->end_vertex())->position().y())*(((*p)->production_vertex())->position().y()-((*p)->end_vertex())->position().y()));
-	  if(dist>theCut)
-	    pass=true;
-	}
-      
-      if(((*p)->production_vertex()==nullptr) && (!((*p)->end_vertex()!=nullptr)))
-	{
-	  if(((*p)->end_vertex())->position().perp()>theCut)
-	    pass=true;
-	}
-      
-      if(pass)
-	return pass;
+        if(((*p)->production_vertex() != nullptr) && ((*p)->end_vertex()!=nullptr)){
+        
+          float dist2 = (((*p)->production_vertex())->position().x()-((*p)->end_vertex())->position().x())*(((*p)->production_vertex())->position().x()-((*p)->end_vertex())->position().x()) +
+                        (((*p)->production_vertex())->position().y()-((*p)->end_vertex())->position().y())*(((*p)->production_vertex())->position().y()-((*p)->end_vertex())->position().y());
+       
+          if( (dist2>=theLowerCut2 || theLowerCut<=0.) && 
+              (dist2< theUpperCut2 || theUpperCut<=0.) ){ //lower cut can be also 0 - prompt particle needs to be accepted in that case
+            pass=true;
+            break;
+	    }
+        }
+         
+        if(((*p)->production_vertex()==nullptr) && (!((*p)->end_vertex()!=nullptr))){
+          if((((*p)->end_vertex()->position().perp() >= theLowerCut) || theLowerCut<=0.) && 
+             (((*p)->end_vertex()->position().perp() <  theUpperCut) || theUpperCut<=0.)){ // lower cut can be also 0 - prompt particle needs to be accepted in that case
+            pass=true;
+            break;
+	   }
+        }
+      }
     }
   
   return pass;

--- a/GeneratorInterface/GenFilters/test/test_MCLongLivedFilter_cfg.py
+++ b/GeneratorInterface/GenFilters/test/test_MCLongLivedFilter_cfg.py
@@ -53,11 +53,9 @@ process.generator = cms.EDFilter("Pythia6GeneratorFilter",
 )
 
 process.select = cms.EDFilter("MCLongLivedParticles",
-    hepMCProductTag = cms.untracked.InputTag("VtxSmeared"),
-    ParticleIDs = cms.untracked.vint32(310), ## in mm
-    #LengCut = cms.untracked.double(100.), ## in mm
-   LengMin = cms.untracked.double(30.), ## in mm
-   LengMax = cms.untracked.double(100.), ## in mm
+    ParticleIDs = cms.vint32(310), ## in mm
+    LengMin = cms.double(0.), ## in mm
+    LengMax = cms.double(100.), ## in mm
 
 )
 

--- a/GeneratorInterface/GenFilters/test/test_MCLongLivedFilter_cfg.py
+++ b/GeneratorInterface/GenFilters/test/test_MCLongLivedFilter_cfg.py
@@ -53,8 +53,10 @@ process.generator = cms.EDFilter("Pythia6GeneratorFilter",
 )
 
 process.select = cms.EDFilter("MCLongLivedParticles",
-    hepMCProductTag = cms.InputTag("VtxSmeared"),
-    LengCut = cms.untracked.double(100.0) ## in mm
+    hepMCProductTag = cms.untracked.InputTag("VtxSmeared"),
+    ParticleIDs = cms.untracked.vint32(310), ## in mm
+    LengMin = cms.untracked.double(0.), ## in mm
+    LengMax = cms.untracked.double(100.), ## in mm
 
 )
 

--- a/GeneratorInterface/GenFilters/test/test_MCLongLivedFilter_cfg.py
+++ b/GeneratorInterface/GenFilters/test/test_MCLongLivedFilter_cfg.py
@@ -55,8 +55,9 @@ process.generator = cms.EDFilter("Pythia6GeneratorFilter",
 process.select = cms.EDFilter("MCLongLivedParticles",
     hepMCProductTag = cms.untracked.InputTag("VtxSmeared"),
     ParticleIDs = cms.untracked.vint32(310), ## in mm
-    LengMin = cms.untracked.double(0.), ## in mm
-    LengMax = cms.untracked.double(100.), ## in mm
+    #LengCut = cms.untracked.double(100.), ## in mm
+   LengMin = cms.untracked.double(30.), ## in mm
+   LengMax = cms.untracked.double(100.), ## in mm
 
 )
 


### PR DESCRIPTION
#### PR description:

The filter generalizes MCLongLivedParticles GenFilter (filter was included in GenFilters up to CMSSW_11_0_X/ ,
 for CMSSW_10_2_X/ see  https://github.com/cms-sw/cmssw/blob/CMSSW_10_2_X/GeneratorInterface/GenFilters/src/MCLongLivedParticles.cc
It selects particles based on transverse displacement (by means of a lower and/or upper cut) and pdgIds.
The filter is developed for searches of long lived HNLs in B meson decays (@rmanzoni  @pandolf  @amlyon)

The filter is included in the `plugins` subdirectory of `GeneratorInterface/GenFilters` . 
It is possible to retrieve the original filter behavior by setting the lower cut only and leaving the pdgIds unspecified.
NOTE: the filter syntax has changed with respect to the original version, as a lower (LengMin) and an upper (LengMax) cut can be specified, while in the CMSSW_11_0_X/  version there was only a lower cut parameter.


#### PR validation:

Filter behavior can be tested in the `test` subdirectory of  `GeneratorInterface/GenFilters` through the module `test_MCLongLivedFilter_cfg.py`

Backporting #37669
