### PR TITLE
Add RPC 4th endcap stations

### DIFF
--- a/RecoLocalMuon/RPCRecHit/plugins/CSCObjectMap.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/CSCObjectMap.cc
@@ -23,7 +23,7 @@ CSCObjectMap::CSCObjectMap(RPCGeometry const& rpcGeo) {
           int cscstation = station;
           RPCGeomServ rpcsrv(rpcId);
           int rpcsegment = rpcsrv.segment();
-          int cscchamber = rpcsegment;                        //FIX THIS ACCORDING TO RPCGeomServ::segment()Definition
+          int cscchamber = rpcsegment;  //FIX THIS ACCORDING TO RPCGeomServ::segment()Definition
           if ((station == 2 || station == 3 || station == 4) && ring == 3) {  //Adding Ring 3 of RPC to the CSC Ring 2
             cscring = 2;
           }

--- a/RecoLocalMuon/RPCRecHit/plugins/CSCObjectMap.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/CSCObjectMap.cc
@@ -24,7 +24,7 @@ CSCObjectMap::CSCObjectMap(RPCGeometry const& rpcGeo) {
           RPCGeomServ rpcsrv(rpcId);
           int rpcsegment = rpcsrv.segment();
           int cscchamber = rpcsegment;                        //FIX THIS ACCORDING TO RPCGeomServ::segment()Definition
-          if ((station == 2 || station == 3) && ring == 3) {  //Adding Ring 3 of RPC to the CSC Ring 2
+          if ((station == 2 || station == 3 || station == 4) && ring == 3) {  //Adding Ring 3 of RPC to the CSC Ring 2
             cscring = 2;
           }
           CSCStationIndex ind(region, cscstation, cscring, cscchamber);

--- a/RecoLocalMuon/RPCRecHit/plugins/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/CSCSegtoRPC.cc
@@ -55,11 +55,11 @@ std::unique_ptr<RPCRecHitCollection> CSCSegtoRPC::thePoints(const CSCSegmentColl
       if (debug)
         std::cout << "CSC \t \t Number of segments in this CSC = " << CSCSegmentsCounter[CSCId] << std::endl;
       if (debug)
-        std::cout << "CSC \t \t Is the only one in this CSC? is not ind the ring 1 or station 4? Are there more than 2 "
+        std::cout << "CSC \t \t Is the only one in this CSC? is not ind the ring 1? Are there more than 2 "
                      "segments in the event?"
                   << std::endl;
 
-      if (CSCSegmentsCounter[CSCId] == 1 && CSCId.station() != 4 && CSCId.ring() != 1 && allCSCSegments->size() >= 2) {
+      if (CSCSegmentsCounter[CSCId] == 1 && CSCId.ring() != 1 && allCSCSegments->size() >= 2) {
         if (debug)
           std::cout << "CSC \t \t yes" << std::endl;
         int cscEndCap = CSCId.endcap();
@@ -121,7 +121,7 @@ std::unique_ptr<RPCRecHitCollection> CSCSegtoRPC::thePoints(const CSCSegmentColl
           if (debug)
             std::cout << "CSC \t \t Printing The Id" << TheId << std::endl;
 
-          if (rpcRing != 1 && rpcStation != 4) {  //They don't exist!
+          if (rpcRing != 1) {  //They don't exist in Run3!
 
             assert(!rollsForThisCSC.empty());
 


### PR DESCRIPTION
#### PR description:

To add RPC 4th endcap stations. The code to be used for an RPC DPG analysis.

#### PR validation:
tested with runTheMatrix.py -l 11650.0
(1650.0_ZMM_14+2021+ZMM_14TeV_TuneCP5_GenSim+Digi+RecoNano+HARVESTNano+ALCA)
exit: 0 0 0 0 0

Mention: @cms-sw/rpc-dpg-l2 
