### PR TITLE
Bugfixes for DQM/BeamMonitor

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.h
@@ -127,6 +127,8 @@ private:
 
   edm::EDGetTokenT<TCDSRecord> tcdsToken_;
   bool logToDb_;
+  bool loggerActive_;
+
   // ----------member data ---------------------------
 
   //   std::vector<BSTrkParameters> fBSvector;


### PR DESCRIPTION
#### PR description:
This PR fixes two bugs introduced in #37614:
 - Remove the `logToDb_` flag from `onlineDbService_->lockRecords()` and `onlineDbService_->releaseLocks()` as this flag is only meant to affect the logging, not the locking of records
 - Add a flag (`loggerActive_`) to avoid calling `onlineDbService_->logger().end()` in case `onlineDbService_->logger().start()` was never called

#### PR validation:
Code compiles

#### Backport:
Not a backport, but a backport for 12_3_X will be provided soon.

FYI @gennai @dzuolo @ggovi 