### PR TITLE
[12_3_X] Add EGM HLT tags to data GTs and introduce fixed snapshot in online GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,18 +33,18 @@ autoCond = {
     'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v2',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v2',
-    # GlobalTag for Run3 HLT: it points to the online GT
-    'run3_hlt'                     : '123X_dataRun3_HLT_v7',
+    # GlobalTag for Run3 HLT: identical to the online GT (123X_dataRun3_HLT_v7) but with snapshot at 2022-05-09 16:40:00 (UTC)
+    'run3_hlt'                     : '123X_dataRun3_HLT_frozen_v2',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v4',
-    # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'            : '123X_dataRun3_Express_v5',
-    # GlobalTag for Run3 data relvals
-    'run3_data_prompt'             : '123X_dataRun3_Prompt_v6',
+    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v5',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 123X_dataRun3_Express_v5 but with snapshot at 2022-05-06 12:00:00
+    'run3_data_express'            : '123X_dataRun3_Express_frozen_v1',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 123X_dataRun3_Prompt_v7 but with snapshot at 2022-05-06 12:00:00
+    'run3_data_prompt'             : '123X_dataRun3_Prompt_frozen_v1',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '123X_dataRun3_v4',
+    'run3_data'                    : '123X_dataRun3_v5',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '123X_dataRun3_relval_v3',
+    'run3_data_relval'             : '123X_dataRun3_relval_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:
Backport of #37870
This PR is a follow-up of PR #37557. As agreed [here](https://github.com/cms-sw/cmssw/pull/37557#issuecomment-1104028810), the EGM supercluster regression for HLT was included also in the Run3 offline GTs (`auto:run3_data` and `auto:run3_data_relval`) and to the Prompt GT.

The tags included in the GTs are:

Label: `pfscecal_EBCorrection_online`, Tag: `pfscecal_EBCorrection_hlt_v1`
Label: `pfscecal_EBUncertainty_online`, Tag: `pfscecal_EBUncertainty_hlt_v1`
Label: `pfscecal_EECorrection_online`, Tag: `pfscecal_EECorrection_hlt_v1`
Label: `pfscecal_EEUncertainty_online`, Tag: `pfscecal_EEUncertainty_hlt_v1`

We also take the chance to do a forward port of PR #37670 on what concerns the revival of an AlCaDB policy of not having any GT with an infinite snapshot in autoCond.py. The new GTs with fixed snapshot are: `123X_dataRun3_HLT_frozen_v2`, `123X_dataRun3_Express_frozen_v1` and `123X_dataRun3_Prompt_frozen_v1`.

The differences in GTs are shown below.

**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_HLT_frozen_v1/123X_dataRun3_HLT_v7

**run3_data_express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_Express_frozen_v1/123X_dataRun3_Express_v5

**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_Prompt_frozen_v1/123X_dataRun3_Prompt_v7

**run3_data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_v5/123X_dataRun3_v4

**run3_data_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_relval_v4/123X_dataRun3_relval_v3


#### PR validation:
Validated with `runTheMatrix.py -l 138.4,138.3,136.897 --ibeos -j16`

#### Backport:
Backport of #37870
Forwardport of #37670 