### PR TITLE
Adding DeepMET SONIC Producer to CMSSW

### DIFF
--- a/Configuration/ProcessModifiers/python/allSonicTriton_cff.py
+++ b/Configuration/ProcessModifiers/python/allSonicTriton_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.ProcessModifiers.enableSonicTriton_cff import enableSonicTriton
 from Configuration.ProcessModifiers.particleNetSonicTriton_cff import particleNetSonicTriton
 from Configuration.ProcessModifiers.particleNetPTSonicTriton_cff import particleNetPTSonicTriton
+from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTriton
 
 # collect all SonicTriton-related process modifiers here
-allSonicTriton = cms.ModifierChain(enableSonicTriton,particleNetSonicTriton)
+allSonicTriton = cms.ModifierChain(enableSonicTriton,deepMETSonicTriton,particleNetSonicTriton)

--- a/Configuration/ProcessModifiers/python/deepMETSonicTriton_cff.py
+++ b/Configuration/ProcessModifiers/python/deepMETSonicTriton_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+deepMETSonicTriton = cms.Modifier()

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -159,7 +159,7 @@ def nanoAOD_recalibrateMETs(process,isData):
         ResponseTune_Graph = cms.untracked.string('RecoMET/METPUSubtraction/data/models/deepmet/deepmet_resp_v1_2018/model.graphdef')
     )
     for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
-        modifier.toModify(nanoAOD_DeepMET_switch, ResponseTune_Graph=cms.untracked.string("RecoMET/METPUSubtraction/data/models/deepmet/deepmet_resp_v1_2016/model.graphdef"))
+        modifier.toModify(nanoAOD_DeepMET_switch, ResponseTune_Graph="RecoMET/METPUSubtraction/data/models/deepmet/deepmet_resp_v1_2016/model.graphdef")
 
     print("add DeepMET Producers")
     process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -156,10 +156,10 @@ from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMet
 def nanoAOD_recalibrateMETs(process,isData):
     # add DeepMETs
     nanoAOD_DeepMET_switch = cms.PSet(
-        ResponseTune_Graph = cms.untracked.string('RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb')
+        ResponseTune_Graph = cms.untracked.string('RecoMET/METPUSubtraction/data/models/deepmet/deepmet_resp_v1_2018/model.graphdef')
     )
     for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
-        modifier.toModify(nanoAOD_DeepMET_switch, ResponseTune_Graph=cms.untracked.string("RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb"))
+        modifier.toModify(nanoAOD_DeepMET_switch, ResponseTune_Graph=cms.untracked.string("RecoMET/METPUSubtraction/data/models/deepmet/deepmet_resp_v1_2016/model.graphdef"))
 
     print("add DeepMET Producers")
     process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -494,12 +494,17 @@ def miniAOD_customizeCommon(process):
     (~pp_on_AA).toModify(process, _add_slimmedMETsPuppi)
 
     def _add_deepMET(process):
-        process.load('RecoMET.METPUSubtraction.deepMETProducer_cfi')
+        process.load('RecoMET.METPUSubtraction.deepMETProducer_cff')
+        from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTriton
 
         addToProcessAndTask('deepMETsResolutionTune', process.deepMETProducer.clone(), process, task)
         addToProcessAndTask('deepMETsResponseTune', process.deepMETProducer.clone(), process, task)
