### PR TITLE
apply the `runDependentForPixel` modifier before the fastSim modifications

### DIFF
--- a/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
+++ b/SimGeneral/PreMixingModule/python/mixOne_premix_on_sim_cfi.py
@@ -153,6 +153,14 @@ mixData = cms.EDProducer("PreMixingModule",
     ),
 )
 
+# pixel run-dependent
+from Configuration.ProcessModifiers.runDependentForPixel_cff import runDependentForPixel
+from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
+(runDependentForPixel & premix_stage2).toModify(mixData.workers.pixel,
+         UseReweighting=False,
+         applyLateReweighting=True,
+         store_SimHitEntryExitPoints=False
+)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 from FastSimulation.Tracking.recoTrackAccumulator_cfi import recoTrackAccumulator as _recoTrackAccumulator
@@ -319,10 +327,3 @@ phase2_hfnose.toModify(mixData,
 # Run-dependent MC
 from Configuration.ProcessModifiers.runDependent_cff import runDependent
 runDependent.toModify(mixData.workers.ecal, timeDependent=True)
-from Configuration.ProcessModifiers.runDependentForPixel_cff import runDependentForPixel  
-from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
-(runDependentForPixel & premix_stage2).toModify(mixData.workers.pixel,
-         UseReweighting=False,
-         applyLateReweighting=True,
-         store_SimHitEntryExitPoints=False
-)


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/38229

#### PR description:

Title says it all. Avoid to modify the `mixData.workers.pixel` after is set to `None` by `fastSim`.

#### PR validation:

`runTheMatrix.py -l 250400.18 -j 0` runs fine after the fix

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
