### PR TITLE
Adding SONIC ParticleNet Producer to CMSSW

### DIFF
--- a/Configuration/ProcessModifiers/python/allSonicTriton_cff.py
+++ b/Configuration/ProcessModifiers/python/allSonicTriton_cff.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.ProcessModifiers.enableSonicTriton_cff import enableSonicTriton
+from Configuration.ProcessModifiers.particleNetSonicTriton_cff import particleNetSonicTriton
+from Configuration.ProcessModifiers.particleNetPTSonicTriton_cff import particleNetPTSonicTriton
 
 # collect all SonicTriton-related process modifiers here
-allSonicTriton = cms.ModifierChain(enableSonicTriton)
+allSonicTriton = cms.ModifierChain(enableSonicTriton,particleNetSonicTriton)

--- a/Configuration/ProcessModifiers/python/particleNetPTSonicTriton_cff.py
+++ b/Configuration/ProcessModifiers/python/particleNetPTSonicTriton_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+particleNetPTSonicTriton = cms.Modifier()

--- a/Configuration/ProcessModifiers/python/particleNetSonicTriton_cff.py
+++ b/Configuration/ProcessModifiers/python/particleNetSonicTriton_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+particleNetSonicTriton = cms.Modifier()

--- a/RecoBTag/FeatureTools/BuildFile.xml
+++ b/RecoBTag/FeatureTools/BuildFile.xml
@@ -4,6 +4,8 @@
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="TrackingTools/IPTools"/>
 <use name="RecoBTag/TrackProbability"/>
+<use name="PhysicsTools/ONNXRuntime"/>
+<use name="json"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoBTag/FeatureTools/interface/deep_helpers.h
+++ b/RecoBTag/FeatureTools/interface/deep_helpers.h
@@ -15,6 +15,17 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <numeric>
+#include <nlohmann/json.hpp>
+
 namespace btagbtvdeep {
 
   // remove infs and NaNs with value  (adapted from DeepNTuples)
@@ -103,6 +114,37 @@ namespace btagbtvdeep {
 
     VarInfo info(const std::string &name) const { return var_info_map.at(name); }
   };
+
+  int center_norm_pad(const std::vector<float> &input,
+                      float center,
+                      float scale,
+                      unsigned min_length,
+                      unsigned max_length,
+                      std::vector<float> &datavec,
+                      int startval,
+                      float pad_value = 0,
+                      float replace_inf_value = 0,
+                      float min = 0,
+                      float max = -1);
+
+  int center_norm_pad_halfRagged(const std::vector<float> &input,
+                                 float center,
+                                 float scale,
+                                 unsigned target_length,
+                                 std::vector<float> &datavec,
+                                 int startval,
+                                 float pad_value = 0,
+                                 float replace_inf_value = 0,
+                                 float min = 0,
+                                 float max = -1);
+
+  void ParticleNetConstructor(const edm::ParameterSet &Config_,
+                              bool doExtra,
+                              std::vector<std::string> &input_names_,
+                              std::unordered_map<std::string, PreprocessParams> &prep_info_map_,
+                              std::vector<std::vector<int64_t>> &input_shapes_,
+                              std::vector<unsigned> &input_sizes_,
+                              cms::Ort::FloatArrays *data_);
 
 }  // namespace btagbtvdeep
 #endif  //RecoBTag_FeatureTools_deep_helpers_h

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -230,7 +230,7 @@ namespace btagbtvdeep {
           double upper_bound = var_pset.at("upper_bound");
           double pad = var_pset.contains("pad") ? double(var_pset.at("pad")) : 0;
           prep_params.var_info_map[var_name] =
-	    PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, pad);
+              PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, pad);
         }
 
         if (doExtra && data_ != nullptr) {
@@ -258,7 +258,7 @@ namespace btagbtvdeep {
           double lower_bound = var_pset.getParameter<double>("lower_bound");
           double upper_bound = var_pset.getParameter<double>("upper_bound");
           prep_params.var_info_map[var_name] =
-	    PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, 0);
+              PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, 0);
         }
 
         if (doExtra && data_ != nullptr) {

--- a/RecoBTag/FeatureTools/src/deep_helpers.cc
+++ b/RecoBTag/FeatureTools/src/deep_helpers.cc
@@ -143,4 +143,131 @@ namespace btagbtvdeep {
     }
     return features;
   }
+
+  int center_norm_pad(const std::vector<float> &input,
+                      float center,
+                      float norm_factor,
+                      unsigned min_length,
+                      unsigned max_length,
+                      std::vector<float> &datavec,
+                      int startval,
+                      float pad_value,
+                      float replace_inf_value,
+                      float min,
+                      float max) {
+    // do variable shifting/scaling/padding/clipping in one go
+
+    assert(min <= pad_value && pad_value <= max);
+    assert(min_length <= max_length);
+
+    unsigned target_length = std::clamp((unsigned)input.size(), min_length, max_length);
+    for (unsigned i = 0; i < target_length; ++i) {
+      if (i < input.size()) {
+        datavec[i + startval] = std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max);
+      } else {
+        datavec[i + startval] = pad_value;
+      }
+    }
+    return target_length;
+  }
+
+  int center_norm_pad_halfRagged(const std::vector<float> &input,
+                                 float center,
+                                 float norm_factor,
+                                 unsigned target_length,
+                                 std::vector<float> &datavec,
+                                 int startval,
+                                 float pad_value,
+                                 float replace_inf_value,
+                                 float min,
+                                 float max) {
+    // do variable shifting/scaling/padding/clipping in one go
+
+    assert(min <= pad_value && pad_value <= max);
+
+    for (unsigned i = 0; i < std::min(static_cast<unsigned int>(input.size()), target_length); ++i) {
+      datavec.push_back(std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max));
+    }
+    if (input.size() < target_length)
+      datavec.insert(datavec.end(), target_length - input.size(), pad_value);
+
+    return target_length;
+  }
+
+  void ParticleNetConstructor(const edm::ParameterSet &Config_,
+                              bool doExtra,
+                              std::vector<std::string> &input_names_,
+                              std::unordered_map<std::string, PreprocessParams> &prep_info_map_,
+                              std::vector<std::vector<int64_t>> &input_shapes_,
+                              std::vector<unsigned> &input_sizes_,
+                              cms::Ort::FloatArrays *data_) {
+    // load preprocessing info
+    auto json_path = Config_.getParameter<std::string>("preprocess_json");
+    if (!json_path.empty()) {
+      // use preprocessing json file if available
+      std::ifstream ifs(edm::FileInPath(json_path).fullPath());
+      nlohmann::json js = nlohmann::json::parse(ifs);
+      js.at("input_names").get_to(input_names_);
+      for (const auto &group_name : input_names_) {
+        const auto &group_pset = js.at(group_name);
+        auto &prep_params = prep_info_map_[group_name];
+        group_pset.at("var_names").get_to(prep_params.var_names);
+        if (group_pset.contains("var_length")) {
+          prep_params.min_length = group_pset.at("var_length");
+          prep_params.max_length = prep_params.min_length;
+        } else {
+          prep_params.min_length = group_pset.at("min_length");
+          prep_params.max_length = group_pset.at("max_length");
+          input_shapes_.push_back({1, (int64_t)prep_params.var_names.size(), -1});
+        }
+        const auto &var_info_pset = group_pset.at("var_infos");
+        for (const auto &var_name : prep_params.var_names) {
+          const auto &var_pset = var_info_pset.at(var_name);
+          double median = var_pset.at("median");
+          double norm_factor = var_pset.at("norm_factor");
+          double replace_inf_value = var_pset.at("replace_inf_value");
+          double lower_bound = var_pset.at("lower_bound");
+          double upper_bound = var_pset.at("upper_bound");
+          double pad = var_pset.contains("pad") ? double(var_pset.at("pad")) : 0;
+          prep_params.var_info_map[var_name] =
+	    PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, pad);
+        }
+
+        if (doExtra && data_ != nullptr) {
+          // create data storage with a fixed size vector initialized w/ 0
+          const auto &len = input_sizes_.emplace_back(prep_params.max_length * prep_params.var_names.size());
+          data_->emplace_back(len, 0);
+        }
+      }
+    } else {
+      // otherwise use the PSet in the python config file
+      const auto &prep_pset = Config_.getParameterSet("preprocessParams");
+      input_names_ = prep_pset.getParameter<std::vector<std::string>>("input_names");
+      for (const auto &group_name : input_names_) {
+        const edm::ParameterSet &group_pset = prep_pset.getParameterSet(group_name);
+        auto &prep_params = prep_info_map_[group_name];
+        prep_params.var_names = group_pset.getParameter<std::vector<std::string>>("var_names");
+        prep_params.min_length = group_pset.getParameter<unsigned>("var_length");
+        prep_params.max_length = prep_params.min_length;
+        const auto &var_info_pset = group_pset.getParameterSet("var_infos");
+        for (const auto &var_name : prep_params.var_names) {
+          const edm::ParameterSet &var_pset = var_info_pset.getParameterSet(var_name);
+          double median = var_pset.getParameter<double>("median");
+          double norm_factor = var_pset.getParameter<double>("norm_factor");
+          double replace_inf_value = var_pset.getParameter<double>("replace_inf_value");
+          double lower_bound = var_pset.getParameter<double>("lower_bound");
+          double upper_bound = var_pset.getParameter<double>("upper_bound");
+          prep_params.var_info_map[var_name] =
+	    PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, 0);
+        }
+
+        if (doExtra && data_ != nullptr) {
+          // create data storage with a fixed size vector initialized w/ 0
+          const auto &len = input_sizes_.emplace_back(prep_params.max_length * prep_params.var_names.size());
+          data_->emplace_back(len, 0);
+        }
+      }
+    }
+  }
+
 }  // namespace btagbtvdeep

