### PR TITLE
New PCL Alignment Threshold object and record for HG PCL Alignment

### DIFF
--- a/CondCore/PCLConfigPlugins/src/plugin.cc
+++ b/CondCore/PCLConfigPlugins/src/plugin.cc
@@ -1,5 +1,8 @@
 #include "CondCore/ESSources/interface/registration_macros.h"
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"
 #include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
+#include "CondFormats/DataRecord/interface/AlignPCLThresholdsHGRcd.h"
 
 REGISTER_PLUGIN(AlignPCLThresholdsRcd, AlignPCLThresholds);
+REGISTER_PLUGIN(AlignPCLThresholdsHGRcd, AlignPCLThresholdsHG);

--- a/CondCore/Utilities/plugins/Module_2XML.cc
+++ b/CondCore/Utilities/plugins/Module_2XML.cc
@@ -5,6 +5,7 @@ PAYLOAD_2XML_MODULE(pluginUtilities_payload2xml) {
   m.def("boost_version_label", &cond::boost_version_label, "Get boost version for this release");
   PAYLOAD_2XML_CLASS(AlCaRecoTriggerBits);
   PAYLOAD_2XML_CLASS(AlignPCLThresholds);
+  PAYLOAD_2XML_CLASS(AlignPCLThresholdsHG);
   PAYLOAD_2XML_CLASS(AlignmentErrors);
   PAYLOAD_2XML_CLASS(AlignmentErrorsExtended);
   PAYLOAD_2XML_CLASS(AlignmentSurfaceDeformations);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -33,6 +33,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE(AlignmentSurfaceDeformations)
       FETCH_PAYLOAD_CASE(Alignments)
       FETCH_PAYLOAD_CASE(AlignPCLThresholds)
+      FETCH_PAYLOAD_CASE(AlignPCLThresholdsHG)
       FETCH_PAYLOAD_CASE(BeamSpotObjects)
       FETCH_PAYLOAD_CASE(BeamSpotOnlineObjects)
       FETCH_PAYLOAD_CASE(CSCBadChambers)

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -53,6 +53,7 @@ namespace cond {
         IMPORT_PAYLOAD_CASE(AlignmentSurfaceDeformations)
         IMPORT_PAYLOAD_CASE(Alignments)
         IMPORT_PAYLOAD_CASE(AlignPCLThresholds)
+        IMPORT_PAYLOAD_CASE(AlignPCLThresholdsHG)
         IMPORT_PAYLOAD_CASE(BeamSpotObjects)
         IMPORT_PAYLOAD_CASE(BeamSpotOnlineObjects)
         IMPORT_PAYLOAD_CASE(CSCBadChambers)

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -279,6 +279,7 @@
 #include "CondFormats/BTauObjects/interface/TrackProbabilityCalibration.h"
 #include "CondFormats/MFObjects/interface/MagFieldConfig.h"
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/TrackerDetToDTCELinkCablingMap.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/SiPhase2OuterTrackerLorentzAngle.h"
 #include "CondFormats/SiPhase2TrackerObjects/interface/DTCELinkId.h"

--- a/CondFormats/DataRecord/interface/AlignPCLThresholdsHGRcd.h
+++ b/CondFormats/DataRecord/interface/AlignPCLThresholdsHGRcd.h
@@ -1,0 +1,8 @@
+#ifndef AlignPCLThresholdsRcd_AlignPCLThresholdsHGRcd_h
+#define AlignPCLThresholdsRcd_AlignPCLThresholdsHGRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class AlignPCLThresholdsHGRcd : public edm::eventsetup::EventSetupRecordImplementation<AlignPCLThresholdsHGRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/AlignPCLThresholdsHGRcd.cc
+++ b/CondFormats/DataRecord/src/AlignPCLThresholdsHGRcd.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/DataRecord/interface/AlignPCLThresholdsHGRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(AlignPCLThresholdsHGRcd);

--- a/CondFormats/PCLConfig/interface/AlignPCLThresholds.h
+++ b/CondFormats/PCLConfig/interface/AlignPCLThresholds.h
@@ -45,7 +45,7 @@ public:
 
   void printAll() const;
 
-private:
+protected:
   threshold_map m_thresholds;
   int m_nrecords;
 

--- a/CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h
+++ b/CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h
@@ -1,0 +1,47 @@
+#ifndef CondFormats_PCLConfig_AlignPCLThresholdsHG_h
+#define CondFormats_PCLConfig_AlignPCLThresholdsHG_h
+
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <map>
+#include <string>
+#include <vector>
+
+class AlignPCLThresholdsHG : public AlignPCLThresholds {
+public:
+  AlignPCLThresholdsHG() {}
+
+  enum FloatParamIndex {
+    FRACTION_CUT_X = 0,
+    FRACTION_CUT_Y = 1,
+    FRACTION_CUT_Z = 2,
+    FRACTION_CUT_TX = 3,
+    FRACTION_CUT_TY = 4,
+    FRACTION_CUT_TZ = 5,
+    FSIZE = 6
+  };
+
+  void SetFractionCut(const std::string &AlignableId, const coordType &type, const float &cut);
+
+  const std::unordered_map<std::string, std::vector<float>> &getFloatMap() const { return floatMap; }
+  const std::vector<float> &getFloatVec(const std::string &AlignableId) const;
+
+  float getFractionCut(const std::string &AlignableId, const coordType &type) const;
+  std::array<float, 6> getFractionCut(const std::string &AlignableId) const;
+
+  int payloadVersion() const;
+
+  void printAllHG() const;
+
+  ~AlignPCLThresholdsHG() override {}
+
+private:
+  std::unordered_map<std::string, std::vector<float>> floatMap;
+  std::unordered_map<std::string, std::vector<int>> intMap;
+  std::unordered_map<std::string, std::vector<std::string>> stringMap;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -6,9 +6,13 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"
 #include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
+#include "CondFormats/DataRecord/interface/AlignPCLThresholdsHGRcd.h"
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
 
 namespace edmtest {
+  template <typename T, typename R>
   class AlignPCLThresholdsReader : public edm::one::EDAnalyzer<> {
   public:
     explicit AlignPCLThresholdsReader(edm::ParameterSet const& p);
@@ -20,38 +24,42 @@ namespace edmtest {
     void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
     // ----------member data ---------------------------
-    const edm::ESGetToken<AlignPCLThresholds, AlignPCLThresholdsRcd> thresholdToken_;
+    const edm::ESGetToken<T, R> thresholdToken_;
     const bool printdebug_;
     const std::string formatedOutput_;
   };
 
-  AlignPCLThresholdsReader::AlignPCLThresholdsReader(edm::ParameterSet const& p)
+  template <typename T, typename R>
+  AlignPCLThresholdsReader<T, R>::AlignPCLThresholdsReader(edm::ParameterSet const& p)
       : thresholdToken_(esConsumes()),
         printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
         formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")) {
     edm::LogInfo("AlignPCLThresholdsReader") << "AlignPCLThresholdsReader" << std::endl;
   }
 
-  AlignPCLThresholdsReader::~AlignPCLThresholdsReader() {
+  template <typename T, typename R>
+  AlignPCLThresholdsReader<T, R>::~AlignPCLThresholdsReader() {
     edm::LogInfo("AlignPCLThresholdsReader") << "~AlignPCLThresholdsReader " << std::endl;
   }
 
-  void AlignPCLThresholdsReader::analyze(const edm::Event& e, const edm::EventSetup& context) {
+  template <typename T, typename R>
+  void AlignPCLThresholdsReader<T, R>::analyze(const edm::Event& e, const edm::EventSetup& context) {
     edm::LogInfo("AlignPCLThresholdsReader") << "### AlignPCLThresholdsReader::analyze  ###" << std::endl;
     edm::LogInfo("AlignPCLThresholdsReader") << " I AM IN RUN NUMBER " << e.id().run() << std::endl;
     edm::LogInfo("AlignPCLThresholdsReader") << " ---EVENT NUMBER " << e.id().event() << std::endl;
 
+    edm::eventsetup::EventSetupRecordKey inputKey = edm::eventsetup::EventSetupRecordKey::makeKey<R>();
     edm::eventsetup::EventSetupRecordKey recordKey(
-        edm::eventsetup::EventSetupRecordKey::TypeTag::findType("AlignPCLThresholdsRcd"));
+        edm::eventsetup::EventSetupRecordKey::TypeTag::findType(inputKey.type().name()));
 
     if (recordKey.type() == edm::eventsetup::EventSetupRecordKey::TypeTag()) {
       //record not found
-      edm::LogInfo("AlignPCLThresholdsReader") << "Record \"AlignPCLThresholdsRcd"
-                                               << "\" does not exist " << std::endl;
+      edm::LogInfo("AlignPCLThresholdsReader")
+          << "Record \"" << inputKey.type().name() << "\" does not exist " << std::endl;
     }
 
     //this part gets the handle of the event source and the record (i.e. the Database)
-    edm::ESHandle<AlignPCLThresholds> thresholdHandle = context.getHandle(thresholdToken_);
+    edm::ESHandle<T> thresholdHandle = context.getHandle(thresholdToken_);
     edm::LogInfo("AlignPCLThresholdsReader") << "got eshandle" << std::endl;
 
     if (!thresholdHandle.isValid()) {
@@ -59,7 +67,7 @@ namespace edmtest {
       return;
     }
 
-    const AlignPCLThresholds* thresholds = thresholdHandle.product();
+    const T* thresholds = thresholdHandle.product();
     edm::LogInfo("AlignPCLThresholdsReader") << "got AlignPCLThresholds* " << std::endl;
     edm::LogInfo("AlignPCLThresholdsReader") << "print  pointer address : ";
     edm::LogInfo("AlignPCLThresholdsReader") << thresholds << std::endl;
@@ -69,6 +77,10 @@ namespace edmtest {
     // use built-in method in the CondFormat to print the content
     if (printdebug_) {
       thresholds->printAll();
+      // print additional thresholds if HG payload is used
+      if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+        thresholds->printAllHG();
+      }
     }
 
     FILE* pFile = nullptr;
@@ -132,16 +144,51 @@ namespace edmtest {
           }
         }
       }
+
+      // print additional thresholds for HG payload
+      if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+        fprintf(pFile, "AlignPCLThresholdsHG::printAllHG() \n");
+        fprintf(pFile, " ======================================= \n");
+        const std::unordered_map<std::string, std::vector<float>>& floatMap = thresholds->getFloatMap();
+        for (auto it = floatMap.begin(); it != floatMap.end(); ++it) {
+          fprintf(pFile, " ======================================= \n");
+
+          fprintf(pFile, "key : %s \n", (it->first).c_str());
+          fprintf(pFile,
+                  "- X_fractionCut             : %8.3f    \n",
+                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::X));
+          fprintf(pFile,
+                  "- thetaX_fractionCut        : %8.3f    \n",
+                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::theta_X));
+          fprintf(pFile,
+                  "- Y_fractionCut             : %8.3f    \n",
+                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::Y));
+          fprintf(pFile,
+                  "- thetaY_fractionCut        : %8.3f    \n",
+                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::theta_Y));
+          fprintf(pFile,
+                  "- Z_fractionCut             : %8.3f    \n",
+                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::Z));
+          fprintf(pFile,
+                  "- thetaZ_fractionCut        : %8.3f    \n",
+                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::theta_Z));
+        }
+      }
     }
   }
 
