### PR TITLE
Correct input collections to the TF emulators for Run 3 MC re-emulation

### DIFF
--- a/L1Trigger/Configuration/python/customiseReEmul.py
+++ b/L1Trigger/Configuration/python/customiseReEmul.py
@@ -284,11 +284,29 @@ def L1TReEmulMCFromRAW(process):
     stage2L1Trigger.toModify(process.simEmtfDigis, CSCInput = 'simCscTriggerPrimitiveDigis:MPCSORTED')
     stage2L1Trigger.toModify(process.simOmtfDigis, srcCSC   = 'simCscTriggerPrimitiveDigis:MPCSORTED')
 
-    # Temporary fix for OMTF inputs in MC re-emulation
+    # Correct input collections for MC re-emulation
+    run3_GEM.toModify(process.simBmtfDigis,
+        DTDigi_Source         = 'simTwinMuxDigis',
+        DTDigi_Theta_Source   = 'simDtTriggerPrimitiveDigis'
+    )
+
+    run3_GEM.toModify(process.simKBmtfStubs,
+        srcPhi     = "simTwinMuxDigis",
+        srcTheta   = "simDtTriggerPrimitiveDigis"
+    )
+
     run3_GEM.toModify(process.simOmtfDigis,
         srcRPC   = 'muonRPCDigis',
         srcDTPh  = 'simDtTriggerPrimitiveDigis',
         srcDTTh  = 'simDtTriggerPrimitiveDigis'
+    )
+
+    run3_GEM.toModify(process.simEmtfDigis,
+      RPCInput  = cms.InputTag('muonRPCDigis'),
+      GEMEnable = cms.bool(False),  # Will be enabled when GEM is in use.
+      GEMInput  = cms.InputTag('simMuonGEMPadDigiClusters'),
+      CPPFEnable = cms.bool(False), # Use CPPF-emulated clustered RPC hits from CPPF as the RPC hits. Set to "False" for MC
+      UseRun3CCLUT_OTMB = cms.bool(False), # TODO: Enable UseRun3CCLUT_OTMB once it's ready.
     )
 
     return process

--- a/L1Trigger/Configuration/python/customiseReEmul.py
+++ b/L1Trigger/Configuration/python/customiseReEmul.py
@@ -302,11 +302,11 @@ def L1TReEmulMCFromRAW(process):
     )
 
     run3_GEM.toModify(process.simEmtfDigis,
-      RPCInput  = cms.InputTag('muonRPCDigis'),
-      GEMEnable = cms.bool(False),  # Will be enabled when GEM is in use.
-      GEMInput  = cms.InputTag('simMuonGEMPadDigiClusters'),
-      CPPFEnable = cms.bool(False), # Use CPPF-emulated clustered RPC hits from CPPF as the RPC hits. Set to "False" for MC
-      UseRun3CCLUT_OTMB = cms.bool(False), # TODO: Enable UseRun3CCLUT_OTMB once it's ready.
+      RPCInput  = 'muonRPCDigis',
+      GEMEnable = False,  # Will be enabled when GEM is in use.
+      GEMInput  = 'simMuonGEMPadDigiClusters',
+      CPPFEnable = False,  # Use CPPF-emulated clustered RPC hits from CPPF as the RPC hits. Set to "False" for MC
+      UseRun3CCLUT_OTMB = False,  # TODO: Enable UseRun3CCLUT_OTMB once it's ready.
     )
 
     return process


### PR DESCRIPTION
#### PR description:

This PR is to fix the input parameters for TFs for Run 3 MC re-emulation. The inputs are now being provided by the TP emulators which are called during the MC re-emulation workflow.

This change reverts https://github.com/cms-l1t-offline/cmssw/issues/886 for Run 3 MC only and fixes the CPPFEnable flag for EMTF which should remain False for MC.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:
Checked with:
SingleNeutrino_E-10-gun/Run3Winter22DR-L1TPU0to99FEVT_SNB_122X_mcRun3_2021_realistic_v9-v2/GEN-SIM-DIGI-RAW

The re-emulation works and produces the correct collections.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->
