### PR TITLE
Update of Heavy Ion Vertexing for pp_on_AA and XeXe eras

### DIFF
--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -185,7 +185,7 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (pp_on_XeXe_2017 | pp_on_AA).toModify(firstStepPrimaryVerticesPreSplitting, 
     TkFilterParameters = dict(
         trackQuality = 'any',
-        maxNumTracksThreshold = 1000000
+        maxNumTracksThreshold = 2**31-1
     ) 
 )
 

--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -182,7 +182,12 @@ firstStepPrimaryVerticesPreSplitting = _offlinePrimaryVertices.clone(
 )
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-(pp_on_XeXe_2017 | pp_on_AA).toModify(firstStepPrimaryVerticesPreSplitting, TkFilterParameters = dict(trackQuality = 'any'))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(firstStepPrimaryVerticesPreSplitting, 
+    TkFilterParameters = dict(
+        trackQuality = 'any',
+        maxNumTracksThreshold = 1000000
+    ) 
+)
 
 #Jet Core emulation to identify jet-tracks
 from RecoTracker.IterativeTracking.InitialStep_cff import initialStepTrackRefsForJets, caloTowerForTrk, ak4CaloJetsForTrk

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -285,7 +285,12 @@ firstStepPrimaryVerticesUnsorted = _offlinePrimaryVertices.clone(
     TrackLabel = 'initialStepTracks',
     vertexCollections = [_offlinePrimaryVertices.vertexCollections[0].clone()]
 )
-(pp_on_XeXe_2017 | pp_on_AA).toModify(firstStepPrimaryVerticesUnsorted, TkFilterParameters = dict(trackQuality = 'any'))
+(pp_on_XeXe_2017 | pp_on_AA).toModify(firstStepPrimaryVerticesUnsorted,
+    TkFilterParameters = dict(
+        trackQuality = 'any',
+        maxNumTracksThreshold = 1000000
+    ) 
+)
 
 # we need a replacment for the firstStepPrimaryVerticesUnsorted
 # that includes tracker information of signal and pile up

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -288,7 +288,7 @@ firstStepPrimaryVerticesUnsorted = _offlinePrimaryVertices.clone(
 (pp_on_XeXe_2017 | pp_on_AA).toModify(firstStepPrimaryVerticesUnsorted,
     TkFilterParameters = dict(
         trackQuality = 'any',
-        maxNumTracksThreshold = 1000000
+        maxNumTracksThreshold = 2**31-1
     ) 
 )
 

--- a/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
@@ -41,7 +41,7 @@ public:
   static void fillPSetDescription(edm::ParameterSetDescription& desc) {
     TrackFilterForPVFinding::fillPSetDescription(desc);
     desc.add<int>("numTracksThreshold", 0);  // HI only
-    desc.add<int>("maxNumTracksThreshold", std::numeric_limits<int>::max() );
+    desc.add<int>("maxNumTracksThreshold", std::numeric_limits<int>::max());
     desc.add<double>("minPtTight", 0.0);
   }
 };

--- a/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
@@ -13,10 +13,14 @@
 class HITrackFilterForPVFinding : public TrackFilterForPVFinding {
 private:
   unsigned int NumTracksThreshold_;
+  unsigned int MaxNumTracksThreshold_;
+  double minPtTight_;
 
 public:
   HITrackFilterForPVFinding(const edm::ParameterSet& conf) : TrackFilterForPVFinding(conf) {
     NumTracksThreshold_ = conf.getParameter<int>("numTracksThreshold");
+    MaxNumTracksThreshold_ = conf.getParameter<int>("maxNumTracksThreshold");
+    minPtTight_ = conf.getParameter<double>("minPtTight");
     //std::cout << "HITrackFilterForPVFinding  numTracksThreshold="<< NumTracksThreshold_ <<  std::endl;
   }
 
@@ -25,14 +29,20 @@ public:
     std::vector<reco::TransientTrack> seltks = TrackFilterForPVFinding::select(tracks);
     if (seltks.size() < NumTracksThreshold_) {
       return tracks;
-    } else {
-      return seltks;
+    } else if (seltks.size() > MaxNumTracksThreshold_) {
+      std::vector<reco::TransientTrack> seltksTight = TrackFilterForPVFinding::selectTight(tracks, minPtTight_);
+      if (seltksTight.size() >= NumTracksThreshold_)
+        return seltksTight;
     }
+
+    return seltks;
   }
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc) {
     TrackFilterForPVFinding::fillPSetDescription(desc);
     desc.add<int>("numTracksThreshold", 0);  // HI only
+    desc.add<int>("maxNumTracksThreshold", 100000000);
+    desc.add<double>("minPtTight", 0.0);
   }
 };
 

--- a/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h
@@ -41,7 +41,7 @@ public:
   static void fillPSetDescription(edm::ParameterSetDescription& desc) {
     TrackFilterForPVFinding::fillPSetDescription(desc);
     desc.add<int>("numTracksThreshold", 0);  // HI only
-    desc.add<int>("maxNumTracksThreshold", 100000000);
+    desc.add<int>("maxNumTracksThreshold", std::numeric_limits<int>::max() );
     desc.add<double>("minPtTight", 0.0);
   }
 };

