### PR TITLE
Fix behavior of SwitchProducer in ConditionalTask with non-chosen EDAlias case(s) that are consumed explicitly with callWhenNewProductsRegistered()

### DIFF
--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -599,19 +599,18 @@ namespace edm {
           }
         }
       }
-      //find SwitchProducers whose chosen case is an alias
+      //find SwitchProducers whose cases are aliases
       {
         auto const& all_modules = proc_pset.getParameter<std::vector<std::string>>("@all_modules");
         std::vector<std::string> switchEDAliases;
         for (auto const& module : all_modules) {
           auto const& mod_pset = proc_pset.getParameter<edm::ParameterSet>(module);
           if (mod_pset.getParameter<std::string>("@module_type") == "SwitchProducer") {
-            auto const& chosen_case = mod_pset.getUntrackedParameter<std::string>("@chosen_case");
-            auto range = aliasMap.equal_range(chosen_case);
-            if (range.first != range.second) {
-              switchEDAliases.push_back(chosen_case);
-              for (auto it = range.first; it != range.second; ++it) {
-                aliasMap.emplace(module, it->second);
+            auto const& all_cases = mod_pset.getParameter<std::vector<std::string>>("@all_cases");
+            for (auto const& case_label : all_cases) {
+              auto range = aliasMap.equal_range(case_label);
+              if (range.first != range.second) {
+                switchEDAliases.push_back(case_label);
               }
             }
           }

--- a/FWCore/Integration/test/run_TestSwitchProducer.sh
+++ b/FWCore/Integration/test/run_TestSwitchProducer.sh
@@ -71,6 +71,14 @@ pushd ${LOCAL_TMP_DIR}
   echo "SwitchProducer in a ConditionalTask, more extensive EDAlias tests, case test2 disabled"
   cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAlias_cfg.py disableTest2 || die "cmsRun ${test}ConditionalTaskEDAlias_cfg.py 2" $?
 
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, test EDAlias with all cases being explicitly consumed"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAliasConsumeAllCases_cfg.py || die "cmsRun ${test}ConditionalTaskEDAliasConsumeAllCases_cfg.py 1" $?
+
+  echo "*************************************************"
+  echo "SwitchProducer in a ConditionalTask, test EDAlias with all cases being explicitly consumed, case test2 disabled"
+  cmsRun -n ${NUMTHREADS} ${LOCAL_TEST_DIR}/${test}ConditionalTaskEDAliasConsumeAllCases_cfg.py disableTest2 || die "cmsRun ${test}ConditionalTaskEDAliasConsumeAllCases_cfg.py 2" $?
+
   
   echo "*************************************************"
   echo "SwitchProducer in a Path"

--- a/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAliasConsumeAllCases_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAliasConsumeAllCases_cfg.py
@@ -1,0 +1,69 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+enableTest2 = (sys.argv[-1] != "disableTest2")
+class SwitchProducerTest(cms.SwitchProducer):
+    def __init__(self, **kargs):
+        super(SwitchProducerTest,self).__init__(
+            dict(
+                test1 = lambda accelerators: (True, -10),
+                test2 = lambda accelerators: (enableTest2, -9)
+            ), **kargs)
+
+process = cms.Process("PROD1")
+
+process.source = cms.Source("EmptySource")
+if enableTest2:
+    process.source.firstLuminosityBlock = cms.untracked.uint32(2)
+
+process.maxEvents.input = 3
+
+process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
+process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
+if enableTest2:
+    process.intProducer1.throw = cms.untracked.bool(True)
+else:
+    process.intProducer2.throw = cms.untracked.bool(True)
+
+process.intProducerAlias = SwitchProducerTest(
+    test1 = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer1")),
+    test2 = cms.EDAlias(intProducer2 = cms.VPSet(cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string(""), toProductInstance = cms.string("")),
+                                                 cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
+)
+process.intProducerAliasConsumer = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducerAlias"))
+
+# Test that direct dependence on SwitchProducer case-EDAlias within
+# the same ConditionalTask does not cause the aliased-for EDProducer
+# (in the same ConditionalTask) to become unscheduled, also when the
+# consumption is registered within callWhenNewProductsRegistered().
+# Note that neither case of intProducerAlias gets run by the Paths in
+# this test.
+process.rejectingFilter = cms.EDFilter("TestFilterModule",
+    acceptValue = cms.untracked.int32(-1)
+)
+process.allCaseGenericConsumer = cms.EDAnalyzer("GenericConsumer", eventProducts = cms.untracked.vstring(
+    "intProducerAlias@test1",
+    "intProducerAlias@test2"
+))
+process.test1Consumer = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer", srcEvent = cms.untracked.VInputTag("intProducerAlias@test1"))
+process.test2Consumer = cms.EDAnalyzer("edmtest::GenericIntsAnalyzer", srcEvent = cms.untracked.VInputTag("intProducerAlias@test2"))
+if enableTest2:
+    process.test1Consumer.inputShouldBeMissing = cms.untracked.bool(True)
+    process.test2Consumer.inputShouldExist = cms.untracked.bool(True)
+else:
+    process.test1Consumer.inputShouldExist = cms.untracked.bool(True)
+    process.test2Consumer.inputShouldBeMissing = cms.untracked.bool(True)
+
+process.ct = cms.ConditionalTask(process.intProducerAlias, process.intProducer1, process.intProducer2)
+
+# This path causes the chosen case of intProducerAlias to run
+process.p1 = cms.Path(process.intProducerAliasConsumer, process.ct)
+
+# This path makes the ConditionalTask system to think that all cases
+# of intProducerAlias would be run, but they are not run as part of
+# this Path because their consumer is behind an EDFilter that rejects
+# all events
+process.p2 = cms.Path(process.rejectingFilter + process.allCaseGenericConsumer, process.ct)
+
+# This path tests that only the chosen case of intProducerAlias was run
+process.p3 = cms.Path(process.test1Consumer + process.test2Consumer)

--- a/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
+++ b/FWCore/Integration/test/testSwitchProducerConditionalTaskEDAlias_cfg.py
@@ -27,6 +27,7 @@ process.out = cms.OutputModule("PoolOutputModule",
     )
 )
 
+# Test that an alias case works
 process.intProducer1 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(1))
 process.intProducer2 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(2), values = cms.VPSet(cms.PSet(instance=cms.string("foo"),value=cms.int32(2))))
 process.intProducer3 = cms.EDProducer("ManyIntProducer", ivalue = cms.int32(3))
@@ -45,6 +46,9 @@ process.intProducerAlias = SwitchProducerTest(
                                                  cms.PSet(type = cms.string("edmtestIntProduct"), fromProductInstance = cms.string("foo"), toProductInstance = cms.string("other"))))
 )
 
