### PR TITLE
EMTF emulator update to add support for Run 3 BDT LUTs

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2017.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2017.cc
@@ -24,9 +24,11 @@ float PtAssignmentEngine2017::scale_pt(const float pt, const int mode) const {
   // TRG       = 1.2*XML / (1 - 0.015*XML)
   // TRG / XML = 1.2 / (1 - 0.015*XML)
 
-  // First "physics" LUTs for 2017, deployed June 7
-  if (ptLUTVersion_ >= 6) {
-    pt_xml = fmin(20., pt);  // Maximum scale set by muons with XML pT = 20 GeV (scaled pT ~35 GeV)
+  if (ptLUTVersion_ > 7) {   // First "physics" LUTs for 2022, will be deployed in June 2022
+    pt_xml = fmin(20., pt);  // Maximum scale set by muons with XML pT = 20 GeV (scaled pT ~32 GeV)
+    pt_scale = 1.13 / (1 - 0.015 * pt_xml);
+  } else if (ptLUTVersion_ >= 6) {  // First "physics" LUTs for 2017, deployed June 7
+    pt_xml = fmin(20., pt);         // Maximum scale set by muons with XML pT = 20 GeV (scaled pT ~35 GeV)
     pt_scale = 1.2 / (1 - 0.015 * pt_xml);
   }
 
@@ -38,8 +40,10 @@ float PtAssignmentEngine2017::unscale_pt(const float pt, const int mode) const {
 
   float pt_unscale = -99;
 
-  // First "physics" LUTs for 2017, deployed June 7
-  if (ptLUTVersion_ >= 6) {
+  if (ptLUTVersion_ > 7) {  // First "physics" LUTs for 2022, will be deployed in June 2022
+    pt_unscale = 1 / (1.13 + 0.015 * pt);
+    pt_unscale = fmax(pt_unscale, (1 - 0.015 * 20) / 1.13);
+  } else if (ptLUTVersion_ >= 6) {  // First "physics" LUTs for 2017, deployed June 7
     pt_unscale = 1 / (1.2 + 0.015 * pt);
     pt_unscale = fmax(pt_unscale, (1 - 0.015 * 20) / 1.2);
   }
@@ -461,11 +465,13 @@ float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address) const {
   forest.predictEvent(tree_event.get(), 400);
 
   // // Adjust this for different XMLs
-  // float log2_pt = tree_event->predictedValue;
-  // pt_xml = pow(2, fmax(0.0, log2_pt)); // Protect against negative values
-
-  float inv_pt = tree_event->predictedValue;
-  pt_xml = 1.0 / fmax(0.001, inv_pt);  // Protect against negative values
+  if (ptLUTVersion_ > 7) {  // Run 3 2022 BDT uses log2(pT) target
+    float log2_pt = tree_event->predictedValue;
+    pt_xml = pow(2, fmax(0.0, log2_pt));  // Protect against negative values
+  } else if (ptLUTVersion_ >= 6) {        // Run 2 2017/2018 BDTs use 1/pT target
+    float inv_pt = tree_event->predictedValue;
+    pt_xml = 1.0 / fmax(0.001, inv_pt);  // Protect against negative values
+  }
 
   return pt_xml;
 
@@ -656,11 +662,13 @@ float PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track) const {
   forest.predictEvent(tree_event.get(), 400);
 
   // // Adjust this for different XMLs
-  // float log2_pt = tree_event->predictedValue;
-  // pt_xml = pow(2, fmax(0.0, log2_pt)); // Protect against negative values
-
-  float inv_pt = tree_event->predictedValue;
-  pt_xml = 1.0 / fmax(0.001, inv_pt);  // Protect against negative values
+  if (ptLUTVersion_ > 7) {  // Run 3 2022 BDT uses log2(pT) target
+    float log2_pt = tree_event->predictedValue;
+    pt_xml = pow(2, fmax(0.0, log2_pt));  // Protect against negative values
+  } else if (ptLUTVersion_ >= 6) {        // Run 2 2017/2018 BDTs use 1/pT target
+    float inv_pt = tree_event->predictedValue;
+    pt_xml = 1.0 / fmax(0.001, inv_pt);  // Protect against negative values
+  }
 
   return pt_xml;
 

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2017.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2017.cc
@@ -24,7 +24,7 @@ float PtAssignmentEngine2017::scale_pt(const float pt, const int mode) const {
   // TRG       = 1.2*XML / (1 - 0.015*XML)
   // TRG / XML = 1.2 / (1 - 0.015*XML)
 
-  if (ptLUTVersion_ > 7) {   // First "physics" LUTs for 2022, will be deployed in June 2022
+  if (ptLUTVersion_ >= 8) {   // First "physics" LUTs for 2022, will be deployed in June 2022
     pt_xml = fmin(20., pt);  // Maximum scale set by muons with XML pT = 20 GeV (scaled pT ~32 GeV)
     pt_scale = 1.13 / (1 - 0.015 * pt_xml);
   } else if (ptLUTVersion_ >= 6) {  // First "physics" LUTs for 2017, deployed June 7
@@ -40,7 +40,7 @@ float PtAssignmentEngine2017::unscale_pt(const float pt, const int mode) const {
 
   float pt_unscale = -99;
 
-  if (ptLUTVersion_ > 7) {  // First "physics" LUTs for 2022, will be deployed in June 2022
+  if (ptLUTVersion_ >= 8) {  // First "physics" LUTs for 2022, will be deployed in June 2022
     pt_unscale = 1 / (1.13 + 0.015 * pt);
     pt_unscale = fmax(pt_unscale, (1 - 0.015 * 20) / 1.13);
   } else if (ptLUTVersion_ >= 6) {  // First "physics" LUTs for 2017, deployed June 7
@@ -465,7 +465,7 @@ float PtAssignmentEngine2017::calculate_pt_xml(const address_t& address) const {
   forest.predictEvent(tree_event.get(), 400);
 
   // // Adjust this for different XMLs
-  if (ptLUTVersion_ > 7) {  // Run 3 2022 BDT uses log2(pT) target
+  if (ptLUTVersion_ >= 8) {  // Run 3 2022 BDT uses log2(pT) target
     float log2_pt = tree_event->predictedValue;
     pt_xml = pow(2, fmax(0.0, log2_pt));  // Protect against negative values
   } else if (ptLUTVersion_ >= 6) {        // Run 2 2017/2018 BDTs use 1/pT target
@@ -662,7 +662,7 @@ float PtAssignmentEngine2017::calculate_pt_xml(const EMTFTrack& track) const {
   forest.predictEvent(tree_event.get(), 400);
 
   // // Adjust this for different XMLs
-  if (ptLUTVersion_ > 7) {  // Run 3 2022 BDT uses log2(pT) target
+  if (ptLUTVersion_ >= 8) {  // Run 3 2022 BDT uses log2(pT) target
     float log2_pt = tree_event->predictedValue;
     pt_xml = pow(2, fmax(0.0, log2_pt));  // Protect against negative values
   } else if (ptLUTVersion_ >= 6) {        // Run 2 2017/2018 BDTs use 1/pT target

--- a/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2017.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PtAssignmentEngine2017.cc
@@ -24,7 +24,7 @@ float PtAssignmentEngine2017::scale_pt(const float pt, const int mode) const {
   // TRG       = 1.2*XML / (1 - 0.015*XML)
   // TRG / XML = 1.2 / (1 - 0.015*XML)
 
-  if (ptLUTVersion_ >= 8) {   // First "physics" LUTs for 2022, will be deployed in June 2022
+  if (ptLUTVersion_ >= 8) {  // First "physics" LUTs for 2022, will be deployed in June 2022
     pt_xml = fmin(20., pt);  // Maximum scale set by muons with XML pT = 20 GeV (scaled pT ~32 GeV)
     pt_scale = 1.13 / (1 - 0.015 * pt_xml);
   } else if (ptLUTVersion_ >= 6) {  // First "physics" LUTs for 2017, deployed June 7


### PR DESCRIPTION
#### PR description:

This PR adds support for the new EMTF BDT training for the start of Run 3. The new LUTs are not yet ready, but once they are ready they will be assigned `ptLUTVersion_ = 8` which will make the emulator use the correct functions for pT scaling and pT conversion. 

There is no change in behaviour when using the older versions of pT LUTs.

#### PR validation:

Validated with `runTheMatrix.py -l limited -i all --ibeos`

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@jrotter2 