### PR TITLE
[GCC12] Added missing array header

### DIFF
--- a/DataFormats/ParticleFlowReco/src/PFTrajectoryPoint.cc
+++ b/DataFormats/ParticleFlowReco/src/PFTrajectoryPoint.cc
@@ -1,4 +1,5 @@
 #include "DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h"
+#include <array>
 #include <ostream>
 #include <algorithm>
 


### PR DESCRIPTION
Adding missing array header to fix GCC12 build errors