### PR TITLE
include EGM and L1T tags in mcRun3 and data GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,18 +33,18 @@ autoCond = {
     'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (123X_dataRun3_HLT_v9) but with snapshot at 2022-05-31 20:00:00 (UTC)
-    'run3_hlt'                     : '123X_dataRun3_HLT_frozen_v5',
+    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v1) but with snapshot at 2022-06-08 15:00:00 (UTC)
+    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v1',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v9',
+    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v2',
     # GlobalTag for Run3 data relvals (express GT) - identical to 123X_dataRun3_Express_v8 but with snapshot at 2022-05-31 20:00:00 (UTC)
     'run3_data_express'            : '123X_dataRun3_Express_frozen_v4',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 123X_dataRun3_Prompt_v10 but with snapshot at 2022-05-31 20:00:00 (UTC)
     'run3_data_prompt'             : '123X_dataRun3_Prompt_frozen_v4',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '124X_dataRun3_v1',
+    'run3_data'                    : '124X_dataRun3_v2',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '124X_dataRun3_relval_v1',
+    'run3_data_relval'             : '124X_dataRun3_relval_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -68,21 +68,21 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '124X_mcRun3_2022_design_v3',
+    'phase1_2022_design'           : '124X_mcRun3_2022_design_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v3',
+    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v4',
+    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v5',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v3',
+    'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v3',
+    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v3',
+    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v3',
+    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v4',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '124X_mcRun4_realistic_v4'
+    'phase2_realistic'             : '124X_mcRun4_realistic_v5'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR is to include the new L1T Menu in the mcRun3 and data GTs, as requested here: https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-l1-menu-tag-v1-1-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/11279 and needed in PR [#38241](https://github.com/cms-sw/cmssw/pull/38241).

We also profit from this change to include the EGM regression tags in the offline data GTs, as requested here: https://cms-talk.web.cern.ch/t/offline-gt-updating-egm-regression-tags-for-run-3-collisions-for-offline-tags/11203

Finally, we include also the run3_hlt GT introduced in PR #38265.

This PR is to be merged together with PR #38241.

The GT diffs are listed below:
**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//123X_dataRun3_HLT_frozen_v6/123X_dataRun3_HLT_frozen_v5

**run3_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_dataRun3_HLT_relval_v1/123X_dataRun3_HLT_relval_v9

**run3_data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_dataRun3_v2/124X_dataRun3_v1

**run3_data_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_dataRun3_relval_v2/124X_dataRun3_relval_v1

**phase1_2022_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_design_v4/124X_mcRun3_2022_design_v3

**phase1_2022_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_v4/124X_mcRun3_2022_realistic_v3

**phase1_2022_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022cosmics_realistic_deco_v5/124X_mcRun3_2022cosmics_realistic_deco_v4

**phase1_2022_cosmics_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022cosmics_design_deco_v4/124X_mcRun3_2022cosmics_design_deco_v3

**phase1_2022_realistic_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_HI_v4/124X_mcRun3_2022_realistic_HI_v3

**phase1_2023_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2023_realistic_v4/124X_mcRun3_2023_realistic_v3

**phase1_2024_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2024_realistic_v4/124X_mcRun3_2024_realistic_v3

**phase2_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun4_realistic_v5/124X_mcRun4_realistic_v4


#### PR validation:

`runTheMatrix.py -l 136.897, 12034.0, 7.23, 12834.0`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

It is not a backport but it will be backported to 124X (as soon as PR #38265 is merged) and to 123X (for the inclusion of the EGM tags only, in run3_data_relval and run3_data).
