### PR TITLE
implement multiple working points in ID for e/g triggers based on HGCAL clusters

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterIdentificationBase.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalTriggerClusterIdentificationBase.h
@@ -10,7 +10,8 @@ public:
   virtual ~HGCalTriggerClusterIdentificationBase(){};
   virtual void initialize(const edm::ParameterSet& conf) = 0;
   virtual float value(const l1t::HGCalMulticluster& cluster) const = 0;
-  virtual bool decision(const l1t::HGCalMulticluster& cluster) const = 0;
+  virtual bool decision(const l1t::HGCalMulticluster& cluster, unsigned wp = 0) const = 0;
+  virtual const std::vector<std::string>& working_points() const = 0;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTriggerClusterIdentificationBDT.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTriggerClusterIdentificationBDT.cc
@@ -33,12 +33,26 @@ public:
     float eta_max_ = 3.;
   };
 
+  class WorkingPoint {
+  public:
+    WorkingPoint(const std::string& name, double wp) : name_(name), wp_(wp) {}
+    ~WorkingPoint() = default;
+
+    const std::string& name() const { return name_; }
+    double working_point() const { return wp_; }
+
+  private:
+    std::string name_;
+    double wp_;
+  };
+
 public:
   HGCalTriggerClusterIdentificationBDT();
   ~HGCalTriggerClusterIdentificationBDT() override{};
   void initialize(const edm::ParameterSet& conf) final;
   float value(const l1t::HGCalMulticluster& cluster) const final;
-  bool decision(const l1t::HGCalMulticluster& cluster) const final;
+  bool decision(const l1t::HGCalMulticluster& cluster, unsigned wp = 0) const final;
+  const std::vector<std::string>& working_points() const final { return working_points_names_; }
 
 private:
   enum class ClusterVariable {
@@ -57,9 +71,10 @@ private:
   };
   std::vector<Category> categories_;
   std::vector<std::unique_ptr<TMVAEvaluator>> bdts_;
-  std::vector<double> working_points_;
+  std::vector<std::vector<WorkingPoint>> working_points_;
   std::vector<std::string> input_variables_;
   std::vector<ClusterVariable> input_variables_id_;
+  std::vector<std::string> working_points_names_;
 
   float clusterVariable(ClusterVariable, const l1t::HGCalMulticluster&) const;
   int category(float pt, float eta) const;
