### PR TITLE
Initialize GEMDQMBase::MEStationInfo:nMinIdxChamber_ and GEMDQMBase::MEStationInfo:nMaxIdxChamber_ in constructor

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -468,7 +468,9 @@ public:
                   Int_t nNumChambers,
                   Int_t nNumEtaPartitions,
                   Int_t nMaxVFAT,
-                  Int_t nNumDigi)
+                  Int_t nNumDigi,
+                  Int_t nMinIdxChamber,
+                  Int_t nMaxIdxChamber)
         : nRegion_(nRegion),
           nStation_(nStation),
           nLayer_(nLayer),
@@ -476,6 +478,8 @@ public:
           nNumEtaPartitions_(nNumEtaPartitions),
           nMaxVFAT_(nMaxVFAT),
           nNumDigi_(nNumDigi),
+          nMinIdxChamber_(nMinIdxChamber),
+          nMaxIdxChamber_(nMaxIdxChamber),
           fMinPhi_(0){};
 
     bool operator==(const MEStationInfo &other) const {

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -107,8 +107,15 @@ int GEMDQMBase::loadChambers() {
       for (auto pchamber : chambers) {
         int layer_number = pchamber->id().layer();
         ME3IdsKey key3(region_number, station_number, layer_number);
-        mapStationInfo_[key3] =
-            MEStationInfo(region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_digi, nMinIdxChamber, nMaxIdxChamber);
+        mapStationInfo_[key3] = MEStationInfo(region_number,
+                                              station_number,
+                                              layer_number,
+                                              num_superchambers,
+                                              num_etas,
+                                              num_vfat,
+                                              num_digi,
+                                              nMinIdxChamber,
+                                              nMaxIdxChamber);
         readGeometryRadiusInfoChamber(station, mapStationInfo_[key3]);
         readGeometryPhiInfoChamber(station, mapStationInfo_[key3]);
       }

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -108,9 +108,7 @@ int GEMDQMBase::loadChambers() {
         int layer_number = pchamber->id().layer();
         ME3IdsKey key3(region_number, station_number, layer_number);
         mapStationInfo_[key3] =
-            MEStationInfo(region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_digi);
-        mapStationInfo_[key3].nMinIdxChamber_ = nMinIdxChamber;
-        mapStationInfo_[key3].nMaxIdxChamber_ = nMaxIdxChamber;
+            MEStationInfo(region_number, station_number, layer_number, num_superchambers, num_etas, num_vfat, num_digi, nMinIdxChamber, nMaxIdxChamber);
         readGeometryRadiusInfoChamber(station, mapStationInfo_[key3]);
         readGeometryPhiInfoChamber(station, mapStationInfo_[key3]);
       }


### PR DESCRIPTION
#### PR description:

Fixes warnings produced by gcc 11 (#38516)

#### PR validation:

Local build does not produce warnings