### PR TITLE
link lost tracks to taus [12_4_X]

### DIFF
--- a/DataFormats/PatCandidates/interface/Tau.h
+++ b/DataFormats/PatCandidates/interface/Tau.h
@@ -256,6 +256,10 @@ namespace pat {
     /// note that the vector is returned by value.
     reco::CandidatePtrVector isolationGammaCands() const;
 
+    /// return the PackedCandidates on miniAOD corresponding with tau "lost" tracks
+    /// note that the vector is returned by value.
+    std::vector<reco::CandidatePtr> signalLostTracks() const;
+
     /// setters for the PtrVectors (for miniAOD)
     void setSignalChargedHadrCands(const reco::CandidatePtrVector& ptrs) { signalChargedHadrCandPtrs_ = ptrs; }
     void setSignalNeutralHadrCands(const reco::CandidatePtrVector& ptrs) { signalNeutralHadrCandPtrs_ = ptrs; }
@@ -263,6 +267,7 @@ namespace pat {
     void setIsolationChargedHadrCands(const reco::CandidatePtrVector& ptrs) { isolationChargedHadrCandPtrs_ = ptrs; }
     void setIsolationNeutralHadrCands(const reco::CandidatePtrVector& ptrs) { isolationNeutralHadrCandPtrs_ = ptrs; }
     void setIsolationGammaCands(const reco::CandidatePtrVector& ptrs) { isolationGammaCandPtrs_ = ptrs; }
+    void setSignalLostTracks(const std::vector<reco::CandidatePtr>& ptrs);
 
     /// ----- Top Projection business -------
     /// get the number of non-null PFCandidates

--- a/DataFormats/PatCandidates/src/Tau.cc
+++ b/DataFormats/PatCandidates/src/Tau.cc
@@ -112,6 +112,15 @@ void Tau::initFromBaseTau(const reco::BaseTau& aTau) {
 
       for (const auto& ptr : pfTau->isolationGammaCands())
         isolationGammaCandPtrs_.push_back(ptr);
+
+      std::vector<reco::CandidatePtr> signalLostTracks;
+      for (const auto& chargedHadron : pfTau->signalTauChargedHadronCandidates()) {
+        if (chargedHadron.algoIs(reco::PFRecoTauChargedHadron::kTrack) &&
+            chargedHadron.getLostTrackCandidate().isNonnull()) {
+          signalLostTracks.push_back(chargedHadron.getLostTrackCandidate());
+        }
+      }
+      this->setSignalLostTracks(signalLostTracks);
     } else {
       pfSpecific_.push_back(pat::tau::TauPFSpecific(*pfTau));
     }

--- a/DataFormats/PatCandidates/src/Tau.cc
+++ b/DataFormats/PatCandidates/src/Tau.cc
@@ -1017,6 +1017,27 @@ reco::CandidatePtrVector Tau::isolationGammaCands() const {
   }
 }
 
+std::vector<reco::CandidatePtr> Tau::signalLostTracks() const {
+  std::vector<reco::CandidatePtr> ret;
+  unsigned int i = 0;
+  std::string label = "_lostTrack_" + std::to_string(i);
+  while (this->hasUserCand(label)) {
+    ret.push_back(userCand(label));
+    i++;
+    label = "_lostTrack_" + std::to_string(i);
+  }
+  return ret;
+}
+
+void Tau::setSignalLostTracks(const std::vector<reco::CandidatePtr>& ptrs) {
+  unsigned int i = 0;
+  for (const auto& ptr : ptrs) {
+    std::string label = "_lostTrack_" + std::to_string(i);
+    addUserCand(label, ptr);
+    i++;
+  }
+}
+
 /// ----- Top Projection business -------
 /// get the number of non-null PFCandidates
 size_t Tau::numberOfSourceCandidatePtrs() const {

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedTaus_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedTaus_cfi.py
@@ -6,8 +6,10 @@ slimmedTaus = cms.EDProducer("PATTauSlimmer",
    dropPiZeroRefs = cms.bool(True),
    dropTauChargedHadronRefs = cms.bool(True),
    dropPFSpecific = cms.bool(True),
-   packedPFCandidates = cms.InputTag("packedPFCandidates"), 
+   packedPFCandidates = cms.InputTag("packedPFCandidates"),
    modifyTaus = cms.bool(True),
-   modifierConfig = cms.PSet( modifications = cms.VPSet() )    
+   modifierConfig = cms.PSet( modifications = cms.VPSet() ),
+   linkToLostTracks = cms.bool(True),
+   lostTracks = cms.InputTag("lostTracks")
 )
 

--- a/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
+++ b/RecoTauTag/Configuration/python/tools/adaptToRunAtMiniAOD.py
@@ -176,6 +176,9 @@ class adaptToRunAtMiniAOD(object):
 			elif mod.name.value() == 'TTIworkaround':
 				_modifiersToRemove.append(mod)
 				continue
+			elif mod.name.value() == 'tau_lost_tracks':
+				_modifiersToRemove.append(mod)
+				continue
 			for name,value in mod.parameters_().items():
 				if name == 'qualityCuts':
 					mod.qualityCuts.primaryVertexSrc = 'offlineSlimmedPrimaryVertices'

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
@@ -313,12 +313,24 @@ double PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef&
 
   if (minPixelHits_ > 0) {
     int numPixelHits = 0;
+    const int nProngs = tau->decayMode() / 5 + 1;  //no. of charged prongs expected for this tau
+    int nTracks = 0;
     for (const auto& chargedHadrCand : tau->signalChargedHadrCands()) {
       const reco::Track* track = getTrack(*chargedHadrCand);
       if (track != nullptr) {
         numPixelHits += track->hitPattern().numberOfValidPixelHits();
+        nTracks++;
       }
     }
+    if (nTracks < nProngs) {  //"lost track" probably used to build this tau
+      for (const auto& track : tau->signalTracks()) {
+        if (track.isNonnull()) {
+          numPixelHits += track->hitPattern().numberOfValidPixelHits();
+          nTracks++;
+        }
+      }
+    }
+    //FIXME: how to deal with @miniAOD case?
     if (!(numPixelHits >= minPixelHits_)) {
       if (verbosity_) {
         edm::LogPrint("PFTauByHPSSelect") << " fails cut on sum of pixel hits.";

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByHPSSelection.cc
@@ -322,6 +322,7 @@ double PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef&
         nTracks++;
       }
     }
+    //MB: how to deal with tau@miniAOD case?
     if (nTracks < nProngs) {  //"lost track" probably used to build this tau
       for (const auto& track : tau->signalTracks()) {
         if (track.isNonnull()) {
@@ -330,7 +331,6 @@ double PFRecoTauDiscriminationByHPSSelection::discriminate(const reco::PFTauRef&
         }
       }
     }
-    //FIXME: how to deal with @miniAOD case?
     if (!(numPixelHits >= minPixelHits_)) {
       if (verbosity_) {
         edm::LogPrint("PFTauByHPSSelect") << " fails cut on sum of pixel hits.";

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauLostTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauLostTrackPlugin.cc
@@ -49,8 +49,9 @@ namespace reco {
     void PFRecoTauLostTrackPlugin::operator()(PFTau& tau) const {
       if (!tracks_.isValid()) {  //track collection not available in the event
         if (verbosity_) {
-          std::cout << "<PFRecoTauLostTrackPlugin::operator()>:" << std::endl;
-          std::cout << "Track collection " << tracks_.provenance() << " is not valid" << std::endl;
+          edm::LogPrint("<PFRecoTauLostTrackPlugin::operator()>:")
+              << " Track collection " << tracks_.provenance() << " is not valid."
+              << " No tracks will be added to tau.";
         }
         return;
       }
@@ -63,10 +64,10 @@ namespace reco {
         }
       }
       if (verbosity_) {
-        std::cout << "<PFRecoTauLostTrackPlugin::operator()>:" << std::endl;
-        std::cout << "tau: Pt = " << tau.pt() << ", eta = " << tau.eta() << ", phi = " << tau.phi()
-                  << ", mass = " << tau.mass() << " (decayMode = " << tau.decayMode() << ")"
-                  << ", nChHadrs = " << chargedHadrons.size() << ", nLostTracks = " << lostTracks.size() << std::endl;
+        edm::LogPrint("<PFRecoTauLostTrackPlugin::operator()>:")
+            << " tau: Pt = " << tau.pt() << ", eta = " << tau.eta() << ", phi = " << tau.phi()
+            << ", mass = " << tau.mass() << " (decayMode = " << tau.decayMode() << ")"
+            << ", nChHadrs = " << chargedHadrons.size() << ", nLostTracks = " << lostTracks.size();
       }
       if (!lostTracks.empty())
         tau.setsignalTracks(lostTracks);

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauLostTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauLostTrackPlugin.cc
@@ -25,24 +25,21 @@ namespace reco {
     class PFRecoTauLostTrackPlugin : public RecoTauModifierPlugin {
     public:
       explicit PFRecoTauLostTrackPlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
-      ~PFRecoTauLostTrackPlugin() override;
+      ~PFRecoTauLostTrackPlugin() override = default;
       void operator()(PFTau&) const override;
       void beginEvent() override;
       void endEvent() override;
 
     private:
       edm::Handle<reco::TrackCollection> tracks_;
-      edm::EDGetTokenT<reco::TrackCollection> track_token_;
-      int verbosity_;
+      const edm::EDGetTokenT<reco::TrackCollection> track_token_;
+      const int verbosity_;
     };
 
     PFRecoTauLostTrackPlugin::PFRecoTauLostTrackPlugin(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
-        : RecoTauModifierPlugin(cfg, std::move(iC)) {
-      track_token_ = iC.consumes(cfg.getParameter<edm::InputTag>("trackSrc"));
-      verbosity_ = cfg.getParameter<int>("verbosity");
-    }
-
-    PFRecoTauLostTrackPlugin::~PFRecoTauLostTrackPlugin() {}
+        : RecoTauModifierPlugin(cfg, std::move(iC)),
+          track_token_(iC.consumes(cfg.getParameter<edm::InputTag>("trackSrc"))),
+          verbosity_(cfg.getParameter<int>("verbosity")) {}
 
     void PFRecoTauLostTrackPlugin::beginEvent() { evt()->getByToken(track_token_, tracks_); }
 
@@ -56,7 +53,7 @@ namespace reco {
         return;
       }
       reco::TrackRefVector lostTracks;
-      const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau.signalTauChargedHadronCandidates();
+      const PFRecoTauChargedHadronCollection& chargedHadrons = tau.signalTauChargedHadronCandidates();
       for (const auto& chargedHadron : chargedHadrons) {
         if (chargedHadron.algoIs(PFRecoTauChargedHadron::kTrack) && chargedHadron.getTrack().isNonnull()) {
           reco::TrackRef trackRef(tracks_, chargedHadron.getTrack().key());

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauLostTrackPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauLostTrackPlugin.cc
@@ -1,0 +1,82 @@
+/*
+ * =============================================================================
+ *       Filename:  PFRecoTauLostTrackPlugin.cc
+ *
+ *    Description: Add references to tracks of tau-charged-hadrons built on 
+ *                 top of a track
+ *
+ *        Created:  25/04/2022
+ *
+ *         Authors:  Michal Bluj (NCBJ, Warsaw)
+ *
+ * =============================================================================
+ */
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "RecoTauTag/RecoTau/interface/RecoTauBuilderPlugins.h"
+#include "DataFormats/TauReco/interface/PFTau.h"
+#include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
+#include "DataFormats/TauReco/interface/PFRecoTauChargedHadronFwd.h"
+
+namespace reco {
+  namespace tau {
+
+    class PFRecoTauLostTrackPlugin : public RecoTauModifierPlugin {
+    public:
+      explicit PFRecoTauLostTrackPlugin(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
+      ~PFRecoTauLostTrackPlugin() override;
+      void operator()(PFTau&) const override;
+      void beginEvent() override;
+      void endEvent() override;
+
+    private:
+      edm::Handle<reco::TrackCollection> tracks_;
+      edm::EDGetTokenT<reco::TrackCollection> track_token_;
+      int verbosity_;
+    };
+
+    PFRecoTauLostTrackPlugin::PFRecoTauLostTrackPlugin(const edm::ParameterSet& cfg, edm::ConsumesCollector&& iC)
+        : RecoTauModifierPlugin(cfg, std::move(iC)) {
+      track_token_ = iC.consumes(cfg.getParameter<edm::InputTag>("trackSrc"));
+      verbosity_ = cfg.getParameter<int>("verbosity");
+    }
+
+    PFRecoTauLostTrackPlugin::~PFRecoTauLostTrackPlugin() {}
+
+    void PFRecoTauLostTrackPlugin::beginEvent() { evt()->getByToken(track_token_, tracks_); }
+
+    void PFRecoTauLostTrackPlugin::operator()(PFTau& tau) const {
+      if (!tracks_.isValid()) {  //track collection not available in the event
+        if (verbosity_) {
+          std::cout << "<PFRecoTauLostTrackPlugin::operator()>:" << std::endl;
+          std::cout << "Track collection " << tracks_.provenance() << " is not valid" << std::endl;
+        }
+        return;
+      }
+      reco::TrackRefVector lostTracks;
+      const std::vector<PFRecoTauChargedHadron>& chargedHadrons = tau.signalTauChargedHadronCandidates();
+      for (const auto& chargedHadron : chargedHadrons) {
+        if (chargedHadron.algoIs(PFRecoTauChargedHadron::kTrack) && chargedHadron.getTrack().isNonnull()) {
+          reco::TrackRef trackRef(tracks_, chargedHadron.getTrack().key());
+          lostTracks.push_back(trackRef);
+        }
+      }
+      if (verbosity_) {
+        std::cout << "<PFRecoTauLostTrackPlugin::operator()>:" << std::endl;
+        std::cout << "tau: Pt = " << tau.pt() << ", eta = " << tau.eta() << ", phi = " << tau.phi()
+                  << ", mass = " << tau.mass() << " (decayMode = " << tau.decayMode() << ")"
+                  << ", nChHadrs = " << chargedHadrons.size() << ", nLostTracks = " << lostTracks.size() << std::endl;
+      }
+      if (!lostTracks.empty())
+        tau.setsignalTracks(lostTracks);
+    }
+
+    void PFRecoTauLostTrackPlugin::endEvent() {}
+
+  }  // namespace tau
+}  // namespace reco
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_EDM_PLUGIN(RecoTauModifierPluginFactory, reco::tau::PFRecoTauLostTrackPlugin, "PFRecoTauLostTrackPlugin");

--- a/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauProducer.cc
@@ -266,6 +266,7 @@ void RecoTauProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
     vpsd_modifiers.addOptional<double>("dRaddPhoton");
     vpsd_modifiers.addOptional<double>("minNeutralHadronEt");
     vpsd_modifiers.addOptional<edm::InputTag>("pfTauTagInfoSrc");
+    vpsd_modifiers.addOptional<edm::InputTag>("trackSrc");
 
     desc.addVPSet("modifiers", vpsd_modifiers);
   }

--- a/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
@@ -99,11 +99,19 @@ combinatoricModifierConfigs = [
     ),
     # Tau energy reconstruction
     # (to avoid double-counting of energy carried by neutral PFCandidates
-    #  in case PFRecoTauChargedHadrons are built from reco::Tracks)                                          
+    #  in case PFRecoTauChargedHadrons are built from reco::Tracks)
     cms.PSet(
         pfTauEnergyAlgorithmPlugin,
         name = cms.string("tau_en_reconstruction"),
         plugin = cms.string("PFRecoTauEnergyAlgorithmPlugin"),
+    ),
+    # Add refs to "lost tracks", i.e. tracks associated to
+    # PFRecoTauChargedHadrons built from reco::Tracks
+    cms.PSet(
+        name = cms.string("tau_lost_tracks"),
+        trackSrc = cms.InputTag("generalTracks"),
+        plugin = cms.string("PFRecoTauLostTrackPlugin"),
+        verbosity = cms.int32(0)
     )
 ]
 


### PR DESCRIPTION
#### PR description:

**This PR is a clone of  #37918**, i.e. it is created with the same development branch. Full description of the original PR is repeated below for convenience.

This PR adds links between taus and tracks used to build their charged hadron candidates, but not contained by PF-particles. The links are added at both RECO/AOD and MiniAOD levels.

At RECO/AOD level the link is created by a dedicated "modifier" plugin which adds to a tau object edm::Ptrs to members of (general)track collection, while at miniAOD level it is done via modified PATTauSlimmer module which stores in tau object edm::Ptrs to members of lostTracks collection. In both cases already existing data members of respectively reco::BaseTau and pat::Tau objects are reused. Linking at RECO/AOD is needed to produce link at miniAOD.

Expected changes: small number of taus (<1%) will contain up to 2 additional edm::Ptrs. Other tau features will stay unchanged.

#### PR validation:

Standard tests, i.e. `runTheMatrix.py -l limited -i all --ibeos`, passed successfully.

Results of other tests like increase of size/CPU/memory usage provided within the original PR. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #37918.

Needed as thanks to it miniAOD user has access to all charged prongs of reconstructed taus.

