### PR TITLE
use `cms_omds_adg` in lieu of `cms_omds_tunnel` for SiStrip O2O unit tests

### DIFF
--- a/CondTools/SiStrip/python/SiStripO2O_cfg_template.py
+++ b/CondTools/SiStrip/python/SiStripO2O_cfg_template.py
@@ -26,8 +26,8 @@ _CFGLINES_
 
 if 'CONFDB' not in os.environ:
     import CondCore.Utilities.credentials as auth
-    user, _, passwd = auth.get_credentials('cms_omds_tunnel/cms_trk_r')
-    process.SiStripConfigDb.ConfDb = '{user}/{passwd}@{path}'.format(user=user, passwd=passwd, path='cms_omds_tunnel')
+    user, _, passwd = auth.get_credentials('cms_omds_adg/cms_trk_r')
+    process.SiStripConfigDb.ConfDb = '{user}/{passwd}@{path}'.format(user=user, passwd=passwd, path='cms_omds_adg')
 
 process.load("OnlineDB.SiStripO2O.SiStripO2OCalibrationFactors_cfi")
 process.SiStripCondObjBuilderFromDb = cms.Service( "SiStripCondObjBuilderFromDb",


### PR DESCRIPTION
#### PR description:

Title says it all, attempt to solve https://github.com/cms-sw/cmssw/issues/37888

#### PR validation:

None, as I don't have the appropriate credentials to test. 
The bot will make the actual test.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but will need to be backported.
