### PR TITLE
Shorten PPS DiamondSampic ALCARECOStream name to fit into DBS database schema

### DIFF
--- a/CalibPPS/TimingCalibration/python/ALCARECOPromptCalibProdPPSDiamondSampicTimingCalib_Output_cff.py
+++ b/CalibPPS/TimingCalibration/python/ALCARECOPromptCalibProdPPSDiamondSampicTimingCalib_Output_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-OutALCARECOPromptCalibProdPPSDiamondSampicTimingCalib_noDrop = cms.PSet(
+OutALCARECOPromptCalibProdPPSDiamondSampic_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('pathALCARECOPromptCalibProdPPSDiamondSampicTiming')
     ),
@@ -9,5 +9,5 @@ OutALCARECOPromptCalibProdPPSDiamondSampicTimingCalib_noDrop = cms.PSet(
     )
 )
 
-OutALCARECOPromptCalibProdPPSDiamondSampicTimingCalib = OutALCARECOPromptCalibProdPPSDiamondSampicTimingCalib_noDrop.clone()
-OutALCARECOPromptCalibProdPPSDiamondSampicTimingCalib.outputCommands.insert(0, 'drop *')
+OutALCARECOPromptCalibProdPPSDiamondSampic = OutALCARECOPromptCalibProdPPSDiamondSampic_noDrop.clone()
+OutALCARECOPromptCalibProdPPSDiamondSampic.outputCommands.insert(0, 'drop *')

--- a/Configuration/AlCa/python/autoPCL.py
+++ b/Configuration/AlCa/python/autoPCL.py
@@ -1,3 +1,7 @@
+# Important note:
+# due to the limitations of the DBS database schema, as described in
+# https://cms-talk.web.cern.ch/t/alcaprompt-datasets-not-loaded-in-dbs/11146/2,
+# the keys of the dict (i.e. the "PromptCalib*") MUST be shorter than 31 characters
 autoPCL = {'PromptCalibProd' : 'BeamSpotByRun+BeamSpotByLumi',
            'PromptCalibProdBeamSpotHP' : 'BeamSpotHPByRun+BeamSpotHPByLumi',
            'PromptCalibProdBeamSpotHPLowPU' : 'BeamSpotHPLowPUByRun+BeamSpotHPLowPUByLumi',
@@ -11,6 +15,6 @@ autoPCL = {'PromptCalibProd' : 'BeamSpotByRun+BeamSpotByLumi',
            'PromptCalibProdEcalPedestals': 'EcalPedestals',
            'PromptCalibProdLumiPCC': 'LumiPCC',
            'PromptCalibProdPPSTimingCalib' : 'PPSTimingCalibration',
-           'PromptCalibProdPPSDiamondSampicTimingCalib' : 'PPSDiamondSampicTimingCalibration',
+           'PromptCalibProdPPSDiamondSampic' : 'PPSDiamondSampicTimingCalibration',
            'PromptCalibProdPPSAlignment' : 'PPSAlignment'
            }

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -925,12 +925,12 @@ ALCARECOStreamPromptCalibProdPPSTimingCalib = cms.FilteredStream(
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 	
-ALCARECOStreamPromptCalibProdPPSDiamondSampicTimingCalib = cms.FilteredStream(
+ALCARECOStreamPromptCalibProdPPSDiamondSampic = cms.FilteredStream(
 	responsible = 'Christopher Misan',
-	name = 'ALCARECOStreamPromptCalibProdPPSDiamondSampicTimingCalib',
+	name = 'ALCARECOStreamPromptCalibProdPPSDiamondSampic',
 	paths  = (pathALCARECOPromptCalibProdPPSDiamondSampicTimingCalib),
-	content = OutALCARECOPromptCalibProdPPSDiamondSampicTimingCalib.outputCommands,
-	selectEvents = OutALCARECOPromptCalibProdPPSDiamondSampicTimingCalib.SelectEvents,
+	content = OutALCARECOPromptCalibProdPPSDiamondSampic.outputCommands,
+	selectEvents = OutALCARECOPromptCalibProdPPSDiamondSampic.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 


### PR DESCRIPTION
#### PR description:
Due to the limitations of the DBS database schema (as described in https://cms-talk.web.cern.ch/t/alcaprompt-datasets-not-loaded-in-dbs/11146/2) and following the example of #38186, this PR shortens the only remaining ALCARECOStream name in autoPCL that was still too long:
- `ALCARECOStreamPromptCalibProdPPSDiamondSampicTimingCalib` 
   is renamed 
   `ALCARECOStreamPromptCalibProdPPSDiamondSampic`

#### PR validation:
Code compiles.
There are no data taken with PPS Diamond Sampic detector yet, so no relvals and no other test can be done at this point.
As soon as we get some data we will set up all the needed tests.

#### Backport:
Not a backport, but backports to 12_3_X and 12_4_X will be provided.

FYI @vavati @ChrisMisan @grzanka