### PR TITLE
[L1] Remove (some) unnecessary framework includes

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
@@ -30,7 +30,6 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -41,7 +40,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1GtStableParameters.h"
 #include "CondFormats/DataRecord/interface/L1GtStableParametersRcd.h"

--- a/L1Trigger/L1GctAnalyzer/interface/compareBitCounts.h
+++ b/L1Trigger/L1GctAnalyzer/interface/compareBitCounts.h
@@ -1,19 +1,11 @@
 #ifndef compareBitCounts_h
 #define compareBitCounts_h
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCollections.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
 
 #include "TH2.h"
 #include "TH1.h"

--- a/L1Trigger/L1GctAnalyzer/interface/compareRingSums.h
+++ b/L1Trigger/L1GctAnalyzer/interface/compareRingSums.h
@@ -1,19 +1,10 @@
 #ifndef compareRingSums_h
 #define compareRingSums_h
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCollections.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
 
 #include "TH2.h"
 #include "TH1.h"

--- a/L1Trigger/L1GctAnalyzer/src/compareBitCounts.cc
+++ b/L1Trigger/L1GctAnalyzer/src/compareBitCounts.cc
@@ -2,19 +2,6 @@
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCollections.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "FWCore/Utilities/interface/InputTag.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"      // Framework services
-#include "CommonTools/UtilAlgos/interface/TFileService.h"  // Framework service for histograms
-
 compareBitCounts::compareBitCounts(const edm::Handle<L1GctHFBitCountsCollection> &data,
                                    const edm::Handle<L1GctHFBitCountsCollection> &emu,
                                    const GctErrorAnalyzerMBxInfo &mbxparams)

--- a/L1Trigger/L1GctAnalyzer/src/compareRingSums.cc
+++ b/L1Trigger/L1GctAnalyzer/src/compareRingSums.cc
@@ -2,19 +2,6 @@
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "DataFormats/L1GlobalCaloTrigger/interface/L1GctCollections.h"
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "FWCore/Utilities/interface/InputTag.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"      // Framework services
-#include "CommonTools/UtilAlgos/interface/TFileService.h"  // Framework service for histograms
-
 compareRingSums::compareRingSums(const edm::Handle<L1GctHFRingEtSumsCollection> &data,
                                  const edm::Handle<L1GctHFRingEtSumsCollection> &emu,
                                  const GctErrorAnalyzerMBxInfo &mbxparams)

--- a/L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/OMTFReconstruction.h
+++ b/L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/OMTFReconstruction.h
@@ -16,7 +16,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 

--- a/L1Trigger/L1TMuonOverlapPhase1/plugins/L1TMuonOverlapPhase1TrackProducer.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/plugins/L1TMuonOverlapPhase1TrackProducer.cc
@@ -1,7 +1,4 @@
-#include "L1Trigger/L1TMuonOverlapPhase1/plugins/L1TMuonOverlapPhase1TrackProducer.h"
-#include "FWCore/Framework/interface/EDConsumerBase.h"
-#include "FWCore/Framework/interface/ProductRegistryHelper.h"
-#include "FWCore/PluginManager/interface/PluginFactory.h"
+#include "L1TMuonOverlapPhase1TrackProducer.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 

--- a/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.cc
+++ b/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.cc
@@ -1,4 +1,4 @@
-#include "L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.h"
+#include "HPSPFTauProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include <cmath>  // std::fabs
 

--- a/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.h
+++ b/L1Trigger/Phase2L1Taus/plugins/HPSPFTauProducer.h
@@ -1,7 +1,6 @@
 #ifndef L1Trigger_Phase2L1Taus_HPSPFTauProducer_h
 #define L1Trigger_Phase2L1Taus_HPSPFTauProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/L1Trigger/TrackFindingTMTT/interface/InputData.h
+++ b/L1Trigger/TrackFindingTMTT/interface/InputData.h
@@ -1,12 +1,11 @@
 #ifndef L1Trigger_TrackFindingTMTT_InputData_h
 #define L1Trigger_TrackFindingTMTT_InputData_h
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "L1Trigger/TrackFindingTMTT/interface/TP.h"
 #include "L1Trigger/TrackFindingTMTT/interface/TrackerModule.h"
 #include "L1Trigger/TrackFindingTMTT/interface/Stub.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include <list>
 
 namespace tmtt {

--- a/L1Trigger/TrackFindingTMTT/src/InputData.cc
+++ b/L1Trigger/TrackFindingTMTT/src/InputData.cc
@@ -1,8 +1,5 @@
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "SimDataFormats/Track/interface/SimTrack.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"

--- a/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
+++ b/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
@@ -16,10 +16,8 @@ C.Brown 28/07/20
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/L1Trigger/VertexFinder/interface/InputData.h
+++ b/L1Trigger/VertexFinder/interface/InputData.h
@@ -1,15 +1,12 @@
 #ifndef __L1Trigger_VertexFinder_InputData_h__
 #define __L1Trigger_VertexFinder_InputData_h__
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "L1Trigger/VertexFinder/interface/Stub.h"
 #include "L1Trigger/VertexFinder/interface/TP.h"
 #include "L1Trigger/VertexFinder/interface/Vertex.h"

--- a/L1Trigger/VertexFinder/src/InputData.cc
+++ b/L1Trigger/VertexFinder/src/InputData.cc
@@ -1,7 +1,6 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"


### PR DESCRIPTION
#### PR description:

This PR removes unnecessary `#include`s of legacy EDModule headers plus some more of framework headers (that were clearly unused). These `#include`s were identified as part of https://github.com/cms-sw/cmssw/pull/37592.

#### PR validation:

Code compiles.