### PR TITLE
checkImportPermission: Fix needed due to new build rules

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -41,7 +41,7 @@ def checkImportPermission(minLevel = 2, allowedPatterns = []):
     import inspect
     import os
 
-    ignorePatterns = ['FWCore/ParameterSet/Config.py','<string>','<frozen ']
+    ignorePatterns = ['FWCore/ParameterSet/Config.py', 'FWCore/ParameterSet/python/Config.py','<string>','<frozen ']
     CMSSWPath = [os.environ['CMSSW_BASE'],os.environ['CMSSW_RELEASE_BASE']]
 
     # Filter the stack to things in CMSSWPath and not in ignorePatterns


### PR DESCRIPTION
This update is needed for new build rules for cmssw python ( which are currently available in CMSSW_12_4_PY_X IBs).

We are in process of changing build rules for `cmssw python` so that scram does not create `python/SubSystem/Package` symlink to `src/SubSystem/Package/python` and also does not generate `__init__.py` files in cmssw src tree ( see https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html ). The new build rules now do not change any file under cmssw src tree and still allows developers to create/modify `src/SubSystem/Package/python/*.py`  files and use those without re-running `scram build`. 

Side effect of this change is that now cmssw python import paths are `cmssw/src/SubSystem/Package/python/module_cfi.py` instead of `cmssw/python/SubSystem/Package/module_cfi.py` due to which unit test `TestIntegrationParameterSet` is failing. This change should fix the unit test failure for CMSSW_12_4_PY_X IBs.