### PR TITLE
[12_4_X] Put sampic subdet id behind the era modifier

### DIFF
--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -88,6 +88,9 @@ private:
   /// label of the CTPPS sub-system
   string subSystemName;
 
+  //subdetector id for sampic
+  unsigned int sampicSubDetId;
+
   /// the mapping files
   std::vector<std::string> mappingFileNames;
 
@@ -245,6 +248,7 @@ const string TotemDAQMappingESSourceXML::tagTotemTimingPlane = "timing_plane";
 TotemDAQMappingESSourceXML::TotemDAQMappingESSourceXML(const edm::ParameterSet &conf)
     : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
       subSystemName(conf.getUntrackedParameter<string>("subSystem")),
+      sampicSubDetId(conf.getUntrackedParameter<unsigned int>("sampicSubDetId", 5)),
       currentBlock(0),
       currentBlockValid(false) {
   for (const auto &it : conf.getParameter<vector<ParameterSet>>("configuration")) {
@@ -754,13 +758,12 @@ void TotemDAQMappingESSourceXML::ParseTreeTotemTiming(ParseType pType,
       unsigned int StationNum = (parentID / 1000) % 10;
       unsigned int RpNum = (parentID / 100) % 10;
 
-      vfatInfo.symbolicID.symbolicID =
-          TotemTimingDetId(ArmNum,
-                           StationNum,
-                           RpNum,
-                           0,
-                           TotemTimingDetId::ID_NOT_SET,
-                           TotemTimingDetId::sdTimingDiamond);  //Dynamical: it is encoded in the frame
+      vfatInfo.symbolicID.symbolicID = TotemTimingDetId(ArmNum,
+                                                        StationNum,
+                                                        RpNum,
+                                                        0,
+                                                        TotemTimingDetId::ID_NOT_SET,
+                                                        sampicSubDetId);  //Dynamical: it is encoded in the frame
 
       mapping->insert(framepos, vfatInfo);
 

--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -248,7 +248,7 @@ const string TotemDAQMappingESSourceXML::tagTotemTimingPlane = "timing_plane";
 TotemDAQMappingESSourceXML::TotemDAQMappingESSourceXML(const edm::ParameterSet &conf)
     : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
       subSystemName(conf.getUntrackedParameter<string>("subSystem")),
-      sampicSubDetId(conf.getUntrackedParameter<unsigned int>("sampicSubDetId", 5)),
+      sampicSubDetId(conf.getParameter<unsigned int>("sampicSubDetId")),
       currentBlock(0),
       currentBlockValid(false) {
   for (const auto &it : conf.getParameter<vector<ParameterSet>>("configuration")) {

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -104,6 +104,7 @@ ctppsDiamondRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXML",
   verbosity = cms.untracked.uint32(10),
   subSystem = cms.untracked.string("TotemTiming"),
+  sampicSubDetId = cms.untracked.uint32(5),
   configuration = cms.VPSet(
     # 2017, before detector inserted in DAQ
     cms.PSet(
@@ -137,6 +138,7 @@ from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 (ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = False )
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemDAQMappingESSourceXML_TotemTiming, sampicSubDetId = cms.untracked.uint32(6) )
 
 # raw-to-digi task and sequence
 ctppsRawToDigiTask = cms.Task(

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -104,7 +104,7 @@ ctppsDiamondRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXML",
   verbosity = cms.untracked.uint32(10),
   subSystem = cms.untracked.string("TotemTiming"),
-  sampicSubDetId = cms.untracked.uint32(5),
+  sampicSubDetId = cms.uint32(5),
   configuration = cms.VPSet(
     # 2017, before detector inserted in DAQ
     cms.PSet(
@@ -138,7 +138,7 @@ from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 (ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = False )
-(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemDAQMappingESSourceXML_TotemTiming, sampicSubDetId = cms.untracked.uint32(6) )
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemDAQMappingESSourceXML_TotemTiming, sampicSubDetId = 6 )
 
 # raw-to-digi task and sequence
 ctppsRawToDigiTask = cms.Task(

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -8,6 +8,7 @@ totemTriggerRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSourceXML",
   verbosity = cms.untracked.uint32(0),
   subSystem = cms.untracked.string("TrackingStrip"),
+  sampicSubDetId = cms.uint32(6),
   configuration = cms.VPSet(
     # 2016, before TS2
     cms.PSet(
@@ -62,6 +63,7 @@ totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSourceXML",
   verbosity = cms.untracked.uint32(0),
   subSystem = cms.untracked.string("TimingDiamond"),
+  sampicSubDetId = cms.uint32(6),
   configuration = cms.VPSet(
     # 2016, before diamonds inserted in DAQ
     cms.PSet(
@@ -102,7 +104,7 @@ ctppsDiamondRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 
 # ---------- Totem Timing ----------
 totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXML",
-  verbosity = cms.untracked.uint32(10),
+  verbosity = cms.untracked.uint32(0),
   subSystem = cms.untracked.string("TotemTiming"),
   sampicSubDetId = cms.uint32(5),
   configuration = cms.VPSet(


### PR DESCRIPTION
#### PR description:
Backport of #38338 and #38366
This PR puts the totemTimingDetId subdetector behind the era modifier. For Run3 subdet=5, for 2016,2017,2018 subdet=6

#### PR validation:
PR was tested with 136.8562 which was previously failing.

#### Backport:
Backport of #38338 and #38366


FYI @ChrisMisan 