-  void AlignPCLThresholdsReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  template <typename T, typename R>
+  void AlignPCLThresholdsReader<T, R>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
     desc.setComment("Reads payloads of type AlignPCLThresholds");
     desc.addUntracked<bool>("printDebug", true);
     desc.addUntracked<std::string>("outputFile", "");
-    descriptions.add("AlignPCLThresholdsReader", desc);
+    descriptions.add(defaultModuleLabel<AlignPCLThresholdsReader<T, R>>(), desc);
   }
 
-  DEFINE_FWK_MODULE(AlignPCLThresholdsReader);
+  typedef AlignPCLThresholdsReader<AlignPCLThresholds, AlignPCLThresholdsRcd> AlignPCLThresholdsLGReader;
+  typedef AlignPCLThresholdsReader<AlignPCLThresholdsHG, AlignPCLThresholdsHGRcd> AlignPCLThresholdsHGReader;
+
+  DEFINE_FWK_MODULE(AlignPCLThresholdsLGReader);
+  DEFINE_FWK_MODULE(AlignPCLThresholdsHGReader);
 }  // namespace edmtest

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
@@ -26,6 +26,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
@@ -48,6 +49,10 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   DOFs::dof mapOntoEnum(std::string coord);
 
+  template <typename T>
+  void writePayload(T& myThresholds);
+  void storeHGthresholds(AlignPCLThresholdsHG& myThresholds, const std::vector<std::string>& alignables);
+
   // ----------member data ---------------------------
   const std::string m_record;
   const unsigned int m_minNrecords;
