### PR TITLE
[CORE][BuildFile] Remove ref to old slc6 arch

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -1,6 +1,3 @@
-<architecture name="slc6_amd64">
-  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
-</architecture>
 <bin name="cmsRunGlibC" file="cmsRun.cpp">
   <use name="roothistmatrix"/>
   <use name="tbb"/>

--- a/FWCore/ParameterSet/bin/BuildFile.xml
+++ b/FWCore/ParameterSet/bin/BuildFile.xml
@@ -1,6 +1,3 @@
-<architecture name="slc6_amd64">
-  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
-</architecture>
 <use name="boost"/>
 <use name="FWCore/ParameterSet"/>
 <bin file="edmPluginHelp.cpp">

--- a/FWCore/PluginManager/bin/BuildFile.xml
+++ b/FWCore/PluginManager/bin/BuildFile.xml
@@ -1,6 +1,3 @@
-<architecture name="slc6_amd64">
-  <flags LDFLAGS="-Wl,-dynamic-linker,$(GLIBC_BASE)/lib64/ld.so"/>
-</architecture>
 <bin name="edmPluginDump" file="dump.cc">
   <use name="boost"/>
   <use name="boost_program_options"/>


### PR DESCRIPTION
BuildFile cleanup: Remove ref to old `slc6` arch