### PR TITLE
[124X] Add EGM regression to online GTs and update Run-3 cosmics MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -38,9 +38,9 @@ autoCond = {
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
     'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v5',
     # GlobalTag for Run3 data relvals (express GT) - identical to 123X_dataRun3_Express_v5 but with snapshot at 2022-05-06 12:00:00
-    'run3_data_express'            : '123X_dataRun3_Express_frozen_v1',
+    'run3_data_express'            : '123X_dataRun3_Express_frozen_v2',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 123X_dataRun3_Prompt_v7 but with snapshot at 2022-05-06 12:00:00
-    'run3_data_prompt'             : '123X_dataRun3_Prompt_frozen_v1',
+    'run3_data_prompt'             : '123X_dataRun3_Prompt_frozen_v2',
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '123X_dataRun3_v5',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
@@ -72,7 +72,9 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2021
     'phase1_2021_realistic'        : '124X_mcRun3_2021_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'          : '124X_mcRun3_2021cosmics_realistic_deco_v1',
+    'phase1_2021_cosmics'          : '124X_mcRun3_2021cosmics_realistic_deco_v2',
+    # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2021, Strip tracker in DECO mode
+    'phase1_2021_cosmics_design'   : '124X_mcRun3_2021cosmics_design_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
     'phase1_2021_realistic_hi'     : '124X_mcRun3_2021_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023


### PR DESCRIPTION
#### PR description:

backport of #38069

In this PR we intend to:
   * update the online GTs with new EGM regression tags as requested in https://cms-talk.web.cern.ch/t/full-track-validation-to-update-egm-regression-tags-in-express-prompt-offline-for-run-3-collisions/10416/5
   * add a new DropboxMetadata tag with same payload as previous and `IOV=1` as announced in https://cms-talk.web.cern.ch/t/gt-express-prompt-update-dropboxmetadata-for-run-3/10626/2
   * update the mcRun3 cosmics DECO GT with realistic SiPixel bad components as requested in https://cms-talk.web.cern.ch/t/gt-mc-special-123x-cosmics-mc-gt-for-tkal-ape-determination/10703
   * create a new key in autoCond for a Run-3 cosmics MC with design conditions
   
Note: there will be a follow-up udpate to include the EGM regression also in the offline data GT.
   
Differences between previous and new GTs are shown below.

**run3_data_express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_Express_frozen_v2/123X_dataRun3_Express_frozen_v1

**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_Prompt_frozen_v2/123X_dataRun3_Prompt_frozen_v1

**phase1_2021_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2021cosmics_realistic_deco_v2/124X_mcRun3_2021cosmics_realistic_deco_v1

**phase1_2021_cosmics_design**
https://cms-conddb.cern.ch/cmsDbBrowser/list/Prod/gts/124X_mcRun3_2021cosmics_design_deco_v1



#### PR validation:

`runTheMatrix.py -l 7.23,138.5,138.4 --ibeos -j16`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
backport of #38069 
