### PR TITLE
Follow up to 37617

### DIFF
--- a/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
+++ b/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
@@ -3,7 +3,6 @@ from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorTrackSoA_cfi import *
 from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorVertexSoA_cfi import *
 from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorRecHitsSoA_cfi import *
 
-from Configuration.ProcessModifiers.gpu_cff import gpu
 from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
 pixelNtupletFit.toModify(siPixelPhase1MonitorRecHitsSoA, pixelHitsSrc = "siPixelRecHitsPreSplittingSoA")
 

--- a/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
+++ b/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
@@ -5,7 +5,7 @@ from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorRecHitsSoA_cfi import *
 
 from Configuration.ProcessModifiers.gpu_cff import gpu
 from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
-(gpu | pixelNtupletFit).toModify(siPixelPhase1MonitorRecHitsSoA, pixelHitsSrc = "siPixelRecHitsPreSplittingSoA")
+pixelNtupletFit.toModify(siPixelPhase1MonitorRecHitsSoA, pixelHitsSrc = "siPixelRecHitsPreSplittingSoA")
 
 monitorpixelSoASource = cms.Sequence(siPixelPhase1MonitorRecHitsSoA * siPixelPhase1MonitorTrackSoA * siPixelPhase1MonitorVertexSoA)
 

--- a/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
+++ b/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
@@ -4,11 +4,10 @@ from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorVertexSoA_cfi import *
 from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorRecHitsSoA_cfi import *
 
 from Configuration.ProcessModifiers.gpu_cff import gpu
-gpu.toModify(siPixelPhase1MonitorRecHitsSoA, pixelHitsSrc = "siPixelRecHitsPreSplittingSoA")
-
+from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
+(gpu | pixelNtupletFit).toModify(siPixelPhase1MonitorRecHitsSoA, pixelHitsSrc = "siPixelRecHitsPreSplittingSoA")
 
 monitorpixelSoASource = cms.Sequence(siPixelPhase1MonitorRecHitsSoA * siPixelPhase1MonitorTrackSoA * siPixelPhase1MonitorVertexSoA)
-
 
 #Define the sequence for GPU vs CPU validation
 #This should run:- individual monitor for the 2 collections + comparison module
@@ -35,8 +34,19 @@ siPixelPhase1MonitorVertexSoAGPU = siPixelPhase1MonitorVertexSoA.clone(
   topFolderName = 'SiPixelHeterogeneous/PixelVertexSoAGPU',
 )
 
+siPixelPhase1MonitorRecHitsSoACPU = siPixelPhase1MonitorRecHitsSoA.clone(
+ pixelHitsSrc = "siPixelRecHitsPreSplittingSoA@cpu",
+ TopFolderName = "SiPixelHeterogeneous/PixelRecHitsSoACPU"
+)
 
