### PR TITLE
Fix CMS deprecated warnings in L1Trigger/L1TGlobal

### DIFF
--- a/L1Trigger/L1TGlobal/plugins/BXVectorInputProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/BXVectorInputProducer.cc
@@ -18,7 +18,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -56,7 +56,7 @@ namespace l1t {
   // class declaration
   //
 
-  class BXVectorInputProducer : public EDProducer {
+  class BXVectorInputProducer : public one::EDProducer<> {
   public:
     explicit BXVectorInputProducer(const ParameterSet&);
     ~BXVectorInputProducer() override;
@@ -65,17 +65,12 @@ namespace l1t {
 
   private:
     void produce(Event&, EventSetup const&) override;
-    void beginJob() override;
-    void endJob() override;
-    void beginRun(Run const& iR, EventSetup const& iE) override;
-    void endRun(Run const& iR, EventSetup const& iE) override;
 
-    int convertPhiToHW(double iphi, int steps);
-    int convertEtaToHW(double ieta, double minEta, double maxEta, int steps);
-    int convertPtToHW(double ipt, int maxPt, double step);
+    int convertPhiToHW(double iphi, int steps) const;
+    int convertEtaToHW(double ieta, double minEta, double maxEta, int steps) const;
+    int convertPtToHW(double ipt, int maxPt, double step) const;
 
     // ----------member data ---------------------------
-    unsigned long long m_paramsCacheId;  // Cache-ID from current parameters, to check if needs to be updated.
     //std::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
     //std::shared_ptr<const FirmwareVersion> m_fwv;
     //std::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
@@ -107,8 +102,6 @@ namespace l1t {
     edm::EDGetToken tauToken;
     edm::EDGetToken jetToken;
     edm::EDGetToken etsumToken;
-
-    int counter_;
 
     std::vector<l1t::Muon> muonVec_bxm2;
     std::vector<l1t::Muon> muonVec_bxm1;
@@ -179,7 +172,6 @@ namespace l1t {
     emptyBxEvt_ = iConfig.getParameter<int>("emptyBxEvt");
 
     // set cache id to zero, will be set at first beginRun:
-    m_paramsCacheId = 0;
     eventCnt_ = 0;
   }
 
@@ -468,25 +460,8 @@ namespace l1t {
     etsumVec_bxp1 = etsumVec;
   }
 
-  // ------------ method called once each job just before starting event loop ------------
-  void BXVectorInputProducer::beginJob() {}
-
-  // ------------ method called once each job just after ending the event loop ------------
-  void BXVectorInputProducer::endJob() {}
-
-  // ------------ method called when starting to processes a run ------------
-
-  void BXVectorInputProducer::beginRun(Run const& iR, EventSetup const& iE) {
-    LogDebug("l1t|Global") << "BXVectorInputProducer::beginRun function called...\n";
-
-    counter_ = 0;
-  }
-
-  // ------------ method called when ending the processing of a run ------------
-  void BXVectorInputProducer::endRun(Run const& iR, EventSetup const& iE) {}
-
   // ------------ methods to convert from physical to HW values ------------
-  int BXVectorInputProducer::convertPhiToHW(double iphi, int steps) {
+  int BXVectorInputProducer::convertPhiToHW(double iphi, int steps) const {
     double phiMax = 2 * M_PI;
     if (iphi < 0)
       iphi += 2 * M_PI;
@@ -497,7 +472,7 @@ namespace l1t {
     return hwPhi;
   }
 
-  int BXVectorInputProducer::convertEtaToHW(double ieta, double minEta, double maxEta, int steps) {
+  int BXVectorInputProducer::convertEtaToHW(double ieta, double minEta, double maxEta, int steps) const {
     double binWidth = (maxEta - minEta) / steps;
 
     //if we are outside the limits, set error
@@ -516,7 +491,7 @@ namespace l1t {
     return binNum;
   }
 
-  int BXVectorInputProducer::convertPtToHW(double ipt, int maxPt, double step) {
+  int BXVectorInputProducer::convertPtToHW(double ipt, int maxPt, double step) const {
     int hwPt = int(ipt / step + 0.0001);
     // if above max Pt, set to largest value
     if (hwPt > maxPt)

--- a/L1Trigger/L1TGlobal/plugins/FakeInputProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/FakeInputProducer.cc
@@ -15,7 +15,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -41,7 +41,7 @@ namespace l1t {
   // class declaration
   //
 
-  class FakeInputProducer : public EDProducer {
+  class FakeInputProducer : public global::EDProducer<> {
   public:
     explicit FakeInputProducer(const ParameterSet&);
     ~FakeInputProducer() override;
@@ -49,14 +49,9 @@ namespace l1t {
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    void produce(Event&, EventSetup const&) override;
-    void beginJob() override;
-    void endJob() override;
-    void beginRun(Run const& iR, EventSetup const& iE) override;
-    void endRun(Run const& iR, EventSetup const& iE) override;
+    void produce(StreamID, Event&, EventSetup const&) const override;
 
     // ----------member data ---------------------------
-    unsigned long long m_paramsCacheId;  // Cache-ID from current parameters, to check if needs to be updated.
     //std::shared_ptr<const CaloParams> m_dbpars; // Database parameters for the trigger, to be updated as needed.
     //std::shared_ptr<const FirmwareVersion> m_fwv;
     //std::shared_ptr<FirmwareVersion> m_fwv; //not const during testing.
@@ -146,9 +141,6 @@ namespace l1t {
     fEtSumBx = etsum_params.getUntrackedParameter<vector<int>>("etsumBx");
     fEtSumHwPt = etsum_params.getUntrackedParameter<vector<int>>("etsumHwPt");
     fEtSumHwPhi = etsum_params.getUntrackedParameter<vector<int>>("etsumHwPhi");
-
-    // set cache id to zero, will be set at first beginRun:
-    m_paramsCacheId = 0;
   }
 
   FakeInputProducer::~FakeInputProducer() {}
@@ -158,7 +150,7 @@ namespace l1t {
   //
 
   // ------------ method called to produce the data ------------
-  void FakeInputProducer::produce(Event& iEvent, const EventSetup& iSetup) {
+  void FakeInputProducer::produce(StreamID, Event& iEvent, const EventSetup& iSetup) const {
     LogDebug("l1t|Global") << "FakeInputProducer::produce function called...\n";
 
     // Set the range of BX....TO DO...move to Params or determine from param set.
@@ -219,21 +211,6 @@ namespace l1t {
     iEvent.put(std::move(jets));
     iEvent.put(std::move(etsums));
   }
-
-  // ------------ method called once each job just before starting event loop ------------
-  void FakeInputProducer::beginJob() {}
-
-  // ------------ method called once each job just after ending the event loop ------------
-  void FakeInputProducer::endJob() {}
-
-  // ------------ method called when starting to processes a run ------------
-
-  void FakeInputProducer::beginRun(Run const& iR, EventSetup const& iE) {
-    LogDebug("l1t|Global") << "FakeInputProducer::beginRun function called...\n";
-  }
-
-  // ------------ method called when ending the processing of a run ------------
-  void FakeInputProducer::endRun(Run const& iR, EventSetup const& iE) {}
 
   // ------------ method fills 'descriptions' with the allowed parameters for the module ------------
   void FakeInputProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {

--- a/L1Trigger/L1TGlobal/plugins/GenToInputProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/GenToInputProducer.cc
@@ -19,7 +19,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -60,7 +60,7 @@ namespace l1t {
   // class declaration
   //
 
-  class GenToInputProducer : public EDProducer {
+  class GenToInputProducer : public one::EDProducer<edm::one::WatchRuns> {
   public:
     explicit GenToInputProducer(const ParameterSet&);
     ~GenToInputProducer() override;
@@ -109,8 +109,6 @@ namespace l1t {
     edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken;
     edm::EDGetTokenT<reco::GenJetCollection> genJetsToken;
     edm::EDGetTokenT<reco::GenMETCollection> genMetToken;
-
-    int counter_;
 
     std::vector<l1t::Muon> muonVec_bxm2;
     std::vector<l1t::Muon> muonVec_bxm1;
@@ -785,7 +783,6 @@ namespace l1t {
   void GenToInputProducer::beginRun(Run const& iR, EventSetup const& iE) {
     LogDebug("GtGenToInputProducer") << "GenToInputProducer::beginRun function called...\n";
 
-    counter_ = 0;
     srand(0);
 
     gRandom = new TRandom3();

--- a/L1Trigger/L1TGlobal/plugins/GtInputDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtInputDump.cc
@@ -24,7 +24,7 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -48,7 +48,7 @@ using namespace std;
 namespace l1t {
 
   // class declaration
-  class GtInputDump : public edm::EDAnalyzer {
+  class GtInputDump : public edm::one::EDAnalyzer<> {
   public:
     explicit GtInputDump(const edm::ParameterSet&);
     ~GtInputDump() override{};

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -16,7 +16,7 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 //#include "FWCore/ParameterSet/interface/InputTag.h"
 
 // system include files
@@ -26,7 +26,7 @@
 
 // user include files
 //   base class
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -60,10 +60,11 @@ using namespace std;
 namespace l1t {
 
   // class declaration
-  class GtRecordDump : public edm::EDAnalyzer {
+  class GtRecordDump : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
   public:
     explicit GtRecordDump(const edm::ParameterSet&);
     ~GtRecordDump() override{};
+    void beginRun(edm::Run const&, edm::EventSetup const&) override {}
     void analyze(const edm::Event&, const edm::EventSetup&) override;
     void endRun(edm::Run const&, edm::EventSetup const&) override;
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalAnalyzer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalAnalyzer.cc
@@ -23,7 +23,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -50,7 +50,7 @@
 
 namespace l1t {
 
-  class L1TGlobalAnalyzer : public edm::EDAnalyzer {
+  class L1TGlobalAnalyzer : public edm::one::EDAnalyzer<> {
   public:
     explicit L1TGlobalAnalyzer(const edm::ParameterSet&);
     ~L1TGlobalAnalyzer() override;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescaler.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalPrescaler.cc
@@ -190,7 +190,7 @@ bool L1TGlobalPrescaler::filter(edm::Event& event, edm::EventSetup const& setup)
   // apply prescales equal to ratio between the given values and the ones read from the EventSetup
   if (m_mode == Mode::ApplyPrescaleRatios and m_oldIndex != index) {
     edm::ESHandle<L1TGlobalPrescalesVetos> h = setup.getHandle(m_l1tGtPrescalesVetosToken);
-    setup.get<L1TGlobalPrescalesVetosRcd>().get(h);
+
     auto const& prescaleTable = h->prescale_table_;
     if (index >= (int)prescaleTable.size())
       throw edm::Exception(edm::errors::LogicError)

--- a/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuDumper.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TUtmTriggerMenuDumper.cc
@@ -19,7 +19,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -33,7 +33,7 @@ using namespace edm;
 using namespace std;
 using namespace tmeventsetup;
 
-class L1TUtmTriggerMenuDumper : public EDAnalyzer {
+class L1TUtmTriggerMenuDumper : public one::EDAnalyzer<edm::one::WatchLuminosityBlocks, edm::one::WatchRuns> {
 public:
   explicit L1TUtmTriggerMenuDumper(const ParameterSet&);
   ~L1TUtmTriggerMenuDumper() override;


### PR DESCRIPTION
#### PR description:

- removed unnecessary deprecated EventSetup get
- Changed to thread friendly module types

#### PR validation:

Code compiles without issuing CMS deprecated warnings.