### PR TITLE
Making RPC digimerge as default at Run3

### DIFF
--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -12,6 +12,7 @@ from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 from Configuration.Eras.Modifier_run3_nanoAOD_devel_cff import run3_nanoAOD_devel
 from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
+from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2021, dd4hep, run3_nanoAOD_devel)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2021, dd4hep, run3_nanoAOD_devel, run3_RPC)
 


### PR DESCRIPTION
#### PR description:

To make the RPC Digi merged collection as default input to the RPC LocalReco for Run3.
Related to the already merged PR 24613 and PR 27672
https://github.com/cms-sw/cmssw/pull/24613
https://github.com/cms-sw/cmssw/pull/27672

#### PR validation:

scram b distclean 
git cms-checkdeps -a -A
scram b -j 8
scram b runtests
For MC chain - runTheMatrix.py -l 11634.24 --command="-n 1000" - zero failed test
For DATA chain - runTheMatrix.py -l 136.897 --command="-n 1000" - zero failed test
Code quality checks

The RPC Digi Merged collection is already in use since the end of 2018 in DQM Online. The output with legacy and merged readout is almost the same.
The very small differences are expected and caused by the different range of the non-central readout windows.

@andresib @jhgoh @ftorresd @mileva