### PR TITLE
[12.3.X] fix the ROOT type of `EventStats` monitor element in `SiStripGainsPCLWorker`

### DIFF
--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -519,7 +519,7 @@ void SiStripGainsPCLWorker::bookHistograms(DQMStore::IBooker& ibooker,
   // this MonitorElement is created to log the number of events / tracks and clusters used
   // by the calibration algorithm
 
-  histograms.EventStats = ibooker.book2S("EventStats", "Statistics", 3, -0.5, 2.5, 1, 0, 1);
+  histograms.EventStats = ibooker.book2I("EventStats", "Statistics", 3, -0.5, 2.5, 1, 0, 1);
   histograms.EventStats->setBinLabel(1, "events count", 1);
   histograms.EventStats->setBinLabel(2, "tracks count", 1);
   histograms.EventStats->setBinLabel(3, "clusters count", 1);

--- a/CalibTracker/SiStripChannelGain/test/checkMultiRunHarvesting.C
+++ b/CalibTracker/SiStripChannelGain/test/checkMultiRunHarvesting.C
@@ -14,7 +14,7 @@ void checkDQMHarvesting(TString filename) {
     exit(EXIT_FAILURE);
   } else {
     std::string searchstring = "DQMData/Run 999999/AlCaReco/Run summary/SiStripGains/EventStats";
-    TH2S *h2 = (TH2S *)f->Get(searchstring.c_str());
+    TH2I *h2 = (TH2I *)f->Get(searchstring.c_str());
     if (!h2) {
       std::cout << "checkMultiRunHarvesting: ERROR. Could not find the histogram " << searchstring << std::endl;
       exit(EXIT_FAILURE);


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/38234

#### PR description:

I noticed when looking at recent 900GeV data that [this particular plot ](https://tinyurl.com/25lnarrd)has truncated entries at 32767 a.k.a. `0b111111111111111`:

![Screenshot from 2022-06-03 16-21-49](https://user-images.githubusercontent.com/5082376/171873135-5e2c3c1b-2f2b-4ce7-a193-89f4348234fc.png)


This happens because we are storing event and track counts with a short per channel, which is clearly insufficient for larger statistic runs.
This PR fixes that by making it a `TH2I` (which has become supported by the DQM infrastructure recently, thanks to https://github.com/cms-sw/cmssw/pull/37665).

#### PR validation:

run unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

verbatim backport of https://github.com/cms-sw/cmssw/pull/38234