### PR TITLE
Improve the DEFINE_FWK_SERVICE macros

### DIFF
--- a/CondCore/Utilities/interface/PayloadInspectorModule.h
+++ b/CondCore/Utilities/interface/PayloadInspectorModule.h
@@ -1,20 +1,18 @@
 #include <pybind11/pybind11.h>
 
+#include "FWCore/Utilities/interface/concatenate.h"
 #include "FWCore/Utilities/interface/stringize.h"
 
 namespace py = pybind11;
 
-#define PPCAT_NX(A, B) A##B
-#define PPCAT(A, B) PPCAT_NX(A, B)
-
 #define PAYLOAD_INSPECTOR_MODULE(PAYLOAD_TYPENAME) PYBIND11_MODULE(plugin##PAYLOAD_TYPENAME##_PayloadInspector, m)
 
-#define PAYLOAD_INSPECTOR_CLASS(CLASS_NAME)                                                            \
-  py::class_<CLASS_NAME, cond::payloadInspector::PlotBase>(m, EDM_STRINGIZE(PPCAT(plot_, CLASS_NAME))) \
-      .def(py::init<>())                                                                               \
-      .def("process", &cond::payloadInspector::PlotBase::process)                                      \
-      .def("payloadType", &cond::payloadInspector::PlotBase::payloadType)                              \
-      .def("title", &cond::payloadInspector::PlotBase::title)                                          \
-      .def("isSingleIov", &cond::payloadInspector::PlotBase::isSingleIov)                              \
-      .def("isTwoTags", &cond::payloadInspector::PlotBase::isTwoTags)                                  \
+#define PAYLOAD_INSPECTOR_CLASS(CLASS_NAME)                                                                      \
+  py::class_<CLASS_NAME, cond::payloadInspector::PlotBase>(m, EDM_STRINGIZE(EDM_CONCATENATE(plot_, CLASS_NAME))) \
+      .def(py::init<>())                                                                                         \
+      .def("process", &cond::payloadInspector::PlotBase::process)                                                \
+      .def("payloadType", &cond::payloadInspector::PlotBase::payloadType)                                        \
+      .def("title", &cond::payloadInspector::PlotBase::title)                                                    \
+      .def("isSingleIov", &cond::payloadInspector::PlotBase::isSingleIov)                                        \
+      .def("isTwoTags", &cond::payloadInspector::PlotBase::isTwoTags)                                            \
       .def("data", &cond::payloadInspector::PlotBase::data);

--- a/CondCore/Utilities/interface/PayloadInspectorModule.h
+++ b/CondCore/Utilities/interface/PayloadInspectorModule.h
@@ -1,21 +1,20 @@
 #include <pybind11/pybind11.h>
+
+#include "FWCore/Utilities/interface/stringize.h"
+
 namespace py = pybind11;
 
 #define PPCAT_NX(A, B) A##B
 #define PPCAT(A, B) PPCAT_NX(A, B)
-#define STRINGIZE_NX(A) #A
-#define STRINGIZE(A) STRINGIZE_NX(A)
 
 #define PAYLOAD_INSPECTOR_MODULE(PAYLOAD_TYPENAME) PYBIND11_MODULE(plugin##PAYLOAD_TYPENAME##_PayloadInspector, m)
 
-#define PAYLOAD_INSPECTOR_CLASS(CLASS_NAME)                                   \
-  py::class_<CLASS_NAME, cond::payloadInspector::PlotBase>(                   \
-      m,                                                                      \
-      STRINGIZE(PPCAT(plot_, CLASS_NAME)))                                    \
-          .def(py::init<>())                                                  \
-          .def("process", &cond::payloadInspector::PlotBase::process)         \
-          .def("payloadType", &cond::payloadInspector::PlotBase::payloadType) \
-          .def("title", &cond::payloadInspector::PlotBase::title)             \
-          .def("isSingleIov", &cond::payloadInspector::PlotBase::isSingleIov) \
-          .def("isTwoTags", &cond::payloadInspector::PlotBase::isTwoTags)     \
-          .def("data", &cond::payloadInspector::PlotBase::data);
+#define PAYLOAD_INSPECTOR_CLASS(CLASS_NAME)                                                            \
+  py::class_<CLASS_NAME, cond::payloadInspector::PlotBase>(m, EDM_STRINGIZE(PPCAT(plot_, CLASS_NAME))) \
+      .def(py::init<>())                                                                               \
+      .def("process", &cond::payloadInspector::PlotBase::process)                                      \
+      .def("payloadType", &cond::payloadInspector::PlotBase::payloadType)                              \
+      .def("title", &cond::payloadInspector::PlotBase::title)                                          \
+      .def("isSingleIov", &cond::payloadInspector::PlotBase::isSingleIov)                              \
+      .def("isTwoTags", &cond::payloadInspector::PlotBase::isTwoTags)                                  \
+      .def("data", &cond::payloadInspector::PlotBase::data);

