### PR TITLE
PPS reco patch for bad pot

### DIFF
--- a/RecoPPS/Local/interface/RPixDetPatternFinder.h
+++ b/RecoPPS/Local/interface/RPixDetPatternFinder.h
@@ -38,7 +38,7 @@ public:
   typedef std::vector<PointInPlane> Road;
 
   void setHits(const edm::DetSetVector<CTPPSPixelRecHit> *hitVector) { hitVector_ = hitVector; }
-  virtual void findPattern() = 0;
+  virtual void findPattern(bool isbadpot) = 0;
   void clear() { patternVector_.clear(); }
   std::vector<Road> const &getPatterns() const { return patternVector_; }
   void setGeometry(const CTPPSGeometry *geometry) { geometry_ = geometry; }

--- a/RecoPPS/Local/interface/RPixRoadFinder.h
+++ b/RecoPPS/Local/interface/RPixRoadFinder.h
@@ -44,6 +44,8 @@ private:
   double roadRadius_;
   unsigned int minRoadSize_;
   unsigned int maxRoadSize_;
+  double roadRadiusBadPot_;
+  bool isBadPot_;
   void run(const edm::DetSetVector<CTPPSPixelRecHit> &input, const CTPPSGeometry &geometry, std::vector<Road> &roads);
 };
 

--- a/RecoPPS/Local/interface/RPixRoadFinder.h
+++ b/RecoPPS/Local/interface/RPixRoadFinder.h
@@ -14,7 +14,6 @@
 #include "DataFormats/Common/interface/DetSet.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelCluster.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSPixelRecHit.h"
@@ -24,7 +23,6 @@
 #include "RecoPPS/Local/interface/RPixClusterToHit.h"
 #include "RecoPPS/Local/interface/RPixDetPatternFinder.h"
 
-#include "FWCore/Framework/interface/ESWatcher.h"
 #include "Geometry/VeryForwardGeometryBuilder/interface/CTPPSGeometry.h"
 #include "Geometry/VeryForwardRPTopology/interface/RPTopology.h"
 #include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
@@ -37,7 +35,7 @@ class RPixRoadFinder : public RPixDetPatternFinder {
 public:
   explicit RPixRoadFinder(const edm::ParameterSet &param);
   ~RPixRoadFinder() override;
-  void findPattern() override;
+  void findPattern(bool isbadpot) override;
 
 private:
   int verbosity_;
@@ -45,7 +43,7 @@ private:
   unsigned int minRoadSize_;
   unsigned int maxRoadSize_;
   double roadRadiusBadPot_;
-  bool isBadPot_;
+  //  bool isBadPot_;
   void run(const edm::DetSetVector<CTPPSPixelRecHit> &input, const CTPPSGeometry &geometry, std::vector<Road> &roads);
 };
 

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -38,6 +38,15 @@
 #include "RecoPPS/Local/interface/RPixRoadFinder.h"
 #include "RecoPPS/Local/interface/RPixPlaneCombinatoryTracking.h"
 
+#include "CondFormats/PPSObjects/interface/CTPPSPixelAnalysisMask.h"
+#include "CondFormats/DataRecord/interface/CTPPSPixelAnalysisMaskRcd.h"
+
+namespace {
+  constexpr int rocMask = 0xE000;
+  constexpr int rocOffset = 13;
+  constexpr int rocSizeInPixels = 4160;
+}  // namespace
+
 class CTPPSPixelLocalTrackProducer : public edm::stream::EDProducer<> {
 public:
   explicit CTPPSPixelLocalTrackProducer(const edm::ParameterSet &parameterSet);
@@ -58,13 +67,16 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelRecHit>> tokenCTPPSPixelRecHit_;
   edm::ESGetToken<CTPPSGeometry, VeryForwardRealGeometryRecord> tokenCTPPSGeometry_;
   edm::ESWatcher<VeryForwardRealGeometryRecord> geometryWatcher_;
+
+  edm::ESGetToken<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd> tokenCTPPSPixelAnalysisMask_;
+
   uint32_t numberOfPlanesPerPot_;
   std::vector<uint32_t> listOfAllPlanes_;
 
   std::unique_ptr<RPixDetPatternFinder> patternFinder_;
   std::unique_ptr<RPixDetTrackFinder> trackFinder_;
 
-  void run(const edm::DetSetVector<CTPPSPixelRecHit> &input, edm::DetSetVector<CTPPSPixelLocalTrack> &output);
+  //  void run(const edm::DetSetVector<CTPPSPixelRecHit> &input, edm::DetSetVector<CTPPSPixelLocalTrack> &output);
 };
 
 //------------------------------------------------------------------------------------------------//
