### PR TITLE
Fix DQM_L1TMonitor_L1TStage2EMTF: there are four RPC planes in the Endcaps

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2EMTF.h
+++ b/DQM/L1TMonitor/interface/L1TStage2EMTF.h
@@ -16,7 +16,7 @@
 class L1TStage2EMTF : public DQMOneEDAnalyzer<> {
 public:
   L1TStage2EMTF(const edm::ParameterSet& ps);
-  ~L1TStage2EMTF() override;
+  ~L1TStage2EMTF() override = default;
 
 protected:
   void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
@@ -85,7 +85,7 @@ private:
   MonitorElement* rpcChamberTheta[12];
 
   MonitorElement* rpcHitTimingInTrack;
-  MonitorElement* emtfTrackModeVsRPCBXDiff[6];  // Add mode vs BXdiff comparison Dec 07 2020
+  MonitorElement* emtfTrackModeVsRPCBXDiff[8];  // Add mode vs BXdiff comparison Dec 07 2020
 
   // Add GEMs Oct 27 2020
   MonitorElement* hitTypeBX;


### PR DESCRIPTION
#### PR description:

Fixes #37686

Since beginning of Run2 there are four RPC planes in the endcaps, but apparently L1TStage2EMTF was never updated for it.
The code for that class is rather involuted, and I cannot  be 100% sure that I fixed it everywhere: @cms-sw/rpc-dpg-l2 is expected to have a look and either approve this fix, or use it as a base for a more correct one (in a separate PR: I will close this one if so)

By the way, if really the error is there since the beginning of Run2, I wonder whether the DQM outputs of this code were ever used, or inspected, since then. Perhaps @cms-sw/rpc-dpg-l2 can decide that a more convenient fix could be simply to remove it from CMSSW as a whole, thus avoiding having to maintain some code which is not needed any more

#### PR validation:

It builds
`runTheMatrix.py -l 136.787` ends without errors

I did not check with UBSAN, because this error is apparently not listed any more in the UBSAN IB builds, see e.g. https://cmssdt.cern.ch/SDT/html/cmssdt-ib/#/relVal/CMSSW_12_4/2022-05-06-1100?selectedArchs=slc7_amd64_gcc11&selectedFlavors=UBSAN_X&selectedStatus=failed

