### PR TITLE
added NanoAOD to PromptReco

### DIFF
--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -59,13 +59,16 @@ class Reco(Scenario):
         if ('nThreads' in args) :
             options.nThreads=args['nThreads']
 
-        miniAODStep=''
+        miniAODStep = ''
+        nanoAODStep = ''
 
-# if miniAOD is asked for - then retrieve the miniaod config 
         if 'outputs' in args:
+            print(args['outputs']) 
             for a in args['outputs']:
                 if a['dataTier'] == 'MINIAOD':
-                    miniAODStep=',PAT' 
+                    miniAODStep = ',PAT' 
+                if a['dataTier'] in ['NANOAOD', 'NANOEDMAOD']:
+                    nanoAODStep = ',NANO' 
 
         self._checkRepackedFlag(options, **args)
 
@@ -74,7 +77,10 @@ class Reco(Scenario):
 
         eiStep=''
 
-        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+PhysicsSkimStep+miniAODStep+',DQM'+dqmStep+',ENDJOB'
+        options.step = 'RAW2DIGI,L1Reco,RECO'
+        options.step += self.recoSeq + eiStep + step + PhysicsSkimStep
+        options.step += miniAODStep + nanoAODStep
+        options.step += ',DQM' + dqmStep + ',ENDJOB'
 
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -21,6 +21,7 @@ class RunPromptReco:
         self.writeRECO = False
         self.writeAOD = False
         self.writeMINIAOD = False
+        self.writeNANOAOD = False
         self.writeDQM = False
         self.writeDQMIO = False
         self.noOutput = False
@@ -65,6 +66,9 @@ class RunPromptReco:
         if self.writeMINIAOD:
             dataTiers.append("MINIAOD")
             print("Configuring to Write out MiniAOD")
+        if self.writeNANOAOD:
+            dataTiers.append("NANOAOD")
+            print("Configuring to Write out NanoAOD")
         if self.writeDQM:
             dataTiers.append("DQM")
             print("Configuring to Write out DQM")
@@ -143,7 +147,7 @@ class RunPromptReco:
 
 
 if __name__ == '__main__':
-    valid = ["scenario=", "reco", "aod", "miniaod","dqm", "dqmio", "no-output", "nThreads=", 
+    valid = ["scenario=", "reco", "aod", "miniaod", "nanoaod", "dqm", "dqmio", "no-output", "nThreads=", 
              "global-tag=", "lfn=", "alcarecos=", "PhysicsSkims=", "dqmSeq=", "isRepacked", "isNotRepacked" ]
     usage = \
 """
@@ -153,6 +157,7 @@ Where options are:
  --reco (to enable RECO output)
  --aod (to enable AOD output)
  --miniaod (to enable MiniAOD output)
+ --nanoaod (to enable NanoAOD output)
  --dqm (to enable DQM output)
  --dqmio (to enable DQMIO output)
  --isRepacked --isNotRepacked (to override default repacked flags)
@@ -187,6 +192,8 @@ python RunPromptReco.py --scenario=ppEra_Run2_2016 --reco --aod --dqmio --global
             recoinator.writeAOD = True
         if opt == "--miniaod":
             recoinator.writeMINIAOD = True
+        if opt == "--nanoaod":
+            recoinator.writeNANOAOD = True
         if opt == "--dqm":
             recoinator.writeDQM = True
         if opt == "--dqmio":

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -58,6 +58,13 @@ do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
+declare -a arr=("ppEra_Run3")
+for scenario in "${arr[@]}"
+do
+     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --nanoaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
+done
+
+
 runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario AlCaTestEnable --global-tag GLOBALTAG --lfn /store/whatever --alcareco PromptCalibProdEcalPedestals "
 runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario AlCaTestEnable --lfn=/store/whatever --global-tag GLOBALTAG --skims PromptCalibProdEcalPedestals"
 runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario AlCaTestEnable --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --alcapromptdataset=PromptCalibProdEcalPedestals"


### PR DESCRIPTION
#### PR description:

Added NanoAOD option to the prompt reco configuration building to be used at Tier0. This PR is critical for NanoAOD integration at Tier0 and targets first collisions. Other developments outside CMSSW (in WMCore) are on hold till we have a working pre-release or IB to use in Tier0 replays.

#### PR validation:

- Executed scram unit tests
- Tested that one can create a working configuration that produces valid output

