### PR TITLE
`PFDisplacedVertexCandidateFinder`: fix deltaPhi cut, don't use std::abs

### DIFF
--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -3,6 +3,7 @@
 #include "RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h"
 
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
@@ -191,7 +192,7 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
     dist = -1;
     return;
   }
-  if (pt1 > 2 && pt2 > 2 && std::abs(phi1 - phi2) > 1) {
+  if (pt1 > 2 && pt2 > 2 && std::abs(::deltaPhi(phi1, phi2)) > 1) {
     dist = -1;
     return;
   }


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/38068

#### PR description:

Implements suggestion at https://github.com/cms-sw/cmssw/issues/38068#issue-1246988087.
   * ~possibly solve https://github.com/cms-sw/cmssw/issues/31158~ (EDIT see: https://github.com/cms-sw/cmssw/pull/38080#issuecomment-1138267381)

#### PR validation:

`cmssw` compiles, waiting for a more thorough validation from PF group.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
