### PR TITLE
Improved use of EventSetup in SiStripDigitizer

### DIFF
--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -44,6 +44,7 @@ class PSimHit;
 class SiStripDigitizerAlgorithm;
 class StripGeomDetUnit;
 class TrackerGeometry;
+class SiStripBadStrip;
 
 /** @brief Accumulator to perform digitisation on the strip tracker sim hits.
  *
@@ -103,8 +104,12 @@ private:
   const edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> noiseToken_;
   const edm::ESGetToken<SiStripThreshold, SiStripThresholdRcd> thresholdToken_;
   const edm::ESGetToken<SiStripPedestals, SiStripPedestalsRcd> pedestalToken_;
+  const edm::ESGetToken<SiStripBadStrip, SiStripBadChannelRcd> deadChannelToken_;
   edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
   edm::ESGetToken<SiStripApvSimulationParameters, SiStripApvSimulationParametersRcd> apvSimulationParametersToken_;
+
+  unsigned long long ddCacheID_ = 0;
+  unsigned long long deadChannelCacheID_ = 0;
 
   ///< Whether or not to create the association to sim truth collection. Set in configuration.
   /** @brief Offset to add to the index of each sim hit to account for which crossing it's in.

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
@@ -60,7 +60,6 @@ SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& co
       inefficiency(conf.getParameter<double>("Inefficiency")),
       pedOffset((unsigned int)conf.getParameter<double>("PedestalsOffset")),
       PreMixing_(conf.getParameter<bool>("PreMixingMode")),
-      deadChannelToken_(iC.esConsumes()),
       pdtToken_(iC.esConsumes()),
       lorentzAngleToken_(iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("LorentzAngle")))),
       theSiHitDigitizer(new SiHitDigitizer(conf)),
@@ -108,9 +107,7 @@ SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& co
 
 SiStripDigitizerAlgorithm::~SiStripDigitizerAlgorithm() {}
 
-void SiStripDigitizerAlgorithm::initializeDetUnit(StripGeomDetUnit const* det, const edm::EventSetup& iSetup) {
-  auto const& deadChannel = iSetup.getData(deadChannelToken_);
-
+void SiStripDigitizerAlgorithm::initializeDetUnit(StripGeomDetUnit const* det, const SiStripBadStrip& deadChannel) {
   unsigned int detId = det->geographicalId().rawId();
   int numStrips = (det->specificTopology()).nstrips();
 

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
@@ -67,7 +67,7 @@ public:
   // Destructor
   ~SiStripDigitizerAlgorithm();
 
-  void initializeDetUnit(StripGeomDetUnit const* det, const edm::EventSetup& iSetup);
+  void initializeDetUnit(StripGeomDetUnit const* det, SiStripBadStrip const&);
 
   void initializeEvent(const edm::EventSetup& iSetup);
 
@@ -134,7 +134,6 @@ private:
   const double inefficiency;
   const double pedOffset;
   const bool PreMixing_;
-  const edm::ESGetToken<SiStripBadStrip, SiStripBadChannelRcd> deadChannelToken_;
   const edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> pdtToken_;
   const edm::ESGetToken<SiStripLorentzAngle, SiStripLorentzAngleSimRcd> lorentzAngleToken_;
 


### PR DESCRIPTION
#### PR description:

- Only update data structure when IOV changes
- Avoid getting same data from EventSetup in a loop

#### PR validation:

Code compiles. This is a refactoring and shouldn't cause any changes to the results.