### PR TITLE
Change tau trigger bits stored in NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -82,7 +82,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
         cms.PSet(
             name = cms.string("Tau"),
             id = cms.int32(15),
-            sel = cms.string("type(84) && pt > 5 && coll('*Tau*') && ( filter('*LooseChargedIso*') || filter('*MediumChargedIso*') || filter('*DeepTau*') || filter('*TightChargedIso*') || filter('*TightOOSCPhotons*') || filter('hltL2TauIsoFilter') || filter('*OverlapFilterIsoMu*') || filter('*OverlapFilterIsoEle*') || filter('*L1HLTMatched*') || filter('*Dz02*') || filter('*DoublePFTau*') || filter('*SinglePFTau*') || filter('hlt*SelectedPFTau') || filter('ParticleNetTauTau') )"), #All trigger objects from a Tau collection + passing at least one filter
+            sel = cms.string("type(84) && pt > 5 && coll('*Tau*') && ( filter('*LooseChargedIso*') || filter('*MediumChargedIso*') || filter('*DeepTau*') || filter('*TightChargedIso*') || filter('*TightOOSCPhotons*') || filter('hltL2TauIsoFilter') || filter('*OverlapFilterIsoMu*') || filter('*OverlapFilterIsoEle*') || filter('*L1HLTMatched*') || filter('*Dz02*') || filter('*DoublePFTau*') || filter('*SinglePFTau*') || filter('hlt*SelectedPFTau') || filter('DisplPFTau') )"), #All trigger objects from a Tau collection + passing at least one filter
             l1seed = cms.string("type(-100)"), l1deltaR = cms.double(0.3),
             l2seed = cms.string("type(84) && coll('hltL2TauJetsL1IsoTauSeeded')"),  l2deltaR = cms.double(0.3),
             skipObjectsNotPassingQualityBits = cms.bool(True),
@@ -102,12 +102,24 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
                             "4096*filter('hlt*DoublePFTau*Track*ChargedIso*AgainstMuon') + " \
                             "8192*filter('hltHpsSinglePFTau*HLTMatched') + " \
                             "16384*filter('hltHpsOverlapFilterDeepTauDoublePFTau*PFJet*') + " \
-                            "32768*filter('hltAK8SinglePFJets*SoftDropMass40*ParticleNetTauTau') + " \
+                            "32768*filter('hlt*Double*ChargedIsoDisplPFTau*Dxy*') + " \
                             "65536*filter('*Monitoring') + " \
                             "131072*filter('*Reg') + " \
                             "262144*filter('*L1Seeded') + " \
                             "524288*filter('*1Prong')"),
