### PR TITLE
[CSC DT RPC] Bug fix to tag-and-probe in DQM

### DIFF
--- a/DQMOffline/MuonDPG/src/BaseTnPEfficiencyTask.cc
+++ b/DQMOffline/MuonDPG/src/BaseTnPEfficiencyTask.cc
@@ -189,10 +189,10 @@ bool BaseTnPEfficiencyTask::hasTrigger(std::vector<int>& trigIndices,
   for (int trigIdx : trigIndices) {
     const std::vector<std::string> trigModuleLabels = m_hltConfig.moduleLabels(trigIdx);
 
-    const unsigned trigModuleIndex = std::find(trigModuleLabels.begin(), trigModuleLabels.end(), "hltBoolEnd") - trigModuleLabels.begin() - 1;
+    const unsigned trigModuleIndex =
+        std::find(trigModuleLabels.begin(), trigModuleLabels.end(), "hltBoolEnd") - trigModuleLabels.begin() - 1;
     const unsigned hltFilterIndex = trigEvent->filterIndex(edm::InputTag(trigModuleLabels[trigModuleIndex], "", "HLT"));
     if (hltFilterIndex < trigEvent->sizeFilters()) {
-
       const trigger::Keys keys = trigEvent->filterKeys(hltFilterIndex);
       const trigger::Vids vids = trigEvent->filterIds(hltFilterIndex);
       const unsigned nTriggers = vids.size();

--- a/DQMOffline/MuonDPG/src/BaseTnPEfficiencyTask.cc
+++ b/DQMOffline/MuonDPG/src/BaseTnPEfficiencyTask.cc
@@ -20,6 +20,7 @@
 #include "TRegexp.h"
 
 #include <tuple>
+#include <algorithm>
 
 BaseTnPEfficiencyTask::BaseTnPEfficiencyTask(const edm::ParameterSet& config)
     : m_nEvents(0),
@@ -187,9 +188,11 @@ bool BaseTnPEfficiencyTask::hasTrigger(std::vector<int>& trigIndices,
   float dR2match = 999.;
   for (int trigIdx : trigIndices) {
     const std::vector<std::string> trigModuleLabels = m_hltConfig.moduleLabels(trigIdx);
-    const unsigned trigModuleIndex = trigModuleLabels.size() - 2;
+
+    const unsigned trigModuleIndex = std::find(trigModuleLabels.begin(), trigModuleLabels.end(), "hltBoolEnd") - trigModuleLabels.begin() - 1;
     const unsigned hltFilterIndex = trigEvent->filterIndex(edm::InputTag(trigModuleLabels[trigModuleIndex], "", "HLT"));
     if (hltFilterIndex < trigEvent->sizeFilters()) {
+
       const trigger::Keys keys = trigEvent->filterKeys(hltFilterIndex);
       const trigger::Vids vids = trigEvent->filterIds(hltFilterIndex);
       const unsigned nTriggers = vids.size();
@@ -202,5 +205,6 @@ bool BaseTnPEfficiencyTask::hasTrigger(std::vector<int>& trigIndices,
       }
     }
   }
+
   return dR2match < 0.01;
 }


### PR DESCRIPTION
#### PR description:
This PR fixes an issue in the tag-and-probe worflow appeared since 12_4_0_pre3. As you can see e.g. here [1] all CSC plots are empty. All DQM plots are empty also for DT and RPC. The reason is that the tag muon trigger matching always fails. 

The trigger matching was originally performed by checking the second last HLT filter (the last filter was always hltBoolEnd). Since 12_4_0_pre3 it seems that additional filters appeared after hltBoolEnd and the HLT filter to check is not the second last one anymore. This problem has been fixed by simply selecting the HLT filter before hltBoolEnd and not assuming that it was always the second last.

[1] https://tinyurl.com/y6dn23ye

#### PR validation:
 
This fix has been validated by running the following test  in 12_4_0_pre3 release:

`runTheMatrix.py -l 11650.0 -i all --ibeos` (to check that output plots are not empty) and `runTheMatrix.py -l limited -i all --ibeos` showed no failed tests