### PR TITLE
Update cppCommentSkipper: don't log the exact error

### DIFF
--- a/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
+++ b/Utilities/ReleaseScripts/python/commentSkipper/cppCommentSkipper.py
@@ -15,7 +15,7 @@ def filterFile(file): #ifstream& input)
     try:
         lines = open(file).readlines()
     except UnicodeDecodeError as e:
-        print("CppCommentSkipper: WARNING: Invalid UTF-8 sequence in {0}: {1}".format(file, e.message))
+        print("CppCommentSkipper: WARNING: Invalid UTF-8 sequence in {0}".format(file))
         lines = open(file, errors='replace').readlines()
     commentStage = False
 


### PR DESCRIPTION
#### PR description:

The attribute containing exception message is different Python in 2.7 vs. 3.x, also the message itself is not very useful.
Technical fix following #37727