### PR TITLE
miscellaneous improvements in `CondFormats/PCLConfig`

### DIFF
--- a/CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h
+++ b/CondFormats/PCLConfig/interface/AlignPCLThresholdsHG.h
@@ -10,6 +10,7 @@
 
 class AlignPCLThresholdsHG : public AlignPCLThresholds {
 public:
+  typedef std::unordered_map<std::string, std::vector<float>> param_map;
   AlignPCLThresholdsHG() {}
 
   enum FloatParamIndex {
@@ -22,24 +23,28 @@ public:
     FSIZE = 6
   };
 
-  void SetFractionCut(const std::string &AlignableId, const coordType &type, const float &cut);
+  enum IntParamIndex { ISIZE = 0 };
+  enum StringParamIndex { SSIZE = 0 };
 
-  const std::unordered_map<std::string, std::vector<float>> &getFloatMap() const { return floatMap; }
+  void setFractionCut(const std::string &AlignableId, const coordType &type, const float &cut);
+
+  const param_map &getFloatMap() const { return floatMap_; }
   const std::vector<float> &getFloatVec(const std::string &AlignableId) const;
 
   float getFractionCut(const std::string &AlignableId, const coordType &type) const;
   std::array<float, 6> getFractionCut(const std::string &AlignableId) const;
 
-  int payloadVersion() const;
+  const int payloadVersion() const;
 
-  void printAllHG() const;
+  void printAll() const;
 
-  ~AlignPCLThresholdsHG() override {}
+  ~AlignPCLThresholdsHG() override = default;
 
 private:
-  std::unordered_map<std::string, std::vector<float>> floatMap;
-  std::unordered_map<std::string, std::vector<int>> intMap;
-  std::unordered_map<std::string, std::vector<std::string>> stringMap;
+  param_map floatMap_;
+  // yet unused, but kept for possible extensions
+  std::unordered_map<std::string, std::vector<int>> intMap_;
+  std::unordered_map<std::string, std::vector<std::string>> stringMap_;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -76,7 +76,7 @@ namespace edmtest {
     edm::LogInfo("AlignPCLThresholdsReader") << "Size " << thresholds->size() << std::endl;
     edm::LogInfo("AlignPCLThresholdsReader") << "Content of myThresholds " << std::endl;
     // use built-in method in the CondFormat to print the content
-    if (printdebug_) {
+    if (thresholds && printdebug_) {
       thresholds->printAll();
     }
 

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsReader.cc
@@ -78,10 +78,6 @@ namespace edmtest {
     // use built-in method in the CondFormat to print the content
     if (printdebug_) {
       thresholds->printAll();
-      // print additional thresholds if HG payload is used
-      if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
-        thresholds->printAllHG();
-      }
     }
 
     FILE* pFile = nullptr;
@@ -91,45 +87,118 @@ namespace edmtest {
       fprintf(pFile, "AlignPCLThresholds::printAll() \n");
       fprintf(pFile,
               " ======================================================================================================="
-              "============ \n");
+              "============\n");
       fprintf(pFile, "N records cut: %i \n", thresholds->getNrecords());
 
       AlignPCLThresholds::threshold_map m_thresholds = thresholds->getThreshold_Map();
+      AlignPCLThresholdsHG::param_map m_floatMap{};
+
+      if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+        m_floatMap = thresholds->getFloatMap();
+      }
 
       for (auto it = m_thresholds.begin(); it != m_thresholds.end(); ++it) {
+        bool hasFractionCut = (m_floatMap.find(it->first) != m_floatMap.end());
+
         fprintf(pFile,
                 " ====================================================================================================="
-                "============== \n");
-        fprintf(pFile, "key : %s \n ", (it->first).c_str());
+                "==============\n");
+        fprintf(pFile, "key : %s \n", (it->first).c_str());
         fprintf(pFile, "- Xcut             : %8.3f   um   ", (it->second).getXcut());
         fprintf(pFile, "| sigXcut          : %8.3f        ", (it->second).getSigXcut());
         fprintf(pFile, "| maxMoveXcut      : %8.3f   um   ", (it->second).getMaxMoveXcut());
-        fprintf(pFile, "| ErrorXcut        : %8.3f   um\n ", (it->second).getErrorXcut());
+        fprintf(pFile, "| ErrorXcut        : %8.3f   um   ", (it->second).getErrorXcut());
+        if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+          if (hasFractionCut) {
+            fprintf(pFile,
+                    "| X_fractionCut      : %8.3f    \n",
+                    thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::X));
+          } else {
+            fprintf(pFile, "\n");
+          }
+        } else {
+          fprintf(pFile, "\n");
+        }
 
         fprintf(pFile, "- thetaXcut        : %8.3f urad   ", (it->second).getThetaXcut());
         fprintf(pFile, "| sigThetaXcut     : %8.3f        ", (it->second).getSigThetaXcut());
         fprintf(pFile, "| maxMoveThetaXcut : %8.3f urad   ", (it->second).getMaxMoveThetaXcut());
