### PR TITLE
Cand level DNN selection in MkFit + application to 2 iterations

### DIFF
--- a/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/HighPtTripletStep_cff.py
@@ -241,6 +241,8 @@ trackingMkFitHighPtTripletStep.toReplaceWith(highPtTripletStepTrackCandidates, m
     seeds = 'highPtTripletStepSeeds',
     mkFitSeeds = 'highPtTripletStepTrackCandidatesMkFitSeeds',
     tracks = 'highPtTripletStepTrackCandidatesMkFit',
+    candMVASel = True,
+    candWP = -0.3,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(highPtTripletStepTrackCandidatesMkFitConfig, minPt=0.7)
 

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -321,6 +321,8 @@ trackingMkFitPixelLessStep.toReplaceWith(pixelLessStepTrackCandidates, mkFitOutp
     seeds = 'pixelLessStepSeeds',
     mkFitSeeds = 'pixelLessStepTrackCandidatesMkFitSeeds',
     tracks = 'pixelLessStepTrackCandidatesMkFit',
+    candMVASel = True,
+    candWP = -0.7,
 ))
 (pp_on_XeXe_2017 | pp_on_AA).toModify(pixelLessStepTrackCandidatesMkFitConfig, minPt=2.0)
 

--- a/RecoTracker/MkFit/plugins/BuildFile.xml
+++ b/RecoTracker/MkFit/plugins/BuildFile.xml
@@ -30,5 +30,9 @@
   <use name="TrackingTools/TrajectoryState"/>
   <use name="TrackingTools/TransientTrackingRecHit"/>
   <use name="rootmath"/>
+  <use name="CondFormats/GBRForest"/>
+  <use name="PhysicsTools/TensorFlow"/>
+  <use name="TrackingTools/PatternTools"/>
+  <use name="RecoTracker/FinalTrackSelectors"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -449,6 +449,7 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
         output, states, bs, vertices, session, chi2, mkFitOutput.propagatedToFirstLayer() && doErrorRescale_);
 
     TrackCandidateCollection reducedOutput;
+    reducedOutput.reserve(output.size());
     int scoreIndex = 0;
     for (const auto& score : dnnScores) {
       if (score > algoCandWorkingPoint_)

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -225,12 +225,8 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
   const reco::VertexCollection* vertices = nullptr;
   const reco::BeamSpot* beamspot = nullptr;
   if (algoCandSelection_) {
-    edm::Handle<reco::VertexCollection> hVtx;
-    iEvent.getByToken(verticesToken_, hVtx);
-    vertices = hVtx.product();
-    edm::Handle<reco::BeamSpot> hBs;
-    iEvent.getByToken(bsToken_, hBs);
-    beamspot = hBs.product();
+    vertices = &iEvent.get(verticesToken_);
+    beamspot = &iEvent.get(bsToken_);
   }
 
   const tensorflow::Session* session = nullptr;

--- a/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
+++ b/RecoTracker/MkFit/plugins/MkFitOutputConverter.cc
@@ -41,6 +41,14 @@
 #include "RecoTracker/MkFitCore/interface/Track.h"
 #include "RecoTracker/MkFitCore/interface/HitStructures.h"
 
+//extra for DNN with cands
+#include "TrackingTools/Records/interface/TfGraphRecord.h"
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "RecoTracker/FinalTrackSelectors/interface/TfGraphDefWrapper.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
 namespace {
   template <typename T>
   bool isBarrel(T subdet) {
@@ -75,7 +83,10 @@ private:
                                              const Propagator& propagatorOpposite,
                                              const TkClonerImpl& hitCloner,
                                              const std::vector<const DetLayer*>& detLayers,
-                                             const mkfit::TrackVec& mkFitSeeds) const;
+                                             const mkfit::TrackVec& mkFitSeeds,
+                                             const reco::BeamSpot& bs,
+                                             const reco::VertexCollection* vertices,
+                                             const tensorflow::Session* session) const;
 
   std::pair<TrajectoryStateOnSurface, const GeomDet*> backwardFit(const FreeTrajectoryState& fts,
                                                                   const edm::OwnVector<TrackingRecHit>& hits,
@@ -89,6 +100,14 @@ private:
                                                                             const edm::OwnVector<TrackingRecHit>& hits,
                                                                             const Propagator& propagatorAlong,
                                                                             const Propagator& propagatorOpposite) const;
+
+  std::vector<float> computeDNNs(TrackCandidateCollection const& tkCC,
+                                 const std::vector<TrajectoryStateOnSurface>& states,
+                                 const reco::BeamSpot& bs,
+                                 const reco::VertexCollection* vertices,
+                                 const tensorflow::Session* session,
+                                 const std::vector<float>& chi2,
+                                 const bool rescaledError) const;
 
   const edm::EDGetTokenT<MkFitEventOfHits> eventOfHitsToken_;
   const edm::EDGetTokenT<MkFitClusterIndexToHit> pixelClusterIndexToHitToken_;
@@ -112,6 +131,14 @@ private:
   const bool qualitySignPt_;
 
   const bool doErrorRescale_;
+
+  const int algo_;
+  const bool algoCandSelection_;
+  const float algoCandWorkingPoint_;
+  const edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  const edm::EDGetTokenT<reco::VertexCollection> verticesToken_;
+  const std::string tfDnnLabel_;
+  const edm::ESGetToken<TfGraphDefWrapper, TfGraphRecord> tfDnnToken_;
 };
 
 MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
