### PR TITLE
[DQM-GEOMETRY] [GCC12] Added missing array header

### DIFF
--- a/Validation/Geometry/interface/MaterialBudgetData.h
+++ b/Validation/Geometry/interface/MaterialBudgetData.h
@@ -11,6 +11,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <memory>
+#include <array>
 
 class MaterialBudgetData;
 class G4Step;


### PR DESCRIPTION
Adding missing `array` header to fix GCC12 build errors