### PR TITLE
Simulation: Add Flat0To200_OOTPoisson PU scenario

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -123,6 +123,7 @@ addMixingScenario("2018_25ns_ProjectedPileup_PoissonOOTPU",{'file': 'SimGeneral.
 addMixingScenario("2018_25ns_JuneProjectionFull18_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi'})
 addMixingScenario("2018_25ns_UltraLegacy_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2018_25ns_UltraLegacy_PoissonOOTPU_cfi'})
 addMixingScenario("Run3_Flat55To75_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_Run3_Flat55To75_PoissonOOTPU_cfi'})
+addMixingScenario("Flat0To200_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_Flat0To200_PoissonOOTPU_cfi'})
 addMixingScenario("ProdStep2",{'file': 'SimGeneral.MixingModule.mixProdStep2_cfi'})
 addMixingScenario("fromDB",{'file': 'SimGeneral.MixingModule.mix_fromDB_cfi'})
 addMixingScenario("2022_LHC_Simulation_10h_2h",{'file': 'SimGeneral.MixingModule.Run3_2022_LHC_Simulation_10h_2h_cfi'})

--- a/SimGeneral/MixingModule/python/mix_Flat0To200_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Flat0To200_PoissonOOTPU_cfi.py
@@ -1,0 +1,8 @@
+# A simple distribution for Run3 studies consisting of a flat distribution from 55
+# to 75 for the average pileup.
+
+import FWCore.ParameterSet.Config as cms
+from SimGeneral.MixingModule.mix_probFunction_25ns_PoissonOOTPU_cfi import *
+mix.input.nbPileupEvents.probFunctionVariable = cms.vint32(range(201))
+
+mix.input.nbPileupEvents.probValue = cms.vdouble([0.00497512 for x in range(201)])


### PR DESCRIPTION
#### PR description:

This PR adds a luminosity scenario with flat probability of PU between 0 and 200 PU events. For possible use for luminosity studies for Phase-2.

#### PR validation:

The configuration produced and expanded with ```edmConfigDump``` looks coherent with the target:

```
        nbPileupEvents = cms.PSet(
            histoFileName = cms.untracked.string('histProbFunction.root'),
            probFunctionVariable = cms.vint32(
                0, 1, 2, 3, 4,
                5, 6, 7, 8, 9,
                10, 11, 12, 13, 14,
                15, 16, 17, 18, 19,
                20, 21, 22, 23, 24,
                25, 26, 27, 28, 29,
                30, 31, 32, 33, 34,
                35, 36, 37, 38, 39,
                40, 41, 42, 43, 44,
                45, 46, 47, 48, 49,
                50, 51, 52, 53, 54,
                55, 56, 57, 58, 59,
                60, 61, 62, 63, 64,
                65, 66, 67, 68, 69,
                70, 71, 72, 73, 74,
                75, 76, 77, 78, 79,
                80, 81, 82, 83, 84,
                85, 86, 87, 88, 89,
                90, 91, 92, 93, 94,
                95, 96, 97, 98, 99,
                100, 101, 102, 103, 104,
                105, 106, 107, 108, 109,
                110, 111, 112, 113, 114,
                115, 116, 117, 118, 119,
                120, 121, 122, 123, 124,
                125, 126, 127, 128, 129,
                130, 131, 132, 133, 134,
                135, 136, 137, 138, 139,
                140, 141, 142, 143, 144,
                145, 146, 147, 148, 149,
                150, 151, 152, 153, 154,
                155, 156, 157, 158, 159,
                160, 161, 162, 163, 164,
                165, 166, 167, 168, 169,
                170, 171, 172, 173, 174,
                175, 176, 177, 178, 179,
                180, 181, 182, 183, 184,
                185, 186, 187, 188, 189,
                190, 191, 192, 193, 194,
                195, 196, 197, 198, 199,
                200
            ),
            probValue = cms.vdouble(
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512, 0.00497512, 0.00497512, 0.00497512, 0.00497512,
                0.00497512
            )
        ),
```