### PR TITLE
Fix static variable problem in payload inspector code

### DIFF
--- a/CondCore/Utilities/src/PayloadInspector.cc
+++ b/CondCore/Utilities/src/PayloadInspector.cc
@@ -101,7 +101,7 @@ namespace cond {
       pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
       psets.push_back(pSet);
       static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
-      static const edm::ServiceRegistry::Operate operate(services);
+      const edm::ServiceRegistry::Operate operate(services);
       bool ret = false;
       size_t nt = tagsWithTimeBoundaries.size();
       if (nt) {


### PR DESCRIPTION
#### PR description:

ServiceRegistry::Operate objects are only ever supposed to be used on the stack.

#### PR validation:

The unit test testGetPayloadData which showed the problem passed.

Fixes #38141