### PR TITLE
Fixed CMS deprecation warnings in L1TriggerConfig/RPCTriggerConfig

### DIFF
--- a/L1TriggerConfig/RPCTriggerConfig/test/DumpConeDefinition.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/test/DumpConeDefinition.cc
@@ -22,7 +22,7 @@
 #include "CondFormats/DataRecord/interface/L1RPCConeDefinitionRcd.h"
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,17 +41,15 @@
 // class decleration
 //
 
-class DumpConeDefinition : public edm::EDAnalyzer {
+class DumpConeDefinition : public edm::global::EDAnalyzer<> {
 public:
   explicit DumpConeDefinition(const edm::ParameterSet&);
-  ~DumpConeDefinition();
 
 private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<L1RPCConeDefinition, L1RPCConeDefinitionRcd> getToken_;
 };
 
 //
@@ -66,14 +64,10 @@ private:
 // constructors and destructor
 //
 DumpConeDefinition::DumpConeDefinition(const edm::ParameterSet& iConfig)
+    : getToken_(esConsumes())
 
 {
   //now do what ever initialization is needed
-}
-
-DumpConeDefinition::~DumpConeDefinition() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -81,14 +75,13 @@ DumpConeDefinition::~DumpConeDefinition() {
 //
 
 // ------------ method called to for each event  ------------
-void DumpConeDefinition::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void DumpConeDefinition::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
-  edm::ESHandle<L1RPCConeDefinition> l1RPCConeDefinition;
-  iSetup.get<L1RPCConeDefinitionRcd>().get(l1RPCConeDefinition);
+  L1RPCConeDefinition const& l1RPCConeDefinition = iSetup.getData(getToken_);
 
-  L1RPCConeDefinition::TLPSizeVec::const_iterator it = l1RPCConeDefinition->getLPSizeVec().begin();
-  L1RPCConeDefinition::TLPSizeVec::const_iterator itEnd = l1RPCConeDefinition->getLPSizeVec().end();
+  L1RPCConeDefinition::TLPSizeVec::const_iterator it = l1RPCConeDefinition.getLPSizeVec().begin();
+  L1RPCConeDefinition::TLPSizeVec::const_iterator itEnd = l1RPCConeDefinition.getLPSizeVec().end();
 
   LogTrace("DumpConeDefinition") << std::endl;
 
@@ -101,21 +94,15 @@ void DumpConeDefinition::analyze(const edm::Event& iEvent, const edm::EventSetup
   }
 
   LogTrace("DumpConeDefinition") << "\nRing to tower connections dump: \n" << std::endl;
-  L1RPCConeDefinition::TRingToTowerVec::const_iterator itR = l1RPCConeDefinition->getRingToTowerVec().begin();
+  L1RPCConeDefinition::TRingToTowerVec::const_iterator itR = l1RPCConeDefinition.getRingToTowerVec().begin();
 
-  const L1RPCConeDefinition::TRingToTowerVec::const_iterator itREnd = l1RPCConeDefinition->getRingToTowerVec().end();
+  const L1RPCConeDefinition::TRingToTowerVec::const_iterator itREnd = l1RPCConeDefinition.getRingToTowerVec().end();
 
   for (; itR != itREnd; ++itR) {
     LogTrace("DumpConeDefinition") << "EP " << (int)itR->m_etaPart << " hwPL " << (int)itR->m_hwPlane << " tw "
                                    << (int)itR->m_tower << " index " << (int)itR->m_index << std::endl;
   }
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void DumpConeDefinition::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void DumpConeDefinition::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(DumpConeDefinition);

--- a/L1TriggerConfig/RPCTriggerConfig/test/DumpL1RPCBxOrConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/test/DumpL1RPCBxOrConfig.cc
@@ -17,7 +17,7 @@
 #include "CondFormats/DataRecord/interface/L1RPCBxOrConfigRcd.h"
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,17 +33,15 @@
 // class decleration
 //
 
-class DumpL1RPCBxOrConfig : public edm::EDAnalyzer {
+class DumpL1RPCBxOrConfig : public edm::global::EDAnalyzer<> {
 public:
   explicit DumpL1RPCBxOrConfig(const edm::ParameterSet&);
-  ~DumpL1RPCBxOrConfig();
 
 private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
+  edm::ESGetToken<L1RPCBxOrConfig, L1RPCBxOrConfigRcd> getToken_;
 };
 
 //
@@ -58,14 +56,10 @@ private:
 // constructors and destructor
 //
 DumpL1RPCBxOrConfig::DumpL1RPCBxOrConfig(const edm::ParameterSet& iConfig)
+    : getToken_(esConsumes())
 
 {
   //now do what ever initialization is needed
-}
-
-DumpL1RPCBxOrConfig::~DumpL1RPCBxOrConfig() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -73,25 +67,18 @@ DumpL1RPCBxOrConfig::~DumpL1RPCBxOrConfig() {
 //
 
 // ------------ method called to for each event  ------------
-void DumpL1RPCBxOrConfig::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void DumpL1RPCBxOrConfig::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
-  edm::ESHandle<L1RPCBxOrConfig> bxOrConfig;
-  iSetup.get<L1RPCBxOrConfigRcd>().get(bxOrConfig);
+  L1RPCBxOrConfig const& bxOrConfig = iSetup.getData(getToken_);
 
   LogTrace("DumpL1RPCBxOrConfig") << std::endl;
   LogDebug("DumpL1RPCBxOrConfig") << "\n\n Printing L1RPCBxOrConfigRcd record\n" << std::endl;
   LogTrace("DumpL1RPCBxOrConfig") << "\nChecking BX Or settings: \n" << std::endl;
 
-  LogTrace("DumpL1RPCBxOrConfig") << "First BX : " << bxOrConfig->getFirstBX()
-                                  << ", Last BX : " << bxOrConfig->getLastBX() << std::endl;
+  LogTrace("DumpL1RPCBxOrConfig") << "First BX : " << bxOrConfig.getFirstBX()
+                                  << ", Last BX : " << bxOrConfig.getLastBX() << std::endl;
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void DumpL1RPCBxOrConfig::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void DumpL1RPCBxOrConfig::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(DumpL1RPCBxOrConfig);

--- a/L1TriggerConfig/RPCTriggerConfig/test/DumpL1RPCConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/test/DumpL1RPCConfig.cc
@@ -22,7 +22,7 @@
 #include "CondFormats/DataRecord/interface/L1RPCConfigRcd.h"
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -38,17 +38,15 @@
 // class decleration
 //
 
-class DumpL1RPCConfig : public edm::EDAnalyzer {
+class DumpL1RPCConfig : public edm::global::EDAnalyzer<> {
 public:
   explicit DumpL1RPCConfig(const edm::ParameterSet&);
-  ~DumpL1RPCConfig();
 
 private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
+  edm::ESGetToken<L1RPCConfig, L1RPCConfigRcd> getToken_;
 };
 
 //
@@ -63,14 +61,10 @@ private:
 // constructors and destructor
 //
 DumpL1RPCConfig::DumpL1RPCConfig(const edm::ParameterSet& iConfig)
+    : getToken_(esConsumes())
 
 {
   //now do what ever initialization is needed
-}
-
-DumpL1RPCConfig::~DumpL1RPCConfig() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -78,11 +72,10 @@ DumpL1RPCConfig::~DumpL1RPCConfig() {
 //
 
 // ------------ method called to for each event  ------------
-void DumpL1RPCConfig::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void DumpL1RPCConfig::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
-  edm::ESHandle<L1RPCConfig> l1RPCConfig;
-  iSetup.get<L1RPCConfigRcd>().get(l1RPCConfig);
+  edm::ESHandle<L1RPCConfig> l1RPCConfig = iSetup.getHandle(getToken_);
 
   LogTrace("DumpL1RPCConfig") << std::endl;
   LogDebug("DumpL1RPCConfig") << "\n Printing L1RPCConfigRcd record\n" << std::endl;
@@ -114,12 +107,6 @@ void DumpL1RPCConfig::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     }
   }
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void DumpL1RPCConfig::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void DumpL1RPCConfig::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(DumpL1RPCConfig);

--- a/L1TriggerConfig/RPCTriggerConfig/test/DumpL1RPCHsbConfig.cc
+++ b/L1TriggerConfig/RPCTriggerConfig/test/DumpL1RPCHsbConfig.cc
@@ -17,7 +17,7 @@
 #include "CondFormats/DataRecord/interface/L1RPCHsbConfigRcd.h"
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,17 +33,15 @@
 // class decleration
 //
 
-class DumpL1RPCHsbConfig : public edm::EDAnalyzer {
+class DumpL1RPCHsbConfig : public edm::global::EDAnalyzer<> {
 public:
   explicit DumpL1RPCHsbConfig(const edm::ParameterSet&);
-  ~DumpL1RPCHsbConfig();
 
 private:
-  virtual void beginJob();
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob();
+  void analyze(edm::StreamID, const edm::Event&, const edm::EventSetup&) const override;
 
   // ----------member data ---------------------------
+  edm::ESGetToken<L1RPCHsbConfig, L1RPCHsbConfigRcd> getToken_;
 };
 
 //
@@ -58,14 +56,10 @@ private:
 // constructors and destructor
 //
 DumpL1RPCHsbConfig::DumpL1RPCHsbConfig(const edm::ParameterSet& iConfig)
+    : getToken_(esConsumes())
 
 {
   //now do what ever initialization is needed
-}
-
-DumpL1RPCHsbConfig::~DumpL1RPCHsbConfig() {
-  // do anything here that needs to be done at desctruction time
-  // (e.g. close files, deallocate resources etc.)
 }
 
 //
@@ -73,11 +67,10 @@ DumpL1RPCHsbConfig::~DumpL1RPCHsbConfig() {
 //
 
 // ------------ method called to for each event  ------------
-void DumpL1RPCHsbConfig::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void DumpL1RPCHsbConfig::analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   using namespace edm;
 
-  edm::ESHandle<L1RPCHsbConfig> hsbConfig;
-  iSetup.get<L1RPCHsbConfigRcd>().get(hsbConfig);
+  edm::ESHandle<L1RPCHsbConfig> hsbConfig = iSetup.getHandle(getToken_);
 
   LogTrace("DumpL1RPCHsbConfig") << std::endl;
   LogDebug("DumpL1RPCHsbConfig") << "\n\n Printing L1RPCHsbConfigRcd record\n" << std::endl;
@@ -95,12 +88,6 @@ void DumpL1RPCHsbConfig::analyze(const edm::Event& iEvent, const edm::EventSetup
     LogTrace("DumpL1RPCHsbConfig") << " Input " << i << " " << hsbConfig->getHsbMask(1, i) << " ";
   }
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void DumpL1RPCHsbConfig::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void DumpL1RPCHsbConfig::endJob() {}
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(DumpL1RPCHsbConfig);


### PR DESCRIPTION
#### PR description:

- changed to thread-friendly module types
- added esConsumes

#### PR validation:

Compilation no longer emits deprecation warnings.