-        fprintf(pFile, "| ErrorThetaXcut   : %8.3f urad\n ", (it->second).getErrorThetaXcut());
+        fprintf(pFile, "| ErrorThetaXcut   : %8.3f urad   ", (it->second).getErrorThetaXcut());
+        if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+          if (hasFractionCut) {
+            fprintf(pFile,
+                    "| thetaX_fractionCut : %8.3f    \n",
+                    thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::theta_X));
+          } else {
+            fprintf(pFile, "\n");
+          }
+        } else {
+          fprintf(pFile, "\n");
+        }
 
         fprintf(pFile, "- Ycut             : %8.3f   um   ", (it->second).getYcut());
         fprintf(pFile, "| sigYcut          : %8.3f        ", (it->second).getSigXcut());
         fprintf(pFile, "| maxMoveYcut      : %8.3f   um   ", (it->second).getMaxMoveYcut());
-        fprintf(pFile, "| ErrorYcut        : %8.3f   um\n ", (it->second).getErrorYcut());
+        fprintf(pFile, "| ErrorYcut        : %8.3f   um   ", (it->second).getErrorYcut());
+        if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+          if (hasFractionCut) {
+            fprintf(pFile,
+                    "| Y_fractionCut      : %8.3f    \n",
+                    thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::Y));
+          } else {
+            fprintf(pFile, "\n");
+          }
+        } else {
+          fprintf(pFile, "\n");
+        }
 
         fprintf(pFile, "- thetaYcut        : %8.3f urad   ", (it->second).getThetaYcut());
         fprintf(pFile, "| sigThetaYcut     : %8.3f        ", (it->second).getSigThetaYcut());
         fprintf(pFile, "| maxMoveThetaYcut : %8.3f urad   ", (it->second).getMaxMoveThetaYcut());
-        fprintf(pFile, "| ErrorThetaYcut   : %8.3f urad\n ", (it->second).getErrorThetaYcut());
+        fprintf(pFile, "| ErrorThetaYcut   : %8.3f urad   ", (it->second).getErrorThetaYcut());
+        if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+          if (hasFractionCut) {
+            fprintf(pFile,
+                    "| thetaY_fractionCut : %8.3f    \n",
+                    thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::theta_Y));
+          } else {
+            fprintf(pFile, "\n");
+          }
+        } else {
+          fprintf(pFile, "\n");
+        }
 
         fprintf(pFile, "- Zcut             : %8.3f   um   ", (it->second).getZcut());
         fprintf(pFile, "| sigZcut          : %8.3f        ", (it->second).getSigZcut());
         fprintf(pFile, "| maxMoveZcut      : %8.3f   um   ", (it->second).getMaxMoveZcut());
-        fprintf(pFile, "| ErrorZcut        : %8.3f   um\n ", (it->second).getErrorZcut());
+        fprintf(pFile, "| ErrorZcut        : %8.3f   um   ", (it->second).getErrorZcut());
+        if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+          if (hasFractionCut) {
+            fprintf(pFile,
+                    "| Z_fractionCut      : %8.3f    \n",
+                    thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::Z));
+          } else {
+            fprintf(pFile, "\n");
+          }
+        } else {
+          fprintf(pFile, "\n");
+        }
 
         fprintf(pFile, "- thetaZcut        : %8.3f urad   ", (it->second).getThetaZcut());
         fprintf(pFile, "| sigThetaZcut     : %8.3f        ", (it->second).getSigThetaZcut());
         fprintf(pFile, "| maxMoveThetaZcut : %8.3f urad   ", (it->second).getMaxMoveThetaZcut());
-        fprintf(pFile, "| ErrorThetaZcut   : %8.3f urad\n ", (it->second).getErrorThetaZcut());
+        fprintf(pFile, "| ErrorThetaZcut   : %8.3f urad   ", (it->second).getErrorThetaZcut());
+        if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+          if (hasFractionCut) {
+            fprintf(pFile,
+                    "| thetaZ_fractionCut : %8.3f    \n",
+                    thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::theta_Z));
+          } else {
+            fprintf(pFile, "\n");
+          }
+        } else {
+          fprintf(pFile, "\n");
+        }
 
         if ((it->second).hasExtraDOF()) {
           for (unsigned int j = 0; j < (it->second).extraDOFSize(); j++) {
@@ -143,36 +212,6 @@ namespace edmtest {
             fprintf(pFile, "| maxMoveCut       : %8.3f        ", extraDOFCuts.at(2));
             fprintf(pFile, "| maxErrorCut      : %8.3f     \n ", extraDOFCuts.at(3));
           }
-        }
-      }
-
-      // print additional thresholds for HG payload
-      if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
-        fprintf(pFile, "AlignPCLThresholdsHG::printAllHG() \n");
-        fprintf(pFile, " ======================================= \n");
-        const std::unordered_map<std::string, std::vector<float>>& floatMap = thresholds->getFloatMap();
-        for (auto it = floatMap.begin(); it != floatMap.end(); ++it) {
-          fprintf(pFile, " ======================================= \n");
-
-          fprintf(pFile, "key : %s \n", (it->first).c_str());
-          fprintf(pFile,
-                  "- X_fractionCut             : %8.3f    \n",
-                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::X));
-          fprintf(pFile,
-                  "- thetaX_fractionCut        : %8.3f    \n",
-                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::theta_X));
-          fprintf(pFile,
-                  "- Y_fractionCut             : %8.3f    \n",
-                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::Y));
-          fprintf(pFile,
-                  "- thetaY_fractionCut        : %8.3f    \n",
-                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::theta_Y));
-          fprintf(pFile,
-                  "- Z_fractionCut             : %8.3f    \n",
-                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::Z));
-          fprintf(pFile,
-                  "- thetaZ_fractionCut        : %8.3f    \n",
-                  thresholds->getFractionCut(it->first, AlignPCLThresholds::coordType::theta_Z));
         }
       }
     }

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
@@ -263,7 +263,6 @@ template <typename T>
 void AlignPCLThresholdsWriter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Plugin to write payloads of type AlignPCLThresholds");
