### PR TITLE
[12_4_X] Adapt uGMT DQM for new readout menu following the disabling of the zero suppression

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -44,7 +44,6 @@ private:
   const float etaScale_;
   const float phiScale_;
 
-  MonitorElement* ugmtBMTFBX;
   MonitorElement* ugmtBMTFnMuons;
   MonitorElement* ugmtBMTFhwPt;
   MonitorElement* ugmtBMTFhwPtUnconstrained;
@@ -61,7 +60,6 @@ private:
   MonitorElement* ugmtBMTFMuMuDPhi;
   MonitorElement* ugmtBMTFMuMuDR;
 
-  MonitorElement* ugmtOMTFBX;
   MonitorElement* ugmtOMTFnMuons;
   MonitorElement* ugmtOMTFhwPt;
   MonitorElement* ugmtOMTFhwEta;
@@ -79,7 +77,6 @@ private:
   MonitorElement* ugmtOMTFMuMuDPhi;
   MonitorElement* ugmtOMTFMuMuDR;
 
-  MonitorElement* ugmtEMTFBX;
   MonitorElement* ugmtEMTFnMuons;
   MonitorElement* ugmtEMTFhwPt;
   MonitorElement* ugmtEMTFhwPtUnconstrained;
@@ -100,8 +97,6 @@ private:
   MonitorElement* ugmtEMTFMuMuDR;
 
   MonitorElement* ugmtEMTFShowerTypeOccupancyPerSector;
-  MonitorElement* ugmtEMTFShowerTypeOccupancyPerBx;
-  MonitorElement* ugmtEMTFShowerSectorOccupancyPerBx;
 
   MonitorElement* ugmtBOMTFposMuMuDEta;
   MonitorElement* ugmtBOMTFposMuMuDPhi;
@@ -116,11 +111,6 @@ private:
   MonitorElement* ugmtEOMTFnegMuMuDEta;
   MonitorElement* ugmtEOMTFnegMuMuDPhi;
   MonitorElement* ugmtEOMTFnegMuMuDR;
-
-  MonitorElement* ugmtBMTFBXvsProcessor;
-  MonitorElement* ugmtOMTFBXvsProcessor;
-  MonitorElement* ugmtEMTFBXvsProcessor;
-  MonitorElement* ugmtBXvsLink;
 
   MonitorElement* ugmtMuonBX;
   MonitorElement* ugmtnMuons;

--- a/DQM/L1TMonitor/interface/L1TStage2uGMTInputBxDistributions.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMTInputBxDistributions.h
@@ -1,0 +1,59 @@
+#ifndef DQM_L1TMonitor_L1TStage2uGMTInputBxDistributions_h
+#define DQM_L1TMonitor_L1TStage2uGMTInputBxDistributions_h
+
+#include "DataFormats/L1Trigger/interface/Muon.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1Trigger/interface/MuonShower.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonShower.h"
+#include "L1Trigger/L1TMuon/interface/MicroGMTConfiguration.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+class L1TStage2uGMTInputBxDistributions : public DQMEDAnalyzer {
+public:
+  L1TStage2uGMTInputBxDistributions(const edm::ParameterSet& ps);
+  ~L1TStage2uGMTInputBxDistributions() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtBMTFToken_;
+  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtOMTFToken_;
+  edm::EDGetTokenT<l1t::RegionalMuonCandBxCollection> ugmtEMTFToken_;
+  edm::EDGetTokenT<l1t::MuonBxCollection> ugmtMuonToken_;
+  edm::EDGetTokenT<l1t::RegionalMuonShowerBxCollection> ugmtEMTFShowerToken_;
+  edm::EDGetTokenT<l1t::MuonShowerBxCollection> ugmtMuonShowerToken_;
+  std::string monitorDir_;
+  bool emul_;
+  bool verbose_;
+  bool hadronicShowers_;
+
+  MonitorElement* ugmtBMTFBX;
+
+  MonitorElement* ugmtOMTFBX;
+
+  MonitorElement* ugmtEMTFBX;
+
+  MonitorElement* ugmtEMTFShowerTypeOccupancyPerBx;
+  MonitorElement* ugmtEMTFShowerSectorOccupancyPerBx;
+
+  MonitorElement* ugmtBMTFBXvsProcessor;
+  MonitorElement* ugmtOMTFBXvsProcessor;
+  MonitorElement* ugmtEMTFBXvsProcessor;
+  MonitorElement* ugmtBXvsLink;
+
+  static constexpr unsigned IDX_TIGHT_SHOWER{2};
+  static constexpr unsigned IDX_NOMINAL_SHOWER{1};
+};
+
+#endif

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -33,6 +33,9 @@ DEFINE_FWK_MODULE(L1TStage2CaloLayer2);
 #include "DQM/L1TMonitor/interface/L1TStage2uGMT.h"
 DEFINE_FWK_MODULE(L1TStage2uGMT);
 
+#include "DQM/L1TMonitor/interface/L1TStage2uGMTInputBxDistributions.h"
+DEFINE_FWK_MODULE(L1TStage2uGMTInputBxDistributions);
+
 #include "DQM/L1TMonitor/interface/L1TObjectsTiming.h"
 DEFINE_FWK_MODULE(L1TObjectsTiming);
 

