### PR TITLE
Particle flow identification of electrons in extended eta

### DIFF
--- a/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowTmpBarrel_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/particleFlowTmpBarrel_cfi.py
@@ -5,7 +5,6 @@ particleFlowTmpBarrel = cms.EDProducer("PFProducer",
     GedPhotonValueMap = cms.InputTag("gedPhotonsTmp","valMapPFEgammaCandToPhoton"),
     PFEGammaCandidates = cms.InputTag("particleFlowEGamma"),
     PFEGammaFiltersParameters = cms.PSet(
-        allowEEEinPF = cms.bool(False),
         electronDnnBkgThresholds = cms.PSet(
             electronDnnBkgHighPtBarrelThr = cms.double(0.8),
             electronDnnBkgHighPtEndcapThr = cms.double(0.75),

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -55,7 +55,7 @@ GsfElectronAlgo::HeavyObjectCache::HeavyObjectCache(const edm::ParameterSet& con
     dconfig.outputTensorName = pset_dnn.getParameter<std::string>("outputTensorName");
     dconfig.modelsFiles = pset_dnn.getParameter<std::vector<std::string>>("modelsFiles");
     dconfig.scalersFiles = pset_dnn.getParameter<std::vector<std::string>>("scalersFiles");
-    dconfig.outputDim = pset_dnn.getParameter<uint>("outputDim");
+    dconfig.outputDim = pset_dnn.getParameter<std::vector<unsigned int>>("outputDim");
     const auto useEBModelInGap = pset_dnn.getParameter<bool>("useEBModelInGap");
     iElectronDNNEstimator = std::make_unique<ElectronDNNEstimator>(dconfig, useEBModelInGap);
   }

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -59,20 +59,20 @@ namespace {
         // get the previous values
         auto& mvaOutput = mva_outputs[jele];
 
-	if (abs(el.superCluster()->eta())<=2.65){
-	    mvaOutput.dnn_e_sigIsolated = values[0];
-	    mvaOutput.dnn_e_sigNonIsolated = values[1];
-	    mvaOutput.dnn_e_bkgNonIsolated = values[2];
-	    mvaOutput.dnn_e_bkgTau = values[3];
-	    mvaOutput.dnn_e_bkgPhoton = values[4];
-	}else{
-	    mvaOutput.dnn_e_sigIsolated = values[0];
-            mvaOutput.dnn_e_sigNonIsolated = 0.0;
-            mvaOutput.dnn_e_bkgNonIsolated = values[1];
-            mvaOutput.dnn_e_bkgTau = 0.0;
-            mvaOutput.dnn_e_bkgPhoton = values[2];
-	}
-	    el.setMvaOutput(mvaOutput);
+        if (abs(el.superCluster()->eta()) <= 2.65) {
+          mvaOutput.dnn_e_sigIsolated = values[0];
+          mvaOutput.dnn_e_sigNonIsolated = values[1];
+          mvaOutput.dnn_e_bkgNonIsolated = values[2];
+          mvaOutput.dnn_e_bkgTau = values[3];
+          mvaOutput.dnn_e_bkgPhoton = values[4];
+        } else {
+          mvaOutput.dnn_e_sigIsolated = values[0];
+          mvaOutput.dnn_e_sigNonIsolated = 0.0;
+          mvaOutput.dnn_e_bkgNonIsolated = values[1];
+          mvaOutput.dnn_e_bkgTau = 0.0;
+          mvaOutput.dnn_e_bkgPhoton = values[2];
+        }
+        el.setMvaOutput(mvaOutput);
         jele++;
       }
     }
@@ -306,18 +306,17 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.pb",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEB/highpTEB_modelDNN.pb",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEE/highpTEE_modelDNN.pb",
-	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/modelDNN.pb",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/modelDNN.pb",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/modelDNN.pb"});
     psd1.add<std::vector<std::string>>(
         "scalersFiles",
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_scaler.txt",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEB/highpTEB_scaler.txt",
-	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEE/highpTEE_scaler.txt",
-	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/scaler.txt",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEE/highpTEE_scaler.txt",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/scaler.txt",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/scaler.txt"});
-    psd1.add<std::vector<unsigned int>>(
-	"outputDim",//Number of output nodes for the above models
-	{5,5,5,5,3});
+    psd1.add<std::vector<unsigned int>>("outputDim",  //Number of output nodes for the above models
+                                        {5, 5, 5, 5, 3});
 
     psd1.add<bool>("useEBModelInGap", true);
     // preselection parameters

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -300,8 +300,7 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
     psd1.add<bool>("enabled", false);
     psd1.add<std::string>("inputTensorName", "FirstLayer_input");
     psd1.add<std::string>("outputTensorName", "sequential/FinalLayer/Softmax");
-    psd1.add<uint>("outputDim", 5);  // Number of output nodes of DNN for |eta| < 2.65
-    psd1.add<uint>("outputDimExtEta2", 3);  // Number of output nodes of DNN for |eta| > 2.65
+
     psd1.add<std::vector<std::string>>(
         "modelsFiles",
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/lowpT/lowpT_modelDNN.pb",
@@ -316,6 +315,10 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
 	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_scaler.txt",
 	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta1/scaler.txt",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta2/scaler.txt"});
+    psd1.add<std::vector<unsigned int>>(
+	"outputDim",//Number of output nodes for the above models
+	{5,5,5,5,3});
+
     psd1.add<bool>("useEBModelInGap", true);
     // preselection parameters
     desc.add<edm::ParameterSetDescription>("EleDNNPFid", psd1);

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -307,15 +307,15 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/lowpT/lowpT_modelDNN.pb",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEB/highpTEB_modelDNN.pb",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_modelDNN.pb",
-	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_modelDNN.pb"});
+	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta1/modelDNN.pb",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta2/modelDNN.pb"});
     psd1.add<std::vector<std::string>>(
         "scalersFiles",
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/lowpT/lowpT_scaler.txt",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEB/highpTEB_scaler.txt",
 	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_scaler.txt",
-	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_scaler.txt",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_scaler.txt"});
+	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta1/scaler.txt",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta2/scaler.txt"});
     psd1.add<bool>("useEBModelInGap", true);
     // preselection parameters
     desc.add<edm::ParameterSetDescription>("EleDNNPFid", psd1);

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -58,12 +58,21 @@ namespace {
         const auto& values = dnn_ele_pfid[jele];
         // get the previous values
         auto& mvaOutput = mva_outputs[jele];
-        mvaOutput.dnn_e_sigIsolated = values[0];
-        mvaOutput.dnn_e_sigNonIsolated = values[1];
-        mvaOutput.dnn_e_bkgNonIsolated = values[2];
-        mvaOutput.dnn_e_bkgTau = values[3];
-        mvaOutput.dnn_e_bkgPhoton = values[4];
-        el.setMvaOutput(mvaOutput);
+
+	if (abs(el.superCluster()->eta())<=2.65){
+	    mvaOutput.dnn_e_sigIsolated = values[0];
+	    mvaOutput.dnn_e_sigNonIsolated = values[1];
+	    mvaOutput.dnn_e_bkgNonIsolated = values[2];
+	    mvaOutput.dnn_e_bkgTau = values[3];
+	    mvaOutput.dnn_e_bkgPhoton = values[4];
+	}else{
+	    mvaOutput.dnn_e_sigIsolated = values[0];
+            mvaOutput.dnn_e_sigNonIsolated = 0.0;
+            mvaOutput.dnn_e_bkgNonIsolated = values[1];
+            mvaOutput.dnn_e_bkgTau = 0.0;
+            mvaOutput.dnn_e_bkgPhoton = values[2];
+	}
+	    el.setMvaOutput(mvaOutput);
         jele++;
       }
     }
@@ -291,16 +300,21 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
     psd1.add<bool>("enabled", false);
     psd1.add<std::string>("inputTensorName", "FirstLayer_input");
     psd1.add<std::string>("outputTensorName", "sequential/FinalLayer/Softmax");
-    psd1.add<uint>("outputDim", 5);  // Number of output nodes of DNN
+    psd1.add<uint>("outputDim", 5);  // Number of output nodes of DNN for |eta| < 2.65
+    psd1.add<uint>("outputDimExtEta2", 3);  // Number of output nodes of DNN for |eta| > 2.65
     psd1.add<std::vector<std::string>>(
         "modelsFiles",
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/lowpT/lowpT_modelDNN.pb",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEB/highpTEB_modelDNN.pb",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_modelDNN.pb",
+	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_modelDNN.pb",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_modelDNN.pb"});
     psd1.add<std::vector<std::string>>(
         "scalersFiles",
         {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/lowpT/lowpT_scaler.txt",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEB/highpTEB_scaler.txt",
+	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_scaler.txt",
+	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_scaler.txt",
          "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_scaler.txt"});
     psd1.add<bool>("useEBModelInGap", true);
     // preselection parameters

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -303,18 +303,18 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
 
     psd1.add<std::vector<std::string>>(
         "modelsFiles",
-        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/lowpT/lowpT_modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEB/highpTEB_modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_modelDNN.pb",
-	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta1/modelDNN.pb",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta2/modelDNN.pb"});
+        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.pb",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEB/highpTEB_modelDNN.pb",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEE/highpTEE_modelDNN.pb",
+	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/modelDNN.pb",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/modelDNN.pb"});
     psd1.add<std::vector<std::string>>(
         "scalersFiles",
-        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/lowpT/lowpT_scaler.txt",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEB/highpTEB_scaler.txt",
-	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/highpTEE/highpTEE_scaler.txt",
-	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta1/scaler.txt",
-         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/v1/exteta2/scaler.txt"});
+        {"RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_scaler.txt",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEB/highpTEB_scaler.txt",
+	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/highpTEE/highpTEE_scaler.txt",
+	 "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/scaler.txt",
+         "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/scaler.txt"});
     psd1.add<std::vector<unsigned int>>(
 	"outputDim",//Number of output nodes for the above models
 	{5,5,5,5,3});

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -35,7 +35,7 @@ namespace {
                      const GsfElectronAlgo::HeavyObjectCache* hoc,
                      reco::VertexCollection const& vertices,
                      bool dnnPFidEnabled,
-		     float extetaboundary,
+                     float extetaboundary,
                      const std::vector<tensorflow::Session*>& tfSessions) {
     std::vector<GsfElectron::MvaOutput> mva_outputs(electrons.size());
     size_t iele = 0;
@@ -744,7 +744,8 @@ void GsfElectronProducer::produce(edm::Event& event, const edm::EventSetup& setu
     for (auto& el : electrons) {
       el.setMvaInput(gsfMVAInputMap.find(el.gsfTrack())->second);  // set Run2 MVA inputs
     }
-    setMVAOutputs(electrons, globalCache(), event.get(inputCfg_.vtxCollectionTag), dnnPFidEnabled_, extetaboundary_, tfSessions_);
+    setMVAOutputs(
+        electrons, globalCache(), event.get(inputCfg_.vtxCollectionTag), dnnPFidEnabled_, extetaboundary_, tfSessions_);
   }
 
   // all electrons

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -27,15 +27,15 @@ gedGsfElectronsTmp = ecalDrivenGsfElectrons.clone(
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.pb",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_modelDNN.pb",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.pb",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.pb",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.pb"
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/modelDNN.pb",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/modelDNN.pb"
         ],
         scalersFiles = [
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_scaler.txt",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_scaler.txt",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_scaler.txt",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_scaler.txt",
-            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_scaler.txt"
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/scaler.txt",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/scaler.txt"
 
         ]
     )    

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -26,12 +26,17 @@ gedGsfElectronsTmp = ecalDrivenGsfElectrons.clone(
         modelsFiles = [
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_modelDNN.pb",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_modelDNN.pb",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.pb",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.pb",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_modelDNN.pb"
         ],
         scalersFiles = [
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/lowpT/lowpT_scaler.txt",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EB_highpT/barrel_highpT_scaler.txt",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_scaler.txt",
+            "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_scaler.txt",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_scaler.txt"
+
         ]
     )    
 )

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
@@ -113,7 +113,7 @@ gedPhotons = cms.EDProducer("GEDPhotonProducer",
                     'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_scaler.txt',
                     'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_scaler.txt'
         ),
-        outputDim = cms.uint32(1),
+        outputDim = cms.vuint32(1,1),
         useEBModelInGap = cms.bool(True)
     ),
 

--- a/RecoEgamma/EgammaPhotonProducers/python/photons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/photons_cfi.py
@@ -104,7 +104,7 @@ photons = cms.EDProducer("GEDPhotonProducer",
                     'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EB/EB_scaler.txt',
                     'RecoEgamma/PhotonIdentification/data/Photon_PFID_dnn/v1/EE/EE_scaler.txt'
         ),
-        outputDim = cms.uint32(1),
+        outputDim = cms.vuint32(1,1),
         useEBModelInGap = cms.bool(True)
     ),
     pfECALClusIsolCfg = cms.PSet(

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -66,7 +66,7 @@ public:
       config.outputTensorName = pset_dnn.getParameter<std::string>("outputTensorName");
       config.modelsFiles = pset_dnn.getParameter<std::vector<std::string>>("modelsFiles");
       config.scalersFiles = pset_dnn.getParameter<std::vector<std::string>>("scalersFiles");
-      config.outputDim = pset_dnn.getParameter<uint>("outputDim");
+      config.outputDim = pset_dnn.getParameter<std::vector<unsigned int>>("outputDim");
       const auto useEBModelInGap = pset_dnn.getParameter<bool>("useEBModelInGap");
       photonDNNEstimator = std::make_unique<PhotonDNNEstimator>(config, useEBModelInGap);
     }

