### PR TITLE
Changes to get the PU info from OnlineMetaData stream [Master]

### DIFF
--- a/DQM/EcalMonitorTasks/BuildFile.xml
+++ b/DQM/EcalMonitorTasks/BuildFile.xml
@@ -9,7 +9,8 @@
 <use name="DataFormats/TCDS"/>
 <use name="DataFormats/L1GlobalTrigger"/>
 <use name="DataFormats/L1GlobalMuonTrigger"/>
-<use name="DataFormats/Scalers"/> <!-- needed in UBSAN builds for typeinfo for LumiScalers -->
+<use name="DataFormats/Luminosity"/>
+<use name="DataFormats/OnlineMetaData"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>

--- a/DQM/EcalMonitorTasks/interface/OccupancyTask.h
+++ b/DQM/EcalMonitorTasks/interface/OccupancyTask.h
@@ -11,7 +11,7 @@
 #include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "DataFormats/Scalers/interface/LumiScalers.h"
+#include "DataFormats/OnlineMetaData/interface/OnlineLuminosityRecord.h"
 
 namespace ecaldqm {
   class OccupancyTask : public DQWorkerTask {
@@ -40,8 +40,8 @@ namespace ecaldqm {
     float recHitThreshold_;
     float tpThreshold_;
     edm::TimeValue_t m_iTime;
-    edm::InputTag lumiTag;
-    edm::EDGetTokenT<LumiScalersCollection> lumiScalersToken_;
+    edm::InputTag metadataTag;
+    edm::EDGetTokenT<OnlineLuminosityRecord> metaDataToken_;
     double scal_pu;
     bool FindPUinLS = false;
     int nEv;

--- a/DQM/EcalMonitorTasks/python/OccupancyTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/OccupancyTask_cfi.py
@@ -8,8 +8,8 @@ ecalOccupancyTask = cms.untracked.PSet(
     params = cms.untracked.PSet(
         recHitThreshold = cms.untracked.double(recHitThreshold),
         tpThreshold = cms.untracked.double(tpThreshold),
-        scalers = cms.InputTag('hltScalersRawToDigi'),
-        lumiCheck = cms.untracked.bool(lumiCheck)
+        metadata = cms.InputTag('onlineMetaDataDigis'),
+	lumiCheck = cms.untracked.bool(lumiCheck)
     ), 
     MEs = cms.untracked.PSet(
         TrendNTPDigi = cms.untracked.PSet(

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -136,10 +136,10 @@ process.preScaler.prescaleFactor = 1
 process.tcdsDigis = tcdsRawToDigi.clone(
   InputLabel = "rawDataCollector"
 )
-###### LumiScalars to get the PU/luminosity info ######
-process.hltScalersRawToDigi = cms.EDProducer( "ScalersRawToDigi",
-    scalersInputTag = cms.InputTag( "rawDataCollector" )
-)
+
+###### For OnlineLuminosityRecord to get the PU/luminosity info ######
+process.load('EventFilter.OnlineMetaDataRawToDigi.onlineMetaDataRawToDigi_cfi')
+process.onlineMetaDataDigis = cms.EDProducer('OnlineMetaDataRawToDigi')
 
 process.dqmEnv.subSystemFolder = 'Ecal'
 process.dqmSaver.tag = 'Ecal'
@@ -173,7 +173,7 @@ process.hybridClusteringSequence = cms.Sequence(process.cleanedHybridSuperCluste
 
 ### Paths ###
 
-process.ecalMonitorPath = cms.Path(process.hltScalersRawToDigi+process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalRecoSequence+process.tcdsDigis+process.ecalMonitorTask)
+process.ecalMonitorPath = cms.Path(process.onlineMetaDataDigis+process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalRecoSequence+process.tcdsDigis+process.ecalMonitorTask)
 process.ecalClientPath = cms.Path(process.preScaler+process.ecalPreRecoSequence+process.ecalPhysicsFilter+process.ecalMonitorClient)
 
 process.dqmEndPath = cms.EndPath(process.dqmEnv)


### PR DESCRIPTION
#### PR description:

The Pileup information needed for the ML DQM plots was not being accessible as the ScalerStream from which it was taken, has been replaced by MetaDataStream [1]
This PR makes the necessary changes to get the PU information from the correct stream.

#### PR validation:
The code was validated by running the modified online Ecal DQM configuration and the PU info is accessed as expected.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
N/A

[1] https://gitlab.cern.ch/cmsos/worksuite/-/commit/c663f7b074b8d9f6e0a12f20d85a397b9ee8a0ef