-            qualityBitsDoc = cms.string("1 = LooseChargedIso, 2 = MediumChargedIso, 4 = TightChargedIso, 8 = DeepTau, 16 = TightID OOSC photons, 32 = HPS, 64 = charged iso di-tau, 128 = deeptau di-tau, 256 = e-tau, 512 = mu-tau, 1024 = single-tau/tau+MET, 2048 = run 2 VBF+ditau, 4096 = run 3 VBF+ditau, 8192 = run 3 double PF jets + ditau, 16384 = di-tau + PFJet, 32768 = PFJetParticleNetTau, 65536 = Monitoring, 131072 = regional paths, 262144 = L1 seeded paths, 524288 = 1 prong tau paths"),            
+            qualityBitsDoc = cms.string("1 = LooseChargedIso, 2 = MediumChargedIso, 4 = TightChargedIso, 8 = DeepTau, 16 = TightID OOSC photons, 32 = HPS, 64 = charged iso di-tau, 128 = deeptau di-tau, 256 = e-tau, 512 = mu-tau, 1024 = single-tau/tau+MET, 2048 = run 2 VBF+ditau, 4096 = run 3 VBF+ditau, 8192 = run 3 double PF jets + ditau, 16384 = di-tau + PFJet, 32768 = Displaced Tau, 65536 = Monitoring, 131072 = regional paths, 262144 = L1 seeded paths, 524288 = 1 prong tau paths"),            
+        ),
+        cms.PSet(
+            name = cms.string("BoostedTau"),
+            id = cms.int32(7),
+            sel = cms.string("type(85) && pt > 120 && coll('hltAK8PFJetsCorrected')"), 
+            l1seed = cms.string("type(-99)"), l1deltaR = cms.double(0.3),
+            l2seed = cms.string("type(85)  && coll('hltAK8CaloJetsCorrectedIDPassed')"),  l2deltaR = cms.double(0.3),
+            skipObjectsNotPassingQualityBits = cms.bool(True),
+            qualityBits = cms.string(
+                "filter('hltAK8SinglePFJets*SoftDropMass40*ParticleNetTauTau')"
+                ), 
+            qualityBitsDoc = cms.string("Bit 0 for HLT_AK8PFJetX_SoftDropMass40_PFAK8ParticleNetTauTau0p30"),
         ),
         cms.PSet(
             name = cms.string("Jet"),
@@ -134,7 +146,10 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
                 "16384     * filter('hlt2PFCentralJetLooseID60') + " \
                 "32768     * filter('hlt3PFCentralJetLooseID45') + " \
                 "65536     * filter('hlt4PFCentralJetLooseID40') + " \
-                "131072    * max(filter('hltBTagPFCSVp070Triple'), max(filter('hltBTagPFDeepCSVp24Triple'), filter('hltBTagPFDeepCSV4p5Triple')) )"
+                "131072    * max(filter('hltBTagPFCSVp070Triple'), max(filter('hltBTagPFDeepCSVp24Triple'), filter('hltBTagPFDeepCSV4p5Triple')) )+ " \
+                "262144    * filter('hltHpsOverlapFilterDeepTauDoublePFTau*PFJet*') + " \
+                "524288   * filter('*CrossCleaned*MediumDeepTauDitauWPPFTau*') + " \
+                "1048576   * filter('*CrossCleanedUsingDiJetCorrChecker*')"
                 ), 
             qualityBitsDoc = cms.string(
                 "Jet bits: bit 0 for VBF cross-cleaned from loose iso PFTau, bit 1 for hltBTagCaloCSVp087Triple, bit 2 for hltDoubleCentralJet90, bit 3 for hltDoublePFCentralJetLooseID90," \
@@ -144,7 +159,10 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
                 " bit 10  for hltL1sQuadJetC60IorHTT380IorHTT280QuadJetIorHTT300QuadJet or hltL1sQuadJetC50to60IorHTT280to500IorHTT250to340QuadJet" \
                 " bit 11 for hltBTagCaloCSVp05Double or hltBTagCaloDeepCSVp17Double, bit 12 for hltPFCentralJetLooseIDQuad30, bit 13 for hlt1PFCentralJetLooseID75," \
                 " bit 14 for hlt2PFCentralJetLooseID60, bit 15 for hlt3PFCentralJetLooseID45, bit 16 for hlt4PFCentralJetLooseID40," \
-                " bit 17 for hltBTagPFCSVp070Triple or hltBTagPFDeepCSVp24Triple or hltBTagPFDeepCSV4p5Triple "),
+                " bit 17 for hltBTagPFCSVp070Triple or hltBTagPFDeepCSVp24Triple or hltBTagPFDeepCSV4p5Triple,"\
+                " bit 18 for Double tau + jet,"\
+                " bit 19 for VBF cross-cleaned from medium deeptau PFTau,"+
+                " bit 20 for VBF cross-cleaned using dijet correlation checker ")
         ),
         cms.PSet(
             name = cms.string("FatJet"),

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -166,7 +166,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
         ),
         cms.PSet(
             name = cms.string("FatJet"),
-            id = cms.int32(6),
+            id = cms.int32(7),
             sel = cms.string("type(85) && pt > 120 && coll('hltAK8PFJetsCorrected')"), 
             l1seed = cms.string("type(-99)"), l1deltaR = cms.double(0.3),
             l2seed = cms.string("type(85)  && coll('hltAK8CaloJetsCorrectedIDPassed')"),  l2deltaR = cms.double(0.3),

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -38,7 +38,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
                             "8*filter('*OverlapFilter*IsoEle*PFTau*') + " \
                             "16*filter('hltEle*Ele*CaloIdLTrackIdLIsoVL*Filter') + " \
                             "32*filter('hltMu*TrkIsoVVL*Ele*CaloIdLTrackIdLIsoVL*Filter*')  + " \
-                            "64*filter('hltOverlapFilterIsoEle*PFTau*') + " \
+                            "64*filter('hlt*OverlapFilterIsoEle*PFTau*') + " \
                             "128*filter('hltEle*Ele*Ele*CaloIdLTrackIdLDphiLeg*Filter') + " \
                             "256*max(filter('hltL3fL1Mu*DoubleEG*Filtered*'),filter('hltMu*DiEle*CaloIdLTrackIdLElectronleg*Filter')) + " \
                             "512*max(filter('hltL3fL1DoubleMu*EG*Filter*'),filter('hltDiMu*Ele*CaloIdLTrackIdLElectronleg*Filter')) + " \
@@ -71,7 +71,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
                             "8*max(filter('hltL3crIsoL1*SingleMu*Filtered0p07'),filter('hltL3crIsoL1sMu*Filtered0p07')) + " \
                             "16*filter('hltDiMuon*Filtered*') + " \
                             "32*filter('hltMu*TrkIsoVVL*Ele*CaloIdLTrackIdLIsoVL*Filter*') + " \
-                            "64*filter('hltOverlapFilterIsoMu*PFTau*') + " \
+                            "64*filter('hlt*OverlapFilterIsoMu*PFTau*') + " \
                             "128*filter('hltL3fL1TripleMu*') + " \
                             "256*max(filter('hltL3fL1DoubleMu*EG*Filtered*'),filter('hltDiMu*Ele*CaloIdLTrackIdLElectronleg*Filter')) + " \
                             "512*max(filter('hltL3fL1Mu*DoubleEG*Filtered*'),filter('hltMu*DiEle*CaloIdLTrackIdLElectronleg*Filter')) + " \
@@ -82,7 +82,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
         cms.PSet(
             name = cms.string("Tau"),
             id = cms.int32(15),
-            sel = cms.string("type(84) && pt > 5 && coll('*Tau*') && ( filter('*LooseChargedIso*') || filter('*MediumChargedIso*') || filter('*TightChargedIso*') || filter('*TightOOSCPhotons*') || filter('hltL2TauIsoFilter') || filter('*OverlapFilterIsoMu*') || filter('*OverlapFilterIsoEle*') || filter('*L1HLTMatched*') || filter('*Dz02*') )"), #All trigger objects from a Tau collection + passing at least one filter
+            sel = cms.string("type(84) && pt > 5 && coll('*Tau*') && ( filter('*LooseChargedIso*') || filter('*MediumChargedIso*') || filter('*DeepTau*') || filter('*TightChargedIso*') || filter('*TightOOSCPhotons*') || filter('hltL2TauIsoFilter') || filter('*OverlapFilterIsoMu*') || filter('*OverlapFilterIsoEle*') || filter('*L1HLTMatched*') || filter('*Dz02*') || filter('*DoublePFTau*') || filter('*SinglePFTau*') || filter('hlt*SelectedPFTau') || filter('ParticleNetTauTau') )"), #All trigger objects from a Tau collection + passing at least one filter
             l1seed = cms.string("type(-100)"), l1deltaR = cms.double(0.3),
             l2seed = cms.string("type(84) && coll('hltL2TauJetsL1IsoTauSeeded')"),  l2deltaR = cms.double(0.3),
             skipObjectsNotPassingQualityBits = cms.bool(True),
@@ -90,14 +90,24 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
                             "filter('*LooseChargedIso*') + " \
                             "2*filter('*MediumChargedIso*') + " \
                             "4*filter('*TightChargedIso*') + " \
-                            "8*filter('*TightOOSCPhotons*') + " \
-                            "16*filter('*Hps*') + " \
-                            "32*filter('hltSelectedPFTau*MediumChargedIsolationL1HLTMatched*') + " \
-                            "64*filter('hltDoublePFTau*TrackPt1*ChargedIsolation*Dz02Reg') + " \
-                            "128*filter('hltOverlapFilterIsoEle*PFTau*') + " \
-                            "256*filter('hltOverlapFilterIsoMu*PFTau*') + " \
-                            "512*filter('hltDoublePFTau*TrackPt1*ChargedIsolation*')"),
-            qualityBitsDoc = cms.string("1 = LooseChargedIso, 2 = MediumChargedIso, 4 = TightChargedIso, 8 = TightID OOSC photons, 16 = HPS, 32 = single-tau + tau+MET, 64 = di-tau, 128 = e-tau, 256 = mu-tau, 512 = VBF+di-tau"),            
+                            "8*filter('*DeepTau*') + " \
+                            "16*filter('*TightOOSCPhotons*') + " \
+                            "32*filter('*Hps*') + " \
+                            "64*filter('hlt*DoublePFTau*TrackPt1*ChargedIsolation*Dz02*') + " \
+                            "128*filter('hlt*DoublePFTau*DeepTau*L1HLTMatched') + " \
+                            "256*filter('hlt*OverlapFilterIsoEle*WPTightGsf*PFTau') + " \
+                            "512*filter('hlt*OverlapFilterIsoMu*PFTau*') + " \
+                            "1024*filter('hlt*SelectedPFTau*L1HLTMatched') + " \
+                            "2048*filter('hlt*DoublePFTau*TrackPt1*ChargedIso*') + " \
+                            "4096*filter('hlt*DoublePFTau*Track*ChargedIso*AgainstMuon') + " \
+                            "8192*filter('hltHpsSinglePFTau*HLTMatched') + " \
+                            "16384*filter('hltHpsOverlapFilterDeepTauDoublePFTau*PFJet*') + " \
+                            "32768*filter('hltAK8SinglePFJets*SoftDropMass40*ParticleNetTauTau') + " \
+                            "65536*filter('*Monitoring') + " \
+                            "131072*filter('*Reg') + " \
+                            "262144*filter('*L1Seeded') + " \
+                            "524288*filter('*1Prong')"),
+            qualityBitsDoc = cms.string("1 = LooseChargedIso, 2 = MediumChargedIso, 4 = TightChargedIso, 8 = DeepTau, 16 = TightID OOSC photons, 32 = HPS, 64 = charged iso di-tau, 128 = deeptau di-tau, 256 = e-tau, 512 = mu-tau, 1024 = single-tau/tau+MET, 2048 = run 2 VBF+ditau, 4096 = run 3 VBF+ditau, 8192 = run 3 double PF jets + ditau, 16384 = di-tau + PFJet, 32768 = PFJetParticleNetTau, 65536 = Monitoring, 131072 = regional paths, 262144 = L1 seeded paths, 524288 = 1 prong tau paths"),            
         ),
         cms.PSet(
             name = cms.string("Jet"),

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -111,7 +111,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
         ),
         cms.PSet(
             name = cms.string("BoostedTau"),
-            id = cms.int32(7),
+            id = cms.int32(6),
             sel = cms.string("type(85) && pt > 120 && coll('hltAK8PFJetsCorrected')"), 
             l1seed = cms.string("type(-99)"), l1deltaR = cms.double(0.3),
             l2seed = cms.string("type(85)  && coll('hltAK8CaloJetsCorrectedIDPassed')"),  l2deltaR = cms.double(0.3),

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -82,7 +82,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
         cms.PSet(
             name = cms.string("Tau"),
             id = cms.int32(15),
-            sel = cms.string("type(84) && pt > 5 && coll('*Tau*') && ( filter('*LooseChargedIso*') || filter('*MediumChargedIso*') || filter('*DeepTau*') || filter('*TightChargedIso*') || filter('*TightOOSCPhotons*') || filter('hltL2TauIsoFilter') || filter('*OverlapFilterIsoMu*') || filter('*OverlapFilterIsoEle*') || filter('*L1HLTMatched*') || filter('*Dz02*') || filter('*DoublePFTau*') || filter('*SinglePFTau*') || filter('hlt*SelectedPFTau') || filter('DisplPFTau') )"), #All trigger objects from a Tau collection + passing at least one filter
+            sel = cms.string("type(84) && pt > 5 && coll('*Tau*') && ( filter('*LooseChargedIso*') || filter('*MediumChargedIso*') || filter('*DeepTau*') || filter('*TightChargedIso*') || filter('*TightOOSCPhotons*') || filter('hltL2TauIsoFilter') || filter('*OverlapFilterIsoMu*') || filter('*OverlapFilterIsoEle*') || filter('*L1HLTMatched*') || filter('*Dz02*') || filter('*DoublePFTau*') || filter('*SinglePFTau*') || filter('hlt*SelectedPFTau') || filter('*DisplPFTau*') )"), #All trigger objects from a Tau collection + passing at least one filter
             l1seed = cms.string("type(-100)"), l1deltaR = cms.double(0.3),
             l2seed = cms.string("type(84) && coll('hltL2TauJetsL1IsoTauSeeded')"),  l2deltaR = cms.double(0.3),
             skipObjectsNotPassingQualityBits = cms.bool(True),
@@ -111,8 +111,8 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
         ),
         cms.PSet(
             name = cms.string("BoostedTau"),
-            id = cms.int32(6),
-            sel = cms.string("type(85) && pt > 120 && coll('hltAK8PFJetsCorrected')"), 
+            id = cms.int32(1515),
+            sel = cms.string("type(85) && pt > 120 && coll('hltAK8PFJetsCorrected') && filter('hltAK8SinglePFJets*SoftDropMass40*ParticleNetTauTau')"), 
             l1seed = cms.string("type(-99)"), l1deltaR = cms.double(0.3),
             l2seed = cms.string("type(85)  && coll('hltAK8CaloJetsCorrectedIDPassed')"),  l2deltaR = cms.double(0.3),
             skipObjectsNotPassingQualityBits = cms.bool(True),
@@ -166,7 +166,7 @@ triggerObjectTable = cms.EDProducer("TriggerObjectTableProducer",
         ),
         cms.PSet(
             name = cms.string("FatJet"),
-            id = cms.int32(7),
+            id = cms.int32(6),
             sel = cms.string("type(85) && pt > 120 && coll('hltAK8PFJetsCorrected')"), 
             l1seed = cms.string("type(-99)"), l1deltaR = cms.double(0.3),
             l2seed = cms.string("type(85)  && coll('hltAK8CaloJetsCorrectedIDPassed')"),  l2deltaR = cms.double(0.3),


### PR DESCRIPTION
#### PR description:

The tau trigger bits in NanoAOD never provided a match in 2018 triggers because the 'Hps' part in the name was forgotten. This PR is meant to fix this issue as well as to prepare to accommodate Run-3 tau triggers. We have decided to go with a unified strategy that will work for both Run-2 and Run-3 triggers which have similar structure and naming conventions, hence the addition of extra bits containing DeepTau. It now also contains trigger bits for taus in the PAG VBF and displaced tau triggers. A full overview of all trigger filters in Run-2 and Run-3 was made and is contained in google sheets [here](https://docs.google.com/spreadsheets/d/1L8P4HeiUSaisewuSFBEJOM5t5xXcDjNbfBtD9hEE5F8/edit#gid=0)

**Changes**:
* Addition of wildcards to original trigger bits to work for both HPS and non-HPS paths;
* Addition of DeepTau trigger bits;
* Addition of bits 4096 to 32768 to include PAG paths;
* Addition of bits 65536 for completeness, they allow to go a bit more specific in the triggers to select;
* Addition of boosted tau block. Right now the bits are redundant, but we expect more to be added in the future;
* Added bits to non-tau blocks from cross triggers.

#### PR validation:
Reran NanoAOD for all three Run-2 years and in a Run-3 sample, everything seemed to act as expected

