### PR TITLE
Backport of MkFitCore vectorization PR 37868

### DIFF
--- a/FWCore/Utilities/interface/CMSUnrollLoop.h
+++ b/FWCore/Utilities/interface/CMSUnrollLoop.h
@@ -28,6 +28,12 @@
 #define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(clang loop unroll_count(N)))
 #define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(clang loop unroll(disable)))
 
+#elif defined(__INTEL_COMPILER)
+// Intel icc compiler
+#define CMS_UNROLL_LOOP _Pragma(EDM_STRINGIZE(unroll))
+#define CMS_UNROLL_LOOP_COUNT(N) _Pragma(EDM_STRINGIZE(unroll(N)))
+#define CMS_UNROLL_LOOP_DISABLE _Pragma(EDM_STRINGIZE(nounroll))
+
 #elif defined(__GNUC__)
 // GCC host compiler
 

--- a/RecoTracker/MkFitCore/src/PropagationMPlex.icc
+++ b/RecoTracker/MkFitCore/src/PropagationMPlex.icc
@@ -24,24 +24,52 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
     errorProp(n, 3, 3) = 1.f;
     errorProp(n, 4, 4) = 1.f;
     errorProp(n, 5, 5) = 1.f;
-
-    float r0 = hipo(inPar(n, 0, 0), inPar(n, 1, 0));
-    const float k = inChg(n, 0, 0) * 100.f /
-                    (-Const::sol * (pf.use_param_b_field ? Config::bFieldFromZR(inPar(n, 2, 0), r0) : Config::Bfield));
-    const float r = msRad(n, 0, 0);
-
+  }
+  float r0[nmax - nmin];
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    //initialize erroProp to identity matrix
+    r0[n - nmin] = hipo(inPar(n, 0, 0), inPar(n, 1, 0));
+  }
+  float k[nmax - nmin];
+  if (pf.use_param_b_field) {
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
+      k[n - nmin] = inChg(n, 0, 0) * 100.f / (-Const::sol * Config::bFieldFromZR(inPar(n, 2, 0), r0[n - nmin]));
+    }
+  } else {
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
+      k[n - nmin] = inChg(n, 0, 0) * 100.f / (-Const::sol * Config::Bfield);
+    }
+  }
+  float r[nmax - nmin];
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    r[n - nmin] = msRad(n, 0, 0);
+  }
+  float xin[nmax - nmin];
+  float yin[nmax - nmin];
+  float ipt[nmax - nmin];
+  float phiin[nmax - nmin];
+  float theta[nmax - nmin];
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
     // if (std::abs(r-r0)<0.0001f) {
     // 	dprint("distance less than 1mum, skip");
     // 	continue;
     // }
 
-    const float xin = inPar(n, 0, 0);
-    const float yin = inPar(n, 1, 0);
-    const float ipt = inPar(n, 3, 0);
-    const float phiin = inPar(n, 4, 0);
-    const float theta = inPar(n, 5, 0);
+    xin[n - nmin] = inPar(n, 0, 0);
+    yin[n - nmin] = inPar(n, 1, 0);
+    ipt[n - nmin] = inPar(n, 3, 0);
+    phiin[n - nmin] = inPar(n, 4, 0);
+    theta[n - nmin] = inPar(n, 5, 0);
 
-    dprint(std::endl);
+    //dprint(std::endl);
+  }
+
+  for (int n = nmin; n < nmax; ++n) {
     dprint_np(n,
               "input parameters"
                   << " inPar(n, 0, 0)=" << std::setprecision(9) << inPar(n, 0, 0) << " inPar(n, 1, 0)="
@@ -49,186 +77,380 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
                   << inPar(n, 2, 0) << " inPar(n, 3, 0)=" << std::setprecision(9) << inPar(n, 3, 0)
                   << " inPar(n, 4, 0)=" << std::setprecision(9) << inPar(n, 4, 0)
                   << " inPar(n, 5, 0)=" << std::setprecision(9) << inPar(n, 5, 0));
+  }
 
-    const float kinv = 1.f / k;
-    const float pt = 1.f / ipt;
+  float kinv[nmax - nmin];
+  float pt[nmax - nmin];
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    kinv[n - nmin] = 1.f / k[n - nmin];
+    pt[n - nmin] = 1.f / ipt[n - nmin];
+  }
+  float D[nmax - nmin];
+  float cosa[nmax - nmin];
+  float sina[nmax - nmin];
+  float cosah[nmax - nmin];
+  float sinah[nmax - nmin];
+  float id[nmax - nmin];
 
-    float D = 0., cosa = 0., sina = 0., cosah = 0., sinah = 0., id = 0.;
-    //no trig approx here, phi can be large
-    float cosPorT = std::cos(phiin), sinPorT = std::sin(phiin);
-    float pxin = cosPorT * pt;
-    float pyin = sinPorT * pt;
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    D[n - nmin] = 0.;
+  }
 
