### PR TITLE
Run3-sim118C Make use of token rather than label in accessing collections in SimCalorimetry/EcalTestBeam

### DIFF
--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -9,6 +9,8 @@
 #include "SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h"
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBTDCRawInfo.h"
 
+#include <memory>
+
 namespace edm {
   class ConsumesCollector;
   class Event;
@@ -21,7 +23,7 @@ class PileUpEventPrincipal;
 class EcalTBDigiProducer : public EcalDigiProducer {
 public:
   EcalTBDigiProducer(const edm::ParameterSet &params, edm::ProducesCollector, edm::ConsumesCollector &iC);
-  ~EcalTBDigiProducer() override;
+  ~EcalTBDigiProducer() override = default;
 
   void initializeEvent(edm::Event const &, edm::EventSetup const &) override;
   void finalizeEvent(edm::Event &, edm::EventSetup const &) override;
@@ -35,7 +37,7 @@ private:
   void fillTBTDCRawInfo(EcalTBTDCRawInfo &theTBTDCRawInfo);
 
   const EcalTrigTowerConstituentsMap m_theTTmap;
-  EcalTBReadout *m_theTBReadout;
+  std::unique_ptr <EcalTBReadout> m_theTBReadout;
 
   std::string m_ecalTBInfoLabel;
   std::string m_EBdigiFinalTag;

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -37,7 +37,7 @@ private:
   void fillTBTDCRawInfo(EcalTBTDCRawInfo &theTBTDCRawInfo);
 
   const EcalTrigTowerConstituentsMap m_theTTmap;
-  std::unique_ptr <EcalTBReadout> m_theTBReadout;
+  std::unique_ptr<EcalTBReadout> m_theTBReadout;
 
   std::string m_ecalTBInfoLabel;
   std::string m_EBdigiFinalTag;

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -1,6 +1,3 @@
-
-#include <memory>
-
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -48,7 +45,8 @@ EcalTBDigiProducer::EcalTBDigiProducer(const edm::ParameterSet &params,
 
   m_doReadout = params.getParameter<bool>("doReadout");
 
-  m_theTBReadout = new EcalTBReadout(m_ecalTBInfoLabel);
+  edm::EDGetTokenT<PEcalTBInfo> ecalTBInfoToken = iC.consumes<PEcalTBInfo>(edm::InputTag(m_ecalTBInfoLabel));
+  m_theTBReadout = std::make_unique<EcalTBReadout>(ecalTBInfoToken);
 
   m_tunePhaseShift = params.getParameter<double>("tunePhaseShift");
 
@@ -57,8 +55,6 @@ EcalTBDigiProducer::EcalTBDigiProducer(const edm::ParameterSet &params,
         edm::InputTag(params.getUntrackedParameter<std::string>("EcalTBInfoLabel", "SimEcalTBG4Object")));
   }
 }
-
-EcalTBDigiProducer::~EcalTBDigiProducer() {}
 
 void EcalTBDigiProducer::initializeEvent(edm::Event const &event, edm::EventSetup const &eventSetup) {
   std::cout << "====****Entering EcalTBDigiProducer produce()" << std::endl;

--- a/SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h
+++ b/SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h
@@ -19,7 +19,7 @@
 
 class EcalTBReadout {
 public:
-  EcalTBReadout(const edm::EDGetTokenT<PEcalTBInfo>& token);
+  EcalTBReadout(const edm::EDGetTokenT<PEcalTBInfo> &token);
   ~EcalTBReadout() = default;
 
   /// tell the readout which cells exist

--- a/SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h
+++ b/SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h
@@ -15,11 +15,12 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 
 class EcalTBReadout {
 public:
-  EcalTBReadout(const std::string theEcalTBInfoLabel);
-  ~EcalTBReadout(){};
+  EcalTBReadout(const edm::EDGetTokenT<PEcalTBInfo>& token);
+  ~EcalTBReadout() = default;
 
   /// tell the readout which cells exist
   void setDetIds(const std::vector<DetId> &detIds) { theDetIds = &detIds; }
@@ -46,6 +47,8 @@ public:
                       EEDigiCollection &output);
 
 private:
+  const edm::EDGetTokenT<PEcalTBInfo> ecalTBInfoToken_;
+
   int theTargetCrystal_;
 
   std::vector<EcalTrigTowerDetId> theTTlist_;
@@ -53,8 +56,6 @@ private:
   static const int NCRYMATRIX = 7;
 
   const std::vector<DetId> *theDetIds;
-
-  std::string ecalTBInfoLabel_;
 };
 
 #endif

--- a/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
+++ b/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
@@ -5,7 +5,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h"
 
-EcalTBReadout::EcalTBReadout(const edm::EDGetTokenT<PEcalTBInfo>& token) : ecalTBInfoToken_(token) {
+EcalTBReadout::EcalTBReadout(const edm::EDGetTokenT<PEcalTBInfo> &token) : ecalTBInfoToken_(token) {
   theTargetCrystal_ = -1;
   theTTlist_.reserve(1);
 }
@@ -153,7 +153,7 @@ void EcalTBReadout::performReadout(edm::Event &event,
   // TB readout
   // step 1: get the target crystal index
 
-  const edm::Handle<PEcalTBInfo> & theEcalTBInfo = event.getHandle(ecalTBInfoToken_);
+  const edm::Handle<PEcalTBInfo> &theEcalTBInfo = event.getHandle(ecalTBInfoToken_);
 
   int crysId = theEcalTBInfo->nCrystal();
 
@@ -173,7 +173,7 @@ void EcalTBReadout::performReadout(edm::Event &event,
   // TB readout
   // step 1: get the target crystal index
 
-  const edm::Handle<PEcalTBInfo> & theEcalTBInfo = event.getHandle(ecalTBInfoToken_);
+  const edm::Handle<PEcalTBInfo> &theEcalTBInfo = event.getHandle(ecalTBInfoToken_);
 
   int crysId = theEcalTBInfo->nCrystal();
 

--- a/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
+++ b/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
@@ -4,9 +4,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h"
-#include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 
-EcalTBReadout::EcalTBReadout(const std::string theEcalTBInfoLabel) : ecalTBInfoLabel_(theEcalTBInfoLabel) {
+EcalTBReadout::EcalTBReadout(const edm::EDGetTokenT<PEcalTBInfo>& token) : ecalTBInfoToken_(token) {
   theTargetCrystal_ = -1;
   theTTlist_.reserve(1);
 }
@@ -154,8 +153,7 @@ void EcalTBReadout::performReadout(edm::Event &event,
   // TB readout
   // step 1: get the target crystal index
 
-  edm::Handle<PEcalTBInfo> theEcalTBInfo;
-  event.getByLabel(ecalTBInfoLabel_, theEcalTBInfo);
+  const edm::Handle<PEcalTBInfo> & theEcalTBInfo = event.getHandle(ecalTBInfoToken_);
 
   int crysId = theEcalTBInfo->nCrystal();
 
@@ -175,8 +173,7 @@ void EcalTBReadout::performReadout(edm::Event &event,
   // TB readout
   // step 1: get the target crystal index
 
-  edm::Handle<PEcalTBInfo> theEcalTBInfo;
-  event.getByLabel(ecalTBInfoLabel_, theEcalTBInfo);
+  const edm::Handle<PEcalTBInfo> & theEcalTBInfo = event.getHandle(ecalTBInfoToken_);
 
   int crysId = theEcalTBInfo->nCrystal();
 


### PR DESCRIPTION
#### PR description:

Make use of token rather than label in accessing collections in SimCalorimetry/EcalTestBeam

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special