### PR TITLE
Replace Geometry_cff with GeometryDB_cff in RecoMuon

### DIFF
--- a/RecoMuon/Configuration/test/RecoMuon_cfg.py
+++ b/RecoMuon/Configuration/test/RecoMuon_cfg.py
@@ -12,7 +12,7 @@ process.load("RecoMuon.Configuration.RecoMuon_cff")
 
 process.load("Configuration.StandardSequences.Services_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 

--- a/RecoMuon/MuonIdentification/test/TestMuonIdProducerCosmics_cfg.py
+++ b/RecoMuon/MuonIdentification/test/TestMuonIdProducerCosmics_cfg.py
@@ -3,18 +3,11 @@ process = cms.Process("TEST")
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.GlobalRuns.ForceZeroTeslaField_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = 'CRZT210_V1::All' 
 process.prefer("GlobalTag")
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
-
-## process.load("Configuration.StandardSequences.Reconstruction_cff")
-#process.load("Configuration.StandardSequences.MagneticField_0T_cff")
-#process.load("Configuration.StandardSequences.Geometry_cff")
-#
-##process.load("Configuration.GlobalRuns.ForceZeroTeslaField_cff")
-
 process.load("RecoMuon.MuonIdentification.muonIdProducerSequence_cff")
 process.load("RecoMuon.MuonIdentification.links_cfi")
 process.maxEvents = cms.untracked.PSet(

--- a/RecoMuon/MuonIdentification/test/TestMuonIdProducer_cfg.py
+++ b/RecoMuon/MuonIdentification/test/TestMuonIdProducer_cfg.py
@@ -1,10 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("TEST")
 
-# process.load("Configuration.StandardSequences.MagneticField_cff")
-# process.load("Configuration.StandardSequences.Geometry_cff")
-# process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-# process.load("Configuration.StandardSequences.Reconstruction_cff")
+# process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/RecoMuon/MuonIsolationProducers/test/isoTest_cfg.py
+++ b/RecoMuon/MuonIsolationProducers/test/isoTest_cfg.py
@@ -33,7 +33,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.load("Configuration.StandardSequences.Services_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 

--- a/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/estimatePt_cfg.py
+++ b/RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/estimatePt_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PROD2")
 
 #process.load("Configuration.StandardSequences.GeometryPilot2_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.Services_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/RecoMuon/MuonSeedGenerator/test/testMuonSeedMerger_cfg.py
+++ b/RecoMuon/MuonSeedGenerator/test/testMuonSeedMerger_cfg.py
@@ -7,7 +7,7 @@ process.load("RecoMuon.Configuration.MessageLogger_cfi")
 
 process.load("Configuration.StandardSequences.Services_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 

--- a/RecoMuon/MuonSeedGenerator/test/testSETMuonSeed_cfg.py
+++ b/RecoMuon/MuonSeedGenerator/test/testSETMuonSeed_cfg.py
@@ -13,7 +13,7 @@ process.load("RecoMuon.Configuration.RecoMuon_cff")
 
 process.load("Configuration.StandardSequences.Services_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 

--- a/RecoMuon/StandAloneMuonProducer/test/StandAloneMuon_cfg.py
+++ b/RecoMuon/StandAloneMuonProducer/test/StandAloneMuon_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("RecoSTAMuon")
 process.load("RecoMuon.Configuration.RecoMuon_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = 'IDEAL_V9::All'
 


### PR DESCRIPTION
**PR description:**
Review on the Reco part of https://github.com/cms-sw/cmssw/issues/31113

`process.load("Configuration.StandardSequences.Geometry_cff")`
 was outdated https://github.com/cms-sw/cmssw/pull/8810 
It should be replaced with
`process.load("Configuration.StandardSequences.GeometryDB_cff")`

In this PR, RecoMuon configuration files (8 files) are fixed.

RecoMuon/Configuration/test/RecoMuon_cfg.py
RecoMuon/MuonIdentification/test/TestMuonIdProducerCosmics_cfg.py
RecoMuon/MuonIdentification/test/TestMuonIdProducer_cfg.py
RecoMuon/MuonIsolationProducers/test/isoTest_cfg.py
RecoMuon/MuonSeedGenerator/test/MuonSeedPTAnalysis/estimatePt_cfg.py
RecoMuon/MuonSeedGenerator/test/testMuonSeedMerger_cfg.py
RecoMuon/MuonSeedGenerator/test/testSETMuonSeed_cfg.py
RecoMuon/StandAloneMuonProducer/test/StandAloneMuon_cfg.py
#### PR validation:
Tested in CMSSW_12_5_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)