### PR TITLE
SHA1 Hash: use correct length to terminate the string instead of hardcoded value

### DIFF
--- a/CondCore/CondDB/src/IOVSchema.cc
+++ b/CondCore/CondDB/src/IOVSchema.cc
@@ -34,7 +34,7 @@ namespace cond {
       for (unsigned int i = 0; i < md_len; i++) {
         ::sprintf(&tmp[i * 2], "%02x", hash[i]);
       }
-      tmp[20 * 2] = 0;
+      tmp[md_len * 2] = 0;
       return tmp;
     }
 


### PR DESCRIPTION
use correct hash length `md_len` instead of hardcode value `20`