### PR TITLE
Making the |eta| cut configurable in QCD bc->e filter

### DIFF
--- a/Configuration/Generator/python/QCD_Pt_30_80_BCtoE_8TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCD_Pt_30_80_BCtoE_8TeV_TuneCUETP8M1_cfi.py
@@ -32,7 +32,8 @@ genParticlesForFilter = cms.EDProducer("GenParticleProducer",
                                        )
 
 bctoefilter = cms.EDFilter("BCToEFilter",
-                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(1),
+                           filterAlgoPSet = cms.PSet(maxAbsEta = cms.double(2.5), 
+                                                     eTThreshold = cms.double(1),
                                                      genParSource = cms.InputTag("genParticlesForFilter")
                                                      )
                            )

--- a/Configuration/Generator/python/QCD_Pt_80_170_BCtoE_8TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCD_Pt_80_170_BCtoE_8TeV_TuneCUETP8M1_cfi.py
@@ -32,7 +32,8 @@ genParticlesForFilter = cms.EDProducer("GenParticleProducer",
                                        )
 
 bctoefilter = cms.EDFilter("BCToEFilter",
-                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(1),
+                           filterAlgoPSet = cms.PSet(maxAbsEta = cms.double(2.5),
+                                                     eTThreshold = cms.double(1),
                                                      genParSource = cms.InputTag("genParticlesForFilter")
                                                      )
                            )

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
@@ -27,8 +27,7 @@ bool BCToEFilterAlgo::filter(const edm::Event& iEvent) const {
 
   for (uint32_t ig = 0; ig < genPars.size(); ig++) {
     reco::GenParticle gp = genPars.at(ig);
-    if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ &&
-        std::fabs(gp.eta()) < maxAbsEta_) {
+    if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ && std::fabs(gp.eta()) < maxAbsEta_) {
       if (hasBCAncestors(gp)) {
         result = true;
       }

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
@@ -10,7 +10,7 @@
 
 BCToEFilterAlgo::BCToEFilterAlgo(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
     :  //set constants
-      FILTER_ETA_MAX_(2.5),
+      maxAbsEta_((float)iConfig.getParameter<double>("maxAbsEta")),
       eTThreshold_((float)iConfig.getParameter<double>("eTThreshold")),
       genParSource_(iC.consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParSource"))) {}
 
@@ -28,7 +28,7 @@ bool BCToEFilterAlgo::filter(const edm::Event& iEvent) const {
   for (uint32_t ig = 0; ig < genPars.size(); ig++) {
     reco::GenParticle gp = genPars.at(ig);
     if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ &&
-        std::fabs(gp.eta()) < FILTER_ETA_MAX_) {
+        std::fabs(gp.eta()) < maxAbsEta_) {
       if (hasBCAncestors(gp)) {
         result = true;
       }

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.h
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.h
@@ -30,9 +30,8 @@ private:
   bool isBCMeson(const reco::GenParticle& gp) const;
   bool isBCBaryon(const reco::GenParticle& gp) const;
 
-  //constants:
-  const float FILTER_ETA_MAX_;
   //filter parameters:
+  const float maxAbsEta_;
   const float eTThreshold_;
   const edm::EDGetTokenT<reco::GenParticleCollection> genParSource_;
 };

--- a/GeneratorInterface/GenFilters/python/BCToEFilter_cfi.py
+++ b/GeneratorInterface/GenFilters/python/BCToEFilter_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 bctoefilter = cms.EDFilter("BCToEFilter",
     filterAlgoPSet = cms.PSet(
+        maxAbsEta = cms.double(3.05),
         eTThreshold = cms.double(10.0)
     )
 )


### PR DESCRIPTION
#### PR description:
This PR is to make the |eta| cut configurable in QCD b/c->electron filter. Currently the |eta| cut is hard-coded in the `.cc` file and it is |eta|<2.5. This is a problem for e/gamma's PF electron ID DNN training targeting eta-extended electrons (in the region 2.5 < |eta| < 3.0) for Run3. The eta-extended electrons were introduced by https://github.com/cms-sw/cmssw/pull/35309 and now we are trying to provide a meaningful PF ID for them. While retraining the PF electron ID for these high eta electrons, we figured out that QCD b/c->e samples are all restricted to |eta|<2.5. We would like to improve it for 12_4 so that the MC samples produced with 12_4 release are more appropriate for our use-case. 

#### PR validation:
I wanted to test by running the following workflows, which looks like the only ones available using b/c->e filter.
`4007.0 QCD_Pt_30_80_BCtoE_8TeV+DIGIPU1+RECOPUDBG`
`4008.0 QCD_Pt_80_170_BCtoE_8TeV+DIGIPU1+RECOPUDBG`
But they did not run due to `FileOpenError`. 

So I tested locally by doing this:
`cmsDriver.py Configuration/Generator/python/egm.py  --fileout file:step1.root --mc --eventcontent GEN --datatier GEN-SIM-RAW --conditions auto:phase1_2021_realistic --beamspot Run3RoundOptics25ns13TeVLowSigmaZ --step GEN,SIM -n 100  --geometry DB:Extended --era Run3 --python_filename bctoe.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring`

where `Configuration/Generator/python/egm.py` is this file: 
https://swmukher.web.cern.ch/swmukher/egm.py

and then `cmsRun bctoe.py` 

It ran fine. 

This PR is not a backport. 