### PR TITLE
Fix memory leak in AlCaHcalHBHEMuonProducer

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalHBHEMuonProducer.cc
+++ b/Calibration/HcalAlCaRecoProducers/plugins/AlCaHcalHBHEMuonProducer.cc
@@ -281,7 +281,8 @@ void AlCaHcalHBHEMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup
   const EcalSeverityLevelAlgo* sevlv = &iSetup.getData(tok_sevlv_);
   const CaloTopology* caloTopology = &iSetup.getData(tok_topo_);
   const HcalDbService* conditions = &iSetup.getData(tok_dbservice_);
-  HcalRespCorrs* respCorrs = new HcalRespCorrs(*resp);
+  HcalRespCorrs respCorrsObj(*resp);
+  HcalRespCorrs* respCorrs = &respCorrsObj;
   respCorrs->setTopo(theHBHETopology);
 
   // Relevant blocks from iEvent
@@ -1014,7 +1015,8 @@ void AlCaHcalHBHEMuonProducer::beginRun(edm::Run const& iRun, edm::EventSetup co
   const HcalRespCorrs* resp = &iSetup.getData(tok_respcorr0_);
   const HcalTopology* theHBHETopology = &iSetup.getData(tok_htopo0_);
   const CaloGeometry* geo = &iSetup.getData(tok_geom0_);
-  HcalRespCorrs* respCorrs = new HcalRespCorrs(*resp);
+  HcalRespCorrs respCorrsObj(*resp);
+  HcalRespCorrs* respCorrs = &respCorrsObj;
   respCorrs->setTopo(theHBHETopology);
 
   // Write correction factors for all HB/HE events


### PR DESCRIPTION
#### PR description:

This PR provides a minimal fix to a memory leak identified in https://cms-talk.web.cern.ch/t/high-memory-usage-in-promptreco-jobs-for-run-352516/11040/9 (I convinced myself that the objects should be small enough for stack).

#### PR validation:

Checked in 12_3_4_patch2 that the copy constructor of `HcalCondObjectContainer<HcalRespCorr>` disappeared from `AlCaHcalHBHEMuonProducer` (in the profile after 21st event in the test configuration):
* IgProf MEM_LIVE after 21st event in 12_3_4_patch2 https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/run352516/test_07.21_live/1334
* IgProf MEM_LIVE after 21st event with this PR https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/run352516/test_17.21_live/55288
