### PR TITLE
Turn on GEMDigis and turn off GEMRecHits for GE2/1 demonstrator

### DIFF
--- a/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
@@ -4,7 +4,7 @@ l1tdeGEMTPGCommon = cms.PSet(
     monitorDir = cms.string("L1TEMU/L1TdeGEMTPG"),
     verbose = cms.bool(False),
     ## when multiple chambers are enabled, order them by station number!
-    chambers = cms.vstring("GE11"),
+    chambers = cms.vstring("GE11", "GE21"),
     dataEmul = cms.vstring("data","emul"),
     clusterVars = cms.vstring("size", "pad", "bx"),
     clusterNBin = cms.vuint32(20,384,10),

--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -7,6 +7,5 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
-# Note that by default we don't unpack the GE2/1 demonstrator digis in run3
-run3_GEM.toModify(muonGEMDigis, useDBEMap = True, ge21Off = True)
-phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True, ge21Off = False)
+run3_GEM.toModify(muonGEMDigis, useDBEMap = True)
+phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True)

--- a/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.h
+++ b/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.h
@@ -65,5 +65,6 @@ private:
   std::map<GEMDetId, EtaPartitionMask> gemMask_;
 
   bool applyMasking_;
+  bool ge21Off_;
 };
 #endif

--- a/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
@@ -10,5 +10,9 @@ gemRecHits = gemRecHitsDef.clone(
     #deadFile = cms.FileInPath("RecoLocalMuon/GEMRecHit/data/deadStrips.txt")
     )
 
+
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
-phase2_GEM.toModify(gemRecHits, gemDigiLabel = "simMuonGEMDigis")
+
+run3_GEM.toModify(gemRecHits, ge21Off=True)
+phase2_GEM.toModify(gemRecHits, gemDigiLabel = "simMuonGEMDigis", ge21Off=False)


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

The GEM group would like to monitor the GE2/1 demonstrator with the DQM using digis. This PR turns on GE2/1 digi unpacking, but turns off creating RecHits with GE2/1 for run3, so the demonstrator doesn't affect muons upstream.

We would like to backport this to 12_3_X and 12_4_X, to be run in data, as it will allow monitoring the GE2/1 demonstrator after the updates from #38062.

@jshlee

#### PR validation:

Checked some workflows to see GEM rechits are still created in phase 2, but not run3.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
