### PR TITLE
Introduce `TkAlJetHT`

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaReco for track based alignment using JetHT events
+OutALCARECOTkAlJetHT_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlJetHT')
+    ),
+    outputCommands = cms.untracked.vstring(
+        'keep *_ALCARECOTkAlJetHT_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
+        'keep *_TriggerResults_*_*',
+        'keep DcsStatuss_scalersRawToDigi_*_*',
+        'keep *_offlinePrimaryVertices_*_*',
+        'keep *_offlineBeamSpot_*_*')
+)
+
+OutALCARECOTkAlJetHT = OutALCARECOTkAlJetHT_noDrop.clone()
+OutALCARECOTkAlJetHT.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_cff.py
@@ -1,0 +1,46 @@
+# AlCaReco for track based alignment using min. bias events
+import FWCore.ParameterSet.Config as cms
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+ALCARECOTkAlJetHTHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+    andOr = True, ## choose logical OR between Triggerbits
+    eventSetupPathsKey = 'TkAlJetHTHLT',
+    throw = False # tolerate triggers stated above, but not available
+    )
+
+# DCS partitions
+# "EBp","EBm","EEp","EEm","HBHEa","HBHEb","HBHEc","HF","HO","RPC"
+# "DT0","DTp","DTm","CSCp","CSCm","CASTOR","TIBTID","TOB","TECp","TECm"
+# "BPIX","FPIX","ESp","ESm"
+import DPGAnalysis.Skims.skim_detstatus_cfi
+ALCARECOTkAlJetHTDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatus.clone(
+    DetectorType = cms.vstring('TIBTID','TOB','TECp','TECm','BPIX','FPIX'),
+    ApplyFilter  = cms.bool(True),
+    AndOr        = cms.bool(True),
+    DebugOn      = cms.untracked.bool(False)
+)
+
+import FWCore.Modules.preScaler_cfi
+ALCARECOTkAlJetHTPrescaler = FWCore.Modules.preScaler_cfi.preScaler.clone(
+    prescaleFactor = cms.int32(10), # selects one event out of 10
+    prescaleOffset = cms.int32(1)
+)
+    
+import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
+ALCARECOTkAlJetHT = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
+    filter = True, ##do not store empty events	
+    applyBasicCuts = True,
+    ptMin = 0.65, ##GeV
+    pMin = 1.5, ##GeV
+    etaMin = -3.5,
+    etaMax = 3.5,
+    nHitMin = 7 ## at least 7 hits required
+)
+
+ALCARECOTkAlJetHT.GlobalSelector.applyIsolationtest = False
+ALCARECOTkAlJetHT.GlobalSelector.applyGlobalMuonFilter = False
+ALCARECOTkAlJetHT.TwoBodyDecaySelector.applyMassrangeFilter = False
+ALCARECOTkAlJetHT.TwoBodyDecaySelector.applyChargeFilter = False
+ALCARECOTkAlJetHT.TwoBodyDecaySelector.applyAcoplanarityFilter = False
+
+seqALCARECOTkAlJetHT = cms.Sequence(ALCARECOTkAlJetHTHLT+ALCARECOTkAlJetHTDCSFilter+ALCARECOTkAlJetHTPrescaler*ALCARECOTkAlJetHT)

