### PR TITLE
[DQM] Dropped dqmOfflineTriggerCert from FakeHLT Cosmics

### DIFF
--- a/Configuration/StandardSequences/python/HarvestingCosmics_cff.py
+++ b/Configuration/StandardSequences/python/HarvestingCosmics_cff.py
@@ -7,7 +7,7 @@ from Validation.Configuration.postValidation_cff import *
 from HLTriggerOffline.Common.HLTValidationHarvest_cff import *
 
 dqmHarvesting = cms.Path(DQMOfflineCosmics_SecondStep*DQMOfflineCosmics_Certification)
-dqmHarvestingFakeHLT = cms.Path(DQMOfflineCosmics_SecondStep_FakeHLT*DQMOfflineCosmics_Certification)
+dqmHarvestingFakeHLT = cms.Path(DQMOfflineCosmics_SecondStep_FakeHLT*DQMOfflineCosmics_CertificationFakeHLT)
 dqmHarvestingPOG = cms.Path(DQMOfflineCosmics_SecondStep_PrePOG)
 
 validationHarvesting = cms.Path(postValidationCosmics)

--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_Certification_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_Certification_cff.py
@@ -3,3 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from DQMOffline.Configuration.DQMOffline_Certification_cff import *
 
 DQMOfflineCosmics_Certification = cms.Sequence(daq_dqmoffline*dcs_dqmoffline*crt_dqmoffline)
+
+DQMOfflineCosmics_CertificationFakeHLT = cms.Sequence( DQMOfflineCosmics_Certification )
+DQMOfflineCosmics_CertificationFakeHLT.remove( dqmOfflineTriggerCert )


### PR DESCRIPTION
#### PR description:

This PR removes HLT certification from FakeHLT Cosmics DQM sequences, which produce HLT DQM error messages in logs, e.g. in

https://cms-talk.web.cern.ch/t/replay-for-testing-the-run-3-collisions-setup/10676/12?u=ggiraldo