### PR TITLE
[12_4_X] Fix EMTF Run 3 CSC pattern calculation

### DIFF
--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -129,29 +129,6 @@ void PrimitiveConversion::convert_csc(int pc_sector,
     }
   }
 
-  // Calculate Pattern
-  unsigned pattern = tp_data.pattern;
-  const auto& detid(conv_hit.CreateCSCDetId());
-  const bool isOTMB(detid.isME11() or detid.isME21() or detid.isME31() or detid.isME41());
-  const bool isTMB((detid.isME12() or detid.isME22() or detid.isME32() or detid.isME42()) or (detid.isME13()));
-
-  // check if CCLUT is on for this CSC TP
-  const bool useRun3CCLUT((useRun3CCLUT_OTMB_ and isOTMB) or (useRun3CCLUT_TMB_ and isTMB));
-  if (useRun3CCLUT) {
-    // convert slope to Run-2 pattern for CSC TPs coming from MEX/1 chambers
-    // where the CCLUT algorithm is enabled
-    const unsigned slopeList[32] = {10, 10, 10, 8, 8, 8, 6, 6, 6, 4, 4, 4, 2, 2, 2, 2,
-                                    10, 10, 10, 9, 9, 9, 7, 7, 7, 5, 5, 5, 3, 3, 3, 3};
-
-    // this LUT follows the same convention as in CSCPatternBank.cc
-    unsigned slope_and_sign(tp_data.slope);
-    if (tp_data.bend == 0) {
-      slope_and_sign += 16;
-    }
-    unsigned run2_converted_PID = slopeList[slope_and_sign];
-    pattern = run2_converted_PID;
-  }
-
   // Set properties
   conv_hit.SetCSCDetId(tp_detId);
 
@@ -182,6 +159,30 @@ void PrimitiveConversion::convert_csc(int pc_sector,
   //conv_hit.set_strip_hi      ( tp_data.strip_hi );
   conv_hit.set_wire(tp_data.keywire);
   conv_hit.set_quality(tp_data.quality);
+
+  // Calculate Pattern
+  unsigned pattern = tp_data.pattern;
+  const auto& detid(conv_hit.CreateCSCDetId());
+  const bool isOTMB(detid.isME11() or detid.isME21() or detid.isME31() or detid.isME41());
+  const bool isTMB((detid.isME12() or detid.isME22() or detid.isME32() or detid.isME42()) or (detid.isME13()));
+
+  // check if CCLUT is on for this CSC TP
+  const bool useRun3CCLUT((useRun3CCLUT_OTMB_ and isOTMB) or (useRun3CCLUT_TMB_ and isTMB));
+  if (useRun3CCLUT) {
+    // convert slope to Run-2 pattern for CSC TPs coming from MEX/1 chambers
+    // where the CCLUT algorithm is enabled
+    const unsigned slopeList[32] = {10, 10, 10, 8, 8, 8, 6, 6, 6, 4, 4, 4, 2, 2, 2, 2,
+                                    10, 10, 10, 9, 9, 9, 7, 7, 7, 5, 5, 5, 3, 3, 3, 3};
+
+    // this LUT follows the same convention as in CSCPatternBank.cc
+    unsigned slope_and_sign(tp_data.slope);
+    if (tp_data.bend == 0) {
+      slope_and_sign += 16;
+    }
+    unsigned run2_converted_PID = slopeList[slope_and_sign];
+    pattern = run2_converted_PID;
+  }
+
   conv_hit.set_pattern(pattern);
   conv_hit.set_bend(tp_data.bend);
   conv_hit.set_time(0.);  // No fine resolution timing


### PR DESCRIPTION
#### PR description:

In `PrimitiveConversion` we use `CreateCSCDetId` to calculate the equivalent Run 2 pattern ID for Run 3 CSC TPs. This was being called before other information about the CSC hit was set, so it was not working properly before. Since Run 3 CSC TPs are not enabled in the emulator yet, this wasn't caught earlier.

I moved the code a couple of lines down and now it gets called after we set endcap, station, ring, and chamber informations to the hit. It now functions as it should.

No changes are epxected until we enable Run 3 CSC TPs


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated with local repository after enabling Run 3 CSC TPs and the run 2 pattern IDs are now set correctly.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

backport of #38319 