### PR TITLE
[L1T] phase-2, update L1 emulation objects

### DIFF
--- a/DataFormats/L1TCorrelator/interface/TkElectronFwd.h
+++ b/DataFormats/L1TCorrelator/interface/TkElectronFwd.h
@@ -21,6 +21,7 @@ namespace l1t {
   typedef edm::RefVector<TkElectronCollection> TkElectronRefVector;
   typedef std::vector<TkElectronRef> TkElectronVectorRef;
   typedef l1t::RegionalOutput<l1t::TkElectronCollection> TkElectronRegionalOutput;
+  typedef l1t::RegionalOutput<l1t::TkElectronCollection> TkElectronRegionalOutput;
 
 }  // namespace l1t
 #endif

--- a/DataFormats/L1TCorrelator/interface/TkElectronFwd.h
+++ b/DataFormats/L1TCorrelator/interface/TkElectronFwd.h
@@ -21,7 +21,6 @@ namespace l1t {
   typedef edm::RefVector<TkElectronCollection> TkElectronRefVector;
   typedef std::vector<TkElectronRef> TkElectronVectorRef;
   typedef l1t::RegionalOutput<l1t::TkElectronCollection> TkElectronRegionalOutput;
-  typedef l1t::RegionalOutput<l1t::TkElectronCollection> TkElectronRegionalOutput;
 
 }  // namespace l1t
 #endif

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -71,6 +71,10 @@ _phase2_siml1emulator = SimL1EmulatorTask.copy()
 # ########################################################################
 # Phase-2 Trigger Primitives
 # ########################################################################
+from L1Trigger.DTTriggerPhase2.CalibratedDigis_cfi import *
+_phase2_siml1emulator.add(CalibratedDigis)
+from L1Trigger.DTTriggerPhase2.dtTriggerPhase2PrimitiveDigis_cfi import *
+_phase2_siml1emulator.add(dtTriggerPhase2PrimitiveDigis)
 
 # HGCAL TP 
 # ########################################################################
@@ -90,17 +94,54 @@ _phase2_siml1emulator.add(L1EGammaClusterEmuProducer)
 from L1Trigger.L1CaloTrigger.l1EGammaEEProducer_cfi import *
 _phase2_siml1emulator.add(l1EGammaEEProducer)
 
+# Barrel and EndCap CaloJet/HT
+# ########################################################################
+# ----    Produce the calibrated tower collection combining Barrel, HGCal, HF
+from L1Trigger.L1CaloTrigger.L1TowerCalibrationProducer_cfi import *
+L1TowerCalibration = L1TowerCalibrationProducer.clone(
+  L1HgcalTowersInputTag = cms.InputTag("hgcalTowerProducer","HGCalTowerProcessor",""),
+  #l1CaloTowers = cms.InputTag("L1EGammaClusterEmuProducer","","")
+  l1CaloTowers = cms.InputTag("L1EGammaClusterEmuProducer","L1CaloTowerCollection","")
+)
+# ----    Produce the L1CaloJets
+from L1Trigger.L1CaloTrigger.L1CaloJetProducer_cfi import *
+L1CaloJet = L1CaloJetProducer.clone (
+    l1CaloTowers = cms.InputTag("L1TowerCalibration","L1CaloTowerCalibratedCollection",""),
+    L1CrystalClustersInputTag = cms.InputTag("L1EGammaClusterEmuProducer", "","")
+)
+# ----    Produce the CaloJet HTT Sums
+from L1Trigger.L1CaloTrigger.L1CaloJetHTTProducer_cfi import *
+L1CaloJetHTT = L1CaloJetHTTProducer.clone(
+    BXVCaloJetsInputTag = cms.InputTag("L1CaloJet", "CaloJets") 
+)
+
+
+_phase2_siml1emulator.add(L1TowerCalibration)
+_phase2_siml1emulator.add(L1CaloJet)
+_phase2_siml1emulator.add(L1CaloJetHTT)
+
 # ########################################################################
 # Phase-2 L1T - TrackTrigger dependent modules
 # ########################################################################
+from L1Trigger.L1TTrackMatch.L1GTTInputProducer_cfi import *
+from L1Trigger.VertexFinder.VertexProducer_cff import *
+L1VertexFinder = VertexProducer.clone()
+L1VertexFinderEmulator = VertexProducer.clone()
+L1VertexFinderEmulator.VertexReconstruction.Algorithm = "fastHistoEmulation"
+L1VertexFinderEmulator.l1TracksInputTag = cms.InputTag("L1GTTInputProducer","Level1TTTracksConverted")
+_phase2_siml1emulator.add(L1VertexFinder)
+_phase2_siml1emulator.add(L1GTTInputProducer)
+_phase2_siml1emulator.add(L1GTTInputProducerExtended)
+_phase2_siml1emulator.add(L1VertexFinderEmulator)
 
 # Tk + StandaloneObj, including L1TkPrimaryVertex
 # ########################################################################
 
 from L1Trigger.L1TTrackMatch.L1TkPrimaryVertexProducer_cfi import L1TkPrimaryVertex
