### PR TITLE
Store variable names in ROOT GBRForest files

### DIFF
--- a/CommonTools/MVAUtils/bin/convertXMLToGBRForestROOT.cc
+++ b/CommonTools/MVAUtils/bin/convertXMLToGBRForestROOT.cc
@@ -1,6 +1,7 @@
 #include "CommonTools/MVAUtils/interface/GBRForestTools.h"
 
 #include "TFile.h"
+#include "TTree.h"
 
 #include <filesystem>
 #include <iostream>
@@ -24,10 +25,15 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  auto gbrForest = createGBRForest(inputFileName);
+  std::vector<std::string> variableNames;
+  auto gbrForest = createGBRForest(inputFileName, variableNames);
   std::cout << "Read GBRForest " << inputFileName << " successfully." << std::endl;
 
-  TFile{outputFileName, "RECREATE"}.WriteObject(gbrForest.get(), "gbrForest");
+  {
+    TFile f{outputFileName, "RECREATE"};
+    f.WriteObject(gbrForest.get(), "gbrForest");
+    f.WriteObject(&variableNames, "variableNames");
+  }
   std::cout << "GBRForest written to " << outputFileName << " successfully." << std::endl;
 
   return 0;

--- a/CommonTools/MVAUtils/src/GBRForestTools.cc
+++ b/CommonTools/MVAUtils/src/GBRForestTools.cc
@@ -126,7 +126,11 @@ namespace {
     if (reco::details::hasEnding(weightsFileFullPath, ".root")) {
       TFile gbrForestFile(weightsFileFullPath.c_str());
       std::unique_ptr<GBRForest> up(gbrForestFile.Get<GBRForest>("gbrForest"));
+      std::unique_ptr<std::vector<std::string>> vars(gbrForestFile.Get<std::vector<std::string>>("variableNames"));
       gbrForestFile.Close("nodelete");
+      if (vars) {
+        varNames = std::move(*vars);
+      }
       return up;
     }
 


### PR DESCRIPTION
#### PR description:

Added storing and retrieving variable names from files.

#### PR validation:

Code compiles. Running a job that uses the original xml files still works.