### PR TITLE
fix LumiPCC AlCaReco trigger bits for Run-3

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 ALCARECORandomHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
-    HLTPaths = cms.vstring("*Random*"),
+    HLTPaths = cms.vstring("AlCa_LumiPixelsCounts_Random_v*"),
     eventSetupPathsKey='',
     TriggerResultsTag = cms.InputTag("TriggerResults","","HLT"),
     andOr = cms.bool(True), # choose logical OR between Triggerbits

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 ALCARECOZeroBiasHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
-    HLTPaths = cms.vstring("*ZeroBias*"),
+    HLTPaths = cms.vstring("AlCa_LumiPixelsCounts_ZeroBias_v*"),
     eventSetupPathsKey='',
     TriggerResultsTag = cms.InputTag("TriggerResults","","HLT"),
     andOr = cms.bool(True), # choose logical OR between Triggerbits


### PR DESCRIPTION
#### PR description:

This PR is to update the trigger bits of the LumiPCC Run-3 AlCaRecos to accept only the following trigger bits:

`AlCa_LumiPixelsCounts_ZeroBias_v*`  for AlCaPCCZeroBias 
`AlCa_LumiPixelsCounts_Random_v*`    for AlCaPCCRandom   

This PR will be followed by another one in the future, as soon as there are 2022 collisions data to update the relval workflow. It will then make use of the AlCaRecoTriggerBits tag. 

For the moment, we update only the hardcoded trigger bits in order to avoid changing the data-taking GTs (Prompt and Express).

#### PR validation:

`runTheMatrix.py -l 1020 --ibeos -j16`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
There will be a backport to 12_3_X as it is intended to be used in the upcoming collision data-taking.
