### PR TITLE
Gathering detail plots into directories, online & offline & relval & …

### DIFF
--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -101,6 +101,8 @@ private:
   MonitorElement *h2SummaryStatusAMCError;
   MonitorElement *h2SummaryStatusAMC13Error;
 
+  std::string strFolderMain_;
+
   Int_t nBXMin_, nBXMax_;
 
   std::map<UInt_t, int> mapFEDIdToRe_;

--- a/DQM/GEM/interface/GEMDigiSource.h
+++ b/DQM/GEM/interface/GEMDigiSource.h
@@ -58,13 +58,11 @@ private:
 
   MEMap4Inf mapDigiOccPerCh_;
 
-  MonitorElement* h2SummaryOcc_;
+  std::string strFolderMain_;
 
   Int_t nBXMin_, nBXMax_;
   Float_t fRadiusMin_;
   Float_t fRadiusMax_;
-
-  Bool_t bModeRelVal_;
 };
 
 #endif  // DQM_GEM_INTERFACE_GEMDigiSource_h

--- a/DQM/GEM/interface/GEMRecHitSource.h
+++ b/DQM/GEM/interface/GEMRecHitSource.h
@@ -32,8 +32,9 @@ private:
 
   int nIdxFirstDigi_;
   int nClusterSizeBinNum_;
+  int nNumDivideEtaPartitionInRPhi_;
 
-  MEMap3Inf mapTotalRecHit_layer_;
+  MEMap3Inf mapRecHitXY_layer_;
   MEMap3Inf mapRecHitWheel_layer_;
   MEMap3Inf mapRecHitOcc_ieta_;
   MEMap3Inf mapRecHitOcc_phi_;
@@ -45,6 +46,8 @@ private:
 
   MEMap4Inf mapCLSPerCh_;
 
+  std::string strFolderMain_;
+
   Int_t nCLSMax_;
   Float_t fRadiusMin_;
   Float_t fRadiusMax_;
@@ -54,8 +57,6 @@ private:
   std::unordered_map<UInt_t, MonitorElement*> DigisFired_vs_eta_;
   std::unordered_map<UInt_t, MonitorElement*> rh_vs_eta_;
   std::unordered_map<UInt_t, MonitorElement*> recGlobalPos;
-
-  Bool_t bModeRelVal_;
 };
 
 #endif  // DQM_GEM_INTERFACE_GEMRecHitSource_h

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -76,19 +76,15 @@ protected:
   void drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t nLumiCurr);
   void createTableWatchingSummary();
   void copyLabels(MonitorElement *h2Src, MonitorElement *h2Dst);
-  void createSummaryHist(edm::Service<DQMStore> &store,
-                         MonitorElement *h2Src,
-                         MonitorElement *&h2Sum,
-                         std::vector<std::string> &listLayers,
-                         std::map<std::string, int> &mapIdxLayer,
-                         std::map<int, int> &mapNumChPerChamber);
+  void getGeometryInfo(edm::Service<DQMStore> &store, MonitorElement *h2Src);
+  void createSummaryHist(edm::Service<DQMStore> &store, MonitorElement *h2Src, MonitorElement *&h2Sum);
   void createSummaryVFAT(edm::Service<DQMStore> &store,
                          MonitorElement *h2Src,
                          std::string strSuffix,
                          MonitorElement *&h2Sum);
   Float_t refineSummaryHistogram(std::string strName,
                                  MonitorElement *h2Sum,
-                                 MonitorElement *h2SrcOcc,
+                                 std::vector<MonitorElement *> &listOccPlots,
                                  MonitorElement *h2SrcStatusA,
                                  MonitorElement *h2SrcStatusE,
                                  MonitorElement *h2SrcStatusW,
@@ -117,6 +113,7 @@ protected:
                             Int_t nLumiCurr,
                             NumStatus numStatusNew);
   void createLumiFuncHist(edm::Service<DQMStore> &store, std::string strSuffix, Int_t nIdxLayer, Int_t nLumiCurr);
+  void createInactiveChannelFracHist(edm::Service<DQMStore> &store, std::string strSuffix, Int_t nNumChamber);
 
   Float_t fCutErr_, fCutLowErr_, fCutWarn_;
 
