### PR TITLE
New PCL Alignment Threshold object in alignment consumers

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -12,7 +12,7 @@
 
 /*** Alignment ***/
 #include "Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h"
-#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"
 
 struct mpPCLresults {
 private:
@@ -59,7 +59,7 @@ class MillePedeFileReader {
 public:  //====================================================================
   explicit MillePedeFileReader(const edm::ParameterSet&,
                                const std::shared_ptr<const PedeLabelerBase>&,
-                               const std::shared_ptr<const AlignPCLThresholds>&);
+                               const std::shared_ptr<const AlignPCLThresholdsHG>&);
 
   virtual ~MillePedeFileReader() = default;
 
@@ -81,7 +81,7 @@ public:  //====================================================================
   const std::array<double, 6>& getTZobs() const { return tZobs_; }
   const std::array<double, 6>& getTZobsErr() const { return tZobsErr_; }
 
-  const AlignPCLThresholds::threshold_map getThresholdMap() const { return theThresholds_.get()->getThreshold_Map(); }
+  const AlignPCLThresholdsHG::threshold_map getThresholdMap() const { return theThresholds_.get()->getThreshold_Map(); }
 
   const int binariesAmount() const { return binariesAmount_; }
 
@@ -119,7 +119,7 @@ private:
   const std::shared_ptr<const PedeLabelerBase> pedeLabeler_;
 
   // thresholds from DB
-  const std::shared_ptr<const AlignPCLThresholds> theThresholds_;
+  const std::shared_ptr<const AlignPCLThresholdsHG> theThresholds_;
 
   // file-names
   const std::string millePedeEndFile_;
@@ -168,8 +168,8 @@ private:
 };
 
 const std::array<std::string, 8> coord_str = {{"X", "Y", "Z", "theta_X", "theta_Y", "theta_Z", "extra_DOF", "none"}};
