### PR TITLE
Cleanup redundant edm ParameterSet exist in PhysicsTools

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -174,32 +174,15 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg)
   // L1Offset correction, which is an additional input to the L1JPTOffset
   // corrector
   if (std::find(levels.begin(), levels.end(), "L1JPTOffset") != levels.end()) {
-    if (cfg.existsAs<std::string>("extraJPTOffset")) {
-      extraJPTOffset_.push_back(cfg.getParameter<std::string>("extraJPTOffset"));
-    } else {
-      throw cms::Exception("No parameter extraJPTOffset specified")
-          << "The configured correction levels contain a L1JPTOffset correction, which re- \n"
-          << "quires the additional parameter extraJPTOffset or type std::string. This     \n"
-          << "string should correspond to the L1Offset corrections that should be applied  \n"
-          << "together with the JPTL1Offset corrections. These corrections can be of type  \n"
-          << "L1Offset or L1FastJet.                                                       \n";
-    }
+    extraJPTOffset_.push_back(cfg.getParameter<std::string>("extraJPTOffset"));
   }
   // if the std::string L1Offset can be found in levels an additional para-
   // meter primaryVertices is needed, which should pass on the offline pri-
   // mary vertex collection. The size of this collection is needed for the
   // L1Offset correction.
   if (useNPV_) {
-    if (cfg.existsAs<edm::InputTag>("primaryVertices")) {
-      primaryVertices_ = cfg.getParameter<edm::InputTag>("primaryVertices");
-      primaryVerticesToken_ = mayConsume<std::vector<reco::Vertex> >(primaryVertices_);
-    } else {
-      throw cms::Exception("No primaryVertices specified")
-          << "The configured correction levels contain an L1Offset or L1FastJet correction, \n"
-          << "which requires the number of offlinePrimaryVertices. Please specify this col- \n"
-          << "lection as additional optional parameter primaryVertices of type edm::InputTag\n"
-          << "in the jetCorrFactors module.                                                 \n";
-    }
+   primaryVertices_ = cfg.getParameter<edm::InputTag>("primaryVertices");
+   primaryVerticesToken_ = mayConsume<std::vector<reco::Vertex> >(primaryVertices_);
   }
   // if the std::string L1FastJet can be found in levels an additional
   // parameter rho is needed, which should pass on the energy density
@@ -207,16 +190,8 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg)
   if (useRho_) {
     if ((!extraJPTOffset_.empty() && extraJPTOffset_.front() == std::string("L1FastJet")) ||
         std::find(levels.begin(), levels.end(), "L1FastJet") != levels.end()) {
-      if (cfg.existsAs<edm::InputTag>("rho")) {
-        rho_ = cfg.getParameter<edm::InputTag>("rho");
-        rhoToken_ = mayConsume<double>(rho_);
-      } else {
-        throw cms::Exception("No parameter rho specified")
-            << "The configured correction levels contain a L1FastJet correction, which re- \n"
-            << "quires the energy density parameter rho. Please specify this collection as \n"
-            << "additional optional parameter rho of type edm::InputTag in the jetCorrFac- \n"
-            << "tors module.                                                               \n";
-      }
+     rho_ = cfg.getParameter<edm::InputTag>("rho");
+     rhoToken_ = mayConsume<double>(rho_);
     } else {
       edm::LogInfo message("Parameter rho not used");
       message << "Module is configured to use the parameter rho, but rho is only used     \n"

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -181,8 +181,8 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg)
   // mary vertex collection. The size of this collection is needed for the
   // L1Offset correction.
   if (useNPV_) {
-   primaryVertices_ = cfg.getParameter<edm::InputTag>("primaryVertices");
-   primaryVerticesToken_ = mayConsume<std::vector<reco::Vertex> >(primaryVertices_);
+    primaryVertices_ = cfg.getParameter<edm::InputTag>("primaryVertices");
+    primaryVerticesToken_ = mayConsume<std::vector<reco::Vertex> >(primaryVertices_);
   }
   // if the std::string L1FastJet can be found in levels an additional
   // parameter rho is needed, which should pass on the energy density
@@ -190,8 +190,8 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg)
   if (useRho_) {
     if ((!extraJPTOffset_.empty() && extraJPTOffset_.front() == std::string("L1FastJet")) ||
         std::find(levels.begin(), levels.end(), "L1FastJet") != levels.end()) {
-     rho_ = cfg.getParameter<edm::InputTag>("rho");
-     rhoToken_ = mayConsume<double>(rho_);
+      rho_ = cfg.getParameter<edm::InputTag>("rho");
+      rhoToken_ = mayConsume<double>(rho_);
     } else {
       edm::LogInfo message("Parameter rho not used");
       message << "Module is configured to use the parameter rho, but rho is only used     \n"

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -316,10 +316,7 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet& iConfig)
       pvToken_(mayConsume<std::vector<reco::Vertex>>(iConfig.getParameter<edm::InputTag>("pvSrc"))),
       addElecID_(iConfig.getParameter<bool>("addElectronID")),
       pTComparator_(),
-      isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
-                                                : edm::ParameterSet(),
-                consumesCollector(),
-                false),
+      isolator_(iConfig.getParameter<edm::ParameterSet>("userIsolation"), consumesCollector(), false),
       addEfficiencies_(iConfig.getParameter<bool>("addEfficiencies")),
       addResolutions_(iConfig.getParameter<bool>("addResolutions")),
       useUserData_(iConfig.exists("userData")),
