### PR TITLE
Made CSCIndexer const thread-safe

### DIFF
--- a/DataFormats/MuonDetId/interface/CSCIndexer.h
+++ b/DataFormats/MuonDetId/interface/CSCIndexer.h
@@ -111,7 +111,7 @@ public:
    *
    * BEWARE! Includes ME42 so claims 2 rings in station 4. There is only 1 at CSC installation 2008.
    */
-  IndexType ringsInStation(IndexType is) const {
+  static IndexType ringsInStation(IndexType is) {
     const IndexType nrins[5] = {0, 3, 2, 2, 2};  // rings per station
     return nrins[is];
   }
@@ -121,7 +121,7 @@ public:
    *
    * Works for ME1a (ring 4 of ME1) too.
    */
-  IndexType chambersInRingOfStation(IndexType is, IndexType ir) const {
+  static IndexType chambersInRingOfStation(IndexType is, IndexType ir) {
     IndexType nc = 36;  // most rings have 36 chambers
     if (is > 1 && ir < 2)
       nc = 18;  // but 21, 31, 41 have 18
@@ -419,9 +419,9 @@ public:
   int dbIndex(const CSCDetId& id, int& channel);
 
 private:
-  void fillChamberLabel() const;  // const so it can be called in const function detIdFromChamberIndex
+  static std::vector<IndexType> fillChamberLabel();
 
-  mutable std::vector<IndexType> chamberLabel;  // mutable so can be filled by fillChamberLabel
+  static std::vector<IndexType> const& chamberLabel();
 };
 
 #endif

--- a/DataFormats/MuonDetId/src/CSCIndexer.cc
+++ b/DataFormats/MuonDetId/src/CSCIndexer.cc
@@ -1,24 +1,32 @@
 #include <DataFormats/MuonDetId/interface/CSCIndexer.h>
 #include <iostream>
 
-void CSCIndexer::fillChamberLabel() const {
+std::vector<CSCIndexer::IndexType> CSCIndexer::fillChamberLabel() {
   // Fill the member vector which permits decoding of the linear chamber index
   // Logically const since initializes cache only,
   // Beware that the ME42 indices 235-270 within this vector do NOT correspond to
   // their 'real' linear indices (which are 469-504 for +z)
-  chamberLabel.resize(271);  // one more than #chambers per endcap. Includes ME42.
+  std::vector<IndexType> tChamberLabel;
+
+  tChamberLabel.resize(271);  // one more than #chambers per endcap. Includes ME42.
   IndexType count = 0;
-  chamberLabel[count] = 0;
+  tChamberLabel[count] = 0;
 
   for (IndexType is = 1; is != 5; ++is) {
     IndexType irmax = ringsInStation(is);
     for (IndexType ir = 1; ir != irmax + 1; ++ir) {
       IndexType icmax = chambersInRingOfStation(is, ir);
       for (IndexType ic = 1; ic != icmax + 1; ++ic) {
-        chamberLabel[++count] = is * 1000 + ir * 100 + ic;
+        tChamberLabel[++count] = is * 1000 + ir * 100 + ic;
       }
     }
   }
+  return tChamberLabel;
+}
+
+const std::vector<CSCIndexer::IndexType>& CSCIndexer::chamberLabel() {
+  static const auto s_chamberLabel = fillChamberLabel();
+  return s_chamberLabel;
 }
 
 CSCDetId CSCIndexer::detIdFromChamberIndex_OLD(IndexType ici) const {
@@ -76,9 +84,7 @@ CSCDetId CSCIndexer::detIdFromChamberIndex(IndexType ici) const {
       ici -= 234;  // now in range 1-234
     }
   }
-  if (chamberLabel.empty())
-    fillChamberLabel();
-  IndexType label = chamberLabel[ici];
+  IndexType label = chamberLabel()[ici];
   return detIdFromChamberLabel(ie, label);
 }
 
@@ -99,9 +105,7 @@ CSCIndexer::IndexType CSCIndexer::chamberLabelFromChamberIndex(IndexType ici) co
       ici -= 234;     // now in range 1-234
     }
   }
-  if (chamberLabel.empty())
-    fillChamberLabel();
-  return chamberLabel[ici];
+  return chamberLabel()[ici];
 }
 
 CSCDetId CSCIndexer::detIdFromChamberLabel(IndexType ie, IndexType label) const {


### PR DESCRIPTION

#### PR description:

Converted delayed creation of fixed value std::vector to be a const static function local.

This problem was identified by the static analyzer.

#### PR validation:

Code compiles.