### PR TITLE
Add overrideGUID option to PoolOutputModule

### DIFF
--- a/FWCore/Utilities/interface/GlobalIdentifier.h
+++ b/FWCore/Utilities/interface/GlobalIdentifier.h
@@ -4,6 +4,8 @@
 #include <string>
 namespace edm {
   std::string createGlobalIdentifier(bool binary = false);
-}
+
+  bool isValidGlobalIdentifier(std::string const& guid);
+}  // namespace edm
 
 #endif

--- a/FWCore/Utilities/interface/Guid.h
+++ b/FWCore/Utilities/interface/Guid.h
@@ -62,6 +62,8 @@ namespace edm {
     /// conversion from formatted string representation
     Guid const& fromString(std::string const& s);
 
+    static bool isValidString(std::string const& s);
+
   private:
     /// initialize a new Guid
     void init(bool usetime = false);

--- a/FWCore/Utilities/src/GlobalIdentifier.cc
+++ b/FWCore/Utilities/src/GlobalIdentifier.cc
@@ -6,4 +6,6 @@ namespace edm {
     Guid guid;
     return binary ? guid.toBinary() : guid.toString();
   }
+
+  bool isValidGlobalIdentifier(std::string const& guid) { return Guid::isValidString(guid); }
 }  // namespace edm

--- a/FWCore/Utilities/src/Guid.cc
+++ b/FWCore/Utilities/src/Guid.cc
@@ -48,5 +48,11 @@ namespace edm {
     return *this;
   }
 
