### PR TITLE
[backport] Fix ECAL TPG emulator discrepancy for saturated strips

### DIFF
--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFormatEB.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFormatEB.cc
@@ -21,6 +21,7 @@ int EcalFenixStripFormatEB::process() {
   int even_output = 0;
   int odd_output = 0;
 
+  // Applying sliding window on the strip output after the peak finder
   if (ecaltpgTPMode_->DisableEBEvenPeakFinder) {
     even_output = input_even_ >> shift_;
   } else {
@@ -34,6 +35,12 @@ int EcalFenixStripFormatEB::process() {
   } else {
     odd_output = input_odd_ >> shift_;
   }
+
+  // Truncating the signals to 12 bit after peak finder sliding window
+  if (odd_output > 0XFFF)
+    odd_output = 0XFFF;
+  if (even_output > 0XFFF)
+    even_output = 0XFFF;
 
   // Prepare the amplitude output for the strip looking at the TPmode options
   int output = 0;

--- a/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFormatEE.cc
+++ b/SimCalorimetry/EcalTrigPrimAlgos/src/EcalFenixStripFormatEE.cc
@@ -32,6 +32,7 @@ int EcalFenixStripFormatEE::process() {
   int even_output = 0;
   int odd_output = 0;
 
+  // Applying sliding window on the strip output after the peak finder
   if (ecaltpgTPMode_->DisableEEEvenPeakFinder) {
     even_output = input_even_ >> shift_;
   } else {
@@ -45,6 +46,12 @@ int EcalFenixStripFormatEE::process() {
   } else {
     odd_output = input_odd_ >> shift_;
   }
+
+  // Truncating the signals to  to 12 bit after peak finder sliding window
+  if (odd_output > 0XFFF)
+    odd_output = 0XFFF;
+  if (even_output > 0XFFF)
+    even_output = 0XFFF;
 
   // Prepare the amplitude output for the strip looking at the TPmode options
   int output = 0;


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/38272 to 12_3_X for P5 operations. 

### PR description:

This PR fixes a discrepancy between the ECAL frontend trigger primitive formation and the emulator code in CMSSW for saturated strips.

In the frontend hardware, after the filter and peak-finder blocks, the even and odd amplitude outputs are checked for saturation and truncated to 12 bits. After that, the even and odd amplitudes are compared with 12 bits precision (only in the EB Fenix TCP board) to determine the double weights flags.

In the emulator the saturation was not checked at that stage and therefore the even/odd comparison was performed with 18 bits precision.

This was causing data/emulator discrepancy in the saturated TPs observed during double weights test with splashes events in April.
