### PR TITLE
improve Tracker geometry comparison plot in Payload Inspector

### DIFF
--- a/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
+++ b/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
@@ -15,6 +15,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/Math/interface/Rounding.h"  // for rounding
 
 //#define MMDEBUG // uncomment for debugging at compile time
 #ifdef MMDEBUG
@@ -28,7 +29,19 @@ namespace AlignmentPI {
 
   // size of the phase-I Tracker APE payload (including both SS + DS modules)
   static const unsigned int phase0size = 19876;
-  static const float cmToUm = 10000;
+  static const float cmToUm = 10000.f;
+  static const float tomRad = 1000.f;
+
+  // method to zero all elements whose difference from 2Pi
+  // is less than the tolerance (2*10e-7)
+  inline float returnZeroIfNear2PI(const float phi) {
+    const double tol = 2.e-7;  // default tolerance 1.e-7 doesn't account for possible variations
+    if (cms_rounding::roundIfNear0(std::abs(phi) - 2 * M_PI, tol) == 0.f) {
+      return 0.f;
+    } else {
+      return phi;
+    }
+  }
 
   enum coordinate {
     t_x = 1,


### PR DESCRIPTION
#### PR description:

Title says it all. Mostly show the Euler angle value difference as 0 if it is within 2 parts per ten million of 2π to avoid altering the overall scale.

#### PR validation:

Private. Run the script:
```bash
elements=(X Y Z Alpha Beta Gamma)

for i in "${elements[@]}"
do
    echo "Processing: $i coordinate"

    getPayloadData.py  \
	--plugin pluginTrackerAlignment_PayloadInspector \
	--plot plot_TrackerAlignmentCompare${i}TwoTags \
	--tag fromGeometry  \
	--tagtwo fromGT \
	--time_type Run \
	--iovs '{"start_iov": "1", "end_iov": "1"}' \
	--iovstwo '{"start_iov": "1", "end_iov": "1"}' \
	--db sqlite_file:toComapre.db \
	--test;

    mv *.png $W_DIR/compareFromGeometry/TrackerAlignmentCompare${i}.png

done
```
with and without this PR and obtained the following sets of plots:
   * vanilla release: [link](http://musich.web.cern.ch/musich/display/checkGeometriesForPR/compareFromGeometry/)
   * this branch: [link](http://musich.web.cern.ch/musich/display/checkIdealGeometry/)

See for example:

| Vanilla release  | This branch | 
| ------------- | ------------- |
|  ![image](https://user-images.githubusercontent.com/5082376/173590579-299817b3-15de-4274-9c53-daa8e230980f.png) | ![image](https://user-images.githubusercontent.com/5082376/173590536-f99eb1a3-a388-4c3d-a46e-17423c4fac7c.png) |


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A