### PR TITLE
Lock more methods of JobReport [12_1]

### DIFF
--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -376,13 +376,11 @@ namespace edm {
   void JobReport::inputFileClosed(InputType inputType, JobReport::Token fileToken) {
     JobReport::InputFile& f = impl_->getInputFileForToken(inputType, fileToken);
     f.fileHasBeenClosed = true;
+    std::lock_guard<std::mutex> lock(write_mutex);
     if (inputType == InputType::Primary) {
       impl_->writeInputFile(f);
     } else {
-      {
-        std::lock_guard<std::mutex> lock(write_mutex);
-        impl_->writeInputFile(f);
-      }
+      impl_->writeInputFile(f);
     }
   }
 
@@ -433,6 +431,7 @@ namespace edm {
   void JobReport::outputFileClosed(JobReport::Token fileToken) {
     JobReport::OutputFile& f = impl_->getOutputFileForToken(fileToken);
     f.fileHasBeenClosed = true;
+    std::lock_guard<std::mutex> lock(write_mutex);
     impl_->writeOutputFile(f);
   }
 
@@ -540,6 +539,7 @@ namespace edm {
 
   void JobReport::reportMemoryInfo(std::vector<std::string> const& memoryData) {
     if (impl_->ost_) {
+      std::lock_guard<std::mutex> lock(write_mutex);
       std::ostream& msg = *(impl_->ost_);
       msg << "<MemoryService>\n";
 
@@ -554,6 +554,7 @@ namespace edm {
 
   void JobReport::reportMessageInfo(std::map<std::string, double> const& messageData) {
     if (impl_->ost_) {
+      std::lock_guard<std::mutex> lock(write_mutex);
       std::ostream& msg = *(impl_->ost_);
       msg << "<MessageSummary>\n";
       typedef std::map<std::string, double>::const_iterator const_iterator;
@@ -571,6 +572,7 @@ namespace edm {
       return;
     impl_->printedReadBranches_ = true;
     if (impl_->ost_) {
+      std::lock_guard<std::mutex> lock(write_mutex);
       std::ostream& ost = *(impl_->ost_);
       ost << "<ReadBranches>\n";
       tinyxml2::XMLDocument doc;


### PR DESCRIPTION
#### PR description:

Production jobs were seeing scrambled job reports caused by pileup file entries.


#### PR validation:

Code compiles

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #37946

Needed for production.