### PR TITLE
[10.6.X] GeometryProducer: fixed backward propagator 

### DIFF
--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -21,11 +21,16 @@ namespace sim {
   class FieldBuilder;
 }
 
+namespace cms {
+  class DDCompactView;
+}
+
 class SimWatcher;
 class SimProducer;
 class DDDWorld;
 class G4RunManagerKernel;
 class SimTrackManager;
+class DDCompactView;
 
 class GeometryProducer : public edm::one::EDProducer<edm::one::SharedResources, edm::one::WatchRuns> {
 public:
@@ -46,9 +51,7 @@ private:
   void updateMagneticField(edm::EventSetup const &es);
 
   G4RunManagerKernel *m_kernel;
-  bool m_pUseMagneticField;
   edm::ParameterSet m_pField;
-  bool m_pUseSensitiveDetectors;
   SimActivityRegistry m_registry;
   std::vector<std::shared_ptr<SimWatcher>> m_watchers;
   std::vector<std::shared_ptr<SimProducer>> m_producers;
@@ -58,7 +61,14 @@ private:
   std::vector<SensitiveTkDetector *> m_sensTkDets;
   std::vector<SensitiveCaloDetector *> m_sensCaloDets;
   edm::ParameterSet m_p;
+
+  mutable const DDCompactView *m_pDD;
+  mutable const cms::DDCompactView *m_pDD4hep;
+
   bool m_firstRun;
+  bool m_pUseMagneticField;
+  bool m_pUseSensitiveDetectors;
+  bool m_pGeoFromDD4hep;
 };
 
 #endif

--- a/SimG4Core/GeometryProducer/interface/GeometryProducer.h
+++ b/SimG4Core/GeometryProducer/interface/GeometryProducer.h
@@ -21,10 +21,6 @@ namespace sim {
   class FieldBuilder;
 }
 
-namespace cms {
-  class DDCompactView;
-}
-
 class SimWatcher;
 class SimProducer;
 class DDDWorld;
@@ -63,12 +59,10 @@ private:
   edm::ParameterSet m_p;
 
   mutable const DDCompactView *m_pDD;
-  mutable const cms::DDCompactView *m_pDD4hep;
 
   bool m_firstRun;
   bool m_pUseMagneticField;
   bool m_pUseSensitiveDetectors;
-  bool m_pGeoFromDD4hep;
 };
 
 #endif

--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -23,6 +23,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include "DetectorDescription/Core/interface/DDCompactView.h"
+//#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 
 #include "G4RunManagerKernel.hh"
 #include "G4TransportationManager.hh"
@@ -59,12 +60,15 @@ static void createWatchers(const edm::ParameterSet &iP,
 
 GeometryProducer::GeometryProducer(edm::ParameterSet const &p)
     : m_kernel(nullptr),
-      m_pUseMagneticField(p.getParameter<bool>("UseMagneticField")),
       m_pField(p.getParameter<edm::ParameterSet>("MagneticField")),
-      m_pUseSensitiveDetectors(p.getParameter<bool>("UseSensitiveDetectors")),
       m_attach(nullptr),
       m_p(p),
-      m_firstRun(true) {
+      m_pDD(nullptr),
+      m_pDD4hep(nullptr),
+      m_firstRun(true),
+      m_pUseMagneticField(p.getParameter<bool>("UseMagneticField")),
+      m_pUseSensitiveDetectors(p.getParameter<bool>("UseSensitiveDetectors")),
+      m_pGeoFromDD4hep(false) {
   // Look for an outside SimActivityRegistry
   // this is used by the visualization code
   edm::Service<SimActivityRegistry> otherRegistry;
@@ -110,21 +114,33 @@ void GeometryProducer::produce(edm::Event &e, const edm::EventSetup &es) {
     return;
   m_firstRun = false;
 
-  edm::LogInfo("GeometryProducer") << "Producing G4 Geom";
+  edm::LogVerbatim("GeometryProducer") << "Producing G4 Geom";
 
   m_kernel = G4RunManagerKernel::GetRunManagerKernel();
   if (m_kernel == nullptr)
     m_kernel = new G4RunManagerKernel();
-  edm::LogInfo("GeometryProducer") << " GeometryProducer initializing ";
+  edm::LogVerbatim("GeometryProducer") << " GeometryProducer initializing ";
   // DDDWorld: get the DDCV from the ES and use it to build the World
-  edm::ESTransientHandle<DDCompactView> pDD;
-  es.get<IdealGeometryRecord>().get(pDD);
+  if (m_pGeoFromDD4hep) {
+    edm::ESTransientHandle<cms::DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    m_pDD4hep = pDD.product();
+  } else {
+    edm::ESTransientHandle<DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    m_pDD = pDD.product();
+  }
 
-  G4LogicalVolumeToDDLogicalPartMap map_;
-  SensitiveDetectorCatalog catalog_;
-  const DDDWorld *world = new DDDWorld(&(*pDD), map_, catalog_, false);
-  m_registry.dddWorldSignal_(world);
+  SensitiveDetectorCatalog catalog;
+  const DDDWorld *dddworld = new DDDWorld(m_pDD, m_pDD4hep, catalog, 1, false, false);
+  G4VPhysicalVolume *world = dddworld->GetWorldVolume();
+  if (nullptr != world)
+    edm::LogVerbatim("GeometryProducer") << " World Volume: " << world->GetName();
+  m_kernel->DefineWorldVolume(world, true);
 
+  m_registry.dddWorldSignal_(dddworld);
+
+  edm::LogVerbatim("GeometryProducer") << " Magnetic field initialisation";
   updateMagneticField(es);
 
   if (m_pUseSensitiveDetectors) {
@@ -135,7 +151,7 @@ void GeometryProducer::produce(edm::Event &e, const edm::EventSetup &es) {
       m_attach = new AttachSD;
     {
       std::pair<std::vector<SensitiveTkDetector *>, std::vector<SensitiveCaloDetector *>> sensDets =
-          m_attach->create((*pDD), catalog_, m_p, m_trackManager.get(), m_registry);
+	m_attach->create((*m_pDD), catalog_, m_p, m_trackManager.get(), m_registry);
 
       m_sensTkDets.swap(sensDets.first);
       m_sensCaloDets.swap(sensDets.second);


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/32833

#### PR description:

`GeometryProducer` is used in order to prepare Geant4 geometry for use in backward propagation. 
These modifications do not affect any WF used in validation, though it is meant to address a small fraction of remaining crashes when using the G4 refitter in analysis setup (e.g. for W mass momentum scale calibration).

#### PR validation:

private

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

partial backport of https://github.com/cms-sw/cmssw/pull/32833
