### PR TITLE
Phase2-hgx317 Add an extra constructor for the HFNoseDetId class

### DIFF
--- a/DataFormats/ForwardDetId/interface/HFNoseDetId.h
+++ b/DataFormats/ForwardDetId/interface/HFNoseDetId.h
@@ -33,6 +33,7 @@ public:
   /** Create cellid from raw id (0=invalid tower id) */
   HFNoseDetId(uint32_t rawid);
   /** Constructor from subdetector, zplus, layer, module, cell numbers */
+  HFNoseDetId(DetId::Detector det, int zp, int type, int layer, int waferU, int waferV, int cellU, int cellV);
   HFNoseDetId(int zp, int type, int layer, int waferU, int waferV, int cellU, int cellV);
   /** Constructor from a generic cell id */
   HFNoseDetId(const DetId& id);

--- a/DataFormats/ForwardDetId/src/HFNoseDetId.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseDetId.cc
@@ -9,6 +9,22 @@ HFNoseDetId::HFNoseDetId() : DetId() {}
 
 HFNoseDetId::HFNoseDetId(uint32_t rawid) : DetId(rawid) {}
 
+HFNoseDetId::HFNoseDetId(DetId::Detector det, int zp, int type, int layer, int waferU, int waferV, int cellU, int cellV)
+    : DetId(det, HFNose) {
+  int waferUabs(std::abs(waferU)), waferVabs(std::abs(waferV));
+  int waferUsign = (waferU >= 0) ? 0 : 1;
+  int waferVsign = (waferV >= 0) ? 0 : 1;
+  int zside = (zp < 0) ? 1 : 0;
+  int lay = std::max(layer - 1, 0);
+  id_ |= (((cellU & kHFNoseCellUMask) << kHFNoseCellUOffset) | ((cellV & kHFNoseCellVMask) << kHFNoseCellVOffset) |
+          ((waferUabs & kHFNoseWaferUMask) << kHFNoseWaferUOffset) |
+          ((waferUsign & kHFNoseWaferUSignMask) << kHFNoseWaferUSignOffset) |
+          ((waferVabs & kHFNoseWaferVMask) << kHFNoseWaferVOffset) |
+          ((waferVsign & kHFNoseWaferVSignMask) << kHFNoseWaferVSignOffset) |
+          ((lay & kHFNoseLayerMask) << kHFNoseLayerOffset) | ((zside & kHFNoseZsideMask) << kHFNoseZsideOffset) |
+          ((type & kHFNoseTypeMask) << kHFNoseTypeOffset));
+}
+
 HFNoseDetId::HFNoseDetId(int zp, int type, int layer, int waferU, int waferV, int cellU, int cellV)
     : DetId(Forward, HFNose) {
   int waferUabs(std::abs(waferU)), waferVabs(std::abs(waferV));

--- a/DataFormats/ForwardDetId/src/HFNoseDetId.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseDetId.cc
@@ -26,20 +26,7 @@ HFNoseDetId::HFNoseDetId(DetId::Detector det, int zp, int type, int layer, int w
 }
 
 HFNoseDetId::HFNoseDetId(int zp, int type, int layer, int waferU, int waferV, int cellU, int cellV)
-    : DetId(Forward, HFNose) {
-  int waferUabs(std::abs(waferU)), waferVabs(std::abs(waferV));
-  int waferUsign = (waferU >= 0) ? 0 : 1;
-  int waferVsign = (waferV >= 0) ? 0 : 1;
-  int zside = (zp < 0) ? 1 : 0;
-  int lay = std::max(layer - 1, 0);
-  id_ |= (((cellU & kHFNoseCellUMask) << kHFNoseCellUOffset) | ((cellV & kHFNoseCellVMask) << kHFNoseCellVOffset) |
-          ((waferUabs & kHFNoseWaferUMask) << kHFNoseWaferUOffset) |
-          ((waferUsign & kHFNoseWaferUSignMask) << kHFNoseWaferUSignOffset) |
-          ((waferVabs & kHFNoseWaferVMask) << kHFNoseWaferVOffset) |
-          ((waferVsign & kHFNoseWaferVSignMask) << kHFNoseWaferVSignOffset) |
-          ((lay & kHFNoseLayerMask) << kHFNoseLayerOffset) | ((zside & kHFNoseZsideMask) << kHFNoseZsideOffset) |
-          ((type & kHFNoseTypeMask) << kHFNoseTypeOffset));
-}
+  : HFNoseDetId(Forward, zp, type, layer, waferU, waferV, cellU, cellV) {}
 
 HFNoseDetId::HFNoseDetId(const DetId& gen) {
   if (!gen.null()) {

--- a/DataFormats/ForwardDetId/src/HFNoseDetId.cc
+++ b/DataFormats/ForwardDetId/src/HFNoseDetId.cc
@@ -26,7 +26,7 @@ HFNoseDetId::HFNoseDetId(DetId::Detector det, int zp, int type, int layer, int w
 }
 
 HFNoseDetId::HFNoseDetId(int zp, int type, int layer, int waferU, int waferV, int cellU, int cellV)
-  : HFNoseDetId(Forward, zp, type, layer, waferU, waferV, cellU, cellV) {}
+    : HFNoseDetId(Forward, zp, type, layer, waferU, waferV, cellU, cellV) {}
 
 HFNoseDetId::HFNoseDetId(const DetId& gen) {
   if (!gen.null()) {


### PR DESCRIPTION
#### PR description:

Add an extra constructor for the HFNoseDetId class. This additional constructor helps in writing some generic code which can work for HGCal silicon part as well as HFNose

#### PR validation:

Use the runTheMatrix test workflows 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special