### PR TITLE
Add support for ZSTD and LZ4 compression for NanoAODOutputModule

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
+++ b/PhysicsTools/NanoAOD/plugins/NanoAODOutputModule.cc
@@ -296,10 +296,14 @@ void NanoAODOutputModule::openFile(edm::FileBlock const&) {
     m_file->SetCompressionAlgorithm(ROOT::kZLIB);
   } else if (m_compressionAlgorithm == std::string("LZMA")) {
     m_file->SetCompressionAlgorithm(ROOT::kLZMA);
+  } else if (m_compressionAlgorithm == std::string("ZSTD")) {
+    m_file->SetCompressionAlgorithm(ROOT::kZSTD);
+  } else if (m_compressionAlgorithm == std::string("LZ4")) {
+    m_file->SetCompressionAlgorithm(ROOT::kLZ4);
   } else {
     throw cms::Exception("Configuration")
         << "NanoAODOutputModule configured with unknown compression algorithm '" << m_compressionAlgorithm << "'\n"
-        << "Allowed compression algorithms are ZLIB and LZMA\n";
+        << "Allowed compression algorithms are ZLIB, LZMA, ZSTD, and LZ4\n";
   }
   /* Setup file structure here */
   m_tables.clear();


### PR DESCRIPTION
#### PR description:

Since ZSTD is supported in ROOT since v6.20, it would be nice to have the option to use it for NanoAOD (and LZ4 as well). 

- No changes expected, this just enables ZSTD and LZ4 as options.


#### PR validation:
PR produces NanoAOD with the desired compression algorithms.