### PR TITLE
Cleanup redundant edm ParameterSet exist in RecoVertex

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -64,53 +64,28 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
   }
 
   // select and configure the vertex fitters
-  if (conf.exists("vertexCollections")) {
-    std::vector<edm::ParameterSet> vertexCollections =
-        conf.getParameter<std::vector<edm::ParameterSet> >("vertexCollections");
+  std::vector<edm::ParameterSet> vertexCollections =
+      conf.getParameter<std::vector<edm::ParameterSet> >("vertexCollections");
 
-    for (std::vector<edm::ParameterSet>::const_iterator algoconf = vertexCollections.begin();
-         algoconf != vertexCollections.end();
-         algoconf++) {
-      algo algorithm;
-      std::string fitterAlgorithm = algoconf->getParameter<std::string>("algorithm");
-      if (fitterAlgorithm == "KalmanVertexFitter") {
-        algorithm.fitter = new KalmanVertexFitter();
-      } else if (fitterAlgorithm == "AdaptiveVertexFitter") {
-        algorithm.fitter = new AdaptiveVertexFitter(GeometricAnnealing(algoconf->getParameter<double>("chi2cutoff")));
-      } else {
-        throw VertexException("PrimaryVertexProducer: unknown algorithm: " + fitterAlgorithm);
-      }
-      algorithm.label = algoconf->getParameter<std::string>("label");
-      algorithm.minNdof = algoconf->getParameter<double>("minNdof");
-      algorithm.useBeamConstraint = algoconf->getParameter<bool>("useBeamConstraint");
-      algorithm.vertexSelector =
-          new VertexCompatibleWithBeam(VertexDistanceXY(), algoconf->getParameter<double>("maxDistanceToBeam"));
-      algorithms.push_back(algorithm);
-
-      produces<reco::VertexCollection>(algorithm.label);
-    }
-  } else {
-    edm::LogWarning("MisConfiguration")
-        << "this module's configuration has changed, please update to have a vertexCollections=cms.VPSet parameter.";
-
+  for (std::vector<edm::ParameterSet>::const_iterator algoconf = vertexCollections.begin();
+       algoconf != vertexCollections.end();
+       algoconf++) {
     algo algorithm;
-    std::string fitterAlgorithm = conf.getParameter<std::string>("algorithm");
+    std::string fitterAlgorithm = algoconf->getParameter<std::string>("algorithm");
     if (fitterAlgorithm == "KalmanVertexFitter") {
       algorithm.fitter = new KalmanVertexFitter();
     } else if (fitterAlgorithm == "AdaptiveVertexFitter") {
-      algorithm.fitter = new AdaptiveVertexFitter();
+      algorithm.fitter = new AdaptiveVertexFitter(GeometricAnnealing(algoconf->getParameter<double>("chi2cutoff")));
     } else {
-      throw VertexException("PrimaryVertexProducerAlgorithm: unknown algorithm: " + fitterAlgorithm);
+      throw VertexException("PrimaryVertexProducer: unknown algorithm: " + fitterAlgorithm);
     }
-    algorithm.label = "";
-    algorithm.minNdof = conf.getParameter<double>("minNdof");
-    algorithm.useBeamConstraint = conf.getParameter<bool>("useBeamConstraint");
-
-    algorithm.vertexSelector = new VertexCompatibleWithBeam(
-        VertexDistanceXY(),
-        conf.getParameter<edm::ParameterSet>("PVSelParameters").getParameter<double>("maxDistanceToBeam"));
-
+    algorithm.label = algoconf->getParameter<std::string>("label");
+    algorithm.minNdof = algoconf->getParameter<double>("minNdof");
+    algorithm.useBeamConstraint = algoconf->getParameter<bool>("useBeamConstraint");
+    algorithm.vertexSelector =
+        new VertexCompatibleWithBeam(VertexDistanceXY(), algoconf->getParameter<double>("maxDistanceToBeam"));
     algorithms.push_back(algorithm);
+
     produces<reco::VertexCollection>(algorithm.label);
   }
 

--- a/RecoVertex/PrimaryVertexProducer/src/PrimaryVertexProducerAlgorithm.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/PrimaryVertexProducerAlgorithm.cc
@@ -54,35 +54,14 @@ PrimaryVertexProducerAlgorithm::PrimaryVertexProducerAlgorithm(const edm::Parame
   }
 
   // select and configure the vertex fitters
-  if (conf.exists("vertexCollections")) {
-    std::vector<edm::ParameterSet> vertexCollections =
-        conf.getParameter<std::vector<edm::ParameterSet> >("vertexCollections");
+  std::vector<edm::ParameterSet> vertexCollections =
+      conf.getParameter<std::vector<edm::ParameterSet> >("vertexCollections");
 
-    for (std::vector<edm::ParameterSet>::const_iterator algoconf = vertexCollections.begin();
-         algoconf != vertexCollections.end();
-         algoconf++) {
-      algo algorithm;
-      std::string fitterAlgorithm = algoconf->getParameter<std::string>("algorithm");
-      if (fitterAlgorithm == "KalmanVertexFitter") {
-        algorithm.fitter = new KalmanVertexFitter();
-      } else if (fitterAlgorithm == "AdaptiveVertexFitter") {
-        algorithm.fitter = new AdaptiveVertexFitter();
-      } else {
-        throw VertexException("PrimaryVertexProducerAlgorithm: unknown algorithm: " + fitterAlgorithm);
-      }
-      algorithm.label = algoconf->getParameter<std::string>("label");
-      algorithm.minNdof = algoconf->getParameter<double>("minNdof");
-      algorithm.useBeamConstraint = algoconf->getParameter<bool>("useBeamConstraint");
-      algorithm.vertexSelector =
-          new VertexCompatibleWithBeam(VertexDistanceXY(), algoconf->getParameter<double>("maxDistanceToBeam"));
-      algorithms.push_back(algorithm);
-    }
-  } else {
-    edm::LogWarning("MisConfiguration")
-        << "this module's configuration has changed, please update to have a vertexCollections=cms.VPSet parameter.";
-
+  for (std::vector<edm::ParameterSet>::const_iterator algoconf = vertexCollections.begin();
+       algoconf != vertexCollections.end();
+       algoconf++) {
     algo algorithm;
-    std::string fitterAlgorithm = conf.getParameter<std::string>("algorithm");
+    std::string fitterAlgorithm = algoconf->getParameter<std::string>("algorithm");
     if (fitterAlgorithm == "KalmanVertexFitter") {
       algorithm.fitter = new KalmanVertexFitter();
     } else if (fitterAlgorithm == "AdaptiveVertexFitter") {
@@ -90,14 +69,11 @@ PrimaryVertexProducerAlgorithm::PrimaryVertexProducerAlgorithm(const edm::Parame
     } else {
       throw VertexException("PrimaryVertexProducerAlgorithm: unknown algorithm: " + fitterAlgorithm);
     }
-    algorithm.label = "";
-    algorithm.minNdof = conf.getParameter<double>("minNdof");
-    algorithm.useBeamConstraint = conf.getParameter<bool>("useBeamConstraint");
-
-    algorithm.vertexSelector = new VertexCompatibleWithBeam(
-        VertexDistanceXY(),
-        conf.getParameter<edm::ParameterSet>("PVSelParameters").getParameter<double>("maxDistanceToBeam"));
-
+    algorithm.label = algoconf->getParameter<std::string>("label");
+    algorithm.minNdof = algoconf->getParameter<double>("minNdof");
+    algorithm.useBeamConstraint = algoconf->getParameter<bool>("useBeamConstraint");
+    algorithm.vertexSelector =
+        new VertexCompatibleWithBeam(VertexDistanceXY(), algoconf->getParameter<double>("maxDistanceToBeam"));
     algorithms.push_back(algorithm);
   }
 }


### PR DESCRIPTION
#### PR description:  
(Technical PR) Optimization of the module configurations: Improve maintainability by cleaning up redundant cases of edm::ParameterSet calls to `existAs` or `exist` for tracked parameters, where redundancy is based on the value being already defined by `fillDescriptions`.

As follow the previous [PR36746](https://github.com/cms-sw/cmssw/pull/36746),  [PR36989](https://github.com/cms-sw/cmssw/pull/36989), [PR37313](https://github.com/cms-sw/cmssw/pull/37313), [PR37314](https://github.com/cms-sw/cmssw/pull/37314), and [PR37548](https://github.com/cms-sw/cmssw/pull/37548).

The list of all calls of `existAs` or `exist` are automatically available in the Static Analyzer report. (Bug: CMS code rules)
It is accessible from IB page. https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/
For this task consider only modules or tools used by the modules that define `fillDescriptions`.

In this PR, 2 files were changed.  
RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
RecoVertex/PrimaryVertexProducer/src/PrimaryVertexProducerAlgorithm.cc

Here, the "vertexCollections" ParameterSet was provided in a `fillDescription` .
cfipython : [cfipython/RecoVertex/PrimaryVertexProducer/primaryVertexProducer_cfi.py](https://cmssdt.cern.ch/lxr/source/cfipython/RecoVertex/PrimaryVertexProducer/primaryVertexProducer_cfi.py)

#### PR validation:
Tested in CMSSW_12_4_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)