### PR TITLE
[123X backport] Simulation: Add Flat0To200_OOTPoisson PU scenario

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -123,6 +123,7 @@ addMixingScenario("2018_25ns_ProjectedPileup_PoissonOOTPU",{'file': 'SimGeneral.
 addMixingScenario("2018_25ns_JuneProjectionFull18_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi'})
 addMixingScenario("2018_25ns_UltraLegacy_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2018_25ns_UltraLegacy_PoissonOOTPU_cfi'})
 addMixingScenario("Run3_Flat55To75_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_Run3_Flat55To75_PoissonOOTPU_cfi'})
+addMixingScenario("Flat0To200_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_Flat0To200_PoissonOOTPU_cfi'})
 addMixingScenario("ProdStep2",{'file': 'SimGeneral.MixingModule.mixProdStep2_cfi'})
 addMixingScenario("fromDB",{'file': 'SimGeneral.MixingModule.mix_fromDB_cfi'})
 addMixingScenario("2022_LHC_Simulation_10h_2h",{'file': 'SimGeneral.MixingModule.Run3_2022_LHC_Simulation_10h_2h_cfi'})

--- a/SimGeneral/MixingModule/python/mix_Flat0To200_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Flat0To200_PoissonOOTPU_cfi.py
@@ -1,0 +1,8 @@
+# A simple distribution for Run3 studies consisting of a flat distribution from 55
+# to 75 for the average pileup.
+
+import FWCore.ParameterSet.Config as cms
+from SimGeneral.MixingModule.mix_probFunction_25ns_PoissonOOTPU_cfi import *
+mix.input.nbPileupEvents.probFunctionVariable = cms.vint32(range(201))
+
+mix.input.nbPileupEvents.probValue = cms.vdouble([0.00497512 for x in range(201)])


### PR DESCRIPTION
#### PR description:

This PR adds a luminosity scenario with flat probability of PU between 0 and 200 PU events. For possible use for luminosity studies for Phase-2. Backport of #38419 .

#### PR validation:

See #38419 .