--- a/Configuration/AlCa/python/autoAlca.py
+++ b/Configuration/AlCa/python/autoAlca.py
@@ -18,7 +18,7 @@ AlCaRecoMatrix = {
                   "ExpressCosmics"              : "SiStripPCLHistos+SiStripCalZeroBias+TkAlCosmics0T+SiPixelCalZeroBias",
                   "HcalNZS"                     : "HcalCalMinBias",
                   "HLTPhysics"                  : "TkAlMinBias",
-                  "JetHT"                       : "HcalCalIsoTrkProducerFilter+TkAlMinBias",
+                  "JetHT"                       : "HcalCalIsoTrkProducerFilter+TkAlJetHT",
                   "MET"                         : "HcalCalNoise",
                   "MinimumBias"                 : "SiStripCalZeroBias+SiStripCalMinBias+TkAlMinBias",
                   "MuOnia"                      : "TkAlUpsilonMuMu",

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,11 +24,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   : '123X_mcRun2_pA_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '123X_dataRun2_v3',
+    'run2_data'                    : '124X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '123X_dataRun2_HEfail_v3',
+    'run2_data_HEfail'             : '124X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '123X_dataRun2_relval_v4',
+    'run2_data_relval'             : '124X_dataRun2_relval_v1',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
@@ -42,9 +42,9 @@ autoCond = {
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 123X_dataRun3_Prompt_v10 but with snapshot at 2022-05-31 20:00:00 (UTC)
     'run3_data_prompt'             : '123X_dataRun3_Prompt_frozen_v4',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '123X_dataRun3_v7',
+    'run3_data'                    : '124X_dataRun3_v1',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '123X_dataRun3_relval_v6',
+    'run3_data_relval'             : '124X_dataRun3_relval_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/EventContent/python/AlCaRecoOutput_RelVal_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_RelVal_cff.py
@@ -22,6 +22,7 @@ ALCARECOEventContent = cms.PSet(
         'keep *_ALCARECOTkAlDiMuonVertexTracks_*_*',
         'keep *_ALCARECOTkAlUpsilonMuMu_*_*',
         'keep *_ALCARECOTkAlMinBias_*_*',
+        'keep *_ALCARECOTkAlJetHT_*_*',
 	'keep *_ALCARECOTkAlBeamHalo_*_*', 
         'keep *_ALCARECOMuAlBeamHalo_*_*', 
 	'keep *_ALCARECOMuAlBeamHaloOverlaps_*_*',

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -39,6 +39,8 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuPA_Output_cff impo
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBias_Output_cff import *
 # AlCaReco for track based alignment using MinBias events for PbPb data-taking
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBiasHI_Output_cff import *
+# AlCaReco for track based alignment using JetHT events
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlJetHT_Output_cff import *
 
 # AlCaReco for pixel calibration using muons
 from Calibration.TkAlCaRecoProducers.ALCARECOSiPixelCalSingleMuon_Output_cff import *

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -31,6 +31,8 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMu_cff import *
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlUpsilonMuMuPA_cff import *
 # AlCaReco for track based alignment using MinBias events
 from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBias_cff import *
+# AlCaReco for track based alignment using JetHT events
+from Alignment.CommonAlignmentProducer.ALCARECOTkAlJetHT_cff import *
 
 ###############################################################
 # Tracker Calibration
@@ -191,7 +193,7 @@ pathALCARECOTkAlJpsiMuMu = cms.Path(seqALCARECOTkAlJpsiMuMu*ALCARECOTkAlJpsiMuMu
 pathALCARECOTkAlUpsilonMuMu = cms.Path(seqALCARECOTkAlUpsilonMuMu*ALCARECOTkAlUpsilonMuMuDQM)
 pathALCARECOTkAlUpsilonMuMuPA = cms.Path(seqALCARECOTkAlUpsilonMuMuPA*ALCARECOTkAlUpsilonMuMuPADQM)
 pathALCARECOTkAlMinBias = cms.Path(seqALCARECOTkAlMinBias*ALCARECOTkAlMinBiasDQM)
-pathALCARECOTkAlMinBias = cms.Path(seqALCARECOTkAlMinBias*ALCARECOTkAlMinBiasDQM)
+pathALCARECOTkAlJetHT = cms.Path(seqALCARECOTkAlJetHT*ALCARECOTkAlJetHTDQM)
 pathALCARECOSiPixelCalSingleMuon = cms.Path(seqALCARECOSiPixelCalSingleMuon)
 pathALCARECOSiPixelCalSingleMuonLoose = cms.Path(seqALCARECOSiPixelCalSingleMuonLoose)
 pathALCARECOSiPixelCalSingleMuonTight = cms.Path(seqALCARECOSiPixelCalSingleMuonTight)
@@ -320,6 +322,15 @@ ALCARECOStreamTkAlMinBias = cms.FilteredStream(
 	paths  = (pathALCARECOTkAlMinBias),
 	content = OutALCARECOTkAlMinBias.outputCommands,
 	selectEvents = OutALCARECOTkAlMinBias.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
+
+ALCARECOStreamTkAlJetHT = cms.FilteredStream(
+	responsible = 'Marco Musich',
+	name = 'TkAlJetHT',
+	paths  = (pathALCARECOTkAlJetHT),
+	content = OutALCARECOTkAlJetHT.outputCommands,
+	selectEvents = OutALCARECOTkAlJetHT.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 

--- a/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
+++ b/DQMOffline/Alignment/python/ALCARECOTkAlDQM_cff.py
@@ -380,6 +380,37 @@ from Alignment.CommonAlignmentProducer.ALCARECOTkAlMinBias_cff import ALCARECOTk
 #ALCARECOTkAlMinBiasDQM = cms.Sequence( ALCARECOTkAlMinBiasTrackingDQM + ALCARECOTkAlMinBiasTkAlDQM+ALCARECOTkAlMinBiasHLTDQM+ALCARECOTkAlMinBiasNOTHLTDQM)
 ALCARECOTkAlMinBiasDQM = cms.Sequence( ALCARECOTkAlMinBiasTrackingDQM + ALCARECOTkAlMinBiasTkAlDQM )
 
+########################################################
+#############---  TkAlJetHT ---#######################
+########################################################
+__selectionName = 'TkAlJetHT'
+ALCARECOTkAlJetHTTrackingDQM = ALCARECOTkAlZMuMuTrackingDQM.clone(
+    #names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    BSFolderName = "AlCaReco/"+__selectionName+"/BeamSpot",
+    # margins and settings
+    TkSizeBin = 71,
+    TkSizeMin = -0.5,
+    TkSizeMax = 70.5,
+    TrackPtMax = 30
+)
+
+ALCARECOTkAlJetHTTkAlDQM = ALCARECOTkAlZMuMuTkAlDQM.clone(
+    #names and desigantions
+    TrackProducer = 'ALCARECO'+__selectionName,
+    AlgoName = 'ALCARECO'+__selectionName,
+    FolderName = "AlCaReco/"+__selectionName,
+    # margins and settings
+    fillInvariantMass = False,
+    TrackPtMax = 30,
+    SumChargeBin = 101,
+    SumChargeMin = -50.5,
+    SumChargeMax = 50.5
+)
+
+ALCARECOTkAlJetHTDQM = cms.Sequence( ALCARECOTkAlJetHTTrackingDQM + ALCARECOTkAlJetHTTkAlDQM)
 
 ########################################################
 #############---  TkAlMinBiasHI ---#####################


### PR DESCRIPTION
#### PR description:

In PR https://github.com/cms-sw/cmssw/pull/27307 the `TkAlMinBias` ALCARECO flavour was added to the `JetHT` dataset in the `autoAlCa` file, in order to have it produced for the Run-2 Ultra-Legacy reprocessing.
Operational experience with it has indicated that the resulting PDs are too large to be able tocomfortably distribute them at the target `T2`s, so that workflow is superseded by adding a new producer `TkAlJetHT` tailored to be used on the `JetHT` sample, which contains a prescale of 10 (1 event of ten input events will be processed). This should alleviate the output size and the burden on disk and operation teams.
This is proposed in this PR. As a new  `eventSetupPathsKey`  (= `TkAlJetHTHLT`) is introduced here a new set of `AlCaRecoTriggerBitsRcd` tags:
   * `AlCaRecoHLTpaths_2017_offline_v6` which is a superset of the production tag `AlCaRecoHLTpaths_2017_offline_v4`, but will all IOVs substituted by new payloads adding the `TkAlJetHT` key (used in `auto:run2_data*`)
   * `AlCaRecoHLTpaths_2021_offline_v2`  which is a superset of the production tag `AlCaRecoHLTpaths_2021_offline_v1`, but will all IOVs substituted by new payloads adding the `TkAlJetHT` key (used in `auto:run3_data*`)

#### PR validation:

Run successfully the Tier-0 testing workflow:
```console
runTheMatrix.py -l 1000.0
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport but it will need to be backported (at least to 12.4.X)