-        process.deepMETsResponseTune.graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb'
+        # different ways to get response tune
+        deepMETSonicTriton.toModify(process.deepMETsResponseTune, Client = dict(modelVersion = "2") )
+        (~deepMETSonicTriton).toModify(process.deepMETsResponseTune, graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb')
 
+        # these will not work with SONIC currently
+        # should probably be moved to RecoMET.METPUSubtraction.deepMETProducer_cff (would simplify nano_cff, which also is not updated for SONIC)
         from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
         phase2_common.toModify(
             process.deepMETsResolutionTune,
@@ -511,7 +516,7 @@ def miniAOD_customizeCommon(process):
             max_n_pf=12500,
             graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb"
         )
-        
+
         from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
         run2_jme_2016.toModify(
             process.deepMETsResponseTune,

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -494,34 +494,10 @@ def miniAOD_customizeCommon(process):
     (~pp_on_AA).toModify(process, _add_slimmedMETsPuppi)
 
     def _add_deepMET(process):
-        process.load('RecoMET.METPUSubtraction.deepMETProducer_cff')
-        from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTriton
+        from RecoMET.METPUSubtraction.deepMETProducer_cff import deepMETsResolutionTune, deepMETsResponseTune
 
-        addToProcessAndTask('deepMETsResolutionTune', process.deepMETProducer.clone(), process, task)
-        addToProcessAndTask('deepMETsResponseTune', process.deepMETProducer.clone(), process, task)
-        # different ways to get response tune
-        deepMETSonicTriton.toModify(process.deepMETsResponseTune, Client = dict(modelVersion = "2") )
-        (~deepMETSonicTriton).toModify(process.deepMETsResponseTune, graph_path = 'RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2018.pb')
-
-        # these will not work with SONIC currently
-        # should probably be moved to RecoMET.METPUSubtraction.deepMETProducer_cff (would simplify nano_cff, which also is not updated for SONIC)
-        from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-        phase2_common.toModify(
-            process.deepMETsResolutionTune,
-            max_n_pf=12500,
-            graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_phase2.pb"
-        )
-        phase2_common.toModify(
-            process.deepMETsResponseTune,
-            max_n_pf=12500,
-            graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_phase2.pb"
-        )
-
-        from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
-        run2_jme_2016.toModify(
-            process.deepMETsResponseTune,
-            graph_path="RecoMET/METPUSubtraction/data/deepmet/deepmet_resp_v1_2016.pb"
-        )
+        addToProcessAndTask('deepMETsResolutionTune', deepMETsResolutionTune, process, task)
+        addToProcessAndTask('deepMETsResponseTune', deepMETsResponseTune, process, task)
     (~pp_on_AA).toModify(process, _add_deepMET)
 
     # add DetIdAssociatorRecords to EventSetup (for isolatedTracks)

--- a/RecoMET/METPUSubtraction/interface/DeepMETHelp.h
+++ b/RecoMET/METPUSubtraction/interface/DeepMETHelp.h
@@ -1,0 +1,15 @@
+#ifndef RecoMET_METPUSubtraction_DeepMETHelp_h
+#define RecoMET_METPUSubtraction_DeepMETHelp_h
+
+#include <unordered_map>
+#include <cstdint>
+
+namespace deepmet_helper {
+  float scale_and_rm_outlier(float val, float scale);
+
+  static const std::unordered_map<int, int32_t> charge_embedding{{-1, 0}, {0, 1}, {1, 2}};
+  static const std::unordered_map<int, int32_t> pdg_id_embedding{
+      {-211, 0}, {-13, 1}, {-11, 2}, {0, 3}, {1, 4}, {2, 5}, {11, 6}, {13, 7}, {22, 8}, {130, 9}, {211, 10}};
+}  // namespace deepmet_helper
+
+#endif

--- a/RecoMET/METPUSubtraction/plugins/BuildFile.xml
+++ b/RecoMET/METPUSubtraction/plugins/BuildFile.xml
@@ -16,6 +16,7 @@
   <use name="RecoMET/METPUSubtraction"/>
   <use name="RecoJets/JetProducers"/>
   <use name="PhysicsTools/TensorFlow"/>
+  <use name="HeterogeneousCore/SonicTriton"/>
   <use name="root"/>
   <use name="roottmva"/>
 </library>

--- a/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
@@ -151,7 +151,7 @@ void DeepMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<double>("norm_factor", 50.);
   desc.add<unsigned int>("max_n_pf", 4500);
   desc.addOptionalUntracked<bool>("debugMode", false);
-  desc.add<std::string>("graph_path", "RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_2018.pb");
+  desc.add<std::string>("graph_path", "RecoMET/METPUSubtraction/data/models/deepmet/deepmet_v1_2018/model.graphdef");
   descriptions.add("deepMETProducer", desc);
 }
 

--- a/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
@@ -7,6 +7,9 @@
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "RecoMET/METPUSubtraction/interface/DeepMETHelp.h"
+
+using namespace deepmet_helper;
 
 struct DeepMETCache {
   std::atomic<tensorflow::GraphDef*> graph_def;
@@ -27,6 +30,7 @@ private:
   const float norm_;
   const bool ignore_leptons_;
   const unsigned int max_n_pf_;
+  const bool debug_;
 
   tensorflow::Session* session_;
 
@@ -34,26 +38,14 @@ private:
   tensorflow::Tensor input_cat0_;
   tensorflow::Tensor input_cat1_;
   tensorflow::Tensor input_cat2_;
-
-  inline static const std::unordered_map<int, int32_t> charge_embedding_{{-1, 0}, {0, 1}, {1, 2}};
-  inline static const std::unordered_map<int, int32_t> pdg_id_embedding_{
-      {-211, 0}, {-13, 1}, {-11, 2}, {0, 3}, {1, 4}, {2, 5}, {11, 6}, {13, 7}, {22, 8}, {130, 9}, {211, 10}};
 };
-
-namespace {
-  float scale_and_rm_outlier(float val, float scale) {
-    float ret_val = val * scale;
-    if (ret_val > 1e6 || ret_val < -1e6)
-      return 0.;
-    return ret_val;
-  }
-}  // namespace
 
 DeepMETProducer::DeepMETProducer(const edm::ParameterSet& cfg, const DeepMETCache* cache)
     : pf_token_(consumes<std::vector<pat::PackedCandidate> >(cfg.getParameter<edm::InputTag>("pf_src"))),
       norm_(cfg.getParameter<double>("norm_factor")),
       ignore_leptons_(cfg.getParameter<bool>("ignore_leptons")),
       max_n_pf_(cfg.getParameter<unsigned int>("max_n_pf")),
+      debug_(cfg.getUntrackedParameter<bool>("debugMode", false)),
       session_(tensorflow::createSession(cache->graph_def)) {
   produces<pat::METCollection>();
 
@@ -103,8 +95,8 @@ void DeepMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     *(++ptr) = pf.puppiWeight();
     *(++ptr) = scale_and_rm_outlier(pf.px(), scale);
     *(++ptr) = scale_and_rm_outlier(pf.py(), scale);
-    input_cat0_.tensor<float, 3>()(0, i_pf, 0) = charge_embedding_.at(pf.charge());
-    input_cat1_.tensor<float, 3>()(0, i_pf, 0) = pdg_id_embedding_.at(pf.pdgId());
+    input_cat0_.tensor<float, 3>()(0, i_pf, 0) = charge_embedding.at(pf.charge());
+    input_cat1_.tensor<float, 3>()(0, i_pf, 0) = pdg_id_embedding.at(pf.pdgId());
     input_cat2_.tensor<float, 3>()(0, i_pf, 0) = pf.fromPV();
 
     ++i_pf;
@@ -125,6 +117,10 @@ void DeepMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 
   px -= px_leptons;
   py -= py_leptons;
+
+  if (debug_) {
+    std::cout << "MET from DeepMET Producer is MET_x " << px << " and MET_y " << py << std::endl;
+  }
 
   auto pf_mets = std::make_unique<pat::METCollection>();
   const reco::Candidate::LorentzVector p4(px, py, 0., std::hypot(px, py));
@@ -154,6 +150,7 @@ void DeepMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<bool>("ignore_leptons", false);
   desc.add<double>("norm_factor", 50.);
   desc.add<unsigned int>("max_n_pf", 4500);
+  desc.addOptionalUntracked<bool>("debugMode", false);
   desc.add<std::string>("graph_path", "RecoMET/METPUSubtraction/data/deepmet/deepmet_v1_2018.pb");
   descriptions.add("deepMETProducer", desc);
 }

--- a/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
@@ -30,7 +30,6 @@ private:
   const float norm_;
   const bool ignore_leptons_;
   const unsigned int max_n_pf_;
-  const bool debug_;
 
   tensorflow::Session* session_;
 
@@ -45,7 +44,6 @@ DeepMETProducer::DeepMETProducer(const edm::ParameterSet& cfg, const DeepMETCach
       norm_(cfg.getParameter<double>("norm_factor")),
       ignore_leptons_(cfg.getParameter<bool>("ignore_leptons")),
       max_n_pf_(cfg.getParameter<unsigned int>("max_n_pf")),
-      debug_(cfg.getUntrackedParameter<bool>("debugMode", false)),
       session_(tensorflow::createSession(cache->graph_def)) {
   produces<pat::METCollection>();
 
@@ -118,9 +116,8 @@ void DeepMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   px -= px_leptons;
   py -= py_leptons;
 
-  if (debug_) {
-    std::cout << "MET from DeepMET Producer is MET_x " << px << " and MET_y " << py << std::endl;
-  }
+  LogDebug("produce") << "<DeepMETProducer::produce>:" << std::endl
+		      << " MET from DeepMET Producer is MET_x " << px << " and MET_y " << py << std::endl;
 
   auto pf_mets = std::make_unique<pat::METCollection>();
   const reco::Candidate::LorentzVector p4(px, py, 0., std::hypot(px, py));
@@ -150,7 +147,6 @@ void DeepMETProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
   desc.add<bool>("ignore_leptons", false);
   desc.add<double>("norm_factor", 50.);
   desc.add<unsigned int>("max_n_pf", 4500);
-  desc.addOptionalUntracked<bool>("debugMode", false);
   desc.add<std::string>("graph_path", "RecoMET/METPUSubtraction/data/models/deepmet/deepmet_v1_2018/model.graphdef");
   descriptions.add("deepMETProducer", desc);
 }

--- a/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
@@ -117,7 +117,7 @@ void DeepMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   py -= py_leptons;
 
   LogDebug("produce") << "<DeepMETProducer::produce>:" << std::endl
-		      << " MET from DeepMET Producer is MET_x " << px << " and MET_y " << py << std::endl;
+                      << " MET from DeepMET Producer is MET_x " << px << " and MET_y " << py << std::endl;
 
   auto pf_mets = std::make_unique<pat::METCollection>();
   const reco::Candidate::LorentzVector p4(px, py, 0., std::hypot(px, py));

--- a/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
@@ -1,0 +1,147 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/PatCandidates/interface/MET.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h"
+#include "RecoMET/METPUSubtraction/interface/DeepMETHelp.h"
+
+using namespace deepmet_helper;
+
+class DeepMETSonicProducer : public TritonEDProducer<> {
+public:
+  explicit DeepMETSonicProducer(const edm::ParameterSet&);
+  void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override;
+  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  const edm::EDGetTokenT<std::vector<pat::PackedCandidate>> pf_token_;
+  const float norm_;
+  const bool ignore_leptons_;
+  const unsigned int max_n_pf_;
+  const bool debug_;
+  const float scale_;
+  float px_leptons_;
+  float py_leptons_;
+};
+
+DeepMETSonicProducer::DeepMETSonicProducer(const edm::ParameterSet& cfg)
+    : TritonEDProducer<>(cfg),
+      pf_token_(consumes<std::vector<pat::PackedCandidate>>(cfg.getParameter<edm::InputTag>("pf_src"))),
+      norm_(cfg.getParameter<double>("norm_factor")),
+      ignore_leptons_(cfg.getParameter<bool>("ignore_leptons")),
+      max_n_pf_(cfg.getParameter<unsigned int>("max_n_pf")),
+      debug_(cfg.getUntrackedParameter<bool>("debugMode", false)),
+      scale_(1.0 / norm_) {
+  produces<pat::METCollection>();
+}
+
+void DeepMETSonicProducer::acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) {
+  // one event per batch
+  client_->setBatchSize(1);
+  px_leptons_ = 0.;
+  py_leptons_ = 0.;
+
+  auto const& pfs = iEvent.get(pf_token_);
+
+  auto& input = iInput.at("input");
+  auto pfdata = input.allocate<float>();
+  auto& vpfdata = (*pfdata)[0];
+
+  auto& input_cat0 = iInput.at("input_cat0");
+  auto pfchg = input_cat0.allocate<float>();
+  auto& vpfchg = (*pfchg)[0];
+
+  auto& input_cat1 = iInput.at("input_cat1");
+  auto pfpdgId = input_cat1.allocate<float>();
+  auto& vpfpdgId = (*pfpdgId)[0];
+
+  auto& input_cat2 = iInput.at("input_cat2");
+  auto pffromPV = input_cat2.allocate<float>();
+  auto& vpffromPV = (*pffromPV)[0];
+
+  size_t i_pf = 0;
+  for (const auto& pf : pfs) {
+    if (ignore_leptons_) {
+      int pdg_id = std::abs(pf.pdgId());
+      if (pdg_id == 11 || pdg_id == 13) {
+        px_leptons_ += pf.px();
+        py_leptons_ += pf.py();
+        continue;
+      }
+    }
+
+    // PF keys [b'PF_dxy', b'PF_dz', b'PF_eta', b'PF_mass', b'PF_pt', b'PF_puppiWeight', b'PF_px', b'PF_py']
+    vpfdata.push_back(pf.dxy());
+    vpfdata.push_back(pf.dz());
+    vpfdata.push_back(pf.eta());
+    vpfdata.push_back(pf.mass());
+    vpfdata.push_back(scale_and_rm_outlier(pf.pt(), scale_));
+    vpfdata.push_back(pf.puppiWeight());
+    vpfdata.push_back(scale_and_rm_outlier(pf.px(), scale_));
+    vpfdata.push_back(scale_and_rm_outlier(pf.py(), scale_));
+
+    vpfchg.push_back(charge_embedding.at(pf.charge()));
+
+    vpfpdgId.push_back(pdg_id_embedding.at(pf.pdgId()));
+
+    vpffromPV.push_back(pf.fromPV());
+
+    ++i_pf;
+    if (i_pf == max_n_pf_) {
+      break;  // output a warning?
+    }
+  }
+
+  // fill the remaining with zeros
+  // resize the vector to 4500 for zero-padding
+  vpfdata.resize(8 * max_n_pf_);
+  vpfchg.resize(max_n_pf_);
+  vpfpdgId.resize(max_n_pf_);
+  vpffromPV.resize(max_n_pf_);
+
+  input.toServer(pfdata);
+  input_cat0.toServer(pfchg);
+  input_cat1.toServer(pfpdgId);
+  input_cat2.toServer(pffromPV);
+}
+
+void DeepMETSonicProducer::produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) {
+  const auto& output1 = iOutput.begin()->second;
+  const auto& outputs = output1.fromServer<float>();
+
+  // outputs are px and py
+  float px = outputs[0][0] * norm_;
+  float py = outputs[0][1] * norm_;
+
+  // subtract the lepton pt contribution
+  px -= px_leptons_;
+  py -= py_leptons_;
+
+  if (debug_) {
+    std::cout << "MET from DeepMET Sonic Producer is MET_x " << px << " and MET_y " << py << std::endl;
+  }
+
+  auto pf_mets = std::make_unique<pat::METCollection>();
+  const reco::Candidate::LorentzVector p4(px, py, 0., std::hypot(px, py));
+  pf_mets->emplace_back(reco::MET(p4, {}));
+  iEvent.put(std::move(pf_mets));
+}
+
+void DeepMETSonicProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  TritonClient::fillPSetDescription(desc);
+  desc.add<edm::InputTag>("pf_src");
+  desc.add<bool>("ignore_leptons", false);
+  desc.add<double>("norm_factor", 50.);
+  desc.add<unsigned int>("max_n_pf", 4500);
+  desc.addOptionalUntracked<bool>("debugMode", false);
+  descriptions.add("deepMETSonicProducer", desc);
+}
+
+DEFINE_FWK_MODULE(DeepMETSonicProducer);

