### PR TITLE
Add checks for ECAL DQM setup objects to prevent crashes on runs with no calibration data

### DIFF
--- a/DQM/EcalCommon/interface/DQWorker.h
+++ b/DQM/EcalCommon/interface/DQWorker.h
@@ -94,6 +94,12 @@ namespace ecaldqm {
 
     void setSetupObjects(edm::EventSetup const &);
     void setSetupObjectsEndLumi(edm::EventSetup const &);
+
+    bool checkElectronicsMap(bool = true);
+    bool checkTrigTowerMap(bool = true);
+    bool checkGeometry(bool = true);
+    bool checkTopology(bool = true);
+
     EcalElectronicsMapping const *GetElectronicsMap();
     EcalTrigTowerConstituentsMap const *GetTrigTowerMap();
     CaloGeometry const *GetGeometry();

--- a/DQM/EcalCommon/src/DQWorker.cc
+++ b/DQM/EcalCommon/src/DQWorker.cc
@@ -115,39 +115,63 @@ namespace ecaldqm {
     edso_.topology = &_es.getData(topoHandleEndLumi);
   }
 
-  EcalElectronicsMapping const *DQWorker::GetElectronicsMap() {
-    if (!edso_.electronicsMap)
+  bool DQWorker::checkElectronicsMap(bool doThrow /* = true*/) {
+    if (edso_.electronicsMap)
+      return true;
+    if (doThrow)
       throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
+    return false;
+  }
+
+  bool DQWorker::checkTrigTowerMap(bool doThrow /* = true*/) {
+    if (edso_.trigtowerMap)
+      return true;
+    if (doThrow)
+      throw cms::Exception("InvalidCall") << "TrigTowerConstituentsMap not initialized";
+    return false;
+  }
+
+  bool DQWorker::checkGeometry(bool doThrow /* = true*/) {
+    if (edso_.geometry)
+      return true;
+    if (doThrow)
+      throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
+    return false;
+  }
+
+  bool DQWorker::checkTopology(bool doThrow /* = true*/) {
+    if (edso_.topology)
+      return true;
+    if (doThrow)
+      throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
+    return false;
+  }
+
+  EcalElectronicsMapping const *DQWorker::GetElectronicsMap() {
+    checkElectronicsMap();
     return edso_.electronicsMap;
   }
 
   EcalTrigTowerConstituentsMap const *DQWorker::GetTrigTowerMap() {
-    if (!edso_.trigtowerMap)
-      throw cms::Exception("InvalidCall") << "TrigTowerConstituentsMap not initialized";
+    checkTrigTowerMap();
     return edso_.trigtowerMap;
   }
 
   CaloGeometry const *DQWorker::GetGeometry() {
-    if (!edso_.geometry)
-      throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
+    checkGeometry();
     return edso_.geometry;
   }
 
   CaloTopology const *DQWorker::GetTopology() {
-    if (!edso_.topology)
-      throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
+    checkTopology();
     return edso_.topology;
   }
 
   EcalDQMSetupObjects const DQWorker::getEcalDQMSetupObjects() {
-    if (!edso_.electronicsMap)
-      throw cms::Exception("InvalidCall") << "Electronics Mapping not initialized";
-    if (!edso_.trigtowerMap)
-      throw cms::Exception("InvalidCall") << "TrigTowerConstituentsMap not initialized";
-    if (!edso_.geometry)
-      throw cms::Exception("InvalidCall") << "CaloGeometry not initialized";
-    if (!edso_.topology)
-      throw cms::Exception("InvalidCall") << "CaloTopology not initialized";
+    checkElectronicsMap();
+    checkTrigTowerMap();
+    checkGeometry();
+    checkTopology();
     return edso_;
   }
 

--- a/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
+++ b/DQM/EcalMonitorClient/plugins/EcalDQMonitorClient.cc
@@ -114,6 +114,8 @@ void EcalDQMonitorClient::dqmEndLuminosityBlock(DQMStore::IBooker& _ibooker,
 void EcalDQMonitorClient::dqmEndJob(DQMStore::IBooker& _ibooker, DQMStore::IGetter& _igetter) {
   executeOnWorkers_(
       [&_ibooker](ecaldqm::DQWorker* worker) {
+        if (!worker->checkElectronicsMap(false))  // to avoid crashes on empty runs
+          return;
         worker->bookMEs(_ibooker);  // worker returns if already booked
       },
       "bookMEs",
@@ -130,6 +132,8 @@ void EcalDQMonitorClient::runWorkers(DQMStore::IGetter& _igetter, ecaldqm::DQWor
 
   executeOnWorkers_(
       [&_igetter, &_type](ecaldqm::DQWorker* worker) {
+        if (!worker->checkElectronicsMap(false))  // to avoid crashes on empty runs
+          return;
         ecaldqm::DQWorkerClient* client(static_cast<ecaldqm::DQWorkerClient*>(worker));
         if (!client->onlineMode() && !client->runsOn(_type))
           return;


### PR DESCRIPTION
#### PR description:

This is an **urgent** fix and needs to be included in the production version at P5 as soon as possible.

This PR fixes an issue causing the client `DQM/Integration/python/clients/ecalcalib_dqm_sourceclient-live_cfg.py` to crash when there is no calibration data available as shown here: https://cmsweb.cern.ch/dqm/dqm-square/tmp/content_parser_productionPARSER_run354309. 

See error log file here: https://cmsweb.cern.ch/dqm/dqm-square/tmp/tmp/content_parser_productionPARSER_run354309PARSER_job9.log

```
%MSG-e EcalDQM:  EcalDQMonitorClient:ecalCalibMonitorClient@endProcessBlock  24-Jun-2022 02:45:57 CEST post-events
EcalCalib Monitor Client: Exception in bookMEs @ LaserClient
%MSG
----- Begin Fatal Exception 24-Jun-2022 02:45:57 CEST-----------------------
An exception of category 'InvalidCall' occurred while
   [0] Processing end ProcessBlock
   [1] Calling method for module EcalDQMonitorClient/'ecalCalibMonitorClient'
Exception Message:
Electronics Mapping not initialized
----- End Fatal Exception -------------------------------------------------
```

The crashes were due to one of the global variables removed in https://github.com/cms-sw/cmssw/pull/33200 being called without being initialized. This PR reintroduces the check functions (eg. `checkElectronicsMap()`) that existed before  https://github.com/cms-sw/cmssw/pull/33200 and uses them to prevent running the code that crashes when there's nothing to run over. 

#### PR validation:

`ecalcalib_dqm_sourceclient-live_cfg.py` no longer crashes in this scenario

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backports made to 12_4_X https://github.com/cms-sw/cmssw/pull/38504 and 12_3_X https://github.com/cms-sw/cmssw/pull/38505 to include this in the production version at P5 as soon as possible