### PR TITLE
Avoid inlining virtual functions in FWCore/Framework

### DIFF
--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -57,7 +57,7 @@ namespace edm {
     ~LuminosityBlock() override;
 
     // AUX functions are defined in LuminosityBlockBase
-    LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const override { return aux_; }
+    LuminosityBlockAuxiliary const& luminosityBlockAuxiliary() const final;
 
     /**\return Reusable index which can be used to separate data for different simultaneous LuminosityBlocks.
      */
@@ -156,7 +156,7 @@ namespace edm {
     // Override version from LuminosityBlockBase class
     BasicHandle getByLabelImpl(std::type_info const& iWrapperType,
                                std::type_info const& iProductType,
-                               InputTag const& iTag) const override;
+                               InputTag const& iTag) const final;
 
     template <typename PROD>
     void putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -59,7 +59,7 @@ namespace edm {
 
     typedef PrincipalGetAdapter Base;
     // AUX functions are defined in RunBase
-    RunAuxiliary const& runAuxiliary() const override { return aux_; }
+    RunAuxiliary const& runAuxiliary() const final;
     // AUX functions.
     //     RunID const& id() const {return aux_.id();}
     //     RunNumber_t run() const {return aux_.run();}
@@ -159,7 +159,7 @@ namespace edm {
     // Override version from RunBase class
     BasicHandle getByLabelImpl(std::type_info const& iWrapperType,
                                std::type_info const& iProductType,
-                               InputTag const& iTag) const override;
+                               InputTag const& iTag) const final;
 
     template <typename PROD>
     void putImpl(EDPutToken::value_type token, std::unique_ptr<PROD> product);

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -25,6 +25,8 @@ namespace edm {
 
   LuminosityBlock::~LuminosityBlock() {}
 
+  LuminosityBlockAuxiliary const& LuminosityBlock::luminosityBlockAuxiliary() const { return aux_; }
+
   LuminosityBlockIndex LuminosityBlock::index() const { return luminosityBlockPrincipal().index(); }
 
   LuminosityBlock::CacheIdentifier_t LuminosityBlock::cacheIdentifier() const {

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -21,6 +21,8 @@ namespace edm {
 
   Run::~Run() {}
 
+  RunAuxiliary const& Run::runAuxiliary() const { return aux_; }
+
   Run::CacheIdentifier_t Run::cacheIdentifier() const { return runPrincipal().cacheIdentifier(); }
 
   RunIndex Run::index() const { return runPrincipal().index(); }


### PR DESCRIPTION
#### PR description:

The gcc 12 compiler fails to generate a global symbols when a virtual function is declared inline in the class.

#### PR validation:

Compiling and linking now works in a gcc 12 IB.