### PR TITLE
RecoTracker/MkfitCore: Add fast-math and function attribute need to prevent segfault

### DIFF
--- a/RecoTracker/MkFitCore/BuildFile.xml
+++ b/RecoTracker/MkFitCore/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="json"/>
 <use name="tbb"/>
 <flags CXXFLAGS="-fopenmp-simd"/>
+<flags CXXFLAGS="-ffast-math"/>
 <flags ADD_SUBDIR="1"/>
 <export>
   <lib name="RecoTrackerMkFitCore"/>

--- a/RecoTracker/MkFitCore/src/MaterialEffects.h
+++ b/RecoTracker/MkFitCore/src/MaterialEffects.h
@@ -19,8 +19,12 @@ namespace mkfit {
   public:
     MaterialEffects();
 
-    int getZbin(const float z) const { return (std::abs(z) * Config::nBinsZME) / (Config::rangeZME); }
-    int getRbin(const float r) const { return (r * Config::nBinsRME) / (Config::rangeRME); }
+    int __attribute__((optimize("no-inline"))) getZbin(const float z) const {
+      return (std::abs(z) * Config::nBinsZME) / (Config::rangeZME);
+    }
+    int __attribute__((optimize("no-inline"))) getRbin(const float r) const {
+      return (r * Config::nBinsRME) / (Config::rangeRME);
+    }
     float getRlVal(const int zb, const int rb) const { return mRlgridME[zb][rb]; }
     float getXiVal(const int zb, const int rb) const { return mXigridME[zb][rb]; }
 


### PR DESCRIPTION
Add fast-math flag and attribute needed to prevent segfault when fast-math is used

This PR adds back the options which enable the vectorized function from libmvec on EL8. This causes a differences in RECO DQM.

Followup PR to https://github.com/cms-sw/cmssw/pull/37868