+  //no trig approx here, phi can be large
+  float cosPorT[nmax - nmin];
+  float sinPorT[nmax - nmin];
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    cosPorT[n - nmin] = std::cos(phiin[n - nmin]);
+  }
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    sinPorT[n - nmin] = std::sin(phiin[n - nmin]);
+  }
+
+  float pxin[nmax - nmin];
+  float pyin[nmax - nmin];
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    pxin[n - nmin] = cosPorT[n - nmin] * pt[n - nmin];
+    pyin[n - nmin] = sinPorT[n - nmin] * pt[n - nmin];
+  }
+
+  for (int n = nmin; n < nmax; ++n) {
     dprint_np(n,
-              "k=" << std::setprecision(9) << k << " pxin=" << std::setprecision(9) << pxin
-                   << " pyin=" << std::setprecision(9) << pyin << " cosPorT=" << std::setprecision(9) << cosPorT
-                   << " sinPorT=" << std::setprecision(9) << sinPorT << " pt=" << std::setprecision(9) << pt);
+              "k=" << std::setprecision(9) << k[n - nmin] << " pxin=" << std::setprecision(9) << pxin[n - nmin]
+                   << " pyin=" << std::setprecision(9) << pyin[n - nmin] << " cosPorT=" << std::setprecision(9)
+                   << cosPorT[n - nmin] << " sinPorT=" << std::setprecision(9) << sinPorT[n - nmin]
+                   << " pt=" << std::setprecision(9) << pt[n - nmin]);
+  }
 
+  float dDdx[nmax - nmin];
+  float dDdy[nmax - nmin];
+  float dDdipt[nmax - nmin];
+  float dDdphi[nmax - nmin];
+
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    dDdipt[n - nmin] = 0.;
+    dDdphi[n - nmin] = 0.;
+  }
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
     //derivatives initialized to value for first iteration, i.e. distance = r-r0in
-    float dDdx = r0 > 0.f ? -xin / r0 : 0.f;
-    float dDdy = r0 > 0.f ? -yin / r0 : 0.f;
-    float dDdipt = 0.;
-    float dDdphi = 0.;
+    dDdx[n - nmin] = r0[n - nmin] > 0.f ? -xin[n - nmin] / r0[n - nmin] : 0.f;
+  }
 
-    for (int i = 0; i < Config::Niter; ++i) {
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    dDdy[n - nmin] = r0[n - nmin] > 0.f ? -yin[n - nmin] / r0[n - nmin] : 0.f;
+  }
+
+  float oodotp[nmax - nmin];
+  float x[nmax - nmin];
+  float y[nmax - nmin];
+  float oor0[nmax - nmin];
+  float dadipt[nmax - nmin];
+  float dadx[nmax - nmin];
+  float dady[nmax - nmin];
+  float pxca[nmax - nmin];
+  float pxsa[nmax - nmin];
+  float pyca[nmax - nmin];
+  float pysa[nmax - nmin];
+  float tmp[nmax - nmin];
+  float tmpx[nmax - nmin];
+  float tmpy[nmax - nmin];
+  float pxinold[nmax - nmin];
+
+  CMS_UNROLL_LOOP_COUNT(Config::Niter)
+  for (int i = 0; i < Config::Niter; ++i) {
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
       //compute distance and path for the current iteration
-      r0 = hipo(outPar(n, 0, 0), outPar(n, 1, 0));
+      r0[n - nmin] = hipo(outPar(n, 0, 0), outPar(n, 1, 0));
+    }
 
-      // Use one over dot produce of transverse momentum and radial
-      // direction to scale the step. Propagation is prevented from reaching
-      // too close to the apex (dotp > 0.2).
-      // - Can / should we come up with a better approximation?
-      // - Can / should take +/- curvature into account?
+    // Use one over dot produce of transverse momentum and radial
+    // direction to scale the step. Propagation is prevented from reaching
+    // too close to the apex (dotp > 0.2).
+    // - Can / should we come up with a better approximation?
+    // - Can / should take +/- curvature into account?
 
-      const float oodotp = r0 * pt / (pxin * outPar(n, 0, 0) + pyin * outPar(n, 1, 0));
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
+      oodotp[n - nmin] =
+          r0[n - nmin] * pt[n - nmin] / (pxin[n - nmin] * outPar(n, 0, 0) + pyin[n - nmin] * outPar(n, 1, 0));
+    }
 
-      if (oodotp > 5.0f || oodotp < 0)  // 0.2 is 78.5 deg
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
+      if (oodotp[n - nmin] > 5.0f || oodotp[n - nmin] < 0)  // 0.2 is 78.5 deg
       {
-        id = 0.0f;
         outFailFlag(n, 0, 0) = 1;
-      } else {
-        // Can we come up with a better approximation?
-        // Should take +/- curvature into account.
-        id = (r - r0) * oodotp;
       }