+# Test
+# - SwitchProducer depending on other SwitchProducer
+# - EDAlias in SwitchProducer uses aliases for two different modules with different instance names
 process.intProducerDep = cms.EDProducer("AddIntsProducer", labels = cms.VInputTag("intProducer2"))
 if not enableTest2:
     process.intProducerDep.labels = ["intProducer1"]
@@ -65,3 +69,5 @@ process.p = cms.Path(process.intProducerAlias+process.intProducerDep +
 
 process.ct2 = cms.ConditionalTask(process.intProducerAlias, process.intProducerDep, process.intProducerDepAlias, process.ct)
 process.p2 = cms.Path(process.intProducerDepAliasDep, process.ct2)
+
+process.ep = cms.EndPath(process.out)


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/issues/36938#issuecomment-1128887595 demonstrated a case where a `SwitchProducer` was in a `ConditionalTask`, and `SwitchProducer`'s non-chosen `EDAlias` case was consumed explicitly by a module with `callWhenNewProductsRegistered()` in the same `ConditionalTask`/`Path`, and the alias-for EDModule was left unscheduled. This PR makes the code to process all `EDAlias` cases of the `SwitchProducer`, so that the `callWhenNewProductsRegistered()` that consume any of the EDAlias cases gets called early enough for the consumes information check in the `ConditionalTask` logic to work properly.

#### PR validation:

Unit tests in `FWCore/Integration` succeed. The test case https://github.com/cms-sw/cmssw/issues/36938#issuecomment-1128887595 works now as expected.