### PR TITLE
EMTF NN version update

### DIFF
--- a/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -126,7 +126,7 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
         PromoteMode7    = cms.bool(False), # Assign station 2-3-4 tracks with |eta| > 1.6 SingleMu quality
         ModeQualVer     = cms.int32(2),    # Version 2 contains modified mode-quality mapping for 2018
 
-        ProtobufFileName = cms.string('model_graph.displ.5.pb'), # Protobuf file name to be used by NN based pT assignment
+        ProtobufFileName = cms.string('model_graph.displ.10.1.pb'), # Protobuf file name to be used by NN based pT assignment
     ),
 
 )

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineDxy.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngineDxy.cc
@@ -21,8 +21,8 @@ void PtAssignmentEngineDxy::configure(int verbose, const std::string pbFileNameD
   pbFileNameDxy_ = pbFileNameDxy;
   std::string pbFilePathDxy_ = "L1Trigger/L1TMuon/data/emtf_luts/" + pbFileNameDxy_;
 
-  inputNameDxy_ = "batch_normalization_1_input";
-  outputNamesDxy_ = {"dense_4/BiasAdd"};
+  inputNameDxy_ = "input1";
+  outputNamesDxy_ = {"Identity"};
 
   if (graphDefDxy_ == nullptr) {
     graphDefDxy_ = tensorflow::loadGraphDef(edm::FileInPath(pbFilePathDxy_).fullPath());


### PR DESCRIPTION
#### PR description:

This PR updates the version of the data file for the EMTF displaced NN `v10.1`. The previous version is outdated, and needs to replaced with the version available in firmware at P5. Some performance changes are expected with respect to the old version `v5`

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Validated with `runTheMatrix.py -l limited -i all --ibeos`. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

This change requires https://github.com/cms-data/L1Trigger-L1TMuon/pull/22 to work 
