### PR TITLE
Backport `ConditionalTask` to CMSSW_12_3_X

### DIFF
--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -84,6 +84,10 @@ namespace edm {
     // If the TypeID for the wrapped type is already available,
     // it is faster to call getContainedTypeFromWrapper directly.
     TypeID getContainedType(TypeID const& typeID);
+
+    bool typeIsViewCompatible(TypeID const& requestedViewType,
+                              TypeID const& wrappedtypeID,
+                              std::string const& className);
   }  // namespace productholderindexhelper
 
   class ProductResolverIndexHelper {

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -70,6 +70,32 @@ namespace edm {
       TypeID const wrappedTypeID = TypeID(wrappedType.typeInfo());
       return getContainedTypeFromWrapper(wrappedTypeID, className);
     }
+
+    bool typeIsViewCompatible(TypeID const& requestedViewType,
+                              TypeID const& wrappedtypeID,
+                              std::string const& className) {
+      auto elementType = getContainedTypeFromWrapper(wrappedtypeID, className);
+      if (elementType == TypeID(typeid(void)) or elementType == TypeID()) {
+        //the wrapped type is not a container
+        return false;
+      }
+      if (elementType == requestedViewType) {
+        return true;
+      }
+      //need to check for inheritance match
+      std::vector<std::string> missingDictionaries;
+      std::vector<TypeWithDict> baseTypes;
+      if (!public_base_classes(missingDictionaries, elementType, baseTypes)) {
+        return false;
+      }
+      for (auto const& base : baseTypes) {
+        if (TypeID(base.typeInfo()) == requestedViewType) {
+          return true;
+        }
+      }
+      return false;
+    }
+
   }  // namespace productholderindexhelper
 
   ProductResolverIndexHelper::ProductResolverIndexHelper()

