### PR TITLE
LowEnergyGFlash code updates

### DIFF
--- a/SimG4Core/Application/interface/LowEnergyFastSimModel.h
+++ b/SimG4Core/Application/interface/LowEnergyFastSimModel.h
@@ -12,6 +12,7 @@
 #include "G4ThreeVector.hh"
 
 class TrackingAction;
+class G4ParticleDefinition;
 
 class LowEnergyFastSimModel : public G4VFastSimulationModel {
 public:
@@ -25,6 +26,7 @@ private:
   G4double fEmax;
   const G4Envelope* fRegion;
   const TrackingAction* fTrackingAction;
+  const G4ParticleDefinition* fPositron;
   G4bool fCheck;
   G4ThreeVector fTailPos;
   GFlashHitMaker fHitMaker;

--- a/SimG4Core/Application/interface/LowEnergyFastSimParam.h
+++ b/SimG4Core/Application/interface/LowEnergyFastSimParam.h
@@ -17,7 +17,7 @@ public:
     constexpr const G4double r1 = 156.52094133;
     constexpr const G4double r2 = -1.02220543;
     const G4double r0 = r1 + r2 * energy;
-    return std::sqrt(r0/G4UniformRand() - r0);
+    return std::sqrt(r0 / G4UniformRand() - r0);
   }
 
   G4double GetZ() const {

--- a/SimG4Core/Application/interface/LowEnergyFastSimParam.h
+++ b/SimG4Core/Application/interface/LowEnergyFastSimParam.h
@@ -3,6 +3,7 @@
 
 #include "G4Types.hh"
 #include "Randomize.hh"
+#include "G4Log.hh"
 
 class LowEnergyFastSimParam {
 public:
@@ -16,17 +17,13 @@ public:
     constexpr const G4double r1 = 156.52094133;
     constexpr const G4double r2 = -1.02220543;
     const G4double r0 = r1 + r2 * energy;
-    const G4double erand = G4UniformRand();
-
-    return sqrt(r0 / erand - r0);
+    return std::sqrt(r0/G4UniformRand() - r0);
   }
 
   G4double GetZ() const {
     constexpr const G4double alpha = 0.02211515;
     constexpr const G4double t = 0.66968625;
-    const G4double erand = G4UniformRand();
-
-    return -log(erand) / alpha + t;
+    return -G4Log(G4UniformRand()) / alpha + t;
   }
 };
 


### PR DESCRIPTION
#### PR description:
LowEnergyGFlash code is slightly optimized. G4Log (VDT code) is used instead of std::log, local pointer to G4Positron is used instead of pdg code.

Because this code is optional no change in any WF is expected.

#### PR validation:
private

#### if this PR is a backport please specify the original PR and why you need to backport that PR: NO
