### PR TITLE
Replace Geometry_cff with GeometryDB_cff in RecoLocalMuon

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/test/run_on_raw.py
+++ b/RecoLocalMuon/CSCRecHitD/test/run_on_raw.py
@@ -1,6 +1,7 @@
 ## Dump  100  events in CSC rechit builder - Tim Cox - 03.12.2012
 ## This version runs in 610preX on a real data RelVal RAW sample,
 ## and uses indexer and mapper algos.
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -14,8 +15,8 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
-
-process.GlobalTag.globaltag = 'GR_R_61_V1::All'
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 # --- NUMBER OF EVENTS --- 
 

--- a/RecoLocalMuon/CSCRecHitD/test/run_on_raw.py
+++ b/RecoLocalMuon/CSCRecHitD/test/run_on_raw.py
@@ -6,10 +6,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 

--- a/RecoLocalMuon/CSCRecHitD/test/run_on_raw_72x.py
+++ b/RecoLocalMuon/CSCRecHitD/test/run_on_raw_72x.py
@@ -1,5 +1,6 @@
 ## Process  100  events in CSC rechit builder - Tim Cox - 06.10.2014
 ## This version runs in 720pre6, 7, 73X IBs  on a real data RelVal RAW sample.
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -13,9 +14,8 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
-
-# This is OK for 72x real data
-process.GlobalTag.globaltag = "GR_R_71_V1::All"
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 # --- NUMBER OF EVENTS --- 
 

--- a/RecoLocalMuon/CSCRecHitD/test/run_on_raw_72x.py
+++ b/RecoLocalMuon/CSCRecHitD/test/run_on_raw_72x.py
@@ -5,10 +5,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
 

--- a/RecoLocalMuon/CSCRecHitD/test/run_on_simdigi.py
+++ b/RecoLocalMuon/CSCRecHitD/test/run_on_simdigi.py
@@ -5,10 +5,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-##process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+##process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
 

--- a/RecoLocalMuon/CSCRecHitD/test/run_on_simdigi.py
+++ b/RecoLocalMuon/CSCRecHitD/test/run_on_simdigi.py
@@ -1,5 +1,6 @@
 ## Dump  10  events in CSC rechit builder - Tim Cox - 07.11.2012
 ## This version runs in 6_0_1_PostLS1 on a simulated data DIGI sample.
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -13,8 +14,8 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
-
-process.GlobalTag.globaltag = "POSTLS161_V11::All"
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 # --- NUMBER OF EVENTS
 

--- a/RecoLocalMuon/CSCRecHitD/test/test_bad_channels.py
+++ b/RecoLocalMuon/CSCRecHitD/test/test_bad_channels.py
@@ -3,7 +3,7 @@
 
 ## Output via MessageLogger - configured, after much flailing, so that
 ## ONLY the LogVerbatim("CSCBadChannels") messages are sent to std:output.
-
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -27,9 +27,8 @@ process.MessageLogger.cout = cms.untracked.PSet(
 )
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
-
-# This is OK for 72x real data
-process.GlobalTag.globaltag = "GR_R_71_V1::All"
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 # --- NUMBER OF EVENTS ---  JUST ONE!
 

--- a/RecoLocalMuon/CSCRecHitD/test/test_bad_channels.py
+++ b/RecoLocalMuon/CSCRecHitD/test/test_bad_channels.py
@@ -9,10 +9,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")

