### PR TITLE
Remove RAWEventContent output commands from Repack keeping its compression config

### DIFF
--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -55,8 +55,8 @@ def repackProcess(**args):
 
         outputModule = cms.OutputModule(
             "PoolOutputModule",
-            compressionAlgorithm=RAWEventContent.compressionAlgorithm,
-            compressionLevel=RAWEventContent.compressionLevel,
+            compressionAlgorithm=cms.untracked.string(RAWEventContent.compressionAlgorithm.value()),
+            compressionLevel=cms.untracked.int32(RAWEventContent.compressionLevel.value()),
             fileName = cms.untracked.string("%s.root" % moduleLabel)
             )
 

--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -55,7 +55,8 @@ def repackProcess(**args):
 
         outputModule = cms.OutputModule(
             "PoolOutputModule",
-            RAWEventContent,
+            compressionAlgorithm=RAWEventContent.compressionAlgorithm,
+            compressionLevel=RAWEventContent.compressionLevel,
             fileName = cms.untracked.string("%s.root" % moduleLabel)
             )
 


### PR DESCRIPTION
#### PR description:
Drops RAWEventContent configuration from repack output, while keeping it compression configuration. Fix to #38017.

#### PR validation:

Used [RunRepack.py](https://github.com/cms-sw/cmssw/blob/master/Configuration/DataProcessing/test/RunRepack.py) to generate a test configuration. The resulting PSet had the required output module attributes.
