### PR TITLE
Make `AlCaPhiSymEcal_Nano` inherit from `pp` instead of `AlCa`

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
@@ -6,16 +6,16 @@ Scenario supporting proton collision data taking for AlCaPhiSymEcal stream with 
 
 """
 
-from Configuration.DataProcessing.Impl.AlCa import AlCa
+from Configuration.DataProcessing.Impl.pp import pp
 from Configuration.Eras.Era_Run3_cff import Run3
 
-class AlCaPhiSymEcal_Nano(AlCa):
+class AlCaPhiSymEcal_Nano(pp):
     def __init__(self):
-        AlCa.__init__(self)
+        pp.__init__(self)
         self.skims=['EcalPhiSymByRun']
         self.eras=Run3
+        self.recoSeq = ':bunchSpacingProducer+ecalMultiFitUncalibRecHitTask+ecalCalibratedRecHitTask'
         self.promptCustoms = [ 'Calibration/EcalCalibAlgos/EcalPhiSymRecoSequence_cff.customise' ]
-        self.step = 'RECO:bunchSpacingProducer+ecalMultiFitUncalibRecHitTask+ecalCalibratedRecHitTask'
     """
     _AlCaPhiSymEcal_Nano_
 


### PR DESCRIPTION
#### PR description:

Outcome of https://github.com/dmwm/T0/pull/4664 is that the RECO steps were not run. This PR now changes the inheritance of the `AlCaPhiSymEcal_Nano` to inherit from `pp` instead of `AlCa`

#### PR validation:

```
python3 Configuration/DataProcessing/test/RunPromptReco.py --scenario AlCaPhiSymEcal_Nano --reco --global-tag 123X_dataRun3_Prompt_v6 --lfn=file:/eos/cms/tier0/store/backfill/1/data/Tier0_REPLAY_2022/AlCaPhiSym/RAW/v91/000/346/512/00000/4887980a-dac3-48e0-be08-d99284f75c5b.root --alcareco EcalPhiSymByRun
```
gives a config which now has
```
process.schedule = cms.Schedule(*[ process.raw2digi_step, process.L1Reco_step, process.reconstruction_step0, process.reconstruction_step1, process.reconstruction_step2, process.pathALCARECOEcalPhiSymByRun, process.dqmoffline_step, process.write_RECO_step, process.write_DQMIO_step, process.write_ALCARECO_step, process.ALCARECOStreamEcalPhiSymOutNanoPath ], tasks=[process.patAlgosToolsTask])
```
where
```
process.reconstruction_step0 = cms.Path(process.bunchSpacingProducer)
process.reconstruction_step1 = cms.Path(process.ecalMultiFitUncalibRecHitTask)
process.reconstruction_step2 = cms.Path(process.ecalCalibratedRecHitTask)
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport but backport to 12_3_X is needed.