@@ -137,7 +164,16 @@ MkFitOutputConverter::MkFitOutputConverter(edm::ParameterSet const& iConfig)
       qualityMaxZ_{float(iConfig.getParameter<double>("qualityMaxZ"))},
       qualityMaxPosErrSq_{float(pow(iConfig.getParameter<double>("qualityMaxPosErr"), 2))},
       qualitySignPt_{iConfig.getParameter<bool>("qualitySignPt")},
-      doErrorRescale_{iConfig.getParameter<bool>("doErrorRescale")} {}
+      doErrorRescale_{iConfig.getParameter<bool>("doErrorRescale")},
+      algo_{reco::TrackBase::algoByName(
+          TString(iConfig.getParameter<edm::InputTag>("seeds").label()).ReplaceAll("Seeds", "").Data())},
+      algoCandSelection_{bool(iConfig.getParameter<bool>("candMVASel"))},
+      algoCandWorkingPoint_{float(iConfig.getParameter<double>("candWP"))},
+      bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
+      verticesToken_(algoCandSelection_ ? consumes<reco::VertexCollection>(edm::InputTag("firstStepPrimaryVertices"))
+                                        : edm::EDGetTokenT<reco::VertexCollection>()),
+      tfDnnLabel_(iConfig.getParameter<std::string>("tfDnnLabel")),
+      tfDnnToken_(esConsumes(edm::ESInputTag("", tfDnnLabel_))) {}
 
 void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -161,6 +197,11 @@ void MkFitOutputConverter::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<bool>("doErrorRescale", true)->setComment("rescale candidate error before final fit");
 
+  desc.add<std::string>("tfDnnLabel", "trackSelectionTf");
+
+  desc.add<bool>("candMVASel", false)->setComment("flag used to trigger MVA selection at cand level");
+  desc.add<double>("candWP", 0)->setComment("MVA selection at cand level working point");
+
   descriptions.addWithDefaultLabel(desc);
 }
 
@@ -175,6 +216,20 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
   }
   const auto& mkFitGeom = iSetup.getData(mkFitGeomToken_);
 
+  edm::Handle<reco::BeamSpot> bsHandle;
+  iEvent.getByToken(bsToken_, bsHandle);
+  const reco::BeamSpot& beamspot = *bsHandle.product();
+
+  // primary vertices under the algo_ because in initialStepPreSplitting there are no firstStepPrimaryVertices
+  const reco::VertexCollection* vertices = nullptr;
+  if (algoCandSelection_) {
+    edm::Handle<reco::VertexCollection> hVtx;
+    iEvent.getByToken(verticesToken_, hVtx);
+    vertices = hVtx.product();
+  }
+
+  const tensorflow::Session* session = iSetup.getData(tfDnnToken_).getSession();
+
   // Convert mkfit presentation back to CMSSW
   iEvent.emplace(putTrackCandidateToken_,
                  convertCandidates(iEvent.get(tracksToken_),
@@ -187,7 +242,10 @@ void MkFitOutputConverter::produce(edm::StreamID iID, edm::Event& iEvent, const 
                                    iSetup.getData(propagatorOppositeToken_),
                                    tkBuilder->cloner(),
                                    mkFitGeom.detLayers(),
-                                   mkfitSeeds.seeds()));
+                                   mkfitSeeds.seeds(),
+                                   beamspot,
+                                   vertices,
+                                   session));
 
   // TODO: SeedStopInfo is currently unfilled
   iEvent.emplace(putSeedStopInfoToken_, seeds.size());
@@ -203,12 +261,20 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
                                                                  const Propagator& propagatorOpposite,
                                                                  const TkClonerImpl& hitCloner,
                                                                  const std::vector<const DetLayer*>& detLayers,
