### PR TITLE
[GEM] GEM packer-unpacker update for GEMChMap

### DIFF
--- a/CondFormats/GEMObjects/interface/GEMChMap.h
+++ b/CondFormats/GEMObjects/interface/GEMChMap.h
@@ -139,7 +139,7 @@ public:
 
   const std::vector<uint16_t> getVfats(const int type) const { return chamVfats_.at(type); }
   void add(int type, uint16_t d) {
-    if (std::find(chamVfats_[type].begin(), chamVfats_[type].end(), d) != chamVfats_[type].end())
+    if (std::find(chamVfats_[type].begin(), chamVfats_[type].end(), d) == chamVfats_[type].end())
       chamVfats_[type].push_back(d);
   }
 
@@ -147,7 +147,7 @@ public:
     return chamIEtas_.at({chamberType, vfatAdd});
   }
   void add(vfatEC d, int iEta) {
-    if (std::find(chamIEtas_[d].begin(), chamIEtas_[d].end(), iEta) != chamIEtas_[d].end())
+    if (std::find(chamIEtas_[d].begin(), chamIEtas_[d].end(), iEta) == chamIEtas_[d].end())
       chamIEtas_[d].push_back(iEta);
   }
 

--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -16,9 +16,8 @@
 
 #include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
 
-#include "CondFormats/DataRecord/interface/GEMeMapRcd.h"
-#include "CondFormats/GEMObjects/interface/GEMeMap.h"
-#include "CondFormats/GEMObjects/interface/GEMROMapping.h"
+#include "CondFormats/DataRecord/interface/GEMChMapRcd.h"
+#include "CondFormats/GEMObjects/interface/GEMChMap.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMVFATStatusCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMOHStatusCollection.h"
@@ -70,9 +69,7 @@ private:
   void SetLabelOHStatus(MonitorElement *h2Status);
   void SetLabelVFATStatus(MonitorElement *h2Status);
 
-  edm::ESGetToken<GEMeMap, GEMeMapRcd> gemEMapToken_;
-  //std::shared_ptr<GEMROMapping> gemROMap_;
-  const GEMeMap *gemEMap_;
+  const edm::ESGetToken<GEMChMap, GEMChMapRcd> gemChMapToken_;
 
   edm::EDGetToken tagVFAT_;
   edm::EDGetToken tagOH_;

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -39,7 +39,7 @@ public:
     Errors error{0};
     error.EvtF = oh.evtF();
     error.InF = oh.inF();
-    error.L1aF = oh.l1aF();
+    error.L1aF = (oh.l1aF() and (oh.version() == 0));
     error.EvtSzOFW = oh.evtSzOFW();
     error.Inv = oh.inv();
     error.OOScAvV = oh.oOScAvV();
@@ -53,7 +53,7 @@ public:
     Warnings warn{0};
     warn.EvtNF = oh.evtNF();
     warn.InNF = oh.inNF();
-    warn.L1aNF = oh.l1aNF();
+    warn.L1aNF = (oh.l1aNF() and (oh.version() == 0));
     warn.EvtSzW = oh.evtSzW();
     warnings_ = warn.wcodes;
   }

--- a/EventFilter/GEMRawToDigi/src/GEMRawToDigi.cc
+++ b/EventFilter/GEMRawToDigi/src/GEMRawToDigi.cc
@@ -27,6 +27,7 @@ std::unique_ptr<GEMAMC13> GEMRawToDigi::convertWordToGEMAMC13(const uint64_t* wo
     // Fill GEB
     for (uint8_t j = 0; j < amc.davCnt(); ++j) {
       auto oh = GEMOptoHybrid();
+      oh.setVersion(amc.formatVer());
       oh.setChamberHeader(*(++word));
 
       // Fill vfat


### PR DESCRIPTION
#### PR description:
* Current GEM packer and unpacker are using GEMeMap which is not corresponding with GE21 readout system.
* GEM packer and unpacker are updated to use GEMChMap.
* Backports to `CMSSW_12_4_X` and `CMSSW_12_3_X` are needed.

#### PR validation:
* The code format has applied with `scram build code-format` and `scram build code-checks`
* Currently the branch is not compatible with `runTheMatrix.py` command, because GEMChMap is not in the condition that is used for the `runTheMatrix.py`.