### PR TITLE
Better configurations for the DAQ status plots of GEM onlineDQM

### DIFF
--- a/DQM/GEM/plugins/GEMDAQStatusSource.cc
+++ b/DQM/GEM/plugins/GEMDAQStatusSource.cc
@@ -23,7 +23,7 @@ void GEMDAQStatusSource::fillDescriptions(edm::ConfigurationDescriptions &descri
   desc.add<edm::InputTag>("AMC13InputLabel", edm::InputTag("muonGEMDigis", "AMC13Status"));
 
   desc.add<Int_t>("AMCSlots", 13);
-  desc.addUntracked<std::string>("runType", "online");
+  desc.addUntracked<std::string>("runType", "relval");
   desc.addUntracked<std::string>("logCategory", "GEMDAQStatusSource");
 
   descriptions.add("GEMDAQStatusSource", desc);
@@ -298,6 +298,11 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
   edm::Handle<GEMAMCStatusCollection> gemAMC;
   edm::Handle<GEMAMC13StatusCollection> gemAMC13;
 
+  event.getByToken(tagVFAT_, gemVFAT);
+  event.getByToken(tagOH_, gemOH);
+  event.getByToken(tagAMC_, gemAMC);
+  event.getByToken(tagAMC13_, gemAMC13);
+
   if (!(gemVFAT.isValid() && gemOH.isValid() && gemAMC.isValid() && gemAMC13.isValid())) {
     if (!bWarnedNotFound_) {
       edm::LogWarning(log_category_) << "DAQ sources from muonGEMDigis are not found";
@@ -305,11 +310,6 @@ void GEMDAQStatusSource::analyze(edm::Event const &event, edm::EventSetup const 
     }
     return;
   }
-
-  event.getByToken(tagVFAT_, gemVFAT);
-  event.getByToken(tagOH_, gemOH);
-  event.getByToken(tagAMC_, gemAMC);
-  event.getByToken(tagAMC13_, gemAMC13);
 
   std::map<ME4IdsKey, bool> mapChamberAll;
   std::map<ME4IdsKey, bool> mapChamberWarning;

--- a/DQM/GEM/python/gem_dqm_offline_source_cff.py
+++ b/DQM/GEM/python/gem_dqm_offline_source_cff.py
@@ -5,8 +5,9 @@ from DQM.GEM.GEMRecHitSource_cfi import *
 from DQM.GEM.GEMDAQStatusSource_cfi import *
 from DQM.GEM.gemEfficiencyAnalyzer_cff import *
 
-GEMDigiSource.runType   = "offline"
-GEMRecHitSource.runType = "offline"
+GEMDigiSource.runType      = "offline"
+GEMRecHitSource.runType    = "offline"
+GEMDAQStatusSource.runType = "offline"
 
 gemSources = cms.Sequence(
     GEMDigiSource *

--- a/DQM/GEM/python/gem_dqm_offline_source_cosmics_cff.py
+++ b/DQM/GEM/python/gem_dqm_offline_source_cosmics_cff.py
@@ -5,8 +5,9 @@ from DQM.GEM.GEMRecHitSource_cfi import *
 from DQM.GEM.GEMDAQStatusSource_cfi import *
 from DQM.GEM.gemEfficiencyAnalyzerCosmics_cff import *
 
-GEMDigiSource.runType   = "offline"
-GEMRecHitSource.runType = "offline"
+GEMDigiSource.runType      = "offline"
+GEMRecHitSource.runType    = "offline"
+GEMDAQStatusSource.runType = "offline"
 
 gemSourcesCosmics = cms.Sequence(
     GEMDigiSource *

--- a/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py
@@ -41,6 +41,10 @@ if (process.runType.getRunType() == process.runType.hi_run):
 process.muonGEMDigis.useDBEMap = True
 process.muonGEMDigis.keepDAQStatus = True
 
+process.GEMDigiSource.runType = "online"
+process.GEMRecHitSource.runType = "online"
+process.GEMDAQStatusSource.runType = "online"
+
 # from csc_dqm_sourceclient-live_cfg.py
 process.CSCGeometryESModule.useGangedStripsInME1a = False
 process.idealForDigiCSCGeometry.useGangedStripsInME1a = False


### PR DESCRIPTION
#### PR description:
I've found that an update on the configurations on some plots is needed to avoid unexpected issues.

It contains updates in #38499 and #38500, which are backports of #38398.

#### PR validation:
Test are done and one can check again by `runTheMatrix` workflows

@jshlee @watson-ij @seungjin-yang