### PR TITLE
[12_3_X] Fix streamLabel name in hcalgpu_dqm_sourceclient-live_cfg.p

### DIFF
--- a/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
@@ -50,7 +50,7 @@ process.load('DQM.Integration.config.environment_cfi')
 #-------------------------------------
 #	Central DQM Customization
 #-------------------------------------
-process.source.streamLabel = cms.untracked.string("DQMGPUvsCPU")
+process.source.streamLabel = cms.untracked.string("streamDQMGPUvsCPU")
 process.dqmEnv.subSystemFolder = subsystem
 process.dqmSaver.tag = subsystem
 process.dqmSaver.runNumber = options.runNumber


### PR DESCRIPTION
#### PR description:
Stream names are started with "stream" prefix in the DQM, so, at the moment hcalgpu_dqm_sourceclient-live_cfg.py does not process any files because of the streamLabel mismatch:
06-Jun-2022 08:22:48 CEST Found and skipped json file (stream label mismatch, streamDQMGPUvsCPU [files] != DQMGPUvsCPU [config]): /fff/BU0/ramdisk/run353121/run353121_ls0001_streamDQMGPUvsCPU_sm-c2a11-43-01.jsn

#### PR validation:

Tested at P5 playback

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/38257
