### PR TITLE
Add -o/--output option to edmConfigDump

### DIFF
--- a/FWCore/ParameterSet/scripts/edmConfigDump
+++ b/FWCore/ParameterSet/scripts/edmConfigDump
@@ -1,6 +1,5 @@
 #! /usr/bin/env python3
 
-from __future__ import print_function
 import sys
 import os 
 from importlib.machinery import SourceFileLoader
@@ -17,6 +16,8 @@ parser.add_argument("--prune", action="store_true",
                     help="Prune the configuration before printing it")
 parser.add_argument("--pruneVerbose", action="store_true",
                     help="With --prune, be verbose on what is pruned")
+parser.add_argument("-o", "--output", type=str, default=None,
+                    help="Save the configuration dump into this file. In this case any printouts from the configuration continue to be printed to stdout. Default is to print the configuration dump to stdout.")
 
 options = parser.parse_args()
 handle = open(options.filename, 'r')
@@ -28,5 +29,9 @@ cmsProcess= mod.process
 if options.prune:
     cmsProcess.prune(options.pruneVerbose)
 
-print(cmsProcess.dumpPython())
+if options.output is not None:
+    with open(options.output, "w") as f:
+        f.write(cmsProcess.dumpPython())
+else:
+    print(cmsProcess.dumpPython())
 


### PR DESCRIPTION
#### PR description:

This PR adds `-o`/`--output` option to `edmConfigDump` to be able to save the output of `process.dumpPython()` directly into a file instead of relying on shell redirection. The direct saving allows to avoid including any printouts in the configuration to be included in the dump. Resolves #37837.

#### PR validation:

Checked with an ad hoc test configuration file that printouts in the configuration do not end up in the saved file.