### PR TITLE
Factor of 2 bugfix for HF PF rechits w/ short-fiber only

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -140,14 +140,16 @@ public:
             std::lower_bound(tmpOut.begin(), tmpOut.end(), longID, [](const reco::PFRecHit& a, HcalDetId b) {
               return a.detId() < b.rawId();
             });
-        double energy = 2 * sHORT;
+        double energy = sHORT;
         if (found_hit != tmpOut.end() && found_hit->detId() == longID.rawId()) {
           double lONG = found_hit->energy();
           //Ask for fraction
 
           //If in this case lONG-sHORT<0 add the energy to the sHORT
           if ((lONG - sHORT) < thresh_HF_)
-            energy = lONG + sHORT;
+            energy += lONG;
+          else
+            energy += sHORT;
 
           if (abs(detid.ieta()) <= 32)
             energy *= HFCalib_;


### PR DESCRIPTION
#### PR description:

Bug-fix for a dropped factor of two in the PF HF rechit reconstruction.  The energy is scaled by a factor of two in the code anticipating that the long and short fibers will be added.  However, when there is only a deposit in the short fiber, this factor of two needs to be scaled back out. 
Heavy-ions use low energy HF rechits for discriminating hadronic interactions from electromagetic and noise.  This bug was found to reduce discrimination compared to using HF towers (which are not available at mini-AOD). 

This was summarized at a recent PF meeting:
https://indico.cern.ch/event/1102173/contributions/4925583/attachments/2464753/4226434/HF_lk_17June_2022.pdf

We would certainty like to fix this for 12_5, where we use the HF essentially only for event selection.
It will be discussed at PPD tomorrow (June 23rd), whether this should also be backported for the upcoming high-lumi pp data. 




#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Bug-fix for a dropped factor of two in the PF HF rechit reconstruction.  The energy is scaled by a factor of two in the code anticipating that the long and short fibers will be added.  However, when there is only a deposit in the short fiber, this factor of two needs to be scaled back out. 
Heavy-ions use low energy HF rechits for discriminating hadronic interactions from electromagetic and noise.  This bug was found to reduce discrimination compared to using HF towers (which are not available at mini-AOD). 

This was summarized at a recent PF meeting:
https://indico.cern.ch/event/1102173/contributions/4925583/attachments/2464753/4226434/HF_lk_17June_2022.pdf

We would certainty like to fix this for 12_5, where we use the HF essentially only for event selection.
It will be discussed at PPD tomorrow (June 23rd), whether this should also be backported for the upcoming high-lumi pp data. 
