### PR TITLE
cppCommentSkipper: catch UnicodeDecodeError and print file name

### DIFF
--- a/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
+++ b/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
@@ -15,7 +15,7 @@ def filterFile(file): #ifstream& input)
     try:
         lines = open(file).readlines()
     except UnicodeDecodeError as e:
-        print("Error reading {0}: {1}".format(file, e.message))
+        print("CppCommentSkipper: ERROR reading {0}: {1}".format(file, e.message))
         raise e
     commentStage = False
 

--- a/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
+++ b/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
@@ -12,8 +12,11 @@ def filterFiles(fileList):
     return files
 
 def filterFile(file): #ifstream& input)
-
-    lines = open(file).readlines()
+    try:
+        lines = open(file).readlines()
+    except UnicodeDecodeError as e:
+        print("Error reading {0}: {1}".format(file, e.message))
+        raise e
     commentStage = False
 
     for i in range(len(lines)):

--- a/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
+++ b/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
@@ -15,8 +15,8 @@ def filterFile(file): #ifstream& input)
     try:
         lines = open(file).readlines()
     except UnicodeDecodeError as e:
-        print("CppCommentSkipper: ERROR reading {0}: {1}".format(file, e.message))
-        raise e
+        print("CppCommentSkipper: WARNING: Invalid UTF-8 sequence in {0}: {1}".format(file, e.message))
+        lines = open(file, errors='replace').readlines()
     commentStage = False
 
     for i in range(len(lines)):


### PR DESCRIPTION
#### PR description:

Provide better feedback on the following kind of errors:
```
07:34:04 Traceback (most recent call last):
07:34:04   File "/cvmfs/cms-ib.cern.ch/nweek-02730/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_CXXMODULE_X_2022-04-27-2300/bin/slc7_amd64_gcc10/cmsCodeRulesChecker.py", line 220, in <module>
07:34:04     result = runRules(ruleNumbers, checkPath)
07:34:04   File "/cvmfs/cms-ib.cern.ch/nweek-02730/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_CXXMODULE_X_2022-04-27-2300/bin/slc7_amd64_gcc10/cmsCodeRulesChecker.py", line 89, in runRules
07:34:04     filesLinesList = skipper(filesLinesList)
07:34:04   File "/cvmfs/cms-ib.cern.ch/nweek-02730/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_CXXMODULE_X_2022-04-27-2300/python/Utilities/ReleaseScripts/commentSkipper/commentSkipper.py", line 21, in filter
07:34:04     fileList = cppCommentSkipper.filterFiles(fileList)
07:34:04   File "/cvmfs/cms-ib.cern.ch/nweek-02730/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_CXXMODULE_X_2022-04-27-2300/python/Utilities/ReleaseScripts/commentSkipper/cppCommentSkipper.py", line 11, in filterFiles
07:34:04     files.append((file, filterFile(file)))
07:34:04   File "/cvmfs/cms-ib.cern.ch/nweek-02730/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_CXXMODULE_X_2022-04-27-2300/python/Utilities/ReleaseScripts/commentSkipper/cppCommentSkipper.py", line 16, in filterFile
07:34:04     lines = open(file).readlines()
07:34:04   File "/cvmfs/cms-ib.cern.ch/nweek-02730/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_4_CXXMODULE_X_2022-04-27-2300/external/slc7_amd64_gcc10/bin/../../../../../../../slc7_amd64_gcc10/external/python3/3.9.6-67e5cf5b4952101922f1d4c8474baa39/lib/python3.9/codecs.py", line 322, in decode
07:34:04     (result, consumed) = self._buffer_decode(data, self.errors, final)
07:34:04 UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe0 in position 291: invalid continuation byte
```
