### PR TITLE
increase size of buffer in `InitMsgBuilder` [`12_3_X`]

### DIFF
--- a/IOPool/Streamer/src/InitMsgBuilder.cc
+++ b/IOPool/Streamer/src/InitMsgBuilder.cc
@@ -72,7 +72,7 @@ InitMsgBuilder::InitMsgBuilder(void* buf,
   // header size was hard-coded.)
   std::vector<bool> dummyL1Bits(l1_names.size());
   std::vector<char> dummyHLTBits(hlt_names.size());
-  const uint32 TEMP_BUFFER_SIZE = 256;
+  const uint32 TEMP_BUFFER_SIZE = 640;
   char msgBuff[TEMP_BUFFER_SIZE];  // not large enough for a real event!
   uint32_t adler32 = 0;
   char host_name[255];


### PR DESCRIPTION
backport of #37937

Attn: @smorovic

#### PR description:

From the original PR:
>This PR fixes a problem reported by @fwyzard when running the full HLT GRun menu using `GlobalEvFOutputModule` as `cms.OutputModule` (which is how the HLT produces output files online).
>
>The issue occurs in the `beginRun` stage, when serializing the content of the "INI" streamer files: the size of the buffer given by `InitMsgBuilder` to `EventMsgBuilder` can be too small if the number of L1 and HL triggers is above certain values.
>
>The current size of `256` is insufficient, for example, in the presence of 500 L1T seeds and 500 HLT paths.
>
>The issue leads to a crash, and it can be reproduced with this minimal update of the relevant DAQ unit test.
```diff
diff --git a/EventFilter/Utilities/test/startFU.py b/EventFilter/Utilities/test/startFU.py
index c00d612aae8..9133a1196aa 100644
--- a/EventFilter/Utilities/test/startFU.py
+++ b/EventFilter/Utilities/test/startFU.py
@@ -128,6 +128,9 @@ process.tcdsRawToDigi.InputLabel = cms.InputTag("rawDataCollector")
 process.p1 = cms.Path(process.a*process.tcdsRawToDigi*process.filter1)
 process.p2 = cms.Path(process.b*process.filter2)
 
+for pidx in range(3,1000):
+  setattr(process, f'p{pidx}', cms.Path(process.b))
+
 process.streamA = cms.OutputModule("EvFOutputModule",
     SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring( 'p1' ))
 )
```
```
./EventFilter/Utilities/test/LocalRunBUFU.sh
```
>To my knowledge, this problem affects both `GlobalEvFOutputModule` and `EvFOutputModule`.
>
>Given the deadline for `12_4_0_pre4` (and possible need for a patch release in `12_3_X`), this PR applies a minimal fix increasing the buffer size.
>
>A buffer size of `640` should be sufficient for 512 L1T seeds and 2000 HLT paths (the current HLT menu for pp collisions has approx. 800 paths).
>
>In the near future, the algorithm could be improved to find an optimal buffer size based on the number of L1 and HL triggers in the configuration.
>
>Debugged with @fwyzard.

#### PR validation:

None. Relies on the testing done for the original PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#37937

Potentially needed for collisions data-taking in `12_3_X`.