### PR TITLE
use cms_omds_adg instead of temp tunnel cmsonr_lb

### DIFF
--- a/CondTools/SiStrip/python/SiStripO2O_cfg_template.py
+++ b/CondTools/SiStrip/python/SiStripO2O_cfg_template.py
@@ -26,8 +26,8 @@ _CFGLINES_
 
 if 'CONFDB' not in os.environ:
     import CondCore.Utilities.credentials as auth
-    user, _, passwd = auth.get_credentials('cmsonr_lb/cms_trk_r')
-    process.SiStripConfigDb.ConfDb = '{user}/{passwd}@{path}'.format(user=user, passwd=passwd, path='cmsonr_lb')
+    user, _, passwd = auth.get_credentials('cms_omds_adg/cms_trk_r')
+    process.SiStripConfigDb.ConfDb = '{user}/{passwd}@{path}'.format(user=user, passwd=passwd, path='cms_omds_adg')
 
 process.load("OnlineDB.SiStripO2O.SiStripO2OCalibrationFactors_cfi")
 process.SiStripCondObjBuilderFromDb = cms.Service( "SiStripCondObjBuilderFromDb",


### PR DESCRIPTION
Use `cms_omds_adg` instead of temp `cmsonr_lb` . This shouod fix the random failures of `SiStripDAQ_O2O_test ` unit test. note that `cms_omds_adg` is part of official cern `tnsnames.ora` so this change will allow us to use official tnsnames.ora 

Fixes #37888