### PR TITLE
Add DQM module using HeavyFlavorAnalysis for BPH common decays

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_standard.py
+++ b/Configuration/PyReleaseValidation/python/relval_standard.py
@@ -599,12 +599,12 @@ workflows[1313] = ['', ['QCD_Pt_3000_3500_13','DIGIUP15','RECOUP15','HARVESTUP15
 workflows.addOverride(1313,overridesEv5)
 workflows[1339] = ['', ['QCD_Pt_600_800_13','DIGIUP15','RECOUP15','HARVESTUP15']]
 
-workflows[1347] = ['', ['Upsilon1SToMuMu_13','DIGIUP15','RECOUP15','HARVESTUP15']]
-workflows[1349] = ['', ['BsToMuMu_13','DIGIUP15','RECOUP15','HARVESTUP15']]
-workflows[1350] = ['', ['JpsiMuMu_Pt-8','DIGIUP15','RECOUP15','HARVESTUP15']]
-workflows[1364] = ['', ['BdToMuMu_13','DIGIUP15','RECOUP15','HARVESTUP15']]
-workflows[1365] = ['', ['BuToJpsiK_13','DIGIUP15','RECOUP15','HARVESTUP15']]
-workflows[1366] = ['', ['BsToJpsiPhi_13','DIGIUP15','RECOUP15','HARVESTUP15']]
+workflows[1347] = ['', ['Upsilon1SToMuMu_13','DIGIUP15','RECOUP15_BPHDQM','HARVESTUP15']]
+workflows[1349] = ['', ['BsToMuMu_13','DIGIUP15','RECOUP15_BPHDQM','HARVESTUP15']]
+workflows[1350] = ['', ['JpsiMuMu_Pt-8','DIGIUP15','RECOUP15_BPHDQM','HARVESTUP15']]
+workflows[1364] = ['', ['BdToMuMu_13','DIGIUP15','RECOUP15_BPHDQM','HARVESTUP15']]
+workflows[1365] = ['', ['BuToJpsiK_13','DIGIUP15','RECOUP15_BPHDQM','HARVESTUP15']]
+workflows[1366] = ['', ['BsToJpsiPhi_13','DIGIUP15','RECOUP15_BPHDQM','HARVESTUP15']]
 
 workflows[1325] = ['', ['TTbar_13','DIGIUP15','RECOUP15','HARVESTUP15','ALCATTUP15','NANOUP15']]
 # the 3 workflows below are for tracking-specific ib test, not to be run in standard relval set.

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2375,6 +2375,7 @@ steps['RECOUP15_trackingOnly']=merge([step3Up2015Defaults_trackingOnly]) # todo:
 steps['RECOUP15_trackingLowPU']=merge([step3_trackingLowPU, step3Up2015Defaults]) # todo: remove UP from label
 steps['RECOUP15_trackingOnlyLowPU']=merge([step3_trackingLowPU, step3Up2015Defaults_trackingOnly]) # todo: remove UP from label
 steps['RECOUP15_HIPM']=merge([step3_HIPM,step3Up2015Defaults]) # todo: remove UP from label
+steps['RECOUP15_BPHDQM']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,RECOSIM,PAT,VALIDATION:@standardValidationNoHLT+@miniAODValidation,DQM:@standardDQMFakeHLT+@miniAODDQM+@heavyFlavor'},step3Up2015Defaults]) # todo: remove UP from label
 
 steps['RECOUP17']=merge([{'--conditions':'auto:phase1_2017_realistic','--era' : 'Run2_2017','--geometry' : 'DB:Extended'},steps['RECOUP15']])
 steps['RECOUP17_PU25']=merge([PU25UP17,steps['RECOUP17']])
@@ -2438,7 +2439,7 @@ steps['RECODR2_2018reHLT_skimJetHT']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:Jet
 steps['RECODR2_2018reHLT_skimDisplacedJet']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:EXODisplacedJet,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@commonFakeHLT'},steps['RECODR2_2018reHLT']])
 steps['RECODR2_2018reHLT_skimMET']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:HighMET+EXOMONOPOLE,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@commonFakeHLT+@jetmet+@hcalOnly'},steps['RECODR2_2018reHLT']])
 steps['RECODR2_2018reHLT_skimMuOnia']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:BPHSkim,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@commonFakeHLT+@muon'},steps['RECODR2_2018reHLT']])
-steps['RECODR2_2018reHLT_skimCharmonium']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:MuonPOGJPsiSkim+BPHSkim,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@commonFakeHLT'},steps['RECODR2_2018reHLT']])
+steps['RECODR2_2018reHLT_skimCharmonium']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:MuonPOGJPsiSkim+BPHSkim,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@commonFakeHLT+@heavyFlavor'},steps['RECODR2_2018reHLT']])
 steps['RECODR2_2018reHLT_skimParkingBPH']=merge([{'-s':'RAW2DIGI,L1Reco,RECO,SKIM:SkimBPark,PAT,ALCA:SiStripCalZeroBias+SiStripCalMinBias+SiStripCalSmallBiasScan+TkAlMinBias+EcalESAlign,DQM:@commonFakeHLT','--era':'Run2_2018,bParking'},steps['RECODR2_2018reHLT']])
 
 for sname in ['RECODR2_50nsreHLT','RECODR2_50nsreHLT_ZB',

--- a/DQM/Physics/BuildFile.xml
+++ b/DQM/Physics/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="DQMServices/Core"/>
 <use name="FWCore/Framework"/>
+<use name="CommonTools/Statistics"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/EgammaCandidates"/>
 <use name="DataFormats/BTauReco"/>
@@ -15,6 +16,7 @@
 <use name="JetMETCorrections/Objects"/>
 <use name="JetMETCorrections/JetCorrector"/>
 <use name="RecoEcal/EgammaCoreTools"/>
+<use name="RecoVertex/VertexTools"/>
 <use name="DataFormats/EcalRecHit"/>
 <use name="CondFormats/EcalObjects"/>
 <use name="RecoJets/JetProducers"/>

--- a/DQM/Physics/python/heavyFlavorDQMFirstStep_cff.py
+++ b/DQM/Physics/python/heavyFlavorDQMFirstStep_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.Physics.HeavyFlavorDQMAnalyzer_cfi import *
+from DQM.Physics.vertexSelectForHeavyFlavorDQM_cfi import recoSelectForHeavyFlavorDQM
+
+bphWriteSpecificDecayForDQM = cms.EDProducer('BPHWriteSpecificDecay',
+    pVertexLabel = cms.string('offlineSlimmedPrimaryVertices'),
+    pfCandsLabel = cms.string('particleFlow'),
+    patMuonLabel = cms.string('selectedPatMuons'),
+    k0CandsLabel = cms.string('generalV0Candidates:Kshort'),
+    l0CandsLabel = cms.string('generalV0Candidates:Lambda'),
+    oniaName  = cms.string('OniaToMuMuCands'),
+    sdName    = cms.string('Kx0ToKPiCands'),
+    ssName    = cms.string('PhiToKKCands'),
+    buName    = cms.string('BuToJPsiKCands'),
+    bpName    = cms.string('BuToPsi2SKCands'),
+    bdName    = cms.string('BdToJPsiKx0Cands'),
+    bsName    = cms.string('BsToJPsiPhiCands'),
+    k0Name    = cms.string('K0sToPiPiCands'),
+    l0Name    = cms.string('Lambda0ToPPiCands'),
+    b0Name    = cms.string('BdToJPsiK0sCands'),
+    lbName    = cms.string('LambdaBToJPsiLambda0Cands'),
+    bcName    = cms.string('BcToJPsiPiCands'),
+    psi2SName = cms.string('Psi2SToJPsiPiPiCands'),
+    writeVertex   = cms.bool( True ),
+    writeMomentum = cms.bool( True ),
+    recoSelect = cms.VPSet(recoSelectForHeavyFlavorDQM)
+)
+
+heavyFlavorDQM = HeavyFlavorDQMAnalyzer.clone(
+    pvCollection = cms.InputTag('offlineSlimmedPrimaryVertices'),
+    OniaToMuMuCands            = cms.InputTag('bphWriteSpecificDecayForDQM:OniaToMuMuCands'),
+    Kx0ToKPiCands              = cms.InputTag('bphWriteSpecificDecayForDQM:Kx0ToKPiCands'),
+    PhiToKKCands               = cms.InputTag('bphWriteSpecificDecayForDQM:PhiToKKCands'),
+    BuToJPsiKCands             = cms.InputTag('bphWriteSpecificDecayForDQM:BuToJPsiKCands'),
+    #BuToPsi2SKCands            = cms.InputTag('bphWriteSpecificDecayForDQM:BuToPsi2SKCands'),
+    BdToJPsiKx0Cands           = cms.InputTag('bphWriteSpecificDecayForDQM:BdToJPsiKx0Cands'),
+    BsToJPsiPhiCands           = cms.InputTag('bphWriteSpecificDecayForDQM:BsToJPsiPhiCands'),
+    K0sToPiPiCands             = cms.InputTag('bphWriteSpecificDecayForDQM:K0sToPiPiCands'),
+    Lambda0ToPPiCands          = cms.InputTag('bphWriteSpecificDecayForDQM:Lambda0ToPPiCands'),
+    BdToJPsiK0sCands           = cms.InputTag('bphWriteSpecificDecayForDQM:BdToJPsiK0sCands'),
+    LambdaBToJPsiLambda0Cands  = cms.InputTag('bphWriteSpecificDecayForDQM:LambdaBToJPsiLambda0Cands'),
+    BcToJPsiPiCands            = cms.InputTag('bphWriteSpecificDecayForDQM:BcToJPsiPiCands'),
+    Psi2SToJPsiPiPiCands       = cms.InputTag('bphWriteSpecificDecayForDQM:Psi2SToJPsiPiPiCands'),
+)
+
+heavyFlavorDQMSource = cms.Sequence(bphWriteSpecificDecayForDQM * heavyFlavorDQM)

--- a/DQM/Physics/python/vertexSelectForHeavyFlavorDQM_cfi.py
+++ b/DQM/Physics/python/vertexSelectForHeavyFlavorDQM_cfi.py
@@ -1,0 +1,234 @@
+import FWCore.ParameterSet.Config as cms
+
+Psi1_pset    = cms.PSet( name = cms.string( 'Psi1' ),
+                        ptMin = cms.double( 2.0 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double( 2.00 ),
+                      massMax = cms.double( 3.40 ),
+                      probMin = cms.double( -1.0 ),
+                  constrMass  = cms.double( 3.096916 ),
+                  constrSigma = cms.double( 0.000040 )
+)
+PhiMuMu_pset = cms.PSet( name = cms.string( 'PhiMuMu' ),
+                        ptMin = cms.double( 2.0 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double( 0.50 ),
+                      massMax = cms.double( 1.50 ),
+                      probMin = cms.double( -1.0 ),
+                  constrMass  = cms.double( 1.019461 ),
+                  constrSigma = cms.double( 0.004266 )
+)
+Psi2_pset    = cms.PSet( name = cms.string( 'Psi2' ),
+                        ptMin = cms.double( 2.0 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double( 3.40 ),
+                      massMax = cms.double( 6.00 ),
+                      probMin = cms.double( -1.0 ),
+                  constrMass  = cms.double( 3.686109 ),
+                  constrSigma = cms.double( 0.000129 )
+)
+Ups_pset     = cms.PSet( name = cms.string( 'Ups' ),
+                        ptMin = cms.double( 2.0 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double(  6.00 ),
+                      massMax = cms.double( 12.00 ),
+                      probMin = cms.double( -1.0 ),
+                  constrMass  = cms.double( -1.0 ),
+                  constrSigma = cms.double( -1.0 )
+)
+Ups1_pset    = cms.PSet( name = cms.string( 'Ups1' ),
+                        ptMin = cms.double( 2.0 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double( 6.00 ),
+                      massMax = cms.double( 9.75 ),
+                      probMin = cms.double( -1.0 ),
+                  constrMass  = cms.double( 9.46030 ),
+                  constrSigma = cms.double( 0.00026 )
+)
+Ups2_pset    = cms.PSet( name = cms.string( 'Ups2' ),
+                        ptMin = cms.double( 2.0 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double(  9.75 ),
+                      massMax = cms.double( 10.20 ),
+                      probMin = cms.double( -1.0 ),
+                  constrMass  = cms.double( 10.02326 ),
+                  constrSigma = cms.double(  0.00031 )
+)
+Ups3_pset    = cms.PSet( name = cms.string( 'Ups3' ),
+                        ptMin = cms.double( 2.0 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double( 10.20 ),
+                      massMax = cms.double( 12.00 ),
+                      probMin = cms.double( -1.0 ),
+                  constrMass  = cms.double( 10.3552 ),
+                  constrSigma = cms.double(  0.0005 )
+)
+Kx0_pset     = cms.PSet( name = cms.string( 'Kx0' ),
+                        ptMin = cms.double( 0.7 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double( 0.75 ),
+                      massMax = cms.double( 1.05 ),
+                      probMin = cms.double( 0.0 ),
+                  constrMass  = cms.double( -1.0 ),
+                  constrSigma = cms.double( -1.0 ),
+                  requireJPsi = cms.bool(False)
+)
+PhiKK_pset   = cms.PSet( name = cms.string( 'PhiKK' ),
+                        ptMin = cms.double( 0.7 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double( 1.00 ),
+                      massMax = cms.double( 1.04 ),
+                      probMin = cms.double( 0.0 ),
+                  constrMass  = cms.double( -1.0 ),
+                  constrSigma = cms.double( -1.0 ),
+                  requireJPsi = cms.bool(False)
+)
+Bu_pset      = cms.PSet( name = cms.string( 'Bu' ),
+                        ptMin = cms.double( 0.7 ),
+                       etaMax = cms.double( 10.0 ),
+                      mJPsiMin = cms.double( 2.80 ),
+                      mJPsiMax = cms.double( 3.40 ),
+                       massMin = cms.double( 3.50 ),
+                       massMax = cms.double( 8.00 ),
+                       probMin = cms.double( 0.02 ),
+                    massFitMin = cms.double( 5.00 ),
+                    massFitMax = cms.double( 6.00 ),
+                   constrMJPsi = cms.bool( True )
+)
+Bp_pset      = cms.PSet( name = cms.string( 'Bp' ),
+                        ptMin = cms.double( 0.7 ),
+                       etaMax = cms.double( 10.0 ),
+                      mJPsiMin = cms.double( 3.60 ),
+                      mJPsiMax = cms.double( 3.80 ),
+                       massMin = cms.double( 3.50 ),
+                       massMax = cms.double( 8.00 ),
+                       probMin = cms.double( 0.02 ),
+                    massFitMin = cms.double( 5.00 ),
+                    massFitMax = cms.double( 6.00 ),
+                   constrMJPsi = cms.bool( False ),
+                   constrMPsi2 = cms.bool( True )
+)
+Bd_pset      = cms.PSet( name = cms.string( 'Bd' ),
+                     mJPsiMin = cms.double( 2.80 ),
+                     mJPsiMax = cms.double( 3.40 ),
+                      mKx0Min = cms.double( 0.77 ),
+                      mKx0Max = cms.double( 1.02 ),
+                      massMin = cms.double( 3.50 ),
+                      massMax = cms.double( 8.00 ),
+                      probMin = cms.double( 0.02 ),
+                   massFitMin = cms.double( 5.00 ),
+                   massFitMax = cms.double( 6.00 ),
+                  constrMJPsi = cms.bool( True )
+)
+Bs_pset      = cms.PSet( name = cms.string( 'Bs' ),
+                     mJPsiMin = cms.double( 2.80 ),
+                     mJPsiMax = cms.double( 3.40 ),
+                      mPhiMin = cms.double( 1.005 ),
+                      mPhiMax = cms.double( 1.035 ),
+                      massMin = cms.double( 3.50 ),
+                      massMax = cms.double( 8.00 ),
+                      probMin = cms.double( 0.02 ),
+                   massFitMin = cms.double( 5.00 ),
+                   massFitMax = cms.double( 6.00 ),
+                  constrMJPsi = cms.bool( True )
+)
+K0s_pset     = cms.PSet( name = cms.string( 'K0s' ),
+                        ptMin = cms.double( 0.0 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double( 0.0 ),
+                      massMax = cms.double( 20.0 ),
+                      probMin = cms.double( -1.0 ),
+                  requireJPsi = cms.bool(False)
+)
+Lambda0_pset = cms.PSet( name = cms.string( 'Lambda0' ),
+                        ptMin = cms.double( 0.0 ),
+                       etaMax = cms.double( 10.0 ),
+                      massMin = cms.double( 0.0 ),
+                      massMax = cms.double( 20.0 ),
+                      probMin = cms.double( -1.0 ),
+                  requireJPsi = cms.bool(False)
+)
+B0_pset      = cms.PSet( name = cms.string( 'B0' ),
+                     mJPsiMin = cms.double( 2.80 ),
+                     mJPsiMax = cms.double( 3.40 ),
+                      mK0sMin = cms.double( 0.00 ),
+                      mK0sMax = cms.double( 2.00 ),
+                      massMin = cms.double( 3.50 ),
+                      massMax = cms.double( 8.00 ),
+                      probMin = cms.double( 0.02 ),
+                   massFitMin = cms.double( 5.00 ),
+                   massFitMax = cms.double( 6.00 ),
+                  constrMJPsi = cms.bool( True )
+)
+Lambdab_pset = cms.PSet( name = cms.string( 'Lambdab' ),
+                     mJPsiMin = cms.double( 2.80 ),
+                     mJPsiMax = cms.double( 3.40 ),
+                  mLambda0Min = cms.double( 0.00 ),
+                  mLambda0Max = cms.double( 3.00 ),
+                      massMin = cms.double( 3.50 ),
+                      massMax = cms.double( 8.00 ),
+                      probMin = cms.double( 0.02 ),
+                   massFitMin = cms.double( 5.00 ),
+                   massFitMax = cms.double( 6.00 ),
+                  constrMJPsi = cms.bool( True )
+)
+Bc_pset      = cms.PSet( name = cms.string( 'Bc' ),
+                        ptMin = cms.double( 3.0 ),
+                       etaMax = cms.double( 10.0 ),
+                     mJPsiMin = cms.double( 2.80 ),
+                     mJPsiMax = cms.double( 3.40 ),
+                      massMin = cms.double( 4.00 ),
+                      massMax = cms.double( 9.00 ),
+                      probMin = cms.double( 0.02 ),
+                   massFitMin = cms.double( 6.00 ),
+                   massFitMax = cms.double( 7.00 ),
+                  constrMJPsi = cms.bool( True )
+)
+X3872_pset   = cms.PSet( name = cms.string( 'X3872' ), # also valid for PSi2S
+                        ptMin = cms.double( 0.5 ),
+                       etaMax = cms.double( 10.0 ),
+                     mJPsiMin = cms.double( 2.80 ),
+                     mJPsiMax = cms.double( 3.40 ),
+                      massMin = cms.double( 3.00 ),
+                      massMax = cms.double( 4.50 ),
+                      probMin = cms.double( 0.02 ),
+                   massFitMin = cms.double( 3.60 ),
+                   massFitMax = cms.double( 4.00 ), 
+                  constrMJPsi = cms.bool( True )
+)
+Psi2S_pset   = cms.PSet( name = cms.string( 'Psi2S' ),
+                        ptMin = cms.double( 1.0 ),
+                       etaMax = cms.double( 10.0 ),
+                     mJPsiMin = cms.double( 2.80 ),
+                     mJPsiMax = cms.double( 3.40 ),
+                      massMin = cms.double( 3.00 ),
+                      massMax = cms.double( 4.50 ),
+                      probMin = cms.double( 0.02 ),
+                   massFitMin = cms.double( 3.60 ),
+                   massFitMax = cms.double( 3.80 ),
+                  constrMJPsi = cms.bool( True )
+)
+
+
+recoSelectForHeavyFlavorDQM = cms.VPSet(
+     Psi1_pset,
+  PhiMuMu_pset,
+     Psi2_pset,
+      Ups_pset,
+     Ups1_pset,
+     Ups2_pset,
+     Ups3_pset,
+      Kx0_pset,
+    PhiKK_pset,
+       Bu_pset,
+       Bp_pset,
+       Bd_pset,
+       Bs_pset,
+      K0s_pset,
+  Lambda0_pset,
+       B0_pset,
+  Lambdab_pset,
+       Bc_pset,
+    Psi2S_pset,
+    X3872_pset
+)

--- a/DQM/Physics/src/HeavyFlavorDQMAnalyzer.cc
+++ b/DQM/Physics/src/HeavyFlavorDQMAnalyzer.cc
@@ -1,0 +1,988 @@
+#include "DQM/Physics/src/HeavyFlavorDQMAnalyzer.h"
+
+void throwMissingCollection(const char* requested, const char* missing) {
+  throw cms::Exception("Configuration") << "Requested plots for from the collection " << requested
+                                        << " also requires a collection in " << missing << std::endl;
+}
+
+float getMass(pat::CompositeCandidate const& cand) {
+  float mass = cand.mass();
+  if (cand.hasUserFloat("fitMass")) {
+    mass = cand.userFloat("fitMass");
+  }
+  return mass;
+}
+
+//
+// constructors and destructor
+//
+HeavyFlavorDQMAnalyzer::HeavyFlavorDQMAnalyzer(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")),
+      pvCollectionToken(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("pvCollection"))) {
+  if (iConfig.existsAs<edm::InputTag>("OniaToMuMuCands")) {
+    oniaToMuMuCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("OniaToMuMuCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("BuToJPsiKCands")) {
+    if (oniaToMuMuCandsToken.isUninitialized())
+      throwMissingCollection("BuToJPsiKCands", "OniaToMuMuCands");
+    buToJPsiKCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("BuToJPsiKCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("Kx0ToKPiCands")) {
+    kx0ToKPiCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("Kx0ToKPiCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("BdToJPsiKx0Cands")) {
+    if (oniaToMuMuCandsToken.isUninitialized())
+      throwMissingCollection("BdToJPsiKx0Cands", "OniaToMuMuCands");
+    if (kx0ToKPiCandsToken.isUninitialized())
+      throwMissingCollection("BdToJPsiKx0Cands", "Kx0ToKPiCands");
+    bdToJPsiKx0CandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("BdToJPsiKx0Cands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("PhiToKKCands")) {
+    phiToKKCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("PhiToKKCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("BsToJPsiPhiCands")) {
+    if (oniaToMuMuCandsToken.isUninitialized())
+      throwMissingCollection("BsToJPsiPhiCands", "OniaToMuMuCands");
+    if (phiToKKCandsToken.isUninitialized())
+      throwMissingCollection("BsToJPsiPhiCands", "PhiToKKCands");
+    bsToJPsiPhiCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("BsToJPsiPhiCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("K0sToPiPiCands")) {
+    k0sToPiPiCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("K0sToPiPiCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("BdToJPsiK0sCands")) {
+    if (oniaToMuMuCandsToken.isUninitialized())
+      throwMissingCollection("BdToJPsiK0sCands", "OniaToMuMuCands");
+    if (k0sToPiPiCandsToken.isUninitialized())
+      throwMissingCollection("BdToJPsiK0sCands", "K0sToPiPiCands");
+    bdToJPsiK0sCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("BdToJPsiK0sCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("Lambda0ToPPiCands")) {
+    lambda0ToPPiCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("Lambda0ToPPiCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("LambdaBToJPsiLambda0Cands")) {
+    if (oniaToMuMuCandsToken.isUninitialized())
+      throwMissingCollection("LambdaBToJPsiLambda0Cands", "OniaToMuMuCands");
+    if (lambda0ToPPiCandsToken.isUninitialized())
+      throwMissingCollection("LambdaBToJPsiLambda0Cands", "Lambda0ToPPiCands");
+    lambdaBToJPsiLambda0CandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("LambdaBToJPsiLambda0Cands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("BcToJPsiPiCands")) {
+    if (oniaToMuMuCandsToken.isUninitialized())
+      throwMissingCollection("BcToJPsiPiCands", "OniaToMuMuCands");
+    bcToJPsiPiCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("BcToJPsiPiCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("Psi2SToJPsiPiPiCands")) {
+    if (oniaToMuMuCandsToken.isUninitialized())
+      throwMissingCollection("Psi2SToJPsiPiPiCands", "OniaToMuMuCands");
+    psi2SToJPsiPiPiCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("Psi2SToJPsiPiPiCands"));
+  }
+  if (iConfig.existsAs<edm::InputTag>("BuToPsi2SKCands")) {
+    if (psi2SToJPsiPiPiCandsToken.isUninitialized())
+      throwMissingCollection("BuToPsi2SKCands", "Psi2SToJPsiPiPiCands");
+    buToPsi2SKCandsToken =
+        consumes<pat::CompositeCandidateCollection>(iConfig.getParameter<edm::InputTag>("BuToPsi2SKCands"));
+  }
+}
+
+HeavyFlavorDQMAnalyzer::~HeavyFlavorDQMAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+
+void HeavyFlavorDQMAnalyzer::dqmAnalyze(edm::Event const& iEvent,
+                                        edm::EventSetup const& iSetup,
+                                        Histograms const& histos) const {
+  auto& pvColl = iEvent.get(pvCollectionToken);
+
+  std::vector<bool> displacedJPsiToMuMu;
+  pat::CompositeCandidateCollection lOniaToMuMu;
+  if (not oniaToMuMuCandsToken.isUninitialized()) {
+    lOniaToMuMu = iEvent.get(oniaToMuMuCandsToken);
+    displacedJPsiToMuMu.resize(lOniaToMuMu.size(), false);
+  }
+
+  if (not buToJPsiKCandsToken.isUninitialized()) {
+    auto lBuToJPsiK = iEvent.get(buToJPsiKCandsToken);
+    for (auto&& cand : lBuToJPsiK) {
+      auto jpsi = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi");
+      auto jpsiMass = getMass(*jpsi);
+      if (jpsiMass < 2.9 or jpsiMass > 3.3)
+        continue;
+
+      if (not fillDecayHistograms(histos.buToJPsiK, cand, pvColl))
+        continue;
+      fillBuToJPsiKComponents(histos.buToJPsiK, cand);
+
+      displacedJPsiToMuMu[jpsi.index()] = true;
+    }
+  }
+
+  std::vector<bool> displacedPsi2SToJPsiPiPi;
+  pat::CompositeCandidateCollection lPsi2SToJPsiPiPi;
+  if (not psi2SToJPsiPiPiCandsToken.isUninitialized()) {
+    lPsi2SToJPsiPiPi = iEvent.get(psi2SToJPsiPiPiCandsToken);
+    displacedPsi2SToJPsiPiPi.resize(lPsi2SToJPsiPiPi.size(), false);
+  }
+
+  if (not buToPsi2SKCandsToken.isUninitialized()) {
+    auto lBuToPsi2SK = iEvent.get(buToPsi2SKCandsToken);
+    for (auto&& cand : lBuToPsi2SK) {
+      auto psi2S = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToPsi2S");
+      auto psi2SMass = getMass(*psi2S);
+      if (psi2SMass < 3.65 or psi2SMass > 3.72)
+        continue;
+
+      auto jpsi = *psi2S->userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi");
+      auto jpsiMass = getMass(*jpsi);
+      if (jpsiMass < 2.9 or jpsiMass > 3.3)
+        continue;
+
+      if (not fillDecayHistograms(histos.buToPsi2SK, cand, pvColl))
+        continue;
+      fillBuToPsi2SKComponents(histos.buToPsi2SK, cand);
+
+      displacedPsi2SToJPsiPiPi[psi2S.index()] = true;
+      displacedJPsiToMuMu[jpsi.index()] = true;
+    }
+  }
+
+  for (size_t i = 0; i < lPsi2SToJPsiPiPi.size(); i++) {
+    auto&& cand = lPsi2SToJPsiPiPi[i];
+
+    auto jpsi = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi");
+    auto jpsiMass = getMass(*jpsi);
+    if (jpsiMass < 2.9 or jpsiMass > 3.3)
+      continue;
+
+    if (not fillDecayHistograms(histos.psi2SToJPsiPiPi, cand, pvColl))
+      continue;
+    fillPsi2SToJPsiPiPiComponents(histos.psi2SToJPsiPiPi, cand);
+
+    auto decayHistos = &histos.psi2SToJPsiPiPiPrompt;
+    if (displacedPsi2SToJPsiPiPi[i]) {
+      decayHistos = &histos.psi2SToJPsiPiPiDispl;
+    }
+
+    fillDecayHistograms(*decayHistos, cand, pvColl);
+    fillPsi2SToJPsiPiPiComponents(*decayHistos, cand);
+  }
+  lPsi2SToJPsiPiPi.clear();
+  displacedPsi2SToJPsiPiPi.clear();
+
+  std::vector<bool> displacedKx0ToKPi;
+  pat::CompositeCandidateCollection lKx0ToKPi;
+  if (not kx0ToKPiCandsToken.isUninitialized()) {
+    lKx0ToKPi = iEvent.get(kx0ToKPiCandsToken);
+    displacedKx0ToKPi.resize(lKx0ToKPi.size(), false);
+  }
+
+  if (not bdToJPsiKx0CandsToken.isUninitialized()) {
+    auto lBdToJPsiKx0 = iEvent.get(bdToJPsiKx0CandsToken);
+    for (auto&& cand : lBdToJPsiKx0) {
+      auto jpsi = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi");
+      auto jpsiMass = getMass(*jpsi);
+      if (jpsiMass < 2.9 or jpsiMass > 3.3)
+        continue;
+
+      auto kx0 = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToKx0");
+      auto kx0Mass = getMass(*kx0);
+      if (kx0Mass < 0.77 or kx0Mass > 1.02)
+        continue;
+
+      if (not fillDecayHistograms(histos.bdToJPsiKx0, cand, pvColl))
+        continue;
+      fillBdToJPsiKx0Components(histos.bdToJPsiKx0, cand);
+
+      displacedKx0ToKPi[kx0.index()] = true;
+    }
+  }
+
+  for (size_t i = 0; i < lKx0ToKPi.size(); i++) {
+    auto&& cand = lKx0ToKPi[i];
+
+    if (not fillDecayHistograms(histos.kx0ToKPi, cand, pvColl))
+      continue;
+    fillKx0ToKPiComponents(histos.kx0ToKPi, cand);
+
+    auto decayHistos = &histos.kx0ToKPiPrompt;
+    if (displacedKx0ToKPi[i]) {
+      decayHistos = &histos.kx0ToKPiDispl;
+    }
+
+    fillDecayHistograms(*decayHistos, cand, pvColl);
+    fillKx0ToKPiComponents(*decayHistos, cand);
+  }
+  lKx0ToKPi.clear();
+  displacedKx0ToKPi.clear();
+
+  std::vector<bool> displacedPhiToKK;
+  pat::CompositeCandidateCollection lPhiToKK;
+  if (not phiToKKCandsToken.isUninitialized()) {
+    lPhiToKK = iEvent.get(phiToKKCandsToken);
+    displacedPhiToKK.resize(lPhiToKK.size(), false);
+  }
+
+  if (not bsToJPsiPhiCandsToken.isUninitialized()) {
+    auto lBsToJPsiPhi = iEvent.get(bsToJPsiPhiCandsToken);
+    for (auto&& cand : lBsToJPsiPhi) {
+      auto jpsi = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi");
+      auto jpsiMass = getMass(*jpsi);
+      if (jpsiMass < 2.9 or jpsiMass > 3.3)
+        continue;
+
+      auto phi = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToPhi");
+      auto phiMass = getMass(*phi);
+      if (phiMass < 1.005 or phiMass > 1.035)
+        continue;
+
+      if (not fillDecayHistograms(histos.bsToJPsiPhi, cand, pvColl))
+        continue;
+      fillBsToJPsiPhiComponents(histos.bsToJPsiPhi, cand);
+
+      displacedJPsiToMuMu[jpsi.index()] = true;
+      displacedPhiToKK[phi.index()] = true;
+    }
+  }
+
+  for (size_t i = 0; i < lPhiToKK.size(); i++) {
+    auto&& cand = lPhiToKK[i];
+
+    if (not fillDecayHistograms(histos.phiToKK, cand, pvColl))
+      continue;
+    fillPhiToKKComponents(histos.phiToKK, cand);
+
+    auto decayHistos = &histos.phiToKKPrompt;
+    if (displacedPhiToKK[i]) {
+      decayHistos = &histos.phiToKKDispl;
+    }
+
+    fillDecayHistograms(*decayHistos, cand, pvColl);
+    fillPhiToKKComponents(*decayHistos, cand);
+  }
+  lPhiToKK.clear();
+  displacedPhiToKK.clear();
+
+  if (not bdToJPsiK0sCandsToken.isUninitialized()) {
+    auto lBdToJPsiK0s = iEvent.get(bdToJPsiK0sCandsToken);
+    for (auto&& cand : lBdToJPsiK0s) {
+      auto jpsi = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi");
+      auto jpsiMass = getMass(*jpsi);
+      if (jpsiMass < 2.9 or jpsiMass > 3.3)
+        continue;
+
+      if (not fillDecayHistograms(histos.bdToJPsiK0s, cand, pvColl))
+        continue;
+      fillBdToJPsiK0sComponents(histos.bdToJPsiK0s, cand);
+
+      displacedJPsiToMuMu[jpsi.index()] = true;
+    }
+  }
+
+  if (not bcToJPsiPiCandsToken.isUninitialized()) {
+    auto lBcToJPsiPi = iEvent.get(bcToJPsiPiCandsToken);
+    for (auto&& cand : lBcToJPsiPi) {
+      auto jpsi = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi");
+      auto jpsiMass = getMass(*jpsi);
+      if (jpsiMass < 2.9 or jpsiMass > 3.3)
+        continue;
+
+      if (not fillDecayHistograms(histos.bcToJPsiPi, cand, pvColl))
+        continue;
+      fillBcToJPsiPiComponents(histos.bcToJPsiPi, cand);
+
+      displacedJPsiToMuMu[jpsi.index()] = true;
+    }
+  }
+
+  if (not lambdaBToJPsiLambda0CandsToken.isUninitialized()) {
+    auto lLambdaBToJPsiLambda0 = iEvent.get(lambdaBToJPsiLambda0CandsToken);
+    for (auto&& cand : lLambdaBToJPsiLambda0) {
+      auto jpsi = *cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi");
+      auto jpsiMass = getMass(*jpsi);
+      if (jpsiMass < 2.9 or jpsiMass > 3.3)
+        continue;
+
+      if (not fillDecayHistograms(histos.lambdaBToJPsiLambda0, cand, pvColl))
+        continue;
+      fillLambdaBToJPsiLambda0Components(histos.lambdaBToJPsiLambda0, cand);
+
+      displacedJPsiToMuMu[jpsi.index()] = true;
+    }
+  }
+
+  for (size_t i = 0; i < lOniaToMuMu.size(); i++) {
+    auto&& cand = lOniaToMuMu[i];
+
+    if (not fillDecayHistograms(histos.oniaToMuMu, cand, pvColl))
+      continue;
+    fillOniaToMuMuComponents(histos.oniaToMuMu, cand);
+
+    auto decayHistos = &histos.oniaToMuMuPrompt;
+    if (displacedJPsiToMuMu[i]) {
+      decayHistos = &histos.oniaToMuMuDispl;
+    }
+
+    fillDecayHistograms(*decayHistos, cand, pvColl);
+    fillOniaToMuMuComponents(*decayHistos, cand);
+  }
+  lOniaToMuMu.clear();
+  displacedJPsiToMuMu.clear();
+
+  if (not k0sToPiPiCandsToken.isUninitialized()) {
+    auto lK0sToPiPi = iEvent.get(k0sToPiPiCandsToken);
+    for (auto&& cand : lK0sToPiPi) {
+      if (not fillDecayHistograms(histos.k0sToPiPi, cand, pvColl))
+        continue;
+      fillK0sToPiPiComponents(histos.k0sToPiPi, cand);
+    }
+  }
+
+  if (not lambda0ToPPiCandsToken.isUninitialized()) {
+    auto lLambda0ToPPi = iEvent.get(lambda0ToPPiCandsToken);
+    for (auto&& cand : lLambda0ToPPi) {
+      if (not fillDecayHistograms(histos.lambda0ToPPi, cand, pvColl))
+        continue;
+      fillLambda0ToPPiComponents(histos.lambda0ToPPi, cand);
+    }
+  }
+}
+
+void HeavyFlavorDQMAnalyzer::bookDecayHists(DQMStore::IBooker& ibook,
+                                            edm::Run const&,
+                                            edm::EventSetup const&,
+                                            DecayHists& decayHists,
+                                            std::string const& name,
+                                            std::string const& products,
+                                            int nMassBins,
+                                            float massMin,
+                                            float massMax,
+                                            float distanceScaleFactor) const {
+  std::string histTitle = name + " #rightarrow " + products + ";";
+
+  decayHists.h_mass =
+      ibook.book1D("h_mass", histTitle + "M(" + products + ") fitted [GeV]", nMassBins, massMin, massMax);
+  decayHists.h_pt = ibook.book1D("h_pt", histTitle + "fitted p_{T} [GeV]", 100, 0.00, 200.0);
+  decayHists.h_eta = ibook.book1D("h_eta", histTitle + "fitted #eta", 100, -3, 3);
+  decayHists.h_phi = ibook.book1D("h_phi", histTitle + "fitted #varphi [rad]", 100, -TMath::Pi(), TMath::Pi());
+  decayHists.h_displ2D =
+      ibook.book1D("h_displ2D", histTitle + "vertex 2D displacement [cm]", 100, 0.00, 2.0 * distanceScaleFactor);
+  decayHists.h_sign2D =
+      ibook.book1D("h_sign2D", histTitle + "vertex 2D displ. significance", 100, 0.00, 200.0 * distanceScaleFactor);
+  decayHists.h_ct = ibook.book1D("h_ct", histTitle + "ct [cm]", 100, 0.00, 0.4 * distanceScaleFactor);
+  decayHists.h_pointing = ibook.book1D("h_pointing", histTitle + "cos( 2D pointing angle )", 100, -1, 1);
+  decayHists.h_vertNormChi2 = ibook.book1D("h_vertNormChi2", histTitle + "vertex #chi^{2}/ndof", 100, 0.00, 10);
+  decayHists.h_vertProb = ibook.book1D("h_vertProb", histTitle + "vertex prob.", 100, 0.00, 1.0);
+}
+
+void HeavyFlavorDQMAnalyzer::bookHistograms(DQMStore::IBooker& ibook,
+                                            edm::Run const& run,
+                                            edm::EventSetup const& iSetup,
+                                            Histograms& histos) const {
+  if (not oniaToMuMuCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/JPsiToMuMuPrompt");
+    bookDecayHists(ibook, run, iSetup, histos.oniaToMuMuPrompt, "J/#psi", "#mu^{+}#mu^{-}", 100, 2.9, 3.3);
+
+    ibook.setCurrentFolder(folder_ + "/JPsiToMuMuPrompt/components");
+    initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos.oniaToMuMuPrompt);
+
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/JPsiToMuMuDisplaced");
+    bookDecayHists(ibook, run, iSetup, histos.oniaToMuMuDispl, "J/#psi", "#mu^{+}#mu^{-}", 100, 2.9, 3.3);
+
+    ibook.setCurrentFolder(folder_ + "/JPsiToMuMuDisplaced/components");
+    initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos.oniaToMuMuDispl);
+
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/OniaToMuMu");
+    bookDecayHists(ibook, run, iSetup, histos.oniaToMuMu, "Onia", "#mu^{+}#mu^{-}", 750, 0, 15);
+
+    ibook.setCurrentFolder(folder_ + "/OniaToMuMu/components");
+    initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos.oniaToMuMu);
+  }
+
+  if (not kx0ToKPiCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/Kx0ToKPiPrompt");
+    bookDecayHists(ibook, run, iSetup, histos.kx0ToKPiPrompt, "K*^{0}", "#pi^{+} K^{-}", 100, 0.75, 1.05);
+
+    ibook.setCurrentFolder(folder_ + "/Kx0ToKPiPrompt/components");
+    initKx0ToKPiComponentHistograms(ibook, run, iSetup, histos.kx0ToKPiPrompt);
+
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/Kx0ToKPiDisplaced");
+    bookDecayHists(ibook, run, iSetup, histos.kx0ToKPiDispl, "K*^{0}", "#pi^{+} K^{-}", 100, 0.75, 1.05);
+
+    ibook.setCurrentFolder(folder_ + "/Kx0ToKPiDisplaced/components");
+    initKx0ToKPiComponentHistograms(ibook, run, iSetup, histos.kx0ToKPiDispl);
+
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/Kx0ToKPi");
+    bookDecayHists(ibook, run, iSetup, histos.kx0ToKPi, "K*^{0}", "#pi^{+} K^{-}", 100, 0.75, 1.05);
+
+    ibook.setCurrentFolder(folder_ + "/Kx0ToKPi/components");
+    initKx0ToKPiComponentHistograms(ibook, run, iSetup, histos.kx0ToKPi);
+  }
+
+  if (not phiToKKCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/PhiToKKPrompt");
+    bookDecayHists(ibook, run, iSetup, histos.phiToKKPrompt, "#phi", "K^{+} K^{-}", 100, 1.005, 1.035);
+
+    ibook.setCurrentFolder(folder_ + "/PhiToKKPrompt/components");
+    initPhiToKKComponentHistograms(ibook, run, iSetup, histos.phiToKKPrompt);
+
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/PhiToKKDisplaced");
+    bookDecayHists(ibook, run, iSetup, histos.phiToKKDispl, "#phi", "K^{+} K^{-}", 100, 1.005, 1.035);
+
+    ibook.setCurrentFolder(folder_ + "/PhiToKKDisplaced/components");
+    initPhiToKKComponentHistograms(ibook, run, iSetup, histos.phiToKKDispl);
+
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/PhiToKK");
+    bookDecayHists(ibook, run, iSetup, histos.phiToKK, "#phi", "K^{+} K^{-}", 100, 1.005, 1.035);
+
+    ibook.setCurrentFolder(folder_ + "/PhiToKK/components");
+    initPhiToKKComponentHistograms(ibook, run, iSetup, histos.phiToKK);
+  }
+
+  if (not psi2SToJPsiPiPiCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/Psi2SToJPsiPiPiPrompt");
+    bookDecayHists(
+        ibook, run, iSetup, histos.psi2SToJPsiPiPiPrompt, "#Psi(2S)", "J/#psi #pi^{+} #pi^{-}", 100, 3.65, 3.72);
+
+    ibook.setCurrentFolder(folder_ + "/Psi2SToJPsiPiPiPrompt/components");
+    initPsi2SToJPsiPiPiComponentHistograms(ibook, run, iSetup, histos.psi2SToJPsiPiPiPrompt);
+
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/Psi2SToJPsiPiPiDisplaced");
+    bookDecayHists(
+        ibook, run, iSetup, histos.psi2SToJPsiPiPiDispl, "#Psi(2S)", "J/#psi #pi^{+} #pi^{-}", 100, 3.65, 3.72);
+
+    ibook.setCurrentFolder(folder_ + "/Psi2SToJPsiPiPiDisplaced/components");
+    initPsi2SToJPsiPiPiComponentHistograms(ibook, run, iSetup, histos.psi2SToJPsiPiPiDispl);
+
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/Psi2SToJPsiPiPi");
+    bookDecayHists(
+        ibook, run, iSetup, histos.psi2SToJPsiPiPi, "#Psi(2S)/X(3872)", "J/#psi #pi^{+} #pi^{-}", 200, 3.60, 3.80);
+
+    ibook.setCurrentFolder(folder_ + "/Psi2SToJPsiPiPi/components");
+    initPsi2SToJPsiPiPiComponentHistograms(ibook, run, iSetup, histos.psi2SToJPsiPiPi);
+  }
+
+  if (not k0sToPiPiCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/K0sToPiPi");
+    bookDecayHists(ibook, run, iSetup, histos.k0sToPiPi, "K^{0}_{S}", "#pi^{+} #pi^{-}", 100, 0.44, 0.56, 4);
+
+    ibook.setCurrentFolder(folder_ + "/K0sToPiPi/components");
+    initK0sToPiPiComponentHistograms(ibook, run, iSetup, histos.k0sToPiPi);
+  }
+
+  if (not lambda0ToPPiCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/Lambda0ToPPi");
+    bookDecayHists(ibook, run, iSetup, histos.lambda0ToPPi, "#Lambda^{0}", "p^{+} #pi^{-}", 100, 1.06, 1.16, 4);
+
+    ibook.setCurrentFolder(folder_ + "/Lambda0ToPPi/components");
+    initLambda0ToPPiComponentHistograms(ibook, run, iSetup, histos.lambda0ToPPi);
+  }
+
+  if (not buToJPsiKCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/BuToJPsiK");
+    bookDecayHists(ibook, run, iSetup, histos.buToJPsiK, "B^{+}", "J/#psi K^{+}", 100, 5.00, 6.00);
+
+    ibook.setCurrentFolder(folder_ + "/BuToJPsiK/components");
+    initBuToJPsiKComponentHistograms(ibook, run, iSetup, histos.buToJPsiK);
+  }
+
+  if (not buToPsi2SKCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/BuToPsi2SK");
+    bookDecayHists(ibook, run, iSetup, histos.buToPsi2SK, "B^{+}", "#Psi(2S) K^{+}", 100, 5.00, 6.00);
+
+    ibook.setCurrentFolder(folder_ + "/BuToPsi2SK/components");
+    initBuToPsi2SKComponentHistograms(ibook, run, iSetup, histos.buToPsi2SK);
+  }
+
+  if (not bdToJPsiKx0CandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/BdToJPsiKx0");
+    bookDecayHists(ibook, run, iSetup, histos.bdToJPsiKx0, "B^{0}", "J/#psi K*^{0}", 100, 5.00, 6.00);
+
+    ibook.setCurrentFolder(folder_ + "/BdToJPsiKx0/components");
+    initBdToJPsiKx0ComponentHistograms(ibook, run, iSetup, histos.bdToJPsiKx0);
+  }
+
+  if (not bsToJPsiPhiCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/BsToJPsiPhi");
+    bookDecayHists(ibook, run, iSetup, histos.bsToJPsiPhi, "B^{0}_{s}", "J/#psi #phi", 100, 5.00, 6.00);
+
+    ibook.setCurrentFolder(folder_ + "/BsToJPsiPhi/components");
+    initBsToJPsiPhiComponentHistograms(ibook, run, iSetup, histos.bsToJPsiPhi);
+  }
+
+  if (not bdToJPsiK0sCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/BdToJPsiK0s");
+    bookDecayHists(ibook, run, iSetup, histos.bdToJPsiK0s, "B^{0}", "J/#psi K^{0}_{S}", 100, 5.00, 6.00);
+
+    ibook.setCurrentFolder(folder_ + "/BdToJPsiK0s/components");
+    initBdToJPsiK0sComponentHistograms(ibook, run, iSetup, histos.bdToJPsiK0s);
+  }
+
+  if (not bcToJPsiPiCandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/BcToJPsiPi");
+    bookDecayHists(ibook, run, iSetup, histos.bcToJPsiPi, "B^{+}_{c}", "J/#psi #pi^{+}", 100, 6.00, 7.00);
+
+    ibook.setCurrentFolder(folder_ + "/BcToJPsiPi/components");
+    initBcToJPsiPiComponentHistograms(ibook, run, iSetup, histos.bcToJPsiPi);
+  }
+
+  if (not lambdaBToJPsiLambda0CandsToken.isUninitialized()) {
+    ibook.cd();
+    ibook.setCurrentFolder(folder_ + "/LambdaBToJPsiLambda0");
+    bookDecayHists(
+        ibook, run, iSetup, histos.lambdaBToJPsiLambda0, "#Lambda^{0}_{b}", "J/#psi #Lambda^{0}", 100, 5.00, 6.00);
+
+    ibook.setCurrentFolder(folder_ + "/LambdaBToJPsiLambda0/components");
+    initLambdaBToJPsiLambda0ComponentHistograms(ibook, run, iSetup, histos.lambdaBToJPsiLambda0);
+  }
+}
+
+void HeavyFlavorDQMAnalyzer::initComponentHists(DQMStore::IBooker& ibook,
+                                                edm::Run const&,
+                                                edm::EventSetup const&,
+                                                DecayHists& histos,
+                                                TString const& componentName) const {
+  ComponentHists comp;
+
+  comp.h_pt = ibook.book1D(componentName + "_pt", "", 200, 0, 20);
+  comp.h_eta = ibook.book1D(componentName + "_eta", "", 200, -3, 3);
+  comp.h_phi = ibook.book1D(componentName + "_phi", "", 200, -TMath::Pi(), TMath::Pi());
+  comp.h_dxy = ibook.book1D(componentName + "_dxy", "", 200, 0, 3);
+  comp.h_exy = ibook.book1D(componentName + "_exy", "", 200, 0, 0.2);
+  comp.h_dz = ibook.book1D(componentName + "_dz", "", 200, 0, 20);
+  comp.h_ez = ibook.book1D(componentName + "_ez", "", 200, 0, 2);
+  comp.h_chi2 = ibook.book1D(componentName + "_chi2", "", 200, 0, 20);
+
+  histos.decayComponents.push_back(comp);
+}
+
+void HeavyFlavorDQMAnalyzer::initOniaToMuMuComponentHistograms(DQMStore::IBooker& ibook,
+                                                               edm::Run const& run,
+                                                               edm::EventSetup const& iSetup,
+                                                               DecayHists& histos) const {
+  initComponentHists(ibook, run, iSetup, histos, "lead_mu");
+  initComponentHists(ibook, run, iSetup, histos, "soft_mu");
+}
+
+void HeavyFlavorDQMAnalyzer::initKx0ToKPiComponentHistograms(DQMStore::IBooker& ibook,
+                                                             edm::Run const& run,
+                                                             edm::EventSetup const& iSetup,
+                                                             DecayHists& histos) const {
+  initComponentHists(ibook, run, iSetup, histos, "k");
+  initComponentHists(ibook, run, iSetup, histos, "pi");
+}
+
+void HeavyFlavorDQMAnalyzer::initPhiToKKComponentHistograms(DQMStore::IBooker& ibook,
+                                                            edm::Run const& run,
+                                                            edm::EventSetup const& iSetup,
+                                                            DecayHists& histos) const {
+  initComponentHists(ibook, run, iSetup, histos, "lead_k");
+  initComponentHists(ibook, run, iSetup, histos, "soft_k");
+}
+
+void HeavyFlavorDQMAnalyzer::initK0sToPiPiComponentHistograms(DQMStore::IBooker& ibook,
+                                                              edm::Run const& run,
+                                                              edm::EventSetup const& iSetup,
+                                                              DecayHists& histos) const {
+  initComponentHists(ibook, run, iSetup, histos, "lead_pi");
+  initComponentHists(ibook, run, iSetup, histos, "soft_pi");
+}
+
+void HeavyFlavorDQMAnalyzer::initLambda0ToPPiComponentHistograms(DQMStore::IBooker& ibook,
+                                                                 edm::Run const& run,
+                                                                 edm::EventSetup const& iSetup,
+                                                                 DecayHists& histos) const {
+  initComponentHists(ibook, run, iSetup, histos, "p");
+  initComponentHists(ibook, run, iSetup, histos, "pi");
+}
+
+void HeavyFlavorDQMAnalyzer::initBuToJPsiKComponentHistograms(DQMStore::IBooker& ibook,
+                                                              edm::Run const& run,
+                                                              edm::EventSetup const& iSetup,
+                                                              DecayHists& histos) const {
+  initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos);
+  initComponentHists(ibook, run, iSetup, histos, "k");
+}
+
+void HeavyFlavorDQMAnalyzer::initBuToPsi2SKComponentHistograms(DQMStore::IBooker& ibook,
+                                                               edm::Run const& run,
+                                                               edm::EventSetup const& iSetup,
+                                                               DecayHists& histos) const {
+  initPsi2SToJPsiPiPiComponentHistograms(ibook, run, iSetup, histos);
+  initComponentHists(ibook, run, iSetup, histos, "k");
+}
+
+void HeavyFlavorDQMAnalyzer::initBdToJPsiKx0ComponentHistograms(DQMStore::IBooker& ibook,
+                                                                edm::Run const& run,
+                                                                edm::EventSetup const& iSetup,
+                                                                DecayHists& histos) const {
+  initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos);
+  initKx0ToKPiComponentHistograms(ibook, run, iSetup, histos);
+}
+
+void HeavyFlavorDQMAnalyzer::initBsToJPsiPhiComponentHistograms(DQMStore::IBooker& ibook,
+                                                                edm::Run const& run,
+                                                                edm::EventSetup const& iSetup,
+                                                                DecayHists& histos) const {
+  initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos);
+  initPhiToKKComponentHistograms(ibook, run, iSetup, histos);
+}
+
+void HeavyFlavorDQMAnalyzer::initBdToJPsiK0sComponentHistograms(DQMStore::IBooker& ibook,
+                                                                edm::Run const& run,
+                                                                edm::EventSetup const& iSetup,
+                                                                DecayHists& histos) const {
+  initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos);
+  initK0sToPiPiComponentHistograms(ibook, run, iSetup, histos);
+}
+
+void HeavyFlavorDQMAnalyzer::initBcToJPsiPiComponentHistograms(DQMStore::IBooker& ibook,
+                                                               edm::Run const& run,
+                                                               edm::EventSetup const& iSetup,
+                                                               DecayHists& histos) const {
+  initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos);
+  initComponentHists(ibook, run, iSetup, histos, "pi");
+}
+
+void HeavyFlavorDQMAnalyzer::initLambdaBToJPsiLambda0ComponentHistograms(DQMStore::IBooker& ibook,
+                                                                         edm::Run const& run,
+                                                                         edm::EventSetup const& iSetup,
+                                                                         DecayHists& histos) const {
+  initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos);
+  initLambda0ToPPiComponentHistograms(ibook, run, iSetup, histos);
+}
+
+void HeavyFlavorDQMAnalyzer::initPsi2SToJPsiPiPiComponentHistograms(DQMStore::IBooker& ibook,
+                                                                    edm::Run const& run,
+                                                                    edm::EventSetup const& iSetup,
+                                                                    DecayHists& histos) const {
+  initOniaToMuMuComponentHistograms(ibook, run, iSetup, histos);
+  initComponentHists(ibook, run, iSetup, histos, "lead_pi");
+  initComponentHists(ibook, run, iSetup, histos, "soft_pi");
+}
+
+bool HeavyFlavorDQMAnalyzer::fillDecayHistograms(DecayHists const& histos,
+                                                 pat::CompositeCandidate const& cand,
+                                                 reco::VertexCollection const& pvs) const {
+  //  if (not cand.hasUserData("fitMomentum")) {
+  //    return -2;
+  //  }
+  //  auto mass = cand.userFloat("fitMass");
+  //  auto& momentum = *cand.userData<GlobalVector>("fitMomentum");
+  if (not allTracksAvailable(cand)) {
+    return false;
+  }
+
+  auto svtx = cand.userData<reco::Vertex>("vertex");
+  if (not svtx->isValid()) {
+    return false;
+  }
+
+  float mass = cand.mass();
+  reco::Candidate::Vector momentum = cand.momentum();
+  if (cand.hasUserData("fitMomentum")) {
+    mass = cand.userFloat("fitMass");
+    momentum = *cand.userData<GlobalVector>("fitMomentum");
+  }
+
+  auto pvtx = std::min_element(pvs.begin(), pvs.end(), [svtx](reco::Vertex const& pv1, reco::Vertex const& pv2) {
+    return abs(pv1.z() - svtx->z()) < abs(pv2.z() - svtx->z());
+  });
+
+  VertexDistanceXY vdistXY;
+  Measurement1D distXY = vdistXY.distance(*svtx, *pvtx);
+
+  auto pvtPos = pvtx->position();
+  auto svtPos = svtx->position();
+
+  math::XYZVector displVect2D(svtPos.x() - pvtPos.x(), svtPos.y() - pvtPos.y(), 0);
+  auto cosAlpha = displVect2D.Dot(momentum) / (displVect2D.Rho() * momentum.rho());
+
+  auto ct = distXY.value() * cosAlpha * mass / momentum.rho();
+
+  histos.h_pointing->Fill(cosAlpha);
+
+  histos.h_mass->Fill(mass);
+
+  histos.h_pt->Fill(momentum.rho());
+  histos.h_eta->Fill(momentum.eta());
+  histos.h_phi->Fill(momentum.phi());
+
+  histos.h_ct->Fill(ct);
+
+  histos.h_displ2D->Fill(distXY.value());
+  histos.h_sign2D->Fill(distXY.significance());
+
+  // FIXME workaround for tracks with non pos-def cov. matrix
+  if (svtx->chi2() >= 0) {
+    histos.h_vertNormChi2->Fill(svtx->chi2() / svtx->ndof());
+    histos.h_vertProb->Fill(ChiSquaredProbability(svtx->chi2(), svtx->ndof()));
+  }
+
+  return true;
+}
+
+int HeavyFlavorDQMAnalyzer::fillOniaToMuMuComponents(DecayHists const& histos,
+                                                     pat::CompositeCandidate const& cand,
+                                                     int startPosition) const {
+  startPosition = fillComponentHistogramsLeadSoft(histos, cand, "MuPos", "MuNeg", startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillKx0ToKPiComponents(DecayHists const& histos,
+                                                   pat::CompositeCandidate const& cand,
+                                                   int startPosition) const {
+  startPosition = fillComponentHistogramsSinglePart(histos, cand, "Kaon", startPosition);
+  startPosition = fillComponentHistogramsSinglePart(histos, cand, "Pion", startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillPhiToKKComponents(DecayHists const& histos,
+                                                  pat::CompositeCandidate const& cand,
+                                                  int startPosition) const {
+  startPosition = fillComponentHistogramsLeadSoft(histos, cand, "KPos", "KNeg", startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillK0sToPiPiComponents(DecayHists const& histos,
+                                                    pat::CompositeCandidate const& cand,
+                                                    int startPosition) const {
+  startPosition = fillComponentHistogramsLeadSoft(histos, cand, "PionPos", "PionNeg", startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillLambda0ToPPiComponents(DecayHists const& histos,
+                                                       pat::CompositeCandidate const& cand,
+                                                       int startPosition) const {
+  startPosition = fillComponentHistogramsSinglePart(histos, cand, "Proton", startPosition);
+  startPosition = fillComponentHistogramsSinglePart(histos, cand, "Pion", startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillBuToJPsiKComponents(DecayHists const& histos,
+                                                    pat::CompositeCandidate const& cand,
+                                                    int startPosition) const {
+  startPosition = fillOniaToMuMuComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi"), startPosition);
+  startPosition = fillComponentHistogramsSinglePart(histos, cand, "Kaon", startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillBuToPsi2SKComponents(DecayHists const& histos,
+                                                     pat::CompositeCandidate const& cand,
+                                                     int startPosition) const {
+  startPosition = fillPsi2SToJPsiPiPiComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToPsi2S"), startPosition);
+  startPosition = fillComponentHistogramsSinglePart(histos, cand, "Kaon", startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillBdToJPsiKx0Components(DecayHists const& histos,
+                                                      pat::CompositeCandidate const& cand,
+                                                      int startPosition) const {
+  startPosition = fillOniaToMuMuComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi"), startPosition);
+  startPosition = fillKx0ToKPiComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToKx0"), startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillBsToJPsiPhiComponents(DecayHists const& histos,
+                                                      pat::CompositeCandidate const& cand,
+                                                      int startPosition) const {
+  startPosition = fillOniaToMuMuComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi"), startPosition);
+  startPosition = fillPhiToKKComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToPhi"), startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillBdToJPsiK0sComponents(DecayHists const& histos,
+                                                      pat::CompositeCandidate const& cand,
+                                                      int startPosition) const {
+  startPosition = fillOniaToMuMuComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi"), startPosition);
+  startPosition = fillK0sToPiPiComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToK0s"), startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillBcToJPsiPiComponents(DecayHists const& histos,
+                                                     pat::CompositeCandidate const& cand,
+                                                     int startPosition) const {
+  startPosition = fillOniaToMuMuComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi"), startPosition);
+  startPosition = fillComponentHistogramsSinglePart(histos, cand, "Pion", startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillLambdaBToJPsiLambda0Components(DecayHists const& histos,
+                                                               pat::CompositeCandidate const& cand,
+                                                               int startPosition) const {
+  startPosition = fillOniaToMuMuComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi"), startPosition);
+  startPosition = fillLambda0ToPPiComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToLambda0"), startPosition);
+
+  return startPosition;
+}
+
+int HeavyFlavorDQMAnalyzer::fillPsi2SToJPsiPiPiComponents(DecayHists const& histos,
+                                                          pat::CompositeCandidate const& cand,
+                                                          int startPosition) const {
+  startPosition = fillOniaToMuMuComponents(
+      histos, **cand.userData<edm::Ref<pat::CompositeCandidateCollection>>("refToJPsi"), startPosition);
+  startPosition = fillComponentHistogramsLeadSoft(histos, cand, "PionPos", "PionNeg", startPosition);
+  return startPosition;
+}
+
+void HeavyFlavorDQMAnalyzer::fillComponentHistograms(ComponentHists const& histos, reco::Track const& component) const {
+  histos.h_pt->Fill(component.pt());
+  histos.h_eta->Fill(component.eta());
+  histos.h_phi->Fill(component.phi());
+
+  histos.h_dxy->Fill(component.dxy());
+  histos.h_exy->Fill(component.dxyError());
+  histos.h_dz->Fill(component.dz());
+  histos.h_ez->Fill(component.dzError());
+
+  histos.h_chi2->Fill(component.chi2() / component.ndof());
+}
+
+bool HeavyFlavorDQMAnalyzer::allTracksAvailable(pat::CompositeCandidate const& cand) const {
+  for (auto&& name : cand.roles()) {
+    auto track = getDaughterTrack(cand, name, false);
+    if (not track) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const reco::Track* HeavyFlavorDQMAnalyzer::getDaughterTrack(pat::CompositeCandidate const& cand,
+                                                            std::string const& name,
+                                                            bool throwOnMissing) const {
+  auto daugh = cand.daughter(name);
+  auto trackModeLabel = "trackMode_" + name;
+  auto trackMode = cand.userData<std::string>(trackModeLabel);
+  if (!trackMode or trackMode->empty()) {
+    if (throwOnMissing) {
+      throw cms::Exception("TrackNotFound") << "Could not determine track mode from candidate with name " << name
+                                            << " with label " << trackModeLabel << std::endl;
+    }
+    return nullptr;
+  }
+
+  auto track = BPHTrackReference::getTrack(*daugh, trackMode->c_str());
+
+  if (throwOnMissing and not track) {
+    throw cms::Exception("TrackNotFound") << "BPHTrackReference could not extract a track as type " << trackMode
+                                          << " from candidate with name " << name << std::endl;
+  }
+
+  return track;
+}
+
+int HeavyFlavorDQMAnalyzer::fillComponentHistogramsSinglePart(DecayHists const& histos,
+                                                              pat::CompositeCandidate const& cand,
+                                                              std::string const& name,
+                                                              int startPosition) const {
+  fillComponentHistograms(histos.decayComponents[startPosition], *getDaughterTrack(cand, name));
+
+  return startPosition + 1;
+}
+
+int HeavyFlavorDQMAnalyzer::fillComponentHistogramsLeadSoft(DecayHists const& histos,
+                                                            pat::CompositeCandidate const& cand,
+                                                            std::string const& name1,
+                                                            std::string const& name2,
+                                                            int startPosition) const {
+  auto daughSoft = getDaughterTrack(cand, name1);
+  auto daughLead = getDaughterTrack(cand, name2);
+
+  if (daughLead->pt() < daughSoft->pt()) {
+    std::swap(daughLead, daughSoft);
+  }
+
+  fillComponentHistograms(histos.decayComponents[startPosition], *daughLead);
+  fillComponentHistograms(histos.decayComponents[startPosition + 1], *daughSoft);
+
+  return startPosition + 2;
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void HeavyFlavorDQMAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("folder", "Physics/HeavyFlavor");
+
+  desc.add<edm::InputTag>("pvCollection");
+
+  desc.addOptional<edm::InputTag>("OniaToMuMuCands");
+  desc.addOptional<edm::InputTag>("Kx0ToKPiCands");
+  desc.addOptional<edm::InputTag>("PhiToKKCands");
+  desc.addOptional<edm::InputTag>("BuToJPsiKCands");
+  desc.addOptional<edm::InputTag>("BuToPsi2SKCands");
+  desc.addOptional<edm::InputTag>("BdToJPsiKx0Cands");
+  desc.addOptional<edm::InputTag>("BsToJPsiPhiCands");
+  desc.addOptional<edm::InputTag>("K0sToPiPiCands");
+  desc.addOptional<edm::InputTag>("Lambda0ToPPiCands");
+  desc.addOptional<edm::InputTag>("BdToJPsiK0sCands");
+  desc.addOptional<edm::InputTag>("LambdaBToJPsiLambda0Cands");
+  desc.addOptional<edm::InputTag>("BcToJPsiPiCands");
+  desc.addOptional<edm::InputTag>("Psi2SToJPsiPiPiCands");
+
+  descriptions.add("HeavyFlavorDQMAnalyzer", desc);
+}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(HeavyFlavorDQMAnalyzer);

--- a/DQM/Physics/src/HeavyFlavorDQMAnalyzer.h
+++ b/DQM/Physics/src/HeavyFlavorDQMAnalyzer.h
@@ -1,0 +1,247 @@
+#ifndef DQMOffline_Physics_HeavyFlavorDQMAnalyzer_h
+#define DQMOffline_Physics_HeavyFlavorDQMAnalyzer_h
+
+// -*- C++ -*-
+//
+// Package:    DQMOffline/HeavyFlavorDQMAnalyzer
+// Class:      HeavyFlavorDQMAnalyzer
+//
+/**\class HeavyFlavorDQMAnalyzer HeavyFlavorDQMAnalyzer.cc DQMOffline/HeavyFlavorDQMAnalyzer/plugins/HeavyFlavorDQMAnalyzer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Enrico Lusiani
+//         Created:  Mon, 22 Nov 2021 14:36:39 GMT
+//
+//
+
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
+
+#include "HeavyFlavorAnalysis/RecoDecay/interface/BPHTrackReference.h"
+
+//
+// class declaration
+//
+
+struct ComponentHists {
+  dqm::reco::MonitorElement* h_pt;
+  dqm::reco::MonitorElement* h_eta;
+  dqm::reco::MonitorElement* h_phi;
+
+  dqm::reco::MonitorElement* h_dxy;
+  dqm::reco::MonitorElement* h_exy;
+  dqm::reco::MonitorElement* h_dz;
+  dqm::reco::MonitorElement* h_ez;
+
+  dqm::reco::MonitorElement* h_chi2;
+};
+
+struct DecayHists {
+  // kinematics
+  dqm::reco::MonitorElement* h_mass;
+  dqm::reco::MonitorElement* h_pt;
+  dqm::reco::MonitorElement* h_eta;
+  dqm::reco::MonitorElement* h_phi;
+
+  // position
+  dqm::reco::MonitorElement* h_displ2D;
+  dqm::reco::MonitorElement* h_displ3D;
+  dqm::reco::MonitorElement* h_sign2D;
+  dqm::reco::MonitorElement* h_sign3D;
+
+  // ct and pointing angle
+  dqm::reco::MonitorElement* h_ct;
+  dqm::reco::MonitorElement* h_pointing;
+
+  // quality
+  dqm::reco::MonitorElement* h_vertNormChi2;
+  dqm::reco::MonitorElement* h_vertProb;
+
+  std::vector<ComponentHists> decayComponents;
+};
+
+struct Histograms_HeavyFlavorDQMAnalyzer {
+  DecayHists oniaToMuMuPrompt;
+  DecayHists oniaToMuMuDispl;
+  DecayHists oniaToMuMu;
+  DecayHists kx0ToKPiPrompt;
+  DecayHists kx0ToKPiDispl;
+  DecayHists kx0ToKPi;
+  DecayHists phiToKKPrompt;
+  DecayHists phiToKKDispl;
+  DecayHists phiToKK;
+  DecayHists psi2SToJPsiPiPiPrompt;
+  DecayHists psi2SToJPsiPiPiDispl;
+  DecayHists psi2SToJPsiPiPi;
+  DecayHists k0sToPiPi;
+  DecayHists lambda0ToPPi;
+  DecayHists buToJPsiK;
+  DecayHists buToPsi2SK;
+  DecayHists bdToJPsiKx0;
+  DecayHists bsToJPsiPhi;
+  DecayHists bdToJPsiK0s;
+  DecayHists bcToJPsiPi;
+  DecayHists lambdaBToJPsiLambda0;
+};
+
+class HeavyFlavorDQMAnalyzer : public DQMGlobalEDAnalyzer<Histograms_HeavyFlavorDQMAnalyzer> {
+public:
+  using Histograms = Histograms_HeavyFlavorDQMAnalyzer;
+
+  explicit HeavyFlavorDQMAnalyzer(const edm::ParameterSet&);
+  ~HeavyFlavorDQMAnalyzer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, Histograms&) const override;
+
+  void dqmAnalyze(edm::Event const&, edm::EventSetup const&, Histograms const&) const override;
+
+  void bookDecayHists(DQMStore::IBooker&,
+                      edm::Run const&,
+                      edm::EventSetup const&,
+                      DecayHists&,
+                      std::string const&,
+                      std::string const&,
+                      int,
+                      float,
+                      float,
+                      float distanceScaleFactor = 1.) const;
+  void initComponentHists(DQMStore::IBooker&,
+                          edm::Run const&,
+                          edm::EventSetup const&,
+                          DecayHists&,
+                          TString const&) const;  // TString for the IBooker interface
+
+  void initOniaToMuMuComponentHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, DecayHists&) const;
+  void initKx0ToKPiComponentHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, DecayHists&) const;
+  void initPhiToKKComponentHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, DecayHists&) const;
+  void initK0sToPiPiComponentHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, DecayHists&) const;
+  void initLambda0ToPPiComponentHistograms(DQMStore::IBooker&,
+                                           edm::Run const&,
+                                           edm::EventSetup const&,
+                                           DecayHists&) const;
+  void initBuToJPsiKComponentHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, DecayHists&) const;
+  void initBuToPsi2SKComponentHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, DecayHists&) const;
+  void initBdToJPsiKx0ComponentHistograms(DQMStore::IBooker&,
+                                          edm::Run const&,
+                                          edm::EventSetup const&,
+                                          DecayHists&) const;
+  void initBsToJPsiPhiComponentHistograms(DQMStore::IBooker&,
+                                          edm::Run const&,
+                                          edm::EventSetup const&,
+                                          DecayHists&) const;
+  void initBdToJPsiK0sComponentHistograms(DQMStore::IBooker&,
+                                          edm::Run const&,
+                                          edm::EventSetup const&,
+                                          DecayHists&) const;
+  void initBcToJPsiPiComponentHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&, DecayHists&) const;
+  void initLambdaBToJPsiLambda0ComponentHistograms(DQMStore::IBooker&,
+                                                   edm::Run const&,
+                                                   edm::EventSetup const&,
+                                                   DecayHists&) const;
+  void initPsi2SToJPsiPiPiComponentHistograms(DQMStore::IBooker&,
+                                              edm::Run const&,
+                                              edm::EventSetup const&,
+                                              DecayHists&) const;
+
+  bool fillDecayHistograms(DecayHists const&,
+                           pat::CompositeCandidate const& cand,
+                           reco::VertexCollection const& pvs) const;
+  void fillComponentHistograms(ComponentHists const& histos, reco::Track const& component) const;
+
+  int fillComponentHistogramsSinglePart(DecayHists const&,
+                                        pat::CompositeCandidate const& cand,
+                                        std::string const& name,
+                                        int startPosition = 0) const;
+  int fillComponentHistogramsLeadSoft(DecayHists const&,
+                                      pat::CompositeCandidate const& cand,
+                                      std::string const& name1,
+                                      std::string const& name2,
+                                      int startPosition = 0) const;
+
+  const reco::Track* getDaughterTrack(pat::CompositeCandidate const& cand,
+                                      std::string const& name,
+                                      bool throwOnMissing = true) const;
+  bool allTracksAvailable(pat::CompositeCandidate const& cand) const;
+
+  int fillOniaToMuMuComponents(DecayHists const& histos,
+                               pat::CompositeCandidate const& cand,
+                               int startPosition = 0) const;
+  int fillKx0ToKPiComponents(DecayHists const& histos,
+                             pat::CompositeCandidate const& cand,
+                             int startPosition = 0) const;
+  int fillPhiToKKComponents(DecayHists const& histos, pat::CompositeCandidate const& cand, int startPosition = 0) const;
+  int fillK0sToPiPiComponents(DecayHists const& histos,
+                              pat::CompositeCandidate const& cand,
+                              int startPosition = 0) const;
+  int fillLambda0ToPPiComponents(DecayHists const& histos,
+                                 pat::CompositeCandidate const& cand,
+                                 int startPosition = 0) const;
+  int fillBuToJPsiKComponents(DecayHists const& histos,
+                              pat::CompositeCandidate const& cand,
+                              int startPosition = 0) const;
+  int fillBuToPsi2SKComponents(DecayHists const& histos,
+                               pat::CompositeCandidate const& cand,
+                               int startPosition = 0) const;
+  int fillBdToJPsiKx0Components(DecayHists const& histos,
+                                pat::CompositeCandidate const& cand,
+                                int startPosition = 0) const;
+  int fillBsToJPsiPhiComponents(DecayHists const& histos,
+                                pat::CompositeCandidate const& cand,
+                                int startPosition = 0) const;
+  int fillBdToJPsiK0sComponents(DecayHists const& histos,
+                                pat::CompositeCandidate const& cand,
+                                int startPosition = 0) const;
+  int fillBcToJPsiPiComponents(DecayHists const& histos,
+                               pat::CompositeCandidate const& cand,
+                               int startPosition = 0) const;
+  int fillLambdaBToJPsiLambda0Components(DecayHists const& histos,
+                                         pat::CompositeCandidate const& cand,
+                                         int startPosition = 0) const;
+  int fillPsi2SToJPsiPiPiComponents(DecayHists const& histos,
+                                    pat::CompositeCandidate const& cand,
+                                    int startPosition = 0) const;
+
+  // ------------ member data ------------
+  std::string folder_;
+
+  edm::EDGetTokenT<reco::VertexCollection> pvCollectionToken;
+
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> oniaToMuMuCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> kx0ToKPiCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> phiToKKCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> buToJPsiKCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> buToPsi2SKCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> bdToJPsiKx0CandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> bsToJPsiPhiCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> k0sToPiPiCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> lambda0ToPPiCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> bdToJPsiK0sCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> lambdaBToJPsiLambda0CandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> bcToJPsiPiCandsToken;
+  edm::EDGetTokenT<pat::CompositeCandidateCollection> psi2SToJPsiPiPiCandsToken;
+};
+
+#endif

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -100,6 +100,7 @@ from DQMOffline.Trigger.DQMOffline_Trigger_cff import *
 from DQMOffline.RecoB.dqmAnalyzer_cff import *
 from DQM.BeamMonitor.AlcaBeamMonitor_cff import *
 from DQM.Physics.DQMPhysics_cff import *
+from DQM.Physics.heavyFlavorDQMFirstStep_cff import *
 
 DQMOfflineVertex = cms.Sequence( pvMonitor )
 
@@ -123,6 +124,8 @@ DQMOfflineBTag = cms.Sequence( bTagPlotsDATA )
 DQMOfflineBeam = cms.Sequence( alcaBeamMonitor )
 
 DQMOfflinePhysics = cms.Sequence( dqmPhysics )
+
+DQMOfflineHeavyFlavor = cms.Sequence( heavyFlavorDQMSource )
 
 DQMOfflinePrePOG = cms.Sequence( DQMOfflineTracking *
                                  DQMOfflineMUO *
@@ -260,14 +263,13 @@ from DQM.TrackingMonitor.tracksDQMMiniAOD_cff import *
 from DQMOffline.RecoB.bTagMiniDQM_cff import *
 from DQMOffline.Muon.miniAOD_cff import *
 from DQM.Physics.DQMTopMiniAOD_cff import *
-from DQM.Physics.heavyFlavorDQMFirstStep_cff import *
 
 DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*bTagMiniDQMSource*muonMonitors_miniAOD*MuonMiniAOD*DQMOfflinePF)
 
 #Post sequences are automatically placed in the EndPath by ConfigBuilder if PAT is run.
 #miniAOD DQM sequences need to access the filter results.
 
-PostDQMOfflineMiniAOD = cms.Sequence(miniAODDQMSequence*jetMETDQMOfflineSourceMiniAOD*tracksDQMMiniAOD*topPhysicsminiAOD*heavyFlavorDQMSource)
+PostDQMOfflineMiniAOD = cms.Sequence(miniAODDQMSequence*jetMETDQMOfflineSourceMiniAOD*tracksDQMMiniAOD*topPhysicsminiAOD)
 PostDQMOffline = cms.Sequence()
 
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -260,13 +260,14 @@ from DQM.TrackingMonitor.tracksDQMMiniAOD_cff import *
 from DQMOffline.RecoB.bTagMiniDQM_cff import *
 from DQMOffline.Muon.miniAOD_cff import *
 from DQM.Physics.DQMTopMiniAOD_cff import *
+from DQM.Physics.heavyFlavorDQMFirstStep_cff import *
 
 DQMOfflineMiniAOD = cms.Sequence(jetMETDQMOfflineRedoProductsMiniAOD*bTagMiniDQMSource*muonMonitors_miniAOD*MuonMiniAOD*DQMOfflinePF)
 
 #Post sequences are automatically placed in the EndPath by ConfigBuilder if PAT is run.
 #miniAOD DQM sequences need to access the filter results.
 
-PostDQMOfflineMiniAOD = cms.Sequence(miniAODDQMSequence*jetMETDQMOfflineSourceMiniAOD*tracksDQMMiniAOD*topPhysicsminiAOD)
+PostDQMOfflineMiniAOD = cms.Sequence(miniAODDQMSequence*jetMETDQMOfflineSourceMiniAOD*tracksDQMMiniAOD*topPhysicsminiAOD*heavyFlavorDQMSource)
 PostDQMOffline = cms.Sequence()
 
 from Configuration.Eras.Modifier_run3_HB_cff import run3_HB

--- a/DQMOffline/Configuration/python/autoDQM.py
+++ b/DQMOffline/Configuration/python/autoDQM.py
@@ -142,6 +142,10 @@ autoDQM = { 'DQMMessageLogger': ['DQMMessageLoggerSeq',
 			'PostDQMOffline',
 			'DQMNone'],
 
+            'heavyFlavor': ['DQMOfflineHeavyFlavor',
+                            'PostDQMOffline',
+                            'DQMNone'],
+
             'L1TMon': ['DQMOfflineL1T',
                        'PostDQMOffline',
                        'DQMHarvestL1T'],


### PR DESCRIPTION
#### PR description:

This PR adds a DQM module based on the HeavyFlavorAnalysis package to create plots for several decays relevant for BPH.
The new plots are available under Physics/HeavyFlavor in the DQM
A more detailed explanation of what plots are available can be found at https://indico.cern.ch/event/1119491/#1-tracking-monitor-in-bph-fina
This PR depends on PR #38524

#### PR validation:
The tests with runTheMatrix return ok, privately tested on a few relvals.
Added processing time is 0.11 s/ev, added size to a DQM file is 0.15%, increase in peak memory consumption is ~10MB

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to 12_4_X