@@ -106,6 +118,7 @@ CTPPSPixelLocalTrackProducer::CTPPSPixelLocalTrackProducer(const edm::ParameterS
 
   tokenCTPPSPixelRecHit_ = consumes<edm::DetSetVector<CTPPSPixelRecHit>>(inputTag_);
   tokenCTPPSGeometry_ = esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord>();
+  tokenCTPPSPixelAnalysisMask_ = esConsumes<CTPPSPixelAnalysisMask, CTPPSPixelAnalysisMaskRcd>();
 
   produces<edm::DetSetVector<CTPPSPixelLocalTrack>>();
 }
@@ -145,7 +158,7 @@ void CTPPSPixelLocalTrackProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<int>("maxRoadSize", 20)->setComment("maximum number of points in a pattern");
   //parameters for bad pot reconstruction patch 45-220-fr 2022
   desc.add<double>("roadRadiusBadPot", 0.5)->setComment("radius of pattern search window for bad Pot");
-  desc.add<bool>("isBadPot", true)->setComment("flag to enable road search for bad pot");
+  //  desc.add<bool>("isBadPot", true)->setComment("flag to enable road search for bad pot");
 
   descriptions.add("ctppsPixelLocalTracks", desc);
 }
@@ -163,6 +176,9 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
   edm::ESHandle<CTPPSGeometry> geometryHandler = iSetup.getHandle(tokenCTPPSGeometry_);
   const CTPPSGeometry &geometry = *geometryHandler;
   geometryWatcher_.check(iSetup);
+
+  // get mask
+  const auto &mask = iSetup.getData(tokenCTPPSPixelAnalysisMask_);
 
   std::vector<CTPPSPixelDetId> listOfPotWithHighOccupancyPlanes;
   std::map<CTPPSPixelDetId, uint32_t> mapHitPerPot;
@@ -204,12 +220,33 @@ void CTPPSPixelLocalTrackProducer::produce(edm::Event &iEvent, const edm::EventS
 
   edm::DetSetVector<CTPPSPixelLocalTrack> foundTracks;
 
+  // Read Mask checking if 45-220-far is masked as bad and needs special treatment
+  std::map<uint32_t, CTPPSPixelROCAnalysisMask> const &maschera = mask.analysisMask;
+
+  bool mask_45_220[6][6] = {{false}};
+  for (auto const &det : maschera) {
+    CTPPSPixelDetId detId(det.first);
+    unsigned int rocNum = (det.first & rocMask) >> rocOffset;
+    if (rocNum > 5 || detId.plane() > 5)
+      throw cms::Exception("InvalidRocOrPlaneNumber") << "roc number from mask: " << rocNum;
+
+    if (detId.arm() == 0 && detId.station() == 2 && detId.rp() == 3) {  // pot 45-220-far
+      if (det.second.maskedPixels.size() == rocSizeInPixels) {          // roc fully masked
+        mask_45_220[detId.plane()][rocNum] = true;
+      }
+    }
+  }
+
+  // search for specific pattern that requires special reconstruction (isBadPot)
+  bool isBadPot_45_220 = mask_45_220[1][4] && mask_45_220[1][5] && mask_45_220[2][4] && mask_45_220[2][5] &&
+                         mask_45_220[3][4] && mask_45_220[3][5] && mask_45_220[4][4] && mask_45_220[4][5];
+
   // Pattern finder
 
   patternFinder_->clear();
   patternFinder_->setHits(&recHitVector);
   patternFinder_->setGeometry(&geometry);
-  patternFinder_->findPattern();
+  patternFinder_->findPattern(isBadPot_45_220);
   std::vector<RPixDetPatternFinder::Road> patternVector = patternFinder_->getPatterns();
 
   //loop on all the patterns

--- a/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
+++ b/RecoPPS/Local/plugins/CTPPSPixelLocalTrackProducer.cc
@@ -143,6 +143,9 @@ void CTPPSPixelLocalTrackProducer::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<double>("roadRadius", 1.0)->setComment("radius of pattern search window");
   desc.add<int>("minRoadSize", 3)->setComment("minimum number of points in a pattern");
   desc.add<int>("maxRoadSize", 20)->setComment("maximum number of points in a pattern");
+  //parameters for bad pot reconstruction patch 45-220-fr 2022
+  desc.add<double>("roadRadiusBadPot", 0.5)->setComment("radius of pattern search window for bad Pot");
+  desc.add<bool>("isBadPot", true)->setComment("flag to enable road search for bad pot");
 
   descriptions.add("ctppsPixelLocalTracks", desc);
 }

