### PR TITLE
[12_3_X] Update HLT GT with ECAL DQM tower and channel status tags

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,10 +33,10 @@ autoCond = {
     'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (123X_dataRun3_HLT_v11) but with snapshot at 2022-05-31 20:00:00 (UTC)
-    'run3_hlt'                     : '123X_dataRun3_HLT_frozen_v6',
+    # GlobalTag for Run3 HLT: identical to the online GT (123X_dataRun3_HLT_v13) but with snapshot at 2022-06-21 14:00:00 (UTC)
+    'run3_hlt'                     : '123X_dataRun3_HLT_frozen_v7',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v9',
+    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v11',
     # GlobalTag for Run3 data relvals (express GT) - identical to 123X_dataRun3_Express_v8 but with snapshot at 2022-05-31 20:00:00 (UTC)
     'run3_data_express'            : '123X_dataRun3_Express_frozen_v4',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 123X_dataRun3_Prompt_v10 but with snapshot at 2022-05-31 20:00:00 (UTC)


### PR DESCRIPTION
#### PR description:

backport of #38455

This PR is mainly to include Ecal DQM channel and tower status in the HLT (and HLT_relval) GTs, needed in PR https://github.com/cms-sw/cmssw/pull/38357 + backports.

The Ecal tags to be included in HLT GT are: EcalDQMChannelStatus_v1_hlt and EcalDQMTowerStatus_v1_hlt.

We also take the chance to include the PPS optical function tag, that had already been included in the Express and Prompt GTs for P5 operations: PPSOpticalFunctions_hlt_v9

All three tags were include in HLT and HLT_relval GTs.

The differences wrt to the previous GTs are shown below:
**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_HLT_frozen_v6/123X_dataRun3_HLT_frozen_v7

**run3_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_HLT_relval_v9/123X_dataRun3_HLT_relval_v11

We also took care that there are no differences other than the L1 menus between the frozen and relval GTs:
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_HLT_relval_v11/123X_dataRun3_HLT_frozen_v7

#### PR validation:

`nohup runTheMatrix.py -l 139.001 --ibeos -j16`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

backport of #38455
