### PR TITLE
[Backport] Turning on GE21 digis to be unpacked for monitoring [12_3_X]

### DIFF
--- a/CondFormats/GEMObjects/interface/GEMChMap.h
+++ b/CondFormats/GEMObjects/interface/GEMChMap.h
@@ -139,7 +139,7 @@ public:
 
   const std::vector<uint16_t> getVfats(const int type) const { return chamVfats_.at(type); }
   void add(int type, uint16_t d) {
-    if (std::find(chamVfats_[type].begin(), chamVfats_[type].end(), d) != chamVfats_[type].end())
+    if (std::find(chamVfats_[type].begin(), chamVfats_[type].end(), d) == chamVfats_[type].end())
       chamVfats_[type].push_back(d);
   }
 
@@ -147,7 +147,7 @@ public:
     return chamIEtas_.at({chamberType, vfatAdd});
   }
   void add(vfatEC d, int iEta) {
-    if (std::find(chamIEtas_[d].begin(), chamIEtas_[d].end(), iEta) != chamIEtas_[d].end())
+    if (std::find(chamIEtas_[d].begin(), chamIEtas_[d].end(), iEta) == chamIEtas_[d].end())
       chamIEtas_[d].push_back(iEta);
   }
 

--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -16,9 +16,8 @@
 
 #include "Validation/MuonGEMHits/interface/GEMValidationUtils.h"
 
-#include "CondFormats/DataRecord/interface/GEMeMapRcd.h"
-#include "CondFormats/GEMObjects/interface/GEMeMap.h"
-#include "CondFormats/GEMObjects/interface/GEMROMapping.h"
+#include "CondFormats/DataRecord/interface/GEMChMapRcd.h"
+#include "CondFormats/GEMObjects/interface/GEMChMap.h"
 #include "DataFormats/GEMDigi/interface/GEMDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMVFATStatusCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMOHStatusCollection.h"
@@ -70,9 +69,7 @@ private:
   void SetLabelOHStatus(MonitorElement *h2Status);
   void SetLabelVFATStatus(MonitorElement *h2Status);
 
-  edm::ESGetToken<GEMeMap, GEMeMapRcd> gemEMapToken_;
-  //std::shared_ptr<GEMROMapping> gemROMap_;
-  const GEMeMap *gemEMap_;
+  const edm::ESGetToken<GEMChMap, GEMChMapRcd> gemChMapToken_;
 
   edm::EDGetToken tagVFAT_;
   edm::EDGetToken tagOH_;

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -3,14 +3,14 @@
 using namespace std;
 using namespace edm;
 