@@ -68,10 +73,47 @@ AlignPCLThresholdsWriter::AlignPCLThresholdsWriter(const edm::ParameterSet& iCon
 
 // ------------ method called for each event  ------------
 void AlignPCLThresholdsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  using namespace edm;
+  // detect if new payload is used
+  bool newClass = false;
+  for (auto& thePSet : m_parameters) {
+    if (thePSet.exists("fractionCut")) {
+      newClass = true;
+      break;
+    }
+  }
 
-  // output object
-  AlignPCLThresholds myThresholds{};
+  // use templated method depending on new/old payload
+  if (newClass) {
+    AlignPCLThresholdsHG myThresholds{};
+    writePayload(myThresholds);
+  } else {
+    AlignPCLThresholds myThresholds{};
+    writePayload(myThresholds);
+  }
+}
+
+DOFs::dof AlignPCLThresholdsWriter::mapOntoEnum(std::string coord) {
+  if (coord == "X") {
+    return DOFs::X;
+  } else if (coord == "Y") {
+    return DOFs::Y;
+  } else if (coord == "Z") {
+    return DOFs::Z;
+  } else if (coord == "thetaX") {
+    return DOFs::thetaX;
+  } else if (coord == "thetaY") {
+    return DOFs::thetaY;
+  } else if (coord == "thetaZ") {
+    return DOFs::thetaZ;
+  } else {
+    return DOFs::extraDOF;
+  }
+}
+
+// ------------ templated method to write the payload  ------------
+template <typename T>
+void AlignPCLThresholdsWriter::writePayload(T& myThresholds) {
+  using namespace edm;
 
   edm::LogInfo("AlignPCLThresholdsWriter") << "Size of AlignPCLThresholds object " << myThresholds.size() << std::endl;
 
@@ -167,6 +209,11 @@ void AlignPCLThresholdsWriter::analyze(const edm::Event& iEvent, const edm::Even
   // use buil-in method in the CondFormat
   myThresholds.printAll();
 
+  // additional thresholds for AlignPCLThresholdsHG
+  if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+    storeHGthresholds(myThresholds, alignables);
+  }
+
   // Form the data here
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
   if (poolDbService.isAvailable()) {
@@ -176,22 +223,34 @@ void AlignPCLThresholdsWriter::analyze(const edm::Event& iEvent, const edm::Even
   }
 }
 
-DOFs::dof AlignPCLThresholdsWriter::mapOntoEnum(std::string coord) {
-  if (coord == "X") {
-    return DOFs::X;
-  } else if (coord == "Y") {
-    return DOFs::Y;
-  } else if (coord == "Z") {
-    return DOFs::Z;
-  } else if (coord == "thetaX") {
-    return DOFs::thetaX;
-  } else if (coord == "thetaY") {
-    return DOFs::thetaY;
-  } else if (coord == "thetaZ") {
-    return DOFs::thetaZ;
-  } else {
-    return DOFs::extraDOF;
+// ------------ method to store additional HG thresholds ------------
+void AlignPCLThresholdsWriter::storeHGthresholds(AlignPCLThresholdsHG& myThresholds,
+                                                 const std::vector<std::string>& alignables) {
+  edm::LogInfo("AlignPCLThresholdsWriter")
+      << "Found type AlignPCLThresholdsHG, additional thresholds are written" << std::endl;
+
+  for (auto& alignable : alignables) {
+    for (auto& thePSet : m_parameters) {
+      const std::string alignableId(thePSet.getParameter<std::string>("alignableId"));
+      const std::string DOF(thePSet.getParameter<std::string>("DOF"));
+
+      // Get coordType from DOF
+      AlignPCLThresholds::coordType type = static_cast<AlignPCLThresholds::coordType>(mapOntoEnum(DOF));
+
+      if (alignableId == alignable) {
+        if (thePSet.exists("fractionCut")) {
+          const double fractionCut(thePSet.getParameter<double>("fractionCut"));
+          myThresholds.SetFractionCut(alignableId, type, fractionCut);
+        } else {
+          myThresholds.SetFractionCut(alignableId, type, -1.);  // better way to define default fraction cut??
+        }
+      }
+    }
   }
+
+  // print additional tresholds
+  edm::LogInfo("AlignPCLThresholdsWriter") << "Additonal content of AlignPCLThresholdsHG " << std::endl;
+  myThresholds.printAllHG();
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -208,6 +267,8 @@ void AlignPCLThresholdsWriter::fillDescriptions(edm::ConfigurationDescriptions& 
   desc_thresholds.add<double>("sigCut");
   desc_thresholds.add<double>("maxMoveCut");
   desc_thresholds.add<double>("maxErrorCut");
+  // optional thresholds from new payload version
+  desc_thresholds.addOptional<double>("fractionCut");
 
   std::vector<edm::ParameterSet> default_thresholds(1);
   desc.addVPSet("thresholds", desc_thresholds, default_thresholds);

--- a/CondFormats/PCLConfig/python/ThresholdsHG_cff.py
+++ b/CondFormats/PCLConfig/python/ThresholdsHG_cff.py
@@ -1,0 +1,962 @@
+import FWCore.ParameterSet.Config as cms
+import copy 
+
+# -----------------------------------------------------------------------
+# Default configuration
+
+default = cms.VPSet(
+    #### Barrel Pixel HB X- 
+    cms.PSet(alignableId       = cms.string("TPBHalfBarrelXminus"),
+             DOF               = cms.string("X"),
+             cut               = cms.double(5.0),
+             sigCut            = cms.double(2.5),
+             maxMoveCut        = cms.double(200.0),
+             maxErrorCut       = cms.double(10.0)
+             ),
+        
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXminus"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXminus"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),                       
+    
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXminus"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXminus"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXminus"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)                         
+             ),
+    
+    ### Barrel Pixel HB X+
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXplus"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXplus"),
+             DOF                = cms.string("thetaX"),        
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0),
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXplus"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),                       
+                 
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXplus"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXplus"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBHalfBarrelXplus"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)                         
+             ),
+    
+    ### Forward Pixel HC X-,Z-
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZminus"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZminus"),
+             DOF                = cms.string("thetaX"),                                                                       
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZminus"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),                       
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZminus"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZminus"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZminus"),
+             DOF                = cms.string("thetaZ"),         
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)                         
+             ),
+    
+    ### Forward Pixel HC X+,Z-
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZminus"),
+             DOF                = cms.string("X"),         
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZminus"),
+             DOF                = cms.string("thetaX"),                  
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZminus"),
+             DOF                = cms.string("Y"),        
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),                       
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZminus"),
+             DOF                = cms.string("thetaY"),                 
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZminus"),
+             DOF                = cms.string("Z"),         
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZminus"),
+             DOF                = cms.string("thetaZ"),         
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)                         
+             ),
+    
+    ### Forward Pixel HC X-,Z+
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZplus"),
+             DOF                = cms.string("X"),        
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut       =  cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZplus"),
+             DOF                = cms.string("thetaX"),                 
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZplus"),
+             DOF                = cms.string("Y"),        
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZplus"),
+             DOF                = cms.string("thetaY"),                
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZplus"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXminusZplus"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)                         
+             ),
+    
+    ### Forward Pixel HC X+,Z+
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZplus"),
+             DOF                = cms.string("X"),       
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),                                                               
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZplus"),
+             DOF                = cms.string("thetaX"),       
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZplus"),
+             DOF                = cms.string("Y"),       
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZplus"),
+             DOF                = cms.string("thetaY"),       
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZplus"),
+             DOF                = cms.string("Z"),       
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPEHalfCylinderXplusZplus"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             maxMoveCut         = cms.double(200.0),
+             maxErrorCut        = cms.double(10.0)                         
+             ),
+
+    ### Barrel Pixel Ladder
+    cms.PSet(alignableId        = cms.string("TPBLadder"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadder"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadder"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadder"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadder"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadder"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    ### EndCap Pixel Panel
+    cms.PSet(alignableId        = cms.string("TPEPanel"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanel"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanel"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanel"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanel"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanel"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### Barrel Pixel Ladder Layer 1
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer1"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer1"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer1"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer1"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer1"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer1"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### Barrel Pixel Ladder Layer 2
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer2"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer2"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer2"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer2"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer2"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer2"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### Barrel Pixel Ladder Layer 3
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer3"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer3"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer3"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer3"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer3"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer3"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### Barrel Pixel Ladder Layer 4
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer4"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer4"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer4"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer4"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer4"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    cms.PSet(alignableId        = cms.string("TPBLadderLayer4"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### EndCap Pixel Panel Disk1
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk1"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk1"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk1"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk1"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk1"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk1"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### EndCap Pixel Panel Disk2
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk2"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk2"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk2"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk2"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk2"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk2"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### EndCap Pixel Panel Disk3
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk3"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk3"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk3"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk3"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk3"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDisk3"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### EndCap Pixel Panel DiskM1
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM1"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM1"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM1"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM1"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM1"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM1"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### EndCap Pixel Panel DiskM2
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM2"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM2"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM2"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM2"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM2"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM2"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+    
+    ### EndCap Pixel Panel DiskM3
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM3"),
+             DOF                = cms.string("X"),
+             cut                = cms.double(5.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM3"),
+             DOF                = cms.string("thetaX"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM3"),
+             DOF                = cms.string("Y"),
+             cut                = cms.double(10.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM3"),
+             DOF                = cms.string("thetaY"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM3"),
+             DOF                = cms.string("Z"),
+             cut                = cms.double(15.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             ),
+
+    cms.PSet(alignableId        = cms.string("TPEPanelDiskM3"),
+             DOF                = cms.string("thetaZ"),
+             cut                = cms.double(30.0),
+             sigCut             = cms.double(2.5),
+             fractionCut        = cms.double(0.25),
+             maxMoveCut         = cms.double(100000.0),
+             maxErrorCut        = cms.double(10000.0)
+             )
+    )
+

--- a/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
+++ b/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
@@ -1,0 +1,122 @@
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <iostream>
+#include <iomanip>  // std::setw
+
+namespace AlignPCLThresholdsHGImpl {
+  template <typename T>
+  const T &getParam(const std::vector<T> &params, size_t index) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    return params[index];
+  }
+
+  template <typename T>
+  void setParam(std::vector<T> &params, size_t index, const T &value) {
+    if (index >= params.size())
+      throw std::out_of_range("Parameter with index " + std::to_string(index) + " is out of range.");
+    params[index] = value;
+  }
+
+}  //namespace AlignPCLThresholdsHGImpl
+
+const std::vector<float> &AlignPCLThresholdsHG::getFloatVec(const std::string &AlignableId) const {
+  std::unordered_map<std::string, std::vector<float>>::const_iterator it = floatMap.find(AlignableId);
+
+  if (it != floatMap.end()) {
+    return it->second;
+  } else {
+    throw cms::Exception("AlignPCLThresholdsHG") << "No float vector defined for Alignable id " << AlignableId << "\n";
+  }
+}
+
+void AlignPCLThresholdsHG::SetFractionCut(const std::string &AlignableId, const coordType &type, const float &cut) {
+  // Set entry in map if not yet available
+  std::unordered_map<std::string, std::vector<float>>::const_iterator it = floatMap.find(AlignableId);
+  if (it == floatMap.end())
+    floatMap[AlignableId] = std::vector<float>(FSIZE, 0.);
+
+  switch (type) {
+    case X:
+      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_X, cut);
+    case Y:
+      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_Y, cut);
+    case Z:
+      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_Z, cut);
+    case theta_X:
+      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_TX, cut);
+    case theta_Y:
+      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_TY, cut);
+    case theta_Z:
+      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_TZ, cut);
+    default:
+      throw cms::Exception("AlignPCLThresholdsHG")
+          << "Requested setting fraction threshold for undefined coordinate" << type << "\n";
+  }
+}
+
+std::array<float, 6> AlignPCLThresholdsHG::getFractionCut(const std::string &AlignableId) const {
+  const std::vector<float> vec = getFloatVec(AlignableId);
+  return {{AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_X),
+           AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_Y),
+           AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_Z),
+           AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_TX),
+           AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_TY),
+           AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_TZ)}};
+}
+
+float AlignPCLThresholdsHG::getFractionCut(const std::string &AlignableId, const coordType &type) const {
+  const std::vector<float> vec = getFloatVec(AlignableId);
+  switch (type) {
+    case X:
+      return AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_X);
+    case Y:
+      return AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_Y);
+    case Z:
+      return AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_Z);
+    case theta_X:
+      return AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_TX);
+    case theta_Y:
+      return AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_TY);
+    case theta_Z:
+      return AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_TZ);
+    default:
+      throw cms::Exception("AlignPCLThresholdsHG")
+          << "Requested fraction threshold for undefined coordinate" << type << "\n";
+  }
+}
+
+int AlignPCLThresholdsHG::payloadVersion() const {
+  switch (FSIZE) {
+    case 6:
+      return 1;
+    default:
+      throw cms::Exception("AlignPCLThresholdsHG")
+          << "Payload version with FSIZE equal to " << FSIZE << " is not defined.\n";
+  }
+}
+
+void AlignPCLThresholdsHG::printAllHG() const {
+  edm::LogVerbatim("AlignPCLThresholdsHG") << "AlignPCLThresholdsHG::printAllHG()";
+  edm::LogVerbatim("AlignPCLThresholdsHG") << " ==================================";
+  for (auto it = floatMap.begin(); it != floatMap.end(); ++it) {
+    edm::LogVerbatim("AlignPCLThresholdsHG") << " ==================================";
+    edm::LogVerbatim("AlignPCLThresholdsHG")
+        << "key : " << it->first << " \n"
+        << "- X_fractionCut             : " << std::setw(4) << getFractionCut(it->first, X) << std::setw(5) << "\n"
+
+        << "- thetaX_fractionCut        : " << std::setw(4) << getFractionCut(it->first, theta_X) << std::setw(5)
+        << "\n"
+
+        << "- Y_fractionCut             : " << std::setw(4) << getFractionCut(it->first, Y) << std::setw(5) << "\n"
+
+        << "- thetaY_fractionCut        : " << std::setw(4) << getFractionCut(it->first, theta_Y) << std::setw(5)
+        << "\n"
+
+        << "- Z_fractionCut             : " << std::setw(4) << getFractionCut(it->first, Z) << std::setw(5) << "\n"
+
+        << "- thetaZ_fractionCut        : " << std::setw(4) << getFractionCut(it->first, theta_Z) << std::setw(5);
+  }
+}

