### PR TITLE
Fixed deprecation warnings in CSCEfficiency

### DIFF
--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.cc
@@ -77,8 +77,7 @@ bool CSCEfficiency::filter(edm::Event &event, const edm::EventSetup &eventSetup)
   edm::ESHandle<CSCGeometry> cscGeom = eventSetup.getHandle(geomToken_);
 
   // use theTrackingGeometry instead of cscGeom?
-  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
-  eventSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
+  //edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry = eventSetup.getHandle(trackingGeomToken_);
 
   bool triggerPassed = true;
   if (useTrigger) {
@@ -2052,11 +2051,5 @@ CSCEfficiency::~CSCEfficiency() {
   //---- Close the file
   theFile->Close();
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void CSCEfficiency::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void CSCEfficiency::endJob() {}
 
 DEFINE_FWK_MODULE(CSCEfficiency);

--- a/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
+++ b/RecoLocalMuon/CSCEfficiency/src/CSCEfficiency.h
@@ -10,7 +10,7 @@
 // how many of the headers below are not needed?...
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -92,7 +92,7 @@ class TFile;
 class CSCLayer;
 class CSCDetId;
 
-class CSCEfficiency : public edm::EDFilter {
+class CSCEfficiency : public edm::one::EDFilter<> {
 public:
   /// Constructor
   CSCEfficiency(const edm::ParameterSet &pset);
@@ -101,11 +101,8 @@ public:
   ~CSCEfficiency() override;
 
 private:
-  void beginJob() override;
   //---- analysis + filter
   bool filter(edm::Event &event, const edm::EventSetup &eventSetup) override;
-
-  void endJob() override;
 
   //---- (input) parameters
   //---- Root file name


### PR DESCRIPTION
#### PR description:

- changed to one::EDFilter
- updated and commented out unused EventSetup get

#### PR validation:

Code compiles without generating deprecation warnings.