### PR TITLE
Fix size of arrays in MillePedeDQMModule to store new HG thresholds

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -132,14 +132,14 @@ void MillePedeDQMModule ::fillStatusHisto(MonitorElement* statusHisto) {
 }
 
 void MillePedeDQMModule ::fillExpertHistos() {
-  std::array<double, 8> Xcut_, sigXcut_, maxMoveXcut_, maxErrorXcut_;
-  std::array<double, 8> tXcut_, sigtXcut_, maxMovetXcut_, maxErrortXcut_;
+  std::array<double, SIZE_INDEX> Xcut_, sigXcut_, maxMoveXcut_, maxErrorXcut_;
+  std::array<double, SIZE_INDEX> tXcut_, sigtXcut_, maxMovetXcut_, maxErrortXcut_;
 
-  std::array<double, 8> Ycut_, sigYcut_, maxMoveYcut_, maxErrorYcut_;
-  std::array<double, 8> tYcut_, sigtYcut_, maxMovetYcut_, maxErrortYcut_;
+  std::array<double, SIZE_INDEX> Ycut_, sigYcut_, maxMoveYcut_, maxErrorYcut_;
+  std::array<double, SIZE_INDEX> tYcut_, sigtYcut_, maxMovetYcut_, maxErrortYcut_;
 
-  std::array<double, 8> Zcut_, sigZcut_, maxMoveZcut_, maxErrorZcut_;
-  std::array<double, 8> tZcut_, sigtZcut_, maxMovetZcut_, maxErrortZcut_;
+  std::array<double, SIZE_INDEX> Zcut_, sigZcut_, maxMoveZcut_, maxErrorZcut_;
+  std::array<double, SIZE_INDEX> tZcut_, sigtZcut_, maxMovetZcut_, maxErrortZcut_;
 
   auto myMap = mpReader_->getThresholdMap();
 
@@ -196,12 +196,12 @@ void MillePedeDQMModule ::fillExpertHistos() {
 }
 
 void MillePedeDQMModule ::fillExpertHisto(MonitorElement* histo,
-                                          const std::array<double, 8>& cut,
-                                          const std::array<double, 8>& sigCut,
-                                          const std::array<double, 8>& maxMoveCut,
-                                          const std::array<double, 8>& maxErrorCut,
-                                          const std::array<double, 6>& obs,
-                                          const std::array<double, 6>& obsErr) {
+                                          const std::array<double, SIZE_INDEX>& cut,
+                                          const std::array<double, SIZE_INDEX>& sigCut,
+                                          const std::array<double, SIZE_INDEX>& maxMoveCut,
+                                          const std::array<double, SIZE_INDEX>& maxErrorCut,
+                                          const std::array<double, SIZE_LG_STRUCTS>& obs,
+                                          const std::array<double, SIZE_LG_STRUCTS>& obsErr) {
   TH1F* histo_0 = histo->getTH1F();
 
   double max_ = *std::max_element(maxMoveCut.begin(), maxMoveCut.end());

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -132,14 +132,14 @@ void MillePedeDQMModule ::fillStatusHisto(MonitorElement* statusHisto) {
 }
 
 void MillePedeDQMModule ::fillExpertHistos() {
-  std::array<double, 6> Xcut_, sigXcut_, maxMoveXcut_, maxErrorXcut_;
-  std::array<double, 6> tXcut_, sigtXcut_, maxMovetXcut_, maxErrortXcut_;
+  std::array<double, 8> Xcut_, sigXcut_, maxMoveXcut_, maxErrorXcut_;
+  std::array<double, 8> tXcut_, sigtXcut_, maxMovetXcut_, maxErrortXcut_;
 
-  std::array<double, 6> Ycut_, sigYcut_, maxMoveYcut_, maxErrorYcut_;
-  std::array<double, 6> tYcut_, sigtYcut_, maxMovetYcut_, maxErrortYcut_;
+  std::array<double, 8> Ycut_, sigYcut_, maxMoveYcut_, maxErrorYcut_;
+  std::array<double, 8> tYcut_, sigtYcut_, maxMovetYcut_, maxErrortYcut_;
 
-  std::array<double, 6> Zcut_, sigZcut_, maxMoveZcut_, maxErrorZcut_;
-  std::array<double, 6> tZcut_, sigtZcut_, maxMovetZcut_, maxErrortZcut_;
+  std::array<double, 8> Zcut_, sigZcut_, maxMoveZcut_, maxErrorZcut_;
+  std::array<double, 8> tZcut_, sigtZcut_, maxMovetZcut_, maxErrortZcut_;
 
   auto myMap = mpReader_->getThresholdMap();
 
@@ -196,10 +196,10 @@ void MillePedeDQMModule ::fillExpertHistos() {
 }
 
 void MillePedeDQMModule ::fillExpertHisto(MonitorElement* histo,
-                                          const std::array<double, 6>& cut,
-                                          const std::array<double, 6>& sigCut,
-                                          const std::array<double, 6>& maxMoveCut,
-                                          const std::array<double, 6>& maxErrorCut,
+                                          const std::array<double, 8>& cut,
+                                          const std::array<double, 8>& sigCut,
+                                          const std::array<double, 8>& maxMoveCut,
+                                          const std::array<double, 8>& maxErrorCut,
                                           const std::array<double, 6>& obs,
                                           const std::array<double, 6>& obsErr) {
   TH1F* histo_0 = histo->getTH1F();

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -64,10 +64,10 @@ private:  //===================================================================
   void fillExpertHistos();
 
   void fillExpertHisto(MonitorElement* histo,
-                       const std::array<double, 6>& cut,
-                       const std::array<double, 6>& sigCut,
-                       const std::array<double, 6>& maxMoveCut,
-                       const std::array<double, 6>& maxErrorCut,
+                       const std::array<double, 8>& cut,
+                       const std::array<double, 8>& sigCut,
+                       const std::array<double, 8>& maxMoveCut,
+                       const std::array<double, 8>& maxErrorCut,
                        const std::array<double, 6>& obs,
                        const std::array<double, 6>& obsErr);
 

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -53,6 +53,8 @@ public:  //====================================================================
 
   void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
+  enum { SIZE_LG_STRUCTS = 6, SIZE_INDEX = 8 };
+
   //========================= PRIVATE METHODS ==================================
 private:  //===================================================================
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
@@ -64,12 +66,12 @@ private:  //===================================================================
   void fillExpertHistos();
 
   void fillExpertHisto(MonitorElement* histo,
-                       const std::array<double, 8>& cut,
-                       const std::array<double, 8>& sigCut,
-                       const std::array<double, 8>& maxMoveCut,
-                       const std::array<double, 8>& maxErrorCut,
-                       const std::array<double, 6>& obs,
-                       const std::array<double, 6>& obsErr);
+                       const std::array<double, SIZE_INDEX>& cut,
+                       const std::array<double, SIZE_INDEX>& sigCut,
+                       const std::array<double, SIZE_INDEX>& maxMoveCut,
+                       const std::array<double, SIZE_INDEX>& maxErrorCut,
+                       const std::array<double, SIZE_LG_STRUCTS>& obs,
+                       const std::array<double, SIZE_LG_STRUCTS>& obsErr);
 
   bool setupChanged(const edm::EventSetup&);
   int getIndexFromString(const std::string& alignableId);


### PR DESCRIPTION
resolves #38364
#### PR description:
Adressing issue https://github.com/cms-sw/cmssw/issues/38364, by adjusting the array size of the threshold containers in `MillePedeDQMModule` to hold the new HG thresholds introduced in PR https://github.com/cms-sw/cmssw/pull/38273 and https://github.com/cms-sw/cmssw/pull/38195.
