### PR TITLE
Replace Geometry_cff with GeometryDB_cff in RecoLocalTracker

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/test/readClusters_cfg.py
+++ b/RecoLocalTracker/SiPixelClusterizer/test/readClusters_cfg.py
@@ -75,14 +75,8 @@ process.TFileService = cms.Service("TFileService",
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 # Choose the global tag here:
-# 2012
-#process.GlobalTag.globaltag = 'GR_P_V40::All'
-# MC 2013
-# process.GlobalTag.globaltag = 'MC_70_V1::All'
-# DATA 2014
-process.GlobalTag.globaltag = 'PRE_R_71_V3::All'
-# MC 2014
-#process.GlobalTag.globaltag = 'PRE_STA71_V4::All'
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 process.analysis = cms.EDAnalyzer("ReadPixClusters",
     Verbosity = cms.untracked.bool(True),

--- a/RecoLocalTracker/SiPixelClusterizer/test/readClusters_cfg.py
+++ b/RecoLocalTracker/SiPixelClusterizer/test/readClusters_cfg.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("cluTest")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 
 

--- a/RecoLocalTracker/SiPixelRecHits/test/readRecHits_cfg.py
+++ b/RecoLocalTracker/SiPixelRecHits/test/readRecHits_cfg.py
@@ -35,7 +35,7 @@ process.TFileService = cms.Service("TFileService",
     fileName = cms.string('histo.root')
 )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 # process.load("Configuration.StandardSequences.Services_cff")
 

--- a/RecoLocalTracker/SiPixelRecHits/test/readRecHits_cfg.py
+++ b/RecoLocalTracker/SiPixelRecHits/test/readRecHits_cfg.py
@@ -40,10 +40,8 @@ process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 # process.load("Configuration.StandardSequences.Services_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")# Choose the global tag here:
-# 2012
-#process.GlobalTag.globaltag = 'GR_P_V40::All'
-# MC 2014
-process.GlobalTag.globaltag = 'MC_70_V1::All'
+# 2022
+process.GlobalTag.globaltag = 'auto:phase1_2022_realistic'
 
 # read rechits
 process.analysis = cms.EDAnalyzer("ReadPixelRecHit",

--- a/RecoLocalTracker/SiStripRecHitConverter/test/DigisToRecHitRead_cfg.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/test/DigisToRecHitRead_cfg.py
@@ -2,13 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("RecHitReader")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
-
-process.load("Configuration.StandardSequences.Geometry_cff")
-
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
-
 process.load("Configuration.StandardSequences.FakeConditions_cff")
-
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 
 process.maxEvents = cms.untracked.PSet(


### PR DESCRIPTION
**PR description:**
Review on the Reco part of https://github.com/cms-sw/cmssw/issues/31113

`process.load("Configuration.StandardSequences.Geometry_cff")`
 was outdated https://github.com/cms-sw/cmssw/pull/8810 
It should be replaced with
`process.load("Configuration.StandardSequences.GeometryDB_cff")`

In this PR, RecoLocalTracker configuration files (3 files) are fixed.
```
        modified:   RecoLocalTracker/SiPixelClusterizer/test/readClusters_cfg.py
        modified:   RecoLocalTracker/SiPixelRecHits/test/readRecHits_cfg.py
        modified:   RecoLocalTracker/SiStripRecHitConverter/test/DigisToRecHitRead_cfg.py
```
#### PR validation:
Tested in CMSSW_12_5_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
