### PR TITLE
Implement ResourceInformationService

### DIFF
--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -16,14 +16,18 @@
 #include "FWCore/Framework/interface/SignallingProductRegistry.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/GetPassID.h"
+#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
 #include <memory>
 
 #include <set>
+#include <string>
+#include <vector>
 
 namespace edm {
   ScheduleItems::ScheduleItems()
@@ -121,6 +125,13 @@ namespace edm {
   }
 
   std::shared_ptr<CommonParams> ScheduleItems::initMisc(ParameterSet& parameterSet) {
+    edm::Service<edm::ResourceInformation> resourceInformationService;
+    if (resourceInformationService.isAvailable()) {
+      auto const& selectedAccelerators =
+          parameterSet.getUntrackedParameter<std::vector<std::string>>("@selected_accelerators");
+      resourceInformationService->initializeAcceleratorTypes(selectedAccelerators);
+    }
+
     act_table_ = std::make_unique<ExceptionToActionTable>(parameterSet);
     std::string processName = parameterSet.getParameter<std::string>("@process_name");
     processConfiguration_ = std::make_shared<ProcessConfiguration>(

--- a/FWCore/Framework/src/defaultCmsRunServices.cc
+++ b/FWCore/Framework/src/defaultCmsRunServices.cc
@@ -23,6 +23,8 @@ namespace edm {
                                             "AdaptorConfig",
                                             "SiteLocalConfigService",
                                             "StatisticsSenderService",
+                                            "ResourceInformationService",
+                                            "CPU",
                                             "CondorStatusService",
                                             "XrdStatisticsService"};
 

--- a/FWCore/Integration/test/testSubProcess_cfg.py
+++ b/FWCore/Integration/test/testSubProcess_cfg.py
@@ -34,9 +34,9 @@ process.DoodadESSource = cms.ESSource("DoodadESSource"
                                       , test2 = cms.untracked.string('z')
 )
 
-process.CPU = cms.Service("CPU")
 process.ZombieKillerService = cms.Service("ZombieKillerService")
 process.JobReportService = cms.Service("JobReportService")
+process.CUDAService = cms.Service("CUDAService")
 
 # ---------------------------------------------------------------
 
@@ -68,6 +68,15 @@ copyProcess.SiteLocalConfigService = cms.Service("SiteLocalConfigService",
     intentionallyIllegalParameter = cms.bool(True)
 )
 copyProcess.AdaptorConfig = cms.Service("AdaptorConfig",
+    intentionallyIllegalParameter = cms.bool(True)
+)
+copyProcess.ResourceInformationService = cms.Service("ResourceInformationService",
+    intentionallyIllegalParameter = cms.bool(True)
+)
+copyProcess.CUDAService = cms.Service("CUDAService",
+    intentionallyIllegalParameter = cms.bool(True)
+)
+copyProcess.CondorStatusService = cms.Service("CondorStatusService",
     intentionallyIllegalParameter = cms.bool(True)
 )
 
@@ -144,7 +153,7 @@ copy2Process.DoodadESSource = cms.ESSource("DoodadESSource"
 prod2Process = cms.Process("PROD2")
 copy2Process.addSubProcess(cms.SubProcess(prod2Process,
     outputCommands = cms.untracked.vstring(
-        "keep *", 
+        "keep *",
         "drop *_putInt_*_*"),
 ))
 prod2Process.DoodadESSource = cms.ESSource("DoodadESSource"
@@ -269,7 +278,7 @@ prod2Process.endPath1 = cms.EndPath(prod2Process.out)
 prod2ProcessAlt = cms.Process("PROD2ALT")
 copy2Process.addSubProcess(cms.SubProcess(prod2ProcessAlt,
     outputCommands = cms.untracked.vstring(
-        "keep *", 
+        "keep *",
         "drop *_putInt_*_*"),
 ))
 prod2ProcessAlt.DoodadESSource = cms.ESSource("DoodadESSource"

--- a/FWCore/Integration/test/testSubProcess_cfg.py
+++ b/FWCore/Integration/test/testSubProcess_cfg.py
@@ -36,7 +36,6 @@ process.DoodadESSource = cms.ESSource("DoodadESSource"
 
 process.ZombieKillerService = cms.Service("ZombieKillerService")
 process.JobReportService = cms.Service("JobReportService")
-process.CUDAService = cms.Service("CUDAService")
 
 # ---------------------------------------------------------------
 
@@ -71,9 +70,6 @@ copyProcess.AdaptorConfig = cms.Service("AdaptorConfig",
     intentionallyIllegalParameter = cms.bool(True)
 )
 copyProcess.ResourceInformationService = cms.Service("ResourceInformationService",
-    intentionallyIllegalParameter = cms.bool(True)
-)
-copyProcess.CUDAService = cms.Service("CUDAService",
     intentionallyIllegalParameter = cms.bool(True)
 )
 copyProcess.CondorStatusService = cms.Service("CondorStatusService",

--- a/FWCore/MessageService/test/u10_cfg.py
+++ b/FWCore/MessageService/test/u10_cfg.py
@@ -22,6 +22,10 @@ process.MessageLogger = cms.Service("MessageLogger",
     )
 )
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )

--- a/FWCore/MessageService/test/u14_cfg.py
+++ b/FWCore/MessageService/test/u14_cfg.py
@@ -40,6 +40,10 @@ process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*')
 )
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(2)
 )

--- a/FWCore/MessageService/test/u16_cfg.py
+++ b/FWCore/MessageService/test/u16_cfg.py
@@ -64,6 +64,10 @@ process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*')
 )
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(2)
 )

--- a/FWCore/MessageService/test/u1_cfg.py
+++ b/FWCore/MessageService/test/u1_cfg.py
@@ -59,6 +59,10 @@ process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
 )
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(2)
 )

