### PR TITLE
Add more context to Vertex exceptions

### DIFF
--- a/DataFormats/VertexReco/src/Vertex.cc
+++ b/DataFormats/VertexReco/src/Vertex.cc
@@ -83,7 +83,7 @@ TrackBaseRef Vertex::originalTrack(const Track& refTrack) const {
     throw cms::Exception("Vertex") << "No refitted tracks stored in vertex\n";
   std::vector<Track>::const_iterator it = find_if(refittedTracks_.begin(), refittedTracks_.end(), TrackEqual(refTrack));
   if (it == refittedTracks_.end())
-    throw cms::Exception("Vertex") << "Refitted track not found in list\n";
+    throw cms::Exception("Vertex") << "Refitted track not found in list.\n pt used for comparison: " << refTrack.pt();
   size_t pos = it - refittedTracks_.begin();
   return tracks_[pos];
 }

--- a/RecoVertex/VertexPrimitives/interface/VertexException.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexException.h
@@ -11,13 +11,8 @@
 
 class VertexException : public cms::Exception {
 public:
-  VertexException() throw() : cms::Exception("VertexException") {}
-  VertexException(const std::string& message) throw() : cms::Exception("VertexException"), theMessage(message) {}
-  ~VertexException() throw() override {}
-  const char* what() const throw() override { return theMessage.c_str(); }
-
-private:
-  std::string theMessage;
+  VertexException() : cms::Exception("VertexException") {}
+  explicit VertexException(const std::string& message) : cms::Exception("VertexException", message) {}
 };
 
 #endif

--- a/RecoVertex/VertexPrimitives/src/TransientVertex.cc
+++ b/RecoVertex/VertexPrimitives/src/TransientVertex.cc
@@ -280,20 +280,23 @@ AlgebraicMatrix33 TransientVertex::tkToTkCovariance(const TransientTrack& t1, co
 
 TransientTrack TransientVertex::originalTrack(const TransientTrack& refTrack) const {
   if (theRefittedTracks.empty())
-    throw VertexException("No refitted tracks stored in vertex");
+    throw VertexException("TransientVertex::requested No refitted tracks stored in vertex");
   std::vector<TransientTrack>::const_iterator it = find(theRefittedTracks.begin(), theRefittedTracks.end(), refTrack);
   if (it == theRefittedTracks.end())
-    throw VertexException("Refitted track not found in list");
+    throw VertexException(
+        "TransientVertex::requested Refitted track not found in list.\n address used for comparison: ")
+        << refTrack.basicTransientTrack();
   size_t pos = it - theRefittedTracks.begin();
   return theOriginalTracks[pos];
 }
 
 TransientTrack TransientVertex::refittedTrack(const TransientTrack& track) const {
   if (theRefittedTracks.empty())
-    throw VertexException("No refitted tracks stored in vertex");
+    throw VertexException("TransientVertex::requested No refitted tracks stored in vertex");
   std::vector<TransientTrack>::const_iterator it = find(theOriginalTracks.begin(), theOriginalTracks.end(), track);
   if (it == theOriginalTracks.end())
-    throw VertexException("Track not found in list");
+    throw VertexException("transientVertex::requested Track not found in list.\n address used for comparison: ")
+        << track.basicTransientTrack();
   size_t pos = it - theOriginalTracks.begin();
   return theRefittedTracks[pos];
 }


### PR DESCRIPTION
#### PR description:

- Simplified VertexException
- Added more context information to exceptions thrown related to Vertex

We are getting frequent exceptions in the ARM related IB RelVals. Having more context may help diagnose what is happening.

#### PR validation:

Code compiles.