### PR TITLE
fix leftover filling methods for `TH1I` and `TH2I`

### DIFF
--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -215,6 +215,8 @@ namespace dqm::impl {
       accessRootObject(access, __PRETTY_FUNCTION__, 1)->Fill(static_cast<double>(x), 1);
     else if (kind() == Kind::TH1S)
       accessRootObject(access, __PRETTY_FUNCTION__, 1)->Fill(static_cast<double>(x), 1);
+    else if (kind() == Kind::TH1I)
+      accessRootObject(access, __PRETTY_FUNCTION__, 1)->Fill(static_cast<double>(x), 1);
     else if (kind() == Kind::TH1D)
       accessRootObject(access, __PRETTY_FUNCTION__, 1)->Fill(static_cast<double>(x), 1);
     else
@@ -325,6 +327,8 @@ namespace dqm::impl {
       static_cast<TH2S *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, y, zw);
     else if (kind() == Kind::TH2D)
       static_cast<TH2D *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, y, zw);
+    else if (kind() == Kind::TH2I)
+      static_cast<TH2I *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, y, zw);
     else if (kind() == Kind::TH3F)
       static_cast<TH3F *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, y, zw, 1);
     else if (kind() == Kind::TPROFILE)


### PR DESCRIPTION
#### PR description:

Title says it all, addresses https://github.com/cms-sw/cmssw/pull/37665#issuecomment-1114255449.

#### PR validation:

`cmssw` compiles. Also run unit tests: `scram b runtests` after having checked out the entire `DQMServices` subsystem.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A