### PR TITLE
Initialise the errors_ data member of SiPixelDigiErrorsSoAFromCUDA [12.4.x]

### DIFF
--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiErrorsSoAFromCUDA.cc
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelDigiErrorsSoAFromCUDA.cc
@@ -28,7 +28,7 @@ private:
   edm::EDPutTokenT<SiPixelErrorsSoA> digiErrorPutToken_;
 
   cms::cuda::host::unique_ptr<SiPixelErrorCompact[]> data_;
-  cms::cuda::SimpleVector<SiPixelErrorCompact> error_;
+  cms::cuda::SimpleVector<SiPixelErrorCompact> error_ = cms::cuda::make_SimpleVector<SiPixelErrorCompact>(0, nullptr);
   const SiPixelFormatterErrors* formatterErrors_ = nullptr;
 };
 


### PR DESCRIPTION
#### PR description:

Initialise the `errors_` data member of the `SiPixelDigiErrorsSoAFromCUDA` producer.

Prevents reading from uninitialised memory when the first event of a job has zero error words, and fixes a crash observed at HLT during data taking.

#### PR validation:

Without this fix, it is possible to reproduce the error observed online running over the "error stream" events that triggered  it.
With this fix, no crash is observed after running 30+ times on the same input.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Backport of #38476, needed for data taking.