### PR TITLE
[12.4.X] Fix incorrect cast in TrackClusterRemoverPhase2

### DIFF
--- a/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemoverPhase2.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/TrackClusterRemoverPhase2.cc
@@ -179,12 +179,12 @@ namespace {
       assert(chi2sX5.size() == track.recHitsSize());
       auto hb = track.recHitsBegin();
       for (unsigned int h = 0; h < track.recHitsSize(); h++) {
-        auto hit = *(hb + h);
+        auto const hit = *(hb + h);
         if (!hit->isValid())
           continue;
         if (chi2sX5[h] > maxChi2_)
           continue;  // skip outliers
-        auto const& thit = reinterpret_cast<BaseTrackerRecHit const&>(*hit);
+        auto const& thit = static_cast<BaseTrackerRecHit const&>(*hit);
         auto const& cluster = thit.firstClusterRef();
         // FIXME when we will get also Phase2 pixel
         if (cluster.isPixel())
@@ -193,9 +193,9 @@ namespace {
           collectedPhase2OTs[cluster.key()] = true;
 
         // Phase 2 OT is defined as Pixel detector (for now)
-        const auto& hitType = typeid(hit);
-        if (hitType == typeid(VectorHit)) {
-          auto const& vectorHit = reinterpret_cast<VectorHit const&>(hit);
+        auto pVectorHits = dynamic_cast<VectorHit const*>(hit);
+        if (pVectorHits != nullptr) {
+          auto const& vectorHit = *pVectorHits;
           auto const& lowCluster = vectorHit.lowerClusterRef();
           auto const& uppCluster = vectorHit.upperClusterRef();
           LogTrace("TrackClusterRemoverPhase2")


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/38486

#### PR description:

   * gcc 12 found that the 8 byte pointer was being cast to a `VectorHit` rather than to a `VectorHit*`. Switched to using dynamic_cast as the original code was basically attempting to do the same thing.
  *  swtich from `reinterpret_cast` to safer `static_cast`.


#### PR validation:

Code compiles in the gcc 12 IB.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/38486.
Might be needed for HLT phase-2 production.