### PR TITLE
ECAL GPU unpacker: adapt the buffer size to the ECAL FEDs size [12.4.x]

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/DeclsForKernels.h
+++ b/EventFilter/EcalRawToDigi/plugins/DeclsForKernels.h
@@ -15,13 +15,6 @@
 namespace ecal {
   namespace raw {
 
-    constexpr auto empty_event_size = EMPTYEVENTSIZE;
-    constexpr uint32_t nfeds_max = 54;
-    constexpr uint32_t nbytes_per_fed_max = 41616;  // max FED size in full readout mode
-                                                    // DCC header and trailer: 10 words (64bit),
-                                                    // TCC block: 18 words, SR block 6 words,
-                                                    // (25 channels per tower * 3 words + 1 header word) * 68 towers
-
     struct InputDataCPU {
       cms::cuda::host::unique_ptr<unsigned char[]> data;
       cms::cuda::host::unique_ptr<uint32_t[]> offsets;

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -189,6 +189,16 @@ def customiseForOffline(process):
     return process
 
 
+# ECAL GPU unpacker: adapt the buffer size to the ECAL FEDs size (#38202)
+# remove the EcalRawToDigi.maxFedSize parameter from the menu
+def customizeHLTfor38202(process):
+    for producer in producers_by_type(process, "EcalRawToDigiGPU"):
+        if hasattr(producer, "maxFedSize"):
+            delattr(producer, "maxFedSize")
+
+    return process
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
@@ -196,5 +206,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customizeHLTfor38202(process)
 
     return process


### PR DESCRIPTION
#### PR description:

Automatically determine the cpu and gpu buffers' size used for the unpacking from the total size of the non-empty ECAL FEDs.
Remove the `maxFedSize` parameter from the `EcalRawToDigi` modules in the HLT menus.

#### PR validation:

None.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #38202 .