--- a/FWCore/PluginManager/interface/PluginFactory.h
+++ b/FWCore/PluginManager/interface/PluginFactory.h
@@ -26,6 +26,7 @@
 // user include files
 #include "FWCore/PluginManager/interface/PluginFactoryBase.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/Utilities/interface/concatenate.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 // forward declarations
 
@@ -84,8 +85,6 @@ namespace edmplugin {
     PluginFactory() { finishedConstruction(); }
   };
 }  // namespace edmplugin
-#define FWCORE_CONCATENATE_HIDDEN(a, b) a##b
-#define FWCORE_CONCATENATE(a, b) FWCORE_CONCATENATE_HIDDEN(a, b)
 #define EDM_REGISTER_PLUGINFACTORY(_factory_, _category_)                                                               \
   namespace edmplugin {                                                                                                 \
     template <>                                                                                                         \
@@ -99,7 +98,7 @@ namespace edmplugin {
       return s_cat;                                                                                                     \
     }                                                                                                                   \
   }                                                                                                                     \
-  enum { FWCORE_CONCATENATE(dummy_edm_register_pluginfactory_, __LINE__) }
+  enum { EDM_CONCATENATE(dummy_edm_register_pluginfactory_, __LINE__) }
 
 #define EDM_REGISTER_PLUGINFACTORY2(_factory_, _category_)                                                              \
   namespace edmplugin {                                                                                                 \
@@ -114,7 +113,7 @@ namespace edmplugin {
       return s_cat;                                                                                                     \
     }                                                                                                                   \
   }                                                                                                                     \
-  enum { FWCORE_CONCATENATE(dummy_edm_register_pluginfactory_2_, __LINE__) }
+  enum { EDM_CONCATENATE(dummy_edm_register_pluginfactory_2_, __LINE__) }
 
 #endif
 

--- a/FWCore/ServiceRegistry/interface/ServiceMaker.h
+++ b/FWCore/ServiceRegistry/interface/ServiceMaker.h
@@ -24,6 +24,7 @@
 #include "FWCore/ServiceRegistry/interface/ServicePluginFactory.h"
 #include "FWCore/ServiceRegistry/interface/ServiceWrapper.h"
 #include "FWCore/ServiceRegistry/interface/ServicesManager.h"
+#include "FWCore/Utilities/interface/stringize.h"
 
 // system include files
 #include <memory>
@@ -94,13 +95,14 @@ namespace edm {
 }  // namespace edm
 
 #define DEFINE_FWK_SERVICE(type)                                                                                  \
