### PR TITLE
EL9 warning fix: use mallinfo2 for glibc>=2.33

### DIFF
--- a/FWCore/Services/plugins/SimpleMemoryCheck.cc
+++ b/FWCore/Services/plugins/SimpleMemoryCheck.cc
@@ -548,14 +548,18 @@ namespace edm {
         eventStatOutput("LargestIncreaseRssEvent", eventDeltaRssT1_, reportData);
 
 #ifdef __linux__
+#if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33)
+      struct mallinfo2 minfo = mallinfo2();
+#else
       struct mallinfo minfo = mallinfo();
-      reportData.insert(std::make_pair("HEAP_ARENA_SIZE_BYTES", i2str(minfo.arena)));
-      reportData.insert(std::make_pair("HEAP_ARENA_N_UNUSED_CHUNKS", i2str(minfo.ordblks)));
-      reportData.insert(std::make_pair("HEAP_TOP_FREE_BYTES", i2str(minfo.keepcost)));
-      reportData.insert(std::make_pair("HEAP_MAPPED_SIZE_BYTES", i2str(minfo.hblkhd)));
-      reportData.insert(std::make_pair("HEAP_MAPPED_N_CHUNKS", i2str(minfo.hblks)));
-      reportData.insert(std::make_pair("HEAP_USED_BYTES", i2str(minfo.uordblks)));
-      reportData.insert(std::make_pair("HEAP_UNUSED_BYTES", i2str(minfo.fordblks)));
+#endif
+      reportData.insert(std::make_pair("HEAP_ARENA_SIZE_BYTES", std::to_string(minfo.arena)));
+      reportData.insert(std::make_pair("HEAP_ARENA_N_UNUSED_CHUNKS", std::to_string(minfo.ordblks)));
+      reportData.insert(std::make_pair("HEAP_TOP_FREE_BYTES", std::to_string(minfo.keepcost)));
+      reportData.insert(std::make_pair("HEAP_MAPPED_SIZE_BYTES", std::to_string(minfo.hblkhd)));
+      reportData.insert(std::make_pair("HEAP_MAPPED_N_CHUNKS", std::to_string(minfo.hblks)));
+      reportData.insert(std::make_pair("HEAP_USED_BYTES", std::to_string(minfo.uordblks)));
+      reportData.insert(std::make_pair("HEAP_UNUSED_BYTES", std::to_string(minfo.fordblks)));
 #endif
 
       // Report Growth rates for VSize and Rss
@@ -642,7 +646,11 @@ namespace edm {
       if (eventDeltaRssT1_.deltaRss > 0)
         eventStatOutput("LargestIncreaseRssEvent", eventDeltaRssT1_, reportData);
 
+#if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33)
+      struct mallinfo2 minfo = mallinfo2();
+#else
       struct mallinfo minfo = mallinfo();
+#endif
       reportData.push_back(mallOutput("HEAP_ARENA_SIZE_BYTES", minfo.arena));
       reportData.push_back(mallOutput("HEAP_ARENA_N_UNUSED_CHUNKS", minfo.ordblks));
       reportData.push_back(mallOutput("HEAP_TOP_FREE_BYTES", minfo.keepcost));
@@ -835,7 +843,11 @@ namespace edm {
                                       << deltaRSS;
           } else {
 #ifdef __linux__
+#if (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33)
+            struct mallinfo2 minfo = mallinfo2();
+#else
             struct mallinfo minfo = mallinfo();
+#endif
 #endif
             LogWarning("MemoryCheck") << "MemoryCheck: " << type << " " << mdname << ":" << mdlabel << " VSIZE "
                                       << current_->vsize << " " << deltaVSIZE << " RSS " << current_->rss << " "


### PR DESCRIPTION
`mallinfo` has been deprecated in newer glibc version e.g. for `el9` IBs we get build warning [a]. glibc 2.33 and above introduced `mallinfo2` which returns the same `mallinfo2` struct but with updated types `size_t` instead of `int` (https://man7.org/linux/man-pages/man3/mallinfo.3.html) . This PR proposes to use `mallinfo2` for glibc version 2.33 and above.

In a separate PR we can also replace `i2str` with `std::to_string()`

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el9_amd64_gcc11/CMSSW_12_4_X_2022-05-01-2300/FWCore/Services
```
  src/FWCore/Services/plugins/SimpleMemoryCheck.cc:551:39: warning: 'mallinfo mallinfo()' is deprecated [-Wdeprecated-declarations]
   551 |       struct mallinfo minfo = mallinfo();
```