-  desc.add<std::string>("record", "AlignPCLThresholdsRcd");
   desc.add<unsigned int>("minNRecords", 25000);
   edm::ParameterSetDescription desc_thresholds;
 
@@ -274,8 +273,11 @@ void AlignPCLThresholdsWriter<T>::fillDescriptions(edm::ConfigurationDescription
   desc_thresholds.add<double>("maxMoveCut");
   desc_thresholds.add<double>("maxErrorCut");
   if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+    desc.add<std::string>("record", "AlignPCLThresholdsHGRcd");
     //optional thresholds from new payload version (not for all the alignables)
     desc_thresholds.addOptional<double>("fractionCut");
+  } else {
+    desc.add<std::string>("record", "AlignPCLThresholdsRcd");
   }
 
   std::vector<edm::ParameterSet> default_thresholds(1);

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
@@ -216,13 +216,13 @@ void AlignPCLThresholdsWriter<T>::writePayload(T& myThresholds) {
   myThresholds.setNRecords(m_minNrecords);
   edm::LogInfo("AlignPCLThresholdsWriter") << "Content of AlignPCLThresholds " << std::endl;
 
-  // use buil-in method in the CondFormat
-  myThresholds.printAll();
-
   // additional thresholds for AlignPCLThresholdsHG
   if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
     storeHGthresholds(myThresholds, alignables);
   }
+
+  // use built-in method in the CondFormat
+  myThresholds.printAll();
 
   // Form the data here
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
@@ -251,17 +251,11 @@ void AlignPCLThresholdsWriter<T>::storeHGthresholds(AlignPCLThresholdsHG& myThre
       if (alignableId == alignable) {
         if (thePSet.exists("fractionCut")) {
           const double fractionCut(thePSet.getParameter<double>("fractionCut"));
-          myThresholds.SetFractionCut(alignableId, type, fractionCut);
-        } else {
-          myThresholds.SetFractionCut(alignableId, type, -1.);  // better way to define default fraction cut??
+          myThresholds.setFractionCut(alignableId, type, fractionCut);
         }
       }
     }
   }
-
-  // print additional tresholds
-  edm::LogInfo("AlignPCLThresholdsWriter") << "Additonal content of AlignPCLThresholdsHG " << std::endl;
-  myThresholds.printAllHG();
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
+++ b/CondFormats/PCLConfig/plugins/AlignPCLThresholdsWriter.cc
@@ -39,6 +39,7 @@ namespace DOFs {
   enum dof { X, Y, Z, thetaX, thetaY, thetaZ, extraDOF };
 }
 
