### PR TITLE
Move `HLT:@relval2022` to `GRun` in `master` branch

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -10,7 +10,7 @@ autoHLT = {
   'relval2016' : 'Fake2',
   'relval2017' : 'Fake2',
   'relval2018' : 'Fake2',
-  'relval2022' : '2022v12',
+  'relval2022' : 'GRun',
   'relval2026' : '75e33',
   'test'       : 'GRun',
 }


### PR DESCRIPTION
#### PR description:

This PR reinstates the use of the `GRun` HLT menu under the alias `@relval2022` (used in PR tests, among other things).

This change is done only for the `master` branch (development release cycle), and it will not be backported (in `12_4_X`, `HLT:@relval2022` will continue to be the frozen menu V1.2 to be used for MC production, see #38483).

#### PR validation:

`runTheMatrix.py -l 11634.0` passes.

#### If this PR is a backport, please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A