--- a/FWCore/Framework/interface/Path.h
+++ b/FWCore/Framework/interface/Path.h
@@ -87,6 +87,7 @@ namespace edm {
     int timesFailed(size_type i) const { return workers_.at(i).timesFailed(); }
     int timesExcept(size_type i) const { return workers_.at(i).timesExcept(); }
     Worker const* getWorker(size_type i) const { return workers_.at(i).getWorker(); }
+    unsigned int bitPosition(size_type i) const { return workers_.at(i).bitPosition(); }
 
     void setEarlyDeleteHelpers(std::map<const Worker*, EarlyDeleteHelper*> const&);
 

--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -95,6 +95,7 @@
 #include <vector>
 #include <sstream>
 #include <atomic>
+#include <unordered_set>
 
 namespace edm {
 
@@ -288,6 +289,21 @@ namespace edm {
 
     void reportSkipped(EventPrincipal const& ep) const;
 
+    struct AliasInfo {
+      std::string friendlyClassName;
+      std::string instanceLabel;
+      std::string originalInstanceLabel;
+      std::string originalModuleLabel;
+    };
+    std::vector<Worker*> tryToPlaceConditionalModules(
+        Worker*,
+        std::unordered_set<std::string>& conditionalModules,
+        std::multimap<std::string, edm::BranchDescription const*> const& conditionalModuleBranches,
+        std::multimap<std::string, AliasInfo> const& aliasMap,
+        ParameterSet& proc_pset,
+        ProductRegistry& preg,
+        PreallocationConfiguration const* prealloc,
+        std::shared_ptr<ProcessConfiguration const> processConfiguration);
     void fillWorkers(ParameterSet& proc_pset,
                      ProductRegistry& preg,
                      PreallocationConfiguration const* prealloc,

--- a/FWCore/Framework/interface/TriggerNamesService.h
+++ b/FWCore/Framework/interface/TriggerNamesService.h
@@ -33,6 +33,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <unordered_set>
 
 namespace edm {
 
@@ -83,6 +84,9 @@ namespace edm {
       std::string const& getTrigPathModule(size_type const i, size_type const j) const {
         return (modulenames_.at(i)).at(j);
       }
+      ///The label is an indicator of a path scheduling construct and not an actual module.
+      using ScheduingConstructLabelSet = std::unordered_set<std::string, std::hash<std::string>, std::equal_to<>>;
+      static ScheduingConstructLabelSet const& schedulingConstructLabels();
 
       Strings const& getEndPathModules(std::string const& name) const {
         return end_modulenames_.at(find(end_pos_, name));

--- a/FWCore/Framework/interface/TriggerNamesService.h
+++ b/FWCore/Framework/interface/TriggerNamesService.h
@@ -84,10 +84,6 @@ namespace edm {
       std::string const& getTrigPathModule(size_type const i, size_type const j) const {
         return (modulenames_.at(i)).at(j);
       }
-      ///The label is an indicator of a path scheduling construct and not an actual module.
-      using ScheduingConstructLabelSet = std::unordered_set<std::string, std::hash<std::string>, std::equal_to<>>;
-      static ScheduingConstructLabelSet const& schedulingConstructLabels();
-
       Strings const& getEndPathModules(std::string const& name) const {
         return end_modulenames_.at(find(end_pos_, name));
       }

--- a/FWCore/Framework/interface/WorkerInPath.h
+++ b/FWCore/Framework/interface/WorkerInPath.h
@@ -51,6 +51,7 @@ namespace edm {
     FilterAction filterAction() const { return filterAction_; }
     Worker* getWorker() const { return worker_; }
     bool runConcurrently() const noexcept { return runConcurrently_; }
+    unsigned int bitPosition() const noexcept { return placeInPathContext_.placeInPath(); }
 
     void setPathContext(PathContext const* v) { placeInPathContext_.setPathContext(v); }
 

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -326,10 +326,11 @@ namespace edm {
                       EventTransitionInfo const& iInfo,
                       StreamID const& streamID) {
     updateCounters(state_);
-    recordStatus(failedModuleIndex_, state_);
+    auto failedModuleBitPosition = bitPosition(failedModuleIndex_);
+    recordStatus(failedModuleBitPosition, state_);
     // Caught exception is propagated via WaitingTaskList
     CMS_SA_ALLOW try {
-      HLTPathStatus status(state_, failedModuleIndex_);
+      HLTPathStatus status(state_, failedModuleBitPosition);
 
       if (pathStatusInserter_) {  // pathStatusInserter is null for EndPaths
         pathStatusInserter_->setPathStatus(streamID, status);

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -48,6 +48,7 @@
 #include <sstream>
 
 #include "make_shared_noexcept_false.h"
+#include "processEDAliases.h"
 
 namespace edm {
 
@@ -143,201 +144,6 @@ namespace edm {
           }
           throw;
         }
-      }
-    }
-
-    void checkAndInsertAlias(std::string const& friendlyClassName,
-                             std::string const& moduleLabel,
-                             std::string const& productInstanceName,
-                             std::string const& processName,
-                             std::string const& alias,
-                             std::string const& instanceAlias,
-                             ProductRegistry const& preg,
-                             std::multimap<BranchKey, BranchKey>& aliasMap,
-                             std::map<BranchKey, BranchKey>& aliasKeys) {
-      std::string const star("*");
-
-      BranchKey key(friendlyClassName, moduleLabel, productInstanceName, processName);
-      if (preg.productList().find(key) == preg.productList().end()) {
-        // No product was found matching the alias.
-        // We throw an exception only if a module with the specified module label was created in this process.
-        for (auto const& product : preg.productList()) {
-          if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
-            throw Exception(errors::Configuration, "EDAlias does not match data\n")
-                << "There are no products of type '" << friendlyClassName << "'\n"
-                << "with module label '" << moduleLabel << "' and instance name '" << productInstanceName << "'.\n";
-          }
-        }
-      }
-
-      if (auto iter = aliasMap.find(key); iter != aliasMap.end()) {
-        // If the same EDAlias defines multiple products pointing to the same product, throw
-        if (iter->second.moduleLabel() == alias) {
-          throw Exception(errors::Configuration, "EDAlias conflict\n")
-              << "The module label alias '" << alias << "' is used for multiple products of type '" << friendlyClassName
-              << "' with module label '" << moduleLabel << "' and instance name '" << productInstanceName
-              << "'. One alias has the instance name '" << iter->first.productInstanceName()
-              << "' and the other has the instance name '" << instanceAlias << "'.";
-        }
-      }
-
-      std::string const& theInstanceAlias(instanceAlias == star ? productInstanceName : instanceAlias);
-      BranchKey aliasKey(friendlyClassName, alias, theInstanceAlias, processName);
-      if (preg.productList().find(aliasKey) != preg.productList().end()) {
-        throw Exception(errors::Configuration, "EDAlias conflicts with data\n")
-            << "A product of type '" << friendlyClassName << "'\n"
-            << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
-            << "already exists.\n";
-      }
-      auto iter = aliasKeys.find(aliasKey);
-      if (iter != aliasKeys.end()) {
-        // The alias matches a previous one.  If the same alias is used for different product, throw.
-        if (iter->second != key) {
-          throw Exception(errors::Configuration, "EDAlias conflict\n")
-              << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
-              << "are used for multiple products of type '" << friendlyClassName << "'\n"
-              << "One has module label '" << moduleLabel << "' and product instance name '" << productInstanceName
-              << "',\n"
-              << "the other has module label '" << iter->second.moduleLabel() << "' and product instance name '"
-              << iter->second.productInstanceName() << "'.\n";
-        }
-      } else {
-        auto prodIter = preg.productList().find(key);
-        if (prodIter != preg.productList().end()) {
-          if (!prodIter->second.produced()) {
-            throw Exception(errors::Configuration, "EDAlias\n")
-                << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
-                << "are used for a product of type '" << friendlyClassName << "'\n"
-                << "with module label '" << moduleLabel << "' and product instance name '" << productInstanceName
-                << "',\n"
-                << "An EDAlias can only be used for products produced in the current process. This one is not.\n";
-          }
-          aliasMap.insert(std::make_pair(key, aliasKey));
-          aliasKeys.insert(std::make_pair(aliasKey, key));
-        }
-      }
-    }
-
-    void processEDAliases(ParameterSet const& proc_pset, std::string const& processName, ProductRegistry& preg) {
-      std::vector<std::string> aliases = proc_pset.getParameter<std::vector<std::string>>("@all_aliases");
-      if (aliases.empty()) {
-        return;
-      }
-      std::string const star("*");
-      std::string const empty("");
-      ParameterSetDescription desc;
-      desc.add<std::string>("type");
-      desc.add<std::string>("fromProductInstance", star);
-      desc.add<std::string>("toProductInstance", star);
-
-      std::multimap<BranchKey, BranchKey> aliasMap;
-
-      std::map<BranchKey, BranchKey> aliasKeys;  // Used to search for duplicates or clashes.
-
-      // Auxiliary search structure to support wildcard for friendlyClassName
-      std::multimap<std::string, BranchKey> moduleLabelToBranches;
-      for (auto const& prod : preg.productList()) {
-        if (processName == prod.second.processName()) {
-          moduleLabelToBranches.emplace(prod.first.moduleLabel(), prod.first);
-        }
-      }
-
-      // Now, loop over the alias information and store it in aliasMap.
-      for (std::string const& alias : aliases) {
-        ParameterSet const& aliasPSet = proc_pset.getParameterSet(alias);
-        std::vector<std::string> vPSetNames = aliasPSet.getParameterNamesForType<VParameterSet>();
-        for (std::string const& moduleLabel : vPSetNames) {
-          VParameterSet vPSet = aliasPSet.getParameter<VParameterSet>(moduleLabel);
-          for (ParameterSet& pset : vPSet) {
-            desc.validate(pset);
-            std::string friendlyClassName = pset.getParameter<std::string>("type");
-            std::string productInstanceName = pset.getParameter<std::string>("fromProductInstance");
-            std::string instanceAlias = pset.getParameter<std::string>("toProductInstance");
-
-            if (friendlyClassName == star) {
-              bool processHasLabel = false;
-              bool match = false;
-              for (auto it = moduleLabelToBranches.lower_bound(moduleLabel);
-                   it != moduleLabelToBranches.end() && it->first == moduleLabel;
-                   ++it) {
-                processHasLabel = true;
-                if (productInstanceName != star and productInstanceName != it->second.productInstanceName()) {
-                  continue;
-                }
-                match = true;
-
-                checkAndInsertAlias(it->second.friendlyClassName(),
-                                    moduleLabel,
-                                    it->second.productInstanceName(),
-                                    processName,
-                                    alias,
-                                    instanceAlias,
-                                    preg,
-                                    aliasMap,
-                                    aliasKeys);
-              }
-              if (not match and processHasLabel) {
-                // No product was found matching the alias.
-                // We throw an exception only if a module with the specified module label was created in this process.
-                // Note that if that condition is ever relatex, it  might be best to throw an exception with different
-                // message (omitting productInstanceName) in case 'productInstanceName == start'
-                throw Exception(errors::Configuration, "EDAlias parameter set mismatch\n")
-                    << "There are no products with module label '" << moduleLabel << "' and product instance name '"
-                    << productInstanceName << "'.\n";
-              }
-            } else if (productInstanceName == star) {
-              bool match = false;
-              BranchKey lowerBound(friendlyClassName, moduleLabel, empty, empty);
-              for (ProductRegistry::ProductList::const_iterator it = preg.productList().lower_bound(lowerBound);
-                   it != preg.productList().end() && it->first.friendlyClassName() == friendlyClassName &&
-                   it->first.moduleLabel() == moduleLabel;
-                   ++it) {
-                if (it->first.processName() != processName) {
-                  continue;
-                }
-                match = true;
-
-                checkAndInsertAlias(friendlyClassName,
-                                    moduleLabel,
-                                    it->first.productInstanceName(),
-                                    processName,
-                                    alias,
-                                    instanceAlias,
-                                    preg,
-                                    aliasMap,
-                                    aliasKeys);
-              }
-              if (!match) {
-                // No product was found matching the alias.
-                // We throw an exception only if a module with the specified module label was created in this process.
-                for (auto const& product : preg.productList()) {
-                  if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
-                    throw Exception(errors::Configuration, "EDAlias parameter set mismatch\n")
-                        << "There are no products of type '" << friendlyClassName << "'\n"
-                        << "with module label '" << moduleLabel << "'.\n";
-                  }
-                }
-              }
-            } else {
-              checkAndInsertAlias(friendlyClassName,
-                                  moduleLabel,
-                                  productInstanceName,
-                                  processName,
-                                  alias,
-                                  instanceAlias,
-                                  preg,
-                                  aliasMap,
-                                  aliasKeys);
-            }
-          }
-        }
-      }
-
-      // Now add the new alias entries to the product registry.
-      for (auto const& aliasEntry : aliasMap) {
-        ProductRegistry::ProductList::const_iterator it = preg.productList().find(aliasEntry.first);
-        assert(it != preg.productList().end());
-        preg.addLabelAlias(it->second, aliasEntry.second.moduleLabel(), aliasEntry.second.productInstanceName());
       }
     }
 
@@ -772,7 +578,10 @@ namespace edm {
     std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string>>("@all_modules"));
     std::map<std::string, std::vector<std::pair<std::string, int>>> outputModulePathPositions;
     reduceParameterSet(proc_pset, tns.getEndPaths(), modulesInConfig, usedModuleLabels, outputModulePathPositions);
-    processEDAliases(proc_pset, processConfiguration->processName(), preg);
+    {
+      std::vector<std::string> aliases = proc_pset.getParameter<std::vector<std::string>>("@all_aliases");
+      detail::processEDAliases(aliases, {}, proc_pset, processConfiguration->processName(), preg);
+    }
 
     // At this point all BranchDescriptions are created. Mark now the
     // ones of unscheduled workers to be on-demand.

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1042,14 +1042,12 @@ namespace edm {
                                      << "Name"
                                      << "";
 
-        unsigned int bitpos = 0;
         for (auto const& mod : p.moduleInPathSummaries) {
           LogFwkVerbatim("FwkSummary") << "TrigReport " << std::right << std::setw(5) << 1 << std::right << std::setw(5)
-                                       << bitpos << " " << std::right << std::setw(10) << mod.timesVisited << " "
-                                       << std::right << std::setw(10) << mod.timesPassed << " " << std::right
+                                       << mod.bitPosition << " " << std::right << std::setw(10) << mod.timesVisited
+                                       << " " << std::right << std::setw(10) << mod.timesPassed << " " << std::right
                                        << std::setw(10) << mod.timesFailed << " " << std::right << std::setw(10)
                                        << mod.timesExcept << " " << mod.moduleLabel << "";
-          ++bitpos;
         }
       }
 

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -599,19 +599,18 @@ namespace edm {
           }
         }
       }
-      //find SwitchProducers whose chosen case is an alias
+      //find SwitchProducers whose cases are aliases
       {
         auto const& all_modules = proc_pset.getParameter<std::vector<std::string>>("@all_modules");
         std::vector<std::string> switchEDAliases;
         for (auto const& module : all_modules) {
           auto const& mod_pset = proc_pset.getParameter<edm::ParameterSet>(module);
           if (mod_pset.getParameter<std::string>("@module_type") == "SwitchProducer") {
-            auto const& chosen_case = mod_pset.getUntrackedParameter<std::string>("@chosen_case");
-            auto range = aliasMap.equal_range(chosen_case);
-            if (range.first != range.second) {
-              switchEDAliases.push_back(chosen_case);
-              for (auto it = range.first; it != range.second; ++it) {
-                aliasMap.emplace(module, it->second);
+            auto const& all_cases = mod_pset.getParameter<std::vector<std::string>>("@all_cases");
+            for (auto const& case_label : all_cases) {
+              auto range = aliasMap.equal_range(case_label);
+              if (range.first != range.second) {
+                switchEDAliases.push_back(case_label);
               }
             }
           }

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -578,21 +578,23 @@ namespace edm {
           auto aliasedToModuleLabels = info.getParameterNames();
           for (auto const& mod : aliasedToModuleLabels) {
             if (not mod.empty() and mod[0] != '@' and conditionalmods.find(mod) != conditionalmods.end()) {
-              auto aliasPSet = proc_pset.getParameter<edm::ParameterSet>(mod);
-              std::string type = star;
-              std::string instance = star;
-              std::string originalInstance = star;
-              if (aliasPSet.exists("type")) {
-                type = aliasPSet.getParameter<std::string>("type");
-              }
-              if (aliasPSet.exists("toProductInstance")) {
-                instance = aliasPSet.getParameter<std::string>("toProductInstance");
-              }
-              if (aliasPSet.exists("fromProductInstance")) {
-                originalInstance = aliasPSet.getParameter<std::string>("fromProductInstance");
-              }
+              auto aliasVPSet = info.getParameter<std::vector<edm::ParameterSet>>(mod);
+              for (auto const& aliasPSet : aliasVPSet) {
+                std::string type = star;
+                std::string instance = star;
+                std::string originalInstance = star;
+                if (aliasPSet.exists("type")) {
+                  type = aliasPSet.getParameter<std::string>("type");
+                }
+                if (aliasPSet.exists("toProductInstance")) {
+                  instance = aliasPSet.getParameter<std::string>("toProductInstance");
+                }
+                if (aliasPSet.exists("fromProductInstance")) {
+                  originalInstance = aliasPSet.getParameter<std::string>("fromProductInstance");
+                }
 
-              aliasMap.emplace(alias, AliasInfo{type, instance, originalInstance, mod});
+                aliasMap.emplace(alias, AliasInfo{type, instance, originalInstance, mod});
+              }
             }
           }
         }

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -28,6 +28,7 @@
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include "LuminosityBlockProcessingStatus.h"
+#include "processEDAliases.h"
 
 #include <algorithm>
 #include <cassert>
@@ -485,6 +486,10 @@ namespace edm {
             }
             if (productFromConditionalModule) {
               itFound = conditionalModules.find(productModuleLabel);
+              //check that the alias-for conditional module has not been used
+              if (itFound == conditionalModules.end()) {
+                continue;
+              }
             }
           } else {
             //need to check the rest of the data product info
@@ -591,6 +596,26 @@ namespace edm {
             }
           }
         }
+      }
+      //find SwitchProducers whose chosen case is an alias
+      {
+        auto const& all_modules = proc_pset.getParameter<std::vector<std::string>>("@all_modules");
+        std::vector<std::string> switchEDAliases;
+        for (auto const& module : all_modules) {
+          auto const& mod_pset = proc_pset.getParameter<edm::ParameterSet>(module);
+          if (mod_pset.getParameter<std::string>("@module_type") == "SwitchProducer") {
+            auto const& chosen_case = mod_pset.getUntrackedParameter<std::string>("@chosen_case");
+            auto range = aliasMap.equal_range(chosen_case);
+            if (range.first != range.second) {
+              switchEDAliases.push_back(chosen_case);
+              for (auto it = range.first; it != range.second; ++it) {
+                aliasMap.emplace(module, it->second);
+              }
+            }
+          }
+        }
+        detail::processEDAliases(
+            switchEDAliases, conditionalmods, proc_pset, processConfiguration->processName(), preg);
       }
       {
         //find branches created by the conditional modules

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -3,6 +3,7 @@
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
 #include "FWCore/Framework/src/OutputModuleDescription.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/Framework/src/TriggerReport.h"
@@ -378,6 +379,155 @@ namespace edm {
     }
   }
 
+  static Worker* getWorker(std::string const& moduleLabel,
+                           ParameterSet& proc_pset,
+                           WorkerManager& workerManager,
+                           ProductRegistry& preg,
+                           PreallocationConfiguration const* prealloc,
+                           std::shared_ptr<ProcessConfiguration const> processConfiguration) {
+    bool isTracked;
+    ParameterSet* modpset = proc_pset.getPSetForUpdate(moduleLabel, isTracked);
+    if (modpset == nullptr) {
+      return nullptr;
+    }
+    assert(isTracked);
+
+    return workerManager.getWorker(*modpset, preg, prealloc, processConfiguration, moduleLabel);
+  }
+
+  std::vector<Worker*> StreamSchedule::tryToPlaceConditionalModules(
+      Worker* worker,
+      std::unordered_set<std::string>& conditionalModules,
+      std::multimap<std::string, edm::BranchDescription const*> const& conditionalModuleBranches,
+      std::multimap<std::string, AliasInfo> const& aliasMap,
+      ParameterSet& proc_pset,
+      ProductRegistry& preg,
+      PreallocationConfiguration const* prealloc,
+      std::shared_ptr<ProcessConfiguration const> processConfiguration) {
+    std::vector<Worker*> returnValue;
+    auto const& consumesInfo = worker->consumesInfo();
+    auto moduleLabel = worker->description()->moduleLabel();
+    using namespace productholderindexhelper;
+    for (auto const& ci : consumesInfo) {
+      if (not ci.skipCurrentProcess() and
+          (ci.process().empty() or ci.process() == processConfiguration->processName())) {
+        auto productModuleLabel = ci.label();
+        if (productModuleLabel.empty()) {
+          //this is a consumesMany request
+          for (auto const& branch : conditionalModuleBranches) {
+            if (ci.kindOfType() == edm::PRODUCT_TYPE) {
+              if (branch.second->unwrappedTypeID() != ci.type()) {
+                continue;
+              }
+            } else {
+              if (not typeIsViewCompatible(
+                      ci.type(), TypeID(branch.second->wrappedType().typeInfo()), branch.second->className())) {
+                continue;
+              }
+            }
+
+            auto condWorker =
+                getWorker(productModuleLabel, proc_pset, workerManager_, preg, prealloc, processConfiguration);
+            assert(condWorker);
+
+            conditionalModules.erase(productModuleLabel);
+
+            auto dependents = tryToPlaceConditionalModules(condWorker,
+                                                           conditionalModules,
+                                                           conditionalModuleBranches,
+                                                           aliasMap,
+                                                           proc_pset,
+                                                           preg,
+                                                           prealloc,
+                                                           processConfiguration);
+            returnValue.insert(returnValue.end(), dependents.begin(), dependents.end());
+            returnValue.push_back(condWorker);
+          }
+        } else {
+          //just a regular consumes
+          bool productFromConditionalModule = false;
+          auto itFound = conditionalModules.find(productModuleLabel);
+          if (itFound == conditionalModules.end()) {
+            //Check to see if this was an alias
+            auto findAlias = aliasMap.equal_range(productModuleLabel);
+            if (findAlias.first != findAlias.second) {
+              for (auto it = findAlias.first; it != findAlias.second; ++it) {
+                //this was previously filtered so only the conditional modules remain
+                productModuleLabel = it->second.originalModuleLabel;
+                if (it->second.friendlyClassName == "*" or
+                    (ci.type().friendlyClassName() == it->second.friendlyClassName)) {
+                  if (it->second.instanceLabel == "*" or ci.instance() == it->second.instanceLabel) {
+                    productFromConditionalModule = true;
+                    //need to check the rest of the data product info
+                    break;
+                  }
+                } else if (ci.kindOfType() == ELEMENT_TYPE) {
+                  //consume is a View so need to do more intrusive search
+                  if (it->second.instanceLabel == "*" or ci.instance() == it->second.instanceLabel) {
+                    //find matching branches in module
+                    auto branches = conditionalModuleBranches.equal_range(productModuleLabel);
+                    for (auto itBranch = branches.first; itBranch != branches.second; ++it) {
+                      if (it->second.originalInstanceLabel == "*" or
+                          itBranch->second->productInstanceName() == it->second.originalInstanceLabel) {
+                        if (typeIsViewCompatible(ci.type(),
+                                                 TypeID(itBranch->second->wrappedType().typeInfo()),
+                                                 itBranch->second->className())) {
+                          productFromConditionalModule = true;
+                          break;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            itFound = conditionalModules.find(productModuleLabel);
+          } else {
+            //need to check the rest of the data product info
+            auto findBranches = conditionalModuleBranches.equal_range(productModuleLabel);
+            for (auto itBranch = findBranches.first; itBranch != findBranches.second; ++itBranch) {
+              if (itBranch->second->productInstanceName() == ci.instance()) {
+                if (ci.kindOfType() == PRODUCT_TYPE) {
+                  if (ci.type() == itBranch->second->unwrappedTypeID()) {
+                    productFromConditionalModule = true;
+                    break;
+                  }
+                } else {
+                  //this is a view
+                  if (typeIsViewCompatible(ci.type(),
+                                           TypeID(itBranch->second->wrappedType().typeInfo()),
+                                           itBranch->second->className())) {
+                    productFromConditionalModule = true;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+          if (productFromConditionalModule) {
+            auto condWorker =
+                getWorker(productModuleLabel, proc_pset, workerManager_, preg, prealloc, processConfiguration);
+            assert(condWorker);
+
+            conditionalModules.erase(itFound);
+
+            auto dependents = tryToPlaceConditionalModules(condWorker,
+                                                           conditionalModules,
+                                                           conditionalModuleBranches,
+                                                           aliasMap,
+                                                           proc_pset,
+                                                           preg,
+                                                           prealloc,
+                                                           processConfiguration);
+            returnValue.insert(returnValue.end(), dependents.begin(), dependents.end());
+            returnValue.push_back(condWorker);
+          }
+        }
+      }
+    }
+    return returnValue;
+  }
+
   void StreamSchedule::fillWorkers(ParameterSet& proc_pset,
                                    ProductRegistry& preg,
                                    PreallocationConfiguration const* prealloc,
@@ -388,6 +538,61 @@ namespace edm {
                                    std::vector<std::string> const& endPathNames) {
     vstring modnames = proc_pset.getParameter<vstring>(pathName);
     PathWorkers tmpworkers;
+
+    //Pull out ConditionalTask modules
+    auto itCondBegin = std::find(modnames.begin(), modnames.end(), "#");
+
+    std::unordered_set<std::string> conditionalmods;
+    //An EDAlias may be redirecting to a module on a ConditionalTask
+    std::multimap<std::string, AliasInfo> aliasMap;
+    std::multimap<std::string, edm::BranchDescription const*> conditionalModsBranches;
+    if (itCondBegin != modnames.end()) {
+      //the last entry should be ignored since it is required to be "@"
+      conditionalmods = std::unordered_set<std::string>(
+          std::make_move_iterator(itCondBegin + 1), std::make_move_iterator(modnames.begin() + modnames.size() - 1));
+
+      for (auto const& cond : conditionalmods) {
+        //force the creation of the conditional modules so alias check can work
+        (void)getWorker(cond, proc_pset, workerManager_, preg, prealloc, processConfiguration);
+      }
+      //find aliases
+      {
+        auto aliases = proc_pset.getParameter<std::vector<std::string>>("@all_aliases");
+        std::string const star("*");
+        for (auto const& alias : aliases) {
+          auto info = proc_pset.getParameter<edm::ParameterSet>(alias);
+          auto aliasedToModuleLabels = info.getParameterNames();
+          for (auto const& mod : aliasedToModuleLabels) {
+            if (not mod.empty() and mod[0] != '@' and conditionalmods.find(mod) != conditionalmods.end()) {
+              auto aliasPSet = proc_pset.getParameter<edm::ParameterSet>(mod);
+              std::string type = star;
+              std::string instance = star;
+              std::string originalInstance = star;
+              if (aliasPSet.exists("type")) {
+                type = aliasPSet.getParameter<std::string>("type");
+              }
+              if (aliasPSet.exists("toProductInstance")) {
+                instance = aliasPSet.getParameter<std::string>("toProductInstance");
+              }
+              if (aliasPSet.exists("fromProductInstance")) {
+                originalInstance = aliasPSet.getParameter<std::string>("fromProductInstance");
+              }
+
+              aliasMap.emplace(alias, AliasInfo{type, instance, originalInstance, mod});
+            }
+          }
+        }
+      }
+      {
+        //find branches created by the conditional modules
+        for (auto const& prod : preg.productList()) {
+          if (conditionalmods.find(prod.first.moduleLabel()) != conditionalmods.end()) {
+            conditionalModsBranches.emplace(prod.first.moduleLabel(), &prod.second);
+          }
+        }
+      }
+    }
+    modnames.erase(itCondBegin, modnames.end());
 
     unsigned int placeInPath = 0;
     for (auto const& name : modnames) {
@@ -409,9 +614,8 @@ namespace edm {
         moduleLabel.erase(0, 1);
       }
 
-      bool isTracked;
-      ParameterSet* modpset = proc_pset.getPSetForUpdate(moduleLabel, isTracked);
-      if (modpset == nullptr) {
+      Worker* worker = getWorker(moduleLabel, proc_pset, workerManager_, preg, prealloc, processConfiguration);
+      if (worker == nullptr) {
         std::string pathType("endpath");
         if (!search_all(endPathNames, pathName)) {
           pathType = std::string("path");
@@ -420,9 +624,7 @@ namespace edm {
             << "The unknown module label \"" << moduleLabel << "\" appears in " << pathType << " \"" << pathName
             << "\"\n please check spelling or remove that label from the path.";
       }
-      assert(isTracked);
 
-      Worker* worker = workerManager_.getWorker(*modpset, preg, prealloc, processConfiguration, moduleLabel);
       if (ignoreFilters && filterAction != WorkerInPath::Ignore && worker->moduleType() == Worker::kFilter) {
         // We have a filter on an end path, and the filter is not explicitly ignored.
         // See if the filter is allowed.
@@ -442,6 +644,14 @@ namespace edm {
       if (runConcurrently && worker->moduleType() == Worker::kFilter and filterAction != WorkerInPath::Ignore) {
         runConcurrently = false;
       }
+
+      auto condModules = tryToPlaceConditionalModules(
+          worker, conditionalmods, conditionalModsBranches, aliasMap, proc_pset, preg, prealloc, processConfiguration);
+      for (auto condMod : condModules) {
+        tmpworkers.emplace_back(condMod, WorkerInPath::Ignore, placeInPath, true);
+        ++placeInPath;
+      }
+
       tmpworkers.emplace_back(worker, filterAction, placeInPath, runConcurrently);
       ++placeInPath;
     }

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -415,6 +415,10 @@ namespace edm {
         if (productModuleLabel.empty()) {
           //this is a consumesMany request
           for (auto const& branch : conditionalModuleBranches) {
+            //check that the conditional module has not been used
+            if (conditionalModules.find(branch.first) == conditionalModules.end()) {
+              continue;
+            }
             if (ci.kindOfType() == edm::PRODUCT_TYPE) {
               if (branch.second->unwrappedTypeID() != ci.type()) {
                 continue;
@@ -426,11 +430,10 @@ namespace edm {
               }
             }
 
-            auto condWorker =
-                getWorker(productModuleLabel, proc_pset, workerManager_, preg, prealloc, processConfiguration);
+            auto condWorker = getWorker(branch.first, proc_pset, workerManager_, preg, prealloc, processConfiguration);
             assert(condWorker);
 
-            conditionalModules.erase(productModuleLabel);
+            conditionalModules.erase(branch.first);
 
             auto dependents = tryToPlaceConditionalModules(condWorker,
                                                            conditionalModules,

--- a/FWCore/Framework/src/TriggerNamesService.cc
+++ b/FWCore/Framework/src/TriggerNamesService.cc
@@ -31,11 +31,24 @@ namespace edm {
       loadPosMap(end_pos_, end_names_);
 
       const unsigned int n(trignames_.size());
+      auto const& labelsToRemove = schedulingConstructLabels();
       for (unsigned int i = 0; i != n; ++i) {
         modulenames_.push_back(pset.getParameter<Strings>(trignames_[i]));
+        auto& names = modulenames_.back();
+        names.erase(
+            std::remove_if(names.begin(),
+                           names.end(),
+                           [&labelsToRemove](auto const& n) { return labelsToRemove.find(n) != labelsToRemove.end(); }),
+            names.end());
       }
       for (unsigned int i = 0; i != end_names_.size(); ++i) {
         end_modulenames_.push_back(pset.getParameter<Strings>(end_names_[i]));
+        auto& names = end_modulenames_.back();
+        names.erase(
+            std::remove_if(names.begin(),
+                           names.end(),
+                           [&labelsToRemove](auto const& n) { return labelsToRemove.find(n) != labelsToRemove.end(); }),
+            names.end());
       }
     }
 
@@ -87,6 +100,11 @@ namespace edm {
     bool TriggerNamesService::getTrigPaths(TriggerResults const& triggerResults, Strings& trigPaths) {
       bool dummy;
       return getTrigPaths(triggerResults, trigPaths, dummy);
+    }
+
+    TriggerNamesService::ScheduingConstructLabelSet const& TriggerNamesService::schedulingConstructLabels() {
+      static const ScheduingConstructLabelSet s_set({{"@"}, {"#"}});
+      return s_set;
     }
   }  // namespace service
 }  // namespace edm

--- a/FWCore/Framework/src/TriggerNamesService.cc
+++ b/FWCore/Framework/src/TriggerNamesService.cc
@@ -11,6 +11,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
+#include "FWCore/Utilities/interface/path_configuration.h"
 
 namespace edm {
   namespace service {
@@ -31,24 +32,13 @@ namespace edm {
       loadPosMap(end_pos_, end_names_);
 
       const unsigned int n(trignames_.size());
-      auto const& labelsToRemove = schedulingConstructLabels();
       for (unsigned int i = 0; i != n; ++i) {
-        modulenames_.push_back(pset.getParameter<Strings>(trignames_[i]));
-        auto& names = modulenames_.back();
-        names.erase(
-            std::remove_if(names.begin(),
-                           names.end(),
-                           [&labelsToRemove](auto const& n) { return labelsToRemove.find(n) != labelsToRemove.end(); }),
-            names.end());
+        modulenames_.push_back(
+            path_configuration::configurationToModuleBitPosition(pset.getParameter<Strings>(trignames_[i])));
       }
       for (unsigned int i = 0; i != end_names_.size(); ++i) {
-        end_modulenames_.push_back(pset.getParameter<Strings>(end_names_[i]));
-        auto& names = end_modulenames_.back();
-        names.erase(
-            std::remove_if(names.begin(),
-                           names.end(),
-                           [&labelsToRemove](auto const& n) { return labelsToRemove.find(n) != labelsToRemove.end(); }),
-            names.end());
+        end_modulenames_.push_back(
+            path_configuration::configurationToModuleBitPosition(pset.getParameter<Strings>(end_names_[i])));
       }
     }
 
@@ -100,11 +90,6 @@ namespace edm {
     bool TriggerNamesService::getTrigPaths(TriggerResults const& triggerResults, Strings& trigPaths) {
       bool dummy;
       return getTrigPaths(triggerResults, trigPaths, dummy);
-    }
-
-    TriggerNamesService::ScheduingConstructLabelSet const& TriggerNamesService::schedulingConstructLabels() {
-      static const ScheduingConstructLabelSet s_set({{"@"}, {"#"}});
-      return s_set;
     }
   }  // namespace service
 }  // namespace edm

--- a/FWCore/Framework/src/TriggerReport.h
+++ b/FWCore/Framework/src/TriggerReport.h
@@ -26,6 +26,7 @@ namespace edm {
     int timesPassed = 0;
     int timesFailed = 0;
     int timesExcept = 0;
+    int bitPosition = 0;
 
     std::string moduleLabel;
   };

--- a/FWCore/Framework/src/processEDAliases.cc
+++ b/FWCore/Framework/src/processEDAliases.cc
@@ -46,11 +46,15 @@ namespace edm {
 
       std::string const& theInstanceAlias(instanceAlias == star ? productInstanceName : instanceAlias);
       BranchKey aliasKey(friendlyClassName, alias, theInstanceAlias, processName);
-      if (preg.productList().find(aliasKey) != preg.productList().end()) {
-        throw Exception(errors::Configuration, "EDAlias conflicts with data\n")
-            << "A product of type '" << friendlyClassName << "'\n"
-            << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
-            << "already exists.\n";
+      if (auto it = preg.productList().find(aliasKey); it != preg.productList().end()) {
+        // We might have already inserted an alias that was a chosen case of a SwitchProducer
+        if (not it->second.isAlias()) {
+          throw Exception(errors::Configuration, "EDAlias conflicts with data\n")
+              << "A product of type '" << friendlyClassName << "'\n"
+              << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
+              << "already exists.\n";
+        }
+        return;
       }
       auto iter = aliasKeys.find(aliasKey);
       if (iter != aliasKeys.end()) {

--- a/FWCore/Framework/src/processEDAliases.cc
+++ b/FWCore/Framework/src/processEDAliases.cc
@@ -1,0 +1,218 @@
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/BranchKey.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "processEDAliases.h"
+
+#include <map>
+
+namespace edm {
+  namespace {
+    void checkAndInsertAlias(std::string const& friendlyClassName,
+                             std::string const& moduleLabel,
+                             std::string const& productInstanceName,
+                             std::string const& processName,
+                             std::string const& alias,
+                             std::string const& instanceAlias,
+                             ProductRegistry const& preg,
+                             std::multimap<BranchKey, BranchKey>& aliasMap,
+                             std::map<BranchKey, BranchKey>& aliasKeys) {
+      std::string const star("*");
+
+      BranchKey key(friendlyClassName, moduleLabel, productInstanceName, processName);
+      if (preg.productList().find(key) == preg.productList().end()) {
+        // No product was found matching the alias.
+        // We throw an exception only if a module with the specified module label was created in this process.
+        for (auto const& product : preg.productList()) {
+          if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
+            throw Exception(errors::Configuration, "EDAlias does not match data\n")
+                << "There are no products of type '" << friendlyClassName << "'\n"
+                << "with module label '" << moduleLabel << "' and instance name '" << productInstanceName << "'.\n";
+          }
+        }
+      }
+
+      if (auto iter = aliasMap.find(key); iter != aliasMap.end()) {
+        // If the same EDAlias defines multiple products pointing to the same product, throw
+        if (iter->second.moduleLabel() == alias) {
+          throw Exception(errors::Configuration, "EDAlias conflict\n")
+              << "The module label alias '" << alias << "' is used for multiple products of type '" << friendlyClassName
+              << "' with module label '" << moduleLabel << "' and instance name '" << productInstanceName
+              << "'. One alias has the instance name '" << iter->first.productInstanceName()
+              << "' and the other has the instance name '" << instanceAlias << "'.";
+        }
+      }
+
+      std::string const& theInstanceAlias(instanceAlias == star ? productInstanceName : instanceAlias);
+      BranchKey aliasKey(friendlyClassName, alias, theInstanceAlias, processName);
+      if (preg.productList().find(aliasKey) != preg.productList().end()) {
+        throw Exception(errors::Configuration, "EDAlias conflicts with data\n")
+            << "A product of type '" << friendlyClassName << "'\n"
+            << "with module label '" << alias << "' and instance name '" << theInstanceAlias << "'\n"
+            << "already exists.\n";
+      }
+      auto iter = aliasKeys.find(aliasKey);
+      if (iter != aliasKeys.end()) {
+        // The alias matches a previous one.  If the same alias is used for different product, throw.
+        if (iter->second != key) {
+          throw Exception(errors::Configuration, "EDAlias conflict\n")
+              << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
+              << "are used for multiple products of type '" << friendlyClassName << "'\n"
+              << "One has module label '" << moduleLabel << "' and product instance name '" << productInstanceName
+              << "',\n"
+              << "the other has module label '" << iter->second.moduleLabel() << "' and product instance name '"
+              << iter->second.productInstanceName() << "'.\n";
+        }
+      } else {
+        auto prodIter = preg.productList().find(key);
+        if (prodIter != preg.productList().end()) {
+          if (!prodIter->second.produced()) {
+            throw Exception(errors::Configuration, "EDAlias\n")
+                << "The module label alias '" << alias << "' and product instance alias '" << theInstanceAlias << "'\n"
+                << "are used for a product of type '" << friendlyClassName << "'\n"
+                << "with module label '" << moduleLabel << "' and product instance name '" << productInstanceName
+                << "',\n"
+                << "An EDAlias can only be used for products produced in the current process. This one is not.\n";
+          }
+          aliasMap.insert(std::make_pair(key, aliasKey));
+          aliasKeys.insert(std::make_pair(aliasKey, key));
+        }
+      }
+    }
+  }  // namespace
+
+  namespace detail {
+    void processEDAliases(std::vector<std::string> const& aliasNamesToProcess,
+                          std::unordered_set<std::string> const& aliasModulesToProcess,
+                          ParameterSet const& proc_pset,
+                          std::string const& processName,
+                          ProductRegistry& preg) {
+      if (aliasNamesToProcess.empty()) {
+        return;
+      }
+      std::string const star("*");
+      std::string const empty("");
+      ParameterSetDescription desc;
+      desc.add<std::string>("type");
+      desc.add<std::string>("fromProductInstance", star);
+      desc.add<std::string>("toProductInstance", star);
+
+      std::multimap<BranchKey, BranchKey> aliasMap;
+
+      std::map<BranchKey, BranchKey> aliasKeys;  // Used to search for duplicates or clashes.
+
+      // Auxiliary search structure to support wildcard for friendlyClassName
+      std::multimap<std::string, BranchKey> moduleLabelToBranches;
+      for (auto const& prod : preg.productList()) {
+        if (processName == prod.second.processName()) {
+          moduleLabelToBranches.emplace(prod.first.moduleLabel(), prod.first);
+        }
+      }
+
+      // Now, loop over the alias information and store it in aliasMap.
+      for (std::string const& alias : aliasNamesToProcess) {
+        ParameterSet const& aliasPSet = proc_pset.getParameterSet(alias);
+        std::vector<std::string> vPSetNames = aliasPSet.getParameterNamesForType<VParameterSet>();
+        for (std::string const& moduleLabel : vPSetNames) {
+          if (not aliasModulesToProcess.empty() and
+              aliasModulesToProcess.find(moduleLabel) == aliasModulesToProcess.end()) {
+            continue;
+          }
+
+          VParameterSet vPSet = aliasPSet.getParameter<VParameterSet>(moduleLabel);
+          for (ParameterSet& pset : vPSet) {
+            desc.validate(pset);
+            std::string friendlyClassName = pset.getParameter<std::string>("type");
+            std::string productInstanceName = pset.getParameter<std::string>("fromProductInstance");
+            std::string instanceAlias = pset.getParameter<std::string>("toProductInstance");
+
+            if (friendlyClassName == star) {
+              bool processHasLabel = false;
+              bool match = false;
+              for (auto it = moduleLabelToBranches.lower_bound(moduleLabel);
+                   it != moduleLabelToBranches.end() && it->first == moduleLabel;
+                   ++it) {
+                processHasLabel = true;
+                if (productInstanceName != star and productInstanceName != it->second.productInstanceName()) {
+                  continue;
+                }
+                match = true;
+
+                checkAndInsertAlias(it->second.friendlyClassName(),
+                                    moduleLabel,
+                                    it->second.productInstanceName(),
+                                    processName,
+                                    alias,
+                                    instanceAlias,
+                                    preg,
+                                    aliasMap,
+                                    aliasKeys);
+              }
+              if (not match and processHasLabel) {
+                // No product was found matching the alias.
+                // We throw an exception only if a module with the specified module label was created in this process.
+                // Note that if that condition is ever relatex, it  might be best to throw an exception with different
+                // message (omitting productInstanceName) in case 'productInstanceName == start'
+                throw Exception(errors::Configuration, "EDAlias parameter set mismatch\n")
+                    << "There are no products with module label '" << moduleLabel << "' and product instance name '"
+                    << productInstanceName << "'.\n";
+              }
+            } else if (productInstanceName == star) {
+              bool match = false;
+              BranchKey lowerBound(friendlyClassName, moduleLabel, empty, empty);
+              for (ProductRegistry::ProductList::const_iterator it = preg.productList().lower_bound(lowerBound);
+                   it != preg.productList().end() && it->first.friendlyClassName() == friendlyClassName &&
+                   it->first.moduleLabel() == moduleLabel;
+                   ++it) {
+                if (it->first.processName() != processName) {
+                  continue;
+                }
+                match = true;
+
+                checkAndInsertAlias(friendlyClassName,
+                                    moduleLabel,
+                                    it->first.productInstanceName(),
+                                    processName,
+                                    alias,
+                                    instanceAlias,
+                                    preg,
+                                    aliasMap,
+                                    aliasKeys);
+              }
+              if (!match) {
+                // No product was found matching the alias.
+                // We throw an exception only if a module with the specified module label was created in this process.
+                for (auto const& product : preg.productList()) {
+                  if (moduleLabel == product.first.moduleLabel() && processName == product.first.processName()) {
+                    throw Exception(errors::Configuration, "EDAlias parameter set mismatch\n")
+                        << "There are no products of type '" << friendlyClassName << "'\n"
+                        << "with module label '" << moduleLabel << "'.\n";
+                  }
+                }
+              }
+            } else {
+              checkAndInsertAlias(friendlyClassName,
+                                  moduleLabel,
+                                  productInstanceName,
+                                  processName,
+                                  alias,
+                                  instanceAlias,
+                                  preg,
+                                  aliasMap,
+                                  aliasKeys);
+            }
+          }
+        }
+      }
+
+      // Now add the new alias entries to the product registry.
+      for (auto const& aliasEntry : aliasMap) {
+        // Then check that the alias-for product exists
+        ProductRegistry::ProductList::const_iterator it = preg.productList().find(aliasEntry.first);
+        assert(it != preg.productList().end());
+        preg.addLabelAlias(it->second, aliasEntry.second.moduleLabel(), aliasEntry.second.productInstanceName());
+      }
+    }
+  }  // namespace detail
+}  // namespace edm

--- a/FWCore/Framework/src/processEDAliases.h
+++ b/FWCore/Framework/src/processEDAliases.h
@@ -1,0 +1,27 @@
+#ifndef FWCore_Framework_src_processEDAliases_h
+#define FWCore_Framework_src_processEDAliases_h
+
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <unordered_set>
+#include <string>
+#include <vector>
+
+namespace edm::detail {
+  /**
+   * Process and insert EDAliases to ProductRegistry
+   *
+   * Processes only those EDAliases whose names are given in
+   * aliasNamesToProcess. If aliasModulesToProcess is not empty, only
+   * those alias branches that point to modules named in
+   * aliasModulesToProcess are processed.
+   */
+  void processEDAliases(std::vector<std::string> const& aliasNamesToProcess,
+                        std::unordered_set<std::string> const& aliasModulesToProcess,
+                        ParameterSet const& proc_pset,
+                        std::string const& processName,
+                        ProductRegistry& preg);
+}  // namespace edm::detail
+
+#endif

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -404,4 +404,12 @@
 <test name="testFWCoreFrameworkBadScheduleException5" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_bad_schedule_exception_message_cfg.py 5; grep -v 'Fatal Exception' test_bad_schedule_5.log | diff -q ${LOCALTOP}/src/FWCore/Framework/test/unit_test_outputs/test_bad_schedule_5.log -"/>
 <test name="testFWCoreFrameworkBadScheduleException6" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_bad_schedule_exception_message_cfg.py 6; grep -v 'Fatal Exception' test_bad_schedule_6.log | diff -q ${LOCALTOP}/src/FWCore/Framework/test/unit_test_outputs/test_bad_schedule_6.log -"/>
 <test name="testFWCoreFrameworkBadScheduleException7" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_bad_schedule_exception_message_cfg.py 7; grep -v 'Fatal Exception' test_bad_schedule_7.log | diff -q ${LOCALTOP}/src/FWCore/Framework/test/unit_test_outputs/test_bad_schedule_7.log -"/>
+<test name="testFWCoreFrameworkConditionalTask" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py --"/>
+<test name="testFWCoreFrameworkConditionalTask_filterSucceeds" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --filterSucceeds"/>
+<test name="testFWCoreFrameworkConditionalTask_reverseDependencies" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --reverseDependencies"/>
+<test name="testFWCoreFrameworkConditionalTask_testAlias" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testAlias"/>
+<test name="testFWCoreFrameworkConditionalTask_testAlias_aliasWithStar" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testAlias --aliasWithStar"/>
+<test name="testFWCoreFrameworkConditionalTask_testView" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testView"/>
+<test name="testFWCoreFrameworkConditionalTask_testView_testAlias" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testView --testAlias"/>
+<test name="testFWCoreFrameworkConditionalTask_testView_testAlias_aliasWithStar" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testView --testAlias --aliasWithStar"/>
 <test name="testFWCoreFrameworkModuleSynchLumiBoundary" command="run_module_synch_lumiboundary.sh"/>

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -412,4 +412,5 @@
 <test name="testFWCoreFrameworkConditionalTask_testView" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testView"/>
 <test name="testFWCoreFrameworkConditionalTask_testView_testAlias" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testView --testAlias"/>
 <test name="testFWCoreFrameworkConditionalTask_testView_testAlias_aliasWithStar" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testView --testAlias --aliasWithStar"/>
+<test name="testFWCoreFrameworkConditionalTask_testConsumesMany" command="cmsRun ${LOCALTOP}/src/FWCore/Framework/test/test_conditionaltasks_cfg.py -- --testConsumesMany"/>
 <test name="testFWCoreFrameworkModuleSynchLumiBoundary" command="run_module_synch_lumiboundary.sh"/>

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -415,6 +415,36 @@ namespace edmtest {
   }
 
   //
+  // Produces an IntProduct instance, using many IntProducts as input.
+  //
+
+  class AddAllIntsProducer : public edm::global::EDProducer<> {
+  public:
+    explicit AddAllIntsProducer(edm::ParameterSet const& p) : putToken_{produces()} { consumesMany<IntProduct>(); }
+    void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      descriptions.addDefault(desc);
+    }
+
+  private:
+    const edm::EDPutTokenT<int> putToken_;
+  };
+
+  void AddAllIntsProducer::produce(edm::StreamID, edm::Event& e, edm::EventSetup const&) const {
+    std::vector<edm::Handle<IntProduct>> ints;
+    e.getManyByType(ints);
+
+    int value = 0;
+    for (auto const& i : ints) {
+      value += i->value;
+    }
+
+    e.emplace(putToken_, value);
+  }
+
+  //
   // Produces multiple IntProduct products
   //
 
@@ -844,6 +874,7 @@ namespace edmtest {
   };
 }  // namespace edmtest
 
+using edmtest::AddAllIntsProducer;
 using edmtest::AddIntsProducer;
 using edmtest::BusyWaitIntLegacyProducer;
 using edmtest::BusyWaitIntLimitedProducer;
@@ -878,6 +909,7 @@ DEFINE_FWK_MODULE(TransientIntProducer);
 DEFINE_FWK_MODULE(IntProducerFromTransient);
 DEFINE_FWK_MODULE(Int16_tProducer);
 DEFINE_FWK_MODULE(AddIntsProducer);
+DEFINE_FWK_MODULE(AddAllIntsProducer);
 DEFINE_FWK_MODULE(ManyIntProducer);
 DEFINE_FWK_MODULE(ManyIntWhenRegisteredProducer);
 DEFINE_FWK_MODULE(NonEventIntProducer);

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -119,6 +119,12 @@ namespace edmtest {
         : token_{produces<IntProduct>()}, value_(p.getParameter<int>("ivalue")) {}
     void produce(edm::Event& e, edm::EventSetup const& c) override;
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<int>("ivalue");
+      descriptions.addDefault(desc);
+    }
+
   private:
     edm::EDPutTokenT<IntProduct> token_;
     int value_;
@@ -373,13 +379,20 @@ namespace edmtest {
     explicit AddIntsProducer(edm::ParameterSet const& p)
         : putToken_{produces<IntProduct>()},
           otherPutToken_{produces<IntProduct>("other")},
-          onlyGetOnEvent_(p.getUntrackedParameter<unsigned int>("onlyGetOnEvent", 0u)) {
+          onlyGetOnEvent_(p.getUntrackedParameter<unsigned int>("onlyGetOnEvent")) {
       auto const& labels = p.getParameter<std::vector<edm::InputTag>>("labels");
       for (auto const& label : labels) {
         tokens_.emplace_back(consumes(label));
       }
     }
     void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<unsigned int>("onlyGetOnEvent", 0u);
+      desc.add<std::vector<edm::InputTag>>("labels");
+      descriptions.addDefault(desc);
+    }
 
   private:
     std::vector<edm::EDGetTokenT<IntProduct>> tokens_;

--- a/FWCore/Framework/test/stubs/ToyModules.cc
+++ b/FWCore/Framework/test/stubs/ToyModules.cc
@@ -378,7 +378,9 @@ namespace edmtest {
       if (product.value < threshold_) {
         return false;
       }
-      iEvent.emplace(putToken_, product);
+      if (shouldProduce_) {
+        iEvent.emplace(putToken_, product);
+      }
       return true;
     }
 

--- a/FWCore/Framework/test/test_conditionaltasks_cfg.py
+++ b/FWCore/Framework/test/test_conditionaltasks_cfg.py
@@ -1,0 +1,82 @@
+import FWCore.ParameterSet.Config as cms
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test ConditionalTasks.')
+
+parser.add_argument("--filterSucceeds", help="Have filter succeed", action="store_true")
+parser.add_argument("--reverseDependencies", help="Switch the order of dependencies", action="store_true")
+parser.add_argument("--testAlias", help="Get data from an alias", action="store_true")
+parser.add_argument("--testView", help="Get data via a view", action="store_true")
+parser.add_argument("--aliasWithStar", help="when using testAlias use '*' as type", action="store_true")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+process = cms.Process("Test")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 1
+
+process.a = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+process.b = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("a")))
+
+process.f1 = cms.EDFilter("IntProductFilter", label = cms.InputTag("b"))
+
+process.c = cms.EDProducer("IntProducer", ivalue = cms.int32(2))
+process.d = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("c")))
+process.e = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("d")))
+
+process.prodOnPath = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("d"), cms.InputTag("e")))
+
+if args.filterSucceeds:
+    threshold = 1
+else:
+    threshold = 3
+
+process.f2 = cms.EDFilter("IntProductFilter", label = cms.InputTag("e"), threshold = cms.int32(threshold))
+
+if args.reverseDependencies:
+    process.d.labels[0]=cms.InputTag("e")
+    process.e.labels[0]=cms.InputTag("c")
+    process.f2.label = cms.InputTag("d")
+
+if args.testView:
+  process.f3 = cms.EDAnalyzer("SimpleViewAnalyzer",
+    label = cms.untracked.InputTag("f"),
+    sizeMustMatch = cms.untracked.uint32(10),
+    checkSize = cms.untracked.bool(False)
+  )
+  process.f = cms.EDProducer("OVSimpleProducer", size = cms.int32(10))
+  producttype = "edmtestSimplesOwned"
+else:
+  process.f= cms.EDProducer("IntProducer", ivalue = cms.int32(3))
+  process.f3 = cms.EDFilter("IntProductFilter", label = cms.InputTag("f"))
+  producttype = "edmtestIntProduct"
+
+if args.testAlias:
+  if args.aliasWithStar:
+    producttype = "*"
+
+  process.f3.label = "aliasToF"
+  process.aliasToF = cms.EDAlias(
+      f = cms.VPSet(
+          cms.PSet(
+              type = cms.string(producttype),
+          )
+      )
+  )
+
+
+process.p = cms.Path(process.f1+process.prodOnPath+process.f2+process.f3, cms.ConditionalTask(process.a, process.b, process.c, process.d, process.e, process.f))
+
+process.tst = cms.EDAnalyzer("IntTestAnalyzer", moduleLabel = cms.untracked.InputTag("f"), valueMustMatch = cms.untracked.int32(3), 
+                                                       valueMustBeMissing = cms.untracked.bool(not args.filterSucceeds))
+
+process.endp = cms.EndPath(process.tst)
+
+#process.add_(cms.Service("Tracer"))

--- a/FWCore/Framework/test/test_conditionaltasks_cfg.py
+++ b/FWCore/Framework/test/test_conditionaltasks_cfg.py
@@ -10,6 +10,7 @@ parser.add_argument("--reverseDependencies", help="Switch the order of dependenc
 parser.add_argument("--testAlias", help="Get data from an alias", action="store_true")
 parser.add_argument("--testView", help="Get data via a view", action="store_true")
 parser.add_argument("--aliasWithStar", help="when using testAlias use '*' as type", action="store_true")
+parser.add_argument("--testConsumesMany", help="use ConsumesMany", action="store_true")
 
 argv = sys.argv[:]
 if '--' in argv:
@@ -32,6 +33,9 @@ process.d = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTa
 process.e = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("d")))
 
 process.prodOnPath = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag(cms.InputTag("d"), cms.InputTag("e")))
+
+if args.testConsumesMany:
+  process.prodOnPath = cms.EDProducer("AddAllIntsProducer")
 
 if args.filterSucceeds:
     threshold = 1
@@ -75,8 +79,9 @@ if args.testAlias:
 process.p = cms.Path(process.f1+process.prodOnPath+process.f2+process.f3, cms.ConditionalTask(process.a, process.b, process.c, process.d, process.e, process.f))
 
 process.tst = cms.EDAnalyzer("IntTestAnalyzer", moduleLabel = cms.untracked.InputTag("f"), valueMustMatch = cms.untracked.int32(3), 
-                                                       valueMustBeMissing = cms.untracked.bool(not args.filterSucceeds))
+                                                       valueMustBeMissing = cms.untracked.bool(not args.filterSucceeds and not args.testConsumesMany))
 
 process.endp = cms.EndPath(process.tst)
 
 #process.add_(cms.Service("Tracer"))
+#process.options.wantSummary=True

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -71,6 +71,14 @@ pushd ${LOCAL_TMP_DIR}
   echo "SwitchProducer in a ConditionalTask, more extensive EDAlias tests, case test2 disabled"
   cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAlias_cfg.py disableTest2 || die "cmsRun ${test}ConditionalTaskEDAlias_cfg.py 2" $?
 
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, test EDAlias with all cases being explicitly consumed"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAliasConsumeAllCases_cfg.py || die "cmsRun ${test}ConditionalTaskEDAliasConsumeAllCases_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, test EDAlias with all cases being explicitly consumed, case test2 disabled"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAliasConsumeAllCases_cfg.py disableTest2 || die "cmsRun ${test}ConditionalTaskEDAliasConsumeAllCases_cfg.py 2" $?
+
   
   echo "*************************************************"
   echo "SwitchProducer in a Path"

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -4,6 +4,8 @@ test=testSwitchProducer
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
+# Running on multiple threads and streams to test any behavior that
+# occurs when there are many of them
 NUMTHREADS=4
 
 pushd ${LOCAL_TMP_DIR}
@@ -37,6 +39,29 @@ pushd ${LOCAL_TMP_DIR}
   echo "*************************************************"
   echo "Test provenance of reversely merged output (Task)"
   cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerTaskMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py Task2" $?
+
+
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTask_cfg.py || die "cmsRun ${test}ConditionalTask_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, case test2 disabled"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTask_cfg.py disableTest2 || die "cmsRun ${test}ConditionalTask_cfg.py 2" $?
+
+  echo "*************************************************"
+  echo "Merge outputs (ConditionalTask)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerConditionalTaskMerge1.root inputFiles=file:testSwitchProducerConditionalTask1.root inputFiles=file:testSwitchProducerConditionalTask2.root || die "Merge ConditionalTask1: order 1 2" $?
+  echo "*************************************************"
+  echo "Merge outputs in reverse order (ConditionalTask)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}Merge_cfg.py outputFile=testSwitchProducerConditionalTaskMerge2.root inputFiles=file:testSwitchProducerConditionalTask2.root inputFiles=file:testSwitchProducerConditionalTask1.root || die "Merge ConditionalTask2: order 2 1" $?
+
+  echo "*************************************************"
+  echo "Test provenance of merged output (ConditionalTask)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerConditionalTaskMerge1.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py ConditionalTask1" $?
+  echo "*************************************************"
+  echo "Test provenance of reversely merged output (ConditionalTask)"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerConditionalTaskMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py ConditionalTask2" $?
 
   
   echo "*************************************************"

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -63,6 +63,14 @@ pushd ${LOCAL_TMP_DIR}
   echo "Test provenance of reversely merged output (ConditionalTask)"
   cmsRun ${LOCAL_TEST_DIR}/${test}ProvenanceAnalyzer_cfg.py testSwitchProducerConditionalTaskMerge2.root || die "cmsRun ${test}ProvenanceAnalyzer_cfg.py ConditionalTask2" $?
 
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, more extensive EDAlias tests"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAlias_cfg.py || die "cmsRun ${test}ConditionalTaskEDAlias_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, more extensive EDAlias tests, case test2 disabled"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAlias_cfg.py disableTest2 || die "cmsRun ${test}ConditionalTaskEDAlias_cfg.py 2" $?
+
   
   echo "*************************************************"
   echo "SwitchProducer in a Path"

--- a/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAliasConsumeAllCases_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAliasConsumeAllCases_cfg.py
@@ -1,0 +1,69 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+enableTest2 = (sys.argv[-1] != "disableTest2")
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda accelerators: (True, -10),
+                test2 = lambda accelerators: (enableTest2, -9)
+            ), **kargs)
+
+process = cms.Process("PROD1")
+
+process.source = cms.Source("EmptySource")
+if enableTest2:
+    process.source.firstLuminosityBlock = cms.untracked.uint32(2)
+
+process.maxEvents.input = 3
+
+process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
+process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
+if enableTest2:
+    process.intProducer1.throw = cms.untracked.bool(True)
+else:
+    process.intProducer2.throw = cms.untracked.bool(True)
+
+process.intProducerAlias = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer1")),
+    test2 = cms.EDAlias(intProducer2 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string(""), toProductInstance = cms.string("")),
+                                                 cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
+)
+process.intProducerAliasConsumer = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducerAlias"))
+
+# Test that direct dependence on SwitchProducer case-EDAlias within
+# the same ConditionalTask does not cause the aliased-for EDProducer
+# (in the same ConditionalTask) to become unscheduled, also when the
+# consumption is registered within callWhenNewProductsRegistered().
+# Note that neither case of intProducerAlias gets run by the Paths in
+# this test.
+process.rejectingFilter = cms.EDFilter("TestFilterModule",
+    acceptValue = cms.untracked.int32(-1)
+)
+process.allCaseGenericConsumer = cms.EDAnalyzer("GenericConsumer", eventProducts = cms.untracked.vstring(
+    "intProducerAlias@test1",
+    "intProducerAlias@test2"
+))
+process.test1Consumer = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer", srcEvent = cms.untracked.VInputTag("intProducerAlias@test1"))
+process.test2Consumer = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer", srcEvent = cms.untracked.VInputTag("intProducerAlias@test2"))
+if enableTest2:
+    process.test1Consumer.inputShouldBeMissing = cms.untracked.bool(True)
+    process.test2Consumer.inputShouldExist = cms.untracked.bool(True)
+else:
+    process.test1Consumer.inputShouldExist = cms.untracked.bool(True)
+    process.test2Consumer.inputShouldBeMissing = cms.untracked.bool(True)
+
+process.ct = cms.ConditionalTask(process.intProducerAlias, process.intProducer1, process.intProducer2)
+
+# This path causes the chosen case of intProducerAlias to run
+process.p1 = cms.Path(process.intProducerAliasConsumer, process.ct)
+
+# This path makes the ConditionalTask system to think that all cases
+# of intProducerAlias would be run, but they are not run as part of
+# this Path because their consumer is behind an EDFilter that rejects
+# all events
+process.p2 = cms.Path(process.rejectingFilter + process.allCaseGenericConsumer, process.ct)
+
+# This path tests that only the chosen case of intProducerAlias was run
+process.p3 = cms.Path(process.test1Consumer + process.test2Consumer)

--- a/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
@@ -27,6 +27,7 @@ process.out = cms.OutputModule("PoolOutputModule",
     )
 )
 
+# Test that an alias case works
 process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
 process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
 process.intProducer3 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(3))
@@ -45,6 +46,9 @@ process.intProducerAlias = SwitchProducerTest(
                                                  cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
 )
 
+# Test
+# - SwitchProducer depending on other SwitchProducer
+# - EDAlias in SwitchProducer uses aliases for two different modules with different instance names
 process.intProducerDep = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer2"))
 if not enableTest2:
     process.intProducerDep.labels = ["intProducer1"]
@@ -65,3 +69,5 @@ process.p = cms.Path(process.intProducerAlias+process.intProducerDep +
 
 process.ct2 = cms.ConditionalTask(process.intProducerAlias, process.intProducerDep, process.intProducerDepAlias, process.ct)
 process.p2 = cms.Path(process.intProducerDepAliasDep, process.ct2)
+
+process.ep = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
@@ -23,15 +23,20 @@ process.out = cms.OutputModule("PoolOutputModule",
     outputCommands = cms.untracked.vstring(
         'keep *_intProducerAlias_*_*',
         'keep *_intProducerDep_*_*',
+        'keep *_intProducerDepAliasDep_*_*',
     )
 )
 
 process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
 process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
+process.intProducer3 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(3))
+process.intProducer4 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(4))
 if enableTest2:
     process.intProducer1.throw = cms.untracked.bool(True)
 else:
     process.intProducer2.throw = cms.untracked.bool(True)
+    process.intProducer3.throw = cms.untracked.bool(True)
+    process.intProducer4.throw = cms.untracked.bool(True)
 
 
 process.intProducerAlias = SwitchProducerTest(
@@ -44,6 +49,19 @@ process.intProducerDep = cms.EDProducer("AddIntsProducer", labels = cms.VInputTa
 if not enableTest2:
     process.intProducerDep.labels = ["intProducer1"]
 
-process.ct = cms.ConditionalTask(process.intProducer1, process.intProducer2)
-process.p = cms.Path(process.intProducerAlias+process.intProducerDep,
+process.intProducerDepAlias = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducerDep", "intProducerAlias")),
+    test2 = cms.EDAlias(intProducer3 = cms.VPSet(cms.PSet(type = cms.string("*"), fromProductInstance = cms.string(""), toProductInstance = cms.string(""))),
+                        intProducer4 = cms.VPSet(cms.PSet(type = cms.string("*"), fromProductInstance = cms.string(""), toProductInstance = cms.string("other"))))
+)
+process.intProducerDepAliasDep = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer3", "intProducer4"))
+if not enableTest2:
+    process.intProducerDepAliasDep.labels = ["intProducerAlias"]
+
+process.ct = cms.ConditionalTask(process.intProducer1, process.intProducer2, process.intProducer3, process.intProducer4)
+process.p = cms.Path(process.intProducerAlias+process.intProducerDep +
+                     process.intProducerDepAlias + process.intProducerDepAliasDep,
                      process.ct)
+
+process.ct2 = cms.ConditionalTask(process.intProducerAlias, process.intProducerDep, process.intProducerDepAlias, process.ct)
+process.p2 = cms.Path(process.intProducerDepAliasDep, process.ct2)

--- a/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+enableTest2 = (sys.argv[-1] != "disableTest2")
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda accelerators: (True, -10),
+                test2 = lambda accelerators: (enableTest2, -9)
+            ), **kargs)
+
+process = cms.Process("PROD1")
+
+process.source = cms.Source("EmptySource")
+if enableTest2:
+    process.source.firstLuminosityBlock = cms.untracked.uint32(2)
+
+process.maxEvents.input = 3
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testSwitchProducerConditionalTaskEDAlias%d.root' % (1 if enableTest2 else 2,)),
+    outputCommands = cms.untracked.vstring(
+        'keep *_intProducerAlias_*_*',
+        'keep *_intProducerDep_*_*',
+    )
+)
+
+process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
+process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
+if enableTest2:
+    process.intProducer1.throw = cms.untracked.bool(True)
+else:
+    process.intProducer2.throw = cms.untracked.bool(True)
+
+
+process.intProducerAlias = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer1")),
+    test2 = cms.EDAlias(intProducer2 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string(""), toProductInstance = cms.string("")),
+                                                 cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
+)
+
+process.intProducerDep = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer2"))
+if not enableTest2:
+    process.intProducerDep.labels = ["intProducer1"]
+
+process.ct = cms.ConditionalTask(process.intProducer1, process.intProducer2)
+process.p = cms.Path(process.intProducerAlias+process.intProducerDep,
+                     process.ct)

--- a/FWCore/Integration/test/testSwitchProducerConditionalTask_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTask_cfg.py
@@ -16,12 +16,10 @@ process.source = cms.Source("EmptySource")
 if enableTest2:
     process.source.firstLuminosityBlock = cms.untracked.uint32(2)
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(3)
-)
+process.maxEvents.input = 3
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('testSwitchProducerTask%d.root' % (1 if enableTest2 else 2,)),
+    fileName = cms.untracked.string('testSwitchProducerConditionalTask%d.root' % (1 if enableTest2 else 2,)),
     outputCommands = cms.untracked.vstring(
         'keep *_intProducer_*_*',
         'keep *_intProducerOther_*_*',
@@ -70,9 +68,8 @@ process.intProducerDep1 = cms.EDProducer("AddIntsProducer", labels = cms.VInputT
 process.intProducerDep2 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer"))
 process.intProducerDep3 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer"))
 
-process.t = cms.Task(process.intProducer, process.intProducerOther, process.intProducerAlias, process.intProducerAlias2,
-                     process.intProducerDep1, process.intProducerDep2, process.intProducerDep3,
-                     process.intProducer1, process.intProducer2, process.intProducer3, process.intProducer4)
-process.p = cms.Path(process.t)
+process.ct = cms.ConditionalTask(process.intProducer, process.intProducerOther, process.intProducerAlias, process.intProducerAlias2,
+                                 process.intProducer1, process.intProducer2, process.intProducer3, process.intProducer4)
+process.p = cms.Path(process.intProducerDep1+process.intProducerDep2+process.intProducerDep3, process.ct)
 
 process.e = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testSwitchProducerPath_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerPath_cfg.py
@@ -12,12 +12,6 @@ class SwitchProducerTest(cms.SwitchProducer):
 
 process = cms.Process("PROD1")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1),
-    numberOfConcurrentRuns = cms.untracked.uint32(1),
-    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
-)
-
 process.source = cms.Source("EmptySource")
 if enableTest2:
     process.source.firstLuminosityBlock = cms.untracked.uint32(2)

--- a/FWCore/Integration/test/testSwitchProducerTaskInput_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerTaskInput_cfg.py
@@ -12,12 +12,6 @@ class SwitchProducerTest(cms.SwitchProducer):
 
 process = cms.Process("PROD2")
 
-process.options = cms.untracked.PSet(
-    numberOfStreams = cms.untracked.uint32(1),
-    numberOfConcurrentRuns = cms.untracked.uint32(1),
-    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
-)
-
 # Test that having SwitchProducers with same labels as products from
 # earlier processes works
 process.source = cms.Source("PoolSource",

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1298,7 +1298,7 @@ class Process(object):
               l.sort()
               decoratedList.extend(l)
               decoratedList.append("@")
-            iPath.insertInto(processPSet, triggername, decoratedList)
+            iPath.insertInto(processPSet, triggername, decoratedList[:])
         for endpathname in endpaths:
             if endpathname is not endPathWithFinalPathModulesName:
               iEndPath = self.endpaths_()[endpathname]
@@ -1308,7 +1308,7 @@ class Process(object):
             endpathValidator.setLabel(endpathname)
             lister.initialize()
             iEndPath.visit(endpathCompositeVisitor)
-            iEndPath.insertInto(processPSet, endpathname, decoratedList)
+            iEndPath.insertInto(processPSet, endpathname, decoratedList[:])
         processPSet.addVString(False, "@filters_on_endpaths", endpathValidator.filtersOnEndpaths)
           
 
@@ -3692,6 +3692,26 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             self.assertEqual((True,"Foo"), p.values["sp@test1"][1].values["@module_type"])
             self.assertEqual((True,"EDAlias"), p.values["sp@test2"][1].values["@module_edm_type"])
             self.assertEqual((True,"Bar"), p.values["sp@test2"][1].values["a"][1][0].values["type"])
+
+            # ConditionalTask
+            proc = Process("test")
+            proc.spct = SwitchProducerTest(test2 = EDProducer("Foo",
+                                                              a = int32(1),
+                                                              b = PSet(c = int32(2))),
+                                           test1 = EDProducer("Bar",
+                                                              aa = int32(11),
+                                                              bb = PSet(cc = int32(12))),
+                                           test3 = EDAlias(a = VPSet(PSet(type = string("Bar")))))
+            proc.spp = proc.spct.clone()
+            proc.a = EDProducer("A")
+            proc.ct = ConditionalTask(proc.spct)
+            proc.p = Path(proc.a, proc.ct)
+            proc.pp = Path(proc.a + proc.spp)
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual(["a", "spct", "spct@test1", "spct@test2", "spp", "spp@test1", "spp@test2"], p.values["@all_modules"][1])
+            self.assertEqual(["a", "#", "spct", "spct@test1", "spct@test2", "@"], p.values["p"][1])
+            self.assertEqual(["a", "spp", "#", "spp@test1", "spp@test2", "@"], p.values["pp"][1])
 
         def testPrune(self):
             p = Process("test")

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -3613,6 +3613,10 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
                                          test1 = EDProducer("Bar",
                                                             aa = int32(11),
                                                             bb = PSet(cc = int32(12))))
+            self.assertEqual(proc.sp.label_(), "sp")
+            self.assertEqual(proc.sp.test1.label_(), "sp@test1")
+            self.assertEqual(proc.sp.test2.label_(), "sp@test2")
+
             proc.a = EDProducer("A")
             proc.s = Sequence(proc.a + proc.sp)
             proc.t = Task(proc.a, proc.sp)
@@ -3990,11 +3994,15 @@ process.schedule = cms.Schedule(*[ process.path1, process.path2 ])""")
             p.f = EDAnalyzer("OurAnalyzer")
             p.g = EDProducer("OurProducer")
             p.h = EDProducer("YourProducer")
-            p.t1 = Task(p.g, p.h)
-            t2 = Task(p.g, p.h)
+            p.i = SwitchProducerTest(
+                test1 = EDProducer("OneProducer"),
+                test2 = EDProducer("TwoProducer")
+            )
+            p.t1 = Task(p.g, p.h, p.i)
+            t2 = Task(p.g, p.h, p.i)
             t3 = Task(p.g, p.h)
             p.t4 = Task(p.h)
-            p.ct1 = ConditionalTask(p.g, p.h)
+            p.ct1 = ConditionalTask(p.g, p.h, p.i)
             ct2 = ConditionalTask(p.g, p.h)
             ct3 = ConditionalTask(p.g, p.h)
             p.ct4 = ConditionalTask(p.h)
@@ -4007,9 +4015,11 @@ process.schedule = cms.Schedule(*[ process.path1, process.path2 ])""")
             p.schedule = Schedule(p.path2, p.path3, p.endpath2, tasks=[t3, p.t4])
             self.assertTrue(hasattr(p, 'f'))
             self.assertTrue(hasattr(p, 'g'))
+            self.assertTrue(hasattr(p, 'i'))
             del p.e
             del p.f
             del p.g
+            del p.i
             self.assertFalse(hasattr(p, 'f'))
             self.assertFalse(hasattr(p, 'g'))
             self.assertEqual(p.t1.dumpPython(), 'cms.Task(process.h)\n')

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1282,8 +1282,8 @@ class Process(object):
         decoratedList = []
         lister = DecoratedNodeNameVisitor(decoratedList)
         condTaskModules = []
-        constTaskVistor = ModuleNodeOnConditionalTaskVisitor(condTaskModules)
-        pathCompositeVisitor = CompositeVisitor(pathValidator, nodeVisitor, lister, constTaskVistor)
+        condTaskVistor = ModuleNodeOnConditionalTaskVisitor(condTaskModules)
+        pathCompositeVisitor = CompositeVisitor(pathValidator, nodeVisitor, lister, condTaskVistor)
         endpathCompositeVisitor = CompositeVisitor(endpathValidator, nodeVisitor, lister)
         for triggername in triggerPaths:
             iPath = self.paths_()[triggername]
@@ -3002,15 +3002,15 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             testTask1.add(testTask3)
             process.myTask1 = testTask1
 
-            # test the validation that occurs when attaching a Task to a Process
+            # test the validation that occurs when attaching a ConditionalTask to a Process
             # first a case that passes, then one the fails on an EDProducer
             # then one that fails on a service
             l = set()
             visitor = NodeNameVisitor(l)
             testTask1.visit(visitor)
             self.assertEqual(l, set(['mesproducer', 'mproducer', 'mproducer2', 'mfilter', 'd', 'messource']))
-            l2 = testTask1.moduleNames
-            self.assertEqual(l, set(['mesproducer', 'mproducer', 'mproducer2', 'mfilter', 'd', 'messource']))
+            l2 = testTask1.moduleNames()
+            self.assertEqual(l2, set(['mesproducer', 'mproducer', 'mproducer2', 'mfilter', 'd', 'messource']))
 
             testTask4 = ConditionalTask(edproducer3)
             l.clear()

--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -123,6 +123,7 @@ class Process(object):
         self.__dict__['_Process__finalpaths'] = DictTypes.SortedKeysDict() # of definition
         self.__dict__['_Process__sequences'] = {}
         self.__dict__['_Process__tasks'] = {}
+        self.__dict__['_Process__conditionaltasks'] = {}
         self.__dict__['_Process__services'] = {}
         self.__dict__['_Process__essources'] = {}
         self.__dict__['_Process__esproducers'] = {}
@@ -304,6 +305,10 @@ class Process(object):
         """returns a dict of the tasks that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__tasks)
     tasks = property(tasks_,doc="dictionary containing the tasks for the process")
+    def conditionaltasks_(self):
+        """returns a dict of the conditionaltasks that have been added to the Process"""
+        return DictTypes.FixedKeysDict(self.__conditionaltasks)
+    conditionaltasks = property(conditionaltasks_,doc="dictionary containing the conditionatasks for the process")
     def schedule_(self):
         """returns the schedule that has been added to the Process or None if none have been added"""
         return self.__schedule
@@ -410,6 +415,9 @@ class Process(object):
                             +"an instance of "+str(type(value))+" will not work - requested label is "+name)
         if not isinstance(value,_Labelable) and not isinstance(value,Source) and not isinstance(value,Looper) and not isinstance(value,Schedule):
             if name == value.type_():
+                if hasattr(self,name) and (getattr(self,name)!=value):
+                    self._replaceInTasks(name, value)
+                    self._replaceInConditionalTasks(name, value)
                 # Only Services get handled here
                 self.add_(value)
                 return
@@ -446,6 +454,7 @@ class Process(object):
             if newValue._isTaskComponent():
                 if not self.__InExtendCall:
                     self._replaceInTasks(name, newValue)
+                    self._replaceInConditionalTasks(name, newValue)
                     self._replaceInSchedule(name, newValue)
                 else:
                     if not isinstance(newValue, Task):
@@ -464,8 +473,10 @@ class Process(object):
                         if s is not None:
                             raise ValueError(msg1+s.label_()+msg2)
 
-            if isinstance(newValue, _Sequenceable) or newValue._isTaskComponent():
+            if isinstance(newValue, _Sequenceable) or newValue._isTaskComponent() or isinstance(newValue, ConditionalTask):
                 if not self.__InExtendCall:
+                    if isinstance(newValue, ConditionalTask):
+                        self._replaceInConditionalTasks(name, newValue)
                     self._replaceInSequences(name, newValue)
                 else:
                     #should check to see if used in sequence before complaining
@@ -566,7 +577,7 @@ class Process(object):
         self._delHelper(name)
         obj = getattr(self,name)
         if not obj is None:
-            if not isinstance(obj, Sequence) and not isinstance(obj, Task):
+            if not isinstance(obj, Sequence) and not isinstance(obj, Task) and not isinstance(obj,ConditionalTask):
                 # For modules, ES modules and services we can also remove
                 # the deleted object from Sequences, Paths, EndPaths, and
                 # Tasks. Note that for Sequences and Tasks that cannot be done
@@ -578,6 +589,7 @@ class Process(object):
                 # has been checked that the deleted Sequence is not used).
                 if obj._isTaskComponent():
                     self._replaceInTasks(name, None)
+                    self._replaceInConditionalTasks(name, None)
                     self._replaceInSchedule(name, None)
                 if isinstance(obj, _Sequenceable) or obj._isTaskComponent():
                     self._replaceInSequences(name, None)
@@ -604,7 +616,6 @@ class Process(object):
             raise TypeError
         if not isinstance(value,_Unlabelable):
             raise TypeError
-        #clone the item
         #clone the item
         if self.__isStrict:
             newValue =value.copy()
@@ -685,6 +696,9 @@ class Process(object):
     def _placeTask(self,name,task):
         self._validateTask(task, name)
         self._place(name, task, self.__tasks)
+    def _placeConditionalTask(self,name,task):
+        self._validateConditionalTask(task, name)
+        self._place(name, task, self.__conditionaltasks)
     def _placeAlias(self,name,mod):
         self._place(name, mod, self.__aliases)
     def _placePSet(self,name,mod):
@@ -740,7 +754,7 @@ class Process(object):
                     self.__setattr__(name,item)
             elif isinstance(item,_ModuleSequenceType):
                 seqs[name]=item
-            elif isinstance(item,Task):
+            elif isinstance(item,Task) or isinstance(item, ConditionalTask):
                 tasksToAttach[name] = item
             elif isinstance(item,_Labelable):
                 self.__setattr__(name,item)
@@ -913,10 +927,18 @@ class Process(object):
             l = set()
             visitor = NodeNameVisitor(l)
             sequence.visit(visitor)
-        except:
-            raise RuntimeError("An entry in sequence "+label + ' has no label')
+        except Exception as e:
+            raise RuntimeError("An entry in sequence {} has no label\n  Seen entries: {}\n  Error: {}".format(label, l, e))
 
     def _validateTask(self, task, label):
+        # See if every module and service has been inserted into the process
+        try:
+            l = set()
+            visitor = NodeNameVisitor(l)
+            task.visit(visitor)
+        except:
+            raise RuntimeError("An entry in task " + label + ' has not been attached to the process')
+    def _validateConditionalTask(self, task, label):
         # See if every module and service has been inserted into the process
         try:
             l = set()
@@ -939,6 +961,8 @@ class Process(object):
             containedItems = []
             if isinstance(item, Task):
                 v = TaskVisitor(containedItems)
+            elif isinstance(item, ConditionalTask):
+                v = ConditionalTaskVisitor(containedItems)
             else:
                 v = SequenceVisitor(containedItems)
             try:
@@ -947,6 +971,9 @@ class Process(object):
                 if isinstance(item, Task):
                     raise RuntimeError("Failed in a Task visitor. Probably " \
                                        "a circular dependency discovered in Task with label " + label)
+                elif isinstance(item, ConditionalTask):
+                    raise RuntimeError("Failed in a ConditionalTask visitor. Probably " \
+                                       "a circular dependency discovered in ConditionalTask with label " + label)
                 else:
                     raise RuntimeError("Failed in a Sequence visitor. Probably a " \
                                        "circular dependency discovered in Sequence with label " + label)
@@ -961,6 +988,10 @@ class Process(object):
                     if testItem is None or containedItem != testItem:
                         if isinstance(item, Task):
                             raise RuntimeError("Task has a label, but using its label to get an attribute" \
+                                               " from the process yields a different object or None\n"+
+                                               "label = " + containedItem.label_())
+                        if isinstance(item, ConditionalTask):
+                            raise RuntimeError("ConditionalTask has a label, but using its label to get an attribute" \
                                                " from the process yields a different object or None\n"+
                                                "label = " + containedItem.label_())
                         else:
@@ -1017,6 +1048,7 @@ class Process(object):
         result+=self._dumpPythonList(self.es_sources_(), options)
         result+=self._dumpPython(self.es_prefers_(), options)
         result+=self._dumpPythonList(self._itemsInDependencyOrder(self.tasks), options)
+        result+=self._dumpPythonList(self._itemsInDependencyOrder(self.conditionaltasks), options)
         result+=self._dumpPythonList(self._itemsInDependencyOrder(self.sequences), options)
         result+=self._dumpPythonList(self.paths_(), options)
         result+=self._dumpPythonList(self.endpaths_(), options)
@@ -1121,6 +1153,10 @@ class Process(object):
     def _replaceInTasks(self, label, new):
         old = getattr(self,label)
         for task in self.tasks.values():
+            task.replace(old, new)
+    def _replaceInConditionalTasks(self, label, new):
+        old = getattr(self,label)
+        for task in self.conditionaltasks.values():
             task.replace(old, new)
     def _replaceInSchedule(self, label, new):
         if self.schedule_() == None:
@@ -1245,14 +1281,23 @@ class Process(object):
         endpathValidator = EndPathValidator()
         decoratedList = []
         lister = DecoratedNodeNameVisitor(decoratedList)
-        pathCompositeVisitor = CompositeVisitor(pathValidator, nodeVisitor, lister)
+        condTaskModules = []
+        constTaskVistor = ModuleNodeOnConditionalTaskVisitor(condTaskModules)
+        pathCompositeVisitor = CompositeVisitor(pathValidator, nodeVisitor, lister, constTaskVistor)
         endpathCompositeVisitor = CompositeVisitor(endpathValidator, nodeVisitor, lister)
         for triggername in triggerPaths:
             iPath = self.paths_()[triggername]
             iPath.resolve(self.__dict__)
             pathValidator.setLabel(triggername)
             lister.initialize()
+            condTaskModules[:] = []
             iPath.visit(pathCompositeVisitor)
+            if condTaskModules:
+              decoratedList.append("#")
+              l = list({x.label_() for x in condTaskModules})
+              l.sort()
+              decoratedList.extend(l)
+              decoratedList.append("@")
             iPath.insertInto(processPSet, triggername, decoratedList)
         for endpathname in endpaths:
             if endpathname is not endPathWithFinalPathModulesName:
@@ -1785,6 +1830,8 @@ class Modifier(object):
             toObj._tasks = fromObj._tasks
         elif isinstance(fromObj,Task):
             toObj._collection = fromObj._collection
+        elif isinstance(fromObj,ConditionalTask):
+            toObj._collection = fromObj._collection
         elif isinstance(fromObj,_Parameterizable):
             #clear old items just incase fromObj is not a complete superset of toObj
             for p in toObj.parameterNames_():
@@ -2263,6 +2310,14 @@ if __name__=="__main__":
 
             p = Process('test')
             p.a = EDProducer("MyProducer")
+            p.t = ConditionalTask(p.a)
+            p.p = Path(p.t)
+            self.assertRaises(ValueError, p.extend, FromArg(a = EDProducer("YourProducer")))
+            self.assertRaises(ValueError, p.extend, FromArg(a = EDAlias()))
+            self.assertRaises(ValueError, p.__setattr__, "a", EDAlias())
+
+            p = Process('test')
+            p.a = EDProducer("MyProducer")
             p.s = Sequence(p.a)
             p.p = Path(p.s)
             self.assertRaises(ValueError, p.extend, FromArg(a = EDProducer("YourProducer")))
@@ -2497,6 +2552,41 @@ process.r = cms.Sequence((process.a))
 process.p = cms.Path(process.a)
 process.p2 = cms.Path(process.r, process.task1, process.task2)
 process.schedule = cms.Schedule(*[ process.p2, process.p ], tasks=[process.task3, process.task4, process.task5])""")
+            # include some conditional tasks
+            p = Process("test")
+            p.a = EDAnalyzer("MyAnalyzer")
+            p.b = EDProducer("bProducer")
+            p.c = EDProducer("cProducer")
+            p.d = EDProducer("dProducer")
+            p.e = EDProducer("eProducer")
+            p.f = EDProducer("fProducer")
+            p.g = EDProducer("gProducer")
+            p.task5 = Task()
+            p.task3 = Task()
+            p.task2 = ConditionalTask(p.c, p.task3)
+            p.task1 = ConditionalTask(p.task5)
+            p.p = Path(p.a)
+            s = Sequence(p.a)
+            p.r = Sequence(s)
+            p.p2 = Path(p.r, p.task1, p.task2)
+            p.schedule = Schedule(p.p2,p.p,tasks=[p.task5])
+            d=p.dumpPython()
+            self.assertEqual(_lineDiff(d,Process("test").dumpPython()),
+"""process.b = cms.EDProducer("bProducer")
+process.c = cms.EDProducer("cProducer")
+process.d = cms.EDProducer("dProducer")
+process.e = cms.EDProducer("eProducer")
+process.f = cms.EDProducer("fProducer")
+process.g = cms.EDProducer("gProducer")
+process.a = cms.EDAnalyzer("MyAnalyzer")
+process.task5 = cms.Task()
+process.task3 = cms.Task()
+process.task2 = cms.ConditionalTask(process.c, process.task3)
+process.task1 = cms.ConditionalTask(process.task5)
+process.r = cms.Sequence((process.a))
+process.p = cms.Path(process.a)
+process.p2 = cms.Path(process.r, process.task1, process.task2)
+process.schedule = cms.Schedule(*[ process.p2, process.p ], tasks=[process.task5])""")
             # only tasks
             p = Process("test")
             p.d = EDProducer("dProducer")
@@ -2565,12 +2655,13 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             t4 = Task(p.d)
             t5 = Task(p.d)
             t6 = Task(p.d)
+            p.ct1 = ConditionalTask(p.d)
             s = Sequence(p.a*p.b)
-            p.s4 = Sequence(p.a*p.b)
+            p.s4 = Sequence(p.a*p.b, p.ct1)
             s.associate(t2)
             p.s4.associate(t2)
             p.p = Path(p.c+s+p.a)
-            p.p2 = Path(p.c+p.s4+p.a)
+            p.p2 = Path(p.c+p.s4+p.a, p.ct1)
             p.e3 = EndPath(p.c+s+p.a)
             new = EDAnalyzer("NewAnalyzer")
             new2 = EDProducer("NewProducer")
@@ -2587,14 +2678,14 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             visitor_p2 = NodeVisitor()
             p.p2.visit(visitor_p2)
             self.assertTrue(visitor_p2.modules == set([new,new2,p.b,p.c]))
-            self.assertEqual(p.p2.dumpPython()[:-1], "cms.Path(process.c+process.s4+process.a)")
+            self.assertEqual(p.p2.dumpPython()[:-1], "cms.Path(process.c+process.s4+process.a, process.ct1)")
             visitor3 = NodeVisitor()
             p.e3.visit(visitor3)
             self.assertTrue(visitor3.modules == set([new,new2,p.b,p.c]))
             visitor4 = NodeVisitor()
             p.s4.visit(visitor4)
             self.assertTrue(visitor4.modules == set([new,new2,p.b]))
-            self.assertEqual(p.s4.dumpPython()[:-1],"cms.Sequence(process.a+process.b, cms.Task(process.d))")
+            self.assertEqual(p.s4.dumpPython()[:-1],"cms.Sequence(process.a+process.b, cms.Task(process.d), process.ct1)")
             visitor5 = NodeVisitor()
             p.t1.visit(visitor5)
             self.assertTrue(visitor5.modules == set([new2]))
@@ -2602,6 +2693,14 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             listOfTasks = list(p.schedule._tasks)
             listOfTasks[0].visit(visitor6)
             self.assertTrue(visitor6.modules == set([new2]))
+            visitor7 = NodeVisitor()
+            p.ct1.visit(visitor7)
+            self.assertTrue(visitor7.modules == set([new2]))
+            visitor8 = NodeVisitor()
+            listOfConditionalTasks = list(p.conditionaltasks.values())
+            listOfConditionalTasks[0].visit(visitor8)
+            self.assertTrue(visitor8.modules == set([new2]))
+
 
             p.d2 = EDProducer("YourProducer")
             p.schedule = Schedule(p.p, p.p2, p.e3, tasks=[p.t1])
@@ -2663,7 +2762,7 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             edproducer9 = EDProducer("b9")
             edfilter = EDFilter("c")
             service = Service("d")
-            service3 = Service("d")
+            service3 = Service("d", v = untracked.uint32(3))
             essource = ESSource("e")
             esproducer = ESProducer("f")
             testTask2 = Task()
@@ -2848,6 +2947,193 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             process.path200.replace(process.g,process.e)
             self.assertEqual(process.path200.dumpPython(), "cms.EndPath(process.c, cms.Task(process.e))\n")
 
+        def testConditionalTask(self):
+
+            # create some objects to use in tests
+            edanalyzer = EDAnalyzer("a")
+            edproducer = EDProducer("b")
+            edproducer2 = EDProducer("b2")
+            edproducer3 = EDProducer("b3")
+            edproducer4 = EDProducer("b4")
+            edproducer8 = EDProducer("b8")
+            edproducer9 = EDProducer("b9")
+            edfilter = EDFilter("c")
+            service = Service("d")
+            service3 = Service("d", v = untracked.uint32(3))
+            essource = ESSource("e")
+            esproducer = ESProducer("f")
+            testTask2 = Task()
+            testCTask2 = ConditionalTask()
+
+            # test adding things to Tasks
+            testTask1 = ConditionalTask(edproducer, edfilter)
+            self.assertRaises(RuntimeError, testTask1.add, edanalyzer)
+            testTask1.add(essource, service)
+            testTask1.add(essource, esproducer)
+            testTask1.add(testTask2)
+            testTask1.add(testCTask2)
+            coll = testTask1._collection
+            self.assertTrue(edproducer in coll)
+            self.assertTrue(edfilter in coll)
+            self.assertTrue(service in coll)
+            self.assertTrue(essource in coll)
+            self.assertTrue(esproducer in coll)
+            self.assertTrue(testTask2 in coll)
+            self.assertTrue(testCTask2 in coll)
+            self.assertTrue(len(coll) == 7)
+            self.assertTrue(len(testTask2._collection) == 0)
+
+            taskContents = []
+            for i in testTask1:
+                taskContents.append(i)
+            self.assertEqual(taskContents, [edproducer, edfilter, essource, service, esproducer, testTask2, testCTask2])
+
+            # test attaching Task to Process
+            process = Process("test")
+
+            process.mproducer = edproducer
+            process.mproducer2 = edproducer2
+            process.mfilter = edfilter
+            process.messource = essource
+            process.mesproducer = esproducer
+            process.d = service
+
+            testTask3 = ConditionalTask(edproducer, edproducer2)
+            testTask1.add(testTask3)
+            process.myTask1 = testTask1
+
+            # test the validation that occurs when attaching a Task to a Process
+            # first a case that passes, then one the fails on an EDProducer
+            # then one that fails on a service
+            l = set()
+            visitor = NodeNameVisitor(l)
+            testTask1.visit(visitor)
+            self.assertEqual(l, set(['mesproducer', 'mproducer', 'mproducer2', 'mfilter', 'd', 'messource']))
+            l2 = testTask1.moduleNames
+            self.assertEqual(l, set(['mesproducer', 'mproducer', 'mproducer2', 'mfilter', 'd', 'messource']))
+
+            testTask4 = ConditionalTask(edproducer3)
+            l.clear()
+            self.assertRaises(RuntimeError, testTask4.visit, visitor)
+            try:
+                process.myTask4 = testTask4
+                self.assertTrue(False)
+            except RuntimeError:
+                pass
+
+            testTask5 = ConditionalTask(service3)
+            l.clear()
+            self.assertRaises(RuntimeError, testTask5.visit, visitor)
+            try:
+                process.myTask5 = testTask5
+                self.assertTrue(False)
+            except RuntimeError:
+                pass
+
+            process.d = service3
+            process.myTask5 = testTask5
+
+            # test placement into the Process and the tasks property
+            expectedDict = { 'myTask1' : testTask1, 'myTask5' : testTask5 }
+            expectedFixedDict = DictTypes.FixedKeysDict(expectedDict);
+            self.assertEqual(process.conditionaltasks, expectedFixedDict)
+            self.assertEqual(process.conditionaltasks['myTask1'], testTask1)
+            self.assertEqual(process.myTask1, testTask1)
+
+            # test replacing an EDProducer in a ConditionalTask when calling __settattr__
+            # for the EDProducer on the Process.
+            process.mproducer2 = edproducer4
+            process.d = service
+            l = list()
+            visitor1 = ModuleNodeVisitor(l)
+            testTask1.visit(visitor1)
+            l.sort(key=lambda mod: mod.__str__())
+            expectedList = sorted([edproducer,essource,esproducer,service,edfilter,edproducer,edproducer4],key=lambda mod: mod.__str__())
+            self.assertEqual(expectedList, l)
+            process.myTask6 = ConditionalTask()
+            process.myTask7 = ConditionalTask()
+            process.mproducer8 = edproducer8
+            process.myTask8 = ConditionalTask(process.mproducer8)
+            process.myTask6.add(process.myTask7)
+            process.myTask7.add(process.myTask8)
+            process.myTask1.add(process.myTask6)
+            process.myTask8.add(process.myTask5)
+            self.assertEqual(process.myTask8.dumpPython(), "cms.ConditionalTask(process.mproducer8, process.myTask5)\n")
+
+            testDict = process._itemsInDependencyOrder(process.conditionaltasks)
+            expectedLabels = ["myTask5", "myTask8", "myTask7", "myTask6", "myTask1"]
+            expectedTasks = [process.myTask5, process.myTask8, process.myTask7, process.myTask6, process.myTask1]
+            index = 0
+            for testLabel, testTask in testDict.items():
+                self.assertEqual(testLabel, expectedLabels[index])
+                self.assertEqual(testTask, expectedTasks[index])
+                index += 1
+
+            pythonDump = testTask1.dumpPython(PrintOptions())
+
+
+            expectedPythonDump = 'cms.ConditionalTask(process.d, process.mesproducer, process.messource, process.mfilter, process.mproducer, process.mproducer2, process.myTask6)\n'
+            self.assertEqual(pythonDump, expectedPythonDump)
+
+            process.myTask5 = ConditionalTask()
+            self.assertEqual(process.myTask8.dumpPython(), "cms.ConditionalTask(process.mproducer8, process.myTask5)\n")
+            process.myTask100 = ConditionalTask()
+            process.mproducer9 = edproducer9
+            sequence1 = Sequence(process.mproducer8, process.myTask1, process.myTask5, testTask2, testTask3)
+            sequence2 = Sequence(process.mproducer8 + process.mproducer9)
+            process.sequence3 = Sequence((process.mproducer8 + process.mfilter))
+            sequence4 = Sequence()
+            process.path1 = Path(process.mproducer+process.mproducer8+sequence1+sequence2+process.sequence3+sequence4)
+            process.path1.associate(process.myTask1, process.myTask5, testTask2, testTask3)
+            process.path11 = Path(process.mproducer+process.mproducer8+sequence1+sequence2+process.sequence3+ sequence4,process.myTask1, process.myTask5, testTask2, testTask3, process.myTask100)
+            process.path2 = Path(process.mproducer)
+            process.path3 = Path(process.mproducer9+process.mproducer8,testTask2)
+
+            self.assertEqual(process.path1.dumpPython(PrintOptions()), 'cms.Path(process.mproducer+process.mproducer8+cms.Sequence(process.mproducer8, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask5)+(process.mproducer8+process.mproducer9)+process.sequence3, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask5)\n')
+
+            self.assertEqual(process.path11.dumpPython(PrintOptions()), 'cms.Path(process.mproducer+process.mproducer8+cms.Sequence(process.mproducer8, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask5)+(process.mproducer8+process.mproducer9)+process.sequence3, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask100, process.myTask5)\n')
+
+            # test NodeNameVisitor and moduleNames
+            l = set()
+            nameVisitor = NodeNameVisitor(l)
+            process.path1.visit(nameVisitor)
+            self.assertTrue(l == set(['mproducer', 'd', 'mesproducer', None, 'mproducer9', 'mproducer8', 'messource', 'mproducer2', 'mfilter']))
+            self.assertTrue(process.path1.moduleNames() == set(['mproducer', 'd', 'mesproducer', None, 'mproducer9', 'mproducer8', 'messource', 'mproducer2', 'mfilter']))
+
+            # test copy
+            process.mproducer10 = EDProducer("b10")
+            process.path21 = process.path11.copy()
+            process.path21.replace(process.mproducer, process.mproducer10)
+
+            self.assertEqual(process.path11.dumpPython(PrintOptions()), 'cms.Path(process.mproducer+process.mproducer8+cms.Sequence(process.mproducer8, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask5)+(process.mproducer8+process.mproducer9)+process.sequence3, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask100, process.myTask5)\n')
+
+            # Some peculiarities of the way things work show up here. dumpPython sorts tasks and
+            # removes duplication at the level of strings. The Task and Sequence objects themselves
+            # remove duplicate tasks in their contents if the instances are the same (exact same python
+            # object id which is not the same as the string representation being the same).
+            # Also note that the mutating visitor replaces sequences and tasks that have
+            # modified contents with their modified contents, it does not modify the sequence
+            # or task itself.
+            self.assertEqual(process.path21.dumpPython(PrintOptions()), 'cms.Path(process.mproducer10+process.mproducer8+process.mproducer8+(process.mproducer8+process.mproducer9)+process.sequence3, cms.ConditionalTask(process.None, process.mproducer10), cms.ConditionalTask(process.d, process.mesproducer, process.messource, process.mfilter, process.mproducer10, process.mproducer2, process.mproducer8, process.myTask5), cms.Task(), process.myTask100, process.myTask5)\n')
+
+            process.path22 = process.path21.copyAndExclude([process.d, process.mesproducer, process.mfilter])
+            self.assertEqual(process.path22.dumpPython(PrintOptions()), 'cms.Path(process.mproducer10+process.mproducer8+process.mproducer8+(process.mproducer8+process.mproducer9)+process.mproducer8, cms.ConditionalTask(process.None, process.mproducer10), cms.ConditionalTask(process.messource, process.mproducer10, process.mproducer2, process.mproducer8, process.myTask5), cms.Task(), process.myTask100, process.myTask5)\n')
+
+            process.path23 = process.path22.copyAndExclude([process.messource, process.mproducer10])
+            self.assertEqual(process.path23.dumpPython(PrintOptions()), 'cms.Path(process.mproducer8+process.mproducer8+(process.mproducer8+process.mproducer9)+process.mproducer8, cms.ConditionalTask(process.None), cms.ConditionalTask(process.mproducer2, process.mproducer8, process.myTask5), cms.Task(), process.myTask100, process.myTask5)\n')
+
+            process = Process("Test")
+
+            process.b = EDProducer("b")
+            process.b2 = EDProducer("b2")
+            process.b3 = EDProducer("b3")
+            process.p = Path(process.b, ConditionalTask(process.b3, process.b2))
+            p = TestMakePSet()
+            process.fillProcessDesc(p)
+            self.assertEqual(p.values["@all_modules"], (True, ['b', 'b2', 'b3']))
+            self.assertEqual(p.values["@paths"], (True, ['p']))
+            self.assertEqual(p.values["p"], (True, ['b','#','b2','b3','@']))
+            
 
         def testPath(self):
             p = Process("test")
@@ -2873,21 +3159,32 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             self.assertRaises(TypeError,Path,p.es)
 
             t = Path()
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path()\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path()\n')
 
             t = Path(p.a)
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path(process.a)\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a)\n')
 
             t = Path(Task())
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path(cms.Task())\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(cms.Task())\n')
 
             t = Path(p.a, Task())
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path(process.a, cms.Task())\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a, cms.Task())\n')
 
             p.prod = EDProducer("prodName")
             p.t1 = Task(p.prod)
             t = Path(p.a, p.t1, Task(), p.t1)
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path(process.a, cms.Task(), process.t1)\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a, cms.Task(), process.t1)\n')
+
+            t = Path(ConditionalTask())
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(cms.ConditionalTask())\n')
+
+            t = Path(p.a, ConditionalTask())
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a, cms.ConditionalTask())\n')
+
+            p.prod = EDProducer("prodName")
+            p.t1 = ConditionalTask(p.prod)
+            t = Path(p.a, p.t1, Task(), p.t1)
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a, cms.Task(), process.t1)\n')
 
         def testFinalPath(self):
             p = Process("test")
@@ -2919,7 +3216,11 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             p.prod = EDProducer("prodName")
             p.t1 = Task(p.prod)
             self.assertRaises(TypeError, FinalPath, p.a, p.t1, Task(), p.t1)
-            
+
+            p.prod = EDProducer("prodName")
+            p.t1 = ConditionalTask(p.prod)
+            self.assertRaises(TypeError, FinalPath, p.a, p.t1, ConditionalTask(), p.t1)
+
             p.t = FinalPath(p.a)
             p.a = OutputModule("ReplacedOutputModule")
             self.assertEqual(p.t.dumpPython(PrintOptions()), 'cms.FinalPath(process.a)\n')
@@ -2959,7 +3260,8 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
 
             seq1 = Sequence(e)
             task1 = Task(g)
-            path = Path(a * c * seq1, task1)
+            ctask1 = ConditionalTask(h)
+            path = Path(a * c * seq1, task1, ctask1)
 
             self.assertTrue(path.contains(a))
             self.assertFalse(path.contains(b))
@@ -2968,6 +3270,7 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             self.assertTrue(path.contains(e))
             self.assertFalse(path.contains(f))
             self.assertTrue(path.contains(g))
+            self.assertTrue(path.contains(h))
 
             endpath = EndPath(h * i)
             self.assertFalse(endpath.contains(b))
@@ -2997,6 +3300,14 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             self.assertTrue(sch.contains(k))
             self.assertTrue(sch.contains(l))
             self.assertTrue(sch.contains(m))
+
+            ctask2 = ConditionalTask(l, task1)
+            ctask = ConditionalTask(j, k, ctask2)
+            self.assertFalse(ctask.contains(b))
+            self.assertTrue(ctask.contains(j))
+            self.assertTrue(ctask.contains(k))
+            self.assertTrue(ctask.contains(l))
+            self.assertTrue(ctask.contains(g))
 
         def testSchedule(self):
             p = Process("test")
@@ -3387,11 +3698,15 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             p.e = EDProducer("MyProducer")
             p.f = EDProducer("YourProducer")
             p.g = EDProducer("TheirProducer")
+            p.h = EDProducer("OnesProducer")
             p.s = Sequence(p.d)
             p.t1 = Task(p.e)
             p.t2 = Task(p.f)
             p.t3 = Task(p.g, p.t1)
-            p.path1 = Path(p.a, p.t3)
+            p.ct1 = ConditionalTask(p.h)
+            p.ct2 = ConditionalTask(p.f)
+            p.ct3 = ConditionalTask(p.ct1)
+            p.path1 = Path(p.a, p.t3, p.ct3)
             p.path2 = Path(p.b)
             self.assertTrue(p.schedule is None)
             pths = p.paths
@@ -3410,6 +3725,7 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             self.assertTrue(hasattr(p, 'e'))
             self.assertTrue(not hasattr(p, 'f'))
             self.assertTrue(hasattr(p, 'g'))
+            self.assertTrue(hasattr(p, 'h'))
             self.assertTrue(not hasattr(p, 's'))
             self.assertTrue(hasattr(p, 't1'))
             self.assertTrue(not hasattr(p, 't2'))
@@ -3431,14 +3747,21 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             p.g = EDProducer("YourProducer")
             p.h = EDProducer("TheirProducer")
             p.i = EDProducer("OurProducer")
+            p.j = EDProducer("OurProducer")
+            p.k = EDProducer("OurProducer")
+            p.l = EDProducer("OurProducer")
             p.t1 = Task(p.f)
             p.t2 = Task(p.g)
             p.t3 = Task(p.h)
             p.t4 = Task(p.i)
-            p.s = Sequence(p.d, p.t1)
-            p.s2 = Sequence(p.b, p.t2)
+            p.ct1 = Task(p.f)
+            p.ct2 = Task(p.j)
+            p.ct3 = Task(p.k)
+            p.ct4 = Task(p.l)
+            p.s = Sequence(p.d, p.t1, p.ct1)
+            p.s2 = Sequence(p.b, p.t2, p.ct2)
             p.s3 = Sequence(p.e)
-            p.path1 = Path(p.a, p.t3)
+            p.path1 = Path(p.a, p.t3, p.ct3)
             p.path2 = Path(p.b)
             p.path3 = Path(p.b+p.s2)
             p.path4 = Path(p.b+p.s3)
@@ -3458,10 +3781,17 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             self.assertTrue(hasattr(p, 'g'))
             self.assertTrue(hasattr(p, 'h'))
             self.assertTrue(hasattr(p, 'i'))
+            self.assertTrue(hasattr(p, 'j'))
+            self.assertTrue(hasattr(p, 'k'))
+            self.assertTrue(not hasattr(p, 'l'))
             self.assertTrue(not hasattr(p, 't1'))
             self.assertTrue(hasattr(p, 't2'))
             self.assertTrue(hasattr(p, 't3'))
             self.assertTrue(hasattr(p, 't4'))
+            self.assertTrue(not hasattr(p, 'ct1'))
+            self.assertTrue(hasattr(p, 'ct2'))
+            self.assertTrue(hasattr(p, 'ct3'))
+            self.assertTrue(not hasattr(p, 'ct4'))
             self.assertTrue(not hasattr(p, 's'))
             self.assertTrue(hasattr(p, 's2'))
             self.assertTrue(not hasattr(p, 's3'))
@@ -3495,6 +3825,17 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             p.a = EDProducer("MyProducer")
             p.b = EDProducer("YourProducer")
             p.s = Task(TaskPlaceholder("a"),p.b)
+            p.pth = Path(p.s)
+            p.prune()
+            self.assertTrue(hasattr(p, 'a'))
+            self.assertTrue(hasattr(p, 'b'))
+            self.assertTrue(hasattr(p, 's'))
+            self.assertTrue(hasattr(p, 'pth'))
+            #test ConditionalTaskPlaceholder
+            p = Process("test")
+            p.a = EDProducer("MyProducer")
+            p.b = EDProducer("YourProducer")
+            p.s = ConditionalTask(ConditionalTaskPlaceholder("a"),p.b)
             p.pth = Path(p.s)
             p.prune()
             self.assertTrue(hasattr(p, 'a'))
@@ -3579,6 +3920,65 @@ process.t5 = cms.Task(process.a, process.g, process.t4)
 process.path1 = cms.Path(process.b, process.t2, process.t3)
 process.endpath1 = cms.EndPath(process.b, process.t5)
 process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[process.t7, process.t8])""")
+        def testConditionalTaskPlaceholder(self):
+            p = Process("test")
+            p.a = EDProducer("ma")
+            p.b = EDAnalyzer("mb")
+            p.t1 = ConditionalTask(ConditionalTaskPlaceholder("c"))
+            p.t2 = ConditionalTask(p.a, ConditionalTaskPlaceholder("d"), p.t1)
+            p.t3 = ConditionalTask(ConditionalTaskPlaceholder("e"))
+            p.path1 = Path(p.b, p.t2, p.t3)
+            p.t5 = ConditionalTask(p.a, ConditionalTaskPlaceholder("g"), ConditionalTaskPlaceholder("t4"))
+            p.t4 = ConditionalTask(ConditionalTaskPlaceholder("f"))
+            p.path2 = Path(p.b, p.t5)
+            p.schedule = Schedule(p.path1, p.path2)
+            p.c = EDProducer("mc")
+            p.d = EDProducer("md")
+            p.e = EDProducer("me")
+            p.f = EDProducer("mf")
+            p.g = EDProducer("mg")
+            p.h = EDProducer("mh")
+            p.i = EDProducer("mi")
+            p.j = EDProducer("mj")
+            self.assertEqual(_lineDiff(p.dumpPython(),Process('test').dumpPython()),
+"""process.a = cms.EDProducer("ma")
+process.c = cms.EDProducer("mc")
+process.d = cms.EDProducer("md")
+process.e = cms.EDProducer("me")
+process.f = cms.EDProducer("mf")
+process.g = cms.EDProducer("mg")
+process.h = cms.EDProducer("mh")
+process.i = cms.EDProducer("mi")
+process.j = cms.EDProducer("mj")
+process.b = cms.EDAnalyzer("mb")
+process.t1 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("c"))
+process.t2 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("d"), process.a, process.t1)
+process.t3 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("e"))
+process.t5 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("g"), cms.ConditionalTaskPlaceholder("t4"), process.a)
+process.t4 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("f"))
+process.path1 = cms.Path(process.b, process.t2, process.t3)
+process.path2 = cms.Path(process.b, process.t5)
+process.schedule = cms.Schedule(*[ process.path1, process.path2 ])""")
+            p.resolve()
+            self.assertEqual(_lineDiff(p.dumpPython(),Process('test').dumpPython()),
+"""process.a = cms.EDProducer("ma")
+process.c = cms.EDProducer("mc")
+process.d = cms.EDProducer("md")
+process.e = cms.EDProducer("me")
+process.f = cms.EDProducer("mf")
+process.g = cms.EDProducer("mg")
+process.h = cms.EDProducer("mh")
+process.i = cms.EDProducer("mi")
+process.j = cms.EDProducer("mj")
+process.b = cms.EDAnalyzer("mb")
+process.t1 = cms.ConditionalTask(process.c)
+process.t2 = cms.ConditionalTask(process.a, process.d, process.t1)
+process.t3 = cms.ConditionalTask(process.e)
+process.t4 = cms.ConditionalTask(process.f)
+process.t5 = cms.ConditionalTask(process.a, process.g, process.t4)
+process.path1 = cms.Path(process.b, process.t2, process.t3)
+process.path2 = cms.Path(process.b, process.t5)
+process.schedule = cms.Schedule(*[ process.path1, process.path2 ])""")
 
         def testDelete(self):
             p = Process("test")
@@ -3594,12 +3994,17 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             t2 = Task(p.g, p.h)
             t3 = Task(p.g, p.h)
             p.t4 = Task(p.h)
+            p.ct1 = ConditionalTask(p.g, p.h)
+            ct2 = ConditionalTask(p.g, p.h)
+            ct3 = ConditionalTask(p.g, p.h)
+            p.ct4 = ConditionalTask(p.h)
             p.s = Sequence(p.d+p.e)
-            p.path1 = Path(p.a+p.f+p.s,t2)
+            p.path1 = Path(p.a+p.f+p.s,t2,ct2)
             p.path2 = Path(p.a)
+            p.path3 = Path(ct3, p.ct4)
             p.endpath2 = EndPath(p.b)
             p.endpath1 = EndPath(p.b+p.f)
-            p.schedule = Schedule(p.path2, p.endpath2, tasks=[t3, p.t4])
+            p.schedule = Schedule(p.path2, p.path3, p.endpath2, tasks=[t3, p.t4])
             self.assertTrue(hasattr(p, 'f'))
             self.assertTrue(hasattr(p, 'g'))
             del p.e
@@ -3608,13 +4013,17 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertFalse(hasattr(p, 'f'))
             self.assertFalse(hasattr(p, 'g'))
             self.assertEqual(p.t1.dumpPython(), 'cms.Task(process.h)\n')
+            self.assertEqual(p.ct1.dumpPython(), 'cms.ConditionalTask(process.h)\n')
             self.assertEqual(p.s.dumpPython(), 'cms.Sequence(process.d)\n')
-            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+process.s, cms.Task(process.h))\n')
+            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+process.s, cms.ConditionalTask(process.h), cms.Task(process.h))\n')
             self.assertEqual(p.endpath1.dumpPython(), 'cms.EndPath(process.b)\n')
+            self.assertEqual(p.path3.dumpPython(), 'cms.Path(cms.ConditionalTask(process.h), process.ct4)\n')
             del p.s
-            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+(process.d), cms.Task(process.h))\n')
-            self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(*[ process.path2, process.endpath2 ], tasks=[cms.Task(process.h), process.t4])\n')
+            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+(process.d), cms.ConditionalTask(process.h), cms.Task(process.h))\n')
+            self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(*[ process.path2, process.path3, process.endpath2 ], tasks=[cms.Task(process.h), process.t4])\n')
             del p.path2
+            self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(*[ process.path3, process.endpath2 ], tasks=[cms.Task(process.h), process.t4])\n')
+            del p.path3
             self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(*[ process.endpath2 ], tasks=[cms.Task(process.h), process.t4])\n')
             del p.endpath2
             self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(tasks=[cms.Task(process.h), process.t4])\n')
@@ -3837,6 +4246,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             p.a =EDAnalyzer("MyAnalyzer", fred = int32(1))
             m1.toReplaceWith(p.a, EDAnalyzer("YourAnalyzer", wilma = int32(3)))
             self.assertRaises(TypeError, lambda: m1.toReplaceWith(p.a, EDProducer("YourProducer")))
+            #Task
             p.b =EDAnalyzer("BAn")
             p.c =EDProducer("c")
             p.d =EDProducer("d")
@@ -3850,6 +4260,23 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertTrue(p.s.dumpPython() == "cms.Sequence(process.a+process.b, process.td)\n")
             p.e =EDProducer("e")
             m1.toReplaceWith(p.td, Task(p.e))
+            self.assertTrue(p.td._collection == OrderedSet([p.e]))
+            #ConditionalTask
+            p.b =EDAnalyzer("BAn")
+            p.c =EDProducer("c")
+            p.d =EDProducer("d")
+            del p.tc
+            del p.td
+            p.tc = ConditionalTask(p.c)
+            p.td = ConditionalTask(p.d)
+            p.s = Sequence(p.a, p.tc)
+            m1.toReplaceWith(p.s, Sequence(p.a+p.b, p.td))
+            self.assertEqual(p.a.wilma.value(),3)
+            self.assertEqual(p.a.type_(),"YourAnalyzer")
+            self.assertEqual(hasattr(p,"fred"),False)
+            self.assertTrue(p.s.dumpPython() == "cms.Sequence(process.a+process.b, process.td)\n")
+            p.e =EDProducer("e")
+            m1.toReplaceWith(p.td, ConditionalTask(p.e))
             self.assertTrue(p.td._collection == OrderedSet([p.e]))
             #check toReplaceWith doesn't activate not chosen
             m1 = Modifier()

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -252,6 +252,14 @@ class SwitchProducer(EDProducer):
         self.__setParameters(kargs)
         self._isModified = False
 
+    def setLabel(self, label):
+        super().setLabel(label)
+        # SwitchProducer owns the contained modules, and therefore
+        # need to set / unset the label for them explicitly here
+        for case in self.parameterNames_():
+            producer = self.__dict__[case]
+            producer.setLabel(self.caseLabel_(label, case) if label is not None else None)
+
     @staticmethod
     def getCpu():
         """Returns a function that returns the priority for a CPU "computing device". Intended to be used by deriving classes."""
@@ -288,6 +296,8 @@ class SwitchProducer(EDProducer):
             message += self.dumpPython() + '\n'
             raise ValueError(message)
         self.__dict__[name]=value
+        if self.hasLabel_():
+            value.setLabel(self.caseLabel_(self.label_(), name))
         self._Parameterizable__parameterNames.append(name)
         self._isModified = True
 
@@ -318,6 +328,8 @@ class SwitchProducer(EDProducer):
                 raise TypeError(name+" can only be set to a cms.EDProducer or cms.EDAlias")
             # We should always receive an cms.EDProducer
             self.__dict__[name] = value
+            if self.hasLabel_():
+                value.setLabel(self.caseLabel_(self.label_(), name))
             self._isModified = True
 
     def clone(self, **params):
@@ -386,8 +398,8 @@ class SwitchProducer(EDProducer):
         newpset.addString(True, "@module_label", self.moduleLabel_(myname))
         newpset.addString(True, "@module_type", "SwitchProducer")
         newpset.addString(True, "@module_edm_type", "EDProducer")
-        newpset.addVString(True, "@all_cases", [myname+"@"+p for p in self.parameterNames_()])
-        newpset.addString(False, "@chosen_case", myname+"@"+self._chooseCase(accelerators))
+        newpset.addVString(True, "@all_cases", [self.caseLabel_(myname, p) for p in self.parameterNames_()])
+        newpset.addString(False, "@chosen_case", self.caseLabel_(myname, self._chooseCase(accelerators)))
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
 
     def _placeImpl(self,name,proc):
@@ -550,6 +562,24 @@ if __name__ == "__main__":
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESProducer("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESPrefer("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = SwitchProducerTest(test1 = EDProducer("Foo"))))
+
+            # Label
+            sp.setLabel("sp")
+            self.assertEqual(sp.label_(), "sp")
+            self.assertEqual(sp.test1.label_(), "sp@test1")
+            self.assertEqual(sp.test2.label_(), "sp@test2")
+            sp.test3 = EDProducer("Xyzzy")
+            self.assertEqual(sp.test3.label_(), "sp@test3")
+            sp.test1 = EDProducer("Fred")
+            self.assertEqual(sp.test1.label_(), "sp@test1")
+            del sp.test1
+            sp.test1 = EDProducer("Wilma")
+            self.assertEqual(sp.test1.label_(), "sp@test1")
+            sp.setLabel(None)
+            sp.setLabel("other")
+            self.assertEqual(sp.label_(), "other")
+            self.assertEqual(sp.test1.label_(), "other@test1")
+            self.assertEqual(sp.test2.label_(), "other@test2")
 
             # Case decision
             accelerators = ["test1", "test2", "test3"]

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -380,6 +380,14 @@ class SwitchProducer(EDProducer):
         return myname
     def caseLabel_(self, name, case):
         return name+"@"+case
+    def modulesForConditionalTask_(self):
+        # Need the contained modules (not EDAliases) for ConditionalTask
+        ret = []
+        for case in self.parameterNames_():
+            caseobj = self.__dict__[case]
+            if not isinstance(caseobj, EDAlias):
+                ret.append(caseobj)
+        return ret
     def appendToProcessDescLists_(self, modules, aliases, myname):
         # This way we can insert the chosen EDProducer to @all_modules
         # so that we get easily a worker for it

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -924,6 +924,12 @@ class ModuleNodeOnConditionalTaskVisitor(object):
     def enter(self,visitee):
         if isinstance(visitee, ConditionalTask):
             self._levelInTasks += 1
+        # This block gets the modules contained by SwitchProducer. It
+        # needs to be before the "levelInTasks == 0" check because the
+        # contained modules need to be treated like in ConditionalTask
+        # also when the SwitchProducer itself is in the Path.
+        if hasattr(visitee, "modulesForConditionalTask_"):
+            self.l.extend(visitee.modulesForConditionalTask_())
         if self._levelInTasks == 0:
             return
         if visitee.isLeaf():

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -1551,7 +1551,7 @@ class _TaskBase(_ConfigureComponent, _Labelable) :
             iFirst = False
             s += item
         if len(taskContents) > 255:
-            return "cms.{}(*[" + s + "])".format(self._taskType())
+            s = "*[" + s + "]"
         return "cms.{}({})".format(self._taskType(),s)
 
     def directDependencies(self,sortByType=True):
@@ -1971,6 +1971,19 @@ if __name__=="__main__":
             s = Sequence(e, ct4)
             p16 = Path(a+b+s+c,ct1)
             self.assertEqual(p16.dumpPython(),"cms.Path(process.a+process.b+cms.Sequence(process.e, cms.ConditionalTask(process.d, process.f))+process.c, cms.ConditionalTask(process.a))\n")
+
+            n = 260
+            mods = []
+            labels = []
+            for i in range(0, n):
+                l = "a{}".format(i)
+                labels.append("process."+l)
+                mods.append(DummyModule(l))
+            labels.sort()
+            task = Task(*mods)
+            self.assertEqual(task.dumpPython(), "cms.Task(*[" + ", ".join(labels) + "])\n")
+            conditionalTask = ConditionalTask(*mods)
+            self.assertEqual(conditionalTask.dumpPython(), "cms.ConditionalTask(*[" + ", ".join(labels) + "])\n")
 
             l = list()
             namesVisitor = DecoratedNodeNameVisitor(l)

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -238,13 +238,19 @@ def findDirectDependencies(element, collection,sortByType=True):
                 continue
             t = 'sequences'
         # cms.Task
-        elif isinstance(item, Task):
+        elif isinstance(item, _Task):
             if not item.hasLabel_():
                 dependencies += item.directDependencies(sortByType)
                 continue
             t = 'tasks'
+        # cms.ConditionalTask
+        elif isinstance(item, ConditionalTask):
+            if not item.hasLabel_():
+                dependencies += item.directDependencies(sortByType)
+                continue
+            t = 'conditionaltasks'
         # SequencePlaceholder and TaskPlaceholder do not add an explicit dependency
-        elif isinstance(item, (SequencePlaceholder, TaskPlaceholder)):
+        elif isinstance(item, (SequencePlaceholder, TaskPlaceholder, ConditionalTaskPlaceholder)):
             continue
         # unsupported elements
         else:
@@ -262,7 +268,7 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
     def __init__(self,*arg, **argv):
         self.__dict__["_isFrozen"] = False
         self._seq = None
-        if (len(arg) > 1 and not isinstance(arg[1], Task)) or (len(arg) > 0 and not isinstance(arg[0],_Sequenceable) and not isinstance(arg[0],Task)):
+        if (len(arg) > 1 and not isinstance(arg[1], _TaskBase)) or (len(arg) > 0 and not isinstance(arg[0],_Sequenceable) and not isinstance(arg[0],_TaskBase)):
             typename = format_typename(self)
             msg = format_outerframe(2)
             msg += "The %s constructor takes zero or one sequenceable argument followed by zero or more arguments of type Task. But the following types are given:\n" %typename
@@ -287,7 +293,7 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
             self.associate(*tasks)
     def associate(self,*tasks):
         for task in tasks:
-            if not isinstance(task, Task):
+            if not isinstance(task, _TaskBase):
                 raise TypeError("associate only works with objects of type Task")
             self._tasks.add(task)
     def isFrozen(self):
@@ -444,7 +450,7 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
         # where objects that contain other objects are involved. See the comments
         # for the _MutatingSequenceVisitor.
 
-        if isinstance(original,Task) != isinstance(replacement,Task):
+        if (isinstance(original,Task) != isinstance(replacement,Task)) or (isinstance(original,ConditionalTask) != isinstance(replacement,ConditionalTask)):
                raise TypeError("replace only works if both arguments are Tasks or neither")
         v = _CopyAndReplaceSequenceVisitor(original,replacement)
         self.visit(v)
@@ -857,6 +863,18 @@ class TaskVisitor(object):
     def leave(self,visitee):
         pass
 
+# Fills a list of all ConditionalTasks visited
+# Can visit a ConditionalTask, Sequence, Path, or EndPath
+class ConditionalTaskVisitor(object):
+    def __init__(self,d):
+        self.deps = d
+    def enter(self,visitee):
+        if isinstance(visitee,ConditionalTask):
+            self.deps.append(visitee)
+        pass
+    def leave(self,visitee):
+        pass
+
 # Fills a list of all modules visited.
 # Can visit a Sequence, Path, EndPath, or Task
 # For purposes of this visitor, a module is considered
@@ -895,6 +913,23 @@ class ModuleNodeOnTaskVisitor(object):
     def leave(self,visitee):
         if self._levelInTasks > 0:
             if isinstance(visitee, Task):
+                self._levelInTasks -= 1
+
+class ModuleNodeOnConditionalTaskVisitor(object):
+    def __init__(self,l):
+        self.l = l
+        self._levelInTasks = 0
+    def enter(self,visitee):
+        if isinstance(visitee, ConditionalTask):
+            self._levelInTasks += 1
+        if self._levelInTasks == 0:
+            return
+        if visitee.isLeaf():
+            self.l.append(visitee)
+        pass
+    def leave(self,visitee):
+        if self._levelInTasks > 0:
+            if isinstance(visitee, ConditionalTask):
                 self._levelInTasks -= 1
 
 # Should not be used on Tasks.
@@ -961,7 +996,7 @@ class NodeNameVisitor(object):
                 if visitee._inProcess:
                     self.l.add(visitee.type_())
                 else:
-                    raise RuntimeError("Service not attached to process")
+                    raise RuntimeError("Service not attached to process: {}".format(visitee.dumpPython()))
     def leave(self,visitee):
         pass
 
@@ -973,14 +1008,25 @@ class ExpandVisitor(object):
         self._type = type
         self.l = []
         self.taskLeaves = []
+        self.taskLeavesInConditionalTasks = []
+        self.presentTaskLeaves = self.taskLeaves
         self._levelInTasks = 0
+        self.conditionaltaskLeaves = []
+        self._levelInConditionalTasks = 0
+
     def enter(self,visitee):
         if isinstance(visitee, Task):
             self._levelInTasks += 1
             return
+        if isinstance(visitee, ConditionalTask):
+            self.presentTaskLeaves = self.taskLeavesInConditionalTasks
+            self._levelInConditionalTasks += 1
+            return
         if visitee.isLeaf():
             if self._levelInTasks > 0:
-                self.taskLeaves.append(visitee)
+                self.presentTaskLeaves.append(visitee)
+            elif self._levelInConditionalTasks > 0:
+                self.conditionaltaskLeaves.append(visitee)
             else:
                 self.l.append(visitee)
     def leave(self, visitee):
@@ -988,18 +1034,31 @@ class ExpandVisitor(object):
             if isinstance(visitee, Task):
                 self._levelInTasks -= 1
             return
+        if self._levelInConditionalTasks > 0:
+            if isinstance(visitee, ConditionalTask):
+                self._levelInConditionalTasks -= 1
+                if 0 == self._levelInConditionalTasks:
+                  self.presentTaskLeaves = self.taskLeaves
+            return
         if isinstance(visitee,_UnarySequenceOperator):
             self.l[-1] = visitee
     def result(self):
-        tsk = Task(*self.taskLeaves)
+        tsks = []
+        if self.taskLeaves:
+          tsks.append(Task(*self.taskLeaves))
+        if self.conditionaltaskLeaves:
+          ct = ConditionalTask(*self.conditionaltaskLeaves)
+          if self.taskLeavesInConditionalTasks:
+            ct.append(*self.taskLeavesInConditionalTasks)
+          tsks.append(ct)
         if len(self.l) > 0:
             # why doesn't (sum(self.l) work?
             seq = self.l[0]
             for el in self.l[1:]:
                 seq += el
-            return self._type(seq, tsk)
+            return self._type(seq, *tsks)
         else:
-            return self._type(tsk)
+            return self._type(*tsks)
     def resultString(self):
         sep = ''
         returnValue = ''
@@ -1031,7 +1090,7 @@ class DecoratedNodeNameVisitor(object):
         self._levelInTasks = 0
 
     def enter(self,visitee):
-        if isinstance(visitee, Task):
+        if isinstance(visitee, _TaskBase):
             self._levelInTasks += 1
         if self._levelInTasks > 0:
             return
@@ -1055,7 +1114,7 @@ class DecoratedNodeNameVisitor(object):
     def leave(self,visitee):
         # Ignore if this visitee is inside a Task
         if self._levelInTasks > 0:
-            if isinstance(visitee, Task):
+            if isinstance(visitee, _TaskBase):
                 self._levelInTasks -= 1
             return
         if isinstance(visitee,_BooleanLogicExpression):
@@ -1335,19 +1394,19 @@ class _MutatingSequenceVisitor(object):
                 node.__init__(contents[0][0])
                 self.__stack[-2][-1] = [node, True, None]
 
-            elif isinstance(visitee, Task):
+            elif isinstance(visitee, _TaskBase):
                 nonNull = []
                 for c in contents:
                     if c[0] is not None:
                         nonNull.append(c[0])
-                self.__stack[-2][-1] = [Task(*nonNull), True, None]
+                self.__stack[-2][-1] = [visitee._makeInstance(*nonNull), True, None]
             elif isinstance(visitee, Sequence):
                 seq = _SequenceCollection()
                 tasks = list()
                 for c in contents:
                     if c[0] is None:
                         continue
-                    if isinstance(c[0], Task):
+                    if isinstance(c[0], _TaskBase):
                         tasks.append(c[0])
                     else:
                         seq = seq + c[0]
@@ -1364,7 +1423,7 @@ class _MutatingSequenceVisitor(object):
 
     def result(self, visitedContainer):
 
-        if isinstance(visitedContainer, Task):
+        if isinstance(visitedContainer, _TaskBase):
             result = list()
             for n in (x[0] for x in self.__stack[0]):
                 if n is not None:
@@ -1376,7 +1435,7 @@ class _MutatingSequenceVisitor(object):
         for c in self.__stack[0]:
             if c[0] is None:
                 continue
-            if isinstance(c[0], Task):
+            if isinstance(c[0], _TaskBase):
                 tasks.append(c[0])
             else:
                 seq = seq + c[0]
@@ -1435,38 +1494,23 @@ class _CopyAndReplaceSequenceVisitor(_MutatingSequenceVisitor):
     def didReplace(self):
         return self._didApply()
 
-class Task(_ConfigureComponent, _Labelable) :
-    """Holds EDProducers, EDFilters, ESProducers, ESSources, Services, and Tasks.
-    A Task can be associated with Sequences, Paths, EndPaths and the Schedule.
-    An EDProducer or EDFilter will be enabled to run unscheduled if it is on
-    a task associated with the Schedule or any scheduled Path or EndPath (directly
-    or indirectly through Sequences) and not be on any scheduled Path or EndPath.
-    ESSources, ESProducers, and Services will be enabled to run if they are on
-    a Task associated with the Schedule or a scheduled Path or EndPath.  In other
-    cases, they will be enabled to run if and only if they are not on a Task attached
-    to the process.
-    """
-
+class _TaskBase(_ConfigureComponent, _Labelable) :
     def __init__(self, *items):
         self._collection = OrderedSet()
         self.add(*items)
 
     def __setattr__(self,name,value):
         if not name.startswith("_"):
-            raise AttributeError("You cannot set parameters for Task objects.")
+            raise AttributeError("You cannot set parameters for {} objects.".format(self._taskType()))
         else:
             self.__dict__[name] = value
 
     def add(self, *items):
         for item in items:
-            if not isinstance(item, _ConfigureComponent) or not item._isTaskComponent():
-                if not isinstance(item, TaskPlaceholder):
-                    raise RuntimeError("Adding an entry of type '" + type(item).__name__ + "'to a Task.\n"
-                                       "It is illegal to add this type to a Task.")
+            if not self._allowedInTask(item):
+                raise RuntimeError("Adding an entry of type '{0}' to a {1}.\n"
+                                   "It is illegal to add this type to a {1}.".format(type(item).__name__, self._taskType()))
             self._collection.add(item)
-
-    def _place(self, name, proc):
-        proc._placeTask(name,self)
 
     def fillContents(self, taskContents, options=PrintOptions()):
         # only dump the label, if possible
@@ -1474,7 +1518,7 @@ class Task(_ConfigureComponent, _Labelable) :
             taskContents.add(_Labelable.dumpSequencePython(self, options))
         else:
             for i in self._collection:
-                if isinstance(i, Task):
+                if isinstance(i, _TaskBase):
                     i.fillContents(taskContents, options)
                 else:
                     taskContents.add(i.dumpSequencePython(options))
@@ -1487,7 +1531,7 @@ class Task(_ConfigureComponent, _Labelable) :
         """Returns a string which is the python representation of the object"""
         taskContents = set()
         for i in self._collection:
-            if isinstance(i, Task):
+            if isinstance(i, _TaskBase):
                 i.fillContents(taskContents, options)
             else:
                 taskContents.add(i.dumpSequencePython(options))
@@ -1499,14 +1543,14 @@ class Task(_ConfigureComponent, _Labelable) :
             iFirst = False
             s += item
         if len(taskContents) > 255:
-            return "cms.Task(*[" + s + "])"
-        return "cms.Task(" + s + ")"
+            return "cms.{}(*[" + s + "])".format(self._taskType())
+        return "cms.{}({})".format(self._taskType(),s)
 
     def directDependencies(self,sortByType=True):
         return findDirectDependencies(self, self._collection,sortByType=sortByType)
 
     def _isTaskComponent(self):
-        return True
+        return False
 
     def isLeaf(self):
         return False
@@ -1519,7 +1563,7 @@ class Task(_ConfigureComponent, _Labelable) :
             visitor.leave(i)
 
     def _errorstr(self):
-        return "Task(...)"
+        return "{}(...)".format(self.taskType_())
 
     def __iter__(self):
         for key in self._collection:
@@ -1551,7 +1595,7 @@ class Task(_ConfigureComponent, _Labelable) :
         self.visit(visitor)
         return visitor.result()
     def copy(self):
-        return Task(*self._collection)
+        return self._makeInstance(*self._collection)
     def copyAndExclude(self,listOfModulesToExclude):
         """Returns a copy of the sequence which excludes those module in 'listOfModulesToExclude'"""
         # You can exclude instances of these types EDProducer, EDFilter, ESSource, ESProducer,
@@ -1564,7 +1608,7 @@ class Task(_ConfigureComponent, _Labelable) :
                 raise TypeError("copyAndExclude can only exclude objects that can be placed on a Task")
         v = _CopyAndExcludeSequenceVisitor(listOfModulesToExclude)
         self.visit(v)
-        return Task(*v.result(self))
+        return self._makeInstance(*v.result(self))
     def copyAndAdd(self, *modulesToAdd):
         """Returns a copy of the Task adding modules/tasks"""
         t = self.copy()
@@ -1578,7 +1622,7 @@ class Task(_ConfigureComponent, _Labelable) :
         l = []
         v = ModuleNodeVisitor(l)
         self.visit(v)
-        return Task(*l)
+        return self._makeInstance(*l)
     def replace(self, original, replacement):
         """Finds all instances of 'original' and substitutes 'replacement' for them.
            Returns 'True' if a replacement occurs."""
@@ -1589,10 +1633,10 @@ class Task(_ConfigureComponent, _Labelable) :
         # where objects that contain other objects are involved. See the comments
         # for the _MutatingSequenceVisitor.
 
-        if not original._isTaskComponent() or (not replacement is None and not replacement._isTaskComponent()):
-           raise TypeError("The Task replace function only works with objects that can be placed on a Task\n" + \
-                           "           replace was called with original type = " + str(type(original)) + "\n" + \
-                           "           and replacement type = " + str(type(replacement)) + "\n")
+        if not self._allowedInTask(original) or (not replacement is None and not self._allowedInTask(replacement)):
+           raise TypeError("The Task replace function only works with objects that can be placed on a {}\n".format(self._taskType()) + \
+                           "           replace was called with original type = {}\n".format(str(type(original))) + \
+                           "           and replacement type = {}\n".format(str(type(replacement))))
         else:
             v = _CopyAndReplaceSequenceVisitor(original,replacement)
             self.visit(v)
@@ -1614,7 +1658,7 @@ class Task(_ConfigureComponent, _Labelable) :
         # Works very similar to copyAndExclude, there are 2 differences. This changes
         # the object itself instead of making a copy and second it only removes
         # the first instance of the argument instead of all of them.
-        if not something._isTaskComponent():
+        if not self._allowedInTask(something):
            raise TypeError("remove only works with objects that can be placed on a Task")
         v = _CopyAndRemoveFirstSequenceVisitor(something)
         self.visit(v)
@@ -1626,18 +1670,18 @@ class Task(_ConfigureComponent, _Labelable) :
     def resolve(self, processDict,keepIfCannotResolve=False):
         temp = OrderedSet()
         for i in self._collection:
-            if isinstance(i, Task) or isinstance(i, TaskPlaceholder):
+            if self._mustResolve(i):
                 temp.add(i.resolve(processDict,keepIfCannotResolve))
             else:
                 temp.add(i)
         self._collection = temp
         return self
-
-class TaskPlaceholder(object):
+        
+class _TaskBasePlaceholder(object):
     def __init__(self, name):
         self._name = name
     def _isTaskComponent(self):
-        return True
+        return False
     def isLeaf(self):
         return False
     def visit(self,visitor):
@@ -1645,31 +1689,116 @@ class TaskPlaceholder(object):
     def __str__(self):
         return self._name
     def insertInto(self, parameterSet, myname):
-        raise RuntimeError("The TaskPlaceholder "+self._name
-                           +" was never overridden")
+        raise RuntimeError("The {} {} was never overridden".format(self._typeName(), self._name))
     def resolve(self, processDict,keepIfCannotResolve=False):
         if not self._name in processDict:
             if keepIfCannotResolve:
                 return self
-            raise RuntimeError("The TaskPlaceholder "+self._name+ " cannot be resolved.\n Known keys are:"+str(processDict.keys()))
+            raise RuntimeError("The {} {} cannot be resolved.\n Known keys are: {}".format(self._typeName(), self._name,str(processDict.keys())))
         o = processDict[self._name]
-        if not o._isTaskComponent():
-            raise RuntimeError("The TaskPlaceholder "+self._name+ " refers to an object type which is not allowed to be on a task: "+str(type(o)))
-        if isinstance(o, Task):
+        if not self._allowedInTask(o):
+            raise RuntimeError("The {} {} refers to an object type which is not allowed to be on a task: {}".format(self._typeName(), self._name, str(type(o))))
+        if isinstance(o, self._taskClass()):
             return o.resolve(processDict)
         return o
     def copy(self):
-        returnValue =TaskPlaceholder.__new__(type(self))
-        returnValue.__init__(self._name)
-        return returnValue
+        return self._makeInstance(self._name)
     def dumpSequencePython(self, options=PrintOptions()):
-        return 'cms.TaskPlaceholder("%s")'%self._name
+        return 'cms.{}("{}")'.format(self._typeName(), self._name)
     def dumpPython(self, options=PrintOptions()):
-        result = 'cms.TaskPlaceholder(\"'
+        result = 'cms.{}(\"'.format(self._typeName())
         if options.isCfg:
            result += 'process.'
         result += self._name+'\")\n'
         return result
+
+class Task(_TaskBase) :
+    """Holds EDProducers, EDFilters, ESProducers, ESSources, Services, and Tasks.
+    A Task can be associated with Sequences, Paths, EndPaths and the Schedule.
+    An EDProducer or EDFilter will be enabled to run unscheduled if it is on
+    a task associated with the Schedule or any scheduled Path or EndPath (directly
+    or indirectly through Sequences) and not be on any scheduled Path or EndPath.
+    ESSources, ESProducers, and Services will be enabled to run if they are on
+    a Task associated with the Schedule or a scheduled Path or EndPath.  In other
+    cases, they will be enabled to run if and only if they are not on a Task attached
+    to the process.
+    """
+    @staticmethod
+    def _taskType():
+      return "Task"
+    def _place(self, name, proc):
+        proc._placeTask(name,self)
+    def _isTaskComponent(self):
+        return True
+    @staticmethod
+    def _makeInstance(*items):
+      return Task(*items)
+    @staticmethod
+    def _allowedInTask(item ):
+      return (isinstance(item, _ConfigureComponent) and item._isTaskComponent()) or isinstance(item, TaskPlaceholder)
+    @staticmethod
+    def _mustResolve(item):
+        return isinstance(item, Task) or isinstance(item, TaskPlaceholder)
+      
+class TaskPlaceholder(_TaskBasePlaceholder):
+    def _isTaskComponent(self):
+        return True
+    @staticmethod
+    def _typeName():
+      return "TaskPlaceholder"
+    @staticmethod
+    def _makeInstance(name):
+      return TaskPlaceholder(name)
+    @staticmethod
+    def _allowedInTask(obj):
+      return Task._allowedInTask(obj)
+    @staticmethod
+    def _taskClass():
+      return Task
+
+
+class ConditionalTask(_TaskBase) :
+    """Holds EDProducers, EDFilters, ESProducers, ESSources, Services, Tasks and ConditionalTasks.
+    A ConditionalTask can be associated with Sequences, Paths, and EndPaths.
+    An EDProducer or EDFilter will be added to a Path or EndPath based on which other
+    modules on the Path consumes its data products. If that ConditionalTask assigned module
+    is placed after an EDFilter, the module will only run if the EDFilter passes. If no module
+    on the Path needs the module's data products, the module will be removed from the job.
+    """
+    @staticmethod
+    def _taskType():
+      return "ConditionalTask"
+    def _place(self, name, proc):
+        proc._placeConditionalTask(name,self)
+    def _isTaskComponent(self):
+        return False
+    @staticmethod
+    def _makeInstance(*items):
+      return ConditionalTask(*items)
+    @staticmethod
+    def _allowedInTask(item):
+      return isinstance(item, ConditionalTask) or isinstance(item, ConditionalTaskPlaceholder) or Task._allowedInTask(item)
+    @staticmethod
+    def _mustResolve(item):
+        return Task._mustResolve(item) or isinstance(item, ConditionalTask) or isinstance(item, ConditionalTaskPlaceholder)
+
+
+class ConditionalTaskPlaceholder(_TaskBasePlaceholder):
+    def _isTaskComponent(self):
+        return False
+    @staticmethod
+    def _typeName():
+      return "ConditionalTaskPlaceholder"
+    @staticmethod
+    def _makeInstance(name):
+      return ConditionalTaskPlaceholder(name)
+    @staticmethod
+    def _allowedInTask(obj):
+      return Task._allowedInTask(obj) or ConditionalTask._allowedInTask(obj)
+    @staticmethod
+    def _taskClass():
+      return ConditionalTask
+
 
 if __name__=="__main__":
     import unittest
@@ -1817,6 +1946,20 @@ if __name__=="__main__":
             s = Sequence(e, t4)
             p12 = Path(a+b+s+c,t1)
             self.assertEqual(p12.dumpPython(),"cms.Path(process.a+process.b+cms.Sequence(process.e, cms.Task(process.d, process.f))+process.c, cms.Task(process.a))\n")
+            ct1 = ConditionalTask(a)
+            ct2 = ConditionalTask(c, b)
+            ct3 = ConditionalTask()
+            p13 = Path((a+b)*c, ct1)
+            self.assertEqual(p13.dumpPython(),"cms.Path(process.a+process.b+process.c, cms.ConditionalTask(process.a))\n")
+            p14 = Path((a+b)*c, ct2, ct1)
+            self.assertEqual(p14.dumpPython(),"cms.Path(process.a+process.b+process.c, cms.ConditionalTask(process.a), cms.ConditionalTask(process.b, process.c))\n")
+            p15 = Path(ct1, ct2, ct3)
+            self.assertEqual(p15.dumpPython(),"cms.Path(cms.ConditionalTask(), cms.ConditionalTask(process.a), cms.ConditionalTask(process.b, process.c))\n")
+            ct4 = ConditionalTask(d, Task(f))
+            s = Sequence(e, ct4)
+            p16 = Path(a+b+s+c,ct1)
+            self.assertEqual(p16.dumpPython(),"cms.Path(process.a+process.b+cms.Sequence(process.e, cms.ConditionalTask(process.d, process.f))+process.c, cms.ConditionalTask(process.a))\n")
+
             l = list()
             namesVisitor = DecoratedNodeNameVisitor(l)
             p.visit(namesVisitor)
@@ -1843,6 +1986,9 @@ if __name__=="__main__":
             p12.visit(namesVisitor)
             self.assertEqual(l, ['a', 'b', 'e', 'c'])
             l[:] = []
+            p16.visit(namesVisitor)
+            self.assertEqual(l, ['a', 'b', 'e', 'c'])
+            l[:] = []
             moduleVisitor = ModuleNodeVisitor(l)
             p8.visit(moduleVisitor)
             names = [m.label_() for m in l]
@@ -1851,6 +1997,8 @@ if __name__=="__main__":
             self.assertEqual(tph.dumpPython(), 'cms.TaskPlaceholder("process.a")\n')
             sph = SequencePlaceholder('a')
             self.assertEqual(sph.dumpPython(), 'cms.SequencePlaceholder("process.a")\n')
+            ctph = ConditionalTaskPlaceholder('a')
+            self.assertEqual(ctph.dumpPython(), 'cms.ConditionalTaskPlaceholder("process.a")\n')
 
         def testDumpConfig(self):
             a = DummyModule("a")
@@ -1913,6 +2061,19 @@ if __name__=="__main__":
             e=DummyModule("e")
             f=DummyModule("f")
             g=DummyModule("g")
+            ct1 = ConditionalTask(d)
+            ct2 = ConditionalTask(e, ct1)
+            ct3 = ConditionalTask(f, g, ct2)
+            s=Sequence(plusAB, ct3, ct2)
+            multSC = s*c
+            p=Path(multSC, ct1, ct2)
+            l = []
+            v = ModuleNodeVisitor(l)
+            p.visit(v)
+            expected = [a,b,f,g,e,d,e,d,c,d,e,d]
+            self.assertEqual(expected,l)
+
+
             t1 = Task(d)
             t2 = Task(e, t1)
             t3 = Task(f, g, t2)
@@ -1924,6 +2085,7 @@ if __name__=="__main__":
             v = ModuleNodeVisitor(l)
             p.visit(v)
             expected = [a,b,f,g,e,d,e,d,c,d,e,d]
+            self.assertEqual(expected,l)
 
             l[:] = []
             v = ModuleNodeOnTaskVisitor(l)
@@ -2050,6 +2212,7 @@ if __name__=="__main__":
             m8 = DummyModule("m8")
             m9 = DummyModule("m9")
 
+            #Task
             t6 = Task(m6)
             t7 = Task(m7)
             t89 = Task(m8, m9)
@@ -2105,7 +2268,65 @@ if __name__=="__main__":
             t3 = Task(m5)
             t2.replace(m2,t3)
             self.assertTrue(t2.dumpPython() == "cms.Task(process.m1, process.m3, process.m5)\n")
-            
+
+            #ConditionalTask
+            ct6 = ConditionalTask(m6)
+            ct7 = ConditionalTask(m7)
+            ct89 = ConditionalTask(m8, m9)
+
+            cs1 = Sequence(m1+m2, ct6)
+            cs2 = Sequence(m3+m4, ct7)
+            cs3 = Sequence(cs1+cs2, ct89)
+            cs3.replace(m3,m5)
+            l[:] = []
+            cs3.visit(namesVisitor)
+            self.assertEqual(l,['m1','m2','m5','m4'])
+
+            cs3.replace(m8,m1)
+            self.assertEqual(cs3.dumpPython(), "cms.Sequence(cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m6))+process.m5+process.m4, cms.ConditionalTask(process.m1, process.m9), cms.ConditionalTask(process.m7))\n")
+
+            cs3.replace(m1,m7)
+            self.assertEqual(cs3.dumpPython(), "cms.Sequence(process.m7+process.m2+process.m5+process.m4, cms.ConditionalTask(process.m6), cms.ConditionalTask(process.m7), cms.ConditionalTask(process.m7, process.m9))\n")
+            result = cs3.replace(ct7, ct89)
+            self.assertEqual(cs3.dumpPython(), "cms.Sequence(process.m7+process.m2+process.m5+process.m4, cms.ConditionalTask(process.m6), cms.ConditionalTask(process.m7, process.m9), cms.ConditionalTask(process.m8, process.m9))\n")
+            self.assertTrue(result)
+            result = cs3.replace(ct7, ct89)
+            self.assertFalse(result)
+
+            ct1 = ConditionalTask()
+            ct1.replace(m1,m2)
+            self.assertEqual(ct1.dumpPython(), "cms.ConditionalTask()\n")
+
+            ct1 = ConditionalTask(m1)
+            ct1.replace(m1,m2)
+            self.assertEqual(ct1.dumpPython(), "cms.ConditionalTask(process.m2)\n")
+
+            ct1 = ConditionalTask(m1,m2, m2)
+            ct1.replace(m2,m3)
+            self.assertEqual(ct1.dumpPython(), "cms.ConditionalTask(process.m1, process.m3)\n")
+
+            ct1 = ConditionalTask(m1,m2)
+            ct2 = ConditionalTask(m1,m3,ct1)
+            ct2.replace(m1,m4)
+            self.assertEqual(ct2.dumpPython(), "cms.ConditionalTask(process.m2, process.m3, process.m4)\n")
+
+            ct1 = ConditionalTask(m2)
+            ct2 = ConditionalTask(m1,m3,ct1)
+            ct2.replace(m1,m4)
+            self.assertEqual(ct2.dumpPython(), "cms.ConditionalTask(process.m2, process.m3, process.m4)\n")
+
+            ct1 = ConditionalTask(m2)
+            ct2 = ConditionalTask(m1,m3,ct1)
+            ct2.replace(ct1,m4)
+            self.assertEqual(ct2.dumpPython(), "cms.ConditionalTask(process.m1, process.m3, process.m4)\n")
+
+            ct1 = ConditionalTask(m2)
+            ct2 = ConditionalTask(m1,m3,ct1)
+            ct3 = ConditionalTask(m5)
+            ct2.replace(m2,ct3)
+            self.assertEqual(ct2.dumpPython(), "cms.ConditionalTask(process.m1, process.m3, process.m5)\n")
+
+            #FinalPath
             fp = FinalPath()
             fp.replace(m1,m2)
             self.assertEqual(fp.dumpPython(), "cms.FinalPath()\n")
@@ -2131,7 +2352,7 @@ if __name__=="__main__":
             s3._replaceIfHeldDirectly(~m1, m2)
             self.assertEqual(s3.dumpPython()[:-1],
                              "cms.Sequence(process.m2+(process.m1+process.m2))")
-
+            #Task
             m6 = DummyModule("m6")
             m7 = DummyModule("m7")
             m8 = DummyModule("m8")
@@ -2153,6 +2374,23 @@ if __name__=="__main__":
             s1._replaceIfHeldDirectly(t6,t7)
             self.assertEqual(s1.dumpPython()[:-1],"cms.Sequence(cms.Task(process.m7))")
 
+            #ConditionalTask
+            ct6 = ConditionalTask(m6)
+            ct7 = ConditionalTask(m7)
+            ct89 = ConditionalTask(m8, m9)
+
+            s1 = Sequence(m1+m2, ct6)
+            s2 = Sequence(m3+m4, ct7)
+            s3 = Sequence(s1+s2, ct89)
+            s3._replaceIfHeldDirectly(m3,m5)
+            self.assertEqual(s3.dumpPython()[:-1], "cms.Sequence(cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m6))+cms.Sequence(process.m3+process.m4, cms.ConditionalTask(process.m7)), cms.ConditionalTask(process.m8, process.m9))")
+            s2._replaceIfHeldDirectly(m3,m5)
+            self.assertEqual(s2.dumpPython()[:-1],"cms.Sequence(process.m5+process.m4, cms.ConditionalTask(process.m7))")
+            self.assertEqual(s3.dumpPython()[:-1], "cms.Sequence(cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m6))+cms.Sequence(process.m5+process.m4, cms.ConditionalTask(process.m7)), cms.ConditionalTask(process.m8, process.m9))")
+
+            s1 = Sequence(ct6)
+            s1._replaceIfHeldDirectly(ct6,ct7)
+            self.assertEqual(s1.dumpPython()[:-1],"cms.Sequence(cms.ConditionalTask(process.m7))")
         def testIndex(self):
             m1 = DummyModule("a")
             m2 = DummyModule("b")
@@ -2199,6 +2437,7 @@ if __name__=="__main__":
             p2.visit(namesVisitor)
             self.assertEqual(l, ['m1', '!m2', 'm1', 'm2', '-m2', '!m1', 'm1', 'm2'])
 
+            #Task
             m6 = DummyModule("m6")
             m7 = DummyModule("m7")
             m8 = DummyModule("m8")
@@ -2208,7 +2447,7 @@ if __name__=="__main__":
             l[:] = []
             p2.visit(namesVisitor)
             self.assertEqual(l, ['m1', '!m2', 'm1', 'm2', '-m2', '!m1', 'm1', 'm2'])
-            self.assertTrue(p2.dumpPython() == "cms.Path(process.m1+~process.m2+process.m1+process.m2+cms.ignore(process.m2)+~process.m1+process.m1+process.m2, cms.Task(process.m6))\n")
+            self.assertEqual(p2.dumpPython(), "cms.Path(process.m1+~process.m2+process.m1+process.m2+cms.ignore(process.m2)+~process.m1+process.m1+process.m2, cms.Task(process.m6))\n")
 
             s2 = Sequence(m1*m2, Task(m9))
             s3 = Sequence(~m1*s2)
@@ -2236,6 +2475,44 @@ if __name__=="__main__":
             t4 = Task()
             t5 = t4.expandAndClone()
             self.assertTrue(t5.dumpPython() == "cms.Task()\n")
+            #ConditionalTask
+            s1 = Sequence(m1*~m2*m1*m2*ignore(m2))
+            s2 = Sequence(m1*m2)
+            s3 = Sequence(~m1*s2)
+            p = Path(s1+s3, ConditionalTask(m6))
+            p2 = p.expandAndClone()
+            l[:] = []
+            p2.visit(namesVisitor)
+            self.assertEqual(l, ['m1', '!m2', 'm1', 'm2', '-m2', '!m1', 'm1', 'm2'])
+            self.assertEqual(p2.dumpPython(), "cms.Path(process.m1+~process.m2+process.m1+process.m2+cms.ignore(process.m2)+~process.m1+process.m1+process.m2, cms.ConditionalTask(process.m6))\n")
+
+            s2 = Sequence(m1*m2, ConditionalTask(m9))
+            s3 = Sequence(~m1*s2)
+            ct8 = ConditionalTask(m8)
+            ct8.setLabel("ct8")
+            p = Path(s1+s3, ConditionalTask(m6, ConditionalTask(m7, ct8)))
+            p2 = p.expandAndClone()
+            l[:] = []
+            p2.visit(namesVisitor)
+            self.assertEqual(l, ['m1', '!m2', 'm1', 'm2', '-m2', '!m1', 'm1', 'm2'])
+            self.assertEqual(p2.dumpPython(), "cms.Path(process.m1+~process.m2+process.m1+process.m2+cms.ignore(process.m2)+~process.m1+process.m1+process.m2, cms.ConditionalTask(process.m6, process.m7, process.m8, process.m9))\n")
+
+            t1 = ConditionalTask(m1,m2,m3)
+            s1 = Sequence(t1)
+            s2 = s1.expandAndClone()
+            l[:] = []
+            s2.visit(namesVisitor)
+            self.assertEqual(l, [])
+            self.assertEqual(s2.dumpPython(), "cms.Sequence(cms.ConditionalTask(process.m1, process.m2, process.m3))\n")
+
+            t1 = ConditionalTask(m1,m2)
+            t2 = ConditionalTask(m1,m3,t1)
+            t3 = t2.expandAndClone()
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.m1, process.m2, process.m3)\n")
+            t4 = ConditionalTask()
+            t5 = t4.expandAndClone()
+            self.assertTrue(t5.dumpPython() == "cms.ConditionalTask()\n")
+
         def testAdd(self):
             m1 = DummyModule("m1")
             m2 = DummyModule("m2")
@@ -2320,6 +2597,7 @@ if __name__=="__main__":
             s4.remove(m1)
             l[:]=[]; s4.visit(namesVisitor); self.assertEqual(l,[])
             self.assertEqual(s4.dumpPython(), "cms.Sequence()\n")
+            #Task
             s1 = Sequence(m1+m2, Task(m3), Task(m4))
             s1.remove(m4)
             self.assertEqual(s1.dumpPython(), "cms.Sequence(process.m1+process.m2, cms.Task(process.m3))\n")
@@ -2339,6 +2617,27 @@ if __name__=="__main__":
             self.assertTrue(t3.dumpPython() == "cms.Task(process.m2)\n")
             t3.remove(m2)
             self.assertTrue(t3.dumpPython() == "cms.Task()\n")
+            #ConditionalTask
+            s1 = Sequence(m1+m2, ConditionalTask(m3), ConditionalTask(m4))
+            s1.remove(m4)
+            self.assertEqual(s1.dumpPython(), "cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m3))\n")
+            s1 = Sequence(m1+m2+Sequence(ConditionalTask(m3,m4), ConditionalTask(m3), ConditionalTask(m4)))
+            s1.remove(m4)
+            self.assertEqual(s1.dumpPython(), "cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m3), cms.ConditionalTask(process.m4))\n")
+            t1 = ConditionalTask(m1)
+            t1.setLabel("t1")
+            t2 = ConditionalTask(m2,t1)
+            t2.setLabel("t2")
+            t3 = ConditionalTask(t1,t2,m1)
+            t3.remove(m1)
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.m1, process.t2)\n")
+            t3.remove(m1)
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.m1, process.m2)\n")
+            t3.remove(m1)
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.m2)\n")
+            t3.remove(m2)
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask()\n")
+            #FinalPath
             fp = FinalPath(m1+m2)
             fp.remove(m1)
             self.assertEqual(fp.dumpPython(), "cms.FinalPath(process.m2)\n")
@@ -2445,6 +2744,7 @@ if __name__=="__main__":
             self.assertEqual(s.copyAndExclude([d]).dumpPython(),"cms.Sequence(process.a+process.b+process.c)\n")
             self.assertEqual(s.copyAndExclude([a,b,c,d]).dumpPython(),"cms.Sequence()\n")
 
+            #Task
             e = DummyModule("e")
             f = DummyModule("f")
             g = DummyModule("g")
@@ -2481,6 +2781,40 @@ if __name__=="__main__":
             self.assertTrue(t3.dumpPython() == "cms.Task(process.f, process.g, process.t11)\n")
             t4 = t2.copyAndExclude([e,f,g,h,a])
             self.assertTrue(t4.dumpPython() == "cms.Task()\n")
+            #ConditionalTask
+            t1 = ConditionalTask(h)
+            s = Sequence(a+b+c+~d, ConditionalTask(e,f,ConditionalTask(g,t1)))
+            self.assertEqual(s.copyAndExclude([a,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d, cms.ConditionalTask(process.e, process.f, process.g))\n")
+            self.assertEqual(s.copyAndExclude([a,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d, cms.ConditionalTask(process.e, process.f, process.g))\n")
+            self.assertEqual(s.copyAndExclude([a,e,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d, cms.ConditionalTask(process.f, process.g))\n")
+            self.assertEqual(s.copyAndExclude([a,e,f,g,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d)\n")
+            self.assertEqual(s.copyAndExclude([a,b,c,d]).dumpPython(),"cms.Sequence(cms.ConditionalTask(process.e, process.f, process.g, process.h))\n")
+            self.assertEqual(s.copyAndExclude([t1]).dumpPython(),"cms.Sequence(process.a+process.b+process.c+~process.d, cms.ConditionalTask(process.e, process.f, process.g))\n")
+            taskList = []
+            taskVisitor = ConditionalTaskVisitor(taskList)
+            s.visit(taskVisitor)
+            self.assertEqual(len(taskList),3)
+            s2 = s.copyAndExclude([g,h])
+            taskList[:] = []
+            s2.visit(taskVisitor)
+            self.assertEqual(len(taskList),1)
+            t2 = ConditionalTask(t1)
+            taskList[:] = []
+            t2.visit(taskVisitor)
+            self.assertEqual(taskList[0],t1)
+            s3 = Sequence(s)
+            self.assertEqual(s3.copyAndExclude([a,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d, cms.ConditionalTask(process.e, process.f, process.g))\n")
+            s4 = Sequence(s)
+            self.assertEqual(s4.copyAndExclude([a,b,c,d,e,f,g,h]).dumpPython(),"cms.Sequence()\n")
+            t1 = ConditionalTask(e,f)
+            t11 = ConditionalTask(a)
+            t11.setLabel("t11")
+            t2 = ConditionalTask(g,t1,h,t11)
+            t3 = t2.copyAndExclude([e,h])
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.f, process.g, process.t11)\n")
+            t4 = t2.copyAndExclude([e,f,g,h,a])
+            self.assertEqual(t4.dumpPython(), "cms.ConditionalTask()\n")
+
         def testSequenceTypeChecks(self):
             m1 = DummyModule("m1")
             m2 = DummyModule("m2")
@@ -2506,6 +2840,7 @@ if __name__=="__main__":
             p1 += e
             self.assertEqual(p1.dumpPython(),"cms.Path(process.a+process.b+process.c+process.e)\n")
             self.assertEqual(p2.dumpPython(),"cms.Path(process.a+process.b+process.c)\n")
+            #Task
             t1 = Task(a, b)
             t2 = t1.copy()
             self.assertTrue(t1.dumpPython() == t2.dumpPython())
@@ -2514,12 +2849,23 @@ if __name__=="__main__":
             self.assertTrue(id(t1Contents[0]) == id(t2Contents[0]))
             self.assertTrue(id(t1Contents[1]) == id(t2Contents[1]))
             self.assertTrue(id(t1._collection) != id(t2._collection))
+            #ConditionalTask
+            t1 = ConditionalTask(a, b)
+            t2 = t1.copy()
+            self.assertTrue(t1.dumpPython() == t2.dumpPython())
+            t1Contents = list(t1._collection)
+            t2Contents = list(t2._collection)
+            self.assertTrue(id(t1Contents[0]) == id(t2Contents[0]))
+            self.assertTrue(id(t1Contents[1]) == id(t2Contents[1]))
+            self.assertTrue(id(t1._collection) != id(t2._collection))
+
         def testCopyAndAdd(self):
             a = DummyModule("a")
             b = DummyModule("b")
             c = DummyModule("c")
             d = DummyModule("d")
             e = DummyModule("e")
+            #Task
             t1 = Task(a, b, c)
             self.assertEqual(t1.dumpPython(), "cms.Task(process.a, process.b, process.c)\n")
             t2 = t1.copyAndAdd(d, e)
@@ -2535,6 +2881,23 @@ if __name__=="__main__":
             self.assertEqual(t5.dumpPython(), "cms.Task(process.a, process.c, process.d, process.e)\n")
             t6 = t4.copyAndAdd(Task(b))
             self.assertEqual(t6.dumpPython(), "cms.Task(process.a, process.b, process.c, process.d)\n")
+            #ConditionalTask
+            t1 = ConditionalTask(a, b, c)
+            self.assertEqual(t1.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c)\n")
+            t2 = t1.copyAndAdd(d, e)
+            self.assertEqual(t1.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c)\n")
+            self.assertEqual(t2.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c, process.d, process.e)\n")
+            t3 = t2.copyAndExclude([b])
+            self.assertEqual(t1.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c)\n")
+            self.assertEqual(t2.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c, process.d, process.e)\n")
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.a, process.c, process.d, process.e)\n")
+            t4 = t1.copyAndExclude([b]).copyAndAdd(d)
+            self.assertEqual(t4.dumpPython(), "cms.ConditionalTask(process.a, process.c, process.d)\n")
+            t5 = t2.copyAndExclude([b]).copyAndAdd(d)
+            self.assertEqual(t5.dumpPython(), "cms.ConditionalTask(process.a, process.c, process.d, process.e)\n")
+            t6 = t4.copyAndAdd(Task(b))
+            self.assertEqual(t6.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c, process.d)\n")
+
         def testInsertInto(self):
             from FWCore.ParameterSet.Types import vstring
             class TestPSet(object):

--- a/FWCore/ParameterSet/python/SequenceVisitors.py
+++ b/FWCore/ParameterSet/python/SequenceVisitors.py
@@ -120,19 +120,24 @@ class NodeVisitor(object):
 
 class CompositeVisitor(object):
     """ Combines 3 different visitor classes in 1 so we only have to visit all the paths and endpaths once"""
-    def __init__(self, validator, node, decorated):
+    def __init__(self, validator, node, decorated, optional=None):
         self._validator = validator
         self._node = node
         self._decorated = decorated
+        self._optional = optional
     def enter(self, visitee):
         self._validator.enter(visitee)
         self._node.enter(visitee)
         self._decorated.enter(visitee)
+        if self._optional:
+          self._optional.enter(visitee)
     def leave(self, visitee):
         self._validator.leave(visitee)
         # The node visitor leave function does nothing
         #self._node.leave(visitee)
         self._decorated.leave(visitee)
+        if self._optional:
+          self._optional.leave(visitee)
 
 class ModuleNamesFromGlobalsVisitor(object):
     """Fill a list with the names of Event module types in a sequence. The names are determined

