### PR TITLE
Add `AlCaNano` and inherit `AlCaPhiSymEcal_Nano` from it

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCaNano.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaNano.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+_AlCaNano_
+
+Scenario supporting proton collisions for AlCa needs when ALCANANO is produced
+
+"""
+from __future__ import print_function
+
+import os
+import sys
+
+from Configuration.DataProcessing.Scenario import *
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,dqmIOSource,harvestingMode,dictIO,gtNameAndConnect,addMonitoring
+import FWCore.ParameterSet.Config as cms
+
+class AlCaNano(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
+        self.recoSeq=''
+        self.promptCustoms= [ 'Configuration/DataProcessing/RecoTLR.customisePrompt' ]
+        self.promptModifiers = cms.ModifierChain()
+
+    """
+    _AlCaNano_
+
+    Implement configuration building for data processing for proton
+    collision data taking for AlCa needs when ALCANANO is produced
+
+    """
+
+    def skimsIfNotGiven(self,args,sl):
+        if not 'skims' in args:
+            args['skims']=sl
+
+    def promptReco(self, globalTag, **args):
+        if not 'skims' in args:
+            args['skims']=self.skims
+        if not 'customs' in args:
+            args['customs']= [ ]
+        for c in self.promptCustoms:
+            args['customs'].append(c)
+
+        options = Options()
+        options.__dict__.update(defaultOptions.__dict__)
+        options.scenario = "pp"
+        dictIO(options,args)
+        options.conditions = gtNameAndConnect(globalTag, args)
+
+        if 'customs' in args:
+            print(args['customs'])
+            options.customisation_file=args['customs']
+
+        options.step = 'RECO'
+        options.step += self.recoSeq
+        options.step += stepALCAPRODUCER(args['skims'])
+
+        process = cms.Process('RECO', cms.ModifierChain(self.eras, self.promptModifiers) )
+        cb = ConfigBuilder(options, process = process, with_output = True)
+
+        # Input source
+        process.source = cms.Source("PoolSource",
+            fileNames = cms.untracked.vstring()
+        )
+        cb.prepare()
+
+        return process

--- a/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaPhiSymEcal_Nano.py
@@ -6,12 +6,12 @@ Scenario supporting proton collision data taking for AlCaPhiSymEcal stream with 
 
 """
 
-from Configuration.DataProcessing.Impl.pp import pp
+from Configuration.DataProcessing.Impl.AlCaNano import AlCaNano
 from Configuration.Eras.Era_Run3_cff import Run3
 
-class AlCaPhiSymEcal_Nano(pp):
+class AlCaPhiSymEcal_Nano(AlCaNano):
     def __init__(self):
-        pp.__init__(self)
+        AlCaNano.__init__(self)
         self.skims=['EcalPhiSymByRun']
         self.eras=Run3
         self.recoSeq = ':bunchSpacingProducer+ecalMultiFitUncalibRecHitTask+ecalCalibratedRecHitTask'


### PR DESCRIPTION
#### PR description:

Follow-up to https://github.com/dmwm/T0/pull/4664#issuecomment-1120214381
Inheriting from the `AlCa` scenario does not allow us to costumize the RECO step
while inheriting from the `pp` scenario forces to use the DQM step. This apparently cannot be switched off in the T0 config. So now I introduce `AlCaNano` and inherit `AlCaPhiSymEcal_Nano` from it.

#### PR validation:

