### PR TITLE
[Backport] Updates related to the L1 menu v1_1_0 for the start of Run 3

### DIFF
--- a/L1Trigger/Configuration/python/customiseUtils.py
+++ b/L1Trigger/Configuration/python/customiseUtils.py
@@ -76,7 +76,7 @@ def L1TGlobalDigisSummary(process):
 def L1TGlobalMenuXML(process):
     process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
     process.load('L1Trigger.L1TGlobal.TriggerMenu_cff')
-    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2022_v1_0_0.xml')
+    process.TriggerMenu.L1TriggerMenuFile = cms.string('L1Menu_Collisions2022_v1_1_0.xml')
     return process
 
 def L1TGlobalSimDigisSummary(process):

--- a/L1Trigger/L1TGlobal/python/PrescalesVetosFract_cff.py
+++ b/L1Trigger/L1TGlobal/python/PrescalesVetosFract_cff.py
@@ -16,8 +16,8 @@ L1TGlobalPrescalesVetosFract = cms.ESProducer("L1TGlobalPrescalesVetosFractESPro
     TriggerMenuLuminosity = cms.string('startup'),
     Verbosity = cms.int32(0),
     AlgoBxMaskDefault = cms.int32(1),
-    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_L1MenuCollisions2022_v1_0_0.xml'),
-    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_L1MenuCollisions2022_v1_0_0.xml'),
-    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_L1MenuCollisions2022_v1_0_0.xml'),
-    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_L1MenuCollisions2022_v1_0_0.xml'),
+    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_L1MenuCollisions2022_v1_1_0.xml'),
+    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_L1MenuCollisions2022_v1_1_0.xml'),
+    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_L1MenuCollisions2022_v1_1_0.xml'),
+    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_L1MenuCollisions2022_v1_1_0.xml'),
 )

--- a/L1Trigger/L1TGlobal/python/PrescalesVetos_cff.py
+++ b/L1Trigger/L1TGlobal/python/PrescalesVetos_cff.py
@@ -15,10 +15,10 @@ L1TGlobalPrescalesVetos = cms.ESProducer("L1TGlobalPrescalesVetosESProducer",
     TriggerMenuLuminosity = cms.string('startup'),
     Verbosity = cms.int32(0),
     AlgoBxMaskDefault = cms.int32(1),
-    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_L1MenuCollisions2022_v1_0_0.xml'),
-    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_L1MenuCollisions2022_v1_0_0.xml'),
-    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_L1MenuCollisions2022_v1_0_0.xml'),
-    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_L1MenuCollisions2022_v1_0_0.xml'),
+    PrescaleXMLFile = cms.string('UGT_BASE_RS_PRESCALES_L1MenuCollisions2022_v1_1_0.xml'),
+    AlgoBxMaskXMLFile = cms.string('UGT_BASE_RS_ALGOBX_MASK_L1MenuCollisions2022_v1_1_0.xml'),
+    FinOrMaskXMLFile = cms.string('UGT_BASE_RS_FINOR_MASK_L1MenuCollisions2022_v1_1_0.xml'),
+    VetoMaskXMLFile = cms.string('UGT_BASE_RS_VETO_MASK_L1MenuCollisions2022_v1_1_0.xml'),
 )
 
 

--- a/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
+++ b/L1Trigger/L1TGlobal/test/runGlobalFakeInputProducer.py
@@ -105,13 +105,7 @@ process.TFileService.fileName = cms.string('l1t_histos.root')
 
 # Other statements
 from Configuration.AlCa.GlobalTag import GlobalTag
-## process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS1', '')
-#process.GlobalTag = GlobalTag(process.GlobalTag, '106X_upgrade2018_realistic_v11', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, '112X_mcRun2_asymptotic_v2', '')
-## process.GlobalTag = GlobalTag(process.GlobalTag, '90X_upgrade2017_realistic_PerfectEcalIc_EGM_PFCalib', '')
-## auto:upgradePLS1
-## 81X_upgrade2017_realistic_v26
-## 80X_mcRun2_asymptotic_v14
+process.GlobalTag = GlobalTag(process.GlobalTag, '123X_mcRun3_2021_realistic_v13', '')
 
 ## ## needed until prescales go into GlobalTag ########################
 ## from CondCore.DBCommon.CondDBSetup_cfi import CondDBSetup
@@ -210,7 +204,7 @@ process.load('L1Trigger.L1TGlobal.GlobalParameters_cff')
 
 process.load("L1Trigger.L1TGlobal.TriggerMenu_cff")
 
-xmlMenu="L1Menu_Collisions2022_v1_0_0.xml"
+xmlMenu="L1Menu_Collisions2022_v1_1_0.xml"
 process.TriggerMenu.L1TriggerMenuFile = cms.string(xmlMenu)
 process.ESPreferL1TXML = cms.ESPrefer("L1TUtmTriggerMenuESProducer","TriggerMenu")
 


### PR DESCRIPTION
#### PR description:
Backport of https://github.com/cms-sw/cmssw/pull/38250 to **CMSSW_12_4_0**.

A full set of xml files for the L1 emulation of prescales and masks coherent with the updated L1 menu for Run 3 has been created and pushed to [L1Trigger-L1TGlobal](https://github.com/cms-data/L1Trigger-L1TGlobal) ([PR#11](https://github.com/cms-data/L1Trigger-L1TGlobal/pull/11)). A backport of these files has been requested in the github issue https://github.com/cms-data/L1Trigger-L1TGlobal/issues/12. Changes will be backported to **CMSSW_12_4_0** in **cms-sw/cmsdist** after the tests: [PR#7926](https://github.com/cms-sw/cmsdist/pull/7926) for 12_4_X cms-dist ready.

#### PR validation:
Basic tests performed successfully starting from CMSSW_12_4_X_2022-06-10-2300.
> cmsrel CMSSW_12_4_X_2022-06-10-2300 
> cd CMSSW_12_4_X_2022-06-10-2300/src
> cmsenv
> git cms-addpkg L1Trigger/Configuration
> git cms-addpkg L1Trigger/L1TGlobal
> cd L1Trigger/L1TGlobal
> mkdir -p data/Luminosity/startup
> wget https://raw.githubusercontent.com/cms-l1-dpg/L1MenuRun3/master/development/L1Menu_Collisions2022_v1_1_0/L1Menu_Collisions2022_v1_1_0.xml 
> cd -
> git cherry-pick df9c038b41c74105effa5a7df3d8ecb02473b1f5
> scram b distclean 
> git cms-checkdeps -a -A
> scram b -j 8
> scram b runtests 
> scram build code-checks
> scram build code-format