--- a/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
+++ b/RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h
@@ -20,6 +20,8 @@ public:
 
   bool operator()(const reco::TransientTrack& tracks) const;
   std::vector<reco::TransientTrack> select(const std::vector<reco::TransientTrack>& tracks) const override;
+  std::vector<reco::TransientTrack> selectTight(const std::vector<reco::TransientTrack>& tracks,
+                                                double minPtTight) const;
 
 private:
   float maxD0Sig_, minPt_, maxEta_;

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -354,7 +354,9 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   {
     edm::ParameterSetDescription psd0;
     TrackFilterForPVFinding::fillPSetDescription(psd0);
-    psd0.add<int>("numTracksThreshold", 0);  // HI only
+    psd0.add<int>("numTracksThreshold", 0);            // HI only
+    psd0.add<int>("maxNumTracksThreshold", 10000000);  // HI only
+    psd0.add<double>("minPtTight", 0.0);               // HI only
     desc.add<edm::ParameterSetDescription>("TkFilterParameters", psd0);
   }
   desc.add<edm::InputTag>("beamSpotLabel", edm::InputTag("offlineBeamSpot"));

--- a/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
+++ b/RecoVertex/PrimaryVertexProducer/python/OfflinePrimaryVertices_cfi.py
@@ -67,20 +67,24 @@ from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (pp_on_XeXe_2017 | pp_on_AA).toModify(offlinePrimaryVertices,
                TkFilterParameters = dict(
+                   algorithm="filterWithThreshold",
                    maxD0Significance = 2.0,
                    maxD0Error = 10.0, 
                    maxDzError = 10.0, 
                    minPixelLayersWithHits=3,
                    minPt = 0.7,
-                   trackQuality = "highPurity"
+                   trackQuality = "highPurity",
+                   numTracksThreshold = cms.int32(10),
+                   maxNumTracksThreshold = cms.int32(1000),
+                   minPtTight = cms.double(1.0)
                ),
                TkClusParameters = cms.PSet(
-            algorithm = cms.string("gap"),
-            TkGapClusParameters = cms.PSet(
-                zSeparation = cms.double(1.0)        
-                )
-            )
+                 algorithm = cms.string("gap"),
+                 TkGapClusParameters = cms.PSet(
+                   zSeparation = cms.double(1.0)        
+                 )
                )
+)
     
 from Configuration.Eras.Modifier_highBetaStar_2018_cff import highBetaStar_2018
 highBetaStar_2018.toModify(offlinePrimaryVertices,

--- a/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
+++ b/RecoVertex/PrimaryVertexProducer/src/TrackFilterForPVFinding.cc
@@ -48,6 +48,19 @@ std::vector<reco::TransientTrack> TrackFilterForPVFinding::select(
   return seltks;
 }
 
+// select the vector of tracks that pass the filter cuts with a tighter pt selection
+std::vector<reco::TransientTrack> TrackFilterForPVFinding::selectTight(const std::vector<reco::TransientTrack>& tracks,
+                                                                       double minPtTight) const {
+  std::vector<reco::TransientTrack> seltks;
+  for (std::vector<reco::TransientTrack>::const_iterator itk = tracks.begin(); itk != tracks.end(); itk++) {
+    if (itk->impactPointState().globalMomentum().transverse() < minPtTight)
+      continue;
+    if (operator()(*itk))
+      seltks.push_back(*itk);  //  calls the filter function for single tracks
+  }
+  return seltks;
+}
+
 void TrackFilterForPVFinding::fillPSetDescription(edm::ParameterSetDescription& desc) {
   desc.add<double>("maxNormalizedChi2", 10.0);
   desc.add<double>("minPt", 0.0);


### PR DESCRIPTION
The vertexing used in 2017/2018 heavy ion AA collisions worked well in most collisions (10-90% centralities), but was found to have deficiencies in very-low and very-high occupancy events.  This PR seeks to fix both of these issues before the start of the HI Run3.

In low-occupancy events, vertex inefficiency was caused by track filters which could lower the number of accepted tracks in the event to a number <2.  This PR removes the track filter requirement if the event has <10 filtered tracks to increase efficiency.  This change is done at the python configuration level.

In high-occupancy events, a fairly large amount of vertex splitting is found and the cpu time consumed is quite large because of the large number of tracks passing the filters.  This PR raises the filter pt threshold if >1000 filtered tracks are found in the event.  This causes the vertexing to run ~40% faster and reduces vertex splitting, while only impacting the vertex resolution minimally.  This change results in small modifications to the C++ code.

A summary of performance can be seen in these slides shown in the heavy ion tracking group, as well as PAG meeting: [here](https://indico.cern.ch/event/1163063/contributions/4885089/attachments/2446935/4192963/VertexingImprovements_May17.pdf)

#### PR validation:

The PR was validated by rerunning the vertexing for 2018 minimum-bias PbPb MC and data and comparing the output collection to the nominal cases.  One vertex is expected per event in these samples.

@CesarBernardes  @mandrenguyen 

