### PR TITLE
[HLT][BuildFile] Remove ref to old slc6 arch

### DIFF
--- a/HLTrigger/Tools/bin/BuildFile.xml
+++ b/HLTrigger/Tools/bin/BuildFile.xml
@@ -1,6 +1,3 @@
-<architecture name="slc6_amd64">
-  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
-</architecture>
 <bin name="hltTimingSummary" file="hltTimingSummary.cpp">
   <flags NO_TESTRUN="1"/>
   <use name="boost"/>


### PR DESCRIPTION
BuildFile cleanup: Remove ref to old `slc6` arch