--- a/RecoLocalMuon/CSCSegment/test/run_on_raw_700.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_raw_700.py
@@ -1,5 +1,6 @@
 ## Dump  100  events in CSC segment builder - Tim Cox - 09.09.2013
 ## This version runs in 700pre3 on a real data RelVal RAW sample.
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -13,8 +14,9 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
-process.GlobalTag.globaltag = 'PRE_62_V8::All'
 
 # --- NUMBER OF EVENTS --- 
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_raw_700.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_raw_700.py
@@ -5,10 +5,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_raw_720p3.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_raw_720p3.py
@@ -1,5 +1,6 @@
 ## Dump  1000  events in CSC segment builder - Tim Cox - 22.08.2014
 ## This version runs in 720pre3 on a real data RelVal RAW sample.
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -13,9 +14,8 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
-
-# This is OK for 72x real data
-process.GlobalTag.globaltag = 'GR_R_71_V1::All'
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 # --- NUMBER OF EVENTS --- 
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_raw_720p3.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_raw_720p3.py
@@ -5,10 +5,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_raw_74x.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_raw_74x.py
@@ -6,10 +6,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_raw_74x.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_raw_74x.py
@@ -1,6 +1,7 @@
 ## Process  100  events in CSC segment builder - Tim Cox - 22.01.2015
 ## This version runs in  74X  on a Real RAW relval sample in 730 
 ## Now testing on FullSim+PU TTbar sample in 730
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -14,13 +15,8 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
-
-# Tag for 730 Real Data relvals
-##process.GlobalTag.globaltag = "GR_P_V43D::All"
-
-# Tag for 730 Sim relvals
-process.GlobalTag.globaltag = "MCRUN2_73_V5::All"
-
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 # --- NUMBER OF EVENTS --- 
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_simdigi.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_simdigi.py
@@ -5,10 +5,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-##process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+##process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_simdigi.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_simdigi.py
@@ -1,5 +1,6 @@
 ## Dump  10  events in CSC rechit & segment builders - Tim Cox - 08.11.2012
 ## This version runs in 6_0_1_PostLS1 on a simulated data DIGI sample.
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -13,8 +14,8 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
-
-process.GlobalTag.globaltag = "POSTLS161_V11::All"
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 # --- NUMBER OF EVENTS
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_simdigi_74x.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_simdigi_74x.py
@@ -1,6 +1,7 @@
 ## Process sim digi events with CSC rechit & segment builders - Tim Cox - 11.02.2015
 ## This version runs in 7_4_0_preX on a 7_3_0 simulated data DIGI relval sample.
 ## Run on  1000  events of a 25ns PU TTbar sample
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -18,8 +19,9 @@ process.CSCIndexerESProducer.AlgoName = cms.string("CSCIndexerPostls1")
 process.CSCChannelMapperESProducer.AlgoName = cms.string("CSCChannelMapperPostls1")
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
-process.GlobalTag.globaltag = "MCRUN2_73_V5::All"
 
 # --- NUMBER OF EVENTS
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_simdigi_74x.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_simdigi_74x.py
@@ -6,20 +6,12 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-# Geometry access changed after Yana hypernews post 10.02.2015
-# had been using...
-##process.load("Configuration.StandardSequences.Geometry_cff")
-# which just points to...
-##process.load("Configuration.Geometry.GeometryIdeal_cff")
-# yana wants...
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 ##process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
-
 process.load("CalibMuon.CSCCalibration.CSCChannelMapper_cfi")
 process.load("CalibMuon.CSCCalibration.CSCIndexer_cfi")
 process.CSCIndexerESProducer.AlgoName = cms.string("CSCIndexerPostls1")

--- a/RecoLocalMuon/CSCSegment/test/run_on_simdigi_st.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_simdigi_st.py
@@ -2,6 +2,7 @@
 ## This version runs in 7_4_0_preX on a 7_3_0 simulated data DIGI relval sample.
 ##     -- USING DEFAULT ALGO "ST"
 ## Run on  100  events of a 25ns PU TTbar sample
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -19,8 +20,8 @@ process.CSCIndexerESProducer.AlgoName = cms.string("CSCIndexerPostls1")
 process.CSCChannelMapperESProducer.AlgoName = cms.string("CSCChannelMapperPostls1")
 
 # --- MATCH GT TO RELEASE AND DATA SAMPLE
-
-process.GlobalTag.globaltag = "MCRUN2_73_V5::All"
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 # --- NUMBER OF EVENTS
 

