### PR TITLE
Fix CMS deprecation warnings in RecoLuminosity/LumiProducer

### DIFF
--- a/RecoLuminosity/LumiProducer/plugins/LumiCalculator.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCalculator.cc
@@ -1,6 +1,6 @@
 #ifndef RecoLuminosity_LumiProducer_LumiCalculator_h
 #define RecoLuminosity_LumiProducer_LumiCalculator_h
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -31,7 +31,7 @@ struct MyPerLumiInfo {
   unsigned long long deadcount;
 };
 
-class LumiCalculator : public edm::EDAnalyzer {
+class LumiCalculator : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit LumiCalculator(edm::ParameterSet const& pset);
   ~LumiCalculator() override;
@@ -40,6 +40,7 @@ private:
   void beginJob() override;
   void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
   void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override {}
   void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
   void endRun(edm::Run const&, edm::EventSetup const&) override;
   void endJob() override;

--- a/RecoLuminosity/LumiProducer/test/TestDIPLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/test/TestDIPLumiProducer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -21,22 +21,21 @@ namespace edm {
 using namespace std;
 using namespace edm;
 
-class TestDIPLumiProducer : public edm::EDAnalyzer {
+class TestDIPLumiProducer : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
 public:
   explicit TestDIPLumiProducer(edm::ParameterSet const&);
-  virtual ~TestDIPLumiProducer();
 
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
-  virtual void endLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c);
+  void beginLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c) override {}
+  void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+  void endLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c) override;
+
+private:
+  edm::ESGetToken<DIPLumiSummary, DIPLuminosityRcd> token_;
 };
 
 // -----------------------------------------------------------------
 
-TestDIPLumiProducer::TestDIPLumiProducer(edm::ParameterSet const& ps) {}
-
-// -----------------------------------------------------------------
-
-TestDIPLumiProducer::~TestDIPLumiProducer() {}
+TestDIPLumiProducer::TestDIPLumiProducer(edm::ParameterSet const& ps) : token_(esConsumes()) {}
 
 // -----------------------------------------------------------------
 
@@ -53,8 +52,7 @@ void TestDIPLumiProducer::endLuminosityBlock(edm::LuminosityBlock const& lumiBlo
               << "\" does not exist " << std::endl;
   }
   try {
-    edm::ESHandle<DIPLumiSummary> datahandle;
-    es.getData(datahandle);
+    edm::ESHandle<DIPLumiSummary> datahandle = es.getHandle(token_);
     if (datahandle.isValid()) {
       const DIPLumiSummary* mydata = datahandle.product();
       if (!mydata->isNull()) {

--- a/RecoLuminosity/LumiProducer/test/TestExpressLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/test/TestExpressLumiProducer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -19,13 +19,13 @@ using namespace edm;
 
 namespace edmtest {
 
-  class TestExpressLumiProducer : public edm::EDAnalyzer {
+  class TestExpressLumiProducer : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
   public:
     explicit TestExpressLumiProducer(edm::ParameterSet const&);
-    virtual ~TestExpressLumiProducer();
 
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
-    virtual void endLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c);
+    void beginLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c) override {}
+    void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+    void endLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c) override;
   };
 
   // -----------------------------------------------------------------
@@ -34,10 +34,6 @@ namespace edmtest {
     consumes<LumiSummary, edm::InLumi>(edm::InputTag("expressLumiProducer", ""));
     consumes<LumiDetails, edm::InLumi>(edm::InputTag("expressLumiProducer", ""));
   }
-
-  // -----------------------------------------------------------------
-
-  TestExpressLumiProducer::~TestExpressLumiProducer() {}
 
   // -----------------------------------------------------------------
 

--- a/RecoLuminosity/LumiProducer/test/TestLumiProducer.cc
+++ b/RecoLuminosity/LumiProducer/test/TestLumiProducer.cc
@@ -1,5 +1,5 @@
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -20,13 +20,13 @@ using namespace edm;
 
 namespace edmtest {
 
-  class TestLumiProducer : public edm::EDAnalyzer {
+  class TestLumiProducer : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
   public:
     explicit TestLumiProducer(edm::ParameterSet const&);
-    virtual ~TestLumiProducer();
 
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
-    virtual void endLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c);
+    void beginLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c) override {}
+    void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+    void endLuminosityBlock(LuminosityBlock const& lumiBlock, EventSetup const& c) override;
   };
 
   // -----------------------------------------------------------------
@@ -35,10 +35,6 @@ namespace edmtest {
     consumes<LumiSummary, edm::InLumi>(edm::InputTag("lumiProducer", ""));
     consumes<LumiDetails, edm::InLumi>(edm::InputTag("lumiProducer", ""));
   }
