### PR TITLE
Remove unnecessary include of legacy EDAnalyzer header from HLTGenericFilter

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTGenericFilter.h
+++ b/HLTrigger/Egamma/plugins/HLTGenericFilter.h
@@ -10,7 +10,6 @@
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

Identified as part of https://github.com/cms-sw/cmssw/pull/37592.

#### PR validation:

Code compiles.