-      D += id;
+    }
 
-      if (Config::useTrigApprox) {
-        sincos4(id * ipt * kinv * 0.5f, sinah, cosah);
-      } else {
-        cosah = std::cos(id * ipt * kinv * 0.5f);
-        sinah = std::sin(id * ipt * kinv * 0.5f);
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
+      // Can we come up with a better approximation?
+      // Should take +/- curvature into account.
+      id[n - nmin] =
+          (oodotp[n - nmin] > 5.0f || oodotp[n - nmin] < 0) ? 0.0f : (r[n - nmin] - r0[n - nmin]) * oodotp[n - nmin];
+    }
+
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
+      D[n - nmin] += id[n - nmin];
+    }
+
+    if constexpr (Config::useTrigApprox) {
+#if !defined(__INTEL_COMPILER)
+#pragma omp simd
+#endif
+      for (int n = nmin; n < nmax; ++n) {
+        sincos4(id[n - nmin] * ipt[n - nmin] * kinv[n - nmin] * 0.5f, sinah[n - nmin], cosah[n - nmin]);
       }
-      cosa = 1.f - 2.f * sinah * sinah;
-      sina = 2.f * sinah * cosah;
+    } else {
+#if !defined(__INTEL_COMPILER)
+#pragma omp simd
+#endif
+      for (int n = nmin; n < nmax; ++n) {
+        cosah[n - nmin] = std::cos(id[n - nmin] * ipt[n - nmin] * kinv[n - nmin] * 0.5f);
+        sinah[n - nmin] = std::sin(id[n - nmin] * ipt[n - nmin] * kinv[n - nmin] * 0.5f);
+      }
+    }
 
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
+      cosa[n - nmin] = 1.f - 2.f * sinah[n - nmin] * sinah[n - nmin];
+      sina[n - nmin] = 2.f * sinah[n - nmin] * cosah[n - nmin];
+    }
+
+    for (int n = nmin; n < nmax; ++n) {
       dprint_np(n,
                 "Attempt propagation from r="
-                    << r0 << " to r=" << r << std::endl
-                    << "   x=" << xin << " y=" << yin << " z=" << inPar(n, 2, 0) << " px=" << pxin << " py=" << pyin
-                    << " pz=" << pt * std::tan(theta) << " q=" << inChg(n, 0, 0) << std::endl
-                    << "   r=" << std::setprecision(9) << r << " r0=" << std::setprecision(9) << r0
-                    << " id=" << std::setprecision(9) << id << " dr=" << std::setprecision(9) << r - r0
-                    << " cosa=" << cosa << " sina=" << sina);
+                    << r0[n - nmin] << " to r=" << r[n - nmin] << std::endl
+                    << "   x=" << xin[n - nmin] << " y=" << yin[n - nmin] << " z=" << inPar(n, 2, 0)
+                    << " px=" << pxin[n - nmin] << " py=" << pyin[n - nmin]
+                    << " pz=" << pt[n - nmin] * std::tan(theta[n - nmin]) << " q=" << inChg(n, 0, 0) << std::endl
+                    << "   r=" << std::setprecision(9) << r[n - nmin] << " r0=" << std::setprecision(9) << r0[n - nmin]
+                    << " id=" << std::setprecision(9) << id[n - nmin] << " dr=" << std::setprecision(9)
+                    << r[n - nmin] - r0[n - nmin] << " cosa=" << cosa[n - nmin] << " sina=" << sina[n - nmin]);
+    }
 
