### PR TITLE
Fix Tracker Alignment Payload writing 

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/test/AlignmentRcdChecker.cpp
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/AlignmentRcdChecker.cpp
@@ -1,0 +1,149 @@
+// \file AlignmentRcdChecker.cpp
+//
+// \author    : Marco Musich
+// Revision   : $Revision: 1.1 $
+// last update: $Date: 2022/05/11 14:44:00 $
+// by         : $Author: musich $
+
+// system includes
+#include <string>
+#include <map>
+#include <vector>
+
+// user includes
+#include "CondFormats/Alignment/interface/AlignTransform.h"
+#include "CondFormats/Alignment/interface/Alignments.h"
+#include "CondFormats/AlignmentRecord/interface/CSCAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/DTAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/TrackerAlignmentRcd.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+// ROOT includes
+#include <TMath.h>
+
+class AlignmentRcdChecker : public edm::one::EDAnalyzer<> {
+public:
+  explicit AlignmentRcdChecker(const edm::ParameterSet& iConfig);
+  ~AlignmentRcdChecker() = default;
+
+  virtual void analyze(const edm::Event& evt, const edm::EventSetup& evtSetup);
+
+private:
+  void inspectRecord(const std::string& rcdname,
+                     const edm::Event& evt,
+                     const Alignments* refAlignments,
+                     const Alignments* alignments);
+
+  bool verbose_;
+  bool compareStrict_;
+  std::string label_;
+
+  const edm::ESGetToken<Alignments, TrackerAlignmentRcd> tkAliTokenRef_;
+  const edm::ESGetToken<Alignments, TrackerAlignmentRcd> tkAliTokenNew_;
+};
+
+AlignmentRcdChecker::AlignmentRcdChecker(const edm::ParameterSet& iConfig)
+    : verbose_(iConfig.getParameter<bool>("verbose")),
+      compareStrict_(iConfig.getParameter<bool>("compareStrict")),
+      label_(iConfig.getParameter<std::string>("label")),
+      tkAliTokenRef_(esConsumes()),
+      tkAliTokenNew_(esConsumes(edm::ESInputTag{"", label_})) {}
+
+void AlignmentRcdChecker::analyze(const edm::Event& evt, const edm::EventSetup& evtSetup) {
+  const Alignments* alignmentsRef = &evtSetup.getData(tkAliTokenRef_);
+  const Alignments* alignmentsNew = &evtSetup.getData(tkAliTokenNew_);
+  inspectRecord("TrackerAlignmentRcd", evt, alignmentsRef, alignmentsNew);
+}
+
+void AlignmentRcdChecker::inspectRecord(const std::string& rcdname,
+                                        const edm::Event& evt,
+                                        const Alignments* refAlignments,
+                                        const Alignments* alignments) {
+  edm::LogPrint("inspectRecord") << rcdname << " content starting from run " << evt.run();
+  edm::LogPrint("inspectRecord") << " with " << alignments->m_align.size() << " entries";
+
+  if (refAlignments && alignments) {
+    double meanX = 0;
+    double rmsX = 0;
+    double meanY = 0;
+    double rmsY = 0;
+    double meanZ = 0;
+    double rmsZ = 0;
+    double meanR = 0;
+    double rmsR = 0;
+    double dPhi;
+    double meanPhi = 0;
+    double rmsPhi = 0;
+
+    std::vector<AlignTransform>::const_iterator iref = refAlignments->m_align.begin();
+    for (std::vector<AlignTransform>::const_iterator i = alignments->m_align.begin(); i != alignments->m_align.end();
+         ++i, ++iref) {
+      meanX += i->translation().x() - iref->translation().x();
+      rmsX += pow(i->translation().x() - iref->translation().x(), 2);
+
+      meanY += i->translation().y() - iref->translation().y();
+      rmsY += pow(i->translation().y() - iref->translation().y(), 2);
+
+      meanZ += i->translation().z() - iref->translation().z();
+      rmsZ += pow(i->translation().z() - iref->translation().z(), 2);
+
+      meanR += i->translation().perp() - iref->translation().perp();
+      rmsR += pow(i->translation().perp() - iref->translation().perp(), 2);
+
+      dPhi = i->translation().phi() - iref->translation().phi();
+      if (dPhi > M_PI)
+        dPhi -= 2.0 * M_PI;
+      if (dPhi < -M_PI)
+        dPhi += 2.0 * M_PI;
+
+      meanPhi += dPhi;
+      rmsPhi += dPhi * dPhi;
+    }
+
+    meanX /= alignments->m_align.size();
+    rmsX /= alignments->m_align.size();
+    meanY /= alignments->m_align.size();
+    rmsY /= alignments->m_align.size();
+    meanZ /= alignments->m_align.size();
+    rmsZ /= alignments->m_align.size();
+    meanR /= alignments->m_align.size();
+    rmsR /= alignments->m_align.size();
+    meanPhi /= alignments->m_align.size();
+    rmsPhi /= alignments->m_align.size();
+
+    if (verbose_) {
+      edm::LogPrint("inspectRecord") << "  Compared to previous record:";
+      edm::LogPrint("inspectRecord") << "    mean X shift:   " << std::setw(12) << std::scientific
+                                     << std::setprecision(3) << meanX << " (RMS = " << sqrt(rmsX) << ")";
+      edm::LogPrint("inspectRecord") << "    mean Y shift:   " << std::setw(12) << std::scientific
+                                     << std::setprecision(3) << meanY << " (RMS = " << sqrt(rmsY) << ")";
+      edm::LogPrint("inspectRecord") << "    mean Z shift:   " << std::setw(12) << std::scientific
+                                     << std::setprecision(3) << meanZ << " (RMS = " << sqrt(rmsZ) << ")";
+      edm::LogPrint("inspectRecord") << "    mean R shift:   " << std::setw(12) << std::scientific
+                                     << std::setprecision(3) << meanR << " (RMS = " << sqrt(rmsR) << ")";
+      edm::LogPrint("inspectRecord") << "    mean Phi shift: " << std::setw(12) << std::scientific
+                                     << std::setprecision(3) << meanPhi << " (RMS = " << sqrt(rmsPhi) << ")";
+    }  // verbose
+
+    if (compareStrict_) {
+      // do not let any of the coordinates to fluctuate less then 1um
+      assert(meanX < 1e-4);
+      assert(meanY < 1e-4);
+      assert(meanZ < 1e-4);
+      assert(meanR < 1e-4);
+      assert(meanPhi < 1e-4);
+    }
+
+  } else {
+    throw cms::Exception("Missing Input Data") << "Could not retrieve the input alignments to compare \n";
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(AlignmentRcdChecker);

--- a/Alignment/MillePedeAlignmentAlgorithm/test/AlignmentRcdChecker_cfg.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/AlignmentRcdChecker_cfg.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+process = cms.Process("scan")
+options = VarParsing.VarParsing("analysis")
+options.register ('inputSqliteFile',
+                  "alignments_MP.db",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "input sql file")
+
+options.parseArguments()
+
+process.load("CondCore.CondDB.CondDB_cfi")
+
+### new alignment to check
+process.CondDB.connect = 'sqlite_file:'+options.inputSqliteFile
+process.newTrackerAlignment = cms.ESSource("PoolDBESSource",process.CondDB,
+                                           toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentRcd"),
+                                                                      tag = cms.string("Alignments"),
+                                                                      label = cms.untracked.string("toCheck"))))
+
+process.es_prefer_newTrackerAlignment = cms.ESPrefer("PoolDBESSource","newTrackerAlignment")
+
+### reference alignment
+process.CondDB.connect = 'frontier://FrontierPrep/CMS_CONDITIONS'
+process.refTrackerAlignment = cms.ESSource("PoolDBESSource",process.CondDB,
+                                           toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentRcd"),
+                                                                      tag = cms.string("TrackerAlignmentForUnitTestChecks_v0"))))
+process.es_prefer_refTrackerAlignment = cms.ESPrefer("PoolDBESSource","refTrackerAlignment")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = cms.untracked.int32(100)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptySource",
+                            numberEventsInRun = cms.untracked.uint32(1), # do not change!
+                            firstRun = cms.untracked.uint32(1))
+
+process.AlignmentRcdScan = cms.EDAnalyzer("AlignmentRcdChecker")
+process.AlignmentRcdScan.verbose = cms.bool(True) 
+process.AlignmentRcdScan.label = cms.string("toCheck") 
+process.AlignmentRcdScan.compareStrict = cms.bool(True) 
+
+process.p = cms.Path(process.AlignmentRcdScan)

