### PR TITLE
Run3-sim118G Make use of token instead of labels in accssig hit collections in SimMuon/Neutron

### DIFF
--- a/SimMuon/Neutron/interface/SubsystemNeutronWriter.h
+++ b/SimMuon/Neutron/interface/SubsystemNeutronWriter.h
@@ -62,10 +62,11 @@ protected:
 private:
   NeutronWriter* theHitWriter;
   bool useRandFlat;
-  edm::InputTag theInputTag;
-  double theNeutronTimeCut;
-  double theTimeWindow;
-  double theT0;
+  const edm::InputTag theInputTag;
+  const double theNeutronTimeCut;
+  const double theTimeWindow;
+  const double theT0;
+  const edm::EDGetTokenT<edm::PSimHitContainer> hitToken_;
   int theNEvents;
   bool initialized;
   // true means to translate DetId into just layer number, e.g., 1-6 in CSC

--- a/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
+++ b/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
@@ -36,22 +36,28 @@
 class NeutronHitsCollector : public edm::stream::EDProducer<> {
 public:
   explicit NeutronHitsCollector(const edm::ParameterSet&);
-  ~NeutronHitsCollector() override{};
+  ~NeutronHitsCollector() override = default;
 
 private:
   virtual void beginJob();
   void produce(edm::Event&, const edm::EventSetup&) override;
   virtual void endJob();
 
-  std::string neutron_label_csc;
-  std::string neutron_label_dt;
-  std::string neutron_label_rpc;
+  const std::string neutron_label_csc;
+  const std::string neutron_label_dt;
+  const std::string neutron_label_rpc;
+  const edm::EDGetTokenT<edm::PSimHitContainer> tokenCSC_;
+  const edm::EDGetTokenT<edm::PSimHitContainer> tokenDT_;
+  const edm::EDGetTokenT<edm::PSimHitContainer> tokenRPC_;
 };
 
