### PR TITLE
Semi-random initial value in the L1 trigger prescale counter [`12_4_X`]

### DIFF
--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -14,6 +14,7 @@
 
 // system include files
 #include <bitset>
+#include <cassert>
 #include <vector>
 
 // user include files
@@ -37,7 +38,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 // forward declarations
@@ -164,6 +165,10 @@ namespace l1t {
     /// pointer to Tau data list
     inline const BXVector<const GlobalExtBlk*>* getCandL1External() const { return m_candL1External; }
 
+    //initializer prescale counter using a semi-random value between [1, prescale value]
+    static const std::vector<double> semirandomNumber(const edm::Event& iEvent,
+                                                      const std::vector<double>& prescaleFactorsAlgoTrig);
+
     /*  Drop individual EtSums for Now
     /// pointer to ETM data list
     inline const l1t::EtSum* getCandL1ETM() const
@@ -194,6 +199,7 @@ namespace l1t {
     void setBxLast(int bx);
 
     void setResetPSCountersEachLumiSec(bool val) { m_resetPSCountersEachLumiSec = val; }
+    void setSemiRandomInitialPSCounters(bool val) { m_semiRandomInitialPSCounters = val; }
 
   public:
     inline void setVerbosity(const int verbosity) { m_verbosity = verbosity; }
@@ -268,6 +274,9 @@ namespace l1t {
 
     //whether we reset the prescales each lumi or not
     bool m_resetPSCountersEachLumiSec = true;
+
+    // start the PS counter from a random value between [1,PS] instead of PS
+    bool m_semiRandomInitialPSCounters = false;
   };
 
 }  // namespace l1t

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -69,6 +69,7 @@ void L1TGlobalProducer::fillDescriptions(edm::ConfigurationDescriptions& descrip
   // switch for muon showers in Run-3
   desc.add<bool>("useMuonShowers", false);
   desc.add<bool>("resetPSCountersEachLumiSec", true);
+  desc.add<bool>("semiRandomInitialPSCounters", false);
   // These parameters have well defined  default values and are not currently
   // part of the L1T/HLT interface.  They can be cleaned up or updated at will:
   desc.add<bool>("ProduceL1GtDaqRecord", true);
@@ -116,6 +117,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
       m_requireMenuToMatchAlgoBlkInput(parSet.getParameter<bool>("RequireMenuToMatchAlgoBlkInput")),
       m_algoblkInputTag(parSet.getParameter<edm::InputTag>("AlgoBlkInputTag")),
       m_resetPSCountersEachLumiSec(parSet.getParameter<bool>("resetPSCountersEachLumiSec")),
+      m_semiRandomInitialPSCounters(parSet.getParameter<bool>("semiRandomInitialPSCounters")),
       m_useMuonShowers(parSet.getParameter<bool>("useMuonShowers")) {
   m_egInputToken = consumes<BXVector<EGamma>>(m_egInputTag);
   m_tauInputToken = consumes<BXVector<Tau>>(m_tauInputTag);
@@ -197,6 +199,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
   m_uGtBrd = std::make_unique<GlobalBoard>();
   m_uGtBrd->setVerbosity(m_verbosity);
   m_uGtBrd->setResetPSCountersEachLumiSec(m_resetPSCountersEachLumiSec);
+  m_uGtBrd->setSemiRandomInitialPSCounters(m_semiRandomInitialPSCounters);
 
   // initialize cached IDs
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -188,6 +188,8 @@ private:
 
   //disables reseting the prescale counters each lumisection (needed for offline)
   bool m_resetPSCountersEachLumiSec;
+  // start the PS counter from a random value between [1,PS] instead of PS
+  bool m_semiRandomInitialPSCounters;
   // switch to load muon showers in the global board
   bool m_useMuonShowers;
 };


### PR DESCRIPTION
backport of #37506

#### PR description:

This PR adds a new option, disabled by default, in `L1TGlobalProducer`. It is a verbatim backport to `12_4_X`, and it would be useful for HLT studies that require the L1T re-emulation.

From the description of the original PR by @silviodonato:

>The standard behavior of the L1 trigger prescaler is to start a counter from the prescale value (eg. 1000) and then reduce it of one unit every time the corresponding L1 trigger is accepted. Once the counter reach 0, the L1 trigger is consider to pass also the L1 prescale, and the counter goes back to the prescale value. The counter is reset at the beginning of each lumisection (unless you enable #37395)
>
>This PR adds the option to set the initial prescale value of the PS counter from PS to a semirandom value taken in the range [0, PS]. This option is required to avoid that running on a heavily prescaled sample (eg. ZeroBias) the PS counter never reach 0 and therefore no events pass the prescaler. Starting on a random value, the average rate will be closer to the actual rate that we would see in the actual datataking (at P5 the L1 trigger evaluate a huge number of events per LS).
>
>The "semi-random" refers to the `std::srand` function which gives a reproducible sequence of random numbers. However the reproducibility is not preserved when running with multithreading because I use also the event number as input of the random number generator. The current L1 trigger precaler does not preserve the reproducibility when multi-threading is on.
>
>This PR is somehow related to #37395.

#### PR validation:

Relies on the validation done for the original PR.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR:

#37506

Studies relevant to the development of Run-3 HLT menus.