### PR TITLE
More plots from GE21 for the GEM DQMs, a backport to 12_3_X

### DIFF
--- a/DQM/GEM/interface/GEMDAQStatusSource.h
+++ b/DQM/GEM/interface/GEMDAQStatusSource.h
@@ -76,9 +76,9 @@ private:
   edm::EDGetToken tagAMC_;
   edm::EDGetToken tagAMC13_;
 
+  Bool_t bWarnedNotFound_;
+
   MonitorElement *h2AMC13Status_;
-  MonitorElement *h2AMCStatusPos_;
-  MonitorElement *h2AMCStatusNeg_;
 
   MEMap3Inf mapStatusOH_;
   MEMap3Inf mapStatusVFAT_;
@@ -100,9 +100,14 @@ private:
 
   std::string strFolderMain_;
 
+  Bool_t bFillAMC_;
+
   Int_t nBXMin_, nBXMax_;
 
   std::map<UInt_t, int> mapFEDIdToRe_;
+  std::map<UInt_t, int> mapFEDIdToSt_;
+  std::map<UInt_t, int> mapFEDIdToPosition_;
+  std::map<UInt_t, MonitorElement *> mapFEDIdToAMCStatus_;
   std::map<int, std::vector<GEMDetId>> mapAMC13ToListChamber_;
   std::map<std::tuple<int, int>, std::vector<GEMDetId>> mapAMCToListChamber_;
   Int_t nAMCSlots_;

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -334,7 +334,7 @@ public:
       return mapHist[key];
     };
 
