### PR TITLE
Use CMS_THREAD_SAFE annotation in externalGenerator

### DIFF
--- a/GeneratorInterface/Core/bin/externalGenerator.cc
+++ b/GeneratorInterface/Core/bin/externalGenerator.cc
@@ -84,7 +84,7 @@ using Serializer = ROOTSerializer<T, WriteBuffer>;
 
 namespace {
   //needed for atexit handling
-  boost::interprocess::scoped_lock<boost::interprocess::named_mutex>* s_sharedLock = nullptr;
+  CMS_THREAD_SAFE boost::interprocess::scoped_lock<boost::interprocess::named_mutex>* s_sharedLock = nullptr;
 
   void atexit_handler() {
     if (s_sharedLock) {


### PR DESCRIPTION
#### PR description:

The application only ever uses one thread so the use of non-const globals is safe.

#### PR validation:

Code compiles.