### PR TITLE
FWCore/Framework: link cmsRunJE to libjemalloc-prof, the jemalloc library with heap profiling compiled in

### DIFF
--- a/FWCore/Framework/bin/BuildFile.xml
+++ b/FWCore/Framework/bin/BuildFile.xml
@@ -59,7 +59,7 @@
   <use name="tbb"/>
   <use name="boost"/>
   <use name="boost_program_options"/>
-  <use name="jemalloc"/>
+  <use name="jemalloc-prof"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/PluginManager"/>


### PR DESCRIPTION
Requires https://github.com/cms-sw/cmsdist/pull/7885