### PR TITLE
Fix for the parameter set of the AlcaPCCIntegrator module

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCIntegrator.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCIntegrator.cc
@@ -47,19 +47,16 @@ public:
                                        reco::PixelClusterCounts const* iCounts) const override;
 
 private:
-  edm::EDPutTokenT<reco::PixelClusterCounts> lumiPutToken_;
-  edm::InputTag thePCCInputTag_;
-  edm::EDGetTokenT<reco::PixelClusterCountsInEvent> pccToken_;
+  const edm::EDPutTokenT<reco::PixelClusterCounts> lumiPutToken_;
+  const edm::EDGetTokenT<reco::PixelClusterCountsInEvent> pccToken_;
 };
 
 AlcaPCCIntegrator::AlcaPCCIntegrator(const edm::ParameterSet& iConfig)
     : lumiPutToken_(produces<reco::PixelClusterCounts, edm::Transition::EndLuminosityBlock>(
           iConfig.getParameter<edm::ParameterSet>("AlcaPCCIntegratorParameters").getParameter<std::string>("ProdInst"))),
-      thePCCInputTag_(iConfig.getParameter<edm::ParameterSet>("AlcaPCCIntegratorParameters")
-                          .getParameter<std::string>("inputPccLabel"),
-                      iConfig.getParameter<edm::ParameterSet>("AlcaPCCIntegratorParameters")
-                          .getUntrackedParameter<std::string>("trigstring", "alcaPCC")),
-      pccToken_(consumes<reco::PixelClusterCountsInEvent>(thePCCInputTag_)) {}
+      pccToken_(consumes<reco::PixelClusterCountsInEvent>(
+          iConfig.getParameter<edm::ParameterSet>("AlcaPCCIntegratorParameters")
+              .getParameter<edm::InputTag>("inputPccLabel"))) {}
 
 std::unique_ptr<reco::PixelClusterCounts> AlcaPCCIntegrator::beginStream(edm::StreamID StreamID) const {
   return std::make_unique<reco::PixelClusterCounts>();

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
@@ -12,9 +12,7 @@ ALCARECORandomHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
 
 from Calibration.LumiAlCaRecoProducers.alcaPCCIntegrator_cfi import alcaPCCIntegrator
 alcaPCCIntegratorRandom = alcaPCCIntegrator.clone()
-alcaPCCIntegratorRandom.AlcaPCCIntegratorParameters.inputPccLabel="hltAlcaPixelClusterCounts"
-alcaPCCIntegratorRandom.AlcaPCCIntegratorParameters.trigstring    = "alcaPCCEvent"
-alcaPCCIntegratorRandom.AlcaPCCIntegratorParameters.ProdInst      = "alcaPCCRandom"
+alcaPCCIntegratorRandom.AlcaPCCIntegratorParameters.ProdInst = "alcaPCCRandom"
 
 
 # Sequence #

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
@@ -11,9 +11,7 @@ ALCARECOZeroBiasHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
 
 from Calibration.LumiAlCaRecoProducers.alcaPCCIntegrator_cfi import alcaPCCIntegrator
 alcaPCCIntegratorZeroBias = alcaPCCIntegrator.clone()
-alcaPCCIntegratorZeroBias.AlcaPCCIntegratorParameters.inputPccLabel="hltAlcaPixelClusterCounts"
-alcaPCCIntegratorZeroBias.AlcaPCCIntegratorParameters.trigstring    = "alcaPCCEvent"
-alcaPCCIntegratorZeroBias.AlcaPCCIntegratorParameters.ProdInst      = "alcaPCCZeroBias"
+alcaPCCIntegratorZeroBias.AlcaPCCIntegratorParameters.ProdInst = "alcaPCCZeroBias"
 
 
 seqALCARECOAlCaPCCZeroBias = cms.Sequence(ALCARECOZeroBiasHLT + alcaPCCIntegratorZeroBias)

--- a/Calibration/LumiAlCaRecoProducers/python/alcaPCCIntegrator_cfi.py
+++ b/Calibration/LumiAlCaRecoProducers/python/alcaPCCIntegrator_cfi.py
@@ -2,8 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 alcaPCCIntegrator = cms.EDProducer("AlcaPCCIntegrator",
     AlcaPCCIntegratorParameters = cms.PSet(
-        inputPccLabel = cms.string("hltAlcaPixelClusterCounts"),
-        trigstring = cms.untracked.string("alcaPCCEvent"),
+        inputPccLabel = cms.InputTag("hltAlcaPixelClusterCounts","alcaPCCEvent"),
         ProdInst = cms.string("alcaPCCRandom")
     )
 )

--- a/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_Integrator_cfg.py
+++ b/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_Integrator_cfg.py
@@ -28,8 +28,7 @@ process.alcaPCCEventProducer = cms.EDProducer("AlcaPCCEventProducer",
 
 process.alcaPCCIntegrator = cms.EDProducer("AlcaPCCIntegrator",
     AlcaPCCIntegratorParameters = cms.PSet(
-        inputPccLabel = cms.string("alcaPCCEventProducer"),
-        trigstring = cms.untracked.string("alcaPCCRandomEvent"),
+        inputPccLabel = cms.InputTag("alcaPCCEventProducer","alcaPCCRandomEvent"),
         ProdInst = cms.string("alcaPCCRandom")
     ),
 )


### PR DESCRIPTION
#### PR description:

Fixes https://github.com/cms-AlCaDB/AlCaTools/issues/61. This is a follow-up PR of the https://github.com/cms-sw/cmssw/pull/37538. The input parameters of the AlcaPCCIntegrator producer are clarified (see https://github.com/cms-sw/cmssw/pull/37538#discussion_r848720360), and the member variables are fixed (https://github.com/cms-sw/cmssw/pull/37538#discussion_r862803323). The changes affect some of the configuration files, but the overall workflow and the output is not modified.

#### PR validation:

Verified by running runtTheMatrix.py -l 1020.0
