### PR TITLE
Adding HepMC3 products to EDMProduct

### DIFF
--- a/SimDataFormats/GeneratorProducts/interface/HepMC3Product.h
+++ b/SimDataFormats/GeneratorProducts/interface/HepMC3Product.h
@@ -9,6 +9,8 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include <TMatrixD.h>
 #include <HepMC3/GenEvent.h>
+#include <HepMC3/GenParticle.h>
+#include <HepMC3/GenVertex.h>
 #include <cstddef>
 
 namespace HepMC3 {
@@ -57,11 +59,11 @@ namespace edm {
   // This allows edm::Refs to work with HepMC3Product
   namespace refhelper {
     template <>
-    struct FindTrait<edm::HepMC3Product, HepMC3::GenParticle> {
+    struct FindTrait<edm::HepMC3Product, HepMC3::GenParticlePtr> {
       struct Find {
         using first_argument_type = edm::HepMC3Product const &;
         using second_argument_type = int;
-        using result_type = HepMC3::GenParticle const *;
+        using result_type = HepMC3::GenParticlePtr const *;
 
         result_type operator()(first_argument_type iContainer, second_argument_type iBarCode) {
           //return iContainer.getHepMCData().barcode_to_particle(iBarCode);
@@ -73,11 +75,11 @@ namespace edm {
     };
 
     template <>
-    struct FindTrait<edm::HepMC3Product, HepMC3::GenVertex> {
+    struct FindTrait<edm::HepMC3Product, HepMC3::GenVertexPtr> {
       struct Find {
         using first_argument_type = edm::HepMC3Product const &;
         using second_argument_type = int;
-        using result_type = HepMC3::GenVertex const *;
+        using result_type = HepMC3::GenVertexPtr const *;
 
         result_type operator()(first_argument_type iContainer, second_argument_type iBarCode) {
           //return iContainer.getHepMCData().barcode_to_vertex(iBarCode);

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -11,10 +11,12 @@
 #include "SimDataFormats/GeneratorProducts/interface/LHEXMLStringProduct.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMC3Product.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct3.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
 #include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorLumiInfo.h"

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -23,6 +23,9 @@
 #include "SimDataFormats/GeneratorProducts/interface/ExternalGeneratorEventInfo.h"
 
 #include <HepMC/GenRanges.h>
+#include <HepMC3/GenVertex.h>
+#include <HepMC3/GenParticle.h>
+#include <HepMC3/Attribute.h>
 
 //needed for backward compatibility between HepMC 2.06.xx and 2.05.yy
 namespace hepmc_rootio {

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -78,7 +78,7 @@
 	<!-- <class name="HepPDT::DecayDataT&lt;HepMCConfig&gt;"/> -->
 	<!-- <class name="HepPDT::ParticleDataT&lt;HepMCConfig&gt;"/> -->
 
-	<!-- HepMCProduct -->
+	  <!-- HepMCProduct -->
 
 	<class name="edm::Wrapper&lt;edm::HepMCProduct&gt;"/>
 	<class name="edm::HepMCProduct" ClassVersion="10">
@@ -96,6 +96,36 @@
 	<class name="std::pair&lt;const int,HepMC::GenParticle*&gt;"/>
 	<class name="std::pair&lt;int,HepMC::GenParticle*&gt;"/>
 	<class name="std::map&lt;int,HepMC::GenVertex*,std::greater&lt;int&gt; &gt;"/>
+
+	<!-- HepMC3 externals -->
+        <class name="HepMC3::GenEvent"/>
+	
+	<class name="HepMC3::GenParticlePtr"/>
+	<class name="HepMC3::GenVertexPtr"/>
+	
+        <class name="HepMC3::GenCrossSection"/>
+        <class name="HepMC3::FourVector"/>
+        <class name="HepMC3::HeavyIon"/>
+	<class name="HepMC3::GenHeavyIon"/>
+
+	<class name="std::vector&lt;HepMC3::GenParticlePtr*&gt;"/>
+
+	<!-- HepMC3Product -->
+	
+	<class name="edm::Wrapper&lt;edm::HepMC3Product&gt;"/>
+        <class name="edm::HepMC3Product"/>
+	<class name="std::vector&lt;const edm::HepMC3Product*&gt;"/>
+        <class name="edm::Ref&lt;edm::HepMC3Product,HepMC3::GenVertexPtr,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenVertexPtr&gt;::Find&gt;"/>
+        <class name="edm::Ref&lt;edm::HepMC3Product,HepMC3::GenParticlePtr,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenParticlePtr&gt;::Find&gt;"/>
+        <class name="edm::RefVector&lt;edm::HepMC3Product,HepMC3::GenVertexPtr,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenVertexPtr&gt;::Find&gt;"/>
+        <class name="edm::RefVector&lt;edm::HepMC3Product,HepMC3::GenParticlePtr,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenParticlePtr&gt;::Find&gt;"/>
+        <class name="std::map&lt;int,HepMC3::GenVertexPtr*&gt;"/>
+        <class name="std::pair&lt;const int,HepMC3::GenVertexPtr*&gt;"/>
+        <class name="std::pair&lt;int,HepMC3::GenVertexPtr*&gt;"/>
+        <class name="std::map&lt;int,HepMC3::GenParticlePtr*&gt;"/>
+        <class name="std::pair&lt;const int,HepMC3::GenParticlePtr*&gt;"/>
+        <class name="std::pair&lt;int,HepMC3::GenParticlePtr*&gt;"/>
+        <class name="std::map&lt;int,HepMC3::GenVertexPtr*,std::greater&lt;int&gt; &gt;"/>
 
 	<!-- Classes shared between different kinds of products -->
 
@@ -185,6 +215,19 @@
  </ioread> 
 	<class name="edm::Wrapper&lt;GenEventInfoProduct&gt;"/>
 
+	<!-- GenEventInfoProduct3 -->
+	<class name="GenEventInfoProduct3"/>
+	<ioread sourceClass = "GenEventInfoProduct3" version="[11]" targetClass="GenEventInfoProduct3" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
+	<![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>
+      </ioread>
+      <ioread sourceClass = "GenEventInfoProduct3" version="[-10]" targetClass="GenEventInfoProduct3" source = "" target="nMEPartons_">
+	<![CDATA[nMEPartons_ = -1;]]>
+      </ioread>
+      <ioread sourceClass = "GenEventInfoProduct3" version="[-10]" targetClass="GenEventInfoProduct3" source = "" target="nMEPartonsFiltered_">
+	<![CDATA[nMEPartonsFiltered_ = -1;]]>
+      </ioread>
+      <class name="edm::Wrapper&lt;GenEventInfoProduct3&gt;"/>
+      
 	<!-- LHE products -->
 
 	<class name="lhef::HEPEUP::FiveVector" ClassVersion="10">

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -78,7 +78,7 @@
 	<!-- <class name="HepPDT::DecayDataT&lt;HepMCConfig&gt;"/> -->
 	<!-- <class name="HepPDT::ParticleDataT&lt;HepMCConfig&gt;"/> -->
 
-	  <!-- HepMCProduct -->
+	<!-- HepMCProduct -->
 
 	<class name="edm::Wrapper&lt;edm::HepMCProduct&gt;"/>
 	<class name="edm::HepMCProduct" ClassVersion="10">
@@ -97,35 +97,34 @@
 	<class name="std::pair&lt;int,HepMC::GenParticle*&gt;"/>
 	<class name="std::map&lt;int,HepMC::GenVertex*,std::greater&lt;int&gt; &gt;"/>
 
-	<!-- HepMC3 externals -->
+
+
+
+        <!-- HepMC3 externals -->
         <class name="HepMC3::GenEvent"/>
-	
-	<class name="HepMC3::GenParticlePtr"/>
-	<class name="HepMC3::GenVertexPtr"/>
-	
-        <class name="HepMC3::GenCrossSection"/>
-        <class name="HepMC3::FourVector"/>
-        <class name="HepMC3::HeavyIon"/>
-	<class name="HepMC3::GenHeavyIon"/>
 
-	<class name="std::vector&lt;HepMC3::GenParticlePtr*&gt;"/>
+        <!-- HepMC3Product -->
 
-	<!-- HepMC3Product -->
-	
-	<class name="edm::Wrapper&lt;edm::HepMC3Product&gt;"/>
+        <class name="edm::Wrapper&lt;edm::HepMC3Product&gt;"/>
         <class name="edm::HepMC3Product"/>
-	<class name="std::vector&lt;const edm::HepMC3Product*&gt;"/>
-        <class name="edm::Ref&lt;edm::HepMC3Product,HepMC3::GenVertexPtr,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenVertexPtr&gt;::Find&gt;"/>
-        <class name="edm::Ref&lt;edm::HepMC3Product,HepMC3::GenParticlePtr,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenParticlePtr&gt;::Find&gt;"/>
-        <class name="edm::RefVector&lt;edm::HepMC3Product,HepMC3::GenVertexPtr,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenVertexPtr&gt;::Find&gt;"/>
-        <class name="edm::RefVector&lt;edm::HepMC3Product,HepMC3::GenParticlePtr,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenParticlePtr&gt;::Find&gt;"/>
-        <class name="std::map&lt;int,HepMC3::GenVertexPtr*&gt;"/>
-        <class name="std::pair&lt;const int,HepMC3::GenVertexPtr*&gt;"/>
-        <class name="std::pair&lt;int,HepMC3::GenVertexPtr*&gt;"/>
-        <class name="std::map&lt;int,HepMC3::GenParticlePtr*&gt;"/>
-        <class name="std::pair&lt;const int,HepMC3::GenParticlePtr*&gt;"/>
-        <class name="std::pair&lt;int,HepMC3::GenParticlePtr*&gt;"/>
-        <class name="std::map&lt;int,HepMC3::GenVertexPtr*,std::greater&lt;int&gt; &gt;"/>
+        <class name="std::vector&lt;const edm::HepMC3Product*&gt;"/>
+	<!--
+        <class name="edm::Ref&lt;edm::HepMC3Product,HepMC3::GenVertex,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenVertex&gt;::Find&gt;"/>
+        <class name="edm::Ref&lt;edm::HepMC3Product,HepMC3::GenParticle,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenParticle&gt;::Find&gt;"/>
+        <class name="edm::RefVector&lt;edm::HepMC3Product,HepMC3::GenVertex,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenVertex&gt;::Find&gt;"/>
+        <class name="edm::RefVector&lt;edm::HepMC3Product,HepMC3::GenParticle,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenParticle&gt;::Find&gt;"/>
+	-->
+        <class name="std::map&lt;int,HepMC3::GenVertex*&gt;"/>
+        <class name="std::pair&lt;const int,HepMC3::GenVertex*&gt;"/>
+        <class name="std::pair&lt;int,HepMC3::GenVertex*&gt;"/>
+        <class name="std::map&lt;int,HepMC3::GenParticle*&gt;"/>
+        <class name="std::pair&lt;const int,HepMC3::GenParticle*&gt;"/>
+        <class name="std::pair&lt;int,HepMC3::GenParticle*&gt;"/>
+        <class name="std::map&lt;int,HepMC3::GenVertex*,std::greater&lt;int&gt; &gt;"/>
+
+
+
+
 
 	<!-- Classes shared between different kinds of products -->
 
@@ -215,19 +214,19 @@
  </ioread> 
 	<class name="edm::Wrapper&lt;GenEventInfoProduct&gt;"/>
 
-	<!-- GenEventInfoProduct3 -->
-	<class name="GenEventInfoProduct3"/>
-	<ioread sourceClass = "GenEventInfoProduct3" version="[11]" targetClass="GenEventInfoProduct3" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
-	<![CDATA[pdf_.reset(onfile.pdf_.get()); onfile.pdf_.release();]]>
-      </ioread>
-      <ioread sourceClass = "GenEventInfoProduct3" version="[-10]" targetClass="GenEventInfoProduct3" source = "" target="nMEPartons_">
-	<![CDATA[nMEPartons_ = -1;]]>
-      </ioread>
-      <ioread sourceClass = "GenEventInfoProduct3" version="[-10]" targetClass="GenEventInfoProduct3" source = "" target="nMEPartonsFiltered_">
-	<![CDATA[nMEPartonsFiltered_ = -1;]]>
-      </ioread>
-      <class name="edm::Wrapper&lt;GenEventInfoProduct3&gt;"/>
-      
+
+
+
+        <!-- GenEventInfoProduct3 -->
+        <class name="GenEventInfoProduct3"/>
+        <ioread sourceClass = "GenEventInfoProduct3" version="[1]" targetClass="GenEventInfoProduct3" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
+        </ioread>
+        <class name="edm::Wrapper&lt;GenEventInfoProduct3&gt;"/>
+
+
+
+
+
 	<!-- LHE products -->
 
 	<class name="lhef::HEPEUP::FiveVector" ClassVersion="10">

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -102,11 +102,12 @@
 
         <!-- HepMC3 externals -->
         <class name="HepMC3::GenEvent"/>
+        <class name="HepMC3::GenVertex"/>
+        <class name="HepMC3::GenParticle"/>
 
         <!-- HepMC3Product -->
 
         <class name="edm::Wrapper&lt;edm::HepMC3Product&gt;"/>
-        <class name="edm::HepMC3Product"/>
         <class name="std::vector&lt;const edm::HepMC3Product*&gt;"/>
 	<!--
         <class name="edm::Ref&lt;edm::HepMC3Product,HepMC3::GenVertex,edm::refhelper::FindTrait&lt;edm::HepMC3Product,HepMC3::GenVertex&gt;::Find&gt;"/>
@@ -219,9 +220,7 @@
 
         <!-- GenEventInfoProduct3 -->
         <class name="GenEventInfoProduct3"/>
-        <ioread sourceClass = "GenEventInfoProduct3" version="[1]" targetClass="GenEventInfoProduct3" source = "std::auto_ptr<gen::PdfInfo> pdf_;" target="pdf_">
-        </ioread>
-        <class name="edm::Wrapper&lt;GenEventInfoProduct3&gt;"/>
+        <class name="edm::Wrapper<GenEventInfoProduct3>"/>
 
 
 


### PR DESCRIPTION
#### PR description:

This PR trying to address the EDM addition in #37187 , using advises from twiki [*]. 
The HepMC3 package adapted new strategy to manipulate event records of High Energy Physics Monte Carlo Event Generators (MCEGs) [**], notably:

1.  Particles and vertices are stored separately in an ordered graph structure; all custom iterators were removed.
2.  Extension on the I/O functionality of the library.
 
[*] https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideCreatingNewProducts
[**] https://iopscience.iop.org/article/10.1088/1742-6596/1525/1/012017/pdf

The HepMC3 new data format poses challenges on defining the corresponding EDMProduct definition.

This PR depicts partial implementation, due to some technical error:

```
Error: Class shared_ptr<HepMC3::GenParticle> has been selected but currently the support for its I/O is not yet available. Note that shared_ptr<HepMC3::GenParticle>, even if not selected, will be available for interpreted code.
Error: Class shared_ptr<HepMC3::GenVertex> has been selected but currently the support for its I/O is not yet available. Note that shared_ptr<HepMC3::GenVertex>, even if not selected, will be available for interpreted code.
```
I am looking for advice(s) on how to solve the error. @smuzaffar, @mkirsano 

Note: class version will be done accordingly after a successful compilation with the amended version classes_def.xml.

Related Issue/PR:
1. Issue #36662
2. configure pythia8 to use hepmc3: [#7677](https://github.com/cms-sw/cmsdist/pull/7677)
3. #37187
4. #37689
5. #37753
 
#### PR validation:

No validation yet, to be finalized as the PR evolve..

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

NA
