### PR TITLE
Replace CMS code rule 1 with clang-tidy check build-using-namespace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,10 +21,11 @@ Checks: -*,
   ,readability-redundant-string-cstr,
   ,readability-static-definition-in-anonymous-namespace,
   ,readability-uniqueptr-delete-release
+  ,google-build-using-namespace
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
-CheckOptions:    
+CheckOptions:
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'
   - key:             google-readability-function-size.StatementThreshold

--- a/Utilities/ReleaseScripts/python/cmsCodeRules/config.py
+++ b/Utilities/ReleaseScripts/python/cmsCodeRules/config.py
@@ -3,8 +3,8 @@ __date__ ="$2010-08-06 14.27.51$"
 
 import os
 from Utilities.ReleaseScripts.commentSkipper.commentSkipper import filter as comment
-from Utilities.ReleaseScripts.cmsCodeRules.cppFunctionSkipper import filterFiles as function
-ordering = ['1', '2', '3', '4', '5', '6']
+# from Utilities.ReleaseScripts.cmsCodeRules.cppFunctionSkipper import filterFiles as function
+ordering = ['2', '3', '4', '5', '6']
 
 # default values for directories
 
@@ -26,17 +26,18 @@ Configuration = {}
 # --------------------------------------------------------------------------------
 
 # configuration for rule 1
+# replaced with clang-tidy check google-build-using-namespace
 
-ruleName = '1'
-rulesNames.append(ruleName)
-Configuration[ruleName] = {}
+#ruleName = '1'
+#rulesNames.append(ruleName)
+#Configuration[ruleName] = {}
 
-Configuration[ruleName]['description'] = 'Search for "using namespace" or "using std::" in header files'
-Configuration[ruleName]['filesToMatch'] = ['*.h']
-Configuration[ruleName]['exceptPaths'] = ['HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h']
-Configuration[ruleName]['skip']  = [comment, function]
-Configuration[ruleName]['filter'] = '(\susing|\Ausing)\s+(namespace|std::)' #should be regular expression
-Configuration[ruleName]['exceptFilter'] = []
+#Configuration[ruleName]['description'] = 'Search for "using namespace" or "using std::" in header files'
+#Configuration[ruleName]['filesToMatch'] = ['*.h']
+#Configuration[ruleName]['exceptPaths'] = ['HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h']
+#Configuration[ruleName]['skip']  = [comment, function]
+#Configuration[ruleName]['filter'] = '(\susing|\Ausing)\s+(namespace|std::)' #should be regular expression
+#Configuration[ruleName]['exceptFilter'] = []
 
 # --------------------------------------------------------------------------------
 


### PR DESCRIPTION
(no "using" in header files outside of functions)

#### PR description:

Current implementation of CMS code rule 1 will choke on [code](https://github.com/cms-sw/cmssw/blob/master/EventFilter/CSCRawToDigi/interface/CSCALCTHeader.h#L43-L58) like
```cpp
unsigned short int NTBins() const {
#ifdef LOCAL_UNPACK
    switch (firmwareVersion) {
#else
    switch (firmwareVersion.load()) {
#endif
<...>
    }
}
```
because of imbalance of curly braces. The rule checking code is ran on raw sources and knows nothing about preprocessor definitions. The clang-tidy rule [google-build-using-namespace](https://clang.llvm.org/extra/clang-tidy/checks/google-build-using-namespace.html) can be used to avoid the mess associated with finding function start and end and eventually removing them.

#### PR validation:

Local tests