-from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkElectronsCrystal, L1TkElectronsLooseCrystal, L1TkElectronsEllipticMatchCrystal, L1TkIsoElectronsCrystal, L1TkElectronsHGC, L1TkElectronsEllipticMatchHGC, L1TkIsoElectronsHGC
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import L1TkElectronsCrystal, L1TkElectronsLooseCrystal, L1TkElectronsEllipticMatchCrystal, L1TkIsoElectronsCrystal, L1TkElectronsHGC, L1TkElectronsEllipticMatchHGC, L1TkIsoElectronsHGC, L1TkElectronsLooseHGC
 from L1Trigger.L1TTrackMatch.L1TkEmParticleProducer_cfi import L1TkPhotonsCrystal, L1TkPhotonsHGC
-from L1Trigger.L1TTrackMatch.L1TkMuonProducer_cfi import L1TkMuons
+from L1Trigger.L1TTrackMatch.L1TkMuonProducer_cfi import L1TkMuons, L1TkMuonsTP
+from L1Trigger.L1TTrackMatch.L1TkGlbMuonProducer_cfi import L1TkGlbMuons
 
 _phase2_siml1emulator.add(L1TkPrimaryVertex)
 
@@ -112,43 +153,105 @@ _phase2_siml1emulator.add(L1TkPhotonsCrystal)
 
 _phase2_siml1emulator.add(L1TkElectronsHGC)
 _phase2_siml1emulator.add(L1TkElectronsEllipticMatchHGC)
+_phase2_siml1emulator.add(L1TkElectronsLooseHGC)
 _phase2_siml1emulator.add(L1TkIsoElectronsHGC)
 _phase2_siml1emulator.add(L1TkPhotonsHGC)
 
 _phase2_siml1emulator.add( L1TkMuons )
+_phase2_siml1emulator.add( L1TkMuonsTP )
+_phase2_siml1emulator.add( L1TkGlbMuons )
+
+
+# Emulated GMT Muons (Tk + Stub, Tk + MuonTFT, StandaloneMuon)
+# ########################################################################
+from L1Trigger.Phase2L1GMT.gmt_cfi  import *
+L1TkStubsGmt = gmtStubs.clone()
+L1TkMuonsGmt = gmtMuons.clone(
+    srcStubs  = cms.InputTag('L1TkStubsGmt')
+)
+L1SAMuonsGmt = standaloneMuons.clone()
+_phase2_siml1emulator.add( L1TkStubsGmt )
+_phase2_siml1emulator.add( L1TkMuonsGmt )
+_phase2_siml1emulator.add( L1SAMuonsGmt )
+
+# Tracker Objects
+# ########################################################################
+from L1Trigger.L1TTrackMatch.L1TrackJetProducer_cfi import *
+from L1Trigger.L1TTrackMatch.L1TrackFastJetProducer_cfi import *
+from L1Trigger.L1TTrackMatch.L1TrackerEtMissProducer_cfi import *
+from L1Trigger.L1TTrackMatch.L1TkHTMissProducer_cfi import *
+# make the input tags consistent with the choice L1VertexFinder above
+L1TrackJets.L1PVertexCollection  = cms.InputTag("L1VertexFinder", L1VertexFinder.l1VertexCollectionName.value())
+L1TrackJetsExtended.L1PVertexCollection  = cms.InputTag("L1VertexFinder", L1VertexFinder.l1VertexCollectionName.value())
+L1TrackerEtMiss.L1VertexInputTag = cms.InputTag("L1VertexFinder", L1VertexFinder.l1VertexCollectionName.value())
+L1TrackerEtMissExtended.L1VertexInputTag = cms.InputTag("L1VertexFinder", L1VertexFinder.l1VertexCollectionName.value())
+_phase2_siml1emulator.add(L1TrackJets)
+_phase2_siml1emulator.add(L1TrackJetsExtended)
+_phase2_siml1emulator.add(L1TrackFastJets)
+
+_phase2_siml1emulator.add(L1TrackerEtMiss)
+_phase2_siml1emulator.add(L1TrackerHTMiss)
+#_phase2_siml1emulator.add(L1TrackerEtMissExtended)
+#_phase2_siml1emulator.add(L1TrackerHTMissExtended)
+
+#Emulated tracker objects
+from L1Trigger.L1TTrackMatch.L1TrackJetEmulationProducer_cfi import *
+_phase2_siml1emulator.add(L1TrackJetsEmulation)
+_phase2_siml1emulator.add(L1TrackJetsExtendedEmulation)
+
+from L1Trigger.L1TTrackMatch.L1TrackerEtMissEmulatorProducer_cfi import *
+L1TrackerEmuEtMiss.L1VertexInputTag = cms.InputTag("L1VertexFinderEmulator","l1verticesEmulation")
+_phase2_siml1emulator.add(L1TrackerEmuEtMiss)
+
+from L1Trigger.L1TTrackMatch.L1TkHTMissEmulatorProducer_cfi import *
+_phase2_siml1emulator.add(L1TrackerEmuHTMiss)
+_phase2_siml1emulator.add(L1TrackerEmuHTMissExtended)
 
 # PF Candidates
 # ########################################################################
 from L1Trigger.Phase2L1ParticleFlow.l1ParticleFlow_cff import *
 _phase2_siml1emulator.add(l1ParticleFlowTask)
