### PR TITLE
Enable forceGeneration for L1 O2O online producers

### DIFF
--- a/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TCaloParamsOnline_cfi.py
@@ -17,7 +17,7 @@ l1caloparProtodb = cms.ESSource("PoolDBESSource",
 
 L1TCaloParamsOnlineProd = cms.ESProducer("L1TCaloParamsOnlineProd",
     onlineAuthentication = cms.string('.'),
-    forceGeneration      = cms.bool(False),
+    forceGeneration      = cms.bool(True),
     onlineDB             = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
     exclusiveLayer       = cms.uint32(0), # process both layers by default
     transactionSafe      = cms.bool(True) # nothrow guarantee if set to False: carry on no matter what

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TGlobalPrescalesVetosOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TGlobalPrescalesVetosOnline_cfi.py
@@ -4,7 +4,7 @@ from L1Trigger.L1TGlobal.PrescalesVetos_cff import *
 
 L1TGlobalPrescalesVetosOnlineProd = cms.ESProducer("L1TGlobalPrescalesVetosOnlineProd",
     onlineAuthentication = cms.string('.'),
-    forceGeneration      = cms.bool(False),
+    forceGeneration      = cms.bool(True),
     onlineDB             = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
     transactionSafe      = cms.bool(True) # nothrow guarantee if set to False: carry on no matter what
 )

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonBarrelParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonBarrelParamsOnline_cfi.py
@@ -17,7 +17,7 @@ l1bmtfparProtodb = cms.ESSource("PoolDBESSource",
 
 L1TMuonBarrelParamsOnlineProd = cms.ESProducer("L1TMuonBarrelParamsOnlineProd",
     onlineAuthentication = cms.string('.'),
-    forceGeneration      = cms.bool(False),
+    forceGeneration      = cms.bool(True),
     onlineDB             = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
     transactionSafe      = cms.bool(True) # nothrow guarantee if set to False: carry on no matter what
 )

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonEndCapParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonEndCapParamsOnline_cfi.py
@@ -17,7 +17,7 @@ l1emtfparProtodb = cms.ESSource("PoolDBESSource",
 
 L1TMuonEndCapParamsOnlineProd = cms.ESProducer("L1TMuonEndCapParamsOnlineProd",
     onlineAuthentication = cms.string('.'),
-    forceGeneration      = cms.bool(False),
+    forceGeneration      = cms.bool(True),
     onlineDB             = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
     transactionSafe      = cms.bool(True) # nothrow guarantee if set to False: carry on no matter what
 )

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonGlobalParamsOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonGlobalParamsOnline_cfi.py
@@ -17,7 +17,7 @@ l1gmtparProtodb = cms.ESSource("PoolDBESSource",
 
 L1TMuonGlobalParamsOnlineProd = cms.ESProducer("L1TMuonGlobalParamsOnlineProd",
     onlineAuthentication = cms.string('.'),
-    forceGeneration      = cms.bool(False),
+    forceGeneration      = cms.bool(True),
     onlineDB             = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
     transactionSafe      = cms.bool(True) # nothrow guarantee if set to False: carry on no matter what
 )

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TMuonOverlapFwVersionOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TMuonOverlapFwVersionOnline_cfi.py
@@ -4,7 +4,7 @@ from L1Trigger.L1TMuonOverlap.fakeOmtfFwVersion_cff import *
 
 L1TMuonOverlapFwVersionOnlineProd = cms.ESProducer("L1TMuonOverlapFwVersionOnlineProd",
     onlineAuthentication = cms.string('.'),
-    forceGeneration      = cms.bool(False),
+    forceGeneration      = cms.bool(True),
     onlineDB             = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R'),
     transactionSafe      = cms.bool(True) # nothrow guarantee if set to False: carry on no matter what
 )

--- a/L1TriggerConfig/L1TConfigProducers/python/L1TUtmTriggerMenuOnline_cfi.py
+++ b/L1TriggerConfig/L1TConfigProducers/python/L1TUtmTriggerMenuOnline_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 L1TUtmTriggerMenuOnlineProd = cms.ESProducer("L1TUtmTriggerMenuOnlineProd",
     onlineAuthentication = cms.string('.'),
-    forceGeneration      = cms.bool(False),
+    forceGeneration      = cms.bool(True),
     onlineDB             = cms.string('oracle://CMS_OMDS_LB/CMS_TRG_R')
     # menu producer must be transaction safe otherwise everyone is screwed
 )


### PR DESCRIPTION
#### PR description:

This PR is complementary to #37602 for fixing several issues of the L1o2o in 12_3 onward.
One of the main problems was that since the producers for the requested ES Rcds are now run in construction time, several exceptions that where handled in the `produce()` method of the L1 `L1CondDBPayloadWriterExt` module now are impossible to be handled properly.

After the P5 deployment of the changes included in 37602, one last case has been found where an exception was thrown when the key of a single subsystem was already included in the db and in this case the o2o procedure was stopped for this subsystem (with an exception to be handled by the code block in `produce()`).
https://github.com/panoskatsoulis/cmssw/blob/0e675061b02ec7636f1a7f726647b7f6dcac2834/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h#L123-L157

This PR includes cfg modifications needed for forcing the L1 online producers to run no matter if the resulting object exist in the db (however will not be uploaded if it already exist)
It's required for cases where the following happens
- L1system 1 **exists**
- L1system 2 **exists**
- L1system 3 **new key**

#### PR validation:
This modification is tested in Prep and also is used atm as local custom patch for the L1 O2O Jobs at P5 (without problems)
The unit tests implemented in 37602 didn't catch this problem because the local sqlite file from the data repo was not prepared for this "real-case" scenario that occurred when we tested with more keys.
So, the file in https://github.com/cms-data/L1TriggerConfig-L1TConfigProducers is meant to be updated too for better future testing.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not sure if a backport is needed
Atm these mods are implemented in a custom patch on the `conddb-1` machine.
In case more 12_3 releases are going to be deployed for the o2o machines at P5 a backport is also required.