### PR TITLE
[12.3.X] Update SiStrip and TkAlignment ALCARECO event content for Run3 

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
@@ -17,3 +17,13 @@ OutALCARECOTkAlJetHT_noDrop = cms.PSet(
 
 OutALCARECOTkAlJetHT = OutALCARECOTkAlJetHT_noDrop.clone()
 OutALCARECOTkAlJetHT.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlJetHT.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlJetHT, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
@@ -17,3 +17,12 @@ OutALCARECOTkAlJpsiMuMuHI_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlJpsiMuMuHI = copy.deepcopy(OutALCARECOTkAlJpsiMuMuHI_noDrop)
 OutALCARECOTkAlJpsiMuMuHI.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlJpsiMuMuHI.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlJpsiMuMuHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
@@ -17,3 +17,12 @@ OutALCARECOTkAlJpsiMuMu_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlJpsiMuMu = copy.deepcopy(OutALCARECOTkAlJpsiMuMu_noDrop)
 OutALCARECOTkAlJpsiMuMu.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlJpsiMuMu.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlJpsiMuMu, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_Output_cff.py
@@ -18,3 +18,12 @@ OutALCARECOTkAlMinBiasHI_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlMinBiasHI = copy.deepcopy(OutALCARECOTkAlMinBiasHI_noDrop)
 OutALCARECOTkAlMinBiasHI.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlMinBiasHI.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlMinBiasHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Output_cff.py
@@ -18,3 +18,13 @@ OutALCARECOTkAlMinBias_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlMinBias = copy.deepcopy(OutALCARECOTkAlMinBias_noDrop)
 OutALCARECOTkAlMinBias.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlMinBias.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlMinBias, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
@@ -17,3 +17,12 @@ OutALCARECOTkAlMuonIsolatedHI_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlMuonIsolatedHI = copy.deepcopy(OutALCARECOTkAlMuonIsolatedHI_noDrop)
 OutALCARECOTkAlMuonIsolatedHI.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlMuonIsolatedHI.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlMuonIsolatedHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_Output_cff.py
@@ -17,3 +17,12 @@ OutALCARECOTkAlMuonIsolated_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlMuonIsolated = copy.deepcopy(OutALCARECOTkAlMuonIsolated_noDrop)
 OutALCARECOTkAlMuonIsolated.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlMuonIsolated.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlMuonIsolated, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
@@ -17,3 +17,12 @@ OutALCARECOTkAlUpsilonMuMuHI_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlUpsilonMuMuHI = copy.deepcopy(OutALCARECOTkAlUpsilonMuMuHI_noDrop)
 OutALCARECOTkAlUpsilonMuMuHI.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlUpsilonMuMuHI.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlUpsilonMuMuHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
@@ -17,3 +17,12 @@ OutALCARECOTkAlUpsilonMuMu_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlUpsilonMuMu = copy.deepcopy(OutALCARECOTkAlUpsilonMuMu_noDrop)
 OutALCARECOTkAlUpsilonMuMu.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlUpsilonMuMu.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlUpsilonMuMu, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
@@ -17,3 +17,12 @@ OutALCARECOTkAlZMuMuHI_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlZMuMuHI = copy.deepcopy(OutALCARECOTkAlZMuMuHI_noDrop)
 OutALCARECOTkAlZMuMuHI.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlZMuMuHI.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlZMuMuHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
@@ -17,3 +17,12 @@ OutALCARECOTkAlZMuMu_noDrop = cms.PSet(
 import copy
 OutALCARECOTkAlZMuMu = copy.deepcopy(OutALCARECOTkAlZMuMu_noDrop)
 OutALCARECOTkAlZMuMu.outputCommands.insert(0, "drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOTkAlZMuMu.outputCommands
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOTkAlZMuMu, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_Output_cff.py
@@ -20,3 +20,14 @@ OutALCARECOSiStripCalCosmics_noDrop = cms.PSet(
 import copy
 OutALCARECOSiStripCalCosmics=copy.deepcopy(OutALCARECOSiStripCalCosmics_noDrop)
 OutALCARECOSiStripCalCosmics.outputCommands.insert(0,"drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOSiStripCalCosmics.outputCommands
+_run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOSiStripCalCosmics, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAGHI_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAGHI_Output_cff.py
@@ -21,3 +21,14 @@ OutALCARECOSiStripCalMinBiasAAG_noDrop = cms.PSet(
 import copy
 OutALCARECOSiStripCalMinBiasAAG=copy.deepcopy(OutALCARECOSiStripCalMinBiasAAG_noDrop)
 OutALCARECOSiStripCalMinBiasAAG.outputCommands.insert(0,"drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOSiStripCalMinBiasAAG.outputCommands
+_run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOSiStripCalMinBiasAAG, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAG_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAG_Output_cff.py
@@ -21,3 +21,14 @@ OutALCARECOSiStripCalMinBiasAAG_noDrop = cms.PSet(
 import copy
 OutALCARECOSiStripCalMinBiasAAG=copy.deepcopy(OutALCARECOSiStripCalMinBiasAAG_noDrop)
 OutALCARECOSiStripCalMinBiasAAG.outputCommands.insert(0,"drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOSiStripCalMinBiasAAG.outputCommands
+_run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOSiStripCalMinBiasAAG, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasHI_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasHI_Output_cff.py
@@ -21,3 +21,14 @@ OutALCARECOSiStripCalMinBias_noDrop = cms.PSet(
 import copy
 OutALCARECOSiStripCalMinBias=copy.deepcopy(OutALCARECOSiStripCalMinBias_noDrop)
 OutALCARECOSiStripCalMinBias.outputCommands.insert(0,"drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOSiStripCalMinBias.outputCommands
+_run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOSiStripCalMinBias, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_Output_cff.py
@@ -21,3 +21,14 @@ OutALCARECOSiStripCalMinBias_noDrop = cms.PSet(
 import copy
 OutALCARECOSiStripCalMinBias=copy.deepcopy(OutALCARECOSiStripCalMinBias_noDrop)
 OutALCARECOSiStripCalMinBias.outputCommands.insert(0,"drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOSiStripCalMinBias.outputCommands
+_run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOSiStripCalMinBias, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalSmallBiasScan_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalSmallBiasScan_Output_cff.py
@@ -21,3 +21,14 @@ OutALCARECOSiStripCalSmallBiasScan_noDrop = cms.PSet(
 import copy
 OutALCARECOSiStripCalSmallBiasScan=copy.deepcopy(OutALCARECOSiStripCalSmallBiasScan_noDrop)
 OutALCARECOSiStripCalSmallBiasScan.outputCommands.insert(0,"drop *")
+
+# in Run3, SCAL digis replaced by onlineMetaDataDigis
+_run3_common_removedCommands = OutALCARECOSiStripCalSmallBiasScan.outputCommands
+_run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
+_run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
+
+_run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
+                              'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
+
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify(OutALCARECOSiStripCalSmallBiasScan, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)


### PR DESCRIPTION
backport of #38415

#### PR description:

In relation to PR https://github.com/cms-sw/cmssw/pull/38386, update also the event content of the input ALCARECO event contents to use S/W FED 1023 information instead of SCAL for all the relevant SiStrip and TkAlignment alcas.

#### PR validation:

run `runTheMatrix.py -nel 138.4` and manually checked that the event content of the output files is the desired one.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

verbatim backport of #38415 in case a new 12.3.X is built