### PR TITLE
Fix CMS deprecated warnings in L1Trigger/GlobalTriggerAnalyzer

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtAnalyzer.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtAnalyzer.h
@@ -29,7 +29,7 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GtTriggerMenuLite.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -44,7 +44,7 @@
 
 // class declaration
 
-class L1GtAnalyzer : public edm::EDAnalyzer {
+class L1GtAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit L1GtAnalyzer(const edm::ParameterSet&);
   ~L1GtAnalyzer() override;

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtBeamModeFilter.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtBeamModeFilter.h
@@ -26,7 +26,7 @@
 // user include files
 
 //   base class
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -34,7 +34,7 @@
 // forward declarations
 
 // class declaration
-class L1GtBeamModeFilter : public edm::EDFilter {
+class L1GtBeamModeFilter : public edm::global::EDFilter<> {
 public:
   /// constructor
   explicit L1GtBeamModeFilter(const edm::ParameterSet&);
@@ -43,7 +43,7 @@ public:
   ~L1GtBeamModeFilter() override;
 
   /// filter the event
-  bool filter(edm::Event&, const edm::EventSetup&) override;
+  bool filter(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
   /// input tag for ConditionInEdm products
@@ -60,9 +60,6 @@ private:
 
   /// cache edm::isDebugEnabled()
   bool m_isDebugEnabled;
-
-  /// valid ConditionsInRunBlock product
-  bool m_condInRunBlockValid;
 };
 
 #endif  // GlobalTriggerAnalyzer_L1GtBeamModeFilter_h

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtDataEmulAnalyzer.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtDataEmulAnalyzer.h
@@ -37,8 +37,6 @@ class L1GtPsbWord;
 class L1TcsWord;
 class L1GtTriggerMenu;
 class L1GtTriggerMask;
-class L1GtTriggerMenu;
-class L1GtTriggerMask;
 class L1GtTriggerMenuRcd;
 class L1GtTriggerMaskAlgoTrigRcd;
 class L1GtTriggerMaskTechTrigRcd;

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtDataEmulAnalyzer.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtDataEmulAnalyzer.h
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -37,6 +37,11 @@ class L1GtPsbWord;
 class L1TcsWord;
 class L1GtTriggerMenu;
 class L1GtTriggerMask;
+class L1GtTriggerMenu;
+class L1GtTriggerMask;
+class L1GtTriggerMenuRcd;
+class L1GtTriggerMaskAlgoTrigRcd;
+class L1GtTriggerMaskTechTrigRcd;
 
 class TH1F;
 class TH1D;
@@ -45,7 +50,7 @@ class TTree;
 
 // class declaration
 
-class L1GtDataEmulAnalyzer : public edm::EDAnalyzer {
+class L1GtDataEmulAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit L1GtDataEmulAnalyzer(const edm::ParameterSet&);
   ~L1GtDataEmulAnalyzer() override;
@@ -125,7 +130,7 @@ private:
   /// GTFE
   TH1F* m_gtfeDataEmul;
 
-  static const int TotalBxInEvent = 5;
+  static constexpr int TotalBxInEvent = 5;
 
   /// FDL (0 for DAQ, 1 for EVM record)
   TH1F* m_fdlDataEmul[TotalBxInEvent][2];
@@ -159,6 +164,10 @@ private:
   TH1F* m_fdlDataEmulTechDecision_Err[2];
 
   /// PSB
+
+  edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> m_l1GtMenuToken;
+  edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskAlgoTrigRcd> m_l1GtTmAlgoToken;
+  edm::ESGetToken<L1GtTriggerMask, L1GtTriggerMaskTechTrigRcd> m_l1GtTmTechToken;
 };
 
 #endif /*GlobalTriggerAnalyzer_L1GtDataEmulAnalyzer_h*/

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPackUnpackAnalyzer.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPackUnpackAnalyzer.h
@@ -23,7 +23,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,7 +33,7 @@
 
 // class declaration
 
-class L1GtPackUnpackAnalyzer : public edm::EDAnalyzer {
+class L1GtPackUnpackAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit L1GtPackUnpackAnalyzer(const edm::ParameterSet&);
   ~L1GtPackUnpackAnalyzer() override;

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPatternGenerator.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtPatternGenerator.h
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -34,7 +34,7 @@
 class L1GtPatternWriter;
 class L1GtPatternMap;
 
-class L1GtPatternGenerator : public edm::EDAnalyzer {
+class L1GtPatternGenerator : public edm::one::EDAnalyzer<> {
 public:
   explicit L1GtPatternGenerator(const edm::ParameterSet&);
   ~L1GtPatternGenerator() override;

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtBeamModeFilter.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtBeamModeFilter.cc
@@ -41,8 +41,7 @@ L1GtBeamModeFilter::L1GtBeamModeFilter(const edm::ParameterSet& parSet)
       m_l1GtEvmReadoutRecordTag(parSet.getParameter<edm::InputTag>("L1GtEvmReadoutRecordTag")),
       m_allowedBeamMode(parSet.getParameter<std::vector<unsigned int> >("AllowedBeamMode")),
       m_invertResult(parSet.getParameter<bool>("InvertResult")),
-      m_isDebugEnabled(edm::isDebugEnabled()),
-      m_condInRunBlockValid(false) {
+      m_isDebugEnabled(edm::isDebugEnabled()) {
   if (m_isDebugEnabled) {
     LogDebug("L1GtBeamModeFilter") << std::endl;
 
@@ -69,7 +68,7 @@ L1GtBeamModeFilter::~L1GtBeamModeFilter() {
 
 // member functions
 
-bool L1GtBeamModeFilter::filter(edm::Event& iEvent, const edm::EventSetup& evSetup) {
+bool L1GtBeamModeFilter::filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& evSetup) const {
   // initialize filter result
   bool filterResult = false;
 
@@ -101,22 +100,24 @@ bool L1GtBeamModeFilter::filter(edm::Event& iEvent, const edm::EventSetup& evSet
   edm::Handle<edm::ConditionsInRunBlock> condInRunBlock;
   iRun.getByLabel(m_condInEdmInputTag, condInRunBlock);
 
+  /// valid ConditionsInRunBlock product
+  bool condInRunBlockValid = true;
+
   if (!condInRunBlock.isValid()) {
     LogDebug("L1GtBeamModeFilter") << "\nConditionsInRunBlock with \n  " << m_condInEdmInputTag
                                    << "\nrequested in configuration, but not found in the event."
                                    << "\n"
                                    << std::endl;
 
-    m_condInRunBlockValid = false;
+    condInRunBlockValid = false;
 
   } else {
-    m_condInRunBlockValid = true;
     beamModeValue = condInRunBlock->beamMode;
   }
 
   // fall through to L1GlobalTriggerEvmReadoutRecord if ConditionsInRunBlock
   // not available
-  if (!m_condInRunBlockValid) {
+  if (!condInRunBlockValid) {
     // get L1GlobalTriggerEvmReadoutRecord and beam mode
     edm::Handle<L1GlobalTriggerEvmReadoutRecord> gtEvmReadoutRecord;
     iEvent.getByLabel(m_l1GtEvmReadoutRecordTag, gtEvmReadoutRecord);

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtDataEmulAnalyzer.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtDataEmulAnalyzer.cc
@@ -47,6 +47,8 @@
 
 // constructor(s)
 L1GtDataEmulAnalyzer::L1GtDataEmulAnalyzer(const edm::ParameterSet& parSet) {
+  usesResource(TFileService::kSharedResource);
+
   // input tag for the L1 GT hardware DAQ/EVM record
   m_l1GtDataInputTag = parSet.getParameter<edm::InputTag>("L1GtDataInputTag");
 
@@ -73,6 +75,10 @@ L1GtDataEmulAnalyzer::L1GtDataEmulAnalyzer(const edm::ParameterSet& parSet) {
 
   // book histograms
   bookHistograms();
+
+  m_l1GtMenuToken = esConsumes();
+  m_l1GtTmAlgoToken = esConsumes();
+  m_l1GtTmTechToken = esConsumes();
 }
 
 // destructor
@@ -298,9 +304,7 @@ void L1GtDataEmulAnalyzer::compareFDL(const edm::Event& iEvent,
   unsigned long long l1GtMenuCacheID = evSetup.get<L1GtTriggerMenuRcd>().cacheIdentifier();
 
   if (m_l1GtMenuCacheID != l1GtMenuCacheID) {
-    edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
-    evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
-    m_l1GtMenu = l1GtMenu.product();
+    m_l1GtMenu = &evSetup.getData(m_l1GtMenuToken);
 
     m_l1GtMenuCacheID = l1GtMenuCacheID;
   }
@@ -310,9 +314,7 @@ void L1GtDataEmulAnalyzer::compareFDL(const edm::Event& iEvent,
   unsigned long long l1GtTmAlgoCacheID = evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().cacheIdentifier();
 
   if (m_l1GtTmAlgoCacheID != l1GtTmAlgoCacheID) {
-    edm::ESHandle<L1GtTriggerMask> l1GtTmAlgo;
-    evSetup.get<L1GtTriggerMaskAlgoTrigRcd>().get(l1GtTmAlgo);
-    m_l1GtTmAlgo = l1GtTmAlgo.product();
+    m_l1GtTmAlgo = &evSetup.getData(m_l1GtTmAlgoToken);
 
     m_triggerMaskAlgoTrig = m_l1GtTmAlgo->gtTriggerMask();
 
@@ -322,9 +324,7 @@ void L1GtDataEmulAnalyzer::compareFDL(const edm::Event& iEvent,
   unsigned long long l1GtTmTechCacheID = evSetup.get<L1GtTriggerMaskTechTrigRcd>().cacheIdentifier();
 
   if (m_l1GtTmTechCacheID != l1GtTmTechCacheID) {
-    edm::ESHandle<L1GtTriggerMask> l1GtTmTech;
-    evSetup.get<L1GtTriggerMaskTechTrigRcd>().get(l1GtTmTech);
-    m_l1GtTmTech = l1GtTmTech.product();
+    m_l1GtTmTech = &evSetup.getData(m_l1GtTmTechToken);
 
     m_triggerMaskTechTrig = m_l1GtTmTech->gtTriggerMask();
 


### PR DESCRIPTION
#### PR description:

- convert to using thread-friendly modules
- use esConsumes

#### PR validation:

Code compiles in DEPRECATED release without warnings.