### PR TITLE
Avoid hiding base class writeCfi_() functions in ParameterDescription<T>

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterDescription.h
+++ b/FWCore/ParameterSet/interface/ParameterDescription.h
@@ -172,6 +172,7 @@ namespace edm {
       return writeParameterValue::hasNestedContent(value_);
     }
 
+    using ParameterDescriptionNode::writeCfi_;
     void writeCfi_(std::ostream& os, int indentation) const override {
       writeParameterValue::writeValue(os, indentation, value_, writeParameterValue::CFI);
     }
@@ -226,6 +227,7 @@ namespace edm {
 
     bool exists_(ParameterSet const& pset) const override;
 
+    using ParameterDescriptionNode::writeCfi_;
     void writeCfi_(std::ostream& os, int indentation) const override;
 
     void writeDoc_(std::ostream& os, int indentation) const override;
@@ -282,6 +284,7 @@ namespace edm {
 
     bool exists_(ParameterSet const& pset) const override;
 
+    using ParameterDescriptionNode::writeCfi_;
     void writeCfi_(std::ostream& os, int indentation) const override;
 
     void writeDoc_(std::ostream& os, int indentation) const override;


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/cmssw/issues/37776

#### PR validation:

Compiled locally with https://github.com/cms-sw/cmssw/pull/37716 and confirmed the `nvcc` warnings without this PR are gone.