### PR TITLE
[12_3_X] AlcaPCCIntegrator thread safety and parameter set fixes for Run3

### DIFF
--- a/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCIntegrator.cc
+++ b/Calibration/LumiAlCaRecoProducers/plugins/AlcaPCCIntegrator.cc
@@ -18,61 +18,60 @@ ________________________________________________________________**/
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 //The class
-class AlcaPCCIntegrator
-    : public edm::one::EDProducer<edm::EndLuminosityBlockProducer, edm::one::WatchLuminosityBlocks> {
+class AlcaPCCIntegrator : public edm::global::EDProducer<edm::LuminosityBlockSummaryCache<reco::PixelClusterCounts>,
+                                                         edm::StreamCache<reco::PixelClusterCounts>,
+                                                         edm::EndLuminosityBlockProducer,
+                                                         edm::Accumulator> {
 public:
   explicit AlcaPCCIntegrator(const edm::ParameterSet&);
   ~AlcaPCCIntegrator() override = default;
 
+  std::unique_ptr<reco::PixelClusterCounts> beginStream(edm::StreamID) const override;
+  std::shared_ptr<reco::PixelClusterCounts> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                                              edm::EventSetup const&) const override;
+  void accumulate(edm::StreamID iID, const edm::Event& iEvent, const edm::EventSetup&) const override;
+  void streamEndLuminosityBlockSummary(edm::StreamID,
+                                       edm::LuminosityBlock const&,
+                                       edm::EventSetup const&,
+                                       reco::PixelClusterCounts*) const override;
+  void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                       edm::EventSetup const&,
+                                       reco::PixelClusterCounts* iCounts) const override;
+  void globalEndLuminosityBlockProduce(edm::LuminosityBlock& iLumi,
+                                       edm::EventSetup const&,
+                                       reco::PixelClusterCounts const* iCounts) const override;
+
 private:
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) override;
-  void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) override;
-  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-
-  edm::EDGetTokenT<reco::PixelClusterCountsInEvent> pccToken_;
-  std::string pccSource_;
-
-  std::string trigstring_;  //specifies the input trigger Rand or ZeroBias
-  std::string prodInst_;    //file product instance
-  int countEvt_;            //counter
-  int countLumi_;           //counter
-
-  std::unique_ptr<reco::PixelClusterCounts> thePCCob;
+  const edm::EDPutTokenT<reco::PixelClusterCounts> lumiPutToken_;
+  const edm::EDGetTokenT<reco::PixelClusterCountsInEvent> pccToken_;
 };
 
-//--------------------------------------------------------------------------------------------------
-AlcaPCCIntegrator::AlcaPCCIntegrator(const edm::ParameterSet& iConfig) {
-  pccSource_ =
-      iConfig.getParameter<edm::ParameterSet>("AlcaPCCIntegratorParameters").getParameter<std::string>("inputPccLabel");
-  auto trigstring_ = iConfig.getParameter<edm::ParameterSet>("AlcaPCCIntegratorParameters")
-                         .getUntrackedParameter<std::string>("trigstring", "alcaPCC");
-  prodInst_ =
-      iConfig.getParameter<edm::ParameterSet>("AlcaPCCIntegratorParameters").getParameter<std::string>("ProdInst");
+AlcaPCCIntegrator::AlcaPCCIntegrator(const edm::ParameterSet& iConfig)
+    : lumiPutToken_(produces<reco::PixelClusterCounts, edm::Transition::EndLuminosityBlock>(
+          iConfig.getParameter<edm::ParameterSet>("AlcaPCCIntegratorParameters").getParameter<std::string>("ProdInst"))),
+      pccToken_(consumes<reco::PixelClusterCountsInEvent>(
+          iConfig.getParameter<edm::ParameterSet>("AlcaPCCIntegratorParameters")
+              .getParameter<edm::InputTag>("inputPccLabel"))) {}
 
-  edm::InputTag PCCInputTag_(pccSource_, trigstring_);
-
-  countLumi_ = 0;
-
-  produces<reco::PixelClusterCounts, edm::Transition::EndLuminosityBlock>(prodInst_);
-  pccToken_ = consumes<reco::PixelClusterCountsInEvent>(PCCInputTag_);
+std::unique_ptr<reco::PixelClusterCounts> AlcaPCCIntegrator::beginStream(edm::StreamID StreamID) const {
+  return std::make_unique<reco::PixelClusterCounts>();
 }
 
-//--------------------------------------------------------------------------------------------------
-void AlcaPCCIntegrator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  countEvt_++;
+std::shared_ptr<reco::PixelClusterCounts> AlcaPCCIntegrator::globalBeginLuminosityBlockSummary(
+    edm::LuminosityBlock const&, edm::EventSetup const&) const {
+  return std::make_shared<reco::PixelClusterCounts>();
+}
 
-  unsigned int bx = iEvent.bunchCrossing();
-  //std::cout<<"The Bunch Crossing Int"<<bx<<std::endl;
+void AlcaPCCIntegrator::globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                        edm::EventSetup const&,
+                                                        reco::PixelClusterCounts*) const {}
 
