### PR TITLE
Remove deprecated Openssl functions SHA1*

### DIFF
--- a/L1TriggerConfig/Utilities/BuildFile.xml
+++ b/L1TriggerConfig/Utilities/BuildFile.xml
@@ -6,4 +6,5 @@
 <use name="L1Trigger/L1TMuon"/>
 <use name="L1Trigger/L1TMuonEndCap"/>
 <use name="L1Trigger/L1TCalorimeter"/>
+<use name="Utilities/OpenSSL"/>
 <flags EDM_PLUGIN="1"/>

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
@@ -101,7 +101,7 @@ std::string L1TCaloParamsViewer::hash(void* buf, size_t len) const {
   for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
-  tmp[20 * 2] = 0;
+  tmp[md_len * 2] = 0;
   return std::string(tmp);
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc
@@ -72,27 +72,33 @@ public:
   ~L1TCaloParamsViewer(void) override {}
 };
 
-#include <openssl/sha.h>
+#include "Utilities/OpenSSL/interface/openssl_init.h"
 #include <cmath>
 #include <iostream>
 using namespace std;
 
 std::string L1TCaloParamsViewer::hash(void* buf, size_t len) const {
-  char tmp[SHA_DIGEST_LENGTH * 2 + 1];
-  bzero(tmp, sizeof(tmp));
-  SHA_CTX ctx;
-  if (!SHA1_Init(&ctx))
+  cms::openssl_init();
+  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  if (!EVP_DigestInit_ex(mdctx, md, nullptr))
     throw cms::Exception("L1TCaloParamsViewer::hash") << "SHA1 initialization error";
 
-  if (!SHA1_Update(&ctx, buf, len))
+  if (!EVP_DigestUpdate(mdctx, buf, len))
     throw cms::Exception("L1TCaloParamsViewer::hash") << "SHA1 processing error";
 
-  unsigned char hash[SHA_DIGEST_LENGTH];
-  if (!SHA1_Final(hash, &ctx))
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int md_len = 0;
+  if (!EVP_DigestFinal_ex(mdctx, hash, &md_len))
     throw cms::Exception("L1TCaloParamsViewer::hash") << "SHA1 finalization error";
 
+  EVP_MD_CTX_free(mdctx);
+
   // re-write bytes in hex
-  for (unsigned int i = 0; i < 20; i++)
+  char tmp[EVP_MAX_MD_SIZE * 2 + 1];
+  if (md_len > 20)
+    md_len = 20;
+  for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
   tmp[20 * 2] = 0;

--- a/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
@@ -30,27 +30,33 @@ public:
   ~L1TGlobalPrescalesVetosViewer(void) override {}
 };
 
