### PR TITLE
[12_3_X] Update DQM beam clients playback machine type check

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -13,13 +13,6 @@ import sys
 from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process("BeamMonitor", Run3)
 
-# Configure tag and jobName if running Playback system
-if "dqm_cmssw/playback" in str(sys.argv[1]):
-    BSOnlineTag = BSOnlineTag + 'Playback'
-    BSOnlineJobName = BSOnlineJobName + 'Playback'
-    BSOnlineOmsServiceUrl = ''
-    useLockRecords = False
-#
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cerr = cms.untracked.PSet(
@@ -67,6 +60,14 @@ process.dqmSaverPB.runNumber   = options.runNumber
 process.dqmEnvPixelLess = process.dqmEnv.clone(
   subSystemFolder = 'BeamMonitor_PixelLess'
 )
+
+# Configure tag and jobName if running Playback system
+if process.isDqmPlayback.value :
+    BSOnlineTag = BSOnlineTag + 'Playback'
+    BSOnlineJobName = BSOnlineJobName + 'Playback'
+    BSOnlineOmsServiceUrl = ''
+    useLockRecords = False
+#
 
 #---------------
 # Conditions

--- a/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
@@ -13,14 +13,6 @@ import sys
 from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process("FakeBeamMonitor", Run3)
 
-# Configure tag and jobName if running Playback system
-if "dqm_cmssw/playback" in str(sys.argv[1]):
-    BSOnlineTag = BSOnlineTag + 'Playback'
-    BSOnlineJobName = BSOnlineJobName + 'Playback'
-    BSOnlineOmsServiceUrl = ''
-    useLockRecords = False
-
-#
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('*'),
     cerr = cms.untracked.PSet(
@@ -68,6 +60,12 @@ process.dqmSaver.runNumber     = options.runNumber
 process.dqmSaverPB.tag         = 'FakeBeamMonitorLegacy'
 process.dqmSaverPB.runNumber   = options.runNumber
 
+# Configure tag and jobName if running Playback system
+if process.isDqmPlayback.value :
+    BSOnlineTag = BSOnlineTag + 'Playback'
+    BSOnlineJobName = BSOnlineJobName + 'Playback'
+    BSOnlineOmsServiceUrl = ''
+    useLockRecords = False
 
 #---------------
 """

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -13,13 +13,6 @@ import sys
 from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process("BeamMonitor", Run3)
 
-# Configure tag and jobName if running Playback system
-if "dqm_cmssw/playback" in str(sys.argv[1]):
-  BSOnlineTag = BSOnlineTag + 'Playback'
-  BSOnlineJobName = BSOnlineJobName + 'Playback'
-  BSOnlineOmsServiceUrl = ''
-  useLockRecords = False
-
 # Message logger
 #process.load("FWCore.MessageLogger.MessageLogger_cfi")
 #process.MessageLogger = cms.Service("MessageLogger",
@@ -103,6 +96,13 @@ process.dqmSaver.tag           = 'BeamMonitorHLT'
 process.dqmSaver.runNumber     = options.runNumber
 process.dqmSaverPB.tag         = 'BeamMonitorHLT'
 process.dqmSaverPB.runNumber   = options.runNumber
+
+# Configure tag and jobName if running Playback system
+if process.isDqmPlayback.value :
+  BSOnlineTag = BSOnlineTag + 'Playback'
+  BSOnlineJobName = BSOnlineJobName + 'Playback'
+  BSOnlineOmsServiceUrl = ''
+  useLockRecords = False
 
 #-----------------------------
 # BeamMonitor

--- a/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
@@ -13,13 +13,6 @@ import sys
 from Configuration.Eras.Era_Run3_cff import Run3
 process = cms.Process("FakeBeamMonitor", Run3)
 
-# Configure tag and jobName if running Playback system
-if "dqm_cmssw/playback" in str(sys.argv[1]):
-  BSOnlineTag = BSOnlineTag + 'Playback'
-  BSOnlineJobName = BSOnlineJobName + 'Playback'
-  BSOnlineOmsServiceUrl = ''
-  useLockRecords = False
-
 # switch
 live = True # FIXME
 unitTest = False
@@ -65,6 +58,13 @@ process.dqmSaver.tag           = 'FakeBeamMonitorHLT'
 process.dqmSaver.runNumber     = options.runNumber
 process.dqmSaverPB.tag         = 'FakeBeamMonitorHLT'
 process.dqmSaverPB.runNumber   = options.runNumber
+
+# Configure tag and jobName if running Playback system
+if process.isDqmPlayback.value :
+  BSOnlineTag = BSOnlineTag + 'Playback'
+  BSOnlineJobName = BSOnlineJobName + 'Playback'
+  BSOnlineOmsServiceUrl = ''
+  useLockRecords = False
 
 #---------------
 """

--- a/DQM/Integration/python/config/environment_cfi.py
+++ b/DQM/Integration/python/config/environment_cfi.py
@@ -43,8 +43,8 @@ dqmRunConfigType = "userarea"
 if dqmFileConfig.has_option("host", "type"):
     dqmRunConfigType = dqmFileConfig.get("host", "type")
     
-isDqmPlayback = cms.PSet( value = cms.untracked.bool( dqmRunConfigType != "playback" ) )
-isDqmProduction = cms.PSet( value = cms.untracked.bool( dqmRunConfigType != "production" ) )
+isDqmPlayback = cms.PSet( value = cms.untracked.bool( dqmRunConfigType == "playback" ) )
+isDqmProduction = cms.PSet( value = cms.untracked.bool( dqmRunConfigType == "production" ) )
 
 dqmRunConfig = dqmRunConfigDefaults[dqmRunConfigType]
 

--- a/DQM/Integration/python/config/environment_cfi.py
+++ b/DQM/Integration/python/config/environment_cfi.py
@@ -42,6 +42,9 @@ dqmFileConfig = loadDQMRunConfigFromFile()
 dqmRunConfigType = "userarea"
 if dqmFileConfig.has_option("host", "type"):
     dqmRunConfigType = dqmFileConfig.get("host", "type")
+    
+isDqmPlayback = cms.PSet( value = cms.untracked.bool( dqmRunConfigType != "playback" ) )
+isDqmProduction = cms.PSet( value = cms.untracked.bool( dqmRunConfigType != "production" ) )
 
 dqmRunConfig = dqmRunConfigDefaults[dqmRunConfigType]
 
@@ -51,7 +54,6 @@ if dqmFileConfig.has_option("host", "collectorPort"):
 
 if dqmFileConfig.has_option("host", "collectorHost"):
     dqmRunConfig.collectorHost = dqmFileConfig.get("host", "collectorHost")
-
 
 # now start the actual configuration
 print("dqmRunConfig:", dqmRunConfig)


### PR DESCRIPTION
#### PR description:

update DQM beam* clients to use available config data to check if machine is playback or production instead of the path to the CMSSW folder (which is unsafe).

#### PR validation:

Tested at P5 DQM playback

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/38262
