### PR TITLE
Fix for hardcoded subdetector id in PPS reconstruction code

### DIFF
--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -754,8 +754,13 @@ void TotemDAQMappingESSourceXML::ParseTreeTotemTiming(ParseType pType,
       unsigned int StationNum = (parentID / 1000) % 10;
       unsigned int RpNum = (parentID / 100) % 10;
 
-      vfatInfo.symbolicID.symbolicID = TotemTimingDetId(
-          ArmNum, StationNum, RpNum, 0, TotemTimingDetId::ID_NOT_SET);  //Dynamical: it is encoded in the frame
+      vfatInfo.symbolicID.symbolicID =
+          TotemTimingDetId(ArmNum,
+                           StationNum,
+                           RpNum,
+                           0,
+                           TotemTimingDetId::ID_NOT_SET,
+                           TotemTimingDetId::sdTimingDiamond);  //Dynamical: it is encoded in the frame
 
       mapping->insert(framepos, vfatInfo);
 

--- a/DataFormats/CTPPSDetId/interface/TotemTimingDetId.h
+++ b/DataFormats/CTPPSDetId/interface/TotemTimingDetId.h
@@ -33,7 +33,12 @@ public:
   TotemTimingDetId(const CTPPSDetId& id) : CTPPSDetId(id) {}
 
   /// Construct from hierarchy indices.
-  TotemTimingDetId(uint32_t arm, uint32_t station, uint32_t romanPot = 0, uint32_t plane = 0, uint32_t channel = 0);
+  TotemTimingDetId(uint32_t arm,
+                   uint32_t station,
+                   uint32_t romanPot = 0,
+                   uint32_t plane = 0,
+                   uint32_t channel = 0,
+                   uint32_t subdet = sdTimingFastSilicon);
 
   static constexpr uint32_t startPlaneBit = 17, maskPlane = 0x3, maxPlane = 3, lowMaskPlane = 0x1FFFF;
   static constexpr uint32_t startDetBit = 12, maskChannel = 0x1F, maxChannel = 31, lowMaskChannel = 0xFFF;
@@ -41,7 +46,8 @@ public:
   /// returns true if the raw ID is a PPS-timing one
   static bool check(unsigned int raw) {
     return (((raw >> DetId::kDetOffset) & 0xF) == DetId::VeryForward &&
-            ((raw >> DetId::kSubdetOffset) & 0x7) == sdTimingFastSilicon);
+            (((raw >> DetId::kSubdetOffset) & 0x7) == sdTimingFastSilicon ||
+             ((raw >> DetId::kSubdetOffset) & 0x7) == sdTimingDiamond));
   }
   //-------------------- getting and setting methods --------------------
 

--- a/DataFormats/CTPPSDetId/src/TotemTimingDetId.cc
+++ b/DataFormats/CTPPSDetId/src/TotemTimingDetId.cc
@@ -18,8 +18,9 @@ TotemTimingDetId::TotemTimingDetId(uint32_t id) : CTPPSDetId(id) {
 
 //----------------------------------------------------------------------------------------------------
 
-TotemTimingDetId::TotemTimingDetId(uint32_t arm, uint32_t station, uint32_t romanPot, uint32_t plane, uint32_t channel)
-    : CTPPSDetId(sdTimingFastSilicon, arm, station, romanPot) {
+TotemTimingDetId::TotemTimingDetId(
+    uint32_t arm, uint32_t station, uint32_t romanPot, uint32_t plane, uint32_t channel, uint32_t subdet)
+    : CTPPSDetId(subdet, arm, station, romanPot) {
   if (arm > maxArm || station > maxStation || romanPot > maxRP || plane > maxPlane || channel > maxChannel) {
     throw cms::Exception("InvalidDetId") << "TotemTimingDetId ctor:"
                                          << " Invalid parameters:"

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -101,6 +101,7 @@ void RawToDigiConverter::runCommon(const VFATFrameCollection &input,
         stopProcessing = true;
       }
     }
+
     // check the id mismatch
     if (testID != tfNoTest && record.frame->isIDPresent() &&
         (record.frame->getChipID() & 0xFFF) != (record.info->hwID & 0xFFF)) {
@@ -331,11 +332,10 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
                                   eventInfoTmp);
           // calculate ids
           TotemTimingDetId detId(record.info->symbolicID.symbolicID);
-
           const TotemDAQMapping::TotemTimingPlaneChannelPair SWpair =
               mapping.getTimingChannel(totemSampicFrame.getHardwareId());
           // for FW Version > 0 plane and channel are encoded in the dataframe
-          if (totemSampicFrame.getFWVersion() < 0x30)  // Mapping not present in HW, read from SW for FW versions < 3.0
+          if (totemSampicFrame.getFWVersion() == 0)  // Mapping not present in HW, read from SW for FW versions == 0
           {
             if (SWpair.plane == -1 || SWpair.channel == -1) {
               if (verbosity > 0)
@@ -345,7 +345,6 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
             } else {
               detId.setPlane(SWpair.plane % 4);
               detId.setChannel(SWpair.channel);
-              detId.setRP(SWpair.plane / 4);  // Top:0 or Bottom:1
             }
           } else  // Mapping read from HW, checked by SW
           {
@@ -368,7 +367,6 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
             }
             detId.setPlane(HWplane % 4);
             detId.setChannel(HWchannel);
-            detId.setRP(HWplane / 4);  // Top:0 or Bottom:1
           }
 
           DetSet<TotemTimingDigi> &digiDetSet = digi.find_or_insert(detId);


### PR DESCRIPTION
#### PR description:
This PR fixes recently discovered bug in detector id class for PPS
subsystem. It also adjust properly raw2digi module to the new hardware
settings for SAMPIC readout for PPS diamond sensors.
The bug was recently discovered and is a blocker for data readout and
reconstruction in PPS, see for example crash reported here:
https://cmsweb.cern.ch/dqm/dqm-square/tmp/tmp/content_parser_productionPARSER_run352682PARSER_job5.log

This patch is needed for PPS alignment run foreseen on 19 June 2022.

#### PR validation:
The PR can be tested locally using data from run 352682 available on EOS
(`/eos/cms/store/t0streamer/Data/ExpressCosmics/000/352/682/`).
The test was based on standard PPS reconstruction.

#### Backport:
The backport to 12_4 (and 12_3 if necessary) will follow shortly.
 