### PR TITLE
avoid overwrite of `options` PSet from `ConfDB` in HLT utilities [`12_4_X`]

### DIFF
--- a/HLTrigger/Configuration/python/CustomConfigs.py
+++ b/HLTrigger/Configuration/python/CustomConfigs.py
@@ -17,15 +17,15 @@ def ProcessName(process):
 def Base(process):
 #   default modifications
 
-    process.options.wantSummary = cms.untracked.bool(True)
-    process.options.numberOfThreads = cms.untracked.uint32( 4 )
-    process.options.numberOfStreams = cms.untracked.uint32( 0 )
-    process.options.sizeOfStackForThreadsInKB = cms.untracked.uint32( 10*1024 )
+    process.options.wantSummary = True
+    process.options.numberOfThreads = 4
+    process.options.numberOfStreams = 0
+    process.options.sizeOfStackForThreadsInKB = 10*1024
 
-    process.MessageLogger.TriggerSummaryProducerAOD=cms.untracked.PSet()
-    process.MessageLogger.L1GtTrigReport=cms.untracked.PSet()
-    process.MessageLogger.L1TGlobalSummary=cms.untracked.PSet()
-    process.MessageLogger.HLTrigReport=cms.untracked.PSet()
+    process.MessageLogger.TriggerSummaryProducerAOD = cms.untracked.PSet()
+    process.MessageLogger.L1GtTrigReport = cms.untracked.PSet()
+    process.MessageLogger.L1TGlobalSummary = cms.untracked.PSet()
+    process.MessageLogger.HLTrigReport = cms.untracked.PSet()
 
 # No longer override - instead use GT config as provided via cmsDriver
 ## override the GlobalTag, connection string and pfnPrefix

--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -333,11 +333,9 @@ if 'hltGetConditions' in %(dict)s and 'HLTriggerFirstPath' in %(dict)s :
 
     self.data += """
 # enable TrigReport, TimeReport and MultiThreading
-%(process)s.options = cms.untracked.PSet(
-    wantSummary = cms.untracked.bool( True ),
-    numberOfThreads = cms.untracked.uint32( 4 ),
-    numberOfStreams = cms.untracked.uint32( 0 ),
-)
+%(process)s.options.wantSummary = True
+%(process)s.options.numberOfThreads = 4
+%(process)s.options.numberOfStreams = 0
 """
 
   def _fix_parameter(self, **args):


### PR DESCRIPTION
backport of #38225

#### PR description:

From the description of the original PR:

> This PR ensures that HLT utilities like `hltGetConfiguration` do not overwrite the `options` PSet downloaded as part of an HLT menu from `ConfDB`.
> 
> This update is intended to be fully backward-compatible. It is needed now since HLT menus have started to introduce the `options` PSet in ConfDB mainly as a way to control GPU offloading via `options.accelerators`.
> 
> In recent CMSSW releases (`CMSSW_11` and higher), the options `PSet` exists by default in the `cms.Process` and the types of its variables do not need to be specified (even if `process.options` is not explictly defined in the python config), so those type specifications are dropped.
> 
> This PR will be backported to `12_4_X`. I'd also suggest to also backport it to `12_3_X` for convenience, since there are recent online menus for `12_3_X` which define the `options` PSet in `ConfDB`.
> 
> _Note_ : [the `options` PSet continues to be removed when the HLT configuration is downloaded as a "fragment"](https://github.com/cms-sw/cmssw/blob/b54d06d5447f6bb55d1da6c42d3a413f526150a0/HLTrigger/Configuration/python/Tools/confdb.py#L859). When using HLT fragments via `cmsDriver.py`, `options.accelerators` can be configured via `cmsDriver.py --accelerators [..]`.
> 
> Merely technical. No changes expected.
> 
> Attn (in case I missed something): @Martin-Grunewald @fwyzard @Sam-Harper

#### PR validation:

Relies on the validation done for the original PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#38225

Development of HLT menus for Run 3.