@@ -81,16 +96,30 @@ void HGCalTriggerClusterIdentificationBDT::initialize(const edm::ParameterSet& c
   std::vector<double> categories_etamax = conf.getParameter<std::vector<double>>("CategoriesEtaMax");
   std::vector<double> categories_ptmin = conf.getParameter<std::vector<double>>("CategoriesPtMin");
   std::vector<double> categories_ptmax = conf.getParameter<std::vector<double>>("CategoriesPtMax");
-  working_points_ = conf.getParameter<std::vector<double>>("WorkingPoints");
 
   if (bdt_files.size() != categories_etamin.size() || categories_etamin.size() != categories_etamax.size() ||
-      categories_etamax.size() != categories_ptmin.size() || categories_ptmin.size() != categories_ptmax.size() ||
-      categories_ptmax.size() != working_points_.size()) {
+      categories_etamax.size() != categories_ptmin.size() || categories_ptmin.size() != categories_ptmax.size()) {
     throw cms::Exception("HGCalTriggerClusterIdentificationBDT|BadInitialization")
         << "Inconsistent numbers of categories, BDT weight files and working points";
   }
-  categories_.reserve(working_points_.size());
-  bdts_.reserve(working_points_.size());
+
+  const auto wps_conf = conf.getParameter<std::vector<edm::ParameterSet>>("WorkingPoints");
+  working_points_.resize(categories_etamin.size());
+  for (const auto& wp_conf : wps_conf) {
+    std::string wp_name = wp_conf.getParameter<std::string>("Name");
+    std::vector<double> wps = wp_conf.getParameter<std::vector<double>>("WorkingPoint");
+    working_points_names_.emplace_back(wp_name);
+    if (wps.size() != categories_etamin.size()) {
+      throw cms::Exception("HGCalTriggerClusterIdentificationBDT|BadInitialization")
+          << "Inconsistent number of categories in working point '" << wp_name << "'";
+    }
+    for (unsigned cat = 0; cat < categories_etamin.size(); cat++) {
+      working_points_[cat].emplace_back(wp_name, wps[cat]);
+    }
+  }
+
+  categories_.reserve(categories_etamin.size());
+  bdts_.reserve(categories_etamin.size());
   for (unsigned cat = 0; cat < categories_etamin.size(); cat++) {
     categories_.emplace_back(
         categories_ptmin[cat], categories_ptmax[cat], categories_etamin[cat], categories_etamax[cat]);
@@ -148,12 +177,12 @@ float HGCalTriggerClusterIdentificationBDT::value(const l1t::HGCalMulticluster& 
   return (cat != -1 ? bdts_.at(cat)->evaluate(inputs) : -999.);
 }
 
-bool HGCalTriggerClusterIdentificationBDT::decision(const l1t::HGCalMulticluster& cluster) const {
+bool HGCalTriggerClusterIdentificationBDT::decision(const l1t::HGCalMulticluster& cluster, unsigned wp) const {
   float bdt_output = value(cluster);
   float pt = cluster.pt();
   float eta = cluster.eta();
   int cat = category(pt, eta);
-  return (cat != -1 ? bdt_output > working_points_.at(cat) : true);
+  return (cat != -1 ? bdt_output > working_points_.at(cat).at(wp).working_point() : true);
 }
 
 int HGCalTriggerClusterIdentificationBDT::category(float pt, float eta) const {

--- a/L1Trigger/L1THGCal/plugins/backend/HGCalTriggerClusterIdentificationBDT.cc
+++ b/L1Trigger/L1THGCal/plugins/backend/HGCalTriggerClusterIdentificationBDT.cc
@@ -102,25 +102,26 @@ void HGCalTriggerClusterIdentificationBDT::initialize(const edm::ParameterSet& c
     throw cms::Exception("HGCalTriggerClusterIdentificationBDT|BadInitialization")
         << "Inconsistent numbers of categories, BDT weight files and working points";
   }
+  size_t categories_size = categories_etamin.size();
 
   const auto wps_conf = conf.getParameter<std::vector<edm::ParameterSet>>("WorkingPoints");
-  working_points_.resize(categories_etamin.size());
+  working_points_.resize(categories_size);
   for (const auto& wp_conf : wps_conf) {
     std::string wp_name = wp_conf.getParameter<std::string>("Name");
     std::vector<double> wps = wp_conf.getParameter<std::vector<double>>("WorkingPoint");
     working_points_names_.emplace_back(wp_name);
-    if (wps.size() != categories_etamin.size()) {
+    if (wps.size() != categories_size) {
       throw cms::Exception("HGCalTriggerClusterIdentificationBDT|BadInitialization")
           << "Inconsistent number of categories in working point '" << wp_name << "'";
     }
-    for (unsigned cat = 0; cat < categories_etamin.size(); cat++) {
+    for (size_t cat = 0; cat < categories_size; cat++) {
       working_points_[cat].emplace_back(wp_name, wps[cat]);
     }
   }
 
-  categories_.reserve(categories_etamin.size());
-  bdts_.reserve(categories_etamin.size());
-  for (unsigned cat = 0; cat < categories_etamin.size(); cat++) {
+  categories_.reserve(categories_size);
+  bdts_.reserve(categories_size);
+  for (size_t cat = 0; cat < categories_size; cat++) {
     categories_.emplace_back(
         categories_ptmin[cat], categories_ptmax[cat], categories_etamin[cat], categories_etamax[cat]);
   }

--- a/L1Trigger/L1THGCal/python/egammaIdentification.py
+++ b/L1Trigger/L1THGCal/python/egammaIdentification.py
@@ -205,23 +205,44 @@ egamma_identification_histomax = cms.PSet(
         CategoriesPtMin=cms.vdouble([cat.pt_min for cat in categories]),
         CategoriesPtMax=cms.vdouble([cat.pt_max for cat in categories]),
         Weights=cms.vstring(bdt_weights_histomax['v10_3151']),
-        WorkingPoints=cms.vdouble(
-                [wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],tight_wp)]
-                )
+        WorkingPoints=cms.VPSet([
+            cms.PSet(
+                Name=cms.string('tight'),
+                WorkingPoint=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],tight_wp)])
+            ),
+            cms.PSet(
+                Name=cms.string('loose'),
+                WorkingPoint=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],loose_wp)])
+            ),
+            ])
         )
 
 phase2_hgcalV10.toModify(egamma_identification_histomax,
         Inputs=cms.vstring(input_features_histomax['v10_3151']),
         Weights=cms.vstring(bdt_weights_histomax['v10_3151']),
-        WorkingPoints=cms.vdouble(
-                [wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],tight_wp)]
-                )
+        WorkingPoints=cms.VPSet([
+            cms.PSet(
+                Name=cms.string('tight'),
+                WorkingPoint=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],tight_wp)])
+            ),
+            cms.PSet(
+                Name=cms.string('loose'),
+                WorkingPoint=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],loose_wp)])
+            ),
+            ])
         )
 
 phase2_hgcalV11.toModify(egamma_identification_histomax,
         Inputs=cms.vstring(input_features_histomax['v10_3151']),
         Weights=cms.vstring(bdt_weights_histomax['v10_3151']),
-        WorkingPoints=cms.vdouble(
-                [wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],tight_wp)]
-                )
+        WorkingPoints=cms.VPSet([
+            cms.PSet(
+                Name=cms.string('tight'),
+                WorkingPoint=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],tight_wp)])
+            ),
+            cms.PSet(
+                Name=cms.string('loose'),
+                WorkingPoint=cms.vdouble([wps[eff] for wps,eff in zip(working_points_histomax['v10_3151'],loose_wp)])
+            ),
+            ])
         )

