### PR TITLE
Don't save flat nano in the ECAL ALCANANO wf

### DIFF
--- a/Calibration/EcalCalibAlgos/python/EcalPhiSymRecoSequence_cff.py
+++ b/Calibration/EcalCalibAlgos/python/EcalPhiSymRecoSequence_cff.py
@@ -169,7 +169,5 @@ def customise(process):
         process.schedule.remove(process.ALCARECOStreamEcalPhiSymByRunOutPath)
     if "ALCARECOStreamEcalPhiSymByLumiOutPath" in process.pathNames():
         process.schedule.remove(process.ALCARECOStreamEcalPhiSymByLumiOutPath)
-    process.ALCARECOStreamEcalPhiSymOutNanoPath = cms.EndPath(ecal_phisym_output(process, save_flatnano=True)[0])
-    process.schedule.append(process.ALCARECOStreamEcalPhiSymOutNanoPath)
 
     return process


### PR DESCRIPTION
#### PR description:

Temporary solution to resolve the problems in https://github.com/dmwm/T0/pull/4664
In the future, the ECAL experts will introduce another customization function that keeps the `save_flatnano` flag true, but for the T0 it needs to be False (given that T0 can deal with the EDM version of NANO only). Because of that I remove the output definition from the current ECAL ALCANANO customization.

#### PR validation:

```
runTheMatrix.py -l 139.005
```
runs fine

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, we could consider backporting it to 12_4_X
