### PR TITLE
EMTF emulator update to make BDT tree loading safer

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
@@ -453,7 +453,7 @@ void Tree::loadFromXML(const char* filename) {
   // I choose to identify the format by checking the top xml node name that is a "BinaryTree" in 2017
   if (std::string("BinaryTree") == xml->GetNodeName(mainnode)) {
     XMLAttrPointer_t attr = xml->GetFirstAttr(mainnode);
-    while(std::string("boostWeight") != xml->GetAttrName(attr)) {
+    while (std::string("boostWeight") != xml->GetAttrName(attr)) {
       attr = xml->GetNextAttr(attr);
     }
     boostWeight = (attr ? strtod(xml->GetAttrValue(attr), nullptr) : 0);
@@ -480,13 +480,13 @@ void Tree::loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t xnode, Node* t
   std::vector<std::string> splitInfo(3);
   if (xmlVersion >= 2017) {
     for (unsigned int i = 0; i < 10; i++) {
-      if(std::string("IVar") == xml->GetAttrName(attr)) {
+      if (std::string("IVar") == xml->GetAttrName(attr)) {
         splitInfo[0] = xml->GetAttrValue(attr);
       }
-      if(std::string("Cut") == xml->GetAttrName(attr)) {
+      if (std::string("Cut") == xml->GetAttrName(attr)) {
         splitInfo[1] = xml->GetAttrValue(attr);
       }
-      if(std::string("res") == xml->GetAttrName(attr)) {
+      if (std::string("res") == xml->GetAttrName(attr)) {
         splitInfo[2] = xml->GetAttrValue(attr);
       }
       attr = xml->GetNextAttr(attr);

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
@@ -453,7 +453,9 @@ void Tree::loadFromXML(const char* filename) {
   // I choose to identify the format by checking the top xml node name that is a "BinaryTree" in 2017
   if (std::string("BinaryTree") == xml->GetNodeName(mainnode)) {
     XMLAttrPointer_t attr = xml->GetFirstAttr(mainnode);
-    attr = xml->GetNextAttr(attr);
+    while(std::string("boostWeight") != xml->GetAttrName(attr)) {
+      attr = xml->GetNextAttr(attr);
+    }
     boostWeight = (attr ? strtod(xml->GetAttrValue(attr), nullptr) : 0);
     // step inside the top-level xml node
     mainnode = xml->GetChild(mainnode);
@@ -478,8 +480,14 @@ void Tree::loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t xnode, Node* t
   std::vector<std::string> splitInfo(3);
   if (xmlVersion >= 2017) {
     for (unsigned int i = 0, j = 0; i < 10; i++) {
-      if (i == 3 || i == 4 || i == 6) {
-        splitInfo[j++] = xml->GetAttrValue(attr);
+      if(std::string("IVar") == xml->GetAttrName(attr)) {
+        splitInfo[0] = xml->GetAttrValue(attr);
+      }
+      if(std::string("Cut") == xml->GetAttrName(attr)) {
+        splitInfo[1] = xml->GetAttrValue(attr);
+      }
+      if(std::string("res") == xml->GetAttrName(attr)) {
+        splitInfo[2] = xml->GetAttrValue(attr);
       }
       attr = xml->GetNextAttr(attr);
     }

--- a/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
+++ b/L1Trigger/L1TMuonEndCap/src/bdt/Tree.cc
@@ -479,7 +479,7 @@ void Tree::loadFromXMLRecursive(TXMLEngine* xml, XMLNodePointer_t xnode, Node* t
   XMLAttrPointer_t attr = xml->GetFirstAttr(xnode);
   std::vector<std::string> splitInfo(3);
   if (xmlVersion >= 2017) {
-    for (unsigned int i = 0, j = 0; i < 10; i++) {
+    for (unsigned int i = 0; i < 10; i++) {
       if(std::string("IVar") == xml->GetAttrName(attr)) {
         splitInfo[0] = xml->GetAttrValue(attr);
       }


### PR DESCRIPTION
#### PR description:

This PR modifies the `Tree::loadFromXML` to make it safer to use with new XMLs. The old method was using a specific order of attributes which is not necessarily the case in general. The change makes it such that we check the name of the attribute before getting the value. 

This PR has no effect on normal CMSSW workflows. This method is only used by experts when making new BDT LUTs.   

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Code compiles and runs. Validated with the private code for loading XML files and it works as expected. 

This is not used in normal emulator behaviour, so it shouldn't affect anything else.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

@jrotter2 
