### PR TITLE
[12_3_X] Fix for printouts with special (for python) chars

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -395,7 +395,10 @@ def output(args, string, *parameters, **kwargs):
 
     output_file = kwargs.get('output_file', sys.stdout)
 
-    print(string % parameters + colors.end, end=' ', file=output_file)
+    to_print = string + colors.end
+    if len(parameters)>0:
+        to_print = string % parameters + colors.end
+    print(to_print, end=' ', file=output_file)
 
     if kwargs.get('newline', True):
         print(file=output_file)


### PR DESCRIPTION
#### PR description:
Backport of #38140
Fixes the  listing functions of `conddb` from command line.

#### PR validation:
Master PR is alredy integrated in CMSSW_12_5_0_pre2 and the `conddb` command works as expected.

#### Backport:
Backport of #38140