### PR TITLE
Fixed CMS deprectation warnings in RecoMuon/TrackingTools

### DIFF
--- a/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.h
+++ b/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.h
@@ -16,32 +16,34 @@
 
 #include <memory>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include <FWCore/Framework/interface/EventSetup.h>
+#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <DataFormats/TrackReco/interface/Track.h>
-#include <DataFormats/TrackReco/interface/TrackExtra.h>
-#include <DataFormats/TrackingRecHit/interface/TrackingRecHit.h>
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackExtra.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 
 #include "FWCore/Utilities/interface/InputTag.h"
 
 class FreeTrajectoryState;
 class MuonErroMatrix;
 class MagneticField;
+class IdealMagneticFieldRecord;
 class MuonErrorMatrix;
+class TrackerTopologyRcd;
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 //
 // class decleration
 //
 
-class MuonErrorMatrixAdjuster : public edm::EDProducer {
+class MuonErrorMatrixAdjuster : public edm::stream::EDProducer<> {
 public:
   /// constructor
   explicit MuonErrorMatrixAdjuster(const edm::ParameterSet&);
@@ -50,9 +52,7 @@ public:
 
 private:
   /// framework method
-  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override;
 
   /// return a corrected error matrix
   reco::TrackBase::CovarianceMatrix fix_cov_matrix(const reco::TrackBase::CovarianceMatrix& error_matrix,
@@ -95,11 +95,12 @@ private:
   bool theRescale;
 
   /// holds the error matrix parametrization
-  edm::ParameterSet theMatrixProvider_pset;
-  MuonErrorMatrix* theMatrixProvider;
+  std::unique_ptr<MuonErrorMatrix> theMatrixProvider;
 
   /// hold on to the magnetic field
   edm::ESHandle<MagneticField> theField;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theHttopoToken;
 
   /// get reference before put track extra to the event, in order to create edm::Ref
   edm::RefProd<reco::TrackExtraCollection> theRefprodTE;

--- a/RecoMuon/TrackingTools/test/MuonErrorMatrixAnalyzer.cc
+++ b/RecoMuon/TrackingTools/test/MuonErrorMatrixAnalyzer.cc
@@ -61,6 +61,7 @@ MuonErrorMatrixAnalyzer::MuonErrorMatrixAnalyzer(const edm::ParameterSet& iConfi
     Surface::RotationType R;
     refRSurface = Cylinder::build(theRadius, O, R);
     thePropagatorName = iConfig.getParameter<std::string>("propagatorName");
+    thePropagatorToken = esConsumes(edm::ESInputTag("", thePropagatorName));
     theZ = iConfig.getParameter<double>("z");
     if (theZ != 0) {
       //plane can only be specified if R is specified
@@ -139,11 +140,11 @@ void MuonErrorMatrixAnalyzer::analyze_from_errormatrix(const edm::Event& iEvent,
 
   if (theRadius != 0) {
     //get a propagator
-    iSetup.get<TrackingComponentsRecord>().get(thePropagatorName, thePropagator);
+    thePropagator = iSetup.getHandle(thePropagatorToken);
   }
 
   //get the mag field
-  iSetup.get<IdealMagneticFieldRecord>().get(theField);
+  theField = iSetup.getHandle(theFieldToken);
 
   //open a collection of track
   edm::Handle<reco::TrackCollection> tracks;
@@ -192,7 +193,7 @@ void MuonErrorMatrixAnalyzer::analyze_from_pull(const edm::Event& iEvent, const 
   using namespace edm;
 
   //get the mag field
-  iSetup.get<IdealMagneticFieldRecord>().get(theField);
+  theField = iSetup.getHandle(theFieldToken);
 
   //open a collection of track
   edm::Handle<View<reco::Track> > tracks;

--- a/RecoMuon/TrackingTools/test/MuonErrorMatrixAnalyzer.h
+++ b/RecoMuon/TrackingTools/test/MuonErrorMatrixAnalyzer.h
@@ -13,7 +13,7 @@
 
 #include <memory>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -30,6 +30,8 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 class MagneticField;
+class IdealMagneticFieldRecord;
+class TrackingComponentsRecord;
 class TH1;
 class TH2;
 class Propagator;
@@ -37,7 +39,7 @@ class Propagator;
 // class decleration
 //
 
-class MuonErrorMatrixAnalyzer : public edm::EDAnalyzer {
+class MuonErrorMatrixAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   /// constructor
   explicit MuonErrorMatrixAnalyzer(const edm::ParameterSet&);
@@ -69,6 +71,7 @@ private:
 
   /// hold on the magnetic field
   edm::ESHandle<MagneticField> theField;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theFieldToken;
 
   /// class holder for the reported error parametrization
   MuonErrorMatrix* theErrorMatrixStore_Reported;
@@ -100,6 +103,7 @@ private:
   /// propagator used to go to the cylinder surface, ALONG momentum
   std::string thePropagatorName;
   edm::ESHandle<Propagator> thePropagator;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
 
   /// put the free trajectory state to the TSCPBuilderNoMaterial or the cylinder surface
   FreeTrajectoryState refLocusState(const FreeTrajectoryState& fts);


### PR DESCRIPTION
#### PR description:

- changed to thread-friendly module types
- added esConsumes calls

#### PR validation:

Code compiles without generating CMS deprecation warnings.