### PR TITLE
Fixing Memory Coruption for large histograms in DQMFileSaverPB

### DIFF
--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -260,8 +260,8 @@ void DQMFileSaverPB::savePB(DQMStore* store, std::string const& filename, int ru
       // Compress ME blob with zlib
       int maxOutputSize = this->getMaxCompressedSize(buffer.Length());
       std::vector<char> compression_output(maxOutputSize);
-      uLong total_out = this->compressME(buffer, maxOutputSize, &compression_output[0]);
-      histo.set_streamed_histo(&compression_output[0], total_out);
+      uLong total_out = this->compressME(buffer, maxOutputSize, compression_output.data());
+      histo.set_streamed_histo(compression_output.data(), total_out);
     }
 
     // Save quality reports

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -259,9 +259,9 @@ void DQMFileSaverPB::savePB(DQMStore* store, std::string const& filename, int ru
     } else {
       // Compress ME blob with zlib
       int maxOutputSize = this->getMaxCompressedSize(buffer.Length());
-      char compression_output[maxOutputSize];
-      uLong total_out = this->compressME(buffer, maxOutputSize, compression_output);
-      histo.set_streamed_histo(compression_output, total_out);
+      std::vector<char> compression_output(maxOutputSize);
+      uLong total_out = this->compressME(buffer, maxOutputSize, &compression_output[0]);
+      histo.set_streamed_histo(&compression_output[0], total_out);
     }
 
     // Save quality reports


### PR DESCRIPTION
#### PR description:

DQMFileSaverPB allocates its buffer to compress the histogram on the stack. This means it is limited to a size of 10MB. There are histograms which are bigger than this (specifically HLT paths vs bx) and thus can exceed this limit and crash the client. We encountered this when running the full menu of 800+ paths.

This PR moves it to the heap.  Feel free to use a different preferred way of doing it. 

#### PR validation:

The firstCollisions v2.0 no longer crashes the P5 DQM workflow when done offline. Further validation to be done by the DQM group. 

