### PR TITLE
[SIMULATION] [GCC12] Added missing array header

### DIFF
--- a/SimG4Core/Application/src/ThreadHandoff.cc
+++ b/SimG4Core/Application/src/ThreadHandoff.cc
@@ -15,6 +15,7 @@
 // user include files
 #include "SimG4Core/Application/interface/ThreadHandoff.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include <array>
 
 //
 // constants, enums and typedefs


### PR DESCRIPTION
Adding missing array header to fix GCC12 build errors