### PR TITLE
Introduce AlCaPPS_Run3 scenario

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCaPPS_Run3.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaPPS_Run3.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+_AlCaPPS_Run3_
+
+Scenario supporting proton collisions for AlCa needs for the CT-PPS detector 
+
+"""
+from __future__ import print_function
+
+import os
+import sys
+
+from Configuration.DataProcessing.Scenario import *
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,dqmIOSource,harvestingMode,dictIO,gtNameAndConnect,addMonitoring
+from Configuration.Eras.Era_Run3_cff import Run3
+import FWCore.ParameterSet.Config as cms
+
+class AlCaPPS_Run3(Scenario):
+    def __init__(self):
+        Scenario.__init__(self)
+        self.eras=Run3
+        self.skims=['PPSCalMaxTracks']
+
+    """
+    _AlCaPPS_Run3_
+
+    Implement configuration building for data processing for proton
+    collision data taking for AlCa needs for the CT-PPS detector 
+
+    """
+
+    def skimsIfNotGiven(self,args,sl):
+        if not 'skims' in args:
+            args['skims']=sl
+
+    def promptReco(self, globalTag, **args):
+        if not 'skims' in args:
+            args['skims']=self.skims
+        if not 'customs' in args:
+            args['customs']= [ ]
+
+        options = Options()
+        options.__dict__.update(defaultOptions.__dict__)
+        options.scenario = "pp"
+        dictIO(options,args)
+        options.conditions = gtNameAndConnect(globalTag, args)
+
+        if 'customs' in args:
+            print(args['customs'])
+            options.customisation_file=args['customs']
+
+        options.step += stepALCAPRODUCER(args['skims'])
+
+        process = cms.Process('RECO', cms.ModifierChain(self.eras) )
+        cb = ConfigBuilder(options, process = process, with_output = True)
+
+        # Input source
+        process.source = cms.Source("PoolSource",
+            fileNames = cms.untracked.vstring()
+        )
+        cb.prepare()
+
+        return process
+
+
+    def alcaSkim(self, skims, **args):
+        """
+        _alcaSkim_
+
+        AlcaReco processing & skims for proton collisions
+
+        """
+        step = ""
+        pclWflws = [x for x in skims if "PromptCalibProd" in x]
+        skims = [x for x in skims if x not in pclWflws]
+
+        if len(pclWflws):
+            step += 'ALCA:'+('+'.join(pclWflws))
+
+        if len(skims) > 0:
+            if step != "":
+                step += ","
+            step += "ALCAOUTPUT:"+('+'.join(skims))
+
+        options = Options()
+        options.__dict__.update(defaultOptions.__dict__)
+        options.scenario = "pp"
+        options.step = step
+        options.conditions = args['globaltag'] if 'globaltag' in args else 'None'
+        if 'globalTagConnect' in args and args['globalTagConnect'] != '':
+            options.conditions += ','+args['globalTagConnect']
+
+        options.triggerResultsProcess = 'RECO'
+
+        process = cms.Process('ALCA', self.eras)
+        cb = ConfigBuilder(options, process=process)
+
+        # Input source
+        process.source = cms.Source(
+           "PoolSource",
+           fileNames=cms.untracked.vstring()
+        )
+
+        cb.prepare()
+
+        # Tier0 needs the dataset used for ALCAHARVEST step to be a different data-tier
+        for wfl in pclWflws:
+            methodToCall = getattr(process, 'ALCARECOStream'+wfl)
+            methodToCall.dataset.dataTier = cms.untracked.string('ALCAPROMPT')
+
+        return process
+
+    def dqmHarvesting(self, datasetName, runNumber, globalTag, **args):
+        """
+        _dqmHarvesting_
+
+        Proton collisions data taking DQM Harvesting
+
+        """
+        options = defaultOptions
+        options.scenario = "pp"
+        options.step = "HARVESTING:alcaHarvesting"
+        options.name = "EDMtoMEConvert"
+        options.conditions = gtNameAndConnect(globalTag, args)
+
+        process = cms.Process("HARVESTING", self.eras)
+        process.source = dqmIOSource(args)
+        configBuilder = ConfigBuilder(options, process = process)
+        configBuilder.prepare()
+
+        # customise process for particular job
+        harvestingMode(process,datasetName,args)
+
+        return process
+
+    def expressProcessing(self, globalTag, **args):
+        """
+        _expressProcessing_
+
+        Proton collision data taking express processing
+
+        """
+        skims = []
+        if 'skims' in args:
+            skims = args['skims']
+            pclWkflws = [x for x in skims if "PromptCalibProd" in x]
+            for wfl in pclWkflws:
+                skims.remove(wfl)
+
+        options = Options()
+        options.__dict__.update(defaultOptions.__dict__)
+        options.scenario = "pp"
+        options.step = stepALCAPRODUCER(skims)
+
+        if 'outputs' in args:
+            # the RAW data-tier needs a special treatment since the event-content as defined in release is not good enough
+            outputs_Raw = [x for x in args['outputs'] if x['dataTier'] == 'RAW']
+            outputs_noRaw = [x for x in args['outputs'] if x['dataTier'] != 'RAW']
+            if len(outputs_Raw) == 1:
+                print('RAW data-tier requested')
+            options.outputDefinition = outputs_noRaw.__str__()
+
+        options.conditions = gtNameAndConnect(globalTag, args)
+
+        options.filein = 'tobeoverwritten.xyz'
+        if 'inputSource' in args:
+            options.filetype = args['inputSource']
+        process = cms.Process('RECO', self.eras)
+
+        if 'customs' in args:
+            options.customisation_file=args['customs']
+
+        cb = ConfigBuilder(options, process = process, with_output = True, with_input = True)
+
+        cb.prepare()
+
+        addMonitoring(process)
+
+        for output in outputs_Raw:
+            print(output)
+            moduleLabel = output['moduleLabel']
+            selectEvents = output.get('selectEvents', None)
+            maxSize = output.get('maxSize', None)
+
+            outputModule = cms.OutputModule(
+                "PoolOutputModule",
+                fileName = cms.untracked.string("%s.root" % moduleLabel)
+                )
+
+            outputModule.dataset = cms.untracked.PSet(dataTier = cms.untracked.string("RAW"))
+
+            if maxSize != None:
+                outputModule.maxSize = cms.untracked.int32(maxSize)
+
+            if selectEvents != None:
+                outputModule.SelectEvents = cms.untracked.PSet(
+                    SelectEvents = cms.vstring(selectEvents)
+                    )
+            outputModule.outputCommands = cms.untracked.vstring('drop *',
+                                                                'keep  *_*_*_HLT')
+
+            setattr(process, moduleLabel, outputModule)
+            setattr(process, moduleLabel+'_step', cms.EndPath(outputModule))
+            path = getattr(process, moduleLabel+'_step')
+            process.schedule.append(path)
+
+        return process

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -38,7 +38,7 @@ do
 done
 
 
-declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano")
+declare -a arr=("AlCaLumiPixels" "AlCaTestEnable" "cosmicsEra_Run2_2018" "hcalnzsEra_Run2_2018" "ppEra_Run2_2018" "hcalnzsEra_Run2_2018_highBetaStar" "hcalnzsEra_Run2_2018_pp_on_AA" "ppEra_Run2_2018_highBetaStar" "ppEra_Run2_2018_pp_on_AA" "cosmicsHybridEra_Run2_2018" "cosmicsEra_Run3" "hcalnzsEra_Run3" "ppEra_Run3" "AlCaLumiPixels_Run3" "AlCaPhiSymEcal_Nano" "AlCaPPS_Run3")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"


### PR DESCRIPTION
#### PR description:

Another T0 replay (https://github.com/dmwm/T0/pull/4686) revealed that we are missing another scenario. This PR adds that.


#### PR validation:
doing
```
cmsrel CMSSW_12_5_X_2022-06-15-1100
cd CMSSW_12_5_X_2022-06-15-1100/src
cmsenv
git cms-addpkg Configuration/DataProcessing
git cms-adpkg IOPool/Streamer
scram b -j
```
edit `IOPool/Streamer/test/NewStreamIn2_cfg.py`
so that it reads
`/eos/cms/store/t0streamer/Data/ALCAPPS/000/352/929/run352929_ls0006_streamALCAPPS_StorageManager.dat`

then doing
```
python3 Configuration/DataProcessing/test/RunPromptReco.py --scenario ppEra_Run3 --global-tag 123X_dataRun3_Prompt_v11 --lfn=file:myout11.root --alcareco PPSCalMaxTracks
 cmsRun -e RunPromptRecoCfg.py
```
I can reproduce the problem in https://github.com/dmwm/T0/pull/4686.

After this PR doing 
```
python3 Configuration/DataProcessing/test/RunPromptReco.py --scenario AlCaPPS_Run3 --global-tag 123X_dataRun3_Prompt_v11 --lfn=file:myout11.root --alcareco PPSCalMaxTracks
 cmsRun -e RunPromptRecoCfg.py
```

I get the file running with the correct output
```
Type                                  Module                      Label             Process   
----------------------------------------------------------------------------------------------
BXVector<GlobalAlgBlk>                "hltGtStage2ObjectMap"      ""                "HLT"     
GlobalObjectMapRecord                 "hltGtStage2ObjectMap"      ""                "HLT"     
edm::TriggerResults                   "TriggerResults"            ""                "HLT"     
trigger::TriggerEvent                 "hltTriggerSummaryAOD"      ""                "HLT"     
edm::DetSetVector<CTPPSDiamondDigi>    "ctppsDiamondRawToDigiAlCaRecoProducer"   "TimingDiamond"   "RECO"    
edm::DetSetVector<CTPPSDiamondLocalTrack>    "ctppsDiamondLocalTracksAlCaRecoProducer"   ""                "RECO"    
edm::DetSetVector<CTPPSDiamondRecHit>    "ctppsDiamondRecHitsAlCaRecoProducer"   ""                "RECO"    
edm::DetSetVector<CTPPSPixelCluster>    "ctppsPixelClustersAlCaRecoProducer"   ""                "RECO"    
edm::DetSetVector<CTPPSPixelDataError>    "ctppsPixelDigisAlCaRecoProducer"   ""                "RECO"    
edm::DetSetVector<CTPPSPixelDigi>     "ctppsPixelDigisAlCaRecoProducer"   ""                "RECO"    
edm::DetSetVector<CTPPSPixelLocalTrack>    "ctppsPixelLocalTracksAlCaRecoProducer"   ""                "RECO"    
edm::DetSetVector<CTPPSPixelRecHit>    "ctppsPixelRecHitsAlCaRecoProducer"   ""                "RECO"    
edm::DetSetVector<TotemTimingDigi>    "totemTimingRawToDigiAlCaRecoProducer"   "TotemTiming"     "RECO"    
edm::DetSetVector<TotemTimingLocalTrack>    "diamondSampicLocalTracksAlCaRecoProducer"   ""                "RECO"    
edm::DetSetVector<TotemTimingRecHit>    "totemTimingRecHitsAlCaRecoProducer"   ""                "RECO"    
edm::DetSetVector<TotemVFATStatus>    "ctppsDiamondRawToDigiAlCaRecoProducer"   "TimingDiamond"   "RECO"    
edm::TriggerResults                   "TriggerResults"            ""                "RECO"    
vector<CTPPSLocalTrackLite>           "ctppsLocalTrackLiteProducerAlCaRecoProducer"   ""                "RECO"    
vector<TotemFEDInfo>                  "ctppsDiamondRawToDigiAlCaRecoProducer"   "TimingDiamond"   "RECO"    
vector<reco::ForwardProton>           "ctppsProtonsAlCaRecoProducer"   "multiRP"         "RECO"    
vector<reco::ForwardProton>           "ctppsProtonsAlCaRecoProducer"   "singleRP"        "RECO"  
```

With the new version I can also successfully run
```
 python3 Configuration/DataProcessing/test/RunExpressProcessing.py --scenario AlCaPPS_Run3 --global-tag 123X_dataRun3_Prompt_v11 --lfn=file:myout11.root --alcarecos PPSCalMaxTracks 
```

The unit test also is introduced

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport but needs to be backported to 12_4_X for sure
