### PR TITLE
[RECO] [GCC12] Disable cuda builds if cuda does not support gcc version

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/EcalRawToDigi/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="cuda"/>
 <use name="root"/>
 <use name="CUDADataFormats/EcalDigi" />
 <use name="CondFormats/DataRecord"/>
@@ -10,6 +9,12 @@
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
 <use name="Utilities/StorageFactory"/>
-<library file="*.cc *.cu" name="EventFilterEcalRawToDigiPlugins">
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+<library file="*.cc ${cuda_src}" name="EventFilterEcalRawToDigiPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/EventFilter/HcalRawToDigi/plugins/BuildFile.xml
+++ b/EventFilter/HcalRawToDigi/plugins/BuildFile.xml
@@ -16,6 +16,7 @@
 <library file="HcalLaserEventFiltProducer2012.cc, HcalLaserEventFilter2012.cc,HcalLaserHFFilter2012.cc,HcalLaserHBHEFilter2012.cc,HcalLaserHBHEHFFilter2012.cc" name="EventFilterHcalRawToDigiFiltersPlugins">
 </library>
 
+<iftool name="cuda-gcc-support">
 <library file="HcalRawToDigiGPU.cc,DecodeGPU.cu,HcalESProducerGPUDefs.cc,ElectronicsMappingGPU.cc,HcalCPUDigisProducer.cc,HcalDigisProducerGPU.cc" name="EventFilterHcalRawToDigiGPUPlugins">
   <use name="cuda" />
   <use name="CUDADataFormats/HcalDigi" />
@@ -23,3 +24,4 @@
   <use name="HeterogeneousCore/CUDAServices"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
 </library>
+</iftool>