-  thePCCob->eventCounter(bx);
-
-  //Looping over the clusters and adding the counts up
+void AlcaPCCIntegrator::accumulate(edm::StreamID iID, const edm::Event& iEvent, const edm::EventSetup&) const {
   edm::Handle<reco::PixelClusterCountsInEvent> pccHandle;
   iEvent.getByToken(pccToken_, pccHandle);
 
@@ -82,23 +81,26 @@ void AlcaPCCIntegrator::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   }
 
   const reco::PixelClusterCountsInEvent inputPcc = *pccHandle;
-  thePCCob->add(inputPcc);
+  unsigned int bx = iEvent.bunchCrossing();
+  // add the BXID of the event to the stream cache
+  streamCache(iID)->eventCounter(bx);
+  // add the PCCs from the event to the stream cache
+  streamCache(iID)->add(inputPcc);
 }
 
-//--------------------------------------------------------------------------------------------------
-void AlcaPCCIntegrator::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) {
-  //PCC object at the beginning of each lumi section
-  thePCCob = std::make_unique<reco::PixelClusterCounts>();
-  countLumi_++;
+void AlcaPCCIntegrator::streamEndLuminosityBlockSummary(edm::StreamID iID,
+                                                        edm::LuminosityBlock const&,
+                                                        edm::EventSetup const&,
+                                                        reco::PixelClusterCounts* iCounts) const {
+  iCounts->merge(*streamCache(iID));
+  // now clear in order to be ready for the next LuminosityBlock
+  streamCache(iID)->reset();
 }
 
-//--------------------------------------------------------------------------------------------------
-void AlcaPCCIntegrator::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) {}
-
-//--------------------------------------------------------------------------------------------------
-void AlcaPCCIntegrator::endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup& iSetup) {
-  //Saving the PCC object
-  lumiSeg.put(std::move(thePCCob), std::string(prodInst_));
+void AlcaPCCIntegrator::globalEndLuminosityBlockProduce(edm::LuminosityBlock& iLumi,
+                                                        edm::EventSetup const&,
+                                                        reco::PixelClusterCounts const* iCounts) const {
+  // save the PCC object
+  iLumi.emplace(lumiPutToken_, *iCounts);
 }
-
 DEFINE_FWK_MODULE(AlcaPCCIntegrator);

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCRandom_cff.py
@@ -12,9 +12,7 @@ ALCARECORandomHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
 
 from Calibration.LumiAlCaRecoProducers.alcaPCCIntegrator_cfi import alcaPCCIntegrator
 alcaPCCIntegratorRandom = alcaPCCIntegrator.clone()
-alcaPCCIntegratorRandom.AlcaPCCIntegratorParameters.inputPccLabel="hltAlcaPixelClusterCounts"
-alcaPCCIntegratorRandom.AlcaPCCIntegratorParameters.trigstring    = "alcaPCCEvent"
-alcaPCCIntegratorRandom.AlcaPCCIntegratorParameters.ProdInst      = "alcaPCCRandom"
+alcaPCCIntegratorRandom.AlcaPCCIntegratorParameters.ProdInst = "alcaPCCRandom"
 
 
 # Sequence #

--- a/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
+++ b/Calibration/LumiAlCaRecoProducers/python/ALCARECOAlCaPCCZeroBias_cff.py
@@ -11,9 +11,7 @@ ALCARECOZeroBiasHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
 
 from Calibration.LumiAlCaRecoProducers.alcaPCCIntegrator_cfi import alcaPCCIntegrator
 alcaPCCIntegratorZeroBias = alcaPCCIntegrator.clone()
-alcaPCCIntegratorZeroBias.AlcaPCCIntegratorParameters.inputPccLabel="hltAlcaPixelClusterCounts"
-alcaPCCIntegratorZeroBias.AlcaPCCIntegratorParameters.trigstring    = "alcaPCCEvent"
-alcaPCCIntegratorZeroBias.AlcaPCCIntegratorParameters.ProdInst      = "alcaPCCZeroBias"
+alcaPCCIntegratorZeroBias.AlcaPCCIntegratorParameters.ProdInst = "alcaPCCZeroBias"
 
 
 seqALCARECOAlCaPCCZeroBias = cms.Sequence(ALCARECOZeroBiasHLT + alcaPCCIntegratorZeroBias)

--- a/Calibration/LumiAlCaRecoProducers/python/alcaPCCIntegrator_cfi.py
+++ b/Calibration/LumiAlCaRecoProducers/python/alcaPCCIntegrator_cfi.py
@@ -2,8 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 alcaPCCIntegrator = cms.EDProducer("AlcaPCCIntegrator",
     AlcaPCCIntegratorParameters = cms.PSet(
-        inputPccLabel = cms.string("hltAlcaPixelClusterCounts"),
-        trigstring = cms.untracked.string("alcaPCCEvent"),
+        inputPccLabel = cms.InputTag("hltAlcaPixelClusterCounts","alcaPCCEvent"),
         ProdInst = cms.string("alcaPCCRandom")
     )
 )

--- a/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_Integrator_cfg.py
+++ b/Calibration/LumiAlCaRecoProducers/test/PCC_Random_Event_Integrator_cfg.py
@@ -28,8 +28,7 @@ process.alcaPCCEventProducer = cms.EDProducer("AlcaPCCEventProducer",
 
 process.alcaPCCIntegrator = cms.EDProducer("AlcaPCCIntegrator",
     AlcaPCCIntegratorParameters = cms.PSet(
-        inputPccLabel = cms.string("alcaPCCEventProducer"),
-        trigstring = cms.untracked.string("alcaPCCRandomEvent"),
+        inputPccLabel = cms.InputTag("alcaPCCEventProducer","alcaPCCRandomEvent"),
         ProdInst = cms.string("alcaPCCRandom")
     ),
 )

--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -62,6 +62,4 @@ AlCaNoConcurrentLumis = [
     'PromptCalibProdSiPixelAli',       # AlignmentProducerAsAnalyzer, MillePedeFileConverter
     'PromptCalibProdBeamSpotHP',       # AlcaBeamSpotProducer
     'PromptCalibProdBeamSpotHPLowPU',  # AlcaBeamSpotProducer
-    'AlCaPCCRandom',                   # AlcaPCCIntegrator 
-    'AlCaPCCZeroBias'                  # AlcaPCCIntegrator
 ]

--- a/DataFormats/Luminosity/interface/PixelClusterCounts.h
+++ b/DataFormats/Luminosity/interface/PixelClusterCounts.h
@@ -42,6 +42,27 @@ namespace reco {
       }
     }
 
+    void merge(reco::PixelClusterCounts const& pcc) {
+      std::vector<int> const& counts = pcc.readCounts();
+      std::vector<int> const& modIDs = pcc.readModID();
+      std::vector<int> const& events = pcc.readEvents();
+      for (unsigned int i = 0; i < modIDs.size(); i++) {
+        for (unsigned int bxID = 0; bxID < LumiConstants::numBX; ++bxID) {
+          increment(modIDs[i], bxID + 1, counts.at(i * LumiConstants::numBX + bxID));
+        }
+      }
+      for (unsigned int i = 0; i < LumiConstants::numBX; ++i) {
+        m_events[i] += events[i];
+      }
+    }
+
+    void reset() {
+      m_counts.clear();
+      m_ModID.clear();
+      m_events.clear();
+      m_events.resize(LumiConstants::numBX, 0);
+    }
+
     std::vector<int> const& readCounts() const { return (m_counts); }
     std::vector<int> const& readEvents() const { return (m_events); }
     std::vector<int> const& readModID() const { return (m_ModID); }


### PR DESCRIPTION
#### PR description:
Backport of the PR https://github.com/cms-sw/cmssw/pull/38077 and the https://github.com/cms-sw/cmssw/pull/37538.

#### PR validation:
Validated by running runTheMatrix.py -l 1020.0 -t 4 --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
The modified AlcaPCCIntegrator module is intended to be used in the next data-taking period.