### PR TITLE
[CORE] [GCC12] Added missing array header

### DIFF
--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <array>
 #include <vector>
 #include <type_traits>
 #include <atomic>

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <array>
 #include <map>
 #include <string>
 #include <vector>

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -18,6 +18,7 @@
 #include "FWCore/Framework/interface/ModuleProcessName.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 
+#include <array>
 #include <memory>
 #include <string>
 #include <utility>

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -82,6 +82,7 @@
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
+#include <array>
 #include <map>
 #include <memory>
 #include <set>

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -58,6 +58,7 @@ the worker is reset().
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
+#include <array>
 #include <atomic>
 #include <cassert>
 #include <map>

--- a/FWCore/Framework/interface/maker/WorkerT.h
+++ b/FWCore/Framework/interface/maker/WorkerT.h
@@ -15,6 +15,7 @@ WorkerT: Code common to all workers.
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
+#include <array>
 #include <map>
 #include <memory>
 #include <string>

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <array>
 #include <map>
 #include <string>
 #include <vector>

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <array>
 #include <map>
 #include <string>
 #include <vector>

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <array>
 #include <algorithm>
 #include <cassert>
 #include <cstring>

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -36,6 +36,7 @@
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
+#include <array>
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <array>
 #include <cassert>
 
 // user include files

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <array>
 #include <cassert>
 
 // user include files


### PR DESCRIPTION
Adding missing `array` header to fix GCC12 build errors