### PR TITLE
[12_3_X] Fill LumiRange for BeamSpotOnline objects

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -1407,6 +1407,9 @@ void BeamMonitor::FitAndFill(const LuminosityBlock& lumiSeg, int& lastlumi, int&
       BSOnline.setEndTimeStamp(timeForDIP.second);
       BSOnline.setEndTime(getGMTstring(timeForDIP.second));
 
+      std::string lumiRangeForDIP = std::to_string(LSRange.first) + " - " + std::to_string(LSRange.second);
+      BSOnline.setLumiRange(lumiRangeForDIP);
+
       edm::LogInfo("BeamMonitor") << "FitAndFill::[PayloadCreation] BeamSpotOnline object created: \n" << std::endl;
       edm::LogInfo("BeamMonitor") << BSOnline << std::endl;
 


### PR DESCRIPTION
#### PR description:
Backport of #37875
As noticed in https://github.com/cms-sw/cmssw/pull/37858#issuecomment-1120905360 the `lumiRange` member of the BeamSpotOnline objects was never filled in `DQM/BeamMonitor` and it defaulted to an empty string.
This PR correctly fills the value with the string `[firstLS] - [lastLS]` used in the BeamSpot fit.

#### PR validation:
Code compiles plus @cms-sw/dqm-l2 experts (@pmandrik @ahmad3213) should test this in P5.

#### Backport:
Backport of #37875

FYI @dzuolo @gennai 