-#include <openssl/sha.h>
+#include "Utilities/OpenSSL/interface/openssl_init.h"
 #include <cmath>
 #include <iostream>
 using namespace std;
 
 std::string L1TGlobalPrescalesVetosViewer::hash(void* buf, size_t len) const {
-  char tmp[SHA_DIGEST_LENGTH * 2 + 1];
-  bzero(tmp, sizeof(tmp));
-  SHA_CTX ctx;
-  if (!SHA1_Init(&ctx))
+  cms::openssl_init();
+  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  if (!EVP_DigestInit_ex(mdctx, md, nullptr))
     throw cms::Exception("L1TGlobalPrescalesVetosViewer::hash") << "SHA1 initialization error";
 
-  if (!SHA1_Update(&ctx, buf, len))
+  if (!EVP_DigestUpdate(mdctx, buf, len))
     throw cms::Exception("L1TGlobalPrescalesVetosViewer::hash") << "SHA1 processing error";
 
-  unsigned char hash[SHA_DIGEST_LENGTH];
-  if (!SHA1_Final(hash, &ctx))
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int md_len = 0;
+  if (!EVP_DigestFinal_ex(mdctx, hash, &md_len))
     throw cms::Exception("L1TGlobalPrescalesVetosViewer::hash") << "SHA1 finalization error";
 
+  EVP_MD_CTX_free(mdctx);
+
   // re-write bytes in hex
-  for (unsigned int i = 0; i < 20; i++)
+  char tmp[EVP_MAX_MD_SIZE * 2 + 1];
+  if (md_len > 20)
+    md_len = 20;
+  for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
   tmp[20 * 2] = 0;

--- a/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
@@ -59,7 +59,7 @@ std::string L1TGlobalPrescalesVetosViewer::hash(void* buf, size_t len) const {
   for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
-  tmp[20 * 2] = 0;
+  tmp[md_len * 2] = 0;
   return std::string(tmp);
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
@@ -58,7 +58,7 @@ std::string L1TMuonBarrelKalmanParamsViewer::hash(void *buf, size_t len) const {
   for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
-  tmp[20 * 2] = 0;
+  tmp[md_len * 2] = 0;
   return std::string(tmp);
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
@@ -36,8 +36,8 @@ using namespace std;
 
 std::string L1TMuonBarrelKalmanParamsViewer::hash(void *buf, size_t len) const {
   cms::openssl_init();
-  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
-  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+  const EVP_MD *md = EVP_get_digestbyname("SHA1");
   if (!EVP_DigestInit_ex(mdctx, md, nullptr))
     throw cms::Exception("L1TMuonBarrelKalmanParamsViewer::hash") << "SHA1 initialization error";
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
@@ -29,27 +29,33 @@ public:
   ~L1TMuonBarrelKalmanParamsViewer(void) override {}
 };
 
-#include <openssl/sha.h>
+#include "Utilities/OpenSSL/interface/openssl_init.h"
 #include <cmath>
 #include <iostream>
 using namespace std;
 
 std::string L1TMuonBarrelKalmanParamsViewer::hash(void *buf, size_t len) const {
-  char tmp[SHA_DIGEST_LENGTH * 2 + 1];
-  bzero(tmp, sizeof(tmp));
-  SHA_CTX ctx;
-  if (!SHA1_Init(&ctx))
+  cms::openssl_init();
+  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  if (!EVP_DigestInit_ex(mdctx, md, nullptr))
     throw cms::Exception("L1TMuonBarrelKalmanParamsViewer::hash") << "SHA1 initialization error";
 
-  if (!SHA1_Update(&ctx, buf, len))
+  if (!EVP_DigestUpdate(mdctx, buf, len))
     throw cms::Exception("L1TMuonBarrelKalmanParamsViewer::hash") << "SHA1 processing error";
 
-  unsigned char hash[SHA_DIGEST_LENGTH];
-  if (!SHA1_Final(hash, &ctx))
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int md_len = 0;
+  if (!EVP_DigestFinal_ex(mdctx, hash, &md_len))
     throw cms::Exception("L1TMuonBarrelKalmanParamsViewer::hash") << "SHA1 finalization error";
 
+  EVP_MD_CTX_free(mdctx);
+
   // re-write bytes in hex
-  for (unsigned int i = 0; i < 20; i++)
+  char tmp[EVP_MAX_MD_SIZE * 2 + 1];
+  if (md_len > 20)
+    md_len = 20;
+  for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
   tmp[20 * 2] = 0;

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
@@ -60,7 +60,7 @@ std::string L1TMuonBarrelParamsViewer::hash(void *buf, size_t len) const {
   for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
-  tmp[20 * 2] = 0;
+  tmp[md_len * 2] = 0;
   return std::string(tmp);
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
@@ -38,8 +38,8 @@ using namespace std;
 
 std::string L1TMuonBarrelParamsViewer::hash(void *buf, size_t len) const {
   cms::openssl_init();
-  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
-  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+  const EVP_MD *md = EVP_get_digestbyname("SHA1");
   if (!EVP_DigestInit_ex(mdctx, md, nullptr))
     throw cms::Exception("L1TMuonBarrelParamsViewer::hash") << "SHA1 initialization error";
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
@@ -31,27 +31,33 @@ public:
   ~L1TMuonBarrelParamsViewer(void) override {}
 };
 
-#include <openssl/sha.h>
+#include "Utilities/OpenSSL/interface/openssl_init.h"
 #include <cmath>
 #include <iostream>
 using namespace std;
 
 std::string L1TMuonBarrelParamsViewer::hash(void *buf, size_t len) const {
-  char tmp[SHA_DIGEST_LENGTH * 2 + 1];
-  bzero(tmp, sizeof(tmp));
-  SHA_CTX ctx;
-  if (!SHA1_Init(&ctx))
+  cms::openssl_init();
+  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  if (!EVP_DigestInit_ex(mdctx, md, nullptr))
     throw cms::Exception("L1TMuonBarrelParamsViewer::hash") << "SHA1 initialization error";
 
-  if (!SHA1_Update(&ctx, buf, len))
+  if (!EVP_DigestUpdate(mdctx, buf, len))
     throw cms::Exception("L1TMuonBarrelParamsViewer::hash") << "SHA1 processing error";
 
-  unsigned char hash[SHA_DIGEST_LENGTH];
-  if (!SHA1_Final(hash, &ctx))
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int md_len = 0;
+  if (!EVP_DigestFinal_ex(mdctx, hash, &md_len))
     throw cms::Exception("L1TMuonBarrelParamsViewer::hash") << "SHA1 finalization error";
 
+  EVP_MD_CTX_free(mdctx);
+
   // re-write bytes in hex
-  for (unsigned int i = 0; i < 20; i++)
+  char tmp[EVP_MAX_MD_SIZE * 2 + 1];
+  if (md_len > 20)
+    md_len = 20;
+  for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
   tmp[20 * 2] = 0;

--- a/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
@@ -35,27 +35,33 @@ public:
   ~L1TMuonGlobalParamsViewer(void) override {}
 };
 
-#include <openssl/sha.h>
+#include "Utilities/OpenSSL/interface/openssl_init.h"
 #include <cmath>
 #include <iostream>
 using namespace std;
 
 string L1TMuonGlobalParamsViewer::hash(void* buf, size_t len) const {
-  char tmp[SHA_DIGEST_LENGTH * 2 + 1];
-  bzero(tmp, sizeof(tmp));
-  SHA_CTX ctx;
-  if (!SHA1_Init(&ctx))
+  cms::openssl_init();
+  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  if (!EVP_DigestInit_ex(mdctx, md, nullptr))
     throw cms::Exception("L1TMuonGlobalParamsViewer::hash") << "SHA1 initialization error";
 
-  if (!SHA1_Update(&ctx, buf, len))
+  if (!EVP_DigestUpdate(mdctx, buf, len))
     throw cms::Exception("L1TMuonGlobalParamsViewer::hash") << "SHA1 processing error";
 
-  unsigned char hash[SHA_DIGEST_LENGTH];
-  if (!SHA1_Final(hash, &ctx))
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int md_len = 0;
+  if (!EVP_DigestFinal_ex(mdctx, hash, &md_len))
     throw cms::Exception("L1TMuonGlobalParamsViewer::hash") << "SHA1 finalization error";
 
+  EVP_MD_CTX_free(mdctx);
+
   // re-write bytes in hex
-  for (unsigned int i = 0; i < 20; i++)
+  char tmp[EVP_MAX_MD_SIZE * 2 + 1];
+  if (md_len > 20)
+    md_len = 20;
+  for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
   tmp[20 * 2] = 0;

--- a/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
@@ -64,7 +64,7 @@ string L1TMuonGlobalParamsViewer::hash(void* buf, size_t len) const {
   for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
-  tmp[20 * 2] = 0;
+  tmp[md_len * 2] = 0;
   return string(tmp);
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
@@ -39,8 +39,8 @@ using namespace std;
 
 string L1TMuonOverlapParamsViewer::hash(void *buf, size_t len) const {
   cms::openssl_init();
-  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
-  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+  const EVP_MD *md = EVP_get_digestbyname("SHA1");
   if (!EVP_DigestInit_ex(mdctx, md, nullptr))
     throw cms::Exception("L1TCaloParamsViewer::hash") << "SHA1 initialization error";
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
@@ -32,27 +32,33 @@ public:
   ~L1TMuonOverlapParamsViewer(void) override {}
 };
 
-#include <openssl/sha.h>
+#include "Utilities/OpenSSL/interface/openssl_init.h"
 #include <cmath>
 #include <iostream>
 using namespace std;
 
 string L1TMuonOverlapParamsViewer::hash(void *buf, size_t len) const {
-  char tmp[SHA_DIGEST_LENGTH * 2 + 1];
-  bzero(tmp, sizeof(tmp));
-  SHA_CTX ctx;
-  if (!SHA1_Init(&ctx))
+  cms::openssl_init();
+  EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+  const EVP_MD* md = EVP_get_digestbyname("SHA1");
+  if (!EVP_DigestInit_ex(mdctx, md, nullptr))
     throw cms::Exception("L1TCaloParamsViewer::hash") << "SHA1 initialization error";
 
-  if (!SHA1_Update(&ctx, buf, len))
+  if (!EVP_DigestUpdate(mdctx, buf, len))
     throw cms::Exception("L1TCaloParamsViewer::hash") << "SHA1 processing error";
 
-  unsigned char hash[SHA_DIGEST_LENGTH];
-  if (!SHA1_Final(hash, &ctx))
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int md_len = 0;
+  if (!EVP_DigestFinal_ex(mdctx, hash, &md_len))
     throw cms::Exception("L1TCaloParamsViewer::hash") << "SHA1 finalization error";
 
+  EVP_MD_CTX_free(mdctx);
+
   // re-write bytes in hex
-  for (unsigned int i = 0; i < 20; i++)
+  char tmp[EVP_MAX_MD_SIZE * 2 + 1];
+  if (md_len > 20)
+    md_len = 20;
+  for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
   tmp[20 * 2] = 0;

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
@@ -61,7 +61,7 @@ string L1TMuonOverlapParamsViewer::hash(void *buf, size_t len) const {
   for (unsigned int i = 0; i < md_len; i++)
     ::sprintf(&tmp[i * 2], "%02x", hash[i]);
 
-  tmp[20 * 2] = 0;
+  tmp[md_len * 2] = 0;
   return string(tmp);
 }
 


### PR DESCRIPTION
These chanegs should fix the remaining OpenSSL warnings
```
L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc:84:17: warning: 'int SHA1_Init(SHA_CTX*)' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
    84 |   if (!SHA1_Init(&ctx))
L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc:87:19: warning: 'int SHA1_Update(SHA_CTX*, const void*, size_t)' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
    87 |   if (!SHA1_Update(&ctx, buf, len))
L1TriggerConfig/Utilities/src/L1TCaloParamsViewer.cc:91:18: warning: 'int SHA1_Final(unsigned char*, SHA_CTX*)' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
    91 |   if (!SHA1_Final(hash, &ctx))
```