### PR TITLE
Pixel Heterogenous DQM: fix bug in TProfile definitions

### DIFF
--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorTrackSoA.cc
@@ -144,18 +144,18 @@ void SiPixelPhase1MonitorTrackSoA::bookHistograms(DQMStore::IBooker& iBook,
 
   toRep = "Number of all RecHits per track (quality #geq loose)";
   hnHits = iBook.book1D("nRecHits", fmt::sprintf(";%s;#tracks",toRep), 15, -0.5, 14.5);
-  hnHitsVsPhi = iBook.bookProfile("nHitsPerTrackVsPhi", fmt::sprintf("%s vs track #eta;Track #eta;%s",toRep,toRep), 30, -3., 3., 0., 15.);
-  hnHitsVsEta = iBook.bookProfile("nHitsPerTrackVsEta", fmt::sprintf("%s vs track #phi;Track #phi;%s",toRep,toRep), 30,-M_PI,-M_PI,0.,15.);
+  hnHitsVsPhi = iBook.bookProfile("nHitsPerTrackVsPhi", fmt::sprintf("%s vs track #phi;Track #phi;%s",toRep,toRep), 30, -M_PI, M_PI,0., 15.);
+  hnHitsVsEta = iBook.bookProfile("nHitsPerTrackVsEta", fmt::sprintf("%s vs track #eta;Track #eta;%s",toRep,toRep), 30, -3., 3., 0., 15.);
 
   toRep = "Number of all layers per track (quality #geq loose)";
   hnLayers = iBook.book1D("nLayers", fmt::sprintf(";%s;#tracks",toRep), 15, -0.5, 14.5);
-  hnLayersVsPhi = iBook.bookProfile("nLayersPerTrackVsPhi", fmt::sprintf("%s vs track #eta;Track #eta;%s",toRep,toRep), 30, -3., 3., 0., 15.);
-  hnLayersVsEta = iBook.bookProfile("nLayersPerTrackVsEta", fmt::sprintf("%s vs track #phi;Track #phi;%s",toRep,toRep), 30,-M_PI,-M_PI,0.,15.);
+  hnLayersVsPhi = iBook.bookProfile("nLayersPerTrackVsPhi", fmt::sprintf("%s vs track #phi;Track #phi;%s",toRep,toRep), 30, -M_PI, M_PI,0., 15.);
+  hnLayersVsEta = iBook.bookProfile("nLayersPerTrackVsEta", fmt::sprintf("%s vs track #eta;Track #eta;%s",toRep,toRep), 30, -3., 3., 0., 15.);
 
   toRep = "Track (quality #geq loose) #chi^{2}/ndof";
   hchi2 = iBook.book1D("nChi2ndof", fmt::sprintf(";%s;#tracks",toRep), 40, 0., 20.);
-  hChi2VsPhi = iBook.bookProfile("nChi2ndofVsPhi", fmt::sprintf("%s vs track #eta;Track #eta;%s",toRep,toRep), 30, -3., 3., 0., 20.);
-  hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::sprintf("%s vs track #phi;Track #phi;%s",toRep,toRep), 30, -M_PI, -M_PI, 0., 20.);
+  hChi2VsPhi = iBook.bookProfile("nChi2ndofVsPhi", fmt::sprintf("%s vs track #phi;Track #phi;%s",toRep,toRep), 30, -M_PI, M_PI, 0., 20.);
+  hChi2VsEta = iBook.bookProfile("nChi2ndofVsEta", fmt::sprintf("%s vs track #eta;Track #eta;%s",toRep,toRep), 30, -3., 3., 0., 20.);
   // clang-format on
 
   hpt = iBook.book1D("pt", ";Track (quality #geq loose) p_{T} [GeV];#tracks", 200, 0., 200.);

--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorVertexSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorVertexSoA.cc
@@ -109,9 +109,9 @@ void SiPixelPhase1MonitorVertexSoA::bookHistograms(DQMStore::IBooker& ibooker,
   ibooker.cd();
   ibooker.setCurrentFolder(topFolderName_);
   hnVertex = ibooker.book1D("nVertex", ";# of Vertex;#entries", 101, -0.5, 100.5);
-  hx = ibooker.book1D("vx", ";Vertez x;#entries", 10, -5., 5.);
-  hy = ibooker.book1D("vy", ";Vertez y;#entries", 10, -5., 5.);
-  hz = ibooker.book1D("vz", ";Vertez z;#entries", 30, -30., 30);
+  hx = ibooker.book1D("vx", ";Vertex x;#entries", 10, -5., 5.);
+  hy = ibooker.book1D("vy", ";Vertex y;#entries", 10, -5., 5.);
+  hz = ibooker.book1D("vz", ";Vertex z;#entries", 30, -30., 30);
   hchi2 = ibooker.book1D("chi2", ";Vertex chi-squared;#entries", 40, 0., 20.);
   hchi2oNdof = ibooker.book1D("chi2oNdof", ";Vertex chi-squared/Ndof;#entries", 40, 0., 20.);
   hptv2 = ibooker.book1D("ptsq", ";Vertex p_T squared;#entries", 200, 0., 200.);


### PR DESCRIPTION
#### PR description:
The definition of TProfile of # of hits, layers, chi2 vs eta, phi is incorrect. See example [plot](https://cmsweb.cern.ch/dqm/online-test/start?runnr=352572;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Everything;size=M;root=SiPixelHeterogeneous/PixelTracksCPU;focus=SiPixelHeterogeneous/PixelTracksCPU/nLayersPerTrackVsEta;zoom=yes;) This PR fixes it. 
#### PR validation:
Pixel only GPU wf runs. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport to 12.4 and 12.3 is needed.