### PR TITLE
[12_3_X] update BeamSpot HLT client to use correct raw data from TCDS

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -668,6 +668,13 @@ void BeamMonitor::beginLuminosityBlock(const LuminosityBlock& lumiSeg, const Eve
 void BeamMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
   const TCDSRecord& tcdsData = iEvent.get(tcdsToken_);
   int beamMode = tcdsData.getBST().getBeamMode();
+
+  // Check that the beamMode information is available in the event content
+  if (beamMode == BSTRecord::BeamMode::NOMODE)
+    edm::LogError("BeamMonitor") << "No BeamMode identified from BSTRecord!"
+                                    "Please check that the event content has the raw data from TCDS FEDs (1024,1025)!";
+
+  // Check if stable beams are present
   if (beamMode == BSTRecord::BeamMode::STABLE)
     logToDb_ = true;
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -155,7 +155,7 @@ elif unitTest:
     rawDataInputTag = "rawDataCollector"
 else:
     # Use raw data from selected TCDS FEDs (1024, 1025)
-    rawDataInputTag = "hltFEDSelector"
+    rawDataInputTag = "hltFEDSelectorTCDS"
 
 process.tcdsDigis.InputLabel = rawDataInputTag
 

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -150,8 +150,12 @@ process.tcdsDigis = tcdsRawToDigi.clone()
 # Set rawDataRepacker (HI and live) or rawDataCollector (for all the rest)
 if (process.runType.getRunType() == process.runType.hi_run and live):
     rawDataInputTag = "rawDataRepacker"
-else:
+elif unitTest:
+    # This is needed until we update the streamer files used for the unitTest
     rawDataInputTag = "rawDataCollector"
+else:
+    # Use raw data from selected TCDS FEDs (1024, 1025)
+    rawDataInputTag = "hltFEDSelector"
 
 process.tcdsDigis.InputLabel = rawDataInputTag
 


### PR DESCRIPTION
#### PR description:
During the first runs with Stable Beams at 900 GeV in 2022 (Fill 7652) we realized that the BeamSpot HLT DQM client was correctly working (producing the beamspot DQM plots and the expected txt files), but no payload (or log) was uploaded to CondDB.

After some debugging this has been traced down to the fact that the stream `DQMOnlineBeamspot` does not contain information on raw tcds data. The need for raw tcds data was introduced in #37614 and it is used to assess the presence of Stable Beams or not.

This PR adds the correct `rawDataInputTag` for the `beamhlt` DQM client and should be deployed in online DQM together with the new menu changes discussed in [JIRA CMSHLT-2325](https://its.cern.ch/jira/browse/CMSHLT-2325) (more details are also available in the JIRA).

#### PR validation:
Code compiles.
We can't do much more testing at the moment because we need a streamer file with the updated menu.

#### Backport:
Not a backport but forwardports to 12_4_X and 12_5_X will be opened soon.
Improvements to the unitTest will be added in a subsequent PR.

FYI @mmusich @dzuolo @gennai @missirol @Sam-Harper @boudoul 