### PR TITLE
Remove L1Reco from Phase2 workflow

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -3643,7 +3643,7 @@ for year,k in [(year,k) for year in upgradeKeys for k in upgradeKeys[year]]:
                                       '--geometry' : geom
                                       }
 
-    upgradeStepDict['RecoGlobal'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM',
+    upgradeStepDict['RecoGlobal'][k] = {'-s':'RAW2DIGI,RECO,RECOSIM,PAT,VALIDATION:@phase2Validation+@miniAODValidation,DQM:@phase2+@miniAODDQM',
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-RECO,MINIAODSIM,DQMIO',
                                       '-n':'10',


### PR DESCRIPTION
#### PR description:
As discussed in https://github.com/cms-sw/cmssw/issues/33012, the L1Reco step is obsolete for Phase-2. It is an unclear point if we should rerun `L1TrackTrigger,L1` again in `RECO` or not. This is to be clarified.

#### PR validation:
None

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
No need of backport.
