### PR TITLE
[12_4_X] Fix ThroughputServiceClient.cc unsigned variables overflow

### DIFF
--- a/HLTrigger/Timer/plugins/ThroughputServiceClient.cc
+++ b/HLTrigger/Timer/plugins/ThroughputServiceClient.cc
@@ -121,12 +121,12 @@ void ThroughputServiceClient::fillSummaryPlots(DQMStore::IBooker &booker, DQMSto
     width = avg_max - avg_min;
 
     // define the range for .../average_sourced
-    uint64_t first = sourced->FindFirstBinAbove(0.);
-    uint64_t last = sourced->FindLastBinAbove(0.);
+    int64_t first = sourced->FindFirstBinAbove(0.);
+    int64_t last = sourced->FindLastBinAbove(0.);
     booker.setCurrentFolder(folder);
     // (re)book and fill .../average_sourced
     average = booker.book1D("average_sourced", "Throughput (sourced events)", (int)width, avg_min, avg_max)->getTH1F();
-    for (unsigned int i = first; i <= last; ++i)
+    for (int64_t i = std::max(first, (int64_t)0); i <= last; ++i)
       average->Fill(sourced->GetBinContent(i));
 
     // define the range for .../average_retired
@@ -135,7 +135,7 @@ void ThroughputServiceClient::fillSummaryPlots(DQMStore::IBooker &booker, DQMSto
     booker.setCurrentFolder(folder);
     // (re)book and fill .../average_retired
     average = booker.book1D("average_retired", "Throughput (retired events)", (int)width, avg_min, avg_max)->getTH1F();
-    for (unsigned int i = first; i <= last; ++i)
+    for (int64_t i = std::max(first, (int64_t)0); i <= last; ++i)
       average->Fill(retired->GetBinContent(i));
   }
 }


### PR DESCRIPTION
#### PR description:

TH1F FindFirstBinAbove() can return -1 [0] when hist is empty overflowing unsigned variables uint64_t first and uint64_t last. The next two loops for (unsigned int i = first; i <= last; ++i) became very long and hlt_clientPB DQM client is not able to exit in time when the run is ended. Affect Online DQM operation.

[0] https://root.cern.ch/doc/master/classTH1.html#a63960594f84aea92e5fa2d5129b49007

#### PR validation:

Tested at P5 DQM playback.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/38282
