### PR TITLE
adding sum of PS weights

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -1108,6 +1108,13 @@ public:
                              "Sum of genEventWeight * LHEPdfWeight[i], divided by genEventSumw" + doclabel,
                              sumPDFs,
                              runCounter->sumw);
+      auto sumPS = runCounter->sumPS;
+      for (auto& val : sumPS)
+        val *= norm;
+      out->addVFloatWithNorm("PSSumw" + label,
+                             "Sum of genEventWeight * PSWeight[i], divided by genEventSumw" + doclabel,
+                             sumPS,
+                             runCounter->sumw);
       if (!runCounter->sumRwgt.empty()) {
         auto sumRwgts = runCounter->sumRwgt;
         for (auto& val : sumRwgts)


### PR DESCRIPTION
#### PR description:

Seems like the sum of the PS weights was missing from the nanoAODs. This PR adds two branches to the "Run" tree, containing the missing information. The format is identical to that of other weights (e.g. scale, PDFs)

#### PR validation:

Run on MiniAOD sample TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8 using CMSSW_10_6_27 (one version after the one used to produce NanoAODv9)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport

