### PR TITLE
Fix cmsCudaSetup.sh to follow the latest changes to cuda.xml

### DIFF
--- a/HeterogeneousCore/CUDAServices/scripts/cmsCudaSetup.sh
+++ b/HeterogeneousCore/CUDAServices/scripts/cmsCudaSetup.sh
@@ -6,12 +6,12 @@ DOTS=$(cudaComputeCapabilities | awk '{ print $2 }' | sort -u)
 CAPS=$(echo $DOTS | sed -e's#\.*##g')
 
 # remove existing capabilities
-sed -i $TOOL -e"s#-gencode arch=compute_..,code=sm_.. *##g"
-sed -i $TOOL -e"\#<flags CUDA_FLAGS=\"\"/>#d"
+sed -i $TOOL -e"s# *-gencode arch=compute_..,code=sm_.. *# #g"
+sed -i $TOOL -e"s# *-gencode arch=compute_..,code=\[sm_..,compute_..\] *# #g"
 
 # add support for the capabilities found on this machine
 for CAP in $CAPS; do
-  sed -i $TOOL -e"\#</client>#a\  <flags CUDA_FLAGS=\"-gencode arch=compute_$CAP,code=sm_$CAP\"/>"
+  sed -i $TOOL -e"/flags CUDA_FLAGS/s#\"/># -gencode arch=compute_$CAP,code=[sm_$CAP,compute_$CAP]\"/>#"
 done
 
 # reconfigure the cuda.xml tool


### PR DESCRIPTION
#### PR description:

Fix cmsCudaSetup.sh to support the changes to the syntax used in the cuda.xml SCRAM tool.

#### PR validation:

Running `cmsCudaSetup.sh` works with the current releases, and changes `cuda.xml` according to the GPUs present on the local machine:
```diff
diff cuda.xml cuda.xml
--- cuda.xml
+++ cuda.xml
@@ -11,7 +11,7 @@
     <environment name="LIBDIR"    default="$CUDA_BASE/lib64"/>
     <environment name="INCLUDE"   default="$CUDA_BASE/include"/>
   </client>
-  <flags CUDA_FLAGS="-std=c++17 -O3 --generate-line-info --source-in-ptx --display-error-number --expt-relaxed-constexpr --extended-lambda -gencode arch=compute_60,code=[sm_60,compute_60] -gencode arch=compute_70,code=[sm_70,compute_70] -gencode arch=compute_75,code=[sm_75,compute_75] -Wno-deprecated-gpu-targets -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --cudart shared"/>
+  <flags CUDA_FLAGS="-std=c++17 -O3 --generate-line-info --source-in-ptx --display-error-number --expt-relaxed-constexpr --extended-lambda   -Wno-deprecated-gpu-targets -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --cudart shared -gencode arch=compute_61,code=[sm_61,compute_61]"/>
   <flags CUDA_HOST_REM_CXXFLAGS="-std=%"/>
   <flags CUDA_HOST_REM_CXXFLAGS="%potentially-evaluated-expression"/>
   <flags CUDA_HOST_CXXFLAGS="-std=c++17"/>
```