--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -1,3 +1,12 @@
+<library file="*Rcd*.cpp" name="MPAlignmentRcdScan">
+  <use name="CondFormats/AlignmentRecord"/>
+  <use name="DataFormats/DetId"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="CondFormats/Alignment"/>
+  <use name="Alignment/CommonAlignment"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
 <test name="test_PrepareInputDb" command="mps_prepare_input_db.py -g auto:run2_data -r 1 -o ${LOCALTOP}/tmp/test_input.db"/>
 <test name="test_MpsWorkFlow" command="test_mps-workflow.sh"/>
 <test name="test_CreateFileLists" command="mps_create_file_lists.py --test-mode --force -i /OVERRIDDEN/IN/TESTMODE -o ${LOCALTOP}/tmp/mps_create_file_lists -n 200000 --iov 42 --iov 174"/>
@@ -9,4 +18,8 @@
   <flags TEST_RUNNER_ARGS="/bin/bash Alignment/MillePedeAlignmentAlgorithm/test test_pede.sh"/>
   <use name="FWCore/Utilities"/>
 </bin>
-
+<bin name="testPayloadSanity" file="TestDriver.cpp">
+  <flags TEST_RUNNER_ARGS="/bin/bash Alignment/MillePedeAlignmentAlgorithm/test test_payload_sanity.sh"/>
+  <flags PRE_TEST="testPedeCampaign"/>
+  <use name="FWCore/Utilities"/>
+</bin>

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_payload_sanity.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_payload_sanity.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+function die { echo $1: status $2; exit $2; }
+
+INPUTFILE=${LOCAL_TEST_DIR}/alignments_MP.db
+(cmsRun ${LOCAL_TEST_DIR}/AlignmentRcdChecker_cfg.py inputSqliteFile=${INPUTFILE}) || die 'failed running AlignmentRcdChecker'
+rm $INPUTFILE

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.py
@@ -1,27 +1,45 @@
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("Alignment")
 