--- a/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
@@ -24,7 +24,6 @@ private:
   const float norm_;
   const bool ignore_leptons_;
   const unsigned int max_n_pf_;
-  const bool debug_;
   const float scale_;
   float px_leptons_;
   float py_leptons_;
@@ -36,7 +35,6 @@ DeepMETSonicProducer::DeepMETSonicProducer(const edm::ParameterSet& cfg)
       norm_(cfg.getParameter<double>("norm_factor")),
       ignore_leptons_(cfg.getParameter<bool>("ignore_leptons")),
       max_n_pf_(cfg.getParameter<unsigned int>("max_n_pf")),
-      debug_(cfg.getUntrackedParameter<bool>("debugMode", false)),
       scale_(1.0 / norm_) {
   produces<pat::METCollection>();
 }
@@ -94,7 +92,9 @@ void DeepMETSonicProducer::acquire(edm::Event const& iEvent, edm::EventSetup con
 
     ++i_pf;
     if (i_pf == max_n_pf_) {
-      break;  // output a warning?
+      edm::LogWarning("acquire") << "<DeepMETSonicProducer::acquire>:" << std::endl
+				 << " The number of particles is equal to or exceeds the maximum considerable for DeepMET" << std::endl;
+      break;
     }
   }
 
@@ -123,9 +123,8 @@ void DeepMETSonicProducer::produce(edm::Event& iEvent, edm::EventSetup const& iS
   px -= px_leptons_;
   py -= py_leptons_;
 
-  if (debug_) {
-    std::cout << "MET from DeepMET Sonic Producer is MET_x " << px << " and MET_y " << py << std::endl;
-  }
+  LogDebug("produce") << "<DeepMETSonicProducer::produce>:" << std::endl
+		      << " MET from DeepMET Sonic Producer is MET_x " << px << " and MET_y " << py << std::endl;
 
   auto pf_mets = std::make_unique<pat::METCollection>();
   const reco::Candidate::LorentzVector p4(px, py, 0., std::hypot(px, py));
@@ -140,7 +139,6 @@ void DeepMETSonicProducer::fillDescriptions(edm::ConfigurationDescriptions& desc
   desc.add<bool>("ignore_leptons", false);
   desc.add<double>("norm_factor", 50.);
   desc.add<unsigned int>("max_n_pf", 4500);
-  desc.addOptionalUntracked<bool>("debugMode", false);
   descriptions.add("deepMETSonicProducer", desc);
 }
 

--- a/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
@@ -1,10 +1,4 @@
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h"
@@ -136,7 +130,7 @@ void DeepMETSonicProducer::produce(edm::Event& iEvent, edm::EventSetup const& iS
 void DeepMETSonicProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   TritonClient::fillPSetDescription(desc);
-  desc.add<edm::InputTag>("pf_src");
+  desc.add<edm::InputTag>("pf_src", edm::InputTag("packedPFCandidates"));
   desc.add<bool>("ignore_leptons", false);
   desc.add<double>("norm_factor", 50.);
   desc.add<unsigned int>("max_n_pf", 4500);

--- a/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
@@ -92,8 +92,9 @@ void DeepMETSonicProducer::acquire(edm::Event const& iEvent, edm::EventSetup con
 
     ++i_pf;
     if (i_pf == max_n_pf_) {
-      edm::LogWarning("acquire") << "<DeepMETSonicProducer::acquire>:" << std::endl
-				 << " The number of particles is equal to or exceeds the maximum considerable for DeepMET" << std::endl;
+      edm::LogWarning("acquire")
+          << "<DeepMETSonicProducer::acquire>:" << std::endl
+          << " The number of particles is equal to or exceeds the maximum considerable for DeepMET" << std::endl;
       break;
     }
   }
@@ -124,7 +125,7 @@ void DeepMETSonicProducer::produce(edm::Event& iEvent, edm::EventSetup const& iS
   py -= py_leptons_;
 
   LogDebug("produce") << "<DeepMETSonicProducer::produce>:" << std::endl
-		      << " MET from DeepMET Sonic Producer is MET_x " << px << " and MET_y " << py << std::endl;
+                      << " MET from DeepMET Sonic Producer is MET_x " << px << " and MET_y " << py << std::endl;
 
   auto pf_mets = std::make_unique<pat::METCollection>();
   const reco::Candidate::LorentzVector p4(px, py, 0., std::hypot(px, py));

--- a/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETSonicProducer.cc
@@ -1,4 +1,8 @@
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/PatCandidates/interface/MET.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h"

--- a/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
@@ -32,8 +32,6 @@ from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTr
 
 def split_model_path(path):
     Client = dict(
-        timeout = 300,
-        mode = "Async",
         modelName = path.split('/')[-3],
         modelConfigPath = '/'.join(path.split('/')[:-2])+'/config.pbtxt',
         # version "1" is the resolutionTune

--- a/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-import FWCore.ParameterSet.pfnInPath as pInP
+from FWCore.ParameterSet.pfnInPath import pfnInPath
 import os
 
 from RecoMET.METPUSubtraction.deepMETProducer_cfi import deepMETProducer as _deepMETProducer
@@ -31,11 +31,10 @@ from RecoMET.METPUSubtraction.deepMETSonicProducer_cff import deepMETSonicProduc
 from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTriton
 
 # propagate possible parameter updates
-#print(pInP.pfnInPath(deepMETsResolutionTune.graph_path.value()))
 _deepMETsResolutionTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResolutionTune.max_n_pf,
     Client = dict(
-        modelVersion = os.path.realpath(pInP.pfnInPath(deepMETsResolutionTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "1"
+        modelVersion = os.path.realpath(pfnInPath(deepMETsResolutionTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "1"
     ),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTuneSonic)
@@ -43,7 +42,7 @@ deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTune
 _deepMETsResponseTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResponseTune.max_n_pf,
     Client = dict(
-        modelVersion = os.path.realpath(pInP.pfnInPath(deepMETsResponseTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "2"
+        modelVersion = os.path.realpath(pfnInPath(deepMETsResponseTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "2"
     ),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResponseTune, _deepMETsResponseTuneSonic)

--- a/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.pfnInPath as pInP
 import os
 
 from RecoMET.METPUSubtraction.deepMETProducer_cfi import deepMETProducer as _deepMETProducer
@@ -30,10 +31,11 @@ from RecoMET.METPUSubtraction.deepMETSonicProducer_cff import deepMETSonicProduc
 from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTriton
 
 # propagate possible parameter updates
+#print(pInP.pfnInPath(deepMETsResolutionTune.graph_path.value()))
 _deepMETsResolutionTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResolutionTune.max_n_pf,
     Client = dict(
-        modelVersion = os.path.realpath(os.environ['CMSSW_BASE']+'/src/'+deepMETsResolutionTune.graph_path.value()).split('/')[-2], #model "1"
+        modelVersion = os.path.realpath(pInP.pfnInPath(deepMETsResolutionTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "1"
     ),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTuneSonic)
@@ -41,7 +43,7 @@ deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTune
 _deepMETsResponseTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResponseTune.max_n_pf,
     Client = dict(
-        modelVersion = os.path.realpath(os.environ['CMSSW_BASE']+'/src/'+deepMETsResponseTune.graph_path.value()).split('/')[-2], #model "2"
+        modelVersion = os.path.realpath(pInP.pfnInPath(deepMETsResponseTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "2"
     ),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResponseTune, _deepMETsResponseTuneSonic)

--- a/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
@@ -1,8 +1,49 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoMET.METPUSubtraction.deepMETProducer_cfi import deepMETProducer
+from RecoMET.METPUSubtraction.deepMETProducer_cfi import deepMETProducer as _deepMETProducer
+
+deepMETsResolutionTune = _deepMETProducer.clone()
+deepMETsResponseTune = _deepMETProducer.clone(
+    graph_path = 'RecoMET/METPUSubtraction/data/models/deepmet/deepmet_resp_v1_2018/model.graphdef',
+)
+
+from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
+phase2_common.toModify(
+    deepMETsResolutionTune,
+    max_n_pf=12500,
+    graph_path="RecoMET/METPUSubtraction/data/models/deepmet/deepmet_v1_phase2/model.graphdef"
+)
+phase2_common.toModify(
+    deepMETsResponseTune,
+    max_n_pf=12500,
+    graph_path="RecoMET/METPUSubtraction/data/models/deepmet/deepmet_resp_v1_phase2/model.graphdef"
+)
+
+from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
+run2_jme_2016.toModify(
+    deepMETsResponseTune,
+    graph_path="RecoMET/METPUSubtraction/data/models/deepmet/deepmet_resp_v1_2016/model.graphdef"
+)
+
 from RecoMET.METPUSubtraction.deepMETSonicProducer_cff import deepMETSonicProducer as _deepMETSonicProducer
 from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTriton
 
-deepMETSonicTriton.toReplaceWith(deepMETProducer,_deepMETSonicProducer)
+# propagate possible parameter updates
+_deepMETsResolutionTuneSonic = _deepMETSonicProducer.clone(
+    max_n_pf = deepMETsResolutionTune.max_n_pf,
+    Client = dict(
+        #modelVersion = deepMETsResolutionTune.graph_path.value().split('/')[-2],
+        modelVersion = "1"
+    ),
+)
+deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTuneSonic)
+
+_deepMETsResponseTuneSonic = _deepMETSonicProducer.clone(
+    max_n_pf = deepMETsResponseTune.max_n_pf,
+    Client = dict(
+        #modelVersion = deepMETsResponseTune.graph_path.value().split('/')[-2],
+        modelVersion = "2"
+    ),
+)
+deepMETSonicTriton.toReplaceWith(deepMETsResponseTune, _deepMETsResponseTuneSonic)
 

--- a/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
@@ -30,24 +30,28 @@ run2_jme_2016.toModify(
 from RecoMET.METPUSubtraction.deepMETSonicProducer_cff import deepMETSonicProducer as _deepMETSonicProducer
 from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTriton
 
+def split_model_path(path):
+    Client = dict(
+        timeout = 300,
+        mode = "Async",
+        modelName = path.split('/')[-3],
+        modelConfigPath = '/'.join(path.split('/')[:-2])+'/config.pbtxt',
+        # version "1" is the resolutionTune
+        # version "2" is the responeTune
+        modelVersion = os.path.realpath(pfnInPath(path).split(':')[-1]).split('/')[-2],
+    )
+    return Client
+
 # propagate possible parameter updates
 _deepMETsResolutionTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResolutionTune.max_n_pf,
-    Client = dict(
-        modelName = deepMETsResolutionTune.graph_path.value().split('/')[-3],
-        modelConfigPath = '/'.join(deepMETsResolutionTune.graph_path.value().split('/')[:-2])+'/config.pbtxt',
-        modelVersion = os.path.realpath(pfnInPath(deepMETsResolutionTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "1"
-    ),
+    Client = split_model_path(deepMETsResolutionTune.graph_path.value()),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTuneSonic)
 
 _deepMETsResponseTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResponseTune.max_n_pf,
-    Client = dict(
-        modelName = deepMETsResponseTune.graph_path.value().split('/')[-3],
-        modelConfigPath = '/'.join(deepMETsResponseTune.graph_path.value().split('/')[:-2])+'/config.pbtxt',
-        modelVersion = os.path.realpath(pfnInPath(deepMETsResponseTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "2"
-    ),
+    Client = split_model_path(deepMETsResponseTune.graph_path.value()),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResponseTune, _deepMETsResponseTuneSonic)
 

--- a/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
@@ -33,7 +33,7 @@ from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTr
 _deepMETsResolutionTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResolutionTune.max_n_pf,
     Client = dict(
-        modelVersion = os.readlink(os.environ['CMSSW_BASE']+'/src/'+'/'.join(deepMETsResolutionTune.graph_path.value().split('/')[:-1])).split('/')[-1], #model "1"
+        modelVersion = os.path.realpath(os.environ['CMSSW_BASE']+'/src/'+deepMETsResolutionTune.graph_path.value()).split('/')[-2], #model "1"
     ),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTuneSonic)
@@ -41,7 +41,7 @@ deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTune
 _deepMETsResponseTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResponseTune.max_n_pf,
     Client = dict(
-        modelVersion = os.readlink(os.environ['CMSSW_BASE']+'/src/'+'/'.join(deepMETsResponseTune.graph_path.value().split('/')[:-1])).split('/')[-1], #model "2"
+        modelVersion = os.path.realpath(os.environ['CMSSW_BASE']+'/src/'+deepMETsResponseTune.graph_path.value()).split('/')[-2], #model "2"
     ),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResponseTune, _deepMETsResponseTuneSonic)

--- a/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoMET.METPUSubtraction.deepMETProducer_cfi import deepMETProducer
+from RecoMET.METPUSubtraction.deepMETSonicProducer_cff import deepMETSonicProducer as _deepMETSonicProducer
+from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTriton
+
+deepMETSonicTriton.toReplaceWith(deepMETProducer,_deepMETSonicProducer)
+

--- a/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+import os
 
 from RecoMET.METPUSubtraction.deepMETProducer_cfi import deepMETProducer as _deepMETProducer
 
@@ -32,8 +33,7 @@ from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTr
 _deepMETsResolutionTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResolutionTune.max_n_pf,
     Client = dict(
-        #modelVersion = deepMETsResolutionTune.graph_path.value().split('/')[-2],
-        modelVersion = "1"
+        modelVersion = os.readlink(os.environ['CMSSW_BASE']+'/src/'+'/'.join(deepMETsResolutionTune.graph_path.value().split('/')[:-1])).split('/')[-1], #model "1"
     ),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTuneSonic)
@@ -41,8 +41,7 @@ deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTune
 _deepMETsResponseTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResponseTune.max_n_pf,
     Client = dict(
-        #modelVersion = deepMETsResponseTune.graph_path.value().split('/')[-2],
-        modelVersion = "2"
+        modelVersion = os.readlink(os.environ['CMSSW_BASE']+'/src/'+'/'.join(deepMETsResponseTune.graph_path.value().split('/')[:-1])).split('/')[-1], #model "2"
     ),
 )
 deepMETSonicTriton.toReplaceWith(deepMETsResponseTune, _deepMETsResponseTuneSonic)

--- a/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETProducer_cff.py
@@ -13,12 +13,12 @@ from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(
     deepMETsResolutionTune,
     max_n_pf=12500,
-    graph_path="RecoMET/METPUSubtraction/data/models/deepmet/deepmet_v1_phase2/model.graphdef"
+    graph_path="RecoMET/METPUSubtraction/data/models/deepmet_phase2/deepmet_v1_phase2/model.graphdef"
 )
 phase2_common.toModify(
     deepMETsResponseTune,
     max_n_pf=12500,
-    graph_path="RecoMET/METPUSubtraction/data/models/deepmet/deepmet_resp_v1_phase2/model.graphdef"
+    graph_path="RecoMET/METPUSubtraction/data/models/deepmet_phase2/deepmet_resp_v1_phase2/model.graphdef"
 )
 
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
@@ -34,6 +34,8 @@ from Configuration.ProcessModifiers.deepMETSonicTriton_cff import deepMETSonicTr
 _deepMETsResolutionTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResolutionTune.max_n_pf,
     Client = dict(
+        modelName = deepMETsResolutionTune.graph_path.value().split('/')[-3],
+        modelConfigPath = '/'.join(deepMETsResolutionTune.graph_path.value().split('/')[:-2])+'/config.pbtxt',
         modelVersion = os.path.realpath(pfnInPath(deepMETsResolutionTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "1"
     ),
 )
@@ -42,6 +44,8 @@ deepMETSonicTriton.toReplaceWith(deepMETsResolutionTune, _deepMETsResolutionTune
 _deepMETsResponseTuneSonic = _deepMETSonicProducer.clone(
     max_n_pf = deepMETsResponseTune.max_n_pf,
     Client = dict(
+        modelName = deepMETsResponseTune.graph_path.value().split('/')[-3],
+        modelConfigPath = '/'.join(deepMETsResponseTune.graph_path.value().split('/')[:-2])+'/config.pbtxt',
         modelVersion = os.path.realpath(pfnInPath(deepMETsResponseTune.graph_path.value()).split(':')[-1]).split('/')[-2], #model "2"
     ),
 )

--- a/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+deepMETSonicProducer = cms.EDProducer("DeepMETSonicProducer",
+    Client = cms.PSet(
+        timeout = cms.untracked.uint32(300),
+        mode = cms.string("Async"),
+        modelName = cms.string("deepmet"),
+        modelConfigPath = cms.FileInPath("HeterogeneousCore/SonicTriton/data/models/deepmet/config.pbtxt"),
+        # version "1" is the resolutionTune
+        # version "2" is the responeTune
+        modelVersion = cms.string("1"),
+        verbose = cms.untracked.bool(False),
+        allowedTries = cms.untracked.uint32(0),
+        useSharedMemory = cms.untracked.bool(True),
+        compression = cms.untracked.string(""),
+    ),
+    pf_src = cms.InputTag("packedPFCandidates"),
+)

--- a/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
@@ -5,7 +5,7 @@ deepMETSonicProducer = cms.EDProducer("DeepMETSonicProducer",
         timeout = cms.untracked.uint32(300),
         mode = cms.string("Async"),
         modelName = cms.string("deepmet"),
-        modelConfigPath = cms.FileInPath("RecoMET/RecoMET-METPUSubtraction/deepmet/deepmet/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoMET/METPUSubtraction/data/deepmet/deepmet/config.pbtxt"),
         # version "1" is the resolutionTune
         # version "2" is the responeTune
         modelVersion = cms.string("1"),

--- a/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
@@ -5,7 +5,7 @@ deepMETSonicProducer = cms.EDProducer("DeepMETSonicProducer",
         timeout = cms.untracked.uint32(300),
         mode = cms.string("Async"),
         modelName = cms.string("deepmet"),
-        modelConfigPath = cms.FileInPath("HeterogeneousCore/SonicTriton/data/models/deepmet/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoMET/RecoMET-METPUSubtraction/deepmet/deepmet/config.pbtxt"),
         # version "1" is the resolutionTune
         # version "2" is the responeTune
         modelVersion = cms.string("1"),

--- a/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
@@ -1,18 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
-deepMETSonicProducer = cms.EDProducer("DeepMETSonicProducer",
-    Client = cms.PSet(
-        timeout = cms.untracked.uint32(300),
-        mode = cms.string("Async"),
-        modelName = cms.string("deepmet"),
-        modelConfigPath = cms.FileInPath("RecoMET/METPUSubtraction/data/models/deepmet/config.pbtxt"),
+from RecoMET.METPUSubtraction.deepMETSonicProducer_cfi import deepMETSonicProducer as _deepMETSonicProducer
+
+deepMETSonicProducer = _deepMETSonicProducer.clone(
+    Client = dict(
+        timeout = 300,
+        mode = "Async",
+        modelName = "deepmet",
+        modelConfigPath = "RecoMET/METPUSubtraction/data/models/deepmet/config.pbtxt",
         # version "1" is the resolutionTune
         # version "2" is the responeTune
-        modelVersion = cms.string("1"),
-        verbose = cms.untracked.bool(False),
-        allowedTries = cms.untracked.uint32(0),
-        useSharedMemory = cms.untracked.bool(True),
-        compression = cms.untracked.string(""),
+        modelVersion = "1",
     ),
     pf_src = cms.InputTag("packedPFCandidates"),
 )

--- a/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
@@ -5,7 +5,7 @@ deepMETSonicProducer = cms.EDProducer("DeepMETSonicProducer",
         timeout = cms.untracked.uint32(300),
         mode = cms.string("Async"),
         modelName = cms.string("deepmet"),
-        modelConfigPath = cms.FileInPath("RecoMET/METPUSubtraction/data/deepmet/deepmet/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoMET/METPUSubtraction/data/models/deepmet/config.pbtxt"),
         # version "1" is the resolutionTune
         # version "2" is the responeTune
         modelVersion = cms.string("1"),

--- a/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
+++ b/RecoMET/METPUSubtraction/python/deepMETSonicProducer_cff.py
@@ -12,5 +12,5 @@ deepMETSonicProducer = _deepMETSonicProducer.clone(
         # version "2" is the responeTune
         modelVersion = "1",
     ),
-    pf_src = cms.InputTag("packedPFCandidates"),
+    pf_src = "packedPFCandidates",
 )

--- a/RecoMET/METPUSubtraction/src/DeepMETHelper.cc
+++ b/RecoMET/METPUSubtraction/src/DeepMETHelper.cc
@@ -1,0 +1,11 @@
+#include "RecoMET/METPUSubtraction/interface/DeepMETHelp.h"
+
+namespace deepmet_helper {
+  float scale_and_rm_outlier(float val, float scale) {
+    float ret_val = val * scale;
+    if (ret_val > 1e6 || ret_val < -1e6)
+      return 0.;
+    return ret_val;
+  }
+
+}  // namespace deepmet_helper

--- a/RecoMET/METPUSubtraction/test/testDeepMETSonic_cfg.py
+++ b/RecoMET/METPUSubtraction/test/testDeepMETSonic_cfg.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+from RecoMET.METPUSubtraction.deepMetSonicProducer_cff import sonic_deepmet
+
+from Configuration.ProcessModifiers.enableSonicTriton_cff import enableSonicTriton
+process = cms.Process('DeepMET',enableSonicTriton)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input=cms.untracked.int32(10)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+                            fileNames=cms.untracked.vstring(
+                                '/store/mc/RunIISummer20UL18MiniAOD/DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8/MINIAODSIM/106X_upgrade2018_realistic_v11_L1v1-v1/260000/03794341-C401-CC45-B5FC-D11264E449CE.root'
+                            ),
+                            )
+
+process.load("HeterogeneousCore.SonicTriton.TritonService_cff")
+process.TritonService.verbose = False
+#process.TritonService.fallback.useDocker = True
+process.TritonService.fallback.verbose = False
+# uncomment this part if there is one server running at 0.0.0.0 with grpc port 8001
+#process.TritonService.servers.append(
+#    cms.PSet(
+#        name = cms.untracked.string("default"),
+#        address = cms.untracked.string("0.0.0.0"),
+#        port = cms.untracked.uint32(8021),
+#    )
+#)
+
+
+process.deepMETProducer = sonic_deepmet.clone(
+)
+process.deepMETProducer.Client.verbose = cms.untracked.bool(True)
+
+process.p = cms.Path()
+process.p += process.deepMETProducer
+
+process.output = cms.OutputModule("PoolOutputModule",
+                                  outputCommands=cms.untracked.vstring(
+                                      'keep *'),
+                                  fileName=cms.untracked.string(
+                                      "DeepMETTestSonic.root"
+                                      )
+                                  )
+process.outpath  = cms.EndPath(process.output)
+
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool( True ),
+    numberOfThreads = cms.untracked.uint32( 1 ),
+    numberOfStreams = cms.untracked.uint32( 0 ),
+    sizeOfStackForThreadsInKB = cms.untracked.uint32( 10*1024 )
+)


### PR DESCRIPTION
#### PR description:

This PR introduces a producer for DeepMET using SONIC for co-processor-enabled inferences-as-a-service.  For more information on the status of SONIC, please refer to this presentation to JetMET DPG: https://indico.cern.ch/event/1143469/contributions/4799423/attachments/2416540/4135308/March_28_JetMET_SONIC.pdf.  Please note that the producer introduced here _does not_ affect the main DeepMET producer in any way.  This is an _alternate_ way to run the standard DeepMET model using inference as a service.  As noted in the linked slides, this producer has been validated locally on Tier 2 resources and at scale with cloud computing, but with this PR, we hope to perform more "official" production tests.  But again, this producer does not any workflow unless explicitly called.  A helper-function macro is slightly modified, as are a few config files.  There will be an accompanying PR into https://github.com/cms-data/RecoMET-METPUSubtraction, which adds needed model files.

Tagging @kpedro88 @yongbinfeng @violatingcp @nhanvtran @jmduarte

#### PR validation:

This PR was tested on LPC using a Triton server running on the GPU-enabled AILab machines at FermiLab.  Tests have also been performed using the DeepMET SONIC producer at Purdue T2 and in Google Cloud.  When the producer is not called, there is no performance impact, and when it is called, the MET results are the same as for the generic DeepMET producer.