### PR TITLE
Fixed Geant4 track information

### DIFF
--- a/SimG4Core/Notification/interface/TrackInformation.h
+++ b/SimG4Core/Notification/interface/TrackInformation.h
@@ -67,7 +67,7 @@ public:
     momentumAtBoundary_ = math::XYZTLorentzVectorF(track->GetMomentum().x() / CLHEP::GeV,
                                                    track->GetMomentum().y() / CLHEP::GeV,
                                                    track->GetMomentum().z() / CLHEP::GeV,
-                                                   track->GetKineticEnergy() / CLHEP::GeV);
+                                                   track->GetTotalEnergy() / CLHEP::GeV);
   }
   bool crossedBoundary() const { return crossedBoundary_; }
   const math::XYZTLorentzVectorF &getPositionAtBoundary() const { return positionAtBoundary_; }


### PR DESCRIPTION
#### PR description:
Fixed incorrect LorentzVector inside TrackInformation object. This object is used as MC truth for validation. Not affecting hits or digi but may affect validation plots.

#### PR validation:
private


#### if this PR is a backport please specify the original PR and why you need to backport that PR: NO
