### PR TITLE
Update online GTs with new AlCaRecoTriggerBits tag and offline GTs with EGM regression

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,18 +33,18 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v2) but with snapshot at 2022-06-21 14:00:00 (UTC)
-    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v3',
+    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v3) but with snapshot at 2022-06-24 15:15:00 (UTC)
+    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v4',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v5',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v1 but with snapshot at 2022-06-09 20:00:00 (UTC)
-    'run3_data_express'            : '124X_dataRun3_Express_frozen_v1',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v1 but with snapshot at 2022-06-09 20:00:00 (UTC)
-    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v1',
-    # GlobalTag for Run3 offline data reprocessing - snapshot updated to 2022-06-20 11:11:45 (UTC)
-    'run3_data'                    : '124X_dataRun3_v4',
+    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v6',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v2 but with snapshot at 2022-06-24 15:15:00 (UTC)
+    'run3_data_express'            : '124X_dataRun3_Express_frozen_v2',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v2 but with snapshot at 2022-06-24 15:15:00 (UTC)
+    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v2',
+    # GlobalTag for Run3 offline data reprocessing - snapshot updated to 2022-06-29 14:53:51 (UTC)
+    'run3_data'                    : '124X_dataRun3_v5',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '124X_dataRun3_relval_v4',
+    'run3_data_relval'             : '124X_dataRun3_relval_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

This is to update the HLT, Express and Prompt GTs with new AlCaRecoTriggerBits tags that include a key for a new AlCaReco introduced in https://github.com/cms-sw/cmssw/pull/38254.
We also take the chance to update the Express and Prompt GTs to be inline with the ones already use for data-taking operations. They contain the PPS tag `PPSOpticalFunctions_express_v9` for the express GGT and `PPSOpticalFunctions_prompt_v9` for the Prompt one.

In addition, we include new offline data GTs with a new snapshot time to take into account a new payload appended recently for EGM regression, announced in https://cms-talk.web.cern.ch/t/offline-gt-updating-egm-electron-sc-regression-tags-for-eta-extended-region-incorporating-122x-ideal-ic-samples/12187

The differences wrt to the previous GTs are listed below:
**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_frozen_v3/124X_dataRun3_HLT_frozen_v4

**run3_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_HLT_relval_v5/124X_dataRun3_HLT_relval_v6

**run3_data_express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Express_frozen_v1/124X_dataRun3_Express_frozen_v2

**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_Prompt_frozen_v1/124X_dataRun3_Prompt_frozen_v2

**run3_data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_v4/124X_dataRun3_v5

**run3_data_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_dataRun3_relval_v4/124X_dataRun3_relval_v5

#### PR validation:

`runTheMatrix.py -l 136.897,139.001,138.5,138.4 --ibeos -j16`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is not a backport but will be backported to 123X and 124X.