### PR TITLE
Remove lumi PCC stream for allForExpress and make a new key for Run3

### DIFF
--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -50,7 +50,8 @@ def buildList(pdList, matrix):
 
 # Update the lists anytime a new PD is added to the matrix
 autoAlca = { 'allForPrompt'         : buildList(['Charmonium', 'Commissioning', 'DoubleMuParked', 'DoubleMuon', 'EGamma', 'HLTPhysics', 'HcalNZS', 'JetHT', 'MET', 'MinimumBias', 'MuOnia', 'MuOniaParked', 'NoBPTX', 'SingleMuon', 'ZeroBias'], AlCaRecoMatrix),
-             'allForExpress'        : buildList(['StreamExpress', 'ALCALumiPixelsCountsExpress'], AlCaRecoMatrix),
+             'allForExpress'        : buildList(['StreamExpress'], AlCaRecoMatrix),
+             'allForExpressRun3   ' : buildList(['StreamExpress', 'ALCALumiPixelsCountsExpress'], AlCaRecoMatrix),
              'allForExpressHI'      : buildList(['StreamExpressHI'], AlCaRecoMatrix),
              'allForPromptCosmics'  : buildList(['Cosmics'], AlCaRecoMatrix),
              'allForExpressCosmics' : buildList(['ExpressCosmics'], AlCaRecoMatrix) }


### PR DESCRIPTION
#### PR description:

`ALCALumiPixelsCountsExpress` is only present in Run-3 data, but `@allForExpress` is also used on Run-2 (and Run-1 data). Like this the relvals running on Run-2 data will be fine.

#### PR validation:

`runTheMatrix.py -l 1001.2`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

The content will be backport to 12_3_X

resolves https://github.com/cms-sw/cmssw/issues/37685