### PR TITLE
ECAL - Fix dereferencing of nullptr in CaloRectangleRange

### DIFF
--- a/RecoCaloTools/Navigation/interface/CaloRectangle.h
+++ b/RecoCaloTools/Navigation/interface/CaloRectangle.h
@@ -21,13 +21,15 @@ struct CaloRectangle {
 };
 
 template <class T>
-T offsetBy(T start, CaloSubdetectorTopology const& topo, int dIEtaOrIX, int dIPhiOrIY) {
-  for (int i = 0; i < std::abs(dIEtaOrIX) && start != T(0); i++) {
-    start = dIEtaOrIX > 0 ? topo.goEast(start) : topo.goWest(start);
-  }
+T offsetBy(T start, CaloSubdetectorTopology const* topo, int dIEtaOrIX, int dIPhiOrIY) {
+  if (topo) {
+    for (int i = 0; i < std::abs(dIEtaOrIX) && start != T(0); i++) {
+      start = dIEtaOrIX > 0 ? topo->goEast(start) : topo->goWest(start);
+    }
 
-  for (int i = 0; i < std::abs(dIPhiOrIY) && start != T(0); i++) {
-    start = dIPhiOrIY > 0 ? topo.goNorth(start) : topo.goSouth(start);
+    for (int i = 0; i < std::abs(dIPhiOrIY) && start != T(0); i++) {
+      start = dIPhiOrIY > 0 ? topo->goNorth(start) : topo->goSouth(start);
+    }
   }
   return start;
 }
@@ -41,7 +43,7 @@ public:
              int iEtaOrIX,
              int iPhiOrIY,
              CaloRectangle const rectangle,
-             CaloSubdetectorTopology const& topology)
+             CaloSubdetectorTopology const* topology)
         : home_(home), rectangle_(rectangle), topology_(topology), iEtaOrIX_(iEtaOrIX), iPhiOrIY_(iPhiOrIY) {}
 
     Iterator& operator++() {
@@ -69,7 +71,7 @@ public:
     const T home_;
 
     const CaloRectangle rectangle_;
-    CaloSubdetectorTopology const& topology_;
+    CaloSubdetectorTopology const* topology_;
 
     int iEtaOrIX_;
     int iPhiOrIY_;
@@ -77,10 +79,10 @@ public:
 
 public:
   CaloRectangleRange(CaloRectangle rectangle, T home, CaloTopology const& topology)
-      : home_(home), rectangle_(rectangle), topology_(*topology.getSubdetectorTopology(home)) {}
+      : home_(home), rectangle_(rectangle), topology_(topology.getSubdetectorTopology(home)) {}
 
   CaloRectangleRange(int size, T home, CaloTopology const& topology)
-      : home_(home), rectangle_{-size, size, -size, size}, topology_(*topology.getSubdetectorTopology(home)) {}
+      : home_(home), rectangle_{-size, size, -size, size}, topology_(topology.getSubdetectorTopology(home)) {}
 
   auto begin() { return Iterator(home_, rectangle_.iEtaOrIXMin, rectangle_.iPhiOrIYMin, rectangle_, topology_); }
   auto end() { return Iterator(home_, rectangle_.iEtaOrIXMax + 1, rectangle_.iPhiOrIYMin, rectangle_, topology_); }
@@ -88,7 +90,7 @@ public:
 private:
   const T home_;
   const CaloRectangle rectangle_;
-  CaloSubdetectorTopology const& topology_;
+  CaloSubdetectorTopology const* topology_;
 };
 
 template <class T>


### PR DESCRIPTION
#### PR description:

This fixes the dereferencing of a nullptr in the `CaloRectangleRange` constructor found by UBSAN and discussed in #37704.
Store a pointer to the topology instead of a reference and handle the nullptr case when calculating the rectangle offset.

#### PR validation:

Passes limited matrix tests.