### PR TITLE
[GEM] bug fix in orbit counter checker between AMC13 and GEM AMC headers

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMAMCStatus.h
+++ b/DataFormats/GEMDigi/interface/GEMAMCStatus.h
@@ -41,13 +41,14 @@ public:
     error.badBC = !((amc13->bunchCrossing() == amc.bunchCrossing()) ||
                     (amc13->bunchCrossing() == 0 && amc.bunchCrossing() == GEMAMC13::lastBC));
     error.badRunType = amc.runType() != 0x1;
+    // Last OC in AMC13 is different to TCDS, AMC, and VFAT
     if (amc.formatVer() == 0)
-      // Last OC in AMC13 is different to TCDS, AMC, and VFAT
       error.badOC =
           !((uint16_t(amc13->orbitNumber()) == amc.orbitNumber()) ||
             (amc13->bunchCrossing() == 0 && uint16_t(amc.orbitNumber() + 1) == uint16_t(amc13->orbitNumber())));
     else
-      error.badOC = (amc13->orbitNumber() != amc.orbitNumber());
+      error.badOC = !((amc13->orbitNumber() == (amc.orbitNumber() + 1)) ||
+                      (amc13->bunchCrossing() == 0 && amc13->orbitNumber() == (amc.orbitNumber() + 2)));
     error.MMCMlocked = !amc.mmcmLocked();
     error.DAQclocklocked = !amc.daqClockLocked();
     error.DAQnotReday = !amc.daqReady();


### PR DESCRIPTION
#### PR description:
Because of the different implementations of orbit counter in AMC13 and GEM AMC, the OC value from GEM AMC should be subtracted with 1 or 2.
- Substract 1 orbit when the AMC13 bunch counter is [1,3563]
- Substract 2 orbits when the AMC13 bunch counter is 0

Because of the wrong implementation of data status checker, we couldn't unpack the data from GEM at the moment.
Backport PR to 12_3_X and 12_4_X is needed.

#### PR validation:

The branch is applied with `scram build code-format` and `scram build code-checks`.
The unpacking test on the data from the compatible firmware version has been performed.

@jshlee 