### PR TITLE
Add another excluded era for displaced muons

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
@@ -53,6 +53,7 @@ _mAOD = (run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy)
                             func = lambda list: list.remove(cms.InputTag("patLowPtElectrons")) )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+from Configuration.Eras.Era_Run2_2016_HIPM_cff import Run2_2016_HIPM
 (pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toReplaceWith(patCandidatesTask,
                                                    patCandidatesTask.copyAndExclude([makePatDisplacedMuonsTask]))
 (pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toModify(patCandidateSummary.candidates,

--- a/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
@@ -53,9 +53,9 @@ _mAOD = (run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy)
                             func = lambda list: list.remove(cms.InputTag("patLowPtElectrons")) )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toReplaceWith(patCandidatesTask,
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toReplaceWith(patCandidatesTask,
                                                    patCandidatesTask.copyAndExclude([makePatDisplacedMuonsTask]))
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toModify(patCandidateSummary.candidates,
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toModify(patCandidateSummary.candidates,
                                               func = lambda list: list.remove(cms.InputTag("patDisplacedMuons")) )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/PhysicsTools/PatAlgos/python/selectionLayer1/selectedPatCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/selectionLayer1/selectedPatCandidates_cff.py
@@ -51,9 +51,10 @@ _mAOD = (run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy)
                             func = lambda list: list.remove(cms.InputTag("selectedPatLowPtElectrons")) )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toReplaceWith(selectedPatCandidatesTask,
+from Configuration.Eras.Era_Run2_2016_HIPM_cff import Run2_2016_HIPM
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toReplaceWith(selectedPatCandidatesTask,
                                                    selectedPatCandidatesTask.copyAndExclude([selectedPatDisplacedMuons]))
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toModify(selectedPatCandidateSummary.candidates,
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toModify(selectedPatCandidateSummary.candidates,
                                               func = lambda list: list.remove(cms.InputTag("selectedPatDisplacedMuons")) )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -80,7 +80,8 @@ _mAOD = (run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy)
                                  slimmingTask.copyAndExclude([slimmedLowPtElectronsTask]))
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toReplaceWith(slimmingTask,
+from Configuration.Eras.Era_Run2_2016_HIPM_cff import Run2_2016_HIPM
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toReplaceWith(slimmingTask,
                                                    slimmingTask.copyAndExclude([slimmedDisplacedMuons, slimmedDisplacedMuonTrackExtras]))
 
 from PhysicsTools.PatAlgos.slimming.hiPixelTracks_cfi import hiPixelTracks


### PR DESCRIPTION
This is an attempt to solve the unit test failure in `testTauEmbeddingProducers` that showed up after the merging of #37805, as notified in https://github.com/cms-sw/cmssw/pull/37805#issuecomment-1126923256

Disclaimer: I am not able to test it now (sunday afternoon, etc.), but to speed up I let bot doing it, something which is not very efficient during working days when I have all computing facilities available, but it could speed up things now that we are otherwise ready to build CMSSW_12_4_0_pre4