### PR TITLE
[12_4_X] Copies RawEventContent compression settings for Repack jobs

### DIFF
--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -5,7 +5,7 @@ _Repack_
 Module that generates standard repack configurations
 
 """
-
+import copy
 import FWCore.ParameterSet.Config as cms
 from Configuration.EventContent.EventContent_cff import RAWEventContent
 
@@ -55,7 +55,8 @@ def repackProcess(**args):
 
         outputModule = cms.OutputModule(
             "PoolOutputModule",
-            RAWEventContent,
+            compressionAlgorithm=copy.copy(RAWEventContent.compressionAlgorithm),
+            compressionLevel=copy.copy(RAWEventContent.compressionLevel),
             fileName = cms.untracked.string("%s.root" % moduleLabel)
             )
 


### PR DESCRIPTION
#### PR description:

Drops RAWEventContent configuration from repack output, while keeping it compression configuration. Fix to https://github.com/cms-sw/cmssw/pull/37791.
Following the discussion in https://github.com/cms-sw/cmssw/pull/38025#discussion_r878162570, this PR uses `copy` to avoid propagating changes done in Repack.py back to the RawEventContent object

#### PR validation:
Used [RunRepack.py](https://github.com/cms-sw/cmssw/blob/master/Configuration/DataProcessing/test/RunRepack.py) to generate a test configuration. The resulting PSet had the required output module attributes and the repack job was executed correctly using cmsRun. The produced RAW file included the expected products.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This is a backport of #38049. Needed to avoid dropping necessary products from T0 RAW files.
