### PR TITLE
Revert "Enable Geant4 gamma general process"

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -180,7 +180,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         G4MscSafetyFactor = cms.double(0.6), 
         G4MscLambdaLimit = cms.double(1.0), # mm 
         G4MscStepLimit = cms.string("UseSafety"), 
-        G4GeneralProcess = cms.bool(True),
+        G4GeneralProcess = cms.bool(False),
         ReadMuonData = cms.bool(False), 
         Verbosity = cms.untracked.int32(0),
         # 1 will print cuts as they get set from DD


### PR DESCRIPTION
Reverts cms-sw/cmssw#38194, as discussed at the ORP meeting on June 21
It will aim to 13_0, instead