### PR TITLE
Run3-hcx333 Try to address wrong SubDetId in some cases

### DIFF
--- a/Geometry/HcalCommonData/data/hcalRecNumbering/NoHE/v1/hcalRecNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalRecNumbering/NoHE/v1/hcalRecNumbering.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection  label="hcalRecNumbering.xml" eval="true">
+  <Vector name="etagroup" type="numeric" nEntries="16">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="phigroup" type="numeric" nEntries="16">
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+  </Vector>
+  <Vector name="layerGroupRecEta1" type="numeric" nEntries="19">
+    1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4
+  </Vector>
+  <Vector name="layerGroupRecEta16" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4
+  </Vector>
+</ConstantsSection>
+
+<SpecParSection label="hcalRecNumbering.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HCal"/>
+    <Parameter name="OnlyForHcalRecNumbering" value="HCAL" eval="false"/>
+    <Parameter name="TopologyMode" value="HcalTopologyMode::SLHC" eval="false"/>
+    <Parameter name="TriggerMode"  value="HcalTopologyMode::TriggerMode_2021" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+
+</DDDefinition>

--- a/Geometry/HcalCommonData/data/hcalSimNumbering/NoHE/v1/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/hcalSimNumbering/NoHE/v1/hcalSimNumbering.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<DDDefinition>
+
+<ConstantsSection  label="hcalSimNumbering.xml" eval="true">
+  <Vector name="phioff" type="numeric" nEntries="5">
+    0.0*deg, 0.0*deg, 0.0*deg, 10.0*deg, 10.0*deg
+  </Vector>
+  <Vector name="etaTable" type="numeric" nEntries="17">
+    0.000, 0.087, 0.174, 0.261, 0.348, 0.435, 0.522, 0.609, 0.696,
+    0.783, 0.870, 0.957, 1.044, 1.131, 1.218, 1.305, 1.392
+  </Vector>
+  <Vector name="rTable" type="numeric" nEntries="14">
+    12.50*cm, 16.90*cm, 20.10*cm, 24.00*cm, 28.60*cm, 34.00*cm,
+    40.60*cm, 48.30*cm, 57.60*cm, 68.60*cm, 81.80*cm, 97.50*cm,
+    116.20*cm, 130.00*cm
+  </Vector>
+  <Vector name="phibin" type="numeric" nEntries="16">
+    5.0*deg, 5.0*deg, 5.0*deg, 5.0*deg, 5.0*deg, 5.0*deg, 5.0*deg,
+    5.0*deg, 5.0*deg, 5.0*deg, 5.0*deg, 5.0*deg, 5.0*deg, 5.0*deg,
+    5.0*deg, 5.0*deg
+  </Vector>
+  <Vector name="phitable" type="numeric" nEntries="13">
+    10.0*deg, 10.0*deg, 10.0*deg, 10.0*deg, 10.0*deg, 10.0*deg,
+    10.0*deg, 10.0*deg, 10.0*deg, 10.0*deg, 10.0*deg, 20.0*deg,
+    20.0*deg
+  </Vector>
+  <Vector name="layerGroupSimEta1" type="numeric" nEntries="19">
+    1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4
+  </Vector>
+  <Vector name="layerGroupSimEta16" type="numeric" nEntries="19">
+    1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4
+  </Vector>
+  <Vector name="etaMin" type="numeric" nEntries="4">
+    1, 28, 29, 1
+  </Vector>
+  <Vector name="etaMax" type="numeric" nEntries="4">
+    16, 15, 41, 15
+  </Vector>
+  <Vector name="MaxDepth" type="numeric" nEntries="4">
+     4,  0,  4,  4
+  </Vector>
+  <Vector name="etaRange" type="numeric" nEntries="4">
+    1.392, 3.000, 5.500, 1.305
+  </Vector>
+  <Vector name="gparHF" type="numeric" nEntries="7">
+    22.0*cm, 165.0*cm, 30.0*cm, 0.0*cm, 1115.0*cm, 0.375*cm,
+    1137.0*cm
+  </Vector>
+  <Vector name="noff" type="numeric" nEntries="18">
+    15, 99, 4, 10, 5, 2, 4, 18, 19, 11, 12, 13, 14,  3,  4,  3,  1,  0
+  </Vector>
+  <Vector name="Layer0Wt" type="numeric" nEntries="2">
+    1.2, 1.2
+  </Vector>
+  <Vector name="HBGains" type="numeric" nEntries="4">
+    117.0, 117.0, 117.0, 217.0
+  </Vector>
+  <Vector name="HBShift" type="numeric" nEntries="4">
+    0, 0, 0, 0
+  </Vector>
+  <Vector name="HEGains" type="numeric" nEntries="4">
+    178.0, 178.0, 178.0, 0.000
+  </Vector>
+  <Vector name="HEShift" type="numeric" nEntries="4">
+    0, 0, 0, 0
+  </Vector>
+  <Vector name="HFGains" type="numeric" nEntries="4">
+    2.840, 2.090, 2.840, 2.090
+  </Vector>
+  <Vector name="HFShift" type="numeric" nEntries="4">
+    0, 0, 0, 0
+  </Vector>
+</ConstantsSection>
+
+<SpecParSection label="hcalSimNumbering.xml" eval="true">
+  <SpecPar name="hcal">
+    <PartSelector path="//HBS.*"/>
+    <PartSelector path="//HTS.*"/>
+    <PartSelector path="//HVQF"/>
+    <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
+  </SpecPar>
+</SpecParSection>
+
+</DDDefinition>

