### PR TITLE
`ConfigBuilder`: raise an exception if the name of the alca producer exceeds the DBS schema constraints

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1274,8 +1274,13 @@ class ConfigBuilder(object):
         alcaConfig=self.loadDefaultOrSpecifiedCFF(sequence,self.ALCADefaultCFF)
         sequence = sequence.split('.')[-1]
 
+        MAXLEN=31 #the alca producer name should be shorter than 31 chars as per https://cms-talk.web.cern.ch/t/alcaprompt-datasets-not-loaded-in-dbs/11146/2
         # decide which ALCA paths to use
         alcaList = sequence.split("+")
+        for alca in alcaList:
+            if (len(alca)>MAXLEN):
+                raise Exception("The following alca "+str(alca)+" name (with length "+str(len(alca))+" chars) cannot be accepted because it exceeds the DBS constraints on the length of the name of the ALCARECOs producers ("+str(MAXLEN)+")!")
+
         maxLevel=0
         from Configuration.AlCa.autoAlca import autoAlca, AlCaNoConcurrentLumis
         # support @X from autoAlca.py, and recursion support: i.e T0:@Mu+@EG+...


### PR DESCRIPTION
#### PR description:

This PR is half-provocative, inspired by the discussion at https://cms-talk.web.cern.ch/t/alcaprompt-datasets-not-loaded-in-dbs/11146.
Since this is the second time it happens in the CMS history  (see also this old [hypernew](https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1439.html)) there should be a way to stop developers to create running configurations that must be abandoned because of the DBS database schema limitations only after these are put into production.
Perhaps this could be generalized to other steps too.

#### PR validation:

Tried using an alca name longer than 31 chars and obtained the exception:

```console
Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/nweek-02735/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_X_2022-05-30-2300/bin/slc7_amd64_gcc10/cmsDriver.py", line 56, in <module>
    run()
  File "/cvmfs/cms-ib.cern.ch/nweek-02735/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_X_2022-05-30-2300/bin/slc7_amd64_gcc10/cmsDriver.py", line 28, in run
    configBuilder.prepare()
  File "/build/musich/massiverename/checkConfigBuilder/CMSSW_12_5_X_2022-06-01-1100/src/Configuration/Applications/python/ConfigBuilder.py", line 2167, in prepare
    self.addStandardSequences()
  File "/build/musich/massiverename/checkConfigBuilder/CMSSW_12_5_X_2022-06-01-1100/src/Configuration/Applications/python/ConfigBuilder.py", line 790, in addStandardSequences
    getattr(self,"prepare_"+stepName)(sequence = '+'.join(stepSpec))
  File "/build/musich/massiverename/checkConfigBuilder/CMSSW_12_5_X_2022-06-01-1100/src/Configuration/Applications/python/ConfigBuilder.py", line 1282, in prepare_ALCA
    raise Exception("The following alca "+str(alca)+" name (with length "+str(len(alca))+" chars) cannot be accepted because it exceeds the DBS constraints on the length of the name of the ALCARECOs producers ("+str(MAXLEN)+")!")
Exception: The following alca PromptCalibProdSiPixelLorentzAngle name (with length 34 chars) cannot be accepted because it exceeds the DBS constraints on the length of the name of the ALCARECOs producers (31)!

```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
