### PR TITLE
[DQM] [GCC12] Added missing array header

### DIFF
--- a/DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelROCMaps.h
@@ -8,6 +8,7 @@
 #include "TLine.h"
 #include "TLatex.h"
 
+#include <array>
 #include <bitset>
 #include <fmt/printf.h>
 #include <fstream>

--- a/DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h
+++ b/DQM/TrackerRemapper/interface/Phase1PixelSummaryMap.h
@@ -10,6 +10,7 @@
 #include "TLatex.h"
 #include "TStyle.h"
 
+#include <array>
 #include <fmt/printf.h>
 #include <fstream>
 #include <memory>

--- a/DQM/TrackerRemapper/plugins/TrackerRemapper.cc
+++ b/DQM/TrackerRemapper/plugins/TrackerRemapper.cc
@@ -6,6 +6,7 @@
 //
 
 // system include files
+#include <array>
 #include <memory>
 #include <fstream>
 #include <utility>

--- a/DQM/TrackerRemapper/src/SiStripTkMaps.cc
+++ b/DQM/TrackerRemapper/src/SiStripTkMaps.cc
@@ -19,6 +19,7 @@
 #include "TStyle.h"
 
 // STL includes
+#include <array>
 #include <fstream>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
Adding missing `array` header to fix GCC12 build errors