### PR TITLE
Update EGM regression MC tags for eta-extended electrons

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,19 +68,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'           : '123X_mcRun3_2021_design_v14',
+    'phase1_2021_design'           : '124X_mcRun3_2021_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'        : '123X_mcRun3_2021_realistic_v14',
+    'phase1_2021_realistic'        : '124X_mcRun3_2021_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '123X_mcRun3_2021cosmics_realistic_deco_v14',
+    'phase1_2021_cosmics'          : '124X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi'     : '123X_mcRun3_2021_realistic_HI_v14',
+    'phase1_2021_realistic_hi'     : '124X_mcRun3_2021_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '123X_mcRun3_2023_realistic_v14',
+    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '123X_mcRun3_2024_realistic_v15',
+    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v1',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '123X_mcRun4_realistic_v11'
+    'phase2_realistic'             : '124X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:
This PR updates the EGM eta-extended electrons regression tags for Run3 and Run4 MC GTs, as requested in:
https://cms-talk.web.cern.ch/t/mc-gt-updating-egm-regression-tags-for-eta-extended-electrons/10366
The six updated tags are:
```
Tag  : electron_ee_ecalTrk_1To500_0p2To2_mean_Run3_122X_V1
Label: electron_ee_ecalTrk_1To300_0p2To2_mean
Rcd  : GBRDWrapperRcd

Tag  : electron_ee_ecalTrk_1To500_0p0002To0p5_sigma_Run3_122X_V1
Label: electron_ee_ecalTrk_1To300_0p0002To0p5_sigma
Rcd  : GBRDWrapperRcd

Tag  : electron_ee_ecalOnly_1To500_0p2To2_mean_Run3_122X_V1
Label: electron_ee_ecalOnly_1To300_0p2To2_mean
Rcd  : GBRDWrapperRcd

Tag  : electron_ee_ecalOnly_1To500_0p0002To0p5_sigma_Run3_122X_V1
Label: electron_ee_ecalOnly_1To300_0p0002To0p5_sigma
Rcd  : GBRDWrapperRcd

Tag  : GEDelectron_EECorrection_122X_EGM_v1
Label: electron_ee_ECALonly
Rcd  : GBRDWrapperRcd

Tag  : GEDelectron_EEUncertainty_122X_EGM_v1
Label: electron_ee_ECALonly_var
Rcd  : GBRDWrapperRcd
```

The GT diffs are:
**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_design_v14/124X_mcRun3_2021_design_v1

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_v14/124X_mcRun3_2021_realistic_v1

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021cosmics_realistic_deco_v14/124X_mcRun3_2021cosmics_realistic_deco_v1

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2021_realistic_HI_v14/124X_mcRun3_2021_realistic_HI_v1

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2023_realistic_v14/124X_mcRun3_2023_realistic_v1

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun3_2024_realistic_v15/124X_mcRun3_2024_realistic_v1

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_mcRun4_realistic_v11/124X_mcRun4_realistic_v2


#### PR validation:
Tested with
`runTheMatrix.py -l 12034.0,11634.0,7.23,159.0,312.0,12434.0,12834.0 --ibeos -j 16`


#### Backport:
Not a backport, no backport needed: these updates are intended for 12_4_X only.

FYI @saumyaphor4252 @swagata87 