+from L1Trigger.Phase2L1ParticleFlow.l1ctLayer1_cff import *
+from L1Trigger.Phase2L1ParticleFlow.l1ctLayer2EG_cff import *
+_phase2_siml1emulator.add(l1ctLayer1TaskInputsTask, l1ctLayer1Task, l1ctLayer2EGTask)
 
 # PF Jet
 # ########################################################################
 from L1Trigger.L1CaloTrigger.Phase1L1TJets_cff import *
 # Describe here l1PFJets_a_la_Phase1 Task
 # ###############################
-l1PFJetsPhase1Task = cms.Task(Phase1L1TJetProducer , Phase1L1TJetCalibrator)
+l1PFJetsPhase1Task = cms.Task(Phase1L1TJetProducer , Phase1L1TJetCalibrator, Phase1L1TJetSumsProducer)
 _phase2_siml1emulator.add(l1PFJetsPhase1Task)
+
+from L1Trigger.Phase2L1Taus.HPSPFTauProducerPF_cfi import *
+_phase2_siml1emulator.add(HPSPFTauProducerPF)
+
+from L1Trigger.Phase2L1Taus.HPSPFTauProducerPuppi_cfi import *
+_phase2_siml1emulator.add(HPSPFTauProducerPuppi)
+
+from L1Trigger.L1CaloTrigger.Phase1L1TJets_9x9_cff import *
+l1PFJetsPhase1Task_9x9 = cms.Task(  Phase1L1TJetProducer9x9, Phase1L1TJetCalibrator9x9, Phase1L1TJetSumsProducer9x9)
+_phase2_siml1emulator.add(l1PFJetsPhase1Task_9x9)
+
 
 # PF MET
 # ########################################################################
 from L1Trigger.Phase2L1ParticleFlow.l1pfJetMet_cff import *
-# Describe here l1PFMets Task
-# ###############################
-l1PFMetsTask = cms.Task(l1PFMetCalo , l1PFMetPF , l1PFMetPuppi)
+_phase2_siml1emulator.add(l1PFJetsTask)
 _phase2_siml1emulator.add(l1PFMetsTask)
+
+from L1Trigger.Phase2L1ParticleFlow.L1MetPfProducer_cfi import *
+_phase2_siml1emulator.add(L1MetPfProducer)
+
 
 # NNTaus
 # ########################################################################
 from L1Trigger.Phase2L1ParticleFlow.L1NNTauProducer_cff import *
-l1NNTauProducer = L1NNTauProducer.clone(
-  L1PFObjects = cms.InputTag("l1pfCandidates","PF")
-)
-l1NNTauProducerPuppi = L1NNTauProducerPuppi.clone(
-  L1PFObjects = cms.InputTag("l1pfCandidates","Puppi")
-)
-_phase2_siml1emulator.add(l1NNTauProducer)
-_phase2_siml1emulator.add(l1NNTauProducerPuppi)
+
+_phase2_siml1emulator.add(L1NNTauProducerPuppi)
+#_phase2_siml1emulator.add(L1NNTauProducerPuppi2Vtx)
+_phase2_siml1emulator.add(tau2VtxTaskHW)
+
 
 # --> add modules
 from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -237,7 +237,7 @@ _phase2_siml1emulator.add(l1PFJetsPhase1Task_9x9)
 # PF MET
 # ########################################################################
 from L1Trigger.Phase2L1ParticleFlow.l1pfJetMet_cff import *
-_phase2_siml1emulator.add(l1PFJetsTask)
+#_phase2_siml1emulator.add(l1PFJetsTask)
 _phase2_siml1emulator.add(l1PFMetsTask)
 
 from L1Trigger.Phase2L1ParticleFlow.L1MetPfProducer_cfi import *
@@ -249,9 +249,6 @@ _phase2_siml1emulator.add(L1MetPfProducer)
 from L1Trigger.Phase2L1ParticleFlow.L1NNTauProducer_cff import *
 
 _phase2_siml1emulator.add(L1NNTauProducerPuppi)
-#_phase2_siml1emulator.add(L1NNTauProducerPuppi2Vtx)
-_phase2_siml1emulator.add(tau2VtxTaskHW)
-
 
 # --> add modules
 from Configuration.Eras.Modifier_phase2_trigger_cff import phase2_trigger


### PR DESCRIPTION
#### PR description:

Porting leftovers of https://github.com/cms-l1t-offline/cmssw/pull/996 in cms-l1t-offline. Mostly changes to SimL1Emulator