### PR TITLE
Update of ECAL conditions for Run3 MC production 12_4

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -70,13 +70,13 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           : '124X_mcRun3_2022_design_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v6',
+    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v7',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v7',
+    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v8',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v6',
+    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
     'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2024


### PR DESCRIPTION
#### PR description:

Update of ECAL conditions for Run3 MC production 12_4 as requested in 
https://cms-talk.web.cern.ch/t/gt-mc-update-of-ecal-conditions-for-run3-mc-production-12-4/12134

 these GTs
```
124X_mcRun3_2022cosmics_realistic_deco_v8
124X_mcRun3_2022_realistic_HI_v7
124X_mcRun3_2022_realistic_v7
```

The diff wrt to the previous versions are
**phase1_2022_realistic**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_v6/124X_mcRun3_2022_realistic_v7

**phase1_2022_cosmics**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022cosmics_realistic_deco_v7/124X_mcRun3_2022cosmics_realistic_deco_v8

**phase1_2022_realistic_hi**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_HI_v6/124X_mcRun3_2022_realistic_HI_v7

The diffs are in the requested tags only.

#### PR validation:

```
test parameters:
  - workflows = 12034.0,11634.0,7.23,159.0,12434.0,12834.0
 ```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Will be backported to 12_4_X