--- a/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
@@ -42,15 +42,6 @@ private:
 
   void produce(edm::Event &, const edm::EventSetup &) override;
 
-  std::vector<float> center_norm_pad(const std::vector<float> &input,
-                                     float center,
-                                     float scale,
-                                     unsigned min_length,
-                                     unsigned max_length,
-                                     float pad_value = 0,
-                                     float replace_inf_value = 0,
-                                     float min = 0,
-                                     float max = -1);
   void make_inputs(const reco::DeepBoostedJetTagInfo &taginfo);
 
   const edm::EDGetTokenT<TagInfoCollection> src_;
@@ -69,69 +60,7 @@ BoostedJetONNXJetTagsProducer::BoostedJetONNXJetTagsProducer(const edm::Paramete
     : src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
       flav_names_(iConfig.getParameter<std::vector<std::string>>("flav_names")),
       debug_(iConfig.getUntrackedParameter<bool>("debugMode", false)) {
-  // load preprocessing info
-  auto json_path = iConfig.getParameter<std::string>("preprocess_json");
-  if (!json_path.empty()) {
-    // use preprocessing json file if available
-    std::ifstream ifs(edm::FileInPath(json_path).fullPath());
-    nlohmann::json js = nlohmann::json::parse(ifs);
-    js.at("input_names").get_to(input_names_);
-    for (const auto &group_name : input_names_) {
-      const auto &group_pset = js.at(group_name);
-      auto &prep_params = prep_info_map_[group_name];
-      group_pset.at("var_names").get_to(prep_params.var_names);
-      if (group_pset.contains("var_length")) {
-        prep_params.min_length = group_pset.at("var_length");
-        prep_params.max_length = prep_params.min_length;
-      } else {
-        prep_params.min_length = group_pset.at("min_length");
-        prep_params.max_length = group_pset.at("max_length");
-        input_shapes_.push_back({1, (int64_t)prep_params.var_names.size(), -1});
-      }
-      const auto &var_info_pset = group_pset.at("var_infos");
-      for (const auto &var_name : prep_params.var_names) {
-        const auto &var_pset = var_info_pset.at(var_name);
-        double median = var_pset.at("median");
-        double norm_factor = var_pset.at("norm_factor");
-        double replace_inf_value = var_pset.at("replace_inf_value");
-        double lower_bound = var_pset.at("lower_bound");
-        double upper_bound = var_pset.at("upper_bound");
-        double pad = var_pset.contains("pad") ? double(var_pset.at("pad")) : 0;
-        prep_params.var_info_map[var_name] =
-            PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, pad);
-      }
-
-      // create data storage with a fixed size vector initilized w/ 0
-      const auto &len = input_sizes_.emplace_back(prep_params.max_length * prep_params.var_names.size());
-      data_.emplace_back(len, 0);
-    }
-  } else {
-    // otherwise use the PSet in the python config file
-    const auto &prep_pset = iConfig.getParameterSet("preprocessParams");
-    input_names_ = prep_pset.getParameter<std::vector<std::string>>("input_names");
-    for (const auto &group_name : input_names_) {
-      const auto &group_pset = prep_pset.getParameterSet(group_name);
-      auto &prep_params = prep_info_map_[group_name];
-      prep_params.var_names = group_pset.getParameter<std::vector<std::string>>("var_names");
-      prep_params.min_length = group_pset.getParameter<unsigned>("var_length");
-      prep_params.max_length = prep_params.min_length;
-      const auto &var_info_pset = group_pset.getParameterSet("var_infos");
-      for (const auto &var_name : prep_params.var_names) {
-        const auto &var_pset = var_info_pset.getParameterSet(var_name);
-        double median = var_pset.getParameter<double>("median");
-        double norm_factor = var_pset.getParameter<double>("norm_factor");
-        double replace_inf_value = var_pset.getParameter<double>("replace_inf_value");
-        double lower_bound = var_pset.getParameter<double>("lower_bound");
-        double upper_bound = var_pset.getParameter<double>("upper_bound");
-        prep_params.var_info_map[var_name] =
-            PreprocessParams::VarInfo(median, norm_factor, replace_inf_value, lower_bound, upper_bound, 0);
-      }
-
-      // create data storage with a fixed size vector initiliazed w/ 0
-      const auto &len = input_sizes_.emplace_back(prep_params.max_length * prep_params.var_names.size());
-      data_.emplace_back(len, 0);
-    }
-  }
+  ParticleNetConstructor(iConfig, true, input_names_, prep_info_map_, input_shapes_, input_sizes_, &data_);
 
   if (debug_) {
     for (unsigned i = 0; i < input_names_.size(); ++i) {
@@ -261,28 +190,6 @@ void BoostedJetONNXJetTagsProducer::produce(edm::Event &iEvent, const edm::Event
   }
 }
 
-std::vector<float> BoostedJetONNXJetTagsProducer::center_norm_pad(const std::vector<float> &input,
-                                                                  float center,
-                                                                  float norm_factor,
-                                                                  unsigned min_length,
-                                                                  unsigned max_length,
-                                                                  float pad_value,
-                                                                  float replace_inf_value,
-                                                                  float min,
-                                                                  float max) {
-  // do variable shifting/scaling/padding/clipping in one go
-
-  assert(min <= pad_value && pad_value <= max);
-  assert(min_length <= max_length);
-
-  unsigned target_length = std::clamp((unsigned)input.size(), min_length, max_length);
-  std::vector<float> out(target_length, pad_value);
-  for (unsigned i = 0; i < input.size() && i < target_length; ++i) {
-    out[i] = std::clamp((catch_infs(input[i], replace_inf_value) - center) * norm_factor, min, max);
-  }
-  return out;
-}
-
 void BoostedJetONNXJetTagsProducer::make_inputs(const reco::DeepBoostedJetTagInfo &taginfo) {
   for (unsigned igroup = 0; igroup < input_names_.size(); ++igroup) {
     const auto &group_name = input_names_[igroup];
@@ -297,26 +204,27 @@ void BoostedJetONNXJetTagsProducer::make_inputs(const reco::DeepBoostedJetTagInf
       const auto &varname = prep_params.var_names[i];
       const auto &raw_value = taginfo.features().get(varname);
       const auto &info = prep_params.info(varname);
-      auto val = center_norm_pad(raw_value,
-                                 info.center,
-                                 info.norm_factor,
-                                 prep_params.min_length,
-                                 prep_params.max_length,
-                                 info.pad,
-                                 info.replace_inf_value,
-                                 info.lower_bound,
-                                 info.upper_bound);
-      std::copy(val.begin(), val.end(), group_values.begin() + curr_pos);
-      curr_pos += val.size();
+      int insize = center_norm_pad(raw_value,
+                                   info.center,
+                                   info.norm_factor,
+                                   prep_params.min_length,
+                                   prep_params.max_length,
+                                   group_values,
+                                   curr_pos,
+                                   info.pad,
+                                   info.replace_inf_value,
+                                   info.lower_bound,
+                                   info.upper_bound);
+      curr_pos += insize;
       if (i == 0 && (!input_shapes_.empty())) {
-        input_shapes_[igroup][2] = val.size();
+        input_shapes_[igroup][2] = insize;
       }
 
       if (debug_) {
         std::cout << " -- var=" << varname << ", center=" << info.center << ", scale=" << info.norm_factor
                   << ", replace=" << info.replace_inf_value << ", pad=" << info.pad << std::endl;
-        for (const auto &v : val) {
-          std::cout << v << ",";
+        for (unsigned i = curr_pos - insize; i < curr_pos; i++) {
+          std::cout << group_values[i] << ",";
         }
         std::cout << std::endl;
       }

--- a/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc
@@ -63,25 +63,26 @@ BoostedJetONNXJetTagsProducer::BoostedJetONNXJetTagsProducer(const edm::Paramete
   ParticleNetConstructor(iConfig, true, input_names_, prep_info_map_, input_shapes_, input_sizes_, &data_);
 
   if (debug_) {
+    LogDebug("BoostedJetONNXJetTagsProducer") << "<BoostedJetONNXJetTagsProducer::produce>:" << std::endl;
     for (unsigned i = 0; i < input_names_.size(); ++i) {
       const auto &group_name = input_names_.at(i);
       if (!input_shapes_.empty()) {
-        std::cout << group_name << "\nshapes: ";
+        LogDebug("BoostedJetONNXJetTagsProducer") << group_name << "\nshapes: ";
         for (const auto &x : input_shapes_.at(i)) {
-          std::cout << x << ", ";
+          LogDebug("BoostedJetONNXJetTagsProducer") << x << ", ";
         }
       }
-      std::cout << "\nvariables: ";
+      LogDebug("BoostedJetONNXJetTagsProducer") << "\nvariables: ";
       for (const auto &x : prep_info_map_.at(group_name).var_names) {
-        std::cout << x << ", ";
+        LogDebug("BoostedJetONNXJetTagsProducer") << x << ", ";
       }
-      std::cout << "\n";
+      LogDebug("BoostedJetONNXJetTagsProducer") << "\n";
     }
-    std::cout << "flav_names: ";
+    LogDebug("BoostedJetONNXJetTagsProducer") << "flav_names: ";
     for (const auto &flav_name : flav_names_) {
-      std::cout << flav_name << ", ";
+      LogDebug("BoostedJetONNXJetTagsProducer") << flav_name << ", ";
     }
-    std::cout << "\n";
+    LogDebug("BoostedJetONNXJetTagsProducer") << "\n";
   }
 
   // get output names from flav_names
@@ -172,14 +173,16 @@ void BoostedJetONNXJetTagsProducer::produce(edm::Event &iEvent, const edm::Event
   }
 
   if (debug_) {
-    std::cout << "=== " << iEvent.id().run() << ":" << iEvent.id().luminosityBlock() << ":" << iEvent.id().event()
-              << " ===" << std::endl;
+    LogDebug("produce") << "<BoostedJetONNXJetTagsProducer::produce>:" << std::endl
+                        << "=== " << iEvent.id().run() << ":" << iEvent.id().luminosityBlock() << ":"
+                        << iEvent.id().event() << " ===" << std::endl;
     for (unsigned jet_n = 0; jet_n < tag_infos->size(); ++jet_n) {
       const auto &jet_ref = tag_infos->at(jet_n).jet();
-      std::cout << " - Jet #" << jet_n << ", pt=" << jet_ref->pt() << ", eta=" << jet_ref->eta()
-                << ", phi=" << jet_ref->phi() << std::endl;
+      LogDebug("produce") << " - Jet #" << jet_n << ", pt=" << jet_ref->pt() << ", eta=" << jet_ref->eta()
+                          << ", phi=" << jet_ref->phi() << std::endl;
       for (std::size_t flav_n = 0; flav_n < flav_names_.size(); ++flav_n) {
-        std::cout << "    " << flav_names_.at(flav_n) << " = " << (*(output_tags.at(flav_n)))[jet_ref] << std::endl;
+        LogDebug("produce") << "    " << flav_names_.at(flav_n) << " = " << (*(output_tags.at(flav_n)))[jet_ref]
+                            << std::endl;
       }
     }
   }
@@ -221,12 +224,13 @@ void BoostedJetONNXJetTagsProducer::make_inputs(const reco::DeepBoostedJetTagInf
       }
 
       if (debug_) {
-        std::cout << " -- var=" << varname << ", center=" << info.center << ", scale=" << info.norm_factor
-                  << ", replace=" << info.replace_inf_value << ", pad=" << info.pad << std::endl;
+        LogDebug("make_inputs") << "<BoostedJetONNXJetTagsProducer::make_inputs>:" << std::endl
+                                << " -- var=" << varname << ", center=" << info.center << ", scale=" << info.norm_factor
+                                << ", replace=" << info.replace_inf_value << ", pad=" << info.pad << std::endl;
         for (unsigned i = curr_pos - insize; i < curr_pos; i++) {
-          std::cout << group_values[i] << ",";
+          LogDebug("make_inputs") << group_values[i] << ",";
         }
-        std::cout << std::endl;
+        LogDebug("make_inputs") << std::endl;
       }
     }
     group_values.resize(curr_pos);

--- a/RecoBTag/ONNXRuntime/plugins/BuildFile.xml
+++ b/RecoBTag/ONNXRuntime/plugins/BuildFile.xml
@@ -5,5 +5,6 @@
   <use name="PhysicsTools/ONNXRuntime"/>
   <use name="RecoBTag/FeatureTools"/>
   <use name="RecoBTag/ONNXRuntime"/>
+  <use name="HeterogeneousCore/SonicTriton"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoBTag/ONNXRuntime/plugins/ParticleNetSonicJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/ParticleNetSonicJetTagsProducer.cc
@@ -1,0 +1,276 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include "DataFormats/BTauReco/interface/JetTag.h"
+
+#include "DataFormats/BTauReco/interface/DeepBoostedJetTagInfo.h"
+
+#include "HeterogeneousCore/SonicTriton/interface/TritonEDProducer.h"
+
+#include "HeterogeneousCore/SonicTriton/interface/TritonData.h"
+
+#include "RecoBTag/FeatureTools/interface/deep_helpers.h"
+
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <numeric>
+#include <nlohmann/json.hpp>
+
+using namespace btagbtvdeep;
+
+class ParticleNetSonicJetTagsProducer : public TritonEDProducer<> {
+public:
+  explicit ParticleNetSonicJetTagsProducer(const edm::ParameterSet &);
+  ~ParticleNetSonicJetTagsProducer() override;
+
+  void acquire(edm::Event const &iEvent, edm::EventSetup const &iSetup, Input &iInput) override;
+  void produce(edm::Event &iEvent, edm::EventSetup const &iSetup, Output const &iOutput) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &);
+
+private:
+  typedef std::vector<reco::DeepBoostedJetTagInfo> TagInfoCollection;
+  typedef reco::JetTagCollection JetTagCollection;
+
+  void make_inputs(const reco::DeepBoostedJetTagInfo &taginfo);
+
+  const edm::EDGetTokenT<TagInfoCollection> src_;
+  std::vector<std::string> flav_names_;             // names of the output scores
+  std::vector<std::string> input_names_;            // names of each input group - the ordering is important!
+  std::vector<std::vector<int64_t>> input_shapes_;  // shapes of each input group (-1 for dynamic axis)
+  std::vector<unsigned> input_sizes_;               // total length of each input vector
+  std::unordered_map<std::string, PreprocessParams> prep_info_map_;  // preprocessing info for each input group
+  bool debug_ = false;
+  bool skippedInference_ = false;
+  constexpr static unsigned numParticleGroups_ = 3;
+};
+
+ParticleNetSonicJetTagsProducer::ParticleNetSonicJetTagsProducer(const edm::ParameterSet &iConfig)
+    : TritonEDProducer<>(iConfig),
+      src_(consumes<TagInfoCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+      flav_names_(iConfig.getParameter<std::vector<std::string>>("flav_names")),
+      debug_(iConfig.getUntrackedParameter<bool>("debugMode", false)) {
+  ParticleNetConstructor(iConfig, false, input_names_, prep_info_map_, input_shapes_, input_sizes_, nullptr);
+
+  if (debug_) {
+    for (unsigned i = 0; i < input_names_.size(); ++i) {
+      const auto &group_name = input_names_.at(i);
+      if (!input_shapes_.empty()) {
+        std::cout << group_name << "\nshapes: ";
+        for (const auto &x : input_shapes_.at(i)) {
+          std::cout << x << ", ";
+        }
+      }
+      std::cout << "\nvariables: ";
+      for (const auto &x : prep_info_map_.at(group_name).var_names) {
+        std::cout << x << ", ";
+      }
+      std::cout << "\n";
+    }
+    std::cout << "flav_names: ";
+    for (const auto &flav_name : flav_names_) {
+      std::cout << flav_name << ", ";
+    }
+    std::cout << "\n";
+  }
+
+  // get output names from flav_names
+  for (const auto &flav_name : flav_names_) {
+    produces<JetTagCollection>(flav_name);
+  }
+  //preprocessInfoLoader(&iConfig);
+}
+
+ParticleNetSonicJetTagsProducer::~ParticleNetSonicJetTagsProducer() {}
+
+void ParticleNetSonicJetTagsProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  // pfDeepBoostedJetTags
+  edm::ParameterSetDescription desc;
+  TritonClient::fillPSetDescription(desc);
+  desc.add<edm::InputTag>("src", edm::InputTag("pfDeepBoostedJetTagInfos"));
+  desc.add<std::string>("preprocess_json", "");
+  // `preprocessParams` is deprecated -- use the preprocessing json file instead
+  edm::ParameterSetDescription preprocessParams;
+  preprocessParams.setAllowAnything();
+  preprocessParams.setComment("`preprocessParams` is deprecated, please use `preprocess_json` instead.");
+  desc.addOptional<edm::ParameterSetDescription>("preprocessParams", preprocessParams);
+  desc.add<std::vector<std::string>>("flav_names",
+                                     std::vector<std::string>{
+                                         "probTbcq",
+                                         "probTbqq",
+                                         "probTbc",
+                                         "probTbq",
+                                         "probWcq",
+                                         "probWqq",
+                                         "probZbb",
+                                         "probZcc",
+                                         "probZqq",
+                                         "probHbb",
+                                         "probHcc",
+                                         "probHqqqq",
+                                         "probQCDbb",
+                                         "probQCDcc",
+                                         "probQCDb",
+                                         "probQCDc",
+                                         "probQCDothers",
+                                     });
+  desc.addOptionalUntracked<bool>("debugMode", false);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+void ParticleNetSonicJetTagsProducer::acquire(edm::Event const &iEvent, edm::EventSetup const &iSetup, Input &iInput) {
+  edm::Handle<TagInfoCollection> tag_infos;
+  iEvent.getByToken(src_, tag_infos);
+  client_->setBatchSize(tag_infos->size());
+  skippedInference_ = false;
+  if (!tag_infos->empty()) {
+    unsigned int maxParticles = 0;
+    unsigned int maxVertices = 0;
+    for (unsigned jet_n = 0; jet_n < tag_infos->size(); ++jet_n) {
+      maxParticles = std::max(maxParticles,
+                              static_cast<unsigned int>(((*tag_infos)[jet_n]).features().get("pfcand_etarel").size()));
+      maxVertices =
+          std::max(maxVertices, static_cast<unsigned int>(((*tag_infos)[jet_n]).features().get("sv_etarel").size()));
+    }
+    if (maxParticles == 0 && maxVertices == 0) {
+      client_->setBatchSize(0);
+      skippedInference_ = true;
+      return;
+    }
+    unsigned int minPartFromJSON = prep_info_map_.at(input_names_[0]).min_length;
+    unsigned int maxPartFromJSON = prep_info_map_.at(input_names_[0]).max_length;
+    unsigned int minVertFromJSON = prep_info_map_.at(input_names_[3]).min_length;
+    unsigned int maxVertFromJSON = prep_info_map_.at(input_names_[3]).max_length;
+    maxParticles = std::clamp(maxParticles, minPartFromJSON, maxPartFromJSON);
+    maxVertices = std::clamp(maxVertices, minVertFromJSON, maxVertFromJSON);
+
+    for (unsigned igroup = 0; igroup < input_names_.size(); ++igroup) {
+      const auto &group_name = input_names_[igroup];
+      auto &input = iInput.at(group_name);
+      unsigned target;
+      if (igroup < numParticleGroups_) {
+        input.setShape(1, maxParticles);
+        target = maxParticles;
+      } else {
+        input.setShape(1, maxVertices);
+        target = maxVertices;
+      }
+      auto tdata = input.allocate<float>(true);
+      for (unsigned jet_n = 0; jet_n < tag_infos->size(); ++jet_n) {
+        const auto &taginfo = (*tag_infos)[jet_n];
+        auto &vdata = (*tdata)[jet_n];
+        const auto &prep_params = prep_info_map_.at(group_name);
+        unsigned curr_pos = 0;
+        // transform/pad
+        for (unsigned i = 0; i < prep_params.var_names.size(); ++i) {
+          const auto &varname = prep_params.var_names[i];
+          const auto &raw_value = taginfo.features().get(varname);
+          const auto &info = prep_params.info(varname);
+          int insize = center_norm_pad_halfRagged(raw_value,
+                                                  info.center,
+                                                  info.norm_factor,
+                                                  target,
+                                                  vdata,
+                                                  curr_pos,
+                                                  info.pad,
+                                                  info.replace_inf_value,
+                                                  info.lower_bound,
+                                                  info.upper_bound);
+          curr_pos += insize;
+          if (i == 0 && (!input_shapes_.empty())) {
+            input_shapes_[igroup][2] = insize;
+          }
+
+          if (debug_) {
+            std::cout << " -- var=" << varname << ", center=" << info.center << ", scale=" << info.norm_factor
+                      << ", replace=" << info.replace_inf_value << ", pad=" << info.pad << std::endl;
+            for (unsigned i = curr_pos - insize; i < curr_pos; i++) {
+              std::cout << vdata[i] << ",";
+            }
+            std::cout << std::endl;
+          }
+        }
+      }
+      input.toServer(tdata);
+    }
+  }
+}
+
+void ParticleNetSonicJetTagsProducer::produce(edm::Event &iEvent,
+                                              const edm::EventSetup &iSetup,
+                                              Output const &iOutput) {
+  edm::Handle<TagInfoCollection> tag_infos;
+  iEvent.getByToken(src_, tag_infos);
+
+  // initialize output collection
+  std::vector<std::unique_ptr<JetTagCollection>> output_tags;
+  if (!tag_infos->empty()) {
+    auto jet_ref = tag_infos->begin()->jet();
+    auto ref2prod = edm::makeRefToBaseProdFrom(jet_ref, iEvent);
+    for (std::size_t i = 0; i < flav_names_.size(); i++) {
+      output_tags.emplace_back(std::make_unique<JetTagCollection>(ref2prod));
+    }
+  } else {
+    for (std::size_t i = 0; i < flav_names_.size(); i++) {
+      output_tags.emplace_back(std::make_unique<JetTagCollection>());
+    }
+  }
+
+  if (!tag_infos->empty()) {
+    if (!skippedInference_) {
+      const auto &output1 = iOutput.begin()->second;
+      const auto &outputs_from_server = output1.fromServer<float>();
+
+      for (unsigned jet_n = 0; jet_n < tag_infos->size(); ++jet_n) {
+        const auto &taginfo = (*tag_infos)[jet_n];
+        const auto &jet_ref = tag_infos->at(jet_n).jet();
+
+        if (!taginfo.features().empty()) {
+          for (std::size_t flav_n = 0; flav_n < flav_names_.size(); flav_n++) {
+            (*(output_tags[flav_n]))[jet_ref] = outputs_from_server[jet_n][flav_n];
+          }
+        } else {
+          for (std::size_t flav_n = 0; flav_n < flav_names_.size(); flav_n++) {
+            (*(output_tags[flav_n]))[jet_ref] = 0.;
+          }
+        }
+      }
+    } else {
+      for (unsigned jet_n = 0; jet_n < tag_infos->size(); ++jet_n) {
+        const auto &jet_ref = tag_infos->at(jet_n).jet();
+        for (std::size_t flav_n = 0; flav_n < flav_names_.size(); flav_n++) {
+          (*(output_tags[flav_n]))[jet_ref] = 0.;
+        }
+      }
+    }
+  }
+
+  if (debug_) {
+    std::cout << "=== " << iEvent.id().run() << ":" << iEvent.id().luminosityBlock() << ":" << iEvent.id().event()
+              << " ===" << std::endl;
+    for (unsigned jet_n = 0; jet_n < tag_infos->size(); ++jet_n) {
+      const auto &jet_ref = tag_infos->at(jet_n).jet();
+      std::cout << " - Jet #" << jet_n << ", pt=" << jet_ref->pt() << ", eta=" << jet_ref->eta()
+                << ", phi=" << jet_ref->phi() << std::endl;
+      for (std::size_t flav_n = 0; flav_n < flav_names_.size(); ++flav_n) {
+        std::cout << "    " << flav_names_.at(flav_n) << " = " << (*(output_tags.at(flav_n)))[jet_ref] << std::endl;
+      }
+    }
+  }
+
+  // put into the event
+  for (std::size_t flav_n = 0; flav_n < flav_names_.size(); ++flav_n) {
+    iEvent.put(std::move(output_tags[flav_n]), flav_names_[flav_n]);
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ParticleNetSonicJetTagsProducer);

--- a/RecoBTag/ONNXRuntime/plugins/ParticleNetSonicJetTagsProducer.cc
+++ b/RecoBTag/ONNXRuntime/plugins/ParticleNetSonicJetTagsProducer.cc
@@ -60,32 +60,32 @@ ParticleNetSonicJetTagsProducer::ParticleNetSonicJetTagsProducer(const edm::Para
   ParticleNetConstructor(iConfig, false, input_names_, prep_info_map_, input_shapes_, input_sizes_, nullptr);
 
   if (debug_) {
+    LogDebug("ParticleNetSonicJetTagsProducer") << "<ParticleNetSonicJetTagsProducer::produce>:" << std::endl;
     for (unsigned i = 0; i < input_names_.size(); ++i) {
       const auto &group_name = input_names_.at(i);
       if (!input_shapes_.empty()) {
-        std::cout << group_name << "\nshapes: ";
+        LogDebug("ParticleNetSonicJetTagsProducer") << group_name << "\nshapes: ";
         for (const auto &x : input_shapes_.at(i)) {
-          std::cout << x << ", ";
+          LogDebug("ParticleNetSonicJetTagsProducer") << x << ", ";
         }
       }
-      std::cout << "\nvariables: ";
+      LogDebug("ParticleNetSonicJetTagsProducer") << "\nvariables: ";
       for (const auto &x : prep_info_map_.at(group_name).var_names) {
-        std::cout << x << ", ";
+        LogDebug("ParticleNetSonicJetTagsProducer") << x << ", ";
       }
-      std::cout << "\n";
+      LogDebug("ParticleNetSonicJetTagsProducer") << "\n";
     }
-    std::cout << "flav_names: ";
+    LogDebug("ParticleNetSonicJetTagsProducer") << "flav_names: ";
     for (const auto &flav_name : flav_names_) {
-      std::cout << flav_name << ", ";
+      LogDebug("ParticleNetSonicJetTagsProducer") << flav_name << ", ";
     }
-    std::cout << "\n";
+    LogDebug("ParticleNetSonicJetTagsProducer") << "\n";
   }
 
   // get output names from flav_names
   for (const auto &flav_name : flav_names_) {
     produces<JetTagCollection>(flav_name);
   }
-  //preprocessInfoLoader(&iConfig);
 }
 
 ParticleNetSonicJetTagsProducer::~ParticleNetSonicJetTagsProducer() {}
@@ -190,12 +190,13 @@ void ParticleNetSonicJetTagsProducer::acquire(edm::Event const &iEvent, edm::Eve
           }
 
           if (debug_) {
-            std::cout << " -- var=" << varname << ", center=" << info.center << ", scale=" << info.norm_factor
-                      << ", replace=" << info.replace_inf_value << ", pad=" << info.pad << std::endl;
+            LogDebug("acquire") << "<ParticleNetSonicJetTagsProducer::produce>:" << std::endl
+                                << " -- var=" << varname << ", center=" << info.center << ", scale=" << info.norm_factor
+                                << ", replace=" << info.replace_inf_value << ", pad=" << info.pad << std::endl;
             for (unsigned i = curr_pos - insize; i < curr_pos; i++) {
-              std::cout << vdata[i] << ",";
+              LogDebug("acquire") << vdata[i] << ",";
             }
-            std::cout << std::endl;
+            LogDebug("acquire") << std::endl;
           }
         }
       }
@@ -254,14 +255,16 @@ void ParticleNetSonicJetTagsProducer::produce(edm::Event &iEvent,
   }
 
   if (debug_) {
-    std::cout << "=== " << iEvent.id().run() << ":" << iEvent.id().luminosityBlock() << ":" << iEvent.id().event()
-              << " ===" << std::endl;
+    LogDebug("produce") << "<ParticleNetSonicJetTagsProducer::produce>:" << std::endl
+                        << "=== " << iEvent.id().run() << ":" << iEvent.id().luminosityBlock() << ":"
+                        << iEvent.id().event() << " ===" << std::endl;
     for (unsigned jet_n = 0; jet_n < tag_infos->size(); ++jet_n) {
       const auto &jet_ref = tag_infos->at(jet_n).jet();
-      std::cout << " - Jet #" << jet_n << ", pt=" << jet_ref->pt() << ", eta=" << jet_ref->eta()
-                << ", phi=" << jet_ref->phi() << std::endl;
+      LogDebug("produce") << " - Jet #" << jet_n << ", pt=" << jet_ref->pt() << ", eta=" << jet_ref->eta()
+                          << ", phi=" << jet_ref->phi() << std::endl;
       for (std::size_t flav_n = 0; flav_n < flav_names_.size(); ++flav_n) {
-        std::cout << "    " << flav_names_.at(flav_n) << " = " << (*(output_tags.at(flav_n)))[jet_ref] << std::endl;
+        LogDebug("produce") << "    " << flav_names_.at(flav_n) << " = " << (*(output_tags.at(flav_n)))[jet_ref]
+                            << std::endl;
       }
     }
   }

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
@@ -2,7 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.FeatureTools.pfDeepBoostedJetTagInfos_cfi import pfDeepBoostedJetTagInfos
 from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
+from RecoBTag.ONNXRuntime.particleNetSonicJetTagsProducer_cfi import particleNetSonicJetTagsProducer as _particleNetSonicJetTagsProducer
 from RecoBTag.ONNXRuntime.pfParticleNetAK4DiscriminatorsJetTags_cfi import pfParticleNetAK4DiscriminatorsJetTags
+from Configuration.ProcessModifiers.particleNetSonicTriton_cff import particleNetSonicTriton
+from Configuration.ProcessModifiers.particleNetPTSonicTriton_cff import particleNetPTSonicTriton
 
 pfParticleNetAK4TagInfos = pfDeepBoostedJetTagInfos.clone(
     jet_radius = 0.4,
@@ -18,6 +21,31 @@ pfParticleNetAK4JetTags = boostedJetONNXJetTagsProducer.clone(
     flav_names = ["probb",  "probbb",  "probc",   "probcc",  "probuds", "probg", "probundef", "probpu"],
 )
 
+particleNetSonicTriton.toReplaceWith(pfParticleNetAK4JetTags, _particleNetSonicJetTagsProducer.clone(
+    src = 'pfParticleNetAK4TagInfos',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/preprocess.json',
+    Client = cms.PSet(
+        timeout = cms.untracked.uint32(300),
+        mode = cms.string("Async"),
+        modelName = cms.string("particlenet_AK4"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK4/config.pbtxt"),
+        modelVersion = cms.string(""),
+        verbose = cms.untracked.bool(False),
+        allowedTries = cms.untracked.uint32(0),
+        useSharedMemory = cms.untracked.bool(True),
+        compression = cms.untracked.string(""),
+    ),
+    flav_names = pfParticleNetAK4JetTags.flav_names,
+))
+
+(particleNetSonicTriton & particleNetPTSonicTriton).toModify(pfParticleNetAK4JetTags,
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/preprocess_PT.json',
+    Client = dict(
+        modelName = "particlenet_AK4_PT",
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK4_PT/config.pbtxt"),
+    )
+)
+
 from CommonTools.PileupAlgos.Puppi_cff import puppi
 from CommonTools.RecoAlgos.primaryVertexAssociation_cfi import primaryVertexAssociation
 
@@ -29,6 +57,7 @@ pfParticleNetAK4Task = cms.Task(puppi, primaryVertexAssociation, pfParticleNetAK
 # probs
 _pfParticleNetAK4JetTagsProbs = ['pfParticleNetAK4JetTags:' + flav_name
                                  for flav_name in pfParticleNetAK4JetTags.flav_names]
+
 # meta-taggers
 _pfParticleNetAK4JetTagsMetaDiscrs = ['pfParticleNetAK4DiscriminatorsJetTags:' + disc.name.value()
                                       for disc in pfParticleNetAK4DiscriminatorsJetTags.discriminators]

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
@@ -17,7 +17,7 @@ pfParticleNetAK4TagInfos = pfDeepBoostedJetTagInfos.clone(
 pfParticleNetAK4JetTags = boostedJetONNXJetTagsProducer.clone(
     src = 'pfParticleNetAK4TagInfos',
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/preprocess.json',
-    model_path = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/particle-net.onnx',
+    model_path = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/modelfile/model.onnx',
     flav_names = ["probb",  "probbb",  "probc",   "probcc",  "probuds", "probg", "probundef", "probpu"],
 )
 

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
@@ -28,7 +28,7 @@ particleNetSonicTriton.toReplaceWith(pfParticleNetAK4JetTags, _particleNetSonicJ
         timeout = cms.untracked.uint32(300),
         mode = cms.string("Async"),
         modelName = cms.string("particlenet_AK4"),
-        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK4/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/models/particlenet_AK4/config.pbtxt"),
         modelVersion = cms.string(""),
         verbose = cms.untracked.bool(False),
         allowedTries = cms.untracked.uint32(0),
@@ -42,7 +42,7 @@ particleNetSonicTriton.toReplaceWith(pfParticleNetAK4JetTags, _particleNetSonicJ
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/preprocess_PT.json',
     Client = dict(
         modelName = "particlenet_AK4_PT",
-        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK4_PT/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/models/particlenet_AK4_PT/config.pbtxt"),
     )
 )
 

--- a/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
@@ -15,7 +15,7 @@ pfParticleNetTagInfos = pfDeepBoostedJetTagInfos.clone(
 pfParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess.json',
-    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/particle-net.onnx',
+    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/modelfile/model.onnx',
     flav_names = ["probTbcq",  "probTbqq",  "probTbc",   "probTbq",  "probTbel", "probTbmu", "probTbta",
                   "probWcq",   "probWqq",   "probZbb",   "probZcc",  "probZqq",  "probHbb", "probHcc",
                   "probHqqqq", "probQCDbb", "probQCDcc", "probQCDb", "probQCDc", "probQCDothers"],
@@ -49,7 +49,7 @@ particleNetSonicTriton.toReplaceWith(pfParticleNetJetTags, _particleNetSonicJetT
 pfMassDecorrelatedParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/preprocess.json',
-    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/particle-net.onnx',
+    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/modelfile/model.onnx',
     flav_names = ["probXbb", "probXcc", "probXqq", "probQCDbb", "probQCDcc",
                   "probQCDb", "probQCDc", "probQCDothers"],
 )
@@ -80,7 +80,7 @@ particleNetSonicTriton.toReplaceWith(pfMassDecorrelatedParticleNetJetTags, _part
 pfParticleNetMassRegressionJetTags = boostedJetONNXJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/preprocess.json',
-    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/particle-net.onnx',
+    model_path = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/modelfile/model.onnx',
     flav_names = ["mass"],
 )
 

--- a/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
@@ -2,8 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.FeatureTools.pfDeepBoostedJetTagInfos_cfi import pfDeepBoostedJetTagInfos
 from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
+from RecoBTag.ONNXRuntime.particleNetSonicJetTagsProducer_cfi import particleNetSonicJetTagsProducer as _particleNetSonicJetTagsProducer
 from RecoBTag.ONNXRuntime.pfParticleNetDiscriminatorsJetTags_cfi import pfParticleNetDiscriminatorsJetTags
 from RecoBTag.ONNXRuntime.pfMassDecorrelatedParticleNetDiscriminatorsJetTags_cfi import pfMassDecorrelatedParticleNetDiscriminatorsJetTags
+from Configuration.ProcessModifiers.particleNetSonicTriton_cff import particleNetSonicTriton
+from Configuration.ProcessModifiers.particleNetPTSonicTriton_cff import particleNetPTSonicTriton
 
 pfParticleNetTagInfos = pfDeepBoostedJetTagInfos.clone(
     use_puppiP4 = False
@@ -18,6 +21,31 @@ pfParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
                   "probHqqqq", "probQCDbb", "probQCDcc", "probQCDb", "probQCDc", "probQCDothers"],
 )
 
+particleNetSonicTriton.toReplaceWith(pfParticleNetJetTags, _particleNetSonicJetTagsProducer.clone(
+    src = 'pfParticleNetTagInfos',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess.json',
+    Client = cms.PSet(
+        timeout = cms.untracked.uint32(300),
+        mode = cms.string("Async"),
+        modelName = cms.string("particlenet"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet/config.pbtxt"),
+        modelVersion = cms.string(""),
+        verbose = cms.untracked.bool(False),
+        allowedTries = cms.untracked.uint32(0),
+        useSharedMemory = cms.untracked.bool(True),
+        compression = cms.untracked.string(""),
+    ),
+    flav_names = pfParticleNetJetTags.flav_names,
+))
+
+(particleNetSonicTriton & particleNetPTSonicTriton).toModify(pfParticleNetJetTags,
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess_PT.json',
+    Client = dict(
+        modelName = "particlenet_PT",
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_PT/config.pbtxt"),
+    )
+)
+
 pfMassDecorrelatedParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/preprocess.json',
@@ -26,11 +54,57 @@ pfMassDecorrelatedParticleNetJetTags = boostedJetONNXJetTagsProducer.clone(
                   "probQCDb", "probQCDc", "probQCDothers"],
 )
 
+particleNetSonicTriton.toReplaceWith(pfMassDecorrelatedParticleNetJetTags, _particleNetSonicJetTagsProducer.clone(
+    src = 'pfParticleNetTagInfos',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/preprocess.json',
+    Client = cms.PSet(
+        timeout = cms.untracked.uint32(300),
+        modelName = cms.string("particlenet_AK8_MD-2prong"),
+        mode = cms.string("Async"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK8_MD-2prong/config.pbtxt"),
+        modelVersion = cms.string(""),
+        verbose = cms.untracked.bool(False),
+        allowedTries = cms.untracked.uint32(0),
+    ),
+    flav_names = pfMassDecorrelatedParticleNetJetTags.flav_names,
+))
+
+(particleNetSonicTriton & particleNetPTSonicTriton).toModify(pfMassDecorrelatedParticleNetJetTags,
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/preprocess_PT.json',
+    Client = dict(
+        modelName = "particlenet_AK8_MD-2prong_PT",
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK8_MD-2prong_PT/config.pbtxt"),
+    )
+)
+
 pfParticleNetMassRegressionJetTags = boostedJetONNXJetTagsProducer.clone(
     src = 'pfParticleNetTagInfos',
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/preprocess.json',
     model_path = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/particle-net.onnx',
     flav_names = ["mass"],
+)
+
+particleNetSonicTriton.toReplaceWith(pfParticleNetMassRegressionJetTags, _particleNetSonicJetTagsProducer.clone(
+    src = 'pfParticleNetTagInfos',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/preprocess.json',
+    Client = cms.PSet(
+        timeout = cms.untracked.uint32(300),
+        modelName = cms.string("particlenet_AK8_MassRegression"),
+        mode = cms.string("Async"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK8_MassRegression/config.pbtxt"),
+        modelVersion = cms.string(""),
+        verbose = cms.untracked.bool(False),
+        allowedTries = cms.untracked.uint32(0),
+    ),
+    flav_names = pfParticleNetMassRegressionJetTags.flav_names,
+))
+
+(particleNetSonicTriton & particleNetPTSonicTriton).toModify(pfParticleNetMassRegressionJetTags,
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/preprocess_PT.json',
+    Client = dict(
+        modelName = "particlenet_AK8_MassRegression_PT",
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK8_MassRegression_PT/config.pbtxt"),
+    )
 )
 
 from CommonTools.PileupAlgos.Puppi_cff import puppi
@@ -45,12 +119,14 @@ pfParticleNetTask = cms.Task(puppi, primaryVertexAssociation, pfParticleNetTagIn
 # nominal: probs
 _pfParticleNetJetTagsProbs = ['pfParticleNetJetTags:' + flav_name
                               for flav_name in pfParticleNetJetTags.flav_names]
+
 # nominal: meta-taggers
 _pfParticleNetJetTagsMetaDiscrs = ['pfParticleNetDiscriminatorsJetTags:' + disc.name.value()
                                    for disc in pfParticleNetDiscriminatorsJetTags.discriminators]
 # mass-decorrelated: probs
 _pfMassDecorrelatedParticleNetJetTagsProbs = ['pfMassDecorrelatedParticleNetJetTags:' + flav_name
                               for flav_name in pfMassDecorrelatedParticleNetJetTags.flav_names]
+
 # mass-decorrelated: meta-taggers
 _pfMassDecorrelatedParticleNetJetTagsMetaDiscrs = ['pfMassDecorrelatedParticleNetDiscriminatorsJetTags:' + disc.name.value()
                                    for disc in pfMassDecorrelatedParticleNetDiscriminatorsJetTags.discriminators]

--- a/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNet_cff.py
@@ -28,7 +28,7 @@ particleNetSonicTriton.toReplaceWith(pfParticleNetJetTags, _particleNetSonicJetT
         timeout = cms.untracked.uint32(300),
         mode = cms.string("Async"),
         modelName = cms.string("particlenet"),
-        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/models/particlenet/config.pbtxt"),
         modelVersion = cms.string(""),
         verbose = cms.untracked.bool(False),
         allowedTries = cms.untracked.uint32(0),
@@ -42,7 +42,7 @@ particleNetSonicTriton.toReplaceWith(pfParticleNetJetTags, _particleNetSonicJetT
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/General/V01/preprocess_PT.json',
     Client = dict(
         modelName = "particlenet_PT",
-        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_PT/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/models/particlenet_PT/config.pbtxt"),
     )
 )
 
@@ -61,7 +61,7 @@ particleNetSonicTriton.toReplaceWith(pfMassDecorrelatedParticleNetJetTags, _part
         timeout = cms.untracked.uint32(300),
         modelName = cms.string("particlenet_AK8_MD-2prong"),
         mode = cms.string("Async"),
-        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK8_MD-2prong/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/models/particlenet_AK8_MD-2prong/config.pbtxt"),
         modelVersion = cms.string(""),
         verbose = cms.untracked.bool(False),
         allowedTries = cms.untracked.uint32(0),
@@ -73,7 +73,7 @@ particleNetSonicTriton.toReplaceWith(pfMassDecorrelatedParticleNetJetTags, _part
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MD-2prong/V01/preprocess_PT.json',
     Client = dict(
         modelName = "particlenet_AK8_MD-2prong_PT",
-        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK8_MD-2prong_PT/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/models/particlenet_AK8_MD-2prong_PT/config.pbtxt"),
     )
 )
 
@@ -91,7 +91,7 @@ particleNetSonicTriton.toReplaceWith(pfParticleNetMassRegressionJetTags, _partic
         timeout = cms.untracked.uint32(300),
         modelName = cms.string("particlenet_AK8_MassRegression"),
         mode = cms.string("Async"),
-        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK8_MassRegression/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/models/particlenet_AK8_MassRegression/config.pbtxt"),
         modelVersion = cms.string(""),
         verbose = cms.untracked.bool(False),
         allowedTries = cms.untracked.uint32(0),
@@ -103,7 +103,7 @@ particleNetSonicTriton.toReplaceWith(pfParticleNetMassRegressionJetTags, _partic
     preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK8/MassRegression/V01/preprocess_PT.json',
     Client = dict(
         modelName = "particlenet_AK8_MassRegression_PT",
-        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/particlenet_modelsForSonic/particlenet_AK8_MassRegression_PT/config.pbtxt"),
+        modelConfigPath = cms.FileInPath("RecoBTag/Combined/data/models/particlenet_AK8_MassRegression_PT/config.pbtxt"),
     )
 )
 

--- a/RecoBTag/ONNXRuntime/test/plot_particle_net.py
+++ b/RecoBTag/ONNXRuntime/test/plot_particle_net.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+import ROOT as rt
+from DataFormats.FWLite import Events,Handle
+import itertools as it
+from ROOT import btagbtvdeep
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+# file evaluated with DeepJet framework
+# jets redone from AOD using CMSSW TF modules
+#cmssw_miniaod = "test_particle_net_MINIAODSIM.root"
+cmssw_miniaod = "test_particle_net_MINIAODSIM_noragged.root"
+
+jetsLabel = "selectedUpdatedPatJets"
+
+from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetJetTagsProbs
+from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetSonicJetTagsProbs
+disc_names = _pfParticleNetJetTagsProbs+_pfParticleNetSonicJetTagsProbs
+
+jet_pt = "fj_pt"
+jet_eta = "fj_eta"
+
+c_numbers = ['event_n']
+
+c_cmssw = { d_name : []  for d_name in disc_names + [jet_pt, jet_eta] + c_numbers }
+jetsHandle = Handle("std::vector<pat::Jet>")
+cmssw_evs = Events(cmssw_miniaod)
+
+max_n_jets = 1000000
+max_n_events = 500000
+n_jets = 0
+
+for i, ev in enumerate(cmssw_evs):
+    event_number = ev.object().id().event()
+    if (n_jets >= max_n_jets): break
+    ev.getByLabel(jetsLabel, jetsHandle)
+    jets = jetsHandle.product()
+    for i_j,j in enumerate(jets):
+        uncorr = j.jecFactor("Uncorrected")
+        ptRaw = j.pt()*uncorr
+        if ptRaw < 200.0 or abs(j.eta()) > 2.4: continue
+        if (n_jets >= max_n_jets): break
+        c_cmssw["event_n"].append(event_number)
+        c_cmssw[jet_pt].append(ptRaw)
+        c_cmssw[jet_eta].append(j.eta())
+        discs = j.getPairDiscri()
+        for d in discs:
+            if d.first in disc_names:
+                c_cmssw[d.first].append(d.second)
+        n_jets +=1
+        
+df_cmssw = pd.DataFrame(c_cmssw)
+df_cmssw.sort_values(['event_n', jet_pt], ascending=[True, False], inplace=True)
+df_cmssw.reset_index(drop=True)
+print(df_cmssw[['event_n','fj_eta','fj_pt',
+                'pfParticleNetJetTags:probTbq','pfParticleNetSonicJetTags:probTbq',
+            ]])
+
+n_bins = 50
+
+print('number of tags', len(disc_names))
+fig, axs = plt.subplots(5,4,figsize=(50,40))
+for i,ax in enumerate(axs.flatten()):
+    cmssw_col = disc_names[i]
+    ax.hist(df_cmssw[cmssw_col], bins=np.linspace(np.amin(df_cmssw[cmssw_col]), np.amax(df_cmssw[cmssw_col]), n_bins))
+    ax.set_yscale('log')
+    ax.set_ylim(0.5, 1000)
+    ax.set_xlim(0, 1)
+    ax.set_xlabel(cmssw_col)
+    ax.set_ylabel('Jets')
+#fig.savefig('particle_net_hist.png')
+fig.savefig('particle_net_hist_noragged.png')

--- a/RecoBTag/ONNXRuntime/test/plot_particle_net_ak4.py
+++ b/RecoBTag/ONNXRuntime/test/plot_particle_net_ak4.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+import ROOT as rt
+from DataFormats.FWLite import Events,Handle
+import itertools as it
+from ROOT import btagbtvdeep
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+
+# file evaluated with DeepJet framework
+# jets redone from AOD using CMSSW TF modules
+#cmssw_miniaod = "test_particle_net_MINIAODSIM.root"
+cmssw_miniaod = "test_particle_net_ak4_MINIAODSIM.root"
+
+jetsLabel = "selectedUpdatedPatJets"
+
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfParticleNetAK4JetTagsAll
+disc_names = _pfParticleNetAK4JetTagsAll
+#disc_names = _pfParticleNetJetTagsProbs+_pfParticleNetSonicJetTagsProbs
+
+jet_pt = "fj_pt"
+jet_eta = "fj_eta"
+
+c_numbers = ['event_n']
+
+c_cmssw = { d_name : []  for d_name in disc_names + [jet_pt, jet_eta] + c_numbers }
+jetsHandle = Handle("std::vector<pat::Jet>")
+cmssw_evs = Events(cmssw_miniaod)
+
+max_n_jets = 1000000
+max_n_events = 500000
+n_jets = 0
+
+for i, ev in enumerate(cmssw_evs):
+    event_number = ev.object().id().event()
+    if (n_jets >= max_n_jets): break
+    ev.getByLabel(jetsLabel, jetsHandle)
+    jets = jetsHandle.product()
+    for i_j,j in enumerate(jets):
+        uncorr = j.jecFactor("Uncorrected")
+        ptRaw = j.pt()*uncorr
+        if ptRaw < 200.0 or abs(j.eta()) > 2.4: continue
+        if (n_jets >= max_n_jets): break
+        c_cmssw["event_n"].append(event_number)
+        c_cmssw[jet_pt].append(ptRaw)
+        c_cmssw[jet_eta].append(j.eta())
+        discs = j.getPairDiscri()
+        for d in discs:
+            if d.first in disc_names:
+                c_cmssw[d.first].append(d.second)
+        n_jets +=1
+        
+df_cmssw = pd.DataFrame(c_cmssw)
+df_cmssw.sort_values(['event_n', jet_pt], ascending=[True, False], inplace=True)
+df_cmssw.reset_index(drop=True)
+print(df_cmssw[['event_n','fj_eta','fj_pt',
+                'pfParticleNetAK4JetTags:probbb','pfParticleNetAK4SonicJetTags:probbb',
+            ]])
+
+n_bins = 50
+
+print('number of tags', len(disc_names))
+fig, axs = plt.subplots(5,4,figsize=(50,40))
+for i,ax in enumerate(axs.flatten()):
+    cmssw_col = disc_names[i]
+    ax.hist(df_cmssw[cmssw_col], bins=np.linspace(np.amin(df_cmssw[cmssw_col]), np.amax(df_cmssw[cmssw_col]), n_bins))
+    ax.set_yscale('log')
+    ax.set_ylim(0.5, 1000)
+    ax.set_xlim(0, 1)
+    ax.set_xlabel(cmssw_col)
+    ax.set_ylabel('Jets')
+fig.savefig('particle_net_hist_ak4_noragged.png')


### PR DESCRIPTION
#### PR description:

This PR introduces a producer for ParticleNet using SONIC for co-processor-enabled inferences-as-a-service.  The main versions of ParticleNet are all included (AK4, AK8 general, MassDecorrelation, and MassRegression), as are configs for both ONNX versions and PyTorch versions of the models.  For more information on the status of SONIC, please refer to this presentation to JetMET DPG: https://indico.cern.ch/event/1143469/contributions/4799423/attachments/2416540/4135308/March_28_JetMET_SONIC.pdf. Please note that the producer introduced here does not affect the main ParticleNet producer in any way (https://github.com/cms-sw/cmssw/blob/master/RecoBTag/ONNXRuntime/plugins/BoostedJetONNXJetTagsProducer.cc). This is an alternate way to run the standard ParticleNet model using inference as a service. As noted in the linked slides, this producer has been validated locally on Tier 2 resources and at scale with cloud computing, but with this PR, we hope to perform more "official" production tests.  Again, this producer does not any workflow unless explicitly called. A helper-function macro is slightly modified, as are a few config files. There will be an accompanying PR into https://github.com/cms-data/RecoBTag-Combined, which adds needed model files.

Tagging @kpedro88 @yongbinfeng @violatingcp @nhanvtran @jmduarte

#### PR validation:

This PR was tested on LPC using a Triton server running on the GPU-enabled AILab machines at FermiLab. Tests have also been performed using the ParticleNet SONIC producer at Purdue T2 and in Google Cloud. When the producer is not called, there is no performance impact, and when it is called, the Jet Tagging results are the same as for the generic ParticleNet producer.