### PR TITLE
Update LHEVpTFilter.cc to avoid excluding the vpt=0 part

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/LHEVpTFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/LHEVpTFilter.cc
@@ -74,7 +74,7 @@ bool LHEVpTFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSet
   if (lepCands.size() == 2) {
     vpt_ = (lepCands[0] + lepCands[1]).pt();
   }
-  if (vpt_ <= vptMax_ && vpt_ > vptMin_) {
+  if (vpt_ < vptMax_ && vpt_ >= vptMin_) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
modify the vptMin selection, e.g., a pt range cut (0, 50) will exclude the vpz=0, which happened in those samples, DYJetsToLL_LHEFilterPtZ-0To50_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
