### PR TITLE
Puppi speedup: use reserve for vectors

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -348,6 +348,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   } else {
     //Use the existing weights
     int lPackCtr = 0;
+    lWeights.reserve(pfCol->size());
     for (auto const& aPF : *pfCol) {
       const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate*>(&aPF);
       float curpupweight = -1.;
@@ -394,6 +395,11 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::vector<reco::CandidatePtr> values(hPFProduct->size());
 
   int iCand = -1;
+  puppiP4s.reserve(hPFProduct->size());
+  if (fUseExistingWeights || fClonePackedCands)
+    fPackedPuppiCandidates.reserve(hPFProduct->size());
+  else
+    fPuppiCandidates.reserve(hPFProduct->size());
   for (auto const& aCand : *hPFProduct) {
     ++iCand;
     std::unique_ptr<pat::PackedCandidate> pCand;


### PR DESCRIPTION
#### PR description:

While profiling, I noticed a non-negligible fraction of time spent in reallocating vectors of candidates in `PuppiProducer`. This occurred because the vectors weren't reserved, and it was noticeable because constructing candidate objects is not lightweight. Therefore, repeating it should be avoided. Properly reserving the offending vectors accomplishes this. This reduced the CPU usage by 10-15% in my tests.

#### PR validation:

Code compiles and runs. CPU impact quantified with igprof. Compared AK8 jet pT in a ttbar workflow to confirm that no changes occurred.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Planned to be backported to 10_6_X (along with some other miscellaneous Puppi speedups that had not yet been backported).