### PR TITLE
[GCC12] Silence may be used uninitialized warning

### DIFF
--- a/CondCore/DBOutputService/interface/PoolDBOutputService.h
+++ b/CondCore/DBOutputService/interface/PoolDBOutputService.h
@@ -113,7 +113,7 @@ namespace cond {
           auto& myrecord = this->getRecord(recordName);
           m_logger.logInfo() << "Tag mapped to record " << recordName << ": " << myrecord.m_tag;
           bool newTag = isNewTagRequest(recordName);
-          cond::Time_t lastSince;
+          cond::Time_t lastSince = 0;
           cond::persistency::IOVEditor editor;
           if (newTag) {
             std::string payloadType = cond::demangledName(typeid(T));


### PR DESCRIPTION
GCC 12 builds have many warnings like [a] . This PR proposes to initialize the variable to `0`. @ggovi  is it the correct initialization or should it be set to `cond::time::MAX_VAL`?

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc12/CMSSW_12_5_X_2022-06-27-1100/CondTools/Ecal
```
  src/CondCore/DBOutputService/interface/PoolDBOutputService.h:136:15: warning: 'lastSince' may be used uninitialized [-Wmaybe-uninitialized]
   136 |               if (time <= lastSince) {
      |               ^~
src/CondCore/DBOutputService/interface/PoolDBOutputService.h:116:24: note: 'lastSince' was declared here
  116 |           cond::Time_t lastSince;
      |                        ^~~~~~~~~
```