-      //update derivatives on total distance
-      if (i + 1 != Config::Niter) {
-        const float x = outPar(n, 0, 0);
-        const float y = outPar(n, 1, 0);
-        const float oor0 = (r0 > 0.f && std::abs(r - r0) < 0.0001f) ? 1.f / r0 : 0.f;
-
-        const float dadipt = id * kinv;
-
-        const float dadx = -x * ipt * kinv * oor0;
-        const float dady = -y * ipt * kinv * oor0;
-
-        const float pxca = pxin * cosa;
-        const float pxsa = pxin * sina;
-        const float pyca = pyin * cosa;
-        const float pysa = pyin * sina;
-
-        float tmp;
-
-        tmp = k * dadx;
-        dDdx -= (x * (1.f + tmp * (pxca - pysa)) + y * tmp * (pyca + pxsa)) * oor0;
-
-        tmp = k * dady;
-        dDdy -= (x * tmp * (pxca - pysa) + y * (1.f + tmp * (pyca + pxsa))) * oor0;
-
-        //now r0 depends on ipt and phi as well
-        tmp = dadipt * ipt;
-        dDdipt -=
-            k *
-            (x * (pxca * tmp - pysa * tmp - pyca - pxsa + pyin) + y * (pyca * tmp + pxsa * tmp - pysa + pxca - pxin)) *
-            pt * oor0;
-        dDdphi += k * (x * (pysa - pxin + pxca) - y * (pxsa - pyin + pyca)) * oor0;
+    //update derivatives on total distance
+    if (i + 1 != Config::Niter) {
+#pragma omp simd
+      for (int n = nmin; n < nmax; ++n) {
+        x[n - nmin] = outPar(n, 0, 0);
+        y[n - nmin] = outPar(n, 1, 0);
+      }
+#pragma omp simd
+      for (int n = nmin; n < nmax; ++n) {
+        oor0[n - nmin] =
+            (r0[n - nmin] > 0.f && std::abs(r[n - nmin] - r0[n - nmin]) < 0.0001f) ? 1.f / r0[n - nmin] : 0.f;
+      }
+#pragma omp simd
+      for (int n = nmin; n < nmax; ++n) {
+        dadipt[n - nmin] = id[n - nmin] * kinv[n - nmin];
+        dadx[n - nmin] = -x[n - nmin] * ipt[n - nmin] * kinv[n - nmin] * oor0[n - nmin];
+        dady[n - nmin] = -y[n - nmin] * ipt[n - nmin] * kinv[n - nmin] * oor0[n - nmin];
+        pxca[n - nmin] = pxin[n - nmin] * cosa[n - nmin];
+        pxsa[n - nmin] = pxin[n - nmin] * sina[n - nmin];
+        pyca[n - nmin] = pyin[n - nmin] * cosa[n - nmin];
+        pysa[n - nmin] = pyin[n - nmin] * sina[n - nmin];
+        tmpx[n - nmin] = k[n - nmin] * dadx[n - nmin];
       }
 
+#pragma omp simd
+      for (int n = nmin; n < nmax; ++n) {
+        dDdx[n - nmin] -= (x[n - nmin] * (1.f + tmpx[n - nmin] * (pxca[n - nmin] - pysa[n - nmin])) +
+                           y[n - nmin] * tmpx[n - nmin] * (pyca[n - nmin] + pxsa[n - nmin])) *
+                          oor0[n - nmin];
+      }
+
+#pragma omp simd
+      for (int n = nmin; n < nmax; ++n) {
+        tmpy[n - nmin] = k[n - nmin] * dady[n - nmin];
+      }
+#pragma omp simd
+      for (int n = nmin; n < nmax; ++n) {
+        dDdy[n - nmin] -= (x[n - nmin] * tmpy[n - nmin] * (pxca[n - nmin] - pysa[n - nmin]) +
+                           y[n - nmin] * (1.f + tmpy[n - nmin] * (pyca[n - nmin] + pxsa[n - nmin]))) *
+                          oor0[n - nmin];
+      }
+#pragma omp simd
+      for (int n = nmin; n < nmax; ++n) {
+        //now r0 depends on ipt and phi as well
+        tmp[n - nmin] = dadipt[n - nmin] * ipt[n - nmin];
+      }
+#pragma omp simd
+      for (int n = nmin; n < nmax; ++n) {
+        dDdipt[n - nmin] -= k[n - nmin] *
+                            (x[n - nmin] * (pxca[n - nmin] * tmp[n - nmin] - pysa[n - nmin] * tmp[n - nmin] -
+                                            pyca[n - nmin] - pxsa[n - nmin] + pyin[n - nmin]) +
+                             y[n - nmin] * (pyca[n - nmin] * tmp[n - nmin] + pxsa[n - nmin] * tmp[n - nmin] -
+                                            pysa[n - nmin] + pxca[n - nmin] - pxin[n - nmin])) *
+                            pt[n - nmin] * oor0[n - nmin];
+      }
+#pragma omp simd
+      for (int n = nmin; n < nmax; ++n) {
+        dDdphi[n - nmin] += k[n - nmin] *
+                            (x[n - nmin] * (pysa[n - nmin] - pxin[n - nmin] + pxca[n - nmin]) -
+                             y[n - nmin] * (pxsa[n - nmin] - pyin[n - nmin] + pyca[n - nmin])) *
+                            oor0[n - nmin];
+      }
+    }
+
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
       //update parameters
-      outPar(n, 0, 0) = outPar(n, 0, 0) + 2.f * k * sinah * (pxin * cosah - pyin * sinah);
-      outPar(n, 1, 0) = outPar(n, 1, 0) + 2.f * k * sinah * (pyin * cosah + pxin * sinah);
-      const float pxinold = pxin;  //copy before overwriting
-      pxin = pxin * cosa - pyin * sina;
-      pyin = pyin * cosa + pxinold * sina;
-
+      outPar(n, 0, 0) = outPar(n, 0, 0) + 2.f * k[n - nmin] * sinah[n - nmin] *
+                                              (pxin[n - nmin] * cosah[n - nmin] - pyin[n - nmin] * sinah[n - nmin]);
+      outPar(n, 1, 0) = outPar(n, 1, 0) + 2.f * k[n - nmin] * sinah[n - nmin] *
+                                              (pyin[n - nmin] * cosah[n - nmin] + pxin[n - nmin] * sinah[n - nmin]);
+      pxinold[n - nmin] = pxin[n - nmin];  //copy before overwriting
+      pxin[n - nmin] = pxin[n - nmin] * cosa[n - nmin] - pyin[n - nmin] * sina[n - nmin];
+      pyin[n - nmin] = pyin[n - nmin] * cosa[n - nmin] + pxinold[n - nmin] * sina[n - nmin];
+    }
+    for (int n = nmin; n < nmax; ++n) {
       dprint_np(n,
-                "outPar(n, 0, 0)=" << outPar(n, 0, 0) << " outPar(n, 1, 0)=" << outPar(n, 1, 0) << " pxin=" << pxin
-                                   << " pyin=" << pyin);
+                "outPar(n, 0, 0)=" << outPar(n, 0, 0) << " outPar(n, 1, 0)=" << outPar(n, 1, 0)
+                                   << " pxin=" << pxin[n - nmin] << " pyin=" << pyin[n - nmin]);
     }
