### PR TITLE
Fix CMS deprecation warnings in PhysicsTools/IsolationAlgos

### DIFF
--- a/PhysicsTools/IsolationAlgos/interface/CalIsolationExtrapolate.h
+++ b/PhysicsTools/IsolationAlgos/interface/CalIsolationExtrapolate.h
@@ -14,10 +14,12 @@ namespace helper {
 
   template <typename Alg>
   struct BFieldIsolationAlgorithmSetup {
-    static void init(Alg& algo, const edm::EventSetup& es) {
-      edm::ESHandle<MagneticField> bFieldHandle;
-      es.template get<IdealMagneticFieldRecord>().get(bFieldHandle);
-      algo.setBfield(bFieldHandle.product());
+    using ESConsumesToken = edm::ESGetToken<MagneticField, IdealMagneticFieldRecord>;
+    static ESConsumesToken esConsumes(edm::ConsumesCollector cc) {
+      return cc.esConsumes<MagneticField, IdealMagneticFieldRecord>();
+    }
+    static void init(Alg& algo, const edm::EventSetup& es, const ESConsumesToken& token) {
+      algo.setBfield(&es.getData(token));
     }
   };
 

--- a/PhysicsTools/IsolationAlgos/interface/IsolationProducerNew.h
+++ b/PhysicsTools/IsolationAlgos/interface/IsolationProducerNew.h
@@ -8,7 +8,7 @@
  *
  */
 #include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/ValueMap.h"
@@ -39,7 +39,7 @@ namespace reco {
               typename Alg,
               typename OutputCollection = edm::ValueMap<float>,
               typename Setup = typename helper::IsolationAlgorithmSetup<Alg>::type>
-    class IsolationProducer : public edm::EDProducer {
+    class IsolationProducer : public edm::stream::EDProducer<> {
     public:
       IsolationProducer(const edm::ParameterSet&);
       ~IsolationProducer() override;

--- a/PhysicsTools/IsolationAlgos/plugins/IsolationProducerForTracks.cc
+++ b/PhysicsTools/IsolationAlgos/plugins/IsolationProducerForTracks.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -8,18 +8,18 @@
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
 #include "DataFormats/RecoCandidate/interface/IsoDepositFwd.h"
 
-class IsolationProducerForTracks : public edm::EDProducer {
+class IsolationProducerForTracks : public edm::global::EDProducer<> {
 public:
   IsolationProducerForTracks(const edm::ParameterSet&);
 
 private:
-  void produce(edm::Event& event, const edm::EventSetup& setup) override;
+  void produce(edm::StreamID, edm::Event& event, const edm::EventSetup& setup) const override;
 
-  edm::EDGetTokenT<reco::CandidateView> tracksToken_;
-  edm::EDGetTokenT<reco::CandidateView> highPtTracksToken_;
-  edm::EDGetTokenT<reco::IsoDepositMap> isoDepsToken_;
-  double trackPtMin_;
-  double coneSize_;
+  const edm::EDGetTokenT<reco::CandidateView> tracksToken_;
+  const edm::EDGetTokenT<reco::CandidateView> highPtTracksToken_;
+  const edm::EDGetTokenT<reco::IsoDepositMap> isoDepsToken_;
+  const double trackPtMin_;
+  const double coneSize_;
 };
 
 #include "DataFormats/Common/interface/Handle.h"
@@ -44,7 +44,7 @@ IsolationProducerForTracks::IsolationProducerForTracks(const ParameterSet& pset)
   produces<TkIsoMap>();
 }
 
-void IsolationProducerForTracks::produce(Event& event, const EventSetup& setup) {
+void IsolationProducerForTracks::produce(edm::StreamID, Event& event, const EventSetup& setup) const {
   auto caloIsolations = std::make_unique<TkIsoMap>();
   TkIsoMap::Filler filler(*caloIsolations);
   {

--- a/PhysicsTools/IsolationAlgos/test/CandIsoComparer.cc
+++ b/PhysicsTools/IsolationAlgos/test/CandIsoComparer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -23,7 +23,7 @@
 #include <TH1.h>
 #include <TProfile.h>
 
-class CandIsoComparer : public edm::EDAnalyzer {
+class CandIsoComparer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   CandIsoComparer(const edm::ParameterSet&);
 
@@ -46,6 +46,7 @@ CandIsoComparer::CandIsoComparer(const edm::ParameterSet& par)
       src2Token_(consumes<reco::CandViewDoubleAssociations>(par.getParameter<edm::InputTag>("src2"))) {
   label_ = par.getParameter<std::string>("@module_label");
 
+  usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
   double max = par.getParameter<double>("max");
   double rmax = par.getParameter<double>("rmax");

--- a/PhysicsTools/IsolationAlgos/test/CandIsoDumper.cc
+++ b/PhysicsTools/IsolationAlgos/test/CandIsoDumper.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -21,7 +21,7 @@
 
 using reco::isodeposit::Direction;
 
-class CandIsoDumper : public edm::EDAnalyzer {
+class CandIsoDumper : public edm::one::EDAnalyzer<> {
 public:
   CandIsoDumper(const edm::ParameterSet&);
 


### PR DESCRIPTION
#### PR description:

- use thread friendly module types
- use esConsumes

#### PR validation:

Code compiles without issuing deprecation warnings.