### PR TITLE
introduce GEMChMap for GE21 chambers

### DIFF
--- a/CondCore/GEMPlugins/src/plugins.cc
+++ b/CondCore/GEMPlugins/src/plugins.cc
@@ -11,11 +11,14 @@
 #include "CondFormats/DataRecord/interface/GEMELMapRcd.h"
 #include "CondFormats/GEMObjects/interface/GEMeMap.h"
 #include "CondFormats/DataRecord/interface/GEMeMapRcd.h"
+#include "CondFormats/GEMObjects/interface/GEMChMap.h"
+#include "CondFormats/DataRecord/interface/GEMChMapRcd.h"
 #include "CondFormats/GEMObjects/interface/GEMMaskedStrips.h"
 #include "CondFormats/DataRecord/interface/GEMMaskedStripsRcd.h"
 #include "CondFormats/GEMObjects/interface/GEMDeadStrips.h"
 #include "CondFormats/DataRecord/interface/GEMDeadStripsRcd.h"
 REGISTER_PLUGIN(GEMELMapRcd, GEMELMap);
 REGISTER_PLUGIN(GEMeMapRcd, GEMeMap);
+REGISTER_PLUGIN(GEMChMapRcd, GEMChMap);
 REGISTER_PLUGIN(GEMMaskedStripsRcd, GEMMaskedStrips);
 REGISTER_PLUGIN(GEMDeadStripsRcd, GEMDeadStrips);

