### PR TITLE
Remove (some) unnecessary framework includes from StringBasedNTupler

### DIFF
--- a/PhysicsTools/UtilAlgos/interface/StringBasedNTupler.h
+++ b/PhysicsTools/UtilAlgos/interface/StringBasedNTupler.h
@@ -3,8 +3,6 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
@@ -31,7 +29,6 @@
 #include <sstream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"


### PR DESCRIPTION
#### PR description:

Identified as part of https://github.com/cms-sw/cmssw/pull/37592.

#### PR validation:

Code compiles.