-                                                                 const mkfit::TrackVec& mkFitSeeds) const {
+                                                                 const mkfit::TrackVec& mkFitSeeds,
+                                                                 const reco::BeamSpot& bs,
+                                                                 const reco::VertexCollection* vertices,
+                                                                 const tensorflow::Session* session) const {
   TrackCandidateCollection output;
   const auto& candidates = mkFitOutput.tracks();
   output.reserve(candidates.size());
 
   LogTrace("MkFitOutputConverter") << "Number of candidates " << candidates.size();
+
+  std::vector<float> chi2;
+  std::vector<TrajectoryStateOnSurface> states;
+  chi2.reserve(candidates.size());
+  states.reserve(candidates.size());
 
   int candIndex = -1;
   for (const auto& cand : candidates) {
@@ -373,7 +439,26 @@ TrackCandidateCollection MkFitOutputConverter::convertCandidates(const MkFitOutp
         0,                                               // mkFit does not produce loopers, so set nLoops=0
         static_cast<uint8_t>(StopReason::UNINITIALIZED)  // TODO: ignore details of stopping reason as well for now
     );
+
+    chi2.push_back(cand.chi2());
+    states.push_back(tsosDet.first);
   }
+
+  if (algoCandSelection_) {
+    const std::vector<float> dnnScores = computeDNNs(
+        output, states, bs, vertices, session, chi2, mkFitOutput.propagatedToFirstLayer() && doErrorRescale_);
+
+    TrackCandidateCollection reducedOutput;
+    int scoreIndex = 0;
+    for (const auto& score : dnnScores) {
+      if (score > algoCandWorkingPoint_)
+        reducedOutput.push_back(output.at(scoreIndex));
+      scoreIndex++;
+    }
+
+    output.swap(reducedOutput);
+  }
+
   return output;
 }
 
@@ -508,6 +593,136 @@ std::pair<TrajectoryStateOnSurface, const GeomDet*> MkFitOutputConverter::conver
   }
 
   return std::make_pair(tsosDouble.first, det);
+}
+
+std::vector<float> MkFitOutputConverter::computeDNNs(TrackCandidateCollection const& tkCC,
+                                                     const std::vector<TrajectoryStateOnSurface>& states,
+                                                     const reco::BeamSpot& bs,
+                                                     const reco::VertexCollection* vertices,
+                                                     const tensorflow::Session* session,
+                                                     const std::vector<float>& chi2,
+                                                     const bool rescaledError) const {
+  int size_in = (int)tkCC.size();
+  int bsize = 16;
+  int nbatches = size_in / bsize;
+
+  std::vector<float> output(size_in, 0);
+
+  TSCBLBuilderNoMaterial tscblBuilder;
+
+  for (auto nb = 0; nb < nbatches + 1; nb++) {
+    // tensorflow part
+    tensorflow::Tensor input1(tensorflow::DT_FLOAT, {bsize, 29});
+    tensorflow::Tensor input2(tensorflow::DT_FLOAT, {bsize, 1});
+
+    for (auto nt = 0; nt < bsize; nt++) {
+      int itrack = nt + bsize * nb;
+      if (itrack >= size_in)
+        continue;
+
+      auto const& tkC = tkCC.at(itrack);
+
+      TrajectoryStateOnSurface state = states.at(itrack);
+
+      if (rescaledError)
+        state.rescaleError(1 / 100.f);
+
+      TrajectoryStateClosestToBeamLine tsAtClosestApproachTrackCand =
+          tscblBuilder(*state.freeState(), bs);  //as in TrackProducerAlgorithm
+
+      if (!(tsAtClosestApproachTrackCand.isValid())) {
+        edm::LogVerbatim("TrackBuilding") << "TrajectoryStateClosestToBeamLine not valid";
+        continue;
+      }
+
+      auto const& stateAtPCA = tsAtClosestApproachTrackCand.trackStateAtPCA();
+      auto v0 = stateAtPCA.position();
+      auto p = stateAtPCA.momentum();
+      math::XYZPoint pos(v0.x(), v0.y(), v0.z());
+      math::XYZVector mom(p.x(), p.y(), p.z());
+
+      //pseudo track for access to easy methods
+      reco::Track trk(0, 0, pos, mom, stateAtPCA.charge(), stateAtPCA.curvilinearError());
+
+      // get best vertex
+      float dzmin = std::numeric_limits<float>::max();
+      float dxy_zmin = 0;
+
+      for (auto const& vertex : *vertices) {
+        if (std::abs(trk.dz(vertex.position())) < dzmin) {
+          dzmin = trk.dz(vertex.position());
+          dxy_zmin = trk.dxy(vertex.position());
+        }
+      }
+
+      // loop over the RecHits
+      int ndof = 0;
+      int pix = 0;
+      int strip = 0;
+      for (auto const& recHit : tkC.recHits()) {
+        ndof += recHit.dimension();
+        auto const subdet = recHit.geographicalId().subdetId();
+        if (subdet == PixelSubdetector::PixelBarrel || subdet == PixelSubdetector::PixelEndcap)
+          pix++;
+        else
+          strip++;
+      }
+      ndof = ndof - 5;
+
+      input1.matrix<float>()(nt, 0) = trk.pt();  //using inner track only
+      input1.matrix<float>()(nt, 1) = p.x();
+      input1.matrix<float>()(nt, 2) = p.y();
+      input1.matrix<float>()(nt, 3) = p.z();
+      input1.matrix<float>()(nt, 4) = p.perp();
+      input1.matrix<float>()(nt, 5) = p.x();
+      input1.matrix<float>()(nt, 6) = p.y();
+      input1.matrix<float>()(nt, 7) = p.z();
+      input1.matrix<float>()(nt, 8) = p.perp();
+      input1.matrix<float>()(nt, 9) = trk.ptError();
+      input1.matrix<float>()(nt, 10) = dxy_zmin;
+      input1.matrix<float>()(nt, 11) = dzmin;
+      input1.matrix<float>()(nt, 12) = trk.dxy(bs.position());
+      input1.matrix<float>()(nt, 13) = trk.dz(bs.position());
+      input1.matrix<float>()(nt, 14) = trk.dxyError();
+      input1.matrix<float>()(nt, 15) = trk.dzError();
+      input1.matrix<float>()(nt, 16) = chi2[itrack] / ndof;
+      input1.matrix<float>()(nt, 17) = trk.eta();
+      input1.matrix<float>()(nt, 18) = trk.phi();
+      input1.matrix<float>()(nt, 19) = trk.etaError();
+      input1.matrix<float>()(nt, 20) = trk.phiError();
+      input1.matrix<float>()(nt, 21) = pix;
+      input1.matrix<float>()(nt, 22) = strip;
+      input1.matrix<float>()(nt, 23) = ndof;
+      input1.matrix<float>()(nt, 24) = 0;
+      input1.matrix<float>()(nt, 25) = 0;
+      input1.matrix<float>()(nt, 26) = 0;
+      input1.matrix<float>()(nt, 27) = 0;
+      input1.matrix<float>()(nt, 28) = 0;
+
+      input2.matrix<float>()(nt, 0) = algo_;
+    }
+
+    //inputs finalized
+    tensorflow::NamedTensorList inputs;
+    inputs.resize(2);
+    inputs[0] = tensorflow::NamedTensor("x", input1);
+    inputs[1] = tensorflow::NamedTensor("y", input2);
+
+    //eval and rescale
+    std::vector<tensorflow::Tensor> outputs;
+    tensorflow::run(const_cast<tensorflow::Session*>(session), inputs, {"Identity"}, &outputs);
+
+    for (auto nt = 0; nt < bsize; nt++) {
+      int itrack = nt + bsize * nb;
+      if (itrack >= size_in)
+        continue;
+
+      float out0 = 2.0 * outputs[0].matrix<float>()(nt, 0) - 1.0;
+      output[itrack] = out0;
+    }
+  }
+
+  return output;
 }
 
 DEFINE_FWK_MODULE(MkFitOutputConverter);


