### PR TITLE
Port DeepJet and ParticleNetAK4 taggers to Puppi jets in MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -444,12 +444,6 @@ def miniAOD_customizeCommon(process):
         from PhysicsTools.PatAlgos.slimming.applyDeepBtagging_cff import applyDeepBtagging
         applyDeepBtagging( process )
 
-        addToProcessAndTask('slimmedJetsPuppi', process.slimmedJetsNoDeepFlavour.clone(
-            src = "selectedPatJetsPuppi", packedPFCandidates = "packedPFCandidates"),
-                            process, task)
-    
-        task.add(process.slimmedJetsPuppi)
-
         process.slimmedJetsNoDeepFlavour.dropTagInfos = '0'
         process.updatedPatJetsTransientCorrectedSlimmedDeepFlavour.addTagInfos = True
         process.updatedPatJetsTransientCorrectedSlimmedDeepFlavour.tagInfoSources = ["pixelClusterTagInfos"]


### PR DESCRIPTION
#### PR description:

Currently DeepJet and ParticleNetAK4 taggers are only evaluated and stored for AK4 CHS jets in MiniAOD. With the move to Puppi jets as the default AK4 jet collection in Run 3, this PR ports the DeepJet and ParticleNetAK4 taggers to the `slimmedJetsPuppi` collection. The existing trainings derived for Run 2 CHS jets are directly applied to AK4 Puppi jets, and they show similar performance on Puppi jets and CHS jets [[1](https://indico.cern.ch/event/1155634/contributions/4859816/attachments/2436515/4175943/%5BUpdated%5D%20ParticleNet_Run3_20220503.pdf)].

Specifically:
 - DeepJet evaluation and storage is added to Puppi jets, but meanwhile it still kept for CHS jets for now per BTV request
 - ParticleNetAK4 evaluation and storage is removed for CHS jets and only applied to Puppi jets

#### PR validation:

Tested w/ `runTheMatrix.py -l 136.88811`.