--- a/MagneticField/Interpolation/test/BinaryTablesGeneration/mergeFieldTable.cc
+++ b/MagneticField/Interpolation/test/BinaryTablesGeneration/mergeFieldTable.cc
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <array>
 
 int main(int argc, char** argv) {
   if (argc != 3) {

--- a/RecoLocalCalo/EcalRecProducers/plugins/BuildFile.xml
+++ b/RecoLocalCalo/EcalRecProducers/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="cuda"/>
 <use name="CUDADataFormats/EcalRecHitSoA"/>
 <use name="CalibCalorimetry/EcalLaserCorrection"/>
 <use name="CalibCalorimetry/EcalTPGTools"/>
@@ -16,7 +15,12 @@
 <use name="RecoLocalCalo/EcalRecAlgos"/>
 <use name="RecoLocalCalo/EcalRecProducers"/>
 <use name="SimCalorimetry/EcalSimAlgos"/>
-
-<library file="*.cc *.cu" name="RecoLocalCaloEcalRecProducersPlugins">
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+<library file="*.cc ${cuda_src}" name="RecoLocalCaloEcalRecProducersPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalCalo/HcalRecProducers/BuildFile.xml
+++ b/RecoLocalCalo/HcalRecProducers/BuildFile.xml
@@ -18,4 +18,8 @@
 <use name="HeterogeneousCore/CUDAUtilities"/>
 <use name="RecoLocalCalo/HcalRecAlgos"/>
 <use name="SimCalorimetry/HcalSimAlgos"/>
+<iftool name="cuda-gcc-support">
+<else/>
+  <flags SKIP_FILES="MahiGPU.cu"/>
+</iftool>
 <flags EDM_PLUGIN="1"/>

--- a/RecoLocalCalo/HcalRecProducers/BuildFile.xml
+++ b/RecoLocalCalo/HcalRecProducers/BuildFile.xml
@@ -20,6 +20,6 @@
 <use name="SimCalorimetry/HcalSimAlgos"/>
 <iftool name="cuda-gcc-support">
 <else/>
-  <flags SKIP_FILES="MahiGPU.cu"/>
+  <flags SKIP_FILES="%.cu"/>
 </iftool>
 <flags EDM_PLUGIN="1"/>

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="boost_serialization"/>
-<use name="cuda"/>
 <use name="CUDADataFormats/SiPixelCluster"/>
 <use name="CUDADataFormats/SiPixelDigi"/>
 <use name="CalibTracker/SiPixelESProducers"/>
@@ -10,6 +9,12 @@
 <use name="FWCore/Utilities"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="RecoTracker/Record"/>
-<library file="*.cc *.cu" name="RecoLocalTrackerSiPixelClusterizerPlugins">
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+<library file="*.cc ${cuda_src}" name="RecoLocalTrackerSiPixelClusterizerPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
@@ -34,6 +34,7 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
+<iftool name="cuda-gcc-support">
 <bin file="gpuClustering_t.cu" name="gpuClustering_t">
   <use name="cuda"/>
   <use name="HeterogeneousCore/CUDAUtilities"/>
@@ -46,6 +47,7 @@
   <flags CXXFLAGS="-g -DGPU_DEBUG"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
 </bin>
+</iftool>
 
 <bin file="cpuClustering_t.cpp" name="cpuClustering_t">
   <use name="HeterogeneousCore/CUDAUtilities"/>

--- a/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="cuda"/>
 <use name="fmt"/>
 <use name="CUDADataFormats/BeamSpot"/>
 <use name="CUDADataFormats/TrackingRecHit"/>
@@ -7,6 +6,12 @@
 <use name="RecoLocalTracker/Records"/>
 <use name="RecoLocalTracker/SiPixelRecHits"/>
 <use name="DataFormats/TrackerCommon"/>
-<library file="*.cc *.cu" name="RecoLocalTrackerSiPixelRecHitsPlugins">
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+<library file="*.cc ${cuda_src}" name="RecoLocalTrackerSiPixelRecHitsPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTrackFitting/test/BuildFile.xml
@@ -27,6 +27,7 @@
   <flags CXXFLAGS="-g -DRFIT_DEBUG"/>
 </bin>
 
+<iftool name="cuda-gcc-support">
 <bin file="testEigenGPU.cu" name="testFitsGPU_t">
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="cuda"/>
@@ -47,6 +48,7 @@
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <flags CXXFLAGS="-g"/>
 </bin>
+</iftool>
 
 <bin file="PixelTrackFits.cc">
   <use name="cuda"/>

--- a/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelTriplets/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="cuda"/>
 <use name="ofast-flag"/>
 <use name="CUDADataFormats/Track"/>
 <use name="CommonTools/RecoAlgos"/>
@@ -10,6 +9,12 @@
 <use name="RecoTracker/Record"/>
 <use name="RecoTracker/TkTrackingRegions"/>
 <use name="RecoTracker/TkSeedingLayers"/>
-<library file="*.cc *.cu" name="RecoPixelVertexingPixelTripletsPlugins">
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+<library file="*.cc ${cuda_src}" name="RecoPixelVertexingPixelTripletsPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoPixelVertexing/PixelVertexFinding/plugins/BuildFile.xml
+++ b/RecoPixelVertexing/PixelVertexFinding/plugins/BuildFile.xml
@@ -23,6 +23,12 @@
 <use name="RecoLocalTracker/Records"/>
 <use name="RecoPixelVertexing/PixelVertexFinding"/>
 <use name="SimDataFormats/PileupSummaryInfo"/>
-<library file="*.cc *.cu" name="RecoPixelVertexingPixelVertexFindingPlugins">
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+<library file="*.cc ${cuda_src}" name="RecoPixelVertexingPixelVertexFindingPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoPixelVertexing/PixelVertexFinding/test/BuildFile.xml
+++ b/RecoPixelVertexing/PixelVertexFinding/test/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="SimDataFormats/Track"/>
 <use name="TrackingTools/TransientTrack"/>
 
+<iftool name="cuda-gcc-support">
 <bin file="gpuVertexFinder_t.cu" name="gpuVertexFinderOneKernel_t">
   <use name="cuda"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG -DONE_KERNEL"/>
@@ -21,10 +22,6 @@
   <flags CXXFLAGS="-g"/>
 </bin>
 
-<bin file="cpuVertexFinder_t.cpp" name="cpuVertexFinderByDensity_t">
-  <flags CXXFLAGS="-g  -DGPU_DEBUG"/>
-</bin>
-
 <bin file="gpuVertexFinder_t.cu" name="gpuVertexFinderDBSCAN_t">
   <use name="cuda"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG -DUSE_DBSCAN"/>
@@ -35,6 +32,11 @@
   <use name="cuda"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG -DUSE_ITERATIVE"/>
   <flags CXXFLAGS="-g"/>
+</bin>
+</iftool>
+
+<bin file="cpuVertexFinder_t.cpp" name="cpuVertexFinderByDensity_t">
+  <flags CXXFLAGS="-g  -DGPU_DEBUG"/>
 </bin>
 
 <bin file="cpuVertexFinder_t.cpp" name="cpuVertexFinderIterative_t">


### PR DESCRIPTION
Disabled building cuda tests/binaries if cuda does not support gcc version e.g. currently cuda with gcc12 does not work.
