### PR TITLE
[DB-DQM][BuildFile] Use ifarch instead of ifarchitecture to match system arch only.

### DIFF
--- a/DQM/BeamMonitor/plugins/BuildFile.xml
+++ b/DQM/BeamMonitor/plugins/BuildFile.xml
@@ -56,10 +56,10 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
-<ifarchitecture name="_amd64_">
+<ifarch value="x86_64">
 <library file="BeamSpotDipServer.cc" name="BeamSpotDipServer">
   <use name="dip"/>
   <use name="log4cplus"/>
   <flags EDM_PLUGIN="1"/>
 </library>
-</ifarchitecture>
+</ifarch>


### PR DESCRIPTION
BuildFile cleanup: Use `ifarch` to match the exact arch