### PR TITLE
Add a method to `EventMsgBuilder` to precompute the message header size [12.4.x]

### DIFF
--- a/IOPool/Streamer/interface/EventMsgBuilder.h
+++ b/IOPool/Streamer/interface/EventMsgBuilder.h
@@ -30,6 +30,8 @@ public:
   uint32 size() const;
   uint32 bufferSize() const { return size_; }
 
+  static uint32 computeHeaderSize(uint32 l1t_bit_count, uint32 hlt_bit_count);
+
 private:
   uint8* buf_;
   uint32 size_;

--- a/IOPool/Streamer/src/EventMsgBuilder.cc
+++ b/IOPool/Streamer/src/EventMsgBuilder.cc
@@ -27,73 +27,64 @@ EventMsgBuilder::EventMsgBuilder(void* buf,
         << " bytes) is not large enough to holde the event header (" << expectedHeaderSize << " bytes)";
   }
 
-  EventHeader* h = (EventHeader*)buf_;
+  // Note: any change to the pos increment logic should be reflected in computeHeaderSize()
+  uint8* pos = buf_;
+
+  // Set the event header
+  EventHeader* h = (EventHeader*)pos;
   h->protocolVersion_ = 11;
   convert(run, h->run_);
   convert(event, h->event_);
   convert(lumi, h->lumi_);
   convert(outModId, h->outModId_);
   convert(droppedEventsCount, h->droppedEventsCount_);
-  uint8* pos = buf_ + sizeof(EventHeader);
+  pos += sizeof(EventHeader);
 
-  // l1 count
+  // Set the L1T triggers count
   uint32 l1_count = l1_bits.size();
   convert(l1_count, pos);
-  pos = pos + sizeof(uint32);
+  pos += sizeof(uint32);
 
-  // set the l1
-  uint32 l1_sz = l1_bits.size();
-  if (l1_sz != 0)
-    l1_sz = 1 + ((l1_sz - 1) / 8);
-
-  uint8* pos_end = pos + l1_sz;
-  memset(pos, 0x00, pos_end - pos);  // clear the bits
+  // Set the L1T bits
+  uint32 l1_sz = (l1_bits.size() + 8 - 1) / 8;  // L1T results (1 bit per trigger)
+  memset(pos, 0x00, l1_sz);                     // clear the bits
   for (std::vector<bool>::size_type i = 0; i < l1_bits.size(); ++i) {
     uint8 v = l1_bits[i] ? 1 : 0;
     pos[i / 8] |= (v << (i & 0x07));
   }
-  pos = pos_end;
+  pos += l1_sz;
 
-  // hlt count
+  // Set HLT triggers count
   convert(hlt_bit_count, pos);
-  pos = pos + sizeof(uint32);
+  pos += sizeof(uint32);
 
-  uint32 hlt_sz = hlt_bit_count;
-  if (hlt_sz != 0)
-    hlt_sz = 1 + ((hlt_sz - 1) / 4);
-
-  // copy the hlt bits over
+  // Copy the HLT bits and increment pos
+  uint32 hlt_sz = (hlt_bit_count + 4 - 1) / 4;  // HLT results (2 bits per trigger)
   pos = std::copy(hlt_bits, hlt_bits + hlt_sz, pos);
 
-  // adler32 check sum of data blob
+  // Set the Adler32 check sum of data blob
   convert(adler_chksum, pos);
-  pos = pos + sizeof(uint32);
+  pos += sizeof(uint32);
 
-  // put host name (Length and then Name) right after check sum
-  //uint32 host_name_len = strlen(host_name);
-  // actually make the host_name a fixed length as the event header size appears in the
-  // Init message and only one goes to a file whereas events can come from any node
-  // We want the max length to be determined inside this Event Message Builder
-  uint32 host_name_len = MAX_HOSTNAME_LEN;
-  assert(host_name_len < 0x00ff);
-  //Put host_name_len
-  *pos++ = host_name_len;
+  // Put the host name (length and then name) right after the check sum.
+  // Use a fixed length for the host_name because the event header size appears in the
+  // init message and only one goes to a file whereas events can come from any node,
+  // while we want the max length to be determined inside this Event Message Builder.
 
-  //Put host_name
-  uint32 real_len = strlen(host_name);
-  if (real_len < host_name_len) {
-    char hostname_2use[MAX_HOSTNAME_LEN];
-    memset(hostname_2use, '\0', host_name_len);
-    memcpy(hostname_2use, host_name, real_len);
-    memcpy(pos, hostname_2use, host_name_len);
-  } else {
-    memcpy(pos, host_name, host_name_len);
-  }
-  pos += host_name_len;
+  // Set the host_name_len and increment pos
+  assert(MAX_HOSTNAME_LEN < 0x00ff);
+  *pos++ = MAX_HOSTNAME_LEN;
+
+  // Copy up to MAX_HOSTNAME_LEN characters of the host_name and pad any extra space
+  // with null characters
+  memset(pos, '\0', MAX_HOSTNAME_LEN);
+  strncpy((char*)pos, host_name, MAX_HOSTNAME_LEN - 1);
+  pos += MAX_HOSTNAME_LEN;
 
   event_addr_ = pos + sizeof(char_uint32);
   setEventLength(0);
 
+  // Check that the size computed by computeHeaderSize() matches what is actually used.
   if (headerSize() != expectedHeaderSize) {
     throw cms::Exception("EventMsgBuilder")
         << "The event message header size (" << headerSize() << " bytes) does not match the computed value ("

--- a/IOPool/Streamer/src/InitMsgBuilder.cc
+++ b/IOPool/Streamer/src/InitMsgBuilder.cc
@@ -67,33 +67,8 @@ InitMsgBuilder::InitMsgBuilder(void* buf,
   //Set the size of Init Header Start of buf to Start of desc.
   convert((uint32)(data_addr_ - buf_), h->init_header_size_);
 
-  // 18-Apr-2008, KAB:  create a dummy event message so that we can
-  // determine the expected event header size.  (Previously, the event
-  // header size was hard-coded.)
-  std::vector<bool> dummyL1Bits(l1_names.size());
-  std::vector<char> dummyHLTBits(hlt_names.size());
-  const uint32 TEMP_BUFFER_SIZE = 640;
-  char msgBuff[TEMP_BUFFER_SIZE];  // not large enough for a real event!
-  uint32_t adler32 = 0;
-  char host_name[255];
-  int got_host = gethostname(host_name, 255);
-  if (got_host != 0)
-    strcpy(host_name, "noHostNameFoundOrTooLong");
-  EventMsgBuilder dummyMsg(&msgBuff[0],
-                           TEMP_BUFFER_SIZE,
-                           0,
-                           0,
-                           0,
-                           0,
-                           0,
-                           dummyL1Bits,
-                           (uint8*)&dummyHLTBits[0],
-                           hlt_names.size(),
-                           adler32,
-                           host_name);
-
   //Size of Event Header
-  uint32 eventHeaderSize = dummyMsg.headerSize();
+  uint32 eventHeaderSize = EventMsgBuilder::computeHeaderSize(l1_names.size(), hlt_names.size());
   convert(eventHeaderSize, h->event_header_size_);
 }
 


### PR DESCRIPTION
#### PR description:

Add a method to `EventMsgBuilder` to precompute the message header size, instead of relying on a small fixed-size buffer.

#### PR validation:

Validated running `./EventFilter/Utilities/test/RunBUFU.sh` with larger than usual number of HLT paths.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #37959 (using the same branch).