@@ -188,7 +185,6 @@ void GEMDQMHarvester::dqmEndLuminosityBlock(DQMStore::IBooker &,
 void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t nLumiCurr) {
   Float_t fReportSummary = -1.0;
 
-  std::string strSrcDigiOcc = "GEM/Digis/summaryOccDigi";
   std::string strSrcStatusA = "GEM/DAQStatus/chamberAllStatus";
   std::string strSrcStatusE = "GEM/DAQStatus/chamberErrors";
   std::string strSrcStatusW = "GEM/DAQStatus/chamberWarnings";
@@ -200,13 +196,12 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
   std::string strSrcStatusWAMC = "GEM/DAQStatus/chamberAMCWarnings";
   std::string strSrcStatusEAMC13 = "GEM/DAQStatus/chamberAMC13Errors";
 
-  std::string strSrcVFATOcc = "GEM/Digis/det";
+  std::string strSrcVFATOcc = "GEM/Digis/occ";
   std::string strSrcVFATStatusW = "GEM/DAQStatus/vfat_statusWarnSum";
   std::string strSrcVFATStatusE = "GEM/DAQStatus/vfat_statusErrSum";
 
   store->setCurrentFolder(strDirSummary_);
 
-  MonitorElement *h2SrcDigiOcc = store->get(strSrcDigiOcc);
   MonitorElement *h2SrcStatusA = store->get(strSrcStatusA);
   MonitorElement *h2SrcStatusE = store->get(strSrcStatusE);
   MonitorElement *h2SrcStatusW = store->get(strSrcStatusW);
@@ -220,16 +215,29 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
 
   std::string strTitleSummary = "summary";
 
-  if (h2SrcDigiOcc != nullptr && h2SrcStatusA != nullptr && h2SrcStatusE != nullptr && h2SrcStatusW != nullptr &&
-      h2SrcStatusEVFAT != nullptr && h2SrcStatusWVFAT != nullptr && h2SrcStatusEOH != nullptr &&
-      h2SrcStatusWOH != nullptr && h2SrcStatusEAMC != nullptr && h2SrcStatusWAMC != nullptr &&
-      h2SrcStatusEAMC13 != nullptr) {
+  getGeometryInfo(store, h2SrcStatusEOH);
+
+  if (h2SrcStatusA != nullptr && h2SrcStatusE != nullptr && h2SrcStatusW != nullptr && h2SrcStatusEVFAT != nullptr &&
+      h2SrcStatusWVFAT != nullptr && h2SrcStatusEOH != nullptr && h2SrcStatusWOH != nullptr &&
+      h2SrcStatusEAMC != nullptr && h2SrcStatusWAMC != nullptr && h2SrcStatusEAMC13 != nullptr) {
     MonitorElement *h2Sum = nullptr;
-    createSummaryHist(store, h2SrcStatusEOH, h2Sum, listLayer_, mapIdxLayer_, mapNumChPerChamber_);
+    createSummaryHist(store, h2SrcStatusEOH, h2Sum);
     createTableWatchingSummary();
+
+    std::vector<MonitorElement *> listOccPlots(listLayer_.size() + 1);  // The index starts at 1
+    for (const auto &strSuffix : listLayer_) {
+      if (mapIdxLayer_.find(strSuffix) == mapIdxLayer_.end())
+        continue;
+      auto nIdxLayer = mapIdxLayer_[strSuffix];
+      MonitorElement *h2SrcVFATOcc = store->get(strSrcVFATOcc + strSuffix);
+      if (h2SrcVFATOcc == nullptr)
+        continue;
+      listOccPlots[nIdxLayer] = h2SrcVFATOcc;
+    }
+
     fReportSummary = refineSummaryHistogram(strTitleSummary,
                                             h2Sum,
-                                            h2SrcDigiOcc,
+                                            listOccPlots,
                                             h2SrcStatusA,
                                             h2SrcStatusE,
                                             h2SrcStatusW,
@@ -243,6 +251,8 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
                                             nLumiCurr);
 
     for (const auto &strSuffix : listLayer_) {
+      if (mapIdxLayer_.find(strSuffix) == mapIdxLayer_.end())
+        continue;
       auto nIdxLayer = mapIdxLayer_[strSuffix];
       MonitorElement *h2SrcVFATOcc = store->get(strSrcVFATOcc + strSuffix);
       MonitorElement *h2SrcVFATStatusW = store->get(strSrcVFATStatusW + strSuffix);
@@ -260,6 +270,13 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
 
       createLumiFuncHist(store, strSuffix, nIdxLayer, nLumiCurr);
     }
+  }
+
+  for (const auto &strSuffix : listLayer_) {
+    if (mapIdxLayer_.find(strSuffix) == mapIdxLayer_.end())
+      continue;
+    auto nNumChamber = mapNumChPerChamber_[mapIdxLayer_[strSuffix]];
+    createInactiveChannelFracHist(store, strSuffix, nNumChamber);
   }
 
   store->bookFloat("reportSummary")->Fill(fReportSummary);
@@ -297,12 +314,45 @@ void GEMDQMHarvester::copyLabels(MonitorElement *h2Src, MonitorElement *h2Dst) {
   h2Dst->setYTitle(h2Src->getAxisTitle(2));
 }
 
-void GEMDQMHarvester::createSummaryHist(edm::Service<DQMStore> &store,
-                                        MonitorElement *h2Src,
-                                        MonitorElement *&h2Sum,
-                                        std::vector<std::string> &listLayers,
-                                        std::map<std::string, int> &mapIdxLayer,
-                                        std::map<int, int> &mapNumChPerChamber) {
+void GEMDQMHarvester::getGeometryInfo(edm::Service<DQMStore> &store, MonitorElement *h2Src) {
+  if (h2Src != nullptr) {  // For online and offline
+    listLayer_.clear();
+    mapIdxLayer_.clear();
+    mapNumChPerChamber_.clear();
+
+    Int_t nBinY = h2Src->getNbinsY();
+    listLayer_.push_back("");
+
+    for (Int_t i = 1; i <= nBinY; i++) {
+      std::string strLabelFull = h2Src->getTH2F()->GetYaxis()->GetBinLabel(i);
+      Int_t nBinXActual = (Int_t)(h2Src->getBinContent(0, i) + 0.5);
+      auto nPos = strLabelFull.find(';');
+      auto strLayer = strLabelFull.substr(nPos + 1);
+      listLayer_.push_back(strLayer);
+      mapIdxLayer_[strLayer] = i;
+      mapNumChPerChamber_[i] = nBinXActual;
+    }
+  } else {  // For others (validation and...?)
+    listLayer_.push_back("");
+    if (store->get("GEM/Digis/occupancy_GE11-M-L1/occ_GE11-M-01L1-S") != nullptr) {
+      listLayer_.push_back("_GE11-P-L2");
+      listLayer_.push_back("_GE11-P-L1");
+      listLayer_.push_back("_GE11-M-L1");
+      listLayer_.push_back("_GE11-M-L2");
+      mapIdxLayer_["_GE11-P-L2"] = 1;
+      mapIdxLayer_["_GE11-P-L1"] = 2;
+      mapIdxLayer_["_GE11-M-L1"] = 3;
+      mapIdxLayer_["_GE11-M-L2"] = 4;
+      mapNumChPerChamber_[1] = 36;
+      mapNumChPerChamber_[2] = 36;
+      mapNumChPerChamber_[3] = 36;
+      mapNumChPerChamber_[4] = 36;
+    }
+    // FIXME: How about GE21 and ME0?
+  }
+}
+
+void GEMDQMHarvester::createSummaryHist(edm::Service<DQMStore> &store, MonitorElement *h2Src, MonitorElement *&h2Sum) {
   //store->setCurrentFolder(strDirSummary_);
 
   Int_t nBinX = h2Src->getNbinsX(), nBinY = h2Src->getNbinsY();
@@ -311,23 +361,10 @@ void GEMDQMHarvester::createSummaryHist(edm::Service<DQMStore> &store,
   h2Sum->setXTitle("Chamber");
   h2Sum->setYTitle("Layer");
 
-  listLayers.clear();
-  mapIdxLayer.clear();
-  mapNumChPerChamber.clear();
-
   for (Int_t i = 1; i <= nBinX; i++)
     h2Sum->setBinLabel(i, h2Src->getTH2F()->GetXaxis()->GetBinLabel(i), 1);
-  for (Int_t i = 1; i <= nBinY; i++) {
-    std::string strLabelFull = h2Src->getTH2F()->GetYaxis()->GetBinLabel(i);
-    Int_t nBinXActual = (Int_t)(h2Src->getBinContent(0, i) + 0.5);
-    auto nPos = strLabelFull.find(';');
-    auto strLabel = strLabelFull.substr(0, nPos);
-    auto strLayer = strLabelFull.substr(nPos + 1);
-    listLayers.push_back(strLabelFull.substr(nPos + 1));
-    h2Sum->setBinLabel(i, strLabel, 2);
-    mapIdxLayer[strLayer] = i;
-    mapNumChPerChamber[i] = nBinXActual;
-  }
+  for (Int_t i = 1; i <= nBinY; i++)
+    h2Sum->setBinLabel(i, listLayer_[i].substr(1), 2);
 }
 
 void GEMDQMHarvester::createSummaryVFAT(edm::Service<DQMStore> &store,
@@ -359,7 +396,7 @@ Int_t GEMDQMHarvester::assessOneBin(
 // FIXME: Need more study about how to summarize
 Float_t GEMDQMHarvester::refineSummaryHistogram(std::string strName,
                                                 MonitorElement *h2Sum,
-                                                MonitorElement *h2SrcOcc,
+                                                std::vector<MonitorElement *> &listOccPlots,
                                                 MonitorElement *h2SrcStatusA,
                                                 MonitorElement *h2SrcStatusE,
                                                 MonitorElement *h2SrcStatusW,
@@ -374,10 +411,20 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(std::string strName,
   Int_t nBinY = h2Sum->getNbinsY();
   Int_t nAllBin = 0, nFineBin = 0;
   for (Int_t j = 1; j <= nBinY; j++) {
-    Int_t nBinX = (Int_t)(h2SrcOcc->getBinContent(0, j) + 0.5);
+    Int_t nBinX = (Int_t)(h2SrcStatusE->getBinContent(0, j) + 0.5);
+    auto h2SrcOcc = listOccPlots[j];
+    Int_t nBinYOcc = 0;
+    if (h2SrcOcc != nullptr) {
+      nBinYOcc = h2SrcOcc->getNbinsY();
+    }
+
     h2Sum->setBinContent(0, j, nBinX);
     for (Int_t i = 1; i <= nBinX; i++) {
-      Float_t fOcc = h2SrcOcc->getBinContent(i, j);
+      Float_t fOcc = 0;
+      for (Int_t r = 1; r <= nBinYOcc; r++) {
+        fOcc += h2SrcOcc->getBinContent(i, r);
+      }
+
       Float_t fStatusAll = h2SrcStatusA->getBinContent(i, j);
       Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
       Float_t fStatusWarn = h2SrcStatusW->getBinContent(i, j);
@@ -581,6 +628,7 @@ void GEMDQMHarvester::createLumiFuncHist(edm::Service<DQMStore> &store,
         }
       }
 
+      nStatusSum &= ~(1 << nBitOcc_);  // No need of displaying the digi occupancy
       h2Summary->setBinContent(nIdxLumi + 1, nIdxCh, nStatusSum);
       if (nMaxBin < nIdxLumi + 1)
         nMaxBin = nIdxLumi + 1;
@@ -589,6 +637,85 @@ void GEMDQMHarvester::createLumiFuncHist(edm::Service<DQMStore> &store,
 
   for (Int_t nX = 1; nX <= nMaxBin; nX++) {
     h2Summary->setBinContent(nX, 0, 1);
+  }
+}
+
+std::string getNameChamberOccGE11(std::string strSuffix, Int_t nIdxCh) {
+  std::string strRegion;
+  std::string strChType = (nIdxCh % 2 == 0 ? "L" : "S");
+  Int_t nLayer;
+
+  if (strSuffix.find("-M-") != std::string::npos)
+    strRegion = "M";
+  else if (strSuffix.find("-P-") != std::string::npos)
+    strRegion = "P";
+  else
+    return "";
+
+  if (strSuffix.find("-L1") != std::string::npos)
+    nLayer = 1;
+  else if (strSuffix.find("-L2") != std::string::npos)
+    nLayer = 2;
+  else
+    return "";
+
+  return Form("GEM/Digis/occupancy_GE11-%s-L%i/occ_GE11-%s-%02iL%i-%s",
+              strRegion.c_str(),
+              nLayer,
+              strRegion.c_str(),
+              nIdxCh,
+              nLayer,
+              strChType.c_str());
+}
+
+std::string getNameChamberOccGE21(std::string strSuffix, Int_t nIdxChamber) {
+  return "";  // FIXME
+}
+
+std::string getNameChamberOccNull(std::string strSuffix, Int_t nIdxChamber) {
+  return "";  // For an initialization
+}
+
+void GEMDQMHarvester::createInactiveChannelFracHist(edm::Service<DQMStore> &store,
+                                                    std::string strSuffix,
+                                                    Int_t nNumChamber) {
+  std::string strTitle = "The fraction of inactive channels in " + strSuffix.substr(1);
+  MonitorElement *h2InactiveChannel =
+      store->book1D("inactive_frac_chamber" + strSuffix, strTitle, nNumChamber, 0.5, nNumChamber + 0.5);
+  h2InactiveChannel->setXTitle("Chamber");
+  h2InactiveChannel->setYTitle("Fraction of inactive channels");
+  for (Int_t i = 1; i <= nNumChamber; i++) {
+    h2InactiveChannel->setBinLabel(i, Form("%i", i), 1);
+  }
+
+  std::string (*funcNameCh)(std::string, Int_t) = getNameChamberOccNull;
+
+  if (strSuffix.find("_GE11") != std::string::npos) {
+    funcNameCh = getNameChamberOccGE11;
+  } else if (strSuffix.find("_GE21") != std::string::npos) {
+    funcNameCh = getNameChamberOccGE21;
+  }
+
+  for (Int_t nIdxCh = 1; nIdxCh <= nNumChamber; nIdxCh++) {
+    std::string strNameCh = funcNameCh(strSuffix, nIdxCh);
+    MonitorElement *h2SrcChamberOcc = store->get(strNameCh);
+    if (h2SrcChamberOcc == nullptr) {
+      // FIXME: It's about sending a message
+      continue;
+    }
+
+    Int_t nNumBinX = h2SrcChamberOcc->getNbinsX();
+    Int_t nNumBinY = h2SrcChamberOcc->getNbinsY();
+    Int_t nNumChannelInactive = 0;
+    for (Int_t i = 1; i <= nNumBinX; i++)
+      for (Int_t j = 1; j <= nNumBinY; j++) {
+        if (h2SrcChamberOcc->getBinContent(i, j) <= 0) {
+          nNumChannelInactive++;
+        }
+      }
+
+    Int_t nNumAllChannel = nNumBinX * nNumBinY;
+    h2InactiveChannel->setBinContent(nIdxCh, ((Double_t)nNumChannelInactive) / nNumAllChannel);
   }
 }
 

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -7,19 +7,20 @@ GEMRecHitSource::GEMRecHitSource(const edm::ParameterSet& cfg) : GEMDQMBase(cfg)
   tagRecHit_ = consumes<GEMRecHitCollection>(cfg.getParameter<edm::InputTag>("recHitsInputLabel"));
 
   nIdxFirstDigi_ = cfg.getParameter<int>("idxFirstDigi");
+  nNumDivideEtaPartitionInRPhi_ = cfg.getParameter<int>("numDivideEtaPartitionInRPhi");
   nCLSMax_ = cfg.getParameter<int>("clsMax");
   nClusterSizeBinNum_ = cfg.getParameter<int>("ClusterSizeBinNum");
-  bModeRelVal_ = cfg.getParameter<bool>("modeRelVal");
 }
 
 void GEMRecHitSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("recHitsInputLabel", edm::InputTag("gemRecHits", ""));
+  desc.addUntracked<std::string>("runType", "online");
 
   desc.add<int>("idxFirstDigi", 0);
+  desc.add<int>("numDivideEtaPartitionInRPhi", 10);
   desc.add<int>("clsMax", 10);
   desc.add<int>("ClusterSizeBinNum", 9);
-  desc.add<bool>("modeRelVal", false);
 
   desc.addUntracked<std::string>("logCategory", "GEMRecHitSource");
 
@@ -34,20 +35,23 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
     return;
   loadChambers();
 
+  strFolderMain_ = "GEM/RecHits";
+
   ibooker.cd();
-  ibooker.setCurrentFolder("GEM/RecHits");
+  ibooker.setCurrentFolder(strFolderMain_);
 
   fRadiusMin_ = 120.0;
   fRadiusMax_ = 250.0;
   float radS = -5.0 / 180 * M_PI;
   float radL = 355.0 / 180 * M_PI;
 
-  mapTotalRecHit_layer_ = MEMap3Inf(this, "det", "RecHit Occupancy", 36, 0.5, 36.5, 8, 0.5, 8.5, "Chamber", "iEta");
-  mapRecHitWheel_layer_ = MEMap3Inf(
-      this, "rphi_occ", "RecHit R-Phi Occupancy", 360, radS, radL, 8, fRadiusMin_, fRadiusMax_, "#phi (rad)", "R [cm]");
+  mapRecHitWheel_layer_ =
+      MEMap3Inf(this, "occ_rphi", "RecHit R-Phi Occupancy", 360, radS, radL, 8, 0, 8, "Phi-direction division", "iEta");
+  mapRecHitXY_layer_ =
+      MEMap3Inf(this, "occ_xy", "RecHit xy Occupancy", 160, -250, 250, 160, -250, 250, "X [cm]", "Y [cm]");
   mapRecHitOcc_ieta_ = MEMap3Inf(this, "occ_ieta", "RecHit iEta Occupancy", 8, 0.5, 8.5, "iEta", "Number of RecHits");
   mapRecHitOcc_phi_ =
-      MEMap3Inf(this, "occ_phi", "RecHit Phi Occupancy", 360, -5, 355, "#phi (degree)", "Number of RecHits");
+      MEMap3Inf(this, "occ_phi", "RecHit Phi Occupancy", 72, -5, 355, "#phi (degree)", "Number of RecHits");
   mapTotalRecHitPerEvtLayer_ = MEMap3Inf(this,
                                          "rechits_per_layer",
                                          "Total number of RecHits per event for each layers",
@@ -87,26 +91,36 @@ void GEMRecHitSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
   mapCLSPerCh_ = MEMap4Inf(
       this, "cls", "Cluster size of RecHits", nCLSMax_, 0.5, nCLSMax_ + 0.5, 1, 0.5, 1.5, "Cluster size", "iEta");
 
-  if (bModeRelVal_) {
-    mapTotalRecHit_layer_.TurnOff();
-    mapRecHitWheel_layer_.TurnOff();
+  if (nRunType_ == GEMDQM_RUNTYPE_OFFLINE) {
+    mapRecHitXY_layer_.TurnOff();
+    mapCLSOver5_.TurnOff();
+    mapCLSPerCh_.TurnOff();
+  }
+
+  if (nRunType_ == GEMDQM_RUNTYPE_RELVAL) {
+    mapRecHitXY_layer_.TurnOff();
     mapCLSAverage_.TurnOff();
     mapCLSOver5_.TurnOff();
     mapCLSPerCh_.TurnOff();
   }
 
+  if (nRunType_ != GEMDQM_RUNTYPE_ALLPLOTS && nRunType_ != GEMDQM_RUNTYPE_OFFLINE) {
+    mapRecHitWheel_layer_.TurnOff();
+  }
+
+  if (nRunType_ != GEMDQM_RUNTYPE_ALLPLOTS && nRunType_ != GEMDQM_RUNTYPE_RELVAL) {
+    mapRecHitOcc_ieta_.TurnOff();
+    mapRecHitOcc_phi_.TurnOff();
+    mapCLSRecHit_ieta_.TurnOff();
+  }
+
+  if (nRunType_ != GEMDQM_RUNTYPE_ALLPLOTS) {
+    mapTotalRecHitPerEvtLayer_.TurnOff();
+    mapTotalRecHitPerEvtIEta_.TurnOff();
+  }
+
   GenerateMEPerChamber(ibooker);
 }
-
-//int GEMRecHitSource::SetupRPhiPlot(ME3IdsKey key) {
-//  MEStationInfo& stationInfo = mapStationInfo_[key];
-//
-//  auto hRPhi = mapRecHitWheel_layer_.FindHist(key);
-//
-//
-//
-//  return 0;
-//}
 
 int GEMRecHitSource::ProcessWithMEMap2WithEta(BookingHelper& bh, ME3IdsKey key) {
   mapTotalRecHitPerEvtIEta_.bookND(bh, key);
@@ -123,20 +137,12 @@ int GEMRecHitSource::ProcessWithMEMap2AbsReWithEta(BookingHelper& bh, ME3IdsKey 
 int GEMRecHitSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   MEStationInfo& stationInfo = mapStationInfo_[key];
 
-  Int_t nNumVFATPerEta = stationInfo.nMaxVFAT_ / stationInfo.nNumEtaPartitions_;
-
-  mapTotalRecHit_layer_.SetBinConfX(stationInfo.nNumChambers_);
-  mapTotalRecHit_layer_.SetBinConfY(stationInfo.nNumEtaPartitions_);
-  mapTotalRecHit_layer_.bookND(bh, key);
-  mapTotalRecHit_layer_.SetLabelForChambers(key, 1);
-  mapTotalRecHit_layer_.SetLabelForIEta(key, 2);
-
-  mapRecHitWheel_layer_.SetBinLowEdgeX(stationInfo.fMinPhi_);
-  mapRecHitWheel_layer_.SetBinHighEdgeX(stationInfo.fMinPhi_ + 2 * M_PI);
-  mapRecHitWheel_layer_.SetNbinsX(nNumVFATPerEta * stationInfo.nNumChambers_);
+  Int_t nNumPartX = stationInfo.nNumChambers_ * nNumDivideEtaPartitionInRPhi_;
+  mapRecHitWheel_layer_.SetBinConfX(nNumPartX);
   mapRecHitWheel_layer_.SetNbinsY(stationInfo.nNumEtaPartitions_);
   mapRecHitWheel_layer_.bookND(bh, key);
-  //SetupRPhiPlot(key);
+
+  mapRecHitXY_layer_.bookND(bh, key);
 
   mapRecHitOcc_ieta_.SetBinConfX(stationInfo.nNumEtaPartitions_);
   mapRecHitOcc_ieta_.bookND(bh, key);
@@ -162,9 +168,13 @@ int GEMRecHitSource::ProcessWithMEMap3WithChamber(BookingHelper& bh, ME4IdsKey k
   ME3IdsKey key3 = key4Tokey3(key);
   MEStationInfo& stationInfo = mapStationInfo_[key3];
 
+  bh.getBooker()->setCurrentFolder(strFolderMain_ + "/clusterSize_" + getNameDirLayer(key3));
+
   mapCLSPerCh_.SetBinConfY(stationInfo.nNumEtaPartitions_);
   mapCLSPerCh_.bookND(bh, key);
   mapCLSPerCh_.SetLabelForIEta(key, 2);
+
+  bh.getBooker()->setCurrentFolder(strFolderMain_);
 
   return 0;
 }
@@ -187,8 +197,8 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     MEStationInfo& stationInfo = mapStationInfo_[key3];
-    for (auto ieta : ch.etaPartitions()) {
-      GEMDetId eId = ieta->id();
+    for (auto iEta : ch.etaPartitions()) {
+      GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};
       ME4IdsKey key4IEta{gid.region(), gid.station(), gid.layer(), eId.ieta()};
@@ -199,22 +209,28 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
       const auto& recHitsRange = gemRecHits->get(eId);
       auto gemRecHit = recHitsRange.first;
       for (auto hit = gemRecHit; hit != recHitsRange.second; ++hit) {
-        GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(hit->localPosition());
-        Float_t fPhi = recHitGP.phi();
+        LocalPoint recHitLP = hit->localPosition();
+        GlobalPoint recHitGP = GEMGeometry_->idToDet(hit->gemId())->surface().toGlobal(recHitLP);
 
-        // Filling of RecHit occupancy
-        mapTotalRecHit_layer_.Fill(key3, chamber, eId.ieta());
+        // Filling of XY occupancy
+        mapRecHitXY_layer_.Fill(key3, recHitGP.x(), recHitGP.y());
 
         // Filling of R-Phi occupancy
-        Float_t fR = fRadiusMin_ + (fRadiusMax_ - fRadiusMin_) * (eId.ieta() - 0.5) / stationInfo.nNumEtaPartitions_;
-        Float_t fPhiShift = restrictAngle(fPhi, stationInfo.fMinPhi_);
-        Float_t fPhiDeg = fPhiShift * 180.0 / M_PI;
-        mapRecHitWheel_layer_.Fill(key3, fPhiShift, fR);
+        // Trick: It would be efficient to find a phi-partition of the eta partition
+        //        in which the recHit places from the 'strip position' of the recHit position
+        Int_t nOffset = chamber * nNumDivideEtaPartitionInRPhi_;
+        Float_t fStripRecHit = iEta->strip(recHitLP);
+        Int_t nStripRecHit = Int_t(fStripRecHit / iEta->nstrips() * nNumDivideEtaPartitionInRPhi_);
+        nStripRecHit = std::min(std::max(0, nStripRecHit), nNumDivideEtaPartitionInRPhi_ - 1);
+        mapRecHitWheel_layer_.Fill(key3, nOffset + nStripRecHit, eId.ieta());
 
         // Filling of RecHit (iEta)
         mapRecHitOcc_ieta_.Fill(key3, eId.ieta());
 
         // Filling of RecHit (phi)
+        Float_t fPhi = recHitGP.phi();
+        Float_t fPhiShift = restrictAngle(fPhi, stationInfo.fMinPhi_);
+        Float_t fPhiDeg = fPhiShift * 180.0 / M_PI;
         mapRecHitOcc_phi_.Fill(key3, fPhiDeg);
 
         // For total RecHits

--- a/DQM/GEM/python/gem_dqm_offline_source_cff.py
+++ b/DQM/GEM/python/gem_dqm_offline_source_cff.py
@@ -4,8 +4,8 @@ from DQM.GEM.GEMDigiSource_cfi import *
 from DQM.GEM.GEMRecHitSource_cfi import *
 from DQM.GEM.gemEfficiencyAnalyzer_cff import *
 
-GEMDigiSource.modeRelVal = True
-GEMRecHitSource.modeRelVal = True
+GEMDigiSource.runType   = "offline"
+GEMRecHitSource.runType = "offline"
 
 gemSources = cms.Sequence(
     GEMDigiSource *

--- a/DQM/GEM/python/gem_dqm_offline_source_cosmics_cff.py
+++ b/DQM/GEM/python/gem_dqm_offline_source_cosmics_cff.py
@@ -4,8 +4,8 @@ from DQM.GEM.GEMDigiSource_cfi import *
 from DQM.GEM.GEMRecHitSource_cfi import *
 from DQM.GEM.gemEfficiencyAnalyzerCosmics_cff import *
 
-GEMDigiSource.modeRelVal = True
-GEMRecHitSource.modeRelVal = True
+GEMDigiSource.runType   = "offline"
+GEMRecHitSource.runType = "offline"
 
 gemSourcesCosmics = cms.Sequence(
     GEMDigiSource *

--- a/Validation/Configuration/python/gemSimValid_cff.py
+++ b/Validation/Configuration/python/gemSimValid_cff.py
@@ -5,7 +5,7 @@ from Validation.MuonGEMDigis.MuonGEMDigis_cff import *
 from Validation.MuonGEMRecHits.MuonGEMRecHits_cff import *
 from DQM.GEM.GEMDQM_cff import *
 
-GEMDigiSource.modeRelVal = True
-GEMRecHitSource.modeRelVal = True
+GEMDigiSource.runType   = "relval"
+GEMRecHitSource.runType = "relval"
 
 gemSimValid = cms.Sequence(GEMDQMForRelval*gemSimValidation*gemDigiValidation*gemLocalRecoValidation)


### PR DESCRIPTION
#### PR description:
We have several updates on GEM onlineDQM.

- Plots for detailed information per chambers are gathered into directories
- Online & offline & relval & allplot modes
- Removed non-useful plots and stuffs

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij 