### PR TITLE
Minor fixes in `ClusterSummary(Producer)`

### DIFF
--- a/DataFormats/TrackerCommon/interface/ClusterSummary.h
+++ b/DataFormats/TrackerCommon/interface/ClusterSummary.h
@@ -50,7 +50,7 @@
 
 How to use ClusterSummary class:
 
-ClusterSummary provides summary inforation for a number of cluster dependent variables.
+ClusterSummary provides summary information for a number of cluster dependent variables.
 All the variables are stored within variables_
 The modules selected are stored within modules_
 The number of variables for each module is stored within iterator_

--- a/DataFormats/TrackerCommon/src/ClusterSummary.cc
+++ b/DataFormats/TrackerCommon/src/ClusterSummary.cc
@@ -49,7 +49,7 @@ int ClusterSummary::getModuleLocation(int mod, bool warn) const {
 
   if (warn)
     edm::LogWarning("NoModule") << "No information for requested module " << mod
-                                << ". Please check in the Provinence Infomation for proper modules.";
+                                << ". Please check in the Provenance Infomation for proper modules.";
 
   return -1;
 }

--- a/DataFormats/TrackerCommon/src/ClusterSummary.cc
+++ b/DataFormats/TrackerCommon/src/ClusterSummary.cc
@@ -48,7 +48,7 @@ int ClusterSummary::getModuleLocation(int mod, bool warn) const {
   }
 
   if (warn)
-    edm::LogWarning("NoModule") << "No information for requested module " << mod
+    edm::LogWarning("NoModule") << "No information for requested module " << mod << " (" << subDetNames[mod] << ")"
                                 << ". Please check in the Provenance Infomation for proper modules.";
 
   return -1;

--- a/RecoLocalTracker/SubCollectionProducers/src/ClusterSummaryProducer.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/ClusterSummaryProducer.cc
@@ -109,12 +109,20 @@ void ClusterSummaryProducer::produce(edm::Event& iEvent, const edm::EventSetup& 
   if (verbose) {
     for (const auto& iS : selectors) {
       const ClusterSummary::CMSTracker module = iS.second;
-      edm::LogInfo("ClusterSummaryProducer")
-          << "n" << moduleNames[module] << ", avg size, avg charge = " << cCluster.getNClusByIndex(module) << ", "
-          << cCluster.getClusSizeByIndex(module) / cCluster.getNClusByIndex(module) << ", "
-          << cCluster.getClusChargeByIndex(module) / cCluster.getNClusByIndex(module) << std::endl;
+      if (cCluster.getNClusByIndex(module) != 0) {
+        edm::LogInfo("ClusterSummaryProducer")
+            << "n" << moduleNames[module] << ", avg size, avg charge = " << cCluster.getNClusByIndex(module) << ", "
+            << cCluster.getClusSizeByIndex(module) / cCluster.getNClusByIndex(module) << ", "
+            << cCluster.getClusChargeByIndex(module) / cCluster.getNClusByIndex(module) << std::endl;
+      } else {
+        edm::LogInfo("ClusterSummaryProducer")
+            << "n" << moduleNames[module] << ", avg size, avg charge = " << cCluster.getNClusByIndex(module) << ", "
+            << "0"
+            << ", "
+            << "0" << std::endl;
+      }
+      edm::LogInfo("ClusterSummaryProducer") << "-------------------------------------------------------" << std::endl;
     }
-    std::cout << "-------------------------------------------------------" << std::endl;
   }
 
   //Put the filled class into the producer


### PR DESCRIPTION
#### PR description:

This PR is a fall-out of issue https://github.com/cms-sw/cmssw/issues/37738:
   * fix a couple of typos in `ClusterSummary`
   * more explicative warning message in `ClusterSummary` (printout explicitly for what subdetector the collection is missing)
   * do not divide by 0 if the number of clusters is zero, when running `ClusterSummaryProducer` in verbose mode
   
#### PR validation:

Executed the commands described at https://github.com/cms-sw/cmssw/issues/37837#issue-1227837530 and verified the fixes are as intended.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A