-GEMDAQStatusSource::GEMDAQStatusSource(const edm::ParameterSet &cfg) : GEMDQMBase(cfg) {
+GEMDAQStatusSource::GEMDAQStatusSource(const edm::ParameterSet &cfg)
+    : GEMDQMBase(cfg), gemChMapToken_(esConsumes<GEMChMap, GEMChMapRcd, edm::Transition::BeginRun>()) {
   tagVFAT_ = consumes<GEMVFATStatusCollection>(cfg.getParameter<edm::InputTag>("VFATInputLabel"));
   tagOH_ = consumes<GEMOHStatusCollection>(cfg.getParameter<edm::InputTag>("OHInputLabel"));
   tagAMC_ = consumes<GEMAMCStatusCollection>(cfg.getParameter<edm::InputTag>("AMCInputLabel"));
   tagAMC13_ = consumes<GEMAMC13StatusCollection>(cfg.getParameter<edm::InputTag>("AMC13InputLabel"));
 
   nAMCSlots_ = cfg.getParameter<Int_t>("AMCSlots");
-  gemEMapToken_ = esConsumes<GEMeMap, GEMeMapRcd, edm::Transition::BeginRun>();
 }
 
 void GEMDAQStatusSource::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
@@ -27,36 +27,35 @@ void GEMDAQStatusSource::fillDescriptions(edm::ConfigurationDescriptions &descri
 }
 
 void GEMDAQStatusSource::LoadROMap(edm::EventSetup const &iSetup) {
-  auto gemROMap = std::make_shared<GEMROMapping>();
   //if (useDBEMap_)
   if (true) {
-    const auto &eMap = iSetup.getData(gemEMapToken_);
-    auto gemEMap = std::make_unique<GEMeMap>(eMap);
-    gemEMap->convert(*gemROMap);
+    const auto &chMap = iSetup.getData(gemChMapToken_);
+    auto gemChMap = std::make_unique<GEMChMap>(chMap);
 
-    for (auto imap : gemEMap->theChamberMap_) {
-      int nNumChamber = (int)imap.fedId.size();
-      for (int i = 0; i < nNumChamber; i++) {
-        unsigned int fedId = imap.fedId[i];
-        uint8_t amcNum = imap.amcNum[i];
-        uint8_t gebId = imap.gebId[i];
-        GEMROMapping::chamEC geb_ec{fedId, amcNum, gebId};
-        GEMROMapping::chamDC geb_dc = gemROMap->chamberPos(geb_ec);
-        GEMDetId gemChId = geb_dc.detId;
+    for (auto const &[ec, dc] : gemChMap->chamberMap()) {
+      unsigned int fedId = ec.fedId;
+      uint8_t amcNum = ec.amcNum;
+      GEMDetId gemChId(dc.detId);
 
-        mapFEDIdToRe_[fedId] = gemChId.region();
-        mapAMC13ToListChamber_[fedId].push_back(gemChId);
-        mapAMCToListChamber_[{fedId, amcNum}].push_back(gemChId);
-      }
+      mapFEDIdToRe_[fedId] = gemChId.region();
+      mapAMC13ToListChamber_[fedId].push_back(gemChId);
+      mapAMCToListChamber_[{fedId, amcNum}].push_back(gemChId);
     }
 
-    gemEMap.reset();
   } else {
     // no EMap in DB, using dummy
-    // FIXME: How to add mapFEDIdToRe_ and mapDetIdToAMC_??
-    auto gemEMap = std::make_unique<GEMeMap>();
-    gemEMap->convertDummy(*gemROMap);
-    gemEMap.reset();
+    auto gemChMap = std::make_unique<GEMChMap>();
+    gemChMap->setDummy();
+
+    for (auto const &[ec, dc] : gemChMap->chamberMap()) {
+      unsigned int fedId = ec.fedId;
+      uint8_t amcNum = ec.amcNum;
+      GEMDetId gemChId(dc.detId);
+
+      mapFEDIdToRe_[fedId] = gemChId.region();
+      mapAMC13ToListChamber_[fedId].push_back(gemChId);
+      mapAMCToListChamber_[{fedId, amcNum}].push_back(gemChId);
+    }
   }
 }
 

--- a/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeGEMTPG_cfi.py
@@ -4,7 +4,7 @@ l1tdeGEMTPGCommon = cms.PSet(
     monitorDir = cms.string("L1TEMU/L1TdeGEMTPG"),
     verbose = cms.bool(False),
     ## when multiple chambers are enabled, order them by station number!
-    chambers = cms.vstring("GE11"),
+    chambers = cms.vstring("GE11", "GE21"),
     dataEmul = cms.vstring("data","emul"),
     clusterVars = cms.vstring("size", "pad", "bx"),
     clusterNBin = cms.vuint32(20,384,10),

--- a/DataFormats/GEMDigi/interface/GEMOHStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMOHStatus.h
@@ -39,7 +39,7 @@ public:
     Errors error{0};
     error.EvtF = oh.evtF();
     error.InF = oh.inF();
-    error.L1aF = oh.l1aF();
+    error.L1aF = (oh.l1aF() and (oh.version() == 0));
     error.EvtSzOFW = oh.evtSzOFW();
     error.Inv = oh.inv();
     error.OOScAvV = oh.oOScAvV();
@@ -53,7 +53,7 @@ public:
     Warnings warn{0};
     warn.EvtNF = oh.evtNF();
     warn.InNF = oh.inNF();
-    warn.L1aNF = oh.l1aNF();
+    warn.L1aNF = (oh.l1aNF() and (oh.version() == 0));
     warn.EvtSzW = oh.evtSzW();
     warnings_ = warn.wcodes;
   }

--- a/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
+++ b/EventFilter/GEMRawToDigi/python/muonGEMDigis_cfi.py
@@ -7,6 +7,5 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run2_GEM_2017.toModify(muonGEMDigis, useDBEMap = True)
-# Note that by default we don't unpack the GE2/1 demonstrator digis in run3
-run3_GEM.toModify(muonGEMDigis, useDBEMap = True, ge21Off = True)
-phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True, ge21Off = False)
+run3_GEM.toModify(muonGEMDigis, useDBEMap = True)
+phase2_GEM.toModify(muonGEMDigis, useDBEMap = False, readMultiBX = True)

--- a/EventFilter/GEMRawToDigi/src/GEMRawToDigi.cc
+++ b/EventFilter/GEMRawToDigi/src/GEMRawToDigi.cc
@@ -27,6 +27,7 @@ std::unique_ptr<GEMAMC13> GEMRawToDigi::convertWordToGEMAMC13(const uint64_t* wo
     // Fill GEB
     for (uint8_t j = 0; j < amc.davCnt(); ++j) {
       auto oh = GEMOptoHybrid();
+      oh.setVersion(amc.formatVer());
       oh.setChamberHeader(*(++word));
 
       // Fill vfat

--- a/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.h
+++ b/RecoLocalMuon/GEMRecHit/plugins/GEMRecHitProducer.h
@@ -65,5 +65,6 @@ private:
   std::map<GEMDetId, EtaPartitionMask> gemMask_;
 
   bool applyMasking_;
+  bool ge21Off_;
 };
 #endif

--- a/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
+++ b/RecoLocalMuon/GEMRecHit/python/gemRecHits_cfi.py
@@ -10,5 +10,9 @@ gemRecHits = gemRecHitsDef.clone(
     #deadFile = cms.FileInPath("RecoLocalMuon/GEMRecHit/data/deadStrips.txt")
     )
 
+
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
-phase2_GEM.toModify(gemRecHits, gemDigiLabel = "simMuonGEMDigis")
+
+run3_GEM.toModify(gemRecHits, ge21Off=True)
+phase2_GEM.toModify(gemRecHits, gemDigiLabel = "simMuonGEMDigis", ge21Off=False)


### PR DESCRIPTION
#### PR description:
* GE 21 demonstrator has installed in P5. And GEM group wants to monitor the demonstrator with DQM using digis.
* GEM packer and unpacker are updated for using GEMChMap to unpack the data from GE21 demonstrator.
* Generating RecHits with GE21 is turned off, so the demonstrator doesn't affect muons upstream.

#### PR validation:
* The code format has applied with `scram build code-format` and `scram build code-checks`.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
* This PR is backport of #38062 and #38119

@jshlee @watson-ij 