### PR TITLE
Replace Geometry_cff with GeometryDB_cff in RecoTracker

### DIFF
--- a/RecoTracker/Configuration/test/reTrackingCosmics_cfg.py
+++ b/RecoTracker/Configuration/test/reTrackingCosmics_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("ReTracking")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("CondCore.DBCommon.CondDBSetup_cfi")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
 process.load("Configuration.EventContent.EventContentCosmics_cff")
 

--- a/RecoTracker/Configuration/test/reTrackingCosmics_cfg.py
+++ b/RecoTracker/Configuration/test/reTrackingCosmics_cfg.py
@@ -12,8 +12,8 @@ process.load("Configuration.EventContent.EventContentCosmics_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 ########## include here the correct global tag. ########## 
 # Have a look here: https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions
-# to check if there are newer tags
-process.GlobalTag.globaltag = "CRAFT_ALL_V11::All"
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 process.prefer("GlobalTag")
 ##########################################################
 

--- a/RecoTracker/Configuration/test/reTrackingCosmics_cfg.py
+++ b/RecoTracker/Configuration/test/reTrackingCosmics_cfg.py
@@ -12,8 +12,8 @@ process.load("Configuration.EventContent.EventContentCosmics_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 ########## include here the correct global tag. ########## 
 # Have a look here: https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions
-# 2022
-process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
+# 2022 data
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 process.prefer("GlobalTag")
 ##########################################################
 

--- a/RecoTracker/SiTrackerMRHTools/test/DAFRecoTrack_cfg.py
+++ b/RecoTracker/SiTrackerMRHTools/test/DAFRecoTrack_cfg.py
@@ -9,9 +9,9 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 
 ### Standard Configurations
 process.load("Configuration.StandardSequences.Services_cff")
-process.load('Configuration/StandardSequences/Geometry_cff')
-process.load('Configuration/StandardSequences/Reconstruction_cff')
-process.load('Configuration/StandardSequences/MagneticField_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 
 ### Conditions
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")

--- a/RecoTracker/SiTrackerMRHTools/test/DAFRecoTrack_cfg.py
+++ b/RecoTracker/SiTrackerMRHTools/test/DAFRecoTrack_cfg.py
@@ -17,7 +17,8 @@ process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #from Configuration.AlCa.GlobalTag import GlobalTag
 #process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
-process.GlobalTag.globaltag = 'START71_V1::All'#POSTLS171_V1::All'
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 ### Track Refitter
 process.load("RecoTracker.TrackProducer.TrackRefitters_cff")

--- a/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
+++ b/RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("NavigationSchoolAnalyze")
 
-# process.load("Configuration.StandardSequences.Geometry_cff")
+#process.load("Configuration.StandardSequences.GeometryDB_cff")
 #process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')

--- a/RecoTracker/TkSeedingLayers/test/seedLayerTest_cfg.py
+++ b/RecoTracker/TkSeedingLayers/test/seedLayerTest_cfg.py
@@ -32,8 +32,8 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
 
 ### standard includes
-process.load('Configuration/StandardSequences/Services_cff')
-process.load('Configuration.StandardSequences.Geometry_cff')
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load("Configuration.StandardSequences.RawToDigi_cff")
 process.load("Configuration.EventContent.EventContent_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")

--- a/RecoTracker/TkSeedingLayers/test/seedLayerTest_cfg.py
+++ b/RecoTracker/TkSeedingLayers/test/seedLayerTest_cfg.py
@@ -26,10 +26,9 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 ### conditions
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = 'STARTUP3X_V14::All'
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic', '')
 
 ### standard includes
 process.load('Configuration.StandardSequences.Services_cff')


### PR DESCRIPTION
**PR description:**
Review on the Reco part of https://github.com/cms-sw/cmssw/issues/31113

`process.load("Configuration.StandardSequences.Geometry_cff")`
 was outdated https://github.com/cms-sw/cmssw/pull/8810 
It should be replaced with
`process.load("Configuration.StandardSequences.GeometryDB_cff")`

In this PR, RecoTracker configuration files (4 files) are fixed.
```
        modified:   RecoTracker/Configuration/test/reTrackingCosmics_cfg.py
        modified:   RecoTracker/SiTrackerMRHTools/test/DAFRecoTrack_cfg.py
        modified:   RecoTracker/TkNavigation/test/NavigationSchoolAnalyzer_cfg.py
        modified:   RecoTracker/TkSeedingLayers/test/seedLayerTest_cfg.py
```
#### PR validation:
Tested in CMSSW_12_5_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