+  }  // iteration loop
 
-    const float alpha = D * ipt * kinv;
-    const float dadx = dDdx * ipt * kinv;
-    const float dady = dDdy * ipt * kinv;
-    const float dadipt = (ipt * dDdipt + D) * kinv;
-    const float dadphi = dDdphi * ipt * kinv;
+  float alpha[nmax - nmin];
+  float dadphi[nmax - nmin];
 
-    if (Config::useTrigApprox) {
-      sincos4(alpha, sina, cosa);
-    } else {
-      cosa = std::cos(alpha);
-      sina = std::sin(alpha);
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    alpha[n - nmin] = D[n - nmin] * ipt[n - nmin] * kinv[n - nmin];
+    dadx[n - nmin] = dDdx[n - nmin] * ipt[n - nmin] * kinv[n - nmin];
+    dady[n - nmin] = dDdy[n - nmin] * ipt[n - nmin] * kinv[n - nmin];
+    dadipt[n - nmin] = (ipt[n - nmin] * dDdipt[n - nmin] + D[n - nmin]) * kinv[n - nmin];
+    dadphi[n - nmin] = dDdphi[n - nmin] * ipt[n - nmin] * kinv[n - nmin];
+  }
+
+  if constexpr (Config::useTrigApprox) {
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
+      sincos4(alpha[n - nmin], sina[n - nmin], cosa[n - nmin]);
     }
-
-    errorProp(n, 0, 0) = 1.f + k * dadx * (cosPorT * cosa - sinPorT * sina) * pt;
-    errorProp(n, 0, 1) = k * dady * (cosPorT * cosa - sinPorT * sina) * pt;
+  } else {
+#pragma omp simd
+    for (int n = nmin; n < nmax; ++n) {
+      cosa[n - nmin] = std::cos(alpha[n - nmin]);
+      sina[n - nmin] = std::sin(alpha[n - nmin]);
+    }
+  }
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    errorProp(n, 0, 0) = 1.f + k[n - nmin] * dadx[n - nmin] *
+                                   (cosPorT[n - nmin] * cosa[n - nmin] - sinPorT[n - nmin] * sina[n - nmin]) *
+                                   pt[n - nmin];
+    errorProp(n, 0, 1) = k[n - nmin] * dady[n - nmin] *
+                         (cosPorT[n - nmin] * cosa[n - nmin] - sinPorT[n - nmin] * sina[n - nmin]) * pt[n - nmin];
     errorProp(n, 0, 2) = 0.f;
     errorProp(n, 0, 3) =
-        k * (cosPorT * (ipt * dadipt * cosa - sina) + sinPorT * ((1.f - cosa) - ipt * dadipt * sina)) * pt * pt;
+        k[n - nmin] *
+        (cosPorT[n - nmin] * (ipt[n - nmin] * dadipt[n - nmin] * cosa[n - nmin] - sina[n - nmin]) +
+         sinPorT[n - nmin] * ((1.f - cosa[n - nmin]) - ipt[n - nmin] * dadipt[n - nmin] * sina[n - nmin])) *
+        pt[n - nmin] * pt[n - nmin];
     errorProp(n, 0, 4) =
-        k * (cosPorT * dadphi * cosa - sinPorT * dadphi * sina - sinPorT * sina + cosPorT * cosa - cosPorT) * pt;
+        k[n - nmin] *
+        (cosPorT[n - nmin] * dadphi[n - nmin] * cosa[n - nmin] - sinPorT[n - nmin] * dadphi[n - nmin] * sina[n - nmin] -
+         sinPorT[n - nmin] * sina[n - nmin] + cosPorT[n - nmin] * cosa[n - nmin] - cosPorT[n - nmin]) *
+        pt[n - nmin];
     errorProp(n, 0, 5) = 0.f;
+  }
 
-    errorProp(n, 1, 0) = k * dadx * (sinPorT * cosa + cosPorT * sina) * pt;
-    errorProp(n, 1, 1) = 1.f + k * dady * (sinPorT * cosa + cosPorT * sina) * pt;
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    errorProp(n, 1, 0) = k[n - nmin] * dadx[n - nmin] *
+                         (sinPorT[n - nmin] * cosa[n - nmin] + cosPorT[n - nmin] * sina[n - nmin]) * pt[n - nmin];
+    errorProp(n, 1, 1) = 1.f + k[n - nmin] * dady[n - nmin] *
+                                   (sinPorT[n - nmin] * cosa[n - nmin] + cosPorT[n - nmin] * sina[n - nmin]) *
+                                   pt[n - nmin];
     errorProp(n, 1, 2) = 0.f;
     errorProp(n, 1, 3) =
-        k * (sinPorT * (ipt * dadipt * cosa - sina) + cosPorT * (ipt * dadipt * sina - (1.f - cosa))) * pt * pt;
+        k[n - nmin] *
+        (sinPorT[n - nmin] * (ipt[n - nmin] * dadipt[n - nmin] * cosa[n - nmin] - sina[n - nmin]) +
+         cosPorT[n - nmin] * (ipt[n - nmin] * dadipt[n - nmin] * sina[n - nmin] - (1.f - cosa[n - nmin]))) *
+        pt[n - nmin] * pt[n - nmin];
     errorProp(n, 1, 4) =
-        k * (sinPorT * dadphi * cosa + cosPorT * dadphi * sina + sinPorT * cosa + cosPorT * sina - sinPorT) * pt;
+        k[n - nmin] *
+        (sinPorT[n - nmin] * dadphi[n - nmin] * cosa[n - nmin] + cosPorT[n - nmin] * dadphi[n - nmin] * sina[n - nmin] +
+         sinPorT[n - nmin] * cosa[n - nmin] + cosPorT[n - nmin] * sina[n - nmin] - sinPorT[n - nmin]) *
+        pt[n - nmin];
     errorProp(n, 1, 5) = 0.f;
+  }
 
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
     //no trig approx here, theta can be large
-    cosPorT = std::cos(theta);
-    sinPorT = std::sin(theta);
+    cosPorT[n - nmin] = std::cos(theta[n - nmin]);
+  }
+
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    sinPorT[n - nmin] = std::sin(theta[n - nmin]);
+  }
+
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
     //redefine sinPorT as 1./sinPorT to reduce the number of temporaries
-    sinPorT = 1.f / sinPorT;
+    sinPorT[n - nmin] = 1.f / sinPorT[n - nmin];
+  }
 
-    outPar(n, 2, 0) = inPar(n, 2, 0) + k * alpha * cosPorT * pt * sinPorT;
-
-    errorProp(n, 2, 0) = k * cosPorT * dadx * pt * sinPorT;
-    errorProp(n, 2, 1) = k * cosPorT * dady * pt * sinPorT;
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    outPar(n, 2, 0) =
+        inPar(n, 2, 0) + k[n - nmin] * alpha[n - nmin] * cosPorT[n - nmin] * pt[n - nmin] * sinPorT[n - nmin];
+    errorProp(n, 2, 0) = k[n - nmin] * cosPorT[n - nmin] * dadx[n - nmin] * pt[n - nmin] * sinPorT[n - nmin];
+    errorProp(n, 2, 1) = k[n - nmin] * cosPorT[n - nmin] * dady[n - nmin] * pt[n - nmin] * sinPorT[n - nmin];
     errorProp(n, 2, 2) = 1.f;
-    errorProp(n, 2, 3) = k * cosPorT * (ipt * dadipt - alpha) * pt * pt * sinPorT;
-    errorProp(n, 2, 4) = k * dadphi * cosPorT * pt * sinPorT;
-    errorProp(n, 2, 5) = -k * alpha * pt * sinPorT * sinPorT;
+    errorProp(n, 2, 3) = k[n - nmin] * cosPorT[n - nmin] * (ipt[n - nmin] * dadipt[n - nmin] - alpha[n - nmin]) *
+                         pt[n - nmin] * pt[n - nmin] * sinPorT[n - nmin];
+    errorProp(n, 2, 4) = k[n - nmin] * dadphi[n - nmin] * cosPorT[n - nmin] * pt[n - nmin] * sinPorT[n - nmin];
+    errorProp(n, 2, 5) = -k[n - nmin] * alpha[n - nmin] * pt[n - nmin] * sinPorT[n - nmin] * sinPorT[n - nmin];
+  }
 
