### PR TITLE
[GEOMETRY] [GCC12] Disable cuda builds if cuda does not support gcc version

### DIFF
--- a/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
+++ b/Geometry/TrackerGeometryBuilder/test/BuildFile.xml
@@ -40,12 +40,14 @@
   <flags EDM_PLUGIN="1"/>
 </library>
 
+<iftool name="cuda-gcc-support">
 <bin file="phase1PixelTopology_t.cu">
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <use name="Geometry/CommonTopologies" source_only="1"/>
   <use name="cuda"/>
   <flags CUDA_FLAGS="-g -DGPU_DEBUG"/>
 </bin>
+</iftool>
 
 <bin file="runTests.cpp" name="GeometryTrackerGeometryBuilderTestDriver">
   <use name="FWCore/Utilities"/>


### PR DESCRIPTION
Disabled building cuda tests/binaries if cuda does not support gcc version e.g. currently cuda with gcc12 does not work.