### PR TITLE
[RFC] Optimize MagGeoBuilder with TBB

### DIFF
--- a/FWCore/Utilities/interface/FileInPath.h
+++ b/FWCore/Utilities/interface/FileInPath.h
@@ -106,6 +106,11 @@ namespace edm {
     /// Should only be called while the edmWriteConfigs executable runs
     static void disableFileLookup();
 
+    /** Uses the same algorithm to find the file but does not determine
+        the location. Returns an empty string if unfound.
+     */
+    static std::string findFile(std::string const&);
+
   private:
     std::string relativePath_;
     std::string canonicalFilename_;
@@ -118,6 +123,7 @@ namespace edm {
     // Helper function for construction.
     void getEnvironment();
     void initialize_();
+    static std::string const& searchPath();
   };
 
   // Free swap function

--- a/MagneticField/GeomBuilder/BuildFile.xml
+++ b/MagneticField/GeomBuilder/BuildFile.xml
@@ -10,6 +10,7 @@
 <use name="CondFormats/MFObjects"/>
 <use name="clhep"/>
 <use name="dd4hep"/>
+<use name="tbb"/>
 <export>
   <lib name="1"/>
 </export>

--- a/MagneticField/GeomBuilder/src/DD4hep_MagGeoBuilder.cc
+++ b/MagneticField/GeomBuilder/src/DD4hep_MagGeoBuilder.cc
@@ -448,15 +448,16 @@ void MagGeoBuilder::buildInterpolator(const volumeHandle* vol, map<string, MagPr
     return;
   }
 
-  string fullPath;
-
-  try {
-    edm::FileInPath mydata("MagneticField/Interpolation/data/" + tableSet_ + "/" + vol->magFile);
-    fullPath = mydata.fullPath();
-  } catch (edm::Exception& exc) {
-    cerr << "MagGeoBuilder: exception in reading table; " << exc.what() << endl;
-    if (!debug_)
-      throw;
+  string fullPath = edm::FileInPath::findFile("MagneticField/Interpolation/data/" + tableSet_ + "/" + vol->magFile);
+  if (fullPath.empty()) {
+    //get the exact error info
+    try {
+      edm::FileInPath mydata("MagneticField/Interpolation/data/" + tableSet_ + "/" + vol->magFile);
+    } catch (edm::Exception& exc) {
+      cerr << "MagGeoBuilder: exception in reading table; " << exc.what() << endl;
+      if (!debug_)
+        throw;
+    }
     return;
   }
 

--- a/MagneticField/GeomBuilder/src/DD4hep_MagGeoBuilder.cc
+++ b/MagneticField/GeomBuilder/src/DD4hep_MagGeoBuilder.cc
@@ -205,14 +205,20 @@ void MagGeoBuilder::build(const cms::DDDetector* det) {
       // not replicated in phi)
       // ASSUMPTION: copyno == sector.
       if (v->copyno == v->masterSector) {
-        buildInterpolator(v, bInterpolators);
+        auto i = buildInterpolator(v);
+        if (i) {
+          bInterpolators[v->magFile] = i;
+        }
         ++bVolCount;
       }
     } else {  // Endcaps
       LogTrace("MagGeoBuilder") << " (Endcaps)";
       eVolumes_.push_back(v);
       if (v->copyno == v->masterSector) {
-        buildInterpolator(v, eInterpolators);
+        auto i = buildInterpolator(v);
+        if (i) {
+          eInterpolators[v->magFile] = i;
+        }
         ++eVolCount;
       }
     }
@@ -384,12 +390,14 @@ void MagGeoBuilder::build(const cms::DDDetector* det) {
   }
 }
 
-void MagGeoBuilder::buildMagVolumes(const handles& volumes, map<string, MagProviderInterpol*>& interpolators) {
+void MagGeoBuilder::buildMagVolumes(const handles& volumes,
+                                    const map<string, MagProviderInterpol*>& interpolators) const {
   // Build all MagVolumes setting the MagProviderInterpol
   for (auto vol : volumes) {
     const MagProviderInterpol* mp = nullptr;
-    if (interpolators.find(vol->magFile) != interpolators.end()) {
-      mp = interpolators[vol->magFile];
+    auto found = interpolators.find(vol->magFile);
+    if (found != interpolators.end()) {
+      mp = found->second;
     } else {
       edm::LogError("MagGeoBuilder") << "No interpolator found for file " << vol->magFile << " vol: " << vol->volumeno
                                      << "\n"
@@ -428,7 +436,8 @@ void MagGeoBuilder::buildMagVolumes(const handles& volumes, map<string, MagProvi
   }
 }
 
-void MagGeoBuilder::buildInterpolator(const volumeHandle* vol, map<string, MagProviderInterpol*>& interpolators) {
+MagProviderInterpol* MagGeoBuilder::buildInterpolator(const volumeHandle* vol) const {
+  MagProviderInterpol* retValue = nullptr;
   // Phi of the master sector
   double masterSectorPhi = (vol->masterSector - 1) * 1._pi / 6.;
 
@@ -444,8 +453,7 @@ void MagGeoBuilder::buildInterpolator(const volumeHandle* vol, map<string, MagPr
   }
 
   if (tableSet_ == "fake" || vol->magFile == "fake") {
-    interpolators[vol->magFile] = new magneticfield::FakeInterpolator();
-    return;
+    return new magneticfield::FakeInterpolator();
   }
 
   string fullPath = edm::FileInPath::findFile("MagneticField/Interpolation/data/" + tableSet_ + "/" + vol->magFile);
@@ -458,7 +466,7 @@ void MagGeoBuilder::buildInterpolator(const volumeHandle* vol, map<string, MagPr
       if (!debug_)
         throw;
     }
-    return;
+    return nullptr;
   }
 
   try {
@@ -482,22 +490,21 @@ void MagGeoBuilder::buildInterpolator(const volumeHandle* vol, map<string, MagPr
                                        vol->placement()->rotation() * rot);
       }
 
-      interpolators[vol->magFile] = MFGridFactory::build(fullPath, rf);
+      retValue = MFGridFactory::build(fullPath, rf);
     }
   } catch (MagException& exc) {
     LogTrace("MagGeoBuilder") << exc.what();
-    interpolators.erase(vol->magFile);
     if (!debug_)
       throw;
-    return;
+    return nullptr;
   }
 
   if (debug_) {
     // Check that all grid points of the interpolator are inside the volume.
     const MagVolume6Faces tempVolume(
-        vol->placement()->position(), vol->placement()->rotation(), vol->sides(), interpolators[vol->magFile]);
+        vol->placement()->position(), vol->placement()->rotation(), vol->sides(), retValue);
 
-    const MFGrid* grid = dynamic_cast<const MFGrid*>(interpolators[vol->magFile]);
+    const MFGrid* grid = dynamic_cast<const MFGrid*>(retValue);
     if (grid != nullptr) {
       Dimensions sizes = grid->dimensions();
       LogTrace("MagGeoBuilder") << "Grid has 3 dimensions "
@@ -526,9 +533,10 @@ void MagGeoBuilder::buildInterpolator(const volumeHandle* vol, map<string, MagPr
                                 << sizes.w * sizes.h * sizes.d;
     }
   }
+  return retValue;
 }
 
-void MagGeoBuilder::testInside(handles& volumes) {
+void MagGeoBuilder::testInside(handles& volumes) const {
   // test inside() for all volumes.
   LogTrace("MagGeoBuilder") << "--------------------------------------------------";
   LogTrace("MagGeoBuilder") << " inside(center) test";

--- a/MagneticField/GeomBuilder/src/DD4hep_MagGeoBuilder.h
+++ b/MagneticField/GeomBuilder/src/DD4hep_MagGeoBuilder.h
@@ -63,16 +63,17 @@ namespace magneticfield {
 
   private:
     // Build interpolator for the volume with "correct" rotation
-    void buildInterpolator(const volumeHandle* vol, std::map<std::string, MagProviderInterpol*>& interpolators);
+    MagProviderInterpol* buildInterpolator(const volumeHandle* vol) const;
 
     // Build all MagVolumes setting the MagProviderInterpol
-    void buildMagVolumes(const handles& volumes, std::map<std::string, MagProviderInterpol*>& interpolators);
+    void buildMagVolumes(const handles& volumes,
+                         const std::map<std::string, MagProviderInterpol*>& interpolators) const;
 
     // Print checksums for surfaces.
     void summary(handles& volumes) const;
 
     // Perform simple sanity checks
-    void testInside(handles& volumes);
+    void testInside(handles& volumes) const;
 
     handles bVolumes_;  // the barrel volumes.
     handles eVolumes_;  // the endcap volumes.


### PR DESCRIPTION
#### PR description:

- Avoid extra work done for provenance tracking when looking up magnetic field related files.
- Use tbb::task_group to concurrently construct interpolators

This is identical to #37934 except with the addition of TBB

#### PR validation:

When using just #37934 running a NANO job with 8 threads and 4 streams, the mag field initialization takes 7 seconds. With this change it drops to 4 seconds. That is about as fast as can be gotten with this change since 1/2 the time in #37934 is still being taken to construct the DDDetector.