### PR TITLE
Support rotated HGCal Wafers in Fireworks

### DIFF
--- a/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
@@ -209,7 +209,7 @@ void FWCaloClusterProxyBuilder::build(const reco::CaloCluster &iData,
         float centerX = (corners[6] + corners[6 + offset]) / 2;
         float centerY = (corners[7] + corners[7 + offset]) / 2;
         float radius = fabs(corners[6] - corners[6 + offset]) / 2;
-        hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, 90.0, shapes[3]);
+        hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, shapes[2], shapes[3]);
         if (heatmap) {
           energy ? hex_boxset->DigitColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor])
                  : hex_boxset->DigitColor(64, 64, 64);

--- a/Fireworks/Calo/plugins/FWHGCRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHGCRecHitProxyBuilder.cc
@@ -139,7 +139,7 @@ void FWHGCRecHitProxyBuilder::build(const HGCRecHit &iData,
     float centerX = (corners[6] + corners[6 + offset]) / 2;
     float centerY = (corners[7] + corners[7 + offset]) / 2;
     float radius = fabs(corners[6] - corners[6 + offset]) / 2;
-    boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, 90.0, shapes[3]);
+    boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, shapes[2], shapes[3]);
   }
 
   if (heatmap) {

--- a/Fireworks/Calo/plugins/FWHGCalTriggerCellProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHGCalTriggerCellProxyBuilder.cc
@@ -122,7 +122,7 @@ void FWHGCalTriggerCellProxyBuilder::build(const l1t::HGCalTriggerCell &iData,
       float centerX = (corners[6] + corners[6 + offset]) / 2;
       float centerY = (corners[7] + corners[7 + offset]) / 2;
       float radius = fabs(corners[6] - corners[6 + offset]) / 2;
-      hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, 90.0, shapes[3]);
+      hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, shapes[2], shapes[3]);
       hex_boxset->DigitColor(energy * 255, 0, 255 - energy * 255);
 
       h_hex = true;

--- a/Fireworks/Calo/plugins/FWHGCalTriggerClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHGCalTriggerClusterProxyBuilder.cc
@@ -127,7 +127,7 @@ void FWHGCalTriggerClusterProxyBuilder::build(const l1t::HGCalMulticluster &iDat
         float centerX = (corners[6] + corners[6 + offset]) / 2;
         float centerY = (corners[7] + corners[7 + offset]) / 2;
         float radius = fabs(corners[6] - corners[6 + offset]) / 2;
-        hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, 90.0, shapes[3]);
+        hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, shapes[2], shapes[3]);
         hex_boxset->DigitColor(energy * 255, 0, 255 - energy * 255);
 
         h_hex = true;

--- a/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWTracksterHitsProxyBuilder.cc
@@ -232,7 +232,7 @@ void FWTracksterHitsProxyBuilder::build(const ticl::Trackster &iData,
         float centerX = (corners[6] + corners[6 + offset]) / 2;
         float centerY = (corners[7] + corners[7 + offset]) / 2;
         float radius = fabs(corners[6] - corners[6 + offset]) / 2;
-        hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, 90.0, shapes[3]);
+        hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, shapes[2], shapes[3]);
         if (heatmap_) {
           energy ? hex_boxset->DigitColor(
                        gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor], alpha)