--- a/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalHistoClusteringImpl.cc
@@ -141,7 +141,11 @@ void HGCalHistoClusteringImpl::finalizeClusters(std::vector<l1t::HGCalMulticlust
       //compute shower shapes
       shape_.fillShapes(multicluster, triggerGeometry);
       // fill quality flag
-      multicluster.setHwQual(id_->decision(multicluster));
+      unsigned hwQual = 0;
+      for (unsigned wp = 0; wp < id_->working_points().size(); wp++) {
+        hwQual |= (id_->decision(multicluster, wp) << wp);
+      }
+      multicluster.setHwQual(hwQual);
       // fill H/E
       multicluster.saveHOverE();
 


### PR DESCRIPTION
#### PR description:
Add the possibility to define several working points in the identification BDTs for the L1 e/g triggers based on HGCAL clusters.
FYI @cerminar 

#### PR validation:
Private tests in `L1Trigger/L1THGCalUtilities/test`:
```
cmsRun testHGCalL1T_RelValV11_cfg.py
cmsRun testHGCalL1T_multialgo_V11_cfg.py
```
Tested D49, D60, D68, D77, D86 workflows
```
runTheMatrix.py -w upgrade -l 23234.0 --maxSteps=2 
runTheMatrix.py -w upgrade -l 28234.0 --maxSteps=2 
runTheMatrix.py -w upgrade -l 31434.0 --maxSteps=2
runTheMatrix.py -w upgrade -l 35034.0 --maxSteps=2
runTheMatrix.py -w upgrade -l 38634.0 --maxSteps=2
```
