### PR TITLE
L1T  fix reading array beyond bounds

### DIFF
--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -833,7 +833,7 @@ namespace tmtt {
     }
 
     bool ambiguous = false;
-    if (settings_->kfUseMaybeLayers())
+    if (settings_->kfUseMaybeLayers() and kfLayer < nKFlayer)
       ambiguous = ambiguityMap[kfEtaReg][kfLayer];
 
     return ambiguous;


### PR DESCRIPTION
#### PR description:

Addressing issue https://github.com/cms-sw/cmssw/issues/37696 where an array was read beyond bounds

