### PR TITLE
implement a tracking particle associator with TrackCandidate and add trackCandidate branches in trackingNtuple

### DIFF
--- a/SimDataFormats/Associations/interface/TrackAssociation.h
+++ b/SimDataFormats/Associations/interface/TrackAssociation.h
@@ -1,8 +1,10 @@
 #ifndef TrackAssociation_h
 #define TrackAssociation_h
 
+#include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "DataFormats/Common/interface/OneToManyWithQualityGeneric.h"
@@ -11,12 +13,21 @@
 
 namespace reco {
 
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<TrackingParticleCollection, edm::View<reco::Track>, double> >
-      SimToRecoCollection;
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<edm::View<reco::Track>, TrackingParticleCollection, double> >
-      RecoToSimCollection;
+  template <typename T_TrackColl>
+  using SimToRecoCollectionT =
+      edm::AssociationMap<edm::OneToManyWithQualityGeneric<TrackingParticleCollection, T_TrackColl, double>>;
+
+  using SimToRecoCollection = SimToRecoCollectionT<edm::View<reco::Track>>;
+  using SimToRecoCollectionSeed = SimToRecoCollectionT<edm::View<TrajectorySeed>>;
+  using SimToRecoCollectionTCandidate = SimToRecoCollectionT<TrackCandidateCollection>;
+
+  template <typename T_TrackColl>
+  using RecoToSimCollectionT =
+      edm::AssociationMap<edm::OneToManyWithQualityGeneric<T_TrackColl, TrackingParticleCollection, double>>;
+
+  using RecoToSimCollection = RecoToSimCollectionT<edm::View<reco::Track>>;
+  using RecoToSimCollectionSeed = RecoToSimCollectionT<edm::View<TrajectorySeed>>;
+  using RecoToSimCollectionTCandidate = RecoToSimCollectionT<TrackCandidateCollection>;
 
 }  // namespace reco
 

