### PR TITLE
Avoid reading off end of vector in SimTrackManager

### DIFF
--- a/SimG4Core/Notification/src/SimTrackManager.cc
+++ b/SimG4Core/Notification/src/SimTrackManager.cc
@@ -81,10 +81,8 @@ void SimTrackManager::saveTrackAndItsBranch(TrackWithHistory* trkWHist) {
   TrackContainer::const_iterator tk_itr = std::lower_bound(
       (*m_trksForThisEvent).begin(), (*m_trksForThisEvent).end(), parent, SimTrackManager::StrictWeakOrdering());
 
-  TrackWithHistory* tempTk = *tk_itr;
-
   if (tk_itr != m_trksForThisEvent->end() && (*tk_itr)->trackID() == parent) {
-    saveTrackAndItsBranch(tempTk);
+    saveTrackAndItsBranch(*tk_itr);
   }
 }
 


### PR DESCRIPTION

#### PR description:

Avoid dereferencing an iterator when it points to the end of the vector.

Test using ASAN in a PR discovered this problem.

#### PR validation:

Code compiles.