-  DEFINE_EDM_PLUGIN(edm::serviceregistry::ServicePluginFactory, edm::serviceregistry::ServiceMaker<type>, #type); \
+  DEFINE_EDM_PLUGIN(                                                                                              \
+      edm::serviceregistry::ServicePluginFactory, edm::serviceregistry::ServiceMaker<type>, EDM_STRINGIZE(type)); \
   DEFINE_DESC_FILLER_FOR_SERVICES(type, type)
 
-#define DEFINE_FWK_SERVICE_MAKER(concrete, maker)                                            \
-  typedef edm::serviceregistry::ServiceMaker<maker::interface_t, maker> concrete##_##_t;     \
-  DEFINE_EDM_PLUGIN(edm::serviceregistry::ServicePluginFactory, concrete##_##_t, #concrete); \
-  typedef maker::concrete_t concrete##_##_##_t;                                              \
-  DEFINE_DESC_FILLER_FOR_SERVICES(concrete, concrete##_##_##_t)
+#define DEFINE_FWK_SERVICE_MAKER(concrete, maker)                                          \
+  typedef edm::serviceregistry::ServiceMaker<maker::interface_t, maker> concrete##__t;     \
+  DEFINE_EDM_PLUGIN(edm::serviceregistry::ServicePluginFactory, concrete##__t, #concrete); \
+  typedef maker::concrete_t concrete##___t;                                                \
+  DEFINE_DESC_FILLER_FOR_SERVICES(concrete, concrete##___t)
 
 #endif

--- a/FWCore/ServiceRegistry/test/stubs/Modules.cc
+++ b/FWCore/ServiceRegistry/test/stubs/Modules.cc
@@ -6,6 +6,7 @@
  *
  */
 
+#include "FWCore/Utilities/interface/concatenate.h"
 #include "FWCore/ServiceRegistry/test/stubs/DependsOnDummyService.h"
 #include "FWCore/ServiceRegistry/test/stubs/DummyService.h"
 #include "FWCore/ServiceRegistry/test/stubs/DummyServiceE0.h"
@@ -15,8 +16,8 @@ using namespace testserviceregistry;
 using namespace edm::serviceregistry;
 DEFINE_FWK_SERVICE_MAKER(DependsOnDummyService, NoArgsMaker<DependsOnDummyService>);
 DEFINE_FWK_SERVICE(DummyService);
-DEFINE_FWK_SERVICE(DummyServiceE0);
-DEFINE_FWK_SERVICE(DummyServiceA1);
-DEFINE_FWK_SERVICE(DummyServiceD2);
-DEFINE_FWK_SERVICE(DummyServiceB3);
-DEFINE_FWK_SERVICE(DummyServiceC4);
+DEFINE_FWK_SERVICE(EDM_CONCATENATE(DummyService, E0));
+DEFINE_FWK_SERVICE(EDM_CONCATENATE(DummyService, A1));
+DEFINE_FWK_SERVICE(EDM_CONCATENATE(DummyService, D2));
+DEFINE_FWK_SERVICE(EDM_CONCATENATE(DummyService, B3));
+DEFINE_FWK_SERVICE(EDM_CONCATENATE(DummyService, C4));

--- a/FWCore/Utilities/interface/CMSUnrollLoop.h
+++ b/FWCore/Utilities/interface/CMSUnrollLoop.h
@@ -1,20 +1,18 @@
 #ifndef FWCore_Utilities_interface_CMSUnrollLoop_h
 #define FWCore_Utilities_interface_CMSUnrollLoop_h
 
-// convert the macro argument to a null-terminated quoted string
-#define STRINGIFY_(ARG) #ARG
-#define STRINGIFY(ARG) STRINGIFY_(ARG)
+#include "FWCore/Utilities/interface/stringize.h"
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
 // CUDA or HIP device compiler
 
-#define CMS_UNROLL_LOOP _Pragma(STRINGIFY(unroll))
-#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(unroll N))
-#define CMS_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(unroll 1))
+#define CMS_UNROLL_LOOP _Pragma(EDM_STRINGIZE(unroll))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(unroll N))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(unroll 1))
 
-#define CMS_DEVICE_UNROLL_LOOP _Pragma(STRINGIFY(unroll))
-#define CMS_DEVICE_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(unroll N))
-#define CMS_DEVICE_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(unroll 1))
+#define CMS_DEVICE_UNROLL_LOOP _Pragma(EDM_STRINGIZE(unroll))
+#define CMS_DEVICE_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(unroll N))
+#define CMS_DEVICE_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(unroll 1))
 
 #else  // defined (__CUDA_ARCH__) || defined (__HIP_DEVICE_COMPILE__)
 
@@ -26,16 +24,16 @@
 #if defined(__clang__)
 // clang host compiler
 
-#define CMS_UNROLL_LOOP _Pragma(STRINGIFY(clang loop unroll(enable)))
-#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(clang loop unroll_count(N)))
-#define CMS_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(clang loop unroll(disable)))
+#define CMS_UNROLL_LOOP _Pragma(EDM_STRINGIZE(clang loop unroll(enable)))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(clang loop unroll_count(N)))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(clang loop unroll(disable)))
 
 #elif defined(__GNUC__)
 // GCC host compiler
 
-#define CMS_UNROLL_LOOP _Pragma(STRINGIFY(GCC ivdep))
-#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(STRINGIFY(GCC unroll N)) _Pragma(STRINGIFY(GCC ivdep))
-#define CMS_UNROLL_LOOP_DISABLE _Pragma(STRINGIFY(GCC unroll 1))
+#define CMS_UNROLL_LOOP _Pragma(EDM_STRINGIZE(GCC ivdep))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(GCC unroll N)) _Pragma(EDM_STRINGIZE(GCC ivdep))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(GCC unroll 1))
 
 #else
 // unsupported or unknown compiler

--- a/FWCore/Utilities/interface/concatenate.h
+++ b/FWCore/Utilities/interface/concatenate.h
@@ -1,0 +1,8 @@
+#ifndef FWCore_Utilities_interface_concatenate_h
+#define FWCore_Utilities_interface_concatenate_h
+
+// concatenate the macro arguments into a single token
+#define EDM_CONCATENATE_(a, b) a##b
+#define EDM_CONCATENATE(a, b) EDM_CONCATENATE_(a, b)
+
+#endif  // FWCore_Utilities_interface_concatenate_h

--- a/FWCore/Utilities/interface/stringize.h
+++ b/FWCore/Utilities/interface/stringize.h
@@ -1,0 +1,8 @@
+#ifndef FWCore_Utilities_interface_stringize_h
+#define FWCore_Utilities_interface_stringize_h
+
+// convert the macro argument to a null-terminated quoted string
+#define EDM_STRINGIZE_(token) #token
+#define EDM_STRINGIZE(token) EDM_STRINGIZE_(token)
+
+#endif  // FWCore_Utilities_interface_stringize_h

--- a/Fireworks/Core/interface/register_dataproxybuilder_macro.h
+++ b/Fireworks/Core/interface/register_dataproxybuilder_macro.h
@@ -20,7 +20,11 @@
 
 // system include files
 #include <cstdlib>
+#include <string>
+
+// user include files
 #include "FWCore/Reflection/interface/TypeWithDict.h"
+#include "FWCore/Utilities/interface/concatenate.h"
 
 // forward declarations
 
@@ -32,9 +36,6 @@
   static const std::string& classTypeName();                      \
   static const std::string& classPurpose();                       \
   static const std::string& classView()
-
-#define CONCATENATE_HIDDEN(a, b) a##b
-#define CONCATENATE(a, b) CONCATENATE_HIDDEN(a, b)
 
 #define DEFINE_PROXYBUILDER_METHODS(_builder_, _type_, _purpose_, _view_) \
   const std::string& _builder_::classTypeName() {                         \
@@ -53,6 +54,6 @@
     static std::string s_purpose(_purpose_);                              \
     return s_purpose;                                                     \
   }                                                                       \
-  enum { CONCATENATE(dummy_proxybuilder_methods_, __LINE__) }
+  enum { EDM_CONCATENATE(dummy_proxybuilder_methods_, __LINE__) }
 
 #endif

--- a/Fireworks/Core/interface/register_itemaccessorbase_macro.h
+++ b/Fireworks/Core/interface/register_itemaccessorbase_macro.h
@@ -19,20 +19,20 @@
 //
 
 // system include files
-#include "FWCore/Reflection/interface/TypeWithDict.h"
+#include <string>
 
 // user include files
+#include "FWCore/Reflection/interface/TypeWithDict.h"
+#include "FWCore/Utilities/interface/concatenate.h"
 
 // forward declarations
+
 #define REGISTER_FWITEMACCESSOR_METHODS()                         \
   const std::string& typeName() const { return classTypeName(); } \
   const std::string& purpose() const { return classPurpose(); }   \
   static const std::string& classRegisterTypeName();              \
   static const std::string& classTypeName();                      \
   static const std::string& classPurpose()
-
-#define CONCATENATE_HIDDEN(a, b) a##b
-#define CONCATENATE(a, b) CONCATENATE_HIDDEN(a, b)
 
 #define DEFINE_FWITEMACCESSOR_METHODS(_accessor_, _type_, _purpose_)      \
   const std::string& _accessor_::classTypeName() {                        \
@@ -47,7 +47,7 @@
     static std::string s_purpose(_purpose_);                              \
     return s_purpose;                                                     \
   }                                                                       \
-  enum { CONCATENATE(dummy_itemaccessor_methods_, __LINE__) }
+  enum { EDM_CONCATENATE(dummy_itemaccessor_methods_, __LINE__) }
 
 #define DEFINE_TEMPLATE_FWITEMACCESSOR_METHODS(_accessor_, _type_, _purpose_) \
   template <>                                                                 \
@@ -65,6 +65,6 @@
     static std::string s_purpose(_purpose_);                                  \
     return s_purpose;                                                         \
   }                                                                           \
-  enum { CONCATENATE(dummy_itemaccessor_methods_, __LINE__) }
+  enum { EDM_CONCATENATE(dummy_itemaccessor_methods_, __LINE__) }
 
 #endif


### PR DESCRIPTION
#### PR description:

Add a macro to convert a preprocessor token to a null-terminated string. If the argument is itself a macro, it will be expanded, and the result of the expansion will be converted to a string.

Improve the `DEFINE_FWK_SERVICE` macro to support types that are themselves the result of a macro expansion.

Remove unnecessary concatenation operators from the definition of the `DEFINE_FWK_SERVICE_MAKER` macro.

#### PR validation:

Various framework services build successfully, and no changes in behaviour have been observed.