### PR TITLE
SonicTriton: increase server startup wait time to 300s

### DIFF
--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -126,7 +126,7 @@ The script has two operations (`start` and `stop`) and the following options:
 * `-s [dir]`: Singularity sandbox directory (default: /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:20.09-py3-geometric)
 * `-t [dir]`: non-default hidden temporary dir
 * `-v`: (verbose) start: activate server debugging info; stop: keep server logs
-* `-w [time]`: maximum time to wait for server to start (default: 120 seconds)
+* `-w [time]`: maximum time to wait for server to start (default: 300 seconds)
 * `-h`: print help message and exit
 
 Additional details and caveats:

--- a/HeterogeneousCore/SonicTriton/scripts/cmsTriton
+++ b/HeterogeneousCore/SonicTriton/scripts/cmsTriton
@@ -5,7 +5,7 @@ USEDOCKER=""
 GPU=""
 VERBOSE=""
 VERBOSE_ARGS="--log-verbose=1 --log-error=1 --log-warning=1 --log-info=1"
-WTIME=120
+WTIME=300
 SERVER=triton_server_instance
 RETRIES=3
 REPOS=()


### PR DESCRIPTION
#### PR description:

Further addressing #37767: the sporadic test failures seem to be due to slow loading from cvmfs or some other slowdown in starting the server instance, so the wait time is increased from 2 minutes to 5 minutes.

#### PR validation:

Modified `cmsTriton` script runs as expected.
