### PR TITLE
HCAL: Bugfix of PFA1' Trigger Primitive algo by removing peak-finder

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -489,19 +489,28 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
       continue;
     }
 
-    bool isPeak = (sum[idx] > sum[idx - 1] && sum[idx] >= sum[idx + 1] && sum[idx] > theThreshold);
+    //Only run the peak-finder when the PFA2 FIR filter is running, which corresponds to weights = 1
+    if (weightsQIE11_[theIeta][0] == 1) {
+      bool isPeak = (sum[idx] > sum[idx - 1] && sum[idx] >= sum[idx + 1] && sum[idx] > theThreshold);
+      if (isPeak) {
+        output[ibin] = std::min<unsigned int>(sum[idx], QIE11_MAX_LINEARIZATION_ET);
 
-    if (isPeak) {
-      output[ibin] = std::min<unsigned int>(sum[idx], QIE11_MAX_LINEARIZATION_ET);
+        if (fix_saturation_ && force_saturation[idx] && ids.size() == 2)
+          output[ibin] = QIE11_MAX_LINEARIZATION_ET * 0.5;
+        else if (fix_saturation_ && force_saturation[idx])
+          output[ibin] = QIE11_MAX_LINEARIZATION_ET;
 
-      if (fix_saturation_ && force_saturation[idx] && ids.size() == 2)
-        output[ibin] = QIE11_MAX_LINEARIZATION_ET * 0.5;
-      else if (fix_saturation_ && force_saturation[idx])
-        output[ibin] = QIE11_MAX_LINEARIZATION_ET;
-
+      } else {
+        // Not a peak
+        output[ibin] = 0;
+      }
     } else {
-      // Not a peak
-      output[ibin] = 0;
+        output[ibin] = std::min<unsigned int>(sum[idx], QIE11_MAX_LINEARIZATION_ET);
+
+        if (fix_saturation_ && force_saturation[idx] && ids.size() == 2)
+          output[ibin] = QIE11_MAX_LINEARIZATION_ET * 0.5;
+        else if (fix_saturation_ && force_saturation[idx])
+          output[ibin] = QIE11_MAX_LINEARIZATION_ET;
     }
     // peak-finding is not applied for FG bits
     // compute(msb) returns two bits (MIP). compute(timingTDC,ids) returns 6 bits (1 depth, 1 prompt, 1 delayed 01, 1 delayed 10, 2 reserved)

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -505,12 +505,12 @@ void HcalTriggerPrimitiveAlgo::analyzeQIE11(IntegerCaloSamples& samples,
         output[ibin] = 0;
       }
     } else {
-        output[ibin] = std::min<unsigned int>(sum[idx], QIE11_MAX_LINEARIZATION_ET);
+      output[ibin] = std::min<unsigned int>(sum[idx], QIE11_MAX_LINEARIZATION_ET);
 
-        if (fix_saturation_ && force_saturation[idx] && ids.size() == 2)
-          output[ibin] = QIE11_MAX_LINEARIZATION_ET * 0.5;
-        else if (fix_saturation_ && force_saturation[idx])
-          output[ibin] = QIE11_MAX_LINEARIZATION_ET;
+      if (fix_saturation_ && force_saturation[idx] && ids.size() == 2)
+        output[ibin] = QIE11_MAX_LINEARIZATION_ET * 0.5;
+      else if (fix_saturation_ && force_saturation[idx])
+        output[ibin] = QIE11_MAX_LINEARIZATION_ET;
     }
     // peak-finding is not applied for FG bits
     // compute(msb) returns two bits (MIP). compute(timingTDC,ids) returns 6 bits (1 depth, 1 prompt, 1 delayed 01, 1 delayed 10, 2 reserved)


### PR DESCRIPTION
#### PR description:

Removing the peak-finder when the FIR filter, PFA1', is running to reconstruct the TP energy. This is to match what is in the firmware on detector. Also, on detector the peak-finder is only run when PFA2 is enabled, which has been implemented in this modification.

#### PR validation:

A basic technical test was performed: runTheMatrix.py -l limited -i all --ibeos

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR is not a backport.