### PR TITLE
Skim for Delayed Jets, MET cut instead of HT

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXODelayedJetMET_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODelayedJetMET_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+DelayedJetMETTrigger = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+DelayedJetMETTrigger.TriggerResultsTag = cms.InputTag( "TriggerResults", "", "HLT" )
+DelayedJetMETTrigger.HLTPaths = cms.vstring(
+    "HLT_PFMET120_PFMHT120_IDTight_v*"
+)
+DelayedJetMETTrigger.throw = False
+DelayedJetMETTrigger.andOr = True
+
+
+caloJetTimingProducerSingle = cms.EDProducer( "HLTCaloJetTimingProducer",
+    jets = cms.InputTag( "ak4CaloJets" ),
+    barrelJets = cms.bool( True ),
+    endcapJets = cms.bool( False ),
+    ecalCellEnergyThresh = cms.double( 0.5 ),
+    ecalCellTimeThresh = cms.double( 12.5 ),
+    ecalCellTimeErrorThresh = cms.double( 100.0 ),
+    matchingRadius = cms.double( 0.4 ),
+    ebRecHitsColl = cms.InputTag( 'ecalRecHit','EcalRecHitsEB' ),
+    eeRecHitsColl = cms.InputTag( 'ecalRecHit','EcalRecHitsEE' )
+)
+
+
+delayedJetSelection = cms.EDFilter( "HLTCaloJetTimingFilter",
+    saveTags = cms.bool( True ),
+    jets = cms.InputTag( "ak4CaloJets" ),
+    jetTimes = cms.InputTag( "caloJetTimingProducerSingle" ),
+    jetCellsForTiming = cms.InputTag( 'caloJetTimingProducerSingle','jetCellsForTiming' ),
+    jetEcalEtForTiming = cms.InputTag( 'caloJetTimingProducerSingle','jetEcalEtForTiming' ),
+    minJets = cms.uint32( 1 ),
+    jetTimeThresh = cms.double( 1.0 ),
+    jetCellsForTimingThresh = cms.uint32( 5 ),
+    jetEcalEtForTimingThresh = cms.double( 10.0 ),
+    minJetPt = cms.double( 40.0 )
+)
+
+EXODelayedJetMETSkimSequence = cms.Sequence(
+    DelayedJetMETTrigger * caloJetTimingProducerSingle * delayedJetSelection
+)

--- a/Configuration/Skimming/python/Skims_PDWG_cff.py
+++ b/Configuration/Skimming/python/Skims_PDWG_cff.py
@@ -271,6 +271,17 @@ SKIMStreamEXODelayedJet = cms.FilteredStream(
     dataTier = cms.untracked.string('AOD')
     )
 
+from Configuration.Skimming.PDWG_EXODelayedJetMET_cff import *
+EXODelayedJetMETPath = cms.Path(EXODelayedJetMETSkimSequence)
+SKIMStreamEXODelayedJetMET = cms.FilteredStream(
+    responsible = 'PDWG',
+    name = 'EXODelayedJetMET',
+    paths = (EXODelayedJetMETPath),
+    content = skimRawAODContent.outputCommands,
+    selectEvents = cms.untracked.PSet(),
+    dataTier = cms.untracked.string('AOD')
+    )
+
 from Configuration.Skimming.PDWG_EXODTCluster_cff import *
 EXODTClusterPath = cms.Path(EXODTClusterSkimSequence)
 SKIMStreamEXODTCluster = cms.FilteredStream(

--- a/Configuration/Skimming/test/test_DelayedJetMET_cfg.py
+++ b/Configuration/Skimming/test/test_DelayedJetMET_cfg.py
@@ -1,0 +1,128 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: skims -s SKIM:EXODelayedJetMET --dasquery=file dataset=/RelValQCD_Pt_1800_2400_14/CMSSW_12_3_0_pre6-123X_mcRun3_2021_realistic_v11-v2/GEN-SIM-RECO -n 10000 --conditions 120X_mcRun3_2021_realistic_v6 --python_filename=EXODelayedJetMET_SKIM.py --processName=SKIMEXODelayedJetMET --no_exec
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('SKIMEXODelayedJetMET',Run3)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Skims_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/649f3446-1698-4910-b879-9a6d94d62a9b.root',
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/aa515779-dad9-4994-b7d2-d672a7c8938a.root',
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/b7315dce-732e-4ec7-b137-ee3bafff1cd6.root',
+        '/store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/10000/df8bd2c1-1e45-479d-9287-2d40fecc25d8.root'
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('skims nevts:10000'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+ 
+process.AODSIMoutput = cms.OutputModule("PoolOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(4),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('AODSIM'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(31457280),
+    fileName = cms.untracked.string('file:skims_AOD.root'),
+    outputCommands = process.AODSIMEventContent.outputCommands
+)
+
+# Additional output definition
+process.SKIMStreamEXODelayedJetMET = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('EXODelayedJetMETPath')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('USER'),
+        filterName = cms.untracked.string('EXODelayedJetMET')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('EXODelayedJetMET.root'),
+    outputCommands = process.AODSIMEventContent.outputCommands
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '120X_mcRun3_2021_realistic_v6', '')
+
+# Path and EndPath definitions
+process.AODSIMoutput_step = cms.EndPath(process.AODSIMoutput)
+process.SKIMStreamEXODelayedJetMETOutPath = cms.EndPath(process.SKIMStreamEXODelayedJetMET)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.EXODelayedJetMETPath,process.AODSIMoutput_step,process.SKIMStreamEXODelayedJetMETOutPath)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+
+
+# Customisation from command line
+
+#Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule
+from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
+process = customiseLogErrorHarvesterUsingOutputCommands(process)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
#### PR description:

This PR adds one RECO level skim that saves all standard AOD collections. This PR is similar to [PR#37509](https://github.com/cms-sw/cmssw/pull/37509), which added a skim over delayed jets using a set of HLT paths, except this skim uses a cut on MET rather than on HT. It does this using the producer/filter for delayed jets in CMSSW and skimming over the HLT path "HLT_PFMET120_PFMHT120_IDTight_v*".

Tested with high-Pt QCD samples /store/relval/CMSSW_12_3_0_pre6/RelValQCD_Pt_1800_2400_14/GEN-SIM-RECO/123X_mcRun3_2021_realistic_v11-v2/, the skimmed AOD file size was 25MB (68 events) and the unskimmed AOD file size was 1.9GB (9000 events).

#### PR validation:

Ran with CMSSW_12_4_0_pre1 and used the config file "test_DelayedJetMET_cfg.py" which is included in this PR.
