### PR TITLE
Run3-sim118CX Use of token instead of label in accessing collection in SimCalorimetry/EcalTestBeamAlgos

### DIFF
--- a/SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h
+++ b/SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h
@@ -15,11 +15,12 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 
 class EcalTBReadout {
 public:
-  EcalTBReadout(const std::string theEcalTBInfoLabel);
-  ~EcalTBReadout(){};
+  EcalTBReadout(const edm::EDGetTokenT<PEcalTBInfo> &token);
+  ~EcalTBReadout() = default;
 
   /// tell the readout which cells exist
   void setDetIds(const std::vector<DetId> &detIds) { theDetIds = &detIds; }
@@ -46,6 +47,8 @@ public:
                       EEDigiCollection &output);
 
 private:
+  const edm::EDGetTokenT<PEcalTBInfo> ecalTBInfoToken_;
+
   int theTargetCrystal_;
 
   std::vector<EcalTrigTowerDetId> theTTlist_;
@@ -53,8 +56,6 @@ private:
   static const int NCRYMATRIX = 7;
 
   const std::vector<DetId> *theDetIds;
-
-  std::string ecalTBInfoLabel_;
 };
 
 #endif

--- a/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
+++ b/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
@@ -4,9 +4,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h"
-#include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 
-EcalTBReadout::EcalTBReadout(const std::string theEcalTBInfoLabel) : ecalTBInfoLabel_(theEcalTBInfoLabel) {
+EcalTBReadout::EcalTBReadout(const edm::EDGetTokenT<PEcalTBInfo> &token) : ecalTBInfoToken_(token) {
   theTargetCrystal_ = -1;
   theTTlist_.reserve(1);
 }
@@ -154,8 +153,7 @@ void EcalTBReadout::performReadout(edm::Event &event,
   // TB readout
   // step 1: get the target crystal index
 
-  edm::Handle<PEcalTBInfo> theEcalTBInfo;
-  event.getByLabel(ecalTBInfoLabel_, theEcalTBInfo);
+  const edm::Handle<PEcalTBInfo> &theEcalTBInfo = event.getHandle(ecalTBInfoToken_);
 
   int crysId = theEcalTBInfo->nCrystal();
 
@@ -175,8 +173,7 @@ void EcalTBReadout::performReadout(edm::Event &event,
   // TB readout
   // step 1: get the target crystal index
 
-  edm::Handle<PEcalTBInfo> theEcalTBInfo;
-  event.getByLabel(ecalTBInfoLabel_, theEcalTBInfo);
+  const edm::Handle<PEcalTBInfo> &theEcalTBInfo = event.getHandle(ecalTBInfoToken_);
 
   int crysId = theEcalTBInfo->nCrystal();
 


### PR DESCRIPTION
#### PR description:

Use of token instead of label in accessing collection in SimCalorimetry/EcalTestBeamAlgos

#### PR validation:

Use the runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special