### PR TITLE
[12.3.X] use cms_omds_adg instead of temp tunnel cms_omds_tunnel

### DIFF
--- a/CondTools/SiStrip/python/SiStripO2O_cfg_template.py
+++ b/CondTools/SiStrip/python/SiStripO2O_cfg_template.py
@@ -26,8 +26,8 @@ _CFGLINES_
 
 if 'CONFDB' not in os.environ:
     import CondCore.Utilities.credentials as auth
-    user, _, passwd = auth.get_credentials('cms_omds_tunnel/cms_trk_r')
-    process.SiStripConfigDb.ConfDb = '{user}/{passwd}@{path}'.format(user=user, passwd=passwd, path='cms_omds_tunnel')
+    user, _, passwd = auth.get_credentials('cms_omds_adg/cms_trk_r')
+    process.SiStripConfigDb.ConfDb = '{user}/{passwd}@{path}'.format(user=user, passwd=passwd, path='cms_omds_adg')
 
 process.load("OnlineDB.SiStripO2O.SiStripO2OCalibrationFactors_cfi")
 process.SiStripCondObjBuilderFromDb = cms.Service( "SiStripCondObjBuilderFromDb",


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/38434
Fixes CondTools/SiStrip unit test