--- a/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
+++ b/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h
@@ -33,21 +33,6 @@
 // forward declarations
 
 namespace reco {
-
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<TrackingParticleCollection, edm::View<TrajectorySeed>, double>>
-      SimToRecoCollectionSeed;
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<edm::View<TrajectorySeed>, TrackingParticleCollection, double>>
-      RecoToSimCollectionSeed;
-
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<TrackingParticleCollection, TrackCandidateCollection, double>>
-      SimToRecoCollectionTCandidate;
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<TrajectorySeedCollection, TrackCandidateCollection, double>>
-      RecoToSimCollectionTCandidate;
-
   class TrackToTrackingParticleAssociator {
   public:
 #ifndef __GCCXML__
@@ -101,13 +86,13 @@ namespace reco {
     }
 
     // TrackCandidate
-    reco::RecoToSimCollectionTCandidate associateRecoToSim(const edm::Handle<TrackCandidateCollection> &tc,
-                                                           const edm::Handle<TrackingParticleCollection> &tpc) const {
+    reco::RecoToSimCollectionTCandidate associateRecoToSim(
+        const edm::Handle<TrackCandidateCollection> &tc, const edm::RefVector<TrackingParticleCollection> &tpc) const {
       return m_impl->associateRecoToSim(tc, tpc);
     }
 
-    reco::SimToRecoCollectionTCandidate associateSimToReco(const edm::Handle<TrackCandidateCollection> &tc,
-                                                           const edm::Handle<TrackingParticleCollection> &tpc) const {
+    reco::SimToRecoCollectionTCandidate associateSimToReco(
+        const edm::Handle<TrackCandidateCollection> &tc, const edm::RefVector<TrackingParticleCollection> &tpc) const {
       return m_impl->associateSimToReco(tc, tpc);
     }
 

--- a/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociatorBaseImpl.h
+++ b/SimDataFormats/Associations/interface/TrackToTrackingParticleAssociatorBaseImpl.h
@@ -16,20 +16,6 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 namespace reco {
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<TrackingParticleCollection, edm::View<TrajectorySeed>, double>>
-      SimToRecoCollectionSeed;
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<edm::View<TrajectorySeed>, TrackingParticleCollection, double>>
-      RecoToSimCollectionSeed;
-
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<TrackingParticleCollection, TrackCandidateCollection, double>>
-      SimToRecoCollectionTCandidate;
-  typedef edm::AssociationMap<
-      edm::OneToManyWithQualityGeneric<TrajectorySeedCollection, TrackCandidateCollection, double>>
-      RecoToSimCollectionTCandidate;
-
   class TrackToTrackingParticleAssociatorBaseImpl {
   public:
     /// Constructor
@@ -63,10 +49,10 @@ namespace reco {
 
     // TrackCandidate
     virtual reco::RecoToSimCollectionTCandidate associateRecoToSim(
-        const edm::Handle<TrackCandidateCollection> &, const edm::Handle<TrackingParticleCollection> &) const;
+        const edm::Handle<TrackCandidateCollection> &, const edm::RefVector<TrackingParticleCollection> &) const;
 
     virtual reco::SimToRecoCollectionTCandidate associateSimToReco(
-        const edm::Handle<TrackCandidateCollection> &, const edm::Handle<TrackingParticleCollection> &) const;
+        const edm::Handle<TrackCandidateCollection> &, const edm::RefVector<TrackingParticleCollection> &) const;
   };
 }  // namespace reco
 

--- a/SimDataFormats/Associations/src/TrackToTrackingParticleAssociatorBaseImpl.cc
+++ b/SimDataFormats/Associations/src/TrackToTrackingParticleAssociatorBaseImpl.cc
@@ -76,13 +76,13 @@ reco::SimToRecoCollectionSeed reco::TrackToTrackingParticleAssociatorBaseImpl::a
 
 // TrackCandidate
 reco::RecoToSimCollectionTCandidate reco::TrackToTrackingParticleAssociatorBaseImpl::associateRecoToSim(
-    const edm::Handle<TrackCandidateCollection> &, const edm::Handle<TrackingParticleCollection> &) const {
+    const edm::Handle<TrackCandidateCollection> &, const edm::RefVector<TrackingParticleCollection> &) const {
   reco::RecoToSimCollectionTCandidate empty;
   return empty;
 }
 
 reco::SimToRecoCollectionTCandidate reco::TrackToTrackingParticleAssociatorBaseImpl::associateSimToReco(
-    const edm::Handle<TrackCandidateCollection> &, const edm::Handle<TrackingParticleCollection> &) const {
+    const edm::Handle<TrackCandidateCollection> &, const edm::RefVector<TrackingParticleCollection> &) const {
   reco::SimToRecoCollectionTCandidate empty;
   return empty;
 }

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -43,8 +43,8 @@ namespace {
     return &*trackCollection[index];  // pretty obscure dereference
   }
 
-  template <template <typename> typename T_Coll, typename T_Track>
-  const T_Track* getTrackAt(const edm::Handle<T_Coll<T_Track>>& pTrackCollection, size_t index) {
+  template <typename T_Coll>
+  const auto* getTrackAt(const edm::Handle<T_Coll>& pTrackCollection, size_t index) {
     return &(*pTrackCollection)[index];
   }
 

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <fstream>
+#include <type_traits>
+#include <typeinfo>
 
 #include "QuickTrackAssociatorByHitsImpl.h"
 
@@ -36,12 +38,23 @@ namespace {
     return collection.size();
   }
 
-  const reco::Track* getTrackAt(const edm::RefToBaseVector<reco::Track>& trackCollection, size_t index) {
+  template <typename T_Track>
+  const T_Track* getTrackAt(const edm::RefToBaseVector<T_Track>& trackCollection, size_t index) {
     return &*trackCollection[index];  // pretty obscure dereference
   }
 
-  const reco::Track* getTrackAt(const edm::Handle<edm::View<reco::Track> >& pTrackCollection, size_t index) {
-    return &(*pTrackCollection.product())[index];
+  template <template <typename> typename T_Coll, typename T_Track>
+  const T_Track* getTrackAt(const edm::Handle<T_Coll<T_Track>>& pTrackCollection, size_t index) {
+    return &(*pTrackCollection)[index];
+  }
+
+  template <typename T_Track>
+  int numberOfValidHits(const T_Track& track) {
+    return std::count_if(track.recHits().begin(), track.recHits().end(), [](auto const& h) { return h.isValid(); });
+  }
+  template <>
+  int numberOfValidHits(const reco::Track& track) {
+    return track.numberOfValidHits();
   }
 
   const TrackingParticle* getTrackingParticleAt(const edm::Handle<TrackingParticleCollection>& pCollection,
@@ -54,13 +67,18 @@ namespace {
     return &*collection[index];
   }
 
-  edm::RefToBase<reco::Track> getRefToTrackAt(const edm::RefToBaseVector<reco::Track>& trackCollection, size_t index) {
+  template <typename T_Track>
+  edm::RefToBase<T_Track> getRefToTrackAt(const edm::RefToBaseVector<T_Track>& trackCollection, size_t index) {
     return trackCollection[index];
   }
-
-  edm::RefToBase<reco::Track> getRefToTrackAt(const edm::Handle<edm::View<reco::Track> >& pTrackCollection,
-                                              size_t index) {
-    return edm::RefToBase<reco::Track>(pTrackCollection, index);
+  template <typename T_Track>
+  edm::RefToBase<T_Track> getRefToTrackAt(const edm::Handle<edm::View<T_Track>>& pTrackCollection, size_t index) {
+    return edm::RefToBase<T_Track>(pTrackCollection, index);
+  }
+  template <typename T_Track>
+  edm::Ref<std::vector<T_Track>> getRefToTrackAt(const edm::Handle<std::vector<T_Track>>& pTrackCollection,
+                                                 size_t index) {
+    return edm::Ref<std::vector<T_Track>>(pTrackCollection, index);
   }
 
   edm::Ref<TrackingParticleCollection> getRefToTrackingParticleAt(
@@ -113,26 +131,26 @@ QuickTrackAssociatorByHitsImpl::QuickTrackAssociatorByHitsImpl(edm::EDProductGet
       absoluteNumberOfHits_(absoluteNumberOfHits) {}
 
 reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSim(
-    const edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
+    const edm::Handle<edm::View<reco::Track>>& trackCollectionHandle,
     const edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle) const {
   // Only pass the one that was successfully created to the templated method.
   if (not clusterToTPMap_)
-    return associateRecoToSimImplementation(
+    return associateRecoToSimImplementation<reco::RecoToSimCollection>(
         trackCollectionHandle, trackingParticleCollectionHandle, nullptr, *hitAssociator_);
   else
-    return associateRecoToSimImplementation(
+    return associateRecoToSimImplementation<reco::RecoToSimCollection>(
         trackCollectionHandle, trackingParticleCollectionHandle, nullptr, *clusterToTPMap_);
 }
 
 reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToReco(
-    const edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
+    const edm::Handle<edm::View<reco::Track>>& trackCollectionHandle,
     const edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle) const {
   // Only pass the one that was successfully created to the templated method.
   if (not clusterToTPMap_)
-    return associateSimToRecoImplementation(
+    return associateSimToRecoImplementation<reco::SimToRecoCollection>(
         trackCollectionHandle, trackingParticleCollectionHandle, nullptr, *hitAssociator_);
   else
-    return associateSimToRecoImplementation(
+    return associateSimToRecoImplementation<reco::SimToRecoCollection>(
         trackCollectionHandle, trackingParticleCollectionHandle, nullptr, *clusterToTPMap_);
 }
 
@@ -141,11 +159,13 @@ reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSim(
     const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection) const {
   // Only pass the one that was successfully created to the templated method.
   if (not clusterToTPMap_)
-    return associateRecoToSimImplementation(trackCollection, trackingParticleCollection, nullptr, *hitAssociator_);
+    return associateRecoToSimImplementation<reco::RecoToSimCollection>(
+        trackCollection, trackingParticleCollection, nullptr, *hitAssociator_);
   else {
     TrackingParticleRefKeySet tpKeys;
     fillKeys(tpKeys, trackingParticleCollection);
-    return associateRecoToSimImplementation(trackCollection, trackingParticleCollection, &tpKeys, *clusterToTPMap_);
+    return associateRecoToSimImplementation<reco::RecoToSimCollection>(
+        trackCollection, trackingParticleCollection, &tpKeys, *clusterToTPMap_);
   }
 }
 
@@ -154,21 +174,26 @@ reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToReco(
     const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection) const {
   // Only pass the one that was successfully created to the templated method.
   if (not clusterToTPMap_)
-    return associateSimToRecoImplementation(trackCollection, trackingParticleCollection, nullptr, *hitAssociator_);
+    return associateSimToRecoImplementation<reco::SimToRecoCollection>(
+        trackCollection, trackingParticleCollection, nullptr, *hitAssociator_);
   else {
     TrackingParticleRefKeySet tpKeys;
     fillKeys(tpKeys, trackingParticleCollection);
-    return associateSimToRecoImplementation(trackCollection, trackingParticleCollection, &tpKeys, *clusterToTPMap_);
+    return associateSimToRecoImplementation<reco::SimToRecoCollection>(
+        trackCollection, trackingParticleCollection, &tpKeys, *clusterToTPMap_);
   }
 }
 
-template <class T_TrackCollection, class T_TrackingParticleCollection, class T_hitOrClusterAssociator>
-reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImplementation(
+template <class T_RecoToSimCollection,
+          class T_TrackCollection,
+          class T_TrackingParticleCollection,
+          class T_hitOrClusterAssociator>
+T_RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImplementation(
     const T_TrackCollection& trackCollection,
     const T_TrackingParticleCollection& trackingParticleCollection,
     const TrackingParticleRefKeySet* trackingParticleKeys,
     T_hitOrClusterAssociator hitOrClusterAssociator) const {
-  reco::RecoToSimCollection returnValue(productGetter_);
+  T_RecoToSimCollection returnValue(productGetter_);
   if (::collectionSize(trackingParticleCollection) == 0)
     return returnValue;
 
@@ -177,16 +202,16 @@ reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImpl
   size_t collectionSize = ::collectionSize(trackCollection);  // Delegate away type specific part
 
   for (size_t i = 0; i < collectionSize; ++i) {
-    const reco::Track* pTrack = ::getTrackAt(
-        trackCollection, i);  // Get a normal pointer for ease of use. This part is type specific so delegate.
+    // Get a normal pointer for ease of use. This part is type specific so delegate.
+    const auto* pTrack = ::getTrackAt(trackCollection, i);
 
     // The return of this function has first as the index and second as the number of associated hits
-    std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > trackingParticleQualityPairs =
+    std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double>> trackingParticleQualityPairs =
         associateTrack(hitOrClusterAssociator,
                        trackingParticleCollection,
                        trackingParticleKeys,
-                       pTrack->recHitsBegin(),
-                       pTrack->recHitsEnd());
+                       pTrack->recHits().begin(),
+                       pTrack->recHits().end());
 
     // int nt = 0;
     for (auto iTrackingParticleQualityPair = trackingParticleQualityPairs.begin();
@@ -202,8 +227,8 @@ reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImpl
       //if electron subtract double counting
       if (abs(trackingParticleRef->pdgId()) == 11 &&
           (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1) {
-        numberOfSharedClusters -=
-            getDoubleCount(hitOrClusterAssociator, pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef);
+        numberOfSharedClusters -= getDoubleCount(
+            hitOrClusterAssociator, pTrack->recHits().begin(), pTrack->recHits().end(), trackingParticleRef);
       }
 
       double quality;
@@ -214,7 +239,7 @@ reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImpl
       else
         quality = 0;
       if (quality > cutRecoToSim_ &&
-          !(threeHitTracksAreSpecial_ && pTrack->numberOfValidHits() == 3 && numberOfSharedClusters < 3.0)) {
+          !(threeHitTracksAreSpecial_ && ::numberOfValidHits(*pTrack) == 3 && numberOfSharedClusters < 3.0)) {
         // Getting the RefToBase is dependent on the type of trackCollection, so delegate that to an overload.
         returnValue.insert(::getRefToTrackAt(trackCollection, i), std::make_pair(trackingParticleRef, quality));
       }
@@ -224,13 +249,16 @@ reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImpl
   return returnValue;
 }
 
-template <class T_TrackCollection, class T_TrackingParticleCollection, class T_hitOrClusterAssociator>
-reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImplementation(
+template <class T_SimToRecoCollection,
+          class T_TrackCollection,
+          class T_TrackingParticleCollection,
+          class T_hitOrClusterAssociator>
+T_SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImplementation(
     const T_TrackCollection& trackCollection,
     const T_TrackingParticleCollection& trackingParticleCollection,
     const TrackingParticleRefKeySet* trackingParticleKeys,
     T_hitOrClusterAssociator hitOrClusterAssociator) const {
-  reco::SimToRecoCollection returnValue(productGetter_);
+  T_SimToRecoCollection returnValue(productGetter_);
   if (::collectionSize(trackingParticleCollection) == 0)
     return returnValue;
 
@@ -239,16 +267,16 @@ reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImpl
   size_t collectionSize = ::collectionSize(trackCollection);  // Delegate away type specific part
 
   for (size_t i = 0; i < collectionSize; ++i) {
-    const reco::Track* pTrack = ::getTrackAt(
-        trackCollection, i);  // Get a normal pointer for ease of use. This part is type specific so delegate.
+    // Get a normal pointer for ease of use. This part is type specific so delegate.
+    const auto* pTrack = ::getTrackAt(trackCollection, i);
 
     // The return of this function has first as an edm:Ref to the associated TrackingParticle, and second as the number of associated hits
-    std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > trackingParticleQualityPairs =
+    std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double>> trackingParticleQualityPairs =
         associateTrack(hitOrClusterAssociator,
                        trackingParticleCollection,
                        trackingParticleKeys,
-                       pTrack->recHitsBegin(),
-                       pTrack->recHitsEnd());
+                       pTrack->recHits().begin(),
+                       pTrack->recHits().end());
 
     // int nt = 0;
     for (auto iTrackingParticleQualityPair = trackingParticleQualityPairs.begin();
@@ -276,8 +304,8 @@ reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImpl
       //if electron subtract double counting
       if (abs(trackingParticleRef->pdgId()) == 11 &&
           (trackingParticleRef->g4Track_end() - trackingParticleRef->g4Track_begin()) > 1) {
-        numberOfSharedClusters -=
-            getDoubleCount(hitOrClusterAssociator, pTrack->recHitsBegin(), pTrack->recHitsEnd(), trackingParticleRef);
+        numberOfSharedClusters -= getDoubleCount(
+            hitOrClusterAssociator, pTrack->recHits().begin(), pTrack->recHits().end(), trackingParticleRef);
       }
 
       double purity = numberOfSharedClusters / numberOfValidTrackClusters;
@@ -304,19 +332,19 @@ reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImpl
 }
 
 template <typename T_TPCollection, typename iter>
-std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > QuickTrackAssociatorByHitsImpl::associateTrack(
+std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double>> QuickTrackAssociatorByHitsImpl::associateTrack(
     const TrackerHitAssociator& hitAssociator,
     const T_TPCollection& trackingParticles,
     const TrackingParticleRefKeySet* trackingParticleKeys,
     iter begin,
     iter end) const {
   // The pairs in this vector have a Ref to the associated TrackingParticle as "first" and the weighted number of associated hits as "second"
-  std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > returnValue;
+  std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double>> returnValue;
 
   // The pairs in this vector have first as the sim track identifiers, and second the number of reco hits associated to that sim track.
   // Most reco hits will probably have come from the same sim track, so the number of entries in this vector should be fewer than the
   // number of reco hits.  The pair::second entries should add up to the total number of reco hits though.
-  std::vector<std::pair<SimTrackIdentifiers, double> > hitIdentifiers =
+  std::vector<std::pair<SimTrackIdentifiers, double>> hitIdentifiers =
       getAllSimTrackIdentifiers(hitAssociator, begin, end);
 
   // Loop over the TrackingParticles
@@ -349,7 +377,7 @@ std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > QuickTrack
 }
 
 template <typename T_TPCollection, typename iter>
-std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > QuickTrackAssociatorByHitsImpl::associateTrack(
+std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double>> QuickTrackAssociatorByHitsImpl::associateTrack(
     const ClusterTPAssociation& clusterToTPMap,
     const T_TPCollection& trackingParticles,
     const TrackingParticleRefKeySet* trackingParticleKeys,
@@ -369,7 +397,7 @@ std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > QuickTrack
 
   // The pairs in this vector have a Ref to the associated TrackingParticle as "first" and the weighted number of associated clusters as "second"
   // Note: typedef edm::Ref<TrackingParticleCollection> TrackingParticleRef;
-  std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > returnValue;
+  std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double>> returnValue;
   if (clusterToTPMap.empty())
     return returnValue;
 
@@ -426,12 +454,12 @@ std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > QuickTrack
 }
 
 template <typename iter>
-std::vector<std::pair<QuickTrackAssociatorByHitsImpl::SimTrackIdentifiers, double> >
+std::vector<std::pair<QuickTrackAssociatorByHitsImpl::SimTrackIdentifiers, double>>
 QuickTrackAssociatorByHitsImpl::getAllSimTrackIdentifiers(const TrackerHitAssociator& hitAssociator,
                                                           iter begin,
                                                           iter end) const {
   // The pairs in this vector have first as the sim track identifiers, and second the number of reco hits associated to that sim track.
-  std::vector<std::pair<SimTrackIdentifiers, double> > returnValue;
+  std::vector<std::pair<SimTrackIdentifiers, double>> returnValue;
 
   std::vector<SimTrackIdentifiers> simTrackIdentifiers;
   // Loop over all of the rec hits in the track
@@ -454,7 +482,7 @@ QuickTrackAssociatorByHitsImpl::getAllSimTrackIdentifiers(const TrackerHitAssoci
       for (std::vector<SimTrackIdentifiers>::const_iterator iIdentifier = simTrackIdentifiers.begin();
            iIdentifier != simTrackIdentifiers.end();
            ++iIdentifier) {
-        std::vector<std::pair<SimTrackIdentifiers, double> >::iterator iIdentifierCountPair;
+        std::vector<std::pair<SimTrackIdentifiers, double>>::iterator iIdentifierCountPair;
         for (auto iIdentifierCountPair = returnValue.begin(); iIdentifierCountPair != returnValue.end();
              ++iIdentifierCountPair) {
           if (iIdentifierCountPair->first.first == iIdentifier->first &&
@@ -589,7 +617,7 @@ double QuickTrackAssociatorByHitsImpl::getDoubleCount(const ClusterTPAssociation
 }
 
 reco::RecoToSimCollectionSeed QuickTrackAssociatorByHitsImpl::associateRecoToSim(
-    const edm::Handle<edm::View<TrajectorySeed> >& pSeedCollectionHandle_,
+    const edm::Handle<edm::View<TrajectorySeed>>& pSeedCollectionHandle_,
     const edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle) const {
   edm::LogVerbatim("TrackAssociator") << "Starting TrackAssociatorByHitsImpl::associateRecoToSim - #seeds="
                                       << pSeedCollectionHandle_->size()
@@ -603,7 +631,7 @@ reco::RecoToSimCollectionSeed QuickTrackAssociatorByHitsImpl::associateRecoToSim
     const TrajectorySeed* pSeed = &(*pSeedCollectionHandle_)[i];
 
     // The return of this function has first as the index and second as the number of associated hits
-    std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > trackingParticleQualityPairs =
+    std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double>> trackingParticleQualityPairs =
         (clusterToTPMap_) ? associateTrack(*clusterToTPMap_,
                                            trackingParticleCollectionHandle,
                                            nullptr,
@@ -659,7 +687,7 @@ reco::RecoToSimCollectionSeed QuickTrackAssociatorByHitsImpl::associateRecoToSim
 }
 
 reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco(
-    const edm::Handle<edm::View<TrajectorySeed> >& pSeedCollectionHandle_,
+    const edm::Handle<edm::View<TrajectorySeed>>& pSeedCollectionHandle_,
     const edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle) const {
   edm::LogVerbatim("TrackAssociator") << "Starting TrackAssociatorByHitsImpl::associateSimToReco - #seeds="
                                       << pSeedCollectionHandle_->size()
@@ -679,7 +707,7 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
     const TrajectorySeed* pSeed = &(*pSeedCollectionHandle_)[i];
 
     // The return of this function has first as an edm:Ref to the associated TrackingParticle, and second as the number of associated hits
-    std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double> > trackingParticleQualityPairs =
+    std::vector<std::pair<edm::Ref<TrackingParticleCollection>, double>> trackingParticleQualityPairs =
         (clusterToTPMap_) ? associateTrack(*clusterToTPMap_,
                                            trackingParticleCollectionHandle,
                                            nullptr,
@@ -750,7 +778,32 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
   return returnValue;
 }
 
+reco::RecoToSimCollectionTCandidate QuickTrackAssociatorByHitsImpl::associateRecoToSim(
+    const edm::Handle<TrackCandidateCollection>& trackCollectionHandle,
+    const edm::RefVector<TrackingParticleCollection>& trackingParticleCollectionHandle) const {
+  // Only pass the one that was successfully created to the templated method.
+  if (not clusterToTPMap_)
+    return associateRecoToSimImplementation<reco::RecoToSimCollectionTCandidate>(
+        trackCollectionHandle, trackingParticleCollectionHandle, nullptr, *hitAssociator_);
+  else
+    return associateRecoToSimImplementation<reco::RecoToSimCollectionTCandidate>(
+        trackCollectionHandle, trackingParticleCollectionHandle, nullptr, *clusterToTPMap_);
+}
+
+reco::SimToRecoCollectionTCandidate QuickTrackAssociatorByHitsImpl::associateSimToReco(
+    const edm::Handle<TrackCandidateCollection>& trackCollectionHandle,
+    const edm::RefVector<TrackingParticleCollection>& trackingParticleCollectionHandle) const {
+  // Only pass the one that was successfully created to the templated method.
+  if (not clusterToTPMap_)
+    return associateSimToRecoImplementation<reco::SimToRecoCollectionTCandidate>(
+        trackCollectionHandle, trackingParticleCollectionHandle, nullptr, *hitAssociator_);
+  else
+    return associateSimToRecoImplementation<reco::SimToRecoCollectionTCandidate>(
+        trackCollectionHandle, trackingParticleCollectionHandle, nullptr, *clusterToTPMap_);
+}
+
 // count hits
+template <>
 double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const reco::Track& track,
                                                                      const TrackerHitAssociator&) const {
   const reco::HitPattern& p = track.hitPattern();
@@ -759,7 +812,8 @@ double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const reco:
   return pixelHits * pixelHitWeight_ + otherHits;
 }
 
-double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const TrajectorySeed& seed,
+template <typename T_Track>
+double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const T_Track& seed,
                                                                      const TrackerHitAssociator&) const {
   double sum = 0.0;
   for (auto iHit = seed.recHits().begin(); iHit != seed.recHits().end(); ++iHit) {
@@ -773,11 +827,13 @@ double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const Traje
 }
 
 // count clusters
+template <>
 double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const reco::Track& track,
                                                                      const ClusterTPAssociation&) const {
   return weightedNumberOfTrackClusters(track.recHitsBegin(), track.recHitsEnd());
 }
-double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const TrajectorySeed& seed,
+template <typename T_Track>
+double QuickTrackAssociatorByHitsImpl::weightedNumberOfTrackClusters(const T_Track& seed,
                                                                      const ClusterTPAssociation&) const {
   const auto& hitRange = seed.recHits();
   return weightedNumberOfTrackClusters(hitRange.begin(), hitRange.end());

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
@@ -99,6 +99,13 @@ public:
   reco::SimToRecoCollectionSeed associateSimToReco(const edm::Handle<edm::View<TrajectorySeed> >&,
                                                    const edm::Handle<TrackingParticleCollection>&) const override;
 
+  //candidate
+  reco::RecoToSimCollectionTCandidate associateRecoToSim(
+      const edm::Handle<TrackCandidateCollection>&, const edm::RefVector<TrackingParticleCollection>&) const override;
+
+  reco::SimToRecoCollectionTCandidate associateSimToReco(
+      const edm::Handle<TrackCandidateCollection>&, const edm::RefVector<TrackingParticleCollection>&) const override;
+
 private:
   typedef std::pair<uint32_t, EncodedEventId>
       SimTrackIdentifiers;  ///< @brief This is enough information to uniquely identify a sim track
@@ -117,12 +124,14 @@ private:
    * in the unnamed namespace of the .cc file. Parts that rely on the type of T_hitOrClusterAssociator
    * are delegated out to overloaded methods.
    */
-  template <class T_TrackCollection, class T_TrackingParticleCollection, class T_hitOrClusterAssociator>
-  reco::RecoToSimCollection associateRecoToSimImplementation(
-      const T_TrackCollection& trackCollection,
-      const T_TrackingParticleCollection& trackingParticleCollection,
-      const TrackingParticleRefKeySet* trackingParticleKeys,
-      T_hitOrClusterAssociator hitOrClusterAssociator) const;
+  template <class T_RecoToSimCollection,
+            class T_TrackCollection,
+            class T_TrackingParticleCollection,
+            class T_hitOrClusterAssociator>
+  T_RecoToSimCollection associateRecoToSimImplementation(const T_TrackCollection& trackCollection,
+                                                         const T_TrackingParticleCollection& trackingParticleCollection,
+                                                         const TrackingParticleRefKeySet* trackingParticleKeys,
+                                                         T_hitOrClusterAssociator hitOrClusterAssociator) const;
 
   /** @brief The method that does the work for both overloads of associateSimToReco.
    *
@@ -130,12 +139,14 @@ private:
    * in the unnamed namespace of the .cc file. Parts that rely on the type of T_hitOrClusterAssociator
    * are delegated out to overloaded methods.
    */
-  template <class T_TrackCollection, class T_TrackingParticleCollection, class T_hitOrClusterAssociator>
-  reco::SimToRecoCollection associateSimToRecoImplementation(
-      const T_TrackCollection& trackCollection,
-      const T_TrackingParticleCollection& trackingParticleCollection,
-      const TrackingParticleRefKeySet* trackingParticleKeys,
-      T_hitOrClusterAssociator hitOrClusterAssociator) const;
+  template <class T_SimToRecoCollection,
+            class T_TrackCollection,
+            class T_TrackingParticleCollection,
+            class T_hitOrClusterAssociator>
+  T_SimToRecoCollection associateSimToRecoImplementation(const T_TrackCollection& trackCollection,
+                                                         const T_TrackingParticleCollection& trackingParticleCollection,
+                                                         const TrackingParticleRefKeySet* trackingParticleKeys,
+                                                         T_hitOrClusterAssociator hitOrClusterAssociator) const;
 
   /** @brief Returns the TrackingParticle that has the most associated hits to the given track.
    *
@@ -196,10 +207,10 @@ private:
       const TrackerHitAssociator& hitAssociator, iter begin, iter end) const;
 
   // The last parameter is used to decide whether we cound hits or clusters
-  double weightedNumberOfTrackClusters(const reco::Track& track, const TrackerHitAssociator&) const;
-  double weightedNumberOfTrackClusters(const TrajectorySeed& seed, const TrackerHitAssociator&) const;
-  double weightedNumberOfTrackClusters(const reco::Track& track, const ClusterTPAssociation&) const;
-  double weightedNumberOfTrackClusters(const TrajectorySeed& seed, const ClusterTPAssociation&) const;
+  template <typename T_Track>
+  double weightedNumberOfTrackClusters(const T_Track& track, const TrackerHitAssociator&) const;
+  template <typename T_Track>
+  double weightedNumberOfTrackClusters(const T_Track& track, const ClusterTPAssociation&) const;
 
   // called only by weightedNumberOfTrackClusters(..., ClusterTPAssociation)
   template <typename iter>

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -346,7 +346,8 @@ namespace {
     int countClusters = 0;
   };
 
-  TrackTPMatch findBestMatchingTrackingParticle(const reco::Track& track,
+  template <typename HRange>
+  TrackTPMatch findBestMatchingTrackingParticle(const HRange& hits,
                                                 const ClusterTPAssociation& clusterToTPMap,
                                                 const TrackingParticleRefKeyToIndex& tpKeyToIndex) {
     struct Count {
@@ -354,8 +355,7 @@ namespace {
       size_t innermostHit = std::numeric_limits<size_t>::max();
     };
 
-    std::vector<OmniClusterRef> clusters =
-        track_associator::hitsToClusterRefs(track.recHitsBegin(), track.recHitsEnd());
+    std::vector<OmniClusterRef> clusters = track_associator::hitsToClusterRefs(hits.begin(), hits.end());
 
     std::unordered_map<int, Count> count;
     for (size_t iCluster = 0, end = clusters.size(); iCluster < end; ++iCluster) {
@@ -392,13 +392,13 @@ namespace {
     return best;
   }
 
-  TrackTPMatch findMatchingTrackingParticleFromFirstHit(const reco::Track& track,
+  template <typename HRange>
+  TrackTPMatch findMatchingTrackingParticleFromFirstHit(const HRange& hits,
                                                         const ClusterTPAssociation& clusterToTPMap,
                                                         const TrackingParticleRefKeyToIndex& tpKeyToIndex) {
     TrackTPMatch best;
 
-    std::vector<OmniClusterRef> clusters =
-        track_associator::hitsToClusterRefs(track.recHitsBegin(), track.recHitsEnd());
+    std::vector<OmniClusterRef> clusters = track_associator::hitsToClusterRefs(hits.begin(), hits.end());
     if (clusters.empty()) {
       return best;
     }
@@ -518,7 +518,7 @@ private:
                      const TrackingParticleRefKeyToIndex& tpKeyToIndex,
                      const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                      const edm::DetSetVector<PixelDigiSimLink>& digiSimLink,
-                     const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                     const TransientTrackingRecHitBuilder& ttrhBuilder,
                      const TrackerTopology& tTopo,
                      const SimHitRefKeyToIndex& simHitRefKeyToIndex,
                      std::set<edm::ProductID>& hitProductIds);
@@ -528,18 +528,18 @@ private:
                                const TrackingParticleRefKeyToIndex& tpKeyToIndex,
                                const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                                const edm::DetSetVector<StripDigiSimLink>& digiSimLink,
-                               const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                               const TransientTrackingRecHitBuilder& ttrhBuilder,
                                const TrackerTopology& tTopo,
                                const SimHitRefKeyToIndex& simHitRefKeyToIndex,
                                std::set<edm::ProductID>& hitProductIds);
 
   void fillStripMatchedHits(const edm::Event& iEvent,
-                            const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                            const TransientTrackingRecHitBuilder& ttrhBuilder,
                             const TrackerTopology& tTopo,
                             std::vector<std::pair<int, int>>& monoStereoClusterList);
 
   size_t addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
-                            const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                            const TransientTrackingRecHitBuilder& ttrhBuilder,
                             const TrackerTopology& tTopo,
                             const std::vector<std::pair<uint64_t, StripMaskContainer const*>>& stripMasks,
                             std::vector<std::pair<int, int>>& monoStereoClusterList);
@@ -549,7 +549,7 @@ private:
                         const TrackingParticleRefKeyToIndex& tpKeyToIndex,
                         const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                         const edm::DetSetVector<PixelDigiSimLink>& digiSimLink,
-                        const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                        const TransientTrackingRecHitBuilder& ttrhBuilder,
                         const TrackerTopology& tTopo,
                         const SimHitRefKeyToIndex& simHitRefKeyToIndex,
                         std::set<edm::ProductID>& hitProductIds);
@@ -560,7 +560,7 @@ private:
                  const reco::BeamSpot& bs,
                  const reco::TrackToTrackingParticleAssociator& associatorByHits,
                  const ClusterTPAssociation& clusterToTPMap,
-                 const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                 const TransientTrackingRecHitBuilder& ttrhBuilder,
                  const MagneticField& theMF,
                  const TrackerTopology& tTopo,
                  std::vector<std::pair<int, int>>& monoStereoClusterList,
@@ -576,12 +576,27 @@ private:
                   const reco::VertexCollection& vertices,
                   const reco::TrackToTrackingParticleAssociator& associatorByHits,
                   const ClusterTPAssociation& clusterToTPMap,
-                  const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                  const TransientTrackingRecHitBuilder& ttrhBuilder,
                   const TrackerTopology& tTopo,
                   const std::set<edm::ProductID>& hitProductIds,
                   const std::map<edm::ProductID, size_t>& seedToCollIndex,
                   const std::vector<const MVACollection*>& mvaColls,
                   const std::vector<const QualityMaskCollection*>& qualColls);
+
+  void fillCandidates(const edm::Handle<TrackCandidateCollection>& candsHandle,
+                      int algo,
+                      const TrackingParticleRefVector& tpCollection,
+                      const TrackingParticleRefKeyToIndex& tpKeyToIndex,
+                      const TrackingParticleRefKeyToCount& tpKeyToClusterCount,
+                      const MagneticField& mf,
+                      const reco::BeamSpot& bs,
+                      const reco::VertexCollection& vertices,
+                      const reco::TrackToTrackingParticleAssociator& associatorByHits,
+                      const ClusterTPAssociation& clusterToTPMap,
+                      const TransientTrackingRecHitBuilder& ttrhBuilder,
+                      const TrackerTopology& tTopo,
+                      const std::set<edm::ProductID>& hitProductIds,
+                      const std::map<edm::ProductID, size_t>& seedToCollIndex);
 
   void fillSimHits(const TrackerGeometry& tracker,
                    const TrackingParticleRefKeyToIndex& tpKeyToIndex,
@@ -639,6 +654,8 @@ private:
 
   std::vector<edm::EDGetTokenT<edm::View<reco::Track>>> seedTokens_;
   std::vector<edm::EDGetTokenT<std::vector<SeedStopInfo>>> seedStopInfoTokens_;
+
+  std::vector<edm::EDGetTokenT<TrackCandidateCollection>> candidateTokens_;
   edm::EDGetTokenT<edm::View<reco::Track>> trackToken_;
   std::vector<std::tuple<edm::EDGetTokenT<MVACollection>, edm::EDGetTokenT<QualityMaskCollection>>>
       mvaQualityCollectionTokens_;
@@ -668,6 +685,7 @@ private:
 
   std::string builderName_;
   const bool includeSeeds_;
+  const bool includeTrackCandidates_;
   const bool addSeedCurvCov_;
   const bool includeAllHits_;
   const bool includeMVA_;
@@ -1038,6 +1056,62 @@ private:
   std::vector<std::vector<int>> trk_hitIdx;             // second index runs through hits
   std::vector<std::vector<int>> trk_hitType;            // second index runs through hits
   ////////////////////
+  // track candidates
+  // (first) index runs through track candidates
+  std::vector<short> tcand_pca_valid;  // pca: propagated params at BS
+  std::vector<float> tcand_pca_px;
+  std::vector<float> tcand_pca_py;
+  std::vector<float> tcand_pca_pz;
+  std::vector<float> tcand_pca_pt;
+  std::vector<float> tcand_pca_eta;
+  std::vector<float> tcand_pca_phi;
+  std::vector<float> tcand_pca_dxy;
+  std::vector<float> tcand_pca_dz;
+  std::vector<float> tcand_pca_ptErr;
+  std::vector<float> tcand_pca_etaErr;
+  std::vector<float> tcand_pca_lambdaErr;
+  std::vector<float> tcand_pca_phiErr;
+  std::vector<float> tcand_pca_dxyErr;
+  std::vector<float> tcand_pca_dzErr;
+  std::vector<float> tcand_px;  // from PState
+  std::vector<float> tcand_py;
+  std::vector<float> tcand_pz;
+  std::vector<float> tcand_pt;
+  std::vector<float> tcand_x;
+  std::vector<float> tcand_y;
+  std::vector<float> tcand_z;
+  std::vector<float> tcand_qbpErr;
+  std::vector<float> tcand_lambdaErr;
+  std::vector<float> tcand_phiErr;
+  std::vector<float> tcand_xtErr;
+  std::vector<float> tcand_ytErr;
+  std::vector<float> tcand_ndof;  // sum(hit.dimention) - 5
+  std::vector<int> tcand_q;
+  std::vector<unsigned int> tcand_nValid;
+  std::vector<unsigned int> tcand_nPixel;
+  std::vector<unsigned int> tcand_nStrip;
+  std::vector<unsigned int> tcand_nCluster;
+  std::vector<unsigned int> tcand_algo;
+  std::vector<unsigned short> tcand_stopReason;
+  std::vector<int> tcand_seedIdx;
+  std::vector<int> tcand_vtxIdx;
+  std::vector<short> tcand_isTrue;
+  std::vector<int> tcand_bestSimTrkIdx;
+  std::vector<float> tcand_bestSimTrkShareFrac;
+  std::vector<float> tcand_bestSimTrkShareFracSimDenom;
+  std::vector<float> tcand_bestSimTrkShareFracSimClusterDenom;
+  std::vector<float> tcand_bestSimTrkNChi2;
+  std::vector<int> tcand_bestFromFirstHitSimTrkIdx;
+  std::vector<float> tcand_bestFromFirstHitSimTrkShareFrac;
+  std::vector<float> tcand_bestFromFirstHitSimTrkShareFracSimDenom;
+  std::vector<float> tcand_bestFromFirstHitSimTrkShareFracSimClusterDenom;
+  std::vector<float> tcand_bestFromFirstHitSimTrkNChi2;
+  std::vector<std::vector<float>> tcand_simTrkShareFrac;  // second index runs through matched TrackingParticles
+  std::vector<std::vector<float>> tcand_simTrkNChi2;      // second index runs through matched TrackingParticles
+  std::vector<std::vector<int>> tcand_simTrkIdx;          // second index runs through matched TrackingParticles
+  std::vector<std::vector<int>> tcand_hitIdx;             // second index runs through hits
+  std::vector<std::vector<int>> tcand_hitType;            // second index runs through hits
+  ////////////////////
   // sim tracks
   // (first) index runs through TrackingParticles
   std::vector<int> sim_event;
@@ -1083,6 +1157,7 @@ private:
   std::vector<short> pix_isBarrel;
   DetIdPixel pix_detId;
   std::vector<std::vector<int>> pix_trkIdx;            // second index runs through tracks containing this hit
+  std::vector<std::vector<int>> pix_tcandIdx;          // second index runs through candidates containing this hit
   std::vector<std::vector<int>> pix_seeIdx;            // second index runs through seeds containing this hit
   std::vector<std::vector<int>> pix_simHitIdx;         // second index runs through SimHits inducing this hit
   std::vector<std::vector<float>> pix_xySignificance;  // second index runs through SimHits inducing this hit
@@ -1109,6 +1184,7 @@ private:
   std::vector<short> str_isBarrel;
   DetIdStrip str_detId;
   std::vector<std::vector<int>> str_trkIdx;            // second index runs through tracks containing this hit
+  std::vector<std::vector<int>> str_tcandIdx;          // second index runs through candidates containing this hit
   std::vector<std::vector<int>> str_seeIdx;            // second index runs through seeds containing this hit
   std::vector<std::vector<int>> str_simHitIdx;         // second index runs through SimHits inducing this hit
   std::vector<std::vector<float>> str_xySignificance;  // second index runs through SimHits inducing this hit
@@ -1160,6 +1236,7 @@ private:
   std::vector<short> ph2_isBarrel;
   DetIdPhase2OT ph2_detId;
   std::vector<std::vector<int>> ph2_trkIdx;            // second index runs through tracks containing this hit
+  std::vector<std::vector<int>> ph2_tcandIdx;          // second index runs through candidates containing this hit
   std::vector<std::vector<int>> ph2_seeIdx;            // second index runs through seeds containing this hit
   std::vector<std::vector<int>> ph2_simHitIdx;         // second index runs through SimHits inducing this hit
   std::vector<std::vector<float>> ph2_xySignificance;  // second index runs through SimHits inducing this hit
@@ -1254,6 +1331,7 @@ private:
   std::vector<unsigned short> see_stopReason;
   std::vector<unsigned short> see_nCands;
   std::vector<int> see_trkIdx;
+  std::vector<int> see_tcandIdx;
   std::vector<short> see_isTrue;
   std::vector<int> see_bestSimTrkIdx;
   std::vector<float> see_bestSimTrkShareFrac;
@@ -1338,6 +1416,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       tpNStripStereoLayersToken_(consumes<edm::ValueMap<unsigned int>>(
           iConfig.getUntrackedParameter<edm::InputTag>("trackingParticleNstripstereolayers"))),
       includeSeeds_(iConfig.getUntrackedParameter<bool>("includeSeeds")),
+      includeTrackCandidates_(iConfig.getUntrackedParameter<bool>("includeTrackCandidates")),
       addSeedCurvCov_(iConfig.getUntrackedParameter<bool>("addSeedCurvCov")),
       includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
       includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
@@ -1359,6 +1438,10 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
                                             << seedStopInfoTokens_.size() << " track candidate collections";
     }
   }
+  if (includeTrackCandidates_)
+    candidateTokens_ =
+        edm::vector_transform(iConfig.getUntrackedParameter<std::vector<edm::InputTag>>("trackCandidates"),
+                              [&](const edm::InputTag& tag) { return consumes<TrackCandidateCollection>(tag); });
 
   if (includeAllHits_) {
     if (includeStripHits_ && includePhase2OTHits_) {
@@ -1503,6 +1586,69 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("trk_hitIdx", &trk_hitIdx);
     t->Branch("trk_hitType", &trk_hitType);
   }
+  if (includeTrackCandidates_) {
+    t->Branch("tcand_pca_valid", &tcand_pca_valid);
+    t->Branch("tcand_pca_px", &tcand_pca_px);
+    t->Branch("tcand_pca_py", &tcand_pca_py);
+    t->Branch("tcand_pca_pz", &tcand_pca_pz);
+    t->Branch("tcand_pca_pt", &tcand_pca_pt);
+    t->Branch("tcand_pca_eta", &tcand_pca_eta);
+    t->Branch("tcand_pca_phi", &tcand_pca_phi);
+    t->Branch("tcand_pca_dxy", &tcand_pca_dxy);
+    t->Branch("tcand_pca_dz", &tcand_pca_dz);
+    t->Branch("tcand_pca_ptErr", &tcand_pca_ptErr);
+    t->Branch("tcand_pca_etaErr", &tcand_pca_etaErr);
+    t->Branch("tcand_pca_lambdaErr", &tcand_pca_lambdaErr);
+    t->Branch("tcand_pca_phiErr", &tcand_pca_phiErr);
+    t->Branch("tcand_pca_dxyErr", &tcand_pca_dxyErr);
+    t->Branch("tcand_pca_dzErr", &tcand_pca_dzErr);
+    t->Branch("tcand_px", &tcand_px);
+    t->Branch("tcand_py", &tcand_py);
+    t->Branch("tcand_pz", &tcand_pz);
+    t->Branch("tcand_pt", &tcand_pt);
+    t->Branch("tcand_x", &tcand_x);
+    t->Branch("tcand_y", &tcand_y);
+    t->Branch("tcand_z", &tcand_z);
+    t->Branch("tcand_qbpErr", &tcand_qbpErr);
+    t->Branch("tcand_lambdaErr", &tcand_lambdaErr);
+    t->Branch("tcand_phiErr", &tcand_phiErr);
+    t->Branch("tcand_xtErr", &tcand_xtErr);
+    t->Branch("tcand_ytErr", &tcand_ytErr);
+    t->Branch("tcand_q", &tcand_q);
+    t->Branch("tcand_ndof", &tcand_ndof);
+    t->Branch("tcand_nValid", &tcand_nValid);
+    t->Branch("tcand_nPixel", &tcand_nPixel);
+    t->Branch("tcand_nStrip", &tcand_nStrip);
+    t->Branch("tcand_nCluster", &tcand_nCluster);
+    t->Branch("tcand_algo", &tcand_algo);
+    t->Branch("tcand_stopReason", &tcand_stopReason);
+    if (includeSeeds_) {
+      t->Branch("tcand_seedIdx", &tcand_seedIdx);
+    }
+    t->Branch("tcand_vtxIdx", &tcand_vtxIdx);
+    if (includeTrackingParticles_) {
+      t->Branch("tcand_simTrkIdx", &tcand_simTrkIdx);
+      t->Branch("tcand_simTrkShareFrac", &tcand_simTrkShareFrac);
+      t->Branch("tcand_simTrkNChi2", &tcand_simTrkNChi2);
+      t->Branch("tcand_bestSimTrkIdx", &tcand_bestSimTrkIdx);
+      t->Branch("tcand_bestFromFirstHitSimTrkIdx", &tcand_bestFromFirstHitSimTrkIdx);
+    } else {
+      t->Branch("tcand_isTrue", &tcand_isTrue);
+    }
+    t->Branch("tcand_bestSimTrkShareFrac", &tcand_bestSimTrkShareFrac);
+    t->Branch("tcand_bestSimTrkShareFracSimDenom", &tcand_bestSimTrkShareFracSimDenom);
+    t->Branch("tcand_bestSimTrkShareFracSimClusterDenom", &tcand_bestSimTrkShareFracSimClusterDenom);
+    t->Branch("tcand_bestSimTrkNChi2", &tcand_bestSimTrkNChi2);
+    t->Branch("tcand_bestFromFirstHitSimTrkShareFrac", &tcand_bestFromFirstHitSimTrkShareFrac);
+    t->Branch("tcand_bestFromFirstHitSimTrkShareFracSimDenom", &tcand_bestFromFirstHitSimTrkShareFracSimDenom);
+    t->Branch("tcand_bestFromFirstHitSimTrkShareFracSimClusterDenom",
+              &tcand_bestFromFirstHitSimTrkShareFracSimClusterDenom);
+    t->Branch("tcand_bestFromFirstHitSimTrkNChi2", &tcand_bestFromFirstHitSimTrkNChi2);
+    if (includeAllHits_) {
+      t->Branch("tcand_hitIdx", &tcand_hitIdx);
+      t->Branch("tcand_hitType", &tcand_hitType);
+    }
+  }
   if (includeTrackingParticles_) {
     //sim tracks
     t->Branch("sim_event", &sim_event);
@@ -1548,6 +1694,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("pix_isBarrel", &pix_isBarrel);
     pix_detId.book("pix", t);
     t->Branch("pix_trkIdx", &pix_trkIdx);
+    if (includeTrackCandidates_)
+      t->Branch("pix_tcandIdx", &pix_tcandIdx);
     if (includeSeeds_) {
       t->Branch("pix_seeIdx", &pix_seeIdx);
     }
@@ -1578,6 +1726,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("str_isBarrel", &str_isBarrel);
       str_detId.book("str", t);
       t->Branch("str_trkIdx", &str_trkIdx);
+      if (includeTrackCandidates_)
+        t->Branch("str_tcandIdx", &str_tcandIdx);
       if (includeSeeds_) {
         t->Branch("str_seeIdx", &str_seeIdx);
       }
@@ -1633,6 +1783,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("ph2_isBarrel", &ph2_isBarrel);
       ph2_detId.book("ph2", t);
       t->Branch("ph2_trkIdx", &ph2_trkIdx);
+      if (includeTrackCandidates_)
+        t->Branch("ph2_tcandIdx", &ph2_tcandIdx);
       if (includeSeeds_) {
         t->Branch("ph2_seeIdx", &ph2_seeIdx);
       }
@@ -1736,6 +1888,8 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("see_stopReason", &see_stopReason);
     t->Branch("see_nCands", &see_nCands);
     t->Branch("see_trkIdx", &see_trkIdx);
+    if (includeTrackCandidates_)
+      t->Branch("see_tcandIdx", &see_tcandIdx);
     if (includeTrackingParticles_) {
       t->Branch("see_simTrkIdx", &see_simTrkIdx);
       t->Branch("see_simTrkShareFrac", &see_simTrkShareFrac);
@@ -1874,6 +2028,60 @@ void TrackingNtuple::clearVariables() {
   trk_simTrkNChi2.clear();
   trk_hitIdx.clear();
   trk_hitType.clear();
+  //track candidates
+  tcand_pca_valid.clear();
+  tcand_pca_px.clear();
+  tcand_pca_py.clear();
+  tcand_pca_pz.clear();
+  tcand_pca_pt.clear();
+  tcand_pca_eta.clear();
+  tcand_pca_phi.clear();
+  tcand_pca_dxy.clear();
+  tcand_pca_dz.clear();
+  tcand_pca_ptErr.clear();
+  tcand_pca_etaErr.clear();
+  tcand_pca_lambdaErr.clear();
+  tcand_pca_phiErr.clear();
+  tcand_pca_dxyErr.clear();
+  tcand_pca_dzErr.clear();
+  tcand_px.clear();
+  tcand_py.clear();
+  tcand_pz.clear();
+  tcand_pt.clear();
+  tcand_x.clear();
+  tcand_y.clear();
+  tcand_z.clear();
+  tcand_qbpErr.clear();
+  tcand_lambdaErr.clear();
+  tcand_phiErr.clear();
+  tcand_xtErr.clear();
+  tcand_ytErr.clear();
+  tcand_ndof.clear();
+  tcand_q.clear();
+  tcand_nValid.clear();
+  tcand_nPixel.clear();
+  tcand_nStrip.clear();
+  tcand_nCluster.clear();
+  tcand_algo.clear();
+  tcand_stopReason.clear();
+  tcand_seedIdx.clear();
+  tcand_vtxIdx.clear();
+  tcand_isTrue.clear();
+  tcand_bestSimTrkIdx.clear();
+  tcand_bestSimTrkShareFrac.clear();
+  tcand_bestSimTrkShareFracSimDenom.clear();
+  tcand_bestSimTrkShareFracSimClusterDenom.clear();
+  tcand_bestSimTrkNChi2.clear();
+  tcand_bestFromFirstHitSimTrkIdx.clear();
+  tcand_bestFromFirstHitSimTrkShareFrac.clear();
+  tcand_bestFromFirstHitSimTrkShareFracSimDenom.clear();
+  tcand_bestFromFirstHitSimTrkShareFracSimClusterDenom.clear();
+  tcand_bestFromFirstHitSimTrkNChi2.clear();
+  tcand_simTrkShareFrac.clear();
+  tcand_simTrkNChi2.clear();
+  tcand_simTrkIdx.clear();
+  tcand_hitIdx.clear();
+  tcand_hitType.clear();
   //sim tracks
   sim_event.clear();
   sim_bunchCrossing.clear();
@@ -1912,6 +2120,7 @@ void TrackingNtuple::clearVariables() {
   pix_isBarrel.clear();
   pix_detId.clear();
   pix_trkIdx.clear();
+  pix_tcandIdx.clear();
   pix_seeIdx.clear();
   pix_simHitIdx.clear();
   pix_xySignificance.clear();
@@ -1935,6 +2144,7 @@ void TrackingNtuple::clearVariables() {
   str_isBarrel.clear();
   str_detId.clear();
   str_trkIdx.clear();
+  str_tcandIdx.clear();
   str_seeIdx.clear();
   str_simHitIdx.clear();
   str_xySignificance.clear();
@@ -1980,6 +2190,7 @@ void TrackingNtuple::clearVariables() {
   ph2_isBarrel.clear();
   ph2_detId.clear();
   ph2_trkIdx.clear();
+  ph2_tcandIdx.clear();
   ph2_seeIdx.clear();
   ph2_xySignificance.clear();
   ph2_simHitIdx.clear();
@@ -2064,6 +2275,7 @@ void TrackingNtuple::clearVariables() {
   see_stopReason.clear();
   see_nCands.clear();
   see_trkIdx.clear();
+  see_tcandIdx.clear();
   see_isTrue.clear();
   see_bestSimTrkIdx.clear();
   see_bestSimTrkShareFrac.clear();
@@ -2108,7 +2320,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   using namespace std;
 
   const auto& mf = iSetup.getData(mfToken_);
-  const auto& theTTRHBuilder = &iSetup.getData(ttrhToken_);
+  const auto& ttrhBuilder = &iSetup.getData(ttrhToken_);
   const TrackerTopology& tTopo = iSetup.getData(tTopoToken_);
   const TrackerGeometry& tracker = iSetup.getData(tGeomToken_);
 
@@ -2223,7 +2435,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
                   tpKeyToIndex,
                   *simHitsTPAssoc,
                   pixelDigiSimLinks,
-                  *theTTRHBuilder,
+                  *ttrhBuilder,
                   tTopo,
                   simHitRefKeyToIndex,
                   hitProductIds);
@@ -2237,13 +2449,13 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
                               tpKeyToIndex,
                               *simHitsTPAssoc,
                               stripDigiSimLinks,
-                              *theTTRHBuilder,
+                              *ttrhBuilder,
                               tTopo,
                               simHitRefKeyToIndex,
                               hitProductIds);
 
       //matched hits
-      fillStripMatchedHits(iEvent, *theTTRHBuilder, tTopo, monoStereoClusterList);
+      fillStripMatchedHits(iEvent, *ttrhBuilder, tTopo, monoStereoClusterList);
     }
 
     if (includePhase2OTHits_) {
@@ -2254,7 +2466,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
                        tpKeyToIndex,
                        *simHitsTPAssoc,
                        phase2OTSimLinks,
-                       *theTTRHBuilder,
+                       *ttrhBuilder,
                        tTopo,
                        simHitRefKeyToIndex,
                        hitProductIds);
@@ -2269,7 +2481,7 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
               bs,
               associatorByHits,
               clusterToTPMap,
-              *theTTRHBuilder,
+              *ttrhBuilder,
               mf,
               tTopo,
               monoStereoClusterList,
@@ -2325,12 +2537,41 @@ void TrackingNtuple::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
              *vertices,
              associatorByHits,
              clusterToTPMap,
-             *theTTRHBuilder,
+             *ttrhBuilder,
              tTopo,
              hitProductIds,
              seedCollToOffset,
              mvaColls,
              qualColls);
+
+  if (includeTrackCandidates_) {
+    //candidates
+    for (auto const& token : candidateTokens_) {
+      auto const tCandsHandle = iEvent.getHandle(token);
+
+      edm::EDConsumerBase::Labels labels;
+      labelsForToken(token, labels);
+      TString label = labels.module;
+      label.ReplaceAll("TrackCandidates", "");
+      label.ReplaceAll("muonSeeded", "muonSeededStep");
+      int algo = reco::TrackBase::algoByName(label.Data());
+
+      fillCandidates(tCandsHandle,
+                     algo,
+                     tpCollection,
+                     tpKeyToIndex,
+                     tpKeyToClusterCount,
+                     mf,
+                     bs,
+                     *vertices,
+                     associatorByHits,
+                     clusterToTPMap,
+                     *ttrhBuilder,
+                     tTopo,
+                     hitProductIds,
+                     seedCollToOffset);
+    }
+  }
 
   //tracking particles
   //sort association maps with simHits
@@ -2686,7 +2927,7 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
                                    const TrackingParticleRefKeyToIndex& tpKeyToIndex,
                                    const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                                    const edm::DetSetVector<PixelDigiSimLink>& digiSimLink,
-                                   const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                   const TransientTrackingRecHitBuilder& ttrhBuilder,
                                    const TrackerTopology& tTopo,
                                    const SimHitRefKeyToIndex& simHitRefKeyToIndex,
                                    std::set<edm::ProductID>& hitProductIds) {
@@ -2711,7 +2952,7 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
   for (auto it = pixelHits->begin(); it != pixelHits->end(); it++) {
     const DetId hitId = it->detId();
     for (auto hit = it->begin(); hit != it->end(); hit++) {
-      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder.build(&*hit);
+      TransientTrackingRecHit::RecHitPointer ttrh = ttrhBuilder.build(&*hit);
 
       hitProductIds.insert(hit->cluster().id());
 
@@ -2720,8 +2961,9 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
 
       pix_isBarrel.push_back(hitId.subdetId() == 1);
       pix_detId.push_back(tTopo, hitId);
-      pix_trkIdx.emplace_back();  // filled in fillTracks
-      pix_seeIdx.emplace_back();  // filled in fillSeeds
+      pix_trkIdx.emplace_back();    // filled in fillTracks
+      pix_tcandIdx.emplace_back();  // filled in fillCandidates
+      pix_seeIdx.emplace_back();    // filled in fillSeeds
       pix_x.push_back(ttrh->globalPosition().x());
       pix_y.push_back(ttrh->globalPosition().y());
       pix_z.push_back(ttrh->globalPosition().z());
@@ -2775,7 +3017,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
                                              const TrackingParticleRefKeyToIndex& tpKeyToIndex,
                                              const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                                              const edm::DetSetVector<StripDigiSimLink>& digiSimLink,
-                                             const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                             const TransientTrackingRecHitBuilder& ttrhBuilder,
                                              const TrackerTopology& tTopo,
                                              const SimHitRefKeyToIndex& simHitRefKeyToIndex,
                                              std::set<edm::ProductID>& hitProductIds) {
@@ -2803,8 +3045,9 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
   int totalStripHits = rphiHits->dataSize() + stereoHits->dataSize();
   str_isBarrel.resize(totalStripHits);
   str_detId.resize(totalStripHits);
-  str_trkIdx.resize(totalStripHits);  // filled in fillTracks
-  str_seeIdx.resize(totalStripHits);  // filled in fillSeeds
+  str_trkIdx.resize(totalStripHits);    // filled in fillTracks
+  str_tcandIdx.resize(totalStripHits);  // filled in fillCandidates
+  str_seeIdx.resize(totalStripHits);    // filled in fillSeeds
   str_simHitIdx.resize(totalStripHits);
   str_simType.resize(totalStripHits);
   str_chargeFraction.resize(totalStripHits);
@@ -2829,7 +3072,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
     for (const auto& detset : hits) {
       const DetId hitId = detset.detId();
       for (const auto& hit : detset) {
-        TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder.build(&hit);
+        TransientTrackingRecHit::RecHitPointer ttrh = ttrhBuilder.build(&hit);
 
         hitProductIds.insert(hit.cluster().id());
 
@@ -2892,7 +3135,7 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
 }
 
 size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
-                                          const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                          const TransientTrackingRecHitBuilder& ttrhBuilder,
                                           const TrackerTopology& tTopo,
                                           const std::vector<std::pair<uint64_t, StripMaskContainer const*>>& stripMasks,
                                           std::vector<std::pair<int, int>>& monoStereoClusterList) {
@@ -2905,7 +3148,7 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
     return mask;
   };
 
-  TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder.build(&hit);
+  TransientTrackingRecHit::RecHitPointer ttrh = ttrhBuilder.build(&hit);
   const auto hitId = hit.geographicalId();
   const int lay = tTopo.layer(hitId);
   monoStereoClusterList.emplace_back(hit.monoHit().cluster().key(), hit.stereoHit().cluster().key());
@@ -2938,7 +3181,7 @@ size_t TrackingNtuple::addStripMatchedHit(const SiStripMatchedRecHit2D& hit,
 }
 
 void TrackingNtuple::fillStripMatchedHits(const edm::Event& iEvent,
-                                          const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                          const TransientTrackingRecHitBuilder& ttrhBuilder,
                                           const TrackerTopology& tTopo,
                                           std::vector<std::pair<int, int>>& monoStereoClusterList) {
   std::vector<std::pair<uint64_t, StripMaskContainer const*>> stripMasks;
@@ -2953,7 +3196,7 @@ void TrackingNtuple::fillStripMatchedHits(const edm::Event& iEvent,
   iEvent.getByToken(stripMatchedRecHitToken_, matchedHits);
   for (auto it = matchedHits->begin(); it != matchedHits->end(); it++) {
     for (auto hit = it->begin(); hit != it->end(); hit++) {
-      addStripMatchedHit(*hit, theTTRHBuilder, tTopo, stripMasks, monoStereoClusterList);
+      addStripMatchedHit(*hit, ttrhBuilder, tTopo, stripMasks, monoStereoClusterList);
     }
   }
 }
@@ -2963,7 +3206,7 @@ void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
                                       const TrackingParticleRefKeyToIndex& tpKeyToIndex,
                                       const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc,
                                       const edm::DetSetVector<PixelDigiSimLink>& digiSimLink,
-                                      const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                      const TransientTrackingRecHitBuilder& ttrhBuilder,
                                       const TrackerTopology& tTopo,
                                       const SimHitRefKeyToIndex& simHitRefKeyToIndex,
                                       std::set<edm::ProductID>& hitProductIds) {
@@ -2972,7 +3215,7 @@ void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
   for (auto it = phase2OTHits->begin(); it != phase2OTHits->end(); it++) {
     const DetId hitId = it->detId();
     for (auto hit = it->begin(); hit != it->end(); hit++) {
-      TransientTrackingRecHit::RecHitPointer ttrh = theTTRHBuilder.build(&*hit);
+      TransientTrackingRecHit::RecHitPointer ttrh = ttrhBuilder.build(&*hit);
 
       hitProductIds.insert(hit->cluster().id());
 
@@ -2981,8 +3224,9 @@ void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
 
       ph2_isBarrel.push_back(hitId.subdetId() == 1);
       ph2_detId.push_back(tTopo, hitId);
-      ph2_trkIdx.emplace_back();  // filled in fillTracks
-      ph2_seeIdx.emplace_back();  // filled in fillSeeds
+      ph2_trkIdx.emplace_back();    // filled in fillTracks
+      ph2_tcandIdx.emplace_back();  // filled in fillCandidates
+      ph2_seeIdx.emplace_back();    // filled in fillSeeds
       ph2_x.push_back(ttrh->globalPosition().x());
       ph2_y.push_back(ttrh->globalPosition().y());
       ph2_z.push_back(ttrh->globalPosition().z());
@@ -3034,7 +3278,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
                                const reco::BeamSpot& bs,
                                const reco::TrackToTrackingParticleAssociator& associatorByHits,
                                const ClusterTPAssociation& clusterToTPMap,
-                               const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                               const TransientTrackingRecHitBuilder& ttrhBuilder,
                                const MagneticField& theMF,
                                const TrackerTopology& tTopo,
                                std::vector<std::pair<int, int>>& monoStereoClusterList,
@@ -3137,12 +3381,12 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
           seedTrack.recHitsBegin(),
           seedTrack.recHitsEnd());  // TODO: this function is called 3 times per track, try to reduce
       const int nClusters = clusters.size();
-      const auto bestKeyCount = findBestMatchingTrackingParticle(seedTrack, clusterToTPMap, tpKeyToIndex);
+      const auto bestKeyCount = findBestMatchingTrackingParticle(seedTrack.recHits(), clusterToTPMap, tpKeyToIndex);
       const float bestShareFrac =
           nClusters > 0 ? static_cast<float>(bestKeyCount.countClusters) / static_cast<float>(nClusters) : 0;
       // Another way starting from the first hit of the seed
       const auto bestFirstHitKeyCount =
-          findMatchingTrackingParticleFromFirstHit(seedTrack, clusterToTPMap, tpKeyToIndex);
+          findMatchingTrackingParticleFromFirstHit(seedTrack.recHits(), clusterToTPMap, tpKeyToIndex);
       const float bestFirstHitShareFrac =
           nClusters > 0 ? static_cast<float>(bestFirstHitKeyCount.countClusters) / static_cast<float>(nClusters) : 0;
 
@@ -3187,7 +3431,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       see_stateTrajPz.push_back(mom.z());
 
       ///the following is useful for analysis in global coords at seed hit surface
-      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder.build(&*(seed.recHits().end() - 1));
+      TransientTrackingRecHit::RecHitPointer lastRecHit = ttrhBuilder.build(&*(seed.recHits().end() - 1));
       TrajectoryStateOnSurface tsos =
           trajectoryStateTransform::transientState(seed.startingState(), lastRecHit->surface(), &theMF);
       auto const& stateGlobal = tsos.globalParameters();
@@ -3221,7 +3465,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
 
       /// Hmm, the following could make sense instead of plain failing if propagation to beam line fails
       /*
-      TransientTrackingRecHit::RecHitPointer lastRecHit = theTTRHBuilder.build(&*(seed.recHits().second-1));
+      TransientTrackingRecHit::RecHitPointer lastRecHit = ttrhBuilder.build(&*(seed.recHits().second-1));
       TrajectoryStateOnSurface state = trajectoryStateTransform::transientState( itSeed->startingState(), lastRecHit->surface(), &theMF);
       float pt  = state.globalParameters().momentum().perp();
       float eta = state.globalParameters().momentum().eta();
@@ -3235,7 +3479,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       std::vector<int> hitType;
 
       for (auto const& hit : seed.recHits()) {
-        TransientTrackingRecHit::RecHitPointer recHit = theTTRHBuilder.build(&hit);
+        TransientTrackingRecHit::RecHitPointer recHit = ttrhBuilder.build(&hit);
         int subid = recHit->geographicalId().subdetId();
         if (subid == (int)PixelSubdetector::PixelBarrel || subid == (int)PixelSubdetector::PixelEndcap) {
           const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*recHit);
@@ -3268,7 +3512,7 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
               // SiStripMatchedRecHit2DCollection, e.g. via muon
               // outside-in seeds (or anything taking hits from
               // MeasurementTrackerEvent). So let's add them here.
-              gluedIndex = addStripMatchedHit(*matchedHit, theTTRHBuilder, tTopo, stripMasks, monoStereoClusterList);
+              gluedIndex = addStripMatchedHit(*matchedHit, ttrhBuilder, tTopo, stripMasks, monoStereoClusterList);
             }
 
             if (includeAllHits_)
@@ -3315,8 +3559,8 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
       //the part below is not strictly needed
       float chi2 = -1;
       if (nHits == 2) {
-        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&*(seed.recHits().begin()));
-        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&*(seed.recHits().begin() + 1));
+        TransientTrackingRecHit::RecHitPointer recHit0 = ttrhBuilder.build(&*(seed.recHits().begin()));
+        TransientTrackingRecHit::RecHitPointer recHit1 = ttrhBuilder.build(&*(seed.recHits().begin() + 1));
         std::vector<GlobalPoint> gp(2);
         std::vector<GlobalError> ge(2);
         gp[0] = recHit0->globalPosition();
@@ -3340,9 +3584,9 @@ void TrackingNtuple::fillSeeds(const edm::Event& iEvent,
                                                     : GlobalPoint(0, 0, 0))
             << " eta,phi: " << gp[0].eta() << "," << gp[0].phi();
       } else if (nHits == 3) {
-        TransientTrackingRecHit::RecHitPointer recHit0 = theTTRHBuilder.build(&*(seed.recHits().begin()));
-        TransientTrackingRecHit::RecHitPointer recHit1 = theTTRHBuilder.build(&*(seed.recHits().begin() + 1));
-        TransientTrackingRecHit::RecHitPointer recHit2 = theTTRHBuilder.build(&*(seed.recHits().begin() + 2));
+        TransientTrackingRecHit::RecHitPointer recHit0 = ttrhBuilder.build(&*(seed.recHits().begin()));
+        TransientTrackingRecHit::RecHitPointer recHit1 = ttrhBuilder.build(&*(seed.recHits().begin() + 1));
+        TransientTrackingRecHit::RecHitPointer recHit2 = ttrhBuilder.build(&*(seed.recHits().begin() + 2));
         declareDynArray(GlobalPoint, 4, gp);
         declareDynArray(GlobalError, 4, ge);
         declareDynArray(bool, 4, bl);
@@ -3409,7 +3653,7 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
                                 const reco::VertexCollection& vertices,
                                 const reco::TrackToTrackingParticleAssociator& associatorByHits,
                                 const ClusterTPAssociation& clusterToTPMap,
-                                const TransientTrackingRecHitBuilder& theTTRHBuilder,
+                                const TransientTrackingRecHitBuilder& ttrhBuilder,
                                 const TrackerTopology& tTopo,
                                 const std::set<edm::ProductID>& hitProductIds,
                                 const std::map<edm::ProductID, size_t>& seedCollToOffset,
@@ -3463,7 +3707,7 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
         itTrack->recHitsEnd());  // TODO: this function is called 3 times per track, try to reduce
     const int nClusters = clusters.size();
 
-    const auto bestKeyCount = findBestMatchingTrackingParticle(*itTrack, clusterToTPMap, tpKeyToIndex);
+    const auto bestKeyCount = findBestMatchingTrackingParticle(itTrack->recHits(), clusterToTPMap, tpKeyToIndex);
     const float bestShareFrac = static_cast<float>(bestKeyCount.countClusters) / static_cast<float>(nClusters);
     float bestShareFracSimDenom = 0;
     float bestShareFracSimClusterDenom = 0;
@@ -3478,7 +3722,8 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
           tkParam, tkCov, *(tpCollection[tpKeyToIndex.at(bestKeyCount.key)]), mf, bs);
     }
     // Another way starting from the first hit of the track
-    const auto bestFirstHitKeyCount = findMatchingTrackingParticleFromFirstHit(*itTrack, clusterToTPMap, tpKeyToIndex);
+    const auto bestFirstHitKeyCount =
+        findMatchingTrackingParticleFromFirstHit(itTrack->recHits(), clusterToTPMap, tpKeyToIndex);
     const float bestFirstHitShareFrac =
         static_cast<float>(bestFirstHitKeyCount.countClusters) / static_cast<float>(nClusters);
     float bestFirstHitShareFracSimDenom = 0;
@@ -3618,7 +3863,7 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
     std::vector<int> hitType;
 
     for (auto i = itTrack->recHitsBegin(); i != itTrack->recHitsEnd(); i++) {
-      TransientTrackingRecHit::RecHitPointer hit = theTTRHBuilder.build(&**i);
+      TransientTrackingRecHit::RecHitPointer hit = ttrhBuilder.build(&**i);
       DetId hitId = hit->geographicalId();
       LogTrace("TrackingNtuple") << "hit #" << std::distance(itTrack->recHitsBegin(), i)
                                  << " subdet=" << hitId.subdetId();
@@ -3679,6 +3924,256 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
 
     trk_hitIdx.push_back(hitIdx);
     trk_hitType.push_back(hitType);
+  }
+}
+
+void TrackingNtuple::fillCandidates(const edm::Handle<TrackCandidateCollection>& candsHandle,
+                                    int algo,
+                                    const TrackingParticleRefVector& tpCollection,
+                                    const TrackingParticleRefKeyToIndex& tpKeyToIndex,
+                                    const TrackingParticleRefKeyToCount& tpKeyToClusterCount,
+                                    const MagneticField& mf,
+                                    const reco::BeamSpot& bs,
+                                    const reco::VertexCollection& vertices,
+                                    const reco::TrackToTrackingParticleAssociator& associatorByHits,
+                                    const ClusterTPAssociation& clusterToTPMap,
+                                    const TransientTrackingRecHitBuilder& ttrhBuilder,
+                                    const TrackerTopology& tTopo,
+                                    const std::set<edm::ProductID>& hitProductIds,
+                                    const std::map<edm::ProductID, size_t>& seedCollToOffset) {
+  reco::RecoToSimCollectionTCandidate recSimColl = associatorByHits.associateRecoToSim(candsHandle, tpCollection);
+
+  TSCBLBuilderNoMaterial tscblBuilder;
+
+  auto const& cands = *candsHandle;
+  for (size_t iCand = 0; iCand < cands.size(); ++iCand) {
+    const auto& aCand = cands[iCand];
+    const edm::Ref<TrackCandidateCollection> aCandRef(candsHandle, iCand);
+
+    //get parameters and errors from the candidate state
+    auto const& geom = ((TkTransientTrackingRecHitBuilder const*)(&ttrhBuilder))->geometry();
+    auto const& pState = aCand.trajectoryStateOnDet();
+    TrajectoryStateOnSurface state =
+        trajectoryStateTransform::transientState(pState, &(geom->idToDet(pState.detId())->surface()), &mf);
+    TrajectoryStateClosestToBeamLine tbStateAtPCA = tscblBuilder(*state.freeState(), bs);
+    if (!tbStateAtPCA.isValid()) {
+      edm::LogVerbatim("TrackBuilding") << "TrajectoryStateClosestToBeamLine not valid";
+    }
+
+    auto const& stateAtPCA = tbStateAtPCA.trackStateAtPCA();
+    auto v0 = stateAtPCA.position();
+    auto p = stateAtPCA.momentum();
+    math::XYZPoint pos(v0.x(), v0.y(), v0.z());
+    math::XYZVector mom(p.x(), p.y(), p.z());
+
+    //pseduo track for access to easy methods
+    reco::Track trk(0, 0, pos, mom, stateAtPCA.charge(), stateAtPCA.curvilinearError());
+
+    const auto& tkParam = trk.parameters();
+    auto tkCov = trk.covariance();
+    tkCov.Invert();
+
+    // Standard track-TP matching
+    int nSimHits = 0;
+    bool isSimMatched = false;
+    std::vector<int> tpIdx;
+    std::vector<float> sharedFraction;
+    std::vector<float> tpChi2;
+    auto foundTPs = recSimColl.find(aCandRef);
+    if (foundTPs != recSimColl.end()) {
+      if (!foundTPs->val.empty()) {
+        nSimHits = foundTPs->val[0].first->numberOfTrackerHits();
+        isSimMatched = true;
+      }
+      for (const auto& tpQuality : foundTPs->val) {
+        tpIdx.push_back(tpKeyToIndex.at(tpQuality.first.key()));
+        sharedFraction.push_back(tpQuality.second);
+        tpChi2.push_back(track_associator::trackAssociationChi2(tkParam, tkCov, *(tpCollection[tpIdx.back()]), mf, bs));
+      }
+    }
+
+    // Search for a best-matching TrackingParticle for a track
+    const auto clusters = track_associator::hitsToClusterRefs(aCand.recHits().begin(), aCand.recHits().end());
+    const int nClusters = clusters.size();
+
+    const auto bestKeyCount = findBestMatchingTrackingParticle(aCand.recHits(), clusterToTPMap, tpKeyToIndex);
+    const float bestCountF = bestKeyCount.countClusters;
+    const float bestShareFrac = bestCountF / nClusters;
+    float bestShareFracSimDenom = 0;
+    float bestShareFracSimClusterDenom = 0;
+    float bestChi2 = -1;
+    if (bestKeyCount.key >= 0) {
+      bestShareFracSimDenom = bestCountF / tpCollection[tpKeyToIndex.at(bestKeyCount.key)]->numberOfTrackerHits();
+      bestShareFracSimClusterDenom = bestCountF / tpKeyToClusterCount.at(bestKeyCount.key);
+      bestChi2 = track_associator::trackAssociationChi2(
+          tkParam, tkCov, *(tpCollection[tpKeyToIndex.at(bestKeyCount.key)]), mf, bs);
+    }
+    // Another way starting from the first hit of the track
+    const auto bestFirstHitKeyCount =
+        findMatchingTrackingParticleFromFirstHit(aCand.recHits(), clusterToTPMap, tpKeyToIndex);
+    const float bestFirstCountF = bestFirstHitKeyCount.countClusters;
+    const float bestFirstHitShareFrac = bestFirstCountF / nClusters;
+    float bestFirstHitShareFracSimDenom = 0;
+    float bestFirstHitShareFracSimClusterDenom = 0;
+    float bestFirstHitChi2 = -1;
+    if (bestFirstHitKeyCount.key >= 0) {
+      bestFirstHitShareFracSimDenom =
+          bestFirstCountF / tpCollection[tpKeyToIndex.at(bestFirstHitKeyCount.key)]->numberOfTrackerHits();
+      bestFirstHitShareFracSimClusterDenom = bestFirstCountF / tpKeyToClusterCount.at(bestFirstHitKeyCount.key);
+      bestFirstHitChi2 = track_associator::trackAssociationChi2(
+          tkParam, tkCov, *(tpCollection[tpKeyToIndex.at(bestFirstHitKeyCount.key)]), mf, bs);
+    }
+
+    tcand_pca_valid.push_back(tbStateAtPCA.isValid());
+    tcand_pca_px.push_back(trk.px());
+    tcand_pca_py.push_back(trk.py());
+    tcand_pca_pz.push_back(trk.pz());
+    tcand_pca_pt.push_back(trk.pt());
+    tcand_pca_eta.push_back(trk.eta());
+    tcand_pca_phi.push_back(trk.phi());
+    tcand_pca_dxy.push_back(trk.dxy());
+    tcand_pca_dz.push_back(trk.dz());
+    tcand_pca_ptErr.push_back(trk.ptError());
+    tcand_pca_etaErr.push_back(trk.etaError());
+    tcand_pca_lambdaErr.push_back(trk.lambdaError());
+    tcand_pca_phiErr.push_back(trk.phiError());
+    tcand_pca_dxyErr.push_back(trk.dxyError());
+    tcand_pca_dzErr.push_back(trk.dzError());
+    tcand_px.push_back(state.globalMomentum().x());
+    tcand_py.push_back(state.globalMomentum().y());
+    tcand_pz.push_back(state.globalMomentum().z());
+    tcand_pt.push_back(state.globalMomentum().perp());
+    tcand_x.push_back(state.globalPosition().x());
+    tcand_y.push_back(state.globalPosition().y());
+    tcand_z.push_back(state.globalPosition().z());
+
+    auto const& pStateCov = state.curvilinearError().matrix();
+    tcand_qbpErr.push_back(sqrt(pStateCov(0, 0)));
+    tcand_lambdaErr.push_back(sqrt(pStateCov(1, 1)));
+    tcand_phiErr.push_back(sqrt(pStateCov(2, 2)));
+    tcand_xtErr.push_back(sqrt(pStateCov(3, 3)));
+    tcand_ytErr.push_back(sqrt(pStateCov(4, 4)));
+
+    int ndof = -5;
+    int nValid = 0;
+    int nPixel = 0;
+    int nStrip = 0;
+    for (auto const& hit : aCand.recHits()) {
+      if (hit.isValid()) {
+        ndof += hit.dimension();
+        nValid++;
+
+        auto const subdet = hit.geographicalId().subdetId();
+        if (subdet == PixelSubdetector::PixelBarrel || subdet == PixelSubdetector::PixelEndcap)
+          nPixel++;
+        else
+          nStrip++;
+      }
+    }
+    tcand_ndof.push_back(ndof);
+    tcand_q.push_back(trk.charge());
+    tcand_nValid.push_back(nValid);
+    tcand_nPixel.push_back(nPixel);
+    tcand_nStrip.push_back(nStrip);
+    tcand_nCluster.push_back(nClusters);
+    tcand_algo.push_back(algo);
+    tcand_stopReason.push_back(aCand.stopReason());
+    if (includeSeeds_) {
+      auto offset = seedCollToOffset.find(aCand.seedRef().id());
+      if (offset == seedCollToOffset.end()) {
+        throw cms::Exception("Configuration")
+            << "Track candidate refers to seed collection " << aCand.seedRef().id()
+            << ", but that seed collection is not given as an input. The following collections were given as an input "
+            << make_ProductIDMapPrinter(seedCollToOffset);
+      }
+
+      const auto seedIndex = offset->second + aCand.seedRef().key();
+      tcand_seedIdx.push_back(seedIndex);
+      if (see_tcandIdx[seedIndex] != -1) {
+        throw cms::Exception("LogicError") << "Track cand index has already been set for seed " << seedIndex << " to "
+                                           << see_tcandIdx[seedIndex] << "; was trying to set it to " << iCand;
+      }
+      see_tcandIdx[seedIndex] = iCand;
+    }
+    tcand_vtxIdx.push_back(-1);  // to be set correctly in fillVertices
+    if (includeTrackingParticles_) {
+      tcand_simTrkIdx.push_back(tpIdx);
+      tcand_simTrkShareFrac.push_back(sharedFraction);
+      tcand_simTrkNChi2.push_back(tpChi2);
+      tcand_bestSimTrkIdx.push_back(bestKeyCount.key >= 0 ? tpKeyToIndex.at(bestKeyCount.key) : -1);
+      tcand_bestFromFirstHitSimTrkIdx.push_back(
+          bestFirstHitKeyCount.key >= 0 ? tpKeyToIndex.at(bestFirstHitKeyCount.key) : -1);
+    } else {
+      tcand_isTrue.push_back(!tpIdx.empty());
+    }
+    tcand_bestSimTrkShareFrac.push_back(bestShareFrac);
+    tcand_bestSimTrkShareFracSimDenom.push_back(bestShareFracSimDenom);
+    tcand_bestSimTrkShareFracSimClusterDenom.push_back(bestShareFracSimClusterDenom);
+    tcand_bestSimTrkNChi2.push_back(bestChi2);
+    tcand_bestFromFirstHitSimTrkShareFrac.push_back(bestFirstHitShareFrac);
+    tcand_bestFromFirstHitSimTrkShareFracSimDenom.push_back(bestFirstHitShareFracSimDenom);
+    tcand_bestFromFirstHitSimTrkShareFracSimClusterDenom.push_back(bestFirstHitShareFracSimClusterDenom);
+    tcand_bestFromFirstHitSimTrkNChi2.push_back(bestFirstHitChi2);
+
+    LogTrace("TrackingNtuple") << "Track cand #" << iCand << " with q=" << trk.charge() << ", pT=" << trk.pt()
+                               << " GeV, eta: " << trk.eta() << ", phi: " << trk.phi() << ", nValid=" << nValid
+                               << " seed#=" << aCand.seedRef().key() << " simMatch=" << isSimMatched
+                               << " nSimHits=" << nSimHits
+                               << " sharedFraction=" << (sharedFraction.empty() ? -1 : sharedFraction[0])
+                               << " tpIdx=" << (tpIdx.empty() ? -1 : tpIdx[0]);
+    std::vector<int> hitIdx;
+    std::vector<int> hitType;
+
+    for (auto i = aCand.recHits().begin(); i != aCand.recHits().end(); i++) {
+      TransientTrackingRecHit::RecHitPointer hit = ttrhBuilder.build(&*i);
+      DetId hitId = hit->geographicalId();
+      LogTrace("TrackingNtuple") << "hit #" << std::distance(aCand.recHits().begin(), i)
+                                 << " subdet=" << hitId.subdetId();
+      if (hitId.det() != DetId::Tracker)
+        continue;
+
+      LogTrace("TrackingNtuple") << " " << subdetstring(hitId.subdetId()) << " " << tTopo.layer(hitId);
+
+      if (hit->isValid()) {
+        //ugly... but works
+        const BaseTrackerRecHit* bhit = dynamic_cast<const BaseTrackerRecHit*>(&*hit);
+        const auto& clusterRef = bhit->firstClusterRef();
+        unsigned int clusterKey;
+        if (clusterRef.isPixel()) {
+          clusterKey = clusterRef.cluster_pixel().key();
+        } else if (clusterRef.isPhase2()) {
+          clusterKey = clusterRef.cluster_phase2OT().key();
+        } else {
+          clusterKey = clusterRef.cluster_strip().key();
+        }
+
+        LogTrace("TrackingNtuple") << " id: " << hitId.rawId() << " - globalPos =" << hit->globalPosition()
+                                   << " cluster=" << clusterKey << " clusterRef ID=" << clusterRef.id()
+                                   << " eta,phi: " << hit->globalPosition().eta() << "," << hit->globalPosition().phi();
+        if (includeAllHits_) {
+          checkProductID(hitProductIds, clusterRef.id(), "track");
+          if (clusterRef.isPixel()) {
+            pix_tcandIdx[clusterKey].push_back(iCand);
+          } else if (clusterRef.isPhase2()) {
+            ph2_tcandIdx[clusterKey].push_back(iCand);
+          } else {
+            str_tcandIdx[clusterKey].push_back(iCand);
+          }
+        }
+
+        hitIdx.push_back(clusterKey);
+        if (clusterRef.isPixel()) {
+          hitType.push_back(static_cast<int>(HitType::Pixel));
+        } else if (clusterRef.isPhase2()) {
+          hitType.push_back(static_cast<int>(HitType::Phase2OT));
+        } else {
+          hitType.push_back(static_cast<int>(HitType::Strip));
+        }
+      }
+    }
+
+    tcand_hitIdx.push_back(hitIdx);
+    tcand_hitType.push_back(hitType);
   }
 }
 

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -688,6 +688,7 @@ private:
   const bool includeTrackCandidates_;
   const bool addSeedCurvCov_;
   const bool includeAllHits_;
+  const bool includeOnTrackHitData_;
   const bool includeMVA_;
   const bool includeTrackingParticles_;
   const bool includeOOT_;
@@ -1157,6 +1158,15 @@ private:
   std::vector<short> pix_isBarrel;
   DetIdPixel pix_detId;
   std::vector<std::vector<int>> pix_trkIdx;            // second index runs through tracks containing this hit
+  std::vector<std::vector<float>> pix_onTrk_x;         // second index runs through tracks containing this hit
+  std::vector<std::vector<float>> pix_onTrk_y;         // same for all pix_onTrk_*
+  std::vector<std::vector<float>> pix_onTrk_z;         //
+  std::vector<std::vector<float>> pix_onTrk_xx;        //
+  std::vector<std::vector<float>> pix_onTrk_xy;        //
+  std::vector<std::vector<float>> pix_onTrk_yy;        //
+  std::vector<std::vector<float>> pix_onTrk_yz;        //
+  std::vector<std::vector<float>> pix_onTrk_zz;        //
+  std::vector<std::vector<float>> pix_onTrk_zx;        //
   std::vector<std::vector<int>> pix_tcandIdx;          // second index runs through candidates containing this hit
   std::vector<std::vector<int>> pix_seeIdx;            // second index runs through seeds containing this hit
   std::vector<std::vector<int>> pix_simHitIdx;         // second index runs through SimHits inducing this hit
@@ -1184,6 +1194,15 @@ private:
   std::vector<short> str_isBarrel;
   DetIdStrip str_detId;
   std::vector<std::vector<int>> str_trkIdx;            // second index runs through tracks containing this hit
+  std::vector<std::vector<float>> str_onTrk_x;         // second index runs through tracks containing this hit
+  std::vector<std::vector<float>> str_onTrk_y;         // same for all pix_onTrk_*
+  std::vector<std::vector<float>> str_onTrk_z;         //
+  std::vector<std::vector<float>> str_onTrk_xx;        //
+  std::vector<std::vector<float>> str_onTrk_xy;        //
+  std::vector<std::vector<float>> str_onTrk_yy;        //
+  std::vector<std::vector<float>> str_onTrk_yz;        //
+  std::vector<std::vector<float>> str_onTrk_zz;        //
+  std::vector<std::vector<float>> str_onTrk_zx;        //
   std::vector<std::vector<int>> str_tcandIdx;          // second index runs through candidates containing this hit
   std::vector<std::vector<int>> str_seeIdx;            // second index runs through seeds containing this hit
   std::vector<std::vector<int>> str_simHitIdx;         // second index runs through SimHits inducing this hit
@@ -1236,6 +1255,15 @@ private:
   std::vector<short> ph2_isBarrel;
   DetIdPhase2OT ph2_detId;
   std::vector<std::vector<int>> ph2_trkIdx;            // second index runs through tracks containing this hit
+  std::vector<std::vector<float>> ph2_onTrk_x;         // second index runs through tracks containing this hit
+  std::vector<std::vector<float>> ph2_onTrk_y;         // same for all pix_onTrk_*
+  std::vector<std::vector<float>> ph2_onTrk_z;         //
+  std::vector<std::vector<float>> ph2_onTrk_xx;        //
+  std::vector<std::vector<float>> ph2_onTrk_xy;        //
+  std::vector<std::vector<float>> ph2_onTrk_yy;        //
+  std::vector<std::vector<float>> ph2_onTrk_yz;        //
+  std::vector<std::vector<float>> ph2_onTrk_zz;        //
+  std::vector<std::vector<float>> ph2_onTrk_zx;        //
   std::vector<std::vector<int>> ph2_tcandIdx;          // second index runs through candidates containing this hit
   std::vector<std::vector<int>> ph2_seeIdx;            // second index runs through seeds containing this hit
   std::vector<std::vector<int>> ph2_simHitIdx;         // second index runs through SimHits inducing this hit
@@ -1419,6 +1447,7 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       includeTrackCandidates_(iConfig.getUntrackedParameter<bool>("includeTrackCandidates")),
       addSeedCurvCov_(iConfig.getUntrackedParameter<bool>("addSeedCurvCov")),
       includeAllHits_(iConfig.getUntrackedParameter<bool>("includeAllHits")),
+      includeOnTrackHitData_(iConfig.getUntrackedParameter<bool>("includeOnTrackHitData")),
       includeMVA_(iConfig.getUntrackedParameter<bool>("includeMVA")),
       includeTrackingParticles_(iConfig.getUntrackedParameter<bool>("includeTrackingParticles")),
       includeOOT_(iConfig.getUntrackedParameter<bool>("includeOOT")),
@@ -1694,6 +1723,17 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
     t->Branch("pix_isBarrel", &pix_isBarrel);
     pix_detId.book("pix", t);
     t->Branch("pix_trkIdx", &pix_trkIdx);
+    if (includeOnTrackHitData_) {
+      t->Branch("pix_onTrk_x", &pix_onTrk_x);
+      t->Branch("pix_onTrk_y", &pix_onTrk_y);
+      t->Branch("pix_onTrk_z", &pix_onTrk_z);
+      t->Branch("pix_onTrk_xx", &pix_onTrk_xx);
+      t->Branch("pix_onTrk_xy", &pix_onTrk_xy);
+      t->Branch("pix_onTrk_yy", &pix_onTrk_yy);
+      t->Branch("pix_onTrk_yz", &pix_onTrk_yz);
+      t->Branch("pix_onTrk_zz", &pix_onTrk_zz);
+      t->Branch("pix_onTrk_zx", &pix_onTrk_zx);
+    }
     if (includeTrackCandidates_)
       t->Branch("pix_tcandIdx", &pix_tcandIdx);
     if (includeSeeds_) {
@@ -1726,6 +1766,17 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("str_isBarrel", &str_isBarrel);
       str_detId.book("str", t);
       t->Branch("str_trkIdx", &str_trkIdx);
+      if (includeOnTrackHitData_) {
+        t->Branch("str_onTrk_x", &str_onTrk_x);
+        t->Branch("str_onTrk_y", &str_onTrk_y);
+        t->Branch("str_onTrk_z", &str_onTrk_z);
+        t->Branch("str_onTrk_xx", &str_onTrk_xx);
+        t->Branch("str_onTrk_xy", &str_onTrk_xy);
+        t->Branch("str_onTrk_yy", &str_onTrk_yy);
+        t->Branch("str_onTrk_yz", &str_onTrk_yz);
+        t->Branch("str_onTrk_zz", &str_onTrk_zz);
+        t->Branch("str_onTrk_zx", &str_onTrk_zx);
+      }
       if (includeTrackCandidates_)
         t->Branch("str_tcandIdx", &str_tcandIdx);
       if (includeSeeds_) {
@@ -1783,6 +1834,17 @@ TrackingNtuple::TrackingNtuple(const edm::ParameterSet& iConfig)
       t->Branch("ph2_isBarrel", &ph2_isBarrel);
       ph2_detId.book("ph2", t);
       t->Branch("ph2_trkIdx", &ph2_trkIdx);
+      if (includeOnTrackHitData_) {
+        t->Branch("ph2_onTrk_x", &ph2_onTrk_x);
+        t->Branch("ph2_onTrk_y", &ph2_onTrk_y);
+        t->Branch("ph2_onTrk_z", &ph2_onTrk_z);
+        t->Branch("ph2_onTrk_xx", &ph2_onTrk_xx);
+        t->Branch("ph2_onTrk_xy", &ph2_onTrk_xy);
+        t->Branch("ph2_onTrk_yy", &ph2_onTrk_yy);
+        t->Branch("ph2_onTrk_yz", &ph2_onTrk_yz);
+        t->Branch("ph2_onTrk_zz", &ph2_onTrk_zz);
+        t->Branch("ph2_onTrk_zx", &ph2_onTrk_zx);
+      }
       if (includeTrackCandidates_)
         t->Branch("ph2_tcandIdx", &ph2_tcandIdx);
       if (includeSeeds_) {
@@ -2120,6 +2182,15 @@ void TrackingNtuple::clearVariables() {
   pix_isBarrel.clear();
   pix_detId.clear();
   pix_trkIdx.clear();
+  pix_onTrk_x.clear();
+  pix_onTrk_y.clear();
+  pix_onTrk_z.clear();
+  pix_onTrk_xx.clear();
+  pix_onTrk_xy.clear();
+  pix_onTrk_yy.clear();
+  pix_onTrk_yz.clear();
+  pix_onTrk_zz.clear();
+  pix_onTrk_zx.clear();
   pix_tcandIdx.clear();
   pix_seeIdx.clear();
   pix_simHitIdx.clear();
@@ -2144,6 +2215,15 @@ void TrackingNtuple::clearVariables() {
   str_isBarrel.clear();
   str_detId.clear();
   str_trkIdx.clear();
+  str_onTrk_x.clear();
+  str_onTrk_y.clear();
+  str_onTrk_z.clear();
+  str_onTrk_xx.clear();
+  str_onTrk_xy.clear();
+  str_onTrk_yy.clear();
+  str_onTrk_yz.clear();
+  str_onTrk_zz.clear();
+  str_onTrk_zx.clear();
   str_tcandIdx.clear();
   str_seeIdx.clear();
   str_simHitIdx.clear();
@@ -2190,6 +2270,15 @@ void TrackingNtuple::clearVariables() {
   ph2_isBarrel.clear();
   ph2_detId.clear();
   ph2_trkIdx.clear();
+  ph2_onTrk_x.clear();
+  ph2_onTrk_y.clear();
+  ph2_onTrk_z.clear();
+  ph2_onTrk_xx.clear();
+  ph2_onTrk_xy.clear();
+  ph2_onTrk_yy.clear();
+  ph2_onTrk_yz.clear();
+  ph2_onTrk_zz.clear();
+  ph2_onTrk_zx.clear();
   ph2_tcandIdx.clear();
   ph2_seeIdx.clear();
   ph2_xySignificance.clear();
@@ -2961,7 +3050,16 @@ void TrackingNtuple::fillPixelHits(const edm::Event& iEvent,
 
       pix_isBarrel.push_back(hitId.subdetId() == 1);
       pix_detId.push_back(tTopo, hitId);
-      pix_trkIdx.emplace_back();    // filled in fillTracks
+      pix_trkIdx.emplace_back();  // filled in fillTracks
+      pix_onTrk_x.emplace_back();
+      pix_onTrk_y.emplace_back();
+      pix_onTrk_z.emplace_back();
+      pix_onTrk_xx.emplace_back();
+      pix_onTrk_xy.emplace_back();
+      pix_onTrk_yy.emplace_back();
+      pix_onTrk_yz.emplace_back();
+      pix_onTrk_zz.emplace_back();
+      pix_onTrk_zx.emplace_back();
       pix_tcandIdx.emplace_back();  // filled in fillCandidates
       pix_seeIdx.emplace_back();    // filled in fillSeeds
       pix_x.push_back(ttrh->globalPosition().x());
@@ -3045,7 +3143,16 @@ void TrackingNtuple::fillStripRphiStereoHits(const edm::Event& iEvent,
   int totalStripHits = rphiHits->dataSize() + stereoHits->dataSize();
   str_isBarrel.resize(totalStripHits);
   str_detId.resize(totalStripHits);
-  str_trkIdx.resize(totalStripHits);    // filled in fillTracks
+  str_trkIdx.resize(totalStripHits);  // filled in fillTracks
+  str_onTrk_x.resize(totalStripHits);
+  str_onTrk_y.resize(totalStripHits);
+  str_onTrk_z.resize(totalStripHits);
+  str_onTrk_xx.resize(totalStripHits);
+  str_onTrk_xy.resize(totalStripHits);
+  str_onTrk_yy.resize(totalStripHits);
+  str_onTrk_yz.resize(totalStripHits);
+  str_onTrk_zz.resize(totalStripHits);
+  str_onTrk_zx.resize(totalStripHits);
   str_tcandIdx.resize(totalStripHits);  // filled in fillCandidates
   str_seeIdx.resize(totalStripHits);    // filled in fillSeeds
   str_simHitIdx.resize(totalStripHits);
@@ -3224,7 +3331,16 @@ void TrackingNtuple::fillPhase2OTHits(const edm::Event& iEvent,
 
       ph2_isBarrel.push_back(hitId.subdetId() == 1);
       ph2_detId.push_back(tTopo, hitId);
-      ph2_trkIdx.emplace_back();    // filled in fillTracks
+      ph2_trkIdx.emplace_back();  // filled in fillTracks
+      ph2_onTrk_x.emplace_back();
+      ph2_onTrk_y.emplace_back();
+      ph2_onTrk_z.emplace_back();
+      ph2_onTrk_xx.emplace_back();
+      ph2_onTrk_xy.emplace_back();
+      ph2_onTrk_yy.emplace_back();
+      ph2_onTrk_yz.emplace_back();
+      ph2_onTrk_zz.emplace_back();
+      ph2_onTrk_zx.emplace_back();
       ph2_tcandIdx.emplace_back();  // filled in fillCandidates
       ph2_seeIdx.emplace_back();    // filled in fillSeeds
       ph2_x.push_back(ttrh->globalPosition().x());
@@ -3893,10 +4009,37 @@ void TrackingNtuple::fillTracks(const edm::RefToBaseVector<reco::Track>& tracks,
           checkProductID(hitProductIds, clusterRef.id(), "track");
           if (clusterRef.isPixel()) {
             pix_trkIdx[clusterKey].push_back(iTrack);
+            pix_onTrk_x[clusterKey].push_back(hit->globalPosition().x());
+            pix_onTrk_y[clusterKey].push_back(hit->globalPosition().y());
+            pix_onTrk_z[clusterKey].push_back(hit->globalPosition().z());
+            pix_onTrk_xx[clusterKey].push_back(hit->globalPositionError().cxx());
+            pix_onTrk_xy[clusterKey].push_back(hit->globalPositionError().cyx());
+            pix_onTrk_yy[clusterKey].push_back(hit->globalPositionError().cyy());
+            pix_onTrk_yz[clusterKey].push_back(hit->globalPositionError().czy());
+            pix_onTrk_zz[clusterKey].push_back(hit->globalPositionError().czz());
+            pix_onTrk_zx[clusterKey].push_back(hit->globalPositionError().czx());
           } else if (clusterRef.isPhase2()) {
             ph2_trkIdx[clusterKey].push_back(iTrack);
+            ph2_onTrk_x[clusterKey].push_back(hit->globalPosition().x());
+            ph2_onTrk_y[clusterKey].push_back(hit->globalPosition().y());
+            ph2_onTrk_z[clusterKey].push_back(hit->globalPosition().z());
+            ph2_onTrk_xx[clusterKey].push_back(hit->globalPositionError().cxx());
+            ph2_onTrk_xy[clusterKey].push_back(hit->globalPositionError().cyx());
+            ph2_onTrk_yy[clusterKey].push_back(hit->globalPositionError().cyy());
+            ph2_onTrk_yz[clusterKey].push_back(hit->globalPositionError().czy());
+            ph2_onTrk_zz[clusterKey].push_back(hit->globalPositionError().czz());
+            ph2_onTrk_zx[clusterKey].push_back(hit->globalPositionError().czx());
           } else {
             str_trkIdx[clusterKey].push_back(iTrack);
+            str_onTrk_x[clusterKey].push_back(hit->globalPosition().x());
+            str_onTrk_y[clusterKey].push_back(hit->globalPosition().y());
+            str_onTrk_z[clusterKey].push_back(hit->globalPosition().z());
+            str_onTrk_xx[clusterKey].push_back(hit->globalPositionError().cxx());
+            str_onTrk_xy[clusterKey].push_back(hit->globalPositionError().cyx());
+            str_onTrk_yy[clusterKey].push_back(hit->globalPositionError().cyy());
+            str_onTrk_yz[clusterKey].push_back(hit->globalPositionError().czy());
+            str_onTrk_zz[clusterKey].push_back(hit->globalPositionError().czz());
+            str_onTrk_zx[clusterKey].push_back(hit->globalPositionError().czx());
           }
         }
 
@@ -4027,7 +4170,7 @@ void TrackingNtuple::fillCandidates(const edm::Handle<TrackCandidateCollection>&
           tkParam, tkCov, *(tpCollection[tpKeyToIndex.at(bestFirstHitKeyCount.key)]), mf, bs);
     }
 
-    auto iglobCand = tcand_pca_valid.size(); //global cand index
+    auto iglobCand = tcand_pca_valid.size();  //global cand index
     tcand_pca_valid.push_back(tbStateAtPCA.isValid());
     tcand_pca_px.push_back(trk.px());
     tcand_pca_py.push_back(trk.py());
@@ -4094,8 +4237,9 @@ void TrackingNtuple::fillCandidates(const edm::Handle<TrackCandidateCollection>&
       const auto seedIndex = offset->second + aCand.seedRef().key();
       tcand_seedIdx.push_back(seedIndex);
       if (see_tcandIdx[seedIndex] != -1) {
-        throw cms::Exception("LogicError") << "Track cand index has already been set for seed " << seedIndex << " to "
-                                           << see_tcandIdx[seedIndex] << "; was trying to set it to " << iglobCand<<" current "<<iCand;
+        throw cms::Exception("LogicError")
+            << "Track cand index has already been set for seed " << seedIndex << " to " << see_tcandIdx[seedIndex]
+            << "; was trying to set it to " << iglobCand << " current " << iCand;
       }
       see_tcandIdx[seedIndex] = iglobCand;
     }
@@ -4119,10 +4263,10 @@ void TrackingNtuple::fillCandidates(const edm::Handle<TrackCandidateCollection>&
     tcand_bestFromFirstHitSimTrkShareFracSimClusterDenom.push_back(bestFirstHitShareFracSimClusterDenom);
     tcand_bestFromFirstHitSimTrkNChi2.push_back(bestFirstHitChi2);
 
-    LogTrace("TrackingNtuple") << "Track cand #" << iCand <<" glob " << iglobCand << " with q=" << trk.charge() << ", pT=" << trk.pt()
-                               << " GeV, eta: " << trk.eta() << ", phi: " << trk.phi() << ", nValid=" << nValid
-                               << " seed#=" << aCand.seedRef().key() << " simMatch=" << isSimMatched
-                               << " nSimHits=" << nSimHits
+    LogTrace("TrackingNtuple") << "Track cand #" << iCand << " glob " << iglobCand << " with q=" << trk.charge()
+                               << ", pT=" << trk.pt() << " GeV, eta: " << trk.eta() << ", phi: " << trk.phi()
+                               << ", nValid=" << nValid << " seed#=" << aCand.seedRef().key()
+                               << " simMatch=" << isSimMatched << " nSimHits=" << nSimHits
                                << " sharedFraction=" << (sharedFraction.empty() ? -1 : sharedFraction[0])
                                << " tpIdx=" << (tpIdx.empty() ? -1 : tpIdx[0]);
     std::vector<int> hitIdx;
@@ -4501,6 +4645,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.addUntracked<bool>("includeTrackCandidates", false);
   desc.addUntracked<bool>("addSeedCurvCov", false);
   desc.addUntracked<bool>("includeAllHits", false);
+  desc.addUntracked<bool>("includeOnTrackHitData", false);
   desc.addUntracked<bool>("includeMVA", true);
   desc.addUntracked<bool>("includeTrackingParticles", true);
   desc.addUntracked<bool>("includeOOT", false);

--- a/Validation/RecoTrack/plugins/TrackingNtuple.cc
+++ b/Validation/RecoTrack/plugins/TrackingNtuple.cc
@@ -4494,6 +4494,7 @@ void TrackingNtuple::fillDescriptions(edm::ConfigurationDescriptions& descriptio
                                    edm::InputTag("trackingParticleNumberOfLayersProducer", "stripStereoLayers"));
   desc.addUntracked<std::string>("TTRHBuilder", "WithTrackAngle");
   desc.addUntracked<bool>("includeSeeds", false);
+  desc.addUntracked<bool>("includeTrackCandidates", false);
   desc.addUntracked<bool>("addSeedCurvCov", false);
   desc.addUntracked<bool>("includeAllHits", false);
   desc.addUntracked<bool>("includeMVA", true);

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -149,4 +149,6 @@ def extendedContent(process):
     process.trackingNtuple.saveSimHitsP3 = True
     process.trackingNtuple.addSeedCurvCov = True
 
+    process.trackingNtuple.includeTrackCandidates = True
+
     return process

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -157,6 +157,7 @@ def extendedContent(process):
     process.trackingNtuple.saveSimHitsP3 = True
     process.trackingNtuple.addSeedCurvCov = True
 
+    process.trackingNtuple.includeOnTrackHitData = True
     process.trackingNtuple.includeTrackCandidates = True
 
     return process

--- a/Validation/RecoTrack/python/customiseTrackingNtuple.py
+++ b/Validation/RecoTrack/python/customiseTrackingNtuple.py
@@ -45,11 +45,19 @@ def customiseTrackingNtupleTool(process, isRECO = True, mergeIters = False):
 
     #combine all *StepTracks (TODO: write one for HLT)
     if mergeIters and isRECO:
-        process.mergedStepTracks = cms.EDProducer("TrackSimpleMerger",
-            src = cms.VInputTag(m.replace("Seeds", "Tracks").replace("seedTracks", "") for m in process.trackingNtuple.seedTracks)
+        import RecoTracker.FinalTrackSelectors.TrackCollectionMerger_cfi as _mod
+        process.mergedStepTracks = _mod.TrackCollectionMerger.clone(
+            trackProducers = cms.VInputTag(m.replace("Seeds", "Tracks").replace("seedTracks", "") for m in process.trackingNtuple.seedTracks),
+            inputClassifiers = cms.vstring(m.replace("StepSeeds", "Step").replace("seedTracks", "").replace("dSeeds", "dTracks")
+                                           .replace("InOut", "InOutClassifier").replace("tIn", "tInClassifier")
+                                           for m in process.trackingNtuple.seedTracks),
+            minQuality = "any",
+            enableMerging = False
         )
         process.trackingNtupleSequence.insert(0,process.mergedStepTracks)
         process.trackingNtuple.tracks = "mergedStepTracks"
+        process.trackingNtuple.includeMVA = True
+        process.trackingNtuple.trackMVAs = ["mergedStepTracks"]
 
     ntuplePath = cms.Path(process.trackingNtupleSequence)
 


### PR DESCRIPTION
- SimDataFormats/Associations: 
    - add alias template to simplify definition of `SimToRecoCollection*` and `RecoToSimCollection*` and removed its partial duplicate definition in TrackToTrackingParticleAssociator.h to keep everything just in TrackAssociation.h. The fully defined types should be the same, so no update should be necessary in the `classes*` files for the dictionaries. There are no use cases at this point for placing `SimToRecoCollectionTCandidate` and `RecoToSimCollectionTCandidate` in `edm::Event`; so, no dictionary is added for this.
    - changed `TrackToTrackingParticleAssociator::associateRecoToSim` arguments/interface from `Handle<TrackingParticleCollection` to `RefVector<TrackingParticleCollection` to be more in common with existing use cases for `reco::Tracks`
- SimTracker/TrackAssociatorProducers: improve templated methods in `QuickTrackAssociatorByHitsImpl` so that `reco::Track` and `TrackCandidate` have maximal overlap in implementation and minimize copy-pasted code
- Validation/RecoTrack: trackingNtuple updates
    - add `tcand_*` branches to provide access to `TrackCandidate` details (optional, enabled for extendedContent custom option). This should allow more straightforward debugging of track pattern recognition, in particular in mkFit. This data can also be used to train track candidate classification and allow removing candidates from the following final fit step (and save computation)
    - refactor mergeIters case (where built tracks are used as inputs) to provide access to per-iteration MVAs
    - add (global) hit positions for rechits as computed with the track-trajectory corrected CPEs to allow for hit position and residual analysis
    - cleanup the outdated use of `TransientTrackingRecHitBuilder` and use tracking hits directly. This is in a sense a somewhat late follow-up to #3344 

No changes are expected in the standard workflows.
If that is confirmed, there may be a backport to an older release (12_2_X where the TRK-Run3Winter22 are made, in case it's not practical to run on those inputs in 12_4_X)