-process.Tracer = cms.Service("Tracer")
-
-setupGlobaltag = "121X_mcRun3_2021_realistic_forpp900GeV_v6"
+################################################################################
+# Variables edited by mps_alisetup.py. Used in functions below.
+# You can change them manually as well.
+# ------------------------------------------------------------------------------
+setupGlobaltag = "122X_dataRun3_Prompt_v3"
 setupCollection = "ALCARECOTkAlCosmicsCosmicTF0T"
 setupCosmicsDecoMode = True
 setupCosmicsZeroTesla = False
 setupPrimaryWidth     = -1.0
 setupJson             = "placeholder_json"
-setupRunStartGeometry = 1
-setupAlgoMode = "pede"
-setupMonitorFile      = "millePedeMonitorISN.root"
-setupBinaryFile       = "milleBinaryISN.dat"
-readFiles = cms.untracked.vstring()
+setupRunStartGeometry = 348908
 
+################################################################################
+# Variables edited by MPS (mps_setup and mps_merge). Be careful.
+# ------------------------------------------------------------------------------
+# Default is "mille". Gets changed to "pede" by mps_merge.
+setupAlgoMode = "pede"
+
+# MPS looks specifically for the string "001" so don't change this.
+setupMonitorFile      = "millePedeMonitor001.root"
+setupBinaryFile       = "milleBinary001.dat"
+
+# Input files. Edited by mps_splice.py
+readFiles = cms.untracked.vstring()
+readFiles.extend([
+    '/store/data/Commissioning2022/Cosmics/ALCARECO/TkAlCosmics0T-PromptReco-v1/000/348/268/00000/863844bd-0350-4131-8ef0-bc2fc1c6cb85.root'])
+################################################################################
+
+
+################################################################################
+# General setup
+# ------------------------------------------------------------------------------
 import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.GeneralSetup as generalSetup
 generalSetup.setup(process, setupGlobaltag, setupCosmicsZeroTesla)
 
 
 ################################################################################
 # setup alignment producer
