### PR TITLE
Conddb tools: fix for printouts containing python-sensitive characters

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -395,7 +395,10 @@ def output(args, string, *parameters, **kwargs):
 
     output_file = kwargs.get('output_file', sys.stdout)
 
-    print(string % parameters + colors.end, end=' ', file=output_file)
+    to_print = string + colors.end
+    if len(parameters)>0:
+        to_print = string % parameters + colors.end
+    print(to_print, end=' ', file=output_file)
 
     if kwargs.get('newline', True):
         print(file=output_file)


### PR DESCRIPTION
#### PR description:
In various conddb functions, user-created parameters (like comments/descriptions for Tag and GT items) may contain keys that have a reserved meaning in the python language. The present fix aims to support a proper printout, avoiding the triggering of the corresponding special treatments.
The function affected by the change are all the listing functions:
list [object], listTags, listGTs, ...
#### PR validation:

Integration tests
