### PR TITLE
[CMSSW_12_3_X] Make `AlCaPhiSymEcal_Nano` inherit from `pp` instead of `AlCa`

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
@@ -6,16 +6,16 @@ Scenario supporting proton collision data taking for AlCaPhiSymEcal stream with 
 
 """
 
-from Configuration.DataProcessing.Impl.AlCa import AlCa
+from Configuration.DataProcessing.Impl.pp import pp
 from Configuration.Eras.Era_Run3_cff import Run3
 
-class AlCaPhiSymEcal_Nano(AlCa):
+class AlCaPhiSymEcal_Nano(pp):
     def __init__(self):
-        AlCa.__init__(self)
+        pp.__init__(self)
         self.skims=['EcalPhiSymByRun']
         self.eras=Run3
+        self.recoSeq = ':bunchSpacingProducer+ecalMultiFitUncalibRecHitTask+ecalCalibratedRecHitTask'
         self.promptCustoms = [ 'Calibration/EcalCalibAlgos/EcalPhiSymRecoSequence_cff.customise' ]
-        self.step = 'RECO:bunchSpacingProducer+ecalMultiFitUncalibRecHitTask+ecalCalibratedRecHitTask'
     """
     _AlCaPhiSymEcal_Nano_
 


### PR DESCRIPTION
#### PR description:

See https://github.com/cms-sw/cmssw/pull/37784


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/37784