### PR TITLE
A little code cleanup in DataFormats/Provenance

### DIFF
--- a/DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h
+++ b/DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h
@@ -23,11 +23,6 @@ namespace edm {
                              Timestamp const& theTime,
                              Timestamp const& theEndTime)
         : processHistoryID_(), id_(theRun, theLumi), beginTime_(theTime), endTime_(theEndTime) {}
-    LuminosityBlockAuxiliary(LuminosityBlockAuxiliary&&) = default;
-    LuminosityBlockAuxiliary(LuminosityBlockAuxiliary const&) = default;
-    ~LuminosityBlockAuxiliary() {}
-    LuminosityBlockAuxiliary& operator=(LuminosityBlockAuxiliary&&) = default;
-    LuminosityBlockAuxiliary& operator=(LuminosityBlockAuxiliary const&) = default;
     void write(std::ostream& os) const;
     ProcessHistoryID const& processHistoryID() const { return processHistoryID_; }
     void setProcessHistoryID(ProcessHistoryID const& phid) { processHistoryID_ = phid; }
@@ -56,7 +51,7 @@ namespace edm {
     // In cases where LuminosityBlock's are merged, the ID of the first process history encountered
     // is stored here.
     ProcessHistoryID processHistoryID_;
-    // LuminosityBlock ID
+
     LuminosityBlockID id_;
     // Times from DAQ
     Timestamp beginTime_;

--- a/DataFormats/Provenance/interface/LuminosityBlockID.h
+++ b/DataFormats/Provenance/interface/LuminosityBlockID.h
@@ -9,23 +9,15 @@
 
  Description: Holds run and luminosityBlock number.
 
- Usage:
-    <usage>
-
 */
-//
-//
 
-// system include files
 #include <functional>
 #include <iosfwd>
 
-// user include files
 #include "DataFormats/Provenance/interface/RunID.h"
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include <cstdint>
 
-// forward declarations
 namespace edm {
 
   class LuminosityBlockID {
@@ -34,8 +26,6 @@ namespace edm {
     explicit LuminosityBlockID(uint64_t id);
     LuminosityBlockID(RunNumber_t iRun, LuminosityBlockNumber_t iLuminosityBlock)
         : run_(iRun), luminosityBlock_(iLuminosityBlock) {}
-
-    //virtual ~LuminosityBlockID();
 
     // ---------- const member functions ---------------------
     RunNumber_t run() const { return run_; }
@@ -84,7 +74,6 @@ namespace edm {
     static LuminosityBlockNumber_t maxLuminosityBlockNumber() { return 0xFFFFFFFFU; }
 
     static LuminosityBlockID firstValidLuminosityBlock() { return LuminosityBlockID(1, 1); }
-    // ---------- member functions ---------------------------
 
   private:
     template <template <typename> class Op>
@@ -97,9 +86,6 @@ namespace edm {
       Op<RunNumber_t> op;
       return op(run_, iRHS.run_);
     }
-    //LuminosityBlockID(LuminosityBlockID const&); // stop default
-
-    //LuminosityBlockID const& operator=(LuminosityBlockID const&); // stop default
 
     // ---------- member data --------------------------------
     RunNumber_t run_;

--- a/DataFormats/Provenance/interface/RunAuxiliary.h
+++ b/DataFormats/Provenance/interface/RunAuxiliary.h
@@ -20,7 +20,6 @@ namespace edm {
         : processHistoryID_(), id_(theId), beginTime_(theTime), endTime_(theEndTime) {}
     RunAuxiliary(RunNumber_t const& run, Timestamp const& theTime, Timestamp const& theEndTime)
         : processHistoryID_(), id_(run), beginTime_(theTime), endTime_(theEndTime) {}
-    ~RunAuxiliary() {}
     void write(std::ostream& os) const;
     ProcessHistoryID const& processHistoryID() const { return processHistoryID_; }
     void setProcessHistoryID(ProcessHistoryID const& phid) { processHistoryID_ = phid; }
@@ -45,7 +44,6 @@ namespace edm {
     // is stored here.
     ProcessHistoryID processHistoryID_;
 
-    // Run ID
     RunID id_;
     // Times from DAQ
     Timestamp beginTime_;

--- a/DataFormats/Provenance/interface/RunID.h
+++ b/DataFormats/Provenance/interface/RunID.h
@@ -9,28 +9,18 @@
 
  Description: Holds run number
 
- Usage:
-    <usage>
-
 */
-//
-//
 
-// system include files
 #include <iosfwd>
 
-// user include files
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 
-// forward declarations
 namespace edm {
 
   class RunID {
   public:
     RunID() : run_(invalidRunNumber) {}
     explicit RunID(RunNumber_t iRun) : run_(iRun) {}
-
-    //virtual ~RunID();
 
     // ---------- const member functions ---------------------
     RunNumber_t run() const { return run_; }
@@ -56,13 +46,8 @@ namespace edm {
     static RunNumber_t maxRunNumber() { return 0xFFFFFFFFU; }
 
     static RunID firstValidRun() { return RunID(1); }
-    // ---------- member functions ---------------------------
 
   private:
-    //RunID(RunID const&); // stop default
-
-    //RunID const& operator=(RunID const&); // stop default
-
     // ---------- member data --------------------------------
     RunNumber_t run_;
   };

--- a/DataFormats/Provenance/interface/Timestamp.h
+++ b/DataFormats/Provenance/interface/Timestamp.h
@@ -9,21 +9,14 @@
 
  Description: Defines an instance in time from the Online system
 
- Usage:
-    <usage>
-
 */
 //
 // Author:      Chris Jones
 // Created:     Thu Mar 24 16:23:05 EST 2005
 //
 
-// system include files
 #include <limits>
 
-// user include files
-
-// forward declarations
 namespace edm {
   typedef unsigned long long TimeValue_t;
 
@@ -83,13 +76,7 @@ namespace edm {
     static Timestamp endOfTime() { return Timestamp(std::numeric_limits<TimeValue_t>::max()); }
     static Timestamp beginOfTime() { return Timestamp(1); }
 
-    // ---------- member functions ---------------------------
-
   private:
-    //Timestamp(Timestamp const&); // allow default
-
-    //Timestamp const& operator=(Timestamp const&); // allow default
-
     // ---------- member data --------------------------------
     // ROOT does not support ULL
     //TimeValue_t time_;


### PR DESCRIPTION
#### PR description:

Delete some unneeded lines of code, mostly comments and a few functions the compiler generates automatically.

(I was motivated to do this because I needed to read these files as I was working on the concurrent run PR and couldn't resist the urge to clean this a little. It makes it easier to read. Originally, the changes were in that PR, but I realized they had nothing to do with concurrent runs so I separated the changes.) 

#### PR validation:

This shouldn't affect anything. Existing tests pass.
