### PR TITLE
Fixing Memory Coruption for large histograms in DQMFileSaverPB : 12_3_X

### DIFF
--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -260,8 +260,8 @@ void DQMFileSaverPB::savePB(DQMStore* store, std::string const& filename, int ru
       // Compress ME blob with zlib
       int maxOutputSize = this->getMaxCompressedSize(buffer.Length());
       std::vector<char> compression_output(maxOutputSize);
-      uLong total_out = this->compressME(buffer, maxOutputSize, &compression_output[0]);
-      histo.set_streamed_histo(&compression_output[0], total_out);
+      uLong total_out = this->compressME(buffer, maxOutputSize, compression_output.data());
+      histo.set_streamed_histo(compression_output.data(), total_out);
     }
 
     // Save quality reports

--- a/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
+++ b/DQMServices/FileIO/plugins/DQMFileSaverPB.cc
@@ -259,9 +259,9 @@ void DQMFileSaverPB::savePB(DQMStore* store, std::string const& filename, int ru
     } else {
       // Compress ME blob with zlib
       int maxOutputSize = this->getMaxCompressedSize(buffer.Length());
-      char compression_output[maxOutputSize];
-      uLong total_out = this->compressME(buffer, maxOutputSize, compression_output);
-      histo.set_streamed_histo(compression_output, total_out);
+      std::vector<char> compression_output(maxOutputSize);
+      uLong total_out = this->compressME(buffer, maxOutputSize, &compression_output[0]);
+      histo.set_streamed_histo(&compression_output[0], total_out);
     }
 
     // Save quality reports


### PR DESCRIPTION
#### PR description:

PR description:
This is the backport of https://github.com/cms-sw/cmssw/pull/38112

DQMFileSaverPB allocates its buffer to compress the histogram on the stack. This means it is limited to a size of 10MB. There are histograms which are bigger than this (specifically HLT paths vs bx) and thus can exceed this limit and crash the client. We encountered this when running the full menu of 800+ paths.

#### PR validation:
DQM team report successful playback

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/38112

needed for P5 DQM release series (aka 12_3, 12_4)