### PR TITLE
[bugfix] Improved Egamma PFID model selection consistency

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -56,17 +56,19 @@ namespace {
       const auto& dnn_ele_pfid = hoc->iElectronDNNEstimator->evaluate(electrons, tfSessions);
       int jele = 0;
       for (auto& el : electrons) {
-        const auto& values = dnn_ele_pfid[jele];
+        const auto& [iModel, values] = dnn_ele_pfid[jele];
         // get the previous values
         auto& mvaOutput = mva_outputs[jele];
 
-        if (abs(el.superCluster()->eta()) <= extetaboundary) {
+        if (iModel <= 3) {  // models 0,1,2,3 have 5 outputs in this version
+          assert(values.size() == 5);
           mvaOutput.dnn_e_sigIsolated = values[0];
           mvaOutput.dnn_e_sigNonIsolated = values[1];
           mvaOutput.dnn_e_bkgNonIsolated = values[2];
           mvaOutput.dnn_e_bkgTau = values[3];
           mvaOutput.dnn_e_bkgPhoton = values[4];
-        } else {
+        } else if (iModel == 4) {  //etaExtended model has 3 outputs
+          assert(values.size() == 3);
           mvaOutput.dnn_e_sigIsolated = values[0];
           mvaOutput.dnn_e_sigNonIsolated = 0.0;
           mvaOutput.dnn_e_bkgNonIsolated = values[1];

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -36,8 +36,8 @@ gedGsfElectronsTmp = ecalDrivenGsfElectrons.clone(
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Summer21_120X/EE_highpT/endcap_highpT_scaler.txt",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta1/scaler.txt",
             "RecoEgamma/ElectronIdentification/data/Ele_PFID_dnn/Run3Winter22_122X/exteta2/scaler.txt"
-
-        ]
+        ],
+        outputDim = [5,5,5,5,3]
     )    
 )
 

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -1030,8 +1030,9 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     const auto& dnn_photon_pfid = globalCache()->photonDNNEstimator->evaluate(outputPhotonCollection, tfSessions_);
     size_t ipho = 0;
     for (auto& photon : outputPhotonCollection) {
-      const auto& values = dnn_photon_pfid[ipho];
+      const auto& [iModel, values] = dnn_photon_pfid[ipho];
       reco::Photon::PflowIDVariables pfID;
+      // The model index it is not useful for the moment
       pfID.dnn = values[0];
       photon.setPflowIDVariables(pfID);
       ipho++;

--- a/RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h
+++ b/RecoEgamma/EgammaTools/interface/EgammaDNNHelper.h
@@ -49,8 +49,9 @@ namespace egammaTools {
     // which has access to all the variables.
     std::pair<uint, std::vector<float>> getScaledInputs(const std::map<std::string, float>& variables) const;
 
-    std::vector<std::vector<float>> evaluate(const std::vector<std::map<std::string, float>>& candidates,
-                                             const std::vector<tensorflow::Session*>& sessions) const;
+    std::vector<std::pair<uint, std::vector<float>>> evaluate(
+        const std::vector<std::map<std::string, float>>& candidates,
+        const std::vector<tensorflow::Session*>& sessions) const;
 
   private:
     void initTensorFlowGraphs();

--- a/RecoEgamma/ElectronIdentification/interface/ElectronDNNEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronDNNEstimator.h
@@ -20,8 +20,8 @@ public:
   std::map<std::string, float> getInputsVars(const reco::GsfElectron& ele) const;
 
   // Evaluate the DNN on all the electrons with the correct model
-  std::vector<std::vector<float>> evaluate(const reco::GsfElectronCollection& ele,
-                                           const std::vector<tensorflow::Session*>& sessions) const;
+  std::vector<std::pair<uint, std::vector<float>>> evaluate(const reco::GsfElectronCollection& ele,
+                                                            const std::vector<tensorflow::Session*>& sessions) const;
 
   // List of input variables names used to check the variables request as
   // inputs in a dynamic way from configuration file.

--- a/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronDNNEstimator.cc
@@ -15,7 +15,7 @@ inline uint electronModelSelector(
   Selection of the model to be applied on the electron based on pt/eta cuts or whatever selection
   */
   const auto pt = vars.at("pt");
-  const auto absEta = std::abs(vars.at("eta"));
+  const auto absEta = std::abs(vars.at("superCluster.eta"));
   if (absEta <= endcapBoundary) {
     if (pt < ptThr)
       return 0;
@@ -156,7 +156,7 @@ std::map<std::string, float> ElectronDNNEstimator::getInputsVars(const reco::Gsf
   return variables;
 }
 
-std::vector<std::vector<float>> ElectronDNNEstimator::evaluate(
+std::vector<std::pair<uint, std::vector<float>>> ElectronDNNEstimator::evaluate(
     const reco::GsfElectronCollection& electrons, const std::vector<tensorflow::Session*>& sessions) const {
   // Collect the map of variables for each candidate and call the dnnHelper
   // Scaling, model selection and running is performed in the helper

--- a/RecoEgamma/PhotonIdentification/interface/PhotonDNNEstimator.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonDNNEstimator.h
@@ -21,8 +21,8 @@ public:
   std::map<std::string, float> getInputsVars(const reco::Photon& ele) const;
 
   // Evaluate the DNN on all the electrons with the correct model
-  std::vector<std::vector<float>> evaluate(const reco::PhotonCollection& ele,
-                                           const std::vector<tensorflow::Session*>& sessions) const;
+  std::vector<std::pair<uint, std::vector<float>>> evaluate(const reco::PhotonCollection& ele,
+                                                            const std::vector<tensorflow::Session*>& sessions) const;
 
   // List of input variables names used to check the variables request as
   // inputs in a dynamic way from configuration file.

--- a/RecoEgamma/PhotonIdentification/src/PhotonDNNEstimator.cc
+++ b/RecoEgamma/PhotonIdentification/src/PhotonDNNEstimator.cc
@@ -66,8 +66,8 @@ std::map<std::string, float> PhotonDNNEstimator::getInputsVars(const reco::Photo
   return variables;
 }
 
-std::vector<std::vector<float>> PhotonDNNEstimator::evaluate(const reco::PhotonCollection& photons,
-                                                             const std::vector<tensorflow::Session*>& sessions) const {
+std::vector<std::pair<uint, std::vector<float>>> PhotonDNNEstimator::evaluate(
+    const reco::PhotonCollection& photons, const std::vector<tensorflow::Session*>& sessions) const {
   // Collect the map of variables for each candidate and call the dnnHelper
   // Scaling, model selection and running is performed in the helper
   std::vector<std::map<std::string, float>> inputs;


### PR DESCRIPTION
#### PR description:

This PR solves the issue https://github.com/cms-sw/cmssw/issues/38175. 
The crash happened because the model selection by "eta" requirement was different in the ElectronDNNEstimator and in the GsfElectronProducer (one was using electron.eta, the other superCluster.eta). Now the model index is directly passed from the DNNHelper evaluator to the caller code, ensuring the consistency in the number of outputs. (Following comment https://github.com/cms-sw/cmssw/issues/38175#issuecomment-1144888684)

Moreover the electron model selection is now performed correctly with SuperCluster.eta instead of Electron.eta.

#### PR Validation: 
The PR has been validated with local tests. 

#### Release notes:
This is urgently needed for the 12_4_0 release.
