### PR TITLE
use cmsonr_lb instead of cms_omds_tunnel for SiStrip O2O unit tests

### DIFF
--- a/CondTools/SiStrip/python/SiStripO2O_cfg_template.py
+++ b/CondTools/SiStrip/python/SiStripO2O_cfg_template.py
@@ -26,8 +26,8 @@ _CFGLINES_
 
 if 'CONFDB' not in os.environ:
     import CondCore.Utilities.credentials as auth
-    user, _, passwd = auth.get_credentials('cms_omds_tunnel/cms_trk_r')
-    process.SiStripConfigDb.ConfDb = '{user}/{passwd}@{path}'.format(user=user, passwd=passwd, path='cms_omds_tunnel')
+    user, _, passwd = auth.get_credentials('cmsonr_lb/cms_trk_r')
+    process.SiStripConfigDb.ConfDb = '{user}/{passwd}@{path}'.format(user=user, passwd=passwd, path='cmsonr_lb')
 
 process.load("OnlineDB.SiStripO2O.SiStripO2OCalibrationFactors_cfi")
 process.SiStripCondObjBuilderFromDb = cms.Service( "SiStripCondObjBuilderFromDb",


### PR DESCRIPTION
`cms_omds_tunnel` tunnal has been removed. See https://github.com/cms-sw/cmssw/issues/37888 and https://github.com/cms-sw/cmssw/pull/38074 for more details. Tracker team has setup a new tunnel `cmsonr_lb` and cms-bot has been updated to use correct `tnsnames.ora` to use this tunnel.

This fixes #37888
