### PR TITLE
[12_2_X backport] fix in bc->e filter 

### DIFF
--- a/Configuration/Generator/python/QCD_Pt_30_80_BCtoE_8TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCD_Pt_30_80_BCtoE_8TeV_TuneCUETP8M1_cfi.py
@@ -32,7 +32,8 @@ genParticlesForFilter = cms.EDProducer("GenParticleProducer",
                                        )
 
 bctoefilter = cms.EDFilter("BCToEFilter",
-                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(1),
+                           filterAlgoPSet = cms.PSet(maxAbsEta = cms.double(2.5), 
+                                                     eTThreshold = cms.double(1),
                                                      genParSource = cms.InputTag("genParticlesForFilter")
                                                      )
                            )

--- a/Configuration/Generator/python/QCD_Pt_80_170_BCtoE_8TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCD_Pt_80_170_BCtoE_8TeV_TuneCUETP8M1_cfi.py
@@ -32,7 +32,8 @@ genParticlesForFilter = cms.EDProducer("GenParticleProducer",
                                        )
 
 bctoefilter = cms.EDFilter("BCToEFilter",
-                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(1),
+                           filterAlgoPSet = cms.PSet(maxAbsEta = cms.double(2.5),
+                                                     eTThreshold = cms.double(1),
                                                      genParSource = cms.InputTag("genParticlesForFilter")
                                                      )
                            )

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
@@ -27,8 +27,7 @@ bool BCToEFilterAlgo::filter(const edm::Event& iEvent) const {
 
   for (uint32_t ig = 0; ig < genPars.size(); ig++) {
     reco::GenParticle gp = genPars.at(ig);
-    if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ &&
-        std::fabs(gp.eta()) < maxAbsEta_) {
+    if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ && std::fabs(gp.eta()) < maxAbsEta_) {
       if (hasBCAncestors(gp)) {
         result = true;
       }

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
@@ -10,7 +10,7 @@
 
 BCToEFilterAlgo::BCToEFilterAlgo(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
     :  //set constants
-      FILTER_ETA_MAX_(2.5),
+      maxAbsEta_((float)iConfig.getParameter<double>("maxAbsEta")),
       eTThreshold_((float)iConfig.getParameter<double>("eTThreshold")),
       genParSource_(iC.consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParSource"))) {}
 
@@ -28,7 +28,7 @@ bool BCToEFilterAlgo::filter(const edm::Event& iEvent) const {
   for (uint32_t ig = 0; ig < genPars.size(); ig++) {
     reco::GenParticle gp = genPars.at(ig);
     if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ &&
-        std::fabs(gp.eta()) < FILTER_ETA_MAX_) {
+        std::fabs(gp.eta()) < maxAbsEta_) {
       if (hasBCAncestors(gp)) {
         result = true;
       }

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.h
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.h
@@ -30,9 +30,8 @@ private:
   bool isBCMeson(const reco::GenParticle& gp) const;
   bool isBCBaryon(const reco::GenParticle& gp) const;
 
-  //constants:
-  const float FILTER_ETA_MAX_;
   //filter parameters:
+  const float maxAbsEta_;
   const float eTThreshold_;
   const edm::EDGetTokenT<reco::GenParticleCollection> genParSource_;
 };

--- a/GeneratorInterface/GenFilters/python/BCToEFilter_cfi.py
+++ b/GeneratorInterface/GenFilters/python/BCToEFilter_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 bctoefilter = cms.EDFilter("BCToEFilter",
     filterAlgoPSet = cms.PSet(
+        maxAbsEta = cms.double(3.05),
         eTThreshold = cms.double(10.0)
     )
 )


### PR DESCRIPTION
#### PR description:

See details in PR description of https://github.com/cms-sw/cmssw/pull/37869
This is an exact backport of 37869. 
The backport is being made following a discussion in today's PPD meeting, during this talk:
https://indico.cern.ch/event/1158486/#30-retraining-of-pf-electron-i
The plan is that once this backport PR is merged and a new 12_2_X release is made, EGM will request QCD b/c->e samples again, in 12_2_X. With those samples, we will check the performance of DNN-based PF ID. 