### PR TITLE
Use RAWEventContent parameter set for Repack output module

### DIFF
--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -7,6 +7,7 @@ Module that generates standard repack configurations
 """
 
 import FWCore.ParameterSet.Config as cms
+from Configuration.EventContent.EventContent_cff import RAWEventContent
 
 
 def repackProcess(**args):
@@ -54,6 +55,7 @@ def repackProcess(**args):
 
         outputModule = cms.OutputModule(
             "PoolOutputModule",
+            RAWEventContent,
             fileName = cms.untracked.string("%s.root" % moduleLabel)
             )
 


### PR DESCRIPTION
#### PR description:

Repack workflows are currently using a default compression configuration with ZLIB instead of LZMA, as was initially identified [here](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/2304/1/1.html). To solve this Repack configuration will start using the already defined [RAWEventContent](https://github.com/germanfgv/cmssw/blob/417d4ed121ff0a963bc4a29ef8423b3efbfe2fe6/Configuration/EventContent/python/EventContent_cff.py#L169-L178) output module configuration.

#### PR validation:
Used [RunRepack.py](https://github.com/cms-sw/cmssw/blob/master/Configuration/DataProcessing/test/RunRepack.py) to generate a test configuration. The resulting PSet had the required output module attributes and the repack job was executed correctly using `cmsRun`