-
-  // -----------------------------------------------------------------
-
-  TestLumiProducer::~TestLumiProducer() {}
 
   // -----------------------------------------------------------------
 

--- a/RecoLuminosity/LumiProducer/test/genLumiRaw.cc
+++ b/RecoLuminosity/LumiProducer/test/genLumiRaw.cc
@@ -1,6 +1,6 @@
 #ifndef RecoLuminosity_LumiProducer_genLumiRaw_h
 #define RecoLuminosity_LumiProducer_genLumiRaw_h
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -19,18 +19,19 @@
    one job can generate data for at most 1 run and unlimited number of LS
 **/
 
-class genLumiRaw : public edm::EDAnalyzer {
+class genLumiRaw : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit genLumiRaw(edm::ParameterSet const&);
-  virtual ~genLumiRaw();
+  ~genLumiRaw();
 
 private:
-  virtual void beginJob();
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c);
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
-  virtual void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-  virtual void endRun(edm::Run const&, edm::EventSetup const&);
-  virtual void endJob();
+  void beginJob() override;
+  void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override {}
+  void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
+  void endJob() override;
 
   void generateRunSummary(unsigned int runnumber, unsigned int totalCMSls);
   void generateHLT(unsigned int runnumber, unsigned int lsnumber);

--- a/RecoLuminosity/LumiProducer/test/testEvtLoop.cc
+++ b/RecoLuminosity/LumiProducer/test/testEvtLoop.cc
@@ -1,6 +1,6 @@
 #ifndef RecoLuminosity_LumiProducer_testEvtLoop_h
 #define RecoLuminosity_LumiProducer_testEvtLoop_h
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -9,27 +9,23 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include <iostream>
 
-class testEvtLoop : public edm::EDAnalyzer {
+class testEvtLoop : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
 public:
   explicit testEvtLoop(edm::ParameterSet const&);
-  virtual ~testEvtLoop();
 
 private:
-  virtual void beginJob();
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c);
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
-  virtual void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-  virtual void endRun(edm::Run const&, edm::EventSetup const&);
-  virtual void endJob();
+  void beginJob() override;
+  void beginRun(const edm::Run& run, const edm::EventSetup& c) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override {}
+  void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
+  void endJob() override;
 };  //end class
 
 // -----------------------------------------------------------------
 
 testEvtLoop::testEvtLoop(edm::ParameterSet const& iConfig) {}
-
-// -----------------------------------------------------------------
-
-testEvtLoop::~testEvtLoop() {}
 
 // -----------------------------------------------------------------
 

--- a/RecoLuminosity/LumiProducer/test/testSiteService.cc
+++ b/RecoLuminosity/LumiProducer/test/testSiteService.cc
@@ -1,6 +1,6 @@
 #ifndef RecoLuminosity_LumiProducer_testSiteService_h
 #define RecoLuminosity_LumiProducer_testSiteService_h
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -13,23 +13,19 @@
 
 #include <iostream>
 
-class testSiteService : public edm::EDAnalyzer {
+class testSiteService : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
 public:
   explicit testSiteService(edm::ParameterSet const&);
-  virtual ~testSiteService();
 
 private:
-  virtual void beginJob();
-  virtual void beginRun(const edm::Run& run, const edm::EventSetup& c);
-  virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
-  virtual void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c);
-  virtual void endRun(edm::Run const&, edm::EventSetup const&);
-  virtual void endJob();
+  void beginJob() override;
+  void beginLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override {}
+  void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+  void endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, edm::EventSetup const& c) override;
+  void endJob() override;
 };  //end class
 // -----------------------------------------------------------------
 testSiteService::testSiteService(edm::ParameterSet const& iConfig) {}
-// -----------------------------------------------------------------
-testSiteService::~testSiteService() {}
 // -----------------------------------------------------------------
 void testSiteService::analyze(edm::Event const& e, edm::EventSetup const&) {}
 // -----------------------------------------------------------------
@@ -52,10 +48,6 @@ void testSiteService::endLuminosityBlock(edm::LuminosityBlock const& lumiBlock, 
 }
 // -----------------------------------------------------------------
 void testSiteService::beginJob() { std::cout << "testEvtLoop::beginJob" << std::endl; }
-// -----------------------------------------------------------------
-void testSiteService::beginRun(const edm::Run& run, const edm::EventSetup& c) {}
-// -----------------------------------------------------------------
-void testSiteService::endRun(edm::Run const& run, edm::EventSetup const& c) {}
 // -----------------------------------------------------------------
 void testSiteService::endJob() {}
 DEFINE_FWK_MODULE(testSiteService);


### PR DESCRIPTION
#### PR description:

- moved to thread friendly module types
- added esConsumes when needed

#### PR validation:

Code compiled in DEPRECATED release no longer issues any warnings.