### PR TITLE
Adding (x, y) hit to HGCal cell (u, v) for partial wafers v17  

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalCellUV.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellUV.h
@@ -21,8 +21,9 @@ public:
 
   std::pair<int32_t, int32_t> cellUVFromXY4(
       double xloc, double yloc, int32_t placement, int32_t type, bool extend, bool debug);
-  
-  std::pair<int32_t, int32_t> cellUVFromXY1(double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug);
+
+  std::pair<int32_t, int32_t> cellUVFromXY1(
+      double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug);
 
 private:
   std::pair<int32_t, int32_t> cellUVFromXY4(double xloc,

--- a/Geometry/HGCalCommonData/interface/HGCalCellUV.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellUV.h
@@ -21,6 +21,8 @@ public:
 
   std::pair<int32_t, int32_t> cellUVFromXY4(
       double xloc, double yloc, int32_t placement, int32_t type, bool extend, bool debug);
+  
+  std::pair<int32_t, int32_t> cellUVFromXY1(double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug);
 
 private:
   std::pair<int32_t, int32_t> cellUVFromXY4(double xloc,

--- a/Geometry/HGCalCommonData/interface/HGCalCellUV.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellUV.h
@@ -21,9 +21,8 @@ public:
 
   std::pair<int32_t, int32_t> cellUVFromXY4(
       double xloc, double yloc, int32_t placement, int32_t type, bool extend, bool debug);
-
-  std::pair<int32_t, int32_t> cellUVFromXY1(
-      double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug);
+  
+  std::pair<int32_t, int32_t> cellUVFromXY1(double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug);
 
 private:
   std::pair<int32_t, int32_t> cellUVFromXY4(double xloc,
@@ -40,6 +39,8 @@ private:
   static constexpr double sqrt3_ = 1.732050807568877;  // std::sqrt(3.0) in double precision
   static constexpr double sin60_ = 0.5 * sqrt3_;
   static constexpr double cos60_ = 0.5;
+  static constexpr int edgeWaferLDTop = 7;             // The edge of wafer defined by u=7
+  static constexpr int edgeWaferHDBottom = 10;         // The edge of wafer defined by u=10
 
   int32_t ncell_[2];
   double cellX_[2], cellY_[2], cellXTotal_[2], cellYTotal_[2], waferSize;

--- a/Geometry/HGCalCommonData/interface/HGCalCellUV.h
+++ b/Geometry/HGCalCommonData/interface/HGCalCellUV.h
@@ -21,8 +21,9 @@ public:
 
   std::pair<int32_t, int32_t> cellUVFromXY4(
       double xloc, double yloc, int32_t placement, int32_t type, bool extend, bool debug);
-  
-  std::pair<int32_t, int32_t> cellUVFromXY1(double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug);
+
+  std::pair<int32_t, int32_t> cellUVFromXY1(
+      double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug);
 
 private:
   std::pair<int32_t, int32_t> cellUVFromXY4(double xloc,
@@ -39,8 +40,8 @@ private:
   static constexpr double sqrt3_ = 1.732050807568877;  // std::sqrt(3.0) in double precision
   static constexpr double sin60_ = 0.5 * sqrt3_;
   static constexpr double cos60_ = 0.5;
-  static constexpr int edgeWaferLDTop = 7;             // The edge of wafer defined by u=7
-  static constexpr int edgeWaferHDBottom = 10;         // The edge of wafer defined by u=10
+  static constexpr int edgeWaferLDTop = 7;      // The edge of wafer defined by u=7
+  static constexpr int edgeWaferHDBottom = 10;  // The edge of wafer defined by u=10
 
   int32_t ncell_[2];
   double cellX_[2], cellY_[2], cellXTotal_[2], cellYTotal_[2], waferSize;

--- a/Geometry/HGCalCommonData/src/HGCalCellUV.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellUV.cc
@@ -46,8 +46,8 @@ HGCalCellUV::HGCalCellUV(double waferSize, double separation, int32_t nFine, int
 std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(
     double xloc, double yloc, int32_t placement, int32_t type, bool extend, bool debug) {
   //--- Reverse transform to placement=0, if placement index ≠ 6
-  double xloc1 = (placement >= 6) ? xloc : -xloc;
-  int rot = placement % 6;
+  double xloc1 = (placement >= HGCalCell::cellPlacementExtra) ? xloc : -xloc;
+  int rot = placement %  HGCalCell::cellPlacementExtra;
   static constexpr std::array<double, 6> fcos = {{1.0, cos60_, -cos60_, -1.0, -cos60_, cos60_}};
   static constexpr std::array<double, 6> fsin = {{0.0, sin60_, sin60_, 0.0, -sin60_, -sin60_}};
   double x = xloc1 * fcos[rot] - yloc * fsin[rot];
@@ -87,8 +87,8 @@ std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY2(
     double xloc, double yloc, int32_t placement, int32_t type, bool extend, bool debug) {
   //--- Using multiple inequalities to find (u, v)
   //--- Reverse transform to placement=0, if placement index ≠ 7
-  double xloc1 = (placement >= 6) ? xloc : -1 * xloc;
-  int rot = placement % 6;
+  double xloc1 = (placement >= HGCalCell::cellPlacementExtra) ? xloc : -1 * xloc;
+  int rot = placement % HGCalCell::cellPlacementExtra;
   static constexpr std::array<double, 6> fcos = {{cos60_, 1.0, cos60_, -cos60_, -1.0, -cos60_}};
   static constexpr std::array<double, 6> fsin = {{-sin60_, 0.0, sin60_, sin60_, 0.0, -sin60_}};
   double x = xloc1 * fcos[rot] - yloc * fsin[rot];
@@ -154,8 +154,8 @@ std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY3(
     double xloc, double yloc, int32_t placement, int32_t type, bool extend, bool debug) {
   //--- Using Cube coordinates to find the (u, v)
   //--- Reverse transform to placement=0, if placement index ≠ 6
-  double xloc1 = (placement >= 6) ? xloc : -xloc;
-  int rot = placement % 6;
+  double xloc1 = (placement >= HGCalCell::cellPlacementExtra) ? xloc : -xloc;
+  int rot = placement % HGCalCell::cellPlacementExtra;
   static constexpr std::array<double, 6> fcos = {{1.0, cos60_, -cos60_, -1.0, -cos60_, cos60_}};
   static constexpr std::array<double, 6> fsin = {{0.0, sin60_, sin60_, 0.0, -sin60_, -sin60_}};
   double xprime = xloc1 * fcos[rot] - yloc * fsin[rot];
@@ -268,44 +268,44 @@ std::pair<int, int> HGCalCellUV::cellUVFromXY4(double xloc,
   return uv;
 }
 
-std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(
-    double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug) {
+
+std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug){
   std::pair<int, int> uv = HGCalCellUV::cellUVFromXY1(xloc, yloc, placement, type, extend, debug);
   int u = uv.first;
   int v = uv.second;
-  if (partial == HGCalTypes::WaferLDTop) {
-    if (u > 7) {
-      double xloc1 = (placement >= 6) ? xloc : -xloc;
-      int rot = placement % 6;
+  if(partial == HGCalTypes::WaferLDTop){
+    if(u > edgeWaferLDTop){
+      double xloc1 = (placement >= HGCalCell::cellPlacementExtra) ? xloc : -xloc;
+      int rot = placement % HGCalCell::cellPlacementExtra;
       static constexpr std::array<double, 6> fcos = {{1.0, cos60_, -cos60_, -1.0, -cos60_, cos60_}};
       static constexpr std::array<double, 6> fsin = {{0.0, sin60_, sin60_, 0.0, -sin60_, -sin60_}};
       double xprime = -1 * (xloc1 * fcos[rot] - yloc * fsin[rot]);
       double yprime = xloc1 * fsin[rot] + yloc * fcos[rot];
       double xcell = -1 * (1.5 * (v - u) + 0.5) * cellX_[type];
       double ycell = (v + u - 2 * ncell_[type] + 1) * cellY_[type];
-      if ((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)) {
-        u += -1;
-      } else {
-        u += -1;
-        v += -1;
+      if((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)){
+	u += -1;
+      }else{
+	u += -1;
+	v += -1;
       }
     }
   }
-  if (partial == HGCalTypes::WaferHDBottom) {
-    if (u < 10) {
-      double xloc1 = (placement >= 6) ? xloc : -xloc;
-      int rot = placement % 6;
+  else if(partial == HGCalTypes::WaferHDBottom){
+    if(u < edgeWaferHDBottom){
+      double xloc1 = (placement >= HGCalCell::cellPlacementExtra) ? xloc : -xloc;
+      int rot = placement % HGCalCell::cellPlacementExtra;
       static constexpr std::array<double, 6> fcos = {{1.0, cos60_, -cos60_, -1.0, -cos60_, cos60_}};
       static constexpr std::array<double, 6> fsin = {{0.0, sin60_, sin60_, 0.0, -sin60_, -sin60_}};
       double xprime = -1 * (xloc1 * fcos[rot] - yloc * fsin[rot]);
       double yprime = xloc1 * fsin[rot] + yloc * fcos[rot];
       double xcell = -1 * (1.5 * (v - u) + 0.5) * cellX_[type];
       double ycell = (v + u - 2 * ncell_[type] + 1) * cellY_[type];
-      if ((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)) {
-        u += 1;
-        v += 1;
-      } else {
-        u += 1;
+      if((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)){
+	u += 1;
+	v += 1;
+      }else{
+	u += 1;
       }
     }
   }

--- a/Geometry/HGCalCommonData/src/HGCalCellUV.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellUV.cc
@@ -268,13 +268,13 @@ std::pair<int, int> HGCalCellUV::cellUVFromXY4(double xloc,
   return uv;
 }
 
-
-std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug){
+std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(
+    double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug) {
   std::pair<int, int> uv = HGCalCellUV::cellUVFromXY1(xloc, yloc, placement, type, extend, debug);
   int u = uv.first;
   int v = uv.second;
-  if(partial == HGCalTypes::WaferLDTop){
-    if(u > 7){
+  if (partial == HGCalTypes::WaferLDTop) {
+    if (u > 7) {
       double xloc1 = (placement >= 6) ? xloc : -xloc;
       int rot = placement % 6;
       static constexpr std::array<double, 6> fcos = {{1.0, cos60_, -cos60_, -1.0, -cos60_, cos60_}};
@@ -283,16 +283,16 @@ std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(double xloc, double yloc,
       double yprime = xloc1 * fsin[rot] + yloc * fcos[rot];
       double xcell = -1 * (1.5 * (v - u) + 0.5) * cellX_[type];
       double ycell = (v + u - 2 * ncell_[type] + 1) * cellY_[type];
-      if((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)){
-	u += -1;
-      }else{
-	u += -1;
-	v += -1;
+      if ((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)) {
+        u += -1;
+      } else {
+        u += -1;
+        v += -1;
       }
     }
   }
-  if(partial == HGCalTypes::WaferHDBottom){
-    if(u<10){
+  if (partial == HGCalTypes::WaferHDBottom) {
+    if (u < 10) {
       double xloc1 = (placement >= 6) ? xloc : -xloc;
       int rot = placement % 6;
       static constexpr std::array<double, 6> fcos = {{1.0, cos60_, -cos60_, -1.0, -cos60_, cos60_}};
@@ -301,11 +301,11 @@ std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(double xloc, double yloc,
       double yprime = xloc1 * fsin[rot] + yloc * fcos[rot];
       double xcell = -1 * (1.5 * (v - u) + 0.5) * cellX_[type];
       double ycell = (v + u - 2 * ncell_[type] + 1) * cellY_[type];
-      if((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)){
-	u += 1;
-	v += 1;
-      }else{
-	u += 1;
+      if ((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)) {
+        u += 1;
+        v += 1;
+      } else {
+        u += 1;
       }
     }
   }

--- a/Geometry/HGCalCommonData/src/HGCalCellUV.cc
+++ b/Geometry/HGCalCommonData/src/HGCalCellUV.cc
@@ -47,7 +47,7 @@ std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(
     double xloc, double yloc, int32_t placement, int32_t type, bool extend, bool debug) {
   //--- Reverse transform to placement=0, if placement index ≠ 6
   double xloc1 = (placement >= HGCalCell::cellPlacementExtra) ? xloc : -xloc;
-  int rot = placement %  HGCalCell::cellPlacementExtra;
+  int rot = placement % HGCalCell::cellPlacementExtra;
   static constexpr std::array<double, 6> fcos = {{1.0, cos60_, -cos60_, -1.0, -cos60_, cos60_}};
   static constexpr std::array<double, 6> fsin = {{0.0, sin60_, sin60_, 0.0, -sin60_, -sin60_}};
   double x = xloc1 * fcos[rot] - yloc * fsin[rot];
@@ -268,13 +268,13 @@ std::pair<int, int> HGCalCellUV::cellUVFromXY4(double xloc,
   return uv;
 }
 
-
-std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug){
+std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(
+    double xloc, double yloc, int32_t placement, int32_t type, int32_t partial, bool extend, bool debug) {
   std::pair<int, int> uv = HGCalCellUV::cellUVFromXY1(xloc, yloc, placement, type, extend, debug);
   int u = uv.first;
   int v = uv.second;
-  if(partial == HGCalTypes::WaferLDTop){
-    if(u > edgeWaferLDTop){
+  if (partial == HGCalTypes::WaferLDTop) {
+    if (u > edgeWaferLDTop) {
       double xloc1 = (placement >= HGCalCell::cellPlacementExtra) ? xloc : -xloc;
       int rot = placement % HGCalCell::cellPlacementExtra;
       static constexpr std::array<double, 6> fcos = {{1.0, cos60_, -cos60_, -1.0, -cos60_, cos60_}};
@@ -283,16 +283,15 @@ std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(double xloc, double yloc,
       double yprime = xloc1 * fsin[rot] + yloc * fcos[rot];
       double xcell = -1 * (1.5 * (v - u) + 0.5) * cellX_[type];
       double ycell = (v + u - 2 * ncell_[type] + 1) * cellY_[type];
-      if((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)){
-	u += -1;
-      }else{
-	u += -1;
-	v += -1;
+      if ((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)) {
+        u += -1;
+      } else {
+        u += -1;
+        v += -1;
       }
     }
-  }
-  else if(partial == HGCalTypes::WaferHDBottom){
-    if(u < edgeWaferHDBottom){
+  } else if (partial == HGCalTypes::WaferHDBottom) {
+    if (u < edgeWaferHDBottom) {
       double xloc1 = (placement >= HGCalCell::cellPlacementExtra) ? xloc : -xloc;
       int rot = placement % HGCalCell::cellPlacementExtra;
       static constexpr std::array<double, 6> fcos = {{1.0, cos60_, -cos60_, -1.0, -cos60_, cos60_}};
@@ -301,11 +300,11 @@ std::pair<int32_t, int32_t> HGCalCellUV::cellUVFromXY1(double xloc, double yloc,
       double yprime = xloc1 * fsin[rot] + yloc * fcos[rot];
       double xcell = -1 * (1.5 * (v - u) + 0.5) * cellX_[type];
       double ycell = (v + u - 2 * ncell_[type] + 1) * cellY_[type];
-      if((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)){
-	u += 1;
-	v += 1;
-      }else{
-	u += 1;
+      if ((yprime - sqrt3_ * xprime) > (ycell - sqrt3_ * xcell)) {
+        u += 1;
+        v += 1;
+      } else {
+        u += 1;
       }
     }
   }


### PR DESCRIPTION
PR description:

There will no changes in the output.
No dependencies
This is related to getting cell id (u, v) form the (x, y) position inside a partial wafer.

PR validation:

Use runTheMatrix test workflows 'runTheMatrix.py -l limited -i all --ibeos'
Specific cfg's in Geometry/HGCalCommonData/test/python/testHGCalCellUVTester_cfg.py to test working

if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing
