### PR TITLE
Convert to thread-friendly modules in CommonTools

### DIFF
--- a/CommonTools/CandAlgos/plugins/CandViewRefMerger.cc
+++ b/CommonTools/CandAlgos/plugins/CandViewRefMerger.cc
@@ -8,13 +8,13 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/transform.h"
 #include "DataFormats/Common/interface/Handle.h"
 
-class CandViewRefMerger : public edm::EDProducer {
+class CandViewRefMerger : public edm::global::EDProducer<> {
 public:
   explicit CandViewRefMerger(const edm::ParameterSet& cfg)
       : srcTokens_(
@@ -24,7 +24,7 @@ public:
   }
 
 private:
-  void produce(edm::Event& evt, const edm::EventSetup&) override {
+  void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup&) const override {
     std::unique_ptr<std::vector<reco::CandidateBaseRef> > out(new std::vector<reco::CandidateBaseRef>);
     for (std::vector<edm::EDGetTokenT<reco::CandidateView> >::const_iterator i = srcTokens_.begin();
          i != srcTokens_.end();

--- a/CommonTools/UtilAlgos/interface/AssociationMapOneToOne2Association.h
+++ b/CommonTools/UtilAlgos/interface/AssociationMapOneToOne2Association.h
@@ -10,18 +10,18 @@
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/Common/interface/OneToOne.h"
 #include "DataFormats/Common/interface/Association.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 template <typename CKey, typename CVal>
-class AssociationMapOneToOne2Association : public edm::EDProducer {
+class AssociationMapOneToOne2Association : public edm::global::EDProducer<> {
 public:
   AssociationMapOneToOne2Association(const edm::ParameterSet&);
 
 private:
   typedef edm::AssociationMap<edm::OneToOne<CKey, CVal> > am_t;
   typedef edm::Association<CVal> as_t;
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   edm::EDGetTokenT<am_t> am_;
 };
 
@@ -38,7 +38,9 @@ AssociationMapOneToOne2Association<CKey, CVal>::AssociationMapOneToOne2Associati
 }
 
 template <typename CKey, typename CVal>
-void AssociationMapOneToOne2Association<CKey, CVal>::produce(edm::Event& evt, const edm::EventSetup&) {
+void AssociationMapOneToOne2Association<CKey, CVal>::produce(edm::StreamID,
+                                                             edm::Event& evt,
+                                                             const edm::EventSetup&) const {
   using namespace edm;
   using namespace std;
   Handle<am_t> am;

--- a/CommonTools/UtilAlgos/interface/AssociationVector2ValueMap.h
+++ b/CommonTools/UtilAlgos/interface/AssociationVector2ValueMap.h
@@ -9,11 +9,11 @@
 
 #include "DataFormats/Common/interface/AssociationVector.h"
 #include "DataFormats/Common/interface/ValueMap.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 template <typename KeyRefProd, typename CVal>
-class AssociationVector2ValueMap : public edm::EDProducer {
+class AssociationVector2ValueMap : public edm::global::EDProducer<> {
 public:
   AssociationVector2ValueMap(const edm::ParameterSet&);
 
@@ -22,7 +22,7 @@ private:
   typedef typename CVal::value_type value_t;
   typedef edm::ValueMap<value_t> vm_t;
   typedef typename av_t::CKey collection_t;
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   edm::EDGetTokenT<av_t> av_;
 };
 
@@ -39,7 +39,9 @@ AssociationVector2ValueMap<KeyRefProd, CVal>::AssociationVector2ValueMap(const e
 }
 
 template <typename KeyRefProd, typename CVal>
-void AssociationVector2ValueMap<KeyRefProd, CVal>::produce(edm::Event& evt, const edm::EventSetup&) {
+void AssociationVector2ValueMap<KeyRefProd, CVal>::produce(edm::StreamID,
+                                                           edm::Event& evt,
+                                                           const edm::EventSetup&) const {
   using namespace edm;
   using namespace std;
   Handle<av_t> av;

--- a/CommonTools/UtilAlgos/interface/AssociationVectorSelector.h
+++ b/CommonTools/UtilAlgos/interface/AssociationVectorSelector.h
@@ -8,12 +8,12 @@
  */
 
 #include "DataFormats/Common/interface/AssociationVector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/UtilAlgos/interface/AnySelector.h"
 
 template <typename KeyRefProd, typename CVal, typename KeySelector = AnySelector, typename ValSelector = AnySelector>
-class AssociationVectorSelector : public edm::EDProducer {
+class AssociationVectorSelector : public edm::stream::EDProducer<> {
 public:
   AssociationVectorSelector(const edm::ParameterSet&);
 

--- a/CommonTools/UtilAlgos/interface/HistoAnalyzer.h
+++ b/CommonTools/UtilAlgos/interface/HistoAnalyzer.h
@@ -10,7 +10,7 @@
  * - C : Concrete candidate collection type
  *
  */
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -19,7 +19,7 @@
 #include "CommonTools/UtilAlgos/interface/ExpressionHisto.h"
 
 template <typename C>
-class HistoAnalyzer : public edm::EDAnalyzer {
+class HistoAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// constructor from parameter set
   HistoAnalyzer(const edm::ParameterSet&);
@@ -47,6 +47,7 @@ HistoAnalyzer<C>::HistoAnalyzer(const edm::ParameterSet& par)
       usingWeights_(par.exists("weights")),
       weightsToken_(
           mayConsume<double>(par.template getUntrackedParameter<edm::InputTag>("weights", edm::InputTag("fake")))) {
+  usesResource(TFileService::kSharedResource);
   edm::Service<TFileService> fs;
   std::vector<edm::ParameterSet> histograms = par.template getParameter<std::vector<edm::ParameterSet> >("histograms");
   std::vector<edm::ParameterSet>::const_iterator it = histograms.begin();

--- a/CommonTools/UtilAlgos/interface/NtpProducer.h
+++ b/CommonTools/UtilAlgos/interface/NtpProducer.h
@@ -10,7 +10,7 @@
  * - C : Concrete candidate collection type
  *
  */
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
@@ -18,7 +18,7 @@
 #include "CommonTools/Utils/interface/StringObjectFunction.h"
 
 template <typename C>
-class NtpProducer : public edm::EDProducer {
+class NtpProducer : public edm::stream::EDProducer<> {
 public:
   /// constructor from parameter set
   NtpProducer(const edm::ParameterSet&);


### PR DESCRIPTION
#### PR description:

- Switched to appropriate thread-friendly module types.

#### PR validation:

Code compiles and does not issue CMS deprecation warnings.