### PR TITLE
Run3-sim118H Use tokens rather than labels in accessing collections in SimMuon/MCtruth

### DIFF
--- a/SimMuon/MCTruth/interface/CSCTruthTest.h
+++ b/SimMuon/MCTruth/interface/CSCTruthTest.h
@@ -1,6 +1,7 @@
 #ifndef MCTruth_CSCTruthTest_h
 #define MCTruth_CSCTruthTest_h
 
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
@@ -9,12 +10,13 @@
 class CSCTruthTest : public edm::stream::EDAnalyzer<> {
 public:
   explicit CSCTruthTest(const edm::ParameterSet &);
-  ~CSCTruthTest() override;
+  ~CSCTruthTest() override = default;
 
 private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   const edm::ParameterSet &conf_;
   edm::ConsumesCollector consumeCollector_;
+  const edm::EDGetTokenT<CSCRecHit2DCollection> cscRecHitToken_;
 };
 
 #endif

--- a/SimMuon/MCTruth/interface/MuonTruth.h
+++ b/SimMuon/MCTruth/interface/MuonTruth.h
@@ -62,15 +62,20 @@ private:
   const DigiSimLinks *theDigiSimLinks;
   const DigiSimLinks *theWireDigiSimLinks;
 
-  edm::InputTag linksTag;
-  edm::InputTag wireLinksTag;
+  const edm::InputTag linksTag;
+  const edm::InputTag wireLinksTag;
 
-  bool crossingframe;
-  edm::InputTag CSCsimHitsTag;
-  edm::InputTag CSCsimHitsXFTag;
+  const bool crossingframe;
+  const edm::InputTag CSCsimHitsTag;
+  const edm::InputTag CSCsimHitsXFTag;
 
-  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
-  edm::ESGetToken<CSCBadChambers, CSCBadChambersRcd> badToken_;
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomToken_;
+  const edm::ESGetToken<CSCBadChambers, CSCBadChambersRcd> badToken_;
+
+  const edm::EDGetTokenT<DigiSimLinks> linksToken_;
+  const edm::EDGetTokenT<DigiSimLinks> wireLinksToken_;
+  edm::EDGetTokenT<CrossingFrame<PSimHit>> simHitsXFToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> simHitsToken_;
 
   std::map<unsigned int, edm::PSimHitContainer> theSimHitMap;
 

--- a/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
+++ b/SimMuon/MCTruth/interface/TrackerMuonHitExtractor.h
@@ -18,20 +18,14 @@
 class TrackerMuonHitExtractor {
 public:
   explicit TrackerMuonHitExtractor(const edm::ParameterSet &, edm::ConsumesCollector &&ic);
-  explicit TrackerMuonHitExtractor(const edm::ParameterSet &);
-  ~TrackerMuonHitExtractor();
+  ~TrackerMuonHitExtractor() = default;
 
   void init(const edm::Event &);
   std::vector<const TrackingRecHit *> getMuonHits(const reco::Muon &mu) const;
 
 private:
-  edm::Handle<DTRecSegment4DCollection> dtSegmentCollectionH_;
-  edm::Handle<CSCSegmentCollection> cscSegmentCollectionH_;
-
-  edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DToken_;
-  edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentToken_;
-  edm::InputTag inputDTRecSegment4DCollection_;
-  edm::InputTag inputCSCSegmentCollection_;
+  const edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DToken_;
+  const edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentToken_;
 };
 
 #endif

--- a/SimMuon/MCTruth/src/CSCTruthTest.cc
+++ b/SimMuon/MCTruth/src/CSCTruthTest.cc
@@ -1,18 +1,12 @@
-#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimMuon/MCTruth/interface/CSCTruthTest.h"
 
-CSCTruthTest::CSCTruthTest(const edm::ParameterSet &iConfig) : conf_(iConfig), consumeCollector_(consumesCollector()) {}
-
-CSCTruthTest::~CSCTruthTest() {}
+CSCTruthTest::CSCTruthTest(const edm::ParameterSet &iConfig) : conf_(iConfig), consumeCollector_(consumesCollector()), cscRecHitToken_(consumes<CSCRecHit2DCollection>(edm::InputTag("csc2DRecHits"))) {}
 
 void CSCTruthTest::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-  using namespace edm;
