### PR TITLE
Fix pickling TreeInfo (directory and file sizes)

### DIFF
--- a/Utilities/ReleaseScripts/scripts/storeTreeInfo.py
+++ b/Utilities/ReleaseScripts/scripts/storeTreeInfo.py
@@ -45,7 +45,7 @@ class TreeAnalyzer(object):
         try:
             import pickle
             pklFileName = self.outFileName.replace('.json','.pkl')
-            pickle.dump([os.path.abspath(dirIn), self.dirSizes, self.fileSizes], open(pklFileName, 'w') )
+            pickle.dump([os.path.abspath(dirIn), self.dirSizes, self.fileSizes], open(pklFileName, 'wb') )
             print('treeInfo info  written to ', pklFileName)
         except Exception as e:
             print("error writing pkl file:", str(e))


### PR DESCRIPTION
#### PR description:

pickle file must be opened in binary mode. This removes the following error message observed in `ib-run-qa` job:
```
error writing pkl file: write() argument must be str, not bytes
```
