### PR TITLE
[12_3_X] Bugfixes for DQM/BeamMonitor

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.h
@@ -127,6 +127,8 @@ private:
 
   edm::EDGetTokenT<TCDSRecord> tcdsToken_;
   bool logToDb_;
+  bool loggerActive_;
+
   // ----------member data ---------------------------
 
   //   std::vector<BSTrkParameters> fBSvector;


### PR DESCRIPTION
#### PR description:
Backport of #37801 to 12_3_X.
This PR fixes two bugs introduced in #37614:
 - Remove the `logToDb_` flag from `onlineDbService_->lockRecords()` and `onlineDbService_->releaseLocks()` as this flag is only meant to affect the logging, not the locking of records
 - Add a flag (`loggerActive_`) to avoid calling `onlineDbService_->logger().end()` in case `onlineDbService_->logger().start()` was never called

#### PR validation:
- Code compiles
- Should be tested online at P5 by the DQM team (@ahmad3213 @pmandrik)

#### Backport:
Backport of #37801 

FYI @gennai @dzuolo @ggovi 