### PR TITLE
[12_4_X] Fix output file name of hcalgpu DQM client

### DIFF
--- a/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalgpu_dqm_sourceclient-live_cfg.py
@@ -52,9 +52,9 @@ process.load('DQM.Integration.config.environment_cfi')
 #-------------------------------------
 process.source.streamLabel = cms.untracked.string("streamDQMGPUvsCPU")
 process.dqmEnv.subSystemFolder = subsystem
-process.dqmSaver.tag = subsystem
+process.dqmSaver.tag = 'HcalGPU'
 process.dqmSaver.runNumber = options.runNumber
-process.dqmSaverPB.tag = subsystem
+process.dqmSaverPB.tag = 'HcalGPU'
 process.dqmSaverPB.runNumber = options.runNumber
 process = customise(process)
 process.DQMStore.verbose = 0


### PR DESCRIPTION
#### PR description:

The output file name of hcalgpu DQM client is the same as of hcal client. Because of this the files are randomly overwritten messing the online dqm GUI ( e.g. compare /Hcal folders for runs 353910 and 353909 ). PR changing 'Hcal' prefix to 'HcalGPU'.

#### PR validation:

Tested at P5

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

https://github.com/cms-sw/cmssw/pull/38411
