### PR TITLE
[DT CSC RPC] Backport of bug fix to tag-and-probe in DQM (https://github.com/cms-sw/cmssw/pull/38028)

### DIFF
--- a/DQMOffline/MuonDPG/src/BaseTnPEfficiencyTask.cc
+++ b/DQMOffline/MuonDPG/src/BaseTnPEfficiencyTask.cc
@@ -189,10 +189,10 @@ bool BaseTnPEfficiencyTask::hasTrigger(std::vector<int>& trigIndices,
   for (int trigIdx : trigIndices) {
     const std::vector<std::string> trigModuleLabels = m_hltConfig.moduleLabels(trigIdx);
 
-    const unsigned trigModuleIndex = std::find(trigModuleLabels.begin(), trigModuleLabels.end(), "hltBoolEnd") - trigModuleLabels.begin() - 1;
+    const unsigned trigModuleIndex =
+        std::find(trigModuleLabels.begin(), trigModuleLabels.end(), "hltBoolEnd") - trigModuleLabels.begin() - 1;
     const unsigned hltFilterIndex = trigEvent->filterIndex(edm::InputTag(trigModuleLabels[trigModuleIndex], "", "HLT"));
     if (hltFilterIndex < trigEvent->sizeFilters()) {
-
       const trigger::Keys keys = trigEvent->filterKeys(hltFilterIndex);
       const trigger::Vids vids = trigEvent->filterIds(hltFilterIndex);
       const unsigned nTriggers = vids.size();

--- a/DQMOffline/MuonDPG/src/BaseTnPEfficiencyTask.cc
+++ b/DQMOffline/MuonDPG/src/BaseTnPEfficiencyTask.cc
@@ -20,6 +20,7 @@
 #include "TRegexp.h"
 
 #include <tuple>
+#include <algorithm>
 
 BaseTnPEfficiencyTask::BaseTnPEfficiencyTask(const edm::ParameterSet& config)
     : m_nEvents(0),
@@ -187,9 +188,11 @@ bool BaseTnPEfficiencyTask::hasTrigger(std::vector<int>& trigIndices,
   float dR2match = 999.;
   for (int trigIdx : trigIndices) {
     const std::vector<std::string> trigModuleLabels = m_hltConfig.moduleLabels(trigIdx);
-    const unsigned trigModuleIndex = trigModuleLabels.size() - 2;
+
+    const unsigned trigModuleIndex = std::find(trigModuleLabels.begin(), trigModuleLabels.end(), "hltBoolEnd") - trigModuleLabels.begin() - 1;
     const unsigned hltFilterIndex = trigEvent->filterIndex(edm::InputTag(trigModuleLabels[trigModuleIndex], "", "HLT"));
     if (hltFilterIndex < trigEvent->sizeFilters()) {
+
       const trigger::Keys keys = trigEvent->filterKeys(hltFilterIndex);
       const trigger::Vids vids = trigEvent->filterIds(hltFilterIndex);
       const unsigned nTriggers = vids.size();
@@ -202,5 +205,6 @@ bool BaseTnPEfficiencyTask::hasTrigger(std::vector<int>& trigIndices,
       }
     }
   }
+
   return dR2match < 0.01;
 }


### PR DESCRIPTION
This PR is a backport of a bug fixed in https://github.com/cms-sw/cmssw/pull/38028. The bug fix ended up in 12_5_X and it is needed also for 12_4_X. 

I've cross checked that the modules work fine by running: `runTheMatrix.py -l 11650.0 -i all --ibeos`