--- a/RecoPPS/Local/python/ctppsPixelLocalReconstruction_cff.py
+++ b/RecoPPS/Local/python/ctppsPixelLocalReconstruction_cff.py
@@ -9,6 +9,11 @@ from RecoPPS.Local.ctppsPixelRecHits_cfi import ctppsPixelRecHits
 # local track producer
 from RecoPPS.Local.ctppsPixelLocalTracks_cfi import ctppsPixelLocalTracks
 
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelLocalTracks, isBadPot = cms.bool(False))
+
 ctppsPixelLocalReconstructionTask = cms.Task(
     ctppsPixelClusters,ctppsPixelRecHits,ctppsPixelLocalTracks
 )

--- a/RecoPPS/Local/python/ctppsPixelLocalReconstruction_cff.py
+++ b/RecoPPS/Local/python/ctppsPixelLocalReconstruction_cff.py
@@ -9,10 +9,10 @@ from RecoPPS.Local.ctppsPixelRecHits_cfi import ctppsPixelRecHits
 # local track producer
 from RecoPPS.Local.ctppsPixelLocalTracks_cfi import ctppsPixelLocalTracks
 
-from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
-from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
-from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
-(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelLocalTracks, isBadPot = cms.bool(False))
+#from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+#from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+#from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+#(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelLocalTracks, isBadPot = cms.bool(False))
 
 ctppsPixelLocalReconstructionTask = cms.Task(
     ctppsPixelClusters,ctppsPixelRecHits,ctppsPixelLocalTracks

--- a/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
@@ -172,21 +172,16 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
 
   if (hitMap_->size() == 2 && hitNum == 2) {  // look for roads with 2 hits in 2 different planes
 
-    // std::cout << " hitMap size = " << hitMap_->size() << std::endl;
-
     GlobalPoint hit[2];
     PointInPlaneList pIPL;
 
     unsigned int i = 0;
     for (const auto &plane : *hitMap_) {
-      // std::cout << "            \tarm " << plane.first.arm() << " station " << plane.first.station() << " rp "                << plane.first.rp() << " plane " << plane.first.plane() << " : " << plane.second.size() << std::endl;
-
       if (plane.second.size() > 1)
         break;  // only 1 hit per plane per road allowed
       GlobalPoint gP(plane.second[0].globalPoint.x(), plane.second[0].globalPoint.y(), plane.second[0].globalPoint.z());
       hit[i] = gP;
       i++;
-      //      std::cout << plane.second[0].globalPoint.x() << std::endl;
       pIPL.push_back(plane.second[0]);
     }
 
@@ -202,19 +197,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
     math::Vector<4>::type parameterVector{xatz0, yatz0, tx, ty};
     math::Error<4>::type covarianceMatrix;
 
-    // std::cout << "    RP zeta  = " << geometry_->rpTranslation(romanPotId_).z() << std::endl;
-
     CTPPSPixelLocalTrack track(z0, parameterVector, covarianceMatrix, 0);
-
-    // printout -----
-    // std::cout << hit[0].x() << " " << hit[0].y() << " " << hit[0].z() << " " << std::endl;
-    // std::cout << hit[1].x() << " " << hit[1].y() << " " << hit[1].z() << " " << std::endl;
-    // std::cout << xatz0 << " " << yatz0 << " " << tx << " " << ty << std::endl;
-
-    // std::cout << track.x0() << " " << track.y0() << " " << track.tx() << " " << track.ty() << std::endl;
-    // std::cout << track.x0Sigma() << " " << track.y0Sigma() << " " << track.txSigma() << " " << track.tySigma()              << std::endl;
-    // std::cout << std::endl;
-    // ------
 
     // save used points into track
     for (const auto &hhit : pIPL) {
@@ -222,6 +205,7 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
       LocalPoint res(0, 0);
       LocalPoint pulls(0, 0);
       CTPPSPixelFittedRecHit usedRecHit(hhit.recHit, pOD, res, pulls);
+      usedRecHit.setIsRealHit(true);
       track.addHit(hhit.detId, usedRecHit);
     }
 

--- a/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
@@ -195,7 +195,8 @@ void RPixPlaneCombinatoryTracking::findTracks(int run) {
     double yatz0 = yat0 + ty * z0;
 
     math::Vector<4>::type parameterVector{xatz0, yatz0, tx, ty};
-    math::Error<4>::type covarianceMatrix;
+    ROOT::Math::SVector<double, 10> v(0.01, 0.0, 0.01, 0.0, 0.0, 0.01, 0.0, 0.0, 0.0, 0.01);
+    math::Error<4>::type covarianceMatrix(v);
 
     CTPPSPixelLocalTrack track(z0, parameterVector, covarianceMatrix, 0);
 

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -83,16 +83,13 @@ void RPixRoadFinder::findPattern() {
 
       // create new collection for planes 0 and 5 of pot 45-220-fr
 
-      if (isBadPot_ == true && myid.arm() == 0 && myid.station() == 2 && (myid.plane() == 0 || myid.plane() == 5) 
-//          && localV.x() > 0 
-	  ){  // 45-220-far
+      if (isBadPot_ == true && myid.arm() == 0 && myid.station() == 2 && (myid.plane() == 0 || myid.plane() == 5) ){  // 45-220-far
 
         temp_all_hits_badPot.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
 
-      } else {
+      } 
         temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-      }
-    }
+     }
   }
 
   Road::iterator it_gh1 = temp_all_hits.begin();

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -86,7 +86,6 @@ void RPixRoadFinder::findPattern() {
       if (isBadPot_ == true && myid.arm() == 0 && myid.station() == 2 && (myid.plane() == 0 || myid.plane() == 5) 
 //          && localV.x() > 0 
 	  ){  // 45-220-far
-      //	std::cout << localV << std::endl;
 
         temp_all_hits_badPot.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
 
@@ -95,8 +94,6 @@ void RPixRoadFinder::findPattern() {
       }
     }
   }
-
-  // std::cout << temp_all_hits_badPot.size() << std::endl;
 
   Road::iterator it_gh1 = temp_all_hits.begin();
   Road::iterator it_gh2;
@@ -146,7 +143,7 @@ void RPixRoadFinder::findPattern() {
 
     while (it_gh2_bP != temp_all_hits_badPot.end()) {
       const auto subtraction = currPoint - it_gh2_bP->globalPoint;
-      // std::cout << "    currpoint   " << it_gh2_bP->globalPoint << std::endl;
+
       if (subtraction.Rho() < roadRadiusBadPot_) {
         temp_road.push_back(*it_gh2_bP);
         temp_all_hits_badPot.erase(it_gh2_bP);
@@ -154,11 +151,9 @@ void RPixRoadFinder::findPattern() {
         ++it_gh2_bP;
       }
     }
-    // std::cout << "temp road size bad pot before cut " << temp_road.size() << std::endl;
+
     if (temp_road.size() == 2) {  // look for isolated tracks
       patternVector_.push_back(temp_road);
-      // std::cout << "temp road size bad pot " << temp_road.size() << std::endl;
     }
   }
-  // std::cout << " ------------ END event " << std::endl;
 }

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -83,13 +83,13 @@ void RPixRoadFinder::findPattern() {
 
       // create new collection for planes 0 and 5 of pot 45-220-fr
 
-      if (isBadPot_ == true && myid.arm() == 0 && myid.station() == 2 && (myid.plane() == 0 || myid.plane() == 5) ){  // 45-220-far
+      if (isBadPot_ == true && myid.arm() == 0 && myid.station() == 2 &&
+          (myid.plane() == 0 || myid.plane() == 5)) {  // 45-220-far
 
         temp_all_hits_badPot.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-
-      } 
-        temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
-     }
+      }
+      temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+    }
   }
 
   Road::iterator it_gh1 = temp_all_hits.begin();

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -3,17 +3,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-//needed for the geometry:
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "TMath.h"
 #include "DataFormats/Math/interface/Error.h"