--- a/FWCore/MessageService/test/u1d_cfg.py
+++ b/FWCore/MessageService/test/u1d_cfg.py
@@ -60,6 +60,10 @@ process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*')
 )
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(2)
 )

--- a/FWCore/MessageService/test/u20_cfg.py
+++ b/FWCore/MessageService/test/u20_cfg.py
@@ -18,6 +18,10 @@ process.MessageLogger.default = cms.untracked.PSet(
 process.MessageLogger.cerr.noTimeStamps = True
 process.MessageLogger.cerr.enableStatistics = True
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )

--- a/FWCore/MessageService/test/u27_cfg.py
+++ b/FWCore/MessageService/test/u27_cfg.py
@@ -35,6 +35,10 @@ process.MessageLogger = cms.Service("MessageLogger",
     )
 )
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )

--- a/FWCore/MessageService/test/u7_cfg.py
+++ b/FWCore/MessageService/test/u7_cfg.py
@@ -33,6 +33,10 @@ process.MessageLogger = cms.Service("MessageLogger",
     )
 )
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(2)
 )

--- a/FWCore/MessageService/test/u9_cfg.py
+++ b/FWCore/MessageService/test/u9_cfg.py
@@ -39,6 +39,10 @@ process.MessageLogger.files.infos = cms.untracked.PSet(
     )
 )
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -1,10 +1,9 @@
 
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "FWCore/Utilities/interface/TimingServiceBase.h"
-#include "FWCore/Utilities/interface/CPUServiceBase.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -51,6 +50,7 @@ namespace edm {
       bool updateChirpImpl(std::string const &key, std::string const &value);
       inline void update();
       void firstUpdate();
+      void secondUpdate();
       void lastUpdate();
       void updateImpl(time_t secsSinceLastUpdate);
 
@@ -81,6 +81,7 @@ namespace edm {
 
       std::uint_least64_t m_lastEventCount = 0;
     };
+    inline bool isProcessWideService(CondorStatusService const *) { return true; }
 
   }  // namespace service
 
