### PR TITLE
Fixed Geant4 Stepping and Stacking actions

### DIFF
--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -214,14 +214,14 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
 
       auto proc = aTrack->GetCreatorProcess();
       G4int subType = proc->GetProcessSubType();
-      if(nullptr != proc &&  subType == 16) {
-	auto ptr = static_cast<const G4GammaGeneralProcess*>(proc);
+      if (nullptr != proc && subType == 16) {
+        auto ptr = static_cast<const G4GammaGeneralProcess*>(proc);
         proc = ptr->GetSelectedProcess();
-	subType = proc->GetProcessSubType();
-	LogDebug("SimG4CoreApplication")
-	  << "##StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent " << aTrack->GetParentID()
-	  << " " << aTrack->GetDefinition()->GetParticleName() << " Ekin(MeV)=" << ke/CLHEP::MeV
-	  << " subType=" << subType << " " << proc->GetProcessName();      
+        subType = proc->GetProcessSubType();
+        LogDebug("SimG4CoreApplication") << "##StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent "
+                                         << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName()
+                                         << " Ekin(MeV)=" << ke / CLHEP::MeV << " subType=" << subType << " "
+                                         << proc->GetProcessName();
       }
 
       // kill tracks in specific regions
@@ -341,9 +341,9 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
           }
           LogDebug("SimG4CoreApplication")
               << "StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent " << aTrack->GetParentID()
-              << " Type " << aTrack->GetDefinition()->GetParticleName() << " K.E. " << ke/MeV
-              << " MeV from process/subprocess " << proc->GetProcessType() << "|"
-              << subType << " as " << classification << " Flag " << flag;
+              << " Type " << aTrack->GetDefinition()->GetParticleName() << " K.E. " << ke / MeV
+              << " MeV from process/subprocess " << proc->GetProcessType() << "|" << subType << " as " << classification
+              << " Flag " << flag;
         }
       }
     }

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -211,18 +211,17 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
     } else {
       // potentially good for tracking
       const double ke = aTrack->GetKineticEnergy();
-
       auto proc = aTrack->GetCreatorProcess();
       G4int subType = proc->GetProcessSubType();
-      if (nullptr != proc && subType == 16) {
+      if (subType == 16) {
         auto ptr = static_cast<const G4GammaGeneralProcess*>(proc);
         proc = ptr->GetSelectedProcess();
         subType = proc->GetProcessSubType();
-        LogDebug("SimG4CoreApplication") << "##StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent "
-                                         << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName()
-                                         << " Ekin(MeV)=" << ke / CLHEP::MeV << " subType=" << subType << " "
-                                         << proc->GetProcessName();
       }
+      LogDebug("SimG4CoreApplication") << "##StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent "
+                                       << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName()
+                                       << " Ekin(MeV)=" << ke / CLHEP::MeV << " subType=" << subType << " "
+                                       << proc->GetProcessName();
 
       // kill tracks in specific regions
       if (isThisRegion(reg, deadRegions)) {
@@ -341,9 +340,9 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
           }
           LogDebug("SimG4CoreApplication")
               << "StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent " << aTrack->GetParentID()
-              << " Type " << aTrack->GetDefinition()->GetParticleName() << " K.E. " << ke / MeV
-              << " MeV from process/subprocess " << proc->GetProcessType() << "|" << subType << " as " << classification
-              << " Flag " << flag;
+              << " Type " << aTrack->GetDefinition()->GetParticleName() << " Ekin=" << ke / CLHEP::MeV
+              << " MeV from process " << proc->GetProcessName() << " subType=" << subType << " as " << classification
+              << " Flag: " << flag;
         }
       }
     }

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -217,6 +217,7 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
         auto ptr = static_cast<const G4GammaGeneralProcess*>(proc);
         proc = ptr->GetSelectedProcess();
         subType = proc->GetProcessSubType();
+        const_cast<G4Track*>(aTrack)->SetCreatorProcess(proc);
       }
       LogDebug("SimG4CoreApplication") << "##StackingAction:Classify Track " << aTrack->GetTrackID() << " Parent "
                                        << aTrack->GetParentID() << " " << aTrack->GetDefinition()->GetParticleName()

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -172,6 +172,7 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
     }
   }
   // check transition tracker/calo
+  bool isKilled = false;
   if (sAlive == tstat || sVeryForward == tstat) {
     if (isThisVolume(preStep->GetTouchable(), tracker) && isThisVolume(postStep->GetTouchable(), calo)) {
       math::XYZVectorD pos((preStep->GetPosition()).x(), (preStep->GetPosition()).y(), (preStep->GetPosition()).z());
@@ -188,12 +189,13 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
     }
   } else {
     theTrack->SetTrackStatus(fStopAndKill);
+    isKilled = true;
 #ifdef DebugLog
     PrintKilledTrack(theTrack, tstat);
 #endif
   }
   if (nullptr != steppingVerbose) {
-    steppingVerbose->NextStep(aStep, fpSteppingManager, (1 < tstat));
+    steppingVerbose->NextStep(aStep, fpSteppingManager, isKilled);
   }
 }
 


### PR DESCRIPTION
#### PR description:
For the case, when G4GammaGeneralProcess is enabled creator process field in MC truth was incorrectly filled. If stepping verbosity is enabled in forward detectors process limiting step was incorrectly printed.

Both modifications does not affect mainstream MC, because these features are optional. So, no change in results are expected.

#### PR validation:
private


#### if this PR is a backport please specify the original PR and why you need to backport that PR: NO
