### PR TITLE
ECAL - Sort digis collections coming from GPU unpacking - 123x

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/EcalCPUDigisProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalCPUDigisProducer.cc
@@ -181,6 +181,9 @@ void EcalCPUDigisProducer::produce(edm::Event& event, edm::EventSetup const& set
   std::memcpy(idsEB, idsebtmp.data(), idsebtmp.size() * sizeof(uint32_t));
   std::memcpy(idsEE, idseetmp.data(), idseetmp.size() * sizeof(uint32_t));
 
+  digisEB->sort();
+  digisEE->sort();
+
   event.put(digisOutEBToken_, std::move(digisEB));
   event.put(digisOutEEToken_, std::move(digisEE));
 

--- a/HLTrigger/special/plugins/HLTEcalPhiSymFilter.cc
+++ b/HLTrigger/special/plugins/HLTEcalPhiSymFilter.cc
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "Calibration/Tools/interface/EcalRingCalibrationTools.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -126,7 +127,12 @@ bool HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
     float amplitude = hit.amplitude();
     if (statusCode <= statusThreshold_ && amplitude > ampCut) {
       const auto digiIt = EBDigis->find(hitDetId);
-      phiSymEBDigiCollection->push_back(digiIt->id(), digiIt->begin());
+      if (digiIt != EBDigis->end()) {
+        phiSymEBDigiCollection->push_back(digiIt->id(), digiIt->begin());
+      } else {
+        throw cms::Exception("DetIdNotFound") << "The detector ID " << hitDetId.rawId()
+                                              << " is not in the EB digis collection or the collection is not sorted.";
+      }
     }
   }
 
@@ -149,7 +155,12 @@ bool HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
     float amplitude = hit.amplitude();
     if (statusCode <= statusThreshold_ && amplitude > ampCut) {
       const auto digiIt = EEDigis->find(hitDetId);
-      phiSymEEDigiCollection->push_back(digiIt->id(), digiIt->begin());
+      if (digiIt != EEDigis->end()) {
+        phiSymEEDigiCollection->push_back(digiIt->id(), digiIt->begin());
+      } else {
+        throw cms::Exception("DetIdNotFound") << "The detector ID " << hitDetId.rawId()
+                                              << " is not in the EE digis collection or the collection is not sorted.";
+      }
     }
   }
 

--- a/HLTrigger/special/plugins/HLTEcalPhiSymFilter.cc
+++ b/HLTrigger/special/plugins/HLTEcalPhiSymFilter.cc
@@ -114,7 +114,7 @@ bool HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
     EBDetId hitDetId = hit.id();
     uint16_t statusCode = 0;
     if (useRecoFlag_)
-      statusCode = (*EBRechits->find(hit.id())).recoFlag();
+      statusCode = EBRechits->find(hitDetId)->recoFlag();
     else
       statusCode = channelStatus[itunb->id().rawId()].getStatusCode();
     int iRing = CalibRing.getRingIndex(hitDetId);
@@ -125,7 +125,8 @@ bool HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
       ampCut = ampCut_barlP_[iRing - N_RING_BARREL / 2];
     float amplitude = hit.amplitude();
     if (statusCode <= statusThreshold_ && amplitude > ampCut) {
-      phiSymEBDigiCollection->push_back((*EBDigis->find(hit.id())).id(), (*EBDigis->find(hit.id())).begin());
+      const auto digiIt = EBDigis->find(hitDetId);
+      phiSymEBDigiCollection->push_back(digiIt->id(), digiIt->begin());
     }
   }
 
@@ -136,7 +137,7 @@ bool HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
     EEDetId hitDetId = hit.id();
     uint16_t statusCode = 0;
     if (useRecoFlag_)
-      statusCode = (*EERechits->find(hit.id())).recoFlag();
+      statusCode = EERechits->find(hitDetId)->recoFlag();
     else
       statusCode = channelStatus[itune->id().rawId()].getStatusCode();
     int iRing = CalibRing.getRingIndex(hitDetId);
@@ -147,7 +148,8 @@ bool HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event& event, const edm::Ev
       ampCut = ampCut_endcP_[iRing - N_RING_BARREL - N_RING_ENDCAP / 2];
     float amplitude = hit.amplitude();
     if (statusCode <= statusThreshold_ && amplitude > ampCut) {
-      phiSymEEDigiCollection->push_back((*EEDigis->find(hit.id())).id(), (*EEDigis->find(hit.id())).begin());
+      const auto digiIt = EEDigis->find(hitDetId);
+      phiSymEEDigiCollection->push_back(digiIt->id(), digiIt->begin());
     }
   }
 


### PR DESCRIPTION
#### PR description:

Contrary to the ECAL digis collections unpacked on a CPU, which are sorted by detector ID, the collections produced from digis that were unpacked on GPU are unsorted. This causes problems with the `find()` function of the `edm::DataFrameContainer`, which only works for sorted detector IDs.
Sorting the collections produced by `EcalCPUDigisProducer` fixes this.

This also adds some code simplifications to `HLTEcalPhiSymFilter`, which is the module for which the issue manifested itself first.

Addresses https://its.cern.ch/jira/browse/CMSHLT-2335

#### PR validation:

The digis collection stored by `hltEcalPhiSymFilter` matches between CPU and GPU machines after sorting the collections.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #38321 needed for ECAL calibrations