### PR TITLE
OMTF muon trigger emulator: fix in the RPC clusterization

### DIFF
--- a/L1Trigger/L1TMuonOverlapPhase1/plugins/L1MuonOverlapPhase1ParamsDBProducer.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/plugins/L1MuonOverlapPhase1ParamsDBProducer.cc
@@ -1,4 +1,4 @@
-#include "L1Trigger/L1TMuonOverlapPhase1/plugins/L1MuonOverlapPhase1ParamsDBProducer.h"
+#include "L1MuonOverlapPhase1ParamsDBProducer.h"
 
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"

--- a/L1Trigger/L1TMuonOverlapPhase1/plugins/L1TMuonOverlapPhase1ParamsESProducer.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/plugins/L1TMuonOverlapPhase1ParamsESProducer.cc
@@ -1,4 +1,5 @@
-#include "L1Trigger/L1TMuonOverlapPhase1/plugins/L1TMuonOverlapPhase1ParamsESProducer.h"
+#include "L1TMuonOverlapPhase1ParamsESProducer.h"
+
 #include "CondFormats/L1TObjects/interface/L1TMuonOverlapParams.h"
 #include "CondFormats/DataRecord/interface/L1TMuonOverlapParamsRcd.h"
 #include "L1Trigger/L1TMuonOverlapPhase1/interface/Omtf/XMLConfigReader.h"

--- a/L1Trigger/L1TMuonOverlapPhase1/plugins/L1TMuonOverlapPhase1TrackProducer.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/plugins/L1TMuonOverlapPhase1TrackProducer.cc
@@ -1,4 +1,5 @@
 #include "L1TMuonOverlapPhase1TrackProducer.h"
+
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/OMTFinputMaker.cc
@@ -191,12 +191,18 @@ void RpcDigiToStubsConverterOmtf::addRPCstub(MuonStubPtrs2D& muonStubsInLayers,
       muonStubsInLayers[iLayer][iInput + 1]->type = MuonStub::RPC_DROPPED;
     } else if (cluster.size() > config->getRpcMaxClusterSize()) {
       //marking as dropped the one that was added before on the iInput
-      if (muonStubsInLayers[iLayer][iInput])
+      if (muonStubsInLayers[iLayer][iInput]) {
         muonStubsInLayers[iLayer][iInput]->type = MuonStub::RPC_DROPPED;
-      else {
+
+        muonStubsInLayers[iLayer][iInput + 1] = std::make_shared<MuonStub>(stub);
+        muonStubsInLayers[iLayer][iInput + 1]->type = MuonStub::RPC_DROPPED;
+      } else {
         //no stub was added at this input already, so adding a stub and marking it as dropped
-        muonStubsInLayers.at(iLayer).at(iInput) = std::make_shared<MuonStub>(stub);
+        muonStubsInLayers[iLayer].at(iInput) = std::make_shared<MuonStub>(stub);
         muonStubsInLayers[iLayer][iInput]->type = MuonStub::RPC_DROPPED;
+
+        muonStubsInLayers[iLayer][iInput + 1] = std::make_shared<MuonStub>(stub);
+        muonStubsInLayers[iLayer][iInput + 1]->type = MuonStub::RPC_DROPPED;
       }
     } else
       OMTFinputMaker::addStub(config, muonStubsInLayers, iLayer, iInput, stub);

--- a/L1Trigger/L1TMuonOverlapPhase1/src/RpcClusterization.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/RpcClusterization.cc
@@ -16,14 +16,7 @@ RpcClusterization::~RpcClusterization() {}
 std::vector<RpcCluster> RpcClusterization::getClusters(const RPCDetId& roll, std::vector<RPCDigi>& digis) const {
   std::vector<RpcCluster> allClusters;
 
-  if (!dropAllClustersIfMoreThanMax) {
-    //with the 2018 firmware the agreement is better with this sort
-    std::sort(digis.begin(), digis.end(), [](const RPCDigi& a, const RPCDigi& b) { return a.strip() < b.strip(); });
-  } else {
-    //with the fixed RPC clusterization (Nov 2021 firmware) the data to emulator agreement is better if this reverse is used here,
-    //with the 2018 firmware the agreement is worse with this reverse,
-    std::reverse(digis.begin(), digis.end());
-  }
+  std::sort(digis.begin(), digis.end(), [](const RPCDigi& a, const RPCDigi& b) { return a.strip() < b.strip(); });
 
   typedef std::pair<unsigned int, unsigned int> Cluster;
 


### PR DESCRIPTION
#### PR description:
Small fixes that should improve data-to-emulator agreement for the OMTF muon trigger, are relevant for the OMTF firmware that is deployed since November 2021 and will be used during the RUN3. The fix is in the codes emulating the RPC clusterization,  it corrects the handling of some corner cases.
With this fix, the data-to-emulator agreement should improve by about 1% and be better than 99%.

Rather urgent - would be good to have it soon in the DQM (for the first collisions).

Modified files:
RpcClusterization::getClusters: sort() called in all cases

OMTFinputMaker.cc RpcDigiToStubsConverterOmtf::addRPCstub: fix in setting MuonStub::RPC_DROPPED

#### PR validation:
The data-to-emulator agreement was checked running a private instance of the DQM for a cosmic run from the February CRAFT, the data-to-emulator agreement improved by ~1%.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
it is not a backport. 