### PR TITLE
Cleanup redundant edm ParameterSet exist in RecoLuminosity

### DIFF
--- a/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
+++ b/RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc
@@ -39,13 +39,8 @@ BunchSpacingProducer::BunchSpacingProducer::BunchSpacingProducer(const edm::Para
   // register your products
   produces<unsigned int>();
   bunchSpacing_ = consumes<int>(edm::InputTag("addPileupInfo", "bunchSpacing"));
-  overRide_ = false;
-  if (iConfig.exists("overrideBunchSpacing")) {
-    overRide_ = iConfig.getParameter<bool>("overrideBunchSpacing");
-    if (overRide_) {
-      bunchSpacingOverride_ = iConfig.getParameter<unsigned int>("bunchSpacingOverride");
-    }
-  }
+  overRide_ = iConfig.getParameter<bool>("overrideBunchSpacing");
+  bunchSpacingOverride_ = iConfig.getParameter<unsigned int>("bunchSpacingOverride");
 }
 
 BunchSpacingProducer::~BunchSpacingProducer() {}

--- a/RecoLuminosity/LumiProducer/python/bunchSpacingProducer_cfi.py
+++ b/RecoLuminosity/LumiProducer/python/bunchSpacingProducer_cfi.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
-bunchSpacingProducer = cms.EDProducer("BunchSpacingProducer")
+import RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi as _mod
+
+bunchSpacingProducer = _mod.bunchSpacingProducer.clone()
 
 from Configuration.Eras.Modifier_run2_50ns_specific_cff import run2_50ns_specific
-run2_50ns_specific.toModify( bunchSpacingProducer, bunchSpacingOverride = cms.uint32(50))
-run2_50ns_specific.toModify( bunchSpacingProducer, overrideBunchSpacing = cms.bool(True))
+run2_50ns_specific.toModify( bunchSpacingProducer, bunchSpacingOverride = 50)
+run2_50ns_specific.toModify( bunchSpacingProducer, overrideBunchSpacing = True)


### PR DESCRIPTION
#### PR description:  
(Technical PR) Optimization of the module configurations: Improve maintainability by cleaning up redundant cases of edm::ParameterSet calls to `existAs` or `exist` for tracked parameters, where redundancy is based on the value being already defined by `fillDescriptions`.

As follow the previous [PR36746](https://github.com/cms-sw/cmssw/pull/36746),  [PR36989](https://github.com/cms-sw/cmssw/pull/36989), [PR37313](https://github.com/cms-sw/cmssw/pull/37313), [PR37314](https://github.com/cms-sw/cmssw/pull/37314), [PR37548](https://github.com/cms-sw/cmssw/pull/37548), [PR37772](https://github.com/cms-sw/cmssw/pull/37772), and [PR37899](https://github.com/cms-sw/cmssw/pull/37899).

The list of all calls of `existAs` or `exist` are automatically available in the Static Analyzer report. (Bug: CMS code rules)
It is accessible from IB page. https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/
For this task consider only modules or tools used by the modules that define `fillDescriptions`.

In this PR, 1 file was changed.  
RecoLuminosity/LumiProducer/plugins/BunchSpacingProducer.cc

Here, the "overrideBunchSpacing", "bunchSpacingOverride" parameters were provided in a `fillDescription`.

[cfipython/RecoLuminosity/LumiProducer/bunchSpacingProducer_cfi.py](https://cmssdt.cern.ch/lxr/source/cfipython/RecoLuminosity/LumiProducer/bunchSpacingProducer_cfi.py) 

#### PR validation:
Tested in CMSSW_12_4_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)