### PR TITLE
Initialization in CPEBase to fix UBSAN error

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -49,7 +49,8 @@ public:
     const PixelTopology* theTopol;
     const RectangularPixelTopology* theRecTopol;
 
-    GeomDetType::SubDetector thePart;
+    //set default value of enum to avoid USBAN errors
+    GeomDetType::SubDetector thePart = GeomDetEnumerators::invalidDet;
     Local3DPoint theOrigin;
     float theThickness;
     float thePitchX;


### PR DESCRIPTION
This PR adds an initialization for one value of the `DetParam` struct in PixelCPEBase that was causing a UBSAN error (#35036
). No changes in output are expected