### PR TITLE
removing mkFit from exlude in Eras for PbPb collisions

### DIFF
--- a/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
+++ b/Configuration/Eras/python/Era_Run2_2018_pp_on_AA_cff.py
@@ -6,5 +6,5 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.ModifierChain_trackingMkFitProd_cff import trackingMkFitProd
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackingMkFitProd, trackdnn, trackingNoLoopers]), pp_on_AA, pp_on_AA_2018)
+Run2_2018_pp_on_AA = cms.ModifierChain(Run2_2018.copyAndExclude([trackdnn, trackingNoLoopers]), pp_on_AA, pp_on_AA_2018)
 

--- a/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
+++ b/Configuration/Eras/python/Era_Run3_pp_on_PbPb_cff.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.ProcessModifiers.trackdnn_CKF_cff import trackdnn_CKF
 from Configuration.ProcessModifiers.trackdnn_cff import trackdnn
-from Configuration.Eras.Era_Run3_noMkFit_cff import Run3_noMkFit
+from Configuration.Eras.Era_Run3_cff import Run3
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 from Configuration.ProcessModifiers.trackingNoLoopers_cff import trackingNoLoopers
 
-Run3_pp_on_PbPb = cms.ModifierChain(Run3_noMkFit.copyAndExclude([trackdnn, trackdnn_CKF, trackingNoLoopers]), pp_on_AA, pp_on_PbPb_run3)
+Run3_pp_on_PbPb = cms.ModifierChain(Run3.copyAndExclude([trackdnn, trackdnn_CKF, trackingNoLoopers]), pp_on_AA, pp_on_PbPb_run3)
 


### PR DESCRIPTION
#### PR description:

This PR enables mkFit on PbPb events. It removes mkFit from "exclude" set in Run2_2018_pp_on_AA and Run3_pp_on_PbPb eras. The change should reduce reconstruction time with similar tracking performances as shown here: https://indico.cern.ch/event/1158382/#3-update-on-mkfit-studies-with.

#### PR validation:
We performed track reconstruction studies on 2018 PbPb data, and PbPb MC produced for Run3 tests.

@mandrenguyen, @abaty, @CesarBernardes
