### PR TITLE
Set a missing parameter in the `dqmSaver` in the `hltHarvesting` test [12.4.x]

### DIFF
--- a/HLTrigger/Configuration/test/hltHarvesting.py
+++ b/HLTrigger/Configuration/test/hltHarvesting.py
@@ -16,5 +16,6 @@ process.load('DQMServices.Components.DQMFileSaver_cfi')
 process.dqmSaver.convention   = "Online"
 process.dqmSaver.saveByRun    = 1
 process.dqmSaver.saveAtJobEnd = False
+process.dqmSaver.workflow     = "/DQM/HLT/Online"
 
 process.DQMFileSaverOutput = cms.EndPath( process.HLTHarvestingSequence + process.dqmSaver )


### PR DESCRIPTION
#### PR description:

Fix the `HLTrigger/Configuration/test/hltHarvesting.py` test file, setting the missing `dqmSaver.workflow` to `"/DQM/HLT/Online"`.

#### PR validation:

`hltHarvesting.py` now runs.

#### Backport

Backport of #38132