### PR TITLE
Remove CMS deprecated warnings from L1Trigger/ConfigUtilities

### DIFF
--- a/L1TriggerConfig/Utilities/src/L1KeyListWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1KeyListWriter.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,23 +15,23 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-class L1KeyListWriter : public edm::EDAnalyzer {
+class L1KeyListWriter : public edm::one::EDAnalyzer<> {
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  explicit L1KeyListWriter(const edm::ParameterSet&) : edm::EDAnalyzer() {}
-  ~L1KeyListWriter(void) override {}
+  explicit L1KeyListWriter(const edm::ParameterSet&) : token_{esConsumes()} {}
+
+private:
+  edm::ESGetToken<L1TriggerKeyListExt, L1TriggerKeyListExtRcd> token_;
 };
 
 void L1KeyListWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1TriggerKeyListExt> handle1;
-  evSetup.get<L1TriggerKeyListExtRcd>().get(handle1);
-  std::shared_ptr<L1TriggerKeyListExt> ptr1(new L1TriggerKeyListExt(*(handle1.product())));
+  L1TriggerKeyListExt const& ptr1 = evSetup.getData(token_);
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOneIOV(*ptr1, firstSinceTime, "L1TriggerKeyListExtRcd");
+    poolDb->writeOneIOV(ptr1, firstSinceTime, "L1TriggerKeyListExtRcd");
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1KeyWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1KeyWriter.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,23 +15,23 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-class L1KeyWriter : public edm::EDAnalyzer {
+class L1KeyWriter : public edm::one::EDAnalyzer<> {
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  explicit L1KeyWriter(const edm::ParameterSet&) : edm::EDAnalyzer() {}
-  ~L1KeyWriter(void) override {}
+  explicit L1KeyWriter(const edm::ParameterSet&) : token_{esConsumes()} {}
+
+private:
+  edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> token_;
 };
 
 void L1KeyWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1TriggerKeyExt> handle1;
-  evSetup.get<L1TriggerKeyExtRcd>().get(handle1);
-  std::shared_ptr<L1TriggerKeyExt> ptr1(new L1TriggerKeyExt(*(handle1.product())));
+  L1TriggerKeyExt const& ptr1 = evSetup.getData(token_);
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOneIOV(*ptr1, firstSinceTime, "L1TriggerKeyExtRcd");
+    poolDb->writeOneIOV(ptr1, firstSinceTime, "L1TriggerKeyExtRcd");
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TCaloParamsUpdater.cc
+++ b/L1TriggerConfig/Utilities/src/L1TCaloParamsUpdater.cc
@@ -2,7 +2,7 @@
 #include <fstream>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -16,19 +16,18 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-class L1TCaloParamsUpdater : public edm::EDAnalyzer {
+class L1TCaloParamsUpdater : public edm::one::EDAnalyzer<> {
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  explicit L1TCaloParamsUpdater(const edm::ParameterSet&) : edm::EDAnalyzer() {}
-  ~L1TCaloParamsUpdater(void) override {}
+  explicit L1TCaloParamsUpdater(const edm::ParameterSet&) : token_{esConsumes()} {}
+
+private:
+  edm::ESGetToken<l1t::CaloParams, L1TCaloStage2ParamsRcd> token_;
 };
 
 void L1TCaloParamsUpdater::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<l1t::CaloParams> handle1;
-  //    evSetup.get<L1TCaloParamsRcd>().get( "l1conddb", handle1 ) ;
-  evSetup.get<L1TCaloStage2ParamsRcd>().get(handle1);
-  l1t::CaloParamsHelper m_params_helper(*(handle1.product()));
+  l1t::CaloParamsHelper m_params_helper(evSetup.getData(token_));
 
   //    std::ifstream is("tauL1CalibLUT_V2.txt");
   //    l1t::LUT lut;

--- a/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TGlobalPrescalesVetosViewer.cc
@@ -1,5 +1,5 @@
 #include <iomanip>
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -10,24 +10,24 @@
 #include "CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetos.h"
 
-class L1TGlobalPrescalesVetosViewer : public edm::EDAnalyzer {
+class L1TGlobalPrescalesVetosViewer : public edm::one::EDAnalyzer<> {
 private:
   int32_t prescale_table_verbosity;
   int32_t bxmask_map_verbosity;
   int32_t veto_verbosity;
+  edm::ESGetToken<L1TGlobalPrescalesVetos, L1TGlobalPrescalesVetosRcd> token_;
 
   std::string hash(void* buf, size_t len) const;
 
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  explicit L1TGlobalPrescalesVetosViewer(const edm::ParameterSet& pset) : edm::EDAnalyzer() {
+  explicit L1TGlobalPrescalesVetosViewer(const edm::ParameterSet& pset) {
+    token_ = esConsumes();
     prescale_table_verbosity = pset.getUntrackedParameter<int32_t>("prescale_table_verbosity", 0);
     bxmask_map_verbosity = pset.getUntrackedParameter<int32_t>("bxmask_map_verbosity", 0);
     veto_verbosity = pset.getUntrackedParameter<int32_t>("veto_verbosity", 0);
   }
-
-  ~L1TGlobalPrescalesVetosViewer(void) override {}
 };
 
 #include "Utilities/OpenSSL/interface/openssl_init.h"
@@ -64,24 +64,22 @@ std::string L1TGlobalPrescalesVetosViewer::hash(void* buf, size_t len) const {
 }
 
 void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1TGlobalPrescalesVetos> handle1;
-  evSetup.get<L1TGlobalPrescalesVetosRcd>().get(handle1);
-  std::shared_ptr<L1TGlobalPrescalesVetos> ptr(new L1TGlobalPrescalesVetos(*(handle1.product())));
+  L1TGlobalPrescalesVetos const& ptr = evSetup.getData(token_);
 
   edm::LogInfo("") << "L1TGlobalPrescalesVetosViewer:";
 
   cout << endl;
-  cout << "  version_        = " << ptr->version_ << endl;
-  cout << "  bxmask_default_ = " << ptr->bxmask_default_ << endl;
+  cout << "  version_        = " << ptr.version_ << endl;
+  cout << "  bxmask_default_ = " << ptr.bxmask_default_ << endl;
 
   size_t len_prescale_table_ = 0;
-  for (size_t col = 0; col < ptr->prescale_table_.size(); col++) {
-    size_t nRows = (ptr->prescale_table_)[col].size();
+  for (size_t col = 0; col < ptr.prescale_table_.size(); col++) {
+    size_t nRows = (ptr.prescale_table_)[col].size();
     len_prescale_table_ += nRows;
     if (prescale_table_verbosity > 0) {
       int column[nRows];
       for (size_t row = 0; row < nRows; row++)
-        column[row] = (ptr->prescale_table_)[col][row];
+        column[row] = (ptr.prescale_table_)[col][row];
       cout << "  prescale_table_[" << col << "][" << nRows << "] = ";
       if (nRows)
         cout << hash(column, sizeof(int) * nRows) << endl;
@@ -90,10 +88,10 @@ void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm:
     }
   }
   int prescale_table_[len_prescale_table_];
-  for (size_t col = 0, pos = 0; col < ptr->prescale_table_.size(); col++) {
-    size_t nRows = (ptr->prescale_table_)[col].size();
+  for (size_t col = 0, pos = 0; col < ptr.prescale_table_.size(); col++) {
+    size_t nRows = (ptr.prescale_table_)[col].size();
     for (size_t row = 0; row < nRows; row++, pos++)
-      prescale_table_[pos] = (ptr->prescale_table_)[col][row];
+      prescale_table_[pos] = (ptr.prescale_table_)[col][row];
   }
   cout << "  prescale_table_[[" << len_prescale_table_ << "]] = ";
   if (len_prescale_table_)
@@ -103,20 +101,20 @@ void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm:
 
   if (prescale_table_verbosity > 1) {
     cout << endl << " Detailed view on the prescales * masks: " << endl;
-    for (size_t col = 0; col < ptr->prescale_table_.size(); col++)
+    for (size_t col = 0; col < ptr.prescale_table_.size(); col++)
       cout << setw(8) << " Index " << col;
     cout << endl;
-    size_t nRows = (ptr->prescale_table_)[0].size();
+    size_t nRows = (ptr.prescale_table_)[0].size();
     for (size_t row = 0; row < nRows; row++) {
-      for (size_t col = 0; col < ptr->prescale_table_.size(); col++)
-        cout << setw(8) << (ptr->prescale_table_)[col][row];
+      for (size_t col = 0; col < ptr.prescale_table_.size(); col++)
+        cout << setw(8) << (ptr.prescale_table_)[col][row];
       cout << endl;
     }
     cout << endl;
   }
 
   size_t len_bxmask_map_ = 0;
-  for (std::map<int, std::vector<int> >::const_iterator it = (ptr->bxmask_map_).begin(); it != (ptr->bxmask_map_).end();
+  for (std::map<int, std::vector<int> >::const_iterator it = (ptr.bxmask_map_).begin(); it != (ptr.bxmask_map_).end();
        it++) {
     len_bxmask_map_ += it->second.size();
     if (bxmask_map_verbosity == 1) {
@@ -138,7 +136,7 @@ void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm:
   }
   int bxmask_map_[len_bxmask_map_];
   size_t pos = 0;
-  for (std::map<int, std::vector<int> >::const_iterator it = (ptr->bxmask_map_).begin(); it != (ptr->bxmask_map_).end();
+  for (std::map<int, std::vector<int> >::const_iterator it = (ptr.bxmask_map_).begin(); it != (ptr.bxmask_map_).end();
        it++) {
     for (size_t i = 0; i < it->second.size(); i++, pos++)
       bxmask_map_[pos] = it->second[i];
@@ -149,17 +147,17 @@ void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm:
   else
     cout << 0 << endl;
 
-  int veto_[(ptr->veto_).size()];
+  int veto_[(ptr.veto_).size()];
   bool veto_allZeros = true;
-  for (size_t i = 0; i < (ptr->veto_).size(); i++) {
-    veto_[i] = (ptr->veto_)[i];
+  for (size_t i = 0; i < (ptr.veto_).size(); i++) {
+    veto_[i] = (ptr.veto_)[i];
     if (veto_[i])
       veto_allZeros = false;
   }
-  cout << "  veto_[" << (ptr->veto_).size() << "]              = ";
+  cout << "  veto_[" << (ptr.veto_).size() << "]              = ";
   if (veto_verbosity == 0) {
-    if (!(ptr->veto_).empty()) {
-      cout << hash(veto_, sizeof(int) * (ptr->veto_).size());
+    if (!(ptr.veto_).empty()) {
+      cout << hash(veto_, sizeof(int) * (ptr.veto_).size());
       if (veto_allZeros)
         cout << " (all zeros)" << endl;
       else
@@ -167,24 +165,24 @@ void L1TGlobalPrescalesVetosViewer::analyze(const edm::Event& iEvent, const edm:
     } else
       cout << 0 << endl;
   } else
-    for (size_t i = 0; i < (ptr->veto_).size(); i++)
+    for (size_t i = 0; i < (ptr.veto_).size(); i++)
       cout << veto_[i] << endl;
 
-  int exp_ints_[(ptr->exp_ints_).size()];
-  for (size_t i = 0; i < (ptr->exp_ints_).size(); i++)
-    exp_ints_[i] = (ptr->exp_ints_)[i];
-  cout << "  exp_ints_[" << (ptr->exp_ints_).size() << "]            = ";
-  if (!(ptr->exp_ints_).empty())
-    cout << hash(exp_ints_, sizeof(int) * (ptr->exp_ints_).size()) << endl;
+  int exp_ints_[(ptr.exp_ints_).size()];
+  for (size_t i = 0; i < (ptr.exp_ints_).size(); i++)
+    exp_ints_[i] = (ptr.exp_ints_)[i];
+  cout << "  exp_ints_[" << (ptr.exp_ints_).size() << "]            = ";
+  if (!(ptr.exp_ints_).empty())
+    cout << hash(exp_ints_, sizeof(int) * (ptr.exp_ints_).size()) << endl;
   else
     cout << 0 << endl;
 
-  int exp_doubles_[(ptr->exp_doubles_).size()];
-  for (size_t i = 0; i < (ptr->exp_doubles_).size(); i++)
-    exp_ints_[i] = (ptr->exp_doubles_)[i];
-  cout << "  exp_doubles_[" << (ptr->exp_doubles_).size() << "]         = ";
-  if (!(ptr->exp_doubles_).empty())
-    cout << hash(exp_doubles_, sizeof(int) * (ptr->exp_doubles_).size()) << endl;
+  int exp_doubles_[(ptr.exp_doubles_).size()];
+  for (size_t i = 0; i < (ptr.exp_doubles_).size(); i++)
+    exp_ints_[i] = (ptr.exp_doubles_)[i];
+  cout << "  exp_doubles_[" << (ptr.exp_doubles_).size() << "]         = ";
+  if (!(ptr.exp_doubles_).empty())
+    cout << hash(exp_doubles_, sizeof(int) * (ptr.exp_doubles_).size()) << endl;
   else
     cout << 0 << endl;
 }

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelKalmanParamsViewer.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -18,15 +18,15 @@
 #include <iostream>
 using namespace std;
 
-class L1TMuonBarrelKalmanParamsViewer : public edm::EDAnalyzer {
+class L1TMuonBarrelKalmanParamsViewer : public edm::one::EDAnalyzer<> {
 private:
+  edm::ESGetToken<L1TMuonBarrelKalmanParams, L1TMuonBarrelKalmanParamsRcd> token_;
   std::string hash(void *buf, size_t len) const;
 
 public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-  L1TMuonBarrelKalmanParamsViewer(const edm::ParameterSet &){};
-  ~L1TMuonBarrelKalmanParamsViewer(void) override {}
+  L1TMuonBarrelKalmanParamsViewer(const edm::ParameterSet &) : token_{esConsumes()} {};
 };
 
 #include "Utilities/OpenSSL/interface/openssl_init.h"
@@ -63,13 +63,11 @@ std::string L1TMuonBarrelKalmanParamsViewer::hash(void *buf, size_t len) const {
 }
 
 void L1TMuonBarrelKalmanParamsViewer::analyze(const edm::Event &iEvent, const edm::EventSetup &evSetup) {
-  edm::ESHandle<L1TMuonBarrelKalmanParams> handle1;
-  evSetup.get<L1TMuonBarrelKalmanParamsRcd>().get(handle1);
-  std::shared_ptr<L1TMuonBarrelKalmanParams> ptr(new L1TMuonBarrelKalmanParams(*(handle1.product())));
+  L1TMuonBarrelKalmanParams const &ptr = evSetup.getData(token_);
 
   // Get the nodes and print out
-  auto pnodes = ptr->pnodes_[ptr->CONFIG];
-  cout << "version    : " << ptr->version_ << endl;
+  auto pnodes = ptr.pnodes_[ptr.CONFIG];
+  cout << "version    : " << ptr.version_ << endl;
   cout << "fwVersion  : " << hex << pnodes.fwVersion_ << dec << endl;
   cout << "LUTsPath   : " << pnodes.kalmanLUTsPath_ << endl;
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonBarrelParamsViewer.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -19,16 +19,16 @@
 #include <iostream>
 using namespace std;
 
-class L1TMuonBarrelParamsViewer : public edm::EDAnalyzer {
+class L1TMuonBarrelParamsViewer : public edm::one::EDAnalyzer<> {
 private:
   std::string hash(void *buf, size_t len) const;
+  edm::ESGetToken<L1TMuonBarrelParams, L1TMuonBarrelParamsRcd> token_;
   bool printPtaThreshold;
 
 public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
-  explicit L1TMuonBarrelParamsViewer(const edm::ParameterSet &) : edm::EDAnalyzer() { printPtaThreshold = false; }
-  ~L1TMuonBarrelParamsViewer(void) override {}
+  explicit L1TMuonBarrelParamsViewer(const edm::ParameterSet &) : token_{esConsumes()} { printPtaThreshold = false; }
 };
 
 #include "Utilities/OpenSSL/interface/openssl_init.h"
@@ -65,11 +65,9 @@ std::string L1TMuonBarrelParamsViewer::hash(void *buf, size_t len) const {
 }
 
 void L1TMuonBarrelParamsViewer::analyze(const edm::Event &iEvent, const edm::EventSetup &evSetup) {
-  edm::ESHandle<L1TMuonBarrelParams> handle1;
-  evSetup.get<L1TMuonBarrelParamsRcd>().get(handle1);
-  std::shared_ptr<L1TMuonBarrelParams> ptr(new L1TMuonBarrelParams(*(handle1.product())));
+  L1TMuonBarrelParams const &ptr = evSetup.getData(token_);
 
-  L1TMuonBarrelParamsHelper *ptr1 = (L1TMuonBarrelParamsHelper *)ptr.get();
+  L1TMuonBarrelParamsHelper *ptr1 = (L1TMuonBarrelParamsHelper *)&ptr;
 
   cout << "AssLUTPath: " << ptr1->AssLUTPath() << endl;
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsViewer.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -20,27 +20,26 @@
 #include <iostream>
 using namespace std;
 
-class L1TMuonEndCapParamsViewer : public edm::EDAnalyzer {
+class L1TMuonEndCapParamsViewer : public edm::one::EDAnalyzer<> {
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  explicit L1TMuonEndCapParamsViewer(const edm::ParameterSet&) : edm::EDAnalyzer() {}
-  ~L1TMuonEndCapParamsViewer(void) override {}
+  explicit L1TMuonEndCapParamsViewer(const edm::ParameterSet&) : token_{esConsumes()} {}
+
+private:
+  edm::ESGetToken<L1TMuonEndCapParams, L1TMuonEndCapParamsRcd> token_;
 };
 
 void L1TMuonEndCapParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1TMuonEndCapParams> handle1;
-  evSetup.get<L1TMuonEndCapParamsRcd>().get(handle1);
-  //    evSetup.get<L1TMuonEndCapParamsRcd>().get( handle1 ) ;
-  std::shared_ptr<L1TMuonEndCapParams> ptr1(new L1TMuonEndCapParams(*(handle1.product())));
+  L1TMuonEndCapParams const& ptr1 = evSetup.getData(token_);
 
   cout << "L1TMuonEndCapParams: " << endl;
-  cout << " PtAssignVersion_ = " << ptr1->PtAssignVersion_ << endl;
-  cout << " firmwareVersion_ = " << ptr1->firmwareVersion_ << endl;
-  cout << " PhiMatchWindowSt1_ = " << ptr1->PhiMatchWindowSt1_ << endl;
-  cout << " PhiMatchWindowSt2_ = " << ptr1->PhiMatchWindowSt2_ << endl;
-  cout << " PhiMatchWindowSt3_ = " << ptr1->PhiMatchWindowSt3_ << endl;
-  cout << " PhiMatchWindowSt4_ = " << ptr1->PhiMatchWindowSt4_ << endl;
+  cout << " PtAssignVersion_ = " << ptr1.PtAssignVersion_ << endl;
+  cout << " firmwareVersion_ = " << ptr1.firmwareVersion_ << endl;
+  cout << " PhiMatchWindowSt1_ = " << ptr1.PhiMatchWindowSt1_ << endl;
+  cout << " PhiMatchWindowSt2_ = " << ptr1.PhiMatchWindowSt2_ << endl;
+  cout << " PhiMatchWindowSt3_ = " << ptr1.PhiMatchWindowSt3_ << endl;
+  cout << " PhiMatchWindowSt4_ = " << ptr1.PhiMatchWindowSt4_ << endl;
 
   ///    edm::ESHandle<L1TMuonEndCapForest> handle2;
   ///    evSetup.get<L1TMuonEndCapForestRcd>().get( handle2 ) ;

--- a/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonEndCapParamsWriter.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,33 +16,39 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-class L1TMuonEndCapParamsWriter : public edm::EDAnalyzer {
+class L1TMuonEndCapParamsWriter : public edm::one::EDAnalyzer<> {
 private:
+  edm::ESGetToken<L1TMuonEndCapParams, L1TMuonEndCapParamsO2ORcd> o2oToken_;
+  edm::ESGetToken<L1TMuonEndCapParams, L1TMuonEndCapParamsRcd> token_;
   bool isO2Opayload;
 
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  explicit L1TMuonEndCapParamsWriter(const edm::ParameterSet& pset) : edm::EDAnalyzer() {
+  explicit L1TMuonEndCapParamsWriter(const edm::ParameterSet& pset) {
     isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload", false);
+    if (isO2Opayload) {
+      o2oToken_ = esConsumes();
+    } else {
+      token_ = esConsumes();
+    }
   }
-  ~L1TMuonEndCapParamsWriter(void) override {}
 };
 
 void L1TMuonEndCapParamsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TMuonEndCapParams> handle1;
 
   if (isO2Opayload)
-    evSetup.get<L1TMuonEndCapParamsO2ORcd>().get(handle1);
+    handle1 = evSetup.getHandle(o2oToken_);
   else
-    evSetup.get<L1TMuonEndCapParamsRcd>().get(handle1);
+    handle1 = evSetup.getHandle(token_);
 
-  std::shared_ptr<L1TMuonEndCapParams> ptr1(new L1TMuonEndCapParams(*(handle1.product())));
+  L1TMuonEndCapParams const& ptr1 = *handle1;
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOneIOV(*ptr1, firstSinceTime, (isO2Opayload ? "L1TMuonEndCapParamsO2ORcd" : "L1TMuonEndCapParamsRcd"));
+    poolDb->writeOneIOV(ptr1, firstSinceTime, (isO2Opayload ? "L1TMuonEndCapParamsO2ORcd" : "L1TMuonEndCapParamsRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsViewer.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -19,20 +19,21 @@
 #include <iostream>
 using namespace std;
 
-class L1TMuonGlobalParamsViewer : public edm::EDAnalyzer {
+class L1TMuonGlobalParamsViewer : public edm::one::EDAnalyzer<> {
 private:
   //    bool printLayerMap;
   std::string hash(void* buf, size_t len) const;
   void printLUT(l1t::LUT* lut, const char* name) const;
 
+  edm::ESGetToken<L1TMuonGlobalParams, L1TMuonGlobalParamsRcd> token_;
+
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   //    string hash(void *buf, size_t len) const ;
 
-  explicit L1TMuonGlobalParamsViewer(const edm::ParameterSet& pset) : edm::EDAnalyzer() {
+  explicit L1TMuonGlobalParamsViewer(const edm::ParameterSet& pset) : token_{esConsumes()} {
     //       printLayerMap   = pset.getUntrackedParameter<bool>("printLayerMap",  false);
   }
-  ~L1TMuonGlobalParamsViewer(void) override {}
 };
 
 #include "Utilities/OpenSSL/interface/openssl_init.h"
@@ -82,71 +83,70 @@ void L1TMuonGlobalParamsViewer::printLUT(l1t::LUT* lut, const char* name) const 
 
 void L1TMuonGlobalParamsViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   // Pull the config from the ES
-  edm::ESHandle<L1TMuonGlobalParams> handle1;
-  evSetup.get<L1TMuonGlobalParamsRcd>().get(handle1);
-  std::shared_ptr<L1TMuonGlobalParams> ptr1(new L1TMuonGlobalParams(*(handle1.product())));
+  //   has to be a copy as call non-const methods
+  L1TMuonGlobalParams ptr1 = evSetup.getData(token_);
 
   //    cout<<"Some fields in L1TMuonGlobalParams: "<<endl;
 
   //    ((L1TMuonGlobalParamsHelper*)ptr1.get())->print(cout);
 
-  printLUT(ptr1.get()->absIsoCheckMemLUT(), "absIsoCheckMemLUT");
-  printLUT(ptr1.get()->absIsoCheckMemLUT(), "absIsoCheckMemLUT");
-  printLUT(ptr1.get()->relIsoCheckMemLUT(), "relIsoCheckMemLUT");
-  printLUT(ptr1.get()->idxSelMemPhiLUT(), "idxSelMemPhiLUT");
-  printLUT(ptr1.get()->idxSelMemEtaLUT(), "idxSelMemEtaLUT");
+  printLUT(ptr1.absIsoCheckMemLUT(), "absIsoCheckMemLUT");
+  printLUT(ptr1.absIsoCheckMemLUT(), "absIsoCheckMemLUT");
+  printLUT(ptr1.relIsoCheckMemLUT(), "relIsoCheckMemLUT");
+  printLUT(ptr1.idxSelMemPhiLUT(), "idxSelMemPhiLUT");
+  printLUT(ptr1.idxSelMemEtaLUT(), "idxSelMemEtaLUT");
   //l1t::LUT* brlSingleMatchQualLUT();
-  printLUT(ptr1.get()->fwdPosSingleMatchQualLUT(), "fwdPosSingleMatchQualLUT");
-  printLUT(ptr1.get()->fwdNegSingleMatchQualLUT(), "fwdNegSingleMatchQualLUT");
-  printLUT(ptr1.get()->ovlPosSingleMatchQualLUT(), "ovlPosSingleMatchQualLUT");
-  printLUT(ptr1.get()->ovlNegSingleMatchQualLUT(), "ovlNegSingleMatchQualLUT");
-  printLUT(ptr1.get()->bOPosMatchQualLUT(), "bOPosMatchQualLUT");
-  printLUT(ptr1.get()->bONegMatchQualLUT(), "bONegMatchQualLUT");
-  printLUT(ptr1.get()->fOPosMatchQualLUT(), "fOPosMatchQualLUT");
-  printLUT(ptr1.get()->fONegMatchQualLUT(), "fONegMatchQualLUT");
-  printLUT(ptr1.get()->bPhiExtrapolationLUT(), "bPhiExtrapolationLUT");
-  printLUT(ptr1.get()->oPhiExtrapolationLUT(), "oPhiExtrapolationLUT");
-  printLUT(ptr1.get()->fPhiExtrapolationLUT(), "fPhiExtrapolationLUT");
-  printLUT(ptr1.get()->bEtaExtrapolationLUT(), "bEtaExtrapolationLUT");
-  printLUT(ptr1.get()->oEtaExtrapolationLUT(), "oEtaExtrapolationLUT");
-  printLUT(ptr1.get()->fEtaExtrapolationLUT(), "fEtaExtrapolationLUT");
-  printLUT(ptr1.get()->sortRankLUT(), "sortRankLUT");
+  printLUT(ptr1.fwdPosSingleMatchQualLUT(), "fwdPosSingleMatchQualLUT");
+  printLUT(ptr1.fwdNegSingleMatchQualLUT(), "fwdNegSingleMatchQualLUT");
+  printLUT(ptr1.ovlPosSingleMatchQualLUT(), "ovlPosSingleMatchQualLUT");
+  printLUT(ptr1.ovlNegSingleMatchQualLUT(), "ovlNegSingleMatchQualLUT");
+  printLUT(ptr1.bOPosMatchQualLUT(), "bOPosMatchQualLUT");
+  printLUT(ptr1.bONegMatchQualLUT(), "bONegMatchQualLUT");
+  printLUT(ptr1.fOPosMatchQualLUT(), "fOPosMatchQualLUT");
+  printLUT(ptr1.fONegMatchQualLUT(), "fONegMatchQualLUT");
+  printLUT(ptr1.bPhiExtrapolationLUT(), "bPhiExtrapolationLUT");
+  printLUT(ptr1.oPhiExtrapolationLUT(), "oPhiExtrapolationLUT");
+  printLUT(ptr1.fPhiExtrapolationLUT(), "fPhiExtrapolationLUT");
+  printLUT(ptr1.bEtaExtrapolationLUT(), "bEtaExtrapolationLUT");
+  printLUT(ptr1.oEtaExtrapolationLUT(), "oEtaExtrapolationLUT");
+  printLUT(ptr1.fEtaExtrapolationLUT(), "fEtaExtrapolationLUT");
+  printLUT(ptr1.sortRankLUT(), "sortRankLUT");
 
-  std::cout << "absIsoCheckMemLUTPath: " << ptr1.get()->absIsoCheckMemLUTPath() << std::endl;
-  std::cout << "relIsoCheckMemLUTPath: " << ptr1.get()->relIsoCheckMemLUTPath() << std::endl;
-  std::cout << "idxSelMemPhiLUTPath: " << ptr1.get()->idxSelMemPhiLUTPath() << std::endl;
-  std::cout << "idxSelMemEtaLUTPath: " << ptr1.get()->idxSelMemEtaLUTPath() << std::endl;
+  std::cout << "absIsoCheckMemLUTPath: " << ptr1.absIsoCheckMemLUTPath() << std::endl;
+  std::cout << "relIsoCheckMemLUTPath: " << ptr1.relIsoCheckMemLUTPath() << std::endl;
+  std::cout << "idxSelMemPhiLUTPath: " << ptr1.idxSelMemPhiLUTPath() << std::endl;
+  std::cout << "idxSelMemEtaLUTPath: " << ptr1.idxSelMemEtaLUTPath() << std::endl;
   //std::string brlSingleMatchQualLUTPath() const    { return pnodes_[brlSingleMatchQual].sparams_.size() > spIdx::fname ? pnodes_[brlSingleMatchQual].sparams_[spIdx::fname] : ""; }
-  std::cout << "fwdPosSingleMatchQualLUTPath: " << ptr1.get()->fwdPosSingleMatchQualLUTPath() << std::endl;
-  std::cout << "fwdNegSingleMatchQualLUTPath: " << ptr1.get()->fwdNegSingleMatchQualLUTPath() << std::endl;
-  std::cout << "ovlPosSingleMatchQualLUTPath: " << ptr1.get()->ovlPosSingleMatchQualLUTPath() << std::endl;
-  std::cout << "ovlNegSingleMatchQualLUTPath: " << ptr1.get()->ovlNegSingleMatchQualLUTPath() << std::endl;
-  std::cout << "bOPosMatchQualLUTPath: " << ptr1.get()->bOPosMatchQualLUTPath() << std::endl;
-  std::cout << "bONegMatchQualLUTPath: " << ptr1.get()->bONegMatchQualLUTPath() << std::endl;
-  std::cout << "fOPosMatchQualLUTPath: " << ptr1.get()->fOPosMatchQualLUTPath() << std::endl;
-  std::cout << "fONegMatchQualLUTPath: " << ptr1.get()->fONegMatchQualLUTPath() << std::endl;
-  std::cout << "bPhiExtrapolationLUTPath: " << ptr1.get()->bPhiExtrapolationLUTPath() << std::endl;
-  std::cout << "oPhiExtrapolationLUTPath: " << ptr1.get()->oPhiExtrapolationLUTPath() << std::endl;
-  std::cout << "fPhiExtrapolationLUTPath: " << ptr1.get()->fPhiExtrapolationLUTPath() << std::endl;
-  std::cout << "bEtaExtrapolationLUTPath: " << ptr1.get()->bEtaExtrapolationLUTPath() << std::endl;
-  std::cout << "oEtaExtrapolationLUTPath: " << ptr1.get()->oEtaExtrapolationLUTPath() << std::endl;
-  std::cout << "fEtaExtrapolationLUTPath: " << ptr1.get()->fEtaExtrapolationLUTPath() << std::endl;
-  std::cout << "sortRankLUTPath: " << ptr1.get()->sortRankLUTPath() << std::endl;
+  std::cout << "fwdPosSingleMatchQualLUTPath: " << ptr1.fwdPosSingleMatchQualLUTPath() << std::endl;
+  std::cout << "fwdNegSingleMatchQualLUTPath: " << ptr1.fwdNegSingleMatchQualLUTPath() << std::endl;
+  std::cout << "ovlPosSingleMatchQualLUTPath: " << ptr1.ovlPosSingleMatchQualLUTPath() << std::endl;
+  std::cout << "ovlNegSingleMatchQualLUTPath: " << ptr1.ovlNegSingleMatchQualLUTPath() << std::endl;
+  std::cout << "bOPosMatchQualLUTPath: " << ptr1.bOPosMatchQualLUTPath() << std::endl;
+  std::cout << "bONegMatchQualLUTPath: " << ptr1.bONegMatchQualLUTPath() << std::endl;
+  std::cout << "fOPosMatchQualLUTPath: " << ptr1.fOPosMatchQualLUTPath() << std::endl;
+  std::cout << "fONegMatchQualLUTPath: " << ptr1.fONegMatchQualLUTPath() << std::endl;
+  std::cout << "bPhiExtrapolationLUTPath: " << ptr1.bPhiExtrapolationLUTPath() << std::endl;
+  std::cout << "oPhiExtrapolationLUTPath: " << ptr1.oPhiExtrapolationLUTPath() << std::endl;
+  std::cout << "fPhiExtrapolationLUTPath: " << ptr1.fPhiExtrapolationLUTPath() << std::endl;
+  std::cout << "bEtaExtrapolationLUTPath: " << ptr1.bEtaExtrapolationLUTPath() << std::endl;
+  std::cout << "oEtaExtrapolationLUTPath: " << ptr1.oEtaExtrapolationLUTPath() << std::endl;
+  std::cout << "fEtaExtrapolationLUTPath: " << ptr1.fEtaExtrapolationLUTPath() << std::endl;
+  std::cout << "sortRankLUTPath: " << ptr1.sortRankLUTPath() << std::endl;
 
-  std::cout << "fwdPosSingleMatchQualLUTMaxDR: " << ptr1.get()->fwdPosSingleMatchQualLUTMaxDR() << std::endl;
-  std::cout << "fwdNegSingleMatchQualLUTMaxDR: " << ptr1.get()->fwdNegSingleMatchQualLUTMaxDR() << std::endl;
-  std::cout << "ovlPosSingleMatchQualLUTMaxDR: " << ptr1.get()->ovlPosSingleMatchQualLUTMaxDR() << std::endl;
-  std::cout << "ovlNegSingleMatchQualLUTMaxDR: " << ptr1.get()->ovlNegSingleMatchQualLUTMaxDR() << std::endl;
-  std::cout << "bOPosMatchQualLUTMaxDR: " << ptr1.get()->bOPosMatchQualLUTMaxDR() << std::endl;
-  std::cout << "bONegMatchQualLUTMaxDR: " << ptr1.get()->bONegMatchQualLUTMaxDR() << std::endl;
-  std::cout << "bOPosMatchQualLUTMaxDREtaFine: " << ptr1.get()->bOPosMatchQualLUTMaxDREtaFine() << std::endl;
-  std::cout << "bONegMatchQualLUTMaxDREtaFine: " << ptr1.get()->bONegMatchQualLUTMaxDREtaFine() << std::endl;
-  std::cout << "fOPosMatchQualLUTMaxDR: " << ptr1.get()->fOPosMatchQualLUTMaxDR() << std::endl;
-  std::cout << "fONegMatchQualLUTMaxDR: " << ptr1.get()->fONegMatchQualLUTMaxDR() << std::endl;
+  std::cout << "fwdPosSingleMatchQualLUTMaxDR: " << ptr1.fwdPosSingleMatchQualLUTMaxDR() << std::endl;
+  std::cout << "fwdNegSingleMatchQualLUTMaxDR: " << ptr1.fwdNegSingleMatchQualLUTMaxDR() << std::endl;
+  std::cout << "ovlPosSingleMatchQualLUTMaxDR: " << ptr1.ovlPosSingleMatchQualLUTMaxDR() << std::endl;
+  std::cout << "ovlNegSingleMatchQualLUTMaxDR: " << ptr1.ovlNegSingleMatchQualLUTMaxDR() << std::endl;
+  std::cout << "bOPosMatchQualLUTMaxDR: " << ptr1.bOPosMatchQualLUTMaxDR() << std::endl;
+  std::cout << "bONegMatchQualLUTMaxDR: " << ptr1.bONegMatchQualLUTMaxDR() << std::endl;
+  std::cout << "bOPosMatchQualLUTMaxDREtaFine: " << ptr1.bOPosMatchQualLUTMaxDREtaFine() << std::endl;
+  std::cout << "bONegMatchQualLUTMaxDREtaFine: " << ptr1.bONegMatchQualLUTMaxDREtaFine() << std::endl;
+  std::cout << "fOPosMatchQualLUTMaxDR: " << ptr1.fOPosMatchQualLUTMaxDR() << std::endl;
+  std::cout << "fONegMatchQualLUTMaxDR: " << ptr1.fONegMatchQualLUTMaxDR() << std::endl;
 
   // Sort rank LUT factors for pT and quality
-  std::cout << "sortRankLUTPtFactor: " << ptr1.get()->sortRankLUTPtFactor() << std::endl;
-  std::cout << "sortRankLUTQualFactor: " << ptr1.get()->sortRankLUTQualFactor() << std::endl;
+  std::cout << "sortRankLUTPtFactor: " << ptr1.sortRankLUTPtFactor() << std::endl;
+  std::cout << "sortRankLUTQualFactor: " << ptr1.sortRankLUTQualFactor() << std::endl;
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonGlobalParamsWriter.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -15,33 +15,39 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-class L1TMuonGlobalParamsWriter : public edm::EDAnalyzer {
+class L1TMuonGlobalParamsWriter : public edm::one::EDAnalyzer<> {
 private:
+  edm::ESGetToken<L1TMuonGlobalParams, L1TMuonGlobalParamsO2ORcd> o2oToken_;
+  edm::ESGetToken<L1TMuonGlobalParams, L1TMuonGlobalParamsRcd> token_;
   bool isO2Opayload;
 
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  explicit L1TMuonGlobalParamsWriter(const edm::ParameterSet& pset) : edm::EDAnalyzer() {
+  explicit L1TMuonGlobalParamsWriter(const edm::ParameterSet& pset) {
     isO2Opayload = pset.getUntrackedParameter<bool>("isO2Opayload", false);
+    if (isO2Opayload) {
+      o2oToken_ = esConsumes();
+    } else {
+      token_ = esConsumes();
+    }
   }
-  ~L1TMuonGlobalParamsWriter(void) override {}
 };
 
 void L1TMuonGlobalParamsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
   edm::ESHandle<L1TMuonGlobalParams> handle1;
 
   if (isO2Opayload)
-    evSetup.get<L1TMuonGlobalParamsO2ORcd>().get(handle1);
+    handle1 = evSetup.getHandle(o2oToken_);
   else
-    evSetup.get<L1TMuonGlobalParamsRcd>().get(handle1);
+    handle1 = evSetup.getHandle(token_);
 
-  std::shared_ptr<L1TMuonGlobalParams> ptr1(new L1TMuonGlobalParams(*(handle1.product())));
+  L1TMuonGlobalParams const& ptr1 = *handle1;
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOneIOV(*ptr1, firstSinceTime, (isO2Opayload ? "L1TMuonGlobalParamsO2ORcd" : "L1TMuonGlobalParamsRcd"));
+    poolDb->writeOneIOV(ptr1, firstSinceTime, (isO2Opayload ? "L1TMuonGlobalParamsO2ORcd" : "L1TMuonGlobalParamsRcd"));
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsViewer.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -18,18 +18,18 @@
 #include <iostream>
 using namespace std;
 
-class L1TMuonOverlapParamsViewer : public edm::EDAnalyzer {
+class L1TMuonOverlapParamsViewer : public edm::one::EDAnalyzer<> {
 private:
+  edm::ESGetToken<L1TMuonOverlapParams, L1TMuonOverlapParamsRcd> token_;
   bool printLayerMap;
 
 public:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   string hash(void *buf, size_t len) const;
 
-  explicit L1TMuonOverlapParamsViewer(const edm::ParameterSet &pset) : edm::EDAnalyzer() {
+  explicit L1TMuonOverlapParamsViewer(const edm::ParameterSet &pset) : token_{esConsumes()} {
     printLayerMap = pset.getUntrackedParameter<bool>("printLayerMap", false);
   }
-  ~L1TMuonOverlapParamsViewer(void) override {}
 };
 
 #include "Utilities/OpenSSL/interface/openssl_init.h"
@@ -67,35 +67,33 @@ string L1TMuonOverlapParamsViewer::hash(void *buf, size_t len) const {
 
 void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::EventSetup &evSetup) {
   // Pull the config from the ES
-  edm::ESHandle<L1TMuonOverlapParams> handle1;
-  evSetup.get<L1TMuonOverlapParamsRcd>().get(handle1);
-  std::shared_ptr<L1TMuonOverlapParams> ptr1(new L1TMuonOverlapParams(*(handle1.product())));
+  L1TMuonOverlapParams const &ptr1 = evSetup.getData(token_);
 
   cout << "Some fields in L1TMuonOverlapParamsParams: " << endl;
 
-  cout << " fwVersion() = " << ptr1->fwVersion() << endl;
-  cout << " nPdfAddrBits() = " << ptr1->nPdfAddrBits() << endl;
-  cout << " nPdfValBits() = " << ptr1->nPdfValBits() << endl;
-  cout << " nHitsPerLayer() = " << ptr1->nHitsPerLayer() << endl;
-  cout << " nPhiBits() = " << ptr1->nPhiBits() << endl;
-  cout << " nPhiBins() = " << ptr1->nPhiBins() << endl;
-  cout << " nRefHits() = " << ptr1->nRefHits() << endl;
-  cout << " nTestRefHits() = " << ptr1->nTestRefHits() << endl;
-  cout << " nProcessors() = " << ptr1->nProcessors() << endl;
-  cout << " nLogicRegions() = " << ptr1->nLogicRegions() << endl;
-  cout << " nInputs() = " << ptr1->nInputs() << endl;
-  cout << " nLayers() = " << ptr1->nLayers() << endl;
-  cout << " nRefLayers() = " << ptr1->nRefLayers() << endl;
-  cout << " nGoldenPatterns() = " << ptr1->nGoldenPatterns() << endl;
+  cout << " fwVersion() = " << ptr1.fwVersion() << endl;
+  cout << " nPdfAddrBits() = " << ptr1.nPdfAddrBits() << endl;
+  cout << " nPdfValBits() = " << ptr1.nPdfValBits() << endl;
+  cout << " nHitsPerLayer() = " << ptr1.nHitsPerLayer() << endl;
+  cout << " nPhiBits() = " << ptr1.nPhiBits() << endl;
+  cout << " nPhiBins() = " << ptr1.nPhiBins() << endl;
+  cout << " nRefHits() = " << ptr1.nRefHits() << endl;
+  cout << " nTestRefHits() = " << ptr1.nTestRefHits() << endl;
+  cout << " nProcessors() = " << ptr1.nProcessors() << endl;
+  cout << " nLogicRegions() = " << ptr1.nLogicRegions() << endl;
+  cout << " nInputs() = " << ptr1.nInputs() << endl;
+  cout << " nLayers() = " << ptr1.nLayers() << endl;
+  cout << " nRefLayers() = " << ptr1.nRefLayers() << endl;
+  cout << " nGoldenPatterns() = " << ptr1.nGoldenPatterns() << endl;
 
-  const std::vector<int> *gp = ptr1->generalParams();
+  const std::vector<int> *gp = ptr1.generalParams();
   cout << " number of general parameters: = " << gp->size() << endl;
   cout << "  ";
   for (auto a : *gp)
     cout << a << ", ";
   cout << endl;
 
-  const std::vector<L1TMuonOverlapParams::LayerMapNode> *lm = ptr1->layerMap();
+  const std::vector<L1TMuonOverlapParams::LayerMapNode> *lm = ptr1.layerMap();
   if (!lm->empty()) {
     cout << " layerMap() =              [" << lm->size() << "] ";
     L1TMuonOverlapParams::LayerMapNode *lm_ = new L1TMuonOverlapParams::LayerMapNode[lm->size()];
@@ -120,7 +118,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " layerMap() =              [0] " << endl;
   }
 
-  const std::vector<L1TMuonOverlapParams::RefLayerMapNode> *rlm = ptr1->refLayerMap();
+  const std::vector<L1TMuonOverlapParams::RefLayerMapNode> *rlm = ptr1.refLayerMap();
   if (!rlm->empty()) {
     cout << " refLayerMap() =           [" << rlm->size() << "] ";
     L1TMuonOverlapParams::RefLayerMapNode *rlm_ = new L1TMuonOverlapParams::RefLayerMapNode[rlm->size()];
@@ -132,7 +130,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " refLayerMap() =           [0] " << endl;
   }
 
-  const std::vector<L1TMuonOverlapParams::RefHitNode> *rhn = ptr1->refHitMap();
+  const std::vector<L1TMuonOverlapParams::RefHitNode> *rhn = ptr1.refHitMap();
   if (!rhn->empty()) {
     cout << " refHitMap() =             [" << rhn->size() << "] ";
     L1TMuonOverlapParams::RefHitNode *rhn_ = new L1TMuonOverlapParams::RefHitNode[rhn->size()];
@@ -144,7 +142,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " refHitMap() =             [0] " << endl;
   }
 
-  const std::vector<int> *gpsm = ptr1->globalPhiStartMap();
+  const std::vector<int> *gpsm = ptr1.globalPhiStartMap();
   if (!gpsm->empty()) {
     cout << " globalPhiStartMap() =     [" << gpsm->size() << "] ";
     int gpsm_[gpsm->size()];
@@ -155,7 +153,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " globalPhiStartMap() =     [0] " << endl;
   }
 
-  const std::vector<L1TMuonOverlapParams::LayerInputNode> *lim = ptr1->layerInputMap();
+  const std::vector<L1TMuonOverlapParams::LayerInputNode> *lim = ptr1.layerInputMap();
   if (!lim->empty()) {
     cout << " layerInputMap() =         [" << lim->size() << "] ";
     L1TMuonOverlapParams::LayerInputNode *lim_ = new L1TMuonOverlapParams::LayerInputNode[lim->size()];
@@ -167,7 +165,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " layerInputMap() =         [0] " << endl;
   }
 
-  const std::vector<int> *css = ptr1->connectedSectorsStart();
+  const std::vector<int> *css = ptr1.connectedSectorsStart();
   if (!css->empty()) {
     cout << " connectedSectorsStart() = [" << css->size() << "] ";
     int css_[css->size()];
@@ -178,7 +176,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " connectedSectorsStart() = [0] " << endl;
   }
 
-  const std::vector<int> *cse = ptr1->connectedSectorsEnd();
+  const std::vector<int> *cse = ptr1.connectedSectorsEnd();
   if (!cse->empty()) {
     cout << " connectedSectorsEnd() = [" << cse->size() << "] ";
     int cse_[cse->size()];
@@ -189,7 +187,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " connectedSectorsEnd() = [0] " << endl;
   }
 
-  const l1t::LUT *clut = ptr1->chargeLUT();
+  const l1t::LUT *clut = ptr1.chargeLUT();
   if (clut->maxSize()) {
     cout << " chargeLUT =      [" << clut->maxSize() << "] ";
     int clut_[clut->maxSize()];
@@ -200,7 +198,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " chargeLUT =      [0] " << endl;
   }
 
-  const l1t::LUT *elut = ptr1->etaLUT();
+  const l1t::LUT *elut = ptr1.etaLUT();
   if (elut->maxSize()) {
     cout << " etaLUT =         [" << elut->maxSize() << "] ";
     int elut_[elut->maxSize()];
@@ -211,7 +209,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " chargeLUT =      [0] " << endl;
   }
 
-  const l1t::LUT *ptlut = ptr1->ptLUT();
+  const l1t::LUT *ptlut = ptr1.ptLUT();
   if (ptlut->maxSize()) {
     cout << " ptLUT =          [" << ptlut->maxSize() << "] " << flush;
     int ptlut_[ptlut->maxSize()];
@@ -222,7 +220,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " ptLUT =          [0] " << endl;
   }
 
-  const l1t::LUT *plut = ptr1->pdfLUT();
+  const l1t::LUT *plut = ptr1.pdfLUT();
   if (plut->maxSize()) {
     cout << " pdfLUT =         [" << plut->maxSize() << "] " << flush;
     int plut_[plut->maxSize()];
@@ -233,7 +231,7 @@ void L1TMuonOverlapParamsViewer::analyze(const edm::Event &iEvent, const edm::Ev
     cout << " pdfLUT =         [0] " << endl;
   }
 
-  const l1t::LUT *mlut = ptr1->meanDistPhiLUT();
+  const l1t::LUT *mlut = ptr1.meanDistPhiLUT();
   if (mlut->maxSize()) {
     cout << " meanDistPhiLUT = [" << mlut->maxSize() << "] " << flush;
     int mlut_[mlut->maxSize()];

--- a/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsWriter.cc
+++ b/L1TriggerConfig/Utilities/src/L1TMuonOverlapParamsWriter.cc
@@ -1,7 +1,7 @@
 #include <iomanip>
 #include <iostream>
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -15,23 +15,23 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-class L1TMuonOverlapParamsWriter : public edm::EDAnalyzer {
+class L1TMuonOverlapParamsWriter : public edm::one::EDAnalyzer<> {
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  explicit L1TMuonOverlapParamsWriter(const edm::ParameterSet&) : edm::EDAnalyzer() {}
-  ~L1TMuonOverlapParamsWriter(void) override {}
+  explicit L1TMuonOverlapParamsWriter(const edm::ParameterSet&) : token_{esConsumes()} {}
+
+private:
+  edm::ESGetToken<L1TMuonOverlapParams, L1TMuonOverlapParamsRcd> token_;
 };
 
 void L1TMuonOverlapParamsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1TMuonOverlapParams> handle1;
-  evSetup.get<L1TMuonOverlapParamsRcd>().get(handle1);
-  std::shared_ptr<L1TMuonOverlapParams> ptr1(new L1TMuonOverlapParams(*(handle1.product())));
+  L1TMuonOverlapParams const& ptr1 = evSetup.getData(token_);
 
   edm::Service<cond::service::PoolDBOutputService> poolDb;
   if (poolDb.isAvailable()) {
     cond::Time_t firstSinceTime = poolDb->beginOfTime();
-    poolDb->writeOneIOV(*ptr1, firstSinceTime, "L1TMuonOverlapPatternParamsRcd");
+    poolDb->writeOneIOV(ptr1, firstSinceTime, "L1TMuonOverlapPatternParamsRcd");
   }
 }
 

--- a/L1TriggerConfig/Utilities/src/L1TriggerKeyExtViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TriggerKeyExtViewer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -8,41 +8,38 @@
 #include "CondFormats/DataRecord/interface/L1TriggerKeyExtRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyExt.h"
 
-class L1TriggerKeyExtViewer : public edm::EDAnalyzer {
+class L1TriggerKeyExtViewer : public edm::one::EDAnalyzer<> {
 private:
   std::string label;
+  edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> token_;
 
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   explicit L1TriggerKeyExtViewer(const edm::ParameterSet& pset)
-      : edm::EDAnalyzer(), label(pset.getParameter<std::string>("label")) {}
-
-  ~L1TriggerKeyExtViewer(void) override {}
+      : label(pset.getParameter<std::string>("label")), token_{esConsumes()} {}
 };
 
 #include <iostream>
 using namespace std;
 
 void L1TriggerKeyExtViewer::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1TriggerKeyExt> handle1;
-  evSetup.get<L1TriggerKeyExtRcd>().get(label, handle1);
-  std::shared_ptr<L1TriggerKeyExt> ptr1(new L1TriggerKeyExt(*(handle1.product())));
+  L1TriggerKeyExt const& ptr1 = evSetup.getData(token_);
 
-  cout << "L1TriggerKeyExt: parent key = " << ptr1->tscKey() << endl;
+  cout << "L1TriggerKeyExt: parent key = " << ptr1.tscKey() << endl;
 
-  cout << " uGT     key: " << ptr1->subsystemKey(L1TriggerKeyExt::kuGT) << endl;
-  cout << " uGMT    key: " << ptr1->subsystemKey(L1TriggerKeyExt::kuGMT) << endl;
-  cout << " CALO    key: " << ptr1->subsystemKey(L1TriggerKeyExt::kCALO) << endl;
-  cout << " BMTF    key: " << ptr1->subsystemKey(L1TriggerKeyExt::kBMTF) << endl;
-  cout << " OMTF    key: " << ptr1->subsystemKey(L1TriggerKeyExt::kOMTF) << endl;
-  cout << " EMTF    key: " << ptr1->subsystemKey(L1TriggerKeyExt::kEMTF) << endl;
-  cout << " TWINMUX key: " << ptr1->subsystemKey(L1TriggerKeyExt::kTWINMUX) << endl;
+  cout << " uGT     key: " << ptr1.subsystemKey(L1TriggerKeyExt::kuGT) << endl;
+  cout << " uGMT    key: " << ptr1.subsystemKey(L1TriggerKeyExt::kuGMT) << endl;
+  cout << " CALO    key: " << ptr1.subsystemKey(L1TriggerKeyExt::kCALO) << endl;
+  cout << " BMTF    key: " << ptr1.subsystemKey(L1TriggerKeyExt::kBMTF) << endl;
+  cout << " OMTF    key: " << ptr1.subsystemKey(L1TriggerKeyExt::kOMTF) << endl;
+  cout << " EMTF    key: " << ptr1.subsystemKey(L1TriggerKeyExt::kEMTF) << endl;
+  cout << " TWINMUX key: " << ptr1.subsystemKey(L1TriggerKeyExt::kTWINMUX) << endl;
 
   cout << "Records: " << endl;
 
-  L1TriggerKeyExt::RecordToKey::const_iterator itr = ptr1->recordToKeyMap().begin();
-  L1TriggerKeyExt::RecordToKey::const_iterator end = ptr1->recordToKeyMap().end();
+  L1TriggerKeyExt::RecordToKey::const_iterator itr = ptr1.recordToKeyMap().begin();
+  L1TriggerKeyExt::RecordToKey::const_iterator end = ptr1.recordToKeyMap().end();
 
   for (; itr != end; ++itr) {
     std::string recordType = itr->first;

--- a/L1TriggerConfig/Utilities/src/L1TriggerKeyListExtViewer.cc
+++ b/L1TriggerConfig/Utilities/src/L1TriggerKeyListExtViewer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -8,28 +8,29 @@
 #include "CondFormats/DataRecord/interface/L1TriggerKeyListExtRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TriggerKeyListExt.h"
 
-class L1TriggerKeyListExtReader : public edm::EDAnalyzer {
+class L1TriggerKeyListExtReader : public edm::one::EDAnalyzer<> {
 private:
 public:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  explicit L1TriggerKeyListExtReader(const edm::ParameterSet&) : edm::EDAnalyzer() {}
+  explicit L1TriggerKeyListExtReader(const edm::ParameterSet&) : token_{esConsumes()} {}
   ~L1TriggerKeyListExtReader(void) override {}
+
+private:
+  edm::ESGetToken<L1TriggerKeyListExt, L1TriggerKeyListExtRcd> token_;
 };
 
 #include <iostream>
 using namespace std;
 
 void L1TriggerKeyListExtReader::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup) {
-  edm::ESHandle<L1TriggerKeyListExt> handle1;
-  evSetup.get<L1TriggerKeyListExtRcd>().get(handle1);
-  std::shared_ptr<L1TriggerKeyListExt> ptr1(new L1TriggerKeyListExt(*(handle1.product())));
+  L1TriggerKeyListExt const& ptr1 = evSetup.getData(token_);
 
-  const L1TriggerKeyListExt::KeyToToken& allKeysTokens = ptr1->tscKeyToTokenMap();
+  const L1TriggerKeyListExt::KeyToToken& allKeysTokens = ptr1.tscKeyToTokenMap();
   for (auto& keyToken : allKeysTokens)
     cout << "  tscKey = " << keyToken.first << " token: " << hex << keyToken.second << dec << endl;
 
-  const L1TriggerKeyListExt::RecordToKeyToToken& records = ptr1->recordTypeToKeyToTokenMap();
+  const L1TriggerKeyListExt::RecordToKeyToToken& records = ptr1.recordTypeToKeyToTokenMap();
   for (auto& rec : records) {
     cout << "  " << rec.first << ":" << endl;
     for (auto& keyToken : rec.second)


### PR DESCRIPTION
#### PR description:

- changed to thread-friendly module types
- added esConsumes

#### PR validation:

Code compiles and no longer issues the warnings.