### PR TITLE
bug fix for DQM bin-by-bin comparison script

### DIFF
--- a/DQMServices/FileIO/scripts/compareDQMOutput.py
+++ b/DQMServices/FileIO/scripts/compareDQMOutput.py
@@ -64,8 +64,8 @@ def get_file_pairs(base_dir, pr_dir):
 
     # Remove base directories and leave
     # only parts of paths that are same
-    base_files = map(lambda x: os.path.relpath(x, base_dir), base_files)
-    pr_files = map(lambda x: os.path.relpath(x, pr_dir), pr_files)
+    base_files = [ os.path.relpath(x, base_dir) for x in base_files ]
+    pr_files =   [ os.path.relpath(x, pr_dir) for x in pr_files ]
     
     # Find intersection
     return [value for value in base_files if value in pr_files]


### PR DESCRIPTION
As discussed in https://github.com/cms-sw/cmssw/pull/37635#issuecomment-1111407431, there is bug in compareDQMOutput.py. This change should fix it.