--- a/Geometry/HcalCommonData/test/python/runHcalParametersFromDD4hepAnalyzer_cfg.py
+++ b/Geometry/HcalCommonData/test/python/runHcalParametersFromDD4hepAnalyzer_cfg.py
@@ -1,9 +1,46 @@
+###############################################################################
+# Way to use this:
+#   cmsRun runHcalParametersFromDD4HepAnalyzer_cfg.py geometry=Run3
+#
+#   Options for geometry Run3, D86, D88
+#
+###############################################################################
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run3_dd4hep_cff import Run3_dd4hep
+import os, sys, imp, re
+import FWCore.ParameterSet.VarParsing as VarParsing
 
-process = cms.Process("HcalParametersTest",Run3_dd4hep)
+####################################################################
+### SETUP OPTIONS
+options = VarParsing.VarParsing('standard')
+options.register('geometry',
+                 "Run3",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "geometry of operations: Run3, D86, D88")
 
-process.load("Configuration.Geometry.GeometryDD4hepExtended2021Reco_cff")
+### get and parse the command line arguments
+options.parseArguments()
+
+print(options)
+
+####################################################################
+# Use the options
+
+if (options.geometry == "D86"):
+    from Configuration.Eras.Era_Phase2C11M9_cff import Phase2C11M9
+    from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+    process = cms.Process("HcalParametersTest",Phase2C11M9,dd4hep)
+    process.load('Configuration.Geometry.GeometryDD4hepExtended2026D86Reco_cff')
+elif (options.geometry == "D88"):
+    from Configuration.Eras.Era_Phase2C11M9_cff import Phase2C11M9
+    from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
+    process = cms.Process("HcalParametersTest",Phase2C11M9,dd4hep)
+    process.load('Configuration.Geometry.GeometryDD4hepExtended2026D88Reco_cff')
+else:
+    from Configuration.Eras.Era_Run3_dd4hep_cff import Run3_dd4hep
+    process = cms.Process("HcalParametersTest",Run3_dd4hep)
+    process.load("Configuration.Geometry.GeometryDD4hepExtended2021Reco_cff")
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 if hasattr(process,'MessageLogger'):

--- a/Geometry/HcalCommonData/test/python/runHcalParametersFromDDDAnalyzer_cfg.py
+++ b/Geometry/HcalCommonData/test/python/runHcalParametersFromDDDAnalyzer_cfg.py
@@ -1,9 +1,44 @@
+###############################################################################
+# Way to use this:
+#   cmsRun runHcalParametersFromDDDAnalyzer_cfg.py geometry=Run3
+#
+#   Options for geometry Run3, D86, D88
+#
+###############################################################################
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run3_DDD_cff import Run3_DDD
+import os, sys, imp, re
+import FWCore.ParameterSet.VarParsing as VarParsing
 
-process = cms.Process("HcalParametersTest",Run3_DDD)
+####################################################################
+### SETUP OPTIONS
+options = VarParsing.VarParsing('standard')
+options.register('geometry',
+                 "Run3",
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "geometry of operations: Run3, D86, D88")
 
-process.load("Configuration.Geometry.GeometryExtended2021Reco_cff")
+### get and parse the command line arguments
+options.parseArguments()
+
+print(options)
+
+####################################################################
+# Use the options
+
+if (options.geometry == "D86"):
+    from Configuration.Eras.Era_Phase2C11M9_cff import Phase2C11M9
+    process = cms.Process("HcalParametersTest",Phase2C11M9)
+    process.load('Configuration.Geometry.GeometryExtended2026D86Reco_cff')
+elif (options.geometry == "D88"):
+    from Configuration.Eras.Era_Phase2C11M9_cff import Phase2C11M9
+    process = cms.Process("HcalParametersTest",Phase2C11M9)
+    process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+else:
+    from Configuration.Eras.Era_Run3_DDD_cff import Run3_DDD
+    process = cms.Process("HcalParametersTest",Run3_DDD)
+    process.load("Configuration.Geometry.GeometryExtended2021Reco_cff")
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
 
 process.source = cms.Source("EmptySource")


### PR DESCRIPTION
#### PR description:

Try to address wrong SubDetId in some cases for HCAL simulation. Some ID's corresponding to HB are classified as HE which are not present in the Phase2 scenarios. Once this PR is merged, the latest phase2 scenarios will be updated to have the changed HCal scenarios.

#### PR validation:

Compared the parameters read in for HCAL simulation with DDD and DD4hep using cfg's in Geometry/HcalCommonData

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special