### PR TITLE
Updated Geant4 sensitive detector code for low-energy gflash method

### DIFF
--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -192,6 +192,7 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   }
 
   // ignore steps without energy deposit
+  edepositEM = edepositHAD = 0.f;
   if (aStep->GetTotalEnergyDeposit() <= 0.0) {
     return false;
   }
@@ -227,7 +228,6 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
     currentID.markAsFinecaloTrackID();
   }
 
-  edepositEM = edepositHAD = 0.f;
   if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
     edepositEM = energy;
   } else {
@@ -244,7 +244,7 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
                               << " currentID= (" << currentID << ") previousID= (" << previousID << ")";
 #endif
   if (!hitExists(aStep)) {
-    currentHit = createNewHit(aStep, aStep->GetTrack());
+    currentHit = createNewHit(aStep, theTrack);
   } else {
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("DoFineCalo") << "Not creating new hit, only updating " << shortreprID(currentHit);

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -177,15 +177,15 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
     if (getFromLibrary(aStep)) {
       // for parameterized showers the primary track should be killed
       // secondary tracks should be killed if they are in the same volume
-      const_cast<G4Track *>(aStep->GetTrack())->SetTrackStatus(fStopAndKill);
-      if(0 < aStep->GetNumberOfSecondariesInCurrentStep()) {
-	auto tv = aStep->GetSecondaryInCurrentStep();
-	auto vol = aStep->GetPreStepPoint()->GetPhysicalVolume();
-	for (auto& tk : *tv) {
-	  if (tk->GetVolume() == vol) {
-	    const_cast<G4Track *>(tk)->SetTrackStatus(fStopAndKill);
-	  }
-	}
+      const_cast<G4Track*>(aStep->GetTrack())->SetTrackStatus(fStopAndKill);
+      if (0 < aStep->GetNumberOfSecondariesInCurrentStep()) {
+        auto tv = aStep->GetSecondaryInCurrentStep();
+        auto vol = aStep->GetPreStepPoint()->GetPhysicalVolume();
+        for (auto& tk : *tv) {
+          if (tk->GetVolume() == vol) {
+            const_cast<G4Track*>(tk)->SetTrackStatus(fStopAndKill);
+          }
+        }
       }
       return true;
     }
@@ -208,8 +208,7 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   } else {
     if (!ignoreReject) {
       const G4TouchableHistory* touch = static_cast<const G4TouchableHistory*>(theTrack->GetTouchable());
-      edm::LogVerbatim("CaloSim") << "CaloSD::ProcessHits: unitID= " << unitID 
-                                  << " currUnit=   " << currentID.unitID()
+      edm::LogVerbatim("CaloSim") << "CaloSD::ProcessHits: unitID= " << unitID << " currUnit=   " << currentID.unitID()
                                   << " Detector: " << GetName() << " trackID= " << theTrack->GetTrackID() << " "
                                   << theTrack->GetDefinition()->GetParticleName()
                                   << "\n Edep= " << aStep->GetTotalEnergyDeposit()
@@ -237,12 +236,12 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
 #ifdef EDM_ML_DEBUG
   G4TouchableHistory* touch = (G4TouchableHistory*)(theTrack->GetTouchable());
   edm::LogVerbatim("CaloSim") << "CaloSD::" << GetName() << " PV:" << touch->GetVolume(0)->GetName()
-			      << " PVid=" << touch->GetReplicaNumber(0) << " MVid=" << touch->GetReplicaNumber(1)
-			      << " Unit:" << std::hex << unitID << std::dec << " Edep=" << edepositEM << " "
-			      << edepositHAD << " ID=" << theTrack->GetTrackID() << " pID=" << theTrack->GetParentID()
-			      << " E=" << theTrack->GetKineticEnergy() << " S=" << aStep->GetStepLength() << "\n "
-			      << theTrack->GetDefinition()->GetParticleName() << " primaryID= " << primaryID
-			      << " currentID= (" << currentID << ") previousID= (" << previousID << ")";
+                              << " PVid=" << touch->GetReplicaNumber(0) << " MVid=" << touch->GetReplicaNumber(1)
+                              << " Unit:" << std::hex << unitID << std::dec << " Edep=" << edepositEM << " "
+                              << edepositHAD << " ID=" << theTrack->GetTrackID() << " pID=" << theTrack->GetParentID()
+                              << " E=" << theTrack->GetKineticEnergy() << " S=" << aStep->GetStepLength() << "\n "
+                              << theTrack->GetDefinition()->GetParticleName() << " primaryID= " << primaryID
+                              << " currentID= (" << currentID << ") previousID= (" << previousID << ")";
 #endif
   if (!hitExists(aStep)) {
     currentHit = createNewHit(aStep, aStep->GetTrack());

--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -172,23 +172,31 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   doFineCaloThisStep_ = (doFineCalo_ && isItFineCalo(aStep->GetPreStepPoint()->GetTouchable()));
 
   // apply shower library or parameterisation
+  // independent on energy deposition at a step
   if (isParameterized) {
     if (getFromLibrary(aStep)) {
       // for parameterized showers the primary track should be killed
-      aStep->GetTrack()->SetTrackStatus(fStopAndKill);
-      auto tv = aStep->GetSecondary();
-      auto vol = aStep->GetPreStepPoint()->GetPhysicalVolume();
-      for (auto& tk : *tv) {
-        if (tk->GetVolume() == vol) {
-          tk->SetTrackStatus(fStopAndKill);
-        }
+      // secondary tracks should be killed if they are in the same volume
+      const_cast<G4Track *>(aStep->GetTrack())->SetTrackStatus(fStopAndKill);
+      if(0 < aStep->GetNumberOfSecondariesInCurrentStep()) {
+	auto tv = aStep->GetSecondaryInCurrentStep();
+	auto vol = aStep->GetPreStepPoint()->GetPhysicalVolume();
+	for (auto& tk : *tv) {
+	  if (tk->GetVolume() == vol) {
+	    const_cast<G4Track *>(tk)->SetTrackStatus(fStopAndKill);
+	  }
+	}
       }
       return true;
     }
   }
 
   // ignore steps without energy deposit
-  edepositEM = edepositHAD = 0.f;
+  if (aStep->GetTotalEnergyDeposit() <= 0.0) {
+    return false;
+  }
+
+  // check unitID
   unsigned int unitID = setDetUnitId(aStep);
   auto const theTrack = aStep->GetTrack();
   uint16_t depth = getDepth(aStep);
@@ -198,9 +206,10 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   if (unitID > 0) {
     currentID.setID(unitID, time, primaryID, depth);
   } else {
-    if (aStep->GetTotalEnergyDeposit() > 0.0 && (!ignoreReject)) {
+    if (!ignoreReject) {
       const G4TouchableHistory* touch = static_cast<const G4TouchableHistory*>(theTrack->GetTouchable());
-      edm::LogVerbatim("CaloSim") << "CaloSD::ProcessHits: unitID= " << unitID << " currUnit=   " << currentID.unitID()
+      edm::LogVerbatim("CaloSim") << "CaloSD::ProcessHits: unitID= " << unitID 
+                                  << " currUnit=   " << currentID.unitID()
                                   << " Detector: " << GetName() << " trackID= " << theTrack->GetTrackID() << " "
                                   << theTrack->GetDefinition()->GetParticleName()
                                   << "\n Edep= " << aStep->GetTotalEnergyDeposit()
@@ -209,42 +218,40 @@ G4bool CaloSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
     }
     return false;
   }
-
-  if (aStep->GetTotalEnergyDeposit() == 0.0) {
+  double energy = getEnergyDeposit(aStep);
+  if (energy <= 0.0) {
     return false;
   }
 
-  double energy = getEnergyDeposit(aStep);
-  if (energy > 0.0) {
-    if (doFineCaloThisStep_) {
-      currentID.setID(unitID, time, findBoundaryCrossingParent(theTrack), depth);
-      currentID.markAsFinecaloTrackID();
-    }
-    if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
-      edepositEM = energy;
-    } else {
-      edepositHAD = energy;
-    }
-#ifdef EDM_ML_DEBUG
-    G4TouchableHistory* touch = (G4TouchableHistory*)(theTrack->GetTouchable());
-    edm::LogVerbatim("CaloSim") << "CaloSD::" << GetName() << " PV:" << touch->GetVolume(0)->GetName()
-                                << " PVid=" << touch->GetReplicaNumber(0) << " MVid=" << touch->GetReplicaNumber(1)
-                                << " Unit:" << std::hex << unitID << std::dec << " Edep=" << edepositEM << " "
-                                << edepositHAD << " ID=" << theTrack->GetTrackID() << " pID=" << theTrack->GetParentID()
-                                << " E=" << theTrack->GetKineticEnergy() << " S=" << aStep->GetStepLength() << "\n "
-                                << theTrack->GetDefinition()->GetParticleName() << " primaryID= " << primaryID
-                                << " currentID= (" << currentID << ") previousID= (" << previousID << ")";
-#endif
-    if (!hitExists(aStep)) {
-      currentHit = createNewHit(aStep, aStep->GetTrack());
-    } else {
-#ifdef EDM_ML_DEBUG
-      edm::LogVerbatim("DoFineCalo") << "Not creating new hit, only updating " << shortreprID(currentHit);
-#endif
-    }
-    return true;
+  if (doFineCaloThisStep_) {
+    currentID.setID(unitID, time, findBoundaryCrossingParent(theTrack), depth);
+    currentID.markAsFinecaloTrackID();
   }
-  return false;
+
+  edepositEM = edepositHAD = 0.f;
+  if (G4TrackToParticleID::isGammaElectronPositron(theTrack)) {
+    edepositEM = energy;
+  } else {
+    edepositHAD = energy;
+  }
+#ifdef EDM_ML_DEBUG
+  G4TouchableHistory* touch = (G4TouchableHistory*)(theTrack->GetTouchable());
+  edm::LogVerbatim("CaloSim") << "CaloSD::" << GetName() << " PV:" << touch->GetVolume(0)->GetName()
+			      << " PVid=" << touch->GetReplicaNumber(0) << " MVid=" << touch->GetReplicaNumber(1)
+			      << " Unit:" << std::hex << unitID << std::dec << " Edep=" << edepositEM << " "
+			      << edepositHAD << " ID=" << theTrack->GetTrackID() << " pID=" << theTrack->GetParentID()
+			      << " E=" << theTrack->GetKineticEnergy() << " S=" << aStep->GetStepLength() << "\n "
+			      << theTrack->GetDefinition()->GetParticleName() << " primaryID= " << primaryID
+			      << " currentID= (" << currentID << ") previousID= (" << previousID << ")";
+#endif
+  if (!hitExists(aStep)) {
+    currentHit = createNewHit(aStep, aStep->GetTrack());
+  } else {
+#ifdef EDM_ML_DEBUG
+    edm::LogVerbatim("DoFineCalo") << "Not creating new hit, only updating " << shortreprID(currentHit);
+#endif
+  }
+  return true;
 }
 
 bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
@@ -266,6 +273,8 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
   fFakePreStepPoint->SetTouchableHandle(fTouchableHandle);
   fFakeStep.SetTotalEnergyDeposit(edep);
   edep = EnergyCorrected(fFakeStep, track);
+
+  // zero edep means hit outside the calorimeter
   if (edep <= 0.0) {
     return false;
   }
@@ -279,7 +288,8 @@ bool CaloSD::ProcessHits(G4GFlashSpot* aSpot, G4TouchableHistory*) {
   unsigned int unitID = setDetUnitId(&fFakeStep);
 
   if (unitID > 0) {
-    double time = 0;
+    // time of initial track
+    double time = track->GetGlobalTime() / nanosecond;
     int primaryID = getTrackID(track);
     uint16_t depth = getDepth(&fFakeStep);
     currentID.setID(unitID, time, primaryID, depth);

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -229,7 +229,8 @@ double ECalSD::getEnergyDeposit(const G4Step* aStep) {
 double ECalSD::EnergyCorrected(const G4Step& step, const G4Track* track) {
   const G4StepPoint* hitPoint = step.GetPreStepPoint();
   const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
-  if(lv->GetSensitiveDetector() != this) return 0.0;
+  if (lv->GetSensitiveDetector() != this)
+    return 0.0;
 
   double edep = step.GetTotalEnergyDeposit();
   if (useWeight && !any(noWeight, lv)) {

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -127,7 +127,7 @@ ECalSD::ECalSD(const std::string& name,
   int type0 = dumpGeom / 1000;
   type += (10 * type0);
 
-  if (scheme)
+  if (nullptr != scheme)
     setNumberingScheme(scheme);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("EcalSim") << "Constructing a ECalSD  with name " << GetName();
@@ -227,10 +227,11 @@ double ECalSD::getEnergyDeposit(const G4Step* aStep) {
 }
 
 double ECalSD::EnergyCorrected(const G4Step& step, const G4Track* track) {
-  double edep = step.GetTotalEnergyDeposit();
   const G4StepPoint* hitPoint = step.GetPreStepPoint();
   const G4LogicalVolume* lv = hitPoint->GetTouchable()->GetVolume(0)->GetLogicalVolume();
+  if(lv->GetSensitiveDetector() != this) return 0.0;
 
+  double edep = step.GetTotalEnergyDeposit();
   if (useWeight && !any(noWeight, lv)) {
     currentLocalPoint = setToLocal(hitPoint->GetPosition(), hitPoint->GetTouchable());
     auto ite = xtalLMap.find(lv);

--- a/SimG4Core/Application/interface/LowEnergyFastSimModel.h
+++ b/SimG4Core/Application/interface/LowEnergyFastSimModel.h
@@ -13,6 +13,7 @@
 
 class TrackingAction;
 class G4ParticleDefinition;
+class G4Material;
 
 class LowEnergyFastSimModel : public G4VFastSimulationModel {
 public:
@@ -27,6 +28,7 @@ private:
   const G4Envelope* fRegion;
   const TrackingAction* fTrackingAction;
   const G4ParticleDefinition* fPositron;
+  const G4Material* fMaterial;
   G4bool fCheck;
   G4ThreeVector fTailPos;
   GFlashHitMaker fHitMaker;

--- a/SimG4Core/Application/interface/LowEnergyFastSimParam.h
+++ b/SimG4Core/Application/interface/LowEnergyFastSimParam.h
@@ -7,7 +7,7 @@
 
 class LowEnergyFastSimParam {
 public:
-  G4double GetInPointEnergyFraction(G4double energy) const { 
+  G4double GetInPointEnergyFraction(G4double energy) const {
     // normalisation of fit parameters to have the result
     constexpr const G4double a0 = 1.02186764;
     constexpr const G4double a1 = 2.14064635e-02 / a0;
@@ -15,7 +15,7 @@ public:
     constexpr const G4double a3 = -6.42310317e-07 / a0;
     const G4double e2 = energy * energy;
     const G4double e3 = e2 * energy;
-    return a3 * e3 +  a2 * e2 - a1 * energy + 1.0;
+    return a3 * e3 + a2 * e2 - a1 * energy + 1.0;
   }
 
   G4double GetRadius(G4double energy) const {
@@ -26,7 +26,7 @@ public:
   }
 
   G4double GetZ() const {
-    constexpr const G4double alpha = 1.0/0.02211515;
+    constexpr const G4double alpha = 1.0 / 0.02211515;
     constexpr const G4double t = 0.66968625;
     return -G4Log(G4UniformRand()) * alpha + t;
   }

--- a/SimG4Core/Application/interface/LowEnergyFastSimParam.h
+++ b/SimG4Core/Application/interface/LowEnergyFastSimParam.h
@@ -7,10 +7,15 @@
 
 class LowEnergyFastSimParam {
 public:
-  G4double GetInPointEnergyFraction(G4double energy) const {
+  G4double GetInPointEnergyFraction(G4double energy) const { 
+    // normalisation of fit parameters to have the result
+    constexpr const G4double a0 = 1.02186764;
+    constexpr const G4double a1 = 2.14064635e-02 / a0;
+    constexpr const G4double a2 = 1.96988997e-04 / a0;
+    constexpr const G4double a3 = -6.42310317e-07 / a0;
     const G4double e2 = energy * energy;
     const G4double e3 = e2 * energy;
-    return -6.42310317e-07 * e3 + 1.96988997e-04 * e2 - 2.14064635e-02 * energy + 1.02186764e+00;
+    return a3 * e3 +  a2 * e2 - a1 * energy + 1.0;
   }
 
   G4double GetRadius(G4double energy) const {
@@ -21,9 +26,9 @@ public:
   }
 
   G4double GetZ() const {
-    constexpr const G4double alpha = 0.02211515;
+    constexpr const G4double alpha = 1.0/0.02211515;
     constexpr const G4double t = 0.66968625;
-    return -G4Log(G4UniformRand()) / alpha + t;
+    return -G4Log(G4UniformRand()) * alpha + t;
   }
 };
 

--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -26,17 +26,17 @@ LowEnergyFastSimModel::LowEnergyFastSimModel(const G4String& name, G4Region* reg
   fPositron = G4Positron::Positron();
   fMaterial = nullptr;
   auto table = G4Material::GetMaterialTable();
-  for(auto & mat : *table) {
+  for (auto& mat : *table) {
     G4String nam = mat->GetName();
     size_t n = nam.size();
-    if(n > 4) {
+    if (n > 4) {
       G4String sn = nam.substr(n - 5, 5);
-      if(sn == "PbW04") {
-	fMaterial = mat;
-	break;
+      if (sn == "PbW04") {
+        fMaterial = mat;
+        break;
       }
     }
-  } 
+  }
 }
 
 G4bool LowEnergyFastSimModel::IsApplicable(const G4ParticleDefinition& particle) {
@@ -82,7 +82,7 @@ void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastS
   // tail energy deposition
   const G4double etail = energy - inPointEnergy;
   const G4int nspots = etail;
-  const G4double tailEnergy = etail/(nspots + 1);
+  const G4double tailEnergy = etail / (nspots + 1);
   /*
   edm::LogVerbatim("LowEnergyFastSimModel") << track->GetDefinition()->GetParticleName()
 					    << " Ekin(MeV)=" << energy << " material: <"

--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -31,12 +31,14 @@ LowEnergyFastSimModel::LowEnergyFastSimModel(const G4String& name, G4Region* reg
     size_t n = nam.size();
     if (n > 4) {
       G4String sn = nam.substr(n - 5, 5);
-      if (sn == "PbW04") {
+      if (sn == "PbWO4") {
         fMaterial = mat;
         break;
       }
     }
   }
+  G4String nm = (nullptr == fMaterial) ? "not found!" : fMaterial->GetName();
+  edm::LogVerbatim("LowEnergyFastSimModel") << "LowEGFlash material: <" << nm << ">";
 }
 
 G4bool LowEnergyFastSimModel::IsApplicable(const G4ParticleDefinition& particle) {
@@ -54,7 +56,12 @@ G4bool LowEnergyFastSimModel::ModelTrigger(const G4FastTrack& fastTrack) {
       return false;
   }
   G4double energy = track->GetKineticEnergy();
-  return (fMaterial == track->GetMaterial() && energy < fEmax);
+  /*
+  edm::LogVerbatim("LowEnergyFastSimModel") << track->GetDefinition()->GetParticleName()
+					    << " Ekin(MeV)=" << energy << " material: <"
+                                            << track->GetMaterial()->GetName() << ">";
+  */
+  return (energy < fEmax && fMaterial == track->GetMaterial());
 }
 
 void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep) {
@@ -83,7 +90,7 @@ void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastS
   const G4double etail = energy - inPointEnergy;
   const G4int nspots = etail;
   const G4double tailEnergy = etail / (nspots + 1);
-  /*
+  /*  
   edm::LogVerbatim("LowEnergyFastSimModel") << track->GetDefinition()->GetParticleName()
 					    << " Ekin(MeV)=" << energy << " material: <"
                                             << track->GetMaterial()->GetName() 

--- a/SimG4Core/Application/src/LowEnergyFastSimModel.cc
+++ b/SimG4Core/Application/src/LowEnergyFastSimModel.cc
@@ -9,6 +9,7 @@
 #include "G4Electron.hh"
 #include "GFlashHitMaker.hh"
 #include "G4Region.hh"
+#include "G4Material.hh"
 #include "G4Positron.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4PhysicalConstants.hh"
@@ -23,6 +24,19 @@ LowEnergyFastSimModel::LowEnergyFastSimModel(const G4String& name, G4Region* reg
       fTailPos(0., 0., 0.) {
   fEmax = parSet.getParameter<double>("LowEnergyGflashEcalEmax") * CLHEP::GeV;
   fPositron = G4Positron::Positron();
+  fMaterial = nullptr;
+  auto table = G4Material::GetMaterialTable();
+  for(auto & mat : *table) {
+    G4String nam = mat->GetName();
+    size_t n = nam.size();
+    if(n > 4) {
+      G4String sn = nam.substr(n - 5, 5);
+      if(sn == "PbW04") {
+	fMaterial = mat;
+	break;
+      }
+    }
+  } 
 }
 
 G4bool LowEnergyFastSimModel::IsApplicable(const G4ParticleDefinition& particle) {
@@ -40,7 +54,7 @@ G4bool LowEnergyFastSimModel::ModelTrigger(const G4FastTrack& fastTrack) {
       return false;
   }
   G4double energy = track->GetKineticEnergy();
-  return (energy < fEmax && fRegion == fastTrack.GetEnvelope());
+  return (fMaterial == track->GetMaterial() && energy < fEmax);
 }
 
 void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastStep) {
@@ -66,10 +80,18 @@ void LowEnergyFastSimModel::DoIt(const G4FastTrack& fastTrack, G4FastStep& fastS
   fHitMaker.make(&spot, &fastTrack);
 
   // tail energy deposition
-  G4double etail = energy - inPointEnergy;
-  const G4int nspots = (G4int)(etail) + 1;
-  const G4double tailEnergy = etail / (G4double)nspots;
-  for (G4int i = 0; i < nspots; ++i) {
+  const G4double etail = energy - inPointEnergy;
+  const G4int nspots = etail;
+  const G4double tailEnergy = etail/(nspots + 1);
+  /*
+  edm::LogVerbatim("LowEnergyFastSimModel") << track->GetDefinition()->GetParticleName()
+					    << " Ekin(MeV)=" << energy << " material: <"
+                                            << track->GetMaterial()->GetName() 
+					    << "> Elocal=" << inPointEnergy
+					    << " Etail=" << tailEnergy
+					    << " Nspots=" << nspots+1;
+  */
+  for (G4int i = 0; i <= nspots; ++i) {
     const G4double r = fParam.GetRadius(energy);
     const G4double z = fParam.GetZ();
 


### PR DESCRIPTION
#### PR description:
Update Geant4 sensitive detector code:
1) trigger low-energy GFlash only inside ECAL crystals and not in pre-shower or absorber;
2) GFlash spots should be inside crystals, not other materials
3) fixed minor numerical problems in low-energy GFlash method

If GFlash is not enabled results should not be affected.

#### PR validation:
private


#### if this PR is a backport please specify the original PR and why you need to backport that PR: NO