```
 python3 Configuration/DataProcessing/test/RunPromptReco.py --scenario AlCaPhiSymEcal_Nano --reco --global-tag 123X_dataRun3_Prompt_v6 --lfn=file:/eos/cms/tier0/store/backfill/1/data/Tier0_REPLAY_2022/AlCaPhiSym/RAW/v91/000/346/512/00000/4887980a-dac3-48e0-be08-d99284f75c5b.root --alcareco EcalPhiSymByRun

Retrieved Scenario: AlCaPhiSymEcal_Nano
Using Global Tag: 123X_dataRun3_Prompt_v6
Configuring to Write out RECO
Configuring to Write out ALCARECO
[{'dataTier': 'RECO', 'eventContent': 'RECO', 'moduleLabel': 'write_RECO'}, {'dataTier': 'ALCARECO', 'eventContent': 'ALCARECO', 'moduleLabel': 'write_ALCARECO'}]
['Calibration/EcalCalibAlgos/EcalPhiSymRecoSequence_cff.customise']
Step: RECO Spec: ['bunchSpacingProducer', 'ecalMultiFitUncalibRecHitTask', 'ecalCalibratedRecHitTask']
Step: ALCAPRODUCER Spec: ['EcalPhiSymByRun']
customising the process with customise from Calibration/EcalCalibAlgos/EcalPhiSymRecoSequence_cff
Now do:
cmsRun -e RunPromptRecoCfg.py
07-May-2022 15:46:13 CEST  Initiating request to open file file:/eos/cms/tier0/store/backfill/1/data/Tier0_REPLAY_2022/AlCaPhiSym/RAW/v91/000/346/512/00000/4887980a-dac3-48e0-be08-d99284f75c5b.root
07-May-2022 15:46:16 CEST  Successfully opened file file:/eos/cms/tier0/store/backfill/1/data/Tier0_REPLAY_2022/AlCaPhiSym/RAW/v91/000/346/512/00000/4887980a-dac3-48e0-be08-d99284f75c5b.root
Begin processing the 1st record. Run 346512, Event 387150, LumiSection 1 on stream 0 at 07-May-2022 15:46:41.306 CEST
Begin processing the 2nd record. Run 346512, Event 683762, LumiSection 1 on stream 0 at 07-May-2022 15:46:42.515 CEST
Begin processing the 3rd record. Run 346512, Event 749995, LumiSection 1 on stream 0 at 07-May-2022 15:46:42.515 CEST
Begin processing the 4th record. Run 346512, Event 688096, LumiSection 1 on stream 0 at 07-May-2022 15:46:42.516 CEST
Begin processing the 5th record. Run 346512, Event 181224, LumiSection 1 on stream 0 at 07-May-2022 15:46:42.517 CEST
Begin processing the 6th record. Run 346512, Event 487945, LumiSection 1 on stream 0 at 07-May-2022 15:46:42.517 CEST
Begin processing the 7th record. Run 346512, Event 630492, LumiSection 1 on stream 0 at 07-May-2022 15:46:42.517 CEST
Begin processing the 8th record. Run 346512, Event 649218, LumiSection 1 on stream 0 at 07-May-2022 15:46:42.518 CEST
Begin processing the 9th record. Run 346512, Event 451961, LumiSection 1 on stream 0 at 07-May-2022 15:46:42.518 CEST
Begin processing the 10th record. Run 346512, Event 453408, LumiSection 1 on stream 0 at 07-May-2022 15:46:42.519 CEST
07-May-2022 15:46:43 CEST  Closed file file:/eos/cms/tier0/store/backfill/1/data/Tier0_REPLAY_2022/AlCaPhiSym/RAW/v91/000/346/512/00000/4887980a-dac3-48e0-be08-d99284f75c5b.root

=============================================

MessageLogger Summary

 type     category        sev    module        subroutine        count    total
 ---- -------------------- -- ---------------- ----------------  -----    -----
    1 fileAction           -s file_close                             1        1
    2 fileAction           -s file_open                              2        2

 type    category    Examples: run/evt        run/evt          run/evt
 ---- -------------------- ---------------- ---------------- ----------------
    1 fileAction           End Run: 346512                   
    2 fileAction           pre-events       pre-events       

Severity    # Occurrences   Total Occurrences
--------    -------------   -----------------
System                  3                   3

dropped waiting message count 0
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport to `12_3_X` will be submitted after T0 replay with the `12_4_0_pre4`