### PR TITLE
[EGM config cleanup] Remove module that uses non-existent input

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/reducedRecHitsSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/reducedRecHitsSequence_cff.py
@@ -143,8 +143,7 @@ reducedEcalRecHitsES = cms.EDProducer("ReducedESRecHitCollectionProducer",
                                         cms.InputTag("interestingEcalDetIdOOTPFES"),
                                       ),
                                       interestingDetIdsNotToClean = cms.VInputTag(
-                                        cms.InputTag("interestingGedEgammaIsoESDetId"),
-                                        cms.InputTag("interestingOotEgammaIsoESDetId"),
+                                          cms.InputTag("interestingOotEgammaIsoESDetId"),
                                       )
 )
 

--- a/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
@@ -100,25 +100,16 @@ interestingOotEgammaIsoHCALDetId = interestingGedEgammaIsoHCALDetId.clone(
 )
 
 import RecoEgamma.EgammaIsolationAlgos.interestingEgammaIsoESDetIdModule_cff
-interestingGedEgammaIsoESDetId = RecoEgamma.EgammaIsolationAlgos.interestingEgammaIsoESDetIdModule_cff.interestingEgammaIsoESDetId.clone(
-    eeClusToESMapLabel = "particleFlowClusterECALRemade",
-    ecalPFClustersLabel= "particleFlowClusterECALRemade",
-    elesLabel          = "gedGsfElectrons",
-    phosLabel          = "gedPhotons",
-    superClustersLabel = "particleFlowEGamma",
-    minSCEt            = 500,
-    minEleEt           = 20,
-    minPhoEt           = 20,
-    maxDR              = 0.4
-)
-
-## OOT Photons
-interestingOotEgammaIsoESDetId = interestingGedEgammaIsoESDetId.clone(
+interestingOotEgammaIsoESDetId = RecoEgamma.EgammaIsolationAlgos.interestingEgammaIsoESDetIdModule_cff.interestingEgammaIsoESDetId.clone(
     eeClusToESMapLabel = "particleFlowClusterOOTECAL",
     ecalPFClustersLabel= "particleFlowClusterOOTECAL",
     phosLabel          = "ootPhotons",
     elesLabel          = "",
-    superClustersLabel = ""
+    superClustersLabel = "",
+    minSCEt            = 500,
+    minEleEt           = 20,
+    minPhoEt           = 20,
+    maxDR              = 0.4
 )
 
 interestingEgammaIsoDetIdsTask = cms.Task(
@@ -132,7 +123,6 @@ interestingEgammaIsoDetIdsTask = cms.Task(
     interestingGamIsoDetIdEE ,
     interestingGedEgammaIsoHCALDetId,
     interestingOotEgammaIsoHCALDetId,
-    interestingGedEgammaIsoESDetId,
     interestingOotEgammaIsoESDetId
 )
 interestingEgammaIsoDetIds = cms.Sequence(interestingEgammaIsoDetIdsTask)
@@ -147,11 +137,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toReplaceWith(interestingEgammaIsoDetIdsTask, _pp_on_AA_interestingEgammaIsoDetIdsTask)
 
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
-egamma_lowPt_exclusive.toModify(interestingGedEgammaIsoESDetId,
-			   minSCEt   = 1.0, #default 500
-			   minEleEt  = 1.0, #default 20
-			   minPhoEt  = 1.0 #default 20
-)
+
 egamma_lowPt_exclusive.toModify(interestingGedEgammaIsoHCALDetId, 
 		           minSCEt = 1.0, #default 20
 		           minEleEt= 1.0, #default 20

--- a/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoESDetIdModule_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoESDetIdModule_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 interestingEgammaIsoESDetId = cms.EDProducer("EgammaIsoESDetIdCollectionProducer",
-                                             eeClusToESMapLabel=cms.InputTag("particleFlowClusterECALRemade"),
-                                             ecalPFClustersLabel=cms.InputTag("particleFlowClusterECALRemade"),
+                                             eeClusToESMapLabel=cms.InputTag(""),
+                                             ecalPFClustersLabel=cms.InputTag(""),
                                              elesLabel=cms.InputTag("gedGsfElectrons"),
                                              phosLabel=cms.InputTag("gedPhotons"),
                                              superClustersLabel=cms.InputTag("particleFlowEGamma"),


### PR DESCRIPTION
#### PR description:

This PR is to address this old issue:  https://github.com/cms-sw/cmssw/issues/19113
In `RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py`, in the module `interestingGedEgammaIsoESDetId`, the collection names provided for `eeClusToESMapLabel` and `ecalPFClustersLabel` were wrong; it was `particleFlowClusterECALRemade`, which does not exist. 
https://github.com/cms-sw/cmssw/blob/6d2f66057131baacc2fcbdd203588c41c885b42c/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py#L103-L105

This PR is meant to clean it up. 

#### PR validation:
Tested with workflow `136.793` (2017C DoubleEG). Ran fine.

This PR is not a backport. 
Backport not needed.