### PR TITLE
Fix CMS deprecation warnings in L1TriggerConfig/L1ScalesProducers 

### DIFF
--- a/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
+++ b/CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h
@@ -46,6 +46,7 @@
 #include "CondCore/CondDB/interface/Session.h"
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 
+#include <optional>
 // forward declarations
 
 template <class TRcd, class TData>
@@ -65,6 +66,7 @@ private:
 
 protected:
   l1t::OMDSReader m_omdsReader;
+  std::optional<edm::ESConsumesCollectorT<TRcd>> m_consumesCollector;
   bool m_forceGeneration;
 
   // Called from produce methods.
@@ -91,6 +93,8 @@ L1ConfigOnlineProdBase<TRcd, TData>::L1ConfigOnlineProdBase(const edm::Parameter
   //now do what ever other initialization is needed
   l1TriggerKeyListToken_ = cc.consumes();
   l1TriggerKeyToken_ = cc.consumes();
+
+  m_consumesCollector = std::move(cc);
 
   if (iConfig.exists("copyFromCondDB")) {
     m_copyFromCondDB = iConfig.getParameter<bool>("copyFromCondDB");

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScaleTester.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScaleTester.h
@@ -16,7 +16,7 @@
 //
 //
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
@@ -32,7 +32,7 @@
 // class declaration
 //
 
-class L1CaloInputScaleTester : public edm::EDAnalyzer {
+class L1CaloInputScaleTester : public edm::one::EDAnalyzer<> {
 public:
   explicit L1CaloInputScaleTester(const edm::ParameterSet&);
   ~L1CaloInputScaleTester() override;

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesGenerator.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1CaloInputScalesGenerator.h
@@ -16,7 +16,7 @@
 //
 //
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
@@ -28,7 +28,7 @@
 // class declaration
 //
 
-class L1CaloInputScalesGenerator : public edm::EDAnalyzer {
+class L1CaloInputScalesGenerator : public edm::one::EDAnalyzer<> {
 public:
   explicit L1CaloInputScalesGenerator(const edm::ParameterSet&);
   ~L1CaloInputScalesGenerator() override;

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1MuScalesTester.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1MuScalesTester.h
@@ -5,19 +5,25 @@
 //
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/L1TObjects/interface/L1MuTriggerScales.h"
+#include "CondFormats/DataRecord/interface/L1MuTriggerScalesRcd.h"
+#include "CondFormats/L1TObjects/interface/L1MuTriggerPtScale.h"
+#include "CondFormats/DataRecord/interface/L1MuTriggerPtScaleRcd.h"
+#include "CondFormats/L1TObjects/interface/L1MuGMTScales.h"
+#include "CondFormats/DataRecord/interface/L1MuGMTScalesRcd.h"
 
 class L1MuScale;
 //
 // class decleration
 //
 
-class L1MuScalesTester : public edm::EDAnalyzer {
+class L1MuScalesTester : public edm::one::EDAnalyzer<> {
 public:
   explicit L1MuScalesTester(const edm::ParameterSet&);
-  ~L1MuScalesTester() override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
@@ -25,4 +31,7 @@ public:
 
 private:
   // ----------member data ---------------------------
+  edm::ESGetToken<L1MuTriggerScales, L1MuTriggerScalesRcd> l1muscalesToken_;
+  edm::ESGetToken<L1MuTriggerPtScale, L1MuTriggerPtScaleRcd> l1muptscaleToken_;
+  edm::ESGetToken<L1MuGMTScales, L1MuGMTScalesRcd> l1gmtscalesToken_;
 };

--- a/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTester.h
+++ b/L1TriggerConfig/L1ScalesProducers/interface/L1ScalesTester.h
@@ -18,23 +18,34 @@
 //
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/L1TObjects/interface/L1CaloEtScale.h"
+#include "CondFormats/DataRecord/interface/L1EmEtScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1JetEtScaleRcd.h"
+#include "CondFormats/L1TObjects/interface/L1CaloEcalScale.h"
+#include "CondFormats/L1TObjects/interface/L1CaloHcalScale.h"
+#include "CondFormats/DataRecord/interface/L1CaloEcalScaleRcd.h"
+#include "CondFormats/DataRecord/interface/L1CaloHcalScaleRcd.h"
 
 //
 // class decleration
 //
 
-class L1ScalesTester : public edm::EDAnalyzer {
+class L1ScalesTester : public edm::one::EDAnalyzer<> {
 public:
   explicit L1ScalesTester(const edm::ParameterSet&);
-  ~L1ScalesTester() override;
 
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
 private:
   // ----------member data ---------------------------
+  const edm::ESGetToken<L1CaloEtScale, L1EmEtScaleRcd> emScaleToken_;
+  const edm::ESGetToken<L1CaloEcalScale, L1CaloEcalScaleRcd> ecalScaleToken_;
+  const edm::ESGetToken<L1CaloHcalScale, L1CaloHcalScaleRcd> hcalScaleToken_;
+  const edm::ESGetToken<L1CaloEtScale, L1JetEtScaleRcd> jetScaleToken_;
 };
 
 //

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -46,6 +46,7 @@ public:
   std::unique_ptr<L1CaloHcalScale> newObject(const std::string& objectKey) override;
 
 private:
+  edm::ESGetToken<HcalTrigTowerGeometry, CaloGeometryRecord> theTrigTowerGeometryToken;
   const HcalTrigTowerGeometry* theTrigTowerGeometry;
   CaloTPGTranscoderULUT* caloTPG;
   typedef std::vector<double> RCTdecompression;
@@ -71,6 +72,7 @@ private:
 //
 L1CaloHcalScaleConfigOnlineProd::L1CaloHcalScaleConfigOnlineProd(const edm::ParameterSet& iConfig)
     : L1ConfigOnlineProdBase<L1CaloHcalScaleRcd, L1CaloHcalScale>(iConfig), theTrigTowerGeometry(nullptr) {
+  theTrigTowerGeometryToken = m_consumesCollector->consumes();
   caloTPG = new CaloTPGTranscoderULUT();
 }
 
@@ -294,9 +296,7 @@ std::unique_ptr<L1CaloHcalScale> L1CaloHcalScaleConfigOnlineProd::newObject(cons
 }
 
 std::unique_ptr<L1CaloHcalScale> L1CaloHcalScaleConfigOnlineProd::produce(const L1CaloHcalScaleRcd& iRecord) {
-  edm::ESHandle<HcalTrigTowerGeometry> pG;
-  iRecord.getRecord<CaloGeometryRecord>().get(pG);
-  theTrigTowerGeometry = pG.product();
+  theTrigTowerGeometry = &iRecord.get(theTrigTowerGeometryToken);
 
   return (L1ConfigOnlineProdBase<L1CaloHcalScaleRcd, L1CaloHcalScale>::produce(iRecord));
 }

--- a/L1TriggerConfig/L1ScalesProducers/src/L1MuScalesTester.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1MuScalesTester.cc
@@ -3,67 +3,56 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "CondFormats/L1TObjects/interface/L1MuTriggerScales.h"
-#include "CondFormats/DataRecord/interface/L1MuTriggerScalesRcd.h"
-#include "CondFormats/L1TObjects/interface/L1MuTriggerPtScale.h"
-#include "CondFormats/DataRecord/interface/L1MuTriggerPtScaleRcd.h"
-#include "CondFormats/L1TObjects/interface/L1MuGMTScales.h"
-#include "CondFormats/DataRecord/interface/L1MuGMTScalesRcd.h"
-
 #include <iomanip>
 using std::cout;
 using std::endl;
 
-L1MuScalesTester::L1MuScalesTester(const edm::ParameterSet& ps) {}
-
-L1MuScalesTester::~L1MuScalesTester() {}
+L1MuScalesTester::L1MuScalesTester(const edm::ParameterSet& ps)
+    : l1muscalesToken_(esConsumes()), l1muptscaleToken_(esConsumes()), l1gmtscalesToken_(esConsumes()) {}
 
 void L1MuScalesTester::analyze(const edm::Event& e, const edm::EventSetup& es) {
   using namespace edm;
 
   const char* detnam[] = {"DT", "RPC barrel", "CSC", "RPC forward"};
 
-  ESHandle<L1MuTriggerScales> l1muscales;
-  es.get<L1MuTriggerScalesRcd>().get(l1muscales);
+  L1MuTriggerScales const& l1muscales = es.getData(l1muscalesToken_);
 
-  ESHandle<L1MuTriggerPtScale> l1muptscale;
-  es.get<L1MuTriggerPtScaleRcd>().get(l1muptscale);
+  L1MuTriggerPtScale const& l1muptscale = es.getData(l1muptscaleToken_);
 
   cout << "**** L1 Mu Pt Scale print *****************************************" << endl;
-  printScale(l1muptscale->getPtScale());
+  printScale(l1muptscale.getPtScale());
 
   cout << "**** L1 Mu Phi Scale print *****************************************" << endl;
-  printScale(l1muscales->getPhiScale());
+  printScale(l1muscales.getPhiScale());
 
   cout << "**** L1 Mu GMT eta Scale print *************************************" << endl;
-  printScale(l1muscales->getGMTEtaScale());
+  printScale(l1muscales.getGMTEtaScale());
 
   for (int i = 0; i < 4; i++) {
     cout << "**** L1 Mu " << detnam[i] << " eta Scale print **************************************" << endl;
-    printScale(l1muscales->getRegionalEtaScale(i));
+    printScale(l1muscales.getRegionalEtaScale(i));
   }
 
-  ESHandle<L1MuGMTScales> l1gmtscales;
-  es.get<L1MuGMTScalesRcd>().get(l1gmtscales);
+  L1MuGMTScales const& l1gmtscales = es.getData(l1gmtscalesToken_);
 
   for (int i = 0; i < 4; i++) {
     cout << "**** L1 GMT " << detnam[i] << " reduced eta Scale print **************************************" << endl;
-    printScale(l1gmtscales->getReducedEtaScale(i));
+    printScale(l1gmtscales.getReducedEtaScale(i));
   }
 
   cout << "**** L1 GMT delta eta Scale print *************************************" << endl;
-  printScale(l1gmtscales->getDeltaEtaScale(0));
+  printScale(l1gmtscales.getDeltaEtaScale(0));
 
   cout << "**** L1 GMT delta phi Scale print *************************************" << endl;
-  printScale(l1gmtscales->getDeltaPhiScale());
+  printScale(l1gmtscales.getDeltaPhiScale());
 
   for (int i = 0; i < 4; i++) {
     cout << "**** L1 GMT " << detnam[i] << " overlap eta Scale print **************************************" << endl;
-    printScale(l1gmtscales->getOvlEtaScale(i));
+    printScale(l1gmtscales.getOvlEtaScale(i));
   }
 
   //   cout << "**** L1 GMT calo eta Scale print *************************************" << endl;
-  //   printScale(l1gmtscales->getCaloEtaScale());
+  //   printScale(l1gmtscales.getCaloEtaScale());
 }
 
 void L1MuScalesTester::printScale(const L1MuScale* l1muscale) { cout << l1muscale->print(); }

--- a/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTester.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTester.cc
@@ -3,74 +3,66 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "CondFormats/L1TObjects/interface/L1CaloEtScale.h"
-#include "CondFormats/DataRecord/interface/L1EmEtScaleRcd.h"
-#include "CondFormats/DataRecord/interface/L1JetEtScaleRcd.h"
-#include "CondFormats/L1TObjects/interface/L1CaloEcalScale.h"
-#include "CondFormats/L1TObjects/interface/L1CaloHcalScale.h"
-#include "CondFormats/DataRecord/interface/L1CaloEcalScaleRcd.h"
-#include "CondFormats/DataRecord/interface/L1CaloHcalScaleRcd.h"
-
 #include <iostream>
 
 using std::cout;
 using std::endl;
 
-L1ScalesTester::L1ScalesTester(const edm::ParameterSet& ps) { cout << "Constructing a L1ScalesTester" << endl; }
-
-L1ScalesTester::~L1ScalesTester() {}
+L1ScalesTester::L1ScalesTester(const edm::ParameterSet& ps)
+    : emScaleToken_(esConsumes()),
+      ecalScaleToken_(esConsumes()),
+      hcalScaleToken_(esConsumes()),
+      jetScaleToken_(esConsumes()) {
+  cout << "Constructing a L1ScalesTester" << endl;
+}
 
 void L1ScalesTester::analyze(const edm::Event& e, const edm::EventSetup& es) {
   using namespace edm;
 
-  ESHandle<L1CaloEtScale> emScale;
-  es.get<L1EmEtScaleRcd>().get(emScale);
+  L1CaloEtScale const& emScale = es.getData(emScaleToken_);
 
   cout << "L1EmEtScaleRcd :" << endl;
-  emScale->print(cout);
+  emScale.print(cout);
   cout << endl;
 
-  ESHandle<L1CaloEcalScale> ecalScale;
-  es.get<L1CaloEcalScaleRcd>().get(ecalScale);
+  L1CaloEcalScale const& ecalScale = es.getData(ecalScaleToken_);
 
-  ESHandle<L1CaloHcalScale> hcalScale;
-  es.get<L1CaloHcalScaleRcd>().get(hcalScale);
+  L1CaloHcalScale const& hcalScale = es.getData(hcalScaleToken_);
 
   cout << " L1ColoEcalScale  :" << endl;
-  ecalScale->print(cout);
+  ecalScale.print(cout);
   cout << endl;
 
   cout << " L1ColoHcalScale  :" << endl;
-  hcalScale->print(cout);
+  hcalScale.print(cout);
   cout << endl;
 
-  ESHandle<L1CaloEtScale> jetScale;
-  es.get<L1JetEtScaleRcd>().get(jetScale);
+  L1CaloEtScale const& jetScale = es.getData(jetScaleToken_);
 
   cout << "L1JetEtScaleRcd :" << endl;
-  jetScale->print(cout);
+  jetScale.print(cout);
   cout << endl;
 
   // test EM lin-rank conversion
   cout << "Testing EM linear-to-rank conversion" << endl;
   for (unsigned short i = 0; i < 32; i++) {
-    unsigned rank = emScale->rank(i);
-    cout << "EM linear : " << i << ", Et : " << i * emScale->linearLsb() << " GeV, rank : " << rank << endl;
+    unsigned rank = emScale.rank(i);
+    cout << "EM linear : " << i << ", Et : " << i * emScale.linearLsb() << " GeV, rank : " << rank << endl;
   }
   cout << endl;
 
   // test jet lin-rank conversion
   cout << "Testing jet linear-to-rank conversion" << endl;
   for (unsigned short i = 0; i < 32; i++) {
-    unsigned rank = jetScale->rank(i);
-    cout << "jet linear : " << i << ", Et : " << i * jetScale->linearLsb() << " GeV, rank : " << rank << endl;
+    unsigned rank = jetScale.rank(i);
+    cout << "jet linear : " << i << ", Et : " << i * jetScale.linearLsb() << " GeV, rank : " << rank << endl;
   }
   cout << endl;
 
   // test EM rank-et conversion
   cout << "Testing EM rank-to-Et conversion" << endl;
   for (unsigned i = 0; i < 32; i++) {
-    double et = emScale->et(i);
+    double et = emScale.et(i);
     cout << "EM rank : " << i << " Et : " << et << " GeV" << endl;
   }
   cout << endl;
@@ -78,7 +70,7 @@ void L1ScalesTester::analyze(const edm::Event& e, const edm::EventSetup& es) {
   // test jet rank-et conversion
   cout << "Testing jet rank-to-Et conversion" << endl;
   for (unsigned i = 0; i < 32; i++) {
-    double et = jetScale->et(i);
+    double et = jetScale.et(i);
     cout << "jet rank : " << i << " Et : " << et << " GeV" << endl;
   }
   cout << endl;


### PR DESCRIPTION
#### PR description:

- changed to thread-friendly module types
- use esConsumes
- extend L1ConfigOnlineProdBase to allow access to the ESConsumesCollector

#### PR validation:

Code compiles without issuing warnings.