### PR TITLE
[HETEROGENEOUS-RECO] [GCC12] Disable cuda builds if cuda does not support gcc

### DIFF
--- a/CUDADataFormats/Track/test/BuildFile.xml
+++ b/CUDADataFormats/Track/test/BuildFile.xml
@@ -10,9 +10,10 @@
   <flags CXXFLAGS="-g -DGPU_DEBUG"/>
 </bin>
 
+<iftool name="cuda-gcc-support">
 <bin file="TrajectoryStateSOA_t.cu" name="gpuTrajectoryStateSOA_t">
   <use name="eigen"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
   <flags CXXFLAGS="-g -DGPU_DEBUG"/>
 </bin>
-
+</iftool>

--- a/CUDADataFormats/TrackingRecHit/test/BuildFile.xml
+++ b/CUDADataFormats/TrackingRecHit/test/BuildFile.xml
@@ -1,3 +1,5 @@
 <use name="CUDADataFormats/TrackingRecHit"/>
 <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
+<iftool name="cuda-gcc-support">
 <bin file="TrackingRecHit2DCUDA_t.cpp TrackingRecHit2DCUDA_t.cu" name="TrackingRecHit2DCUDA_t"/>
+</iftool>


### PR DESCRIPTION
Disabled building cuda tests/binaries if cuda does not support gcc version e.g. currently cuda with gcc12 does not work.