-NeutronHitsCollector::NeutronHitsCollector(const edm::ParameterSet& iConfig) {
-  neutron_label_csc = iConfig.getUntrackedParameter<std::string>("neutronLabelCSC", "");
-  neutron_label_dt = iConfig.getUntrackedParameter<std::string>("neutronLabelDT", "");
-  neutron_label_rpc = iConfig.getUntrackedParameter<std::string>("neutronLabelRPC", "");
+NeutronHitsCollector::NeutronHitsCollector(const edm::ParameterSet& iConfig) :
+  neutron_label_csc(iConfig.getUntrackedParameter<std::string>("neutronLabelCSC", "")),
+  neutron_label_dt(iConfig.getUntrackedParameter<std::string>("neutronLabelDT", "")),
+  neutron_label_rpc(iConfig.getUntrackedParameter<std::string>("neutronLabelRPC", "")),
+  tokenCSC_(consumes<edm::PSimHitContainer>(neutron_label_csc)),
+  tokenDT_(consumes<edm::PSimHitContainer>(neutron_label_dt)),
+  tokenRPC_(consumes<edm::PSimHitContainer>(neutron_label_rpc)) {
 
   // The following list duplicates
   // http://cmslxr.fnal.gov/lxr/source/SimG4Core/Application/plugins/OscarProducer.cc
@@ -106,8 +112,7 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   //
   std::unique_ptr<edm::PSimHitContainer> simCSC(new edm::PSimHitContainer);
   if (neutron_label_csc.length() > 0) {
-    edm::Handle<edm::PSimHitContainer> MuonCSCHits;
-    iEvent.getByLabel(neutron_label_csc, MuonCSCHits);
+    const edm::Handle<edm::PSimHitContainer> &MuonCSCHits = iEvent.getHandle(tokenCSC_);
     for (hit = MuonCSCHits->begin(); hit != MuonCSCHits->end(); ++hit)
       simCSC->push_back(*hit);
   }
@@ -117,8 +122,7 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   //
   std::unique_ptr<edm::PSimHitContainer> simDT(new edm::PSimHitContainer);
   if (neutron_label_dt.length() > 0) {
-    edm::Handle<edm::PSimHitContainer> MuonDTHits;
-    iEvent.getByLabel(neutron_label_dt, MuonDTHits);
+    const edm::Handle<edm::PSimHitContainer> &MuonDTHits = iEvent.getHandle(tokenDT_);
     for (hit = MuonDTHits->begin(); hit != MuonDTHits->end(); ++hit)
       simDT->push_back(*hit);
   }
@@ -128,8 +132,7 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   //
   std::unique_ptr<edm::PSimHitContainer> simRPC(new edm::PSimHitContainer);
   if (neutron_label_rpc.length() > 0) {
-    edm::Handle<edm::PSimHitContainer> MuonRPCHits;
-    iEvent.getByLabel(neutron_label_rpc, MuonRPCHits);
+    const edm::Handle<edm::PSimHitContainer> &MuonRPCHits = iEvent.getHandle(tokenRPC_);
     for (hit = MuonRPCHits->begin(); hit != MuonRPCHits->end(); ++hit)
       simRPC->push_back(*hit);
   }

--- a/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
+++ b/SimMuon/Neutron/plugins/NeutronHitsCollector.cc
@@ -51,14 +51,13 @@ private:
   const edm::EDGetTokenT<edm::PSimHitContainer> tokenRPC_;
 };
 
-NeutronHitsCollector::NeutronHitsCollector(const edm::ParameterSet& iConfig) :
-  neutron_label_csc(iConfig.getUntrackedParameter<std::string>("neutronLabelCSC", "")),
-  neutron_label_dt(iConfig.getUntrackedParameter<std::string>("neutronLabelDT", "")),
-  neutron_label_rpc(iConfig.getUntrackedParameter<std::string>("neutronLabelRPC", "")),
-  tokenCSC_(consumes<edm::PSimHitContainer>(neutron_label_csc)),
-  tokenDT_(consumes<edm::PSimHitContainer>(neutron_label_dt)),
-  tokenRPC_(consumes<edm::PSimHitContainer>(neutron_label_rpc)) {
-
+NeutronHitsCollector::NeutronHitsCollector(const edm::ParameterSet& iConfig)
+    : neutron_label_csc(iConfig.getUntrackedParameter<std::string>("neutronLabelCSC", "")),
+      neutron_label_dt(iConfig.getUntrackedParameter<std::string>("neutronLabelDT", "")),
+      neutron_label_rpc(iConfig.getUntrackedParameter<std::string>("neutronLabelRPC", "")),
+      tokenCSC_(consumes<edm::PSimHitContainer>(neutron_label_csc)),
+      tokenDT_(consumes<edm::PSimHitContainer>(neutron_label_dt)),
+      tokenRPC_(consumes<edm::PSimHitContainer>(neutron_label_rpc)) {
   // The following list duplicates
   // http://cmslxr.fnal.gov/lxr/source/SimG4Core/Application/plugins/OscarProducer.cc
 
@@ -112,7 +111,7 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   //
   std::unique_ptr<edm::PSimHitContainer> simCSC(new edm::PSimHitContainer);
   if (neutron_label_csc.length() > 0) {
-    const edm::Handle<edm::PSimHitContainer> &MuonCSCHits = iEvent.getHandle(tokenCSC_);
+    const edm::Handle<edm::PSimHitContainer>& MuonCSCHits = iEvent.getHandle(tokenCSC_);
     for (hit = MuonCSCHits->begin(); hit != MuonCSCHits->end(); ++hit)
       simCSC->push_back(*hit);
   }
@@ -122,7 +121,7 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   //
   std::unique_ptr<edm::PSimHitContainer> simDT(new edm::PSimHitContainer);
   if (neutron_label_dt.length() > 0) {
-    const edm::Handle<edm::PSimHitContainer> &MuonDTHits = iEvent.getHandle(tokenDT_);
+    const edm::Handle<edm::PSimHitContainer>& MuonDTHits = iEvent.getHandle(tokenDT_);
     for (hit = MuonDTHits->begin(); hit != MuonDTHits->end(); ++hit)
       simDT->push_back(*hit);
   }
@@ -132,7 +131,7 @@ void NeutronHitsCollector::produce(edm::Event& iEvent, const edm::EventSetup& iS
   //
   std::unique_ptr<edm::PSimHitContainer> simRPC(new edm::PSimHitContainer);
   if (neutron_label_rpc.length() > 0) {
-    const edm::Handle<edm::PSimHitContainer> &MuonRPCHits = iEvent.getHandle(tokenRPC_);
+    const edm::Handle<edm::PSimHitContainer>& MuonRPCHits = iEvent.getHandle(tokenRPC_);
     for (hit = MuonRPCHits->begin(); hit != MuonRPCHits->end(); ++hit)
       simRPC->push_back(*hit);
   }

--- a/SimMuon/Neutron/src/SubsystemNeutronWriter.cc
+++ b/SimMuon/Neutron/src/SubsystemNeutronWriter.cc
@@ -28,6 +28,7 @@ SubsystemNeutronWriter::SubsystemNeutronWriter(edm::ParameterSet const& pset)
       theNeutronTimeCut(pset.getParameter<double>("neutronTimeCut")),
       theTimeWindow(pset.getParameter<double>("timeWindow")),
       theT0(pset.getParameter<double>("t0")),
+      hitToken_(consumes<edm::PSimHitContainer>(theInputTag)),
       theNEvents(0),
       initialized(false),
       useLocalDetId_(true) {
@@ -78,18 +79,17 @@ void SubsystemNeutronWriter::produce(edm::Event& e, edm::EventSetup const& c) {
   }
   theHitWriter->beginEvent(e, c);
   ++theNEvents;
-  edm::Handle<edm::PSimHitContainer> hits;
-  e.getByLabel(theInputTag, hits);
+  const edm::Handle<edm::PSimHitContainer> &hits = e.getHandle(hitToken_);
 
   // sort hits by chamber
-  map<int, edm::PSimHitContainer> hitsByChamber;
+  std::map<int, edm::PSimHitContainer> hitsByChamber;
   for (edm::PSimHitContainer::const_iterator hitItr = hits->begin(); hitItr != hits->end(); ++hitItr) {
     int chamberIndex = chamberId(hitItr->detUnitId());
     hitsByChamber[chamberIndex].push_back(*hitItr);
   }
 
   // now write out each chamber's contents
-  for (map<int, edm::PSimHitContainer>::iterator hitsByChamberItr = hitsByChamber.begin();
+  for (std::map<int, edm::PSimHitContainer>::iterator hitsByChamberItr = hitsByChamber.begin();
        hitsByChamberItr != hitsByChamber.end();
        ++hitsByChamberItr) {
     int chambertype = chamberType(hitsByChamberItr->first);

--- a/SimMuon/Neutron/src/SubsystemNeutronWriter.cc
+++ b/SimMuon/Neutron/src/SubsystemNeutronWriter.cc
@@ -79,7 +79,7 @@ void SubsystemNeutronWriter::produce(edm::Event& e, edm::EventSetup const& c) {
   }
   theHitWriter->beginEvent(e, c);
   ++theNEvents;
-  const edm::Handle<edm::PSimHitContainer> &hits = e.getHandle(hitToken_);
+  const edm::Handle<edm::PSimHitContainer>& hits = e.getHandle(hitToken_);
 
   // sort hits by chamber
   std::map<int, edm::PSimHitContainer> hitsByChamber;


### PR DESCRIPTION
#### PR description:

Make use of token instead of labels in accssig hit collections in SimMuon/Neutron

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special