### PR TITLE
MTD validation: update track-MTD matching efficiency monitoring

### DIFF
--- a/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
@@ -1,3 +1,5 @@
+#define EDM_ML_DEBUG
+
 // Our own includes
 #include "RecoLocalFastTime/FTLClusterizer/interface/MTDArrayBuffer.h"
 #include "RecoLocalFastTime/FTLClusterizer/interface/MTDThresholdClusterizer.h"
@@ -10,6 +12,8 @@
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 // STL
 #include <stack>
 #include <vector>
@@ -17,16 +21,6 @@
 #include <atomic>
 #include <cmath>
 using namespace std;
-
-//#define DEBUG_ENABLED
-#ifdef DEBUG_ENABLED
-#define DEBUG(x)                 \
-  do {                           \
-    std::cout << x << std::endl; \
-  } while (0)
-#else
-#define DEBUG(x)
-#endif
 
 //----------------------------------------------------------------------------
 //! Constructor:
@@ -78,7 +72,7 @@ bool MTDThresholdClusterizer::setup(const MTDGeometry* geom, const MTDTopology* 
   theNumOfRows = nrows;  // Set new sizes
   theNumOfCols = ncols;
 
-  DEBUG("Buffer size [" << theNumOfRows + 1 << "," << theNumOfCols + 1 << "]");
+  LogDebug("MTDThresholdClusterizer") << "Buffer size [" << theNumOfRows + 1 << "," << theNumOfCols + 1 << "]";
 
   if (nrows > theBuffer.rows() || ncols > theBuffer.columns()) {  // change only when a larger is needed
     // Resize the buffer
@@ -108,7 +102,7 @@ void MTDThresholdClusterizer::clusterize(const FTLRecHitCollection& input,
     return;
   }
 
-  DEBUG("Input collection " << input.size());
+  LogDebug("MTDThresholdClusterizer") << "Input collection " << input.size();
   assert(output.empty());
 
   std::set<unsigned> geoIds;
@@ -148,8 +142,8 @@ void MTDThresholdClusterizer::clusterize(const FTLRecHitCollection& input,
       return;
 
     auto range = geoIdToIdx.equal_range(id);
-    DEBUG("Matching Ids for " << std::hex << id << std::dec << " [" << range.first->second << ","
-                              << range.second->second << "]");
+    LogDebug("MTDThresholdClusterizer") << "Matching Ids for " << std::hex << id << std::dec << " ["
+                                        << range.first->second << "," << range.second->second << "]";
 
     //  Copy MTDRecHits to the buffer array; select the seed hits
     //  on the way, and store them in theSeeds.
@@ -167,8 +161,9 @@ void MTDThresholdClusterizer::clusterize(const FTLRecHitCollection& input,
 
         //  Check if the cluster is above threshold
         if (cluster.energy() > theClusterThreshold) {
-          DEBUG("putting in this cluster " << i << " #hits:" << cluster.size() << " E:" << cluster.energy()
-                                           << " T:" << cluster.time() << " X:" << cluster.x() << " Y:" << cluster.y());
+          LogDebug("MTDThresholdClusterizer")
+              << "putting in this cluster " << i << " #hits:" << cluster.size() << " E:" << cluster.energy()
+              << " T:" << cluster.time() << " X:" << cluster.x() << " Y:" << cluster.y();
           clustersOnDet.push_back(cluster);
         }
       }
@@ -236,7 +231,7 @@ void MTDThresholdClusterizer::copy_to_buffer(RecHitIterator itr, const MTDGeomet
     global_point = det->toGlobal(lp);
   }
 
-  DEBUG("ROW " << row << " COL " << col << " ENERGY " << energy << " TIME " << time);
+  LogDebug("MTDThresholdClusterizer") << "ROW " << row << " COL " << col << " ENERGY " << energy << " TIME " << time;
   if (energy > theHitThreshold) {
     theBuffer.set(row, col, subDet, energy, time, timeError, local_error, global_point);
     if (energy > theSeedThreshold)

--- a/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
@@ -1,5 +1,3 @@
-#define EDM_ML_DEBUG
-
 // Our own includes
 #include "RecoLocalFastTime/FTLClusterizer/interface/MTDArrayBuffer.h"
 #include "RecoLocalFastTime/FTLClusterizer/interface/MTDThresholdClusterizer.h"

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDTrackingRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDTrackingRecHitProducer.cc
@@ -1,3 +1,5 @@
+#define EDM_ML_DEBUG
+
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -74,7 +76,7 @@ void MTDTrackingRecHitProducer::produce(edm::StreamID, edm::Event& evt, const ed
 
   for (auto const& theInput : inputHandle) {
     if (!theInput.isValid()) {
-      edm::LogWarning("MTDReco") << "MTDTrackingRecHitProducer: Invalid collection";
+      edm::LogWarning("MTDTrackingRecHitProducer") << "MTDTrackingRecHitProducer: Invalid collection";
       continue;
     }
     const edmNew::DetSetVector<FTLCluster>& input = *theInput;
@@ -92,7 +94,7 @@ void MTDTrackingRecHitProducer::produce(edm::StreamID, edm::Event& evt, const ed
       MTDTrackingDetSetVector::FastFiller recHitsOnDet(theoutputhits, detid);
 
       for (const auto& clustIt : DSVit) {
-        LogDebug("MTDTrackingRcHitProducer") << "Cluster: size " << clustIt.size() << " " << clustIt.x() << ","
+        LogDebug("MTDTrackingRecHitProducer") << "Cluster: size " << clustIt.size() << " " << clustIt.x() << ","
                                              << clustIt.y() << " " << clustIt.energy() << " " << clustIt.time();
         MTDClusterParameterEstimator::ReturnType tuple = cpe.getParameters(clustIt, *genericDet);
         LocalPoint lp(std::get<0>(tuple));
@@ -102,7 +104,7 @@ void MTDTrackingRecHitProducer::produce(edm::StreamID, edm::Event& evt, const ed
         edm::Ref<edmNew::DetSetVector<FTLCluster>, FTLCluster> cluster = edmNew::makeRefTo(theInput, &clustIt);
         // Make a RecHit and add it to the DetSet
         MTDTrackingRecHit hit(lp, le, *genericDet, cluster);
-        LogDebug("MTDTrackingRcHitProducer")
+        LogDebug("MTDTrackingRecHitProducer")
             << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y() << " : "
             << hit.localPositionError().xx() << "," << hit.localPositionError().yy() << " : " << hit.time() << " : "
             << hit.timeError();
@@ -110,7 +112,7 @@ void MTDTrackingRecHitProducer::produce(edm::StreamID, edm::Event& evt, const ed
         recHitsOnDet.push_back(hit);
       }  //  <-- End loop on Clusters
     }    //    <-- End loop on DetUnits
-    LogDebug("MTDTrackingRcHitProducer") << "outputCollection " << theoutputhits.size();
+    LogDebug("MTDTrackingRecHitProducer") << "outputCollection " << theoutputhits.size();
   }
 
   evt.put(std::move(outputhits));

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDTrackingRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDTrackingRecHitProducer.cc
@@ -93,9 +93,11 @@ void MTDTrackingRecHitProducer::produce(edm::StreamID, edm::Event& evt, const ed
 
       MTDTrackingDetSetVector::FastFiller recHitsOnDet(theoutputhits, detid);
 
+      LogDebug("MTDTrackingRecHitProducer") << "MTD cluster DetId " << detid << " # cluster " << DSVit.size();
+
       for (const auto& clustIt : DSVit) {
         LogDebug("MTDTrackingRecHitProducer") << "Cluster: size " << clustIt.size() << " " << clustIt.x() << ","
-                                             << clustIt.y() << " " << clustIt.energy() << " " << clustIt.time();
+                                              << clustIt.y() << " " << clustIt.energy() << " " << clustIt.time();
         MTDClusterParameterEstimator::ReturnType tuple = cpe.getParameters(clustIt, *genericDet);
         LocalPoint lp(std::get<0>(tuple));
         LocalError le(std::get<1>(tuple));

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDTrackingRecHitProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDTrackingRecHitProducer.cc
@@ -1,5 +1,3 @@
-#define EDM_ML_DEBUG
-
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"

--- a/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlDigiHitsValidation.cc
@@ -50,7 +50,7 @@ private:
   // ------------ member data ------------
 
   const std::string folder_;
-  const bool LocalPosDebug_;
+  const bool optionalPlots_;
 
   edm::EDGetTokenT<BTLDigiCollection> btlDigiHitsToken_;
 
@@ -90,7 +90,7 @@ private:
 // ------------ constructor and destructor --------------
 BtlDigiHitsValidation::BtlDigiHitsValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
-      LocalPosDebug_(iConfig.getParameter<bool>("LocalPositionDebug")) {
+      optionalPlots_(iConfig.getParameter<bool>("optionalPlots")) {
   btlDigiHitsToken_ = consumes<BTLDigiCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
   mtdgeoToken_ = esConsumes<MTDGeometry, MTDDigiGeometryRecord>();
   mtdtopoToken_ = esConsumes<MTDTopology, MTDTopologyRcd>();
@@ -143,7 +143,7 @@ void BtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
       meOccupancy_[iside]->Fill(global_point.z(), global_point.phi());
 
-      if (LocalPosDebug_) {
+      if (optionalPlots_) {
         meLocalOccupancy_[iside]->Fill(local_point.x(), local_point.y());
         meHitXlocal_[iside]->Fill(local_point.x());
         meHitYlocal_[iside]->Fill(local_point.y());
@@ -206,7 +206,7 @@ void BtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  126,
                                  -3.15,
                                  3.15);
-  if (LocalPosDebug_) {
+  if (optionalPlots_) {
     meLocalOccupancy_[0] = ibook.book2D("BtlLocalOccupancyL",
                                         "BTL DIGI hits local occupancy (L);X_{DIGI} [cm]; Y_{DIGI} [cm]",
                                         100,
@@ -292,7 +292,7 @@ void BtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& des
 
   desc.add<std::string>("folder", "MTD/BTL/DigiHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "FTLBarrel"));
-  desc.add<bool>("LocalPositionDebug", false);
+  desc.add<bool>("optionalPlots", false);
 
   descriptions.add("btlDigiHitsDefaultValid", desc);
 }

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -68,7 +68,7 @@ private:
 
   const std::string folder_;
   const double hitMinEnergy_;
-  const bool LocalPosDebug_;
+  const bool optionalPlots_;
   const bool uncalibRecHitsPlots_;
   const double hitMinAmplitude_;
 
@@ -182,7 +182,7 @@ bool BtlLocalRecoValidation::isSameCluster(const FTLCluster& clu1, const FTLClus
 BtlLocalRecoValidation::BtlLocalRecoValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
       hitMinEnergy_(iConfig.getParameter<double>("HitMinimumEnergy")),
-      LocalPosDebug_(iConfig.getParameter<bool>("LocalPositionDebug")),
+      optionalPlots_(iConfig.getParameter<bool>("optionalPlots")),
       uncalibRecHitsPlots_(iConfig.getParameter<bool>("UncalibRecHitsPlots")),
       hitMinAmplitude_(iConfig.getParameter<double>("HitMinimumAmplitude")) {
   btlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsTag"));
@@ -216,6 +216,13 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   auto btlRecCluHandle = makeValid(iEvent.getHandle(btlRecCluToken_));
   auto mtdTrkHitHandle = makeValid(iEvent.getHandle(mtdTrackingHitToken_));
   MixCollection<PSimHit> btlSimHits(btlSimHitsHandle.product());
+
+  for ( const auto& hits : *mtdTrkHitHandle) {
+    edm::LogPrint("BtlLocalRecoValidation") << "MTDRH DetId " << hits.id() << " size " << hits.size();
+    for ( const auto& hit : hits ) {
+       edm::LogPrint("BtlLocalRecoValidation") << "MTDRH pos " << hit.localPosition().x() << " " << hit.localPosition().y() <<  " err " << hit.localPositionError().xx() << " " << hit.localPositionError().yy();
+    }
+  }
 
   // --- Loop over the BTL SIM hits
   std::unordered_map<uint32_t, MTDHit> m_btlSimHits;
@@ -267,7 +274,7 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
     meOccupancy_->Fill(global_point.z(), global_point.phi());
 
-    if (LocalPosDebug_) {
+    if (optionalPlots_) {
       meLocalOccupancy_->Fill(local_point.x() + recHit.position(), local_point.y());
       meHitXlocal_->Fill(local_point.x());
       meHitYlocal_->Fill(local_point.y());
@@ -391,12 +398,14 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
           cluEneSIM += m_btlSimHits[recHit.id().rawId()].energy;
           cluTimeSIM += m_btlSimHits[recHit.id().rawId()].time * m_btlSimHits[recHit.id().rawId()].energy;
 
+          break;
+
         }  // recHit loop
 
       }  // ihit loop
 
       // Find the MTDTrackingRecHit corresponding to the cluster
-      MTDTrackingRecHit* comp(nullptr);
+      const MTDTrackingRecHit* comp(nullptr);
       bool matchClu = false;
       const auto& trkHits = (*mtdTrkHitHandle)[detIdObject];
       for (const auto& trkHit : trkHits) {
@@ -435,13 +444,13 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
         meCluZRes_->Fill(z_res);
 
-        if (LocalPosDebug_) {
+        if (optionalPlots_) {
           if (matchClu && comp != nullptr) {
             meCluLocalXRes_->Fill(xlocal_res);
             meCluLocalYRes_->Fill(ylocal_res);
-            meCluLocalXPull_->Fill(xlocal_res / std::sqrt(comp->localPositionError().xx()));
-            meCluLocalYPull_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
-            meCluZPull_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
+	    meCluLocalXPull_->Fill(xlocal_res / std::sqrt(comp->localPositionError().xx()));
+	    meCluLocalYPull_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
+	    meCluZPull_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
             meCluXLocalErr_->Fill(std::sqrt(comp->localPositionError().xx()));
             meCluYLocalErr_->Fill(std::sqrt(comp->localPositionError().yy()));
           }
@@ -569,7 +578,7 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitTimeError_ = ibook.book1D("BtlHitTimeError", "BTL RECO hits ToA error;#sigma^{ToA}_{RECO} [ns]", 50, 0., 0.1);
   meOccupancy_ = ibook.book2D(
       "BtlOccupancy", "BTL RECO hits occupancy;Z_{RECO} [cm]; #phi_{RECO} [rad]", 65, -260., 260., 126, -3.2, 3.2);
-  if (LocalPosDebug_) {
+  if (optionalPlots_) {
     meLocalOccupancy_ = ibook.book2D(
         "BtlLocalOccupancy", "BTL RECO hits local occupancy;X_{RECO} [cm]; Y_{RECO} [cm]", 100, 10., 10., 60, -3., 3.);
     meHitXlocal_ = ibook.book1D("BtlHitXlocal", "BTL RECO local X;X_{RECO}^{LOC} [cm]", 100, -10., 10.);
@@ -687,7 +696,7 @@ void BtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meCluPhiRes_ =
       ibook.book1D("BtlCluPhiRes", "BTL cluster #phi resolution;#phi_{RECO}-#phi_{SIM} [rad]", 100, -0.03, 0.03);
   meCluZRes_ = ibook.book1D("BtlCluZRes", "BTL cluster Z resolution;Z_{RECO}-Z_{SIM} [cm]", 100, -0.2, 0.2);
-  if (LocalPosDebug_) {
+  if (optionalPlots_) {
     meCluLocalXRes_ =
         ibook.book1D("BtlCluLocalXRes", "BTL cluster local X resolution;X_{RECO}-X_{SIM} [cm]", 100, -3.1, 3.1);
     meCluLocalYRes_ =
@@ -763,7 +772,7 @@ void BtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<edm::InputTag>("recCluTag", edm::InputTag("mtdClusters", "FTLBarrel"));
   desc.add<edm::InputTag>("trkHitTag", edm::InputTag("mtdTrackingRecHits"));
   desc.add<double>("HitMinimumEnergy", 1.);  // [MeV]
-  desc.add<bool>("LocalPositionDebug", false);
+  desc.add<bool>("optionalPlots", false);
   desc.add<bool>("UncalibRecHitsPlots", false);
   desc.add<double>("HitMinimumAmplitude", 30.);  // [pC]
 

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -1,3 +1,5 @@
+#define EDM_ML_DEBUG
+
 // -*- C++ -*-
 //
 // Package:    Validation/MtdValidation
@@ -217,12 +219,17 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   auto mtdTrkHitHandle = makeValid(iEvent.getHandle(mtdTrackingHitToken_));
   MixCollection<PSimHit> btlSimHits(btlSimHitsHandle.product());
 
-  for ( const auto& hits : *mtdTrkHitHandle) {
-    edm::LogPrint("BtlLocalRecoValidation") << "MTDRH DetId " << hits.id() << " size " << hits.size();
-    for ( const auto& hit : hits ) {
-       edm::LogPrint("BtlLocalRecoValidation") << "MTDRH pos " << hit.localPosition().x() << " " << hit.localPosition().y() <<  " err " << hit.localPositionError().xx() << " " << hit.localPositionError().yy();
+#ifdef EDM_ML_DEBUG
+  for (const auto& hits : *mtdTrkHitHandle) {
+    LogDebug("BtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
+    for (const auto& hit : hits) {
+      LogDebug("BtlLocalRecoValidation")
+          << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y() << " : "
+          << hit.localPositionError().xx() << "," << hit.localPositionError().yy() << " : " << hit.time() << " : "
+          << hit.timeError();
     }
   }
+#endif
 
   // --- Loop over the BTL SIM hits
   std::unordered_map<uint32_t, MTDHit> m_btlSimHits;
@@ -448,9 +455,9 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
           if (matchClu && comp != nullptr) {
             meCluLocalXRes_->Fill(xlocal_res);
             meCluLocalYRes_->Fill(ylocal_res);
-	    meCluLocalXPull_->Fill(xlocal_res / std::sqrt(comp->localPositionError().xx()));
-	    meCluLocalYPull_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
-	    meCluZPull_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
+            meCluLocalXPull_->Fill(xlocal_res / std::sqrt(comp->localPositionError().xx()));
+            meCluLocalYPull_->Fill(ylocal_res / std::sqrt(comp->localPositionError().yy()));
+            meCluZPull_->Fill(z_res / std::sqrt(comp->globalPositionError().czz()));
             meCluXLocalErr_->Fill(std::sqrt(comp->localPositionError().xx()));
             meCluYLocalErr_->Fill(std::sqrt(comp->localPositionError().yy()));
           }

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -1,5 +1,3 @@
-#define EDM_ML_DEBUG
-
 // -*- C++ -*-
 //
 // Package:    Validation/MtdValidation
@@ -221,12 +219,14 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
 #ifdef EDM_ML_DEBUG
   for (const auto& hits : *mtdTrkHitHandle) {
-    LogDebug("BtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
-    for (const auto& hit : hits) {
-      LogDebug("BtlLocalRecoValidation") << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y()
-                                         << " : " << hit.localPositionError().xx() << ","
-                                         << hit.localPositionError().yy() << " : " << hit.time() << " : "
-                                         << hit.timeError();
+    if (MTDDetId(hits.id()).mtdSubDetector() == MTDDetId::MTDType::BTL) {
+      LogDebug("BtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
+      for (const auto& hit : hits) {
+        LogDebug("BtlLocalRecoValidation")
+            << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y() << " : "
+            << hit.localPositionError().xx() << "," << hit.localPositionError().yy() << " : " << hit.time() << " : "
+            << hit.timeError();
+      }
     }
   }
 #endif

--- a/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/BtlLocalRecoValidation.cc
@@ -223,10 +223,10 @@ void BtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   for (const auto& hits : *mtdTrkHitHandle) {
     LogDebug("BtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
     for (const auto& hit : hits) {
-      LogDebug("BtlLocalRecoValidation")
-          << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y() << " : "
-          << hit.localPositionError().xx() << "," << hit.localPositionError().yy() << " : " << hit.time() << " : "
-          << hit.timeError();
+      LogDebug("BtlLocalRecoValidation") << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y()
+                                         << " : " << hit.localPositionError().xx() << ","
+                                         << hit.localPositionError().yy() << " : " << hit.time() << " : "
+                                         << hit.timeError();
     }
   }
 #endif

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -46,7 +46,7 @@ private:
   // ------------ member data ------------
 
   const std::string folder_;
-  const bool LocalPosDebug_;
+  const bool optionalPlots_;
 
   edm::EDGetTokenT<ETLDigiCollection> etlDigiHitsToken_;
 
@@ -82,7 +82,7 @@ private:
 // ------------ constructor and destructor --------------
 EtlDigiHitsValidation::EtlDigiHitsValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
-      LocalPosDebug_(iConfig.getParameter<bool>("LocalPositionDebug")) {
+      optionalPlots_(iConfig.getParameter<bool>("optionalPlots")) {
   etlDigiHitsToken_ = consumes<ETLDigiCollection>(iConfig.getParameter<edm::InputTag>("inputTag"));
   mtdgeoToken_ = esConsumes<MTDGeometry, MTDDigiGeometryRecord>();
   mtdtopoToken_ = esConsumes<MTDTopology, MTDTopologyRcd>();
@@ -167,7 +167,7 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     meHitTime_[idet]->Fill(sample.toa());
     meOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
 
-    if (LocalPosDebug_) {
+    if (optionalPlots_) {
       if ((idet == 0) || (idet == 1)) {
         meLocalOccupancy_[0]->Fill(local_point.x(), local_point.y());
         meHitXlocal_[0]->Fill(local_point.x());
@@ -294,7 +294,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  135,
                                  -135.,
                                  135.);
-  if (LocalPosDebug_) {
+  if (optionalPlots_) {
     meLocalOccupancy_[0] = ibook.book2D("EtlLocalOccupancyZneg",
                                         "ETL DIGI hits local occupancy (-Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
                                         100,
@@ -519,7 +519,7 @@ void EtlDigiHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& des
 
   desc.add<std::string>("folder", "MTD/ETL/DigiHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "FTLEndcap"));
-  desc.add<bool>("LocalPositionDebug", false);
+  desc.add<bool>("optionalPlots", false);
 
   descriptions.add("etlDigiHitsDefaultValid", desc);
 }

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -203,12 +203,14 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
 #ifdef EDM_ML_DEBUG
   for (const auto& hits : *mtdTrkHitHandle) {
-    LogDebug("EtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
-    for (const auto& hit : hits) {
-      LogDebug("EtlLocalRecoValidation") << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y()
-                                         << " : " << hit.localPositionError().xx() << ","
-                                         << hit.localPositionError().yy() << " : " << hit.time() << " : "
-                                         << hit.timeError();
+    if (MTDDetId(hits.id()).mtdSubDetector() == MTDDetId::MTDType::ETL) {
+      LogDebug("EtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
+      for (const auto& hit : hits) {
+        LogDebug("EtlLocalRecoValidation")
+            << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y() << " : "
+            << hit.localPositionError().xx() << "," << hit.localPositionError().yy() << " : " << hit.time() << " : "
+            << hit.timeError();
+      }
     }
   }
 #endif

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -66,7 +66,7 @@ private:
   const std::string folder_;
   const float hitMinEnergy1Dis_;
   const float hitMinEnergy2Dis_;
-  const bool LocalPosDebug_;
+  const bool optionalPlots_;
   const bool uncalibRecHitsPlots_;
   const double hitMinAmplitude_;
 
@@ -157,7 +157,7 @@ EtlLocalRecoValidation::EtlLocalRecoValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
       hitMinEnergy1Dis_(iConfig.getParameter<double>("hitMinimumEnergy1Dis")),
       hitMinEnergy2Dis_(iConfig.getParameter<double>("hitMinimumEnergy2Dis")),
-      LocalPosDebug_(iConfig.getParameter<bool>("LocalPositionDebug")),
+      optionalPlots_(iConfig.getParameter<bool>("optionalPlots")),
       uncalibRecHitsPlots_(iConfig.getParameter<bool>("UncalibRecHitsPlots")),
       hitMinAmplitude_(iConfig.getParameter<double>("HitMinimumAmplitude")) {
   etlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsTag"));
@@ -293,7 +293,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
     meOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
 
-    if (LocalPosDebug_) {
+    if (optionalPlots_) {
       if ((idet == 0) || (idet == 1)) {
         meLocalOccupancy_[0]->Fill(local_point.x(), local_point.y());
         meHitXlocal_[0]->Fill(local_point.x());
@@ -450,6 +450,8 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
           cluEneSIM += m_etlSimHits[idet][recHit.id().rawId()].energy;
           cluTimeSIM += m_etlSimHits[idet][recHit.id().rawId()].time * m_etlSimHits[idet][recHit.id().rawId()].energy;
 
+          break;
+
         }  // recHit loop
 
       }  // ihit loop
@@ -493,7 +495,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
         meCluTPullvsEta_[iside]->Fill(cluGlobalPosSIM.eta(), time_res / cluster.timeError());
         meCluTPullvsE_[iside]->Fill(cluEneSIM, time_res / cluster.timeError());
 
-        if (LocalPosDebug_) {
+        if (optionalPlots_) {
           if (matchClu && comp != nullptr) {
             meCluXPull_[iside]->Fill(x_res / std::sqrt(comp->globalPositionError().cxx()));
             meCluYPull_[iside]->Fill(y_res / std::sqrt(comp->globalPositionError().cyy()));
@@ -648,7 +650,7 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  135,
                                  -135.,
                                  135.);
-  if (LocalPosDebug_) {
+  if (optionalPlots_) {
     meLocalOccupancy_[0] = ibook.book2D("EtlLocalOccupancyZneg",
                                         "ETL RECO hits local occupancy (-Z);X_{RECO} [cm];Y_{RECO} [cm]",
                                         100,
@@ -1002,7 +1004,7 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("EtlCluZResZneg", "ETL cluster Z resolution (-Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
   meCluZRes_[1] =
       ibook.book1D("EtlCluZResZpos", "ETL cluster Z resolution (+Z);Z_{RECO}-Z_{SIM} [cm]", 100, -0.003, 0.003);
-  if (LocalPosDebug_) {
+  if (optionalPlots_) {
     meCluXPull_[0] =
         ibook.book1D("EtlCluXPullZneg", "ETL cluster X pull (-Z);X_{RECO}-X_{SIM}/sigmaX_[RECO] [cm]", 100, -5., 5.);
     meCluXPull_[1] =
@@ -1093,7 +1095,7 @@ void EtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<edm::InputTag>("trkHitTag", edm::InputTag("mtdTrackingRecHits"));
   desc.add<double>("hitMinimumEnergy1Dis", 1.);     // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
-  desc.add<bool>("LocalPositionDebug", false);
+  desc.add<bool>("optionalPlots", false);
   desc.add<bool>("UncalibRecHitsPlots", false);
   desc.add<double>("HitMinimumAmplitude", 0.33);  // [MIP]
 

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -205,10 +205,10 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   for (const auto& hits : *mtdTrkHitHandle) {
     LogDebug("EtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
     for (const auto& hit : hits) {
-      LogDebug("EtlLocalRecoValidation")
-          << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y() << " : "
-          << hit.localPositionError().xx() << "," << hit.localPositionError().yy() << " : " << hit.time() << " : "
-          << hit.timeError();
+      LogDebug("EtlLocalRecoValidation") << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y()
+                                         << " : " << hit.localPositionError().xx() << ","
+                                         << hit.localPositionError().yy() << " : " << hit.time() << " : "
+                                         << hit.timeError();
     }
   }
 #endif

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -201,6 +201,18 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   auto mtdTrkHitHandle = makeValid(iEvent.getHandle(mtdTrackingHitToken_));
   MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());
 
+#ifdef EDM_ML_DEBUG
+  for (const auto& hits : *mtdTrkHitHandle) {
+    LogDebug("EtlLocalRecoValidation") << "MTD cluster DetId " << hits.id() << " # cluster " << hits.size();
+    for (const auto& hit : hits) {
+      LogDebug("EtlLocalRecoValidation")
+          << "MTD_TRH: " << hit.localPosition().x() << "," << hit.localPosition().y() << " : "
+          << hit.localPositionError().xx() << "," << hit.localPositionError().yy() << " : " << hit.time() << " : "
+          << hit.timeError();
+    }
+  }
+#endif
+
   // --- Loop over the ETL SIM hits
   std::unordered_map<uint32_t, MTDHit> m_etlSimHits[4];
   for (auto const& simHit : etlSimHits) {

--- a/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksHarvester.cc
@@ -36,6 +36,14 @@ private:
   MonitorElement* meMVAEtaSelEff_;
   MonitorElement* meMVAPtMatchEff_;
   MonitorElement* meMVAEtaMatchEff_;
+  MonitorElement* meTPPtSelEff_;
+  MonitorElement* meTPEtaSelEff_;
+  MonitorElement* meTPPtMatchEff_;
+  MonitorElement* meTPEtaMatchEff_;
+  MonitorElement* meTPmtdPtSelEff_;
+  MonitorElement* meTPmtdEtaSelEff_;
+  MonitorElement* meTPmtdPtMatchEff_;
+  MonitorElement* meTPmtdEtaMatchEff_;
 };
 
 // ------------ constructor and destructor --------------
@@ -83,9 +91,17 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
   MonitorElement* meMVATrackEffPtTot = igetter.get(folder_ + "MVAEffPtTot");
   MonitorElement* meMVATrackMatchedEffPtTot = igetter.get(folder_ + "MVAMatchedEffPtTot");
   MonitorElement* meMVATrackMatchedEffPtMtd = igetter.get(folder_ + "MVAMatchedEffPtMtd");
+  MonitorElement* meTrackMatchedTPEffPtTot = igetter.get(folder_ + "MatchedTPEffPtTot");
+  MonitorElement* meTrackMatchedTPEffPtMtd = igetter.get(folder_ + "MatchedTPEffPtMtd");
+  MonitorElement* meTrackMatchedTPmtdEffPtTot = igetter.get(folder_ + "MatchedTPmtdEffPtTot");
+  MonitorElement* meTrackMatchedTPmtdEffPtMtd = igetter.get(folder_ + "MatchedTPmtdEffPtMtd");
   MonitorElement* meMVATrackEffEtaTot = igetter.get(folder_ + "MVAEffEtaTot");
   MonitorElement* meMVATrackMatchedEffEtaTot = igetter.get(folder_ + "MVAMatchedEffEtaTot");
   MonitorElement* meMVATrackMatchedEffEtaMtd = igetter.get(folder_ + "MVAMatchedEffEtaMtd");
+  MonitorElement* meTrackMatchedTPEffEtaTot = igetter.get(folder_ + "MatchedTPEffEtaTot");
+  MonitorElement* meTrackMatchedTPEffEtaMtd = igetter.get(folder_ + "MatchedTPEffEtaMtd");
+  MonitorElement* meTrackMatchedTPmtdEffEtaTot = igetter.get(folder_ + "MatchedTPmtdEffEtaTot");
+  MonitorElement* meTrackMatchedTPmtdEffEtaMtd = igetter.get(folder_ + "MatchedTPmtdEffEtaMtd");
 
   if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
       !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
@@ -93,7 +109,8 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
       !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZpos ||
       !meETLTrackEffPhiMtdZpos || !meETLTrackEffPtMtdZpos || !meMVATrackEffPtTot || !meMVATrackMatchedEffPtTot ||
       !meMVATrackMatchedEffPtMtd || !meMVATrackEffEtaTot || !meMVATrackMatchedEffEtaTot ||
-      !meMVATrackMatchedEffEtaMtd) {
+      !meMVATrackMatchedEffEtaMtd || !meTrackMatchedTPEffPtTot || !meTrackMatchedTPEffPtMtd ||
+      !meTrackMatchedTPmtdEffPtTot || !meTrackMatchedTPmtdEffPtMtd) {
     edm::LogError("MtdTracksHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -203,6 +220,70 @@ void MtdTracksHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGetter& 
                                    meMVATrackMatchedEffEtaTot->getTH1()->GetXaxis()->GetXmax());
   meMVAEtaMatchEff_->getTH1()->SetMinimum(0.);
   computeEfficiency1D(meMVATrackMatchedEffEtaMtd, meMVATrackMatchedEffEtaTot, meMVAEtaMatchEff_);
+
+  meTPPtSelEff_ = ibook.book1D("TPPtSelEff",
+                               "Track selected efficiency TP VS Pt;Pt [GeV];Efficiency",
+                               meMVATrackEffPtTot->getNbinsX(),
+                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                               meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meTPPtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPEffPtTot, meMVATrackEffPtTot, meTPPtSelEff_);
+
+  meTPEtaSelEff_ = ibook.book1D("TPEtaSelEff",
+                                "Track selected efficiency TP VS Eta;Eta;Efficiency",
+                                meMVATrackEffEtaTot->getNbinsX(),
+                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meTPEtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPEffEtaTot, meMVATrackEffEtaTot, meTPEtaSelEff_);
+
+  meTPPtMatchEff_ = ibook.book1D("TPPtMatchEff",
+                                 "Track matched to TP efficiency VS Pt;Pt [GeV];Efficiency",
+                                 meTrackMatchedTPEffPtTot->getNbinsX(),
+                                 meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                 meTrackMatchedTPEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meTPPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPEffPtMtd, meTrackMatchedTPEffPtTot, meTPPtMatchEff_);
+
+  meTPEtaMatchEff_ = ibook.book1D("TPEtaMatchEff",
+                                  "Track matched to TP efficiency VS Eta;Eta;Efficiency",
+                                  meTrackMatchedTPEffEtaTot->getNbinsX(),
+                                  meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meTrackMatchedTPEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meTPEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPEffEtaMtd, meTrackMatchedTPEffEtaTot, meTPEtaMatchEff_);
+
+  meTPmtdPtSelEff_ = ibook.book1D("TPmtdPtSelEff",
+                                  "Track selected efficiency TP-mtd hit VS Pt;Pt [GeV];Efficiency",
+                                  meMVATrackEffPtTot->getNbinsX(),
+                                  meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                  meMVATrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meTPmtdPtSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPmtdEffPtTot, meMVATrackEffPtTot, meTPmtdPtSelEff_);
+
+  meTPmtdEtaSelEff_ = ibook.book1D("TPmtdEtaSelEff",
+                                   "Track selected efficiency TPmtd hit VS Eta;Eta;Efficiency",
+                                   meMVATrackEffEtaTot->getNbinsX(),
+                                   meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                   meMVATrackEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meTPmtdEtaSelEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPmtdEffEtaTot, meMVATrackEffEtaTot, meTPmtdEtaSelEff_);
+
+  meTPmtdPtMatchEff_ = ibook.book1D("TPmtdPtMatchEff",
+                                    "Track matched to TP-mtd hit efficiency VS Pt;Pt [GeV];Efficiency",
+                                    meTrackMatchedTPmtdEffPtTot->getNbinsX(),
+                                    meTrackMatchedTPmtdEffPtTot->getTH1()->GetXaxis()->GetXmin(),
+                                    meTrackMatchedTPmtdEffPtTot->getTH1()->GetXaxis()->GetXmax());
+  meTPmtdPtMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPmtdEffPtMtd, meTrackMatchedTPmtdEffPtTot, meTPmtdPtMatchEff_);
+
+  meTPmtdEtaMatchEff_ = ibook.book1D("TPmtdEtaMatchEff",
+                                     "Track matched to TP-mtd hit efficiency VS Eta;Eta;Efficiency",
+                                     meTrackMatchedTPmtdEffEtaTot->getNbinsX(),
+                                     meTrackMatchedTPmtdEffEtaTot->getTH1()->GetXaxis()->GetXmin(),
+                                     meTrackMatchedTPmtdEffEtaTot->getTH1()->GetXaxis()->GetXmax());
+  meTPmtdEtaMatchEff_->getTH1()->SetMinimum(0.);
+  computeEfficiency1D(meTrackMatchedTPmtdEffEtaMtd, meTrackMatchedTPmtdEffEtaTot, meTPmtdEtaMatchEff_);
 
   meBtlPhiEff_->getTH1()->SetMinimum(0.);
   meBtlPtEff_->getTH1()->SetMinimum(0.);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -658,7 +658,8 @@ const bool MtdTracksValidation::mvaRecSel(const reco::TrackBase& trk,
                                           const double& t0,
                                           const double& st0) {
   bool match = false;
-  match = trk.pt() > pTcut_ && std::abs(trk.eta()) < etacutREC_ && (std::abs(trk.vz() - vtx.z()) <= deltaZcut_ || vtx.isFake());
+  match = trk.pt() > pTcut_ && std::abs(trk.eta()) < etacutREC_ &&
+          (std::abs(trk.vz() - vtx.z()) <= deltaZcut_ || vtx.isFake());
   if (st0 > 0.) {
     match = match && std::abs(t0 - vtx.t()) < 3. * st0;
   }
@@ -668,12 +669,12 @@ const bool MtdTracksValidation::mvaRecSel(const reco::TrackBase& trk,
 const bool MtdTracksValidation::mvaGenRecMatch(const HepMC::GenParticle& genP,
                                                const double& zsim,
                                                const reco::TrackBase& trk,
-					       const bool& vtxFake) {
+                                               const bool& vtxFake) {
   bool match = false;
   double dR = reco::deltaR(genP.momentum(), trk.momentum());
   double genPT = genP.momentum().perp();
-  match =
-      std::abs(genPT - trk.pt()) < trk.pt() * deltaPTcut_ && dR < deltaDRcut_ && ( std::abs(trk.vz() - zsim) < deltaZcut_ || vtxFake);
+  match = std::abs(genPT - trk.pt()) < trk.pt() * deltaPTcut_ && dR < deltaDRcut_ &&
+          (std::abs(trk.vz() - zsim) < deltaZcut_ || vtxFake);
   return match;
 }
 

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -33,6 +33,13 @@
 #include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "HepMC/GenRanges.h"
@@ -51,8 +58,11 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   const bool mvaGenSel(const HepMC::GenParticle&, const float&);
+  const bool mvaTPSel(const TrackingParticle&);
   const bool mvaRecSel(const reco::TrackBase&, const reco::Vertex&, const double&, const double&);
   const bool mvaGenRecMatch(const HepMC::GenParticle&, const double&, const reco::TrackBase&);
+  const edm::Ref<std::vector<TrackingParticle>>* getMatchedTP(const reco::TrackBaseRef&, const double&);
+  const bool tpWithMTD(const TrackingParticle&, const std::unordered_set<uint32_t>&);
 
   // ------------ member data ------------
 
@@ -69,11 +79,19 @@ private:
   static constexpr double deltaPTcut_ = 0.05;  // dPT < 5%
   static constexpr double deltaDRcut_ = 0.03;  // DeltaR separation
 
+  const reco::RecoToSimCollection* r2s_;
+  const reco::SimToRecoCollection* s2r_;
+
   edm::EDGetTokenT<reco::TrackCollection> GenRecTrackToken_;
   edm::EDGetTokenT<reco::TrackCollection> RecTrackToken_;
   edm::EDGetTokenT<std::vector<reco::Vertex>> RecVertexToken_;
 
   edm::EDGetTokenT<edm::HepMCProduct> HepMCProductToken_;
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleCollectionToken_;
+  edm::EDGetTokenT<reco::SimToRecoCollection> simToRecoAssociationToken_;
+  edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimAssociationToken_;
+  edm::EDGetTokenT<CrossingFrame<PSimHit>> btlSimHitsToken_;
+  edm::EDGetTokenT<CrossingFrame<PSimHit>> etlSimHitsToken_;
 
   edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> pathLengthToken_;
@@ -123,9 +141,17 @@ private:
   MonitorElement* meMVATrackEffPtTot_;
   MonitorElement* meMVATrackMatchedEffPtTot_;
   MonitorElement* meMVATrackMatchedEffPtMtd_;
+  MonitorElement* meTrackMatchedTPEffPtTot_;
+  MonitorElement* meTrackMatchedTPEffPtMtd_;
+  MonitorElement* meTrackMatchedTPmtdEffPtTot_;
+  MonitorElement* meTrackMatchedTPmtdEffPtMtd_;
   MonitorElement* meMVATrackEffEtaTot_;
   MonitorElement* meMVATrackMatchedEffEtaTot_;
   MonitorElement* meMVATrackMatchedEffEtaMtd_;
+  MonitorElement* meTrackMatchedTPEffEtaTot_;
+  MonitorElement* meTrackMatchedTPEffEtaMtd_;
+  MonitorElement* meTrackMatchedTPmtdEffEtaTot_;
+  MonitorElement* meTrackMatchedTPmtdEffEtaMtd_;
   MonitorElement* meMVATrackResTot_;
   MonitorElement* meMVATrackPullTot_;
   MonitorElement* meMVATrackZposResTot_;
@@ -142,6 +168,14 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
   RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
   RecVertexToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("inputTagV"));
   HepMCProductToken_ = consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("inputTagH"));
+  trackingParticleCollectionToken_ =
+      consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("SimTag"));
+  simToRecoAssociationToken_ =
+      consumes<reco::SimToRecoCollection>(iConfig.getParameter<edm::InputTag>("TPtoRecoTrackAssoc"));
+  recoToSimAssociationToken_ =
+      consumes<reco::RecoToSimCollection>(iConfig.getParameter<edm::InputTag>("TPtoRecoTrackAssoc"));
+  btlSimHitsToken_ = consumes<CrossingFrame<PSimHit>>(iConfig.getParameter<edm::InputTag>("btlSimHits"));
+  etlSimHitsToken_ = consumes<CrossingFrame<PSimHit>>(iConfig.getParameter<edm::InputTag>("etlSimHits"));
   trackAssocToken_ = consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("trackAssocSrc"));
   pathLengthToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathLengthSrc"));
   tmtdToken_ = consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tmtd"));
@@ -353,6 +387,33 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
   auto pdt = iSetup.getHandle(particleTableToken_);
   const HepPDT::ParticleDataTable* pdTable = pdt.product();
 
+  auto TPCollectionH = makeValid(iEvent.getHandle(trackingParticleCollectionToken_));
+
+  auto simToRecoH = makeValid(iEvent.getHandle(simToRecoAssociationToken_));
+  s2r_ = simToRecoH.product();
+
+  auto recoToSimH = makeValid(iEvent.getHandle(recoToSimAssociationToken_));
+  r2s_ = recoToSimH.product();
+
+  // find all signal event trackId corresponding to an MTD simHit
+  std::unordered_set<uint32_t> mtdTrackId;
+
+  auto btlSimHitsHandle = makeValid(iEvent.getHandle(btlSimHitsToken_));
+  MixCollection<PSimHit> btlSimHits(btlSimHitsHandle.product());
+  for (const auto& btlSH : btlSimHits) {
+    if (btlSH.eventId().bunchCrossing() == 0 && btlSH.eventId().event() == 0) {
+      mtdTrackId.insert(btlSH.trackId());
+    }
+  }
+
+  auto etlSimHitsHandle = makeValid(iEvent.getHandle(etlSimHitsToken_));
+  MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());
+  for (const auto& etlSH : btlSimHits) {
+    if (etlSH.eventId().bunchCrossing() == 0 && etlSH.eventId().event() == 0) {
+      mtdTrackId.insert(etlSH.trackId());
+    }
+  }
+
   // select events with reco vertex close to true simulated primary vertex
   if (std::abs(primRecoVtx.z() - zsim) < deltaZcut_) {
     index = 0;
@@ -404,6 +465,36 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
                 meMVATrackMatchedEffEtaMtd_->Fill(std::abs(trackGen.eta()));
               }
               break;
+            }
+          }
+        }
+
+        // TrackingParticle based matching
+        const reco::TrackBaseRef trkrefb(trackref);
+        auto tp_info = getMatchedTP(trkrefb, zsim);
+
+        if (tp_info != nullptr) {
+          const bool withMTD = tpWithMTD(**tp_info, mtdTrackId);
+          if (noCrack) {
+            meTrackMatchedTPEffPtTot_->Fill(trackGen.pt());
+            if (withMTD) {
+              meTrackMatchedTPmtdEffPtTot_->Fill(trackGen.pt());
+            }
+          }
+          meTrackMatchedTPEffEtaTot_->Fill(std::abs(trackGen.eta()));
+          if (withMTD) {
+            meTrackMatchedTPmtdEffEtaTot_->Fill(std::abs(trackGen.eta()));
+          }
+          if (pullT > -9999.) {
+            if (noCrack) {
+              meTrackMatchedTPEffPtMtd_->Fill(trackGen.pt());
+              if (withMTD) {
+                meTrackMatchedTPmtdEffPtMtd_->Fill(trackGen.pt());
+              }
+            }
+            meTrackMatchedTPEffEtaMtd_->Fill(std::abs(trackGen.eta()));
+            if (withMTD) {
+              meTrackMatchedTPmtdEffEtaMtd_->Fill(std::abs(trackGen.eta()));
             }
           }
         }
@@ -475,11 +566,31 @@ void MtdTracksValidation::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
       ibook.book1D("MVAMatchedEffPtTot", "Pt of tracks associated to LV matched to GEN; track pt [GeV] ", 110, 0., 11.);
   meMVATrackMatchedEffPtMtd_ = ibook.book1D(
       "MVAMatchedEffPtMtd", "Pt of tracks associated to LV matched to GEN with time; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPEffPtTot_ =
+      ibook.book1D("MatchedTPEffPtTot", "Pt of tracks associated to LV matched to TP; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPEffPtMtd_ = ibook.book1D(
+      "MatchedTPEffPtMtd", "Pt of tracks associated to LV matched to TP with time; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPmtdEffPtTot_ = ibook.book1D(
+      "MatchedTPmtdEffPtTot", "Pt of tracks associated to LV matched to TP-mtd hit; track pt [GeV] ", 110, 0., 11.);
+  meTrackMatchedTPmtdEffPtMtd_ =
+      ibook.book1D("MatchedTPmtdEffPtMtd",
+                   "Pt of tracks associated to LV matched to TP-mtd hit with time; track pt [GeV] ",
+                   110,
+                   0.,
+                   11.);
   meMVATrackEffEtaTot_ = ibook.book1D("MVAEffEtaTot", "Pt of tracks associated to LV; track eta ", 66, 0., 3.3);
   meMVATrackMatchedEffEtaTot_ =
       ibook.book1D("MVAMatchedEffEtaTot", "Pt of tracks associated to LV matched to GEN; track eta ", 66, 0., 3.3);
   meMVATrackMatchedEffEtaMtd_ = ibook.book1D(
       "MVAMatchedEffEtaMtd", "Pt of tracks associated to LV matched to GEN with time; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPEffEtaTot_ =
+      ibook.book1D("MatchedTPEffEtaTot", "Pt of tracks associated to LV matched to TP; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPEffEtaMtd_ = ibook.book1D(
+      "MatchedTPEffEtaMtd", "Pt of tracks associated to LV matched to TP with time; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPmtdEffEtaTot_ = ibook.book1D(
+      "MatchedTPmtdEffEtaTot", "Pt of tracks associated to LV matched to TP-mtd hit; track eta ", 66, 0., 3.3);
+  meTrackMatchedTPmtdEffEtaMtd_ = ibook.book1D(
+      "MatchedTPmtdEffEtaMtd", "Pt of tracks associated to LV matched to TP-mtd hit with time; track eta ", 66, 0., 3.3);
   meMVATrackResTot_ = ibook.book1D(
       "MVATrackRes", "t_{rec} - t_{sim} for LV associated tracks; t_{rec} - t_{sim} [ns] ", 120, -0.15, 0.15);
   meMVATrackPullTot_ =
@@ -498,6 +609,10 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD"));
   desc.add<edm::InputTag>("inputTagV", edm::InputTag("offlinePrimaryVertices4D"));
   desc.add<edm::InputTag>("inputTagH", edm::InputTag("generatorSmeared"));
+  desc.add<edm::InputTag>("SimTag", edm::InputTag("mix", "MergedTrackTruth"));
+  desc.add<edm::InputTag>("TPtoRecoTrackAssoc", edm::InputTag("trackingParticleRecoTrackAsssociation"));
+  desc.add<edm::InputTag>("btlSimHits", edm::InputTag("mix", "g4SimHitsFastTimerHitsBarrel"));
+  desc.add<edm::InputTag>("etlSimHits", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));
   desc.add<edm::InputTag>("tmtd", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"));
   desc.add<edm::InputTag>("sigmatmtd", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"));
   desc.add<edm::InputTag>("t0Src", edm::InputTag("trackExtenderWithMTD:generalTrackt0"));
@@ -527,6 +642,15 @@ const bool MtdTracksValidation::mvaGenSel(const HepMC::GenParticle& gp, const fl
   return match;
 }
 
+const bool MtdTracksValidation::mvaTPSel(const TrackingParticle& tp) {
+  bool match = false;
+  if (tp.status() != 1) {
+    return match;
+  }
+  match = tp.charge() != 0 && tp.pt() > pTcut_ && std::abs(tp.eta()) < etacutGEN_;
+  return match;
+}
+
 const bool MtdTracksValidation::mvaRecSel(const reco::TrackBase& trk,
                                           const reco::Vertex& vtx,
                                           const double& t0,
@@ -548,6 +672,37 @@ const bool MtdTracksValidation::mvaGenRecMatch(const HepMC::GenParticle& genP,
   match =
       std::abs(genPT - trk.pt()) < trk.pt() * deltaPTcut_ && dR < deltaDRcut_ && std::abs(trk.vz() - zsim) < deltaZcut_;
   return match;
+}
+
+const edm::Ref<std::vector<TrackingParticle>>* MtdTracksValidation::getMatchedTP(const reco::TrackBaseRef& recoTrack,
+                                                                                 const double& zsim) {
+  auto found = r2s_->find(recoTrack);
+
+  // reco track not matched to any TP
+  if (found == r2s_->end())
+    return nullptr;
+
+  //matched TP equal to any TP associated to signal sim vertex
+  for (const auto& tp : found->val) {
+    if (tp.first->eventId().bunchCrossing() == 0 && tp.first->eventId().event() == 0 &&
+        std::abs(tp.first->parentVertex()->position().z() - zsim) < deltaZcut_) {
+      return &tp.first;
+    }
+  }
+
+  // reco track not matched to any TP from vertex
+  return nullptr;
+}
+
+const bool MtdTracksValidation::tpWithMTD(const TrackingParticle& tp, const std::unordered_set<uint32_t>& trkList) {
+  for (const auto& simTrk : tp.g4Tracks()) {
+    for (const auto& mtdTrk : trkList) {
+      if (mtdTrk == simTrk.trackId()) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 DEFINE_FWK_MODULE(MtdTracksValidation);

--- a/Validation/MtdValidation/plugins/MtdTracksValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdTracksValidation.cc
@@ -87,7 +87,6 @@ private:
   edm::EDGetTokenT<std::vector<reco::Vertex>> RecVertexToken_;
 
   edm::EDGetTokenT<edm::HepMCProduct> HepMCProductToken_;
-  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleCollectionToken_;
   edm::EDGetTokenT<reco::SimToRecoCollection> simToRecoAssociationToken_;
   edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimAssociationToken_;
   edm::EDGetTokenT<CrossingFrame<PSimHit>> btlSimHitsToken_;
@@ -168,8 +167,6 @@ MtdTracksValidation::MtdTracksValidation(const edm::ParameterSet& iConfig)
   RecTrackToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("inputTagT"));
   RecVertexToken_ = consumes<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("inputTagV"));
   HepMCProductToken_ = consumes<edm::HepMCProduct>(iConfig.getParameter<edm::InputTag>("inputTagH"));
-  trackingParticleCollectionToken_ =
-      consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("SimTag"));
   simToRecoAssociationToken_ =
       consumes<reco::SimToRecoCollection>(iConfig.getParameter<edm::InputTag>("TPtoRecoTrackAssoc"));
   recoToSimAssociationToken_ =
@@ -386,8 +383,6 @@ void MtdTracksValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 
   auto pdt = iSetup.getHandle(particleTableToken_);
   const HepPDT::ParticleDataTable* pdTable = pdt.product();
-
-  auto TPCollectionH = makeValid(iEvent.getHandle(trackingParticleCollectionToken_));
 
   auto simToRecoH = makeValid(iEvent.getHandle(simToRecoAssociationToken_));
   s2r_ = simToRecoH.product();
@@ -611,7 +606,6 @@ void MtdTracksValidation::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<edm::InputTag>("inputTagT", edm::InputTag("trackExtenderWithMTD"));
   desc.add<edm::InputTag>("inputTagV", edm::InputTag("offlinePrimaryVertices4D"));
   desc.add<edm::InputTag>("inputTagH", edm::InputTag("generatorSmeared"));
-  desc.add<edm::InputTag>("SimTag", edm::InputTag("mix", "MergedTrackTruth"));
   desc.add<edm::InputTag>("TPtoRecoTrackAssoc", edm::InputTag("trackingParticleRecoTrackAsssociation"));
   desc.add<edm::InputTag>("btlSimHits", edm::InputTag("mix", "g4SimHitsFastTimerHitsBarrel"));
   desc.add<edm::InputTag>("etlSimHits", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));

--- a/Validation/MtdValidation/test/mtdValidation_cfg.py
+++ b/Validation/MtdValidation/test/mtdValidation_cfg.py
@@ -49,10 +49,10 @@ etlValidation = cms.Sequence(process.etlSimHitsValid + process.etlDigiHitsValid 
 process.load("Validation.MtdValidation.mtdTracksValid_cfi")
 process.load("Validation.MtdValidation.vertices4DValid_cfi")
 
-process.btlDigiHitsValid.LocalPositionDebug = True
-process.etlDigiHitsValid.LocalPositionDebug = True
-process.btlLocalRecoValid.LocalPositionDebug = True
-process.etlLocalRecoValid.LocalPositionDebug = True
+process.btlDigiHitsValid.optionalPlots = True
+process.etlDigiHitsValid.optionalPlots = True
+process.btlLocalRecoValid.optionalPlots = True
+process.etlLocalRecoValid.optionalPlots = True
 process.vertices4DValid.optionalPlots = True
 
 process.validation = cms.Sequence(btlValidation + etlValidation + process.mtdTracksValid + process.vertices4DValid)


### PR DESCRIPTION
#### PR description:

This PR proposes several updates to the MTD validation and reconstruction code, in view of a detailed study of the MTD clustering:

- the ```MtdTracksValidation``` class is updated by adding histograms to monitor track - ```TrackingParticle``` matching, also including TP with a ```SimTrack``` linked to MTD hits, to better disentangle acceptance effects from other inefficiency sources. This monitoring is now running also in case of fake primary vertex, allowing the code to run also on particle guns output, where the usual vertex selection fails;
- the local reconstruction monitoring is optimised by adding a ```break``` statement in the loop to match simulated and reconstructed hits inside a cluster. The time taken should be significantly cut, especially on events with PU;
- several debugging printout is added or polished, also in cluster reconstruction classes.

The memory addition to histogram output has been measured to be about 6 KiB.

#### PR validation:

Test MTD validation configuration runs smoothly and provide the desired histograms. As a side note ```SimTrack``` producing hits in ETL are not saved, as outside the tracker volume. This issue should be addressed in a separate development.