@@ -328,14 +325,8 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet& iConfig)
   // MC matching configurables (scheduled mode)
 
   if (addGenMatch_) {
-    if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
+    genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
           iConfig.getParameter<edm::InputTag>("genParticleMatch")));
-    } else {
-      genMatchTokens_ = edm::vector_transform(
-          iConfig.getParameter<std::vector<edm::InputTag>>("genParticleMatch"),
-          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection>>(tag); });
-    }
   }
   // resolution configurables
   if (addResolutions_) {

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -326,7 +326,7 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet& iConfig)
 
   if (addGenMatch_) {
     genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
-          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+        iConfig.getParameter<edm::InputTag>("genParticleMatch")));
   }
   // resolution configurables
   if (addResolutions_) {

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -352,10 +352,7 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyO
       computeSoftMuonMVA_(false),
       recomputeBasicSelectors_(false),
       mvaUseJec_(false),
-      isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
-                                                : edm::ParameterSet(),
-                consumesCollector(),
-                false),
+      isolator_(iConfig.getParameter<edm::ParameterSet>("userIsolation"), consumesCollector(), false),
       geometryToken_{esConsumes()},
       transientTrackBuilderToken_{esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))},
       patMuonPutToken_{produces<std::vector<Muon>>()} {
@@ -394,14 +391,8 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyO
   addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
     embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
-    if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
+    genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
           iConfig.getParameter<edm::InputTag>("genParticleMatch")));
-    } else {
-      genMatchTokens_ = edm::vector_transform(
-          iConfig.getParameter<std::vector<edm::InputTag>>("genParticleMatch"),
-          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection>>(tag); });
-    }
   }
   // efficiencies
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -391,8 +391,14 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyO
   addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
     embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
-    genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
-        iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+    if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
+      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
+          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+    } else {
+      genMatchTokens_ = edm::vector_transform(
+          iConfig.getParameter<std::vector<edm::InputTag>>("genParticleMatch"),
+          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection>>(tag); });
+    }
   }
   // efficiencies
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -392,7 +392,7 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet& iConfig, PATMuonHeavyO
   if (addGenMatch_) {
     embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
     genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
-          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+        iConfig.getParameter<edm::InputTag>("genParticleMatch")));
   }
   // efficiencies
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
@@ -194,12 +194,8 @@ using namespace pat;
 
 PATPhotonProducer::PATPhotonProducer(const edm::ParameterSet& iConfig)
     :
-
       ecalClusterToolsESGetTokens_{consumesCollector()},