@@ -32,7 +21,7 @@ RPixRoadFinder::RPixRoadFinder(edm::ParameterSet const& parameterSet) : RPixDetP
   minRoadSize_ = parameterSet.getParameter<int>("minRoadSize");
   maxRoadSize_ = parameterSet.getParameter<int>("maxRoadSize");
   roadRadiusBadPot_ = parameterSet.getParameter<double>("roadRadiusBadPot");
-  isBadPot_ = parameterSet.getParameter<bool>("isBadPot");
+  //  isBadPot_ = parameterSet.getParameter<bool>("isBadPot");
 }
 
 //------------------------------------------------------------------------------------------------//
@@ -41,7 +30,7 @@ RPixRoadFinder::~RPixRoadFinder() {}
 
 //------------------------------------------------------------------------------------------------//
 
-void RPixRoadFinder::findPattern() {
+void RPixRoadFinder::findPattern(bool isBadPot) {
   Road temp_all_hits;
   temp_all_hits.clear();
 
@@ -83,7 +72,7 @@ void RPixRoadFinder::findPattern() {
 
       // create new collection for planes 0 and 5 of pot 45-220-fr
 
-      if (isBadPot_ == true && myid.arm() == 0 && myid.station() == 2 && localV.x() > 0 &&
+      if (isBadPot == true && myid.arm() == 0 && myid.station() == 2 && localV.x() > 0 &&
           (myid.plane() == 0 || myid.plane() == 5)) {  // 45-220-far
 
         temp_all_hits_badPot.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -31,6 +31,8 @@ RPixRoadFinder::RPixRoadFinder(edm::ParameterSet const& parameterSet) : RPixDetP
   roadRadius_ = parameterSet.getParameter<double>("roadRadius");
   minRoadSize_ = parameterSet.getParameter<int>("minRoadSize");
   maxRoadSize_ = parameterSet.getParameter<int>("maxRoadSize");
+  roadRadiusBadPot_ = parameterSet.getParameter<double>("roadRadiusBadPot");
+  isBadPot_ = parameterSet.getParameter<bool>("isBadPot");
 }
 
 //------------------------------------------------------------------------------------------------//
@@ -42,6 +44,9 @@ RPixRoadFinder::~RPixRoadFinder() {}
 void RPixRoadFinder::findPattern() {
   Road temp_all_hits;
   temp_all_hits.clear();
+
+  Road temp_all_hits_badPot;
+  temp_all_hits_badPot.clear();
 
   // convert local hit sto global and push them to a vector
   for (const auto& ds_rh2 : *hitVector_) {
@@ -75,9 +80,23 @@ void RPixRoadFinder::findPattern() {
                                       theRotationTMatrix(2, 2));
 
       math::Error<3>::type globalError = ROOT::Math::SimilarityT(theRotationTMatrix, localError);
-      temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+
+      // create new collection for planes 0 and 5 of pot 45-220-fr
+
+      if (isBadPot_ == true && myid.arm() == 0 && myid.station() == 2 && (myid.plane() == 0 || myid.plane() == 5) 
+//          && localV.x() > 0 
+	  ){  // 45-220-far
+      //	std::cout << localV << std::endl;
+
+        temp_all_hits_badPot.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+
+      } else {
+        temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
+      }
     }
   }
+
+  // std::cout << temp_all_hits_badPot.size() << std::endl;
 
   Road::iterator it_gh1 = temp_all_hits.begin();
   Road::iterator it_gh2;
@@ -113,4 +132,33 @@ void RPixRoadFinder::findPattern() {
       patternVector_.push_back(temp_road);
   }
   // end of algorithm
+
+  // badPot algorithm
+  Road::iterator it_gh1_bP = temp_all_hits_badPot.begin();
+  Road::iterator it_gh2_bP;
+
+  while (it_gh1_bP != temp_all_hits_badPot.end() && temp_all_hits_badPot.size() >= 2) {
+    Road temp_road;
+
+    it_gh2_bP = it_gh1_bP;
+
+    const auto currPoint = it_gh1_bP->globalPoint;
+
+    while (it_gh2_bP != temp_all_hits_badPot.end()) {
+      const auto subtraction = currPoint - it_gh2_bP->globalPoint;
+      // std::cout << "    currpoint   " << it_gh2_bP->globalPoint << std::endl;
+      if (subtraction.Rho() < roadRadiusBadPot_) {
+        temp_road.push_back(*it_gh2_bP);
+        temp_all_hits_badPot.erase(it_gh2_bP);
+      } else {
+        ++it_gh2_bP;
+      }
+    }
+    // std::cout << "temp road size bad pot before cut " << temp_road.size() << std::endl;
+    if (temp_road.size() == 2) {  // look for isolated tracks
+      patternVector_.push_back(temp_road);
+      // std::cout << "temp road size bad pot " << temp_road.size() << std::endl;
+    }
+  }
+  // std::cout << " ------------ END event " << std::endl;
 }

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -83,7 +83,7 @@ void RPixRoadFinder::findPattern() {
 
       // create new collection for planes 0 and 5 of pot 45-220-fr
 
-      if (isBadPot_ == true && myid.arm() == 0 && myid.station() == 2 &&
+      if (isBadPot_ == true && myid.arm() == 0 && myid.station() == 2 && localV.x() > 0 &&
           (myid.plane() == 0 || myid.plane() == 5)) {  // 45-220-far
 
         temp_all_hits_badPot.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});

--- a/Validation/CTPPS/test/simu/template_cfg.py
+++ b/Validation/CTPPS/test/simu/template_cfg.py
@@ -7,6 +7,16 @@ process = cms.Process('CTPPSTest', $ERA)
 import Validation.CTPPS.simu_config.year_$CONFIG_cff as config
 process.load("Validation.CTPPS.simu_config.year_$CONFIG_cff")
 
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = 'frontier://FrontierProd/CMS_CONDITIONS'
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('CTPPSPixelAnalysisMaskRcd'),
+        tag = cms.string("CTPPSPixelAnalysisMask_Run3_v1_hlt")
+    ))
+)
+
 # minimal logger settings
 process.MessageLogger = cms.Service("MessageLogger",
   statistics = cms.untracked.vstring(),


### PR DESCRIPTION
#### PR description:
This PR provides a patch to be able to produce tracks inside PPS roman pot 45-220-fr that has only 2 planes working out of 6 (as to the current date). The code creates tracks using two hits (one per plane) drawing a straight line between them. The track is required to be isolated and horizontal. The goal is to recover at least some proton tracks for alignment/debugging purposes.
The patch is enabled by means of a runtime flag. Run2 processes are protected via Era mechanism.

#### PR validation:

Run2 data show no difference. Preliminary run3 data show recovered tracks as expected.

This PR will have to be backported to 12_4 and 12_3

@jpata @grzanka @AndreaBellora 