-################################################################################
+# ------------------------------------------------------------------------------
 import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.ConfigureAlignmentProducer as confAliProducer
 
 confAliProducer.setConfiguration(process,
@@ -35,22 +53,22 @@ confAliProducer.setConfiguration(process,
 
 ################################################################################
 # Overwrite some conditions in global tag
-################################################################################
+# ------------------------------------------------------------------------------
 import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.SetCondition as tagwriter
 
-################################################################################
-# insert Startgeometry 
-################################################################################
-# You can use tagwriter.setCondition() to overwrite conditions in globaltag
+#######################
+## insert Alignables ##
+#######################
 
-################################################################################
-# insert Alignables 
-################################################################################
-process.AlignmentProducer.ParameterBuilder.parameterTypes = ["SelectorRigid,RigidBody"]
-
-################################################################################
-# Define the high-level structure alignables
-################################################################################
+# # to run a high-level alignment on real data (including TOB centering; use
+# # pixel-barrel centering for MC) of the whole tracker you can use the
+# # following configuration:
+##
+process.AlignmentProducer.ParameterBuilder.parameterTypes = [
+    "SelectorRigid,RigidBody"
+    ]
+#
+# # Define the high-level structure alignables
 process.AlignmentProducer.ParameterBuilder.SelectorRigid = cms.PSet(
     alignParams = cms.vstring(
         "TrackerP1PXBHalfBarrel,111111",
@@ -59,18 +77,22 @@ process.AlignmentProducer.ParameterBuilder.SelectorRigid = cms.PSet(
         "TrackerTOBHalfBarrel,rrrrrr",
         "TrackerTIDEndcap,111111",
         "TrackerTECEndcap,111111",
+        )
     )
-)
 
-################################################################################
-# insert Pedesettings 
-################################################################################
+#########################
+## insert Pedesettings ##
+#########################
+import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.helper as helper
+helper.set_pede_option(process, "entries 100 10 2")
+# helper.set_pede_option(process, "compress", drop = True)
+
 import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.helper as helper
 helper.set_pede_option(process, "skipemptycons")
 
 ################################################################################
 # Mille-procedure
-################################################################################
+# ------------------------------------------------------------------------------
 if setupAlgoMode == "mille":
     import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.MilleSetup as mille
     mille.setup(process,
@@ -82,19 +104,127 @@ if setupAlgoMode == "mille":
 
 ################################################################################
 # Pede-procedure
-################################################################################
+# ------------------------------------------------------------------------------
 else:
+    # placeholers get replaced by mps_merge.py, which is called in mps_setup.pl
     merge_binary_files = [
-                'milleBinary001.dat',
-                'milleBinary002.dat',
-                'milleBinary003.dat']
-    merge_tree_files   = [
-                'treeFile001.root',
-                'treeFile002.root',
-                'treeFile003.root']
+        'milleBinary055.dat',
+        'milleBinary056.dat',
+        'milleBinary057.dat',
+        'milleBinary058.dat',
+        'milleBinary059.dat',
+        'milleBinary076.dat',
+        'milleBinary077.dat',
+        'milleBinary078.dat',
+        'milleBinary079.dat',
+        'milleBinary096.dat',
+        'milleBinary098.dat',
+        'milleBinary099.dat',
+        'milleBinary100.dat',
+        'milleBinary101.dat',
+        'milleBinary134.dat',
+        'milleBinary135.dat',
+        'milleBinary136.dat',
+        'milleBinary137.dat',
+        'milleBinary138.dat',
+        'milleBinary139.dat',
+        'milleBinary140.dat',
+        'milleBinary141.dat',
+        'milleBinary142.dat',
+        'milleBinary143.dat',
+        'milleBinary144.dat',
+        'milleBinary145.dat',
+        'milleBinary146.dat',
+        'milleBinary147.dat',
+        'milleBinary149.dat',
+        'milleBinary150.dat',
+        'milleBinary151.dat',
+        'milleBinary152.dat',
+        'milleBinary153.dat',
+        'milleBinary154.dat',
+        'milleBinary163.dat',
+        'milleBinary164.dat',
+        'milleBinary165.dat',
+        'milleBinary166.dat',
+        'milleBinary167.dat',
+        'milleBinary168.dat',
+        'milleBinary177.dat',
+        'milleBinary180.dat',
+        'milleBinary182.dat',
+        'milleBinary183.dat',
+        'milleBinary184.dat',
+        'milleBinary185.dat',
+        'milleBinary186.dat',
+        'milleBinary187.dat']
+    merge_tree_files = [
+        'treeFile055.dat',
+        'treeFile056.dat',
+        'treeFile057.dat',
+        'treeFile058.dat',
+        'treeFile059.dat',
+        'treeFile076.dat',
+        'treeFile077.dat',
+        'treeFile078.dat',
+        'treeFile079.dat',
+        'treeFile096.dat',
+        'treeFile098.dat',
+        'treeFile099.dat',
+        'treeFile100.dat',
+        'treeFile101.dat',
+        'treeFile134.dat',
+        'treeFile135.dat',
+        'treeFile136.dat',
+        'treeFile137.dat',
+        'treeFile138.dat',
+        'treeFile139.dat',
+        'treeFile140.dat',
+        'treeFile141.dat',
+        'treeFile142.dat',
+        'treeFile143.dat',
+        'treeFile144.dat',
+        'treeFile145.dat',
+        'treeFile146.dat',
+        'treeFile147.dat',
+        'treeFile149.dat',
+        'treeFile150.dat',
+        'treeFile151.dat',
+        'treeFile152.dat',
+        'treeFile153.dat',
+        'treeFile154.dat',
+        'treeFile163.dat',
+        'treeFile164.dat',
+        'treeFile165.dat',
+        'treeFile166.dat',
+        'treeFile167.dat',
+        'treeFile168.dat',
+        'treeFile177.dat',
+        'treeFile180.dat',
+        'treeFile182.dat',
+        'treeFile183.dat',
+        'treeFile184.dat',
+        'treeFile185.dat',
+        'treeFile186.dat',
+        'treeFile187.dat']
 
     import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.PedeSetup as pede
     pede.setup(process,
                binary_files = merge_binary_files,
                tree_files = merge_tree_files,
                run_start_geometry = setupRunStartGeometry)
+
+import Alignment.MillePedeAlignmentAlgorithm.alignmentsetup.SetCondition as tagwriter
+
+tagwriter.setCondition(process,
+       connect = "sqlite_file:alignment_input.db",
+       record = "TrackerAlignmentRcd",
+       tag = "TrackerAlignment_PCL_byRun_v2_express_348155")
+
+tagwriter.setCondition(process,
+       connect = "sqlite_file:alignment_input.db",
+       record = "TrackerSurfaceDeformationRcd",
+       tag = "TrackerSurafceDeformations_v1_express_299685")
+
+tagwriter.setCondition(process,
+       connect = "sqlite_file:alignment_input.db",
+       record = "TrackerAlignmentErrorExtendedRcd",
+       tag = "TrackerAlignmentExtendedErr_2009_v2_express_IOVs_347303")

--- a/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/test_pede.sh
@@ -6,27 +6,46 @@ if [ "${SCRAM_TEST_NAME}" != "" ] ; then
   cd ${SCRAM_TEST_NAME}
 fi
 
-if test -f "milleBinary00*"; then
+clean_up(){
     echo "cleaning the local test area"
     rm -fr milleBinary00* 
     rm -fr pedeSteer* 
+    rm -fr millepede.*
+    rm -fr *.root
+    rm -fr *.log
+    rm -fr *.dat
+    rm -fr *.tar
+    rm -fr *.gz
+    rm -fr *.db
+}
+
+if test -f "milleBinary*"; then
+    clean_up
 fi
 
 pwd
 echo " testing Aligment/MillePedeAlignmentAlgorithm"
 
 REMOTE="/store/group/alca_global/tkal_millepede_tests/"
-TESTPACKAGE="test_pede_package.tar"
-COMMMAND=`xrdfs cms-xrd-global.cern.ch locate ${REMOTE}${TESTPACKAGE}`
+TESTPACKAGE="test_pede_package_v1"
+COMMMAND=`xrdfs cms-xrd-global.cern.ch locate ${REMOTE}${TESTPACKAGE}.tar`
 STATUS=$?
 echo "xrdfs command status = "$STATUS
 if [ $STATUS -eq 0 ]; then
     echo "Using file ${TESTPACKAGE}. Running in ${LOCAL_TEST_DIR}."
-    xrdcp root://cms-xrd-global.cern.ch/${REMOTE}${TESTPACKAGE} ${LOCAL_TEST_DIR}
-    tar -xvf ${LOCAL_TEST_DIR}/${TESTPACKAGE} 
-    gunzip milleBinary00*    
+    xrdcp root://cms-xrd-global.cern.ch/${REMOTE}${TESTPACKAGE}.tar .
+    tar -xvf ${TESTPACKAGE}.tar
+    mv ${TESTPACKAGE}/milleBinary* .
+    mv ${TESTPACKAGE}/alignment_input.db .
+    gunzip milleBinary*
     (cmsRun ${LOCAL_TEST_DIR}/test_pede.py) || die 'failed running test_pede.py' $?
-    echo -e "\n MillePede Exit Status: "`cat millepede.end`
+    echo -e "\n @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+    echo -e " @ MillePede Exit Status: "`cat millepede.end`
+    echo -e " @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+    ## mv the output file to the local test directory for the subsequent payload sanity check
+    mv alignments_MP.db ${LOCAL_TEST_DIR}
+    ## clean the house now...
+    clean_up
 else 
-  die "SKIPPING test, file ${TESTPACKAGE} not found" 0
+  die "SKIPPING test, file ${TESTPACKAGE}.tar not found" 0
 fi


### PR DESCRIPTION
#### PR description:

The goal of this PR is to fix a bug inadvertently introduced at https://github.com/cms-sw/cmssw/pull/36076 (aimed to migrate Alignment codes to new `PoolDBOutputService` methods).
Moving to usage of instances instead of pointers led to the `GeometryAligner::removeGlobalTransform` call (to remove global roto-translations after computation of the alignment corrections) to be ineffective. This in turn lead to large spurious rotations and shifts of the alignment output geometry with respect to the input one.
This is fixed here in commit e5a18da8858d8d42858db32bcbde2806b58b4873.
I profit of this PR to refresh the inputs for the `testPedeCampaign` unit test (at 0460fec0ecd56b86298237ac2e17a2e42ce9e973) and introduce a new unit test to check the sanity of the output payload against large roto-translations (at 7818525b328440829f8b3c1bd67ae638c1c48f5e)

#### PR validation:

Run the unit tests introduced here and compared the output payloads with respect to the input one. Results (obtained from the payload inspector) are collected:
   * [here](http://musich.web.cern.ch/musich/display/comparison_PromptVsAlignmentCRAFT22/old/): before the fix
   * [here](http://musich.web.cern.ch/musich/display/comparison_PromptVsAlignmentCRAFT22/fixed/): after the fix
   
Here is a couple of plots selected from the folders above (**notice the scale**).   

| Before the fix | After the fix |
| ------------- | ------------- |
|  ![image](https://user-images.githubusercontent.com/5082376/168073606-f38cb43b-312a-45ca-8d5d-57a48b3c8ec8.png) | ![image](https://user-images.githubusercontent.com/5082376/168073732-57d41695-e253-4b12-a674-c06e26ed70a6.png) |

  
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but a backport will be needed to all production cycles after 12_2_X.

cc:
@consuegs @antoniovagnerini @connorpa 