### PR TITLE
[12_3_X] Use RAWEventContent parameter set for Repack output module

### DIFF
--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -7,6 +7,7 @@ Module that generates standard repack configurations
 """
 
 import FWCore.ParameterSet.Config as cms
+from Configuration.EventContent.EventContent_cff import RAWEventContent
 
 
 def repackProcess(**args):
@@ -54,6 +55,7 @@ def repackProcess(**args):
 
         outputModule = cms.OutputModule(
             "PoolOutputModule",
+            RAWEventContent,
             fileName = cms.untracked.string("%s.root" % moduleLabel)
             )
 


### PR DESCRIPTION
#### PR description:
Changes repack to use the defined [RAWEventContent](https://github.com/germanfgv/cmssw/blob/417d4ed121ff0a963bc4a29ef8423b3efbfe2fe6/Configuration/EventContent/python/EventContent_cff.py#L169-L178) output module configuration.

#### PR validation:
None beyond the tests in  #37791 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport of #37791. Needed to use the right compression algorithm during 900 GeV collisions.