### PR TITLE
Code Fix to read tower geometry correctly in Ecal DQM StatusManager [Master]

### DIFF
--- a/DQM/EcalCommon/src/StatusManager.cc
+++ b/DQM/EcalCommon/src/StatusManager.cc
@@ -172,12 +172,15 @@ namespace ecaldqm {
           int iEta((channel - 1) / 4 + 1);
           int zside(0);
           int iPhi(0);
-          if (module(3) == '-') {
+          std::string smName = module.Data();
+          unsigned smNumber(std::atoi(smName.substr(3).c_str()));
+
+          if (module(2) == '-') {
             zside = -1;
-            iPhi = (channel - 1) % 4 + 1;
+            iPhi = 4 * (smNumber - 1) + (channel - 1) % 4 - 1;
           } else {
             zside = 1;
-            iPhi = (68 - channel) % 4 + 1;
+            iPhi = 4 * (smNumber - 1) + (68 - channel) % 4 - 1;
           }
 
           status_.insert(

--- a/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecal_dqm_sourceclient-live_cfg.py
@@ -122,15 +122,6 @@ process.ecalMonitorClient.workers = ['IntegrityClient', 'OccupancyClient', 'Pres
 process.ecalMonitorClient.workerParameters.SummaryClient.params.activeSources = ['Integrity', 'RawData', 'Presample', 'TriggerPrimitives', 'Timing', 'HotCell']
 process.ecalMonitorClient.commonParameters.onlineMode = True
 
-process.GlobalTag.toGet = cms.VPSet(cms.PSet(
-    record = cms.string('EcalDQMChannelStatusRcd'),
-    tag = cms.string('EcalDQMChannelStatus_v1_hlt'),
-), 
-    cms.PSet(
-        record = cms.string('EcalDQMTowerStatusRcd'),
-        tag = cms.string('EcalDQMTowerStatus_v1_hlt'),
-    ))
-
 process.preScaler.prescaleFactor = 1
 
 process.tcdsDigis = tcdsRawToDigi.clone(


### PR DESCRIPTION
#### PR description:

This PR fixes the code to read tower geometry correctly in Ecal DQM StatusManager. 
Additionally the `toGet` method of accessing the DB tags is removed from the Ecal DQM config, on the suggestion of AlcaDB.

#### PR validation:
PR is validated by running a local test which creates an sqlite file which is uploaded to the DB and verified with an online DQM run on a test DQM GUI. Everything looks as expected.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is the Master PR. The backport to 12_4_X is https://github.com/cms-sw/cmssw/pull/38359 and 12_3_X is https://github.com/cms-sw/cmssw/pull/38360 