### PR TITLE
Fix range in recHitsEndcapsPosXY

### DIFF
--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorRecHitsSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorRecHitsSoA.cc
@@ -167,7 +167,7 @@ void SiPixelPhase1MonitorRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
     hBsizeyL[il] = iBook.book1D(Form("recHitsBLay%dSizey",il+1), Form("RecHits SizeY Barrel Layer%d;SizeY;#events",il+1), 50, 0, 50);
   }
   //Endcaps
-  hFposXY = iBook.book2D("recHitsEndcapsPosXY", "RecHits position Endcaps;X;Y", 200, -20, 20, 200,-20,-20);
+  hFposXY = iBook.book2D("recHitsEndcapsPosXY", "RecHits position Endcaps;X;Y", 200, -20, 20, 200,-20, 20);
   hFposZP = iBook.book2D("recHitsEndcapsPosZP", "RecHits position Endcaps;Z;#phi", 600, -60, 60, 200,-3.2,3.2);
   hFcharge = iBook.book1D("recHitsEndcapsCharge", "RecHits Charge Endcaps;Charge;#events", 250, 0, 100000);
   hFsizex = iBook.book1D("recHitsEndcapsSizex", "RecHits SizeX Endcaps;SizeX;#events", 50, 0, 50);


### PR DESCRIPTION
#### PR description:

During a fast track validation of HLT of a global tag @elfontan and @swagata87 found the error [1]
which complains that the range of `recHitsEndcapsPosXY` changed between the lumisections.
Looking at the code, the bug is evident and the bug fix is very trivial.

[1]
```
getting timing results...
Info in <TH2F::Add>: Attempt to add histograms with different axis limits - trying to use TH1::Merge
Error in <Merge>: Cannot merge histograms - limits are inconsistent:
 first: recHitsEndcapsPosXY (200, -19.000000, 18.600000), second: recHitsEndcapsPosXY (200, -19.000000, 18.800000)
Info in <TH2F::Add>: Attempt to add histograms with different axis limits - trying to use TH1::Merge
Error in <Merge>: Cannot merge histograms - limits are inconsistent:
 first: recHitsEndcapsPosXY (200, -19.000000, 18.600000), second: recHitsEndcapsPosXY (200, -19.000000, 18.800000)
DEBUG: Converting file /cmsnfsscratch/globalscratch/hltpro/fastTrack/reference_run352929/ref_DQM_hists.pb

[reference] DQM histograms (including timing) dumped to: ref_DQM_hists.root (copy to lxplus and open in TBrowser to examine timing plots)
Info in <TH2F::Add>: Attempt to add histograms with different axis limits - trying to use TH1::Merge
Error in <Merge>: Cannot merge histograms - limits are inconsistent:
 first: recHitsEndcapsPosXY (200, -19.000000, 18.000000), second: recHitsEndcapsPosXY (200, -19.000000, 18.800000)
Info in <TH2F::Add>: Attempt to add histograms with different axis limits - trying to use TH1::Merge
Error in <Merge>: Cannot merge histograms - limits are inconsistent:
 first: recHitsEndcapsPosXY (200, -19.000000, 18.000000), second: recHitsEndcapsPosXY (200, -19.000000, 18.800000)
Info in <TH2F::Add>: Attempt to add histograms with different axis limits - trying to use TH1::Merge
Error in <Merge>: Cannot merge histograms - limits are inconsistent:
 first: recHitsEndcapsPosXY (200, -19.000000, 18.000000), second: recHitsEndcapsPosXY (200, -19.000000, 18.800000)
Info in <TH2F::Add>: Attempt to add histograms with different axis limits - trying to use TH1::Merge
Error in <Merge>: Cannot merge histograms - limits are inconsistent:
 first: recHitsEndcapsPosXY (200, -19.000000, 18.000000), second: recHitsEndcapsPosXY (200, -19.000000, 18.800000)
DEBUG: Converting file /cmsnfsscratch/globalscratch/hltpro/fastTrack/test_run352929/test_DQM_hists.pb
[test, GT=123X_dataRun3_HLT_v11] DQM histograms (including timing) dumped to: test_DQM_hists.root (copy to lxplus and open in TBrowser to examine timing plots)
End of script.
```


#### PR validation:

Very trivial bug fix, I admit no validation...

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

We will need a backport down to 12_3_X for the data taking