### PR TITLE
Sort pixel tracks in the SoA converter (12_3_X)

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducerFromSoA.cc
@@ -160,16 +160,23 @@ void PixelTrackProducerFromSoA::produce(edm::StreamID streamID,
 
   int32_t nt = 0;
 
-  for (int32_t it = 0; it < nTracks; ++it) {
+  //sort index by pt
+  std::vector<int32_t> sortIdxs(nTracks);
+  std::iota(sortIdxs.begin(), sortIdxs.end(), 0);
+  std::sort(
+      sortIdxs.begin(), sortIdxs.end(), [&](int32_t const i1, int32_t const i2) { return tsoa.pt(i1) > tsoa.pt(i2); });
+
+  //store the index of the SoA: indToEdm[index_SoAtrack] -> index_edmTrack (if it exists)
+  indToEdm.resize(sortIdxs.size(), -1);
+  for (const auto &it : sortIdxs) {
     auto nHits = tsoa.nHits(it);
     assert(nHits >= 3);
-    indToEdm.push_back(-1);
     auto q = quality[it];
     if (q < minQuality_)
       continue;
     if (nHits < minNumberOfHits_)
       continue;
-    indToEdm.back() = nt;
+    indToEdm[it] = nt;
     ++nt;
 
     hits.resize(nHits);


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/38065 to 12_3_X

---------------------------

#### PR description:

This PR helps to reduce the CPU-GPU differences. Testing on 10k of events of 900 GeV collisions, the hltAK4PFJets with difference in pt greater than 0.35 GeV passed from 5 to 2.

Moreover, having the pixel tracks sorted by pT helps the CPU-GPU comparison.

#### PR validation:
I checked on 10k of events that this PR does not change the CPU reconstruction, while it changes 3 jets reconstructed using GPU, reducing the differences from CPU.


```
root [2] Events->Scan("EventAuxiliary.event():EventAuxiliary.run():recoPFJets_hltAK4PFJets__CPU3.obj.pt():recoPFJets_hltAK4PFJets__GPU3.obj.pt():recoPFJets_hltAK4PFJets__CPU4.obj.pt():recoPFJets_hltAK4PFJets__GPU4.obj.pt()","abs(recoPFJets_hltAK4PFJets__CPU4.obj.pt()-recoPFJets_hltAK4PFJets__GPU4.obj.pt())>0.35 || abs(recoPFJets_hltAK4PFJets__CPU3.obj.pt()-recoPFJets_hltAK4PFJets__GPU3.obj.pt())>0.35")
***********************************************************************************************
*    Row   * Instance * EventAuxi * EventAuxi * recoPFJet * recoPFJet * recoPFJet * recoPFJet *
***********************************************************************************************
*     2787 *        1 * 249032616 *    346512 * 1.9907082 * 1.6183525 * 1.9907082 * 1.6183525 *
*     4010 *        2 * 251712216 *    346512 * 2.0095655 * 2.0095655 * 2.0095655 * 2.6015811 *
*     4010 *        3 * 251712216 *    346512 * 1.6040698 * 1.6040675 * 1.6040698 * 2.0095655 *
*     7289 *        2 * 260018739 *    346512 * 1.7360442 * 2.2783870 * 1.7360442 * 2.2783870 *
*     7962 *        1 * 261754240 *    346512 * 0.8782627 * 0.8782627 * 0.8782627 * 1.2651753 *
***********************************************************************************************
```
CPU3 and GPU3 are after the PR and CPU4 and GPU4 before the PR 

#### Backport:

I will open soon the backport PRs to use this PR in the HLT at P5

cc @cms-sw/hlt-l2 @fwyzard @VinInn 
