### PR TITLE
[SIMULATION] [GCC12] Added missing array header

### DIFF
--- a/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
+++ b/SimG4CMS/Calo/src/HGCalNumberingScheme.cc
@@ -8,6 +8,7 @@
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
 #include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferIndex.h"
+#include <array>
 #include <iostream>
 
 //#define EDM_ML_DEBUG


### PR DESCRIPTION
Adding missing `array` header to fix GCC12 build errors