--- a/RecoLocalMuon/CSCSegment/test/run_on_simdigi_st.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_simdigi_st.py
@@ -7,20 +7,12 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-# Geometry access changed after Yana hypernews post 10.02.2015
-# had been using...
-##process.load("Configuration.StandardSequences.Geometry_cff")
-# which just points to...
-##process.load("Configuration.Geometry.GeometryIdeal_cff")
-# yana wants...
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 ##process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.EndOfProcess_cff")
-
 process.load("CalibMuon.CSCCalibration.CSCChannelMapper_cfi")
 process.load("CalibMuon.CSCCalibration.CSCIndexer_cfi")
 process.CSCIndexerESProducer.AlgoName = cms.string("CSCIndexerPostls1")

--- a/RecoLocalMuon/CSCValidation/test/CSCVal_example_cfg.py
+++ b/RecoLocalMuon/CSCValidation/test/CSCVal_example_cfg.py
@@ -8,8 +8,8 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 
-process.GlobalTag.globaltag = 'GR_R_36X_V10::All'
-
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )

--- a/RecoLocalMuon/CSCValidation/test/CSCVal_example_cfg.py
+++ b/RecoLocalMuon/CSCValidation/test/CSCVal_example_cfg.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 
 process.GlobalTag.globaltag = 'GR_R_36X_V10::All'

--- a/RecoLocalMuon/CSCValidation/test/cscv_RAW.py
+++ b/RecoLocalMuon/CSCValidation/test/cscv_RAW.py
@@ -5,10 +5,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.load("Configuration/StandardSequences/Geometry_cff")
-process.load("Configuration/StandardSequences/MagneticField_cff")
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 

--- a/RecoLocalMuon/CSCValidation/test/cscv_RAW.py
+++ b/RecoLocalMuon/CSCValidation/test/cscv_RAW.py
@@ -1,5 +1,6 @@
 # Test CSCValidation running on raw relval file - Tim Cox - 09.09.2013 
 # For raw relval in 700, with useDigis ON, and request only 100 events.
+## Change Geometry_cff to GeometryDB_cff and update GT July.2022
 
 import FWCore.ParameterSet.Config as cms
 
@@ -12,8 +13,9 @@ process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
-# As of 09.09.2013 only a temp gloabl tag exists for 620/700
-process.GlobalTag.globaltag = 'PRE_62_V8::All'
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
+
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 process.options = cms.untracked.PSet( SkipEvent = cms.untracked.vstring('ProductNotFound') )


### PR DESCRIPTION
**PR description:**
Review on the Reco part of https://github.com/cms-sw/cmssw/issues/31113

`process.load("Configuration.StandardSequences.Geometry_cff")`
 was outdated https://github.com/cms-sw/cmssw/pull/8810 
It should be replaced with
`process.load("Configuration.StandardSequences.GeometryDB_cff")`

In this PR, RecoLocalMuon configuration files (12 files) are fixed.
```
        modified:   RecoLocalMuon/CSCRecHitD/test/run_on_raw.py
        modified:   RecoLocalMuon/CSCRecHitD/test/run_on_raw_72x.py
        modified:   RecoLocalMuon/CSCRecHitD/test/run_on_simdigi.py
        modified:   RecoLocalMuon/CSCRecHitD/test/test_bad_channels.py
        modified:   RecoLocalMuon/CSCSegment/test/run_on_raw_700.py
        modified:   RecoLocalMuon/CSCSegment/test/run_on_raw_720p3.py
        modified:   RecoLocalMuon/CSCSegment/test/run_on_raw_74x.py
        modified:   RecoLocalMuon/CSCSegment/test/run_on_simdigi.py
        modified:   RecoLocalMuon/CSCSegment/test/run_on_simdigi_74x.py
        modified:   RecoLocalMuon/CSCSegment/test/run_on_simdigi_st.py
        modified:   RecoLocalMuon/CSCValidation/test/CSCVal_example_cfg.py
        modified:   RecoLocalMuon/CSCValidation/test/cscv_RAW.py
```
#### PR validation:
Tested in CMSSW_12_5_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)