### PR TITLE
Alignment/MillePedeAlignmentAlgorithm/test_CreateFileLists: give a better error message in case of failure

### DIFF
--- a/Alignment/CommonAlignment/scripts/tkal_create_file_lists.py
+++ b/Alignment/CommonAlignment/scripts/tkal_create_file_lists.py
@@ -916,6 +916,7 @@ def das_client(query, check_key = None):
     """
 
     error = True
+    das_data = {'status': 'error'}
     for i in range(5):         # maximum of 5 tries
         try:
             das_data = cmssw_das_client.get_data(query, limit = 0)
@@ -924,6 +925,7 @@ def das_client(query, check_key = None):
                 continue
         except ValueError as e:
             if str(e) == "No JSON object could be decoded":
+                das_data['reason'] = str(e)
                 continue
 
         if das_data["status"] == "ok":
@@ -945,7 +947,7 @@ def das_client(query, check_key = None):
     if das_data["status"] == "error":
         print_msg("DAS query '{}' failed 5 times. "
                   "The last time for the the following reason:".format(query))
-        print(das_data["reason"])
+        print(das_data.get("reason", "ERROR:UNKNOWN"))
         sys.exit(1)
     return das_data["data"]
 

--- a/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
+++ b/Alignment/MillePedeAlignmentAlgorithm/test/BuildFile.xml
@@ -9,7 +9,7 @@
 </library>
 <test name="test_PrepareInputDb" command="mps_prepare_input_db.py -g auto:run2_data -r 1 -o ${LOCALTOP}/tmp/test_input.db"/>
 <test name="test_MpsWorkFlow" command="test_mps-workflow.sh"/>
-<test name="test_CreateFileLists" command="mps_create_file_lists.py --test-mode --force -i /OVERRIDDEN/IN/TESTMODE -o ${LOCALTOP}/tmp/mps_create_file_lists -n 200000 --iov 42 --iov 174"/>
+<test name="test_CreateFileLists" command="tkal_create_file_lists.py --test-mode --force -i /OVERRIDDEN/IN/TESTMODE -o ${LOCALTOP}/tmp/mps_create_file_lists -n 200000 --iov 42 --iov 174"/>
 <test name="test-pede" command="pede -t">
   <use name="millepede"/>
   <flags USE_UNITTEST_DIR="1"/>


### PR DESCRIPTION
#### PR description:

test_CreateFileLists failed in CMSSW_12_5_ASAN_X_2022-06-06-1100 IB: [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc10/CMSSW_12_5_ASAN_X_2022-06-06-1100/unitTestLogs/Alignment/MillePedeAlignmentAlgorithm#/426-426)

```

Traceback (most recent call last):
  File "/cvmfs/cms-ib.cern.ch/week0/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_ASAN_X_2022-06-06-1100/bin/el8_amd64_gcc10/mps_create_file_lists.py", line 12, in <module>
    exec(open(subprocess.check_output(["which", "tkal_create_file_lists.py"], universal_newlines=True).rstrip()).read())
  File "<string>", line 1174, in <module>
  File "<string>", line 44, in main
  File "<string>", line 120, in create
  File "<string>", line 375, in _request_dataset_information
  File "/cvmfs/cms-ib.cern.ch/week0/el8_amd64_gcc10/external/python3/3.9.6-67e5cf5b4952101922f1d4c8474baa39/lib/python3.9/multiprocessing/pool.py", line 771, in get
    raise self._value
UnboundLocalError: local variable 'das_data' referenced before assignment
```

This PR fixes the error by initializing `das_data` with some generic state before running DAS query. Also, the PR updates test definition to use `tkal_create_file_lists.py` instead of `mps_create_file_lists.py` as indicated in [mps_create_file_lists.py](https://github.com/cms-sw/cmssw/blob/master/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_create_file_lists.py):

```
=======================================
This script is moved to its new home in
tkal_create_file_lists.py              
(in Alignment/CommonAlignment/scripts).
=======================================
```

#### PR validation:

Test ran locally without errors