### PR TITLE
[12_3_X] Fix in QCD b/c->electron filter

### DIFF
--- a/Configuration/Generator/python/QCD_Pt_30_80_BCtoE_8TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCD_Pt_30_80_BCtoE_8TeV_TuneCUETP8M1_cfi.py
@@ -32,7 +32,8 @@ genParticlesForFilter = cms.EDProducer("GenParticleProducer",
                                        )
 
 bctoefilter = cms.EDFilter("BCToEFilter",
-                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(1),
+                           filterAlgoPSet = cms.PSet(maxAbsEta = cms.double(2.5), 
+                                                     eTThreshold = cms.double(1),
                                                      genParSource = cms.InputTag("genParticlesForFilter")
                                                      )
                            )

--- a/Configuration/Generator/python/QCD_Pt_80_170_BCtoE_8TeV_TuneCUETP8M1_cfi.py
+++ b/Configuration/Generator/python/QCD_Pt_80_170_BCtoE_8TeV_TuneCUETP8M1_cfi.py
@@ -32,7 +32,8 @@ genParticlesForFilter = cms.EDProducer("GenParticleProducer",
                                        )
 
 bctoefilter = cms.EDFilter("BCToEFilter",
-                           filterAlgoPSet = cms.PSet(eTThreshold = cms.double(1),
+                           filterAlgoPSet = cms.PSet(maxAbsEta = cms.double(2.5),
+                                                     eTThreshold = cms.double(1),
                                                      genParSource = cms.InputTag("genParticlesForFilter")
                                                      )
                            )

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
@@ -27,8 +27,7 @@ bool BCToEFilterAlgo::filter(const edm::Event& iEvent) const {
 
   for (uint32_t ig = 0; ig < genPars.size(); ig++) {
     reco::GenParticle gp = genPars.at(ig);
-    if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ &&
-        std::fabs(gp.eta()) < maxAbsEta_) {
+    if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ && std::fabs(gp.eta()) < maxAbsEta_) {
       if (hasBCAncestors(gp)) {
         result = true;
       }

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.cc
@@ -10,7 +10,7 @@
 
 BCToEFilterAlgo::BCToEFilterAlgo(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
     :  //set constants
-      FILTER_ETA_MAX_(2.5),
+      maxAbsEta_((float)iConfig.getParameter<double>("maxAbsEta")),
       eTThreshold_((float)iConfig.getParameter<double>("eTThreshold")),
       genParSource_(iC.consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParSource"))) {}
 
@@ -28,7 +28,7 @@ bool BCToEFilterAlgo::filter(const edm::Event& iEvent) const {
   for (uint32_t ig = 0; ig < genPars.size(); ig++) {
     reco::GenParticle gp = genPars.at(ig);
     if (gp.status() == 1 && std::abs(gp.pdgId()) == 11 && gp.et() > eTThreshold_ &&
-        std::fabs(gp.eta()) < FILTER_ETA_MAX_) {
+        std::fabs(gp.eta()) < maxAbsEta_) {
       if (hasBCAncestors(gp)) {
         result = true;
       }

--- a/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.h
+++ b/GeneratorInterface/GenFilters/plugins/BCToEFilterAlgo.h
@@ -30,9 +30,8 @@ private:
   bool isBCMeson(const reco::GenParticle& gp) const;
   bool isBCBaryon(const reco::GenParticle& gp) const;
 
-  //constants:
-  const float FILTER_ETA_MAX_;
   //filter parameters:
+  const float maxAbsEta_;
   const float eTThreshold_;
   const edm::EDGetTokenT<reco::GenParticleCollection> genParSource_;
 };

--- a/GeneratorInterface/GenFilters/python/BCToEFilter_cfi.py
+++ b/GeneratorInterface/GenFilters/python/BCToEFilter_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 bctoefilter = cms.EDFilter("BCToEFilter",
     filterAlgoPSet = cms.PSet(
+        maxAbsEta = cms.double(3.05),
         eTThreshold = cms.double(10.0)
     )
 )


### PR DESCRIPTION
This PR is a backport. 
PR for master/12_4_X: https://github.com/cms-sw/cmssw/pull/37869 (one can read detailed PR description from there). 
backport PR for 12_2_X: https://github.com/cms-sw/cmssw/pull/37931

Since the change is integrated to 12_4 onwards and in 12_2, it was suggested in yesterday's ORP meeting to propagate it to 12_3 as well, for code consistency. 

Later, I found out that this backport might be useful also for Phase2 MC production (planned in 12_3_X) for TSG studies. E/gamma had asked for QCD b/c->E samples for upcoming Phase2 production. Without this fix, the electrons in those samples will be usable (meaningfully) only up to |eta|<2.5, which is not catastrophic, but if we can produce the MC samples with this fix in, then it would be better, because in that case electrons all the way up to |eta|=3 will be usable for the timing studies (MTD/HGCAL etc) that e/gamma plans to do.  

So, once this PR is merged, if possible kindly make a new 12_3_X release and we request to produce the samples using that new release. Again, if this is not possible for some reason, it's not a big problem for us. We can just restrict our phase2 timing studies to |eta|<2.5 range. 