-    outPar(n, 3, 0) = ipt;
-
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    outPar(n, 3, 0) = ipt[n - nmin];
     errorProp(n, 3, 0) = 0.f;
     errorProp(n, 3, 1) = 0.f;
     errorProp(n, 3, 2) = 0.f;
     errorProp(n, 3, 3) = 1.f;
     errorProp(n, 3, 4) = 0.f;
     errorProp(n, 3, 5) = 0.f;
+  }
 
-    outPar(n, 4, 0) = inPar(n, 4, 0) + alpha;
-
-    errorProp(n, 4, 0) = dadx;
-    errorProp(n, 4, 1) = dady;
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    outPar(n, 4, 0) = inPar(n, 4, 0) + alpha[n - nmin];
+    errorProp(n, 4, 0) = dadx[n - nmin];
+    errorProp(n, 4, 1) = dady[n - nmin];
     errorProp(n, 4, 2) = 0.f;
-    errorProp(n, 4, 3) = dadipt;
-    errorProp(n, 4, 4) = 1.f + dadphi;
+    errorProp(n, 4, 3) = dadipt[n - nmin];
+    errorProp(n, 4, 4) = 1.f + dadphi[n - nmin];
     errorProp(n, 4, 5) = 0.f;
+  }
 
-    outPar(n, 5, 0) = theta;
-
+#pragma omp simd
+  for (int n = nmin; n < nmax; ++n) {
+    outPar(n, 5, 0) = theta[n - nmin];
     errorProp(n, 5, 0) = 0.f;
     errorProp(n, 5, 1) = 0.f;
     errorProp(n, 5, 2) = 0.f;
     errorProp(n, 5, 3) = 0.f;
     errorProp(n, 5, 4) = 0.f;
     errorProp(n, 5, 5) = 1.f;
+  }
 
+  for (int n = nmin; n < nmax; ++n) {
     dprint_np(n,
               "propagation end, dump parameters"
                   << std::endl
@@ -237,8 +459,10 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
                   << "   mom = " << std::cos(outPar(n, 4, 0)) / outPar(n, 3, 0) << " "
                   << std::sin(outPar(n, 4, 0)) / outPar(n, 3, 0) << " " << 1. / (outPar(n, 3, 0) * tan(outPar(n, 5, 0)))
                   << "\t\tpT=" << 1. / std::abs(outPar(n, 3, 0)) << std::endl);
+  }
 
 #ifdef DEBUG
+  for (int n = nmin; n < nmax; ++n) {
     if (n < N_proc) {
       dmutex_guard;
       std::cout << n << ": jacobian" << std::endl;
@@ -286,6 +510,6 @@ static inline void helixAtRFromIterativeCCS_impl(const Tf& __restrict__ inPar,
              errorProp(n, 5, 5));
       printf("\n");
     }
-#endif
   }
+#endif
 }

--- a/RecoTracker/MkFitCore/standalone/README_buildFromCMSSW.txt
+++ b/RecoTracker/MkFitCore/standalone/README_buildFromCMSSW.txt
@@ -6,6 +6,7 @@ cd mkFitFromCMSSW
 git config core.sparsecheckout true
 echo -e "/.gitignore\n/.clang-tidy\n/.clang-format" > .git/info/sparse-checkout
 echo -e "/RecoTracker/MkFit/\n/RecoTracker/MkFitCMS/\n/RecoTracker/MkFitCore/" >> .git/info/sparse-checkout
+echo -e "/FWCore/Utilities/interface/" >> .git/info/sparse-checkout
 git checkout  # enter detached-head state
 ./RecoTracker/MkFitCore/standalone/configure $PWD
 source ./RecoTracker/MkFitCore/standalone/xeon_scripts/init-env.sh


### PR DESCRIPTION
commit 18abd3a967c4794bd081ef2af94a85f2585b25eb
Author: Patrick Gartung <gartung@fnal.gov>
Date:   Wed May 25 02:12:21 2022 +0200

    Code format

commit f067f254ac785d8cdd2d46112174b3f044f82553
Author: Patrick Gartung <gartung@fnal.gov>
Date:   Wed May 25 02:08:47 2022 +0200

    Fix icc compilation errors

commit b265ce2d97be1f38a882e53aa0f1ad8c6469263e
Author: Patrick Gartung <gartung@fnal.gov>
Date:   Fri May 20 23:22:10 2022 +0200

    Add line to RecoTracker/MkFitCore/standalone/README_buildFromCMSSW.txt

commit 861899759440ffb1e2aedc848014bf2c23765b2b
Author: Patrick Gartung <gartung@fnal.gov>
Date:   Fri May 20 18:18:50 2022 +0200

    Add CMS_UNROLL_LOOP defines for Intel compilers and use with pragme omp simd instructions that cause internal icc error

