### PR TITLE
Add pythia8 gun to generate particles with flat pt and Lxy (transverse displacement)

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtAndLxyGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtAndLxyGun.cc
@@ -1,0 +1,192 @@
+#include <memory>
+
+#include "GeneratorInterface/Core/interface/GeneratorFilter.h"
+#include "GeneratorInterface/ExternalDecays/interface/ExternalDecayDriver.h"
+
+#include "GeneratorInterface/Pythia8Interface/interface/Py8GunBase.h"
+
+namespace gen {
+
+  class Py8PtAndLxyGun : public Py8GunBase {
+  public:
+    Py8PtAndLxyGun(edm::ParameterSet const&);
+    ~Py8PtAndLxyGun() override {}
+
+    bool generatePartonsAndHadronize() override;
+    const char* classname() const override;
+
+  private:
+    // PtAndLxyGun particle(s) characteristics
+    double fMinEta;
+    double fMaxEta;
+    double fMinPt;
+    double fMaxPt;
+    bool fAddAntiParticle;
+    double fDxyMax;
+    double fDzMax;
+    double fLxyMin;
+    double fLxyMax;
+    double fLzMax;
+    double fConeRadius;
+    double fConeH;
+    double fDistanceToAPEX;
+  };
+
+  // implementation
+  //
+  Py8PtAndLxyGun::Py8PtAndLxyGun(edm::ParameterSet const& ps) : Py8GunBase(ps) {
+    // ParameterSet defpset ;
+    edm::ParameterSet pgun_params = ps.getParameter<edm::ParameterSet>("PGunParameters");  // , defpset ) ;
+    fMinEta = pgun_params.getParameter<double>("MinEta");                                  // ,-2.2);
+    fMaxEta = pgun_params.getParameter<double>("MaxEta");                                  // , 2.2);
+    fMinPt = pgun_params.getParameter<double>("MinPt");                                    // ,  0.);
+    fMaxPt = pgun_params.getParameter<double>("MaxPt");                                    // ,  0.);
+    fAddAntiParticle = pgun_params.getParameter<bool>("AddAntiParticle");                  //, false) ;
+    fDxyMax = pgun_params.getParameter<double>("dxyMax");
+    fDzMax = pgun_params.getParameter<double>("dzMax");
+    fLxyMin = pgun_params.getParameter<double>("LxyMin");
+    fLxyMax = pgun_params.getParameter<double>("LxyMax");
+    fLzMax = pgun_params.getParameter<double>("LzMax");
+    fConeRadius = pgun_params.getParameter<double>("ConeRadius");
+    fConeH = pgun_params.getParameter<double>("ConeH");
+    fDistanceToAPEX = pgun_params.getParameter<double>("DistanceToAPEX");
+  }
+
+  bool Py8PtAndLxyGun::generatePartonsAndHadronize() {
+    fMasterGen->event.reset();
+
+    for (size_t i = 0; i < fPartIDs.size(); i++) {
+      int particleID = fPartIDs[i];  // this is PDG - need to convert to Py8 ???
+
+      double phi = 0;
+      double dxy = 0;
+      double pt = 0;
+      double eta = 0;
+      double px = 0;
+      double py = 0;
+      double pz = 0;
+      double mass = 0;
+      double ee = 0;
+      double vx = 0;
+      double vy = 0;
+      double vz = 0;
+      double lxy = 0;
+
+      bool passLoop = false;
+      while (!passLoop) {
+        bool passDxy = false;
+        bool passLz = false;
+        bool passDz = false;
+
+        phi = (fMaxPhi - fMinPhi) * randomEngine().flat() + fMinPhi;
+        pt = (fMaxPt - fMinPt) * randomEngine().flat() + fMinPt;
+        px = pt * cos(phi);
+        py = pt * sin(phi);
+
+        lxy = (fLxyMax - fLxyMin) * randomEngine().flat() + fLxyMin;
+
+        for (int i = 0; i < 10000; i++) {
+          double vphi = 2 * M_PI * randomEngine().flat();
+          vx = lxy * cos(vphi);
+          vy = lxy * sin(vphi);
+
+          dxy = -vx * sin(phi) + vy * cos(phi);
+
+          if ((std::abs(dxy) < fDxyMax || fDxyMax < 0) && (vx * px + vy * py) > 0) {
+            passDxy = true;
+            break;
+          }
+        }
+
+        eta = (fMaxEta - fMinEta) * randomEngine().flat() + fMinEta;
+        double theta = 2. * atan(exp(-eta));
+
+        mass = (fMasterGen->particleData).m0(particleID);
+
+        double pp = pt / sin(theta);  // sqrt( ee*ee - mass*mass );
+        ee = sqrt(pp * pp + mass * mass);
+
+        pz = pp * cos(theta);
+
+        float coneTheta = fConeRadius / fConeH;
+        for (int j = 0; j < 100; j++) {
+          vz = fLzMax * randomEngine().flat();  // this is abs(vz)
+          float v0 = vz - fDistanceToAPEX;
+          if (v0 <= 0 || lxy * lxy / (coneTheta * coneTheta) > v0 * v0) {
+            passLz = true;
+            break;
+          }
+        }
+        if (pz < 0)
+          vz = -vz;
+
+        double dz = vz - (vx * cos(phi) + vy * sin(phi)) / tan(theta);
+        if (std::abs(dz) < fDzMax || fDzMax < 0) {
+          passDz = true;
+        }
+
+        passLoop = (passDxy && passLz && passDz);
+
+        if (passLoop)
+          break;
+      }
+
+      float time = sqrt(vx * vx + vy * vy + vz * vz);
+
+      if (!((fMasterGen->particleData).isParticle(particleID))) {
+        particleID = std::abs(particleID);
+      }
+      if (1 <= std::abs(particleID) && std::abs(particleID) <= 6)  // quarks
+        (fMasterGen->event).append(particleID, 23, 101, 0, px, py, pz, ee, mass);
+      else if (std::abs(particleID) == 21)  // gluons
+        (fMasterGen->event).append(21, 23, 101, 102, px, py, pz, ee, mass);
+      // other
+      else {
+        (fMasterGen->event).append(particleID, 1, 0, 0, px, py, pz, ee, mass);
+        int eventSize = (fMasterGen->event).size() - 1;
+        // -log(flat) = exponential distribution
+        double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+        (fMasterGen->event)[eventSize].tau(tauTmp);
+      }
+      (fMasterGen->event).back().vProd(vx, vy, vz, time);
+
+      // Here also need to add anti-particle (if any)
+      // otherwise just add a 2nd particle of the same type
+      // (for example, gamma)
+      //
+      if (fAddAntiParticle) {
+        if (1 <= std::abs(particleID) && std::abs(particleID) <= 6) {  // quarks
+          (fMasterGen->event).append(-particleID, 23, 0, 101, -px, -py, -pz, ee, mass);
+        } else if (std::abs(particleID) == 21) {  // gluons
+          (fMasterGen->event).append(21, 23, 102, 101, -px, -py, -pz, ee, mass);
+        } else {
+          if ((fMasterGen->particleData).isParticle(-particleID)) {
+            (fMasterGen->event).append(-particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
+          } else {
+            (fMasterGen->event).append(particleID, 1, 0, 0, -px, -py, -pz, ee, mass);
+          }
+          int eventSize = (fMasterGen->event).size() - 1;
+          // -log(flat) = exponential distribution
+          double tauTmp = -(fMasterGen->event)[eventSize].tau0() * log(randomEngine().flat());
+          (fMasterGen->event)[eventSize].tau(tauTmp);
+        }
+        (fMasterGen->event).back().vProd(-vx, -vy, -vz, time);
+      }
+    }
+
+    if (!fMasterGen->next())
+      return false;
+    evtGenDecay();
+
+    event() = std::make_unique<HepMC::GenEvent>();
+    return toHepMC.fill_next_event(fMasterGen->event, event().get());
+  }
+
+  const char* Py8PtAndLxyGun::classname() const { return "Py8PtAndLxyGun"; }
+
+  typedef edm::GeneratorFilter<gen::Py8PtAndLxyGun, gen::ExternalDecayDriver> Pythia8PtAndLxyGun;
+
+}  // namespace gen
+
+using gen::Pythia8PtAndLxyGun;
+DEFINE_FWK_MODULE(Pythia8PtAndLxyGun);

--- a/GeneratorInterface/Pythia8Interface/plugins/Py8PtAndLxyGun.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Py8PtAndLxyGun.cc
@@ -31,7 +31,8 @@ namespace gen {
     double fConeRadius;
     double fConeH;
     double fDistanceToAPEX;
-    double fBackFraction;
+    double fLxyBackFraction;
+    double fLzOppositeFraction;
   };
 
   // implementation
@@ -51,7 +52,8 @@ namespace gen {
     fConeRadius = pgun_params.getParameter<double>("ConeRadius");
     fConeH = pgun_params.getParameter<double>("ConeH");
     fDistanceToAPEX = pgun_params.getParameter<double>("DistanceToAPEX");
-    fBackFraction = std::clamp(pgun_params.getParameter<double>("BackFraction"), 0., 1.);
+    fLxyBackFraction = std::clamp(pgun_params.getParameter<double>("LxyBackFraction"), 0., 1.);
+    fLzOppositeFraction = std::clamp(pgun_params.getParameter<double>("LzOppositeFraction"), 0., 1.);
   }
 
   bool Py8PtAndLxyGun::generatePartonsAndHadronize() {
@@ -96,7 +98,7 @@ namespace gen {
           dxy = -vx * sin(phi) + vy * cos(phi);
 
           sign = 1;
-          if (fBackFraction > 0 && randomEngine().flat() < fBackFraction) {
+          if (fLxyBackFraction > 0 && randomEngine().flat() <= fLxyBackFraction) {
             sign = -1;
           }
           if ((std::abs(dxy) < fDxyMax || fDxyMax < 0) && sign * (vx * px + vy * py) > 0) {
@@ -124,6 +126,9 @@ namespace gen {
             break;
           }
         }
+
+        if (fLzOppositeFraction > 0 && randomEngine().flat() <= fLzOppositeFraction)
+          sign *= -1;
         if (sign * pz < 0)
           vz = -vz;
 
@@ -133,7 +138,6 @@ namespace gen {
         }
 
         passLoop = (passDxy && passLz && passDz);
-
         if (passLoop)
           break;
       }

--- a/GeneratorInterface/Pythia8Interface/python/Py8PtLxyGun_4tau_cfi.py
+++ b/GeneratorInterface/Pythia8Interface/python/Py8PtLxyGun_4tau_cfi.py
@@ -1,0 +1,33 @@
+import FWCore.ParameterSet.Config as cms
+
+#Note: distances in mm instead of in cm usually used in CMS
+generator = cms.EDFilter("Pythia8PtAndLxyGun",
+
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    pythiaHepMCVerbosity = cms.untracked.bool(True),
+
+    PGunParameters = cms.PSet(
+        ParticleID = cms.vint32(-15, -15),
+        AddAntiParticle = cms.bool(True), # antiparticle has opposite momentum and production point symmetric wrt (0,0,0) compared to corresponding particle
+        MinPt  = cms.double(15.00),
+        MaxPt  = cms.double(300.00),
+        MinEta = cms.double(-2.5),
+        MaxEta = cms.double(2.5),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        LxyMin = cms.double(0.0),
+        LxyMax = cms.double(550.0), # most tau generated within TOB (55cm)
+        LzMax = cms.double(300.0),
+        dxyMax = cms.double(30.0),
+        dzMax = cms.double(120.0),
+        ConeRadius = cms.double(1000.0),
+        ConeH = cms.double(3000.0),
+        DistanceToAPEX = cms.double(850.0)
+    ),
+
+    Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+    psethack = cms.string('displaced taus'),
+    firstRun = cms.untracked.uint32(1),
+    PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+)

--- a/GeneratorInterface/Pythia8Interface/python/Py8PtLxyGun_4tau_cfi.py
+++ b/GeneratorInterface/Pythia8Interface/python/Py8PtLxyGun_4tau_cfi.py
@@ -24,7 +24,8 @@ generator = cms.EDFilter("Pythia8PtAndLxyGun",
         ConeRadius = cms.double(1000.0),
         ConeH = cms.double(3000.0),
         DistanceToAPEX = cms.double(850.0),
-        BackFraction = cms.double(0.0) # fraction of particles going back towards to center; numbers outside the [0,1] range are set to 0 or 1
+        LxyBackFraction = cms.double(0.0), # fraction of particles going back towards to center at transverse plan; numbers outside the [0,1] range are set to 0 or 1
+        LzOppositeFraction = cms.double(0.0), # fraction of particles going in opposite direction wrt to center along beam-line than in transverse plane; numbers outside the [0,1] range are set to 0 or 1
     ),
 
     Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts

--- a/GeneratorInterface/Pythia8Interface/python/Py8PtLxyGun_4tau_cfi.py
+++ b/GeneratorInterface/Pythia8Interface/python/Py8PtLxyGun_4tau_cfi.py
@@ -23,7 +23,8 @@ generator = cms.EDFilter("Pythia8PtAndLxyGun",
         dzMax = cms.double(120.0),
         ConeRadius = cms.double(1000.0),
         ConeH = cms.double(3000.0),
-        DistanceToAPEX = cms.double(850.0)
+        DistanceToAPEX = cms.double(850.0),
+        BackFraction = cms.double(0.0) # fraction of particles going back towards to center; numbers outside the [0,1] range are set to 0 or 1
     ),
 
     Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts


### PR DESCRIPTION
#### PR description:

This PR adds a new pythia8 gun to generate particles with flat pt and Lxy (transverse displacement). The gun has number of parameters to tune phase-space of generate particles. It is planned to use the gun to produce a sample of displaced taus to train DNN-based tauID dedicated to displaced taus. 

This PR contains the pythia8 gun itself and an example cfi file.

It is foreseen to back-port this gun to 12_4_X and 10_6_X for production of Run-3 and Run-2 samples. The cmsDriver command to repeat the test as follows:
```
cmsDriver.py GeneratorInterface/Pythia8Interface/python/Py8PtLxyGun_4tau_cfi.py --fileout file:gensim.root \
--mc --eventcontent RAWSIM --datatier GEN-SIM --era Run3 --conditions 124X_mcRun3_2021_realistic_v1 \
--beamspot Run3RoundOptics25ns13TeVLowSigmaZ --step GEN,SIM --geometry DB:Extended --nThreads 4 \
--nConcurrentLumis 1 --python_filename GEN-SIM_step_cfg.py -n 1000 --no_exec
```
The gun is not used in any official workflow.

#### PR validation:

The gun was tested by using it with typical gen-sim workflow (as Run-3 Summer21 production).
