### PR TITLE
fixing minHieraParPerConstr and python3 compatibility for validation …

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
@@ -69,7 +69,7 @@ MillePedeAlignmentAlgorithm = cms.PSet(
         # AlignmentProducer.ParameterBuilder.Selector, cf. Twiki page SWGuideMillepedeIIAlgorithm.
         Presigmas = cms.VPSet(),
         minHieraConstrCoeff = cms.double(1.e-10), # min abs value of coeff. in hierarchy constr.
-        minHieraParPerConstr = cms.uint32(2), # ignore hierarchy constraints with less params
+        minHieraParPerConstr = cms.uint32(1), # ignore hierarchy constraints with less params
         constrPrecision = cms.uint32(10), # precision for writing constraints to text file. Default is 6 and can be setup with constrPrecision = cms.uint32(0)
         # specify additional steering files
         additionalSteerFiles = cms.vstring(), # obsolete - can be given as entries in 'options'

--- a/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/subModule.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/mpsvalidate/subModule.py
@@ -102,10 +102,10 @@ def plot(MillePedeUser, alignables, mode, struct, parentPlot, config):
 
                 # count entries which are not shown anymore
                 # bin 1 to begin of histogram
-                for j in range(1, numberOfBins / 2 - binShift):
+                for j in range(1, numberOfBins // 2 - binShift):
                     plot.hiddenEntries[i] += plot.histo[i].GetBinContent(j)
                 # from the end of shown bins to the end of histogram
-                for j in range(numberOfBins / 2 + binShift, plot.histo[i].GetNbinsX()):
+                for j in range(numberOfBins // 2 + binShift, plot.histo[i].GetNbinsX()):
                     plot.hiddenEntries[i] += plot.histo[i].GetBinContent(j)
 
                 # merge bins, ca. 100 should be visible in the resulting plot
@@ -128,8 +128,8 @@ def plot(MillePedeUser, alignables, mode, struct, parentPlot, config):
                     # set view range. it is important to note that the number of bins have changed with the rebinning
                     # the total number and the number of shift must be
                     # corrected with / mergeNumberBins
-                    plot.histo[i].GetXaxis().SetRange(int(numberOfBins / (2 * mergeNumberBins) - binShift /
-                                                          mergeNumberBins), int(numberOfBins / (2 * mergeNumberBins) + binShift / mergeNumberBins))
+                    plot.histo[i].GetXaxis().SetRange(int(numberOfBins // (2 * mergeNumberBins) - binShift /
+                                                          mergeNumberBins), int(numberOfBins // (2 * mergeNumberBins) + binShift / mergeNumberBins))
 
         # save copy
         plots[subStructNumber] = plot

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_check.py
@@ -239,6 +239,7 @@ for i in range(len(lib.JOBID)):
             #$mOutSize = `nsls -l $mssDir | grep $milleOut | head -1 | awk '{print \$5}'`;
             #$mOutSize = `cmsLs -l $mssDir | grep $milleOut | head -1 | awk '{print \$2}'`;
             mOutSize = 0
+            #print(">>>eoslsoutput:", eoslsoutput, " \ttype(eoslsoutput):", type(eoslsoutput))
             for line in eoslsoutput:
                 if milleOut in line:
                     columns = line.split()

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_fire.py
@@ -313,6 +313,7 @@ if not args.fireMerge:
                                                      shell=True).decode()
                 except subprocess.CalledProcessError as e:
                     result = "" # -> check for successful job submission will fail
+                #print('      '+result, end=' ')
                 print(result)
                 result = result.strip()
 


### PR DESCRIPTION
…output scripts

1) Lowering minimum #  of paramenters per constraint type to include constraints with a single parameter in Millepede fit.
2) Fixing residual python3 compatibility issues in validation of pede output.

