### PR TITLE
[12_4_X] Update L1T menu tag in MC and relval GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,7 +36,7 @@ autoCond = {
     # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v1) but with snapshot at 2022-06-08 15:00:00 (UTC)
     'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v1',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v2',
+    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v3',
     # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v1 but with snapshot at 2022-06-09 20:00:00 (UTC)
     'run3_data_express'            : '124X_dataRun3_Express_frozen_v1',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v1 but with snapshot at 2022-06-09 20:00:00 (UTC)
@@ -44,7 +44,7 @@ autoCond = {
     # GlobalTag for Run3 offline data reprocessing
     'run3_data'                    : '124X_dataRun3_v2',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '124X_dataRun3_relval_v2',
+    'run3_data_relval'             : '124X_dataRun3_relval_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -68,21 +68,21 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '124X_mcRun3_2022_design_v5',
+    'phase1_2022_design'           : '124X_mcRun3_2022_design_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v5',
+    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v6',
+    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v7',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v5',
+    'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v5',
+    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v5',
+    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v5',
+    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '124X_mcRun4_realistic_v6'
+    'phase2_realistic'             : '124X_mcRun4_realistic_v7'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,16 +33,16 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v1) but with snapshot at 2022-06-08 15:00:00 (UTC)
-    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v1',
+    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v1) but with snapshot at 2022-06-20 11:11:45 (UTC)
+    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v2',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
     'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v3',
     # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v1 but with snapshot at 2022-06-09 20:00:00 (UTC)
     'run3_data_express'            : '124X_dataRun3_Express_frozen_v1',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v1 but with snapshot at 2022-06-09 20:00:00 (UTC)
     'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v1',
-    # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '124X_dataRun3_v2',
+    # GlobalTag for Run3 offline data reprocessing - snapshot updated to 2022-06-20 11:11:45 (UTC)
+    'run3_data'                    : '124X_dataRun3_v4',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
     'run3_data_relval'             : '124X_dataRun3_relval_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)


### PR DESCRIPTION
#### PR description:
Backport of #38438 
This PR updates the L1T menu tag for the 12_4_X MC prouduction campaign, as requested in [this CMSTalk post](https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-l1-menu-tag-v1-2-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/11830) for Run3 MC GTs and the Run3 relval GTs used for TSG tests.
The new L1T tag is `L1Menu_Collisions2022_v1_2_0_xml`.

*Note:* The GTs `run3_data_relval` and `run3_data` also contain the `SiPixelAliThresholdsHG_offline_v0` tag that was introduced in #38273, but never propagated to `autoCond`.

*Note2:* Both `run3_hlt` and `run3_data` GTs have been updated to have the same snapshot time of `run3_hlt_relval` and `run3_data_relval`, as suggested in https://github.com/cms-sw/cmssw/pull/38438#issuecomment-1160443211.

See master PR for GT diffs.

#### PR validation:
Tested with:
`runTheMatrix.py -l 7.23,159.0,11634.0,12034.0,12434.0,12834.0 --ibeos -j16`

#### Backport:
Backport of #38438 