### PR TITLE
[12.4.X] protect `ALCARECOSiStripCalCosmicsNano` for missing tracks (when Tracker DCS is OFF)

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmicsNano_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmicsNano_cff.py
@@ -13,6 +13,16 @@ ALCARECOSiStripCalCosmicsNanoHLT = triggerResultsFilter.clone(
         throw=cms.bool(False)
         )
 
+# Select only events where tracker had HV on (according to DCS bit information)
+# AND respective partition is in the run (according to FED information)
+import CalibTracker.SiStripCommon.SiStripDCSFilter_cfi
+DCSStatusForSiStripCalCosmicsNano = CalibTracker.SiStripCommon.SiStripDCSFilter_cfi.siStripDCSFilter.clone(
+    DetectorType = cms.vstring('TIBTID','TOB','TECp','TECm'),
+    ApplyFilter  = cms.bool(True),
+    AndOr        = cms.bool(True),
+    DebugOn      = cms.untracked.bool(False)
+    )
+
 from CalibTracker.Configuration.Filter_Refit_cff import CalibrationTracks, CalibrationTracksRefit, MeasurementTrackerEvent, offlineBeamSpot
 
 ALCARECOSiStripCalCosmicsNanoCalibTracks = CalibrationTracks.clone(src=cms.InputTag("ALCARECOSiStripCalCosmics"))
@@ -23,6 +33,7 @@ ALCARECOSiStripCalCosmicsNanoCalibTracksRefit = CalibrationTracksRefit.clone(
 ALCARECOSiStripCalCosmicsNanoTkCalSeq = cms.Sequence(
         ALCARECOSiStripCalCosmicsNanoPrescale*
         ALCARECOSiStripCalCosmicsNanoHLT*
+        DCSStatusForSiStripCalCosmicsNano*
         ALCARECOSiStripCalCosmicsNanoCalibTracks,
         cms.Task(MeasurementTrackerEvent),
         cms.Task(offlineBeamSpot),


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/38213

#### PR description:

Title says it all.
The problem arises because the input events for `SiStripCalCosmics` (which is the input for this workflow)

https://github.com/cms-sw/cmssw/blob/cb55e6486f92e4277753268c7bf9770b5c994602/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmicsNano_cff.py#L18

are DSC-filtered:

https://github.com/cms-sw/cmssw/blob/cb55e6486f92e4277753268c7bf9770b5c994602/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_cff.py#L13-L19

but the `SiStripCalCosmicsNano` is not, hence in circulating beams situation (when TK HV is off) there are no input tracks, but the producer is run nonetheless.

Resolves problem described at https://cms-talk.web.cern.ch/t/failure-at-tier0-of-sistripcalcosmicsnano/11186.

#### PR validation:

Private.
After the fix, successfully run the following command:

```console
python3 Configuration/DataProcessing/test/RunPromptReco.py --scenario cosmicsEra_Run3 --reco --global-tag 123X_dataRun3_Prompt_v8 --lfn=root://eoscms.cern.ch//eos/cms/tier0/store/data/Run2022A/Cosmics/RAW/v1/000/352/705/00000/636e0528-de8a-4acd-bd7c-e99bf0c4aa27.root --alcareco SiStripCalCosmicsNano
```

using the problematic input file specified in the [cmsTalk posting](https://cms-talk.web.cern.ch/t/failure-at-tier0-of-sistripcalcosmicsnano/11186)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of https://github.com/cms-sw/cmssw/pull/38213