@@ -148,6 +149,7 @@ void CondorStatusService::filePost(std::string const & /*lfn*/) {
 }
 
 void CondorStatusService::beginPre(PathsAndConsumesOfModulesBase const &, ProcessContext const &processContext) {
+  secondUpdate();
   if (!m_processParameterSetID.isValid()) {
     m_processParameterSetID = processContext.parameterSetID();
   }
@@ -231,13 +233,17 @@ void CondorStatusService::firstUpdate() {
   updateChirp("MaxLumis", "-1");
   updateChirp("Done", "false");
   updateChirpQuoted("Guid", edm::processGUID().toString());
+}
 
-  edm::Service<edm::CPUServiceBase> cpusvc;
-  std::string models;
-  double avgSpeed;
-  if (cpusvc.isAvailable() && cpusvc->cpuInfo(models, avgSpeed)) {
-    updateChirpQuoted("CPUModels", models);
-    updateChirp("CPUSpeed", avgSpeed);
+void CondorStatusService::secondUpdate() {
+  edm::Service<edm::ResourceInformation> resourceInformationService;
+  if (resourceInformationService.isAvailable()) {
+    std::string models = resourceInformationService->cpuModelsFormatted();
+    double avgSpeed = resourceInformationService->cpuAverageSpeed();
+    if (!models.empty()) {
+      updateChirpQuoted("CPUModels", models);
+      updateChirp("CPUSpeed", avgSpeed);
+    }
   }
 }
 
@@ -245,9 +251,9 @@ void CondorStatusService::lastUpdate() {
   time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
   updateImpl(now - m_lastUpdate);
   updateChirp("Done", "true");
-  edm::Service<edm::CPUServiceBase> cpusvc;
-  if (!cpusvc.isAvailable()) {
-    std::cout << "At post, CPU service is NOT available.\n";
+  edm::Service<edm::ResourceInformation> resourceInformationService;
+  if (!resourceInformationService.isAvailable()) {
+    std::cout << "At post, ResourceInformationService is NOT available.\n";
   }
 }
 
@@ -427,6 +433,8 @@ void CondorStatusService::fillDescriptions(ConfigurationDescriptions &descriptio
   desc.addOptionalUntracked<bool>("enable", true)->setComment("Enable this service");
   descriptions.add("CondorStatusService", desc);
 }
+
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 typedef edm::serviceregistry::AllArgsMaker<edm::service::CondorStatusService> CondorStatusServiceMaker;
 DEFINE_FWK_SERVICE_MAKER(CondorStatusService, CondorStatusServiceMaker);

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -1,6 +1,7 @@
 
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/ResourceInformation.h"
 #include "FWCore/Utilities/interface/TimingServiceBase.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -253,7 +254,7 @@ void CondorStatusService::lastUpdate() {
   updateChirp("Done", "true");
   edm::Service<edm::ResourceInformation> resourceInformationService;
   if (!resourceInformationService.isAvailable()) {
-    std::cout << "At post, ResourceInformationService is NOT available.\n";
+    edm::LogWarning("CondorStatusService") << "At post, ResourceInformationService is NOT available.\n";
   }
 }
 

--- a/FWCore/Services/plugins/ResourceInformationService.cc
+++ b/FWCore/Services/plugins/ResourceInformationService.cc
@@ -1,0 +1,213 @@
+// -*- C++ -*-
+//
+// Package:     Services
+// Class  :     ResourceInformationService
+//
+// Implementation:
+
+/** \class edm::service::ResourceInformationService
+
+\author W. David Dagenhart, created 29 April, 2022
+
+*/
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/ResourceInformation.h"
+
+#include <string>
+#include <vector>
+
+namespace edm {
+  namespace service {
+
+    class ResourceInformationService : public ResourceInformation {
+    public:
+      ResourceInformationService(ParameterSet const&, ActivityRegistry&);
+
+      static void fillDescriptions(ConfigurationDescriptions&);
+
+      std::vector<AcceleratorType> const& acceleratorTypes() const final;
+      std::vector<std::string> const& cpuModels() const final;
+      std::vector<std::string> const& gpuModels() const final;
+
+      std::string const& nvidiaDriverVersion() const final;
+      int cudaDriverVersion() const final;
+      int cudaRuntimeVersion() const final;
+
+      // Same as cpuModels except in a single string with models separated by ", "
+      std::string const& cpuModelsFormatted() const final;
+      double cpuAverageSpeed() const final;
+
+      void initializeAcceleratorTypes(std::vector<std::string> const& selectedAccelerators) final;
+      void setCPUModels(std::vector<std::string> const&) final;
+      void setGPUModels(std::vector<std::string> const&) final;
+
+      void setNvidiaDriverVersion(std::string const&) final;
+      void setCudaDriverVersion(int) final;
+      void setCudaRuntimeVersion(int) final;
+
+      void setCpuModelsFormatted(std::string const&) final;
+      void setCpuAverageSpeed(double) final;
+
+      void postBeginJob();
+
+    private:
+      void throwIfLocked() const;
+
+      std::vector<AcceleratorType> acceleratorTypes_;
+      std::vector<std::string> cpuModels_;
+      std::vector<std::string> gpuModels_;
+
+      std::string nvidiaDriverVersion_;
+      int cudaDriverVersion_ = 0;
+      int cudaRuntimeVersion_ = 0;
+
+      std::string cpuModelsFormatted_;
+      double cpuAverageSpeed_ = 0;
+
+      bool locked_ = false;
+      bool verbose_;
+    };
+
+    inline bool isProcessWideService(ResourceInformationService const*) { return true; }
+
+    ResourceInformationService::ResourceInformationService(ParameterSet const& pset, ActivityRegistry& iRegistry)
+        : verbose_(pset.getUntrackedParameter<bool>("verbose")) {
+      iRegistry.watchPostBeginJob(this, &ResourceInformationService::postBeginJob);
+    }
+
+    void ResourceInformationService::fillDescriptions(ConfigurationDescriptions& descriptions) {
+      ParameterSetDescription desc;
+      desc.addUntracked<bool>("verbose", false);
+      descriptions.add("ResourceInformationService", desc);
+    }
+
+    std::vector<ResourceInformation::AcceleratorType> const& ResourceInformationService::acceleratorTypes() const {
+      return acceleratorTypes_;
+    }
+
+    std::vector<std::string> const& ResourceInformationService::cpuModels() const { return cpuModels_; }
+
+    std::vector<std::string> const& ResourceInformationService::gpuModels() const { return gpuModels_; }
+
+    std::string const& ResourceInformationService::nvidiaDriverVersion() const { return nvidiaDriverVersion_; }
+
+    int ResourceInformationService::cudaDriverVersion() const { return cudaDriverVersion_; }
+
+    int ResourceInformationService::cudaRuntimeVersion() const { return cudaRuntimeVersion_; }
+
+    std::string const& ResourceInformationService::cpuModelsFormatted() const { return cpuModelsFormatted_; }
+
+    double ResourceInformationService::cpuAverageSpeed() const { return cpuAverageSpeed_; }
+
+    void ResourceInformationService::initializeAcceleratorTypes(std::vector<std::string> const& selectedAccelerators) {
+      if (!locked_) {
+        for (auto const& selected : selectedAccelerators) {
+          // Test if the string begins with "gpu-"
+          if (selected.rfind("gpu-", 0) == 0) {
+            acceleratorTypes_.push_back(AcceleratorType::GPU);
+            break;
+          }
+        }
+        locked_ = true;
+      }
+    }
+
+    void ResourceInformationService::setCPUModels(std::vector<std::string> const& val) {
+      throwIfLocked();
+      cpuModels_ = val;
+    }
+
+    void ResourceInformationService::setGPUModels(std::vector<std::string> const& val) {
+      throwIfLocked();
+      gpuModels_ = val;
+    }
+
+    void ResourceInformationService::setNvidiaDriverVersion(std::string const& val) {
+      throwIfLocked();
+      nvidiaDriverVersion_ = val;
+    }
+
+    void ResourceInformationService::setCudaDriverVersion(int val) {
+      throwIfLocked();
+      cudaDriverVersion_ = val;
+    }
+
+    void ResourceInformationService::setCudaRuntimeVersion(int val) {
+      throwIfLocked();
+      cudaRuntimeVersion_ = val;
+    }
+
+    void ResourceInformationService::setCpuModelsFormatted(std::string const& val) {
+      throwIfLocked();
+      cpuModelsFormatted_ = val;
+    }
+
+    void ResourceInformationService::setCpuAverageSpeed(double val) {
+      throwIfLocked();
+      cpuAverageSpeed_ = val;
+    }
+
+    void ResourceInformationService::throwIfLocked() const {
+      if (locked_) {
+        // Only Services should modify ResourceInformationService. Service construction is run serially.
+        // The lock provides thread safety and prevents modules from modifying ResourceInformationService.
+        throw edm::Exception(errors::LogicError)
+            << "Attempt to modify member data after ResourceInformationService was locked ";
+      }
+    }
+
+    void ResourceInformationService::postBeginJob() {
+      if (verbose_) {
+        LogAbsolute("ResourceInformation") << "ResourceInformationService";
+        LogAbsolute("ResourceInformation") << "    cpu models:";
+        if (cpuModels().empty()) {
+          LogAbsolute("ResourceInformation") << "        None";
+        } else {
+          for (auto const& iter : cpuModels()) {
+            LogAbsolute("ResourceInformation") << "        " << iter;
+          }
+        }
+        LogAbsolute("ResourceInformation") << "    gpu models:";
+        if (gpuModels().empty()) {
+          LogAbsolute("ResourceInformation") << "        None";
+        } else {
+          for (auto const& iter : gpuModels()) {
+            LogAbsolute("ResourceInformation") << "        " << iter;
+          }
+        }
+
+        LogAbsolute("ResourceInformation") << "    acceleratorTypes:";
+        if (acceleratorTypes().empty()) {
+          LogAbsolute("ResourceInformation") << "        None";
+        } else {
+          for (auto const& iter : acceleratorTypes()) {
+            std::string acceleratorTypeString("unknown type");
+            if (iter == AcceleratorType::GPU) {
+              acceleratorTypeString = std::string("GPU");
+            }
+            LogAbsolute("ResourceInformation") << "        " << acceleratorTypeString;
+          }
+        }
+        LogAbsolute("ResourceInformation") << "    nvidiaDriverVersion: " << nvidiaDriverVersion();
+        LogAbsolute("ResourceInformation") << "    cudaDriverVersion: " << cudaDriverVersion();
+        LogAbsolute("ResourceInformation") << "    cudaRuntimeVersion: " << cudaRuntimeVersion();
+        LogAbsolute("ResourceInformation") << "    cpuModelsFormatted: " << cpuModelsFormatted();
+        LogAbsolute("ResourceInformation") << "    cpuAverageSpeed: " << cpuAverageSpeed();
+      }
+    }
+
+  }  // namespace service
+}  // namespace edm
+
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+using edm::service::ResourceInformationService;
+using ResourceInformationMaker =
+    edm::serviceregistry::AllArgsMaker<edm::ResourceInformation, ResourceInformationService>;
+DEFINE_FWK_SERVICE_MAKER(ResourceInformationService, ResourceInformationMaker);

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -22,3 +22,8 @@
   <use name="cpu_features"/>
   <use name="FWCore/Services"/>
 </bin>
+
+<bin file="TestFWCoreServicesDriver.cpp" name="TestResourceInformationService">
+  <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Services/test test_resourceInformationService.sh"/>
+  <use name="FWCore/Utilities"/>
+</bin>

--- a/FWCore/Services/test/test_resourceInformationService.sh
+++ b/FWCore/Services/test/test_resourceInformationService.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+LOCAL_TEST_DIR=${CMSSW_BASE}/src/FWCore/Services/test
+LOCAL_TMP_DIR=${CMSSW_BASE}/tmp/${SCRAM_ARCH}
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+cmsRun -p ${LOCAL_TEST_DIR}/test_resourceInformationService_cfg.py &> test_resourceInformationService.log || die "cmsRun test_resourceInformationService_cfg.py" $?
+
+grep -A 1 "acceleratorTypes:" test_resourceInformationService.log | grep "GPU" || die "Check for existence of GPU acceleratorType" $?
+grep -A 1 "cpu models:" test_resourceInformationService.log | grep "None" && die "Check there is at least one model (not None)" 1
+popd
+
+exit 0

--- a/FWCore/Services/test/test_resourceInformationService_cfg.py
+++ b/FWCore/Services/test/test_resourceInformationService_cfg.py
@@ -8,11 +8,10 @@ class ProcessAcceleratorTest(cms.ProcessAccelerator):
     def __init__(self):
         super(ProcessAcceleratorTest,self).__init__()
         self._labels = ["test1", "gpu-foo", "test2"]
-        self._enabled = ["test1", "gpu-foo", "test2"]
     def labels(self):
         return self._labels
     def enabledLabels(self):
-        return self._enabled
+        return self._labels
 
 process = cms.Process("PROD")
 process.add_(ProcessAcceleratorTest())

--- a/FWCore/Services/test/test_resourceInformationService_cfg.py
+++ b/FWCore/Services/test/test_resourceInformationService_cfg.py
@@ -1,0 +1,30 @@
+# Test ResourceInformationService
+# The shell script will examine its printout
+import FWCore.ParameterSet.Config as cms
+
+# This class is a hack just for the test to get
+# 'gpu-foo' into @selected_accelerators
+class ProcessAcceleratorTest(cms.ProcessAccelerator):
+    def __init__(self):
+        super(ProcessAcceleratorTest,self).__init__()
+        self._labels = ["test1", "gpu-foo", "test2"]
+        self._enabled = ["test1", "gpu-foo", "test2"]
+    def labels(self):
+        return self._labels
+    def enabledLabels(self):
+        return self._enabled
+
+process = cms.Process("PROD")
+process.add_(ProcessAcceleratorTest())
+
+process.ResourceInformationService = cms.Service("ResourceInformationService",
+  verbose = cms.untracked.bool(True)
+)
+
+process.options.accelerators = ["*"]
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptySource")
+

--- a/FWCore/Utilities/interface/CPUServiceBase.h
+++ b/FWCore/Utilities/interface/CPUServiceBase.h
@@ -5,7 +5,7 @@
 // Package:     FWCore/Utilities
 // Class  :     CPUServiceBase
 //
-/**\class CPUServiceBase CPUServiceBase.h "CPUServiceBase.h"
+/**\class edm::CPUServiceBase
 
  Description: Base class for CPU Services
 
@@ -19,10 +19,6 @@
 //         Created:  Wed Sep  7 12:05:13 CDT 2016
 //
 
-// system include files
-#include <string>
-
-// forward declarations
 namespace edm {
   class CPUServiceBase {
   public:
@@ -31,10 +27,6 @@ namespace edm {
     const CPUServiceBase &operator=(const CPUServiceBase &) = delete;  // stop default
 
     virtual ~CPUServiceBase();
-
-    // ---------- member functions ---------------------------
-    ///CPU information - the models present and average speed.
-    virtual bool cpuInfo(std::string &models, double &avgSpeed) = 0;
   };
 }  // namespace edm
 

--- a/FWCore/Utilities/interface/ResourceInformation.h
+++ b/FWCore/Utilities/interface/ResourceInformation.h
@@ -1,0 +1,51 @@
+#ifndef FWCore_Utilities_ResourceInformation_h
+#define FWCore_Utilities_ResourceInformation_h
+
+/** \class edm::ResourceInformation
+
+  Description:
+
+  Usage:
+
+\author W. David Dagenhart, created May 3, 2022
+*/
+
+#include <string>
+#include <vector>
+
+namespace edm {
+
+  class ResourceInformation {
+  public:
+    ResourceInformation();
+    ResourceInformation(ResourceInformation const&) = delete;
+    ResourceInformation const& operator=(ResourceInformation const&) = delete;
+    virtual ~ResourceInformation();
+
+    enum class AcceleratorType { GPU };
+
+    virtual std::vector<AcceleratorType> const& acceleratorTypes() const = 0;
+    virtual std::vector<std::string> const& cpuModels() const = 0;
+    virtual std::vector<std::string> const& gpuModels() const = 0;
+
+    virtual std::string const& nvidiaDriverVersion() const = 0;
+    virtual int cudaDriverVersion() const = 0;
+    virtual int cudaRuntimeVersion() const = 0;
+
+    // Same as cpuModels except in a single string with models separated by ", "
+    virtual std::string const& cpuModelsFormatted() const = 0;
+    virtual double cpuAverageSpeed() const = 0;
+
+    virtual void initializeAcceleratorTypes(std::vector<std::string> const& selectedAccelerators) = 0;
+    virtual void setCPUModels(std::vector<std::string> const&) = 0;
+    virtual void setGPUModels(std::vector<std::string> const&) = 0;
+
+    virtual void setNvidiaDriverVersion(std::string const&) = 0;
+    virtual void setCudaDriverVersion(int) = 0;
+    virtual void setCudaRuntimeVersion(int) = 0;
+
+    virtual void setCpuModelsFormatted(std::string const&) = 0;
+    virtual void setCpuAverageSpeed(double) = 0;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/Utilities/src/CPUServiceBase.cc
+++ b/FWCore/Utilities/src/CPUServiceBase.cc
@@ -10,19 +10,10 @@
 //         Created:  Wed Sep  7 12:05:13 CDT 2016
 //
 
-// system include files
-
-// user include files
 #include "FWCore/Utilities/interface/CPUServiceBase.h"
 
 using namespace edm;
-//
-// constants, enums and typedefs
-//
 
-//
-// constructors and destructor
-//
 CPUServiceBase::CPUServiceBase() {}
 
 CPUServiceBase::~CPUServiceBase() {}

--- a/FWCore/Utilities/src/ResourceInformation.cc
+++ b/FWCore/Utilities/src/ResourceInformation.cc
@@ -1,0 +1,4 @@
+#include "FWCore/Utilities/interface/ResourceInformation.h"
+
+edm::ResourceInformation::ResourceInformation() {}
+edm::ResourceInformation::~ResourceInformation() {}

--- a/HeterogeneousCore/CUDAServices/interface/CUDAService.h
+++ b/HeterogeneousCore/CUDAServices/interface/CUDAService.h
@@ -36,4 +36,10 @@ private:
   bool verbose_ = false;
 };
 
+namespace edm {
+  namespace service {
+    inline bool isProcessWideService(CUDAService const*) { return true; }
+  }  // namespace service
+}  // namespace edm
+
 #endif

--- a/HeterogeneousCore/CUDAServices/plugins/plugins.cc
+++ b/HeterogeneousCore/CUDAServices/plugins/plugins.cc
@@ -1,4 +1,4 @@
-#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 DEFINE_FWK_SERVICE_MAKER(CUDAService, edm::serviceregistry::ParameterSetMaker<CUDAService>);

--- a/IOPool/Common/test/FastMergeTestRL_cfg.py
+++ b/IOPool/Common/test/FastMergeTestRL_cfg.py
@@ -7,6 +7,10 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("TESTMERGE")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.AdaptorConfig = cms.Service("AdaptorConfig",
     stats = cms.untracked.bool(False)
 )

--- a/IOPool/Common/test/FastMergeTestR_cfg.py
+++ b/IOPool/Common/test/FastMergeTestR_cfg.py
@@ -7,6 +7,10 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("TESTMERGE")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.AdaptorConfig = cms.Service("AdaptorConfig",
     stats = cms.untracked.bool(False)
 )

--- a/IOPool/Common/test/FastMergeTest_cfg.py
+++ b/IOPool/Common/test/FastMergeTest_cfg.py
@@ -7,6 +7,10 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("TESTMERGE")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.AdaptorConfig = cms.Service("AdaptorConfig",
     stats = cms.untracked.bool(False)
 )

--- a/IOPool/Common/test/FastMergeTest_x_cfg.py
+++ b/IOPool/Common/test/FastMergeTest_x_cfg.py
@@ -7,6 +7,10 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("TESTMERGE")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
+process.CPU = cms.Service("CPU",
+    disableJobReportOutput = cms.untracked.bool(True)
+)
+
 process.AdaptorConfig = cms.Service("AdaptorConfig",
     stats = cms.untracked.bool(False)
 )


### PR DESCRIPTION
#### PR description:

Initial implementation of ResourceInformationService. The function acceleratorsTypes() will return a container holding enumeration values. Currently it will always be empty or contain a value for "GPU" if any item in "@selected_accelerators" starts with the substring "gpu-". We expect addition possible enumeration values may be added in the future.

The following additional functions are added:

- cpuModels()
- gpuModels()
- nvidiaDriverVersion()
- cudaDriverVersion()
- cudaRuntimeVersion()
- cpuModelsFormatted()
- cpuAverageSpeed()

The service contains data members to hold the data returned by those functions. Other services (CPU and CUDAService) must be configured for these to be filled. We expect other accelerator devices may be added to this in the future.

This does not include changes for anything to get information out of ResourceInformationService. Those changes will come in a future PR.

This also does not include changes to store this information persistently. That will also come in a future PR.

If the service has its verbose parameter set true, then it will print out some information at begin job.

#### PR validation:

There is a unit test that checks the information printed out when the service is set to be verbose. Nothing uses this service yet so I do not expect this will have any immediate effect on RelVals or production executables.
