### PR TITLE
Fix CMS deprecation warning in L1Trigger/TextToDigi

### DIFF
--- a/L1Trigger/TextToDigi/plugins/RawToText.h
+++ b/L1Trigger/TextToDigi/plugins/RawToText.h
@@ -14,14 +14,14 @@
 #include <memory>
 #include <string>
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 
-class RawToText : public edm::EDAnalyzer {
+class RawToText : public edm::one::EDAnalyzer<> {
 public:
   explicit RawToText(const edm::ParameterSet &);
   ~RawToText() override;

--- a/L1Trigger/TextToDigi/plugins/RctDigiToRctText.cc
+++ b/L1Trigger/TextToDigi/plugins/RctDigiToRctText.cc
@@ -39,7 +39,6 @@ RctDigiToRctText::~RctDigiToRctText() {
 
 void RctDigiToRctText::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   /// count bunch crossing
-  static int nevt = -1;
   nevt++;
 
   /// get the RCT data

--- a/L1Trigger/TextToDigi/plugins/RctDigiToRctText.h
+++ b/L1Trigger/TextToDigi/plugins/RctDigiToRctText.h
@@ -14,7 +14,7 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -27,7 +27,7 @@
 
 const static unsigned NUM_RCT_CRATES = 18;
 
-class RctDigiToRctText : public edm::EDAnalyzer {
+class RctDigiToRctText : public edm::one::EDAnalyzer<> {
 public:
   explicit RctDigiToRctText(const edm::ParameterSet &);
   ~RctDigiToRctText() override;
@@ -49,6 +49,8 @@ private:
 
   /// handle for debug file
   std::ofstream fdebug;
+
+  int nevt = -1;
 };
 
 #endif

--- a/L1Trigger/TextToDigi/plugins/RctInputTextToDigi.cc
+++ b/L1Trigger/TextToDigi/plugins/RctInputTextToDigi.cc
@@ -7,9 +7,10 @@
 RctInputTextToDigi::RctInputTextToDigi(const edm::ParameterSet &iConfig)
     : inputFile_(iConfig.getParameter<edm::FileInPath>("inputFile")),
       inputStream_(inputFile_.fullPath().c_str()),
+      lookupTables_(new L1RCTLookupTables),
+      paramsToken_(esConsumes()),
       nEvent_(0),
-      oldVersion_(false),
-      lookupTables_(new L1RCTLookupTables) {
+      oldVersion_(false) {
   // register your products
   /* Examples
      produces<ExampleData2>();
@@ -52,9 +53,7 @@ void RctInputTextToDigi::produce(edm::Event &iEvent, const edm::EventSetup &iSet
   // L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc rev. 1.6
   // Refresh configuration information every event
   // Hopefully doesn't take too much time
-  ESHandle<L1RCTParameters> rctParameters;
-  iSetup.get<L1RCTParametersRcd>().get(rctParameters);
-  const L1RCTParameters *r = rctParameters.product();
+  const L1RCTParameters *r = &iSetup.getData(paramsToken_);
   lookupTables_->setRCTParameters(r);
 
   std::unique_ptr<EcalTrigPrimDigiCollection> ecalTPs(new EcalTrigPrimDigiCollection());

--- a/L1Trigger/TextToDigi/plugins/RctInputTextToDigi.h
+++ b/L1Trigger/TextToDigi/plugins/RctInputTextToDigi.h
@@ -28,7 +28,7 @@
 #include <string>
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -47,7 +47,7 @@
 // class declaration
 //
 
-class RctInputTextToDigi : public edm::EDProducer {
+class RctInputTextToDigi : public edm::one::EDProducer<> {
 public:
   explicit RctInputTextToDigi(const edm::ParameterSet &);
   ~RctInputTextToDigi() override;
@@ -61,9 +61,10 @@ private:
 
   edm::FileInPath inputFile_;
   std::ifstream inputStream_;
+  L1RCTLookupTables *lookupTables_;
+  edm::ESGetToken<L1RCTParameters, L1RCTParametersRcd> paramsToken_;
   int nEvent_;
   bool oldVersion_;
-  L1RCTLookupTables *lookupTables_;
 };
 
 #endif

--- a/L1Trigger/TextToDigi/plugins/TextToRaw.h
+++ b/L1Trigger/TextToDigi/plugins/TextToRaw.h
@@ -27,7 +27,7 @@
 #include <string>
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -38,7 +38,7 @@
 // class decleration
 //
 
-class TextToRaw : public edm::EDProducer {
+class TextToRaw : public edm::one::EDProducer<> {
 public:
   explicit TextToRaw(const edm::ParameterSet &);
   ~TextToRaw() override;
@@ -57,7 +57,7 @@ private:
   std::ifstream file_;
 
   // array to store the data
-  static const unsigned EVT_MAX_SIZE = 8192;
+  static constexpr unsigned EVT_MAX_SIZE = 8192;
   char data_[EVT_MAX_SIZE];
 
   int fileEventOffset_;


### PR DESCRIPTION
#### PR description:

- convert to thread-friendly module type
- added esConsumes when needed

#### PR validation:

Code compiles without issuing warning.