### PR TITLE
[DB][BuildFile] Use ifarch instead of ifarchitecture to match system arch only.

### DIFF
--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -41,10 +41,10 @@
 <bin file="testGroupSelection.cpp" name="testGroupSelection">
 </bin>
 
-<architecture name="(slc|cc).*_amd64_.*">
+<ifarch value="x86_64">
   <bin file="testConnectionPool.cpp" name="testConnectionPool">
     <use name="CondFormats/RunInfo"/>
   </bin>
 
   <test name="condTestRegression" command="condTestRegression.py"/>
-</architecture>
+</ifarch>

--- a/CondTools/Ecal/test/BuildFile.xml
+++ b/CondTools/Ecal/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="CondTools/Ecal"/>
-<architecture name="(slc|cc).*_amd64_.*">
+<ifarch value="x86_64">
   <ifcxx11_abi value="1">
     <flags SETENV="LD_PRELOAD=$(CMS_ORACLEOCCI_LIB)"/>
   </ifcxx11_abi>
@@ -24,4 +24,4 @@
   <test name="EcalTPGTowerStatus_O2O_test" command="EcalTPGTowerStatus_O2O_test.sh"/>
   <test name="EcalADCToGeV_update_test" command="EcalADCToGeV_update_test.sh"/>
   <test name="EcalIntercalibConstants_O2O_test" command="EcalIntercalibConstants_O2O_test.sh"/>
-</architecture>
+</ifarch>

--- a/CondTools/RunInfo/test/BuildFile.xml
+++ b/CondTools/RunInfo/test/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="CondTools/RunInfo"/>
-<architecture name="(slc|cc).*_amd64_.*">
+<ifarch value="x86_64">
   <use name="py3-sqlalchemy"/>
   <test name="RunInfoStart_O2O_test" command="RunInfoStart_O2O_test.sh"/>
-</architecture>
+</ifarch>
 <test name="CondToolsRunInfoTest" command="test_runinfo.sh"/>

--- a/CondTools/SiStrip/test/BuildFile.xml
+++ b/CondTools/SiStrip/test/BuildFile.xml
@@ -1,10 +1,10 @@
-<architecture name="(slc|cc).*_amd64_.*">
+<ifarch value="x86_64">
   <ifcxx11_abi value="1">
     <flags SETENV="LD_PRELOAD=$(CMS_ORACLEOCCI_LIB)"/>
   </ifcxx11_abi>
   <test name="SiStripDCS_O2O_test" command="testSiStripDCSO2O.sh"/>
   <test name="SiStripDAQ_O2O_test" command="testSiStripDAQO2O.sh"/>
-</architecture>
+</ifarch>
 
 <bin file="runTests.cpp" name="testCondToolsSiStripBuildersReaders">
   <use name="FWCore/Utilities"/>

--- a/OnlineDB/Oracle/test/BuildFile.xml
+++ b/OnlineDB/Oracle/test/BuildFile.xml
@@ -1,7 +1,6 @@
-<architecture name="_amd64_">
+<ifarch value="x86_64">
   <bin name="test_occi_std_length" file="test.cpp">
     <use name="oracleocci"/>
     <flags TEST_RUNNER_ARGS="12154"/>
   </bin>
-
-</architecture>
+</ifarch>


### PR DESCRIPTION
BuildFile cleanup: Use ifarch to match the exact arch