### PR TITLE
[12_4_X] Update XiMinus_14TeV_SoftQCDInel_TuneCP5_cfi config

### DIFF
--- a/Configuration/Generator/python/XiMinus_13p6TeV_SoftQCDInel_TuneCP5_cfi.py
+++ b/Configuration/Generator/python/XiMinus_13p6TeV_SoftQCDInel_TuneCP5_cfi.py
@@ -10,7 +10,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
                          pythiaPylistVerbosity = cms.untracked.int32(1),
                          filterEfficiency = cms.untracked.double(1.0),
                          pythiaHepMCVerbosity = cms.untracked.bool(False),
-                         comEnergy = cms.double(14000.0),
+                         comEnergy = cms.double(13600.0),
     PythiaParameters = cms.PSet(
         pythia8CommonSettingsBlock,
         pythia8CP5SettingsBlock,
@@ -24,7 +24,7 @@ generator = cms.EDFilter("Pythia8GeneratorFilter",
                          )
 
 XiFilter = cms.EDFilter("PythiaFilter",
-    MinPt = cms.untracked.double(1.3),
+    MinPt = cms.untracked.double(1.0),
     ParticleID = cms.untracked.int32(3312),
     MaxEta = cms.untracked.double(2.6),
     MinEta = cms.untracked.double(-2.6)


### PR DESCRIPTION
Backport of #38466
- lowering `pT` thresholds. Enhance gen efficiency (from 1 to 2 %).
- moving to `13.6 TeV`. 
To be used as validation for the  *rollback of the pixelles tracking to CKF*. See #38390 and #38450.

No validation needed. In a next PR a wf in the matrix will be added to test this for possible RelVal production.
