### PR TITLE
[HGCAL] Remove hardcoded values according to geometry scenario

### DIFF
--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -7,8 +7,8 @@ tracksterLabels = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMer
 tracksterLabels.extend(['ticlSimTracksters', 'ticlSimTracksters_fromCPs'])
 
 prefix = 'HGCAL/HGCalValidator/'
-maxlayerzm =  50# last layer of BH -z
-maxlayerzp =  100# last layer of BH +z
+maxlayerzm = hgcalValidator.totallayers_to_monitor.value()# last layer of BH -z
+maxlayerzp = 2 * hgcalValidator.totallayers_to_monitor.value()# last layer of BH +z
 
 #hgcalLayerClusters
 eff_layers = ["effic_eta_layer{:02d} 'LayerCluster Efficiency vs #eta Layer{:02d} in z-' Num_CaloParticle_Eta_perlayer{:02d} Denom_CaloParticle_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) if (i<maxlayerzm) else "effic_eta_layer{:02d} 'LayerCluster Efficiency vs #eta Layer{:02d} in z+' Num_CaloParticle_Eta_perlayer{:02d} Denom_CaloParticle_Eta_perlayer{:02d}".format(i, i%maxlayerzm+1, i, i) for i in range(maxlayerzp) ]

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -20,6 +20,8 @@ from Validation.HGCalValidation.HGCalValidator_cfi import hgcalValidator
 from Validation.HGCalValidation.PostProcessorHGCAL_cfi import lcToCP_linking, simDict, tsToCP_linking, tsToSTS_patternRec, variables
 
 hgcVal_dqm = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/"
+#The number of layers per endcap in the current default geometry scenario. 
+geometryscenario = 47
 
 #To be able to spot any issues both in -z and +z a layer id was introduced
 #that spans from 0 to 103 for hgcal_v9 geometry. The mapping for hgcal_v9 is:
@@ -68,8 +70,20 @@ print(layerscheme)
 #For V9:
 #layerscheme = { 'lastLayerEEzm': 28, 'lastLayerFHzm': 40, 'maxlayerzm': 52, 'lastLayerEEzp': 80, 'lastLayerFHzp': 92, 'maxlayerzp': 104 }
 #For V10:
-'''
 layerscheme = { 'lastLayerEEzm': 28, 'lastLayerFHzm': 40, 'maxlayerzm': 50, 'lastLayerEEzp': 78, 'lastLayerFHzp': 90, 'maxlayerzp': 100 }
+#For V16
+layerscheme = { 'lastLayerEEzm': 26, 'lastLayerFHzm': 37, 'maxlayerzm': 47, 'lastLayerEEzp': 73, 'lastLayerFHzp': 84, 'maxlayerzp': 94 }
+'''
+#print(layerscheme)
+
+layerscheme = {}
+
+if geometryscenario == 52:
+   layerscheme = { 'lastLayerEEzm': 28, 'lastLayerFHzm': 40, 'maxlayerzm': 52, 'lastLayerEEzp': 80, 'lastLayerFHzp': 92, 'maxlayerzp': 104 }
+elif geometryscenario == 50:
+   layerscheme = { 'lastLayerEEzm': 28, 'lastLayerFHzm': 40, 'maxlayerzm': 50, 'lastLayerEEzp': 78, 'lastLayerFHzp': 90, 'maxlayerzp': 100 }
+elif geometryscenario == 47:
+   layerscheme = { 'lastLayerEEzm': 26, 'lastLayerFHzm': 37, 'maxlayerzm': 47, 'lastLayerEEzp': 73, 'lastLayerFHzp': 84, 'maxlayerzp': 94 }
 #print(layerscheme)
 
 lastLayerEEzm = layerscheme['lastLayerEEzm']  # last layer of EE -z
@@ -1254,7 +1268,7 @@ _cell_association_table_zplus = PlotGroup("cellAssociation_table", [
         ], ncols=8 )
 
 
-_bin_count = 50
+_bin_count = maxlayerzm
 _xtitle = "Layer Numbers in z+"
 _common_eff = {"stat": False, "legend": False, "ymin":0.0, "ymax":1.1}
 _effplots_zplus_eta = [Plot("effic_eta_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(maxlayerzm,maxlayerzp)]
@@ -1508,7 +1522,7 @@ _shared_plots2_sc_zplus.extend([Plot("SharedEnergy_layercl2simcluster_vs_phi_per
 _sharedEnergy_layercluster_to_simcluster_zplus = PlotGroup("sharedEnergy_layercluster_to_simcluster_zplus", _shared_plots2_sc_zplus, ncols=8)
 
 
-_bin_count = 50
+_bin_count = maxlayerzm
 _common_eff = {"stat": False, "legend": False}
 _effplots_sc_zplus_eta = [Plot("effic_eta_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(maxlayerzm,maxlayerzp)]
 _effplots_sc_zplus_phi = [Plot("effic_phi_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(maxlayerzm,maxlayerzp)]

--- a/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
+++ b/Validation/HGCalValidation/scripts/hgcalPerformanceValidation.py
@@ -22,9 +22,7 @@ from collections import OrderedDict
 from Validation.RecoTrack.plotting.validation import Sample, Validation
 from Validation.HGCalValidation.hgcalHtml import _sampleName,_pageNameMap,_summary,_summobj,_MatBudSections,_geoPageNameMap,_individualmaterials,_matPageNameMap,_individualmatplots,_individualMatPlotsDesc,_hideShowFun,_allmaterialsplots,_allmaterialsPlotsDesc, _fromvertexplots, _fromVertexPlotsDesc
 
-from RecoHGCal.TICL.iterativeTICL_cff import ticlIterLabelsMerge
-trackstersIters = ['ticlTracksters'+iteration for iteration in ticlIterLabelsMerge]
-trackstersIters.extend(["ticlSimTracksters", "ticlSimTracksters_fromCPs"])
+from Validation.HGCalValidation.PostProcessorHGCAL_cfi import tracksterLabels as trackstersIters
 
 #------------------------------------------------------------------------------------------
 #Parsing input options
@@ -87,7 +85,14 @@ def putype(t):
 #------------------------------------------------------------------------------------------
 #thereleases = { "CMSSW 11_1_X" : ["CMSSW_11_1_0_pre4_GEANT4","CMSSW_11_1_0_pre3","CMSSW_11_1_0_pre2"] }
 thereleases = OrderedDict()
-thereleases = { "CMSSW 12_3_X" : [
+thereleases = { "CMSSW 12_4_X" : [
+    "CMSSW_12_4_0_pre3_DD4HEP_vs_CMSSW_12_4_0_pre3_DDD",
+    "CMSSW_12_4_0_pre3_vs_CMSSW_12_4_0_pre2",
+    "CMSSW_12_4_0_pre2_vs_CMSSW_12_3_0_pre6"
+                ],
+                "CMSSW 12_3_X" : [
+    "CMSSW_12_3_1_vs_CMSSW_12_3_0_pre6",
+    "CMSSW_12_3_0_pre6_vs_CMSSW_12_3_0_pre5",
     "CMSSW_12_3_0_pre5_D88_vs_CMSSW_12_3_0_pre5_D77",
     "CMSSW_12_3_0_pre5_D77_vs_CMSSW_12_3_0_pre3_D77",
     "CMSSW_12_3_0_pre4_vs_CMSSW_12_3_0_pre3",
@@ -171,9 +176,9 @@ geometryTests = { "Material budget" : [
 
 GeoScenario = "Extended2026D77_vs_Extended2026D88"
 
-RefRelease='CMSSW_12_3_0_pre5'
+RefRelease='CMSSW_12_3_0_pre6'
 
-NewRelease='CMSSW_12_3_0_pre5'
+NewRelease='CMSSW_12_3_1'
 
 NotNormalRelease = "normal"
 NotNormalRefRelease = "normal"
@@ -190,11 +195,15 @@ if "raw" in NotNormalRelease:
     #   appendglobaltag = "_2026D49noPU_gcc900"
     #appendglobaltag = "_2026D77noPU"
     appendglobaltag = "_2026D88noPU"
+    #appendglobaltag = "_2026D88noPU_DDD"
+    #appendglobaltag = "_2026D88noPU_DD4HEP"
 else: 
     #   appendglobaltag = "_2026D49noPU"
     #appendglobaltag = "_2026D76noPU"
     #appendglobaltag = "_2026D77noPU"
     appendglobaltag = "_2026D88noPU"
+    #appendglobaltag = "_2026D88noPU_DDD"
+    #appendglobaltag = "_2026D88noPU_DD4HEP"
 
 #Until the final list of RelVals settles down the following sample list is under constant review
 '''
@@ -468,8 +477,8 @@ if (opt.OBJ == 'layerClusters' or opt.OBJ == 'hitCalibration' or opt.OBJ == 'hit
             #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
             cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("_raw1100","_raw1100_rsb") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         elif "normal" in NotNormalRelease and "normal" in NotNormalRefRelease:
-            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
-            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D88noPU-v1","2026D77noPU-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease) + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
+            #cmd = 'python3 Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py ' +  inputpathRef + infi.filename(RefRelease).replace("2026D88noPU_DD4HEP-v1","2026D88noPU_DDD-v1") + ' ' +  inputpathNew + infi.filename(NewRelease) + ' --outputDir HGCValid_%s_Plots --no-ratio --png --separate --html-sample "%s" ' %(opt.HTMLVALNAME, _sampleName[infi.name()] ) + ' --html-validation-name %s --subdirprefix ' %(opt.HTMLVALNAME) + ' plots_%s' % (samplename) + ' --collection %s' %(opt.HTMLVALNAME)
         else: 
             #print inputpathRef, infi.filename(RefRelease).replace("D49","D41")
             #YOU SHOULD INSPECT EACH TIME THIS COMMAND AND THE REPLACE


### PR DESCRIPTION
#### PR description:

In this PR we : 

1. Update the basic script used for the RelVal campaigns removing some unneeded code and instead importing the relevant part. 
2. Correct the values used for the efficiency plots, which were hardcoded to previous 50 layer scenario, so that they use the right number of layers. 

#### PR validation:

We have tested these changes in the latest `12_4_0_pre3_Phase2` RelVal campaigns. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport. 

@rovere @felicepantaleo @pfs @lecriste @ebrondol @youyingli