--- a/CondFormats/DataRecord/interface/GEMChMapRcd.h
+++ b/CondFormats/DataRecord/interface/GEMChMapRcd.h
@@ -1,0 +1,23 @@
+#ifndef CondFormats_DataRecord_GEMChMapRcd_h
+#define CondFormats_DataRecord_GEMChMapRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     GEMChMapRcd
+//
+/**\class GEMChMapRcd GEMChMapRcd.h CondFormats/DataRecord/interface/GEMChMapRcd.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+// Author:      Yechan KANG (University of Seoul)
+// Created:     Mon, 05 Apr 2022
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class GEMChMapRcd : public edm::eventsetup::EventSetupRecordImplementation<GEMChMapRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/GEMChMapRcd.cc
+++ b/CondFormats/DataRecord/src/GEMChMapRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     GEMChMapRcd
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Yechan KANG (University of Seoul)
+// Created:     Mon, 05 Apr 2022
+
+#include "CondFormats/DataRecord/interface/GEMChMapRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(GEMChMapRcd);

--- a/CondFormats/GEMObjects/interface/GEMChMap.h
+++ b/CondFormats/GEMObjects/interface/GEMChMap.h
@@ -138,8 +138,8 @@ public:
   void add(chamEC e, chamDC d) { chamberMap_[e] = d; }
 
   const std::vector<uint16_t> getVfats(const int type) const { return chamVfats_.at(type); }
-  void add(int type, uint16_t d) { 
-    if (std::find(chamVfats_[type].begin(), chamVfats_[type].end(), d) != chamVfats_[type].end()) 
+  void add(int type, uint16_t d) {
+    if (std::find(chamVfats_[type].begin(), chamVfats_[type].end(), d) != chamVfats_[type].end())
       chamVfats_[type].push_back(d);
   }
 

--- a/CondFormats/GEMObjects/interface/GEMChMap.h
+++ b/CondFormats/GEMObjects/interface/GEMChMap.h
@@ -1,0 +1,195 @@
+#ifndef CondFormats_GEMObjects_GEMChMap_h
+#define CondFormats_GEMObjects_GEMChMap_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include <map>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+class GEMChMap {
+public:
+  struct sectorEC {
+    unsigned int fedId;
+    uint8_t amcNum;
+    bool operator==(const sectorEC& r) const {
+      if (fedId == r.fedId) {
+        return amcNum == r.amcNum;
+      } else {
+        return false;
+      }
+    }
+
+    COND_SERIALIZABLE;
+  };
+
+  struct chamEC {
+    unsigned int fedId;
+    uint8_t amcNum;
+    uint16_t gebId;
+    bool operator<(const chamEC& r) const {
+      if (fedId == r.fedId) {
+        if (amcNum == r.amcNum) {
+          return gebId < r.gebId;
+        } else {
+          return amcNum < r.amcNum;
+        }
+      } else {
+        return fedId < r.fedId;
+      }
+    }
+
+    COND_SERIALIZABLE;
+  };
+
+  struct chamDC {
+    uint32_t detId;
+    int chamberType;
+    bool operator<(const chamDC& r) const { return detId < r.detId; }
+
+    COND_SERIALIZABLE;
+  };
+
+  struct vfatEC {
+    int chamberType;
+    uint16_t vfatAdd;
+    bool operator<(const vfatEC& r) const {
+      if (vfatAdd == r.vfatAdd) {
+        return chamberType < r.chamberType;
+      } else {
+        return vfatAdd < r.vfatAdd;
+      }
+    }
+
+    COND_SERIALIZABLE;
+  };
+
+  struct channelNum {
+    int chamberType;
+    int vfatAdd;
+    int chNum;
+    bool operator<(const channelNum& c) const {
+      if (chamberType == c.chamberType) {
+        if (vfatAdd == c.vfatAdd) {
+          return chNum < c.chNum;
+        } else {
+          return vfatAdd < c.vfatAdd;
+        }
+      } else {
+        return chamberType < c.chamberType;
+      }
+    }
+
+    COND_SERIALIZABLE;
+  };
+
+  struct stripNum {
+    int chamberType;
+    int iEta;
+    int stNum;
+    bool operator<(const stripNum& s) const {
+      if (chamberType == s.chamberType) {
+        if (iEta == s.iEta) {
+          return stNum < s.stNum;
+        } else {
+          return iEta < s.iEta;
+        }
+      } else {
+        return chamberType < s.chamberType;
+      }
+    }
+
+    COND_SERIALIZABLE;
+  };
+
+  GEMChMap();
+
+  explicit GEMChMap(const std::string& version);
+
+  ~GEMChMap();
+
+  const std::string& version() const;
+  void setDummy();
+
+  std::map<chamEC, chamDC> chamberMap() { return chamberMap_; };
+
+  bool isValidAMC(unsigned int fedId, uint8_t amcNum) const {
+    return std::find(amcVec_.begin(), amcVec_.end(), sectorEC({fedId, amcNum})) != amcVec_.end();
+  }
+
+  bool isValidChamber(unsigned int fedId, uint8_t amcNum, uint16_t gebId) const {
+    return chamberMap_.find({fedId, amcNum, gebId}) != chamberMap_.end();
+  }
+
+  bool isValidVFAT(int chamberType, uint16_t vfatAdd) const {
+    return chamIEtas_.find({chamberType, vfatAdd}) != chamIEtas_.end();
+  }
+
+  bool isValidStrip(int chamberType, int iEta, int strip) const {
+    return stChMap_.find({chamberType, iEta, strip}) != stChMap_.end();
+  }
+
+  void add(sectorEC e) { amcVec_.push_back(e); }
+
+  const chamDC& chamberPos(unsigned int fedId, uint8_t amcNum, uint16_t gebId) const {
+    return chamberMap_.at({fedId, amcNum, gebId});
+  }
+  void add(chamEC e, chamDC d) { chamberMap_[e] = d; }
+
+  const std::vector<uint16_t> getVfats(const int type) const { return chamVfats_.at(type); }
+  void add(int type, uint16_t d) { 
+    if (std::find(chamVfats_[type].begin(), chamVfats_[type].end(), d) != chamVfats_[type].end()) 
+      chamVfats_[type].push_back(d);
+  }
+
+  const std::vector<int> getIEtas(int chamberType, uint16_t vfatAdd) const {
+    return chamIEtas_.at({chamberType, vfatAdd});
+  }
+  void add(vfatEC d, int iEta) {
+    if (std::find(chamIEtas_[d].begin(), chamIEtas_[d].end(), iEta) != chamIEtas_[d].end())
+      chamIEtas_[d].push_back(iEta);
+  }
+
+  const channelNum& getChannel(int chamberType, int iEta, int strip) const {
+    return stChMap_.at({chamberType, iEta, strip});
+  }
+  const stripNum& getStrip(int chamberType, int vfatAdd, int channel) const {
+    return chStMap_.at({chamberType, vfatAdd, channel});
+  }
+
+  void add(channelNum c, stripNum s) { chStMap_[c] = s; }
+  void add(stripNum s, channelNum c) { stChMap_[s] = c; }
+
+private:
+  std::string theVersion;
+
+  std::vector<sectorEC> amcVec_;
+
+  // electronics map to GEMDetId chamber
+  std::map<chamEC, chamDC> chamberMap_;
+
+  std::map<int, std::vector<uint16_t>> chamVfats_;
+  std::map<vfatEC, std::vector<int>> chamIEtas_;
+
+  std::map<channelNum, stripNum> chStMap_;
+  std::map<stripNum, channelNum> stChMap_;
+
+  COND_SERIALIZABLE;
+
+public:
+  // size of ID bits
+  static const int chipIdMask_ = 0xfff;  // chipId mask for 12 bits
+  static const int maxGEBs_ = 24;        // 5 bits for GEB id
+  static const int maxGEB1_ = 12;        // 5 bits for GEB id
+  static const int maxGEB2_ = 12;        // 5 bits for GEB id
+  static const int maxAMCs_ = 15;        // 4 bits for AMC no.
+  static const int maxVFatGE0_ = 12;     // vFat per eta partition, not known yet for ME0
+  static const int maxVFatGE11_ = 3;     // vFat per eta partition in GE11
+  static const int maxVFatGE21_ = 6;     // vFat per eta partition in GE21
+  static const int maxiEtaIdGE0_ = 8;    // no. eta partitions for GE0
+  static const int maxiEtaIdGE11_ = 8;   // no. eta partitions for GE11
+  static const int maxiEtaIdGE21_ = 16;  // no. eta partitions for GE21
+  static const int maxChan_ = 128;       // channels per vFat
+};
+#endif  // GEMChMap_H

--- a/CondFormats/GEMObjects/src/GEMChMap.cc
+++ b/CondFormats/GEMObjects/src/GEMChMap.cc
@@ -15,7 +15,7 @@ void GEMChMap::setDummy() {
   amcVec_.clear();
 
   chamberMap_.clear();
-  
+
   chamVfats_.clear();
   chamIEtas_.clear();
 

--- a/CondFormats/GEMObjects/src/GEMChMap.cc
+++ b/CondFormats/GEMObjects/src/GEMChMap.cc
@@ -1,0 +1,122 @@
+#include "CondFormats/GEMObjects/interface/GEMChMap.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+
+GEMChMap::GEMChMap() : theVersion("") {}
+
+GEMChMap::GEMChMap(const std::string& version) : theVersion(version) {}
+
+GEMChMap::~GEMChMap() {}
+
+const std::string& GEMChMap::version() const { return theVersion; }
+
+void GEMChMap::setDummy() {
+  // 12 bits for vfat, 5 bits for geb, 8 bit long GLIB serial number
+  amcVec_.clear();
+
+  chamberMap_.clear();
+  
+  chamVfats_.clear();
+  chamIEtas_.clear();
+
+  chStMap_.clear();
+  stChMap_.clear();
+
+  unsigned int fedId = 0;
+
+  for (int st = GEMDetId::minStationId0; st <= GEMDetId::maxStationId; ++st) {
+    int maxVFat = 0;
+    int maxLayerId = GEMDetId::maxLayerId;
+    int maxiEtaId = 0;
+    if (st == 0) {
+      maxVFat = maxVFatGE0_;
+      maxLayerId = GEMDetId::maxLayerId0;
+      maxiEtaId = maxiEtaIdGE0_;
+    } else if (st == 1) {
+      maxVFat = maxVFatGE11_;
+      maxiEtaId = maxiEtaIdGE11_;
+    } else if (st == 2) {
+      maxVFat = maxVFatGE21_;
+      maxiEtaId = maxiEtaIdGE21_;
+    }
+
+    uint16_t chipPos = 0;
+    for (int lphi = 0; lphi < maxVFat; ++lphi) {
+      for (int ieta = 1; ieta <= maxiEtaId; ++ieta) {
+        if (st == 2 and ieta % 2 == 0)
+          continue;
+        for (int i = 0; i < maxChan_; ++i) {
+          // only 1 vfat type for dummy map
+          GEMChMap::channelNum cMap;
+          cMap.chamberType = st;
+          cMap.vfatAdd = chipPos;
+          cMap.chNum = i;
+
+          GEMChMap::stripNum sMap;
+          sMap.chamberType = st;
+          if (st != 2) {
+            sMap.iEta = ieta;
+            sMap.stNum = i + lphi * maxChan_;
+          } else {
+            sMap.iEta = ieta + i % 2;
+            sMap.stNum = i / 2 + lphi * maxChan_ / 2;
+          }
+
+          add(cMap, sMap);
+          add(sMap, cMap);
+
+          GEMChMap::vfatEC ec;
+          ec.vfatAdd = cMap.vfatAdd;
+          ec.chamberType = st;
+
+          add(cMap.chamberType, cMap.vfatAdd);
+          add(ec, sMap.iEta);
+        }
+        chipPos++;
+      }
+    }
+
+    for (int re = -1; re <= 1; re = re + 2) {
+      uint8_t amcNum = 1;  //amc
+      uint8_t gebId = 0;
+      if (st == 0)
+        fedId = (re == 1 ? FEDNumbering::MINGE0FEDID + 1 : FEDNumbering::MINGE0FEDID);
+      else if (st == 1)
+        fedId = (re == 1 ? FEDNumbering::MINGEMFEDID + 1 : FEDNumbering::MINGEMFEDID);
+      else if (st == 2)
+        fedId = (re == 1 ? FEDNumbering::MINGE21FEDID + 1 : FEDNumbering::MINGE21FEDID);
+
+      for (int ch = 1; ch <= GEMDetId::maxChamberId; ++ch) {
+        for (int ly = 1; ly <= maxLayerId; ++ly) {
+          GEMDetId gemId(re, 1, st, ly, ch, 0);
+
+          GEMChMap::chamEC ec;
+          ec.fedId = fedId;
+          ec.gebId = gebId;
+          ec.amcNum = amcNum;
+
+          GEMChMap::chamDC dc;
+          dc.detId = gemId;
+          dc.chamberType = st;
+          add(ec, dc);
+
+          GEMChMap::sectorEC amcEC = {fedId, amcNum};
+          if (!isValidAMC(fedId, amcNum))
+            add(amcEC);
+
+          // 5 bits for gebId
+          if (st > 0 && gebId == maxGEB1_) {
+            gebId = 0;
+            amcNum += 2;  // only odd amc No. is used for GE11
+          } else if (st == 0 && gebId == maxGEBs_) {
+            gebId = 0;
+            amcNum++;
+          } else {
+            // 1 geb per chamber
+            gebId++;
+          }
+        }
+      }
+    }
+  }
+}

--- a/CondFormats/GEMObjects/src/T_EventSetup_GEMChMap.cc
+++ b/CondFormats/GEMObjects/src/T_EventSetup_GEMChMap.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/GEMObjects/interface/GEMChMap.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(GEMChMap);

--- a/CondFormats/GEMObjects/src/classes_def.xml
+++ b/CondFormats/GEMObjects/src/classes_def.xml
@@ -13,6 +13,20 @@
   <class name="std::vector<GEMeMap::GEMVFatMap>"/>
   <class name="GEMeMap::GEMStripMap"/>
   <class name="std::vector<GEMeMap::GEMStripMap>"/>
+
+  <class name="GEMChMap"/>
+  <class name="GEMChMap::sectorEC"/>
+  <class name="GEMChMap::chamEC"/>
+  <class name="GEMChMap::chamDC"/>
+  <class name="GEMChMap::vfatEC"/>
+  <class name="GEMChMap::channelNum"/>
+  <class name="GEMChMap::stripNum"/>
+  <class name="std::vector<GEMChMap::sectorEC>"/>
+  <class name="std::map<GEMChMap::chamEC, GEMChMap::chamDC>"/>
+  <class name="std::map<int, std::vector<uint16_t>>"/>
+  <class name="std::map<GEMChMap::vfatEC, std::vector<int>>"/>
+  <class name="std::map<GEMChMap::channelNum, GEMChMap::stripNum>"/>
+  <class name="std::map<GEMChMap::stripNum, GEMChMap::channelNum>"/>
   
   <class name="GEMDeadStrips"/>
   <class name="GEMDeadStrips::DeadItem"/>

--- a/CondFormats/GEMObjects/src/headers.h
+++ b/CondFormats/GEMObjects/src/headers.h
@@ -1,4 +1,5 @@
 #include "CondFormats/GEMObjects/interface/GEMELMap.h"
 #include "CondFormats/GEMObjects/interface/GEMeMap.h"
+#include "CondFormats/GEMObjects/interface/GEMChMap.h"
 #include "CondFormats/GEMObjects/interface/GEMDeadStrips.h"
 #include "CondFormats/GEMObjects/interface/GEMMaskedStrips.h"

--- a/CondFormats/GEMObjects/test/test_serialization.cpp
+++ b/CondFormats/GEMObjects/test/test_serialization.cpp
@@ -16,6 +16,20 @@ int main() {
   testSerialization<GEMeMap::GEMStripMap>();
   testSerialization<std::vector<GEMeMap::GEMStripMap>>();
 
+  testSerialization<GEMChMap>();
+  testSerialization<GEMChMap::sectorEC>();
+  testSerialization<GEMChMap::chamEC>();
+  testSerialization<GEMChMap::chamDC>();
+  testSerialization<GEMChMap::vfatEC>();
+  testSerialization<GEMChMap::channelNum>();
+  testSerialization<GEMChMap::stripNum>();
+  testSerialization<std::vector<GEMChMap::sectorEC>>();
+  testSerialization<std::map<GEMChMap::chamEC, GEMChMap::chamDC>>();
+  testSerialization<std::map<int, std::vector<uint16_t>>>();
+  testSerialization<std::map<GEMChMap::vfatEC, std::vector<int>>>();
+  testSerialization<std::map<GEMChMap::channelNum, GEMChMap::stripNum>>();
+  testSerialization<std::map<GEMChMap::stripNum, GEMChMap::channelNum>>();
+
   testSerialization<GEMDeadStrips>();
   testSerialization<GEMDeadStrips::DeadItem>();
   testSerialization<GEMMaskedStrips>();


### PR DESCRIPTION
# PR description:

* The current GEM electronics mapping can not handle the vfat that reads the signal from more than 1 unit detector module.
* In the GE21, a single vfat reads the signal from 2 different unit detector modules.
* The new electronics mapping format will be introduced with this PR.
* No changes are expected with this PR.

# PR validation:

* The code format has applied with scram build code-format and scram build code-checks.
* The branch is compileable.

@jshlee @watson-ij