### PR TITLE
[RECO-UPGRADE] [GCC12] Disable cuda builds if cuda does not support gcc version

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="cuda"/>
 <use name="CommonTools/UtilAlgos"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="HeterogeneousCore/CUDAUtilities"/>
@@ -18,6 +17,12 @@
 <use name="Geometry/HGCalCommonData"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/HGCalObjects"/>
-<library   file="*.cc *.cu" name="RecoLocalCaloHGCalRecProducersPlugins">
+<iftool name="cuda-gcc-support">
+  <use name="cuda"/>
+  <set name="cuda_src" value="*.cu"/>
+<else/>
+  <set name="cuda_src" value=""/>
+</iftool>
+<library   file="*.cc ${cuda_src}" name="RecoLocalCaloHGCalRecProducersPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
Disabled building cuda tests/binaries if cuda does not support gcc version e.g. currently cuda with gcc12 does not work.