### PR TITLE
[EGM MVA ID] xml.gz to root conversion 

### DIFF
--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_iso_V1_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_iso_V1_cff.py
@@ -26,12 +26,12 @@ mvaTag = "Fall17IsoV1"
 
 
 mvaFall17WeightFiles_V1 = cms.vstring(
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_5_2017_puinfo_iso_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_5_2017_puinfo_iso_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_5_2017_puinfo_iso_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_10_2017_puinfo_iso_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_10_2017_puinfo_iso_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_10_2017_puinfo_iso_BDT.weights.xml.gz"
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_5_2017_puinfo_iso_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_5_2017_puinfo_iso_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_5_2017_puinfo_iso_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_10_2017_puinfo_iso_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_10_2017_puinfo_iso_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_10_2017_puinfo_iso_BDT.weights.root"
     )
 
 ## The working point for this MVA that is expected to have about 90% signal

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_iso_V2_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_iso_V2_cff.py
@@ -10,12 +10,12 @@ mvaTag = "Fall17IsoV2"
 weightFileDir = "RecoEgamma/ElectronIdentification/data/MVAWeightFiles/Fall17IsoV2"
 
 mvaWeightFiles = [
-     path.join(weightFileDir, "EB1_5.weights.xml.gz"), # EB1_5
-     path.join(weightFileDir, "EB2_5.weights.xml.gz"), # EB2_5
-     path.join(weightFileDir, "EE_5.weights.xml.gz"), # EE_5
-     path.join(weightFileDir, "EB1_10.weights.xml.gz"), # EB1_10
-     path.join(weightFileDir, "EB2_10.weights.xml.gz"), # EB2_10
-     path.join(weightFileDir, "EE_10.weights.xml.gz"), # EE_10
+     path.join(weightFileDir, "EB1_5.weights.root"), # EB1_5
+     path.join(weightFileDir, "EB2_5.weights.root"), # EB2_5
+     path.join(weightFileDir, "EE_5.weights.root"), # EE_5
+     path.join(weightFileDir, "EB1_10.weights.root"), # EB1_10
+     path.join(weightFileDir, "EB2_10.weights.root"), # EB2_10
+     path.join(weightFileDir, "EE_10.weights.root"), # EE_10
      ]
 
 mvaEleID_Fall17_iso_V2_wpHZZ_container = EleMVARaw_WP(

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_noIso_V1_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_noIso_V1_cff.py
@@ -26,12 +26,12 @@ mvaTag = "Fall17NoIsoV1"
 
 
 mvaFall17WeightFiles_V1 = cms.vstring(
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_5_2017_puinfo_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_5_2017_puinfo_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_5_2017_puinfo_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_10_2017_puinfo_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_10_2017_puinfo_BDT.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_10_2017_puinfo_BDT.weights.xml.gz"
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_5_2017_puinfo_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_5_2017_puinfo_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_5_2017_puinfo_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB1_10_2017_puinfo_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EB2_10_2017_puinfo_BDT.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Fall17/EIDmva_EE_10_2017_puinfo_BDT.weights.root"
     )
 
 ## The working point for this MVA that is expected to have about 90% signal

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_noIso_V2_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Fall17_noIso_V2_cff.py
@@ -10,12 +10,12 @@ mvaTag = "Fall17NoIsoV2"
 weightFileDir = "RecoEgamma/ElectronIdentification/data/MVAWeightFiles/Fall17NoIsoV2"
 
 mvaWeightFiles = cms.vstring(
-     path.join(weightFileDir, "EB1_5.weights.xml.gz"), # EB1_5
-     path.join(weightFileDir, "EB2_5.weights.xml.gz"), # EB2_5
-     path.join(weightFileDir, "EE_5.weights.xml.gz"), # EE_5
-     path.join(weightFileDir, "EB1_10.weights.xml.gz"), # EB1_10
-     path.join(weightFileDir, "EB2_10.weights.xml.gz"), # EB2_10
-     path.join(weightFileDir, "EE_10.weights.xml.gz"), # EE_10
+     path.join(weightFileDir, "EB1_5.weights.root"), # EB1_5
+     path.join(weightFileDir, "EB2_5.weights.root"), # EB2_5
+     path.join(weightFileDir, "EE_5.weights.root"), # EE_5
+     path.join(weightFileDir, "EB1_10.weights.root"), # EB1_10
+     path.join(weightFileDir, "EB2_10.weights.root"), # EB2_10
+     path.join(weightFileDir, "EE_10.weights.root"), # EE_10
      )
 
 mvaEleID_Fall17_noIso_V2_wp80_container = EleMVARaw_WP(

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Spring16_GeneralPurpose_V1_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Spring16_GeneralPurpose_V1_cff.py
@@ -25,9 +25,9 @@ mvaTag = "Spring16GeneralPurposeV1"
 #   2   EE             pt 10-inf GeV
 
 mvaSpring16WeightFiles_V1 = cms.vstring(
-    "RecoEgamma/ElectronIdentification/data/Spring16_GeneralPurpose_V1/electronID_mva_Spring16_GeneralPurpose_V1_EB1_10.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Spring16_GeneralPurpose_V1/electronID_mva_Spring16_GeneralPurpose_V1_EB2_10.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Spring16_GeneralPurpose_V1/electronID_mva_Spring16_GeneralPurpose_V1_EE_10.weights.xml.gz"
+    "RecoEgamma/ElectronIdentification/data/Spring16_GeneralPurpose_V1/electronID_mva_Spring16_GeneralPurpose_V1_EB1_10.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Spring16_GeneralPurpose_V1/electronID_mva_Spring16_GeneralPurpose_V1_EB2_10.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Spring16_GeneralPurpose_V1/electronID_mva_Spring16_GeneralPurpose_V1_EE_10.weights.root"
     )
 
 ### WP to give about 90 and 80% signal efficiecny for electrons from Drell-Yan with pT > 25 GeV

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Spring16_HZZ_V1_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Spring16_HZZ_V1_cff.py
@@ -31,12 +31,12 @@ mvaTag = "Spring16HZZV1"
 #   5   EE             pt 10-inf GeV
 
 mvaSpring16WeightFiles_V1 = cms.vstring(
-    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EB1_5.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EB2_5.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EE_5.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EB1_10.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EB2_10.weights.xml.gz",
-    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EE_10.weights.xml.gz"
+    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EB1_5.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EB2_5.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EE_5.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EB1_10.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EB2_10.weights.root",
+    "RecoEgamma/ElectronIdentification/data/Spring16_HZZ_V1/electronID_mva_Spring16_HZZ_V1_EE_10.weights.root"
     )
 
 ### WP tuned for HZZ analysis with very high efficiency (about 98%)

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer16UL_ID_ISO_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer16UL_ID_ISO_cff.py
@@ -7,12 +7,12 @@ mvaTag = "Summer16ULIdIso"
 weightFileDir = "RecoEgamma/ElectronIdentification/data/MVAWeightFiles/Summer_16UL_ID_ISO"
 
 mvaWeightFiles = cms.vstring(
-     path.join(weightFileDir, "EB1_5.weights.xml.gz"), # EB1_5
-     path.join(weightFileDir, "EB2_5.weights.xml.gz"), # EB2_5
-     path.join(weightFileDir, "EE_5.weights.xml.gz"), # EE_5
-     path.join(weightFileDir, "EB1_10.weights.xml.gz"), # EB1_10
-     path.join(weightFileDir, "EB2_10.weights.xml.gz"), # EB2_10
-     path.join(weightFileDir, "EE_10.weights.xml.gz"), # EE_10
+     path.join(weightFileDir, "EB1_5.weights.root"), # EB1_5
+     path.join(weightFileDir, "EB2_5.weights.root"), # EB2_5
+     path.join(weightFileDir, "EE_5.weights.root"), # EE_5
+     path.join(weightFileDir, "EB1_10.weights.root"), # EB1_10
+     path.join(weightFileDir, "EB2_10.weights.root"), # EB2_10
+     path.join(weightFileDir, "EE_10.weights.root"), # EE_10
      )
 
 categoryCuts = cms.vstring(

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer17UL_ID_ISO_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer17UL_ID_ISO_cff.py
@@ -7,12 +7,12 @@ mvaTag = "Summer17ULIdIso"
 weightFileDir = "RecoEgamma/ElectronIdentification/data/MVAWeightFiles/Summer_17UL_ID_ISO"
 
 mvaWeightFiles = cms.vstring(
-     path.join(weightFileDir, "EB1_5.weights.xml.gz"), # EB1_5
-     path.join(weightFileDir, "EB2_5.weights.xml.gz"), # EB2_5
-     path.join(weightFileDir, "EE_5.weights.xml.gz"), # EE_5
-     path.join(weightFileDir, "EB1_10.weights.xml.gz"), # EB1_10
-     path.join(weightFileDir, "EB2_10.weights.xml.gz"), # EB2_10
-     path.join(weightFileDir, "EE_10.weights.xml.gz"), # EE_10
+     path.join(weightFileDir, "EB1_5.weights.root"), # EB1_5
+     path.join(weightFileDir, "EB2_5.weights.root"), # EB2_5
+     path.join(weightFileDir, "EE_5.weights.root"), # EE_5
+     path.join(weightFileDir, "EB1_10.weights.root"), # EB1_10
+     path.join(weightFileDir, "EB2_10.weights.root"), # EB2_10
+     path.join(weightFileDir, "EE_10.weights.root"), # EE_10
      )
 
 categoryCuts = cms.vstring(

--- a/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer18UL_ID_ISO_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/mvaElectronID_Summer18UL_ID_ISO_cff.py
@@ -7,12 +7,12 @@ mvaTag = "Summer18ULIdIso"
 weightFileDir = "RecoEgamma/ElectronIdentification/data/MVAWeightFiles/Summer_18UL_ID_ISO"
 
 mvaWeightFiles = cms.vstring(
-     path.join(weightFileDir, "EB1_5.weights.xml.gz"), # EB1_5
-     path.join(weightFileDir, "EB2_5.weights.xml.gz"), # EB2_5
-     path.join(weightFileDir, "EE_5.weights.xml.gz"), # EE_5
-     path.join(weightFileDir, "EB1_10.weights.xml.gz"), # EB1_10
-     path.join(weightFileDir, "EB2_10.weights.xml.gz"), # EB2_10
-     path.join(weightFileDir, "EE_10.weights.xml.gz"), # EE_10
+     path.join(weightFileDir, "EB1_5.weights.root"), # EB1_5
+     path.join(weightFileDir, "EB2_5.weights.root"), # EB2_5
+     path.join(weightFileDir, "EE_5.weights.root"), # EE_5
+     path.join(weightFileDir, "EB1_10.weights.root"), # EB1_10
+     path.join(weightFileDir, "EB2_10.weights.root"), # EB2_10
+     path.join(weightFileDir, "EE_10.weights.root"), # EE_10
      )
 
 categoryCuts = cms.vstring(


### PR DESCRIPTION
#### PR description:
This is a technical PR, and no change in physics is expected.
This is aimed at addressing the github issue https://github.com/cms-sw/cmssw/issues/37867 (and also https://github.com/cms-sw/cmssw/issues/38089, which is basically the same). The needed functionality is recently provided via https://github.com/cms-sw/cmssw/pull/38091 , which was merged some days ago. 

Electron MVA ID's xml.gz files are converted to .root files by using `convertXMLToGBRForestROOT`.
This PR requires this external: https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/26

#### PR validation:
Tested with workflow `11834.21`. 

This PR is not a backport. 
Backport not necessary.