-    int SetLabelForChambers(K key, Int_t nAxis, Int_t nNumBin = -1) {
+    int SetLabelForChambers(K key, Int_t nAxis, Int_t nNumBin = -1, Int_t nIdxStart = 1) {
       if (!bOperating_)
         return 0;
       if (nNumBin <= 0) {
@@ -348,7 +348,7 @@ public:
       dqm::impl::MonitorElement *histCurr = FindHist(key);
       if (histCurr == nullptr)
         return -999;
-      for (Int_t i = 1; i <= nNumBin; i++) {
+      for (Int_t i = nIdxStart; i <= nNumBin; i++) {
         histCurr->setBinLabel(i, Form("%i", i), nAxis);
       }
       return 0;
@@ -492,6 +492,8 @@ public:
     Int_t nMaxVFAT_;  // the number of all VFATs in each chamber (= # of VFATs in eta partition * nNumEtaPartitions_)
     Int_t nNumDigi_;  // the number of digis of each VFAT
 
+    Int_t nMinIdxChamber_;
+    Int_t nMaxIdxChamber_;
     Float_t fMinPhi_;
 
     std::vector<Float_t> listRadiusEvenChamber_;
@@ -562,7 +564,9 @@ protected:
   inline int getVFATNumberGE11(const int, const int, const int);
   inline int getVFATNumberByDigi(const int, const int, const int);
   inline int getIEtaFromVFAT(const int station, const int vfat);
+  inline int getIEtaFromVFATGE0(const int vfat);
   inline int getIEtaFromVFATGE11(const int vfat);
+  inline int getIEtaFromVFATGE21(const int vfat);
   inline int getMaxVFAT(const int);
   inline int getDetOccXBin(const int, const int, const int);
   inline Float_t restrictAngle(const Float_t fTheta, const Float_t fStart);
@@ -583,10 +587,6 @@ protected:
   int nMaxNumCh_;
   std::map<ME3IdsKey, int> mapStationToIdx_;
   std::map<ME3IdsKey, MEStationInfo> mapStationInfo_;
-
-  Int_t nNumEtaPartitionGE0_;
-  Int_t nNumEtaPartitionGE11_;
-  Int_t nNumEtaPartitionGE21_;
 };
 
 // Borrwed from DQM/GEM/interface/GEMOfflineDQMBase.h
@@ -601,6 +601,8 @@ inline bool GEMDQMBase::checkRefs(const std::vector<T *> &refs) {
 
 // The 'get...' functions in the below are borrwed from DQM/GEM/interface/GEMOfflineDQMBase.h
 inline int GEMDQMBase::getMaxVFAT(const int station) {
+  if (station == 0)
+    return GEMeMap::maxVFatGE0_;
   if (station == 1)
     return GEMeMap::maxVFatGE11_;
   else if (station == 2)
@@ -616,7 +618,7 @@ inline int GEMDQMBase::getVFATNumber(const int station, const int ieta, const in
 }
 
 inline int GEMDQMBase::getVFATNumberGE11(const int station, const int ieta, const int vfat_phi) {
-  return vfat_phi * nNumEtaPartitionGE11_ + (nNumEtaPartitionGE11_ - ieta);
+  return vfat_phi * GEMeMap::maxiEtaIdGE11_ + (GEMeMap::maxiEtaIdGE11_ - ieta);
 }
 
 inline int GEMDQMBase::getVFATNumberByDigi(const int station, const int ieta, const int digi) {
@@ -625,12 +627,26 @@ inline int GEMDQMBase::getVFATNumberByDigi(const int station, const int ieta, co
 }
 
 inline int GEMDQMBase::getIEtaFromVFAT(const int station, const int vfat) {
+  if (station == 0)
+    return getIEtaFromVFATGE0(vfat);
   if (station == 1)
     return getIEtaFromVFATGE11(vfat);
+  if (station == 2)
+    return getIEtaFromVFATGE21(vfat);
   return getIEtaFromVFATGE11(vfat);  // FIXME: What about GE21 and GE0?
 }
 
-inline int GEMDQMBase::getIEtaFromVFATGE11(const int vfat) { return 8 - (vfat % nNumEtaPartitionGE11_); }
+inline int GEMDQMBase::getIEtaFromVFATGE0(const int vfat) {
+  return GEMeMap::maxiEtaIdGE0_ - (vfat % GEMeMap::maxiEtaIdGE0_);
+}
+
+inline int GEMDQMBase::getIEtaFromVFATGE11(const int vfat) {
+  return GEMeMap::maxiEtaIdGE11_ - (vfat % GEMeMap::maxiEtaIdGE11_);
+}
+
+inline int GEMDQMBase::getIEtaFromVFATGE21(const int vfat) {
+  return GEMeMap::maxiEtaIdGE21_ - (vfat % GEMeMap::maxiEtaIdGE21_);
+}
 
 inline int GEMDQMBase::getDetOccXBin(const int chamber, const int layer, const int n_chambers) {
   return n_chambers * (chamber - 1) + layer;
@@ -644,9 +660,9 @@ inline Float_t GEMDQMBase::restrictAngle(const Float_t fTheta, const Float_t fSt
 
 inline std::string GEMDQMBase::getNameDirLayer(ME3IdsKey key3) {
   auto nStation = keyToStation(key3);
-  const char *szRegion = (keyToRegion(key3) > 0 ? "P" : "M");
+  char cRegion = (keyToRegion(key3) > 0 ? 'P' : 'M');
   auto nLayer = keyToLayer(key3);
-  return std::string(Form("GE%i1-%s-L%i", nStation, szRegion, nLayer));
+  return std::string(Form("GE%i1-%c-L%i", nStation, cRegion, nLayer));
 }
 
 #endif  // DQM_GEM_INTERFACE_GEMDQMBase_h

--- a/DQM/GEM/interface/GEMRecHitSource.h
+++ b/DQM/GEM/interface/GEMRecHitSource.h
@@ -35,7 +35,6 @@ private:
   int nNumDivideEtaPartitionInRPhi_;
 
   MEMap3Inf mapRecHitXY_layer_;
-  MEMap3Inf mapRecHitWheel_layer_;
   MEMap3Inf mapRecHitOcc_ieta_;
   MEMap3Inf mapRecHitOcc_phi_;
   MEMap3Inf mapTotalRecHitPerEvtLayer_;

--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -23,7 +23,7 @@ void GEMDAQStatusSource::fillDescriptions(edm::ConfigurationDescriptions &descri
   desc.add<edm::InputTag>("AMC13InputLabel", edm::InputTag("muonGEMDigis", "AMC13Status"));
 
   desc.add<Int_t>("AMCSlots", 13);
-  desc.addUntracked<std::string>("runType", "online");
+  desc.addUntracked<std::string>("runType", "relval");
   desc.addUntracked<std::string>("logCategory", "GEMDAQStatusSource");
 
   descriptions.add("GEMDAQStatusSource", desc);
@@ -298,6 +298,11 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
   edm::Handle<GEMAMCStatusCollection> gemAMC;
   edm::Handle<GEMAMC13StatusCollection> gemAMC13;
 
+  event.getByToken(tagVFAT_, gemVFAT);
+  event.getByToken(tagOH_, gemOH);
+  event.getByToken(tagAMC_, gemAMC);
+  event.getByToken(tagAMC13_, gemAMC13);
+
   if (!(gemVFAT.isValid() && gemOH.isValid() && gemAMC.isValid() && gemAMC13.isValid())) {
     if (!bWarnedNotFound_) {
       edm::LogWarning(log_category_) << "DAQ sources from muonGEMDigis are not found";
@@ -305,11 +310,6 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
     }
     return;
   }
-
-  event.getByToken(tagVFAT_, gemVFAT);
-  event.getByToken(tagOH_, gemOH);
-  event.getByToken(tagAMC_, gemAMC);
-  event.getByToken(tagAMC13_, gemAMC13);
 
   std::map<ME4IdsKey, bool> mapChamberAll;
   std::map<ME4IdsKey, bool> mapChamberWarning;

--- a/DQM/GEM/plugins/GEMDQMHarvester.cc
+++ b/DQM/GEM/plugins/GEMDQMHarvester.cc
@@ -213,13 +213,11 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
 
   std::string strTitleSummary = "summary";
 
-  getGeometryInfo(store, h2SrcStatusEOH);
+  getGeometryInfo(store, h2SrcStatusE);
 
-  if (h2SrcStatusA != nullptr && h2SrcStatusE != nullptr && h2SrcStatusW != nullptr && h2SrcStatusEVFAT != nullptr &&
-      h2SrcStatusWVFAT != nullptr && h2SrcStatusEOH != nullptr && h2SrcStatusWOH != nullptr &&
-      h2SrcStatusEAMC != nullptr && h2SrcStatusWAMC != nullptr && h2SrcStatusEAMC13 != nullptr) {
+  if (h2SrcStatusA != nullptr && h2SrcStatusE != nullptr && h2SrcStatusW != nullptr) {
     MonitorElement *h2Sum = nullptr;
-    createSummaryHist(store, h2SrcStatusEOH, h2Sum);
+    createSummaryHist(store, h2SrcStatusE, h2Sum);
     createTableWatchingSummary();
 
     std::vector<MonitorElement *> listOccPlots(listLayer_.size() + 1);  // The index starts at 1
@@ -273,7 +271,8 @@ void GEMDQMHarvester::drawSummaryHistogram(edm::Service<DQMStore> &store, Int_t 
   for (const auto &strSuffix : listLayer_) {
     if (mapIdxLayer_.find(strSuffix) == mapIdxLayer_.end())
       continue;
-    auto nNumChamber = mapNumChPerChamber_[mapIdxLayer_[strSuffix]];
+    //auto nNumChamber = mapNumChPerChamber_[mapIdxLayer_[strSuffix]];
+    Int_t nNumChamber = 36;
     createInactiveChannelFracHist(store, strSuffix, nNumChamber);
   }
 
@@ -426,13 +425,13 @@ Float_t GEMDQMHarvester::refineSummaryHistogram(std::string strName,
       Float_t fStatusAll = h2SrcStatusA->getBinContent(i, j);
       Float_t fStatusErr = h2SrcStatusE->getBinContent(i, j);
       Float_t fStatusWarn = h2SrcStatusW->getBinContent(i, j);
-      Float_t fStatusErrVFAT = h2SrcStatusEVFAT->getBinContent(i, j);
-      Float_t fStatusWarnVFAT = h2SrcStatusWVFAT->getBinContent(i, j);
-      Float_t fStatusErrOH = h2SrcStatusEOH->getBinContent(i, j);
-      Float_t fStatusWarnOH = h2SrcStatusWOH->getBinContent(i, j);
-      Float_t fStatusErrAMC = h2SrcStatusEAMC->getBinContent(i, j);
-      Float_t fStatusWarnAMC = h2SrcStatusWAMC->getBinContent(i, j);
-      Float_t fStatusErrAMC13 = h2SrcStatusEAMC13->getBinContent(i, j);
+      Float_t fStatusErrVFAT = h2SrcStatusEVFAT != nullptr ? h2SrcStatusEVFAT->getBinContent(i, j) : 0;
+      Float_t fStatusWarnVFAT = h2SrcStatusWVFAT != nullptr ? h2SrcStatusWVFAT->getBinContent(i, j) : 0;
+      Float_t fStatusErrOH = h2SrcStatusEOH != nullptr ? h2SrcStatusEOH->getBinContent(i, j) : 0;
+      Float_t fStatusWarnOH = h2SrcStatusWOH != nullptr ? h2SrcStatusWOH->getBinContent(i, j) : 0;
+      Float_t fStatusErrAMC = h2SrcStatusEAMC != nullptr ? h2SrcStatusEAMC->getBinContent(i, j) : 0;
+      Float_t fStatusWarnAMC = h2SrcStatusWAMC != nullptr ? h2SrcStatusWAMC->getBinContent(i, j) : 0;
+      Float_t fStatusErrAMC13 = h2SrcStatusEAMC13 != nullptr ? h2SrcStatusEAMC13->getBinContent(i, j) : 0;
       NumStatus numStatus(fStatusAll,
                           fOcc,
                           fStatusErrVFAT,
@@ -661,8 +660,28 @@ std::string getNameChamberOccGE11(std::string strSuffix, Int_t nIdxCh) {
       "GEM/Digis/occupancy_GE11-%c-L%i/occ_GE11-%c-%02iL%i-%c", cRegion, nLayer, cRegion, nIdxCh, nLayer, cChType);
 }
 
-std::string getNameChamberOccGE21(std::string strSuffix, Int_t nIdxChamber) {
-  return "";  // FIXME
+// FIXME: The naming convention of GE21 could be changed to be different from GE11
+std::string getNameChamberOccGE21(std::string strSuffix, Int_t nIdxCh) {
+  char cRegion;
+  char cChType = (nIdxCh % 2 == 0 ? 'L' : 'S');
+  Int_t nLayer;
+
+  if (strSuffix.find("-M-") != std::string::npos)
+    cRegion = 'M';
+  else if (strSuffix.find("-P-") != std::string::npos)
+    cRegion = 'P';
+  else
+    return "";
+
+  if (strSuffix.find("-L1") != std::string::npos)
+    nLayer = 1;
+  else if (strSuffix.find("-L2") != std::string::npos)
+    nLayer = 2;
+  else
+    return "";
+
+  return Form(
+      "GEM/Digis/occupancy_GE21-%c-L%i/occ_GE21-%c-%02iL%i-%c", cRegion, nLayer, cRegion, nIdxCh, nLayer, cChType);
 }
 
 std::string getNameChamberOccNull(std::string strSuffix, Int_t nIdxChamber) {

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -66,7 +66,6 @@ void GEMDigiSource::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&, 
   if (nRunType_ == GEMDQM_RUNTYPE_OFFLINE) {
     mapDigiWheel_layer_.TurnOff();
     mapBX_.TurnOff();
-    mapTotalDigi_layer_.TurnOff();
   }
 
   if (nRunType_ == GEMDQM_RUNTYPE_RELVAL) {
@@ -110,7 +109,7 @@ int GEMDigiSource::ProcessWithMEMap3(BookingHelper& bh, ME3IdsKey key) {
   mapTotalDigi_layer_.SetBinConfX(stationInfo.nNumChambers_);
   mapTotalDigi_layer_.SetBinConfY(stationInfo.nMaxVFAT_, -0.5);
   mapTotalDigi_layer_.bookND(bh, key);
-  mapTotalDigi_layer_.SetLabelForChambers(key, 1);
+  mapTotalDigi_layer_.SetLabelForChambers(key, 1, -1, stationInfo.nMinIdxChamber_);
   mapTotalDigi_layer_.SetLabelForVFATs(key, stationInfo.nNumEtaPartitions_, 2);
 
   mapDigiWheel_layer_.SetBinLowEdgeX(stationInfo.fMinPhi_);

--- a/DQM/GEM/python/gem_dqm_offline_source_cff.py
+++ b/DQM/GEM/python/gem_dqm_offline_source_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.GEM.GEMDigiSource_cfi import *
 from DQM.GEM.GEMRecHitSource_cfi import *
+from DQM.GEM.GEMDAQStatusSource_cfi import *
 from DQM.GEM.gemEfficiencyAnalyzer_cff import *
 
 GEMDigiSource.runType   = "offline"
@@ -10,6 +11,7 @@ GEMRecHitSource.runType = "offline"
 gemSources = cms.Sequence(
     GEMDigiSource *
     GEMRecHitSource *
+    GEMDAQStatusSource *
     gemEfficiencyAnalyzerTightGlbSeq *
     gemEfficiencyAnalyzerStaSeq
 )

--- a/DQM/GEM/python/gem_dqm_offline_source_cff.py
+++ b/DQM/GEM/python/gem_dqm_offline_source_cff.py
@@ -5,8 +5,9 @@ from DQM.GEM.GEMRecHitSource_cfi import *
 from DQM.GEM.GEMDAQStatusSource_cfi import *
 from DQM.GEM.gemEfficiencyAnalyzer_cff import *
 
-GEMDigiSource.runType   = "offline"
-GEMRecHitSource.runType = "offline"
+GEMDigiSource.runType      = "offline"
+GEMRecHitSource.runType    = "offline"
+GEMDAQStatusSource.runType = "offline"
 
 gemSources = cms.Sequence(
     GEMDigiSource *

--- a/DQM/GEM/python/gem_dqm_offline_source_cosmics_cff.py
+++ b/DQM/GEM/python/gem_dqm_offline_source_cosmics_cff.py
@@ -5,8 +5,9 @@ from DQM.GEM.GEMRecHitSource_cfi import *
 from DQM.GEM.GEMDAQStatusSource_cfi import *
 from DQM.GEM.gemEfficiencyAnalyzerCosmics_cff import *
 
-GEMDigiSource.runType   = "offline"
-GEMRecHitSource.runType = "offline"
+GEMDigiSource.runType      = "offline"
+GEMRecHitSource.runType    = "offline"
+GEMDAQStatusSource.runType = "offline"
 
 gemSourcesCosmics = cms.Sequence(
     GEMDigiSource *

--- a/DQM/GEM/python/gem_dqm_offline_source_cosmics_cff.py
+++ b/DQM/GEM/python/gem_dqm_offline_source_cosmics_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQM.GEM.GEMDigiSource_cfi import *
 from DQM.GEM.GEMRecHitSource_cfi import *
+from DQM.GEM.GEMDAQStatusSource_cfi import *
 from DQM.GEM.gemEfficiencyAnalyzerCosmics_cff import *
 
 GEMDigiSource.runType   = "offline"
@@ -10,6 +11,7 @@ GEMRecHitSource.runType = "offline"
 gemSourcesCosmics = cms.Sequence(
     GEMDigiSource *
     GEMRecHitSource *
+    GEMDAQStatusSource *
     gemEfficiencyAnalyzerCosmicsGlb *
     gemEfficiencyAnalyzerCosmicsSta
 )

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -6,7 +6,7 @@ process = cms.Process('GEMDQM', Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:
-    unitTest = True
+    unitTest=True
 
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
@@ -40,6 +40,10 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
 process.muonGEMDigis.useDBEMap = True
 process.muonGEMDigis.keepDAQStatus = True
+
+process.GEMDigiSource.runType = "online"
+process.GEMRecHitSource.runType = "online"
+process.GEMDAQStatusSource.runType = "online"
 
 # from csc_dqm_sourceclient-live_cfg.py
 process.CSCGeometryESModule.useGangedStripsInME1a = False

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -83,7 +83,7 @@ void GEMRawToDigiModule::fillDescriptions(edm::ConfigurationDescriptions& descri
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
   desc.add<bool>("useDBEMap", false);
-  desc.add<bool>("keepDAQStatus", false);
+  desc.add<bool>("keepDAQStatus", true);
   desc.add<bool>("readMultiBX", false);
   desc.add<bool>("ge21Off", false);
   desc.add<unsigned int>("fedIdStart", FEDNumbering::MINGEMFEDID);


### PR DESCRIPTION
#### PR description:
We have several updates on GEM DQMs.

- Migrations of some plots to other places (online -> offline or vice versa)
- More plots for GE21 is now available

This PR is the backport of #38398 (+#38526) to CMSSW_12_3_X.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij @seungjin-yang