--- a/Fireworks/Core/src/FWGeometry.cc
+++ b/Fireworks/Core/src/FWGeometry.cc
@@ -274,7 +274,7 @@ std::vector<unsigned int> FWGeometry::getMatchedIds(Detector det) const {
     if (det == HGCalHSc) {
       ids.push_back(it.id);
     } else {
-      auto key = 0x3FF; // 10 bits mask of 1s.
+      auto key = 0x3FF;  // 10 bits mask of 1s.
       if ((it.id | key) == it.id) {
         ids.push_back(it.id);
       }
@@ -362,13 +362,13 @@ TEveGeoShape* FWGeometry::getHGCSiliconEveShape(unsigned int id) const {
   TGeoXtru* geoShape = new TGeoXtru(2);
   Double_t x[6];
   Double_t y[6];
-  for (unsigned int i = 0 ; i < 6; ++i) {
+  for (unsigned int i = 0; i < 6; ++i) {
     x[i] = info.points[i * 3];
     y[i] = info.points[3 * i + 1];
   }
   geoShape->DefinePolygon(6, x, y);
-  geoShape->DefineSection(0, info.points[2] - 0.0150); // First plane at the Z position of the wafer, minus 150um
-  geoShape->DefineSection(1, info.points[2] + 0.0150); // Second plane at the Z position of the wafer, minus 150um
+  geoShape->DefineSection(0, info.points[2] - 0.0150);  // First plane at the Z position of the wafer, minus 150um
+  geoShape->DefineSection(1, info.points[2] + 0.0150);  // Second plane at the Z position of the wafer, minus 150um
 
   shape->SetShape(geoShape);
   double array[16] = {info.matrix[0],
@@ -383,9 +383,9 @@ TEveGeoShape* FWGeometry::getHGCSiliconEveShape(unsigned int id) const {
                       info.matrix[5],
                       info.matrix[8],
                       0.,
-                      0., // translation x
-                      0., // translation y
-                      0., // translation z
+                      0.,  // translation x
+                      0.,  // translation y
+                      0.,  // translation z
                       1.};
   // Set transformation matrix from a column-major array
   shape->SetTransMatrix(array);

--- a/Fireworks/Core/src/FWGeometry.cc
+++ b/Fireworks/Core/src/FWGeometry.cc
@@ -264,22 +264,21 @@ std::vector<unsigned int> FWGeometry::getMatchedIds(Detector det, SubDetector su
 
 std::vector<unsigned int> FWGeometry::getMatchedIds(Detector det) const {
   std::vector<unsigned int> ids;
-  std::set<unsigned int> cached_wafers;
   for (const auto& it : m_idToInfo) {
     if (((it.id >> kDetOffset) & 0xF) != det)
       continue;
 
-    // select only the first cell of each wafer
-    if (det != HGCalHSc) {
-      auto key = ~0x3FF & it.id;
-      if (cached_wafers.find(key) == cached_wafers.end()) {
-        cached_wafers.insert(key);
+    // select only the fake DetIds that have all the (u,v) bits set at 1.  This
+    // is used to draw the HGCal Geometry that is wafer-based for the silicon
+    // part. The Scintillators are treated on a tile-basis.
+    if (det == HGCalHSc) {
+      ids.push_back(it.id);
+    } else {
+      auto key = 0x3FF; // 10 bits mask of 1s.
+      if ((it.id | key) == it.id) {
         ids.push_back(it.id);
       }
-      continue;
     }
-
-    ids.push_back(it.id);
   }
   return ids;
 }
@@ -349,25 +348,6 @@ TEveGeoShape* FWGeometry::getEveShape(unsigned int id) const {
 }
 
 TEveGeoShape* FWGeometry::getHGCSiliconEveShape(unsigned int id) const {
-#if 0
-   const unsigned int type = (id>>26)&0x3;
-   // select the middle cell of each waifer
-   id &= ~0x3FF;
-   id |= (type == 0) ? 0x16B : 0xE7;
-#else
-  float sideToSideWaferSize = 16.7441f;
-  float dx = sideToSideWaferSize / 2;
-  float sidey = dx / sqrt(3);
-  float dy = 2 * sidey;
-
-  int waferUint = (id >> 10) & 0xF;
-  int waferVint = (id >> 15) & 0xF;
-  float waferU = ((id >> 14) & 0x1) ? -sideToSideWaferSize * waferUint : sideToSideWaferSize * waferUint;
-  float waferV = ((id >> 19) & 0x1) ? -sideToSideWaferSize * waferVint : sideToSideWaferSize * waferVint;
-
-  float waferX = (-2 * waferU + waferV) / 2;
-  float waferY = waferV * sqrt(3) / 2;
-#endif
   IdToInfoItr it = FWGeometry::find(id);
   if (it == m_idToInfo.end()) {
     fwLog(fwlog::kWarning) << "no reco geometry found for id " << id << std::endl;
@@ -379,18 +359,16 @@ TEveGeoShape* FWGeometry::getHGCSiliconEveShape(unsigned int id) const {
   TEveGeoManagerHolder gmgr(TEveGeoShape::GetGeoMangeur());
   TEveGeoShape* shape = new TEveGeoShape(TString::Format("RecoGeom Id=%u", id));
 
-  float dz = fabs(info.points[14] - info.points[2]) * 0.5;
-
-  info.translation[2] = (info.points[14] + info.points[2]) / 2.0f;
-  info.translation[0] = waferX * ((0 < info.translation[2]) - (info.translation[2] < 0));
-  info.translation[1] = waferY;
-
   TGeoXtru* geoShape = new TGeoXtru(2);
-  Double_t x[6] = {-dx, -dx, 0.0, dx, dx, 0.0};
-  Double_t y[6] = {-sidey, sidey, dy, sidey, -sidey, -dy};
+  Double_t x[6];
+  Double_t y[6];
+  for (unsigned int i = 0 ; i < 6; ++i) {
+    x[i] = info.points[i * 3];
+    y[i] = info.points[3 * i + 1];
+  }
   geoShape->DefinePolygon(6, x, y);
-  geoShape->DefineSection(0, -dz);
-  geoShape->DefineSection(1, dz);
+  geoShape->DefineSection(0, info.points[2] - 0.0150); // First plane at the Z position of the wafer, minus 150um
+  geoShape->DefineSection(1, info.points[2] + 0.0150); // Second plane at the Z position of the wafer, minus 150um
 
   shape->SetShape(geoShape);
   double array[16] = {info.matrix[0],
@@ -405,9 +383,9 @@ TEveGeoShape* FWGeometry::getHGCSiliconEveShape(unsigned int id) const {
                       info.matrix[5],
                       info.matrix[8],
                       0.,
-                      info.translation[0],
-                      info.translation[1],
-                      info.translation[2],
+                      0., // translation x
+                      0., // translation y
+                      0., // translation z
                       1.};
   // Set transformation matrix from a column-major array
   shape->SetTransMatrix(array);

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -560,7 +560,7 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
       // such that the cells are oriented with a vertex down (assuming those
       // layers will have a 30 degrees rotation): this will establish an angle
       // of 60 degrees wrt the Y axis. The default way in which an hexagon is
-      // rendered inside Fireworks is with the side down.
+      // rendered inside Fireworks is with the vertex down.
       if (rhtools.isSilicon(it->rawId())) {
         auto val_x = (cor[0].x()-cor[3].x());
         auto val_y = (cor[0].y()-cor[3].y());

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -562,9 +562,9 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
       // of 60 degrees wrt the Y axis. The default way in which an hexagon is
       // rendered inside Fireworks is with the vertex down.
       if (rhtools.isSilicon(it->rawId())) {
-        auto val_x = (cor[0].x()-cor[3].x());
-        auto val_y = (cor[0].y()-cor[3].y());
-        auto val = round(std::acos(val_y / std::sqrt(val_x*val_x + val_y*val_y))/M_PI*180.);
+        auto val_x = (cor[0].x() - cor[3].x());
+        auto val_y = (cor[0].y() - cor[3].y());
+        auto val = round(std::acos(val_y / std::sqrt(val_x * val_x + val_y * val_y)) / M_PI * 180.);
         // Pass down the chain the vaue of the rotation of the cell wrt the Y axis.
         fwRecoGeometry.idToName[id].shape[2] = val;
       }
@@ -580,23 +580,24 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
       if ((det == DetId::HGCalEE) || (det == DetId::HGCalHSi)) {
         // Avoid hard coding masks by using static data members from HGCSiliconDetId
         auto maskZeroUV = (HGCSiliconDetId::kHGCalCellVMask << HGCSiliconDetId::kHGCalCellVOffset) |
-          (HGCSiliconDetId::kHGCalCellUMask << HGCSiliconDetId::kHGCalCellUOffset);
+                          (HGCSiliconDetId::kHGCalCellUMask << HGCSiliconDetId::kHGCalCellUOffset);
         DetId wafer_detid = it->rawId() | maskZeroUV;
         // Just be damn sure that's a fake id.
         assert(wafer_detid != it->rawId());
         auto [iter, is_new] = cache.insert(wafer_detid);
         if (is_new) {
           unsigned int local_id = insert_id(wafer_detid, fwRecoGeometry);
-          auto const & dddConstants = geom->topology().dddConstants();
+          auto const& dddConstants = geom->topology().dddConstants();
           auto wafer_size = static_cast<float>(dddConstants.waferSize(true));
           auto R = wafer_size / std::sqrt(3.f);
           auto r = wafer_size / 2.f;
           float x[6] = {-r, -r, 0.f, r, r, 0.f};
-          float y[6] = {R/2.f, -R/2.f, -R, -R/2.f, R/2.f, R};
+          float y[6] = {R / 2.f, -R / 2.f, -R, -R / 2.f, R / 2.f, R};
           float z[6] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
           for (unsigned int i = 0; i < 6; ++i) {
             HepGeom::Point3D<float> wafer_corner(x[i], y[i], z[i]);
-            auto point = geom->topology().dddConstants().waferLocal2Global(wafer_corner, wafer_detid, true, true, false);
+            auto point =
+                geom->topology().dddConstants().waferLocal2Global(wafer_corner, wafer_detid, true, true, false);
             fwRecoGeometry.idToName[local_id].points[i * 3 + 0] = point.x();
             fwRecoGeometry.idToName[local_id].points[i * 3 + 1] = point.y();
             fwRecoGeometry.idToName[local_id].points[i * 3 + 2] = point.z();
@@ -626,7 +627,7 @@ void FWRecoGeometryESProducer::addCaloGeometry(FWRecoGeometry& fwRecoGeometry) {
 
           // Silicon index
           fwRecoGeometry.idToName[local_id].topology[4] =
-            rhtools.isSilicon(it->rawId()) ? rhtools.getSiThickIndex(it->rawId()) : -1.;
+              rhtools.isSilicon(it->rawId()) ? rhtools.getSiThickIndex(it->rawId()) : -1.;
 
           // Last EE layer
           fwRecoGeometry.idToName[local_id].topology[5] = rhtools.lastLayerEE();

--- a/Fireworks/SimData/plugins/FWCaloParticleProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWCaloParticleProxyBuilder.cc
@@ -126,7 +126,7 @@ void FWCaloParticleProxyBuilder::build(const CaloParticle &iData,
         float centerX = (corners[6] + corners[6 + offset]) / 2;
         float centerY = (corners[7] + corners[7 + offset]) / 2;
         float radius = fabs(corners[6] - corners[6 + offset]) / 2;
-        hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, 90.0, shapes[3]);
+        hex_boxset->AddHex(TEveVector(centerX, centerY, corners[2]), radius, shapes[2], shapes[3]);
         if (heatmap) {
           const uint8_t colorFactor = gradient_steps * (fmin(hitmap->at(it.first)->energy() / saturation_energy, 1.0f));
           hex_boxset->DigitColor(gradient[0][colorFactor], gradient[1][colorFactor], gradient[2][colorFactor]);

--- a/Geometry/HGCalGeometry/src/HGCalGeometry.cc
+++ b/Geometry/HGCalGeometry/src/HGCalGeometry.cc
@@ -402,7 +402,8 @@ HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid, bool 
       co[i] = GlobalPoint(
           (r + signr[i] * dr) * cos(fi + signf[i] * dfi), (r + signr[i] * dr) * sin(fi + signf[i] * dfi), (v.z() + dz));
     }
-    co[ncorner - 1] = co[0];
+    // Used to pass downstream the thickness of this cell
+    co[ncorner - 1] = GlobalPoint(0, 0, -2 * dz);
   } else if (cellIndex < m_cellVec.size() && m_det != DetId::HGCalHSc) {
     std::pair<float, float> xy;
     float dx = k_fac2 * m_cellVec[cellIndex].param()[FlatHexagon::k_r];
@@ -438,7 +439,8 @@ HGCalGeometry::CornersVec HGCalGeometry::getNewCorners(const DetId& detid, bool 
         co[i] = GlobalPoint(xx, xyglob.second, id.zSide * (zz + dz));
       }
     }
-    co[ncorner - 1] = co[0];
+    // Used to pass downstream the thickness of this cell
+    co[ncorner - 1] = GlobalPoint(0, 0, -2 * dz);
   }
   return co;
 }


### PR DESCRIPTION
#### PR description:

This PR addresses the following point:

* Improve geometry handling in Fireworks by supporting fully rotated layers in HGCal. The old handling of reconstruction geometry in Fireworks was too decoupled from the tools developed to create and handle the HGCal geometry. Now every aspect of the geometry relevant for a correct rendering is handled while creating the geometry itself, not by homemade code at rendering time. Comments in the single git commits and inside the code are far more explanatory.
* Correctly handle the cells' orientation of the fully rotated layers. The improved handling should be generic enough to be valid for arbitrary rotations, not just the current one at 30 degrees. Comments in the single git commits and inside the code contain more information.
* Correctly pass the thickness of every single cell or tile inside the geometry, so that the `3DRecHits` rendering of the single cells and tiles is properly done. Comments have been added to the code to alert the developer about the downstream effects in case she wants to change the behaviour.
* Update the Fireworks plugins to use the feature that has been added and stored along with the HGCal reconstruction geometry.

#### PR validation:

The code has been tested using `D86` and `D88` geometry. No further bugs nor strange behaviour is observed.
In particular, layers 28, 30 and 32 show the correct rendering, as shown in the following images:
![Layer28_D86](https://user-images.githubusercontent.com/1169991/169965343-13408abb-b2e7-417a-8d4d-912026d52ff3.png)
![Layer30_D86](https://user-images.githubusercontent.com/1169991/169965341-2fdc29e1-2030-477c-9be3-92f3bd0ac78c.png)
![Layer32_D86](https://user-images.githubusercontent.com/1169991/169965335-fff6de39-83e7-4b87-823a-018ca3ecab91.png)

Moreover, one can see the different orientations of the single cells within the rotated layers with respect to the default orientation, as shown in this picture:

![cellsOrientation_28_30_32](https://user-images.githubusercontent.com/1169991/169965640-fd2c254f-16da-4871-9d9a-1e0c8c1545ac.png)