-
-  Handle<CSCRecHit2DCollection> cscRecHits;
-  iEvent.getByLabel("csc2DRecHits", cscRecHits);
+  const edm::Handle<CSCRecHit2DCollection> &cscRecHits = iEvent.getHandle(cscRecHitToken_);
 
   MuonTruth theTruth(iEvent, iSetup, conf_, consumeCollector_);
 

--- a/SimMuon/MCTruth/src/CSCTruthTest.cc
+++ b/SimMuon/MCTruth/src/CSCTruthTest.cc
@@ -3,7 +3,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimMuon/MCTruth/interface/CSCTruthTest.h"
 
-CSCTruthTest::CSCTruthTest(const edm::ParameterSet &iConfig) : conf_(iConfig), consumeCollector_(consumesCollector()), cscRecHitToken_(consumes<CSCRecHit2DCollection>(edm::InputTag("csc2DRecHits"))) {}
+CSCTruthTest::CSCTruthTest(const edm::ParameterSet &iConfig)
+    : conf_(iConfig),
+      consumeCollector_(consumesCollector()),
+      cscRecHitToken_(consumes<CSCRecHit2DCollection>(edm::InputTag("csc2DRecHits"))) {}
 
 void CSCTruthTest::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   const edm::Handle<CSCRecHit2DCollection> &cscRecHits = iEvent.getHandle(cscRecHitToken_);

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -78,7 +78,7 @@ namespace muonAssociatorByHitsDiagnostics {
     }
 
     if (crossingframe) {
-      const auto& cf_simtracks = event.getHandle(simtracksXFToken_);
+      const auto &cf_simtracks = event.getHandle(simtracksXFToken_);
       unique_ptr<MixCollection<SimTrack>> SimTk(new MixCollection<SimTrack>(cf_simtracks.product()));
       edm::LogVerbatim("MuonAssociatorByHits")
           << "\n"
@@ -92,7 +92,7 @@ namespace muonAssociatorByHitsDiagnostics {
             << ", pT = " << ITER->momentum().Pt() << ", eta = " << ITER->momentum().Eta()
             << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
       }
-      const auto& cf_simvertices = event.getHandle(simvertexXFToken_);
+      const auto &cf_simvertices = event.getHandle(simvertexXFToken_);
       unique_ptr<MixCollection<SimVertex>> SimVtx(new MixCollection<SimVertex>(cf_simvertices.product()));
       edm::LogVerbatim("MuonAssociatorByHits")
           << "\n"
@@ -103,7 +103,7 @@ namespace muonAssociatorByHitsDiagnostics {
         edm::LogVerbatim("MuonAssociatorByHits") << "SimVertex " << kv << " : " << *VITER << endl;
       }
     } else {
-      const auto& simTrackCollection = event.getHandle(simtracksToken_);
+      const auto &simTrackCollection = event.getHandle(simtracksToken_);
       const edm::SimTrackContainer simTC = *(simTrackCollection.product());
       edm::LogVerbatim("MuonAssociatorByHits")
           << "\n"
@@ -117,7 +117,7 @@ namespace muonAssociatorByHitsDiagnostics {
             << ", pT = " << ITER->momentum().Pt() << ", eta = " << ITER->momentum().Eta()
             << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
       }
-      const auto& simVertexCollection = event.getHandle(simvertexToken_);
+      const auto &simVertexCollection = event.getHandle(simvertexToken_);
       const edm::SimVertexContainer simVC = *(simVertexCollection.product());
       edm::LogVerbatim("MuonAssociatorByHits") << "\n"
                                                << "SimVertex collection with InputTag = "

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -31,11 +31,11 @@ namespace muonAssociatorByHitsDiagnostics {
 
     InputDumper(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC) : InputDumper(conf) {
       if (crossingframe) {
-        iC.consumes<CrossingFrame<SimTrack>>(simtracksXFTag);
-        iC.consumes<CrossingFrame<SimVertex>>(simtracksXFTag);
+        simtracksXFToken_ = iC.consumes<CrossingFrame<SimTrack>>(simtracksXFTag);
+        simvertexXFToken_ = iC.consumes<CrossingFrame<SimVertex>>(simtracksXFTag);
       } else {
-        iC.consumes<edm::SimTrackContainer>(simtracksTag);
-        iC.consumes<edm::SimVertexContainer>(simtracksTag);
+        simtracksToken_ = iC.consumes<edm::SimTrackContainer>(simtracksTag);
+        simvertexToken_ = iC.consumes<edm::SimVertexContainer>(simtracksTag);
       }
     }
 
@@ -45,6 +45,10 @@ namespace muonAssociatorByHitsDiagnostics {
     edm::InputTag const simtracksTag;
     edm::InputTag const simtracksXFTag;
     bool const crossingframe;
+    edm::EDGetTokenT<CrossingFrame<SimTrack>> simtracksXFToken_;
+    edm::EDGetTokenT<CrossingFrame<SimVertex>> simvertexXFToken_;
+    edm::EDGetTokenT<edm::SimTrackContainer> simtracksToken_;
+    edm::EDGetTokenT<edm::SimVertexContainer> simvertexToken_;
   };
 
   void InputDumper::dump(const TrackHitsCollection &tC,
@@ -73,16 +77,8 @@ namespace muonAssociatorByHitsDiagnostics {
       }
     }
 
-    // SimTrack collection
-    edm::Handle<CrossingFrame<SimTrack>> cf_simtracks;
-    edm::Handle<edm::SimTrackContainer> simTrackCollection;
-
-    // SimVertex collection
-    edm::Handle<CrossingFrame<SimVertex>> cf_simvertices;
-    edm::Handle<edm::SimVertexContainer> simVertexCollection;
-
     if (crossingframe) {
-      event.getByLabel(simtracksXFTag, cf_simtracks);
+      const auto& cf_simtracks = event.getHandle(simtracksXFToken_);
       unique_ptr<MixCollection<SimTrack>> SimTk(new MixCollection<SimTrack>(cf_simtracks.product()));
       edm::LogVerbatim("MuonAssociatorByHits")
           << "\n"
@@ -96,7 +92,7 @@ namespace muonAssociatorByHitsDiagnostics {
             << ", pT = " << ITER->momentum().Pt() << ", eta = " << ITER->momentum().Eta()
             << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
       }
-      event.getByLabel(simtracksXFTag, cf_simvertices);
+      const auto& cf_simvertices = event.getHandle(simvertexXFToken_);
       unique_ptr<MixCollection<SimVertex>> SimVtx(new MixCollection<SimVertex>(cf_simvertices.product()));
       edm::LogVerbatim("MuonAssociatorByHits")
           << "\n"
@@ -107,7 +103,7 @@ namespace muonAssociatorByHitsDiagnostics {
         edm::LogVerbatim("MuonAssociatorByHits") << "SimVertex " << kv << " : " << *VITER << endl;
       }
     } else {
-      event.getByLabel(simtracksTag, simTrackCollection);
+      const auto& simTrackCollection = event.getHandle(simtracksToken_);
       const edm::SimTrackContainer simTC = *(simTrackCollection.product());
       edm::LogVerbatim("MuonAssociatorByHits")
           << "\n"
@@ -121,7 +117,7 @@ namespace muonAssociatorByHitsDiagnostics {
             << ", pT = " << ITER->momentum().Pt() << ", eta = " << ITER->momentum().Eta()
             << ", phi = " << ITER->momentum().Phi() << "\n * " << *ITER << endl;
       }
-      event.getByLabel(simtracksTag, simVertexCollection);
+      const auto& simVertexCollection = event.getHandle(simvertexToken_);
       const edm::SimVertexContainer simVC = *(simVertexCollection.product());
       edm::LogVerbatim("MuonAssociatorByHits") << "\n"
                                                << "SimVertex collection with InputTag = "

--- a/SimMuon/MCTruth/src/MuonTruth.cc
+++ b/SimMuon/MCTruth/src/MuonTruth.cc
@@ -51,18 +51,18 @@ void MuonTruth::initEvent(const edm::Event &event, const edm::EventSetup &setup)
   theWireDigiSimLinks = wireDigiSimLinks.product();
 
   // get CSC Geometry to use CSCLayer methods
-  const edm::ESHandle<CSCGeometry>& mugeom = setup.getHandle(geomToken_);
+  const edm::ESHandle<CSCGeometry> &mugeom = setup.getHandle(geomToken_);
   cscgeom = mugeom.product();
 
   // get CSC Bad Chambers (ME4/2)
-  const edm::ESHandle<CSCBadChambers>& badChambers = setup.getHandle(badToken_);
+  const edm::ESHandle<CSCBadChambers> &badChambers = setup.getHandle(badToken_);
   cscBadChambers = badChambers.product();
 
   theSimHitMap.clear();
 
   if (crossingframe) {
     LogTrace("MuonTruth") << "getting CrossingFrame<PSimHit> collection - " << CSCsimHitsXFTag;
-    const edm::Handle<CrossingFrame<PSimHit>>& cf = event.getHandle(simHitsXFToken_);
+    const edm::Handle<CrossingFrame<PSimHit>> &cf = event.getHandle(simHitsXFToken_);
 
     std::unique_ptr<MixCollection<PSimHit>> CSCsimhits(new MixCollection<PSimHit>(cf.product()));
     LogTrace("MuonTruth") << "... size = " << CSCsimhits->size();

--- a/SimMuon/MCTruth/src/MuonTruth.cc
+++ b/SimMuon/MCTruth/src/MuonTruth.cc
@@ -17,7 +17,9 @@ MuonTruth::MuonTruth(const edm::Event &event,
       CSCsimHitsTag(conf.getParameter<edm::InputTag>("CSCsimHitsTag")),
       CSCsimHitsXFTag(conf.getParameter<edm::InputTag>("CSCsimHitsXFTag")),
       geomToken_(iC.esConsumes<CSCGeometry, MuonGeometryRecord>()),
-      badToken_(iC.esConsumes<CSCBadChambers, CSCBadChambersRcd>()) {
+      badToken_(iC.esConsumes<CSCBadChambers, CSCBadChambersRcd>()),
+      linksToken_(iC.consumes<DigiSimLinks>(linksTag)),
+      wireLinksToken_(iC.consumes<DigiSimLinks>(wireLinksTag)) {
   initEvent(event, setup);
 }
 
@@ -29,43 +31,38 @@ MuonTruth::MuonTruth(const edm::ParameterSet &conf, edm::ConsumesCollector &&iC)
       // CrossingFrame used or not ?
       crossingframe(conf.getParameter<bool>("crossingframe")),
       CSCsimHitsTag(conf.getParameter<edm::InputTag>("CSCsimHitsTag")),
-      CSCsimHitsXFTag(conf.getParameter<edm::InputTag>("CSCsimHitsXFTag"))
-
-{
-  iC.consumes<DigiSimLinks>(linksTag);
-  iC.consumes<DigiSimLinks>(wireLinksTag);
+      CSCsimHitsXFTag(conf.getParameter<edm::InputTag>("CSCsimHitsXFTag")),
+      linksToken_(iC.consumes<DigiSimLinks>(linksTag)),
+      wireLinksToken_(iC.consumes<DigiSimLinks>(wireLinksTag)) {
   if (crossingframe) {
-    iC.consumes<CrossingFrame<PSimHit>>(CSCsimHitsXFTag);
+    simHitsXFToken_ = iC.consumes<CrossingFrame<PSimHit>>(CSCsimHitsXFTag);
   } else if (!CSCsimHitsTag.label().empty()) {
-    iC.consumes<edm::PSimHitContainer>(CSCsimHitsTag);
+    simHitsToken_ = iC.consumes<edm::PSimHitContainer>(CSCsimHitsTag);
   }
 }
 
 void MuonTruth::initEvent(const edm::Event &event, const edm::EventSetup &setup) {
-  edm::Handle<DigiSimLinks> digiSimLinks;
   LogTrace("MuonTruth") << "getting CSC Strip DigiSimLink collection - " << linksTag;
-  event.getByLabel(linksTag, digiSimLinks);
+  const edm::Handle<DigiSimLinks> &digiSimLinks = event.getHandle(linksToken_);
   theDigiSimLinks = digiSimLinks.product();
 
-  edm::Handle<DigiSimLinks> wireDigiSimLinks;
   LogTrace("MuonTruth") << "getting CSC Wire DigiSimLink collection - " << wireLinksTag;
-  event.getByLabel(wireLinksTag, wireDigiSimLinks);
+  const edm::Handle<DigiSimLinks> &wireDigiSimLinks = event.getHandle(wireLinksToken_);
   theWireDigiSimLinks = wireDigiSimLinks.product();
 
   // get CSC Geometry to use CSCLayer methods
-  edm::ESHandle<CSCGeometry> mugeom = setup.getHandle(geomToken_);
+  const edm::ESHandle<CSCGeometry>& mugeom = setup.getHandle(geomToken_);
   cscgeom = mugeom.product();
 
   // get CSC Bad Chambers (ME4/2)
-  edm::ESHandle<CSCBadChambers> badChambers = setup.getHandle(badToken_);
+  const edm::ESHandle<CSCBadChambers>& badChambers = setup.getHandle(badToken_);
   cscBadChambers = badChambers.product();
 
   theSimHitMap.clear();
 
   if (crossingframe) {
-    edm::Handle<CrossingFrame<PSimHit>> cf;
     LogTrace("MuonTruth") << "getting CrossingFrame<PSimHit> collection - " << CSCsimHitsXFTag;
-    event.getByLabel(CSCsimHitsXFTag, cf);
+    const edm::Handle<CrossingFrame<PSimHit>>& cf = event.getHandle(simHitsXFToken_);
 
     std::unique_ptr<MixCollection<PSimHit>> CSCsimhits(new MixCollection<PSimHit>(cf.product()));
     LogTrace("MuonTruth") << "... size = " << CSCsimhits->size();
@@ -75,9 +72,8 @@ void MuonTruth::initEvent(const edm::Event &event, const edm::EventSetup &setup)
     }
 
   } else if (!CSCsimHitsTag.label().empty()) {
-    edm::Handle<edm::PSimHitContainer> CSCsimhits;
     LogTrace("MuonTruth") << "getting PSimHit collection - " << CSCsimHitsTag;
-    event.getByLabel(CSCsimHitsTag, CSCsimhits);
+    const edm::Handle<edm::PSimHitContainer> &CSCsimhits = event.getHandle(simHitsToken_);
     LogTrace("MuonTruth") << "... size = " << CSCsimhits->size();
 
     for (edm::PSimHitContainer::const_iterator hitItr = CSCsimhits->begin(); hitItr != CSCsimhits->end(); ++hitItr) {

--- a/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
+++ b/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
@@ -20,8 +20,8 @@ TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet &parset
           ic.consumes<CSCSegmentCollection>(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))) {}
 
 void TrackerMuonHitExtractor::init(const edm::Event &iEvent) {
-  const edm::Handle<DTRecSegment4DCollection>& dtSegmentCollectionH = iEvent.getHandle(inputDTRecSegment4DToken_);
-  const edm::Handle<CSCSegmentCollection>& cscSegmentCollectionH = iEvent.getHandle(inputCSCSegmentToken_);
+  const edm::Handle<DTRecSegment4DCollection> &dtSegmentCollectionH = iEvent.getHandle(inputDTRecSegment4DToken_);
+  const edm::Handle<CSCSegmentCollection> &cscSegmentCollectionH = iEvent.getHandle(inputCSCSegmentToken_);
 
   edm::LogVerbatim("TrackerMuonHitExtractor") << "\nThere are " << dtSegmentCollectionH->size() << " DT segments.";
   unsigned int index_dt_segment = 0;

--- a/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
+++ b/SimMuon/MCTruth/src/TrackerMuonHitExtractor.cc
@@ -17,24 +17,16 @@ TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet &parset
     : inputDTRecSegment4DToken_(
           ic.consumes<DTRecSegment4DCollection>(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
       inputCSCSegmentToken_(
-          ic.consumes<CSCSegmentCollection>(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))),
-      inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
-      inputCSCSegmentCollection_(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection")) {}
-
-TrackerMuonHitExtractor::TrackerMuonHitExtractor(const edm::ParameterSet &parset)
-    : inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
-      inputCSCSegmentCollection_(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection")) {}
-
-TrackerMuonHitExtractor::~TrackerMuonHitExtractor() {}
+          ic.consumes<CSCSegmentCollection>(parset.getParameter<edm::InputTag>("inputCSCSegmentCollection"))) {}
 
 void TrackerMuonHitExtractor::init(const edm::Event &iEvent) {
-  iEvent.getByLabel(inputDTRecSegment4DCollection_, dtSegmentCollectionH_);
-  iEvent.getByLabel(inputCSCSegmentCollection_, cscSegmentCollectionH_);
+  const edm::Handle<DTRecSegment4DCollection>& dtSegmentCollectionH = iEvent.getHandle(inputDTRecSegment4DToken_);
+  const edm::Handle<CSCSegmentCollection>& cscSegmentCollectionH = iEvent.getHandle(inputCSCSegmentToken_);
 
-  edm::LogVerbatim("TrackerMuonHitExtractor") << "\nThere are " << dtSegmentCollectionH_->size() << " DT segments.";
+  edm::LogVerbatim("TrackerMuonHitExtractor") << "\nThere are " << dtSegmentCollectionH->size() << " DT segments.";
   unsigned int index_dt_segment = 0;
-  for (DTRecSegment4DCollection::const_iterator segment = dtSegmentCollectionH_->begin();
-       segment != dtSegmentCollectionH_->end();
+  for (DTRecSegment4DCollection::const_iterator segment = dtSegmentCollectionH->begin();
+       segment != dtSegmentCollectionH->end();
        ++segment, index_dt_segment++) {
     LocalPoint segmentLocalPosition = segment->localPosition();
     LocalVector segmentLocalDirection = segment->localDirection();
@@ -63,10 +55,10 @@ void TrackerMuonHitExtractor::init(const edm::Event &iEvent) {
         << segmentdYdZerr << ")";
   }
 
-  edm::LogVerbatim("TrackerMuonHitExtractor") << "\nThere are " << cscSegmentCollectionH_->size() << " CSC segments.";
+  edm::LogVerbatim("TrackerMuonHitExtractor") << "\nThere are " << cscSegmentCollectionH->size() << " CSC segments.";
   unsigned int index_csc_segment = 0;
-  for (CSCSegmentCollection::const_iterator segment = cscSegmentCollectionH_->begin();
-       segment != cscSegmentCollectionH_->end();
+  for (CSCSegmentCollection::const_iterator segment = cscSegmentCollectionH->begin();
+       segment != cscSegmentCollectionH->end();
        ++segment, index_csc_segment++) {
     LocalPoint segmentLocalPosition = segment->localPosition();
     LocalVector segmentLocalDirection = segment->localDirection();

--- a/SimMuon/MCTruth/test/testReader.cc
+++ b/SimMuon/MCTruth/test/testReader.cc
@@ -1,7 +1,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimMuon/MCTruth/test/testReader.h"
 
-testReader::testReader(const edm::ParameterSet &parset)
+testReader::testReader(const edm::ParameterSet& parset)
     : tracksTag_(parset.getParameter<edm::InputTag>("tracksTag")),
       tpTag_(parset.getParameter<edm::InputTag>("tpTag")),
       assoMapsTag_(parset.getParameter<edm::InputTag>("assoMapsTag")),
@@ -10,7 +10,7 @@ testReader::testReader(const edm::ParameterSet &parset)
       recoToSimToken_(consumes<reco::RecoToSimCollection>(assoMapsTag_)),
       simToRecoToken_(consumes<reco::SimToRecoCollection>(assoMapsTag_)) {}
 
-void testReader::analyze(const edm::Event &event, const edm::EventSetup &setup) {
+void testReader::analyze(const edm::Event& event, const edm::EventSetup& setup) {
   LogTrace("testReader") << "testReader::analyze : getting reco::Track collection, " << tracksTag_;
   edm::View<reco::Track> trackCollection;
   const edm::Handle<edm::View<reco::Track>>& trackCollectionH = event.getHandle(tracksToken_);

--- a/SimMuon/MCTruth/test/testReader.cc
+++ b/SimMuon/MCTruth/test/testReader.cc
@@ -1,41 +1,37 @@
-#include "SimDataFormats/Associations/interface/TrackAssociation.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimMuon/MCTruth/test/testReader.h"
 
 testReader::testReader(const edm::ParameterSet &parset)
-    : tracksTag(parset.getParameter<edm::InputTag>("tracksTag")),
-      tpTag(parset.getParameter<edm::InputTag>("tpTag")),
-      assoMapsTag(parset.getParameter<edm::InputTag>("assoMapsTag")) {}
-
-testReader::~testReader() {}
+    : tracksTag_(parset.getParameter<edm::InputTag>("tracksTag")),
+      tpTag_(parset.getParameter<edm::InputTag>("tpTag")),
+      assoMapsTag_(parset.getParameter<edm::InputTag>("assoMapsTag")),
+      tracksToken_(consumes<edm::View<reco::Track>>(tracksTag_)),
+      tpToken_(consumes<TrackingParticleCollection>(tpTag_)),
+      recoToSimToken_(consumes<reco::RecoToSimCollection>(assoMapsTag_)),
+      simToRecoToken_(consumes<reco::SimToRecoCollection>(assoMapsTag_)) {}
 
 void testReader::analyze(const edm::Event &event, const edm::EventSetup &setup) {
-  edm::Handle<edm::View<reco::Track>> trackCollectionH;
+  LogTrace("testReader") << "testReader::analyze : getting reco::Track collection, " << tracksTag_;
   edm::View<reco::Track> trackCollection;
-  LogTrace("testReader") << "testReader::analyze : getting reco::Track collection, " << tracksTag;
-  event.getByLabel(tracksTag, trackCollectionH);
+  const edm::Handle<edm::View<reco::Track>>& trackCollectionH = event.getHandle(tracksToken_);
   if (trackCollectionH.isValid()) {
     trackCollection = *(trackCollectionH.product());
     LogTrace("testReader") << "... size = " << trackCollection.size();
   } else
     LogTrace("testReader") << "... NOT FOUND.";
 
-  edm::Handle<TrackingParticleCollection> TPCollectionH;
+  LogTrace("testReader") << "testReader::analyze : getting TrackingParticle collection, " << tpTag_;
   TrackingParticleCollection tPC;
-  LogTrace("testReader") << "testReader::analyze : getting TrackingParticle collection, " << tpTag;
-  event.getByLabel(tpTag, TPCollectionH);
+  const edm::Handle<TrackingParticleCollection>& TPCollectionH = event.getHandle(tpToken_);
   if (TPCollectionH.isValid()) {
     tPC = *(TPCollectionH.product());
     LogTrace("testReader") << "... size = " << tPC.size();
   } else
     LogTrace("testReader") << "... NOT FOUND.";
 
-  edm::Handle<reco::RecoToSimCollection> recSimH;
+  LogTrace("testReader") << "testReader::analyze : getting  RecoToSimCollection - " << assoMapsTag_;
   reco::RecoToSimCollection recSimColl;
-  LogTrace("testReader") << "testReader::analyze : getting  RecoToSimCollection - " << assoMapsTag;
-  event.getByLabel(assoMapsTag, recSimH);
+  const edm::Handle<reco::RecoToSimCollection>& recSimH = event.getHandle(recoToSimToken_);
   if (recSimH.isValid()) {
     recSimColl = *(recSimH.product());
     LogTrace("testReader") << "... size = " << recSimColl.size();
@@ -43,10 +39,9 @@ void testReader::analyze(const edm::Event &event, const edm::EventSetup &setup) 
     LogTrace("testReader") << "... NOT FOUND.";
   }
 
-  edm::Handle<reco::SimToRecoCollection> simRecH;
+  LogTrace("testReader") << "testReader::analyze : getting  SimToRecoCollection - " << assoMapsTag_;
   reco::SimToRecoCollection simRecColl;
-  LogTrace("testReader") << "testReader::analyze : getting  SimToRecoCollection - " << assoMapsTag;
-  event.getByLabel(assoMapsTag, simRecH);
+  const edm::Handle<reco::SimToRecoCollection>& simRecH = event.getHandle(simToRecoToken_);
   if (simRecH.isValid()) {
     simRecColl = *(simRecH.product());
     LogTrace("testReader") << "... size = " << simRecColl.size();

--- a/SimMuon/MCTruth/test/testReader.h
+++ b/SimMuon/MCTruth/test/testReader.h
@@ -6,19 +6,26 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "SimDataFormats/Associations/interface/TrackAssociation.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include <memory>
 
 class testReader : public edm::one::EDAnalyzer<> {
 public:
   testReader(const edm::ParameterSet &);
-  ~testReader() override;
+  ~testReader() override = default;
   void beginJob() override {}
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
-  edm::InputTag tracksTag;
-  edm::InputTag tpTag;
-  edm::InputTag assoMapsTag;
+  const edm::InputTag tracksTag_;
+  const edm::InputTag tpTag_;
+  const edm::InputTag assoMapsTag_;
+  const edm::EDGetTokenT<edm::View<reco::Track>> tracksToken_;
+  const edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
+  const edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimToken_;
+  const edm::EDGetTokenT<reco::SimToRecoCollection> simToRecoToken_;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

Use tokens rather than labels in accessing collections in SimMuon/MCtruth

#### PR validation:

Use the runTheMatrix test workflows 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special