### PR TITLE
Cleanup redundant edm ParameterSet exist in JetMETCorrections

### DIFF
--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -82,16 +82,14 @@ public:
         skipMuonSelection_(nullptr) {
     token_ = consumes<std::vector<T> >(cfg.getParameter<edm::InputTag>("src"));
 
-    if (cfg.exists("offsetCorrLabel")) {
-      offsetCorrLabel_ = cfg.getParameter<edm::InputTag>("offsetCorrLabel");
-      offsetCorrToken_ = consumes<reco::JetCorrector>(offsetCorrLabel_);
-    }
+    offsetCorrLabel_ = cfg.getParameter<edm::InputTag>("offsetCorrLabel");
+    offsetCorrToken_ = consumes<reco::JetCorrector>(offsetCorrLabel_);
     jetCorrLabel_ = cfg.getParameter<edm::InputTag>("jetCorrLabel");        //for MC
     jetCorrLabelRes_ = cfg.getParameter<edm::InputTag>("jetCorrLabelRes");  //for data
     jetCorrToken_ = mayConsume<reco::JetCorrector>(jetCorrLabel_);
     jetCorrResToken_ = mayConsume<reco::JetCorrector>(jetCorrLabelRes_);
 
-    jetCorrEtaMax_ = (cfg.exists("jetCorrEtaMax")) ? cfg.getParameter<double>("jetCorrEtaMax") : 9.9;
+    jetCorrEtaMax_ = cfg.getParameter<double>("jetCorrEtaMax") ;
 
     type1JetPtThreshold_ = cfg.getParameter<double>("type1JetPtThreshold");
 

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -89,7 +89,7 @@ public:
     jetCorrToken_ = mayConsume<reco::JetCorrector>(jetCorrLabel_);
     jetCorrResToken_ = mayConsume<reco::JetCorrector>(jetCorrLabelRes_);
 
-    jetCorrEtaMax_ = cfg.getParameter<double>("jetCorrEtaMax") ;
+    jetCorrEtaMax_ = cfg.getParameter<double>("jetCorrEtaMax");
 
     type1JetPtThreshold_ = cfg.getParameter<double>("type1JetPtThreshold");
 

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -260,7 +260,6 @@ private:
     }
   }
 
-
   edm::EDGetTokenT<std::vector<T> > token_;
 
   edm::InputTag offsetCorrLabel_;

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -76,8 +76,7 @@ namespace PFJetMETcorrInputProducer_namespace {
 template <typename T, typename Textractor>
 class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<> {
 public:
-  explicit PFJetMETcorrInputProducerT(const edm::ParameterSet& cfg)
-      : skipMuonSelection_(nullptr) {
+  explicit PFJetMETcorrInputProducerT(const edm::ParameterSet& cfg) : skipMuonSelection_(nullptr) {
     token_ = consumes<std::vector<T> >(cfg.getParameter<edm::InputTag>("src"));
     offsetCorrLabel_ = cfg.getParameter<edm::InputTag>("offsetCorrLabel");
     offsetCorrToken_ = consumes<reco::JetCorrector>(offsetCorrLabel_);

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -82,7 +82,6 @@ public:
         skipMuonSelection_(nullptr) {
     token_ = consumes<std::vector<T> >(cfg.getParameter<edm::InputTag>("src"));
 
-    offsetCorrLabel_ = cfg.getParameter<edm::InputTag>("offsetCorrLabel");
     offsetCorrToken_ = consumes<reco::JetCorrector>(offsetCorrLabel_);
     jetCorrLabel_ = cfg.getParameter<edm::InputTag>("jetCorrLabel");        //for MC
     jetCorrLabelRes_ = cfg.getParameter<edm::InputTag>("jetCorrLabelRes");  //for data
@@ -263,7 +262,6 @@ private:
     }
   }
 
-  std::string moduleLabel_;
 
   edm::EDGetTokenT<std::vector<T> > token_;
 

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -77,11 +77,9 @@ template <typename T, typename Textractor>
 class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<> {
 public:
   explicit PFJetMETcorrInputProducerT(const edm::ParameterSet& cfg)
-      : moduleLabel_(cfg.getParameter<std::string>("@module_label")),
-        offsetCorrLabel_(""),
-        skipMuonSelection_(nullptr) {
+      : skipMuonSelection_(nullptr) {
     token_ = consumes<std::vector<T> >(cfg.getParameter<edm::InputTag>("src"));
-
+    offsetCorrLabel_ = cfg.getParameter<edm::InputTag>("offsetCorrLabel");
     offsetCorrToken_ = consumes<reco::JetCorrector>(offsetCorrLabel_);
     jetCorrLabel_ = cfg.getParameter<edm::InputTag>("jetCorrLabel");        //for MC
     jetCorrLabelRes_ = cfg.getParameter<edm::InputTag>("jetCorrLabelRes");  //for data


### PR DESCRIPTION
#### PR description:  
(Technical PR) Optimization of the module configurations: Improve maintainability by cleaning up redundant cases of edm::ParameterSet calls to `existAs` or `exist` for tracked parameters, where redundancy is based on the value being already defined by `fillDescriptions`.

As follow the previous [PR36746](https://github.com/cms-sw/cmssw/pull/36746),  [PR36989](https://github.com/cms-sw/cmssw/pull/36989), [PR37313](https://github.com/cms-sw/cmssw/pull/37313), [PR37314](https://github.com/cms-sw/cmssw/pull/37314), [PR37548](https://github.com/cms-sw/cmssw/pull/37548), and [PR37772](https://github.com/cms-sw/cmssw/pull/37772).

The list of all calls of `existAs` or `exist` are automatically available in the Static Analyzer report. (Bug: CMS code rules)
It is accessible from IB page. https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/
For this task consider only modules or tools used by the modules that define `fillDescriptions`.

In this PR, 1 file was changed.  
JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h

Here, the "offsetCorrLabel", "jetCorrEtaMax" parameters were provided in a `fillDescription`.

cfipython : [cfipython/JetMETCorrections/Type1MET/pfJetMETcorrInputProducerTRecoPFJetJetCorrExtractorTRecoPFJet_cfi.py](https://cmssdt.cern.ch/lxr/source/cfipython/JetMETCorrections/Type1MET/pfJetMETcorrInputProducerTRecoPFJetJetCorrExtractorTRecoPFJet_cfi.py)


#### PR validation:
Tested in CMSSW_12_4_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)