--- a/FWCore/Utilities/interface/path_configuration.h
+++ b/FWCore/Utilities/interface/path_configuration.h
@@ -1,0 +1,40 @@
+#ifndef FWCore_Utilities_path_configuration_h
+#define FWCore_Utilities_path_configuration_h
+// -*- C++ -*-
+//
+// Package  :     FWCore/Utilities
+// namespace:     path_configuration
+//
+/**\class path_configuration path_configuration.h "FWCore/Utilities/interface/path_configuration.h"
+
+ Description: Functions used to understand Path configurations
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 30 Mar 2022 14:59:29 GMT
+//
+
+// system include files
+#include <vector>
+#include <string>
+#include <unordered_set>
+
+// user include files
+
+// forward declarations
+
+namespace edm::path_configuration {
+  ///The label is an indicator of a path scheduling construct and not an actual module.
+  using SchedulingConstructLabelSet = std::unordered_set<std::string, std::hash<std::string>, std::equal_to<>>;
+  SchedulingConstructLabelSet const& schedulingConstructLabels();
+
+  //Takes the Parameter associated to a given Path and converts it to the list of modules
+  // in the same order as the Path's position bits
+  std::vector<std::string> configurationToModuleBitPosition(std::vector<std::string>);
+}  // namespace edm::path_configuration
+
+#endif

--- a/FWCore/Utilities/src/path_configuration.cc
+++ b/FWCore/Utilities/src/path_configuration.cc
@@ -1,0 +1,38 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// namespace  :     path_configuration
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Wed, 30 Mar 2022 15:04:35 GMT
+//
+
+// system include files
+#include <algorithm>
+
+// user include files
+#include "FWCore/Utilities/interface/path_configuration.h"
+
+namespace edm::path_configuration {
+
+  SchedulingConstructLabelSet const& schedulingConstructLabels() {
+    static const SchedulingConstructLabelSet s_set({{"@"}, {"#"}});
+    return s_set;
+  }
+
+  //Takes the Parameter associated to a given Path and converts it to the list of modules
+  // in the same order as the Path's position bits
+  std::vector<std::string> configurationToModuleBitPosition(std::vector<std::string> iConfig) {
+    auto const& labelsToRemove = schedulingConstructLabels();
+    iConfig.erase(
+        std::remove_if(iConfig.begin(),
+                       iConfig.end(),
+                       [&labelsToRemove](auto const& n) { return labelsToRemove.find(n) != labelsToRemove.end(); }),
+        iConfig.end());
+    return iConfig;
+  }
+
+}  // namespace edm::path_configuration

--- a/HLTrigger/HLTcore/src/HLTConfigData.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigData.cc
@@ -10,6 +10,7 @@
 #include "HLTrigger/HLTcore/interface/HLTConfigData.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include <unordered_set>
 #include <iostream>
 
 //Using this function with the 'const static within s_dummyPSet'
@@ -117,9 +118,17 @@ void HLTConfigData::extract() {
   // Obtain module labels of all modules on all trigger paths
   const unsigned int n(size());
   moduleLabels_.reserve(n);
+  std::unordered_set<std::string> processDirectives = {{"@"}, {"#"}};
   for (unsigned int i = 0; i != n; ++i) {
     if (processPSet_->existsAs<vector<string>>(triggerNames_[i], true)) {
       moduleLabels_.push_back(processPSet_->getParameter<vector<string>>(triggerNames_[i]));
+      auto& ml = moduleLabels_.back();
+      ml.erase(std::remove_if(ml.begin(),
+                              ml.end(),
+                              [&processDirectives](auto const& l) {
+                                return processDirectives.find(l) != processDirectives.end();
+                              }),
+               ml.end());
     }
   }
   saveTagsModules_.reserve(n);

--- a/HLTrigger/HLTcore/src/HLTConfigData.cc
+++ b/HLTrigger/HLTcore/src/HLTConfigData.cc
@@ -9,6 +9,7 @@
 
 #include "HLTrigger/HLTcore/interface/HLTConfigData.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/path_configuration.h"
 
 #include <unordered_set>
 #include <iostream>
@@ -118,17 +119,10 @@ void HLTConfigData::extract() {
   // Obtain module labels of all modules on all trigger paths
   const unsigned int n(size());
   moduleLabels_.reserve(n);
-  std::unordered_set<std::string> processDirectives = {{"@"}, {"#"}};
   for (unsigned int i = 0; i != n; ++i) {
     if (processPSet_->existsAs<vector<string>>(triggerNames_[i], true)) {
-      moduleLabels_.push_back(processPSet_->getParameter<vector<string>>(triggerNames_[i]));
-      auto& ml = moduleLabels_.back();
-      ml.erase(std::remove_if(ml.begin(),
-                              ml.end(),
-                              [&processDirectives](auto const& l) {
-                                return processDirectives.find(l) != processDirectives.end();
-                              }),
-               ml.end());
+      moduleLabels_.push_back(path_configuration::configurationToModuleBitPosition(
+          processPSet_->getParameter<vector<string>>(triggerNames_[i])));
     }
   }
   saveTagsModules_.reserve(n);

--- a/HLTrigger/HLTcore/test/BuildFile.xml
+++ b/HLTrigger/HLTcore/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin file="test_catch2_*.cc" name="testHLTriggerHLTcoreCatch2">
+  <use name="HLTrigger/HLTcore"/>
+  <use name="catch2"/>
+</bin>

--- a/HLTrigger/HLTcore/test/test_catch2_HLTConfigData.cc
+++ b/HLTrigger/HLTcore/test/test_catch2_HLTConfigData.cc
@@ -1,0 +1,72 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "HLTrigger/HLTcore/interface/HLTConfigData.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+namespace {
+  edm::ParameterSet buildModulePSet(std::string const& iLabel, std::string const& iType, std::string const& iEDMType) {
+    edm::ParameterSet pset;
+    pset.addParameter<std::string>("@module_label", iLabel);
+    pset.addParameter<std::string>("@module_type", iType);
+    pset.addParameter<std::string>("@module_edm_type", iEDMType);
+    return pset;
+  }
+}  // namespace
+
+TEST_CASE("Test HLTConfigData", "[HLTConfigData]") {
+  SECTION("TriggerPaths") {
+    edm::ParameterSet pset;
+    pset.addParameter<std::string>("@process_name", "TEST");
+    const std::vector<std::string> names = {{"b1"}, {"b2"}, {"a1"}, {"z5"}};
+    {
+      edm::ParameterSet tpset;
+      tpset.addParameter<std::vector<std::string>>("@trigger_paths", names);
+      pset.addParameter<edm::ParameterSet>("@trigger_paths", tpset);
+    }
+    pset.addParameter<std::vector<std::string>>("b1", {{"f1"}, {"f2"}});
+    pset.addParameter<std::vector<std::string>>("b2", {{"f3"}, {"#"}, {"c1"}, {"c2"}, {"@"}});
+    pset.addParameter<std::vector<std::string>>("a1", {{"f1"}, {"f4"}});
+    pset.addParameter<std::vector<std::string>>("z5", {{"f5"}});
+
+    pset.addParameter<edm::ParameterSet>("f1", buildModulePSet("f1", "F1Filter", "EDFilter"));
+    pset.addParameter<edm::ParameterSet>("f2", buildModulePSet("f2", "F2Filter", "EDFilter"));
+    pset.addParameter<edm::ParameterSet>("f3", buildModulePSet("f3", "F3Filter", "EDFilter"));
+    pset.addParameter<edm::ParameterSet>("f4", buildModulePSet("f4", "F4Filter", "EDFilter"));
+    pset.addParameter<edm::ParameterSet>("f5", buildModulePSet("f5", "F5Filter", "EDFilter"));
+
+    pset.addParameter<edm::ParameterSet>("c1", buildModulePSet("c1", "CProducer", "EDProducer"));
+    pset.addParameter<edm::ParameterSet>("c2", buildModulePSet("c2", "CProducer", "EDProducer"));
+    pset.registerIt();
+
+    HLTConfigData cd(&pset);
+
+    SECTION("check paths") {
+      REQUIRE(cd.size() == 4);
+      REQUIRE(cd.triggerName(0) == names[0]);
+      REQUIRE(cd.triggerName(1) == names[1]);
+      REQUIRE(cd.triggerName(2) == names[2]);
+      REQUIRE(cd.triggerName(3) == names[3]);
+      //cd.dump("Triggers");
+    }
+
+    SECTION("check modules on paths") {
+      REQUIRE(cd.size(0) == 2);
+      REQUIRE(cd.moduleLabel(0, 0) == "f1");
+      REQUIRE(cd.moduleLabel(0, 1) == "f2");
+
+      REQUIRE(cd.size(1) == 3);
+      REQUIRE(cd.moduleLabel(1, 0) == "f3");
+      REQUIRE(cd.moduleLabel(1, 1) == "c1");
+      REQUIRE(cd.moduleLabel(1, 2) == "c2");
+
+      REQUIRE(cd.size(2) == 2);
+      REQUIRE(cd.moduleLabel(2, 0) == "f1");
+      REQUIRE(cd.moduleLabel(2, 1) == "f4");
+
+      REQUIRE(cd.size(3) == 1);
+      REQUIRE(cd.moduleLabel(3, 0) == "f5");
+      //cd.dump("Modules");
+    }
+  }
+}


### PR DESCRIPTION
#### PR description:

This PR backports from CMSSW 12.4.x/12.5.x the PRs that implement the `ConditionalTask`:
  - #37305: Added ConditionalTask
  - #37563: Make SwitchProducer work with ConditionalTask
  - #37872: Fix dumpPython() for Task and ConditionalTask when they contain > 255 elements
  - #38006: Fix behavior of SwitchProducer in ConditionalTask with non-chosen EDAlias case(s) that are consumed explicitly

#### PR validation:

Unit tests in `FWCore/Integration` pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backports #37305, #37563, #37872, #38006.