### PR TITLE
[12_2_X] Push_back 0th weight manually, prevent duplication of PS weights in P8.30x

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -204,6 +204,9 @@ Pythia8Hadronizer::Pythia8Hadronizer(const edm::ParameterSet &params)
     throw edm::Exception(edm::errors::Configuration, "Pythia8Interface")
         << " UNKNOWN INITIAL STATE. \n The allowed initial states are: PP, PPbar, ElectronPositron \n";
   }
+        
+  // avoid filling weights twice (from v8.30x)
+  toHepMC.set_store_weights(false);
 
   // Reweight user hook
   //
@@ -711,6 +714,9 @@ bool Pythia8Hadronizer::generatePartonsAndHadronize() {
   if (!py8hepmc) {
     return false;
   }
+  
+  // 0th weight is not filled anymore since v8.30x, pushback manually
+  event()->weights().push_back(fMasterGen->info.weight());
 
   //add ckkw/umeps/unlops merging weight
   if (mergeweight != 1.) {
@@ -825,6 +831,9 @@ bool Pythia8Hadronizer::hadronize() {
   if (!py8hepmc) {
     return false;
   }
+  
+  // 0th weight is not filled anymore since v8.30x, pushback manually
+  event()->weights().push_back(fMasterGen->info.weight());
 
   //add ckkw/umeps/unlops merging weight
   if (mergeweight != 1.) {


### PR DESCRIPTION
#### PR description:

Echoing PR's description from https://github.com/cms-sw/cmssw/pull/38012, created by @SanghyunKo.
"
The weight storage logic in Pythia8 had been changed since 8.30x version, causing the duplication of PS weights in CMS. This PR prevents weight duplication by setting Pythia8ToHepMC::set_store_weights(false) and keeps the old weight structure the same as in UL by push_back 0th weight manually. Fixes https://github.com/cms-sw/cmssw/issues/36705
"

The PR is needed for sample production for Early analysis, which rely on PS. @agrohsje

The Issue and PR involves:
 - Issue : https://github.com/cms-sw/cmssw/issues/36705
 - [12_5_X] : https://github.com/cms-sw/cmssw/pull/38012
 - [12_4_X] : https://github.com/cms-sw/cmssw/pull/38057
 
#### PR validation:

Testing with the workflow 555, 556 (should reduce the number of weights from 134 to 46)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of PR https://github.com/cms-sw/cmssw/pull/38012