--- a/RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h
@@ -20,6 +20,7 @@ namespace egammaTools {
     std::vector<std::string> modelsFiles;
     std::vector<std::string> scalersFiles;
     uint outputDim = 1;
+    uint outputDimExtEta2 = 1;
   };
 
   struct ScalerConfiguration {

--- a/RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h
@@ -19,8 +19,7 @@ namespace egammaTools {
     std::string outputTensorName;
     std::vector<std::string> modelsFiles;
     std::vector<std::string> scalersFiles;
-    uint outputDim = 1;
-    uint outputDimExtEta2 = 1;
+    std::vector<unsigned int> outputDim;
   };
 
   struct ScalerConfiguration {

--- a/RecoEgamma/EgammaTools/src/EgammaDNNHelper.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaDNNHelper.cc
@@ -155,7 +155,7 @@ std::vector<std::vector<float>> EgammaDNNHelper::evaluate(const std::vector<std:
   // Define the output and run
   std::vector<std::pair<int, std::vector<float>>> outputs;
   // Run all the models
-  for (size_t m = 0; m < nModels_; m++) {
+  for (size_t m = 0; m < nModels_; m++) {  
     if (counts[m] == 0)
       continue;  //Skip model witout inputs
     std::vector<tensorflow::Tensor> output;
@@ -164,10 +164,13 @@ std::vector<std::vector<float>> EgammaDNNHelper::evaluate(const std::vector<std:
     // Get the output and save the ElectronDNNEstimator::outputDim numbers along with the ele index
     const auto& r = output[0].tensor<float, 2>();
     // Iterate on the list of elements in the batch --> many electrons
+    float outputDim=cfg_.outputDim;
+    if(m==4) outputDim=cfg_.outputDimExtEta2;
+    std::cout<<"EgammaDNNHelper" << "Run model: " << m << " with " << counts[m] << " electrons"<<std::endl;
     for (uint b = 0; b < counts[m]; b++) {
-      std::vector<float> result(cfg_.outputDim);
-      for (size_t k = 0; k < cfg_.outputDim; k++)
-        result[k] = r(b, k);
+	std::vector<float> result(outputDim);
+	for (size_t k = 0; k < outputDim; k++)
+	    result[k] = r(b, k);
       // Get the original index of the electorn in the original order
       const auto cand_index = indexMap[m][b];
       outputs.push_back(std::make_pair(cand_index, result));

--- a/RecoEgamma/EgammaTools/src/EgammaDNNHelper.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaDNNHelper.cc
@@ -159,18 +159,19 @@ std::vector<std::vector<float>> EgammaDNNHelper::evaluate(const std::vector<std:
     if (counts[m] == 0)
       continue;  //Skip model witout inputs
     std::vector<tensorflow::Tensor> output;
-    LogDebug("EgammaDNNHelper") << "Run model: " << m << " with " << counts[m] << " electrons";
+    LogDebug("EgammaDNNHelper") << "Run model: " << m << " with " << counts[m] << "objects";
     tensorflow::run(sessions[m], {{cfg_.inputTensorName, input_tensors[m]}}, {cfg_.outputTensorName}, &output);
     // Get the output and save the ElectronDNNEstimator::outputDim numbers along with the ele index
     const auto& r = output[0].tensor<float, 2>();
     // Iterate on the list of elements in the batch --> many electrons
-    float outputDim=cfg_.outputDim;
-    if(m==4) outputDim=cfg_.outputDimExtEta2;
-    std::cout<<"EgammaDNNHelper" << "Run model: " << m << " with " << counts[m] << " electrons"<<std::endl;
+    LogDebug("EgammaDNNHelper") << "Model has "<< cfg_.outputDim[m] <<" nodes!";
     for (uint b = 0; b < counts[m]; b++) {
-	std::vector<float> result(outputDim);
-	for (size_t k = 0; k < outputDim; k++)
+	//auto outputDim=cfg_.outputDim;
+	std::vector<float> result(cfg_.outputDim[m]);
+	for (size_t k = 0; k < cfg_.outputDim[m]; k++){
 	    result[k] = r(b, k);
+	    LogDebug("EgammaDNNHelper") << "For Object "<< b+1 <<" : Node "<<k+1<<" score = "<<r(b, k);
+	}
       // Get the original index of the electorn in the original order
       const auto cand_index = indexMap[m][b];
       outputs.push_back(std::make_pair(cand_index, result));

--- a/RecoEgamma/EgammaTools/src/EgammaDNNHelper.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaDNNHelper.cc
@@ -155,7 +155,7 @@ std::vector<std::vector<float>> EgammaDNNHelper::evaluate(const std::vector<std:
   // Define the output and run
   std::vector<std::pair<int, std::vector<float>>> outputs;
   // Run all the models
-  for (size_t m = 0; m < nModels_; m++) {  
+  for (size_t m = 0; m < nModels_; m++) {
     if (counts[m] == 0)
       continue;  //Skip model witout inputs
     std::vector<tensorflow::Tensor> output;
@@ -164,14 +164,14 @@ std::vector<std::vector<float>> EgammaDNNHelper::evaluate(const std::vector<std:
     // Get the output and save the ElectronDNNEstimator::outputDim numbers along with the ele index
     const auto& r = output[0].tensor<float, 2>();
     // Iterate on the list of elements in the batch --> many electrons
-    LogDebug("EgammaDNNHelper") << "Model "<<m<<" has "<< cfg_.outputDim[m] <<" nodes!";
+    LogDebug("EgammaDNNHelper") << "Model " << m << " has " << cfg_.outputDim[m] << " nodes!";
     for (uint b = 0; b < counts[m]; b++) {
-	//auto outputDim=cfg_.outputDim;
-	std::vector<float> result(cfg_.outputDim[m]);
-	for (size_t k = 0; k < cfg_.outputDim[m]; k++){
-	    result[k] = r(b, k);
-	    LogDebug("EgammaDNNHelper") << "For Object "<< b+1 <<" : Node "<<k+1<<" score = "<<r(b, k);
-	}
+      //auto outputDim=cfg_.outputDim;
+      std::vector<float> result(cfg_.outputDim[m]);
+      for (size_t k = 0; k < cfg_.outputDim[m]; k++) {
+        result[k] = r(b, k);
+        LogDebug("EgammaDNNHelper") << "For Object " << b + 1 << " : Node " << k + 1 << " score = " << r(b, k);
+      }
       // Get the original index of the electorn in the original order
       const auto cand_index = indexMap[m][b];
       outputs.push_back(std::make_pair(cand_index, result));

--- a/RecoEgamma/EgammaTools/src/EgammaDNNHelper.cc
+++ b/RecoEgamma/EgammaTools/src/EgammaDNNHelper.cc
@@ -42,7 +42,7 @@ void EgammaDNNHelper::initScalerFiles(const std::vector<std::string>& availableV
     std::ifstream inputfile_scaler{edm::FileInPath(scaler_file).fullPath()};
     int ninputs = 0;
     if (inputfile_scaler.fail()) {
-      throw cms::Exception("MissingFile") << "Scaler file for Electron PFid DNN not found";
+      throw cms::Exception("MissingFile") << "Scaler file for PFid DNN not found";
     } else {
       // Now read mean, scale factors for each variable
       float par1, par2;
@@ -164,7 +164,7 @@ std::vector<std::vector<float>> EgammaDNNHelper::evaluate(const std::vector<std:
     // Get the output and save the ElectronDNNEstimator::outputDim numbers along with the ele index
     const auto& r = output[0].tensor<float, 2>();
     // Iterate on the list of elements in the batch --> many electrons
-    LogDebug("EgammaDNNHelper") << "Model has "<< cfg_.outputDim[m] <<" nodes!";
+    LogDebug("EgammaDNNHelper") << "Model "<<m<<" has "<< cfg_.outputDim[m] <<" nodes!";
     for (uint b = 0; b < counts[m]; b++) {
 	//auto outputDim=cfg_.outputDim;
 	std::vector<float> result(cfg_.outputDim[m]);

--- a/RecoEgamma/ElectronIdentification/interface/ElectronDNNEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronDNNEstimator.h
@@ -31,6 +31,8 @@ public:
   static constexpr float ptThreshold = 10.;
   static constexpr float ecalBarrelMaxEtaWithGap = 1.566;
   static constexpr float ecalBarrelMaxEtaNoGap = 1.485;
+  static constexpr float endcapBoundary = 2.5;
+  static constexpr float extEtaBoundary = 2.65;
 
 private:
   const egammaTools::EgammaDNNHelper dnnHelper_;

--- a/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
@@ -9,29 +9,29 @@
 
 using namespace std::placeholders;
 
-inline uint electronModelSelector(const std::map<std::string, float>& vars, float ptThr, float etaThr, float endcapBoundary, float extEtaBoundary) {
+inline uint electronModelSelector(
+    const std::map<std::string, float>& vars, float ptThr, float etaThr, float endcapBoundary, float extEtaBoundary) {
   /* 
   Selection of the model to be applied on the electron based on pt/eta cuts or whatever selection
   */
   const auto pt = vars.at("pt");
   const auto absEta = std::abs(vars.at("eta"));
-  if(absEta<=endcapBoundary){
-      if (pt < ptThr)
-	  return 0;
-      else {
-	  if (absEta <= etaThr) {
-	      return 1;
-	  } else {
-	      return 2;
-	  }
+  if (absEta <= endcapBoundary) {
+    if (pt < ptThr)
+      return 0;
+    else {
+      if (absEta <= etaThr) {
+        return 1;
+      } else {
+        return 2;
       }
+    }
   } else {
-      if (absEta < extEtaBoundary)
-	  return 3;
-      else{
-      	  return 4;
-      }
-      
+    if (absEta < extEtaBoundary)
+      return 3;
+    else {
+      return 4;
+    }
   }
 }
 
@@ -42,8 +42,8 @@ ElectronDNNEstimator::ElectronDNNEstimator(const egammaTools::DNNConfiguration& 
                            ElectronDNNEstimator::ptThreshold,
                            (useEBModelInGap) ? ElectronDNNEstimator::ecalBarrelMaxEtaWithGap
                                              : ElectronDNNEstimator::ecalBarrelMaxEtaNoGap,
-			   ElectronDNNEstimator::endcapBoundary,
-			   ElectronDNNEstimator::extEtaBoundary),
+                           ElectronDNNEstimator::endcapBoundary,
+                           ElectronDNNEstimator::extEtaBoundary),
                  ElectronDNNEstimator::dnnAvaibleInputs),
       useEBModelInGap_(useEBModelInGap) {}
 

--- a/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
@@ -9,20 +9,29 @@
 
 using namespace std::placeholders;
 
-inline uint electronModelSelector(const std::map<std::string, float>& vars, float ptThr, float etaThr) {
+inline uint electronModelSelector(const std::map<std::string, float>& vars, float ptThr, float etaThr, float endcapBoundary, float extEtaBoundary) {
   /* 
   Selection of the model to be applied on the electron based on pt/eta cuts or whatever selection
   */
   const auto pt = vars.at("pt");
   const auto absEta = std::abs(vars.at("eta"));
-  if (pt < ptThr)
-    return 0;
-  else {
-    if (absEta <= etaThr) {
-      return 1;
-    } else {
-      return 2;
-    }
+  if(absEta<=endcapBoundary){
+      if (pt < ptThr)
+	  return 0;
+      else {
+	  if (absEta <= etaThr) {
+	      return 1;
+	  } else {
+	      return 2;
+	  }
+      }
+  } else {
+      if (absEta < extEtaBoundary)
+	  return 3;
+      else{
+      	  return 4;
+      }
+      
   }
 }
 
@@ -32,7 +41,9 @@ ElectronDNNEstimator::ElectronDNNEstimator(const egammaTools::DNNConfiguration& 
                            _1,
                            ElectronDNNEstimator::ptThreshold,
                            (useEBModelInGap) ? ElectronDNNEstimator::ecalBarrelMaxEtaWithGap
-                                             : ElectronDNNEstimator::ecalBarrelMaxEtaNoGap),
+                                             : ElectronDNNEstimator::ecalBarrelMaxEtaNoGap,
+			   ElectronDNNEstimator::endcapBoundary,
+			   ElectronDNNEstimator::extEtaBoundary),
                  ElectronDNNEstimator::dnnAvaibleInputs),
       useEBModelInGap_(useEBModelInGap) {}
 
@@ -69,6 +80,8 @@ const std::vector<std::string> ElectronDNNEstimator::dnnAvaibleInputs = {
      "full5x5_e1x5_ratio_full5x5_e5x5",
      "full5x5_r9",
      "gsfTrack.trackerLayersWithMeasurement",
+     "gsfTrack.numberOfValidPixelBarrelHits",
+     "gsfTrack.numberOfValidPixelEndcapHits",
      "superCluster.energy",
      "superCluster.rawEnergy",
      "superClusterFbrem",
@@ -119,6 +132,8 @@ std::map<std::string, float> ElectronDNNEstimator::getInputsVars(const reco::Gsf
   variables["full5x5_e1x5_ratio_full5x5_e5x5"] = ele.full5x5_e1x5() / ele.full5x5_e5x5();
   variables["full5x5_r9"] = ele.full5x5_r9();
   variables["gsfTrack.trackerLayersWithMeasurement"] = ele.gsfTrack()->hitPattern().trackerLayersWithMeasurement();
+  variables["gsfTrack.numberOfValidPixelBarrelHits"] = ele.gsfTrack()->hitPattern().numberOfValidPixelBarrelHits();
+  variables["gsfTrack.numberOfValidPixelEndcapHits"] = ele.gsfTrack()->hitPattern().numberOfValidPixelEndcapHits();
   variables["superCluster.energy"] = ele.superCluster()->energy();
   variables["superCluster.rawEnergy"] = ele.superCluster()->rawEnergy();
   variables["superClusterFbrem"] = ele.superClusterFbrem();

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -32,7 +32,6 @@ public:
 
 private:
   bool passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron &) const;
-  bool thisEleIsNotAllowedInPF(const reco::GsfElectron &, bool) const;
 
   // Photon selections
   const float ph_Et_;
@@ -74,7 +73,6 @@ private:
   const int ele_missinghits_;
   const float ele_ecalDrivenHademPreselCut_;
   const float ele_maxElePtForOnlyMVAPresel_;
-  const bool allowEEEinPF_;
   float ele_maxNtracks_;
   float ele_maxHcalE_;
   float ele_maxTrackPOverEele_;

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -47,6 +47,8 @@ private:
   const bool useElePFidDNN_;
   const bool usePhotonPFidDNN_;
   const bool useEBModelInGap_;
+  const float endcapBoundary_;
+  const float extEtaBoundary_;
   const float ele_iso_pt_;
   const float ele_iso_mva_eb_;
   const float ele_iso_mva_ee_;

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaFilters.h
@@ -57,10 +57,14 @@ private:
   float ele_dnnLowPtThr_;
   float ele_dnnHighPtBarrelThr_;
   float ele_dnnHighPtEndcapThr_;
+  float ele_dnnExtEta1Thr_;
+  float ele_dnnExtEta2Thr_;
   // Thresholds for DNN Bkg ele pfid
   float ele_dnnBkgLowPtThr_;
   float ele_dnnBkgHighPtBarrelThr_;
   float ele_dnnBkgHighPtEndcapThr_;
+  float ele_dnnBkgExtEta1Thr_;
+  float ele_dnnBkgExtEta2Thr_;
   // Threshold for DNN photon pfid
   float photon_dnnBarrelThr_;
   float photon_dnnEndcapThr_;

--- a/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
@@ -20,16 +20,16 @@ particleFlowTmp.PFEGammaFiltersParameters.electronDnnThresholds = cms.PSet(
             electronDnnHighPtBarrelThr = cms.double(0.068),
             electronDnnHighPtEndcapThr = cms.double(0.056),
             electronDnnLowPtThr = cms.double(0.075), 
-            electronDnnExtEta1Thr = cms.double(0.075), 
-            electronDnnExtEta2Thr = cms.double(0.075) 
+            electronDnnExtEta1Thr = cms.double(0.113604), 
+            electronDnnExtEta2Thr = cms.double(0.118044) 
         )
 # Thresholds for electron: Bkg_nonIsolated
 particleFlowTmp.PFEGammaFiltersParameters.electronDnnBkgThresholds = cms.PSet(
             electronDnnBkgHighPtBarrelThr = cms.double(0.8),
             electronDnnBkgHighPtEndcapThr = cms.double(0.75),
             electronDnnBkgLowPtThr = cms.double(0.75), 
-            electronDnnBkgExtEta1Thr = cms.double(0.75), 
-            electronDnnBkgExtEta2Thr = cms.double(0.75) 
+            electronDnnBkgExtEta1Thr = cms.double(0.7), 
+            electronDnnBkgExtEta2Thr = cms.double(0.85) 
         )
 # Thresholds for photons
 particleFlowTmp.PFEGammaFiltersParameters.photonDnnThresholds = cms.PSet(

--- a/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
@@ -19,13 +19,17 @@ particleFlowTmp.PFEGammaFiltersParameters.allowEEEinPF = cms.bool(False)
 particleFlowTmp.PFEGammaFiltersParameters.electronDnnThresholds = cms.PSet(
             electronDnnHighPtBarrelThr = cms.double(0.068),
             electronDnnHighPtEndcapThr = cms.double(0.056),
-            electronDnnLowPtThr = cms.double(0.075) 
+            electronDnnLowPtThr = cms.double(0.075), 
+            electronDnnExtEta1Thr = cms.double(0.075), 
+            electronDnnExtEta2Thr = cms.double(0.075) 
         )
 # Thresholds for electron: Bkg_nonIsolated
 particleFlowTmp.PFEGammaFiltersParameters.electronDnnBkgThresholds = cms.PSet(
             electronDnnBkgHighPtBarrelThr = cms.double(0.8),
             electronDnnBkgHighPtEndcapThr = cms.double(0.75),
-            electronDnnBkgLowPtThr = cms.double(0.75) 
+            electronDnnBkgLowPtThr = cms.double(0.75), 
+            electronDnnBkgExtEta1Thr = cms.double(0.75), 
+            electronDnnBkgExtEta2Thr = cms.double(0.75) 
         )
 # Thresholds for photons
 particleFlowTmp.PFEGammaFiltersParameters.photonDnnThresholds = cms.PSet(

--- a/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlow_cff.py
@@ -10,10 +10,6 @@ from RecoParticleFlow.PFProducer.particleFlowTmpPtrs_cfi import *
 
 particleFlowTmp = particleFlow.clone()
 
-## temporary for 12_1; EtaExtendedEles do not enter PF because ID/regression of EEEs are not ready yet
-## In 12_2, we expect to have EEE's ID/regression, then this switch can flip to True
-particleFlowTmp.PFEGammaFiltersParameters.allowEEEinPF = cms.bool(False)
-
 # Thresholds for e/gamma PFID DNN 
 # Thresholds for electron: Sig_isolated+Sig_nonIsolated
 particleFlowTmp.PFEGammaFiltersParameters.electronDnnThresholds = cms.PSet(

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -181,9 +181,11 @@ bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron& electron,
     if (electronPt > ele_iso_pt_) {
       // using the Barrel model for electron in the EB-EE gap
       if (eleEta <= etaThreshold) {
-        passEleSelection = (dnn_sig > ele_dnnHighPtBarrelThr_) && (dnn_bkg < ele_dnnBkgHighPtBarrelThr_);
-      } else if (eleEta > etaThreshold) {
-        passEleSelection = (dnn_sig > ele_dnnHighPtEndcapThr_) && (dnn_bkg < ele_dnnBkgHighPtEndcapThr_);
+	  passEleSelection = (dnn_sig > ele_dnnHighPtBarrelThr_) && (dnn_bkg < ele_dnnBkgHighPtBarrelThr_);
+      } else if (eleEta > etaThreshold && eleEta < 2.5) {
+	  passEleSelection = (dnn_sig > ele_dnnHighPtEndcapThr_) && (dnn_bkg < ele_dnnBkgHighPtEndcapThr_);
+      } else if (eleEta >= 2.5) {
+	  passEleSelection = false;
       }
     } else {  // pt < ele_iso_pt_
       passEleSelection = (dnn_sig > ele_dnnLowPtThr_) && (dnn_bkg < ele_dnnBkgLowPtThr_);
@@ -226,7 +228,7 @@ bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron& electron,
   //this is to be taken care of by EGM POG
   //https://github.com/cms-sw/cmssw/issues/35374
   if (thisEleIsNotAllowedInPF(electron, allowEEEinPF_))
-    passEleSelection = false;
+      passEleSelection = false;
 
   return passEleSelection && passGsfElePreSelWithOnlyConeHadem(electron);
 }

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -191,11 +191,10 @@ bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron& electron,
           passEleSelection = (dnn_sig > ele_dnnHighPtBarrelThr_) && (dnn_bkg < ele_dnnBkgHighPtBarrelThr_);
         } else if (eleEta > etaThreshold) {  //high pT endcap (eleEta < 2.5)
           passEleSelection = (dnn_sig > ele_dnnHighPtEndcapThr_) && (dnn_bkg < ele_dnnBkgHighPtEndcapThr_);
-        } else {  // pt < ele_iso_pt_ (eleEta < 2.5)
-          passEleSelection = (dnn_sig > ele_dnnLowPtThr_) && (dnn_bkg < ele_dnnBkgLowPtThr_);
         }
+      } else {  // pt < ele_iso_pt_ (eleEta < 2.5)
+        passEleSelection = (dnn_sig > ele_dnnLowPtThr_) && (dnn_bkg < ele_dnnBkgLowPtThr_);
       }
-
     } else if ((eleEta >= endcapBoundary_) && (eleEta <= extEtaBoundary_)) {  //First region in extended eta
       passEleSelection = (dnn_sig > ele_dnnExtEta1Thr_) && (dnn_bkg < ele_dnnBkgExtEta1Thr_);
     } else if (eleEta > extEtaBoundary_) {  //Second region in extended eta

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -184,25 +184,25 @@ bool PFEGammaFilters::passElectronSelection(const reco::GsfElectron& electron,
     const auto dnn_sig = electron.dnn_signal_Isolated() + electron.dnn_signal_nonIsolated();
     const auto dnn_bkg = electron.dnn_bkg_nonIsolated();
     const auto etaThreshold = (useEBModelInGap_) ? ecalBarrelMaxEtaWithGap : ecalBarrelMaxEtaNoGap;
-    if (eleEta < endcapBoundary_){
-	if (electronPt > ele_iso_pt_) {
-	    // using the Barrel model for electron in the EB-EE gap
-	    if (eleEta <= etaThreshold) { //high pT barrel
-		passEleSelection = (dnn_sig > ele_dnnHighPtBarrelThr_) && (dnn_bkg < ele_dnnBkgHighPtBarrelThr_);
-	    } else if (eleEta > etaThreshold) { //high pT endcap (eleEta < 2.5)
-		passEleSelection = (dnn_sig > ele_dnnHighPtEndcapThr_) && (dnn_bkg < ele_dnnBkgHighPtEndcapThr_);
-	    } else {  // pt < ele_iso_pt_ (eleEta < 2.5)
-		passEleSelection = (dnn_sig > ele_dnnLowPtThr_) && (dnn_bkg < ele_dnnBkgLowPtThr_);
-	    }
-	}
+    if (eleEta < endcapBoundary_) {
+      if (electronPt > ele_iso_pt_) {
+        // using the Barrel model for electron in the EB-EE gap
+        if (eleEta <= etaThreshold) {  //high pT barrel
+          passEleSelection = (dnn_sig > ele_dnnHighPtBarrelThr_) && (dnn_bkg < ele_dnnBkgHighPtBarrelThr_);
+        } else if (eleEta > etaThreshold) {  //high pT endcap (eleEta < 2.5)
+          passEleSelection = (dnn_sig > ele_dnnHighPtEndcapThr_) && (dnn_bkg < ele_dnnBkgHighPtEndcapThr_);
+        } else {  // pt < ele_iso_pt_ (eleEta < 2.5)
+          passEleSelection = (dnn_sig > ele_dnnLowPtThr_) && (dnn_bkg < ele_dnnBkgLowPtThr_);
+        }
+      }
 
-    } else if ((eleEta >= endcapBoundary_) && (eleEta <= extEtaBoundary_)){//First region in extended eta
-	passEleSelection = (dnn_sig > ele_dnnExtEta1Thr_) && (dnn_bkg < ele_dnnBkgExtEta1Thr_);
-    } else if (eleEta > extEtaBoundary_){//Second region in extended eta
-	passEleSelection = (dnn_sig > ele_dnnExtEta2Thr_) && (dnn_bkg < ele_dnnBkgExtEta2Thr_);
+    } else if ((eleEta >= endcapBoundary_) && (eleEta <= extEtaBoundary_)) {  //First region in extended eta
+      passEleSelection = (dnn_sig > ele_dnnExtEta1Thr_) && (dnn_bkg < ele_dnnBkgExtEta1Thr_);
+    } else if (eleEta > extEtaBoundary_) {  //Second region in extended eta
+      passEleSelection = (dnn_sig > ele_dnnExtEta2Thr_) && (dnn_bkg < ele_dnnBkgExtEta2Thr_);
     }
-// TODO: For the moment do not evaluate further conditions on isolation and HCAL cleaning..
-// To be understood if they are needed
+    // TODO: For the moment do not evaluate further conditions on isolation and HCAL cleaning..
+    // To be understood if they are needed
   } else {  // Use legacy MVA for ele pfID < CMSSW_12_1
     if (electronPt > ele_iso_pt_) {
       double isoDr03 = electron.dr03TkSumPt() + electron.dr03EcalRecHitSumEt() + electron.dr03HcalTowerSumEt();

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -45,8 +45,7 @@ PFEGammaFilters::PFEGammaFilters(const edm::ParameterSet& cfg)
       ele_noniso_mva_(cfg.getParameter<double>("electron_noniso_mvaCut")),
       ele_missinghits_(cfg.getParameter<unsigned int>("electron_missinghits")),
       ele_ecalDrivenHademPreselCut_(cfg.getParameter<double>("electron_ecalDrivenHademPreselCut")),
-      ele_maxElePtForOnlyMVAPresel_(cfg.getParameter<double>("electron_maxElePtForOnlyMVAPresel")),
-      allowEEEinPF_(cfg.getParameter<bool>("allowEEEinPF")) {
+      ele_maxElePtForOnlyMVAPresel_(cfg.getParameter<double>("electron_maxElePtForOnlyMVAPresel")) {
   auto const& eleProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("electron_protectionsForBadHcal");
   auto const& eleProtectionsForJetMET = cfg.getParameter<edm::ParameterSet>("electron_protectionsForJetMET");
   auto const& phoProtectionsForBadHcal = cfg.getParameter<edm::ParameterSet>("photon_protectionsForBadHcal");
@@ -467,18 +466,6 @@ bool PFEGammaFilters::passGsfElePreSelWithOnlyConeHadem(const reco::GsfElectron&
     return passCutBased || passMVA;
 }
 
-// bool PFEGammaFilters::thisEleIsNotAllowedInPF(const reco::GsfElectron& electron, bool allowEtaExtEleinPF) const {
-//   bool returnVal = false;
-//   if (!allowEtaExtEleinPF) {
-//     const auto nHitGsf = electron.gsfTrack()->numberOfValidHits();
-//     const auto absEleEta = std::abs(electron.eta());
-//     if ((absEleEta > 2.5) && (nHitGsf < 5)) {
-//       returnVal = true;
-//     }
-//   }
-//   return returnVal;
-// }
-
 void PFEGammaFilters::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
   // Electron selection cuts
   iDesc.add<double>("electron_iso_pt", 10.0);
@@ -490,7 +477,6 @@ void PFEGammaFilters::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
   iDesc.add<unsigned int>("electron_missinghits", 1);
   iDesc.add<double>("electron_ecalDrivenHademPreselCut", 0.15);
   iDesc.add<double>("electron_maxElePtForOnlyMVAPresel", 50.0);
-  iDesc.add<bool>("allowEEEinPF", false);
   iDesc.add<bool>("useElePFidDnn", false);
   iDesc.add<double>("endcapBoundary", 2.5);
   iDesc.add<double>("extEtaBoundary", 2.65);

--- a/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaFilters.cc
@@ -73,10 +73,14 @@ PFEGammaFilters::PFEGammaFilters(const edm::ParameterSet& cfg)
   ele_dnnLowPtThr_ = eleDNNIdThresholds.getParameter<double>("electronDnnLowPtThr");
   ele_dnnHighPtBarrelThr_ = eleDNNIdThresholds.getParameter<double>("electronDnnHighPtBarrelThr");
   ele_dnnHighPtEndcapThr_ = eleDNNIdThresholds.getParameter<double>("electronDnnHighPtEndcapThr");
+  ele_dnnExtEta1Thr_ = eleDNNIdThresholds.getParameter<double>("electronDnnExtEta1Thr");
+  ele_dnnExtEta2Thr_ = eleDNNIdThresholds.getParameter<double>("electronDnnExtEta2Thr");
 
   ele_dnnBkgLowPtThr_ = eleDNNBkgIdThresholds.getParameter<double>("electronDnnBkgLowPtThr");
   ele_dnnBkgHighPtBarrelThr_ = eleDNNBkgIdThresholds.getParameter<double>("electronDnnBkgHighPtBarrelThr");
   ele_dnnBkgHighPtEndcapThr_ = eleDNNBkgIdThresholds.getParameter<double>("electronDnnBkgHighPtEndcapThr");
+  ele_dnnBkgExtEta1Thr_ = eleDNNBkgIdThresholds.getParameter<double>("electronDnnBkgExtEta1Thr");
+  ele_dnnBkgExtEta2Thr_ = eleDNNBkgIdThresholds.getParameter<double>("electronDnnBkgExtEta2Thr");
 
   photon_dnnBarrelThr_ = photonDNNIdThresholds.getParameter<double>("photonDnnBarrelThr");
   photon_dnnEndcapThr_ = photonDNNIdThresholds.getParameter<double>("photonDnnEndcapThr");
@@ -505,6 +509,8 @@ void PFEGammaFilters::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
     psd.add<double>("electronDnnLowPtThr", 0.5);
     psd.add<double>("electronDnnHighPtBarrelThr", 0.5);
     psd.add<double>("electronDnnHighPtEndcapThr", 0.5);
+    psd.add<double>("electronDnnExtEta1Thr", 0.5);
+    psd.add<double>("electronDnnExtEta2Thr", 0.5);
     iDesc.add<edm::ParameterSetDescription>("electronDnnThresholds", psd);
   }
   {
@@ -512,6 +518,8 @@ void PFEGammaFilters::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
     psd.add<double>("electronDnnBkgLowPtThr", 1);
     psd.add<double>("electronDnnBkgHighPtBarrelThr", 1);
     psd.add<double>("electronDnnBkgHighPtEndcapThr", 1);
+    psd.add<double>("electronDnnBkgExtEta1Thr", 1);
+    psd.add<double>("electronDnnBkgExtEta2Thr", 1);
     iDesc.add<edm::ParameterSetDescription>("electronDnnBkgThresholds", psd);
   }
   iDesc.add<bool>("usePhotonPFidDnn", false);


### PR DESCRIPTION
#### PR description:
The reconstruction efficiency of electrons in |&eta;|>2.5 was significantly improved via [#35309](https://github.com/cms-sw/cmssw/pull/35309). These electrons are now available as gsf electrons but were not allowed to enter Particle Flow (PF) when PF ID for electrons in |&eta;|<=2.5 was added via [#35403](https://github.com/cms-sw/cmssw/pull/35403), [#36243](https://github.com/cms-sw/cmssw/pull/36243/), [#36292](https://github.com/cms-sw/cmssw/pull/36292) 

This PR adds the code needed for the PF ID of electrons in |&eta;|>2.5. Dedicated PF IDs have been developed, for electrons in this region. There are two dedicated trainings, one for  **Region 1:** 2.5<|&eta;|<=2.65 and one for **Region 2:** |&eta;|>2.65, given that electrons in these regions look very different. More details can be found in this [presentation](https://indico.cern.ch/event/1146227/#10-pf-egm-id-of-eta-extended-e).

```mermaid
graph TD
A(GSF Electrons) -->|PF-Electron-ID in PFEGammaFilters| B("PF Electrons")
PF-Electron-ID -->|"|&eta;|<=2.5 "| C[ID already in CMSSW]
PF-Electron-ID -->|" 2.5<|&eta;|<=2.65"| D["extended eta region 1 ID (**This PR**)"]
PF-Electron-ID -->|"|&eta;|>2.65"| E["extended eta region 2 ID (**This PR**)"]
```

This PR depends on [#25](https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/25) to cms-data that has been made to merge the model files.


Since before this PR, electrons in |&eta;|>2.5 must have been identified by Particle Flow as other objects like photons and jets, this PR might lead to some efficiency changes for primarily PF Photons and to some extent Taus and Jets in |&eta;|>2.5.

Some points:
It is understood that this ID will not give the most optimal performance that can be achieved in this region, since some kinds of electrons needed for the training were not fully produced due to hard cuts on | &eta; | in the Tau Gun and QCD_bcToE samples. The hard cuts for the TauGun sample were in the config so this can be easily fixed in the next iteration of samples. However, for the QCD_bcToE sample the cut was hard-coded in [BCToEFilterAlgo.cc](https://github.com/cms-sw/cmssw/blob/d8184188a4f5843b1b4a84e5d800ad178ae8bacf/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc#L13). Given these constraints, the model in |&eta;|>2.65 has only 3 output nodes instead of the 5 nodes that all other DNN models have. In [#37869](https://github.com/cms-sw/cmssw/pull/37869) we have fixed this. Given the timeline for 12_4_0, update of samples is not possible in this iteration. The PF ID of electrons in |&eta;|>2.5 will thus be updated in a later release, possibly at the end of this year. 

**Main code changes:**
- Output dimension of the DNN for each region is now configurable independently by changing it from a "single int" to a "vector of ints"
- PFEGammaFilters.cc has been modified to allow the new electrons to enter PF and also select the right ID thresholds for these electrons.
- ElectronDNNEstimator has been modified to select the right model depending on the pt and &eta; of the electron.

#### PR validation:

A general validation to check the effect on objects downstream in PF is currently ongoing. A dedicated validation to check the effect on PF Taus is also being carried out. This section will be updated as the results of the validation become available.