### PR TITLE
SiStripHitEfficiency PCL Workflow: miscellaneous fixes

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h
@@ -17,7 +17,8 @@ namespace {
     k_LayersAtTIBEnd = 4,
     k_LayersAtTOBEnd = 10,
     k_LayersAtTIDEnd = 13,
-    k_LayersAtTECEnd = 22
+    k_LayersAtTECEnd = 22,
+    k_END_OF_LAYERS = 23
   };
 
   inline unsigned int checkLayer(unsigned int iidd, const TrackerTopology* tTopo) {

--- a/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h
@@ -12,31 +12,39 @@
 
 namespace {
 
+  enum bounds {
+    k_LayersStart = 0,
+    k_LayersAtTIBEnd = 4,
+    k_LayersAtTOBEnd = 10,
+    k_LayersAtTIDEnd = 13,
+    k_LayersAtTECEnd = 22
+  };
+
   inline unsigned int checkLayer(unsigned int iidd, const TrackerTopology* tTopo) {
     switch (DetId(iidd).subdetId()) {
       case SiStripSubdetector::TIB:
         return tTopo->tibLayer(iidd);
       case SiStripSubdetector::TOB:
-        return tTopo->tobLayer(iidd) + 4;
+        return tTopo->tobLayer(iidd) + bounds::k_LayersAtTIBEnd;
       case SiStripSubdetector::TID:
-        return tTopo->tidWheel(iidd) + 10;
+        return tTopo->tidWheel(iidd) + bounds::k_LayersAtTOBEnd;
       case SiStripSubdetector::TEC:
-        return tTopo->tecWheel(iidd) + 13;
+        return tTopo->tecWheel(iidd) + bounds::k_LayersAtTIDEnd;
       default:
-        return 0;
+        return bounds::k_LayersStart;
     }
   }
 
   inline std::string layerName(unsigned int k, const bool showRings, const unsigned int nTEClayers) {
     const std::string ringlabel{showRings ? "R" : "D"};
-    if (k > 0 && k < 5) {
+    if (k > bounds::k_LayersStart && k <= bounds::k_LayersAtTIBEnd) {
       return fmt::format("TIB L{:d}", k);
-    } else if (k > 4 && k < 11) {
-      return fmt::format("TOB L{:d}", k - 4);
-    } else if (k > 10 && k < 14) {
-      return fmt::format("TID {0}{1:d}", ringlabel, k - 10);
-    } else if (k > 13 && k < 14 + nTEClayers) {
-      return fmt::format("TEC {0}{1:d}", ringlabel, k - 13);
+    } else if (k > bounds::k_LayersAtTIBEnd && k <= bounds::k_LayersAtTOBEnd) {
+      return fmt::format("TOB L{:d}", k - bounds::k_LayersAtTIBEnd);
+    } else if (k > bounds::k_LayersAtTOBEnd && k <= bounds::k_LayersAtTIDEnd) {
+      return fmt::format("TID {0}{1:d}", ringlabel, k - bounds::k_LayersAtTOBEnd);
+    } else if (k > bounds::k_LayersAtTIDEnd && k <= bounds::k_LayersAtTIDEnd + nTEClayers) {
+      return fmt::format("TEC {0}{1:d}", ringlabel, k - bounds::k_LayersAtTIDEnd);
     } else {
       return "";
     }

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyHarvester.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyHarvester.cc
@@ -144,9 +144,9 @@ void SiStripHitEfficiencyHarvester::dqmEndJob(DQMStore::IBooker& booker, DQMStor
              << " and has at least " << nModsMin_ << " nModsMin.";
 
   auto h_module_total = std::make_unique<TkHistoMap>(tkDetMap_.get());
-  h_module_total->loadTkHistoMap(inputFolder_, "perModule_total");
+  h_module_total->loadTkHistoMap(fmt::format("{}/TkDetMaps", inputFolder_), "perModule_total");
   auto h_module_found = std::make_unique<TkHistoMap>(tkDetMap_.get());
-  h_module_found->loadTkHistoMap(inputFolder_, "perModule_found");
+  h_module_found->loadTkHistoMap(fmt::format("{}/TkDetMaps", inputFolder_), "perModule_found");
 
   // collect how many layers are missing
   const auto& totalMaps = h_module_total->getAllMaps();
@@ -169,6 +169,9 @@ void SiStripHitEfficiencyHarvester::dqmEndJob(DQMStore::IBooker& booker, DQMStor
   LogDebug("SiStripHitEfficiencyHarvester")
       << "Entries in total TkHistoMap for layer 3: " << h_module_total->getMap(3)->getEntries() << ", found "
       << h_module_found->getMap(3)->getEntries();
+
+  // come back to the main folder
+  booker.setCurrentFolder(inputFolder_);
 
   std::vector<MonitorElement*> hEffInLayer(std::size_t(1), nullptr);
   hEffInLayer.reserve(23);
@@ -396,16 +399,16 @@ void SiStripHitEfficiencyHarvester::makeSummaryVsBX(DQMStore::IGetter& getter, T
 
 void SiStripHitEfficiencyHarvester::makeSummaryVsLumi(DQMStore::IGetter& getter) const {
   for (unsigned int iLayer = 1; iLayer != (showRings_ ? 20 : 22); ++iLayer) {
-    auto hfound = getter.get(fmt::format("{}/layerfound_vsLumi_layer_{}", inputFolder_, iLayer))->getTH1F();
-    auto htotal = getter.get(fmt::format("{}/layertotal_vsLumi_layer_{}", inputFolder_, iLayer))->getTH1F();
+    auto hfound = getter.get(fmt::format("{}/VsLumi/layerfound_vsLumi_layer_{}", inputFolder_, iLayer))->getTH1F();
+    auto htotal = getter.get(fmt::format("{}/VsLumi/layertotal_vsLumi_layer_{}", inputFolder_, iLayer))->getTH1F();
 
     if (hfound == nullptr or htotal == nullptr) {
       if (hfound == nullptr)
         edm::LogError("SiStripHitEfficiencyHarvester")
-            << fmt::format("{}/layerfound_vsLumi_layer_{}", inputFolder_, iLayer) << " was not found!";
+            << fmt::format("{}/VsLumi/layerfound_vsLumi_layer_{}", inputFolder_, iLayer) << " was not found!";
       if (htotal == nullptr)
         edm::LogError("SiStripHitEfficiencyHarvester")
-            << fmt::format("{}/layertotal_vsLumi_layer_{}", inputFolder_, iLayer) << " was not found!";
+            << fmt::format("{}/VsLumi/layertotal_vsLumi_layer_{}", inputFolder_, iLayer) << " was not found!";
       // no input histograms -> continue in the loop
       continue;
     }

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyHarvester.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyHarvester.cc
@@ -171,8 +171,9 @@ void SiStripHitEfficiencyHarvester::dqmEndJob(DQMStore::IBooker& booker, DQMStor
   std::vector<MonitorElement*> hEffInLayer(std::size_t(1), nullptr);
   hEffInLayer.reserve(23);
   for (std::size_t i = 1; i != 23; ++i) {
-    hEffInLayer.push_back(
-        booker.book1D(Form("eff_layer%i", int(i)), Form("Module efficiency in layer %i", int(i)), 201, 0, 1.005));
+    const auto lyrName = ::layerName(i, showRings_, nTEClayers_);
+    hEffInLayer.push_back(booker.book1D(
+        Form("eff_layer%i", int(i)), Form("Module efficiency in layer %s", lyrName.c_str()), 201, 0, 1.005));
   }
   std::array<long, 23> layerTotal{};
   std::array<long, 23> layerFound{};

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
@@ -300,20 +300,20 @@ void SiStripHitEfficiencyWorker::bookHistograms(DQMStore::IBooker& booker,
         booker.book1D(Form("foundVsBx_layer%i", layer), Form("layer %i (%s)", layer, lyrName.c_str()), 3565, 0, 3565)));
 
     // book hot and cold
-    booker.setCurrentFolder(fmt::format("{}/HotAndCold", dqmDir_));
+    booker.setCurrentFolder(fmt::format("{}/MissingHits", dqmDir_));
     if (layer <= bounds::k_LayersAtTOBEnd) {
       const bool isTIB = layer <= bounds::k_LayersAtTIBEnd;
       const auto partition = (isTIB ? "TIB" : "TOB");
       const auto yMax = (isTIB ? 100 : 120);
 
-      const auto tit = Form("%s%i", partition, (isTIB ? layer : layer - bounds::k_LayersAtTIBEnd));
+      const auto tit = Form("%s%i: Map of missing hits", partition, (isTIB ? layer : layer - bounds::k_LayersAtTIBEnd));
 
       auto ihhotcold = booker.book2D(tit, tit, 100, -1, 361, 100, -yMax, yMax);
-      ihhotcold->setAxisTitle("Phi", 1);
+      ihhotcold->setAxisTitle("#phi [deg]", 1);
       ihhotcold->setBinLabel(1, "360", 1);
       ihhotcold->setBinLabel(50, "180", 1);
       ihhotcold->setBinLabel(100, "0", 1);
-      ihhotcold->setAxisTitle("Global Z", 2);
+      ihhotcold->setAxisTitle("Global Z [cm]", 2);
       ihhotcold->setOption("colz");
       h_hotcold.push_back(ihhotcold);
     } else {
@@ -322,8 +322,9 @@ void SiStripHitEfficiencyWorker::bookHistograms(DQMStore::IBooker& booker,
           (isTID ? std::vector<std::string>{"TID-", "TID+"} : std::vector<std::string>{"TEC-", "TEC+"});
       const auto axMax = (isTID ? 100 : 120);
       for (const auto& part : partitions) {
-        const auto tit =
-            Form("%s%i", part.c_str(), (isTID ? layer - bounds::k_LayersAtTOBEnd : layer - bounds::k_LayersAtTIDEnd));
+        const auto tit = Form("%s%i: Map of missing hits",
+                              part.c_str(),
+                              (isTID ? layer - bounds::k_LayersAtTOBEnd : layer - bounds::k_LayersAtTIDEnd));
 
         auto ihhotcold = booker.book2D(tit, tit, 100, -axMax, axMax, 100, -axMax, axMax);
         ihhotcold->setAxisTitle("Global Y", 1);

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
@@ -159,6 +159,7 @@ private:
   };
 
   MonitorElement *h_bx, *h_instLumi, *h_PU;
+  MonitorElement *h_nTracks, *h_nTracksVsPU;
   EffME1 h_goodLayer;
   EffME1 h_allLayer;
   EffME1 h_layer;
@@ -254,6 +255,9 @@ void SiStripHitEfficiencyWorker::bookHistograms(DQMStore::IBooker& booker,
   h_bx = booker.book1D("bx", "bx", 3600, 0, 3600);
   h_instLumi = booker.book1D("instLumi", "inst. lumi.", 250, 0, 25000);
   h_PU = booker.book1D("PU", "PU", 200, 0, 200);
+
+  h_nTracks = booker.book1D("ntracks", "n.tracks;n. tracks;n.events", 500, -0.5, 499.5);
+  h_nTracksVsPU = booker.bookProfile("nTracksVsPU", "n. tracks vs PU; PU; n.tracks ", 200, 0, 200, 500, -0.5, 499.5);
 
   h_goodLayer = EffME1(booker.book1D("goodlayer_total", "goodlayer_total", 35, 0., 35.),
                        booker.book1D("goodlayer_found", "goodlayer_found", 35, 0., 35.));
@@ -376,6 +380,10 @@ void SiStripHitEfficiencyWorker::analyze(const edm::Event& e, const edm::EventSe
 
   // Tracking
   LogDebug("SiStripHitEfficiencyWorker") << "number ckf tracks found = " << tracksCKF->size();
+
+  h_nTracks->Fill(tracksCKF->size());
+  h_nTracksVsPU->Fill(PU, tracksCKF->size());
+
   if (!tracksCKF->empty()) {
     if (cutOnTracks_ && (tracksCKF->size() >= trackMultiplicityCut_))
       return;

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
@@ -265,10 +265,13 @@ void SiStripHitEfficiencyWorker::bookHistograms(DQMStore::IBooker& booker,
   h_allLayer = EffME1(booker.book1D("alllayer_total", "alllayer_total", 35, 0., 35.),
                       booker.book1D("alllayer_found", "alllayer_found", 35, 0., 35.));
 
-  h_layer = EffME1(booker.book1D("layer_found", "layer_found", 23, 0., 23.),
-                   booker.book1D("layer_total", "layer_total", 23, 0., 23.));
+  h_layer = EffME1(
+      booker.book1D(
+          "layer_found", "layer_found", bounds::k_END_OF_LAYERS, 0., static_cast<float>(bounds::k_END_OF_LAYERS)),
+      booker.book1D(
+          "layer_total", "layer_total", bounds::k_END_OF_LAYERS, 0., static_cast<float>(bounds::k_END_OF_LAYERS)));
 
-  for (int layer = 1; layer != 23; ++layer) {
+  for (int layer = 1; layer != bounds::k_END_OF_LAYERS; ++layer) {
     const auto lyrName = ::layerName(layer, showRings_, nTEClayers_);
 
     // book resolutions
@@ -903,7 +906,7 @@ void SiStripHitEfficiencyWorker::fillForTraj(const TrajectoryAtInvalidHit& tm,
           } else if (layer > bounds::k_LayersAtTOBEnd && layer <= bounds::k_LayersAtTIDEnd) {
             //We are in the TID
             //There are 2 different maps here
-            int side = tTopo->tidSide(iidd);  //((iidd >> 13) & 0x3);
+            int side = tTopo->tidSide(iidd);
             if (side == 1)
               h_hotcold[(layer - 1) + (layer - 11)]->Fill(-tm.globalY(), tm.globalX(), 1.);
             else if (side == 2)
@@ -911,7 +914,7 @@ void SiStripHitEfficiencyWorker::fillForTraj(const TrajectoryAtInvalidHit& tm,
           } else if (layer > bounds::k_LayersAtTIDEnd) {
             //We are in the TEC
             //There are 2 different maps here
-            int side = tTopo->tecSide(iidd);  //((iidd >> 18) & 0x3);
+            int side = tTopo->tecSide(iidd);
             if (side == 1)
               h_hotcold[(layer + 2) + (layer - 14)]->Fill(-tm.globalY(), tm.globalX(), 1.);
             else if (side == 2)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripHitEfficiency_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripHitEfficiency_cff.py
@@ -47,6 +47,7 @@ ALCARECOTrackFilterRefit = cms.Sequence(ALCARECOMonitoringTracks +
 # This is the module actually doing the calibration
 from CalibTracker.SiStripHitEfficiency.siStripHitEfficiencyWorker_cfi import siStripHitEfficiencyWorker
 ALCARECOSiStripHitEff =  siStripHitEfficiencyWorker.clone(
+    dqmDir = "AlCaReco/SiStripHitEfficiency",
     lumiScalers= "scalersRawToDigi",
     addLumi = True,
     commonMode = "siStripDigis:CommonMode",

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripHitEfficiency_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripHitEfficiency_cff.py
@@ -60,8 +60,8 @@ ALCARECOSiStripHitEff =  siStripHitEfficiencyWorker.clone(
     Layer = 0, # =0 means do all layers
     Debug = True,
     # do not cut on the total number of tracks
-    cutOnTracks = True,
-    trackMultiplicity = 100,
+    cutOnTracks = False,
+    trackMultiplicity = 1000,
     # use or not first and last measurement of a trajectory (biases), default is false
     useFirstMeas = False,
     useLastMeas = False,

--- a/Calibration/TkAlCaRecoProducers/python/AlcaSiStripHitEfficiencyHarvester_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaSiStripHitEfficiencyHarvester_cfi.py
@@ -1,8 +1,12 @@
+import copy
 import FWCore.ParameterSet.Config as cms
 
 from DQM.SiStripCommon.TkHistoMap_cff import *
 from CalibTracker.SiStripHitEfficiency.siStripHitEfficiencyHarvester_cfi import siStripHitEfficiencyHarvester
+from Calibration.TkAlCaRecoProducers.ALCARECOPromptCalibProdSiStripHitEfficiency_cff import ALCARECOSiStripHitEff
+
 alcasiStripHitEfficiencyHarvester =  siStripHitEfficiencyHarvester.clone(
+    inputFolder         = copy.copy(ALCARECOSiStripHitEff.dqmDir), # make sure the harvester is always in synch with worker
     isAtPCL             = True,
     Threshold           = 0.1,
     nModsMin            = 5,


### PR DESCRIPTION
#### PR description:

This PR implements few bug-fixes in the SiStripHitEfficiency PCL Workflow as spotted in the Tier-0 replay https://github.com/dmwm/T0/pull/4674#issuecomment-1131255929.
   * 84cca3f5b88606cd33bbe8790678db602f638e32 loosens the cut on the track multiplicity (used to be 100 to limit the size of the internal SiStrip Calibration Trees, but now that the workflow is centrally supported that is not a problem anymore)
   * f7cfd9a15a7ee5e890a086319334d95f096b4adf adds plots for monitoring the total number of tracks used and its correlation with PU
   * 220edeb00ee92ee81ebc4193d2f21e7f58097246 and e133da4ed570736c5c386744b72feda05283b56c are the core of the bug-fix and allow several histograms that were previously empty to be filled.
   * 17d25f53f70e21858129edf5ec0b1018626a84a7 makes the input / output folder in the DQM file configurable
   * b527086299cb20a95dd490884dd2d767e15d7068 reduces the amount of hardcoded constants in the code

#### PR validation:

I've run the following commands to test the `ALCAPROMPT` production:

```console
cmsDriver.py testReAlCa -s ALCA:PromptCalibProdSiStripHitEfficiency --conditions 123X_dataRun2_v2 --scenario pp --data --era Run2_2018 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 100000 --dasquery='file dataset=/StreamExpress/Run2018D-SiStripCalMinBias-Express-v1/ALCARECO run=325172' --nThreads=4 --no_exec 
```

followed by:

```console
cmsDriver.py stepHarvest -s ALCAHARVEST:SiStripHitEff --conditions 123X_dataRun2_v2 --scenario pp --data --era Run2_2018 --filein file:PromptCalibProdSiStripHitEfficiency.root -n -1 --no_exec                        
```
to test the `ALCAHARVESTING` step.
I have also run successfully:
   * `runTheMatrix.py -l 1001.0, 1001.2` 
   * `scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but will need to be backported.