### PR DESCRIPTION
#### PR description:

In this PR we introduce the possibility to compute the track selection DNN on a simplified set of inputs at the track candidate level

A loose selection at this level allows a reduction of the fitting time. 

The DNN is evaluated in batches to speed up this extra step and not increase significantly the overall tracking time.

The selection can be enabled/disabled in RecoTracker/IterativeTracking/python/**_cff.py

Currently, it is enabled only for the pixelLess and HighPtTriplet iterations.

Premises and preliminary results were presented here [TK POG update 25 April](https://indico.cern.ch/event/1152032/contributions/4841692/attachments/2430728/4162233/mkFit%20-%20update-1.pdf) 


#### PR validation:

- physics validation
the original is in blue, to be compared to red, after the cand level selection
http://uaf-10.t2.ucsd.edu/~legianni/test-2configurations-html/

- timing reduction iterations where DNN cand selection is applied
there is noticleable speed up in the fit (and selection) column and a smaller increase in the build column due to the DNN computation
![image](https://user-images.githubusercontent.com/7805577/167452073-481d2767-2943-49c8-a9ae-d97fda43a860.png)
![image](https://user-images.githubusercontent.com/7805577/167453073-f8d14ea1-9f92-48d4-b716-f1dfe820ceb2.png)

- timing global - overall reduced
![image](https://user-images.githubusercontent.com/7805577/167452360-e8434b7a-1b6c-41a4-a013-aaea46a836ce.png)



- profiling with igprof

- mem
  before  https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/NODNNMEM3
  after  https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/DNNMEM3
  
  in particular
  (https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/NODNNMEM3/1028 before)
  (https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/DNNMEM3/1087 after)

- cpu
  before  https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/NODNNCPU
  after  https://legianni.web.cern.ch/legianni/cgi-bin/igprof-navigator/candDNN-batch-profiles/DNNCPU2
