### PR TITLE
Introduce more plots in `DiMuonVertexMonitor` and add unit tests

### DIFF
--- a/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
+++ b/DQMOffline/Alignment/interface/DiMuonVertexMonitor.h
@@ -48,7 +48,7 @@ private:
   const std::string MEFolderName_;  // Top-level folder name
   const float maxSVdist_;
 
-  // 1D
+  // vertex quantities
   MonitorElement *hSVProb_;
   MonitorElement *hSVDist_;
   MonitorElement *hSVDistErr_;
@@ -62,5 +62,15 @@ private:
   MonitorElement *hCosPhiInv3D_;
   MonitorElement *hTrackInvMass_;
   MonitorElement *hCutFlow_;
+
+  // impact parameters information
+  MonitorElement *hdxy_;
+  MonitorElement *hdz_;
+  MonitorElement *hdxyErr_;
+  MonitorElement *hdzErr_;
+  MonitorElement *hIP2d_;
+  MonitorElement *hIP3d_;
+  MonitorElement *hIP2dsig_;
+  MonitorElement *hIP3dsig_;
 };
 #endif

--- a/DQMOffline/Alignment/test/BuildFile.xml
+++ b/DQMOffline/Alignment/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<bin file="TestDriver.cpp" name="testDiMuonVertexMonitor">
+  <use name="FWCore/Utilities"/>
+  <flags TEST_RUNNER_ARGS="/bin/bash DQMOffline/Alignment/test testDiMuonVertexMonitor.sh"/>
+</bin>

--- a/DQMOffline/Alignment/test/DiMuonVertexValidator_cfg.py
+++ b/DQMOffline/Alignment/test/DiMuonVertexValidator_cfg.py
@@ -1,0 +1,96 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('reRECO',Run3)
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing()
+options.register('maxEvents',
+                 -1,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "maximum events")
+options.register('globalTag',
+                 'auto:phase1_2022_realistic',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "conditions")
+options.parseArguments()
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 200
+
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('DQMServices.Core.DQMStoreNonLegacy_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring('/store/relval/CMSSW_12_5_0_pre2/RelValZMM_14/ALCARECO/TkAlDiMuonAndVertex-124X_mcRun3_2022_realistic_v3-v1/2580000/4f9aee02-35a2-49b7-93f5-831214cf32d8.root'),
+                            secondaryFileNames = cms.untracked.vstring()
+                            )
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('DQMIO'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:step3_inDQM.root'),
+    outputCommands = process.DQMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+process.load("DQMOffline.Configuration.AlCaRecoDQM_cff")
+process.seqALCARECOTkAlDiMuonAndVertex = cms.Sequence(process.ALCARECOTkAlDiMuonAndVertexVtxDQM)
+
+process.dqmoffline_step = cms.EndPath(process.seqALCARECOTkAlDiMuonAndVertex)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+process.schedule = cms.Schedule(process.dqmoffline_step,process.DQMoutput_step)

--- a/DQMOffline/Alignment/test/DiMuonVertex_HARVESTING.py
+++ b/DQMOffline/Alignment/test/DiMuonVertex_HARVESTING.py
@@ -1,0 +1,106 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: DiMuonVertex -s HARVESTING:alcaHarvesting --conditions auto:phase1_2022_realistic --mc --filetype DQM --scenario pp --era Run3 -n -1 --filein file:step3_inDQM.root
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('HARVESTING',Run3)
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing()
+options.register('maxEvents',
+                 -1,
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "maximum events")
+options.register('globalTag',
+                 'auto:phase1_2022_realistic',
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "conditions")
+options.parseArguments()
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.DQMSaverAtRunEnd_cff')
+process.load('Configuration.StandardSequences.Harvesting_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("DQMRootSource",
+    fileNames = cms.untracked.vstring('file:step3_inDQM.root')
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring('ProductNotFound'),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('DiMuonVertex nevts:-1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+process.dqmsave_step = cms.Path(process.DQMSaver)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.alcaHarvesting,process.dqmsave_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/DQMOffline/Alignment/test/TestDriver.cpp
+++ b/DQMOffline/Alignment/test/TestDriver.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/DQMOffline/Alignment/test/testDiMuonVertexMonitor.sh
+++ b/DQMOffline/Alignment/test/testDiMuonVertexMonitor.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+ function die { echo $1: status $2; exit $2; }
+
+if [ "${SCRAM_TEST_NAME}" != "" ] ; then
+  mkdir ${SCRAM_TEST_NAME}
+  cd ${SCRAM_TEST_NAME}
+fi
+
+cmsRun ${LOCAL_TEST_DIR}/DiMuonVertexValidator_cfg.py  || die "Failure using DiMuonVertexValidator_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/DiMuonVertex_HARVESTING.py || die "Failure using DiMuonVertex_HARVESTING.py" $? 


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to introduce some more needed monitoring plots to the module `DiMuonVertexMonitor`  introduced at 
and add unit test to the  `DQMOffline/Alignment package`

#### PR validation:

Relies on running the introduced unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, but I will backport it to https://github.com/cms-sw/cmssw/pull/38425
