### PR TITLE
Compute muon index bits using idx from dataformat

### DIFF
--- a/DataFormats/L1TMuon/interface/RegionalMuonCand.h
+++ b/DataFormats/L1TMuon/interface/RegionalMuonCand.h
@@ -144,6 +144,8 @@ namespace l1t {
     void setTFIdentifiers(int processor, tftype trackFinder);
     // this is left to still be compatible with OMTF
     void setLink(int link) { m_link = link; };
+    // Set the muon index on the link (i.e., 0, 1, or 2)
+    void setMuIdx(int muIdx) { m_muIdx = muIdx; };
     // Set the 64 bit word from two 32 words. bits 0-31->lsbs, bits 32-63->msbs
     void setDataword(uint32_t msbs, uint32_t lsbs) { m_dataword = (((uint64_t)msbs) << 32) + lsbs; };
     // Set the 64 bit word coming from HW directly
@@ -175,6 +177,8 @@ namespace l1t {
     const int hwQual() const { return m_hwQuality; };
     /// Get link on which the MicroGMT receives the candidate
     const int link() const { return m_link; };
+    /// Get muon index (i.e., 0, 1, or 2)
+    const int muIdx() const { return m_muIdx; };
     /// Get processor ID on which the candidate was found (0..5 for OMTF/EMTF; 0..11 for BMTF)
     const int processor() const { return m_processor; };
     /// Get track-finder which found the muon (bmtf, emtf_pos/emtf_neg or omtf_pos/omtf_neg)
@@ -216,6 +220,7 @@ namespace l1t {
 
     /// This is the 64 bit word as transmitted in HW
     uint64_t m_dataword;
+    int m_muIdx{-1};
   };
 
 }  // namespace l1t

--- a/DataFormats/L1TMuon/src/RegionalMuonCand.cc
+++ b/DataFormats/L1TMuon/src/RegionalMuonCand.cc
@@ -28,7 +28,7 @@ namespace l1t {
     return m_hwPt == rhs.hwPt() && m_hwPtUnconstrained == rhs.hwPtUnconstrained() && m_hwDXY == rhs.hwDXY() &&
            m_hwPhi == rhs.hwPhi() && m_hwEta == rhs.hwEta() && m_hwHF == (bool)rhs.hwHF() && m_hwSign == rhs.hwSign() &&
            m_hwSignValid == rhs.hwSignValid() && m_hwQuality == rhs.hwQual() && m_link == rhs.link() &&
-           m_processor == rhs.processor() && m_trackFinder == rhs.trackFinderType() &&
+           m_muIdx == rhs.muIdx() && m_processor == rhs.processor() && m_trackFinder == rhs.trackFinderType() &&
            m_trackAddress == rhs.trackAddress();
   }
 

--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -1,7 +1,8 @@
 <lcgdict>
  <selection>
 
-  <class name="l1t::RegionalMuonCand" ClassVersion="11">
+  <class name="l1t::RegionalMuonCand" ClassVersion="12">
+   <version ClassVersion="12" checksum="1761665561"/>
     <version ClassVersion="11" checksum="2292293737"/>
     <version ClassVersion="10" checksum="1070099328"/>
   </class>
@@ -81,7 +82,8 @@
 
 
 
-  <class name="L1MuBMTrack" ClassVersion="14">
+  <class name="L1MuBMTrack" ClassVersion="15">
+   <version ClassVersion="15" checksum="99482231"/>
    <version ClassVersion="14" checksum="2164413511"/>
     <version ClassVersion="10" checksum="955528069"/>
     <version ClassVersion="11" checksum="1941187557"/>

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/MuonUnpacker.cc
@@ -66,7 +66,7 @@ namespace l1t {
       if (startIdx + nWords_ <= payload.size()) {
         // Unpacking showers.
         // The shower from uGMT is transmitted via four links, each link
-        // carrying on of the bits of the shower. We therefore have to
+        // carrying one of the bits of the shower. We therefore have to
         // determine which link we're looking at and act accordingly.
         // Output links are odd and input links are even.
         int link_offset{0};  // This is correct for the uGT unpacker

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/RegionalMuonGMTUnpacker.cc
@@ -107,6 +107,7 @@ namespace l1t {
             }
 
             RegionalMuonCand mu;
+            mu.setMuIdx(nWord / 2);
 
             RegionalMuonRawDigiTranslator::fillRegionalMuonCand(
                 mu, raw_data_00_31, raw_data_32_63, processor, trackFinder, isKbmtf_, useEmtfDisplacementInfo_);

--- a/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
+++ b/L1Trigger/L1TMuon/plugins/L1TMuonProducer.cc
@@ -531,8 +531,9 @@ void L1TMuonProducer::convertMuons(const edm::Handle<MicroGMTConfiguration::Inpu
     wedges[i] = std::vector<std::shared_ptr<GMTInternalMuon>>();
     wedges[i].reserve(3);
   }
-  if (bx < in->getFirstBX() || bx > in->getLastBX())
+  if (bx < in->getFirstBX() || bx > in->getLastBX()) {
     return;
+  }
   int muIdx = 0;
   int currentLink = 0;
   for (size_t i = 0; i < in->size(bx); ++i, ++muIdx) {
@@ -547,16 +548,19 @@ void L1TMuonProducer::convertMuons(const edm::Handle<MicroGMTConfiguration::Inpu
       }
       int gPhi = MicroGMTConfiguration::calcGlobalPhi(
           in->at(bx, i).hwPhi(), in->at(bx, i).trackFinderType(), in->at(bx, i).processor());
-      int tfMuonIdx = 3 * (currentLink - 36) + muIdx;
+      // If the muon index was set in the data format we should use that. Otherwise we use the value computed from the position in the vector.
+      int muIdxDF{in->at(bx, i).muIdx()};
+      int tfMuonIdx{3 * (currentLink - 36) + ((muIdxDF != -1) ? muIdxDF : muIdx)};
       std::shared_ptr<GMTInternalMuon> outMu = std::make_shared<GMTInternalMuon>(in->at(bx, i), gPhi, tfMuonIdx);
       out.emplace_back(outMu);
       wedges[in->at(bx, i).processor()].push_back(outMu);
     }
   }
   for (int i = 0; i < 12; ++i) {
-    if (wedges[i].size() > 3)
+    if (wedges[i].size() > 3) {
       edm::LogWarning("Input Mismatch") << " too many inputs per processor for barrel. Wedge " << i << ": Size "
                                         << wedges[i].size() << std::endl;
+    }
   }
 }
 


### PR DESCRIPTION
#### PR description:

We currently compute the muon index within the link from the position in the vector, however this is packed densely and during cosmics the EMTF always sends muon stubs in third position (even if the second position is free), causing a mismatch in index bits. 

Therefore we now assign the muon index on the link in the uGMT unpacker and use that index if it is set. The behaviour when the `muIdx` field is not explicitly set should be identical to the current one.

#### PR validation:

Running the usual standard tests locally. (WIP until they succeed.)