+template <typename T>
 class AlignPCLThresholdsWriter : public edm::one::EDAnalyzer<> {
 public:
   explicit AlignPCLThresholdsWriter(const edm::ParameterSet&);
@@ -50,7 +51,6 @@ private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   DOFs::dof mapOntoEnum(std::string coord);
 
-  template <typename T>
   void writePayload(T& myThresholds);
   void storeHGthresholds(AlignPCLThresholdsHG& myThresholds, const std::vector<std::string>& alignables);
 
@@ -63,7 +63,8 @@ private:
 //
 // constructors and destructor
 //
-AlignPCLThresholdsWriter::AlignPCLThresholdsWriter(const edm::ParameterSet& iConfig)
+template <typename T>
+AlignPCLThresholdsWriter<T>::AlignPCLThresholdsWriter(const edm::ParameterSet& iConfig)
     : m_record(iConfig.getParameter<std::string>("record")),
       m_minNrecords(iConfig.getParameter<unsigned int>("minNRecords")),
       m_parameters(iConfig.getParameter<std::vector<edm::ParameterSet> >("thresholds")) {}
@@ -73,7 +74,8 @@ AlignPCLThresholdsWriter::AlignPCLThresholdsWriter(const edm::ParameterSet& iCon
 //
 
 // ------------ method called for each event  ------------
-void AlignPCLThresholdsWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+template <typename T>
+void AlignPCLThresholdsWriter<T>::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // detect if new payload is used
   bool newClass = false;
   for (auto& thePSet : m_parameters) {
@@ -83,17 +85,24 @@ void AlignPCLThresholdsWriter::analyze(const edm::Event& iEvent, const edm::Even
     }
   }
 
-  // use templated method depending on new/old payload
-  if (newClass) {
-    AlignPCLThresholdsHG myThresholds{};
-    writePayload(myThresholds);
+  T myThresholds{};
+  if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+    if (newClass) {
+      this->writePayload(myThresholds);
+    } else {
+      throw cms::Exception("AlignPCLThresholdsWriter") << "mismatched configuration";
+    }
   } else {
-    AlignPCLThresholds myThresholds{};
-    writePayload(myThresholds);
+    if (!newClass) {
+      this->writePayload(myThresholds);
+    } else {
+      throw cms::Exception("AlignPCLThresholdsWriter") << "mismatched configuration";
+    }
   }
 }
 
-DOFs::dof AlignPCLThresholdsWriter::mapOntoEnum(std::string coord) {
+template <typename T>
+DOFs::dof AlignPCLThresholdsWriter<T>::mapOntoEnum(std::string coord) {
   if (coord == "X") {
     return DOFs::X;
   } else if (coord == "Y") {
@@ -113,7 +122,7 @@ DOFs::dof AlignPCLThresholdsWriter::mapOntoEnum(std::string coord) {
 
 // ------------ templated method to write the payload  ------------
 template <typename T>
-void AlignPCLThresholdsWriter::writePayload(T& myThresholds) {
+void AlignPCLThresholdsWriter<T>::writePayload(T& myThresholds) {
   using namespace edm;
 
   edm::LogInfo("AlignPCLThresholdsWriter") << "Size of AlignPCLThresholds object " << myThresholds.size() << std::endl;
@@ -225,8 +234,9 @@ void AlignPCLThresholdsWriter::writePayload(T& myThresholds) {
 }
 
 // ------------ method to store additional HG thresholds ------------
-void AlignPCLThresholdsWriter::storeHGthresholds(AlignPCLThresholdsHG& myThresholds,
-                                                 const std::vector<std::string>& alignables) {
+template <typename T>
+void AlignPCLThresholdsWriter<T>::storeHGthresholds(AlignPCLThresholdsHG& myThresholds,
+                                                    const std::vector<std::string>& alignables) {
   edm::LogInfo("AlignPCLThresholdsWriter")
       << "Found type AlignPCLThresholdsHG, additional thresholds are written" << std::endl;
 
@@ -255,7 +265,8 @@ void AlignPCLThresholdsWriter::storeHGthresholds(AlignPCLThresholdsHG& myThresho
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void AlignPCLThresholdsWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+template <typename T>
+void AlignPCLThresholdsWriter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.setComment("Plugin to write payloads of type AlignPCLThresholds");
   desc.add<std::string>("record", "AlignPCLThresholdsRcd");
@@ -268,13 +279,18 @@ void AlignPCLThresholdsWriter::fillDescriptions(edm::ConfigurationDescriptions& 
   desc_thresholds.add<double>("sigCut");
   desc_thresholds.add<double>("maxMoveCut");
   desc_thresholds.add<double>("maxErrorCut");
-  // optional thresholds from new payload version
-  desc_thresholds.addOptional<double>("fractionCut");
+  if constexpr (std::is_same_v<T, AlignPCLThresholdsHG>) {
+    //optional thresholds from new payload version (not for all the alignables)
+    desc_thresholds.addOptional<double>("fractionCut");
+  }
 
   std::vector<edm::ParameterSet> default_thresholds(1);
   desc.addVPSet("thresholds", desc_thresholds, default_thresholds);
   descriptions.addWithDefaultLabel(desc);
 }
 
-//define this as a plug-in
-DEFINE_FWK_MODULE(AlignPCLThresholdsWriter);
+typedef AlignPCLThresholdsWriter<AlignPCLThresholds> AlignPCLThresholdsLGWriter;
+typedef AlignPCLThresholdsWriter<AlignPCLThresholdsHG> AlignPCLThresholdsHGWriter;
+
+DEFINE_FWK_MODULE(AlignPCLThresholdsLGWriter);
+DEFINE_FWK_MODULE(AlignPCLThresholdsHGWriter);

--- a/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
+++ b/CondFormats/PCLConfig/src/AlignPCLThresholdsHG.cc
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <iomanip>  // std::setw
 
+//****************************************************************************//
 namespace AlignPCLThresholdsHGImpl {
   template <typename T>
   const T &getParam(const std::vector<T> &params, size_t index) {
@@ -22,41 +23,44 @@ namespace AlignPCLThresholdsHGImpl {
 
 }  //namespace AlignPCLThresholdsHGImpl
 
+//****************************************************************************//
 const std::vector<float> &AlignPCLThresholdsHG::getFloatVec(const std::string &AlignableId) const {
-  std::unordered_map<std::string, std::vector<float>>::const_iterator it = floatMap.find(AlignableId);
+  const auto &it = floatMap_.find(AlignableId);
 
-  if (it != floatMap.end()) {
+  if (it != floatMap_.end()) {
     return it->second;
   } else {
     throw cms::Exception("AlignPCLThresholdsHG") << "No float vector defined for Alignable id " << AlignableId << "\n";
   }
 }
 
-void AlignPCLThresholdsHG::SetFractionCut(const std::string &AlignableId, const coordType &type, const float &cut) {
+//****************************************************************************//
+void AlignPCLThresholdsHG::setFractionCut(const std::string &AlignableId, const coordType &type, const float &cut) {
   // Set entry in map if not yet available
-  std::unordered_map<std::string, std::vector<float>>::const_iterator it = floatMap.find(AlignableId);
-  if (it == floatMap.end())
-    floatMap[AlignableId] = std::vector<float>(FSIZE, 0.);
+  const auto &it = floatMap_.find(AlignableId);
+  if (it == floatMap_.end())
+    floatMap_[AlignableId] = std::vector<float>(FSIZE, -1.);
 
   switch (type) {
     case X:
-      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_X, cut);
+      return AlignPCLThresholdsHGImpl::setParam(floatMap_[AlignableId], FRACTION_CUT_X, cut);
     case Y:
-      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_Y, cut);
+      return AlignPCLThresholdsHGImpl::setParam(floatMap_[AlignableId], FRACTION_CUT_Y, cut);
     case Z:
-      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_Z, cut);
+      return AlignPCLThresholdsHGImpl::setParam(floatMap_[AlignableId], FRACTION_CUT_Z, cut);
     case theta_X:
-      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_TX, cut);
+      return AlignPCLThresholdsHGImpl::setParam(floatMap_[AlignableId], FRACTION_CUT_TX, cut);
     case theta_Y:
-      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_TY, cut);
+      return AlignPCLThresholdsHGImpl::setParam(floatMap_[AlignableId], FRACTION_CUT_TY, cut);
     case theta_Z:
-      return AlignPCLThresholdsHGImpl::setParam(floatMap[AlignableId], FRACTION_CUT_TZ, cut);
+      return AlignPCLThresholdsHGImpl::setParam(floatMap_[AlignableId], FRACTION_CUT_TZ, cut);
     default:
       throw cms::Exception("AlignPCLThresholdsHG")
           << "Requested setting fraction threshold for undefined coordinate" << type << "\n";
   }
 }
 
+//****************************************************************************//
 std::array<float, 6> AlignPCLThresholdsHG::getFractionCut(const std::string &AlignableId) const {
   const std::vector<float> vec = getFloatVec(AlignableId);
   return {{AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_X),
@@ -67,6 +71,7 @@ std::array<float, 6> AlignPCLThresholdsHG::getFractionCut(const std::string &Ali
            AlignPCLThresholdsHGImpl::getParam(vec, FRACTION_CUT_TZ)}};
 }
 
+//****************************************************************************//
 float AlignPCLThresholdsHG::getFractionCut(const std::string &AlignableId, const coordType &type) const {
   const std::vector<float> vec = getFloatVec(AlignableId);
   switch (type) {
@@ -88,35 +93,110 @@ float AlignPCLThresholdsHG::getFractionCut(const std::string &AlignableId, const
   }
 }
 
-int AlignPCLThresholdsHG::payloadVersion() const {
-  switch (FSIZE) {
+//****************************************************************************//
+const int AlignPCLThresholdsHG::payloadVersion() const {
+  switch (FSIZE + ISIZE + SSIZE) {
     case 6:
       return 1;
     default:
       throw cms::Exception("AlignPCLThresholdsHG")
-          << "Payload version with FSIZE equal to " << FSIZE << " is not defined.\n";
+          << "Payload version with parameter size equal to " << FSIZE + ISIZE + SSIZE << " is not defined.\n";
   }
 }
 
-void AlignPCLThresholdsHG::printAllHG() const {
-  edm::LogVerbatim("AlignPCLThresholdsHG") << "AlignPCLThresholdsHG::printAllHG()";
-  edm::LogVerbatim("AlignPCLThresholdsHG") << " ==================================";
-  for (auto it = floatMap.begin(); it != floatMap.end(); ++it) {
-    edm::LogVerbatim("AlignPCLThresholdsHG") << " ==================================";
-    edm::LogVerbatim("AlignPCLThresholdsHG")
-        << "key : " << it->first << " \n"
-        << "- X_fractionCut             : " << std::setw(4) << getFractionCut(it->first, X) << std::setw(5) << "\n"
+//****************************************************************************//
+void AlignPCLThresholdsHG::printAll() const {
+  edm::LogVerbatim out("AlignPCLThresholdsHG");
 
-        << "- thetaX_fractionCut        : " << std::setw(4) << getFractionCut(it->first, theta_X) << std::setw(5)
-        << "\n"
+  out << "AlignPCLThresholdsHG::printAll()\n";
+  out << "============================================================================================================="
+         "======\n";
+  out << "N records cut: " << this->getNrecords() << "\n";
+  for (auto it = m_thresholds.begin(); it != m_thresholds.end(); ++it) {
+    out << "==========================================================================================================="
+           "========\n";
 
-        << "- Y_fractionCut             : " << std::setw(4) << getFractionCut(it->first, Y) << std::setw(5) << "\n"
+    std::stringstream ss;
 
-        << "- thetaY_fractionCut        : " << std::setw(4) << getFractionCut(it->first, theta_Y) << std::setw(5)
-        << "\n"
+    ss << "key : " << it->first << " \n"
+       << "- Xcut             : " << std::setw(4) << (it->second).getXcut() << std::setw(5) << "   um"
+       << "| sigXcut          : " << std::setw(4) << (it->second).getSigXcut() << std::setw(1) << " "
+       << "| maxMoveXcut      : " << std::setw(4) << (it->second).getMaxMoveXcut() << std::setw(5) << "   um"
+       << "| ErrorXcut        : " << std::setw(4) << (it->second).getErrorXcut() << std::setw(5) << "   um";
 
-        << "- Z_fractionCut             : " << std::setw(4) << getFractionCut(it->first, Z) << std::setw(5) << "\n"
+    if (floatMap_.find(it->first) != floatMap_.end()) {
+      ss << "| X_fractionCut      : " << std::setw(4) << getFractionCut(it->first, X) << std::setw(5) << "\n";
+    } else {
+      ss << "\n";
+    }
 
-        << "- thetaZ_fractionCut        : " << std::setw(4) << getFractionCut(it->first, theta_Z) << std::setw(5);
+    ss << "- thetaXcut        : " << std::setw(4) << (it->second).getThetaXcut() << std::setw(5) << " urad"
+       << "| sigThetaXcut     : " << std::setw(4) << (it->second).getSigThetaXcut() << std::setw(1) << " "
+       << "| maxMoveThetaXcut : " << std::setw(4) << (it->second).getMaxMoveThetaXcut() << std::setw(5) << " urad"
+       << "| ErrorThetaXcut   : " << std::setw(4) << (it->second).getErrorThetaXcut() << std::setw(5) << " urad";
+
+    if (floatMap_.find(it->first) != floatMap_.end()) {
+      ss << "| thetaX_fractionCut : " << std::setw(4) << getFractionCut(it->first, theta_X) << std::setw(5) << "\n";
+    } else {
+      ss << "\n";
+    }
+
+    ss << "- Ycut             : " << std::setw(4) << (it->second).getYcut() << std::setw(5) << "   um"
+       << "| sigYcut          : " << std::setw(4) << (it->second).getSigXcut() << std::setw(1) << " "
+       << "| maxMoveYcut      : " << std::setw(4) << (it->second).getMaxMoveYcut() << std::setw(5) << "   um"
+       << "| ErrorYcut        : " << std::setw(4) << (it->second).getErrorYcut() << std::setw(5) << "   um";
+
+    if (floatMap_.find(it->first) != floatMap_.end()) {
+      ss << "| Y_fractionCut      : " << std::setw(4) << getFractionCut(it->first, Y) << std::setw(5) << "\n";
+    } else {
+      ss << "\n";
+    }
+
+    ss << "- thetaYcut        : " << std::setw(4) << (it->second).getThetaYcut() << std::setw(5) << " urad"
+       << "| sigThetaYcut     : " << std::setw(4) << (it->second).getSigThetaYcut() << std::setw(1) << " "
+       << "| maxMoveThetaYcut : " << std::setw(4) << (it->second).getMaxMoveThetaYcut() << std::setw(5) << " urad"
+       << "| ErrorThetaYcut   : " << std::setw(4) << (it->second).getErrorThetaYcut() << std::setw(5) << " urad";
+
+    if (floatMap_.find(it->first) != floatMap_.end()) {
+      ss << "| thetaY_fractionCut : " << std::setw(4) << getFractionCut(it->first, theta_Y) << std::setw(5) << "\n";
+    } else {
+      ss << "\n";
+    }
+
+    ss << "- Zcut             : " << std::setw(4) << (it->second).getZcut() << std::setw(5) << "   um"
+       << "| sigZcut          : " << std::setw(4) << (it->second).getSigZcut() << std::setw(1) << " "
+       << "| maxMoveZcut      : " << std::setw(4) << (it->second).getMaxMoveZcut() << std::setw(5) << "   um"
+       << "| ErrorZcut        : " << std::setw(4) << (it->second).getErrorZcut() << std::setw(5) << "   um";
+
+    if (floatMap_.find(it->first) != floatMap_.end()) {
+      ss << "| Z_fractionCut      : " << std::setw(4) << getFractionCut(it->first, Z) << std::setw(5) << "\n";
+    } else {
+      ss << "\n";
+    }
+
+    ss << "- thetaZcut        : " << std::setw(4) << (it->second).getThetaZcut() << std::setw(5) << " urad"
+       << "| sigThetaZcut     : " << std::setw(4) << (it->second).getSigThetaZcut() << std::setw(1) << " "
+       << "| maxMoveThetaZcut : " << std::setw(4) << (it->second).getMaxMoveThetaZcut() << std::setw(5) << " urad"
+       << "| ErrorThetaZcut   : " << std::setw(4) << (it->second).getErrorThetaZcut() << std::setw(5) << " urad";
+
+    if (floatMap_.find(it->first) != floatMap_.end()) {
+      ss << "| thetaZ_fractionCut : " << std::setw(4) << getFractionCut(it->first, theta_Z) << std::setw(5) << "\n";
+    } else {
+      ss << "\n";
+    }
+
+    out << ss.str() << std::endl;
+
+    if ((it->second).hasExtraDOF()) {
+      for (unsigned int j = 0; j < (it->second).extraDOFSize(); j++) {
+        std::array<float, 4> extraDOFCuts = getExtraDOFCutsForAlignable(it->first, j);
+
+        out << "Extra DOF " << j << " with label: " << getExtraDOFLabelForAlignable(it->first, j);
+        out << "- cut              : " << std::setw(4) << extraDOFCuts.at(0) << std::setw(5) << "    "
+            << "| sigCut           : " << std::setw(4) << extraDOFCuts.at(1) << std::setw(1) << " "
+            << "| maxMoveCut       : " << std::setw(4) << extraDOFCuts.at(2) << std::setw(5) << "    "
+            << "| maxErrorCut      : " << std::setw(4) << extraDOFCuts.at(3) << std::setw(5) << "    ";
+      }
+    }
   }
 }

--- a/CondFormats/PCLConfig/test/AlignPCLThresholdsReader_cfg.py
+++ b/CondFormats/PCLConfig/test/AlignPCLThresholdsReader_cfg.py
@@ -37,15 +37,10 @@ options.parseArguments()
 ##
 ## Define record, class and module based on option
 ##
-rcdName = "AlignPCLThresholdsHGRcd"
-className = "AlignPCLThresholdsHG"
-moduleName = "AlignPCLThresholdsHGReader"
+[rcdName, className, moduleName] = ["AlignPCLThresholdsRcd","AlignPCLThresholds","AlignPCLThresholdsLGReader"] \
+                                   if (options.readLGpayload) else ["AlignPCLThresholdsHGRcd","AlignPCLThresholdsHG","AlignPCLThresholdsHGReader"]
 
-if options.readLGpayload:
-    rcdName = "AlignPCLThresholdsRcd"
-    className = "AlignPCLThresholds"
-    moduleName = "AlignPCLThresholdsLGReader"
-
+print("using %s %s %s" % (rcdName, className, moduleName))
 ##
 ## Empty Source
 ##

--- a/CondFormats/PCLConfig/test/AlignPCLThresholdsReader_cfg.py
+++ b/CondFormats/PCLConfig/test/AlignPCLThresholdsReader_cfg.py
@@ -54,7 +54,9 @@ process.source = cms.Source("EmptyIOVSource",
 ## Get the payload
 ##
 from CondCore.CondDB.CondDB_cfi import *
-CondDBThresholds = CondDB.clone(connect = cms.string("sqlite_file:mythresholds.db"))
+inputDBfile = 'sqlite_file:mythresholds_%s.db' % ("LG" if(options.readLGpayload) else "HG") 
+
+CondDBThresholds = CondDB.clone(connect = cms.string(inputDBfile))
 
 process.dbInput = cms.ESSource("PoolDBESSource",
                                CondDBThresholds,
@@ -79,6 +81,6 @@ process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
 ##
 process.ReadDB = cms.EDAnalyzer(moduleName)
 process.ReadDB.printDebug = cms.untracked.bool(True)
-process.ReadDB.outputFile = cms.untracked.string('AlignPCLThresholds.log')
+process.ReadDB.outputFile = cms.untracked.string('AlignPCLThresholds_%s.log' % ("LG" if(options.readLGpayload) else "HG"))
 
 process.p = cms.Path(process.get+process.ReadDB)

--- a/CondFormats/PCLConfig/test/AlignPCLThresholdsReader_cfg.py
+++ b/CondFormats/PCLConfig/test/AlignPCLThresholdsReader_cfg.py
@@ -79,8 +79,18 @@ process.get = cms.EDAnalyzer("EventSetupRecordDataGetter",
 ##
 ## Read it back
 ##
-process.ReadDB = cms.EDAnalyzer(moduleName)
-process.ReadDB.printDebug = cms.untracked.bool(True)
-process.ReadDB.outputFile = cms.untracked.string('AlignPCLThresholds_%s.log' % ("LG" if(options.readLGpayload) else "HG"))
+from CondFormats.PCLConfig.edmtestAlignPCLThresholdsReaderAlignPCLThresholdsAlignPCLThresholdsRcd_cfi import *
+from CondFormats.PCLConfig.edmtestAlignPCLThresholdsReaderAlignPCLThresholdsHGAlignPCLThresholdsHGRcd_cfi import *
+
+if(options.readLGpayload):
+    process.ReadDB = edmtestAlignPCLThresholdsReaderAlignPCLThresholdsAlignPCLThresholdsRcd.clone(
+        printDebug = True,
+        outputFile = 'AlignPCLThresholds_%s.log' % ("LG" if(options.readLGpayload) else "HG")
+    )
+else:
+    process.ReadDB = edmtestAlignPCLThresholdsReaderAlignPCLThresholdsHGAlignPCLThresholdsHGRcd.clone(
+        printDebug = True,
+        outputFile = 'AlignPCLThresholds_%s.log' % ("LG" if(options.readLGpayload) else "HG")
+    )
 
 process.p = cms.Path(process.get+process.ReadDB)

--- a/CondFormats/PCLConfig/test/AlignPCLThresholdsWriter_cfg.py
+++ b/CondFormats/PCLConfig/test/AlignPCLThresholdsWriter_cfg.py
@@ -24,6 +24,18 @@ process.MessageLogger.cout = cms.untracked.PSet(
     )
 
 ##
+## Var Parsing
+##
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing()
+options.register('writeLGpayload',
+                False,
+                VarParsing.VarParsing.multiplicity.singleton,
+                VarParsing.VarParsing.varType.bool,
+                "Write old payload type used for LG thresholds")
+options.parseArguments()
+
+##
 ## Empty source
 ##
 process.source = cms.Source("EmptyIOVSource",
@@ -53,12 +65,15 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
 ##
 ## Impot the thresholds configuration
 ##
-import CondFormats.PCLConfig.ThresholdsHG_cff as Thresholds
+import CondFormats.PCLConfig.Thresholds_cff as Thresholds
+import CondFormats.PCLConfig.ThresholdsHG_cff as ThresholdsHG
 
 ##
 ## Example on how to add to the default extra degrees of freedom
 ##
 AddSurfaceThresholds = copy.deepcopy(Thresholds.default)
+AddSurfaceThresholdsHG = copy.deepcopy(ThresholdsHG.default)
+
 BPixSurface= cms.VPSet(
     cms.PSet(alignableId       = cms.string("TPBModule"),
              DOF               = cms.string("Surface1"),
@@ -72,13 +87,16 @@ BPixSurface= cms.VPSet(
 DefaultPlusSurface = AddSurfaceThresholds+BPixSurface
 #print DefaultPlusSurface.dumpPython()
 
-process.WriteInDB = cms.EDAnalyzer("AlignPCLThresholdsWriter",
+[MODULE_NAME, THRS_NAME] = ["AlignPCLThresholdsLGWriter",AddSurfaceThresholds] if(options.writeLGpayload) else ["AlignPCLThresholdsHGWriter",AddSurfaceThresholdsHG]
+
+
+process.WriteInDB = cms.EDAnalyzer(MODULE_NAME,
                                    record= cms.string('FooRcd'),
                                    ### minimum number of records found in pede output 
                                    minNRecords = cms.uint32(25000), 
                                    #thresholds  = cms.VPSet()         # empty object
                                    #thresholds = DefaultPlusSurface   # add extra deegree of freedom
-                                   thresholds = Thresholds.default   # as a cms.VPset
+                                   thresholds =  THRS_NAME #Thresholds.default   # as a cms.VPset
                                    )
 
 process.p = cms.Path(process.WriteInDB)

--- a/CondFormats/PCLConfig/test/AlignPCLThresholdsWriter_cfg.py
+++ b/CondFormats/PCLConfig/test/AlignPCLThresholdsWriter_cfg.py
@@ -52,7 +52,7 @@ process.load("CondCore.CondDB.CondDB_cfi")
 ##
 ## Output database (in this case local sqlite file)
 ##
-process.CondDB.connect = 'sqlite_file:mythresholds.db'
+process.CondDB.connect = 'sqlite_file:mythresholds_%s.db' % ("LG" if(options.writeLGpayload) else "HG")
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),

--- a/CondFormats/PCLConfig/test/AlignPCLThresholdsWriter_cfg.py
+++ b/CondFormats/PCLConfig/test/AlignPCLThresholdsWriter_cfg.py
@@ -88,15 +88,26 @@ DefaultPlusSurface = AddSurfaceThresholds+BPixSurface
 #print DefaultPlusSurface.dumpPython()
 
 [MODULE_NAME, THRS_NAME] = ["AlignPCLThresholdsLGWriter",AddSurfaceThresholds] if(options.writeLGpayload) else ["AlignPCLThresholdsHGWriter",AddSurfaceThresholdsHG]
+print("Writing payload with",MODULE_NAME)
 
+from CondFormats.PCLConfig.alignPCLThresholdsHGWriter_cfi import alignPCLThresholdsHGWriter
+from CondFormats.PCLConfig.alignPCLThresholdsLGWriter_cfi import alignPCLThresholdsLGWriter
 
-process.WriteInDB = cms.EDAnalyzer(MODULE_NAME,
-                                   record= cms.string('FooRcd'),
-                                   ### minimum number of records found in pede output 
-                                   minNRecords = cms.uint32(25000), 
-                                   #thresholds  = cms.VPSet()         # empty object
-                                   #thresholds = DefaultPlusSurface   # add extra deegree of freedom
-                                   thresholds =  THRS_NAME #Thresholds.default   # as a cms.VPset
-                                   )
+if(options.writeLGpayload):
+    process.WriteInDB = alignPCLThresholdsLGWriter.clone(
+        record = 'FooRcd',
+        ### minimum number of records found in pede output
+        minNRecords = 25000,
+        #thresholds  = cms.VPSet()         # empty object
+        #thresholds = DefaultPlusSurface   # add extra deegree of freedom
+        thresholds =  THRS_NAME
+    )
+else:
+    process.WriteInDB = alignPCLThresholdsHGWriter.clone(
+        record = 'FooRcd',
+        ### minimum number of records found in pede output
+        minNRecords = 25000,
+        thresholds =  THRS_NAME
+    )
 
 process.p = cms.Path(process.WriteInDB)

--- a/CondFormats/PCLConfig/test/testReadWriteAlignPCLThresholds.sh
+++ b/CondFormats/PCLConfig/test/testReadWriteAlignPCLThresholds.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 function die { echo $1: status $2; exit $2; }
+# test High Granularity
 cmsRun ${LOCAL_TEST_DIR}/AlignPCLThresholdsWriter_cfg.py || die 'failed running AlignPCLThresholdsWriter_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/AlignPCLThresholdsReader_cfg.py || die 'failed running AlignPCLThresholdsReader_cfg.py' $?
+
+# test Low Granularity
+(cmsRun ${LOCAL_TEST_DIR}/AlignPCLThresholdsWriter_cfg.py writeLGpayload=True) || die 'failed running AlignPCLThresholdsWriter_cfg.py writeLGpayload=True' $?
+(cmsRun ${LOCAL_TEST_DIR}/AlignPCLThresholdsReader_cfg.py readLGpayload=True) || die 'failed running AlignPCLThresholdsReader_cfg.py readLGpayload=True' $?


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/38195, introducing miscellaneous improvements to the `CondFormats/PCLConfig` package.
   * added integer and string parameter size `enum`s for not yet used parameters and changed the logic to calculate the payload version
   * fully templated also the `AlignPCLThresholdsWriter` writer class;
   * improved the `printAll()` method of `AlignPCLThresholdsHG` in order to give a more synoptic view of the parameters;
   * complemented unit tests in order to test both LG and HG classes;

#### PR validation:

run the dedicated unit tests: `scram b runtests`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
