### PR TITLE
Fixed deprecation warnings in RecoLocalMuon/CSCSegment

### DIFF
--- a/RecoLocalMuon/CSCSegment/test/CSCSegmentReader.cc
+++ b/RecoLocalMuon/CSCSegment/test/CSCSegmentReader.cc
@@ -28,6 +28,12 @@ CSCSegmentReader::CSCSegmentReader(const edm::ParameterSet& pset) {
   maxPhi = pset.getUntrackedParameter<double>("maxPhiSeparation");
   maxTheta = pset.getUntrackedParameter<double>("maxThetaSeparation");
 
+  geomToken_ = esConsumes();
+  simTracksToken_ = consumes(edm::InputTag("g4SimHits"));
+  simHitsToken_ = consumes(edm::InputTag("g4SimHits", "MuonCSCHits"));
+  recHitsToken_ = consumes(edm::InputTag("csc2DRecHits"));
+  cscSegmentsToken_ = consumes(edm::InputTag("cscSegments"));
+
   file = new TFile(filename.c_str(), "RECREATE");
 
   if (file->IsOpen())
@@ -123,21 +129,15 @@ CSCSegmentReader::~CSCSegmentReader() {
 
 // The real analysis
 void CSCSegmentReader::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
-  edm::ESHandle<CSCGeometry> h;
-  eventSetup.get<MuonGeometryRecord>().get(h);
-  const CSCGeometry* geom = &*h;
+  const CSCGeometry* geom = &eventSetup.getData(geomToken_);
 
-  edm::Handle<edm::SimTrackContainer> simTracks;
-  event.getByLabel("g4SimHits", simTracks);
+  edm::Handle<edm::SimTrackContainer> simTracks = event.getHandle(simTracksToken_);
 
-  edm::Handle<edm::PSimHitContainer> simHits;
-  event.getByLabel("g4SimHits", "MuonCSCHits", simHits);
+  edm::Handle<edm::PSimHitContainer> simHits = event.getHandle(simHitsToken_);
 
-  edm::Handle<CSCRecHit2DCollection> recHits;
-  event.getByLabel("csc2DRecHits", recHits);
+  edm::Handle<CSCRecHit2DCollection> recHits = event.getHandle(recHitsToken_);
 
-  edm::Handle<CSCSegmentCollection> cscSegments;
-  event.getByLabel("cscSegments", cscSegments);
+  edm::Handle<CSCSegmentCollection> cscSegments = event.getHandle(cscSegmentsToken_);
 
   simInfo(simTracks);
   resolution(simHits, recHits, cscSegments, geom);

--- a/RecoLocalMuon/CSCSegment/test/CSCSegmentReader.h
+++ b/RecoLocalMuon/CSCSegment/test/CSCSegmentReader.h
@@ -9,7 +9,7 @@
 
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include <FWCore/Framework/interface/one/EDAnalyzer.h>
 #include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/Framework/interface/Frameworkfwd.h>
 #include <DataFormats/Common/interface/Handle.h>
@@ -20,6 +20,7 @@
 #include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
 
 #include <Geometry/CSCGeometry/interface/CSCGeometry.h>
+#include <Geometry/Records/interface/MuonGeometryRecord.h>
 
 #include <vector>
 #include <map>
@@ -28,7 +29,7 @@
 #include "TFile.h"
 #include "TH1F.h"
 
-class CSCSegmentReader : public edm::EDAnalyzer {
+class CSCSegmentReader : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   CSCSegmentReader(const edm::ParameterSet& pset);
@@ -69,6 +70,12 @@ private:
   TH1I *hrechit, *hsegment;
   TH1F *hphiDir[9], *hthetaDir[9];
   TH1F *hdxOri[9], *hdyOri[9];
+
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
+  edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> simHitsToken_;
+  edm::EDGetTokenT<CSCRecHit2DCollection> recHitsToken_;
+  edm::EDGetTokenT<CSCSegmentCollection> cscSegmentsToken_;
 
   TFile* file;
   std::map<std::string, int> segMap1;

--- a/RecoLocalMuon/CSCSegment/test/CSCSegmentVisualise.h
+++ b/RecoLocalMuon/CSCSegment/test/CSCSegmentVisualise.h
@@ -8,7 +8,7 @@
  * performance of segment reconstruction
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "DataFormats/Common/interface/Handle.h"
 
 #include <Geometry/CSCGeometry/interface/CSCChamberSpecs.h>
@@ -19,6 +19,8 @@
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2D.h>
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 #include <DataFormats/CSCRecHit/interface/CSCRangeMapAccessor.h>
+#include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
@@ -30,7 +32,7 @@
 #include "TH1F.h"
 #include "TH2F.h"
 
-class CSCSegmentVisualise : public edm::EDAnalyzer {
+class CSCSegmentVisualise : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   explicit CSCSegmentVisualise(const edm::ParameterSet &pset);
@@ -52,6 +54,12 @@ private:
   TH2F *hyvszSegP[100];
 
   TFile *file;
+
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> simHitsToken_;
+  edm::EDGetTokenT<CSCRecHit2DCollection> recHitsToken_;
+  edm::EDGetTokenT<CSCSegmentCollection> segmentsToken_;
+
   int idxHisto;
   int minRechitChamber;
   int maxRechitChamber;


### PR DESCRIPTION
#### PR description:

- converted to thread friendly module types
- added consumes and esConsumes statements

#### PR validation:

Code compiles without issuing deprecation warnings.