--- a/CondFormats/PCLConfig/src/T_EventSetup_AlignPCLThresholdsHG.cc
+++ b/CondFormats/PCLConfig/src/T_EventSetup_AlignPCLThresholdsHG.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(AlignPCLThresholdsHG);

--- a/CondFormats/PCLConfig/src/classes_def.xml
+++ b/CondFormats/PCLConfig/src/classes_def.xml
@@ -4,4 +4,5 @@
   </class>
   <class name="AlignPCLThreshold"/>
   <class name="std::map<std::string,AlignPCLThreshold>"/>
+  <class name="AlignPCLThresholdsHG"/>
 </lcgdict> 

--- a/CondFormats/PCLConfig/src/headers.h
+++ b/CondFormats/PCLConfig/src/headers.h
@@ -1,1 +1,2 @@
 #include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"

--- a/CondFormats/PCLConfig/test/AlignPCLThresholdsReader_cfg.py
+++ b/CondFormats/PCLConfig/test/AlignPCLThresholdsReader_cfg.py
@@ -18,8 +18,33 @@ process.MessageLogger.cout = cms.untracked.PSet(
                                    reportEvery = cms.untracked.int32(1000)
                                    ),                                                      
     AlignPCLThresholdsReader = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
-    AlignPCLThresholds       = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    AlignPCLThresholds       = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    AlignPCLThresholdsHG     = cms.untracked.PSet( limit = cms.untracked.int32(-1))
     )
