### PR TITLE
Disabled looper reconstruction in HI Era for Run 3

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
@@ -4,7 +4,6 @@ from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
-from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd, trackdnn, trackingNoLoopers]), pp_on_AA, pp_on_AA_2018)
+Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd, trackdnn]), pp_on_AA, pp_on_AA_2018)
 

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
@@ -4,7 +4,6 @@ from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
 from Configuration.Eras.Era_Run3_noMkFit_cff import Run3_noMkFit
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit.copyAndExclude([trackdnn, trackdnn_CKF, trackingNoLoopers]), pp_on_AA, pp_on_PbPb_run3)
+Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit.copyAndExclude([trackdnn, trackdnn_CKF]), pp_on_AA, pp_on_PbPb_run3)
 


### PR DESCRIPTION
#### PR description:

Title: Disabled looper reconstruction in HI Era for Run 3

Description: This PR has disabled looper reconstruction from HI Era after checking timing and CPU usage, tracking efficiency, fake, multiple, non-primary reconstructions fractions for peripheral and central events. Also, the same checks were performed in the MinimumBias dataset produced for 1000 events. Please, see slides 1-9 from here [1].

No significant changes were observed in event and track variables while removing the No-Looper condition except the Hit count distribution. 

An issue had been raised already regarding disabling looper reconstruction for HeavyIons. Please look here [2] for detail. 

 
Link for the HI Trackin POG: 
[1] https://indico.cern.ch/event/1153062/contributions/4841907/attachments/2429416/4159748/NoLooper_HITracking.pdf 

Link for the issue:
[2] https://github.com/cms-sw/cmssw/issues/35758


#### PR validation:

Run time observations and a detailed study of each track variable have been performed with enabling and disabling trackingNoLoopers. We have also performed a detailed comparison of tracking efficiency, fake, multiple, and nonprimary reconstruction fractions for central, peripheral, and minimum bias events with enabling and disabling trackingNoLoopers.



#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A


cc: @mandrenguyen, @abaty, @CesarBernardes