### PR TITLE
Print fallback server log in TritonService

### DIFF
--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -92,6 +92,9 @@ If an `edm::GlobalCache` of type `T` is needed, there are two changes:
     }
     ```
 
+For `TritonEDProducer` and `TritonEDFilter`, the function `tritonEndStream()` replaces the standard `endStream()`.
+For `TritonOneEDAnalyzer`, the function `tritonEndJob()` replaces the standard `endJob()`.
+
 In a SONIC Triton producer, the basic flow should follow this pattern:
 1. `acquire()`:  
     a. access input object(s) from `TritonInputMap`  

--- a/HeterogeneousCore/SonicTriton/interface/TritonEDFilter.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonEDFilter.h
@@ -27,7 +27,11 @@ public:
   static void globalEndJob(G*) {}
 
   //destroy client before destructor called to unregister any shared memory before TritonService shuts down fallback server
-  void endStream() override { this->client_.reset(); }
+  virtual void tritonEndStream() {}
+  void endStream() final {
+    tritonEndStream();
+    this->client_.reset();
+  }
 };
 
 template <typename... Capabilities>

--- a/HeterogeneousCore/SonicTriton/interface/TritonEDFilter.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonEDFilter.h
@@ -25,6 +25,9 @@ public:
   }
 
   static void globalEndJob(G*) {}
+
+  //destroy client before destructor called to unregister any shared memory before TritonService shuts down fallback server
+  void endStream() override { this->client_.reset(); }
 };
 
 template <typename... Capabilities>

--- a/HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h
@@ -27,7 +27,11 @@ public:
   static void globalEndJob(G*) {}
 
   //destroy client before destructor called to unregister any shared memory before TritonService shuts down fallback server
-  void endStream() override { this->client_.reset(); }
+  virtual void tritonEndStream() {}
+  void endStream() final {
+    tritonEndStream();
+    this->client_.reset();
+  }
 };
 
 template <typename... Capabilities>

--- a/HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h
@@ -25,6 +25,9 @@ public:
   }
 
   static void globalEndJob(G*) {}
+
+  //destroy client before destructor called to unregister any shared memory before TritonService shuts down fallback server
+  void endStream() override { this->client_.reset(); }
 };
 
 template <typename... Capabilities>

--- a/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
@@ -17,6 +17,9 @@ public:
     ts->addModel(this->clientPset_.template getParameter<std::string>("modelName"),
                  this->clientPset_.template getParameter<edm::FileInPath>("modelConfigPath").fullPath());
   }
+
+  //destroy client before destructor called to unregister any shared memory before TritonService shuts down fallback server
+  void endJob() override { this->client_.reset(); }
 };
 
 #endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonOneEDAnalyzer.h
@@ -19,7 +19,11 @@ public:
   }
 
   //destroy client before destructor called to unregister any shared memory before TritonService shuts down fallback server
-  void endJob() override { this->client_.reset(); }
+  virtual void tritonEndJob() {}
+  void endJob() final {
+    tritonEndJob();
+    this->client_.reset();
+  }
 };
 
 #endif

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -117,6 +117,10 @@ private:
   void preModuleDestruction(edm::ModuleDescription const&);
   void preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&);
 
+  //helper
+  template <typename LOG>
+  void printFallbackServerLog() const;
+
   bool verbose_;
   FallbackOpts fallbackOpts_;
   unsigned currentModuleId_;

--- a/HeterogeneousCore/SonicTriton/interface/TritonService.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonService.h
@@ -58,6 +58,7 @@ public:
     std::string tempDir;
     std::string imageName;
     std::string sandboxName;
+    std::string command;
   };
   struct Server {
     Server(const edm::ParameterSet& pset)
@@ -116,6 +117,7 @@ private:
   void postModuleConstruction(edm::ModuleDescription const&);
   void preModuleDestruction(edm::ModuleDescription const&);
   void preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&);
+  void postEndJob();
 
   //helper
   template <typename LOG>

--- a/HeterogeneousCore/SonicTriton/src/TritonService.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonService.cc
@@ -271,8 +271,7 @@ void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::
     printFallbackServerLog<edm::LogError>();
     throw cms::Exception("FallbackFailed")
         << "TritonService: Starting the fallback server failed with exit code " << rv;
-  }
-  else if (verbose_)
+  } else if (verbose_)
     edm::LogInfo("TritonService") << output;
   //get the port
   const std::string& portIndicator("CMS_TRITON_GRPC_PORT: ");
@@ -289,7 +288,8 @@ void TritonService::preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::
 }
 
 void TritonService::postEndJob() {
-  if (!startedFallback_) return;
+  if (!startedFallback_)
+    return;
 
   std::string command = fallbackOpts_.command + " stop";
   if (verbose_)
@@ -301,8 +301,7 @@ void TritonService::postEndJob() {
     printFallbackServerLog<edm::LogError>();
     throw cms::Exception("FallbackFailed")
         << "TritonService: Stopping the fallback server failed with exit code " << rv;
-  }
-  else if (verbose_) {
+  } else if (verbose_) {
     edm::LogInfo("TritonService") << output;
     printFallbackServerLog<edm::LogInfo>();
   }
@@ -310,12 +309,12 @@ void TritonService::postEndJob() {
 
 template <typename LOG>
 void TritonService::printFallbackServerLog() const {
-  std::vector<std::string> logNames{"log_"+fallbackOpts_.instanceName+".log"};
+  std::vector<std::string> logNames{"log_" + fallbackOpts_.instanceName + ".log"};
   //cmsTriton script moves log from temp to current dir in verbose mode or in some cases when auto_stop is called
   // -> check both places
-  logNames.push_back(fallbackOpts_.tempDir+"/"+logNames[0]);
+  logNames.push_back(fallbackOpts_.tempDir + "/" + logNames[0]);
   bool foundLog = false;
-  for (const auto& logName : logNames){
+  for (const auto& logName : logNames) {
     std::ifstream infile(logName);
     if (infile.is_open()) {
       LOG("TritonService") << "TritonService: server log " << logName << "\n" << infile.rdbuf();
@@ -324,7 +323,8 @@ void TritonService::printFallbackServerLog() const {
     }
   }
   if (!foundLog)
-    LOG("TritonService") << "TritonService: could not find server log " << logNames[0] << " in current directory or " << fallbackOpts_.tempDir;
+    LOG("TritonService") << "TritonService: could not find server log " << logNames[0] << " in current directory or "
+                         << fallbackOpts_.tempDir;
 }
 
 void TritonService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/SonicTriton/test/unittest.sh
+++ b/HeterogeneousCore/SonicTriton/test/unittest.sh
@@ -64,19 +64,6 @@ cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py modu
 CMSEXIT=$?
 
 cat $tmpFile
-sleep 15
-
-STOP_COUNTER=0
-while ! LOGFILE="$(ls -rt ${LOCALTOP}/log_${fallbackName}_*.log 2>/dev/null | tail -n 1)" && [ "$STOP_COUNTER" -lt 5 ]; do
-	STOP_COUNTER=$((STOP_COUNTER+1))
-	sleep 5
-done
-
-if [ -n "$LOGFILE" ]; then
-	echo -e '\n=====\nContents of '$LOGFILE':\n=====\n'
-	cat "$LOGFILE"
-	rm $LOGFILE
-fi
 
 if grep -q "Socket closed" $tmpFile; then
 	echo "Transient server error (not caused by client code)"


### PR DESCRIPTION
#### PR description:

To investigate #37767 further, the fallback server log is now printed as a `LogError` if the server fails to start (including because of a timeout).

Since the log-printing functionality is now available in `TritonService`, the redundant functionality has been removed from the unit test script. `TritonService` now manually shuts down the server at the end of the job and prints the log as a `LogInfo` if verbose mode is enabled. (This required some minor re-engineering of SonicTriton modules to ensure that clients are destroyed before the server is shut down; otherwise, there could be an exception or segfault from the client trying to unregister shared memory from a nonexistent server.)

#### PR validation:

Ran unit tests repeatedly, including with artificially-short server startup wait times (1s or 10s), to see that server log is printed as expected in the different cases above.