### PR TITLE
[Fix] Put sampic subdet id behind the era modifier

### DIFF
--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -88,6 +88,9 @@ private:
   /// label of the CTPPS sub-system
   string subSystemName;
 
+  //subdetector id for sampic
+  unsigned int sampicSubDetId;
+
   /// the mapping files
   std::vector<std::string> mappingFileNames;
 
@@ -245,6 +248,7 @@ const string TotemDAQMappingESSourceXML::tagTotemTimingPlane = "timing_plane";
 TotemDAQMappingESSourceXML::TotemDAQMappingESSourceXML(const edm::ParameterSet &conf)
     : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
       subSystemName(conf.getUntrackedParameter<string>("subSystem")),
+      sampicSubDetId(conf.getUntrackedParameter<unsigned int>("sampicSubDetId", 5)),
       currentBlock(0),
       currentBlockValid(false) {
   for (const auto &it : conf.getParameter<vector<ParameterSet>>("configuration")) {
@@ -754,13 +758,12 @@ void TotemDAQMappingESSourceXML::ParseTreeTotemTiming(ParseType pType,
       unsigned int StationNum = (parentID / 1000) % 10;
       unsigned int RpNum = (parentID / 100) % 10;
 
-      vfatInfo.symbolicID.symbolicID =
-          TotemTimingDetId(ArmNum,
-                           StationNum,
-                           RpNum,
-                           0,
-                           TotemTimingDetId::ID_NOT_SET,
-                           TotemTimingDetId::sdTimingDiamond);  //Dynamical: it is encoded in the frame
+      vfatInfo.symbolicID.symbolicID = TotemTimingDetId(ArmNum,
+                                                        StationNum,
+                                                        RpNum,
+                                                        0,
+                                                        TotemTimingDetId::ID_NOT_SET,
+                                                        sampicSubDetId);  //Dynamical: it is encoded in the frame
 
       mapping->insert(framepos, vfatInfo);
 

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -104,6 +104,7 @@ ctppsDiamondRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXML",
   verbosity = cms.untracked.uint32(10),
   subSystem = cms.untracked.string("TotemTiming"),
+  sampicSubDetId = cms.untracked.uint32(5),
   configuration = cms.VPSet(
     # 2017, before detector inserted in DAQ
     cms.PSet(
@@ -137,6 +138,7 @@ from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 (ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = False )
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemDAQMappingESSourceXML_TotemTiming, sampicSubDetId = cms.untracked.uint32(6) )
 
 # raw-to-digi task and sequence
 ctppsRawToDigiTask = cms.Task(


### PR DESCRIPTION
#### PR description:
This PR puts the totemTimingDetId subdetector behind the era modifier. For Run3 subdet=5, for 2016,2017,2018 subdet=6
resolves https://github.com/cms-sw/cmssw/issues/38268

#### PR validation:
PR was tested with  136.8562 which was previously failing.

This PR needs to be backported to 12_4 and 12_3.
