### PR TITLE
Updating EGM regression tags and conditions for the L1 EMTF and CALO tags for Run-3 MCs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,21 +68,21 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '124X_mcRun3_2022_design_v4',
+    'phase1_2022_design'           : '124X_mcRun3_2022_design_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v4',
+    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v5',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v5',
+    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v4',
+    'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v4',
+    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v4',
+    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v4',
+    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v5',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '124X_mcRun4_realistic_v5'
+    'phase2_realistic'             : '124X_mcRun4_realistic_v6'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Requested in https://cms-talk.web.cern.ch/t/new-l1tags-included-in-124x-candidates-for-the-mc-production/11514 and in https://cms-talk.web.cern.ch/t/mc-gt-updating-electron-supercluster-regression-tags-for-eta-extended-electrons-incorporating-122x-ideal-ic-samples/11500

Diffs of the new GTs are
**phase1_2022_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_design_v4/124X_mcRun3_2022_design_v5

**phase1_2022_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_v4/124X_mcRun3_2022_realistic_v5

**phase1_2022_cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022cosmics_realistic_deco_v5/124X_mcRun3_2022cosmics_realistic_deco_v6

**phase1_2022_cosmics_design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022cosmics_design_deco_v4/124X_mcRun3_2022cosmics_design_deco_v5

**phase1_2022_realistic_hi**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_HI_v4/124X_mcRun3_2022_realistic_HI_v5

**phase1_2023_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2023_realistic_v4/124X_mcRun3_2023_realistic_v5

**phase1_2024_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2024_realistic_v4/124X_mcRun3_2024_realistic_v5

**phase2_realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun4_realistic_v5/124X_mcRun4_realistic_v6

#### PR validation:

```
test parameters:
  - workflows = 12034.0,11634.0,7.23,159.0,12434.0,12834.0
 ```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport but backport to 12_4_X is needed