+
+##
+## Var Parsing
+##
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('readLGpayload',
+                False,
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.bool,
+                "Read old payload type used for LG thresholds")
+options.parseArguments()
+
+##
+## Define record, class and module based on option
+##
+rcdName = "AlignPCLThresholdsHGRcd"
+className = "AlignPCLThresholdsHG"
+moduleName = "AlignPCLThresholdsHGReader"
+
+if options.readLGpayload:
+    rcdName = "AlignPCLThresholdsRcd"
+    className = "AlignPCLThresholds"
+    moduleName = "AlignPCLThresholdsLGReader"
 
 ##
 ## Empty Source
@@ -38,7 +63,7 @@ CondDBThresholds = CondDB.clone(connect = cms.string("sqlite_file:mythresholds.d
 
 process.dbInput = cms.ESSource("PoolDBESSource",
                                CondDBThresholds,
-                               toGet = cms.VPSet(cms.PSet(record = cms.string('AlignPCLThresholdsRcd'),
+                               toGet = cms.VPSet(cms.PSet(record = cms.string(rcdName),
                                                           tag = cms.string('PCLThresholds_express_v0') # choose tag you want
                                                           )
                                                  )
@@ -47,16 +72,17 @@ process.dbInput = cms.ESSource("PoolDBESSource",
 ## Retrieve it and check it's available in the ES
 ##
 process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
-                             toGet = cms.VPSet(cms.PSet(record = cms.string('AlignPCLThresholdsRcd'),
-                                                        data = cms.vstring('AlignPCLThresholds')
+                             toGet = cms.VPSet(cms.PSet(record = cms.string(rcdName),
+                                                        data = cms.vstring(className)
                                                         )
                                                ),
                              verbose = cms.untracked.bool(True)
                              )
+
 ##
 ## Read it back
 ##
-process.ReadDB = cms.EDAnalyzer("AlignPCLThresholdsReader")
+process.ReadDB = cms.EDAnalyzer(moduleName)
 process.ReadDB.printDebug = cms.untracked.bool(True)
 process.ReadDB.outputFile = cms.untracked.string('AlignPCLThresholds.log')
 

--- a/CondFormats/PCLConfig/test/AlignPCLThresholdsWriter_cfg.py
+++ b/CondFormats/PCLConfig/test/AlignPCLThresholdsWriter_cfg.py
@@ -19,7 +19,8 @@ process.MessageLogger.cout = cms.untracked.PSet(
                                    reportEvery = cms.untracked.int32(1000)
                                    ),                                                      
     AlignPCLThresholdsWriter = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
-    AlignPCLThresholds       = cms.untracked.PSet( limit = cms.untracked.int32(-1))
+    AlignPCLThresholds       = cms.untracked.PSet( limit = cms.untracked.int32(-1)),
+    AlignPCLThresholdsHG     = cms.untracked.PSet( limit = cms.untracked.int32(-1))
     )
 
 ##
@@ -43,7 +44,7 @@ process.CondDB.connect = 'sqlite_file:mythresholds.db'
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),
-                                          toPut = cms.VPSet(cms.PSet(record = cms.string('AlignPCLThresholdsRcd'),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('FooRcd'),
                                                                      tag = cms.string('PCLThresholds_express_v0')
                                                                      )
                                                             )
@@ -52,7 +53,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
 ##
 ## Impot the thresholds configuration
 ##
-import CondFormats.PCLConfig.Thresholds_cff as Thresholds
+import CondFormats.PCLConfig.ThresholdsHG_cff as Thresholds
 
 ##
 ## Example on how to add to the default extra degrees of freedom
@@ -72,7 +73,7 @@ DefaultPlusSurface = AddSurfaceThresholds+BPixSurface
 #print DefaultPlusSurface.dumpPython()
 
 process.WriteInDB = cms.EDAnalyzer("AlignPCLThresholdsWriter",
-                                   record= cms.string('AlignPCLThresholdsRcd'),
+                                   record= cms.string('FooRcd'),
                                    ### minimum number of records found in pede output 
                                    minNRecords = cms.uint32(25000), 
                                    #thresholds  = cms.VPSet()         # empty object


### PR DESCRIPTION
#### PR description:
This PR is the first step towards using a higher granularity (HG) for the pixel alignment in the PCL. A new threshold object is introduced, which allows to use additional cuts/vetoes on top of the ones already used in the low granularity (LG) alignment.

In detail the following changes/adaption have been made:

- New class `AlignPCLThresholdsHG`, which inherits from `AlignPCLThresholds`, and adds containers for floats, ints and strings with variable sizes to allow for different types of new thresholds in the future. So far, only methods for a fraction cut are implemented.
- New record `AlignPCLThresholdsHGRcd`, which is based on the new class `AlignPCLThresholdsHG`
- Templated `AlignPCLThresholdsWriter` and `AlignPCLThresholdsReader` to handle `AlignPCLThresholdsHG` and `AlignPCLThresholds`
- Adapt the config of `AlignPCLThresholdsReader` to handle both payload types

#### PR validation:
The PR can be tested with the old payload type based on `AlignPCLThresholdsHG` and the new payload type based on `AlignPCLThresholdsHG`:

- Testing the new payload type: `cmsRun AlignPCLThresholdsWriter_cfg.py && cmsRun AlignPCLThresholdsWriter_cfg.py`
- Testing the old payload type: Remove `fractionCut` entries in `Thresholds_cff.py` and run `cmsRun AlignPCLThresholdsWriter_cfg.py && cmsRun AlignPCLThresholdsWriter_cfg.py readLGpayload=True`

#### Upcoming PRs:
This PR will be followed by two more PRs:
- Changing to the new object in the consumer code in `Alingment` package
- Introducing the changes needed to run and store the HG alignment

cc:
@mmusich, @connorpa, @antoniovagnerini, @consuegs 

