### PR TITLE
Add  Transformer ability to modules

### DIFF
--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -81,6 +81,8 @@ namespace edm {
     std::string const& productInstanceName() const { return productInstanceName_; }
     bool produced() const { return transient_.produced_; }
     void setProduced(bool isProduced) { transient_.produced_ = isProduced; }
+    bool isTransform() const { return transient_.isTransform_; }
+    void setIsTransform(bool isTransform) { transient_.isTransform_ = isTransform; }
     bool present() const { return !transient_.dropped_; }
     bool dropped() const { return transient_.dropped_; }
     void setDropped(bool isDropped) { transient_.dropped_ = isDropped; }
@@ -177,6 +179,9 @@ namespace edm {
       // Was this branch produced in this current process and by unscheduled production
       // This item is set only in the framework, not by FWLite.
       bool onDemand_;
+
+      // Was this branch produced in this current process via the transform ability
+      bool isTransform_;
 
       // Has the branch been dropped from the product tree in this file
       // (or if this is a merged product registry, in the first file).

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -27,6 +27,7 @@ namespace edm {
         basketSize_(),
         produced_(false),
         onDemand_(false),
+        isTransform_(false),
         dropped_(false),
         transient_(false),
         availableOnlyAtEndTransition_(false),

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -243,6 +243,7 @@ namespace edm {
     void resetItemsToGetFrom(BranchType iType) { itemsToGetFromBranch_[iType].clear(); }
 
   private:
+    virtual void extendUpdateLookup(BranchType iBranchType, ProductResolverIndexHelper const&);
     virtual void registerLateConsumes(eventsetup::ESRecordsToProxyIndices const&) {}
     unsigned int recordConsumes(BranchType iBranch, TypeToGet const& iType, edm::InputTag const& iTag, bool iAlwaysGets);
     ESTokenIndex recordESConsumes(Transition,

--- a/FWCore/Framework/interface/EventForTransformer.h
+++ b/FWCore/Framework/interface/EventForTransformer.h
@@ -1,0 +1,42 @@
+#ifndef FWCore_Framework_EventForTransformer_h
+#define FWCore_Framework_EventForTransformer_h
+
+// -*- C++ -*-
+//
+// Package:     Framework
+// Class  :     EventForTransformer
+//
+/**\class edm::EventForTransformer
+
+*/
+/*----------------------------------------------------------------------
+----------------------------------------------------------------------*/
+
+#include "DataFormats/Common/interface/BasicHandle.h"
+#include "DataFormats/Common/interface/WrapperBase.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+#include "FWCore/Utilities/interface/ProductResolverIndex.h"
+
+#include <memory>
+
+namespace edm {
+
+  class EventPrincipal;
+  class ModuleCallingContext;
+
+  class EventForTransformer {
+  public:
+    EventForTransformer(EventPrincipal const&, ModuleCallingContext const*);
+
+    BasicHandle get(edm::TypeID const& iTypeID, ProductResolverIndex iIndex) const;
+
+    void put(ProductResolverIndex index, std::unique_ptr<WrapperBase> edp, BasicHandle const& iGetHandle);
+
+  private:
+    EventPrincipal const& eventPrincipal_;
+    ModuleCallingContext const* mcc_;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -229,6 +229,7 @@ namespace edm {
     void addDelayedReaderInputProduct(std::shared_ptr<BranchDescription const> bd);
     void addPutOnReadInputProduct(std::shared_ptr<BranchDescription const> bd);
     void addUnscheduledProduct(std::shared_ptr<BranchDescription const> bd);
+    void addTransformProduct(std::shared_ptr<BranchDescription const> bd);
     void addAliasedProduct(std::shared_ptr<BranchDescription const> bd);
     void addSwitchProducerProduct(std::shared_ptr<BranchDescription const> bd);
     void addSwitchAliasProduct(std::shared_ptr<BranchDescription const> bd);

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -82,6 +82,9 @@ namespace edm {
     using ProductRegistryHelper::recordProvenanceList;
     using ProductRegistryHelper::typeLabelList;
 
+    template <typename T>
+    using BranchAliasSetterT = ProductRegistryHelper::BranchAliasSetterT<T>;
+
     void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
       callWhenNewProductsRegistered_ = func;
     }
@@ -114,6 +117,7 @@ namespace edm {
     friend class limited::EDProducerBase;
     friend class limited::EDFilterBase;
     friend class PuttableSourceBase;
+    friend class TransformerBase;
     template <typename T>
     friend class stream::ProducingModuleAdaptorBase;
 
@@ -126,6 +130,8 @@ namespace edm {
     void commit_(P& iPrincipal, I* iID) {
       iPrincipal.commit_(putIndicies_[producerbasehelper::PrincipalTraits<P>::kBranchType], iID);
     }
+
+    using ProductRegistryHelper::transforms;
 
     std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
     std::array<std::vector<edm::ProductResolverIndex>, edm::NumBranchTypes> putIndicies_;

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -36,19 +36,21 @@ namespace edm {
     };
 
     struct TypeLabelItem {
-      enum class AliasType { kBranchAlias, kSwitchAlias };
+      enum class AliasType : char { kBranchAlias, kSwitchAlias };
 
       TypeLabelItem(Transition const& transition, TypeID const& tid, std::string pin)
           : transition_(transition),
             typeID_(tid),
             productInstanceName_(std::move(pin)),
             branchAlias_(),
-            aliasType_(AliasType::kBranchAlias) {}
+            aliasType_(AliasType::kBranchAlias),
+            isTransform_(false) {}
       Transition transition_;
       TypeID typeID_;
       std::string productInstanceName_;
       std::string branchAlias_;
       AliasType aliasType_;
+      bool isTransform_;
     };
 
     struct BranchAliasSetter {
@@ -179,6 +181,14 @@ namespace edm {
       typeLabelList_.emplace_back(B, id, std::move(instanceName));
       recordProvenanceList_.push_back(recordProvenance and B == Transition::Event);
       return BranchAliasSetter{typeLabelList_.back(), EDPutToken{index}};
+    }
+
+    EDPutToken transforms(const TypeID& id, std::string instanceName) {
+      unsigned int index = typeLabelList_.size();
+      typeLabelList_.emplace_back(Transition::Event, id, std::move(instanceName));
+      typeLabelList_.back().isTransform_ = true;
+      recordProvenanceList_.push_back(true);
+      return EDPutToken{index};
     }
 
     virtual bool hasAbilityToProduceInBeginProcessBlocks() const { return false; }

--- a/FWCore/Framework/interface/TransformerBase.h
+++ b/FWCore/Framework/interface/TransformerBase.h
@@ -1,0 +1,54 @@
+//
+//  TransformerBase.h
+//  CMSSW
+//
+//  Created by Chris Jones on 6/02/22.
+//
+
+#ifndef FWCore_Framework_TransformerBase_h
+#define FWCore_Framework_TransformerBase_h
+
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/SoATuple.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+#include "FWCore/Utilities/interface/ProductResolverIndex.h"
+
+#include <string>
+#include <functional>
+#include <memory>
+
+namespace edm {
+  class ProducerBase;
+  class TypeID;
+  class WrapperBase;
+  class EventForTransformer;
+  class BranchDescription;
+  class ProductResolverIndexHelper;
+  class ModuleDescription;
+
+  class TransformerBase {
+  public:
+    TransformerBase() = default;
+    virtual ~TransformerBase() noexcept(false) = default;
+
+  protected:
+    //The function takes the WrapperBase corresponding to the data product from the EDPutToken
+    // and returns the WrapperBase associated to the id and instanceName
+    using TransformFunction = std::function<std::unique_ptr<edm::WrapperBase>(edm::WrapperBase const&)>;
+
+    void registerTransformImp(ProducerBase&, EDPutToken, const TypeID& id, std::string instanceName, TransformFunction);
+
+    std::size_t findMatchingIndex(ProducerBase const& iBase, edm::BranchDescription const&) const;
+    ProductResolverIndex prefetchImp(std::size_t iIndex) const { return transformInfo_.get<0>(iIndex); }
+    void transformImp(std::size_t iIndex, ProducerBase const& iBase, edm::EventForTransformer&) const;
+
+    void extendUpdateLookup(ProducerBase const&,
+                            ModuleDescription const& iModuleDesc,
+                            ProductResolverIndexHelper const& iHelper);
+
+  private:
+    SoATuple<ProductResolverIndex, TypeID, EDPutToken, TransformFunction> transformInfo_;
+  };
+}  // namespace edm
+
+#endif /* TransformerBase_h */

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -38,6 +38,7 @@ namespace edm {
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTaskWithArenaHolder;
+  class EventForTransformer;
 
   namespace maker {
     template <typename T>
@@ -77,6 +78,10 @@ namespace edm {
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);
+      void doTransform(size_t iTransformIndex,
+                       EventPrincipal const& iEvent,
+                       ActivityRegistry*,
+                       ModuleCallingContext const*);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                     ModuleCallingContext const& iModuleCallingContext,
@@ -146,6 +151,10 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+
+      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const;
+      virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const;
+      virtual void transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const;
 
       virtual void clearInputProcessBlockCaches();
       virtual bool hasAcquire() const { return false; }

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -39,6 +39,7 @@ namespace edm {
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTaskWithArenaHolder;
+  class EventForTransformer;
 
   namespace maker {
     template <typename T>
@@ -80,6 +81,10 @@ namespace edm {
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);
+      void doTransform(size_t iTransformIndex,
+                       EventPrincipal const& iEvent,
+                       ActivityRegistry*,
+                       ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();
@@ -149,6 +154,10 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+
+      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const;
+      virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const;
+      virtual void transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const;
 
       virtual void clearInputProcessBlockCaches();
       virtual bool hasAccumulator() const { return false; }

--- a/FWCore/Framework/interface/global/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/filterAbilityToImplementor.h
@@ -101,6 +101,11 @@ namespace edm {
         using Type = edm::global::impl::ExternalWork<edm::global::EDFilterBase>;
       };
 
+      template <>
+      struct AbilityToImplementor<edm::Transformer> {
+        using Type = edm::global::impl::Transformer<edm::global::EDFilterBase>;
+      };
+
       template <bool, bool, typename T>
       struct SpecializeAbilityToImplementor {
         using Type = typename AbilityToImplementor<T>::Type;

--- a/FWCore/Framework/interface/global/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/producerAbilityToImplementor.h
@@ -103,6 +103,11 @@ namespace edm {
       };
 
       template <>
+      struct AbilityToImplementor<edm::Transformer> {
+        using Type = edm::global::impl::Transformer<edm::global::EDProducerBase>;
+      };
+
+      template <>
       struct AbilityToImplementor<edm::Accumulator> {
         using Type = edm::global::impl::Accumulator<edm::global::EDProducerBase>;
       };

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -38,6 +38,7 @@ namespace edm {
   class StreamID;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
+  class EventForTransformer;
 
   namespace maker {
     template <typename T>
@@ -77,6 +78,11 @@ namespace edm {
 
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
+      void doTransform(size_t iTransformIndex,
+                       EventPrincipal const& iEvent,
+                       ActivityRegistry*,
+                       ModuleCallingContext const*);
+
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
                                                     ModuleCallingContext const&,
@@ -146,6 +152,10 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+
+      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const;
+      virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const;
+      virtual void transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const;
 
       virtual void clearInputProcessBlockCaches();
 

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -39,6 +39,7 @@ namespace edm {
   class GlobalSchedule;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
+  class EventForTransformer;
 
   namespace maker {
     template <typename T>
@@ -80,6 +81,10 @@ namespace edm {
 
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
+      void doTransform(size_t iTransformIndex,
+                       EventPrincipal const& iEvent,
+                       ActivityRegistry*,
+                       ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();
@@ -150,6 +155,10 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+
+      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const;
+      virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const;
+      virtual void transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const;
 
       virtual void clearInputProcessBlockCaches();
       virtual bool hasAccumulator() const { return false; }

--- a/FWCore/Framework/interface/limited/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/filterAbilityToImplementor.h
@@ -97,6 +97,11 @@ namespace edm {
         using Type = edm::limited::impl::EndLuminosityBlockProducer<edm::limited::EDFilterBase>;
       };
 
+      template <>
+      struct AbilityToImplementor<edm::Transformer> {
+        using Type = edm::limited::impl::Transformer<edm::limited::EDFilterBase>;
+      };
+
       template <bool, bool, typename T>
       struct SpecializeAbilityToImplementor {
         using Type = typename AbilityToImplementor<T>::Type;

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -32,12 +32,15 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/InputProcessBlockCacheImpl.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/TransformerBase.h"
+#include "FWCore/Framework/interface/ProductRegistryHelper.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/ProcessBlockIndex.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "DataFormats/Common/interface/Wrapper.h"
 
 // forward declarations
 namespace edm {
@@ -424,6 +427,54 @@ namespace edm {
         void produce(StreamID streamID, Event& ev, EventSetup const& es) const final { accumulate(streamID, ev, es); }
 
         virtual void accumulate(StreamID streamID, Event const& ev, EventSetup const& es) const = 0;
+      };
+
+      template <typename T>
+      class Transformer : public virtual T, private TransformerBase {
+      public:
+        Transformer(edm::ParameterSet const& iPSet) : T(iPSet) {}
+        Transformer() = default;
+        Transformer(Transformer const&) = delete;
+        Transformer& operator=(Transformer const&) = delete;
+        ~Transformer() noexcept(false) override{};
+
+        template <typename G, typename F>
+        void registerTransform(ProductRegistryHelper::BranchAliasSetterT<G> iSetter,
+                               F&& iF,
+                               std::string productInstance = std::string()) {
+          registerTransform(edm::EDPutTokenT<G>(iSetter), std::forward<F>(iF), std::move(productInstance));
+        }
+
+        template <typename G, typename F>
+        void registerTransform(edm::EDPutTokenT<G> iToken, F iF, std::string productInstance = std::string()) {
+          using ReturnTypeT = decltype(iF(std::declval<G>()));
+          TypeID returnType(typeid(ReturnTypeT));
+          TransformerBase::registerTransformImp(*this,
+                                                EDPutToken(iToken),
+                                                returnType,
+                                                std::move(productInstance),
+                                                [f = std::move(iF)](edm::WrapperBase const& iGotProduct) {
+                                                  return std::make_unique<edm::Wrapper<ReturnTypeT>>(
+                                                      WrapperBase::Emplace{},
+                                                      f(*static_cast<edm::Wrapper<G> const&>(iGotProduct).product()));
+                                                });
+        }
+
+      private:
+        size_t transformIndex_(edm::BranchDescription const& iBranch) const final {
+          return TransformerBase::findMatchingIndex(*this, iBranch);
+        }
+        ProductResolverIndex transformPrefetch_(std::size_t iIndex) const final {
+          return TransformerBase::prefetchImp(iIndex);
+        }
+        void transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const final {
+          return TransformerBase::transformImp(iIndex, *this, iEvent);
+        }
+        void extendUpdateLookup(BranchType iBranchType, ProductResolverIndexHelper const& iHelper) override {
+          if (iBranchType == InEvent) {
+            TransformerBase::extendUpdateLookup(*this, this->moduleDescription(), iHelper);
+          }
+        }
       };
     }  // namespace impl
   }    // namespace limited

--- a/FWCore/Framework/interface/limited/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/limited/producerAbilityToImplementor.h
@@ -98,6 +98,11 @@ namespace edm {
       };
 
       template <>
+      struct AbilityToImplementor<edm::Transformer> {
+        using Type = edm::limited::impl::Transformer<edm::limited::EDProducerBase>;
+      };
+
+      template <>
       struct AbilityToImplementor<edm::Accumulator> {
         using Type = edm::limited::impl::Accumulator<edm::limited::EDProducerBase>;
       };

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -289,7 +289,6 @@ namespace edm {
 
     virtual std::vector<ESProxyIndex> const& esItemsToGetFrom(Transition) const = 0;
     virtual std::vector<ESRecordIndex> const& esRecordsToGetFrom(Transition) const = 0;
-    virtual std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const = 0;
 
     virtual void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                               ModuleCallingContext const& moduleCallingContext,

--- a/FWCore/Framework/interface/maker/Worker.h
+++ b/FWCore/Framework/interface/maker/Worker.h
@@ -165,6 +165,15 @@ namespace edm {
                                          ParentContext const&,
                                          typename T::Context const*);
 
+    virtual size_t transformIndex(edm::BranchDescription const&) const = 0;
+    void doTransformAsync(WaitingTaskHolder,
+                          size_t iTransformIndex,
+                          EventPrincipal const&,
+                          ServiceToken const&,
+                          StreamID,
+                          ModuleCallingContext const&,
+                          StreamContext const*);
+
     void callWhenDoneAsync(WaitingTaskHolder task) { waitingTasks_.add(std::move(task)); }
     void skipOnPath(EventPrincipal const& iEvent);
     void beginJob();
@@ -256,6 +265,9 @@ namespace edm {
     virtual void implDoAcquire(EventTransitionInfo const&,
                                ModuleCallingContext const*,
                                WaitingTaskWithArenaHolder&) = 0;
+
+    virtual void implDoTransform(size_t iTransformIndex, EventPrincipal const&, ParentContext const&) = 0;
+    virtual ProductResolverIndex itemToGetForTransform(size_t iTransformIndex) const = 0;
 
     virtual bool implDoPrePrefetchSelection(StreamID, EventPrincipal const&, ModuleCallingContext const*) = 0;
     virtual bool implDoBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;

--- a/FWCore/Framework/interface/maker/WorkerT.h
+++ b/FWCore/Framework/interface/maker/WorkerT.h
@@ -149,8 +149,6 @@ namespace edm {
       return module_->esGetTokenRecordIndicesVector(iTransition);
     }
 
-    std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const override;
-
     void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                       ModuleCallingContext const& iModuleCallingContext,
                                       Principal const& iPrincipal) const override {

--- a/FWCore/Framework/interface/maker/WorkerT.h
+++ b/FWCore/Framework/interface/maker/WorkerT.h
@@ -92,6 +92,10 @@ namespace edm {
 
     void implDoAcquire(EventTransitionInfo const&, ModuleCallingContext const*, WaitingTaskWithArenaHolder&) final;
 
+    size_t transformIndex(edm::BranchDescription const&) const final;
+    void implDoTransform(size_t iTransformIndex, EventPrincipal const&, ParentContext const&) final;
+    ProductResolverIndex itemToGetForTransform(size_t iTransformIndex) const final;
+
     bool implDoPrePrefetchSelection(StreamID, EventPrincipal const&, ModuleCallingContext const*) override;
     bool implDoBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) override;
     bool implDoAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) override;

--- a/FWCore/Framework/interface/moduleAbilities.h
+++ b/FWCore/Framework/interface/moduleAbilities.h
@@ -123,6 +123,11 @@ namespace edm {
     typedef module::Empty Type;
   };
 
+  struct Transformer {
+    static constexpr module::Abilities kAbilities = module::Abilities::kTransformer;
+    using Type = module::Empty;
+  };
+
   //Recursively checks VArgs template arguments looking for the ABILITY
   template <module::Abilities ABILITY, typename... VArgs>
   struct CheckAbility;

--- a/FWCore/Framework/interface/moduleAbilityEnums.h
+++ b/FWCore/Framework/interface/moduleAbilityEnums.h
@@ -47,7 +47,8 @@ namespace edm {
       kOneWatchLuminosityBlocks,
       kWatchInputFiles,
       kExternalWork,
-      kAccumulator
+      kAccumulator,
+      kTransformer
     };
 
     namespace AbilityBits {

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -36,6 +36,7 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
+  class EventForTransformer;
 
   namespace maker {
     template <typename T>
@@ -74,6 +75,10 @@ namespace edm {
 
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
+      void doTransform(size_t iTransformIndex,
+                       EventPrincipal const& iEvent,
+                       ActivityRegistry*,
+                       ModuleCallingContext const*);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
                                                     ModuleCallingContext const&,
@@ -124,6 +129,10 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+
+      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const;
+      virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const;
+      virtual void transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const;
 
       virtual void clearInputProcessBlockCaches();
 

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -36,6 +36,7 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
+  class EventForTransformer;
 
   namespace maker {
     template <typename T>
@@ -79,6 +80,10 @@ namespace edm {
                                                     ModuleCallingContext const&,
                                                     Principal const&) const {}
 
+      void doTransform(size_t iTransformIndex,
+                       EventPrincipal const& iEvent,
+                       ActivityRegistry*,
+                       ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocLumis(unsigned int);
       void doBeginJob();
@@ -124,6 +129,10 @@ namespace edm {
       virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
       virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
       virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+
+      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const;
+      virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const;
+      virtual void transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const;
 
       virtual void clearInputProcessBlockCaches();
       virtual bool hasAccumulator() const { return false; }

--- a/FWCore/Framework/interface/one/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/filterAbilityToImplementor.h
@@ -84,6 +84,11 @@ namespace edm {
         using Type = edm::one::impl::EndLuminosityBlockProducer<edm::one::EDFilterBase>;
       };
 
+      template <>
+      struct AbilityToImplementor<edm::Transformer> {
+        using Type = edm::one::impl::Transformer<edm::one::EDFilterBase>;
+      };
+
       template <typename... Cs>
       struct AbilityToImplementor<edm::InputProcessBlockCache<Cs...>> {
         using Type = edm::one::impl::InputProcessBlockCacheHolder<edm::one::EDFilterBase, Cs...>;

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -33,11 +33,14 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/InputProcessBlockCacheImpl.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/TransformerBase.h"
+#include "FWCore/Framework/interface/ProductRegistryHelper.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ProcessBlockIndex.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
+#include "DataFormats/Common/interface/Wrapper.h"
 
 // forward declarations
 
@@ -326,6 +329,53 @@ namespace edm {
         void produce(Event& ev, EventSetup const& es) final { accumulate(ev, es); }
 
         virtual void accumulate(Event const& ev, EventSetup const& es) = 0;
+      };
+
+      template <typename T>
+      class Transformer : public virtual T, private TransformerBase {
+      public:
+        Transformer() = default;
+        Transformer(Transformer const&) = delete;
+        Transformer& operator=(Transformer const&) = delete;
+        ~Transformer() noexcept(false) override{};
+
+        template <typename G, typename F>
+        void registerTransform(ProductRegistryHelper::BranchAliasSetterT<G> iSetter,
+                               F&& iF,
+                               std::string productInstance = std::string()) {
+          registerTransform(edm::EDPutTokenT<G>(iSetter), std::forward<F>(iF), std::move(productInstance));
+        }
+
+        template <typename G, typename F>
+        void registerTransform(edm::EDPutTokenT<G> iToken, F iF, std::string productInstance = std::string()) {
+          using ReturnTypeT = decltype(iF(std::declval<G>()));
+          TypeID returnType(typeid(ReturnTypeT));
+          TransformerBase::registerTransformImp(*this,
+                                                EDPutToken(iToken),
+                                                returnType,
+                                                std::move(productInstance),
+                                                [f = std::move(iF)](edm::WrapperBase const& iGotProduct) {
+                                                  return std::make_unique<edm::Wrapper<ReturnTypeT>>(
+                                                      WrapperBase::Emplace{},
+                                                      f(*static_cast<edm::Wrapper<G> const&>(iGotProduct).product()));
+                                                });
+        }
+
+      private:
+        size_t transformIndex_(edm::BranchDescription const& iBranch) const final {
+          return TransformerBase::findMatchingIndex(*this, iBranch);
+        }
+        ProductResolverIndex transformPrefetch_(std::size_t iIndex) const final {
+          return TransformerBase::prefetchImp(iIndex);
+        }
+        void transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const final {
+          return TransformerBase::transformImp(iIndex, *this, iEvent);
+        }
+        void extendUpdateLookup(BranchType iBranchType, ProductResolverIndexHelper const& iHelper) override {
+          if (iBranchType == InEvent) {
+            TransformerBase::extendUpdateLookup(*this, this->moduleDescription(), iHelper);
+          }
+        }
       };
     }  // namespace impl
   }    // namespace one

--- a/FWCore/Framework/interface/one/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/producerAbilityToImplementor.h
@@ -84,6 +84,11 @@ namespace edm {
         using Type = edm::one::impl::EndLuminosityBlockProducer<edm::one::EDProducerBase>;
       };
 
+      template <>
+      struct AbilityToImplementor<edm::Transformer> {
+        using Type = edm::one::impl::Transformer<edm::one::EDProducerBase>;
+      };
+
       template <typename... Cs>
       struct AbilityToImplementor<edm::InputProcessBlockCache<Cs...>> {
         using Type = edm::one::impl::InputProcessBlockCacheHolder<edm::one::EDProducerBase, Cs...>;

--- a/FWCore/Framework/interface/stream/AbilityChecker.h
+++ b/FWCore/Framework/interface/stream/AbilityChecker.h
@@ -103,6 +103,11 @@ namespace edm {
       };
 
       template <typename... U>
+      struct HasAbility<edm::Transformer, U...> : public HasAbility<U...> {
+        static constexpr bool kTransformer = true;
+      };
+
+      template <typename... U>
       struct HasAbility<edm::Accumulator, U...> : public HasAbility<U...> {
         static constexpr bool kAccumulator = true;
       };
@@ -124,6 +129,7 @@ namespace edm {
         static constexpr bool kEndLuminosityBlockProducer = false;
         static constexpr bool kExternalWork = false;
         static constexpr bool kAccumulator = false;
+        static constexpr bool kTransformer = false;
       };
     }  // namespace impl
     template <typename... T>

--- a/FWCore/Framework/interface/stream/AbilityToImplementor.h
+++ b/FWCore/Framework/interface/stream/AbilityToImplementor.h
@@ -103,6 +103,13 @@ namespace edm {
     // As currently implemented this ability only works
     // with EDProducer, not with EDAnalyzers or EDFilters!
     template <>
+    struct AbilityToImplementor<edm::Transformer> {
+      using Type = edm::stream::impl::Transformer;
+    };
+
+    // As currently implemented this ability only works
+    // with EDProducer, not with EDAnalyzers or EDFilters!
+    template <>
     struct AbilityToImplementor<edm::Accumulator> {
       using Type = edm::stream::impl::Accumulator;
     };

--- a/FWCore/Framework/interface/stream/EDProducer.h
+++ b/FWCore/Framework/interface/stream/EDProducer.h
@@ -34,7 +34,8 @@ namespace edm {
 
     template <typename... T>
     class EDProducer : public AbilityToImplementor<T>::Type...,
-                       public std::conditional<CheckAbility<edm::module::Abilities::kAccumulator, T...>::kHasIt,
+                       public std::conditional<CheckAbility<edm::module::Abilities::kAccumulator, T...>::kHasIt or
+                                                   CheckAbility<edm::module::Abilities::kTransformer, T...>::kHasIt,
                                                impl::EmptyType,
                                                EDProducerBase>::type {
     public:

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/stream/EDProducerAdaptor.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Utilities/interface/ProductResolverIndex.h"
 
 // forward declarations
 namespace edm {
@@ -35,6 +36,7 @@ namespace edm {
   class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTaskWithArenaHolder;
+  class EventForTransformer;
 
   namespace stream {
     class EDProducerAdaptorBase;
@@ -73,6 +75,9 @@ namespace edm {
       virtual void registerThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}
 
       virtual void doAcquire_(Event const&, EventSetup const&, WaitingTaskWithArenaHolder&) = 0;
+      virtual size_t transformIndex_(edm::BranchDescription const& iBranch) const;
+      virtual ProductResolverIndex transformPrefetch_(std::size_t iIndex) const;
+      virtual void transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const;
 
       void setModuleDescriptionPtr(ModuleDescription const* iDesc) { moduleDescriptionPtr_ = iDesc; }
       // ---------- member data --------------------------------

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -53,6 +53,7 @@ namespace edm {
   class PreallocationConfiguration;
   class ProductResolverIndexAndSkipBit;
   class ThinnedAssociationsHelper;
+  class ActivityRegistry;
 
   namespace maker {
     template <typename T>
@@ -124,6 +125,13 @@ namespace edm {
                               std::string const& moduleLabel);
 
       std::vector<edm::ProductResolverIndex> const& indiciesForPutProducts(BranchType iBranchType) const;
+
+      ProductResolverIndex transformPrefetch_(size_t iTransformIndex) const;
+      size_t transformIndex_(edm::BranchDescription const& iBranch) const;
+      void doTransform(size_t iTransformIndex,
+                       EventPrincipal const& iEvent,
+                       ActivityRegistry*,
+                       ModuleCallingContext const*);
 
     protected:
       template <typename F>

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -110,11 +110,14 @@ unsigned int EDConsumerBase::recordConsumes(BranchType iBranch,
   return index;
 }
 
+void EDConsumerBase::extendUpdateLookup(BranchType, ProductResolverIndexHelper const&) {}
+
 void EDConsumerBase::updateLookup(BranchType iBranchType,
                                   ProductResolverIndexHelper const& iHelper,
                                   bool iPrefetchMayGet) {
   frozen_ = true;
   assert(!containsCurrentProcessAlias_);
+  extendUpdateLookup(iBranchType, iHelper);
   {
     auto itKind = m_tokenInfo.begin<kKind>();
     auto itLabels = m_tokenInfo.begin<kLabels>();

--- a/FWCore/Framework/src/EventForTransformer.cc
+++ b/FWCore/Framework/src/EventForTransformer.cc
@@ -1,0 +1,28 @@
+#include "FWCore/Framework/interface/EventForTransformer.h"
+
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "FWCore/Common/interface/TriggerResultsByName.h"
+#include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/TransitionInfoTypes.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/Utilities/interface/Algorithms.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace edm {
+
+  EventForTransformer::EventForTransformer(EventPrincipal const& ep, ModuleCallingContext const* moduleCallingContext)
+      : eventPrincipal_{ep}, mcc_{moduleCallingContext} {}
+
+  BasicHandle EventForTransformer::get(edm::TypeID const& iTypeID, ProductResolverIndex iIndex) const {
+    bool amb = false;
+    return eventPrincipal_.getByToken(PRODUCT_TYPE, iTypeID, iIndex, false, amb, nullptr, mcc_);
+  }
+
+  void EventForTransformer::put(ProductResolverIndex index,
+                                std::unique_ptr<WrapperBase> edp,
+                                BasicHandle const& iGetHandle) {
+    eventPrincipal_.put(index, std::move(edp), iGetHandle.provenance()->productProvenance()->parentageID());
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -162,7 +162,11 @@ namespace edm {
                 addSourceProduct(cbd);
               } else if (bd.onDemand()) {
                 assert(branchType_ == InEvent);
-                addUnscheduledProduct(cbd);
+                if (bd.isTransform()) {
+                  addTransformProduct(cbd);
+                } else {
+                  addUnscheduledProduct(cbd);
+                }
               } else {
                 addScheduledProduct(cbd);
               }
@@ -348,6 +352,10 @@ namespace edm {
 
   void Principal::addUnscheduledProduct(std::shared_ptr<BranchDescription const> bd) {
     addProductOrThrow(std::make_unique<UnscheduledProductResolver>(std::move(bd)));
+  }
+
+  void Principal::addTransformProduct(std::shared_ptr<BranchDescription const> bd) {
+    addProductOrThrow(std::make_unique<TransformingProductResolver>(std::move(bd)));
   }
 
   void Principal::addAliasedProduct(std::shared_ptr<BranchDescription const> bd) {

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -94,6 +94,10 @@ namespace edm {
         }
         pdesc.setSwitchAliasModuleLabel(p->branchAlias_);
       }
+      if (p->isTransform_) {
+        pdesc.setOnDemand(true);
+        pdesc.setIsTransform(true);
+      }
       setIsMergeable(pdesc);
 
       if (pdesc.transient()) {

--- a/FWCore/Framework/src/TransformerBase.cc
+++ b/FWCore/Framework/src/TransformerBase.cc
@@ -1,0 +1,63 @@
+#include "FWCore/Framework/interface/TransformerBase.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/EventForTransformer.h"
+#include "DataFormats/Provenance/interface/ProductResolverIndexHelper.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+
+namespace edm {
+  void TransformerBase::registerTransformImp(
+      ProducerBase& iBase, EDPutToken iToken, const TypeID& id, std::string instanceName, TransformFunction iFunc) {
+    auto transformPut = iBase.transforms(id, std::move(instanceName));
+    transformInfo_.emplace_back(iToken.index(), id, transformPut, std::move(iFunc));
+  }
+
+  std::size_t TransformerBase::findMatchingIndex(ProducerBase const& iBase,
+                                                 edm::BranchDescription const& iBranch) const {
+    auto const& list = iBase.typeLabelList();
+
+    std::size_t index = 0;
+    bool found = false;
+    for (auto const& element : list) {
+      if (not element.isTransform_) {
+        continue;
+      }
+      if (element.typeID_ == iBranch.unwrappedTypeID() &&
+          element.productInstanceName_ == iBranch.productInstanceName()) {
+        found = true;
+        break;
+      }
+      ++index;
+    }
+    assert(found);
+    return index;
+  }
+
+  void TransformerBase::extendUpdateLookup(ProducerBase const& iBase,
+                                           ModuleDescription const& iModuleDesc,
+                                           ProductResolverIndexHelper const& iHelper) {
+    auto const& list = iBase.typeLabelList();
+
+    for (auto it = transformInfo_.begin<0>(); it != transformInfo_.end<0>(); ++it) {
+      auto const& putInfo = list[*it];
+      *it = iHelper.index(PRODUCT_TYPE,
+                          putInfo.typeID_,
+                          iModuleDesc.moduleLabel().c_str(),
+                          putInfo.productInstanceName_.c_str(),
+                          iModuleDesc.processName().c_str());
+    }
+  }
+
+  void TransformerBase::transformImp(std::size_t iIndex,
+                                     ProducerBase const& iBase,
+                                     edm::EventForTransformer& iEvent) const {
+    auto handle = iEvent.get(transformInfo_.get<1>(iIndex), transformInfo_.get<0>(iIndex));
+
+    if (handle.wrapper()) {
+      iEvent.put(iBase.putTokenIndexToProductResolverIndex()[transformInfo_.get<2>(iIndex).index()],
+                 transformInfo_.get<3>(iIndex)(*handle.wrapper()),
+                 handle);
+    }
+  }
+
+}  // namespace edm

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -696,22 +696,6 @@ namespace edm {
       iProd->resolvePutIndicies(iBranchType, iIndicies, iModuleLabel);
     }
 
-    std::vector<ProductResolverIndex> s_emptyIndexList;
-
-    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(void const*) { return s_emptyIndexList; }
-
-    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(ProducerBase const* iProd) {
-      return iProd->indiciesForPutProducts(edm::InEvent);
-    }
-
-    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(edm::stream::EDProducerAdaptorBase const* iProd) {
-      return iProd->indiciesForPutProducts(edm::InEvent);
-    }
-
-    std::vector<ProductResolverIndex> const& itemsShouldPutInEventImpl(edm::stream::EDFilterAdaptorBase const* iProd) {
-      return iProd->indiciesForPutProducts(edm::InEvent);
-    }
-
   }  // namespace
 
   template <typename T>
@@ -720,11 +704,6 @@ namespace edm {
       std::unordered_multimap<std::string, std::tuple<TypeID const*, const char*, edm::ProductResolverIndex>> const&
           iIndicies) {
     resolvePutIndiciesImpl(&module(), iBranchType, iIndicies, description()->moduleLabel());
-  }
-
-  template <typename T>
-  std::vector<ProductResolverIndex> const& WorkerT<T>::itemsShouldPutInEvent() const {
-    return itemsShouldPutInEventImpl(&module());
   }
 
   template <>

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -269,6 +269,132 @@ namespace edm {
   }
 
   template <typename T>
+  inline void WorkerT<T>::implDoTransform(size_t iTransformIndex, EventPrincipal const&, ParentContext const&) {}
+  template <>
+  inline void WorkerT<global::EDFilterBase>::implDoTransform(size_t iTransformIndex,
+                                                             EventPrincipal const& iEvent,
+                                                             ParentContext const& iParent) {
+    ModuleCallingContext mcc(
+        &module_->moduleDescription(), ModuleCallingContext::State::kPrefetching, iParent, nullptr);
+    module_->doTransform(iTransformIndex, iEvent, activityRegistry(), &mcc);
+  }
+  template <>
+  inline void WorkerT<global::EDProducerBase>::implDoTransform(size_t iTransformIndex,
+                                                               EventPrincipal const& iEvent,
+                                                               ParentContext const& iParent) {
+    ModuleCallingContext mcc(
+        &module_->moduleDescription(), ModuleCallingContext::State::kPrefetching, iParent, nullptr);
+    module_->doTransform(iTransformIndex, iEvent, activityRegistry(), &mcc);
+  }
+  template <>
+  inline void WorkerT<stream::EDProducerAdaptorBase>::implDoTransform(size_t iTransformIndex,
+                                                                      EventPrincipal const& iEvent,
+                                                                      ParentContext const& iParent) {
+    ModuleCallingContext mcc(
+        &module_->moduleDescription(), ModuleCallingContext::State::kPrefetching, iParent, nullptr);
+    module_->doTransform(iTransformIndex, iEvent, activityRegistry(), &mcc);
+  }
+  template <>
+  inline void WorkerT<limited::EDFilterBase>::implDoTransform(size_t iTransformIndex,
+                                                              EventPrincipal const& iEvent,
+                                                              ParentContext const& iParent) {
+    ModuleCallingContext mcc(
+        &module_->moduleDescription(), ModuleCallingContext::State::kPrefetching, iParent, nullptr);
+    module_->doTransform(iTransformIndex, iEvent, activityRegistry(), &mcc);
+  }
+  template <>
+  inline void WorkerT<limited::EDProducerBase>::implDoTransform(size_t iTransformIndex,
+                                                                EventPrincipal const& iEvent,
+                                                                ParentContext const& iParent) {
+    ModuleCallingContext mcc(
+        &module_->moduleDescription(), ModuleCallingContext::State::kPrefetching, iParent, nullptr);
+    module_->doTransform(iTransformIndex, iEvent, activityRegistry(), &mcc);
+  }
+  template <>
+  inline void WorkerT<one::EDFilterBase>::implDoTransform(size_t iTransformIndex,
+                                                          EventPrincipal const& iEvent,
+                                                          ParentContext const& iParent) {
+    ModuleCallingContext mcc(
+        &module_->moduleDescription(), ModuleCallingContext::State::kPrefetching, iParent, nullptr);
+    module_->doTransform(iTransformIndex, iEvent, activityRegistry(), &mcc);
+  }
+  template <>
+  inline void WorkerT<one::EDProducerBase>::implDoTransform(size_t iTransformIndex,
+                                                            EventPrincipal const& iEvent,
+                                                            ParentContext const& iParent) {
+    ModuleCallingContext mcc(
+        &module_->moduleDescription(), ModuleCallingContext::State::kPrefetching, iParent, nullptr);
+    module_->doTransform(iTransformIndex, iEvent, activityRegistry(), &mcc);
+  }
+
+  template <typename T>
+  inline size_t WorkerT<T>::transformIndex(edm::BranchDescription const&) const {
+    return -1;
+  }
+  template <>
+  inline size_t WorkerT<global::EDFilterBase>::transformIndex(edm::BranchDescription const& iBranch) const {
+    return module_->transformIndex_(iBranch);
+  }
+  template <>
+  inline size_t WorkerT<global::EDProducerBase>::transformIndex(edm::BranchDescription const& iBranch) const {
+    return module_->transformIndex_(iBranch);
+  }
+  template <>
+  inline size_t WorkerT<stream::EDProducerAdaptorBase>::transformIndex(edm::BranchDescription const& iBranch) const {
+    return module_->transformIndex_(iBranch);
+  }
+  template <>
+  inline size_t WorkerT<limited::EDFilterBase>::transformIndex(edm::BranchDescription const& iBranch) const {
+    return module_->transformIndex_(iBranch);
+  }
+  template <>
+  inline size_t WorkerT<limited::EDProducerBase>::transformIndex(edm::BranchDescription const& iBranch) const {
+    return module_->transformIndex_(iBranch);
+  }
+  template <>
+  inline size_t WorkerT<one::EDFilterBase>::transformIndex(edm::BranchDescription const& iBranch) const {
+    return module_->transformIndex_(iBranch);
+  }
+  template <>
+  inline size_t WorkerT<one::EDProducerBase>::transformIndex(edm::BranchDescription const& iBranch) const {
+    return module_->transformIndex_(iBranch);
+  }
+
+  template <typename T>
+  inline ProductResolverIndex WorkerT<T>::itemToGetForTransform(size_t iTransformIndex) const {
+    return -1;
+  }
+  template <>
+  inline ProductResolverIndex WorkerT<global::EDFilterBase>::itemToGetForTransform(size_t iTransformIndex) const {
+    return module_->transformPrefetch_(iTransformIndex);
+  }
+  template <>
+  inline ProductResolverIndex WorkerT<global::EDProducerBase>::itemToGetForTransform(size_t iTransformIndex) const {
+    return module_->transformPrefetch_(iTransformIndex);
+  }
+  template <>
+  inline ProductResolverIndex WorkerT<stream::EDProducerAdaptorBase>::itemToGetForTransform(
+      size_t iTransformIndex) const {
+    return module_->transformPrefetch_(iTransformIndex);
+  }
+  template <>
+  inline ProductResolverIndex WorkerT<limited::EDFilterBase>::itemToGetForTransform(size_t iTransformIndex) const {
+    return module_->transformPrefetch_(iTransformIndex);
+  }
+  template <>
+  inline ProductResolverIndex WorkerT<limited::EDProducerBase>::itemToGetForTransform(size_t iTransformIndex) const {
+    return module_->transformPrefetch_(iTransformIndex);
+  }
+  template <>
+  inline ProductResolverIndex WorkerT<one::EDFilterBase>::itemToGetForTransform(size_t iTransformIndex) const {
+    return module_->transformPrefetch_(iTransformIndex);
+  }
+  template <>
+  inline ProductResolverIndex WorkerT<one::EDProducerBase>::itemToGetForTransform(size_t iTransformIndex) const {
+    return module_->transformPrefetch_(iTransformIndex);
+  }
+
+  template <typename T>
   inline bool WorkerT<T>::implNeedToRunSelection() const {
     return false;
   }

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
+#include "FWCore/Framework/interface/EventForTransformer.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -82,6 +83,18 @@ namespace edm {
           info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
+
+    void EDFilterBase::doTransform(size_t iTransformIndex,
+                                   EventPrincipal const& iEvent,
+                                   ActivityRegistry*,
+                                   ModuleCallingContext const* iMCC) {
+      EventForTransformer ev(iEvent, iMCC);
+      transform_(iTransformIndex, ev);
+    }
+
+    size_t EDFilterBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
+    ProductResolverIndex EDFilterBase::transformPrefetch_(std::size_t iIndex) const { return 0; }
+    void EDFilterBase::transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const {}
 
     void EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       const auto nStreams = iPrealloc.numberOfStreams();

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
+#include "FWCore/Framework/interface/EventForTransformer.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -88,6 +89,18 @@ namespace edm {
           info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), parentC};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
+
+    void EDProducerBase::doTransform(size_t iTransformIndex,
+                                     EventPrincipal const& iEvent,
+                                     ActivityRegistry*,
+                                     ModuleCallingContext const* iMCC) {
+      EventForTransformer ev(iEvent, iMCC);
+      transform_(iTransformIndex, ev);
+    }
+
+    size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
+    ProductResolverIndex EDProducerBase::transformPrefetch_(std::size_t iIndex) const { return 0; }
+    void EDProducerBase::transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const {}
 
     void EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       auto const nStreams = iPrealloc.numberOfStreams();

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
+#include "FWCore/Framework/interface/EventForTransformer.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -66,6 +67,18 @@ namespace edm {
       commit_(e, &previousParentageIds_[streamIndex]);
       return returnValue;
     }
+
+    void EDFilterBase::doTransform(size_t iTransformIndex,
+                                   EventPrincipal const& iEvent,
+                                   ActivityRegistry*,
+                                   ModuleCallingContext const* iMCC) {
+      EventForTransformer ev(iEvent, iMCC);
+      transform_(iTransformIndex, ev);
+    }
+
+    size_t EDFilterBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
+    ProductResolverIndex EDFilterBase::transformPrefetch_(std::size_t iIndex) const { return 0; }
+    void EDFilterBase::transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const {}
 
     void EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       const auto nStreams = iPrealloc.numberOfStreams();

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
+#include "FWCore/Framework/interface/EventForTransformer.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -66,6 +67,18 @@ namespace edm {
       commit_(e, &previousParentageIds_[streamIndex]);
       return true;
     }
+
+    void EDProducerBase::doTransform(size_t iTransformIndex,
+                                     EventPrincipal const& iEvent,
+                                     ActivityRegistry*,
+                                     ModuleCallingContext const* iMCC) {
+      EventForTransformer ev(iEvent, iMCC);
+      transform_(iTransformIndex, ev);
+    }
+
+    size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
+    ProductResolverIndex EDProducerBase::transformPrefetch_(std::size_t iIndex) const { return 0; }
+    void EDProducerBase::transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const {}
 
     void EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       auto const nStreams = iPrealloc.numberOfStreams();

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
+#include "FWCore/Framework/interface/EventForTransformer.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -78,6 +79,18 @@ namespace edm {
     }
 
     void EDFilterBase::doEndJob() { this->endJob(); }
+
+    void EDFilterBase::doTransform(size_t iTransformIndex,
+                                   EventPrincipal const& iEvent,
+                                   ActivityRegistry*,
+                                   ModuleCallingContext const* iMCC) {
+      EventForTransformer ev(iEvent, iMCC);
+      transform_(iTransformIndex, ev);
+    }
+
+    size_t EDFilterBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
+    ProductResolverIndex EDFilterBase::transformPrefetch_(std::size_t iIndex) const { return 0; }
+    void EDFilterBase::transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const {}
 
     void EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       auto const nThreads = iPrealloc.numberOfThreads();

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
+#include "FWCore/Framework/interface/EventForTransformer.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -69,6 +70,18 @@ namespace edm {
 
     SerialTaskQueue* EDProducerBase::globalRunsQueue() { return nullptr; }
     SerialTaskQueue* EDProducerBase::globalLuminosityBlocksQueue() { return nullptr; };
+
+    void EDProducerBase::doTransform(size_t iTransformIndex,
+                                     EventPrincipal const& iEvent,
+                                     ActivityRegistry*,
+                                     ModuleCallingContext const* iMCC) {
+      EventForTransformer ev(iEvent, iMCC);
+      transform_(iTransformIndex, ev);
+    }
+
+    size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
+    ProductResolverIndex EDProducerBase::transformPrefetch_(std::size_t iIndex) const { return 0; }
+    void EDProducerBase::transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const {}
 
     void EDProducerBase::doBeginJob() {
       resourcesAcquirer_ = createAcquirer();

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -32,6 +32,25 @@ using namespace edm::stream;
 namespace edm {
   namespace stream {
 
+    template <>
+    ProductResolverIndex ProducingModuleAdaptorBase<edm::stream::EDProducerBase>::transformPrefetch_(
+        size_t iTransformIndex) const {
+      return m_streamModules[0]->transformPrefetch_(iTransformIndex);
+    }
+    template <>
+    size_t ProducingModuleAdaptorBase<edm::stream::EDProducerBase>::transformIndex_(
+        edm::BranchDescription const& iBranch) const {
+      return m_streamModules[0]->transformIndex_(iBranch);
+    }
+    template <>
+    void ProducingModuleAdaptorBase<edm::stream::EDProducerBase>::doTransform(size_t iTransformIndex,
+                                                                              EventPrincipal const& iEvent,
+                                                                              ActivityRegistry*,
+                                                                              ModuleCallingContext const* iMCC) {
+      EventForTransformer ev(iEvent, iMCC);
+      m_streamModules[iEvent.streamID()]->transform_(iTransformIndex, ev);
+    }
+
     //
     // constants, enums and typedefs
     //

--- a/FWCore/Framework/src/stream/EDProducerBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerBase.cc
@@ -69,6 +69,10 @@ void EDProducerBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
   descriptions.addDefault(desc);
 }
 
+size_t EDProducerBase::transformIndex_(edm::BranchDescription const& iBranch) const { return -1; }
+edm::ProductResolverIndex EDProducerBase::transformPrefetch_(std::size_t iIndex) const { return 0; }
+void EDProducerBase::transform_(std::size_t iIndex, edm::EventForTransformer& iEvent) const {}
+
 void EDProducerBase::prevalidate(ConfigurationDescriptions& iConfig) { edmodule_mightGet_config(iConfig); }
 
 static const std::string kBaseType("EDProducer");

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Framework/interface/TransitionInfoTypes.h"
+#include "FWCore/Framework/interface/EventForTransformer.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 
 //
@@ -180,6 +181,20 @@ namespace edm {
         BranchType iBranchType) const {
       return m_streamModules[0]->indiciesForPutProducts(iBranchType);
     }
+
+    template <typename T>
+    ProductResolverIndex ProducingModuleAdaptorBase<T>::transformPrefetch_(size_t iTransformIndex) const {
+      return 0;
+    }
+    template <typename T>
+    size_t ProducingModuleAdaptorBase<T>::transformIndex_(edm::BranchDescription const& iBranch) const {
+      return 0;
+    }
+    template <typename T>
+    void ProducingModuleAdaptorBase<T>::doTransform(size_t iTransformIndex,
+                                                    EventPrincipal const& iEvent,
+                                                    ActivityRegistry*,
+                                                    ModuleCallingContext const* iMCC) {}
 
     template <typename T>
     void ProducingModuleAdaptorBase<T>::doBeginStream(StreamID id) {

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -156,18 +156,14 @@ private:
       return std::unique_ptr<int>{};
     }
 
-    virtual void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
-    virtual void streamBeginLuminosityBlock(edm::StreamID,
-                                            edm::LuminosityBlock const&,
-                                            edm::EventSetup const&) const override {
+    void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
+    void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
       ++m_count;
     }
-    virtual void streamEndLuminosityBlock(edm::StreamID,
-                                          edm::LuminosityBlock const&,
-                                          edm::EventSetup const&) const override {
+    void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
       ++m_count;
     }
-    virtual void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
+    void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override { ++m_count; }
     void endStream(edm::StreamID) const override { ++m_count; }
   };
 
@@ -355,6 +351,22 @@ private:
       CPPUNIT_ASSERT(m_globalEndLuminosityBlockSummaryCalled == true);
       m_globalEndLuminosityBlockSummaryCalled = false;
     }
+  };
+
+  class TransformProd : public edm::global::EDFilter<edm::Transformer> {
+  public:
+    TransformProd(edm::ParameterSet const&) {
+      token_ = produces<float>();
+      registerTransform(token_, [](float iV) { return int(iV); });
+    }
+
+    bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
+      //iEvent.emplace(token_, 3.625);
+      return true;
+    }
+
+  private:
+    edm::EDPutTokenT<float> token_;
   };
 };
 

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -321,6 +321,20 @@ private:
       m_globalEndLuminosityBlockSummaryCalled = false;
     }
   };
+  class TransformProd : public edm::global::EDProducer<edm::Transformer> {
+  public:
+    TransformProd(edm::ParameterSet const&) {
+      token_ = produces<float>();
+      registerTransform(token_, [](float iV) { return int(iV); });
+    }
+
+    void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
+      //iEvent.emplace(token_, 3.625);
+    }
+
+  private:
+    edm::EDPutTokenT<float> token_;
+  };
 };
 
 ///registration of the test so that the runner can find it

--- a/FWCore/Framework/test/limited_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_filter_t.cppunit.cc
@@ -385,6 +385,23 @@ private:
       m_globalEndLuminosityBlockSummaryCalled = false;
     }
   };
+
+  class TransformProd : public edm::limited::EDFilter<edm::Transformer> {
+  public:
+    TransformProd(edm::ParameterSet const&)
+        : edm::limited::EDFilterBase(s_pset), edm::limited::EDFilter<edm::Transformer>(s_pset) {
+      token_ = produces<float>();
+      registerTransform(token_, [](float iV) { return int(iV); });
+    }
+
+    bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
+      //iEvent.emplace(token_, 3.625);
+      return true;
+    }
+
+  private:
+    edm::EDPutTokenT<float> token_;
+  };
 };
 
 ///registration of the test so that the runner can find it

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -352,6 +352,21 @@ private:
       m_globalEndLuminosityBlockSummaryCalled = false;
     }
   };
+  class TransformProd : public edm::limited::EDProducer<edm::Transformer> {
+  public:
+    TransformProd(edm::ParameterSet const&)
+        : edm::limited::EDProducerBase(s_pset), edm::limited::EDProducer<edm::Transformer>(s_pset) {
+      token_ = produces<float>();
+      registerTransform(token_, [](float iV) { return int(iV); });
+    }
+
+    void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const {
+      //iEvent.emplace(token_, 3.625);
+    }
+
+  private:
+    edm::EDPutTokenT<float> token_;
+  };
 };
 
 ///registration of the test so that the runner can find it

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -947,7 +947,6 @@ namespace edmtest {
       std::vector<int> expectedByRun_;
       int expectedSum_{0};
     };
-
   }  // namespace global
 }  // namespace edmtest
 

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -440,6 +440,20 @@
     <use name="FWCore/MessageLogger"/>
     <use name="clhep"/>
   </library>
+  <library file="TransformIntProducer.cc, TransformIntStreamProducer.cc" name = "FWCoreIntegrationTransformIntProducer">
+    <flags EDM_PLUGIN="1"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/ParameterSet"/>
+  </library>
+  <test name="testFWCoreIntegrationTransform" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py"/>
+  <test name="testFWCoreIntegrationTransform_onPath" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py -- --onPath"/>
+  <test name="testFWCoreIntegrationTransform_noTransform" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py -- --noTransform"/>
+  <test name="testFWCoreIntegrationTransform_noTransform_onPath" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py -- --noTransform --onPath"/>
+  <test name="testFWCoreIntegrationTransform_stream" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py -- --stream"/>
+  <test name="testFWCoreIntegrationTransform_stream_onPath" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py -- --stream --onPath"/>
+  <!-- uncomment once scram supports ! <test name="testFWCoreIntegrationTransform_noPut" command="! cmsRun ${LOCALTOP}/src/FWCore/Integration/test/transformTest_cfg.py - - - -noPut"/> -->
+
+
   <test name="TestFWCoreIntegrationModuleThread" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/moduleThread_test_cfg.py"/>
 
   <bin file="RandomIntProducer_t.cpp">

--- a/FWCore/Integration/test/TransformIntProducer.cc
+++ b/FWCore/Integration/test/TransformIntProducer.cc
@@ -1,0 +1,54 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace edmtest {
+  class TransformIntProducer : public edm::global::EDProducer<edm::Transformer> {
+  public:
+    TransformIntProducer(edm::ParameterSet const& iPSet)
+        : getToken_(consumes(iPSet.getParameter<edm::InputTag>("get"))),
+          offset_(iPSet.getParameter<unsigned int>("offset")),
+          transformOffset_(iPSet.getParameter<unsigned int>("transformOffset")),
+          noPut_(iPSet.getParameter<bool>("noPut")) {
+      putToken_ = produces<IntProduct>();
+      bool check = iPSet.getUntrackedParameter<bool>("checkTransformNotCalled");
+      registerTransform(
+          putToken_,
+          [offset = transformOffset_, check](auto const& iFrom) {
+            if (check) {
+              throw cms::Exception("TransformShouldNotBeCalled");
+            }
+            return IntProduct(iFrom.value + offset);
+          },
+          "transform");
+    }
+
+    void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const override {
+      if (not noPut_) {
+        iEvent.emplace(putToken_, iEvent.get(getToken_).value + offset_);
+      }
+    }
+    static void fillDescriptions(edm::ConfigurationDescriptions& desc) {
+      edm::ParameterSetDescription pset;
+      pset.add<edm::InputTag>("get");
+      pset.add<unsigned int>("offset", 0);
+      pset.add<unsigned int>("transformOffset", 1);
+      pset.addUntracked<bool>("checkTransformNotCalled", false);
+      pset.add<bool>("noPut", false);
+
+      desc.addDefault(pset);
+    }
+
+  private:
+    const edm::EDGetTokenT<IntProduct> getToken_;
+    edm::EDPutTokenT<IntProduct> putToken_;
+    const unsigned int offset_;
+    const unsigned int transformOffset_;
+    const bool noPut_;
+  };
+}  // namespace edmtest
+
+using edmtest::TransformIntProducer;
+DEFINE_FWK_MODULE(TransformIntProducer);

--- a/FWCore/Integration/test/TransformIntStreamProducer.cc
+++ b/FWCore/Integration/test/TransformIntStreamProducer.cc
@@ -1,0 +1,49 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace edmtest {
+  class TransformIntStreamProducer : public edm::stream::EDProducer<edm::Transformer> {
+  public:
+    TransformIntStreamProducer(edm::ParameterSet const& iPSet)
+        : getToken_(consumes(iPSet.getParameter<edm::InputTag>("get"))),
+          offset_(iPSet.getParameter<unsigned int>("offset")),
+          transformOffset_(iPSet.getParameter<unsigned int>("transformOffset")) {
+      putToken_ = produces<IntProduct>();
+      bool check = iPSet.getUntrackedParameter<bool>("checkTransformNotCalled");
+      registerTransform(
+          putToken_,
+          [offset = transformOffset_, check](auto const& iFrom) {
+            if (check) {
+              throw cms::Exception("TransformShouldNotBeCalled");
+            }
+            return IntProduct(iFrom.value + offset);
+          },
+          "transform");
+    }
+
+    void produce(edm::Event& iEvent, edm::EventSetup const&) override {
+      iEvent.emplace(putToken_, iEvent.get(getToken_).value + offset_);
+    }
+    static void fillDescriptions(edm::ConfigurationDescriptions& desc) {
+      edm::ParameterSetDescription pset;
+      pset.add<edm::InputTag>("get");
+      pset.add<unsigned int>("offset", 0);
+      pset.add<unsigned int>("transformOffset", 1);
+      pset.addUntracked<bool>("checkTransformNotCalled", false);
+
+      desc.addDefault(pset);
+    }
+
+  private:
+    const edm::EDGetTokenT<IntProduct> getToken_;
+    edm::EDPutTokenT<IntProduct> putToken_;
+    const unsigned int offset_;
+    const unsigned int transformOffset_;
+  };
+}  // namespace edmtest
+
+using edmtest::TransformIntStreamProducer;
+DEFINE_FWK_MODULE(TransformIntStreamProducer);

--- a/FWCore/Integration/test/transformTest_cfg.py
+++ b/FWCore/Integration/test/transformTest_cfg.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test module transform.')
+
+#do not call transform
+#on Path/off Path
+
+parser.add_argument("--onPath", help="Put transform module on the Path", action="store_true")
+parser.add_argument("--noTransform", help="do not consume transform", action="store_true")
+parser.add_argument("--stream", help="use stream module", action="store_true")
+parser.add_argument("--noPut", help="do not put data used by transform", action="store_true")
+parser.add_argument("--addTracer", help="add Tracer service", action="store_true")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 4
+
+process.start = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+if args.stream:
+  process.t = cms.EDProducer("TransformIntStreamProducer", get = cms.InputTag("start"), offset = cms.uint32(1), checkTransformNotCalled = cms.untracked.bool(False))
+else:
+  process.t = cms.EDProducer("TransformIntProducer", get = cms.InputTag("start"), offset = cms.uint32(1), checkTransformNotCalled = cms.untracked.bool(False), noPut = cms.bool(args.noPut))
+
+process.tester = cms.EDAnalyzer("IntTestAnalyzer",
+                                moduleLabel = cms.untracked.InputTag("t","transform"),
+                                valueMustMatch = cms.untracked.int32(3))
+
+if args.noTransform:
+    process.tester.moduleLabel = "t"
+    process.tester.valueMustMatch = 2
+    process.t.checkTransformNotCalled = True
+
+if args.onPath:
+    process.p = cms.Path(process.t+process.tester, cms.Task(process.start))
+else:
+    process.p = cms.Path(process.tester, cms.Task(process.start, process.t))
+
+if args.addTracer:
+    process.add_(cms.Service("Tracer"))


### PR DESCRIPTION
#### PR description:

Added ability to register `tranform` methods to modules. This allows a module to have a method which takes a data product already put into the Event by the same module and then create a new data product from it which is also put into the Event.

The plan is to use this ability to implement an automatic conversion from GPU to CPU data products.

#### PR validation:

Code compiles and new unit test passes.