### PR TITLE
Remove unused variable use_preshower from PFECALSuperClusterProducer

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowSuperClusterECALL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowSuperClusterECALL1Seeded_cfi.py
@@ -42,6 +42,5 @@ hltParticleFlowSuperClusterECALL1Seeded = cms.EDProducer("PFECALSuperClusterProd
     thresh_SCEt = cms.double(10.0),
     useDynamicDPhiWindow = cms.bool(True),
     useRegression = cms.bool(True),
-    use_preshower = cms.bool(True),
     verbose = cms.untracked.bool(False)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowSuperClusterECALUnseeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/hltParticleFlowSuperClusterECALUnseeded_cfi.py
@@ -42,6 +42,5 @@ hltParticleFlowSuperClusterECALUnseeded = cms.EDProducer("PFECALSuperClusterProd
     thresh_SCEt = cms.double(10.0),
     useDynamicDPhiWindow = cms.bool(True),
     useRegression = cms.bool(True),
-    use_preshower = cms.bool(True),
     verbose = cms.untracked.bool(False)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowSuperClusterECAL_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowSuperClusterECAL_cfi.py
@@ -57,6 +57,5 @@ particleFlowSuperClusterECAL = cms.EDProducer("PFECALSuperClusterProducer",
     thresh_SCEt = cms.double(4),
     useDynamicDPhiWindow = cms.bool(True),
     useRegression = cms.bool(True),
-    use_preshower = cms.bool(True),
     verbose = cms.untracked.bool(False)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowSuperClusterHGCalFromTICLL1Seeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowSuperClusterHGCalFromTICLL1Seeded_cfi.py
@@ -48,6 +48,5 @@ particleFlowSuperClusterHGCalFromTICLL1Seeded = cms.EDProducer("PFECALSuperClust
     thresh_SCEt = cms.double(10.0),
     useDynamicDPhiWindow = cms.bool(True),
     useRegression = cms.bool(True),
-    use_preshower = cms.bool(False),
     verbose = cms.untracked.bool(False)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowSuperClusterHGCalFromTICLUnseeded_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowSuperClusterHGCalFromTICLUnseeded_cfi.py
@@ -48,6 +48,5 @@ particleFlowSuperClusterHGCalFromTICLUnseeded = cms.EDProducer("PFECALSuperClust
     thresh_SCEt = cms.double(10.0),
     useDynamicDPhiWindow = cms.bool(True),
     useRegression = cms.bool(True),
-    use_preshower = cms.bool(False),
     verbose = cms.untracked.bool(False)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowSuperClusterHGCal_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowSuperClusterHGCal_cfi.py
@@ -57,6 +57,5 @@ particleFlowSuperClusterHGCal = cms.EDProducer("PFECALSuperClusterProducer",
     thresh_SCEt = cms.double(4),
     useDynamicDPhiWindow = cms.bool(True),
     useRegression = cms.bool(False),
-    use_preshower = cms.bool(False),
     verbose = cms.untracked.bool(False)
 )

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -172,6 +172,15 @@ def customiseFor37231(process):
 
     return process
 
+def customiseFor37756(process):
+    """https://github.com/cms-sw/cmssw/pull/37756
+    Removal of use_preshower parameter from PFECALSuperClusterProducer
+    """
+    for prod in producers_by_type(process, 'PFECALSuperClusterProducer'):
+        if hasattr(prod, 'use_preshower'):
+            delattr(prod, 'use_preshower')
+
+    return process
 
 def customiseFor37646(process):
     """ Customisation to remove a renamed parameter in HLTScoutingPFProducer
@@ -204,7 +213,7 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # process = customiseFor12718(process)
 
     process = customiseFor37231(process)
-
     process = customiseFor37646(process)
-
+    process = customiseFor37756(process)
+    
     return process

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECALBox_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECALBox_cfi.py
@@ -24,9 +24,6 @@ particleFlowSuperClusterECALBox = _mod.particleFlowSuperClusterECALMustache.clon
     PFBasicClusterCollectionPreshower = "particleFlowBasicClusterECALPreshower",
     PFSuperClusterCollectionEndcapWithPreshower = "particleFlowSuperClusterECALEndcapWithPreshower",
 
-    # use preshower ?
-    use_preshower = True,
-
     # are the seed thresholds Et or Energy?
     seedThresholdIsET = True,
 

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
@@ -17,7 +17,6 @@ phase2_hgcal.toModify(
     particleFlowSuperClusterHGCal,
     PFClusters                     = 'particleFlowClusterHGCal',
     useRegression                  = True,
-    use_preshower                  = False,
     PFBasicClusterCollectionEndcap = "",
     PFSuperClusterCollectionEndcap = "",
     PFSuperClusterCollectionEndcapWithPreshower = "",

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -341,7 +341,6 @@ void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<double>("thresh_PFClusterEndcap", 0.0);
   desc.add<edm::InputTag>("ESAssociation", edm::InputTag("particleFlowClusterECAL"));
   desc.add<std::string>("PFBasicClusterCollectionPreshower", "particleFlowBasicClusterECALPreshower");
-  desc.add<bool>("use_preshower", true);
   desc.addUntracked<bool>("verbose", false);
   desc.add<double>("thresh_SCEt", 4.0);
   desc.add<double>("etawidth_SuperClusterEndcap", 0.04);


### PR DESCRIPTION
#### PR description:

The variable `use_preshower` in `PFECALSuperClusterProducer.cc` is not used anywhere, but just creates confusion. It seems like setting it to true/false would lead to using/not using preshower energy for superclustering; while that is not the case. This variable has no effect anywhere and should just be removed to avoid further confusion.

This PR is just meant for code cleanup. No change in physics is expected.

#### PR validation:
`cmsDriver.py --filein /store/relval/CMSSW_12_4_0_pre3/RelValZpToEE_m6000_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v14-v1/2580000/42d345d9-79a2-4006-8d6b-b4241a553f42.root  --fileout file:AOD.root --mc --eventcontent AODSIM --runUnscheduled --customise Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions 123X_mcRun3_2021_realistic_v14  --step RAW2DIGI,RECO --geometry DB:Extended --era Run3 --python_filename aod_cfg.py --beamspot Run3RoundOptics25ns13TeVLowSigmaZ --no_exec -n 200`
then 
`cmsRun aod_cfg.py`
It ran fine.

This PR is not a backport. 
Backport not necessary.