--- a/DQM/L1TMonitor/python/L1TStage2uGMTInputBxDistributions_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMTInputBxDistributions_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+# the uGMT DQM module
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2uGMTInputBxDistributions = DQMEDAnalyzer(
+    "L1TStage2uGMTInputBxDistributions",
+    bmtfProducer = cms.InputTag("gmtStage2Digis", "BMTF"),
+    omtfProducer = cms.InputTag("gmtStage2Digis", "OMTF"),
+    emtfProducer = cms.InputTag("gmtStage2Digis", "EMTF"),
+    emtfShowerProducer = cms.InputTag("gmtStage2Digis", "EMTF"),
+    muonProducer = cms.InputTag("gmtStage2Digis", "Muon"),
+    muonShowerProducer = cms.InputTag("gmtStage2Digis", "MuonShower"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT"),
+    emulator = cms.untracked.bool(False),
+    verbose = cms.untracked.bool(False),
+    hadronicShowers = cms.untracked.bool(False)
+)
+
+## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2uGMTInputBxDistributions, hadronicShowers = cms.untracked.bool(True))

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -60,10 +60,11 @@ stage2L1Trigger_2021.toModify(l1tStage2uGMTIntermediateEMTFPos, displacedQuantit
 
 # List of bins to ignore
 ignoreBins = {
-    'Bmtf'        : [1],
-    'Omtf'        : [1],
-    'Emtf'        : [1],
-    'EmtfShowers' : [1]
+    'OutputCopies' : [1],
+    'Bmtf'         : [1],
+    'Omtf'         : [1],
+    'Emtf'         : [1],
+    'EmtfShowers'  : [1]
     }
 
 # compares the unpacked BMTF output regional muon collection with the unpacked uGMT input regional muon collection from BMTF
@@ -148,7 +149,7 @@ l1tStage2uGMTMuonVsuGMTMuonCopy1 = DQMEDAnalyzer(
 ## Era: Run3_2021; Displaced muons used in uGMT from Run-3
  # Additionally: Ignore BX range mismatches. This is necessary because we only read out the central BX for the output copies.
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tStage2uGMTMuonVsuGMTMuonCopy1, displacedQuantities = cms.untracked.bool(True), ignoreBin = cms.untracked.vint32(1))
+stage2L1Trigger_2021.toModify(l1tStage2uGMTMuonVsuGMTMuonCopy1, displacedQuantities = cms.untracked.bool(True), ignoreBin = cms.untracked.vint32(ignoreBins['OutputCopies']))
 
 l1tStage2uGMTMuonVsuGMTMuonCopy2 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
     muonCollection2 = "gmtStage2Digis:MuonCopy2",
@@ -183,7 +184,7 @@ l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1= DQMEDAnalyzer("L1TStage2MuonShower
     muonShowerCollection2Title = cms.untracked.string("uGMT muon showers copy 1"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT showers and uGMT shower copy 1"),
     verbose = cms.untracked.bool(False),
-    ignoreBin = cms.untracked.vint32(1), # Ignore BX range mismatches. This is necessary because we only read out the central BX for the output copies.
+    ignoreBin = cms.untracked.vint32(ignoreBins['OutputCopies']), # Ignore BX range mismatches. This is necessary because we only read out the central BX for the output copies.
 )
 
 l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy2 = l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1.clone(

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 # the uGMT DQM module
 from DQM.L1TMonitor.L1TStage2uGMT_cfi import *
+from DQM.L1TMonitor.L1TStage2uGMTInputBxDistributions_cfi import *
 
 # the uGMT intermediate muon DQM modules
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
@@ -215,6 +216,7 @@ l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy5 = l1tStage2uGMTMuonShowerVsuGMTMuon
 # sequences
 l1tStage2uGMTOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMT +
+    l1tStage2uGMTInputBxDistributions +
     l1tStage2uGMTIntermediateBMTF +
     l1tStage2uGMTIntermediateOMTFNeg +
     l1tStage2uGMTIntermediateOMTFPos +
@@ -234,7 +236,7 @@ l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(
 )
 
 
-## Era: Run3_2021; Hadronic showers from EMTF used in uGMT from Run-3. Comparing output copies routinely, but moving the uGMT main DQM behind the fat event filter so the BX comparisons aren't biased.
+## Era: Run3_2021; Hadronic showers from EMTF used in uGMT from Run-3. Comparing output copies routinely, but moving the uGMT BX distribution plots behind the fat event filter so the BX comparisons aren't biased.
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
 
 _run3_l1tStage2uGMTOnlineDQMSeq = cms.Sequence(l1tStage2uGMTOnlineDQMSeq.copy() +
@@ -250,10 +252,9 @@ _run3_l1tStage2uGMTOnlineDQMSeq = cms.Sequence(l1tStage2uGMTOnlineDQMSeq.copy() 
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy4 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy5
 )
-_run3_l1tStage2uGMTOnlineDQMSeq.remove(l1tStage2uGMT)
+_run3_l1tStage2uGMTOnlineDQMSeq.remove(l1tStage2uGMTInputBxDistributions)
 stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTOnlineDQMSeq, _run3_l1tStage2uGMTOnlineDQMSeq)
 
 # The following needs to go after the fat events filter, because inputs are read out with only the central BX for the standard events, so the BX distributions would otherwise be heavily biased toward the central BX.
-_run3_l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(l1tStage2uGMT)
+_run3_l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(l1tStage2uGMTInputBxDistributions)
 stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTValidationEventOnlineDQMSeq, _run3_l1tStage2uGMTValidationEventOnlineDQMSeq)
-

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -242,7 +242,7 @@ _run3_l1tStage2uGMTOnlineDQMSeq = cms.Sequence(l1tStage2uGMTOnlineDQMSeq.copy() 
     l1tStage2uGMTMuonVsuGMTMuonCopy3 +
     l1tStage2uGMTMuonVsuGMTMuonCopy4 +
     l1tStage2uGMTMuonVsuGMTMuonCopy5 +
-    # l1tStage2EmtfOutVsuGMTInShowers +
+    l1tStage2EmtfOutVsuGMTInShowers +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy2 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy3 +

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -58,58 +58,6 @@ l1tStage2uGMTIntermediateEMTFPos = DQMEDAnalyzer(
 stage2L1Trigger_2021.toModify(l1tStage2uGMTIntermediateEMTFNeg, displacedQuantities = cms.untracked.bool(True))
 stage2L1Trigger_2021.toModify(l1tStage2uGMTIntermediateEMTFPos, displacedQuantities = cms.untracked.bool(True))
 
-# zero suppression DQM
-l1tStage2uGMTZeroSupp = DQMEDAnalyzer(
-    "L1TMP7ZeroSupp",
-    fedIds = cms.vint32(1402),
-    rawData = cms.InputTag("rawDataCollector"),
-    # mask for inputs (pt==0 defines empty muon)
-    maskCapId1 = cms.untracked.vint32(0x000001FF,
-                                      0x00000000,
-                                      0x000001FF,
-                                      0x00000000,
-                                      0x000001FF,
-                                      0x00000000),
-    # mask for outputs (pt==0 defines empty muon)
-    maskCapId2 = cms.untracked.vint32(0x0007FC00,
-                                      0x00000000,
-                                      0x0007FC00,
-                                      0x00000000,
-                                      0x0007FC00,
-                                      0x00000000),
-    # mask for validation event outputs (pt==0 defines empty muon)
-    maskCapId3 = cms.untracked.vint32(0x0007FC00,
-                                      0x00000000,
-                                      0x0007FC00,
-                                      0x00000000,
-                                      0x0007FC00,
-                                      0x00000000),
-    # no masks defined for caption IDs 0 and 4-11
-    maxFEDReadoutSize = cms.untracked.int32(10000),
-    monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts"),
-    verbose = cms.untracked.bool(False),
-)
-
-## Era: Run3_2021; Changed data format for Run-3
-from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tStage2uGMTZeroSupp, maskCapId2 = cms.untracked.vint32(0x00000000,
-                                                                                       0x00000000,
-                                                                                       0x0007FC00,
-                                                                                       0x00000000,
-                                                                                       0x0007FC00,
-                                                                                       0x00000000),
-                                                     # mask for validation event outputs (pt==0 defines empty muon)
-                                                     maskCapId3 = cms.untracked.vint32(0x00000000,
-                                                                                       0x00000000,
-                                                                                       0x0007FC00,
-                                                                                       0x00000000,
-                                                                                       0x0007FC00,
-                                                                                       0x00000000))
-
-# ZS of validation events (to be used after fat event filter)
-l1tStage2uGMTZeroSuppFatEvts = l1tStage2uGMTZeroSupp.clone()
-l1tStage2uGMTZeroSuppFatEvts.monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/FatEvts")
-
 # List of bins to ignore
 ignoreBins = {
     'Bmtf'        : [1],
@@ -193,12 +141,14 @@ l1tStage2uGMTMuonVsuGMTMuonCopy1 = DQMEDAnalyzer(
     muonCollection2Title = cms.untracked.string("uGMT muons copy 1"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 1"),
     verbose = cms.untracked.bool(False),
-    displacedQuantities = cms.untracked.bool(False)
+    displacedQuantities = cms.untracked.bool(False),
+    ignoreBin = cms.untracked.vint32(),
 )
 
-## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
+## Era: Run3_2021; Displaced muons used in uGMT from Run-3
+ # Additionally: Ignore BX range mismatches. This is necessary because we only read out the central BX for the output copies.
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tStage2uGMTMuonVsuGMTMuonCopy1, displacedQuantities = cms.untracked.bool(True))
+stage2L1Trigger_2021.toModify(l1tStage2uGMTMuonVsuGMTMuonCopy1, displacedQuantities = cms.untracked.bool(True), ignoreBin = cms.untracked.vint32(1))
 
 l1tStage2uGMTMuonVsuGMTMuonCopy2 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone(
     muonCollection2 = "gmtStage2Digis:MuonCopy2",
@@ -232,7 +182,8 @@ l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1= DQMEDAnalyzer("L1TStage2MuonShower
     muonShowerCollection1Title = cms.untracked.string("uGMT muon showers"),
     muonShowerCollection2Title = cms.untracked.string("uGMT muon showers copy 1"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT showers and uGMT shower copy 1"),
-    verbose = cms.untracked.bool(False)
+    verbose = cms.untracked.bool(False),
+    ignoreBin = cms.untracked.vint32(1), # Ignore BX range mismatches. This is necessary because we only read out the central BX for the output copies.
 )
 
 l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy2 = l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1.clone(
@@ -268,14 +219,12 @@ l1tStage2uGMTOnlineDQMSeq = cms.Sequence(
     l1tStage2uGMTIntermediateOMTFPos +
     l1tStage2uGMTIntermediateEMTFNeg +
     l1tStage2uGMTIntermediateEMTFPos +
-    l1tStage2uGMTZeroSupp +
     l1tStage2BmtfOutVsuGMTIn +
     l1tStage2OmtfOutVsuGMTIn +
     l1tStage2EmtfOutVsuGMTIn
 )
 
 l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(
-    l1tStage2uGMTZeroSuppFatEvts +
     l1tStage2uGMTMuonVsuGMTMuonCopy1 +
     l1tStage2uGMTMuonVsuGMTMuonCopy2 +
     l1tStage2uGMTMuonVsuGMTMuonCopy3 +
@@ -284,19 +233,26 @@ l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(
 )
 
 
-## Era: Run3_2021; Hadronic showers from EMTF used in uGMT from Run-3
+## Era: Run3_2021; Hadronic showers from EMTF used in uGMT from Run-3. Comparing output copies routinely, but moving the uGMT main DQM behind the fat event filter so the BX comparisons aren't biased.
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
 
-## TODO: To be enabled once we have unpacked EMTF showers
-# _run3_l1tStage2uGMTOnlineDQMSeq = cms.Sequence(l1tStage2uGMTOnlineDQMSeq.copy() + l1tStage2EmtfOutVsuGMTInShowers)
-# stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTOnlineDQMSeq, _run3_l1tStage2uGMTOnlineDQMSeq)
-
-_run3_l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(l1tStage2uGMTValidationEventOnlineDQMSeq.copy() +
+_run3_l1tStage2uGMTOnlineDQMSeq = cms.Sequence(l1tStage2uGMTOnlineDQMSeq.copy() +
+    l1tStage2uGMTMuonVsuGMTMuonCopy1 +
+    l1tStage2uGMTMuonVsuGMTMuonCopy2 +
+    l1tStage2uGMTMuonVsuGMTMuonCopy3 +
+    l1tStage2uGMTMuonVsuGMTMuonCopy4 +
+    l1tStage2uGMTMuonVsuGMTMuonCopy5 +
+    # l1tStage2EmtfOutVsuGMTInShowers +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy1 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy2 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy3 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy4 +
     l1tStage2uGMTMuonShowerVsuGMTMuonShowerCopy5
 )
+_run3_l1tStage2uGMTOnlineDQMSeq.remove(l1tStage2uGMT)
+stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTOnlineDQMSeq, _run3_l1tStage2uGMTOnlineDQMSeq)
+
+# The following needs to go after the fat events filter, because inputs are read out with only the central BX for the standard events, so the BX distributions would otherwise be heavily biased toward the central BX.
+_run3_l1tStage2uGMTValidationEventOnlineDQMSeq = cms.Sequence(l1tStage2uGMT)
 stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTValidationEventOnlineDQMSeq, _run3_l1tStage2uGMTValidationEventOnlineDQMSeq)
 

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -11,6 +11,7 @@ ugmtEmuImdMuDqmDir = ugmtEmuDqmDir+"/intermediate_muons"
 
 # List of bins to ignore
 ignoreBins = [7, 8, 12, 13]
+ignoreBinsRun3 = [1, 7, 8, 12, 13]
 
 # fills histograms with all uGMT emulated muons
 # uGMT input muon histograms from track finders are not filled since they are identical to the data DQM plots
@@ -87,9 +88,10 @@ l1tdeStage2uGMT = DQMEDAnalyzer(
     ignoreBin = cms.untracked.vint32(),
 )
 
-## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
+## Era: Run3_2021; Displaced muons used in uGMT from Run-3
+ # Additionally: Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tdeStage2uGMT, displacedQuantities = cms.untracked.bool(True))
+stage2L1Trigger_2021.toModify(l1tdeStage2uGMT, displacedQuantities = cms.untracked.bool(True), ignoreBin = cms.untracked.vint32(1))
 
 # compares the unpacked uGMT muon shower collection to the emulated uGMT muon shower collection
 # only showers that do not match are filled in the histograms
@@ -102,7 +104,7 @@ l1tdeStage2uGMTShowers = DQMEDAnalyzer(
     muonShowerCollection2Title = cms.untracked.string("uGMT emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT showers and uGMT emulator showers"),
     verbose = cms.untracked.bool(False),
-    ignoreBin = cms.untracked.vint32(),
+    ignoreBin = cms.untracked.vint32(1), # Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
 )
 
 # compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection
@@ -114,13 +116,16 @@ l1tdeStage2uGMTIntermediateBMTF = l1tdeStage2uGMT.clone(
     summaryTitle = "Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated",
     ignoreBin = ignoreBins
 )
+## Era: Run3_2021; Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tdeStage2uGMTIntermediateBMTF, ignoreBin = ignoreBinsRun3)
+
 l1tdeStage2uGMTIntermediateOMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone(
     displacedQuantities = False,
     muonCollection1 = (unpackerModule, "imdMuonsOMTFNeg"),
     muonCollection2 = (emulatorModule, "imdMuonsOMTFNeg"),
     monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison"),
     summaryTitle = ("Summary of uGMT intermediate muon from OMTF- comparison between unpacked and emulated"),
-    ignoreBin = ignoreBins
 )
 l1tdeStage2uGMTIntermediateOMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone(
     displacedQuantities = False,
@@ -128,7 +133,6 @@ l1tdeStage2uGMTIntermediateOMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone(
     muonCollection2 = (emulatorModule, "imdMuonsOMTFPos"),
     monitorDir = (ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison"),
     summaryTitle = "Summary of uGMT intermediate muon from OMTF+ comparison between unpacked and emulated",
-    ignoreBin = ignoreBins
 )
 l1tdeStage2uGMTIntermediateEMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone(
     displacedQuantities = False,
@@ -136,7 +140,6 @@ l1tdeStage2uGMTIntermediateEMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone(
     muonCollection2 = (emulatorModule, "imdMuonsEMTFNeg"),
     monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison"),
     summaryTitle = "Summary of uGMT intermediate muon from EMTF- comparison between unpacked and emulated",
-    ignoreBin = ignoreBins
 )
 l1tdeStage2uGMTIntermediateEMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone(
     displacedQuantities = False,
@@ -144,7 +147,6 @@ l1tdeStage2uGMTIntermediateEMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone(
     muonCollection2 = (emulatorModule, "imdMuonsEMTFPos"),
     monitorDir = (ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison"),
     summaryTitle = "Summary of uGMT intermediate muon from EMTF+ comparison between unpacked and emulated",
-    ignoreBin = ignoreBins
 )
 # sequences
 l1tStage2uGMTEmulatorOnlineDQMSeq = cms.Sequence(

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -10,8 +10,9 @@ ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
 ugmtEmuImdMuDqmDir = ugmtEmuDqmDir+"/intermediate_muons"
 
 # List of bins to ignore
-ignoreBins = [7, 8, 12, 13]
-ignoreBinsRun3 = [1, 7, 8, 12, 13]
+ignoreFinalsBinsRun3 = [1]
+ignoreIntermediatesBins = [7, 8, 12, 13]
+ignoreIntermediatesBinsRun3 = [1, 7, 8, 12, 13]
 
 # fills histograms with all uGMT emulated muons
 # uGMT input muon histograms from track finders are not filled since they are identical to the data DQM plots
@@ -91,7 +92,7 @@ l1tdeStage2uGMT = DQMEDAnalyzer(
 ## Era: Run3_2021; Displaced muons used in uGMT from Run-3
  # Additionally: Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tdeStage2uGMT, displacedQuantities = cms.untracked.bool(True), ignoreBin = cms.untracked.vint32(1))
+stage2L1Trigger_2021.toModify(l1tdeStage2uGMT, displacedQuantities = cms.untracked.bool(True), ignoreBin = ignoreFinalsBinsRun3)
 
 # compares the unpacked uGMT muon shower collection to the emulated uGMT muon shower collection
 # only showers that do not match are filled in the histograms
@@ -104,7 +105,7 @@ l1tdeStage2uGMTShowers = DQMEDAnalyzer(
     muonShowerCollection2Title = cms.untracked.string("uGMT emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT showers and uGMT emulator showers"),
     verbose = cms.untracked.bool(False),
-    ignoreBin = cms.untracked.vint32(1), # Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
+    ignoreBin = cms.untracked.vint32(ignoreFinalsBinsRun3), # Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
 )
 
 # compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection
@@ -114,11 +115,11 @@ l1tdeStage2uGMTIntermediateBMTF = l1tdeStage2uGMT.clone(
     muonCollection2 = (emulatorModule, "imdMuonsBMTF"),
     monitorDir = ugmtEmuImdMuDqmDir+"/BMTF/data_vs_emulator_comparison",
     summaryTitle = "Summary of uGMT intermediate muon from BMTF comparison between unpacked and emulated",
-    ignoreBin = ignoreBins
+    ignoreBin = ignoreIntermediatesBins
 )
 ## Era: Run3_2021; Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tdeStage2uGMTIntermediateBMTF, ignoreBin = ignoreBinsRun3)
+stage2L1Trigger_2021.toModify(l1tdeStage2uGMTIntermediateBMTF, ignoreBin = ignoreIntermediatesBinsRun3)
 
 l1tdeStage2uGMTIntermediateOMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone(
     displacedQuantities = False,

--- a/DQM/L1TMonitor/src/L1TStage2uGMT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMT.cc
@@ -46,9 +46,6 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     // BMTF Input
     ibooker.setCurrentFolder(monitorDir_ + "/BMTFInput");
 
-    ugmtBMTFBX = ibooker.book1D("ugmtBMTFBX", "uGMT BMTF Input BX", 7, -3.5, 3.5);
-    ugmtBMTFBX->setAxisTitle("BX", 1);
-
     ugmtBMTFnMuons = ibooker.book1D("ugmtBMTFnMuons", "uGMT BMTF Input Muon Multiplicity", 37, -0.5, 36.5);
     ugmtBMTFnMuons->setAxisTitle("Muon Multiplicity (BX == 0)", 1);
 
@@ -106,9 +103,6 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
 
     // OMTF Input
     ibooker.setCurrentFolder(monitorDir_ + "/OMTFInput");
-
-    ugmtOMTFBX = ibooker.book1D("ugmtOMTFBX", "uGMT OMTF Input BX", 7, -3.5, 3.5);
-    ugmtOMTFBX->setAxisTitle("BX", 1);
 
     ugmtOMTFnMuons = ibooker.book1D("ugmtOMTFnMuons", "uGMT OMTF Input Muon Multiplicity", 37, -0.5, 36.5);
     ugmtOMTFnMuons->setAxisTitle("Muon Multiplicity (BX == 0)", 1);
@@ -173,9 +167,6 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
 
     // EMTF Input
     ibooker.setCurrentFolder(monitorDir_ + "/EMTFInput");
-
-    ugmtEMTFBX = ibooker.book1D("ugmtEMTFBX", "uGMT EMTF Input BX", 7, -3.5, 3.5);
-    ugmtEMTFBX->setAxisTitle("BX", 1);
 
     ugmtEMTFnMuons = ibooker.book1D("ugmtEMTFnMuons", "uGMT EMTF Input Muon Multiplicity", 37, -0.5, 36.5);
     ugmtEMTFnMuons->setAxisTitle("Muon Multiplicity (BX == 0)", 1);
@@ -269,30 +260,6 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
       ugmtEMTFShowerTypeOccupancyPerSector->setAxisTitle("Shower type", 2);
       ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
       ugmtEMTFShowerTypeOccupancyPerSector->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
-
-      ugmtEMTFShowerTypeOccupancyPerBx =
-          ibooker.book2D("ugmtEMTFShowerTypeOccupancyPerBx", "Shower type occupancy per BX", 7, -3.5, 3.5, 2, 1, 3);
-      ugmtEMTFShowerTypeOccupancyPerBx->setAxisTitle("BX", 1);
-      ugmtEMTFShowerTypeOccupancyPerBx->setAxisTitle("Shower type", 2);
-      ugmtEMTFShowerTypeOccupancyPerBx->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
-      ugmtEMTFShowerTypeOccupancyPerBx->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
-
-      ugmtEMTFShowerSectorOccupancyPerBx = ibooker.book2D(
-          "ugmtEMTFShowerSectorOccupancyPerBx", "Shower BX occupancy per sector", 7, -3.5, 3.5, 12, 1, 13);
-      ugmtEMTFShowerSectorOccupancyPerBx->setAxisTitle("BX", 1);
-      ugmtEMTFShowerSectorOccupancyPerBx->setAxisTitle("Processor", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(12, "+6", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(11, "+5", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(10, "+4", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(9, "+3", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(8, "+2", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(7, "+1", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(6, "-6", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(5, "-5", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(4, "-4", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(3, "-3", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(2, "-2", 2);
-      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(1, "-1", 2);
     }
 
     // inter-TF muon correlations
@@ -349,46 +316,6 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
 
   // Subsystem Monitoring and Muon Output
   ibooker.setCurrentFolder(monitorDir_);
-
-  if (!emul_) {
-    ugmtBMTFBXvsProcessor =
-        ibooker.book2D("ugmtBXvsProcessorBMTF", "uGMT BMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
-    ugmtBMTFBXvsProcessor->setAxisTitle("Wedge", 1);
-    for (int bin = 1; bin <= 12; ++bin) {
-      ugmtBMTFBXvsProcessor->setBinLabel(bin, std::to_string(bin), 1);
-    }
-    ugmtBMTFBXvsProcessor->setAxisTitle("BX", 2);
-
-    ugmtOMTFBXvsProcessor =
-        ibooker.book2D("ugmtBXvsProcessorOMTF", "uGMT OMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
-    ugmtOMTFBXvsProcessor->setAxisTitle("Sector (Detector Side)", 1);
-    for (int bin = 1; bin <= 6; ++bin) {
-      ugmtOMTFBXvsProcessor->setBinLabel(bin, std::to_string(7 - bin) + " (-)", 1);
-      ugmtOMTFBXvsProcessor->setBinLabel(bin + 6, std::to_string(bin) + " (+)", 1);
-    }
-    ugmtOMTFBXvsProcessor->setAxisTitle("BX", 2);
-
-    ugmtEMTFBXvsProcessor =
-        ibooker.book2D("ugmtBXvsProcessorEMTF", "uGMT EMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
-    ugmtEMTFBXvsProcessor->setAxisTitle("Sector (Detector Side)", 1);
-    for (int bin = 1; bin <= 6; ++bin) {
-      ugmtEMTFBXvsProcessor->setBinLabel(bin, std::to_string(7 - bin) + " (-)", 1);
-      ugmtEMTFBXvsProcessor->setBinLabel(bin + 6, std::to_string(bin) + " (+)", 1);
-    }
-    ugmtEMTFBXvsProcessor->setAxisTitle("BX", 2);
-
-    ugmtBXvsLink = ibooker.book2D("ugmtBXvsLink", "uGMT BX vs Input Links", 36, 35.5, 71.5, 5, -2.5, 2.5);
-    ugmtBXvsLink->setAxisTitle("Link", 1);
-    for (int bin = 1; bin <= 6; ++bin) {
-      ugmtBXvsLink->setBinLabel(bin, Form("E+%d", bin), 1);
-      ugmtBXvsLink->setBinLabel(bin + 6, Form("O+%d", bin), 1);
-      ugmtBXvsLink->setBinLabel(bin + 12, Form("B%d", bin), 1);
-      ugmtBXvsLink->setBinLabel(bin + 18, Form("B%d", bin + 6), 1);
-      ugmtBXvsLink->setBinLabel(bin + 24, Form("O-%d", bin), 1);
-      ugmtBXvsLink->setBinLabel(bin + 30, Form("E-%d", bin), 1);
-    }
-    ugmtBXvsLink->setAxisTitle("BX", 2);
-  }
 
   ugmtMuonBX = ibooker.book1D("ugmtMuonBX", "uGMT Muon BX", 7, -3.5, 3.5);
   ugmtMuonBX->setAxisTitle("BX", 1);
@@ -757,7 +684,6 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       for (l1t::RegionalMuonCandBxCollection::const_iterator BMTF = BMTFBxCollection->begin(itBX);
            BMTF != BMTFBxCollection->end(itBX);
            ++BMTF) {
-        ugmtBMTFBX->Fill(itBX);
         ugmtBMTFhwPt->Fill(BMTF->hwPt());
         if (displacedQuantities_) {
           ugmtBMTFhwPtUnconstrained->Fill(BMTF->hwPtUnconstrained());
@@ -774,9 +700,7 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
             l1t::MicroGMTConfiguration::calcGlobalPhi(BMTF->hwPhi(), BMTF->trackFinderType(), BMTF->processor());
         ugmtBMTFglbPhi->Fill(global_hw_phi);
 
-        ugmtBMTFBXvsProcessor->Fill(BMTF->processor(), itBX);
         ugmtBMTFProcvshwPhi->Fill(BMTF->hwPhi(), BMTF->processor());
-        ugmtBXvsLink->Fill(BMTF->link(), itBX);
 
         // Analyse muon correlations
         for (l1t::RegionalMuonCandBxCollection::const_iterator BMTF2 = BMTF + 1; BMTF2 != BMTFBxCollection->end(itBX);
@@ -806,7 +730,6 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       for (l1t::RegionalMuonCandBxCollection::const_iterator OMTF = OMTFBxCollection->begin(itBX);
            OMTF != OMTFBxCollection->end(itBX);
            ++OMTF) {
-        ugmtOMTFBX->Fill(itBX);
         ugmtOMTFhwPt->Fill(OMTF->hwPt());
         ugmtOMTFhwEta->Fill(OMTF->hwEta());
         ugmtOMTFhwSign->Fill(OMTF->hwSign());
@@ -820,18 +743,14 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
         l1t::tftype trackFinderType = OMTF->trackFinderType();
 
         if (trackFinderType == l1t::omtf_neg) {
-          ugmtOMTFBXvsProcessor->Fill(5 - OMTF->processor(), itBX);
           ugmtOMTFhwPhiNeg->Fill(OMTF->hwPhi());
           ugmtOMTFglbPhiNeg->Fill(global_hw_phi);
           ugmtOMTFProcvshwPhiNeg->Fill(OMTF->hwPhi(), OMTF->processor());
         } else {
-          ugmtOMTFBXvsProcessor->Fill(OMTF->processor() + 6, itBX);
           ugmtOMTFhwPhiPos->Fill(OMTF->hwPhi());
           ugmtOMTFglbPhiPos->Fill(global_hw_phi);
           ugmtOMTFProcvshwPhiPos->Fill(OMTF->hwPhi(), OMTF->processor());
         }
-
-        ugmtBXvsLink->Fill(OMTF->link(), itBX);
 
         // Analyse muon correlations
         for (l1t::RegionalMuonCandBxCollection::const_iterator OMTF2 = OMTF + 1; OMTF2 != OMTFBxCollection->end(itBX);
@@ -861,7 +780,6 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       for (l1t::RegionalMuonCandBxCollection::const_iterator EMTF = EMTFBxCollection->begin(itBX);
            EMTF != EMTFBxCollection->end(itBX);
            ++EMTF) {
-        ugmtEMTFBX->Fill(itBX);
         ugmtEMTFhwPt->Fill(EMTF->hwPt());
         if (displacedQuantities_) {
           ugmtEMTFhwPtUnconstrained->Fill(EMTF->hwPtUnconstrained());
@@ -879,18 +797,14 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
         l1t::tftype trackFinderType = EMTF->trackFinderType();
 
         if (trackFinderType == l1t::emtf_neg) {
-          ugmtEMTFBXvsProcessor->Fill(5 - EMTF->processor(), itBX);
           ugmtEMTFhwPhiNeg->Fill(EMTF->hwPhi());
           ugmtEMTFglbPhiNeg->Fill(global_hw_phi);
           ugmtEMTFProcvshwPhiNeg->Fill(EMTF->hwPhi(), EMTF->processor());
         } else {
-          ugmtEMTFBXvsProcessor->Fill(EMTF->processor() + 6, itBX);
           ugmtEMTFhwPhiPos->Fill(EMTF->hwPhi());
           ugmtEMTFglbPhiPos->Fill(global_hw_phi);
           ugmtEMTFProcvshwPhiPos->Fill(EMTF->hwPhi(), EMTF->processor());
         }
-
-        ugmtBXvsLink->Fill(EMTF->link(), itBX);
 
         // Analyse muon correlations
         for (l1t::RegionalMuonCandBxCollection::const_iterator EMTF2 = EMTF + 1; EMTF2 != EMTFBxCollection->end(itBX);
@@ -924,20 +838,14 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
             continue;
           }
           if (shower->isOneNominalInTime()) {
-            ugmtEMTFShowerSectorOccupancyPerBx->Fill(
-                itBX, shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
             ugmtEMTFShowerTypeOccupancyPerSector->Fill(
                 shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0),
                 IDX_NOMINAL_SHOWER);
-            ugmtEMTFShowerTypeOccupancyPerBx->Fill(itBX, IDX_NOMINAL_SHOWER);
           }
           if (shower->isOneTightInTime()) {
-            ugmtEMTFShowerSectorOccupancyPerBx->Fill(
-                itBX, shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
             ugmtEMTFShowerTypeOccupancyPerSector->Fill(
                 shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0),
                 IDX_TIGHT_SHOWER);
-            ugmtEMTFShowerTypeOccupancyPerBx->Fill(itBX, IDX_TIGHT_SHOWER);
           }
         }
       }
@@ -1158,7 +1066,6 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       }
     }
   }
-
   // Fill shower plots
   if (hadronicShowers_) {
     edm::Handle<l1t::MuonShowerBxCollection> showersBxCollection;

--- a/DQM/L1TMonitor/src/L1TStage2uGMT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMT.cc
@@ -317,88 +317,88 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   // Subsystem Monitoring and Muon Output
   ibooker.setCurrentFolder(monitorDir_);
 
-  ugmtMuonBX = ibooker.book1D("ugmtMuonBX", "uGMT Muon BX", 7, -3.5, 3.5);
+  ugmtMuonBX = ibooker.book1D("ugmtMuonBX", "uGMT output muon BX", 7, -3.5, 3.5);
   ugmtMuonBX->setAxisTitle("BX", 1);
 
-  ugmtnMuons = ibooker.book1D("ugmtnMuons", "uGMT Muon Multiplicity", 9, -0.5, 8.5);
+  ugmtnMuons = ibooker.book1D("ugmtnMuons", "uGMT output muon Multiplicity", 9, -0.5, 8.5);
   ugmtnMuons->setAxisTitle("Muon Multiplicity (BX == 0)", 1);
 
   ugmtMuonIndex = ibooker.book1D("ugmtMuonIndex", "uGMT Input Muon Index", 108, -0.5, 107.5);
   ugmtMuonIndex->setAxisTitle("Index", 1);
 
-  ugmtMuonhwPt = ibooker.book1D("ugmtMuonhwPt", "uGMT Muon HW p_{T}", 512, -0.5, 511.5);
+  ugmtMuonhwPt = ibooker.book1D("ugmtMuonhwPt", "uGMT output muon HW p_{T}", 512, -0.5, 511.5);
   ugmtMuonhwPt->setAxisTitle("Hardware p_{T}", 1);
 
   if (displacedQuantities_) {
     ugmtMuonhwPtUnconstrained =
-        ibooker.book1D("ugmtMuonhwPtUnconstrained", "uGMT Muon HW p_{T} unconstrained", 256, -0.5, 255.5);
+        ibooker.book1D("ugmtMuonhwPtUnconstrained", "uGMT output muon HW p_{T} unconstrained", 256, -0.5, 255.5);
     ugmtMuonhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
 
-    ugmtMuonhwDXY = ibooker.book1D("ugmtMuonhwDXY", "uGMT Muon HW impact parameter", 4, -0.5, 3.5);
+    ugmtMuonhwDXY = ibooker.book1D("ugmtMuonhwDXY", "uGMT output muon HW impact parameter", 4, -0.5, 3.5);
     ugmtMuonhwDXY->setAxisTitle("Hardware dXY", 1);
   }
 
-  ugmtMuonhwEta = ibooker.book1D("ugmtMuonhwEta", "uGMT Muon HW #eta", 461, -230.5, 230.5);
+  ugmtMuonhwEta = ibooker.book1D("ugmtMuonhwEta", "uGMT output muon HW #eta", 461, -230.5, 230.5);
   ugmtMuonhwEta->setAxisTitle("Hardware Eta", 1);
 
-  ugmtMuonhwPhi = ibooker.book1D("ugmtMuonhwPhi", "uGMT Muon HW #phi", 577, -1.5, 575.5);
+  ugmtMuonhwPhi = ibooker.book1D("ugmtMuonhwPhi", "uGMT output muon HW #phi", 577, -1.5, 575.5);
   ugmtMuonhwPhi->setAxisTitle("Hardware Phi", 1);
 
-  ugmtMuonhwEtaAtVtx = ibooker.book1D("ugmtMuonhwEtaAtVtx", "uGMT Muon HW #eta at vertex", 461, -230.5, 230.5);
+  ugmtMuonhwEtaAtVtx = ibooker.book1D("ugmtMuonhwEtaAtVtx", "uGMT output muon HW #eta at vertex", 461, -230.5, 230.5);
   ugmtMuonhwEtaAtVtx->setAxisTitle("Hardware Eta at Vertex", 1);
 
-  ugmtMuonhwPhiAtVtx = ibooker.book1D("ugmtMuonhwPhiAtVtx", "uGMT Muon HW #phi at vertex", 577, -1.5, 575.5);
+  ugmtMuonhwPhiAtVtx = ibooker.book1D("ugmtMuonhwPhiAtVtx", "uGMT output muon HW #phi at vertex", 577, -1.5, 575.5);
   ugmtMuonhwPhiAtVtx->setAxisTitle("Hardware Phi at Vertex", 1);
 
-  ugmtMuonhwCharge = ibooker.book1D("ugmtMuonhwCharge", "uGMT Muon HW Charge", 4, -1.5, 2.5);
+  ugmtMuonhwCharge = ibooker.book1D("ugmtMuonhwCharge", "uGMT output muon HW Charge", 4, -1.5, 2.5);
   ugmtMuonhwCharge->setAxisTitle("Hardware Charge", 1);
 
-  ugmtMuonhwChargeValid = ibooker.book1D("ugmtMuonhwChargeValid", "uGMT Muon ChargeValid", 2, -0.5, 1.5);
+  ugmtMuonhwChargeValid = ibooker.book1D("ugmtMuonhwChargeValid", "uGMT output muon ChargeValid", 2, -0.5, 1.5);
   ugmtMuonhwChargeValid->setAxisTitle("ChargeValid", 1);
 
-  ugmtMuonhwQual = ibooker.book1D("ugmtMuonhwQual", "uGMT Muon Quality", 16, -0.5, 15.5);
+  ugmtMuonhwQual = ibooker.book1D("ugmtMuonhwQual", "uGMT output muon Quality", 16, -0.5, 15.5);
   ugmtMuonhwQual->setAxisTitle("Quality", 1);
 
-  ugmtMuonhwIso = ibooker.book1D("ugmtMuonhwIso", "uGMT Muon Isolation", 4, -0.5, 3.5);
+  ugmtMuonhwIso = ibooker.book1D("ugmtMuonhwIso", "uGMT output muon Isolation", 4, -0.5, 3.5);
   ugmtMuonhwIso->setAxisTitle("Isolation", 1);
 
-  ugmtMuonPt = ibooker.book1D("ugmtMuonPt", "uGMT Muon p_{T}", 128, -0.5, 255.5);
+  ugmtMuonPt = ibooker.book1D("ugmtMuonPt", "uGMT output muon p_{T}", 128, -0.5, 255.5);
   ugmtMuonPt->setAxisTitle("p_{T} [GeV]", 1);
 
   if (displacedQuantities_) {
     ugmtMuonPtUnconstrained =
-        ibooker.book1D("ugmtMuonPtUnconstrained", "uGMT Muon p_{T} unconstrained", 128, -0.5, 255.5);
+        ibooker.book1D("ugmtMuonPtUnconstrained", "uGMT output muon p_{T} unconstrained", 128, -0.5, 255.5);
     ugmtMuonPtUnconstrained->setAxisTitle("p_{T} unconstrained [GeV]", 1);
   }
 
-  ugmtMuonEta = ibooker.book1D("ugmtMuonEta", "uGMT Muon #eta", 52, -2.6, 2.6);
+  ugmtMuonEta = ibooker.book1D("ugmtMuonEta", "uGMT output muon #eta", 52, -2.6, 2.6);
   ugmtMuonEta->setAxisTitle("#eta", 1);
 
-  ugmtMuonPhi = ibooker.book1D("ugmtMuonPhi", "uGMT Muon #phi", 66, -3.3, 3.3);
+  ugmtMuonPhi = ibooker.book1D("ugmtMuonPhi", "uGMT output muon #phi", 66, -3.3, 3.3);
   ugmtMuonPhi->setAxisTitle("#phi", 1);
 
-  ugmtMuonEtaAtVtx = ibooker.book1D("ugmtMuonEtaAtVtx", "uGMT Muon #eta at vertex", 52, -2.6, 2.6);
+  ugmtMuonEtaAtVtx = ibooker.book1D("ugmtMuonEtaAtVtx", "uGMT output muon #eta at vertex", 52, -2.6, 2.6);
   ugmtMuonEtaAtVtx->setAxisTitle("#eta at vertex", 1);
 
-  ugmtMuonPhiAtVtx = ibooker.book1D("ugmtMuonPhiAtVtx", "uGMT Muon #phi at vertex", 66, -3.3, 3.3);
+  ugmtMuonPhiAtVtx = ibooker.book1D("ugmtMuonPhiAtVtx", "uGMT output muon #phi at vertex", 66, -3.3, 3.3);
   ugmtMuonPhiAtVtx->setAxisTitle("#phi at vertex", 1);
 
-  ugmtMuonCharge = ibooker.book1D("ugmtMuonCharge", "uGMT Muon Charge", 3, -1.5, 1.5);
+  ugmtMuonCharge = ibooker.book1D("ugmtMuonCharge", "uGMT output muon Charge", 3, -1.5, 1.5);
   ugmtMuonCharge->setAxisTitle("Charge", 1);
 
-  ugmtMuonPhiBmtf = ibooker.book1D("ugmtMuonPhiBmtf", "uGMT Muon #phi for BMTF Inputs", 66, -3.3, 3.3);
+  ugmtMuonPhiBmtf = ibooker.book1D("ugmtMuonPhiBmtf", "uGMT output muon #phi for BMTF Inputs", 66, -3.3, 3.3);
   ugmtMuonPhiBmtf->setAxisTitle("#phi", 1);
 
-  ugmtMuonPhiOmtf = ibooker.book1D("ugmtMuonPhiOmtf", "uGMT Muon #phi for OMTF Inputs", 66, -3.3, 3.3);
+  ugmtMuonPhiOmtf = ibooker.book1D("ugmtMuonPhiOmtf", "uGMT output muon #phi for OMTF Inputs", 66, -3.3, 3.3);
   ugmtMuonPhiOmtf->setAxisTitle("#phi", 1);
 
-  ugmtMuonPhiEmtf = ibooker.book1D("ugmtMuonPhiEmtf", "uGMT Muon #phi for EMTF Inputs", 66, -3.3, 3.3);
+  ugmtMuonPhiEmtf = ibooker.book1D("ugmtMuonPhiEmtf", "uGMT output muon #phi for EMTF Inputs", 66, -3.3, 3.3);
   ugmtMuonPhiEmtf->setAxisTitle("#phi", 1);
 
   const float dPhiScale = 4 * phiScale_;
   const float dEtaScale = etaScale_;
   ugmtMuonDEtavsPtBmtf = ibooker.book2D("ugmtMuonDEtavsPtBmtf",
-                                        "uGMT Muon from BMTF #eta_{at vertex} - #eta_{at muon system} vs p_{T}",
+                                        "uGMT output muon from BMTF #eta_{at vertex} - #eta_{at muon system} vs p_{T}",
                                         32,
                                         0,
                                         64,
@@ -409,7 +409,7 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonDEtavsPtBmtf->setAxisTitle("#eta_{at vertex} - #eta", 2);
 
   ugmtMuonDPhivsPtBmtf = ibooker.book2D("ugmtMuonDPhivsPtBmtf",
-                                        "uGMT Muon from BMTF #phi_{at vertex} - #phi_{at muon system} vs p_{T}",
+                                        "uGMT output muon from BMTF #phi_{at vertex} - #phi_{at muon system} vs p_{T}",
                                         32,
                                         0,
                                         64,
@@ -420,7 +420,7 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonDPhivsPtBmtf->setAxisTitle("#phi_{at vertex} - #phi", 2);
 
   ugmtMuonDEtavsPtOmtf = ibooker.book2D("ugmtMuonDEtavsPtOmtf",
-                                        "uGMT Muon from OMTF #eta_{at vertex} - #eta_{at muon system} vs p_{T}",
+                                        "uGMT output muon from OMTF #eta_{at vertex} - #eta_{at muon system} vs p_{T}",
                                         32,
                                         0,
                                         64,
@@ -431,7 +431,7 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonDEtavsPtOmtf->setAxisTitle("#eta_{at vertex} - #eta", 2);
 
   ugmtMuonDPhivsPtOmtf = ibooker.book2D("ugmtMuonDPhivsPtOmtf",
-                                        "uGMT Muon from OMTF #phi_{at vertex} - #phi_{at muon system} vs p_{T}",
+                                        "uGMT output muon from OMTF #phi_{at vertex} - #phi_{at muon system} vs p_{T}",
                                         32,
                                         0,
                                         64,
@@ -442,7 +442,7 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonDPhivsPtOmtf->setAxisTitle("#phi_{at vertex} - #phi", 2);
 
   ugmtMuonDEtavsPtEmtf = ibooker.book2D("ugmtMuonDEtavsPtEmtf",
-                                        "uGMT Muon from EMTF #eta_{at vertex} - #eta_{at muon system} vs p_{T}",
+                                        "uGMT output muon from EMTF #eta_{at vertex} - #eta_{at muon system} vs p_{T}",
                                         32,
                                         0,
                                         64,
@@ -453,7 +453,7 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonDEtavsPtEmtf->setAxisTitle("#eta_{at vertex} - #eta", 2);
 
   ugmtMuonDPhivsPtEmtf = ibooker.book2D("ugmtMuonDPhivsPtEmtf",
-                                        "uGMT Muon from EMTF #phi_{at vertex} - #phi_{at muon system} vs p_{T}",
+                                        "uGMT output muon from EMTF #phi_{at vertex} - #phi_{at muon system} vs p_{T}",
                                         32,
                                         0,
                                         64,
@@ -463,24 +463,27 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonDPhivsPtEmtf->setAxisTitle("p_{T} [GeV]", 1);
   ugmtMuonDPhivsPtEmtf->setAxisTitle("#phi_{at vertex} - #phi", 2);
 
-  ugmtMuonPtvsEta = ibooker.book2D("ugmtMuonPtvsEta", "uGMT Muon p_{T} vs #eta", 100, -2.5, 2.5, 128, -0.5, 255.5);
+  ugmtMuonPtvsEta =
+      ibooker.book2D("ugmtMuonPtvsEta", "uGMT output muon p_{T} vs #eta", 100, -2.5, 2.5, 128, -0.5, 255.5);
   ugmtMuonPtvsEta->setAxisTitle("#eta", 1);
   ugmtMuonPtvsEta->setAxisTitle("p_{T} [GeV]", 2);
 
-  ugmtMuonPtvsPhi = ibooker.book2D("ugmtMuonPtvsPhi", "uGMT Muon p_{T} vs #phi", 64, -3.2, 3.2, 128, -0.5, 255.5);
+  ugmtMuonPtvsPhi =
+      ibooker.book2D("ugmtMuonPtvsPhi", "uGMT output muon p_{T} vs #phi", 64, -3.2, 3.2, 128, -0.5, 255.5);
   ugmtMuonPtvsPhi->setAxisTitle("#phi", 1);
   ugmtMuonPtvsPhi->setAxisTitle("p_{T} [GeV]", 2);
 
-  ugmtMuonPhivsEta = ibooker.book2D("ugmtMuonPhivsEta", "uGMT Muon #phi vs #eta", 100, -2.5, 2.5, 64, -3.2, 3.2);
+  ugmtMuonPhivsEta = ibooker.book2D("ugmtMuonPhivsEta", "uGMT output muon #phi vs #eta", 100, -2.5, 2.5, 64, -3.2, 3.2);
   ugmtMuonPhivsEta->setAxisTitle("#eta", 1);
   ugmtMuonPhivsEta->setAxisTitle("#phi", 2);
 
   ugmtMuonPhiAtVtxvsEtaAtVtx = ibooker.book2D(
-      "ugmtMuonPhiAtVtxvsEtaAtVtx", "uGMT Muon #phi at vertex vs #eta at vertex", 100, -2.5, 2.5, 64, -3.2, 3.2);
+      "ugmtMuonPhiAtVtxvsEtaAtVtx", "uGMT output muon #phi at vertex vs #eta at vertex", 100, -2.5, 2.5, 64, -3.2, 3.2);
   ugmtMuonPhiAtVtxvsEtaAtVtx->setAxisTitle("#eta at vertex", 1);
   ugmtMuonPhiAtVtxvsEtaAtVtx->setAxisTitle("#phi at vertex", 2);
 
-  ugmtMuonBXvsLink = ibooker.book2D("ugmtMuonBXvsLink", "uGMT Muon BX vs Input Links", 36, 35.5, 71.5, 5, -2.5, 2.5);
+  ugmtMuonBXvsLink =
+      ibooker.book2D("ugmtMuonBXvsLink", "uGMT output muon BX vs Input Links", 36, 35.5, 71.5, 5, -2.5, 2.5);
   ugmtMuonBXvsLink->setAxisTitle("Muon Input Links", 1);
   for (int bin = 1; bin <= 6; ++bin) {
     ugmtMuonBXvsLink->setBinLabel(bin, Form("E+%d", bin), 1);
@@ -493,7 +496,7 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonBXvsLink->setAxisTitle("BX", 2);
 
   ugmtMuonChargevsLink =
-      ibooker.book2D("ugmtMuonChargevsLink", "uGMT Muon Charge vs Input Links", 36, 35.5, 71.5, 3, -1.5, 1.5);
+      ibooker.book2D("ugmtMuonChargevsLink", "uGMT output muon Charge vs Input Links", 36, 35.5, 71.5, 3, -1.5, 1.5);
   ugmtMuonChargevsLink->setAxisTitle("Muon Input Links", 1);
   for (int bin = 1; bin <= 6; ++bin) {
     ugmtMuonChargevsLink->setBinLabel(bin, Form("E+%d", bin), 1);
@@ -514,33 +517,38 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     ugmtMuonShowerTypeOccupancyPerBx->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
   }
 
-  ugmtMuonBXvshwPt = ibooker.book2D("ugmtMuonBXvshwPt", "uGMT Muon BX vs HW p_{T}", 128, -0.5, 511.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwPt =
+      ibooker.book2D("ugmtMuonBXvshwPt", "uGMT output muon BX vs HW p_{T}", 128, -0.5, 511.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwPt->setAxisTitle("Hardware p_{T}", 1);
   ugmtMuonBXvshwPt->setAxisTitle("BX", 2);
 
-  ugmtMuonBXvshwEta = ibooker.book2D("ugmtMuonBXvshwEta", "uGMT Muon BX vs HW #eta", 93, -232.5, 232.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwEta =
+      ibooker.book2D("ugmtMuonBXvshwEta", "uGMT output muon BX vs HW #eta", 93, -232.5, 232.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwEta->setAxisTitle("Hardware #eta", 1);
   ugmtMuonBXvshwEta->setAxisTitle("BX", 2);
 
-  ugmtMuonBXvshwPhi = ibooker.book2D("ugmtMuonBXvshwPhi", "uGMT Muon BX vs HW #phi", 116, -2.5, 577.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwPhi =
+      ibooker.book2D("ugmtMuonBXvshwPhi", "uGMT output muon BX vs HW #phi", 116, -2.5, 577.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwPhi->setAxisTitle("Hardware #phi", 1);
   ugmtMuonBXvshwPhi->setAxisTitle("BX", 2);
 
   ugmtMuonBXvshwCharge =
-      ibooker.book2D("ugmtMuonBXvshwCharge", "uGMT Muon BX vs HW Charge", 2, -0.5, 1.5, 5, -2.5, 2.5);
+      ibooker.book2D("ugmtMuonBXvshwCharge", "uGMT output muon BX vs HW Charge", 2, -0.5, 1.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwCharge->setAxisTitle("Hardware Charge", 1);
   ugmtMuonBXvshwCharge->setAxisTitle("BX", 2);
 
   ugmtMuonBXvshwChargeValid =
-      ibooker.book2D("ugmtMuonBXvshwChargeValid", "uGMT Muon BX vs ChargeValid", 2, -0.5, 1.5, 5, -2.5, 2.5);
+      ibooker.book2D("ugmtMuonBXvshwChargeValid", "uGMT output muon BX vs ChargeValid", 2, -0.5, 1.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwChargeValid->setAxisTitle("ChargeValid", 1);
   ugmtMuonBXvshwChargeValid->setAxisTitle("BX", 2);
 
-  ugmtMuonBXvshwQual = ibooker.book2D("ugmtMuonBXvshwQual", "uGMT Muon BX vs Quality", 16, -0.5, 15.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwQual =
+      ibooker.book2D("ugmtMuonBXvshwQual", "uGMT output muon BX vs Quality", 16, -0.5, 15.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwQual->setAxisTitle("Quality", 1);
   ugmtMuonBXvshwQual->setAxisTitle("BX", 2);
 
-  ugmtMuonBXvshwIso = ibooker.book2D("ugmtMuonBXvshwIso", "uGMT Muon BX vs Isolation", 4, -0.5, 3.5, 5, -2.5, 2.5);
+  ugmtMuonBXvshwIso =
+      ibooker.book2D("ugmtMuonBXvshwIso", "uGMT output muon BX vs Isolation", 4, -0.5, 3.5, 5, -2.5, 2.5);
   ugmtMuonBXvshwIso->setAxisTitle("Isolation", 1);
   ugmtMuonBXvshwIso->setAxisTitle("BX", 2);
 
@@ -554,119 +562,123 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
       ibooker.book1D("ugmtMuMuInvMassAtVtx", "uGMT dimuon invariant mass with coordinates at vertex", 200, 0., 200.);
   ugmtMuMuInvMassAtVtx->setAxisTitle("m(#mu#mu) [GeV]", 1);
 
-  ugmtMuMuDEta = ibooker.book1D("ugmtMuMuDEta", "uGMT Muons #Delta#eta", 100, -1., 1.);
+  ugmtMuMuDEta = ibooker.book1D("ugmtMuMuDEta", "uGMT output muons #Delta#eta", 100, -1., 1.);
   ugmtMuMuDEta->setAxisTitle("#Delta#eta", 1);
 
-  ugmtMuMuDPhi = ibooker.book1D("ugmtMuMuDPhi", "uGMT Muons #Delta#phi", 100, -1., 1.);
+  ugmtMuMuDPhi = ibooker.book1D("ugmtMuMuDPhi", "uGMT output muons #Delta#phi", 100, -1., 1.);
   ugmtMuMuDPhi->setAxisTitle("#Delta#phi", 1);
 
-  ugmtMuMuDR = ibooker.book1D("ugmtMuMuDR", "uGMT Muons #DeltaR", 50, 0., 1.);
+  ugmtMuMuDR = ibooker.book1D("ugmtMuMuDR", "uGMT output muons #DeltaR", 50, 0., 1.);
   ugmtMuMuDR->setAxisTitle("#DeltaR", 1);
 
   // barrel - overlap
   ugmtMuMuDEtaBOpos =
-      ibooker.book1D("ugmtMuMuDEtaBOpos", "uGMT Muons #Delta#eta barrel-overlap positive side", 100, -1., 1.);
+      ibooker.book1D("ugmtMuMuDEtaBOpos", "uGMT output muons #Delta#eta barrel-overlap positive side", 100, -1., 1.);
   ugmtMuMuDEtaBOpos->setAxisTitle("#Delta#eta", 1);
 
   ugmtMuMuDPhiBOpos =
-      ibooker.book1D("ugmtMuMuDPhiBOpos", "uGMT Muons #Delta#phi barrel-overlap positive side", 100, -1., 1.);
+      ibooker.book1D("ugmtMuMuDPhiBOpos", "uGMT output muons #Delta#phi barrel-overlap positive side", 100, -1., 1.);
   ugmtMuMuDPhiBOpos->setAxisTitle("#Delta#phi", 1);
 
-  ugmtMuMuDRBOpos = ibooker.book1D("ugmtMuMuDRBOpos", "uGMT Muons #DeltaR barrel-overlap positive side", 50, 0., 1.);
+  ugmtMuMuDRBOpos =
+      ibooker.book1D("ugmtMuMuDRBOpos", "uGMT output muons #DeltaR barrel-overlap positive side", 50, 0., 1.);
   ugmtMuMuDRBOpos->setAxisTitle("#DeltaR", 1);
 
   ugmtMuMuDEtaBOneg =
-      ibooker.book1D("ugmtMuMuDEtaBOneg", "uGMT Muons #Delta#eta barrel-overlap negative side", 100, -1., 1.);
+      ibooker.book1D("ugmtMuMuDEtaBOneg", "uGMT output muons #Delta#eta barrel-overlap negative side", 100, -1., 1.);
   ugmtMuMuDEtaBOneg->setAxisTitle("#Delta#eta", 1);
 
   ugmtMuMuDPhiBOneg =
-      ibooker.book1D("ugmtMuMuDPhiBOneg", "uGMT Muons #Delta#phi barrel-overlap negative side", 100, -1., 1.);
+      ibooker.book1D("ugmtMuMuDPhiBOneg", "uGMT output muons #Delta#phi barrel-overlap negative side", 100, -1., 1.);
   ugmtMuMuDPhiBOneg->setAxisTitle("#Delta#phi", 1);
 
-  ugmtMuMuDRBOneg = ibooker.book1D("ugmtMuMuDRBOneg", "uGMT Muons #DeltaR barrel-overlap negative side", 50, 0., 1.);
+  ugmtMuMuDRBOneg =
+      ibooker.book1D("ugmtMuMuDRBOneg", "uGMT output muons #DeltaR barrel-overlap negative side", 50, 0., 1.);
   ugmtMuMuDRBOneg->setAxisTitle("#DeltaR", 1);
 
   // endcap - overlap
   ugmtMuMuDEtaEOpos =
-      ibooker.book1D("ugmtMuMuDEtaEOpos", "uGMT Muons #Delta#eta endcap-overlap positive side", 100, -1., 1.);
+      ibooker.book1D("ugmtMuMuDEtaEOpos", "uGMT output muons #Delta#eta endcap-overlap positive side", 100, -1., 1.);
   ugmtMuMuDEtaEOpos->setAxisTitle("#Delta#eta", 1);
 
   ugmtMuMuDPhiEOpos =
-      ibooker.book1D("ugmtMuMuDPhiEOpos", "uGMT Muons #Delta#phi endcap-overlap positive side", 100, -1., 1.);
+      ibooker.book1D("ugmtMuMuDPhiEOpos", "uGMT output muons #Delta#phi endcap-overlap positive side", 100, -1., 1.);
   ugmtMuMuDPhiEOpos->setAxisTitle("#Delta#phi", 1);
 
-  ugmtMuMuDREOpos = ibooker.book1D("ugmtMuMuDREOpos", "uGMT Muons #DeltaR endcap-overlap positive side", 50, 0., 1.);
+  ugmtMuMuDREOpos =
+      ibooker.book1D("ugmtMuMuDREOpos", "uGMT output muons #DeltaR endcap-overlap positive side", 50, 0., 1.);
   ugmtMuMuDREOpos->setAxisTitle("#DeltaR", 1);
 
   ugmtMuMuDEtaEOneg =
-      ibooker.book1D("ugmtMuMuDEtaEOneg", "uGMT Muons #Delta#eta endcap-overlap negative side", 100, -1., 1.);
+      ibooker.book1D("ugmtMuMuDEtaEOneg", "uGMT output muons #Delta#eta endcap-overlap negative side", 100, -1., 1.);
   ugmtMuMuDEtaEOneg->setAxisTitle("#Delta#eta", 1);
 
   ugmtMuMuDPhiEOneg =
-      ibooker.book1D("ugmtMuMuDPhiEOneg", "uGMT Muons #Delta#phi endcap-overlap negative side", 100, -1., 1.);
+      ibooker.book1D("ugmtMuMuDPhiEOneg", "uGMT output muons #Delta#phi endcap-overlap negative side", 100, -1., 1.);
   ugmtMuMuDPhiEOneg->setAxisTitle("#Delta#phi", 1);
 
-  ugmtMuMuDREOneg = ibooker.book1D("ugmtMuMuDREOneg", "uGMT Muons #DeltaR endcap-overlap negative side", 50, 0., 1.);
+  ugmtMuMuDREOneg =
+      ibooker.book1D("ugmtMuMuDREOneg", "uGMT output muons #DeltaR endcap-overlap negative side", 50, 0., 1.);
   ugmtMuMuDREOneg->setAxisTitle("#DeltaR", 1);
 
   // barrel wedges
-  ugmtMuMuDEtaB = ibooker.book1D("ugmtMuMuDEtaB", "uGMT Muons #Delta#eta between barrel wedges", 100, -1., 1.);
+  ugmtMuMuDEtaB = ibooker.book1D("ugmtMuMuDEtaB", "uGMT output muons #Delta#eta between barrel wedges", 100, -1., 1.);
   ugmtMuMuDEtaB->setAxisTitle("#Delta#eta", 1);
 
-  ugmtMuMuDPhiB = ibooker.book1D("ugmtMuMuDPhiB", "uGMT Muons #Delta#phi between barrel wedges", 100, -1., 1.);
+  ugmtMuMuDPhiB = ibooker.book1D("ugmtMuMuDPhiB", "uGMT output muons #Delta#phi between barrel wedges", 100, -1., 1.);
   ugmtMuMuDPhiB->setAxisTitle("#Delta#phi", 1);
 
-  ugmtMuMuDRB = ibooker.book1D("ugmtMuMuDRB", "uGMT Muons #DeltaR between barrel wedges", 50, 0., 1.);
+  ugmtMuMuDRB = ibooker.book1D("ugmtMuMuDRB", "uGMT output muons #DeltaR between barrel wedges", 50, 0., 1.);
   ugmtMuMuDRB->setAxisTitle("#DeltaR", 1);
 
   // overlap sectors
-  ugmtMuMuDEtaOpos =
-      ibooker.book1D("ugmtMuMuDEtaOpos", "uGMT Muons #Delta#eta between overlap positive side sectors", 100, -1., 1.);
+  ugmtMuMuDEtaOpos = ibooker.book1D(
+      "ugmtMuMuDEtaOpos", "uGMT output muons #Delta#eta between overlap positive side sectors", 100, -1., 1.);
   ugmtMuMuDEtaOpos->setAxisTitle("#Delta#eta", 1);
 
-  ugmtMuMuDPhiOpos =
-      ibooker.book1D("ugmtMuMuDPhiOpos", "uGMT Muons #Delta#phi between overlap positive side sectors", 100, -1., 1.);
+  ugmtMuMuDPhiOpos = ibooker.book1D(
+      "ugmtMuMuDPhiOpos", "uGMT output muons #Delta#phi between overlap positive side sectors", 100, -1., 1.);
   ugmtMuMuDPhiOpos->setAxisTitle("#Delta#phi", 1);
 
   ugmtMuMuDROpos =
-      ibooker.book1D("ugmtMuMuDROpos", "uGMT Muons #DeltaR between overlap positive side sectors", 50, 0., 1.);
+      ibooker.book1D("ugmtMuMuDROpos", "uGMT output muons #DeltaR between overlap positive side sectors", 50, 0., 1.);
   ugmtMuMuDROpos->setAxisTitle("#DeltaR", 1);
 
-  ugmtMuMuDEtaOneg =
-      ibooker.book1D("ugmtMuMuDEtaOneg", "uGMT Muons #Delta#eta between overlap negative side sectors", 100, -1., 1.);
+  ugmtMuMuDEtaOneg = ibooker.book1D(
+      "ugmtMuMuDEtaOneg", "uGMT output muons #Delta#eta between overlap negative side sectors", 100, -1., 1.);
   ugmtMuMuDEtaOneg->setAxisTitle("#Delta#eta", 1);
 
-  ugmtMuMuDPhiOneg =
-      ibooker.book1D("ugmtMuMuDPhiOneg", "uGMT Muons #Delta#phi between overlap negative side sectors", 100, -1., 1.);
+  ugmtMuMuDPhiOneg = ibooker.book1D(
+      "ugmtMuMuDPhiOneg", "uGMT output muons #Delta#phi between overlap negative side sectors", 100, -1., 1.);
   ugmtMuMuDPhiOneg->setAxisTitle("#Delta#phi", 1);
 
   ugmtMuMuDROneg =
-      ibooker.book1D("ugmtMuMuDROneg", "uGMT Muons #DeltaR between overlap negative side sectors", 50, 0., 1.);
+      ibooker.book1D("ugmtMuMuDROneg", "uGMT output muons #DeltaR between overlap negative side sectors", 50, 0., 1.);
   ugmtMuMuDROneg->setAxisTitle("#DeltaR", 1);
 
   // endcap sectors
-  ugmtMuMuDEtaEpos =
-      ibooker.book1D("ugmtMuMuDEtaEpos", "uGMT Muons #Delta#eta between endcap positive side sectors", 100, -1., 1.);
+  ugmtMuMuDEtaEpos = ibooker.book1D(
+      "ugmtMuMuDEtaEpos", "uGMT output muons #Delta#eta between endcap positive side sectors", 100, -1., 1.);
   ugmtMuMuDEtaEpos->setAxisTitle("#Delta#eta", 1);
 
-  ugmtMuMuDPhiEpos =
-      ibooker.book1D("ugmtMuMuDPhiEpos", "uGMT Muons #Delta#phi between endcap positive side sectors", 100, -1., 1.);
+  ugmtMuMuDPhiEpos = ibooker.book1D(
+      "ugmtMuMuDPhiEpos", "uGMT output muons #Delta#phi between endcap positive side sectors", 100, -1., 1.);
   ugmtMuMuDPhiEpos->setAxisTitle("#Delta#phi", 1);
 
   ugmtMuMuDREpos =
-      ibooker.book1D("ugmtMuMuDREpos", "uGMT Muons #DeltaR between endcap positive side sectors", 50, 0., 1.);
+      ibooker.book1D("ugmtMuMuDREpos", "uGMT output muons #DeltaR between endcap positive side sectors", 50, 0., 1.);
   ugmtMuMuDREpos->setAxisTitle("#DeltaR", 1);
 
-  ugmtMuMuDEtaEneg =
-      ibooker.book1D("ugmtMuMuDEtaEneg", "uGMT Muons #Delta#eta between endcap negative side sectors", 100, -1., 1.);
+  ugmtMuMuDEtaEneg = ibooker.book1D(
+      "ugmtMuMuDEtaEneg", "uGMT output muons #Delta#eta between endcap negative side sectors", 100, -1., 1.);
   ugmtMuMuDEtaEneg->setAxisTitle("#Delta#eta", 1);
 
-  ugmtMuMuDPhiEneg =
-      ibooker.book1D("ugmtMuMuDPhiEneg", "uGMT Muons #Delta#phi between endcap negative side sectors", 100, -1., 1.);
+  ugmtMuMuDPhiEneg = ibooker.book1D(
+      "ugmtMuMuDPhiEneg", "uGMT output muons #Delta#phi between endcap negative side sectors", 100, -1., 1.);
   ugmtMuMuDPhiEneg->setAxisTitle("#Delta#phi", 1);
 
   ugmtMuMuDREneg =
-      ibooker.book1D("ugmtMuMuDREneg", "uGMT Muons #DeltaR between endcap negative side sectors", 50, 0., 1.);
+      ibooker.book1D("ugmtMuMuDREneg", "uGMT output muons #DeltaR between endcap negative side sectors", 50, 0., 1.);
   ugmtMuMuDREneg->setAxisTitle("#DeltaR", 1);
 }
 

--- a/DQM/L1TMonitor/src/L1TStage2uGMTInputBxDistributions.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMTInputBxDistributions.cc
@@ -1,0 +1,222 @@
+#include "DQM/L1TMonitor/interface/L1TStage2uGMTInputBxDistributions.h"
+
+L1TStage2uGMTInputBxDistributions::L1TStage2uGMTInputBxDistributions(const edm::ParameterSet& ps)
+    : ugmtMuonToken_(consumes<l1t::MuonBxCollection>(ps.getParameter<edm::InputTag>("muonProducer"))),
+      ugmtMuonShowerToken_(consumes<l1t::MuonShowerBxCollection>(ps.getParameter<edm::InputTag>("muonShowerProducer"))),
+      monitorDir_(ps.getUntrackedParameter<std::string>("monitorDir")),
+      emul_(ps.getUntrackedParameter<bool>("emulator")),
+      verbose_(ps.getUntrackedParameter<bool>("verbose")),
+      hadronicShowers_(ps.getUntrackedParameter<bool>("hadronicShowers")) {
+  if (!emul_) {
+    ugmtBMTFToken_ = consumes<l1t::RegionalMuonCandBxCollection>(ps.getParameter<edm::InputTag>("bmtfProducer"));
+    ugmtOMTFToken_ = consumes<l1t::RegionalMuonCandBxCollection>(ps.getParameter<edm::InputTag>("omtfProducer"));
+    ugmtEMTFToken_ = consumes<l1t::RegionalMuonCandBxCollection>(ps.getParameter<edm::InputTag>("emtfProducer"));
+    ugmtEMTFShowerToken_ =
+        consumes<l1t::RegionalMuonShowerBxCollection>(ps.getParameter<edm::InputTag>("emtfShowerProducer"));
+  }
+}
+
+L1TStage2uGMTInputBxDistributions::~L1TStage2uGMTInputBxDistributions() {}
+
+void L1TStage2uGMTInputBxDistributions::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("muonProducer")->setComment("uGMT output muons.");
+
+  desc.add<edm::InputTag>("bmtfProducer")->setComment("RegionalMuonCands from BMTF.");
+  desc.add<edm::InputTag>("omtfProducer")->setComment("RegionalMuonCands from OMTF.");
+  desc.add<edm::InputTag>("emtfProducer")->setComment("RegionalMuonCands from EMTF.");
+  desc.add<edm::InputTag>("muonShowerProducer")->setComment("uGMT output showers.");
+  desc.add<edm::InputTag>("emtfShowerProducer")->setComment("RegionalMuonShowers from EMTF.");
+  desc.addUntracked<std::string>("monitorDir", "")
+      ->setComment("Target directory in the DQM file. Will be created if not existing.");
+  desc.addUntracked<bool>("emulator", false)
+      ->setComment("Create histograms for muonProducer input only. xmtfProducer inputs are ignored.");
+  desc.addUntracked<bool>("verbose", false);
+  desc.addUntracked<bool>("hadronicShowers", false);
+  descriptions.add("l1tStage2uGMTInputBxDistributions", desc);
+}
+
+void L1TStage2uGMTInputBxDistributions::bookHistograms(DQMStore::IBooker& ibooker,
+                                                       const edm::Run&,
+                                                       const edm::EventSetup&) {
+  if (!emul_) {
+    // BMTF Input
+    ibooker.setCurrentFolder(monitorDir_ + "/BMTFInput");
+
+    ugmtBMTFBX = ibooker.book1D("ugmtBMTFBX", "uGMT BMTF Input BX", 7, -3.5, 3.5);
+    ugmtBMTFBX->setAxisTitle("BX", 1);
+
+    // OMTF Input
+    ibooker.setCurrentFolder(monitorDir_ + "/OMTFInput");
+
+    ugmtOMTFBX = ibooker.book1D("ugmtOMTFBX", "uGMT OMTF Input BX", 7, -3.5, 3.5);
+    ugmtOMTFBX->setAxisTitle("BX", 1);
+
+    // EMTF Input
+    ibooker.setCurrentFolder(monitorDir_ + "/EMTFInput");
+
+    ugmtEMTFBX = ibooker.book1D("ugmtEMTFBX", "uGMT EMTF Input BX", 7, -3.5, 3.5);
+    ugmtEMTFBX->setAxisTitle("BX", 1);
+
+    // EMTF muon showers
+    if (hadronicShowers_) {
+      ibooker.setCurrentFolder(monitorDir_ + "/EMTFInput/Muon showers");
+
+      ugmtEMTFShowerTypeOccupancyPerBx =
+          ibooker.book2D("ugmtEMTFShowerTypeOccupancyPerBx", "Shower type occupancy per BX", 7, -3.5, 3.5, 2, 1, 3);
+      ugmtEMTFShowerTypeOccupancyPerBx->setAxisTitle("BX", 1);
+      ugmtEMTFShowerTypeOccupancyPerBx->setAxisTitle("Shower type", 2);
+      ugmtEMTFShowerTypeOccupancyPerBx->setBinLabel(IDX_TIGHT_SHOWER, "Tight", 2);
+      ugmtEMTFShowerTypeOccupancyPerBx->setBinLabel(IDX_NOMINAL_SHOWER, "Nominal", 2);
+
+      ugmtEMTFShowerSectorOccupancyPerBx = ibooker.book2D(
+          "ugmtEMTFShowerSectorOccupancyPerBx", "Shower BX occupancy per sector", 7, -3.5, 3.5, 12, 1, 13);
+      ugmtEMTFShowerSectorOccupancyPerBx->setAxisTitle("BX", 1);
+      ugmtEMTFShowerSectorOccupancyPerBx->setAxisTitle("Processor", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(12, "+6", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(11, "+5", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(10, "+4", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(9, "+3", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(8, "+2", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(7, "+1", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(6, "-6", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(5, "-5", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(4, "-4", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(3, "-3", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(2, "-2", 2);
+      ugmtEMTFShowerSectorOccupancyPerBx->setBinLabel(1, "-1", 2);
+    }
+  }
+
+  // Subsystem Monitoring and Muon Output
+  ibooker.setCurrentFolder(monitorDir_);
+
+  if (!emul_) {
+    ugmtBMTFBXvsProcessor =
+        ibooker.book2D("ugmtBXvsProcessorBMTF", "uGMT BMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
+    ugmtBMTFBXvsProcessor->setAxisTitle("Wedge", 1);
+    for (int bin = 1; bin <= 12; ++bin) {
+      ugmtBMTFBXvsProcessor->setBinLabel(bin, std::to_string(bin), 1);
+    }
+    ugmtBMTFBXvsProcessor->setAxisTitle("BX", 2);
+
+    ugmtOMTFBXvsProcessor =
+        ibooker.book2D("ugmtBXvsProcessorOMTF", "uGMT OMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
+    ugmtOMTFBXvsProcessor->setAxisTitle("Sector (Detector Side)", 1);
+    for (int bin = 1; bin <= 6; ++bin) {
+      ugmtOMTFBXvsProcessor->setBinLabel(bin, std::to_string(7 - bin) + " (-)", 1);
+      ugmtOMTFBXvsProcessor->setBinLabel(bin + 6, std::to_string(bin) + " (+)", 1);
+    }
+    ugmtOMTFBXvsProcessor->setAxisTitle("BX", 2);
+
+    ugmtEMTFBXvsProcessor =
+        ibooker.book2D("ugmtBXvsProcessorEMTF", "uGMT EMTF Input BX vs Processor", 12, -0.5, 11.5, 5, -2.5, 2.5);
+    ugmtEMTFBXvsProcessor->setAxisTitle("Sector (Detector Side)", 1);
+    for (int bin = 1; bin <= 6; ++bin) {
+      ugmtEMTFBXvsProcessor->setBinLabel(bin, std::to_string(7 - bin) + " (-)", 1);
+      ugmtEMTFBXvsProcessor->setBinLabel(bin + 6, std::to_string(bin) + " (+)", 1);
+    }
+    ugmtEMTFBXvsProcessor->setAxisTitle("BX", 2);
+
+    ugmtBXvsLink = ibooker.book2D("ugmtBXvsLink", "uGMT BX vs Input Links", 36, 35.5, 71.5, 5, -2.5, 2.5);
+    ugmtBXvsLink->setAxisTitle("Link", 1);
+    for (int bin = 1; bin <= 6; ++bin) {
+      ugmtBXvsLink->setBinLabel(bin, Form("E+%d", bin), 1);
+      ugmtBXvsLink->setBinLabel(bin + 6, Form("O+%d", bin), 1);
+      ugmtBXvsLink->setBinLabel(bin + 12, Form("B%d", bin), 1);
+      ugmtBXvsLink->setBinLabel(bin + 18, Form("B%d", bin + 6), 1);
+      ugmtBXvsLink->setBinLabel(bin + 24, Form("O-%d", bin), 1);
+      ugmtBXvsLink->setBinLabel(bin + 30, Form("E-%d", bin), 1);
+    }
+    ugmtBXvsLink->setAxisTitle("BX", 2);
+  }
+}
+
+void L1TStage2uGMTInputBxDistributions::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  if (verbose_)
+    edm::LogInfo("L1TStage2uGMTInputBxDistributions") << "L1TStage2uGMTInputBxDistributions: analyze..." << std::endl;
+
+  if (!emul_) {
+    edm::Handle<l1t::RegionalMuonCandBxCollection> BMTFBxCollection;
+    e.getByToken(ugmtBMTFToken_, BMTFBxCollection);
+
+    for (int itBX = BMTFBxCollection->getFirstBX(); itBX <= BMTFBxCollection->getLastBX(); ++itBX) {
+      for (l1t::RegionalMuonCandBxCollection::const_iterator BMTF = BMTFBxCollection->begin(itBX);
+           BMTF != BMTFBxCollection->end(itBX);
+           ++BMTF) {
+        ugmtBMTFBX->Fill(itBX);
+
+        ugmtBMTFBXvsProcessor->Fill(BMTF->processor(), itBX);
+        ugmtBXvsLink->Fill(BMTF->link(), itBX);
+      }
+    }
+
+    edm::Handle<l1t::RegionalMuonCandBxCollection> OMTFBxCollection;
+    e.getByToken(ugmtOMTFToken_, OMTFBxCollection);
+
+    for (int itBX = OMTFBxCollection->getFirstBX(); itBX <= OMTFBxCollection->getLastBX(); ++itBX) {
+      for (l1t::RegionalMuonCandBxCollection::const_iterator OMTF = OMTFBxCollection->begin(itBX);
+           OMTF != OMTFBxCollection->end(itBX);
+           ++OMTF) {
+        ugmtOMTFBX->Fill(itBX);
+
+        l1t::tftype trackFinderType = OMTF->trackFinderType();
+
+        if (trackFinderType == l1t::omtf_neg) {
+          ugmtOMTFBXvsProcessor->Fill(5 - OMTF->processor(), itBX);
+        } else {
+          ugmtOMTFBXvsProcessor->Fill(OMTF->processor() + 6, itBX);
+        }
+
+        ugmtBXvsLink->Fill(OMTF->link(), itBX);
+      }
+    }
+
+    edm::Handle<l1t::RegionalMuonCandBxCollection> EMTFBxCollection;
+    e.getByToken(ugmtEMTFToken_, EMTFBxCollection);
+
+    for (int itBX = EMTFBxCollection->getFirstBX(); itBX <= EMTFBxCollection->getLastBX(); ++itBX) {
+      for (l1t::RegionalMuonCandBxCollection::const_iterator EMTF = EMTFBxCollection->begin(itBX);
+           EMTF != EMTFBxCollection->end(itBX);
+           ++EMTF) {
+        ugmtEMTFBX->Fill(itBX);
+
+        l1t::tftype trackFinderType = EMTF->trackFinderType();
+
+        if (trackFinderType == l1t::emtf_neg) {
+          ugmtEMTFBXvsProcessor->Fill(5 - EMTF->processor(), itBX);
+        } else {
+          ugmtEMTFBXvsProcessor->Fill(EMTF->processor() + 6, itBX);
+        }
+
+        ugmtBXvsLink->Fill(EMTF->link(), itBX);
+      }
+    }
+
+    // Fill shower plots
+    if (hadronicShowers_) {
+      edm::Handle<l1t::RegionalMuonShowerBxCollection> EMTFShowersBxCollection;
+      e.getByToken(ugmtEMTFShowerToken_, EMTFShowersBxCollection);
+
+      for (int itBX = EMTFShowersBxCollection->getFirstBX(); itBX <= EMTFShowersBxCollection->getLastBX(); ++itBX) {
+        for (l1t::RegionalMuonShowerBxCollection::const_iterator shower = EMTFShowersBxCollection->begin(itBX);
+             shower != EMTFShowersBxCollection->end(itBX);
+             ++shower) {
+          if (not shower->isValid()) {
+            continue;
+          }
+          if (shower->isOneNominalInTime()) {
+            ugmtEMTFShowerSectorOccupancyPerBx->Fill(
+                itBX, shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+            ugmtEMTFShowerTypeOccupancyPerBx->Fill(itBX, IDX_NOMINAL_SHOWER);
+          }
+          if (shower->isOneTightInTime()) {
+            ugmtEMTFShowerSectorOccupancyPerBx->Fill(
+                itBX, shower->processor() + 1 + (shower->trackFinderType() == l1t::tftype::emtf_pos ? 6 : 0));
+            ugmtEMTFShowerTypeOccupancyPerBx->Fill(itBX, IDX_TIGHT_SHOWER);
+          }
+        }
+      }
+    }
+  }
+}

--- a/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
+++ b/DQM/L1TMonitorClient/data/L1TStage2uGMTQualityTests.xml
@@ -320,19 +320,4 @@
       <TestName activate="true">uGMTCopies_MismatchRatioMax0</TestName>
   </LINK>
 
-  <!-- Bad Zero Suppression Rates -->
-
-  <QTEST name="zeroSupp_MismatchRatioMax0">
-    <TYPE>ContentsYRange</TYPE>
-    <PARAM name="ymin">0.00</PARAM>
-    <PARAM name="ymax">0.00</PARAM>
-    <PARAM name="error">0.95</PARAM>
-    <PARAM name="warning">0.99</PARAM>
-    <PARAM name="useEmptyBins">1</PARAM>
-  </QTEST>
-  
-  <LINK name="*/L1TStage2uGMT/zeroSuppression/*/mismatchRatio">
-      <TestName activate="true">zeroSupp_MismatchRatioMax0</TestName>
-  </LINK>
-
 </TESTSCONFIGURATION>

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -5,7 +5,6 @@ from DQM.L1TMonitor.L1TStage2uGMT_cff import ignoreBins
 # directory path shortening
 ugmtDqmDir = 'L1T/L1TStage2uGMT'
 ugmtMuCpyDqmDir = ugmtDqmDir+'/uGMTMuonCopies'
-ugmtZSDqmDir = ugmtDqmDir+'/zeroSuppression'
 # input histograms
 errHistNumStr = 'errorSummaryNum'
 errHistDenStr = 'errorSummaryDen'
@@ -21,6 +20,9 @@ l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient = DQMEDHarvester("L1TStage2RatioClie
     binomialErr = cms.untracked.bool(True),
     ignoreBin = cms.untracked.vint32()                                                         
 )
+## Era: Run3_2021; Ignore BX range mismatches. This is necessary because we only read out the central BX for the output copies.
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient, ignoreBin = cms.untracked.vint32(ignoreBins['OutputCopies']))
 
 l1tStage2uGMTMuonVsuGMTMuonCopy2RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
     monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonCopy2',
@@ -68,20 +70,7 @@ l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClien
     ratioTitle = 'Summary of mismatch rates between EMTF output muons and uGMT input muons from EMTF',
     ignoreBin = ignoreBins['Emtf']
 )
-# zero suppression
-l1tStage2uGMTZeroSuppRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
-    monitorDir = ugmtZSDqmDir+'/AllEvts',
-    inputNum = ugmtZSDqmDir+'/AllEvts/'+errHistNumStr,
-    inputDen = ugmtZSDqmDir+'/AllEvts/'+errHistDenStr,
-    ratioTitle = 'Summary of bad zero suppression rates',
-    yAxisTitle = '# fail / # total'
-)
-l1tStage2uGMTZeroSuppFatEvtsRatioClient = l1tStage2uGMTZeroSuppRatioClient.clone(
-    monitorDir = ugmtZSDqmDir+'/FatEvts',
-    inputNum = ugmtZSDqmDir+'/FatEvts/'+errHistNumStr,
-    inputDen = ugmtZSDqmDir+'/FatEvts/'+errHistDenStr,
-    ratioTitle = 'Summary of bad zero suppression rates'
-)
+
 # sequences
 l1tStage2uGMTMuonCompClient = cms.Sequence(
     l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient
@@ -97,14 +86,8 @@ l1tStage2uGMTRegionalMuonCandCompClient = cms.Sequence(
   + l1tStage2EmtfOutVsuGMTInRatioClient
 )
 
-l1tStage2uGMTZeroSuppCompClient = cms.Sequence(
-    l1tStage2uGMTZeroSuppRatioClient
-  + l1tStage2uGMTZeroSuppFatEvtsRatioClient
-)
-
 l1tStage2uGMTClient = cms.Sequence(
     l1tStage2uGMTMuonCompClient
   + l1tStage2uGMTRegionalMuonCandCompClient
-  + l1tStage2uGMTZeroSuppCompClient
 )
 

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTClient_cff.py
@@ -48,6 +48,44 @@ l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1Ra
     inputDen = ugmtMuCpyDqmDir+'/uGMTMuonCopy5/'+errHistDenStr,
     ratioTitle = 'Summary of mismatch rates between uGMT muons and uGMT muon copy 5'
 )
+
+# Showers
+l1tStage2uGMTShowerVsuGMTShowerCopy1RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+    monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonShoweruGMTMuonShowerCopy2',
+    inputNum = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy1/'+errHistNumStr,
+    inputDen = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy1/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between uGMT showers and uGMT shower copy 1',
+    ignoreBin = cms.untracked.vint32(ignoreBins['OutputCopies'])
+)
+l1tStage2uGMTShowerVsuGMTShowerCopy2RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+    monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonShoweruGMTMuonShowerCopy2',
+    inputNum = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy2/'+errHistNumStr,
+    inputDen = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy2/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between uGMT showers and uGMT shower copy 2',
+    ignoreBin = cms.untracked.vint32(ignoreBins['OutputCopies'])
+)
+l1tStage2uGMTShowerVsuGMTShowerCopy3RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+    monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonShoweruGMTMuonShowerCopy3',
+    inputNum = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy3/'+errHistNumStr,
+    inputDen = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy3/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between uGMT showers and uGMT shower copy 3',
+    ignoreBin = cms.untracked.vint32(ignoreBins['OutputCopies'])
+)
+l1tStage2uGMTShowerVsuGMTShowerCopy4RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+    monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonShoweruGMTMuonShowerCopy4',
+    inputNum = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy4/'+errHistNumStr,
+    inputDen = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy4/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between uGMT showers and uGMT shower copy 4',
+    ignoreBin = cms.untracked.vint32(ignoreBins['OutputCopies'])
+)
+l1tStage2uGMTShowerVsuGMTShowerCopy5RatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+    monitorDir = ugmtMuCpyDqmDir+'/uGMTMuonShoweruGMTMuonShowerCopy5',
+    inputNum = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy5/'+errHistNumStr,
+    inputDen = ugmtMuCpyDqmDir+'/uGMTMuonShowerCopies/uGMTMuonShowerCopy5/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between uGMT showers and uGMT shower copy 5',
+    ignoreBin = cms.untracked.vint32(ignoreBins['OutputCopies'])
+)
+
 # RegionalMuonCands
 l1tStage2BmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
     monitorDir = ugmtDqmDir+'/BMTFoutput_vs_uGMTinput',
@@ -71,6 +109,15 @@ l1tStage2EmtfOutVsuGMTInRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClien
     ignoreBin = ignoreBins['Emtf']
 )
 
+# RegionalShowerCands
+l1tStage2EmtfOutVsuGMTInShowerRatioClient = l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient.clone(
+    monitorDir = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/Muon Showers',
+    inputNum = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/Muon Showers/'+errHistNumStr,
+    inputDen = ugmtDqmDir+'/EMTFoutput_vs_uGMTinput/Muon Showers/'+errHistDenStr,
+    ratioTitle = 'Summary of mismatch rates between EMTF output showers and uGMT input showers from EMTF',
+    ignoreBin = ignoreBins['EmtfShowers']
+)
+
 # sequences
 l1tStage2uGMTMuonCompClient = cms.Sequence(
     l1tStage2uGMTMuonVsuGMTMuonCopy1RatioClient
@@ -79,12 +126,25 @@ l1tStage2uGMTMuonCompClient = cms.Sequence(
   + l1tStage2uGMTMuonVsuGMTMuonCopy4RatioClient
   + l1tStage2uGMTMuonVsuGMTMuonCopy5RatioClient
 )
+# Add shower copy tests for Run-3
+_run3_l1tStage2uGMTMuonCompClient = cms.Sequence(
+    l1tStage2uGMTMuonCompClient.copy()
+  + l1tStage2uGMTShowerVsuGMTShowerCopy1RatioClient
+  + l1tStage2uGMTShowerVsuGMTShowerCopy2RatioClient
+  + l1tStage2uGMTShowerVsuGMTShowerCopy3RatioClient
+  + l1tStage2uGMTShowerVsuGMTShowerCopy4RatioClient
+  + l1tStage2uGMTShowerVsuGMTShowerCopy5RatioClient
+)
+stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTMuonCompClient, _run3_l1tStage2uGMTMuonCompClient)
 
 l1tStage2uGMTRegionalMuonCandCompClient = cms.Sequence(
     l1tStage2BmtfOutVsuGMTInRatioClient
   + l1tStage2OmtfOutVsuGMTInRatioClient
   + l1tStage2EmtfOutVsuGMTInRatioClient
 )
+# Add input vs. output shower tests in Run-3.
+_run3_l1tStage2uGMTRegionalMuonCandCompClient = cms.Sequence(l1tStage2uGMTRegionalMuonCandCompClient.copy() + l1tStage2EmtfOutVsuGMTInShowerRatioClient)
+stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTRegionalMuonCandCompClient, _run3_l1tStage2uGMTRegionalMuonCandCompClient)
 
 l1tStage2uGMTClient = cms.Sequence(
     l1tStage2uGMTMuonCompClient

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
-from DQM.L1TMonitor.L1TdeStage2uGMT_cff import ignoreBins
+from DQM.L1TMonitor.L1TdeStage2uGMT_cff import ignoreFinalsBinsRun3, ignoreIntermediatesBins, ignoreIntermediatesBinsRun3
 
 # directories
 ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGMT"
@@ -20,6 +20,9 @@ l1tStage2uGMTEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
     yAxisTitle = cms.untracked.string('# mismatch / # total'),
     binomialErr = cms.untracked.bool(True)
 )
+## Era: Run3_2021; Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2uGMTEmulatorCompRatioClient, ignoreBin = ignoreFinalsBinsRun3)
 
 # intermediate muons
 titleStr = 'Summary of mismatch rates between uGMT intermediate muons and uGMT emulator intermediate muons from '
@@ -28,35 +31,34 @@ l1tStage2uGMTEmulImdMuBMTFCompRatioClient.monitorDir = cms.untracked.string(ugmt
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/BMTF/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'BMTF')
-l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
+l1tStage2uGMTEmulImdMuBMTFCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreIntermediatesBins)
+## Era: Run3_2021; Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2uGMTEmulImdMuBMTFCompRatioClient, ignoreBin = ignoreIntermediatesBinsRun3)
 
-l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
+l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient = l1tStage2uGMTEmulImdMuBMTFCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF-')
-l1tStage2uGMTEmulImdMuOMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
-l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
+l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient = l1tStage2uGMTEmulImdMuBMTFCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/OMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'OMTF+')
-l1tStage2uGMTEmulImdMuOMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
-l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
+l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient = l1tStage2uGMTEmulImdMuBMTFCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_neg/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF-')
-l1tStage2uGMTEmulImdMuEMTFNegCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
-l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient = l1tStage2uGMTEmulatorCompRatioClient.clone()
+l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient = l1tStage2uGMTEmulImdMuBMTFCompRatioClient.clone()
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison')
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputNum = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistNumStr)
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.inputDen = cms.untracked.string(ugmtEmuImdMuDqmDir+'/EMTF_pos/data_vs_emulator_comparison/'+errHistDenStr)
 l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ratioTitle = cms.untracked.string(titleStr+'EMTF+')
-l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 # sequences
 l1tStage2uGMTEmulatorClient = cms.Sequence(

--- a/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGMTEmulatorClient_cff.py
@@ -22,7 +22,19 @@ l1tStage2uGMTEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
 )
 ## Era: Run3_2021; Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(l1tStage2uGMTEmulatorCompRatioClient, ignoreBin = ignoreFinalsBinsRun3)
+stage2L1Trigger_2021.toModify(l1tStage2uGMTEmulatorCompRatioClient, ignoreBin = cms.untracked.vint32(ignoreFinalsBinsRun3))
+
+# Showers
+l1tStage2uGMTShowerEmulatorCompRatioClient = DQMEDHarvester("L1TStage2RatioClient",
+    monitorDir = cms.untracked.string(ugmtEmuDEDqmDir+"/Muon showers"),
+    inputNum = cms.untracked.string(ugmtEmuDEDqmDir+'/Muon showers/'+errHistNumStr),
+    inputDen = cms.untracked.string(ugmtEmuDEDqmDir+'/Muon showers/'+errHistDenStr),
+    ratioName = cms.untracked.string('mismatchRatio'),
+    ratioTitle = cms.untracked.string('Summary of mismatch rates between uGMT showers and uGMT emulator showers'),
+    yAxisTitle = cms.untracked.string('# mismatch / # total'),
+    binomialErr = cms.untracked.bool(True),
+    ignoreBin = cms.untracked.vint32(ignoreFinalsBinsRun3), # Ignore BX range mismatches. This is necessary because we only read out the central BX for the inputs, so that is what the emulator has to work on.
+)
 
 # intermediate muons
 titleStr = 'Summary of mismatch rates between uGMT intermediate muons and uGMT emulator intermediate muons from '
@@ -70,3 +82,6 @@ l1tStage2uGMTEmulatorClient = cms.Sequence(
   + l1tStage2uGMTEmulImdMuEMTFPosCompRatioClient
 )
 
+# Add shower tests for Run3
+_run3_l1tStage2uGMTEmulatorClient = cms.Sequence(l1tStage2uGMTEmulatorClient.copy() + l1tStage2uGMTShowerEmulatorCompRatioClient)
+stage2L1Trigger_2021.toReplaceWith(l1tStage2uGMTEmulatorClient, _run3_l1tStage2uGMTEmulatorClient)

--- a/DQM/L1TMonitorClient/python/L1TStage2uGTEmulatorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TStage2uGTEmulatorClient_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
-from DQM.L1TMonitor.L1TdeStage2uGMT_cff import ignoreBins
 
 # directories
 ugmtEmuDqmDir = "L1TEMU/L1TdeStage2uGT"


### PR DESCRIPTION
#### PR description:

This PR updates the uGMT DQM following changes made to the readout menu after we disabled the zero suppression. It also includes some changes to add plots for the new hadronic showers.

In particular:
- Removed zero suppression folder from uGMT DQM
- Ignored BX range mismatches in uGMT muon copy comparisons. (We now read out only the central BX for the copies but +/-2 for the main outputs.)
- Ignore BX range mismatches for the data-emulator comparisons for the same reason.
- Move the main uGMT DQM plots behind the fat events filter as otherwise the BX distribution plots would be heavily biased towards the central BX. (Because only the central BX is read out in standard events for the inputs.)
- Enable uGMT muon copy comparisons for all events (not just the validation events).
- Remove alerting on incorrect zero suppression and disable BX range checks.
- Add hadronic shower comparisons between the EMTF outputs and uGMT inputs
- Add uGMT muon showers to DQM quality tests

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #38115. Would like to have this in the P5 DQM.