-monitorpixelSoACompareSource = cms.Sequence(siPixelPhase1MonitorTrackSoAGPU *
+siPixelPhase1MonitorRecHitsSoAGPU = siPixelPhase1MonitorRecHitsSoA.clone(
+ pixelHitsSrc = "siPixelRecHitsPreSplittingSoA@cuda",
+ TopFolderName = "SiPixelHeterogeneous/PixelRecHitsSoAGPU"
+)
+
+monitorpixelSoACompareSource = cms.Sequence(siPixelPhase1MonitorRecHitsSoACPU *
+                                            siPixelPhase1MonitorRecHitsSoAGPU *
+                                            siPixelPhase1MonitorTrackSoAGPU *
                                             siPixelPhase1MonitorTrackSoACPU *
                                             siPixelPhase1CompareTrackSoA *
                                             siPixelPhase1MonitorVertexSoACPU *

--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
@@ -31,11 +31,17 @@ siPixelRecHitsPreSplittingCPU = _siPixelRecHitsPreSplittingSoA.clone(convertToLe
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(siPixelRecHitsPreSplittingCPU,
     isPhase2 = True)
+
 # modifier used to prompt patatrack pixel tracks reconstruction on cpu
 from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
 pixelNtupletFit.toModify(siPixelRecHitsPreSplitting,
-    cpu = _siPixelRecHitsPreSplittingSoA.clone(convertToLegacy=True)
-)
+    cpu = cms.EDAlias(
+            siPixelRecHitsPreSplittingCPU = cms.VPSet(
+                 cms.PSet(type = cms.string("SiPixelRecHitedmNewDetSetVector")),
+                 cms.PSet(type = cms.string("uintAsHostProduct"))
+             )
+))
+
 
 siPixelRecHitsPreSplittingTask = cms.Task(
     # SwitchProducer wrapping the legacy pixel rechit producer or the cpu SoA producer
@@ -58,17 +64,22 @@ siPixelRecHitsPreSplittingSoA = SwitchProducerCUDA(
                  cms.PSet(type = cms.string("cmscudacompatCPUTraitsTrackingRecHit2DHeterogeneous")),
                  cms.PSet(type = cms.string("uintAsHostProduct"))
              )),
-    cuda = _siPixelRecHitSoAFromCUDA.clone()
 )
 
-(gpu & pixelNtupletFit).toModify(siPixelRecHitsPreSplitting,
-    cpu = cms.EDAlias(
-            siPixelRecHitsPreSplittingCPU = cms.VPSet(
-                 cms.PSet(type = cms.string("SiPixelRecHitedmNewDetSetVector")),
-                 cms.PSet(type = cms.string("uintAsHostProduct"))
-             )
-         ),
-    cuda = _siPixelRecHitFromCUDA.clone())
+gpu.toModify(siPixelRecHitsPreSplittingSoA,cuda = _siPixelRecHitSoAFromCUDA.clone())
+
+(gpu & pixelNtupletFit).toModify(siPixelRecHitsPreSplitting, cuda = _siPixelRecHitFromCUDA.clone())
+
+pixelNtupletFit.toReplaceWith(siPixelRecHitsPreSplittingTask, cms.Task(
+    cms.Task(
+        # reconstruct the pixel rechits on the cpu
+        siPixelRecHitsPreSplittingCPU,
+        # SwitchProducer wrapping an EDAlias on cpu or the converter from SoA to legacy on gpu
+        siPixelRecHitsPreSplittingTask.copy(),
+        # producing and converting on cpu (if needed)
+        siPixelRecHitsPreSplittingSoA)
+        )
+        )
 
 (gpu & pixelNtupletFit).toReplaceWith(siPixelRecHitsPreSplittingTask, cms.Task(
     # reconstruct the pixel rechits on the gpu or on the cpu

--- a/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/SiPixelRecHits_cfi.py
@@ -66,7 +66,7 @@ siPixelRecHitsPreSplittingSoA = SwitchProducerCUDA(
              )),
 )
 
-gpu.toModify(siPixelRecHitsPreSplittingSoA,cuda = _siPixelRecHitSoAFromCUDA.clone())
+(gpu & pixelNtupletFit).toModify(siPixelRecHitsPreSplittingSoA,cuda = _siPixelRecHitSoAFromCUDA.clone())
 
 (gpu & pixelNtupletFit).toModify(siPixelRecHitsPreSplitting, cuda = _siPixelRecHitFromCUDA.clone())
 

--- a/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
+++ b/RecoPixelVertexing/PixelTrackFitting/python/PixelTracks_cff.py
@@ -97,7 +97,7 @@ from RecoPixelVertexing.PixelTriplets.pixelTracksCUDA_cfi import pixelTracksCUDA
 pixelTracksSoA = SwitchProducerCUDA(
     # build pixel ntuplets and pixel tracks in SoA format on the CPU
     cpu = _pixelTracksCUDA.clone(
-        pixelRecHitSrc = "siPixelRecHitsPreSplitting",
+        pixelRecHitSrc = "siPixelRecHitsPreSplittingSoA",
         idealConditions = False,
         onGPU = False
     )
@@ -123,9 +123,6 @@ from RecoPixelVertexing.PixelTrackFitting.pixelTrackProducerFromSoA_cfi import p
 
 # "Patatrack" sequence running on GPU (or CPU if not available)
 from Configuration.ProcessModifiers.gpu_cff import gpu
-
-(pixelNtupletFit & gpu).toModify(pixelTracksSoA.cpu,
-    pixelRecHitSrc = "siPixelRecHitsPreSplittingSoA")
 
 # build the pixel ntuplets and pixel tracks in SoA format on the GPU
 pixelTracksCUDA = _pixelTracksCUDA.clone(


### PR DESCRIPTION
#### PR description:

Follow up to #37617 : 

- fix issue highlighted in https://github.com/cms-sw/cmssw/pull/37617#issuecomment-1117041610;
- fix misalignment for `.501` and `.502` running on CPU (see https://github.com/cms-sw/cmssw/pull/37617#issuecomment-1116414917). The wfs are now identical (same naming, same results, see [501](https://adiflori.web.cern.ch/adiflori/PR37617/501_new.png) and [502](https://adiflori.web.cern.ch/adiflori/PR37617/502_cpu_new.png) on CPU). This is accomplished  (when `pixelNtupletFit ` modifier is on) by:  

   - when only `pixelNtupletFit ` modifier is on:
         - adding `siPixelRecHitsPreSplittingCPU`, which is the actual producer on CPU, to the task;
         - replacing the `siPixelRecHitsPreSplitting@cpu` with and `EDAlias` for legacy formats;
         - adding `siPixelRecHitsPreSplittingSoA` as a `SwitchProducerCUDA` with only `@cpu` branch as an `EDAlias` for SoA formats; 
         
   - when also the `gpu` modifier is on:
         - adding `siPixelRecHitsPreSplittingCUDA`, which is the actual producer on GPU, to the task;
         - adding to the `siPixelRecHitsPreSplitting@cuda` branch the `CUDA` to legacy converter;
         - adding to the `siPixelRecHitsPreSplitting@cuda` branch the `CUDA` to SoA converter;
         
- add GPU and CPU local reco validation in `monitorpixelSoACompareSource` (the CPUvsGPU will come in a later PR).

#### PR validation:

Running `39434.501` and `11634.x` , with x=`501`, `502` and `503`.
