### PR TITLE
Fix CMS deprecation warnings in L1TriggerConfig/L1GtConfigProducers

### DIFF
--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtBoardMapsTester.h
@@ -19,23 +19,25 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // forward declarations
+class L1GtBoardMaps;
+class L1GtBoardMapsRcd;
 
 // class declaration
-class L1GtBoardMapsTester : public edm::EDAnalyzer {
+class L1GtBoardMapsTester : public edm::global::EDAnalyzer<> {
 public:
   // constructor
   explicit L1GtBoardMapsTester(const edm::ParameterSet&);
 
-  // destructor
-  ~L1GtBoardMapsTester() override;
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+private:
+  edm::ESGetToken<L1GtBoardMaps, L1GtBoardMapsRcd> m_getToken;
 };
 
 #endif /*L1GtConfigProducers_L1GtBoardMapsTester_h*/

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtParametersTester.h
@@ -22,24 +22,25 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // forward declarations
 class L1GtParameters;
+class L1GtParametersRcd;
 
 // class declaration
-class L1GtParametersTester : public edm::EDAnalyzer {
+class L1GtParametersTester : public edm::global::EDAnalyzer<> {
 public:
   // constructor
   explicit L1GtParametersTester(const edm::ParameterSet&);
 
-  // destructor
-  ~L1GtParametersTester() override;
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+private:
+  const edm::ESGetToken<L1GtParameters, L1GtParametersRcd> m_l1GtParToken;
 };
 
 #endif /*L1GtConfigProducers_L1GtParametersTester_h*/

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAndMasksTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPrescaleFactorsAndMasksTester.h
@@ -19,7 +19,7 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -28,19 +28,30 @@
 class L1GtPrescaleFactors;
 class L1GtTriggerMask;
 
+class L1GtPrescaleFactorsAlgoTrigRcd;
+class L1GtPrescaleFactorsTechTrigRcd;
+class L1GtTriggerMaskAlgoTrigRcd;
+class L1GtTriggerMaskTechTrigRcd;
+class L1GtTriggerMaskVetoAlgoTrigRcd;
+class L1GtTriggerMaskVetoTechTrigRcd;
+
 // class declaration
-class L1GtPrescaleFactorsAndMasksTester : public edm::EDAnalyzer {
+class L1GtPrescaleFactorsAndMasksTester
+    : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   // constructor
   explicit L1GtPrescaleFactorsAndMasksTester(const edm::ParameterSet&);
 
-  // destructor
-  ~L1GtPrescaleFactorsAndMasksTester() override;
+  struct Tokens {
+    edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsAlgoTrigRcd> m_l1GtPfAlgo;
+    edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsTechTrigRcd> m_l1GtPfTech;
+    edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskAlgoTrigRcd> m_l1GtTmAlgo;
+    edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskTechTrigRcd> m_l1GtTmTech;
+    edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskVetoAlgoTrigRcd> m_l1GtTmVetoAlgo;
+    edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskVetoTechTrigRcd> m_l1GtTmVetoTech;
+  };
 
 private:
-  /// begin job
-  void beginJob() override;
-
   /// begin run
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
@@ -56,15 +67,12 @@ private:
   /// end run
   void endRun(const edm::Run&, const edm::EventSetup&) override;
 
-  /// end job
-  void endJob() override;
-
 private:
   /// retrieve all the relevant L1 trigger event setup records
-  void retrieveL1EventSetup(const edm::EventSetup&);
+  void retrieveL1EventSetup(const edm::EventSetup&, const Tokens&);
 
   /// print the requred records
-  void printL1EventSetup(const edm::EventSetup&);
+  void printL1EventSetup();
 
 private:
   /// input parameters
@@ -98,6 +106,10 @@ private:
 
   const L1GtTriggerMask* m_l1GtTmVetoAlgo;
   const L1GtTriggerMask* m_l1GtTmVetoTech;
+
+  Tokens m_run;
+  Tokens m_lumi;
+  Tokens m_event;
 };
 
 #endif /*L1GtConfigProducers_L1GtPrescaleFactorsAndMasksTester_h*/

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtPsbSetupTester.h
@@ -19,23 +19,25 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // forward declarations
+class L1GtPsbSetup;
+class L1GtPsbSetupRcd;
 
 // class declaration
-class L1GtPsbSetupTester : public edm::EDAnalyzer {
+class L1GtPsbSetupTester : public edm::global::EDAnalyzer<> {
 public:
   // constructor
   explicit L1GtPsbSetupTester(const edm::ParameterSet&);
 
-  // destructor
-  ~L1GtPsbSetupTester() override;
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+private:
+  edm::ESGetToken<L1GtPsbSetup, L1GtPsbSetupRcd> m_getToken;
 };
 
 #endif /*L1GtConfigProducers_L1GtPsbSetupTester_h*/

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtStableParametersTester.h
@@ -22,24 +22,25 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // forward declarations
 class L1GtStableParameters;
+class L1GtStableParametersRcd;
 
 // class declaration
-class L1GtStableParametersTester : public edm::EDAnalyzer {
+class L1GtStableParametersTester : public edm::global::EDAnalyzer<> {
 public:
   // constructor
   explicit L1GtStableParametersTester(const edm::ParameterSet&);
 
-  // destructor
-  ~L1GtStableParametersTester() override;
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
+private:
+  const edm::ESGetToken<L1GtStableParameters, L1GtStableParametersRcd> m_l1GtParToken;
 };
 
 #endif /*L1GtConfigProducers_L1GtStableParametersTester_h*/

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuTester.h
@@ -24,7 +24,7 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -40,36 +40,30 @@ class L1GtPrescaleFactors;
 class L1GtTriggerMask;
 class L1GtTriggerMenu;
 
+class L1GtStableParametersRcd;
+class L1GtPrescaleFactorsAlgoTrigRcd;
+class L1GtPrescaleFactorsTechTrigRcd;
+class L1GtTriggerMaskAlgoTrigRcd;
+class L1GtTriggerMaskTechTrigRcd;
+class L1GtTriggerMaskVetoAlgoTrigRcd;
+class L1GtTriggerMaskVetoTechTrigRcd;
+class L1GtTriggerMenuRcd;
+
 // class declaration
-class L1GtTriggerMenuTester : public edm::EDAnalyzer {
+class L1GtTriggerMenuTester : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
   // constructor
   explicit L1GtTriggerMenuTester(const edm::ParameterSet&);
 
-  // destructor
-  ~L1GtTriggerMenuTester() override;
-
 private:
-  /// begin job
-  void beginJob() override;
-
   /// begin run
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
-
-  /// begin luminosity block
-  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
 
   /// analyze
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  /// end luminosity block
-  void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
-
   /// end run
   void endRun(const edm::Run&, const edm::EventSetup&) override;
-
-  /// end job
-  void endJob() override;
 
 private:
   /// retrieve all the relevant L1 trigger event setup records
@@ -119,6 +113,15 @@ private:
 
 private:
   /// event setup cached stuff
+
+  edm::ESGetToken<L1GtStableParameters, L1GtStableParametersRcd> m_l1GtStableParToken;
+  edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsAlgoTrigRcd> m_l1GtPfAlgoToken;
+  edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsTechTrigRcd> m_l1GtPfTechToken;
+  edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskAlgoTrigRcd> m_l1GtTmAlgoToken;
+  edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskTechTrigRcd> m_l1GtTmTechToken;
+  edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskVetoAlgoTrigRcd> m_l1GtTmVetoAlgoToken;
+  edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskVetoTechTrigRcd> m_l1GtTmVetoTechToken;
+  edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> m_l1GtMenuToken;
 
   /// stable parameters
   const L1GtStableParameters* m_l1GtStablePar;

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuXmlProducer.h
@@ -30,6 +30,7 @@
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 
 // forward declarations
+class L1GtStableParameters;
 
 // class declaration
 class L1GtTriggerMenuXmlProducer : public edm::ESProducer {
@@ -51,6 +52,8 @@ private:
 
   /// XML file for Global Trigger VME configuration (vme.xml)
   std::string m_vmeXmlFile;
+
+  edm::ESGetToken<L1GtStableParameters, L1GtStableParametersRcd> m_getToken;
 };
 
 #endif

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlWriter.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtVhdlWriter.h
@@ -20,13 +20,16 @@
 
 // base class
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
+#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 
 class Event;
 class EventSetup;
@@ -35,13 +38,10 @@ class ParameterSet;
 // forward declarations
 
 // class declaration
-class L1GtVhdlWriter : public edm::EDAnalyzer {
+class L1GtVhdlWriter : public edm::one::EDAnalyzer<> {
 public:
   /// constructor
   explicit L1GtVhdlWriter(const edm::ParameterSet&);
-
-  /// destructor
-  ~L1GtVhdlWriter() override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
@@ -51,5 +51,7 @@ private:
 
   /// output directory
   std::string outputDir_;
+
+  edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> menuToken_;
 };
 #endif /*L1GtConfigProducers_L1GtVhdlWriter_h*/

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtBoardMapsTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtBoardMapsTester.cc
@@ -31,43 +31,37 @@
 // forward declarations
 
 // constructor(s)
-L1GtBoardMapsTester::L1GtBoardMapsTester(const edm::ParameterSet& parSet) {
-  // empty
-}
-
-// destructor
-L1GtBoardMapsTester::~L1GtBoardMapsTester() {
+L1GtBoardMapsTester::L1GtBoardMapsTester(const edm::ParameterSet& parSet) : m_getToken(esConsumes()) {
   // empty
 }
 
 // loop over events
-void L1GtBoardMapsTester::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1GtBoardMaps> l1GtBM;
-  evSetup.get<L1GtBoardMapsRcd>().get(l1GtBM);
+void L1GtBoardMapsTester::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& evSetup) const {
+  L1GtBoardMaps const& l1GtBM = evSetup.getData(m_getToken);
 
-  l1GtBM->print(std::cout);
+  l1GtBM.print(std::cout);
   std::cout << std::endl;
 
   // print for simplicity the individual maps
 
-  l1GtBM->printGtDaqRecordMap(std::cout);
+  l1GtBM.printGtDaqRecordMap(std::cout);
   std::cout << std::endl;
 
-  l1GtBM->printGtEvmRecordMap(std::cout);
+  l1GtBM.printGtEvmRecordMap(std::cout);
   std::cout << std::endl;
 
-  l1GtBM->printGtDaqActiveBoardsMap(std::cout);
+  l1GtBM.printGtDaqActiveBoardsMap(std::cout);
   std::cout << std::endl;
 
-  l1GtBM->printGtEvmActiveBoardsMap(std::cout);
+  l1GtBM.printGtEvmActiveBoardsMap(std::cout);
   std::cout << std::endl;
 
-  l1GtBM->printGtBoardSlotMap(std::cout);
+  l1GtBM.printGtBoardSlotMap(std::cout);
   std::cout << std::endl;
 
-  l1GtBM->printGtBoardHexNameMap(std::cout);
+  l1GtBM.printGtBoardHexNameMap(std::cout);
   std::cout << std::endl;
 
-  l1GtBM->printGtQuadToPsbMap(std::cout);
+  l1GtBM.printGtQuadToPsbMap(std::cout);
   std::cout << std::endl;
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtParametersTester.cc
@@ -37,19 +37,11 @@
 // forward declarations
 
 // constructor(s)
-L1GtParametersTester::L1GtParametersTester(const edm::ParameterSet& parSet) {
-  // empty
-}
-
-// destructor
-L1GtParametersTester::~L1GtParametersTester() {
+L1GtParametersTester::L1GtParametersTester(const edm::ParameterSet& parSet) : m_l1GtParToken(esConsumes()) {
   // empty
 }
 
 // loop over events
-void L1GtParametersTester::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1GtParameters> l1GtPar;
-  evSetup.get<L1GtParametersRcd>().get(l1GtPar);
-
-  LogDebug("L1GtParametersTester") << (*l1GtPar) << std::endl;
+void L1GtParametersTester::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& evSetup) const {
+  LogDebug("L1GtParametersTester") << evSetup.getData(m_l1GtParToken) << std::endl;
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPsbSetupTester.cc
@@ -31,20 +31,12 @@
 // forward declarations
 
 // constructor(s)
-L1GtPsbSetupTester::L1GtPsbSetupTester(const edm::ParameterSet& parSet) {
-  // empty
-}
-
-// destructor
-L1GtPsbSetupTester::~L1GtPsbSetupTester() {
+L1GtPsbSetupTester::L1GtPsbSetupTester(const edm::ParameterSet& parSet) : m_getToken(esConsumes()) {
   // empty
 }
 
 // loop over events
-void L1GtPsbSetupTester::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1GtPsbSetup> l1GtPsbSet;
-  evSetup.get<L1GtPsbSetupRcd>().get(l1GtPsbSet);
-
-  l1GtPsbSet->print(std::cout);
+void L1GtPsbSetupTester::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& evSetup) const {
+  evSetup.getData(m_getToken).print(std::cout);
   std::cout << std::endl;
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTester.cc
@@ -35,19 +35,13 @@
 // forward declarations
 
 // constructor(s)
-L1GtStableParametersTester::L1GtStableParametersTester(const edm::ParameterSet& parSet) {
-  // empty
-}
-
-// destructor
-L1GtStableParametersTester::~L1GtStableParametersTester() {
+L1GtStableParametersTester::L1GtStableParametersTester(const edm::ParameterSet& parSet) : m_l1GtParToken(esConsumes()) {
   // empty
 }
 
 // loop over events
-void L1GtStableParametersTester::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1GtStableParameters> l1GtPar;
-  evSetup.get<L1GtStableParametersRcd>().get(l1GtPar);
-
-  l1GtPar->print(std::cout);
+void L1GtStableParametersTester::analyze(edm::StreamID,
+                                         const edm::Event& iEvent,
+                                         const edm::EventSetup& evSetup) const {
+  evSetup.getData(m_l1GtParToken).print(std::cout);
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuTester.cc
@@ -64,18 +64,17 @@ L1GtTriggerMenuTester::L1GtTriggerMenuTester(const edm::ParameterSet& parSet)
       m_noThrowIncompatibleMenu(parSet.getParameter<bool>("NoThrowIncompatibleMenu")),
       m_printPfsRates(parSet.getParameter<bool>("PrintPfsRates")),
       m_indexPfSet(parSet.getParameter<int>("IndexPfSet")),
+      m_l1GtStableParToken(esConsumes<edm::Transition::BeginRun>()),
+      m_l1GtPfAlgoToken(esConsumes<edm::Transition::BeginRun>()),
+      m_l1GtPfTechToken(esConsumes<edm::Transition::BeginRun>()),
+      m_l1GtTmTechToken(esConsumes<edm::Transition::BeginRun>()),
+      m_l1GtTmVetoAlgoToken(esConsumes<edm::Transition::BeginRun>()),
+      m_l1GtTmVetoTechToken(esConsumes<edm::Transition::BeginRun>()),
+      m_l1GtMenuToken(esConsumes<edm::Transition::BeginRun>()),
       m_numberAlgorithmTriggers(0),
       m_numberTechnicalTriggers(0) {
   // empty
 }
-
-// destructor
-L1GtTriggerMenuTester::~L1GtTriggerMenuTester() {
-  // empty
-}
-
-// begin job
-void L1GtTriggerMenuTester::beginJob() {}
 
 // begin run
 void L1GtTriggerMenuTester::beginRun(const edm::Run& iRun, const edm::EventSetup& evSetup) {
@@ -123,32 +122,18 @@ void L1GtTriggerMenuTester::beginRun(const edm::Run& iRun, const edm::EventSetup
   printWiki();
 }
 
-// begin luminosity block
-void L1GtTriggerMenuTester::beginLuminosityBlock(const edm::LuminosityBlock& iLumiBlock,
-                                                 const edm::EventSetup& evSetup) {}
-
 // loop over events
 void L1GtTriggerMenuTester::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   // empty
 }
 
-// end luminosity block
-void L1GtTriggerMenuTester::endLuminosityBlock(const edm::LuminosityBlock& iLumiBlock, const edm::EventSetup& evSetup) {
-
-}
-
 // end run
 void L1GtTriggerMenuTester::endRun(const edm::Run&, const edm::EventSetup& evSetup) {}
-
-// end job
-void L1GtTriggerMenuTester::endJob() {}
 
 void L1GtTriggerMenuTester::retrieveL1EventSetup(const edm::EventSetup& evSetup) {
   // get / update the stable parameters from the EventSetup
 
-  edm::ESHandle<L1GtStableParameters> l1GtStablePar;
-  evSetup.get<L1GtStableParametersRcd>().get(l1GtStablePar);
-  m_l1GtStablePar = l1GtStablePar.product();
+  m_l1GtStablePar = &evSetup.getData(m_l1GtStableParToken);
 
   // number of algorithm triggers
   m_numberAlgorithmTriggers = m_l1GtStablePar->gtNumberPhysTriggers();
@@ -164,49 +149,35 @@ void L1GtTriggerMenuTester::retrieveL1EventSetup(const edm::EventSetup& evSetup)
 
   // get / update the prescale factors from the EventSetup
 
-  edm::ESHandle<L1GtPrescaleFactors> l1GtPfAlgo;
-  evSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().get(l1GtPfAlgo);
-  m_l1GtPfAlgo = l1GtPfAlgo.product();
+  m_l1GtPfAlgo = &evSetup.getData(m_l1GtPfAlgoToken);
 
   m_prescaleFactorsAlgoTrig = &(m_l1GtPfAlgo->gtPrescaleFactors());
 
-  edm::ESHandle<L1GtPrescaleFactors> l1GtPfTech;
-  evSetup.get<L1GtPrescaleFactorsTechTrigRcd>().get(l1GtPfTech);
-  m_l1GtPfTech = l1GtPfTech.product();
+  m_l1GtPfTech = &evSetup.getData(m_l1GtPfTechToken);
 
   m_prescaleFactorsTechTrig = &(m_l1GtPfTech->gtPrescaleFactors());
 
   // get / update the trigger mask from the EventSetup
 
-  edm::ESHandle<L1GtTriggerMask> l1GtTmAlgo;
-  evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().get(l1GtTmAlgo);
-  m_l1GtTmAlgo = l1GtTmAlgo.product();
+  m_l1GtTmAlgo = &evSetup.getData(m_l1GtTmAlgoToken);
 
   m_triggerMaskAlgoTrig = &(m_l1GtTmAlgo->gtTriggerMask());
 
-  edm::ESHandle<L1GtTriggerMask> l1GtTmTech;
-  evSetup.get<L1GtTriggerMaskTechTrigRcd>().get(l1GtTmTech);
-  m_l1GtTmTech = l1GtTmTech.product();
+  m_l1GtTmTech = &evSetup.getData(m_l1GtTmTechToken);
 
   m_triggerMaskTechTrig = &(m_l1GtTmTech->gtTriggerMask());
 
-  edm::ESHandle<L1GtTriggerMask> l1GtTmVetoAlgo;
-  evSetup.get<L1GtTriggerMaskVetoAlgoTrigRcd>().get(l1GtTmVetoAlgo);
-  m_l1GtTmVetoAlgo = l1GtTmVetoAlgo.product();
+  m_l1GtTmVetoAlgo = &evSetup.getData(m_l1GtTmVetoAlgoToken);
 
   m_triggerMaskVetoAlgoTrig = &(m_l1GtTmVetoAlgo->gtTriggerMask());
 
-  edm::ESHandle<L1GtTriggerMask> l1GtTmVetoTech;
-  evSetup.get<L1GtTriggerMaskVetoTechTrigRcd>().get(l1GtTmVetoTech);
-  m_l1GtTmVetoTech = l1GtTmVetoTech.product();
+  m_l1GtTmVetoTech = &evSetup.getData(m_l1GtTmVetoTechToken);
 
   m_triggerMaskVetoTechTrig = &(m_l1GtTmVetoTech->gtTriggerMask());
 
   // get / update the trigger menu from the EventSetup
 
-  edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
-  evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
-  m_l1GtMenu = l1GtMenu.product();
+  m_l1GtMenu = &evSetup.getData(m_l1GtMenuToken);
   m_algorithmMap = &(m_l1GtMenu->gtAlgorithmMap());
   m_algorithmAliasMap = &(m_l1GtMenu->gtAlgorithmAliasMap());
   m_technicalTriggerMap = &(m_l1GtMenu->gtTechnicalTriggerMap());

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlProducer.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlProducer.cc
@@ -41,7 +41,7 @@
 // constructor(s)
 L1GtTriggerMenuXmlProducer::L1GtTriggerMenuXmlProducer(const edm::ParameterSet& parSet) {
   // tell the framework what data is being produced
-  setWhatProduced(this, &L1GtTriggerMenuXmlProducer::produceGtTriggerMenu);
+  m_getToken = setWhatProduced(this, &L1GtTriggerMenuXmlProducer::produceGtTriggerMenu).consumes();
 
   // now do what ever other initialization is needed
 
@@ -81,10 +81,7 @@ L1GtTriggerMenuXmlProducer::~L1GtTriggerMenuXmlProducer() {
 std::unique_ptr<L1GtTriggerMenu> L1GtTriggerMenuXmlProducer::produceGtTriggerMenu(
     const L1GtTriggerMenuRcd& l1MenuRecord) {
   // get the parameters needed from other records
-  const L1GtStableParametersRcd& stableParametersRcd = l1MenuRecord.getRecord<L1GtStableParametersRcd>();
-
-  edm::ESHandle<L1GtStableParameters> stableParameters;
-  stableParametersRcd.get(stableParameters);
+  edm::ESHandle<L1GtStableParameters> stableParameters = l1MenuRecord.getHandle(m_getToken);
 
   unsigned int numberConditionChips = stableParameters->gtNumberConditionChips();
   unsigned int pinsOnConditionChip = stableParameters->gtPinsOnConditionChip();

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriter.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriter.cc
@@ -41,6 +41,7 @@ L1GtVhdlWriter::L1GtVhdlWriter(const edm::ParameterSet& parSet) {
   // directory in /data for the VHDL templates
   vhdlDir_ = parSet.getParameter<std::string>("VhdlTemplatesDir");
   outputDir_ = parSet.getParameter<std::string>("OutputDir");
+  menuToken_ = esConsumes();
 
   if (vhdlDir_[vhdlDir_.length() - 1] != '/')
     vhdlDir_ += "/";
@@ -58,18 +59,12 @@ L1GtVhdlWriter::L1GtVhdlWriter(const edm::ParameterSet& parSet) {
   edm::LogInfo("L1GtConfigProducers") << "\n\nL1 GT VHDL directory: " << vhdlDir_ << "\n\n" << std::endl;
 }
 
-// destructor
-L1GtVhdlWriter::~L1GtVhdlWriter() {
-  // empty
-}
-
 // loop over events
 void L1GtVhdlWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
-  evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
+  edm::ESHandle<L1GtTriggerMenu> l1GtMenu = evSetup.getHandle(menuToken_);
 
-  std::vector<ConditionMap> conditionMap = l1GtMenu->gtConditionMap();
-  AlgorithmMap algorithmMap = l1GtMenu->gtAlgorithmMap();
+  std::vector<ConditionMap> const& conditionMap = l1GtMenu->gtConditionMap();
+  AlgorithmMap const& algorithmMap = l1GtMenu->gtAlgorithmMap();
 
   // print with various level of verbosities
   int printVerbosity = 0;
@@ -88,6 +83,7 @@ void L1GtVhdlWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& ev
   headerParameters["designer_comments"] = "produced in CMSSW";
   headerParameters["gtl_setup_name"] = "L1Menu2007NovGR";
 
+  channelVector.reserve(10);
   channelVector.push_back("-- ca1: ieg");
   channelVector.push_back("-- ca2: eg");
   channelVector.push_back("-- ca3: jet");


### PR DESCRIPTION
#### PR description:

- changed to thread-friendly module types
- use ESGetTokens

#### PR validation:

Code compiles