### PR TITLE
fix use after scope in `DMRChecker::bookResidualsHistogram`

### DIFF
--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -1963,12 +1963,12 @@ private:
     for (unsigned int i = 1; i <= theNLayers; i++) {
       const char *name_;
       const char *title_;
-      const char *xAxisTitle_;
+      std::string xAxisTitle_;
 
       if (varType.find("Res") != std::string::npos) {
-        xAxisTitle_ = ("res_{" + resType + "'} [#mum]").c_str();
+        xAxisTitle_ = fmt::sprintf("res_{%s'} [#mum]", resType);
       } else {
-        xAxisTitle_ = ("res_{" + resType + "'}/#sigma_{res_{" + resType + "`}}").c_str();
+        xAxisTitle_ = fmt::sprintf("res_{%s'}/#sigma_{res_{%s`}}", resType, resType);
       }
 
       unsigned int side = -1;
@@ -1990,12 +1990,16 @@ private:
                       plane,
                       resType.c_str(),
                       varType.c_str(),
-                      xAxisTitle_);
+                      xAxisTitle_.c_str());
 
       } else {
         name_ = Form("h_%s%s%s_layer%i", detType.c_str(), varType.c_str(), resType.c_str(), i);
-        title_ = Form(
-            "%s (layer %i) track %s-%s;%s;hits", detType.c_str(), i, resType.c_str(), varType.c_str(), xAxisTitle_);
+        title_ = Form("%s (layer %i) track %s-%s;%s;hits",
+                      detType.c_str(),
+                      i,
+                      resType.c_str(),
+                      varType.c_str(),
+                      xAxisTitle_.c_str());
 
         //edm::LogPrint("DMRChecker")<<"bookResidualsHistogram(): "<<i<<" layer:"<<i<<std::endl;
       }


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/37765

#### PR description:

Title says is all, fix for https://github.com/cms-sw/cmssw/issues/37765

#### PR validation:

`cmssw` compiles, run successfully unit tests of package `Alignment/OfflineValidation` with these changes in`CMSSW_12_4_ASAN_X_2022-05-02-1100`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A