### PR TITLE
Adding sum of PS weights to NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -1119,6 +1119,13 @@ public:
                              "Sum of genEventWeight * LHEPdfWeight[i], divided by genEventSumw" + doclabel,
                              sumPDFs,
                              runCounter->sumw);
+      auto sumPS = runCounter->sumPS;
+      for (auto& val : sumPS)
+        val *= norm;
+      out->addVFloatWithNorm("PSSumw" + label,
+                             "Sum of genEventWeight * PSWeight[i], divided by genEventSumw" + doclabel,
+                             sumPS,
+                             runCounter->sumw);
       if (!runCounter->sumRwgt.empty()) {
         auto sumRwgts = runCounter->sumRwgt;
         for (auto& val : sumRwgts)


### PR DESCRIPTION
#### PR description:

Seems like the sum of the PS weights was missing from the nanoAODs. This PR adds two branches to the "Run" tree, containing the missing information. The format is identical to that of other weights (e.g. scale, PDFs)

#### PR validation:

Run on MiniAOD sample: TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

It is not a backport, but I am not sure to which branch I should make the PR. This is the CMSSW version that I am currently using in my analysis (one version after the one used to produce NanoAODv9). Ideally, this should be fixed for all future versions of NanoAODs.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