commit 45977ea512079ea324b009a2edd03df9c3e58e50
Author: Patrick Gartung <gartung@fnal.gov>
Date:   Fri May 20 18:17:54 2022 +0200

    Squashed commit of the following:

    commit a565f528861deb96fb549f12c8ec619dc60fde1d
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Thu May 19 15:23:44 2022 +0200

        Remove fast-math flag and attribute needed to prevent segfault when fast-math is used

    commit c3fbce9e16987ce4f152b3ae1197c543f988a363
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Mon May 16 17:28:41 2022 +0200

        Code format

    commit c388ab36ccecad460b22042ca882b0f572ce7c6e
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Mon May 16 17:27:00 2022 +0200

        Update location of #endif after enabling debug. #pragma omp simd not needed for debug statements. Move debug statements to own loop.

    commit 468b4760a1a6df6bf8545903339b6312e8420c31
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Sat May 14 19:51:00 2022 +0200

        No need to link to libmvec. It is called from libm on el8. Always use -ffastmath

    commit 0ef90368b2b7c5345b417d9e99fb37acef9f8685
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Fri May 13 20:01:43 2022 +0200

        Only works on el8_amd64 arch

    commit 8866ca64dc913d274f25da401c321cc5d2193790
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Fri May 13 16:10:23 2022 +0200

        Update for macro name change

    commit fe4a38fa1fca00e3746b14c1d72a9e35c675360c
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Thu May 12 21:43:02 2022 +0200

        code format?

    commit 8326129cd2333b8fcc256880f70a5deb9e5d899f
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Thu May 12 21:18:44 2022 +0200

    	    Add CMS_UNROLL_LOOP defines for Intel compilers and use with pragme omp simd instructions that cause internal icc error

    commit 056f7ef4fcc745107ff55365f0a1d9e0a2634349
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Thu May 12 03:42:01 2022 +0200

        Add CMS_UNROLL_LOOP_COUNT(Config::Niter) and initialize arrays with += and -= assignment statements to 0. first

    commit 31e2c8351f4f988e97b04ec39eb52547654c3923
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Wed May 11 05:16:27 2022 +0200

        Add CMS_UNROLL_LOOP_COUNT(Config::Niter)
        and #include "FWCore/Utilities/interface/CMSUnrollLoop.h"

    commit 8eab5b1ea5f6d29b90d4670ef7aedbec0ff8af72
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Wed May 11 04:57:47 2022 +0200

        Change atrribute from no-fast-math to match-errno

    commit 688e905a36b83cf8d5da1313b703098598cd74ae
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Tue May 10 17:37:25 2022 +0200

        Code format

    commit ed58228b16f3b86686725556739cc93508d3af14
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Tue May 10 17:23:08 2022 +0200

        Change attribute from no-inline to no-fast-math. Back out changes to applyMaterialEffects since it does not vectorize with the conditional on radL.

    commit c19f9c8b6bb718ae110f914177788bb760a5e59a
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Mon May 9 19:49:15 2022 +0200

        code format

    commit 373ea0d28c50e3b7d949604eddae5ac0859e0a93
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Mon May 9 19:02:48 2022 +0200

        missed a few initialization of variable length arrays

    commit 753934cb32362ecf846b24e726ec4c1b49cf644c
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Mon May 9 18:51:13 2022 +0200

        for all el8 archs

    commit 2eb25ef5bf7c45353d4cae9c852d5b75fd848a85
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Mon May 9 18:31:35 2022 +0200

        clang does not allow initialization of variable length arrays

    commit 7f237622ef7b3c216e6ed3ce1a0a03f978b03817
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Mon May 9 17:41:29 2022 +0200

        Add fast-math and mvec when compiling under el8

    commit 5f6efe223081fe7a17becd39d5f27088c227136b
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Mon May 9 16:07:08 2022 +0200

        Comment out changes that are CERN specific

    commit 1ba6e069887f2ca38a3318f292d409a5c19b8406
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Thu May 5 21:25:33 2022 +0200

        Try to break loop in applyMaterialEffects into smaller loops
        Combine arithmetic ops into one loop.
        Add -lmvec which is avaiable on RHEL8

    commit dbc748cdd84b82a3faa3d621eb3ea9cb2621bc7c
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Wed May 4 20:02:05 2022 +0200

        Incorporate Dan Riley's suggested changes

    commit d6ae2c9c7bb50e03e3e9f187a1413568f5aeb7e0
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Tue May 3 20:20:47 2022 +0200

        Update helixAtZ to use small calculation loops

    commit 3d704ba96e6cefc4d7d1959f621c0d47fc57879e
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Fri Apr 29 21:43:00 2022 +0200

        Work in progress

    commit 31550b4446669845eb696676f47a257726923532
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Fri Apr 29 20:03:09 2022 +0200

        Fixups

    commit f10ef52690510ba9ad9ad00dc9285bc4951e651e
    Author: Patrick Gartung <gartung@fnal.gov>
    Date:   Fri Apr 29 00:57:47 2022 +0200

        WIP

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
