### PR TITLE
Implemented new strategy to generate OI seeds for displaced muons (backport)

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIFromL2.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIFromL2.h
@@ -91,10 +91,14 @@ private:
   const double pT1_, pT2_, pT3_;
   const double eta1_, eta2_, eta3_, eta4_, eta5_, eta6_, eta7_;
   const double SF1_, SF2_, SF3_, SF4_, SF5_, SF6_;
+  const double SFHld_, SFHd_;
 
   /// Distance of L2 TSOSs before and after updated with vertex
   const double tsosDiff1_;
   const double tsosDiff2_;
+
+  /// Displaced reconstruction
+  const bool displacedReco_;
 
   /// Counters and flags for the implementation
   const std::string propagatorName_;


### PR DESCRIPTION
#### PR description:

backport of #38076 

This PR implements a new iteration to generate OI seeds for displaced muons. To activate this iteration a flag is added in order to be able to turn off this part of the code and don't interfere with the current algorithm. These [slides](https://github.com/cms-sw/cmssw/files/8770320/HLT-Muon-Displaced_2022-05-25.pdf) contain information regarding the problem that we observed and this solution. In slide 7, the performance is shown (compare yellow and brown histograms) and more information regarding the rates and timing is in the backup.

#### PR validation:

PR validated in #38076 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #38076  
Backport needed for HLT during 2022 pp data-taking.
