### PR TITLE
[124X (backport)] Introduce era with CKF pixelLessStep: backport of #38437

### DIFF
--- a/Configuration/Eras/python/Era_Run3_ckfPixelLessStep.py
+++ b/Configuration/Eras/python/Era_Run3_ckfPixelLessStep.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.ProcessModifiers.trackingMkFitPixelLessStep_cff import *
+from Configuration.Eras.Era_Run3_cff import Run3
+
+Run3_ckfPixelLessStep = cms.ModifierChain(Run3.copyAndExclude([trackingMkFitPixelLessStep]))

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -398,6 +398,9 @@ trackdnn.toReplaceWith(pixelLessStep, trackTfClassifier.clone(
 ))
 (trackdnn & fastSim).toModify(pixelLessStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
+((~trackingMkFitPixelLessStep) & trackdnn).toModify(pixelLessStep, mva.tfDnnLabel = 'trackSelectionTf_CKF',
+                                                    qualityCuts = [-0.81, -0.61, -0.17])
+
 pp_on_AA.toModify(pixelLessStep, qualityCuts = [-0.4,0.0,0.8])
 
 # For LowPU

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -398,7 +398,7 @@ trackdnn.toReplaceWith(pixelLessStep, trackTfClassifier.clone(
 ))
 (trackdnn & fastSim).toModify(pixelLessStep,vertices = 'firstStepPrimaryVerticesBeforeMixing')
 
-((~trackingMkFitPixelLessStep) & trackdnn).toModify(pixelLessStep, mva.tfDnnLabel = 'trackSelectionTf_CKF',
+((~trackingMkFitPixelLessStep) & trackdnn).toModify(pixelLessStep, mva = dict(tfDnnLabel  = 'trackSelectionTf_CKF'),
                                                     qualityCuts = [-0.81, -0.61, -0.17])
 
 pp_on_AA.toModify(pixelLessStep, qualityCuts = [-0.4,0.0,0.8])


### PR DESCRIPTION
### PR description:

This PR introduces a new era modifier where mkFit is disabled for PixelLessStep.
This is meant as a (temporary) fix for the inefficiency previously reported by BPH (https://indico.cern.ch/event/1166179/#3-feedback-from-bph-on-mkfit).

**This is a backport of PR #38437.**

### PR validation:
As described in https://indico.cern.ch/event/1169208/#5-mkfit-cross-check-of-ineffic