### PR TITLE
Unit test DRNTest: disabled setting LD_PRELOAD for xSAN IBs

### DIFF
--- a/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
+++ b/RecoEcal/EgammaClusterProducers/test/BuildFile.xml
@@ -9,12 +9,10 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<export>
-</export>
-<environment>
-  <bin name="DRNTest" file="runtestRecoEcalEgammaClusterProducers.cpp">
-    <flags TEST_RUNNER_ARGS="/bin/bash RecoEcal/EgammaClusterProducers/test runtests.sh"/>
-    <use name="FWCore/Utilities"/>
-  </bin>
-
-</environment>
+<bin name="DRNTest" file="runtestRecoEcalEgammaClusterProducers.cpp">
+  <flags TEST_RUNNER_ARGS="/bin/bash RecoEcal/EgammaClusterProducers/test runtests.sh"/>
+  <use name="FWCore/Utilities"/>
+  <ifrelease name="_ASAN_|_UBSAN_">
+    <flags NO_TEST_PREFIX="1"/>
+  </ifrelease>
+</bin>


### PR DESCRIPTION
`DRNTest` unit test fails for ASAN and UBSAN IBs as it is not able to start the fallback server. This PR proposes to disabled setting LD_PRELOAD=`libXsan.so` for this test. Same change was done in https://github.com/cms-sw/cmssw/pull/36874 to fix `HeterogeneousCore/SonicTriton` unit tests