-      isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
-                                                : edm::ParameterSet(),
-                consumesCollector(),
-                false),
+      isolator_(iConfig.getParameter<edm::ParameterSet>("userIsolation"), consumesCollector(), false),
       useUserData_(iConfig.exists("userData")),
       ecalTopologyToken_{esConsumes()},
       ecalGeometryToken_{esConsumes()} {
@@ -221,14 +217,8 @@ PATPhotonProducer::PATPhotonProducer(const edm::ParameterSet& iConfig)
   addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
     embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
-    if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
-          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
-    } else {
-      genMatchTokens_ = edm::vector_transform(
-          iConfig.getParameter<std::vector<edm::InputTag>>("genParticleMatch"),
-          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection>>(tag); });
-    }
+    genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
+      iConfig.getParameter<edm::InputTag>("genParticleMatch")));
   }
   // Efficiency configurables
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
@@ -193,8 +193,7 @@ void pat::PATPhotonProducer::readIsolationLabels(const edm::ParameterSet& iConfi
 using namespace pat;
 
 PATPhotonProducer::PATPhotonProducer(const edm::ParameterSet& iConfig)
-    :
-      ecalClusterToolsESGetTokens_{consumesCollector()},
+    : ecalClusterToolsESGetTokens_{consumesCollector()},
       isolator_(iConfig.getParameter<edm::ParameterSet>("userIsolation"), consumesCollector(), false),
       useUserData_(iConfig.exists("userData")),
       ecalTopologyToken_{esConsumes()},
@@ -218,7 +217,7 @@ PATPhotonProducer::PATPhotonProducer(const edm::ParameterSet& iConfig)
   if (addGenMatch_) {
     embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
     genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
-      iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+        iConfig.getParameter<edm::InputTag>("genParticleMatch")));
   }
   // Efficiency configurables
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -141,8 +141,7 @@ namespace pat {
 using namespace pat;
 
 PATTauProducer::PATTauProducer(const edm::ParameterSet& iConfig)
-    : 
-      isolator_(iConfig.getParameter<edm::ParameterSet>("userIsolation"), consumesCollector(), false),
+    : isolator_(iConfig.getParameter<edm::ParameterSet>("userIsolation"), consumesCollector(), false),
       useUserData_(iConfig.exists("userData")),
       posAtECalEntranceComputer_(consumesCollector()) {
   firstOccurence_ = true;
@@ -169,7 +168,7 @@ PATTauProducer::PATTauProducer(const edm::ParameterSet& iConfig)
   if (addGenMatch_) {
     embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
     genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
-          iConfig.getParameter<edm::InputTag>("genParticleMatch")));
+        iConfig.getParameter<edm::InputTag>("genParticleMatch")));
   }
   addGenJetMatch_ = iConfig.getParameter<bool>("addGenJetMatch");
   if (addGenJetMatch_) {

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -141,10 +141,8 @@ namespace pat {
 using namespace pat;
 
 PATTauProducer::PATTauProducer(const edm::ParameterSet& iConfig)
-    : isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
-                                                : edm::ParameterSet(),
-                consumesCollector(),
-                false),
+    : 
+      isolator_(iConfig.getParameter<edm::ParameterSet>("userIsolation"), consumesCollector(), false),
       useUserData_(iConfig.exists("userData")),
       posAtECalEntranceComputer_(consumesCollector()) {
   firstOccurence_ = true;
@@ -170,14 +168,8 @@ PATTauProducer::PATTauProducer(const edm::ParameterSet& iConfig)
   addGenMatch_ = iConfig.getParameter<bool>("addGenMatch");
   if (addGenMatch_) {
     embedGenMatch_ = iConfig.getParameter<bool>("embedGenMatch");
-    if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
+    genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection>>(
           iConfig.getParameter<edm::InputTag>("genParticleMatch")));
-    } else {
-      genMatchTokens_ = edm::vector_transform(
-          iConfig.getParameter<std::vector<edm::InputTag>>("genParticleMatch"),
-          [this](edm::InputTag const& tag) { return consumes<edm::Association<reco::GenParticleCollection>>(tag); });
-    }
   }
   addGenJetMatch_ = iConfig.getParameter<bool>("addGenJetMatch");
   if (addGenJetMatch_) {


### PR DESCRIPTION
#### PR description:  
(Technical PR) Optimization of the module configurations: Improve maintainability by cleaning up redundant cases of edm::ParameterSet calls to `existAs` or `exist` for tracked parameters, where redundancy is based on the value being already defined by `fillDescriptions`.

As follow the previous [PR36746](https://github.com/cms-sw/cmssw/pull/36746),  [PR36989](https://github.com/cms-sw/cmssw/pull/36989), [PR37313](https://github.com/cms-sw/cmssw/pull/37313), [PR37314](https://github.com/cms-sw/cmssw/pull/37314), [PR37548](https://github.com/cms-sw/cmssw/pull/37548), [PR37772](https://github.com/cms-sw/cmssw/pull/37772), [PR37899](https://github.com/cms-sw/cmssw/pull/37899), and [PR38218](https://github.com/cms-sw/cmssw/pull/38218).

In this PR, 5 files were changed.  
PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc

Here, the `extraJPTOffset`, `primaryVertices`, `rho` parameters were provided in a fillDescription.  cfipython : [cfipython/PhysicsTools/PatAlgos/JetCorrFactorsProducer_cfi.py](https://cmssdt.cern.ch/lxr/source/cfipython/PhysicsTools/PatAlgos/JetCorrFactorsProducer_cfi.py)

PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
PhysicsTools/PatAlgos/plugins/PATTauProducer.cc

Here, the `userIsolation`, `genParticleMatch` parameters were provided in a fillDescription.  cfipython : [cfipython/PhysicsTools/PatAlgos/PATElectronProducer_cfi.py](https://cmssdt.cern.ch/lxr/source/cfipython/PhysicsTools/PatAlgos/PATElectronProducer_cfi.py),
[cfipython/PhysicsTools/PatAlgos/PATPhotonProducer_cfi.py](https://cmssdt.cern.ch/lxr/source/cfipython/PhysicsTools/PatAlgos/PATPhotonProducer_cfi.py)

#### PR validation:
Tested in CMSSW_12_5_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)