### PR TITLE
add protection against missing input histograms in L1Tde* clients

### DIFF
--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGClient.cc
@@ -199,6 +199,13 @@ void L1TdeCSCTPGClient::processHistograms(DQMStore::IGetter &igetter) {
         dataMon = igetter.get(monitorDir_ + "/" + histData);
         emulMon = igetter.get(monitorDir_ + "/" + histEmul);
 
+        if (dataMon == nullptr or emulMon == nullptr) {
+          edm::LogWarning("L1TdeCSCTPGClient")
+              << __PRETTY_FUNCTION__ << " could not load the necessary histograms for harvesting " << histData << " / "
+              << histEmul;
+          continue;
+        }
+
         TH1F *hDiff = chamberHistos_[iType][key + "_diff"]->getTH1F();
 
         if (dataMon && emulMon) {
@@ -217,6 +224,13 @@ void L1TdeCSCTPGClient::processHistograms(DQMStore::IGetter &igetter) {
         dataMon = igetter.get(monitorDir_ + "/" + histData);
         emulMon = igetter.get(monitorDir_ + "/" + histEmul);
 
+        if (dataMon == nullptr or emulMon == nullptr) {
+          edm::LogWarning("L1TdeCSCTPGClient")
+              << __PRETTY_FUNCTION__ << " could not load the necessary histograms for harvesting " << histData << " / "
+              << histEmul;
+          continue;
+        }
+
         TH1F *hDiff = chamberHistos_[iType][key + "_diff"]->getTH1F();
 
         if (dataMon && emulMon) {
@@ -234,6 +248,13 @@ void L1TdeCSCTPGClient::processHistograms(DQMStore::IGetter &igetter) {
 
         dataMon = igetter.get(monitorDir_ + "/" + histData);
         emulMon = igetter.get(monitorDir_ + "/" + histEmul);
+
+        if (dataMon == nullptr or emulMon == nullptr) {
+          edm::LogWarning("L1TdeCSCTPGClient")
+              << __PRETTY_FUNCTION__ << " could not load the necessary histograms for harvesting " << histData << " / "
+              << histEmul;
+          continue;
+        }
 
         TH1F *hDiff = chamberHistos_[iType][key + "_diff"]->getTH1F();
 
@@ -254,12 +275,26 @@ void L1TdeCSCTPGClient::processHistograms(DQMStore::IGetter &igetter) {
   MonitorElement *clctDataSummary_denom_ = igetter.get(monitorDir_ + "/clct_csctp_data_summary_denom");
   MonitorElement *clctDataSummary_num_ = igetter.get(monitorDir_ + "/clct_csctp_data_summary_num");
 
+  if (lctDataSummary_denom_ == nullptr or lctDataSummary_num_ == nullptr or alctDataSummary_denom_ == nullptr or
+      alctDataSummary_num_ == nullptr or clctDataSummary_denom_ == nullptr or clctDataSummary_num_ == nullptr) {
+    edm::LogWarning("L1TdeCSCTPGClient") << __PRETTY_FUNCTION__
+                                         << " could not load the necessary data histograms for 2D summary plots";
+    return;
+  }
+
   MonitorElement *lctEmulSummary_denom_ = igetter.get(monitorDir_ + "/lct_csctp_emul_summary_denom");
   MonitorElement *lctEmulSummary_num_ = igetter.get(monitorDir_ + "/lct_csctp_emul_summary_num");
   MonitorElement *alctEmulSummary_denom_ = igetter.get(monitorDir_ + "/alct_csctp_emul_summary_denom");
   MonitorElement *alctEmulSummary_num_ = igetter.get(monitorDir_ + "/alct_csctp_emul_summary_num");
   MonitorElement *clctEmulSummary_denom_ = igetter.get(monitorDir_ + "/clct_csctp_emul_summary_denom");
   MonitorElement *clctEmulSummary_num_ = igetter.get(monitorDir_ + "/clct_csctp_emul_summary_num");
+
+  if (lctEmulSummary_denom_ == nullptr or lctEmulSummary_num_ == nullptr or alctEmulSummary_denom_ == nullptr or
+      alctEmulSummary_num_ == nullptr or clctEmulSummary_denom_ == nullptr or clctEmulSummary_num_ == nullptr) {
+    edm::LogWarning("L1TdeCSCTPGClient")
+        << __PRETTY_FUNCTION__ << " could not load the necessary emulation histograms for the 2D summary plots";
+    return;
+  }
 
   lctDataSummary_eff_->getTH2F()->Divide(lctDataSummary_num_->getTH2F(), lctDataSummary_denom_->getTH2F(), 1, 1, "");
   alctDataSummary_eff_->getTH2F()->Divide(alctDataSummary_num_->getTH2F(), alctDataSummary_denom_->getTH2F(), 1, 1, "");

--- a/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeCSCTPGShowerClient.cc
@@ -213,12 +213,28 @@ void L1TdeCSCTPGShowerClient::processHistograms(DQMStore::IGetter &igetter) {
   MonitorElement *clctShowerDataNomSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_data_nom_summary_denom");
   MonitorElement *clctShowerDataNomSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_data_nom_summary_num");
 
+  if (lctShowerDataNomSummary_denom_ == nullptr or lctShowerDataNomSummary_num_ == nullptr or
+      alctShowerDataNomSummary_denom_ == nullptr or alctShowerDataNomSummary_num_ == nullptr or
+      clctShowerDataNomSummary_denom_ == nullptr or clctShowerDataNomSummary_num_ == nullptr) {
+    edm::LogWarning("L1TdeCSCTPGShowerClient")
+        << __PRETTY_FUNCTION__ << " could not load the necessary shower data histograms for harvesting";
+    return;
+  }
+
   MonitorElement *lctShowerEmulNomSummary_denom_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_nom_summary_denom");
   MonitorElement *lctShowerEmulNomSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_nom_summary_num");
   MonitorElement *alctShowerEmulNomSummary_denom_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_nom_summary_denom");
   MonitorElement *alctShowerEmulNomSummary_num_ = igetter.get(monitorDir_ + "/alct_cscshower_emul_nom_summary_num");
   MonitorElement *clctShowerEmulNomSummary_denom_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_nom_summary_denom");
   MonitorElement *clctShowerEmulNomSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_nom_summary_num");
+
+  if (lctShowerEmulNomSummary_denom_ == nullptr or lctShowerEmulNomSummary_num_ == nullptr or
+      alctShowerEmulNomSummary_denom_ == nullptr or alctShowerEmulNomSummary_num_ == nullptr or
+      clctShowerEmulNomSummary_denom_ == nullptr or clctShowerEmulNomSummary_num_ == nullptr) {
+    edm::LogWarning("L1TdeCSCTPGShowerClient")
+        << __PRETTY_FUNCTION__ << " could not load the necessary shower emulation histograms for harvesting";
+    return;
+  }
 
   MonitorElement *lctShowerDataTightSummary_denom_ =
       igetter.get(monitorDir_ + "/lct_cscshower_data_tight_summary_denom");
@@ -230,6 +246,14 @@ void L1TdeCSCTPGShowerClient::processHistograms(DQMStore::IGetter &igetter) {
       igetter.get(monitorDir_ + "/clct_cscshower_data_tight_summary_denom");
   MonitorElement *clctShowerDataTightSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_data_tight_summary_num");
 
+  if (lctShowerDataTightSummary_denom_ == nullptr or lctShowerDataTightSummary_num_ == nullptr or
+      alctShowerDataTightSummary_denom_ == nullptr or alctShowerDataTightSummary_num_ == nullptr or
+      clctShowerDataTightSummary_denom_ == nullptr or clctShowerDataTightSummary_num_ == nullptr) {
+    edm::LogWarning("L1TdeCSCTPGShowerClient")
+        << __PRETTY_FUNCTION__ << " could not load the necessary shower data (tight) histograms for harvesting";
+    return;
+  }
+
   MonitorElement *lctShowerEmulTightSummary_denom_ =
       igetter.get(monitorDir_ + "/lct_cscshower_emul_tight_summary_denom");
   MonitorElement *lctShowerEmulTightSummary_num_ = igetter.get(monitorDir_ + "/lct_cscshower_emul_tight_summary_num");
@@ -239,6 +263,14 @@ void L1TdeCSCTPGShowerClient::processHistograms(DQMStore::IGetter &igetter) {
   MonitorElement *clctShowerEmulTightSummary_denom_ =
       igetter.get(monitorDir_ + "/clct_cscshower_emul_tight_summary_denom");
   MonitorElement *clctShowerEmulTightSummary_num_ = igetter.get(monitorDir_ + "/clct_cscshower_emul_tight_summary_num");
+
+  if (lctShowerEmulTightSummary_denom_ == nullptr or lctShowerEmulTightSummary_num_ == nullptr or
+      alctShowerEmulTightSummary_denom_ == nullptr or alctShowerEmulTightSummary_num_ == nullptr or
+      clctShowerEmulTightSummary_denom_ == nullptr or clctShowerEmulTightSummary_num_ == nullptr) {
+    edm::LogWarning("L1TdeCSCTPGShowerClient")
+        << __PRETTY_FUNCTION__ << " could not load the necessary shower emulation (tight) histograms for harvesting";
+    return;
+  }
 
   lctShowerDataNomSummary_eff_->getTH2F()->Divide(
       lctShowerDataNomSummary_num_->getTH2F(), lctShowerDataNomSummary_denom_->getTH2F(), 1, 1, "");

--- a/DQM/L1TMonitorClient/src/L1TdeStage2ShowerRegionalClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TdeStage2ShowerRegionalClient.cc
@@ -63,6 +63,13 @@ void L1TdeStage2RegionalShowerClient::processHistograms(DQMStore::IGetter &igett
   MonitorElement *emtfShowerEmulSummary_denom_ = igetter.get(monitorDir_ + "/emtf_shower_emul_summary_denom");
   MonitorElement *emtfShowerEmulSummary_num_ = igetter.get(monitorDir_ + "/emtf_shower_emul_summary_num");
 
+  if (emtfShowerDataSummary_denom_ == nullptr or emtfShowerDataSummary_num_ == nullptr or
+      emtfShowerEmulSummary_denom_ == nullptr or emtfShowerEmulSummary_num_ == nullptr) {
+    edm::LogWarning("L1TdeStage2RegionalShowerClient")
+        << __PRETTY_FUNCTION__ << " could not load the necessary histograms for the harvesting";
+    return;
+  }
+
   emtfShowerDataSummary_eff_->getTH2F()->Divide(
       emtfShowerDataSummary_num_->getTH2F(), emtfShowerDataSummary_denom_->getTH2F(), 1, 1, "");
   emtfShowerEmulSummary_eff_->getTH2F()->Divide(


### PR DESCRIPTION
#### PR description:

When trying to setup the unit tests for PR https://github.com/cms-sw/cmssw/pull/38463 I noticed that no matter what `HARVESTING` flavor one chose, if the input histograms for the L1T harvesting are not available the process crashed as:

```bash
Thread 1 (Thread 0x7f4b1bb6a540 (LWP 26954) "cmsRun"):
#0  0x00007f4b1da0addd in poll () from /lib64/libc.so.6
#1  0x00007f4b16f6773f in full_read.constprop () from /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_X_2022-06-23-2300/lib/slc7_amd64_gcc10/pluginFWCoreServicesPlugins.so
#2  0x00007f4b16f680cc in edm::service::InitRootHandlers::stacktraceFromThread() () from /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_X_2022-06-23-2300/lib/slc7_amd64_gcc10/pluginFWCoreServicesPlugins.so
#3  0x00007f4b16f6aa1b in sig_dostack_then_abort () from /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_X_2022-06-23-2300/lib/slc7_amd64_gcc10/pluginFWCoreServicesPlugins.so
#4  <signal handler called>
#5  0x00007f4ad3a7ade9 in L1TdeCSCTPGClient::processHistograms(dqm::implementation::IGetter&) () from /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_X_2022-06-23-2300/lib/slc7_amd64_gcc10/pluginDQML1TMonitorClient.so
#6  0x00007f4ad3a17c6d in DQMEDHarvester::endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) () from /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_X_2022-06-23-2300/lib/slc7_amd64_gcc10/pluginDQML1TMonitorClient.so
#7  0x00007f4b2047285d in edm::one::EDProducerBase::doEndLuminosityBlock(edm::LumiTransitionInfo const&, edm::ModuleCallingContext const*) () from /cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_X_2022-06-23-2300/lib/slc7_amd64_gcc10/libFWCoreFramework.so
```

I propose to fix the issue by putting in place some protection to stop executing the harvesting if the input histograms are not available.

#### PR validation:

Using the files at `/afs/cern.ch/user/m/musich/public/L1THarvFix/` the process doesn't crash.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A