+  bool Guid::isValidString(std::string const& source) {
+    uuid_t tmp;
+    auto err = ::uuid_parse(source.c_str(), tmp);
+    return err == 0;
+  }
+
   bool Guid::operator<(Guid const& g) const { return ::uuid_compare(data_, g.data_) < 0; }
 }  // namespace edm

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -216,6 +216,7 @@ namespace edm {
     bool mergeJob_;
     edm::propagate_const<std::unique_ptr<RootOutputFile>> rootOutputFile_;
     std::string statusFileName_;
+    std::string overrideGUID_;
     std::vector<std::string> processesWithSelectedMergeableRunProducts_;
   };
 }  // namespace edm

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -64,7 +64,8 @@ namespace edm {
         compactEventAuxiliary_(pset.getUntrackedParameter<bool>("compactEventAuxiliary")),
         mergeJob_(pset.getUntrackedParameter<bool>("mergeJob")),
         rootOutputFile_(),
-        statusFileName_() {
+        statusFileName_(),
+        overrideGUID_(pset.getUntrackedParameter<std::string>("overrideGUID")) {
     if (pset.getUntrackedParameter<bool>("writeStatusFile")) {
       std::ostringstream statusfilename;
       statusfilename << moduleLabel_ << '_' << getpid();
@@ -386,11 +387,11 @@ namespace edm {
 
   void PoolOutputModule::reallyOpenFile() {
     auto names = physicalAndLogicalNameForNewFile();
-    rootOutputFile_ = std::make_unique<RootOutputFile>(
-        this,
-        names.first,
-        names.second,
-        processesWithSelectedMergeableRunProducts_);  // propagate_const<T> has no reset() function
+    rootOutputFile_ = std::make_unique<RootOutputFile>(this,
+                                                       names.first,
+                                                       names.second,
+                                                       processesWithSelectedMergeableRunProducts_,
+                                                       overrideGUID_);  // propagate_const<T> has no reset() function
   }
 
   void PoolOutputModule::updateBranchParentsForOneBranch(ProductProvenanceRetriever const* provRetriever,
@@ -508,6 +509,10 @@ namespace edm {
             "'PRIOR':   Keep it for products produced in current process. Drop it for products produced in prior "
             "processes.\n"
             "'ALL':     Drop all of it.");
+    desc.addUntracked<std::string>("overrideGUID", defaultString)
+        ->setComment(
+            "Allows to override the GUID of the file. Intended to be used only in Tier0 for re-creating files. The "
+            "GUID needs to be of the proper format.");
     {
       ParameterSetDescription dataSet;
       dataSet.setAllowAnything();

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -392,6 +392,9 @@ namespace edm {
                                                        names.second,
                                                        processesWithSelectedMergeableRunProducts_,
                                                        overrideGUID_);  // propagate_const<T> has no reset() function
+    // Override the GUID of the first file only, in order to avoid two
+    // output files from one Output Module to have identical GUID.
+    overrideGUID_.clear();
   }
 
   void PoolOutputModule::updateBranchParentsForOneBranch(ProductProvenanceRetriever const* provRetriever,
@@ -511,8 +514,9 @@ namespace edm {
             "'ALL':     Drop all of it.");
     desc.addUntracked<std::string>("overrideGUID", defaultString)
         ->setComment(
-            "Allows to override the GUID of the file. Intended to be used only in Tier0 for re-creating files. The "
-            "GUID needs to be of the proper format.");
+            "Allows to override the GUID of the file. Intended to be used only in Tier0 for re-creating files.\n"
+            "The GUID needs to be of the proper format. If a new output file is started (see maxSize), the GUID of\n"
+            "the first file only is overridden, i.e. the subsequent output files have different, generated GUID.");
     {
       ParameterSetDescription dataSet;
       dataSet.setAllowAnything();

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -81,7 +81,8 @@ namespace edm {
   RootOutputFile::RootOutputFile(PoolOutputModule* om,
                                  std::string const& fileName,
                                  std::string const& logicalFileName,
-                                 std::vector<std::string> const& processesWithSelectedMergeableRunProducts)
+                                 std::vector<std::string> const& processesWithSelectedMergeableRunProducts,
+                                 std::string const& overrideGUID)
       : file_(fileName),
         logicalFile_(logicalFileName),
         reportToken_(0),
@@ -196,7 +197,15 @@ namespace edm {
     parentageTree_ = RootOutputTree::makeTTree(filePtr_.get(), poolNames::parentageTreeName(), 0);
     parameterSetsTree_ = RootOutputTree::makeTTree(filePtr_.get(), poolNames::parameterSetsTreeName(), 0);
 
-    fid_ = FileID(createGlobalIdentifier());
+    if (overrideGUID.empty()) {
+      fid_ = FileID(createGlobalIdentifier());
+    } else {
+      if (not isValidGlobalIdentifier(overrideGUID)) {
+        throw edm::Exception(errors::Configuration)
+            << "GUID to be used for output file is not valid (is '" << overrideGUID << "')";
+      }
+      fid_ = FileID(overrideGUID);
+    }
 
     // For the Job Report, get a vector of branch names in the "Events" tree.
     // Also create a hash of all the branch names in the "Events" tree

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -52,7 +52,8 @@ namespace edm {
     explicit RootOutputFile(PoolOutputModule* om,
                             std::string const& fileName,
                             std::string const& logicalFileName,
-                            std::vector<std::string> const& processesWithSelectedMergeableRunProducts);
+                            std::vector<std::string> const& processesWithSelectedMergeableRunProducts,
+                            std::string const& overrideGUID);
     ~RootOutputFile() {}
     void writeOne(EventForOutput const& e);
     //void endFile();

--- a/IOPool/Output/test/PoolOutputTestOverrideGUID_cfg.py
+++ b/IOPool/Output/test/PoolOutputTestOverrideGUID_cfg.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+import argparse
+import sys
+parser = argparse.ArgumentParser(prog=sys.argv[0], description="Test PoolOutputModule")
+parser.add_argument("--guid", type=str, help="GUID that overrides")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+process = cms.Process("TESTOUTPUT")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents.input = 20
+
+process.Thing = cms.EDProducer("ThingProducer")
+
+process.OtherThing = cms.EDProducer("OtherThingProducer")
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('file:PoolOutputTestOverrideGUID.root'),
+    overrideGUID = cms.untracked.string(args.guid),
+)
+
+process.source = cms.Source("EmptySource")
+
+process.p = cms.Path(process.Thing*process.OtherThing)
+process.ep = cms.EndPath(process.output)
+
+

--- a/IOPool/Output/test/PoolOutputTestOverrideGUID_cfg.py
+++ b/IOPool/Output/test/PoolOutputTestOverrideGUID_cfg.py
@@ -4,13 +4,15 @@ import argparse
 import sys
 parser = argparse.ArgumentParser(prog=sys.argv[0], description="Test PoolOutputModule")
 parser.add_argument("--guid", type=str, help="GUID that overrides")
+parser.add_argument("--maxSize", type=int, default=None, help="Set maximum file size")
+parser.add_argument("--input", type=str, default=[], nargs="*", help="Optional list of input files")
 
 argv = sys.argv[:]
 if '--' in argv:
     argv.remove("--")
 args, unknown = parser.parse_known_args(argv)
 
-process = cms.Process("TESTOUTPUT")
+process = cms.Process("TESTOUTPUTGUID")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
 process.maxEvents.input = 20
@@ -19,12 +21,19 @@ process.Thing = cms.EDProducer("ThingProducer")
 
 process.OtherThing = cms.EDProducer("OtherThingProducer")
 
+process.source = cms.Source("EmptySource")
+if len(args.input) > 0:
+    process.maxEvents.input = -1
+    process.source = cms.Source("PoolSource",
+        fileNames = cms.untracked.vstring("file:"+x for x in args.input)
+    )
+
 process.output = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('file:PoolOutputTestOverrideGUID.root'),
     overrideGUID = cms.untracked.string(args.guid),
 )
-
-process.source = cms.Source("EmptySource")
+if args.maxSize is not None:
+    process.output.maxSize = cms.untracked.int32(args.maxSize)
 
 process.p = cms.Path(process.Thing*process.OtherThing)
 process.ep = cms.EndPath(process.output)

--- a/IOPool/Output/test/PoolOutputTest_cfg.py
+++ b/IOPool/Output/test/PoolOutputTest_cfg.py
@@ -1,11 +1,21 @@
 import FWCore.ParameterSet.Config as cms
 
+import argparse
+import sys
+parser = argparse.ArgumentParser(prog=sys.argv[0], description="Test PoolOutputModule")
+parser.add_argument("--firstLumi", type=int, default=None, help="Set first lumi to process ")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+
 process = cms.Process("TESTOUTPUT")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(20)
-)
+process.maxEvents.input = 20
+
 process.Thing = cms.EDProducer("ThingProducer")
 
 process.OtherThing = cms.EDProducer("OtherThingProducer")
@@ -15,6 +25,9 @@ process.output = cms.OutputModule("PoolOutputModule",
 )
 
 process.source = cms.Source("EmptySource")
+if args.firstLumi is not None:
+    process.source.firstLuminosityBlock = cms.untracked.uint32(args.firstLumi)
+    process.output.fileName = "file:PoolOutputTestLumi{}.root".format(args.firstLumi)
 
 process.p = cms.Path(process.Thing*process.OtherThing)
 process.ep = cms.EndPath(process.output)

--- a/IOPool/Output/test/TestPoolOutput.sh
+++ b/IOPool/Output/test/TestPoolOutput.sh
@@ -60,4 +60,19 @@ cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef012-3
 cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd-ef012345678g && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 5 did not fail' 1
 cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd_ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 6 did not fail' 1
 
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py -- --firstLumi 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py -- --firstLumi 2
+
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd-ef0123456789 --input PoolOutputTestLumi1.root PoolOutputTestLumi2.root --maxSize 1 || die 'Failure using PoolOutputTestOverrideGUID_cfg.py with valid GUID and two input files' $?
+GUID1=$(edmFileUtil -u PoolOutputTestOverrideGUID.root | fgrep uuid | awk '{print $10}')
+GUID2=$(edmFileUtil -u PoolOutputTestOverrideGUID001.root | fgrep uuid | awk '{print $10}')
+if [ "x${GUID1}" != "xabcdef01-2345-6789-abcd-ef0123456789" ]; then
+    echo "GUID in first file '${GUID1}' did not match 'abcdef01-2345-6789-abcd-ef0123456789'"
+    exit 1
+fi
+if [ "x${GUID1}" == "x${GUID2}" ]; then
+    echo "GUID from two output files are the same: ${GUID1}"
+    exit 1
+fi
+
 popd

--- a/IOPool/Output/test/TestPoolOutput.sh
+++ b/IOPool/Output/test/TestPoolOutput.sh
@@ -4,7 +4,14 @@ function die { echo $1: status $2 ;  exit $2; }
 
 pushd ${LOCAL_TMP_DIR}
 
-cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py || die 'Failure using PoolOutputTest_cfg.py' $?
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py || die 'Failure using PoolOutputTest_cfg.py 1' $?
+GUID1=$(edmFileUtil -u PoolOutputTest.root | fgrep uuid | awk '{print $10}')
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolOutputTest_cfg.py || die 'Failure using PoolOutputTest_cfg.py 2' $?
+GUID2=$(edmFileUtil -u PoolOutputTest.root | fgrep uuid | awk '{print $10}')
+if [ "x${GUID1}" == "x${GUID2}" ]; then
+    echo "GUID from two executions are the same: ${GUID1}"
+    exit 1
+fi
 
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolDropTest_cfg.py || die 'Failure using PoolDropTest_cfg.py' $?
 
@@ -32,5 +39,25 @@ cmsRun ${LOCAL_TEST_DIR}/TestProvC_cfg.py || die 'Failure using TestProvC_cfg.py
 
 cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestUnscheduled_cfg.py || die 'Failure using PoolOutputTestUnscheduled_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestUnscheduledRead_cfg.py || die 'Failure using PoolOutputTestUnscheduledRead_cfg.py' $?
+
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd-ef0123456789 || die 'Failure using PoolOutputTestOverrideGUID_cfg.py with valid GUID' $?
+GUID=$(edmFileUtil -u PoolOutputTestOverrideGUID.root | fgrep uuid | awk '{print $10}')
+if [ "x${GUID}" != "xabcdef01-2345-6789-abcd-ef0123456789" ]; then
+    echo "GUID in file '${GUID}' did not match 'abcdef01-2345-6789-abcd-ef0123456789'"
+    exit 1
+fi
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid ABCDEF01-2345-6789-abcd-ef0123456789 || die 'Failure using PoolOutputTestOverrideGUID_cfg.py with valid GUID (with some capital letteters)' $?
+GUID=$(edmFileUtil -u PoolOutputTestOverrideGUID.root | fgrep uuid | awk '{print $10}')
+if [ "x${GUID}" != "xABCDEF01-2345-6789-abcd-ef0123456789" ]; then
+    echo "GUID in file '${GUID}' did not match 'ABCDEF01-2345-6789-abcd-ef0123456789'"
+    exit 1
+fi
+
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd-ef01234567890 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 1 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-0abcd-ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 2 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid 0abcdef01-2345-6789-abcd-ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 3 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef012-345-6789-abcd-ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 4 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd-ef012345678g && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 5 did not fail' 1
+cmsRun ${LOCAL_TEST_DIR}/PoolOutputTestOverrideGUID_cfg.py -- --guid abcdef01-2345-6789-abcd_ef0123456789 && die 'PoolOutputTestOverrideGUID_cfg.py with invalid GUID 6 did not fail' 1
 
 popd


### PR DESCRIPTION
#### PR description:

This PR adds `overrideGUID` parameter to `PoolOutputModule`. The intended use case is to ensure consistency of the GUID in the file name and in the file for the manual recovery at Tier0, requested in https://github.com/cms-sw/cmssw/issues/37742#issuecomment-1116227468.

#### PR validation:

Unit tests run.