### PR TITLE
Enable Geant4 gamma general process

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -180,7 +180,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         G4MscSafetyFactor = cms.double(0.6), 
         G4MscLambdaLimit = cms.double(1.0), # mm 
         G4MscStepLimit = cms.string("UseSafety"), 
-        G4GeneralProcess = cms.bool(False),
+        G4GeneralProcess = cms.bool(True),
         ReadMuonData = cms.bool(False), 
         Verbosity = cms.untracked.int32(0),
         # 1 will print cuts as they get set from DD


### PR DESCRIPTION
#### PR description:
Geant4 gamma general process approach allowing safe few % CPU in Run3 SIM production, more pronounced effect is expected for Phase2. This method was disabled in past, because of problems in validation. These problems are understood and should not be there in the next per-release tests. The method is adopted by ATLAS for production.

Simulation history will be different, so regression is not expected in any WF. 

#### PR validation:
private


#### if this PR is a backport please specify the original PR and why you need to backport that PR: NO
