### PR TITLE
Add HepMC3 products and methods to Generator base clases

### DIFF
--- a/GeneratorInterface/Core/BuildFile.xml
+++ b/GeneratorInterface/Core/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="heppdt"/>
 <use name="boost"/>
 <use name="hepmc"/>
+<use name="hepmc3"/>
 <use name="clhep"/>
 <use name="lhapdf"/>
 <use name="f77compiler"/>

--- a/GeneratorInterface/Core/interface/BaseHadronizer.h
+++ b/GeneratorInterface/Core/interface/BaseHadronizer.h
@@ -17,9 +17,11 @@
 #include <memory>
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMC3Product.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct3.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
@@ -51,12 +53,16 @@ namespace gen {
     // GenRunInfo and GenEvent passing
     GenRunInfoProduct& getGenRunInfo() { return genRunInfo_; }
     std::unique_ptr<HepMC::GenEvent> getGenEvent() { return std::move(genEvent_); }
+    std::unique_ptr<HepMC3::GenEvent> getGenEvent3() { return std::move(genEvent3_); }
     std::unique_ptr<GenEventInfoProduct> getGenEventInfo() { return std::move(genEventInfo_); }
+    std::unique_ptr<GenEventInfoProduct3> getGenEventInfo3() { return std::move(genEventInfo3_); }
     virtual std::unique_ptr<GenLumiInfoHeader> getGenLumiInfoHeader() const;
     std::unique_ptr<lhef::LHEEvent> getLHEEvent() { return std::move(lheEvent_); }
 
     void resetEvent(std::unique_ptr<HepMC::GenEvent> event) { genEvent_ = std::move(event); }
+    void resetEvent3(std::unique_ptr<HepMC3::GenEvent> event3) { genEvent3_ = std::move(event3); }
     void resetEventInfo(std::unique_ptr<GenEventInfoProduct> eventInfo) { genEventInfo_ = std::move(eventInfo); }
+    void resetEventInfo3(std::unique_ptr<GenEventInfoProduct3> eventInfo) { genEventInfo3_ = std::move(eventInfo); }
 
     // LHERunInfo and LHEEvent passing
     const std::shared_ptr<lhef::LHERunInfo>& getLHERunInfo() const { return lheRunInfo_; }
@@ -80,11 +86,16 @@ namespace gen {
     void randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine);
     void generateLHE(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine, unsigned int ncpu);
     void cleanLHE();
+    unsigned int getVHepMC() {return ivhepmc;}
 
   protected:
+    unsigned int ivhepmc = 2;
     GenRunInfoProduct& runInfo() { return genRunInfo_; }
     std::unique_ptr<HepMC::GenEvent>& event() { return genEvent_; }
     std::unique_ptr<GenEventInfoProduct>& eventInfo() { return genEventInfo_; }
+    //HepMC3:
+    std::unique_ptr<HepMC3::GenEvent>& event3() { return genEvent3_; }
+    std::unique_ptr<GenEventInfoProduct3>& eventInfo3() { return genEventInfo3_; }
 
     lhef::LHEEvent* lheEvent() { return lheEvent_.get(); }
     lhef::LHERunInfo* lheRunInfo() { return lheRunInfo_.get(); }
@@ -98,7 +109,9 @@ namespace gen {
 
     GenRunInfoProduct genRunInfo_;
     std::unique_ptr<HepMC::GenEvent> genEvent_;
+    std::unique_ptr<HepMC3::GenEvent> genEvent3_;
     std::unique_ptr<GenEventInfoProduct> genEventInfo_;
+    std::unique_ptr<GenEventInfoProduct3> genEventInfo3_;
 
     std::shared_ptr<lhef::LHERunInfo> lheRunInfo_;
     std::unique_ptr<lhef::LHEEvent> lheEvent_;

--- a/GeneratorInterface/Core/interface/BaseHadronizer.h
+++ b/GeneratorInterface/Core/interface/BaseHadronizer.h
@@ -86,7 +86,7 @@ namespace gen {
     void randomizeIndex(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine);
     void generateLHE(edm::LuminosityBlock const& lumi, CLHEP::HepRandomEngine* rengine, unsigned int ncpu);
     void cleanLHE();
-    unsigned int getVHepMC() {return ivhepmc;}
+    unsigned int getVHepMC() { return ivhepmc; }
 
   protected:
     unsigned int ivhepmc = 2;

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -121,13 +121,13 @@ namespace edm {
       usesResource(edm::uniqueSharedResourceName());
     }
 
-    if(ivhepmc == 2) {
+    if (ivhepmc == 2) {
       produces<edm::HepMCProduct>("unsmeared");
       produces<GenEventInfoProduct>();
     }
-    if(ivhepmc == 3) {
-//      produces<edm::HepM3CProduct>("unsmeared");
-//      produces<GenEventInfoProduct3>();
+    if (ivhepmc == 3) {
+      //produces<edm::HepM3CProduct>("unsmeared");
+      //produces<GenEventInfoProduct3>();
     }
     produces<GenLumiInfoHeader, edm::Transition::BeginLuminosityBlock>();
     produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>();
@@ -175,25 +175,24 @@ namespace edm {
 
       event = hadronizer_.getGenEvent();
       event3 = hadronizer_.getGenEvent3();
-      if(ivhepmc == 2 && !event.get()) return false;
-      if(ivhepmc == 3 && !event3.get()) return false;
+      if (ivhepmc == 2 && !event.get())
+        return false;
+      if (ivhepmc == 3 && !event3.get())
+        return false;
 
       // The external decay driver is being added to the system,
       // it should be called here
       //
-      if (decayer_) { // handle only HepMC2 for the moment
+      if (decayer_) {  // handle only HepMC2 for the moment
         auto t = decayer_->decay(event.get());
         if (t != event.get()) {
           event.reset(t);
         }
       }
-      if(ivhepmc == 2) { // HepMC
-        if (!event.get())
-          return false;
-      }
-      if(ivhepmc == 3) { // HepMC3
-        if (!event3.get())
-          return false;
+      if (ivhepmc == 2 && !event.get())  // HepMC
+        return false;
+      if (ivhepmc == 3 && !event3.get())  // HepMC3
+        return false;
       }
 
       passEvtGenSelector = hadronizer_.select(event.get());
@@ -203,9 +202,9 @@ namespace edm {
     //
     // fisrt of all, put back modified event tree (after external decay)
     //
-    if(ivhepmc == 2) // HepMC
+    if (ivhepmc == 2)  // HepMC
       hadronizer_.resetEvent(std::move(event));
-    if(ivhepmc == 3) // HepMC3
+    if (ivhepmc == 3)  // HepMC3
       hadronizer_.resetEvent3(std::move(event3));
 
     //
@@ -218,13 +217,13 @@ namespace edm {
 
     event = hadronizer_.getGenEvent();
     event3 = hadronizer_.getGenEvent3();
-    if(ivhepmc == 2) { // HepMC
+    if (ivhepmc == 2) {  // HepMC
       if (!event.get())
         return false;
       event->set_event_number(ev.id().event());
     }
 
-    if(ivhepmc == 3) { // HepMC3
+    if (ivhepmc == 3) {  // HepMC3
       if (!event3.get())
         return false;
       event3->set_event_number(ev.id().event());
@@ -233,7 +232,7 @@ namespace edm {
     //
     // tutto bene - finally, form up EDM products !
     //
-    if(ivhepmc == 2) { // HepMC
+    if (ivhepmc == 2) {  // HepMC
       auto genEventInfo = hadronizer_.getGenEventInfo();
       if (!genEventInfo.get()) {
         // create GenEventInfoProduct from HepMC event in case hadronizer didn't provide one
@@ -246,18 +245,18 @@ namespace edm {
       bare_product->addHepMCData(event.release());
       ev.put(std::move(bare_product), "unsmeared");
     }
-    if(ivhepmc == 3) { // HepMC3
+    if (ivhepmc == 3) {  // HepMC3
       auto genEventInfo3 = hadronizer_.getGenEventInfo3();
       if (!genEventInfo3.get()) {
         // create GenEventInfoProduct3 from HepMC3 event in case hadronizer didn't provide one
         genEventInfo3.reset(new GenEventInfoProduct3(event3.get()));
       }
 
-//      ev.put(std::move(genEventInfo3));
+      //ev.put(std::move(genEventInfo3));
 
-//      std::unique_ptr<HepMCProduct3> bare_product(new HepMCProduct3());
-//      bare_product->addHepMCData(event3.release());
-//      ev.put(std::move(bare_product), "unsmeared");
+      //std::unique_ptr<HepMCProduct3> bare_product(new HepMCProduct3());
+      //bare_product->addHepMCData(event3.release());
+      //ev.put(std::move(bare_product), "unsmeared");
     }
 
     nEventsInLumiBlock_++;

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -125,7 +125,7 @@ namespace edm {
       produces<edm::HepMCProduct>("unsmeared");
       produces<GenEventInfoProduct>();
     }
-    if (ivhepmc == 3) {
+    else if (ivhepmc == 3) {
       //produces<edm::HepM3CProduct>("unsmeared");
       //produces<GenEventInfoProduct3>();
     }
@@ -203,7 +203,7 @@ namespace edm {
     //
     if (ivhepmc == 2)
       hadronizer_.resetEvent(std::move(event));
-    if (ivhepmc == 3)
+    else if (ivhepmc == 3)
       hadronizer_.resetEvent3(std::move(event3));
 
     //
@@ -222,7 +222,7 @@ namespace edm {
       event->set_event_number(ev.id().event());
     }
 
-    if (ivhepmc == 3) {  // HepMC3
+    else if (ivhepmc == 3) {  // HepMC3
       if (!event3.get())
         return false;
       event3->set_event_number(ev.id().event());
@@ -244,7 +244,7 @@ namespace edm {
       bare_product->addHepMCData(event.release());
       ev.put(std::move(bare_product), "unsmeared");
     }
-    if (ivhepmc == 3) {  // HepMC3
+    else if (ivhepmc == 3) {  // HepMC3
       auto genEventInfo3 = hadronizer_.getGenEventInfo3();
       if (!genEventInfo3.get()) {
         // create GenEventInfoProduct3 from HepMC3 event in case hadronizer didn't provide one

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <vector>
 
+#include "HepMC3/GenEvent.h"
+
 #include "FWCore/Concurrency/interface/SharedResourceNames.h"
 #include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -35,6 +37,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct3.h"
 
 namespace edm {
   template <class HAD, class DEC>
@@ -71,6 +74,7 @@ namespace edm {
     unsigned int nEventsInLumiBlock_ = 0;
     unsigned int nThreads_{1};
     bool initialized_ = false;
+    unsigned int ivhepmc = 2;
   };
 
   //------------------------------------------------------------------------
@@ -92,6 +96,8 @@ namespace edm {
     //
     // other maybe added as needs be
     //
+
+    ivhepmc = hadronizer_.getVHepMC();
 
     std::vector<std::string> const& sharedResources = hadronizer_.sharedResources();
     for (auto const& resource : sharedResources) {
@@ -115,8 +121,14 @@ namespace edm {
       usesResource(edm::uniqueSharedResourceName());
     }
 
-    produces<edm::HepMCProduct>("unsmeared");
-    produces<GenEventInfoProduct>();
+    if(ivhepmc == 2) {
+      produces<edm::HepMCProduct>("unsmeared");
+      produces<GenEventInfoProduct>();
+    }
+    if(ivhepmc == 3) {
+//      produces<edm::HepM3CProduct>("unsmeared");
+//      produces<GenEventInfoProduct3>();
+    }
     produces<GenLumiInfoHeader, edm::Transition::BeginLuminosityBlock>();
     produces<GenLumiInfoProduct, edm::Transition::EndLuminosityBlock>();
     produces<GenRunInfoProduct, edm::Transition::EndRun>();
@@ -142,9 +154,11 @@ namespace edm {
 
     bool passEvtGenSelector = false;
     std::unique_ptr<HepMC::GenEvent> event(nullptr);
+    std::unique_ptr<HepMC3::GenEvent> event3(nullptr);
 
     while (!passEvtGenSelector) {
       event.reset();
+      event3.reset();
       hadronizer_.setEDMEvent(ev);
 
       if (!hadronizer_.generatePartonsAndHadronize())
@@ -160,20 +174,27 @@ namespace edm {
         return false;
 
       event = hadronizer_.getGenEvent();
-      if (!event.get())
-        return false;
+      event3 = hadronizer_.getGenEvent3();
+      if(ivhepmc == 2 && !event.get()) return false;
+      if(ivhepmc == 3 && !event3.get()) return false;
 
       // The external decay driver is being added to the system,
       // it should be called here
       //
-      if (decayer_) {
+      if (decayer_) { // handle only HepMC2 for the moment
         auto t = decayer_->decay(event.get());
         if (t != event.get()) {
           event.reset(t);
         }
       }
-      if (!event.get())
-        return false;
+      if(ivhepmc == 2) { // HepMC
+        if (!event.get())
+          return false;
+      }
+      if(ivhepmc == 3) { // HepMC3
+        if (!event3.get())
+          return false;
+      }
 
       passEvtGenSelector = hadronizer_.select(event.get());
     }
@@ -182,7 +203,10 @@ namespace edm {
     //
     // fisrt of all, put back modified event tree (after external decay)
     //
-    hadronizer_.resetEvent(std::move(event));
+    if(ivhepmc == 2) // HepMC
+      hadronizer_.resetEvent(std::move(event));
+    if(ivhepmc == 3) // HepMC3
+      hadronizer_.resetEvent3(std::move(event3));
 
     //
     // now run residual decays
@@ -193,25 +217,49 @@ namespace edm {
     hadronizer_.finalizeEvent();
 
     event = hadronizer_.getGenEvent();
-    if (!event.get())
-      return false;
+    event3 = hadronizer_.getGenEvent3();
+    if(ivhepmc == 2) { // HepMC
+      if (!event.get())
+        return false;
+      event->set_event_number(ev.id().event());
+    }
 
-    event->set_event_number(ev.id().event());
+    if(ivhepmc == 3) { // HepMC3
+      if (!event3.get())
+        return false;
+      event3->set_event_number(ev.id().event());
+    }
 
     //
     // tutto bene - finally, form up EDM products !
     //
-    auto genEventInfo = hadronizer_.getGenEventInfo();
-    if (!genEventInfo.get()) {
-      // create GenEventInfoProduct from HepMC event in case hadronizer didn't provide one
-      genEventInfo.reset(new GenEventInfoProduct(event.get()));
+    if(ivhepmc == 2) { // HepMC
+      auto genEventInfo = hadronizer_.getGenEventInfo();
+      if (!genEventInfo.get()) {
+        // create GenEventInfoProduct from HepMC event in case hadronizer didn't provide one
+        genEventInfo.reset(new GenEventInfoProduct(event.get()));
+      }
+
+      ev.put(std::move(genEventInfo));
+
+      std::unique_ptr<HepMCProduct> bare_product(new HepMCProduct());
+      bare_product->addHepMCData(event.release());
+      ev.put(std::move(bare_product), "unsmeared");
+    }
+    if(ivhepmc == 3) { // HepMC3
+      auto genEventInfo3 = hadronizer_.getGenEventInfo3();
+      if (!genEventInfo3.get()) {
+        // create GenEventInfoProduct3 from HepMC3 event in case hadronizer didn't provide one
+        genEventInfo3.reset(new GenEventInfoProduct3(event3.get()));
+      }
+
+//      ev.put(std::move(genEventInfo3));
+
+//      std::unique_ptr<HepMCProduct3> bare_product(new HepMCProduct3());
+//      bare_product->addHepMCData(event3.release());
+//      ev.put(std::move(bare_product), "unsmeared");
     }
 
-    ev.put(std::move(genEventInfo));
-
-    std::unique_ptr<HepMCProduct> bare_product(new HepMCProduct());
-    bare_product->addHepMCData(event.release());
-    ev.put(std::move(bare_product), "unsmeared");
     nEventsInLumiBlock_++;
     return true;
   }

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -124,8 +124,7 @@ namespace edm {
     if (ivhepmc == 2) {
       produces<edm::HepMCProduct>("unsmeared");
       produces<GenEventInfoProduct>();
-    }
-    else if (ivhepmc == 3) {
+    } else if (ivhepmc == 3) {
       //produces<edm::HepM3CProduct>("unsmeared");
       //produces<GenEventInfoProduct3>();
     }
@@ -220,9 +219,8 @@ namespace edm {
       if (!event.get())
         return false;
       event->set_event_number(ev.id().event());
-    }
 
-    else if (ivhepmc == 3) {  // HepMC3
+    } else if (ivhepmc == 3) {  // HepMC3
       if (!event3.get())
         return false;
       event3->set_event_number(ev.id().event());
@@ -243,8 +241,8 @@ namespace edm {
       std::unique_ptr<HepMCProduct> bare_product(new HepMCProduct());
       bare_product->addHepMCData(event.release());
       ev.put(std::move(bare_product), "unsmeared");
-    }
-    else if (ivhepmc == 3) {  // HepMC3
+
+    } else if (ivhepmc == 3) {  // HepMC3
       auto genEventInfo3 = hadronizer_.getGenEventInfo3();
       if (!genEventInfo3.get()) {
         // create GenEventInfoProduct3 from HepMC3 event in case hadronizer didn't provide one

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -125,7 +125,7 @@ namespace edm {
       produces<edm::HepMCProduct>("unsmeared");
       produces<GenEventInfoProduct>();
     } else if (ivhepmc == 3) {
-      //produces<edm::HepM3CProduct>("unsmeared");
+      //produces<edm::HepMC3Product>("unsmeared");
       //produces<GenEventInfoProduct3>();
     }
     produces<GenLumiInfoHeader, edm::Transition::BeginLuminosityBlock>();

--- a/GeneratorInterface/Core/interface/GeneratorFilter.h
+++ b/GeneratorInterface/Core/interface/GeneratorFilter.h
@@ -189,11 +189,10 @@ namespace edm {
           event.reset(t);
         }
       }
-      if (ivhepmc == 2 && !event.get())  // HepMC
+      if (ivhepmc == 2 && !event.get())
         return false;
-      if (ivhepmc == 3 && !event3.get())  // HepMC3
+      if (ivhepmc == 3 && !event3.get())
         return false;
-      }
 
       passEvtGenSelector = hadronizer_.select(event.get());
     }
@@ -202,9 +201,9 @@ namespace edm {
     //
     // fisrt of all, put back modified event tree (after external decay)
     //
-    if (ivhepmc == 2)  // HepMC
+    if (ivhepmc == 2)
       hadronizer_.resetEvent(std::move(event));
-    if (ivhepmc == 3)  // HepMC3
+    if (ivhepmc == 3)
       hadronizer_.resetEvent3(std::move(event3));
 
     //

--- a/GeneratorInterface/Core/test/FailingGeneratorFilter.cc
+++ b/GeneratorInterface/Core/test/FailingGeneratorFilter.cc
@@ -13,6 +13,7 @@
 // system include files
 
 // user include files
+#include "GeneratorInterface/Core/interface/BaseHadronizer.h"
 #include "GeneratorInterface/Core/interface/GeneratorFilter.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -41,13 +42,17 @@ namespace test {
     }
     bool decay() const { return true; }
 
+    unsigned int getVHepMC() {return ivhepmc;}
     std::unique_ptr<HepMC::GenEvent> getGenEvent() { return std::move(event_); }
+    std::unique_ptr<HepMC3::GenEvent> getGenEvent3() { return std::move(event3_); }
 
     bool select(HepMC::GenEvent*) const { return true; }
     void resetEvent(std::unique_ptr<HepMC::GenEvent> iEvent) { event_ = std::move(iEvent); }
+    void resetEvent3(std::unique_ptr<HepMC3::GenEvent> iEvent) { event3_ = std::move(iEvent); }
     bool residualDecay() const { return true; }
     void finalizeEvent() const {}
     std::unique_ptr<GenEventInfoProduct> getGenEventInfo() const { return std::make_unique<GenEventInfoProduct>(); }
+    std::unique_ptr<GenEventInfoProduct3> getGenEventInfo3() const { return std::make_unique<GenEventInfoProduct3>(); }
 
     //caled at endRunProduce, endLumiProduce
     void statistics() const {}
@@ -102,8 +107,10 @@ namespace test {
       }
     }
     std::unique_ptr<HepMC::GenEvent> event_;
+    std::unique_ptr<HepMC3::GenEvent> event3_;
     int failAt_;
     int failureType_;
+    unsigned int ivhepmc = 2;
   };
 
   class DummyDec {

--- a/GeneratorInterface/Core/test/FailingGeneratorFilter.cc
+++ b/GeneratorInterface/Core/test/FailingGeneratorFilter.cc
@@ -42,7 +42,7 @@ namespace test {
     }
     bool decay() const { return true; }
 
-    unsigned int getVHepMC() {return ivhepmc;}
+    unsigned int getVHepMC() { return ivhepmc; }
     std::unique_ptr<HepMC::GenEvent> getGenEvent() { return std::move(event_); }
     std::unique_ptr<HepMC3::GenEvent> getGenEvent3() { return std::move(event3_); }
 


### PR DESCRIPTION
#### PR description:

Add HepMC3 products and corresponding methods to Generator base classes. This will allow the new plugins Pythia8HepMC3Hadronizer to work at the generation step. There will be no change for the old plugins.

#### PR validation:

Tests with Pythia8Interface tests and a SIM step test

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
