### PR TITLE
[12_4_X Backport] Set appropriate streamLabel for online DQM GPU validation

### DIFF
--- a/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
@@ -57,6 +57,9 @@ process.maxEvents = cms.untracked.PSet(
 
 process.preScaler.prescaleFactor = 1
 
+if not options.inputFiles:
+    process.source.streamLabel = cms.untracked.string("streamDQMGPUvsCPU")
+
 process.dqmEnv.subSystemFolder = 'EcalGPU'
 process.dqmSaver.tag = 'EcalGPU'
 process.dqmSaver.runNumber = options.runNumber


### PR DESCRIPTION
#### PR description:

Porting over commit https://github.com/cms-sw/cmssw/pull/38428/commits/f49557a49e5020e6eedc61ea10b02a9127342377 from 
- https://github.com/cms-sw/cmssw/pull/38428 [12_3_X] 

into master and 12_4_X since these corresponding PRs have been already merged

- https://github.com/cms-sw/cmssw/pull/38427
- https://github.com/cms-sw/cmssw/pull/38429

This PR corrects the stream label used for online ECAL DQM GPU validation as described in https://github.com/cms-sw/cmssw/pull/38428#issuecomment-1167419492

#### PR validation:

Running client on local file still works but should be checked on playback tests

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a port of https://github.com/cms-sw/cmssw/pull/38428 to master https://github.com/cms-sw/cmssw/pull/38527 and 12_4_X (this PR)