### PR TITLE
[Backport of] modify HCAL output LUT for saturated TPs with |ieta|>=21

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -83,6 +83,10 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
       for (unsigned int i = threshold; i < lutsize; ++i)
         if (allLinear_) {
           outputLUT_[index][i] = isOnlyQIE11(id) ? linearQIE11LUT[i] : linearQIE8LUT[i];
+          //Modifying the saturation (127 -> 255) for the 'split cells'.
+          if (abs(ieta) > 20 && isOnlyQIE11(id) && linearQIE11LUT[i] >= (TPGMAX - 2) / 2.) {
+            outputLUT_[index][i] = TPGMAX - 1;
+          }
         } else {
           outputLUT_[index][i] = analyticalLUT[i];
         }
@@ -104,6 +108,10 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
           if (outputLUT_[index][i] != tpg) {
             tpg = outputLUT_[index][i];
             hcaluncomp_[index][tpg] = lsb_factor_ * i / (isOnlyQIE11(id) ? lin11_factor_ : lin8_factor_);
+            //Modifying the saturation for the 'split cells'
+            if (abs(ieta) > 20 && isOnlyQIE11(id) && linearQIE11LUT[i] >= (TPGMAX - 2) / 2.) {
+              hcaluncomp_[index][tpg] = (TPGMAX - 1) / 2.;
+            }
           }
         }
       } else {


### PR DESCRIPTION
#### PR description:

This PR updates the output LUT for the HCAL Trigger Primitives (TPs). Specifically, it modifies the LUT for TPs with |ieta|>=21 that have a saturated energy of 64 GeV and changes their energy to 128 GeV so that no TPs underestimate the energy. The studies supporting this change can be seen on slide 10 in the following slides from the L1 trigger workshop: [indico](https://indico.cern.ch/event/1137504/contributions/4811186/attachments/2433047/4166643/L1T_Workshop.pdf).

#### PR validation:

A basic technical test was performed in CMSSW_12_3_X_2022-04-28-1100: runTheMatrix.py -l limited -i all --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

This PR is a backport of PR https://github.com/cms-sw/cmssw/pull/37745 to 123X, so that the s/w matches our f/w for 900 GeV collision data