### PR TITLE
Properly pass strings to Fortran in two generators

### DIFF
--- a/GeneratorInterface/AMPTInterface/src/AMPTHadronizer.cc
+++ b/GeneratorInterface/AMPTInterface/src/AMPTHadronizer.cc
@@ -228,8 +228,11 @@ bool AMPTHadronizer::get_particles(HepMC::GenEvent* evt) {
 bool AMPTHadronizer::call_amptset(
     double efrm, std::string frame, std::string proj, std::string targ, int iap, int izp, int iat, int izt) {
   // initialize hydjet
+  frame.resize(4, ' ');
+  proj.resize(4, ' ');
+  targ.resize(4, ' ');
   AMPTSET(
-      efrm, frame.c_str(), proj.c_str(), targ.c_str(), iap, izp, iat, izt, frame.length(), proj.length(), targ.length());
+      efrm, frame.data(), proj.data(), targ.data(), iap, izp, iat, izt, frame.length(), proj.length(), targ.length());
   return true;
 }
 //______________________________________________________________________

--- a/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
+++ b/GeneratorInterface/HijingInterface/src/HijingHadronizer.cc
@@ -243,8 +243,10 @@ bool HijingHadronizer::call_hijset(
     double efrm, std::string frame, std::string proj, std::string targ, int iap, int izp, int iat, int izt) {
   float ef = efrm;
   // initialize hydjet
-  HIJSET(
-      ef, frame.c_str(), proj.c_str(), targ.c_str(), iap, izp, iat, izt, frame.length(), proj.length(), targ.length());
+  frame.resize(4, ' ');
+  proj.resize(4, ' ');
+  targ.resize(4, ' ');
+  HIJSET(ef, frame.data(), proj.data(), targ.data(), iap, izp, iat, izt, frame.length(), proj.length(), targ.length());
   return true;
 }
 


### PR DESCRIPTION
#### PR description:

- Fortran string arrays are fixed size and padded with spaces.

#### PR validation:

Code compiles and workflow 575.0 runs fine on x86. I do not know what machine to use to test on ARM.

fixes #37799 