### PR TITLE
ECAL - GPU unpacker buffer overflow fix - 12_3_X

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/DeclsForKernels.h
+++ b/EventFilter/EcalRawToDigi/plugins/DeclsForKernels.h
@@ -17,7 +17,10 @@ namespace ecal {
 
     constexpr auto empty_event_size = EMPTYEVENTSIZE;
     constexpr uint32_t nfeds_max = 54;
-    constexpr uint32_t nbytes_per_fed_max = 10 * 1024;
+    constexpr uint32_t nbytes_per_fed_max = 41616;  // max FED size in full readout mode
+                                                    // DCC header and trailer: 10 words (64bit),
+                                                    // TCC block: 18 words, SR block 6 words,
+                                                    // (25 channels per tower * 3 words + 1 header word) * 68 towers
 
     struct InputDataCPU {
       cms::cuda::host::unique_ptr<unsigned char[]> data;


### PR DESCRIPTION
#### PR description:

Increase the default maximum number of bytes per ECAL FED to support the full readout mode. This fixes the crash from http://cmsonline.cern.ch/cms-elog/1140795 

#### PR validation:

Increasing the value in the HLT configuration fixes the ECAL full readout GPU unpacker crash in run 352176.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #38088 on request.