-inline std::ostream& operator<<(std::ostream& os, const AlignPCLThresholds::coordType& c) {
-  if (c >= AlignPCLThresholds::endOfTypes || c < AlignPCLThresholds::X)
+inline std::ostream& operator<<(std::ostream& os, const AlignPCLThresholdsHG::coordType& c) {
+  if (c >= AlignPCLThresholdsHG::endOfTypes || c < AlignPCLThresholdsHG::X)
     return os << "unrecongnized coordinate";
   return os << coord_str[c];
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.cc
@@ -87,7 +87,7 @@ using namespace gbl;
 MillePedeAlignmentAlgorithm::MillePedeAlignmentAlgorithm(const edm::ParameterSet &cfg, edm::ConsumesCollector &iC)
     : AlignmentAlgorithmBase(cfg, iC),
       topoToken_(iC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
-      aliThrToken_(iC.esConsumes<AlignPCLThresholds, AlignPCLThresholdsRcd, edm::Transition::BeginRun>()),
+      aliThrToken_(iC.esConsumes<AlignPCLThresholdsHG, AlignPCLThresholdsHGRcd, edm::Transition::BeginRun>()),
       theConfig(cfg),
       theMode(this->decodeMode(theConfig.getUntrackedParameter<std::string>("mode"))),
       theDir(theConfig.getUntrackedParameter<std::string>("fileDir")),
@@ -183,7 +183,7 @@ void MillePedeAlignmentAlgorithm::initialize(const edm::EventSetup &setup,
   //Retrieve the thresolds cuts from DB for the PCL
   if (runAtPCL_) {
     const auto &th = &setup.getData(aliThrToken_);
-    theThresholds = std::make_shared<AlignPCLThresholds>();
+    theThresholds = std::make_shared<AlignPCLThresholdsHG>();
     storeThresholds(th->getNrecords(), th->getThreshold_Map());
   }
 
@@ -301,7 +301,7 @@ bool MillePedeAlignmentAlgorithm::addCalibrations(const std::vector<IntegratedCa
 
 //____________________________________________________
 bool MillePedeAlignmentAlgorithm::storeThresholds(const int &nRecords,
-                                                  const AlignPCLThresholds::threshold_map &thresholdMap) {
+                                                  const AlignPCLThresholdsHG::threshold_map &thresholdMap) {
   theThresholds->setAlignPCLThresholds(nRecords, thresholdMap);
   return true;
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeAlignmentAlgorithm.h
@@ -25,8 +25,8 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-#include "CondFormats/PCLConfig/interface/AlignPCLThresholds.h"
-#include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
+#include "CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h"
+#include "CondFormats/DataRecord/interface/AlignPCLThresholdsHGRcd.h"
 
 #include <vector>
 #include <string>
@@ -76,7 +76,7 @@ public:
   /// Pass integrated calibrations to Millepede (they are not owned by Millepede!)
   bool addCalibrations(const std::vector<IntegratedCalibrationBase *> &iCals) override;
 
-  virtual bool storeThresholds(const int &nRecords, const AlignPCLThresholds::threshold_map &thresholdMap);
+  virtual bool storeThresholds(const int &nRecords, const AlignPCLThresholdsHG::threshold_map &thresholdMap);
 
   /// Called at end of job
   void terminate(const edm::EventSetup &iSetup) override;
@@ -271,7 +271,7 @@ private:
   //--------------------------------------------------------
 
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
-  const edm::ESGetToken<AlignPCLThresholds, AlignPCLThresholdsRcd> aliThrToken_;
+  const edm::ESGetToken<AlignPCLThresholdsHG, AlignPCLThresholdsHGRcd> aliThrToken_;
 
   enum EModeBit { myMilleBit = 1 << 0, myPedeRunBit = 1 << 1, myPedeSteerBit = 1 << 2, myPedeReadBit = 1 << 3 };
   unsigned int decodeMode(const std::string &mode) const;
@@ -291,7 +291,7 @@ private:
   std::unique_ptr<PedeSteerer> thePedeSteer;
   std::unique_ptr<TrajectoryFactoryBase> theTrajectoryFactory;
   std::vector<IntegratedCalibrationBase *> theCalibrations;
-  std::shared_ptr<AlignPCLThresholds> theThresholds;
+  std::shared_ptr<AlignPCLThresholdsHG> theThresholds;
   unsigned int theMinNumHits;
   double theMaximalCor2D;  /// maximal correlation allowed for 2D hit in TID/TEC.
                            /// If larger, the 2D measurement gets diagonalized!!!

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -93,7 +93,7 @@ void MillePedeDQMModule ::beginRun(const edm::Run&, const edm::EventSetup& setup
   // take the thresholds from DB
   const auto& thresholds_ = &setup.getData(aliThrToken_);
 
-  auto myThresholds = std::make_shared<AlignPCLThresholds>();
+  auto myThresholds = std::make_shared<AlignPCLThresholdsHG>();
   myThresholds->setAlignPCLThresholds(thresholds_->getNrecords(), thresholds_->getThreshold_Map());
 
   TrackerGeomBuilderFromGeometricDet builder;
@@ -110,7 +110,7 @@ void MillePedeDQMModule ::beginRun(const edm::Run&, const edm::EventSetup& setup
       labelerPlugin, PedeLabelerBase::TopLevelAlignables(tracker_.get(), nullptr, nullptr), labelerConfig)};
 
   mpReader_ = std::make_unique<MillePedeFileReader>(
-      mpReaderConfig_, pedeLabeler, std::shared_ptr<const AlignPCLThresholds>(myThresholds));
+      mpReaderConfig_, pedeLabeler, std::shared_ptr<const AlignPCLThresholdsHG>(myThresholds));
 }
 
 void MillePedeDQMModule ::fillStatusHisto(MonitorElement* statusHisto) {
@@ -264,6 +264,10 @@ int MillePedeDQMModule ::getIndexFromString(const std::string& alignableId) {
     return 5;
   } else if (alignableId == "TPEHalfCylinderXplusZplus") {
     return 4;
+  } else if (alignableId.rfind("TPBLadder", 0) == 0) {
+    return 6;
+  } else if (alignableId.rfind("TPEPanel", 0) == 0) {
+    return 7;
   } else {
     throw cms::Exception("LogicError") << "@SUB=MillePedeDQMModule::getIndexFromString\n"
                                        << "Retrieving conversion for not supported Alignable partition" << alignableId;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -30,7 +30,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeomBuilderFromGeometricDet.h"
 
 /*** Thresholds from DB ***/
-#include "CondFormats/DataRecord/interface/AlignPCLThresholdsRcd.h"
+#include "CondFormats/DataRecord/interface/AlignPCLThresholdsHGRcd.h"
 
 /*** DQM ***/
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
@@ -82,7 +82,7 @@ private:  //===================================================================
   const edm::ESGetToken<GeometricDet, IdealGeometryRecord> gDetToken_;
   const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
   const edm::ESGetToken<PTrackerAdditionalParametersPerDet, PTrackerAdditionalParametersPerDetRcd> ptitpToken_;
-  const edm::ESGetToken<AlignPCLThresholds, AlignPCLThresholdsRcd> aliThrToken_;
+  const edm::ESGetToken<AlignPCLThresholdsHG, AlignPCLThresholdsHGRcd> aliThrToken_;
 
   const edm::ParameterSet mpReaderConfig_;
   std::unique_ptr<AlignableTracker> tracker_;

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -14,7 +14,7 @@
 
 MillePedeFileReader ::MillePedeFileReader(const edm::ParameterSet& config,
                                           const std::shared_ptr<const PedeLabelerBase>& pedeLabeler,
-                                          const std::shared_ptr<const AlignPCLThresholds>& theThresholds)
+                                          const std::shared_ptr<const AlignPCLThresholdsHG>& theThresholds)
     : pedeLabeler_(pedeLabeler),
       theThresholds_(theThresholds),
       millePedeEndFile_(config.getParameter<std::string>("millePedeEndFile")),
@@ -142,32 +142,32 @@ void MillePedeFileReader ::readMillePedeResultFile() {
 
         auto det = getHLS(alignable);
         int detIndex = static_cast<int>(det);
-        auto coord = static_cast<AlignPCLThresholds::coordType>(alignableIndex);
+        auto coord = static_cast<AlignPCLThresholdsHG::coordType>(alignableIndex);
         std::string detLabel = getStringFromHLS(det);
 
         if (det != PclHLS::NotInPCL) {
           switch (coord) {
-            case AlignPCLThresholds::X:
+            case AlignPCLThresholdsHG::X:
               Xobs_[detIndex] = ObsMove;
               XobsErr_[detIndex] = ObsErr;
               break;
-            case AlignPCLThresholds::Y:
+            case AlignPCLThresholdsHG::Y:
               Yobs_[detIndex] = ObsMove;
               YobsErr_[detIndex] = ObsErr;
               break;
-            case AlignPCLThresholds::Z:
+            case AlignPCLThresholdsHG::Z:
               Zobs_[detIndex] = ObsMove;
               ZobsErr_[detIndex] = ObsErr;
               break;
-            case AlignPCLThresholds::theta_X:
+            case AlignPCLThresholdsHG::theta_X:
               tXobs_[detIndex] = ObsMove;
               tXobsErr_[detIndex] = ObsErr;
               break;
-            case AlignPCLThresholds::theta_Y:
+            case AlignPCLThresholdsHG::theta_Y:
               tYobs_[detIndex] = ObsMove;
               tYobsErr_[detIndex] = ObsErr;
               break;
-            case AlignPCLThresholds::theta_Z:
+            case AlignPCLThresholdsHG::theta_Z:
               tZobs_[detIndex] = ObsMove;
               tZobsErr_[detIndex] = ObsErr;
               break;

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -24,23 +24,23 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'                   : '123X_mcRun2_pA_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'                    : '124X_dataRun2_v1',
+    'run2_data'                    : '124X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'             : '124X_dataRun2_HEfail_v1',
+    'run2_data_HEfail'             : '124X_dataRun2_HEfail_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'             : '124X_dataRun2_relval_v1',
+    'run2_data_relval'             : '124X_dataRun2_relval_v2',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v3',
+    'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
     # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v1) but with snapshot at 2022-06-08 15:00:00 (UTC)
     'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v1',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
     'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v2',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 123X_dataRun3_Express_v8 but with snapshot at 2022-05-31 20:00:00 (UTC)
-    'run3_data_express'            : '123X_dataRun3_Express_frozen_v4',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 123X_dataRun3_Prompt_v10 but with snapshot at 2022-05-31 20:00:00 (UTC)
-    'run3_data_prompt'             : '123X_dataRun3_Prompt_frozen_v4',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v1 but with snapshot at 2022-06-09 20:00:00 (UTC)
+    'run3_data_express'            : '124X_dataRun3_Express_frozen_v1',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v1 but with snapshot at 2022-06-09 20:00:00 (UTC)
+    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v1',
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '124X_dataRun3_v2',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu


### PR DESCRIPTION
#### PR description:
This PR is the second step towards using a higher granularity (HG) for the pixel alignment in the PCL, following https://github.com/cms-sw/cmssw/pull/38195, where the new alignment threshold object was introduced. In this PR the consumer in the `Alignment` package are adapted to use the new threshold object.

In detail the following changes have been made:
- Change from `AlignPCLThresholds` to `AlignPCLThresholdsHG` in the consumer code of the `Alignment` package
- This PR updates the autoCond with GTs containing `SiPixelAliThresholdsHG_offline_v0` and `SiPixelAliThresholdsHG_express_v0`

#### PR validation:
The PR was tested and validated using `runTheMatrix -l 1001.0`

#### Upcoming PRs:
This PR will be followed by one additional PR, which will introduces the changes needed to run and store the HG alignment

#### New GlobalTags:
The new GTs are

124X_dataRun2_v2
124X_dataRun2_relval_v2
124X_dataRun2_HEfail_v2

124X_dataRun3_v3
124X_dataRun3_relval_v3

124X_dataRun3_Express_frozen_v1
124X_dataRun2_PromptLike_HI_v1
124X_dataRun3_Prompt_frozen_v1
where the frozen GTs are the snapshotter versions of the newly created

124X_dataRun3_Express_v1
124X_dataRun3_Prompt_v1
The snapshot time is
2022-06-09 20:00:00 (UTC)

The diffs

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun2_v1/124X_dataRun2_v2

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun2_relval_v1/124X_dataRun2_relval_v2

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun2_HEfail_v1/124X_dataRun2_HEfail_v2

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v2/124X_dataRun3_v3

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_relval_v2/124X_dataRun3_relval_v3

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_Express_frozen_v4/124X_dataRun3_Express_frozen_v1

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun2_PromptLike_HI_v3/124X_dataRun2_PromptLike_HI_v1

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_Prompt_frozen_v4/124X_dataRun3_Prompt_frozen_v1

cc:
@mmusich, @connorpa, @antoniovagnerini, @consuegs

