### PR TITLE
Fix isProcessWideService

### DIFF
--- a/CommonTools/UtilAlgos/plugins/TFileService.cc
+++ b/CommonTools/UtilAlgos/plugins/TFileService.cc
@@ -1,5 +1,5 @@
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 DEFINE_FWK_SERVICE(TFileService);

--- a/FWCore/Integration/test/testSubProcess_cfg.py
+++ b/FWCore/Integration/test/testSubProcess_cfg.py
@@ -34,10 +34,42 @@ process.DoodadESSource = cms.ESSource("DoodadESSource"
                                       , test2 = cms.untracked.string('z')
 )
 
+process.CPU = cms.Service("CPU")
+process.ZombieKillerService = cms.Service("ZombieKillerService")
+process.JobReportService = cms.Service("JobReportService")
+
 # ---------------------------------------------------------------
 
 copyProcess = cms.Process("COPY")
 process.addSubProcess(cms.SubProcess(copyProcess))
+
+# The following services are intended to test the isProcessWideService
+# function which is defined in some services. These services
+# should never be constructed and ignored, because
+# The service from the top level process should be used.
+# They intentionally have an illegal parameter to fail
+# if they are ever constructed.
+copyProcess.MessageLogger = cms.Service("MessageLogger",
+    intentionallyIllegalParameter = cms.bool(True)
+)
+copyProcess.CPU = cms.Service("CPU",
+    intentionallyIllegalParameter = cms.bool(True)
+)
+copyProcess.InitRootHandlers = cms.Service("InitRootHandlers",
+    intentionallyIllegalParameter = cms.bool(True)
+)
+copyProcess.ZombieKillerService = cms.Service("ZombieKillerService",
+    intentionallyIllegalParameter = cms.bool(True)
+)
+copyProcess.JobReportService = cms.Service("JobReportService",
+    intentionallyIllegalParameter = cms.bool(True)
+)
+copyProcess.SiteLocalConfigService = cms.Service("SiteLocalConfigService",
+    intentionallyIllegalParameter = cms.bool(True)
+)
+copyProcess.AdaptorConfig = cms.Service("AdaptorConfig",
+    intentionallyIllegalParameter = cms.bool(True)
+)
 
 copyProcess.DoodadESSource = cms.ESSource("DoodadESSource"
                                           , appendToDataLabel = cms.string('abc')

--- a/FWCore/Services/plugins/CPU.cc
+++ b/FWCore/Services/plugins/CPU.cc
@@ -8,8 +8,6 @@
 // Original Author:  Natalia Garcia
 // CPU.cc: v 1.0 2009/01/08 11:31:07
 
-#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
-
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -283,6 +281,8 @@ namespace edm {
     }
   }  // namespace service
 }  // namespace edm
+
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 using edm::service::CPU;
 typedef edm::serviceregistry::AllArgsMaker<edm::CPUServiceBase, CPU> CPUMaker;

--- a/FWCore/Services/plugins/InitRootHandlers.cc
+++ b/FWCore/Services/plugins/InitRootHandlers.cc
@@ -1,5 +1,3 @@
-#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
-
 #include "FWCore/Utilities/interface/RootHandlers.h"
 
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
@@ -977,6 +975,8 @@ namespace edm {
 
   }  // end of namespace service
 }  // end of namespace edm
+
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 using edm::service::InitRootHandlers;
 typedef edm::serviceregistry::AllArgsMaker<edm::RootHandlers, InitRootHandlers> RootHandlersMaker;

--- a/FWCore/Services/plugins/ZombieKillerService.cc
+++ b/FWCore/Services/plugins/ZombieKillerService.cc
@@ -18,10 +18,11 @@
 #include <exception>
 
 // user include files
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 namespace edm {
   class ZombieKillerService {
@@ -49,19 +50,12 @@ namespace edm {
 
 using namespace edm;
 
-inline bool isProcessWideService(ZombieKillerService const*) { return true; }
+namespace edm {
+  namespace service {
+    inline bool isProcessWideService(ZombieKillerService const*) { return true; }
+  }  // namespace service
+}  // namespace edm
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 ZombieKillerService::ZombieKillerService(edm::ParameterSet const& iPSet, edm::ActivityRegistry& iRegistry)
     : m_checkThreshold(iPSet.getUntrackedParameter<unsigned int>("numberOfAllowedFailedChecksInARow")),
       m_secsBetweenChecks(iPSet.getUntrackedParameter<unsigned int>("secondsBetweenChecks")),
@@ -205,5 +199,6 @@ void ZombieKillerService::fillDescriptions(ConfigurationDescriptions& descriptio
 //
 // static member functions
 //
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 DEFINE_FWK_SERVICE(ZombieKillerService);

--- a/IgTools/IgProf/plugins/IgProfService.h
+++ b/IgTools/IgProf/plugins/IgProfService.h
@@ -43,8 +43,6 @@ namespace edm {
 
       void postCloseFile(std::string const &);
 
-      inline bool isProcessWideService(IgProfService const *) { return true; }
-
     private:
       void makeDump(const std::string &format, std::string_view moduleLabel = "");
       static std::string replace(const std::string &s, const char *pat, int val);
@@ -81,6 +79,7 @@ namespace edm {
       int nfileopened_;  // counter of files opened thus far
       int nfileclosed_;  // counter of files closed thus far
     };
+    inline bool isProcessWideService(IgProfService const *) { return true; }
   }  // namespace service
 }  // namespace edm
 


### PR DESCRIPTION
#### PR description:

Bug fix for the function isProcessWideService. It was incorrectly implemented in some Services.

For the most part this bug should not affect anything. This affects only jobs using SubProcess in the special case when certain Services have been defined in multiple SubProcesses. There is nothing that I am aware of currently that uses the SubProcess feature. Production does not. RelVal tests do not.

We might consider in the future improving the interface for this because 5 of the 10 services using this function had it implemented incorrectly. Although it probably is not worth the effort given how rare it is that a new service with this function is created... (I happened to notice because I was testing a new service. This problem was not reported by a user.)

The requirements are:

1. Definition of isProcessWideService must come before including ServiceMaker.h
2. Must be outside of the relevant class
3. Must be in the edm::service namespace

#### PR validation:

I manually tested all 10 of the relevant services. This should have no effect on existing unit tests and RelVal tests. I added to an existing SubProcess unit test verifying the behavior for 7 of the services.
