### PR TITLE
[12_3_X] Move counter initialization and printout+destruction to begin/endJob

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletCUDA.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletCUDA.cc
@@ -31,6 +31,9 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  void beginJob() override;
+  void endJob() override;
+
   void produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
 
   bool onGPU_;
@@ -65,6 +68,10 @@ void CAHitNtupletCUDA::fillDescriptions(edm::ConfigurationDescriptions& descript
   CAHitNtupletGeneratorOnGPU::fillDescriptions(desc);
   descriptions.add("pixelTracksCUDA", desc);
 }
+
+void CAHitNtupletCUDA::beginJob() { gpuAlgo_.beginJob(); }
+
+void CAHitNtupletCUDA::endJob() { gpuAlgo_.endJob(); }
 
 void CAHitNtupletCUDA::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& es) const {
   auto bf = 1. / es.getData(tokenField_).inverseBzAtOriginInGeV();

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.h
@@ -41,10 +41,11 @@ public:
       : CAHitNtupletGeneratorOnGPU(cfg, iC) {}
   CAHitNtupletGeneratorOnGPU(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
-  ~CAHitNtupletGeneratorOnGPU();
-
   static void fillDescriptions(edm::ParameterSetDescription& desc);
   static const char* fillDescriptionsLabel() { return "caHitNtupletOnGPU"; }
+
+  void beginJob();
+  void endJob();
 
   PixelTrackHeterogeneous makeTuplesAsync(TrackingRecHit2DGPU const& hits_d, float bfield, cudaStream_t stream) const;
 


### PR DESCRIPTION
#### PR description:

Backport of #38145

> This avoids possible exception being thrown in CAHitNtupletGeneratorOnGPU destructor that occurred in https://github.com/cms-sw/cmssw/issues/38125.

#### PR validation:

Nothing beyond #38145

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #38145 