### PR TITLE
[ALCA-DB] [GCC12] Added missing array header

### DIFF
--- a/CondFormats/PCLConfig/interface/AlignPCLThreshold.h
+++ b/CondFormats/PCLConfig/interface/AlignPCLThreshold.h
@@ -2,6 +2,7 @@
 #define CondFormats_PCLConfig_AlignPCLThreshold_h
 
 #include "CondFormats/Serialization/interface/Serializable.h"
+#include <array>
 
 class AlignPCLThreshold {
 public:

--- a/CondFormats/PCLConfig/interface/AlignPCLThresholds.h
+++ b/CondFormats/PCLConfig/interface/AlignPCLThresholds.h
@@ -4,6 +4,7 @@
 #include "CondFormats/PCLConfig/interface/AlignPCLThreshold.h"
 #include "CondFormats/Serialization/interface/Serializable.h"
 
+#include <array>
 #include <map>
 #include <string>
 #include <vector>

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -1,3 +1,4 @@
+#include <array>
 #include <string>
 #include <iostream>
 #include <map>

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
@@ -15,6 +15,7 @@
 //
 
 // system include files
+#include <array>
 #include <memory>
 
 // user include files


### PR DESCRIPTION
Adding missing `array` header to fix GCC12 build errors