### PR TITLE
[EGM MVA ID] xml.gz to root conversion for photons

### DIFF
--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Fall17_94X_V1_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Fall17_94X_V1_cff.py
@@ -10,8 +10,8 @@ from RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_tools import *
 mvaTag                       = "RunIIFall17v1"
 mvaVariablesFile             = "RecoEgamma/PhotonIdentification/data/PhotonMVAEstimatorRun2VariablesFall17.txt"
 mvaWeightFiles = [
-    path.join(weightFileBaseDir, "Fall17/EB_V1.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Fall17/EE_V1.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Fall17/EB_V1.weights.root"),
+    path.join(weightFileBaseDir, "Fall17/EE_V1.weights.root"),
     ]
 
 # Set up the VID working point parameters

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Fall17_94X_V1p1_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Fall17_94X_V1p1_cff.py
@@ -10,8 +10,8 @@ from RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_tools import *
 mvaTag                       = "RunIIFall17v1p1"
 mvaVariablesFile             = "RecoEgamma/PhotonIdentification/data/PhotonMVAEstimatorRun2VariablesFall17V1p1.txt"
 mvaWeightFiles = [
-    path.join(weightFileBaseDir, "Fall17/EB_V1.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Fall17/EE_V1.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Fall17/EB_V1.weights.root"),
+    path.join(weightFileBaseDir, "Fall17/EE_V1.weights.root"),
     ]
 
 # Set up the VID working point parameters

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Fall17_94X_V2_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Fall17_94X_V2_cff.py
@@ -11,8 +11,8 @@ from RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_tools import *
 mvaTag = "RunIIFall17v2"
 mvaVariablesFile = "RecoEgamma/PhotonIdentification/data/PhotonMVAEstimatorRun2VariablesFall17V1p1.txt"
 mvaWeightFiles = [
-    path.join(weightFileBaseDir, "Fall17/EB_V2.weights.xml.gz"),
-    path.join(weightFileBaseDir, "Fall17/EE_V2.weights.xml.gz"),
+    path.join(weightFileBaseDir, "Fall17/EB_V2.weights.root"),
+    path.join(weightFileBaseDir, "Fall17/EE_V2.weights.root"),
     ]
 # Set up the VID working point parameters
 wpConfig = [


### PR DESCRIPTION
#### PR description:

This is a follow up of https://github.com/cms-sw/cmssw/pull/38339, which addressed xml to root conversion of electron MVA IDs, while this PR does the same for photon MVA ID. This is motivated by the noticeable improvement reported in https://github.com/cms-sw/cmssw/pull/38339. Since the number of photon xml files are much smaller than electron, it could very well be that the improvement brought in by this PR won't be as noticeable. But I'm curious to see the effect of this PR, taking advantage of the profiling options of the bot. If the improvement is negligible, then.. oh well. 

#### PR validation:
Tested with workflow `11834.21`.

This PR is not a backport.
Backport not necessary.