### PR TITLE
Fix CMS deprecation warnings in L1TriggerConfig/DTTrackFinder

### DIFF
--- a/L1TriggerConfig/DTTrackFinder/interface/DTEtaPatternLutTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTEtaPatternLutTester.h
@@ -13,22 +13,21 @@
 #ifndef DTEtaPatternLutTester_h
 #define DTEtaPatternLutTester_h
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1MuDTEtaPatternLut.h"
 #include "CondFormats/DataRecord/interface/L1MuDTEtaPatternLutRcd.h"
 
-class DTEtaPatternLutTester : public edm::EDAnalyzer {
+class DTEtaPatternLutTester : public edm::one::EDAnalyzer<> {
 public:
-  DTEtaPatternLutTester(const edm::ParameterSet& ps);
-
-  ~DTEtaPatternLutTester() override;
+  explicit DTEtaPatternLutTester(const edm::ParameterSet& ps);
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  edm::ESGetToken<L1MuDTEtaPatternLut, L1MuDTEtaPatternLutRcd> token_;
 };
 
 #endif

--- a/L1TriggerConfig/DTTrackFinder/interface/DTExtLutTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTExtLutTester.h
@@ -13,22 +13,21 @@
 #ifndef DTExtLutTester_h
 #define DTExtLutTester_h
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1MuDTExtLut.h"
 #include "CondFormats/DataRecord/interface/L1MuDTExtLutRcd.h"
 
-class DTExtLutTester : public edm::EDAnalyzer {
+class DTExtLutTester : public edm::one::EDAnalyzer<> {
 public:
   DTExtLutTester(const edm::ParameterSet& ps);
-
-  ~DTExtLutTester() override;
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  edm::ESGetToken<L1MuDTExtLut, L1MuDTExtLutRcd> token_;
 };
 
 #endif

--- a/L1TriggerConfig/DTTrackFinder/interface/DTPhiLutTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTPhiLutTester.h
@@ -13,22 +13,21 @@
 #ifndef DTPhiLutTester_h
 #define DTPhiLutTester_h
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1MuDTPhiLut.h"
 #include "CondFormats/DataRecord/interface/L1MuDTPhiLutRcd.h"
 
-class DTPhiLutTester : public edm::EDAnalyzer {
+class DTPhiLutTester : public edm::one::EDAnalyzer<> {
 public:
   DTPhiLutTester(const edm::ParameterSet& ps);
-
-  ~DTPhiLutTester() override;
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  edm::ESGetToken<L1MuDTPhiLut, L1MuDTPhiLutRcd> token_;
 };
 
 #endif

--- a/L1TriggerConfig/DTTrackFinder/interface/DTPtaLutTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTPtaLutTester.h
@@ -13,22 +13,21 @@
 #ifndef DTPtaLutTester_h
 #define DTPtaLutTester_h
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1MuDTPtaLut.h"
 #include "CondFormats/DataRecord/interface/L1MuDTPtaLutRcd.h"
 
-class DTPtaLutTester : public edm::EDAnalyzer {
+class DTPtaLutTester : public edm::one::EDAnalyzer<> {
 public:
   DTPtaLutTester(const edm::ParameterSet& ps);
-
-  ~DTPtaLutTester() override;
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  edm::ESGetToken<L1MuDTPtaLut, L1MuDTPtaLutRcd> token_;
 };
 
 #endif

--- a/L1TriggerConfig/DTTrackFinder/interface/DTQualPatternLutTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTQualPatternLutTester.h
@@ -13,22 +13,21 @@
 #ifndef DTQualPatternLutTester_h
 #define DTQualPatternLutTester_h
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1MuDTQualPatternLut.h"
 #include "CondFormats/DataRecord/interface/L1MuDTQualPatternLutRcd.h"
 
-class DTQualPatternLutTester : public edm::EDAnalyzer {
+class DTQualPatternLutTester : public edm::one::EDAnalyzer<> {
 public:
   DTQualPatternLutTester(const edm::ParameterSet& ps);
-
-  ~DTQualPatternLutTester() override;
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  edm::ESGetToken<L1MuDTQualPatternLut, L1MuDTQualPatternLutRcd> token_;
 };
 
 #endif

--- a/L1TriggerConfig/DTTrackFinder/interface/DTTFMasksTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTTFMasksTester.h
@@ -13,22 +13,21 @@
 #ifndef DTTFMasksTester_h
 #define DTTFMasksTester_h
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1MuDTTFMasks.h"
 #include "CondFormats/DataRecord/interface/L1MuDTTFMasksRcd.h"
 
-class DTTFMasksTester : public edm::EDAnalyzer {
+class DTTFMasksTester : public edm::one::EDAnalyzer<> {
 public:
   DTTFMasksTester(const edm::ParameterSet& ps);
-
-  ~DTTFMasksTester() override;
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  edm::ESGetToken<L1MuDTTFMasks, L1MuDTTFMasksRcd> token_;
 };
 
 #endif

--- a/L1TriggerConfig/DTTrackFinder/interface/DTTFParametersTester.h
+++ b/L1TriggerConfig/DTTrackFinder/interface/DTTFParametersTester.h
@@ -13,22 +13,21 @@
 #ifndef DTTFParametersTester_h
 #define DTTFParametersTester_h
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "CondFormats/L1TObjects/interface/L1MuDTTFParameters.h"
 #include "CondFormats/DataRecord/interface/L1MuDTTFParametersRcd.h"
 
-class DTTFParametersTester : public edm::EDAnalyzer {
+class DTTFParametersTester : public edm::one::EDAnalyzer<> {
 public:
   DTTFParametersTester(const edm::ParameterSet& ps);
-
-  ~DTTFParametersTester() override;
 
   void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 private:
+  edm::ESGetToken<L1MuDTTFParameters, L1MuDTTFParametersRcd> token_;
 };
 
 #endif

--- a/L1TriggerConfig/DTTrackFinder/src/DTEtaPatternLutTester.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTEtaPatternLutTester.cc
@@ -13,12 +13,6 @@
 
 #include "L1TriggerConfig/DTTrackFinder/interface/DTEtaPatternLutTester.h"
 
-DTEtaPatternLutTester::DTEtaPatternLutTester(const edm::ParameterSet& ps) {}
+DTEtaPatternLutTester::DTEtaPatternLutTester(const edm::ParameterSet& ps) : token_{esConsumes()} {}
 
-DTEtaPatternLutTester::~DTEtaPatternLutTester() {}
-
-void DTEtaPatternLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) {
-  edm::ESHandle<L1MuDTEtaPatternLut> etalut;
-  c.get<L1MuDTEtaPatternLutRcd>().get(etalut);
-  etalut->print();
-}
+void DTEtaPatternLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) { c.getData(token_).print(); }

--- a/L1TriggerConfig/DTTrackFinder/src/DTExtLutTester.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTExtLutTester.cc
@@ -13,12 +13,6 @@
 
 #include "L1TriggerConfig/DTTrackFinder/interface/DTExtLutTester.h"
 
-DTExtLutTester::DTExtLutTester(const edm::ParameterSet& ps) {}
+DTExtLutTester::DTExtLutTester(const edm::ParameterSet& ps) : token_{esConsumes()} {}
 
-DTExtLutTester::~DTExtLutTester() {}
-
-void DTExtLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) {
-  edm::ESHandle<L1MuDTExtLut> extlut;
-  c.get<L1MuDTExtLutRcd>().get(extlut);
-  extlut->print();
-}
+void DTExtLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) { c.getData(token_).print(); }

--- a/L1TriggerConfig/DTTrackFinder/src/DTPhiLutTester.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTPhiLutTester.cc
@@ -13,12 +13,6 @@
 
 #include "L1TriggerConfig/DTTrackFinder/interface/DTPhiLutTester.h"
 
-DTPhiLutTester::DTPhiLutTester(const edm::ParameterSet& ps) {}
+DTPhiLutTester::DTPhiLutTester(const edm::ParameterSet& ps) : token_{esConsumes()} {}
 
-DTPhiLutTester::~DTPhiLutTester() {}
-
-void DTPhiLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) {
-  edm::ESHandle<L1MuDTPhiLut> philut;
-  c.get<L1MuDTPhiLutRcd>().get(philut);
-  philut->print();
-}
+void DTPhiLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) { c.getData(token_).print(); }

--- a/L1TriggerConfig/DTTrackFinder/src/DTPtaLutTester.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTPtaLutTester.cc
@@ -13,12 +13,6 @@
 
 #include "L1TriggerConfig/DTTrackFinder/interface/DTPtaLutTester.h"
 
-DTPtaLutTester::DTPtaLutTester(const edm::ParameterSet& ps) {}
+DTPtaLutTester::DTPtaLutTester(const edm::ParameterSet& ps) : token_{esConsumes()} {}
 
-DTPtaLutTester::~DTPtaLutTester() {}
-
-void DTPtaLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) {
-  edm::ESHandle<L1MuDTPtaLut> ptalut;
-  c.get<L1MuDTPtaLutRcd>().get(ptalut);
-  ptalut->print();
-}
+void DTPtaLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) { c.getData(token_).print(); }

