### PR TITLE
[GENERATORS][BuildFile] Remove ref to old slc5 arch

### DIFF
--- a/GeneratorInterface/Pythia6Interface/plugins/BuildFile.xml
+++ b/GeneratorInterface/Pythia6Interface/plugins/BuildFile.xml
@@ -1,7 +1,4 @@
 <use name="GeneratorInterface/Pythia6Interface"/>
-<architecture name="slc5_amd64_gcc47">
-  <use name="pydata"/>
-</architecture>
 <architecture name="osx">
   <use name="pydata"/>
 </architecture>


### PR DESCRIPTION
BuildFile cleanup: Remove ref to old `slc5` arch