### PR TITLE
[12_3_X] Add streamerFile-based unitTest for BeamSpotOnlineHLT DQM client

### DIFF
--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -48,6 +48,30 @@ if 'unitTest=True' in sys.argv:
 if unitTest:
   process.load("DQM.Integration.config.unittestinputsource_cfi")
   from DQM.Integration.config.unittestinputsource_cfi import options
+
+  # Overwrite source of the unitTest to use a streamer file instead of the DAS query output
+  print("[beamhlt_dqm_sourceclient-live_cfg]:: Overriding DAS input to use a streamer file")
+
+  # Read streamer files from https://github.com/cms-data/DQM-Integration
+  import os
+  dqm_integration_data = [os.path.join(dir,'DQM/Integration/data') for dir in os.getenv('CMSSW_SEARCH_PATH','').split(":") if os.path.exists(os.path.join(dir,'DQM/Integration/data'))][0]
+
+  # Set the process source
+  process.source = cms.Source("DQMStreamerReader",
+      runNumber = cms.untracked.uint32(346373),
+      runInputDir = cms.untracked.string(dqm_integration_data),
+      SelectEvents = cms.untracked.vstring('*'),
+      streamLabel = cms.untracked.string('streamDQMOnlineBeamspot'),
+      scanOnce = cms.untracked.bool(True),
+      minEventsPerLumi = cms.untracked.int32(1000),
+      delayMillis = cms.untracked.uint32(500),
+      nextLumiTimeoutMillis = cms.untracked.int32(0),
+      skipFirstLumis = cms.untracked.bool(False),
+      deleteDatFiles = cms.untracked.bool(False),
+      endOfRunKills  = cms.untracked.bool(False),
+      inputFileTransitionsEachEvent = cms.untracked.bool(False)
+  )
+
 elif live:
   # for live online DQM in P5
   process.load("DQM.Integration.config.inputsource_cfi")
@@ -224,7 +248,7 @@ if (process.runType.getRunType() == process.runType.pp_run or
         connect = cms.string('sqlite_file:BeamSpotOnlineHLT.db'),
         preLoadConnectionString = cms.untracked.string('sqlite_file:BeamSpotOnlineHLT.db'),
         runNumber = cms.untracked.uint64(options.runNumber),
-        lastLumiFile = cms.untracked.string('last_lumi.txt'),
+        lastLumiFile = cms.untracked.string('src/DQM/Integration/python/clients/last_lumi.txt'),
         latency = cms.untracked.uint32(2),
         autoCommit = cms.untracked.bool(True),
         toPut = cms.VPSet(cms.PSet(

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -2,6 +2,7 @@
   <flags NO_TEST_PREFIX="1"/>
 </ifrelease>
 <test name="TestDQMOnlineClient-beam_dqm_sourceclient" command="runtest.sh beam_dqm_sourceclient-live_cfg.py"/>
+<test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" />
 <test name="TestDQMOnlineClient-beampixel_dqm_sourceclient" command="runtest.sh beampixel_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-csc_dqm_sourceclient" command="runtest.sh csc_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-ctpps_dqm_sourceclient" command="runtest.sh ctpps_dqm_sourceclient-live_cfg.py"/>
@@ -25,8 +26,6 @@
 <test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py"/>
-<!-- Need an HLT stream -->
-<!-- <test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->
 <!-- <test name="TestDQMOnlineClient-ecalcalib_dqm_sourceclient" command="runtest.sh ecalcalib_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->


### PR DESCRIPTION
#### PR description:
Backport of #37667
This PR adds the unitTest for the DQM BeamSpotHLT client (`beamhlt_dqm_sourceclient-live_cfg.py`).
The client requires to be run on streamer files (in production it runs on an ad hoc stream `streamDQMOnlineBeamspot`) which are added in https://github.com/cms-data/DQM-Integration/pull/1

#### PR validation:
UnitTest in the master PR runs successfully.
As I mentioned already this PR does **NOT** modify the production behavior, it just adds a new unitTest.
I opened the PR in case the DQM team (@cms-sw/dqm-l2) wants to test it in a replay (although I'm not sure
how meaningful it would be).

#### Backport:
Backport of #37667