--- a/L1TriggerConfig/DTTrackFinder/src/DTQualPatternLutTester.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTQualPatternLutTester.cc
@@ -13,12 +13,6 @@
 
 #include "L1TriggerConfig/DTTrackFinder/interface/DTQualPatternLutTester.h"
 
-DTQualPatternLutTester::DTQualPatternLutTester(const edm::ParameterSet& ps) {}
+DTQualPatternLutTester::DTQualPatternLutTester(const edm::ParameterSet& ps) : token_{esConsumes()} {}
 
-DTQualPatternLutTester::~DTQualPatternLutTester() {}
-
-void DTQualPatternLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) {
-  edm::ESHandle<L1MuDTQualPatternLut> qualut;
-  c.get<L1MuDTQualPatternLutRcd>().get(qualut);
-  qualut->print();
-}
+void DTQualPatternLutTester::analyze(const edm::Event& e, const edm::EventSetup& c) { c.getData(token_).print(); }

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFMasksTester.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFMasksTester.cc
@@ -13,12 +13,6 @@
 
 #include "L1TriggerConfig/DTTrackFinder/interface/DTTFMasksTester.h"
 
-DTTFMasksTester::DTTFMasksTester(const edm::ParameterSet& ps) {}
+DTTFMasksTester::DTTFMasksTester(const edm::ParameterSet& ps) : token_{esConsumes()} {}
 
