### PR TITLE
improve `uint`-overflow fix in `ThroughputServiceClient`

### DIFF
--- a/HLTrigger/Timer/plugins/ThroughputServiceClient.cc
+++ b/HLTrigger/Timer/plugins/ThroughputServiceClient.cc
@@ -121,13 +121,14 @@ void ThroughputServiceClient::fillSummaryPlots(DQMStore::IBooker &booker, DQMSto
     width = avg_max - avg_min;
 
     // define the range for .../average_sourced
-    int64_t first = sourced->FindFirstBinAbove(0.);
-    int64_t last = sourced->FindLastBinAbove(0.);
+    auto first = sourced->FindFirstBinAbove(0.);
+    auto last = sourced->FindLastBinAbove(0.);
     booker.setCurrentFolder(folder);
     // (re)book and fill .../average_sourced
     average = booker.book1D("average_sourced", "Throughput (sourced events)", (int)width, avg_min, avg_max)->getTH1F();
-    for (int64_t i = std::max(first, (int64_t)0); i <= last; ++i)
-      average->Fill(sourced->GetBinContent(i));
+    if (first >= 0)
+      for (auto i = first; i <= last; ++i)
+        average->Fill(sourced->GetBinContent(i));
 
     // define the range for .../average_retired
     first = retired->FindFirstBinAbove(0.);
@@ -135,8 +136,9 @@ void ThroughputServiceClient::fillSummaryPlots(DQMStore::IBooker &booker, DQMSto
     booker.setCurrentFolder(folder);
     // (re)book and fill .../average_retired
     average = booker.book1D("average_retired", "Throughput (retired events)", (int)width, avg_min, avg_max)->getTH1F();
-    for (int64_t i = std::max(first, (int64_t)0); i <= last; ++i)
-      average->Fill(retired->GetBinContent(i));
+    if (first >= 0)
+      for (auto i = first; i <= last; ++i)
+        average->Fill(retired->GetBinContent(i));
   }
 }
 


### PR DESCRIPTION
#### PR description:




This PR improves the fix introduced by @pmandrik in #38282 according to https://github.com/cms-sw/cmssw/pull/38287#pullrequestreview-1002336288.

I prefer to have the cleaner implementation (i.e. this PR) in `master`. Since it is equivalent to the existing fix (i.e. #38282), this PR won't need to be backported.

Merely technical. No changes expected.

#### PR validation:

None.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A