### PR TITLE
[123X] Update online GTs with new AlCaRecoTriggerBits tag and offline GTs with EGM regression

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,18 +33,18 @@ autoCond = {
     'run2_data_promptlike_hi'      : '123X_dataRun2_PromptLike_HI_v3',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (123X_dataRun3_HLT_v13) but with snapshot at 2022-06-21 14:00:00 (UTC)
-    'run3_hlt'                     : '123X_dataRun3_HLT_frozen_v7',
+    # GlobalTag for Run3 HLT: identical to the online GT (123X_dataRun3_HLT_v14) but with snapshot at 2022-06-29 14:00:00 (UTC)
+    'run3_hlt'                     : '123X_dataRun3_HLT_frozen_v8',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v11',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 123X_dataRun3_Express_v8 but with snapshot at 2022-05-31 20:00:00 (UTC)
-    'run3_data_express'            : '123X_dataRun3_Express_frozen_v4',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 123X_dataRun3_Prompt_v10 but with snapshot at 2022-05-31 20:00:00 (UTC)
-    'run3_data_prompt'             : '123X_dataRun3_Prompt_frozen_v4',
+    'run3_hlt_relval'              : '123X_dataRun3_HLT_relval_v12',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 123X_dataRun3_Express_v10 but with snapshot at 2022-06-29 14:00:00 (UTC)
+    'run3_data_express'            : '123X_dataRun3_Express_frozen_v6',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 123X_dataRun3_Prompt_v12 but with snapshot at 2022-06-29 14:00:00 (UTC)
+    'run3_data_prompt'             : '123X_dataRun3_Prompt_frozen_v6',
     # GlobalTag for Run3 offline data reprocessing
-    'run3_data'                    : '123X_dataRun3_v9',
+    'run3_data'                    : '123X_dataRun3_v10',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '123X_dataRun3_relval_v8',
+    'run3_data_relval'             : '123X_dataRun3_relval_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

backport of PR #38555 

This is to update the HLT, Express and Prompt GTs with new AlCaRecoTriggerBits tags that include a key for a new AlCaReco introduced in https://github.com/cms-sw/cmssw/pull/38254.
We also take the chance to update the Express and Prompt GTs to be inline with the ones already use for data-taking operations. They contain the PPS tag `PPSOpticalFunctions_express_v9` for the express GT and `PPSOpticalFunctions_prompt_v9` for the Prompt one.

In addition, we include new offline data GTs with a new snapshot time to take into account a new payload appended recently for EGM regression, announced in https://cms-talk.web.cern.ch/t/offline-gt-updating-egm-electron-sc-regression-tags-for-eta-extended-region-incorporating-122x-ideal-ic-samples/12187

The differences wrt to the previous GTs are listed below:
**run3_hlt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_HLT_frozen_v7/123X_dataRun3_HLT_frozen_v8

**run3_hlt_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_HLT_relval_v11/123X_dataRun3_HLT_relval_v12

**run3_data_express**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_Express_frozen_v4/123X_dataRun3_Express_frozen_v6

**run3_data_prompt**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_Prompt_frozen_v4/123X_dataRun3_Prompt_frozen_v6

**run3_data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_v9/123X_dataRun3_v10

**run3_data_relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/123X_dataRun3_relval_v8/123X_dataRun3_relval_v9

#### PR validation:

`runTheMatrix.py -l 136.897,139.001,138.5,138.4 --ibeos -j16`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

backport of #38555 