-DTTFMasksTester::~DTTFMasksTester() {}
-
-void DTTFMasksTester::analyze(const edm::Event& e, const edm::EventSetup& c) {
-  edm::ESHandle<L1MuDTTFMasks> dttfmsk;
-  c.get<L1MuDTTFMasksRcd>().get(dttfmsk);
-  dttfmsk->print();
-}
+void DTTFMasksTester::analyze(const edm::Event& e, const edm::EventSetup& c) { c.getData(token_).print(); }

--- a/L1TriggerConfig/DTTrackFinder/src/DTTFParametersTester.cc
+++ b/L1TriggerConfig/DTTrackFinder/src/DTTFParametersTester.cc
@@ -13,12 +13,6 @@
 
 #include "L1TriggerConfig/DTTrackFinder/interface/DTTFParametersTester.h"
 
-DTTFParametersTester::DTTFParametersTester(const edm::ParameterSet& ps) {}
+DTTFParametersTester::DTTFParametersTester(const edm::ParameterSet& ps) : token_{esConsumes()} {}
 
-DTTFParametersTester::~DTTFParametersTester() {}
-
-void DTTFParametersTester::analyze(const edm::Event& e, const edm::EventSetup& c) {
-  edm::ESHandle<L1MuDTTFParameters> dttfpar;
-  c.get<L1MuDTTFParametersRcd>().get(dttfpar);
-  dttfpar->print();
-}
+void DTTFParametersTester::analyze(const edm::Event& e, const edm::EventSetup& c) { c.getData(token_).print(); }


### PR DESCRIPTION
#### PR description:

- changed to thread friendly module types
- added esConsumes

#### PR validation:

Code compiles and does not issue the warning messages.