### PR TITLE
Remove CMS deprecation warnings from RecoMuon/MuonSeedGenerator

### DIFF
--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedFinder.cc
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedFinder.cc
@@ -39,8 +39,9 @@ void RPCSeedFinder::setrecHits(ConstMuonRecHitContainer &recHits) {
   isrecHitsset = true;
 }
 
-void RPCSeedFinder::setEventSetup(const edm::EventSetup &iSetup) {
-  eSetup = &iSetup;
+void RPCSeedFinder::setEventSetup(const MagneticField &field, const RPCGeometry &rpcGeom) {
+  pField = &field;
+  pRPCGeom = &rpcGeom;
   isEventSetupset = true;
 }
 
@@ -54,8 +55,8 @@ void RPCSeedFinder::seed() {
 
   weightedTrajectorySeed theweightedSeed;
   int isGoodSeed = 0;
-  const edm::EventSetup &iSetup = *eSetup;
-  theweightedSeed = oneSeed.seed(iSetup, isGoodSeed);
+
+  theweightedSeed = oneSeed.seed(*pField, *pRPCGeom, isGoodSeed);
   // Push back the good seed
   if (isGoodSeed == 1) {
     cout << "[RPCSeedFinder] --> Seeds from " << oneSeed.nrhit() << " recHits." << endl;

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedFinder.h
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedFinder.h
@@ -12,13 +12,11 @@
 #include <DataFormats/TrajectorySeed/interface/TrajectorySeed.h>
 #include <RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <FWCore/Framework/interface/EventSetup.h>
 #include <vector>
 #include <algorithm>
 
-namespace edm {
-  class EventSetup;
-}
+class MagneticField;
+class RPCGeometry;
 
 class RPCSeedFinder {
   typedef MuonTransientTrackingRecHit::MuonRecHitPointer MuonRecHitPointer;
@@ -34,7 +32,7 @@ public:
   void setOutput(std::vector<weightedTrajectorySeed> *goodweightedRef,
                  std::vector<weightedTrajectorySeed> *candidateweightedRef);
   void setrecHits(ConstMuonRecHitContainer &recHits);
-  void setEventSetup(const edm::EventSetup &iSetup);
+  void setEventSetup(const MagneticField &field, const RPCGeometry &rpcGeom);
   void seed();
 
 private:
@@ -43,7 +41,8 @@ private:
   bool isConfigured;
   bool isOutputset;
   bool isEventSetupset;
-  const edm::EventSetup *eSetup;
+  const MagneticField *pField = nullptr;
+  const RPCGeometry *pRPCGeom = nullptr;
   RPCSeedPattern oneSeed;
   //ConstMuonRecHitContainer theRecHits;
   std::vector<weightedTrajectorySeed> *goodweightedSeedsRef;

--- a/RecoMuon/MuonSeedGenerator/src/RPCSeedPattern.h
+++ b/RecoMuon/MuonSeedGenerator/src/RPCSeedPattern.h
@@ -25,6 +25,8 @@
 #define lower_limit_pt 3.0
 #endif
 
+class RPCGeometry;
+
 class RPCSeedPattern {
   typedef MuonTransientTrackingRecHit::MuonRecHitPointer MuonRecHitPointer;
   typedef MuonTransientTrackingRecHit::ConstMuonRecHitPointer ConstMuonRecHitPointer;
@@ -45,18 +47,18 @@ public:
 
 private:
   friend class RPCSeedFinder;
-  weightedTrajectorySeed seed(const edm::EventSetup& eSetup, int& isGoodSeed);
+  weightedTrajectorySeed seed(const MagneticField& Field, const RPCGeometry& rpcGeom, int& isGoodSeed);
   void ThreePointsAlgorithm();
   void MiddlePointsAlgorithm();
   void SegmentAlgorithm();
-  void SegmentAlgorithmSpecial(const edm::EventSetup& eSetup);
+  void SegmentAlgorithmSpecial(const MagneticField& Field);
   bool checkSegment() const;
   ConstMuonRecHitPointer FirstRecHit() const;
   ConstMuonRecHitPointer BestRefRecHit() const;
   LocalTrajectoryError getSpecialAlgorithmErrorMatrix(const ConstMuonRecHitPointer& first,
                                                       const ConstMuonRecHitPointer& best);
-  weightedTrajectorySeed createFakeSeed(int& isGoodSeed, const edm::EventSetup& eSetup);
-  weightedTrajectorySeed createSeed(int& isGoodSeed, const edm::EventSetup& eSetup);
+  weightedTrajectorySeed createFakeSeed(int& isGoodSeed, const MagneticField&);
+  weightedTrajectorySeed createSeed(int& isGoodSeed, const MagneticField&);
   double getDistance(const ConstMuonRecHitPointer& precHit, const GlobalVector& Center) const;
   bool checkStraightwithThreerecHits(ConstMuonRecHitPointer (&precHit)[3], double MinDeltaPhi) const;
   GlobalVector computePtwithThreerecHits(double& pt, double& pt_err, ConstMuonRecHitPointer (&precHit)[3]) const;
@@ -65,14 +67,15 @@ private:
   bool checkStraightwithThreerecHits(double (&x)[3], double (&y)[3], double MinDeltaPhi) const;
   GlobalVector computePtWithThreerecHits(double& pt, double& pt_err, double (&x)[3], double (&y)[3]) const;
 
-  void checkSimplePattern(const edm::EventSetup& eSetup);
-  void checkSegmentAlgorithmSpecial(const edm::EventSetup& eSetup);
+  void checkSimplePattern(const MagneticField& Field);
+  void checkSegmentAlgorithmSpecial(const MagneticField& Field, const RPCGeometry& rpcGeometry);
   double extropolateStep(const GlobalPoint& startPosition,
                          const GlobalVector& startMomentum,
                          ConstMuonRecHitContainer::const_iterator iter,
                          const int ClockwiseDirection,
                          double& tracklength,
-                         const edm::EventSetup& eSetup);
+                         const MagneticField& Field,
+                         const RPCGeometry& rpcGeometry);
 
   //void computeBestPt(double* pt, double* spt, double& ptmean0, double& sptmean0, unsigned int NumberofPt) const;
 

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedParametrization.cc
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedParametrization.cc
@@ -28,7 +28,8 @@ using namespace std;
 using namespace edm;
 
 // constructors
-MuonSeedParametrization::MuonSeedParametrization(const ParameterSet& pset) {
+MuonSeedParametrization::MuonSeedParametrization(const ParameterSet& pset)
+    : cscGeomToken(esConsumes()), dtGeomToken(esConsumes()) {
   debug = pset.getUntrackedParameter<bool>("debug");
   scale = pset.getUntrackedParameter<bool>("scale");
   rootFileName = pset.getUntrackedParameter<string>("rootFileName");
@@ -192,12 +193,10 @@ MuonSeedParametrization::~MuonSeedParametrization() {
 
 void MuonSeedParametrization::analyze(const Event& event, const EventSetup& eventSetup) {
   //Get the CSC Geometry :
-  ESHandle<CSCGeometry> cscGeom;
-  eventSetup.get<MuonGeometryRecord>().get(cscGeom);
+  ESHandle<CSCGeometry> cscGeom = eventSetup.getHandle(cscGeomToken);
 
   //Get the DT Geometry :
-  ESHandle<DTGeometry> dtGeom;
-  eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+  ESHandle<DTGeometry> dtGeom = eventSetup.getHandle(dtGeomToken);
 
   // Get the RecHits collection :
   Handle<CSCRecHit2DCollection> csc2DRecHits;

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedParametrization.h
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedParametrization.h
@@ -11,7 +11,7 @@
 #include "MuonSeedParaFillHisto.h"
 #include "MuonSeeddPhiScale.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include <DataFormats/Common/interface/Handle.h>
 
@@ -70,7 +70,7 @@ class SegSelector;
 class MuonSeedParaFillHisto;
 class MuonSeeddPhiScale;
 
-class MuonSeedParametrization : public edm::EDAnalyzer {
+class MuonSeedParametrization : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   MuonSeedParametrization(const edm::ParameterSet &pset);
@@ -200,6 +200,9 @@ private:
   std::string simHitLabel;
   std::string simTrackLabel;
   std::string muonseedLabel;
+
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken;
 };
 
 #endif

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.cc
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.cc
@@ -39,7 +39,7 @@ using namespace edm;
 using namespace reco;
 
 // constructors
-MuonSeedValidator::MuonSeedValidator(const ParameterSet& pset) {
+MuonSeedValidator::MuonSeedValidator(const ParameterSet& pset) : cscGeomToken(esConsumes()), dtGeomToken(esConsumes()) {
   rootFileName = pset.getUntrackedParameter<string>("rootFileName");
   recHitLabel = pset.getUntrackedParameter<string>("recHitLabel");
   cscSegmentLabel = pset.getUntrackedParameter<string>("cscSegmentLabel");
@@ -138,12 +138,8 @@ void MuonSeedValidator::analyze(const Event& event, const EventSetup& eventSetup
   //ESHandle<GlobalTrackingGeometry> globalGeometry;
   //eventSetup.get<GlobalTrackingGeometryRecord>().get(globalGeometry);
 
-  ESHandle<CSCGeometry> cscGeom;
-  eventSetup.get<MuonGeometryRecord>().get(cscGeom);
-
-  //Get the DT Geometry :
-  ESHandle<DTGeometry> dtGeom;
-  eventSetup.get<MuonGeometryRecord>().get(dtGeom);
+  ESHandle<CSCGeometry> cscGeom = eventSetup.getHandle(cscGeomToken);
+  ESHandle<DTGeometry> dtGeom = eventSetup.getHandle(dtGeomToken);
 
   // Get the RecHits collection :
   Handle<CSCRecHit2DCollection> csc2DRecHits;

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.h
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/MuonSeedValidator.h
@@ -10,7 +10,7 @@
 #include "MuonSeedValidatorHisto.h"
 #include "SegSelector.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include <DataFormats/Common/interface/Handle.h>
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -72,7 +72,7 @@ class DTChamberId;
 class SegSelector;
 //class MuonSeedBuilder;
 
-class MuonSeedValidator : public edm::EDAnalyzer {
+class MuonSeedValidator : public edm::one::EDAnalyzer<> {
 public:
   /// Constructor
   MuonSeedValidator(const edm::ParameterSet &pset);
@@ -267,6 +267,9 @@ private:
   double pTCutMin;
   double eta_Low;
   double eta_High;
+
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeomToken;
+  const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:

- change to thread-friendly module types
- use esConsumes

#### PR validation:

Code compiles and does not produce CMS deprecation warnings.