### PR TITLE
TrackingTools/PatternTools/test: avoid ClosestApproachInRPhi.cc include

### DIFF
--- a/TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h
+++ b/TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h
@@ -16,16 +16,7 @@
  *     the z-coordinates on the 2 tracks are the closest is chosen. 
  */
 
-// Function for testing ClosestApproachInRPhi
-namespace test {
-  namespace ClosestApproachInRPhi_t {
-    int test();
-  }
-}  // namespace test
-
 class ClosestApproachInRPhi final : public ClosestApproachOnHelices {
-  friend int test::ClosestApproachInRPhi_t::test();
-
 public:
   ClosestApproachInRPhi() { status_ = false; }
   ~ClosestApproachInRPhi() override {}
@@ -56,6 +47,13 @@ public:
    */
   ClosestApproachInRPhi* clone() const override { return new ClosestApproachInRPhi(*this); }
 
+  // given the old Parameters, and a new GlobalPoint,
+  // we return the full new GlobalTrajectoryParameters at the
+  // Point.
+  static GlobalTrajectoryParameters newTrajectory(const GlobalPoint& newpt,
+                                                  const GlobalTrajectoryParameters& oldpar,
+                                                  double bz);
+
 private:
   bool compute(const TrackCharge& chargeA,
                const GlobalVector& momentumA,
@@ -63,13 +61,6 @@ private:
                const TrackCharge& chargeB,
                const GlobalVector& momentumB,
                const GlobalPoint& positionB) dso_internal;
-
-  // given the old Parameters, and a new GlobalPoint,
-  // we return the full new GlobalTrajectoryParameters at the
-  // Point.
-  static GlobalTrajectoryParameters newTrajectory(const GlobalPoint& newpt,
-                                                  const GlobalTrajectoryParameters& oldpar,
-                                                  double bz) dso_internal;
 
   // Computes center coordinates and unsigned radius of circle;
   static void circleParameters(const TrackCharge& charge,

--- a/TrackingTools/PatternTools/test/BuildFile.xml
+++ b/TrackingTools/PatternTools/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="TrackingTools/PatternTools"/>
 <use name="MagneticField/Engine"/>
-<use name="boost"/>
 <bin file="ClosestApproachInRPhi_t.cpp">
 </bin>
 

--- a/TrackingTools/PatternTools/test/ClosestApproachInRPhi_t.cpp
+++ b/TrackingTools/PatternTools/test/ClosestApproachInRPhi_t.cpp
@@ -1,13 +1,7 @@
+#include "MagneticField/Engine/interface/MagneticField.h"
 #include "TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h"
 #include "TrackingTools/PatternTools/interface/TwoTrackMinimumDistanceHelixHelix.h"
-
-// #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-
-// #include "TrackingTools/TrajectoryState/interface/BasicSingleTrajectoryState.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
-
-#include "TrackingTools/PatternTools/src/ClosestApproachInRPhi.cc"
 
 #include <iostream>
 


### PR DESCRIPTION
It should be avoided to include `.cc` files from one library in other
libraries, as it unnecessarily duplicates compile time and library size.

To this end, the `dso_internal` attribute that was added to the
`ClosestApproachInRPhi::newTrajectory` function was removed, and the
function made public, such that it can be reused in the the test binary.