### PR TITLE
Enable EMTF regional shower DQM with unpacked inputs (backport)

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -55,7 +55,7 @@ process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 
 # remove unneeded unpackers
 process.RawToDigi.remove(process.ecalPreshowerDigis)
-process.RawToDigi.remove(process.muonCSCDigis)
+#process.RawToDigi.remove(process.muonCSCDigis)
 process.RawToDigi.remove(process.muonDTDigis)
 process.RawToDigi.remove(process.muonRPCDigis)
 process.RawToDigi.remove(process.siPixelDigis)

--- a/DQM/L1TMonitor/python/L1TStage2RegionalShower_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2RegionalShower_cfi.py
@@ -3,10 +3,12 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tStage2RegionalShower = DQMEDAnalyzer(
     "L1TStage2RegionalShower",
-    emtfSource = cms.InputTag("emtfStage2Digis"),                   ## EMTF unpacker tag
-    cscSource = cms.InputTag("muonCSCDigis", "MuonCSCShowerDigi"),  ## CSC  unpacker tag
-#    emtfSource = cms.InputTag("simEmtfShowers", "EMTF"),           ## EMTF emulator tag
-#    cscSource = cms.InputTag("simCscTriggerPrimitiveDigis"),       ## CSC  emulator tag
+    emtfSource = cms.InputTag("emtfStage2Digis"),            
+#   EMTF shower unpacker ready in CMSSW_12_4_0_p2
+#   Enable this module for EMTF and CSC showers
+#   CSC showers are not in firmware as of 2022.04.06
+#   But dummy object exists so it gives empty histograms without errors 
+    cscSource = cms.InputTag("muonCSCDigis", "MuonCSCShowerDigi"), 
     monitorDir = cms.untracked.string("L1T/L1TStage2EMTF/Shower"), 
     verbose = cms.untracked.bool(False),
 )

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -40,9 +40,7 @@ l1tStage2OnlineDQM = cms.Sequence(
     l1tStage2BmtfOnlineDQMSeq +
     l1tStage2Omtf +
     l1tStage2Emtf +
-# Do not include shower DQM module in the sequence because there is no EMTF shower unpacker (as of CMSSW_12_2_0_pre2).
-# It will be enabled once the EMTF shower unpacker is ready.
-#    l1tStage2RegionalShower +  
+    l1tStage2RegionalShower +  
     l1tStage2uGMTOnlineDQMSeq +
     l1tObjectsTiming +
     l1tStage2uGTOnlineDQMSeq

--- a/DQM/L1TMonitor/python/L1TdeStage2RegionalShower_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2RegionalShower_cfi.py
@@ -3,14 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 l1tdeStage2RegionalShower = DQMEDAnalyzer(
     "L1TdeStage2RegionalShower",
-    # EMTF Showers not in data yet. Use Emul for both
-    # Once Run 3 firmware are implemented, should change data tags to 
-    # cms.InputTag("emtfStage2Digis")
-    # - 2021.12.06 Xunwu Zuo
-
-#    dataSource = cms.InputTag("simEmtfShowers", "EMTF"),
-#    emulSource = cms.InputTag("simEmtfShowers", "EMTF"),
-    dataSource = cms.InputTag("valEmtfStage2Showers", "EMTF"),
+    dataSource = cms.InputTag("emtfStage2Digis"),
     emulSource = cms.InputTag("valEmtfStage2Showers", "EMTF"),
     monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2EMTF/Shower"),
 )


### PR DESCRIPTION
#### PR description:
Backport of [PR#37634](https://github.com/cms-sw/cmssw/pull/37634) and [PR#37544](https://github.com/cms-sw/cmssw/pull/37544) to enable EMTF shower DQM modules with unpacked info as inputs.

#### PR validation:

Passed local unit tests and matrix tests 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of [PR#37634](https://github.com/cms-sw/cmssw/pull/37634) and [PR#37544](https://github.com/cms-sw/cmssw/pull/37544) to have the DQM plots for the incoming cosmic data-taking.

EMTF operation contact @eyigitba 