### PR TITLE
Add CPPF DQM modules 

### DIFF
--- a/DQM/L1TMonitor/plugins/L1TStage2CPPF.cc
+++ b/DQM/L1TMonitor/plugins/L1TStage2CPPF.cc
@@ -1,0 +1,163 @@
+#include <vector>
+#include <string>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "Geometry/RPCGeometry/interface/RPCRoll.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
+
+// class decleration
+
+class L1TStage2CPPF : public DQMEDAnalyzer {
+public:
+  // class constructor
+  L1TStage2CPPF(const edm::ParameterSet& ps);
+  // class destructor
+  ~L1TStage2CPPF() override;
+
+  // member functions
+  edm::ESHandle<RPCGeometry> rpcGeom;
+
+protected:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+
+  // data members
+private:
+  std::string monitorDir;
+  bool verbose;
+  float global_phi;
+  const edm::EDGetTokenT<l1t::CPPFDigiCollection> cppfDigiToken_;
+  int EMTF_sector;
+  int EMTF_subsector;
+  int EMTF_bx;
+
+  std::vector<int> EMTFsector1bins;
+  std::vector<int> EMTFsector2bins;
+  std::vector<int> EMTFsector3bins;
+  std::vector<int> EMTFsector4bins;
+  std::vector<int> EMTFsector5bins;
+  std::vector<int> EMTFsector6bins;
+
+  std::map<int, std::vector<int>> fill_info;
+
+  MonitorElement* Occupancy_EMTFSector;
+  MonitorElement* Track_Bx;
+};
+
+L1TStage2CPPF::L1TStage2CPPF(const edm::ParameterSet& ps)
+    : monitorDir(ps.getUntrackedParameter<std::string>("monitorDir", "")),
+      verbose(ps.getUntrackedParameter<bool>("verbose", false)),
+      global_phi(-1000),
+      cppfDigiToken_(consumes<l1t::CPPFDigiCollection>(ps.getParameter<edm::InputTag>("cppfSource"))) {}
+
+L1TStage2CPPF::~L1TStage2CPPF() {}
+
+void L1TStage2CPPF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run& iRun, const edm::EventSetup& eveSetup) {
+  ibooker.setCurrentFolder(monitorDir);
+
+  Occupancy_EMTFSector = ibooker.book2D("Occupancy_EMTFSector", "Occupancy_EMTFSector", 36, 1., 37., 12, 1., 13.);
+  Track_Bx = ibooker.book2D("Track_Bx", "Track_Bx", 12, 1., 13., 7, -3., 4.);
+}
+
+void L1TStage2CPPF::analyze(const edm::Event& eve, const edm::EventSetup& eveSetup) {
+  if (verbose) {
+    edm::LogInfo("L1TStage2CPPF") << "L1TStage2CPPF: analyze....";
+  }
+
+  edm::Handle<l1t::CPPFDigiCollection> CppfDigis;
+  eve.getByToken(cppfDigiToken_, CppfDigis);
+
+  //Fill the specific bin for each EMTF sector
+  EMTFsector1bins.clear();
+  EMTFsector2bins.clear();
+  EMTFsector3bins.clear();
+  EMTFsector4bins.clear();
+  EMTFsector5bins.clear();
+  EMTFsector6bins.clear();
+  for (int i = 1; i < 7; i++) {
+    EMTFsector1bins.push_back(i);
+    EMTFsector2bins.push_back(i + 6);
+    EMTFsector3bins.push_back(i + 12);
+    EMTFsector4bins.push_back(i + 18);
+    EMTFsector5bins.push_back(i + 24);
+    EMTFsector6bins.push_back(i + 30);
+  }
+  //FIll the map for each EMTF sector
+  fill_info[1] = EMTFsector1bins;
+  fill_info[2] = EMTFsector2bins;
+  fill_info[3] = EMTFsector3bins;
+  fill_info[4] = EMTFsector4bins;
+  fill_info[5] = EMTFsector5bins;
+  fill_info[6] = EMTFsector6bins;
+
+  for (auto& cppf_digis : *CppfDigis) {
+    RPCDetId rpcId = cppf_digis.rpcId();
+    int ring = rpcId.ring();
+    int station = rpcId.station();
+    int region = rpcId.region();
+    int subsector = rpcId.subsector();
+
+    //Region -
+    if (region == -1) {
+      //for Occupancy
+      EMTF_sector = rpcId.sector();
+      EMTF_subsector = fill_info[EMTF_sector][subsector - 1];
+
+      if ((station == 4) && (ring == 3)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 1);
+      } else if ((station == 4) && (ring == 2)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 2);
+      } else if ((station == 3) && (ring == 3)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 3);
+      } else if ((station == 3) && (ring == 2)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 4);
+      } else if ((station == 2) && (ring == 2)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 5);
+      } else if ((station == 1) && (ring == 2)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 6);
+      }
+
+      //for Track_Bx
+      if (EMTF_sector >= 1 && EMTF_sector <= 6) {
+        EMTF_bx = cppf_digis.bx();
+        Track_Bx->Fill(7 - EMTF_sector, EMTF_bx);
+      }
+    }
+    //Region +
+    if (region == 1) {
+      //for Occupancy
+      EMTF_sector = rpcId.sector();
+      EMTF_subsector = fill_info[EMTF_sector][subsector - 1];
+
+      if ((station == 1) && (ring == 2)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 7);
+      } else if ((station == 2) && (ring == 2)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 8);
+      } else if ((station == 3) && (ring == 2)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 9);
+      } else if ((station == 3) && (ring == 3)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 10);
+      } else if ((station == 4) && (ring == 2)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 11);
+      } else if ((station == 4) && (ring == 3)) {
+        Occupancy_EMTFSector->Fill(EMTF_subsector, 12);
+      }
+
+      //for Track_Bx
+      if (EMTF_sector >= 1 && EMTF_sector <= 6) {
+        EMTF_bx = cppf_digis.bx();
+        Track_Bx->Fill(6 + EMTF_sector, EMTF_bx);
+      }
+    }
+  }  //loop over CPPFDigis
+}
+DEFINE_FWK_MODULE(L1TStage2CPPF);

--- a/DQM/L1TMonitor/plugins/L1TdeStage2CPPF.cc
+++ b/DQM/L1TMonitor/plugins/L1TdeStage2CPPF.cc
@@ -1,0 +1,515 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "Geometry/RPCGeometry/interface/RPCRoll.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DataFormats/L1TMuon/interface/CPPFDigi.h"
+#include <string>
+
+class L1TdeStage2CPPF : public DQMEDAnalyzer {
+public:
+  L1TdeStage2CPPF(const edm::ParameterSet& ps);
+  ~L1TdeStage2CPPF() override;
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  int occupancy_value(int region_, int station_, int ring_);
+  int bx_value(int region_, int emtfsector_);
+  int GetSubsector(int emtfsector_, int lsubsector_);
+
+  edm::EDGetTokenT<l1t::CPPFDigiCollection> dataToken;
+  edm::EDGetTokenT<l1t::CPPFDigiCollection> emulToken;
+  std::string monitorDir;
+  bool verbose;
+
+  MonitorElement* h2_Matching_SameKey_OnPhi_phi_Ce_phi_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OnPhi_theta_Ce_theta_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OnPhi_zone_Ce_zone_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OnPhi_ID_Ce_ID_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OnPhi_ID_Ce_roll_Ce_bx;
+
+  MonitorElement* h2_Matching_SameKey_OffPhi_phi_Ce_phi_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OffPhi_theta_Ce_theta_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OffPhi_zone_Ce_zone_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OffPhi_ID_Ce_ID_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OffPhi_ID_Ce_roll_Ce_bx;
+
+  MonitorElement* h2_Matching_SameKey_OnTheta_phi_Ce_phi_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OnTheta_theta_Ce_theta_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OnTheta_zone_Ce_zone_Cu_bx;
+
+  MonitorElement* h2_Matching_SameKey_OffTheta_phi_Ce_phi_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OffTheta_theta_Ce_theta_Cu_bx;
+  MonitorElement* h2_Matching_SameKey_OffTheta_zone_Ce_zone_Cu_bx;
+
+  MonitorElement* h1_Matching_SameKey_bx_Summary;
+};
+
+L1TdeStage2CPPF::L1TdeStage2CPPF(const edm::ParameterSet& ps)
+    : dataToken(consumes<l1t::CPPFDigiCollection>(ps.getParameter<edm::InputTag>("dataSource"))),
+      emulToken(consumes<l1t::CPPFDigiCollection>(ps.getParameter<edm::InputTag>("emulSource"))),
+      monitorDir(ps.getUntrackedParameter<std::string>("monitorDir", "")),
+      verbose(ps.getUntrackedParameter<bool>("verbose", false)) {}
+
+L1TdeStage2CPPF::~L1TdeStage2CPPF() {}
+
+void L1TdeStage2CPPF::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
+  ibooker.setCurrentFolder(monitorDir);
+
+  h2_Matching_SameKey_OnPhi_phi_Ce_phi_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OnPhi_phi_Ce_phi_Cu_bx",
+                     "Matching && Same SubSector && OnPhi ; Emulator #phi ; Unpacker #phi",
+                     62,
+                     0.0,
+                     1240.,
+                     62,
+                     0.0,
+                     1240.);
+  h2_Matching_SameKey_OnPhi_theta_Ce_theta_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OnPhi_theta_Ce_theta_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OnPhi ; Emulator #theta ; Unpacker #theta ",
+                     32,
+                     0,
+                     32.,
+                     32,
+                     0,
+                     32.);
+  h2_Matching_SameKey_OnPhi_zone_Ce_zone_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OnPhi_zone_Ce_zone_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OnPhi ;Emulator Zone ;Unpacker Zone ",
+                     15,
+                     0,
+                     15,
+                     15,
+                     0,
+                     15);
+  h2_Matching_SameKey_OnPhi_ID_Ce_ID_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OnPhi_ID_Ce_ID_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OnPhi ; Emulator Chamber ID;Unpacker Chamber ID ",
+                     38,
+                     0,
+                     38,
+                     38,
+                     0,
+                     38);
+  h2_Matching_SameKey_OnPhi_ID_Ce_roll_Ce_bx =
+      ibooker.book2D("h2_Matching_SameKey_OnPhi_ID_Ce_roll_Ce_bx",
+                     "Matching && Same SubSector && bx==0 && OnPhi ;Emulator Chamber ID ;Emulator Roll ",
+                     38,
+                     0,
+                     38,
+                     4,
+                     0,
+                     4);
+
+  h2_Matching_SameKey_OffPhi_phi_Ce_phi_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OffPhi_phi_Ce_phi_Cu_bx",
+                     "Matching && Same SubSector && OffPhi ; Emulator #phi ; Unpacker #phi",
+                     62,
+                     0.0,
+                     1240.,
+                     62,
+                     0.0,
+                     1240.);
+  h2_Matching_SameKey_OffPhi_theta_Ce_theta_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OffPhi_theta_Ce_theta_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OffPhi ; Emulator #theta ; Unpacker #theta ",
+                     32,
+                     0,
+                     32.,
+                     32,
+                     0,
+                     32.);
+  h2_Matching_SameKey_OffPhi_zone_Ce_zone_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OffPhi_zone_Ce_zone_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OffPhi ;Emulator Zone ;Unpacker Zone ",
+                     15,
+                     0,
+                     15,
+                     15,
+                     0,
+                     15);
+  h2_Matching_SameKey_OffPhi_ID_Ce_ID_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OffPhi_ID_Ce_ID_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OffPhi ; Emulator Chamber ID;Unpacker Chamber ID ",
+                     38,
+                     0,
+                     38,
+                     38,
+                     0,
+                     38);
+  h2_Matching_SameKey_OffPhi_ID_Ce_roll_Ce_bx =
+      ibooker.book2D("h2_Matching_SameKey_OffPhi_ID_Ce_roll_Ce_bx",
+                     "Matching && Same SubSector && bx==0 && OffPhi ;Emulator Chamber ID ;Emulator Roll ",
+                     38,
+                     0,
+                     38,
+                     4,
+                     0,
+                     4);
+
+  h2_Matching_SameKey_OnTheta_phi_Ce_phi_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OnTheta_phi_Ce_phi_Cu_bx",
+                     "Matching && Same SubSector && OnTheta ; Emulator #phi ; Unpacker #phi",
+                     62,
+                     0.0,
+                     1240.,
+                     62,
+                     0.0,
+                     1240.);
+  h2_Matching_SameKey_OnTheta_theta_Ce_theta_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OnTheta_theta_Ce_theta_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OnTheta ; Emulator #theta ; Unpacker #theta ",
+                     32,
+                     0,
+                     32.,
+                     32,
+                     0,
+                     32.);
+  h2_Matching_SameKey_OnTheta_zone_Ce_zone_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OnTheta_zone_Ce_zone_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OnTheta ;Emulator Zone ;Unpacker Zone ",
+                     15,
+                     0,
+                     15,
+                     15,
+                     0,
+                     15);
+
+  h2_Matching_SameKey_OffTheta_phi_Ce_phi_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OffTheta_phi_Ce_phi_Cu_bx",
+                     "Matching && Same SubSector && OffTheta ; Emulator #phi ; Unpacker #phi",
+                     62,
+                     0.0,
+                     1240.,
+                     62,
+                     0.0,
+                     1240.);
+  h2_Matching_SameKey_OffTheta_theta_Ce_theta_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OffTheta_theta_Ce_theta_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OffTheta ; Emulator #theta ; Unpacker #theta ",
+                     32,
+                     0,
+                     32.,
+                     32,
+                     0,
+                     32.);
+  h2_Matching_SameKey_OffTheta_zone_Ce_zone_Cu_bx =
+      ibooker.book2D("h2_Matching_SameKey_OffTheta_zone_Ce_zone_Cu_bx",
+                     "Matching && Same SubSector && bx==0 && OffTheta ;Emulator Zone ;Unpacker Zone ",
+                     15,
+                     0,
+                     15,
+                     15,
+                     0,
+                     15);
+
+  h1_Matching_SameKey_bx_Summary =
+      ibooker.book1D("h1_Matching_SameKey_bx_Summary",
+                     "cppf data-emul mismatch fraction summary; ; Fraction events with mismatch",
+                     2,
+                     1,
+                     3);
+  h1_Matching_SameKey_bx_Summary->setBinLabel(1, "off/on-phi");
+  h1_Matching_SameKey_bx_Summary->setBinLabel(2, "off/on-theta");
+  h1_Matching_SameKey_bx_Summary->setAxisRange(0, 0.01, 2);
+}
+
+void L1TdeStage2CPPF::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  if (verbose)
+    edm::LogInfo("L1TdeStage2CPPF") << "L1TdeStage2CPPF: analyze...";
+
+  edm::Handle<l1t::CPPFDigiCollection> dataCPPFs;
+  e.getByToken(dataToken, dataCPPFs);
+
+  edm::Handle<l1t::CPPFDigiCollection> emulCPPFs;
+  e.getByToken(emulToken, emulCPPFs);
+
+  std::unordered_map<int, int> _nHit_Ce;
+  std::unordered_map<int, int> _nHit_Cu;
+  std::unordered_map<int, std::vector<int>> _phi_Ce;
+  std::unordered_map<int, std::vector<int>> _phi_Cu;
+  std::unordered_map<int, std::vector<int>> _phi_glob_Ce;
+  std::unordered_map<int, std::vector<int>> _phi_glob_Cu;
+  std::unordered_map<int, std::vector<int>> _theta_Ce;
+  std::unordered_map<int, std::vector<int>> _theta_Cu;
+  std::unordered_map<int, std::vector<int>> _theta_glob_Ce;
+  std::unordered_map<int, std::vector<int>> _theta_glob_Cu;
+  std::unordered_map<int, std::vector<int>> _roll_Ce;
+  std::unordered_map<int, std::vector<int>> _roll_Cu;
+  std::unordered_map<int, std::vector<int>> _zone_Ce;
+  std::unordered_map<int, std::vector<int>> _zone_Cu;
+  std::unordered_map<int, std::vector<int>> _ID_Ce;
+  std::unordered_map<int, std::vector<int>> _ID_Cu;
+  std::unordered_map<int, std::vector<int>> _emtfSubsector_Ce;
+  std::unordered_map<int, std::vector<int>> _emtfSubsector_Cu;
+  std::unordered_map<int, std::vector<int>> _emtfSector_Ce;
+  std::unordered_map<int, std::vector<int>> _emtfSector_Cu;
+  std::unordered_map<int, std::vector<int>> _bx_Ce;
+  std::unordered_map<int, std::vector<int>> _bx_Cu;
+  std::unordered_map<int, std::vector<int>> _cluster_size_Ce;
+  std::unordered_map<int, std::vector<int>> _cluster_size_Cu;
+
+  for (auto& cppf_digis : *emulCPPFs) {
+    RPCDetId rpcIdCe = (int)cppf_digis.rpcId();
+    int regionCe = (int)rpcIdCe.region();
+    int stationCe = (int)rpcIdCe.station();
+    int sectorCe = (int)rpcIdCe.sector();
+    int subsectorCe = (int)rpcIdCe.subsector();
+    int ringCe = (int)rpcIdCe.ring();
+    int rollCe = (int)(rpcIdCe.roll());
+    int phiIntCe = (int)cppf_digis.phi_int();
+    int thetaIntCe = (int)cppf_digis.theta_int();
+    int phiGlobalCe = (int)cppf_digis.phi_glob();
+    int thetaGlobalCe = (int)cppf_digis.theta_glob();
+    int cluster_sizeCe = (int)cppf_digis.cluster_size();
+    int bxCe = cppf_digis.bx();
+    int emtfSectorCe = (int)cppf_digis.emtf_sector();
+    int emtfSubsectorCe = GetSubsector(emtfSectorCe, subsectorCe);
+    int fillOccupancyCe = occupancy_value(regionCe, stationCe, ringCe);
+
+    int nsubCe = 6;
+    (ringCe == 1 && stationCe > 1) ? nsubCe = 3 : nsubCe = 6;
+    int chamberIDCe = subsectorCe + nsubCe * (sectorCe - 1);
+
+    std::ostringstream oss;
+    oss << regionCe << stationCe << ringCe << sectorCe << subsectorCe << emtfSectorCe << emtfSubsectorCe;
+    std::istringstream iss(oss.str());
+    int unique_id;
+    iss >> unique_id;
+
+    if (_nHit_Ce.find(unique_id) == _nHit_Ce.end()) {
+      _nHit_Ce.insert({unique_id, 1});
+      _phi_Ce[unique_id].push_back(phiIntCe);
+      _phi_glob_Ce[unique_id].push_back(phiGlobalCe);
+      _theta_Ce[unique_id].push_back(thetaIntCe);
+      _theta_glob_Ce[unique_id].push_back(thetaGlobalCe);
+      _roll_Ce[unique_id].push_back(rollCe);
+      _ID_Ce[unique_id].push_back(chamberIDCe);
+      _zone_Ce[unique_id].push_back(fillOccupancyCe);
+      _emtfSubsector_Ce[unique_id].push_back(emtfSubsectorCe);
+      _emtfSector_Ce[unique_id].push_back(emtfSectorCe);
+      _bx_Ce[unique_id].push_back(bxCe);
+      _cluster_size_Ce[unique_id].push_back(cluster_sizeCe);
+    } else {
+      _nHit_Ce.at(unique_id) += 1;
+      _phi_Ce[unique_id].push_back(phiIntCe);
+      _phi_glob_Ce[unique_id].push_back(phiGlobalCe);
+      _theta_Ce[unique_id].push_back(thetaIntCe);
+      _theta_glob_Ce[unique_id].push_back(thetaGlobalCe);
+      _roll_Ce[unique_id].push_back(rollCe);
+      _ID_Ce[unique_id].push_back(chamberIDCe);
+      _zone_Ce[unique_id].push_back(fillOccupancyCe);
+      _emtfSubsector_Ce[unique_id].push_back(emtfSubsectorCe);
+      _emtfSector_Ce[unique_id].push_back(emtfSectorCe);
+      _bx_Ce[unique_id].push_back(bxCe);
+      _cluster_size_Ce[unique_id].push_back(cluster_sizeCe);
+    }
+
+  }  // END :: for(auto& cppf_digis : *CppfDigis1)
+
+  for (auto& cppf_digis2 : *dataCPPFs) {
+    RPCDetId rpcIdCu = cppf_digis2.rpcId();
+    int regionCu = (int)rpcIdCu.region();
+    int stationCu = (int)rpcIdCu.station();
+    int sectorCu = (int)rpcIdCu.sector();
+    int subsectorCu = (int)rpcIdCu.subsector();
+    int ringCu = (int)rpcIdCu.ring();
+    int rollCu = (int)(rpcIdCu.roll());
+    int phiIntCu = (int)cppf_digis2.phi_int();
+    int thetaIntCu = (int)cppf_digis2.theta_int();
+    int phiGlobalCu = (int)cppf_digis2.phi_glob();
+    int thetaGlobalCu = (int)cppf_digis2.theta_glob();
+    int cluster_sizeCu = (int)cppf_digis2.cluster_size();
+    int bxCu = (int)cppf_digis2.bx();
+    int emtfSectorCu = (int)cppf_digis2.emtf_sector();
+    int emtfSubsectorCu = GetSubsector(emtfSectorCu, subsectorCu);
+    int fillOccupancyCu = occupancy_value(regionCu, stationCu, ringCu);
+
+    int nsubCu = 6;
+    (ringCu == 1 && stationCu > 1) ? nsubCu = 3 : nsubCu = 6;
+    int chamberIDCu = subsectorCu + nsubCu * (sectorCu - 1);
+
+    std::ostringstream oss2;
+    oss2 << regionCu << stationCu << ringCu << sectorCu << subsectorCu << emtfSectorCu << emtfSubsectorCu;
+    std::istringstream iss2(oss2.str());
+    int unique_id;
+    iss2 >> unique_id;
+
+    if (_nHit_Cu.find(unique_id) == _nHit_Cu.end()) {  // chamber had no hit so far
+      _nHit_Cu.insert({unique_id, 1});
+      _phi_Cu[unique_id].push_back(phiIntCu);
+      _theta_Cu[unique_id].push_back(thetaIntCu);
+      _phi_glob_Cu[unique_id].push_back(phiGlobalCu);
+      _theta_glob_Cu[unique_id].push_back(thetaGlobalCu);
+      _ID_Cu[unique_id].push_back(chamberIDCu);
+      _zone_Cu[unique_id].push_back(fillOccupancyCu);
+      _roll_Cu[unique_id].push_back(rollCu);
+      _emtfSubsector_Cu[unique_id].push_back(emtfSubsectorCu);
+      _emtfSector_Cu[unique_id].push_back(emtfSectorCu);
+      _bx_Cu[unique_id].push_back(bxCu);
+      _cluster_size_Cu[unique_id].push_back(cluster_sizeCu);
+    } else {
+      _nHit_Cu.at(unique_id) += 1;
+      _phi_Cu[unique_id].push_back(phiIntCu);
+      _theta_Cu[unique_id].push_back(thetaIntCu);
+      _phi_glob_Cu[unique_id].push_back(phiGlobalCu);
+      _theta_glob_Cu[unique_id].push_back(thetaGlobalCu);
+      _ID_Cu[unique_id].push_back(chamberIDCu);
+      _zone_Cu[unique_id].push_back(fillOccupancyCu);
+      _roll_Cu[unique_id].push_back(rollCu);
+      _emtfSubsector_Cu[unique_id].push_back(emtfSubsectorCu);
+      _emtfSector_Cu[unique_id].push_back(emtfSectorCu);
+      _bx_Cu[unique_id].push_back(bxCu);
+      _cluster_size_Cu[unique_id].push_back(cluster_sizeCu);
+    }
+  }  // END: : for(auto& cppf_digis2 : *CppfDigis2)
+
+  for (auto const& Ce : _nHit_Ce) {
+    int key_Ce = Ce.first;
+    int nHit_Ce = Ce.second;
+
+    for (auto const& Cu : _nHit_Cu) {
+      int key_Cu = Cu.first;
+      int nHit_Cu = Cu.second;
+
+      if (key_Ce != key_Cu)
+        continue;
+      if (nHit_Ce != nHit_Cu)
+        continue;
+
+      for (int vecSize = 0; vecSize < nHit_Cu; ++vecSize) {
+        if (_bx_Cu.at(key_Cu)[vecSize] != _bx_Ce.at(key_Ce)[vecSize])
+          continue;
+
+        bool OnPhi_Matching = false;
+        int index_Ce = vecSize;
+        int index_Cu = vecSize;
+        for (int i = 0; i < nHit_Ce; ++i) {
+          if (_phi_Ce.at(key_Ce)[i] == _phi_Cu.at(key_Cu)[vecSize]) {
+            OnPhi_Matching = true;
+            index_Cu = vecSize;
+            index_Ce = i;
+          }
+        }
+        if (OnPhi_Matching) {
+          h2_Matching_SameKey_OnPhi_phi_Ce_phi_Cu_bx->Fill(_phi_Ce.at(key_Ce)[index_Ce], _phi_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OnPhi_theta_Ce_theta_Cu_bx->Fill(_theta_Ce.at(key_Ce)[index_Ce],
+                                                               _theta_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OnPhi_zone_Ce_zone_Cu_bx->Fill(_zone_Ce.at(key_Ce)[index_Ce],
+                                                             _zone_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OnPhi_ID_Ce_ID_Cu_bx->Fill(_ID_Ce.at(key_Ce)[index_Ce], _ID_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OnPhi_ID_Ce_roll_Ce_bx->Fill(_ID_Ce.at(key_Ce)[index_Ce], _roll_Ce.at(key_Ce)[index_Ce]);
+        } else {
+          h2_Matching_SameKey_OffPhi_phi_Ce_phi_Cu_bx->Fill(_phi_Ce.at(key_Ce)[index_Ce], _phi_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OffPhi_theta_Ce_theta_Cu_bx->Fill(_theta_Ce.at(key_Ce)[index_Ce],
+                                                                _theta_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OffPhi_zone_Ce_zone_Cu_bx->Fill(_zone_Ce.at(key_Ce)[index_Ce],
+                                                              _zone_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OffPhi_ID_Ce_ID_Cu_bx->Fill(_ID_Ce.at(key_Ce)[index_Ce], _ID_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OffPhi_ID_Ce_roll_Ce_bx->Fill(_ID_Ce.at(key_Ce)[index_Ce], _roll_Ce.at(key_Ce)[index_Ce]);
+        }
+
+        bool OnTheta_Matching = false;
+        for (int i = 0; i < nHit_Ce; ++i) {
+          if (_theta_Ce.at(key_Ce)[i] == _theta_Cu.at(key_Cu)[index_Cu]) {
+            OnTheta_Matching = true;
+            index_Cu = vecSize;
+            index_Ce = i;
+          }
+        }
+        if (OnTheta_Matching) {
+          h2_Matching_SameKey_OnTheta_phi_Ce_phi_Cu_bx->Fill(_phi_Ce.at(key_Ce)[index_Ce],
+                                                             _phi_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OnTheta_theta_Ce_theta_Cu_bx->Fill(_theta_Ce.at(key_Ce)[index_Ce],
+                                                                 _theta_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OnTheta_zone_Ce_zone_Cu_bx->Fill(_zone_Ce.at(key_Ce)[index_Ce],
+                                                               _zone_Cu.at(key_Cu)[index_Cu]);
+        } else {
+          h2_Matching_SameKey_OffTheta_phi_Ce_phi_Cu_bx->Fill(_phi_Ce.at(key_Ce)[index_Ce],
+                                                              _phi_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OffTheta_theta_Ce_theta_Cu_bx->Fill(_theta_Ce.at(key_Ce)[index_Ce],
+                                                                  _theta_Cu.at(key_Cu)[index_Cu]);
+          h2_Matching_SameKey_OffTheta_zone_Ce_zone_Cu_bx->Fill(_zone_Ce.at(key_Ce)[index_Ce],
+                                                                _zone_Cu.at(key_Cu)[index_Cu]);
+        }
+      }
+
+      double off_phi, on_phi, off_theta, on_theta;
+      on_phi = h2_Matching_SameKey_OnPhi_phi_Ce_phi_Cu_bx->getEntries();
+      off_phi = h2_Matching_SameKey_OffPhi_phi_Ce_phi_Cu_bx->getEntries();
+      on_theta = h2_Matching_SameKey_OnTheta_theta_Ce_theta_Cu_bx->getEntries();
+      off_theta = h2_Matching_SameKey_OffTheta_theta_Ce_theta_Cu_bx->getEntries();
+      if (on_phi == 0)
+        on_phi = 0.0001;
+      if (on_theta == 0)
+        on_theta = 0.0001;
+      h1_Matching_SameKey_bx_Summary->setBinContent(1, off_phi / on_phi);
+      h1_Matching_SameKey_bx_Summary->setBinContent(2, off_theta / on_theta);
+    }
+  }
+}
+
+int L1TdeStage2CPPF::GetSubsector(int emtfsector_, int lsubsector_) {
+  const int nsectors = 6;
+  int gsubsector = 0;
+  if ((emtfsector_ != -99) and (lsubsector_ != 0)) {
+    gsubsector = (emtfsector_ - 1) * nsectors + lsubsector_;
+  }
+  return gsubsector;
+}
+
+int L1TdeStage2CPPF::occupancy_value(int region_, int station_, int ring_) {
+  int fill_val = 0;
+  if (region_ == -1) {
+    if ((station_ == 4) && (ring_ == 3))
+      fill_val = 1;
+    else if ((station_ == 4) && (ring_ == 2))
+      fill_val = 2;
+    else if ((station_ == 3) && (ring_ == 3))
+      fill_val = 3;
+    else if ((station_ == 3) && (ring_ == 2))
+      fill_val = 4;
+    else if ((station_ == 2) && (ring_ == 2))
+      fill_val = 5;
+    else if ((station_ == 1) && (ring_ == 2))
+      fill_val = 6;
+
+  } else if (region_ == +1) {
+    if ((station_ == 1) && (ring_ == 2))
+      fill_val = 7;
+    else if ((station_ == 2) && (ring_ == 2))
+      fill_val = 8;
+    else if ((station_ == 3) && (ring_ == 2))
+      fill_val = 9;
+    else if ((station_ == 3) && (ring_ == 3))
+      fill_val = 10;
+    else if ((station_ == 4) && (ring_ == 2))
+      fill_val = 11;
+    else if ((station_ == 4) && (ring_ == 3))
+      fill_val = 12;
+  }
+  return fill_val;
+}
+
+int L1TdeStage2CPPF::bx_value(int region_, int emtfsector_) {
+  int fill_val = 0;
+
+  if (region_ == -1) {
+    fill_val = 7 - emtfsector_;
+  } else if (region_ == +1) {
+    fill_val = 6 + emtfsector_;
+  }
+  return fill_val;
+}
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(L1TdeStage2CPPF);

--- a/DQM/L1TMonitor/python/L1TStage2CPPF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2CPPF_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tStage2Cppf = DQMEDAnalyzer(
+    "L1TStage2CPPF",
+    cppfSource = cms.InputTag("rpcCPPFRawToDigi"),
+    monitorDir = cms.untracked.string("L1T/L1TStage2CPPF"), 
+    verbose = cms.untracked.bool(False),
+)

--- a/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2Emulator_cff.py
@@ -71,6 +71,16 @@ valCscStage2Digis = cscTriggerPrimitiveDigis.clone(
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( valCscStage2Digis, GEMPadDigiClusterProducer = "valMuonGEMPadDigiClusters" )
 
+# CPPF
+from RecoLocalMuon.RPCRecHit.rpcRecHits_cfi import *
+valRpcRecHits = rpcRecHits.clone(
+	rpcDigiLabel = 'rpcunpacker'
+)
+from L1Trigger.L1TMuonCPPF.emulatorCppfDigis_cfi import *
+valCppfStage2Digis = emulatorCppfDigis.clone(
+	recHitLabel = 'valRpcRecHits'
+)
+
 # EMTF
 from L1Trigger.L1TMuonEndCap.simEmtfDigis_cfi import *
 valEmtfStage2Digis = simEmtfDigis.clone(
@@ -125,6 +135,8 @@ Stage2L1HardwareValidation = cms.Sequence(
     valKBmtfDigis +
     valBmtfAlgoSel +
     valOmtfDigis +
+    valRpcRecHits +
+    valCppfStage2Digis +
     valEmtfStage2Digis +
     valGmtCaloSumDigis +
     valGmtStage2Digis +
@@ -166,6 +178,9 @@ from DQM.L1TMonitor.L1TdeStage2BMTFSecond_cff import *
 # OMTF
 from DQM.L1TMonitor.L1TdeStage2OMTF_cfi import *
 
+# CPPF
+from DQM.L1TMonitor.L1TdeStage2CPPF_cff import *
+
 # EMTF
 from DQM.L1TMonitor.L1TdeStage2EMTF_cff import *
 
@@ -185,6 +200,7 @@ l1tStage2EmulatorOnlineDQM = cms.Sequence(
     l1tdeStage2BmtfSecond +
     l1tdeStage2Omtf +
     l1tdeCSCTPG +
+    l1tdeStage2CppfOnlineDQMSeq +
     l1tdeStage2EmtfOnlineDQMSeq +
     l1tStage2uGMTEmulatorOnlineDQMSeq +
     l1tdeStage2uGT +

--- a/DQM/L1TMonitor/python/L1TStage2_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2_cff.py
@@ -15,6 +15,9 @@ from DQM.L1TMonitor.L1TStage2BMTF_cff import *
 # OMTF
 from DQM.L1TMonitor.L1TStage2OMTF_cfi import *
 
+# CPPF
+from DQM.L1TMonitor.L1TStage2CPPF_cfi import *
+
 # EMTF
 from DQM.L1TMonitor.L1TStage2EMTF_cfi import *
 
@@ -40,6 +43,7 @@ l1tStage2OnlineDQM = cms.Sequence(
     l1tStage2BmtfOnlineDQMSeq +
     l1tStage2Omtf +
     l1tStage2Emtf +
+    l1tStage2Cppf +
     l1tStage2RegionalShower +  
     l1tStage2uGMTOnlineDQMSeq +
     l1tObjectsTiming +

--- a/DQM/L1TMonitor/python/L1TdeStage2CPPF_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2CPPF_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQM.L1TMonitor.L1TdeStage2CPPF_cfi import *
+
+
+# sequences
+l1tdeStage2CppfOnlineDQMSeq = cms.Sequence(
+    l1tdeStage2Cppf 
+)
+

--- a/DQM/L1TMonitor/python/L1TdeStage2CPPF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2CPPF_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tdeStage2Cppf = DQMEDAnalyzer(
+    "L1TdeStage2CPPF",
+    dataSource = cms.InputTag("rpcCPPFRawToDigi"),
+    emulSource = cms.InputTag("valCppfStage2Digis","recHit"),
+    monitorDir = cms.untracked.string("L1TEMU/L1TdeStage2CPPF"),
+    verbose = cms.untracked.bool(False),
+)
+

--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
@@ -257,12 +257,14 @@ void RPCCPPFUnpacker::processTXRecord(RPCAMCLink link,
   static int const station[6] = {1, 2, 3, 3, 4, 4};
   int region(link.getAMCNumber() < 7 ? 1 : -1);
   unsigned int endcap_sector((35 + (link.getAMCNumber() - (region > 0 ? 3 : 7)) * 9 + (block >> 1)) % 36 + 1);
+  unsigned int emtf_link(((34 + (link.getAMCNumber() - (region > 0 ? 3 : 7)) * 9 + (block >> 1)) % 36) % 6 + 1);
+  unsigned int emtf_sector(((34 + (link.getAMCNumber() - (region > 0 ? 3 : 7)) * 9 + (block >> 1)) % 36) / 6 + 1);
   RPCDetId rpc_id(region,
                   ring[word]  // ring
                   ,
                   station[word]  // station
                   ,
-                  (endcap_sector / 6) + 1  // sector
+                  ((endcap_sector - 1) / 6) + 1  // sector
                   ,
                   1  // layer
                   ,
@@ -271,10 +273,12 @@ void RPCCPPFUnpacker::processTXRecord(RPCAMCLink link,
                   0);  // roll
 
   if (record.isValid(0)) {
-    rpc_cppf_digis.push_back(l1t::CPPFDigi(rpc_id, 0, record.getTheta(0), record.getPhi(0)));
+    rpc_cppf_digis.push_back(
+        l1t::CPPFDigi(rpc_id, 0, record.getPhi(0), record.getTheta(0), 0, 0, 0, emtf_sector, emtf_link, 0, 0, 0, 0));
   }
   if (record.isValid(1)) {
-    rpc_cppf_digis.push_back(l1t::CPPFDigi(rpc_id, 0, record.getTheta(1), record.getPhi(1)));
+    rpc_cppf_digis.push_back(
+        l1t::CPPFDigi(rpc_id, 0, record.getPhi(1), record.getTheta(1), 1, 0, 0, emtf_sector, emtf_link, 0, 0, 0, 0));
   }
 }
 

--- a/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
+++ b/L1Trigger/Configuration/python/L1TRawToDigi_cff.py
@@ -43,6 +43,7 @@ L1TRawToDigi_Stage1.add(gtDigis,caloStage1Digis,caloStage1FinalDigis,caloStage1L
 # Stage-2 Trigger:  fow now, unpack Stage 1 and Stage 2 (in case both available)
 #
 from EventFilter.RPCRawToDigi.rpcTwinMuxRawToDigi_cfi import rpcTwinMuxRawToDigi
+from EventFilter.RPCRawToDigi.rpcUnpacker_cfi import rpcunpacker
 from EventFilter.RPCRawToDigi.RPCCPPFRawToDigi_cfi import rpcCPPFRawToDigi
 from EventFilter.L1TRawToDigi.bmtfDigis_cfi import bmtfDigis
 from EventFilter.L1TRawToDigi.omtfStage2Digis_cfi import omtfStage2Digis
@@ -56,7 +57,7 @@ from EventFilter.L1TXRawToDigi.twinMuxStage2Digis_cfi import twinMuxStage2Digis
 stage2L1Trigger.toModify(caloStage2Digis, MinFeds = cms.uint32(1))
 stage2L1Trigger.toModify(gmtStage2Digis, MinFeds = cms.uint32(1))
 stage2L1Trigger.toModify(gtStage2Digis, MinFeds = cms.uint32(1))
-L1TRawToDigi_Stage2 = cms.Task(rpcTwinMuxRawToDigi, twinMuxStage2Digis, bmtfDigis, omtfStage2Digis, rpcCPPFRawToDigi, emtfStage2Digis, caloLayer1Digis, caloStage2Digis, gmtStage2Digis, gtStage2Digis)
+L1TRawToDigi_Stage2 = cms.Task(rpcunpacker, rpcTwinMuxRawToDigi, twinMuxStage2Digis, bmtfDigis, omtfStage2Digis, rpcCPPFRawToDigi, emtfStage2Digis, caloLayer1Digis, caloStage2Digis, gmtStage2Digis, gtStage2Digis)
 stage2L1Trigger.toReplaceWith(L1TRawToDigiTask, cms.Task(L1TRawToDigi_Stage1,L1TRawToDigi_Stage2))
 
 L1TRawToDigi = cms.Sequence(L1TRawToDigiTask)

--- a/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
+++ b/L1Trigger/L1TMuonCPPF/interface/EmulateCPPF.h
@@ -28,6 +28,7 @@ private:
   const edm::EDGetToken rpcDigiToken_;
   const edm::EDGetToken recHitToken_;
   const edm::EDGetToken rpcDigiSimLinkToken_;
+  const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken_;
 
   enum class CppfSource { File, EventSetup } cppfSource_;
   std::vector<RecHitProcessor::CppfItem> CppfVec_1;

--- a/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
+++ b/L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h
@@ -55,6 +55,7 @@ public:
       const edm::EDGetToken &recHitToken,
       const edm::EDGetToken &rpcDigiToken,
       const edm::EDGetToken &rpcDigiSimLinkToken,
+      const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> &rpcGeomToken,
       std::vector<RecHitProcessor::CppfItem> &CppfVec1,
       // Output
       l1t::CPPFDigiCollection &cppfDigis,
@@ -67,6 +68,7 @@ public:
       const edm::EDGetToken &recHitToken,
       const edm::EDGetToken &rpcDigiToken,
       const edm::EDGetToken &rpcDigiSimLinkToken,
+      const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> &rpcGeomToken,
       // Output
       l1t::CPPFDigiCollection &cppfDigis) const;
 

--- a/L1Trigger/L1TMuonCPPF/python/emulatorCppfDigis_cfi.py
+++ b/L1Trigger/L1TMuonCPPF/python/emulatorCppfDigis_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 emulatorCppfDigis = cms.EDProducer("L1TMuonCPPFDigiProducer",                                   
                                    ## Input collection
                                    recHitLabel = cms.InputTag("rpcRecHits"),
-                                   rpcDigiLabel = cms.InputTag("simMuonRPCDigis"),
+                                   rpcDigiLabel = cms.InputTag("muonRPCDigis"),
                                    rpcDigiSimLinkLabel = cms.InputTag("simMuonRPCDigis", "RPCDigiSimLink"),
 				   MaxClusterSize = cms.int32(3),
                                    #  cppfSource = cms.string('Geo'), #'File' for Look up table and 'Geo' for CMSSW Geometry 

--- a/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
+++ b/L1Trigger/L1TMuonCPPF/src/EmulateCPPF.cc
@@ -17,6 +17,7 @@ EmulateCPPF::EmulateCPPF(const edm::ParameterSet &iConfig, edm::ConsumesCollecto
       recHitToken_(iConsumes.consumes<RPCRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitLabel"))),
       rpcDigiSimLinkToken_(iConsumes.consumes<edm::DetSetVector<RPCDigiSimLink> >(
           iConfig.getParameter<edm::InputTag>("rpcDigiSimLinkLabel"))),
+      rpcGeomToken_(iConsumes.esConsumes()),
       cppfSource_(CppfSource::EventSetup),
       MaxClusterSize_(0) {
   MaxClusterSize_ = iConfig.getParameter<int>("MaxClusterSize");
@@ -58,8 +59,15 @@ void EmulateCPPF::process(const edm::Event &iEvent,
   if (cppfSource_ == CppfSource::File) {  // Using the look up table to fill the information
     cppf_recHit.clear();
     for (auto &recHit_processor : recHit_processors_) {
-      recHit_processor.processLook(
-          iEvent, iSetup, recHitToken_, rpcDigiToken_, rpcDigiSimLinkToken_, CppfVec_1, cppf_recHit, MaxClusterSize_);
+      recHit_processor.processLook(iEvent,
+                                   iSetup,
+                                   recHitToken_,
+                                   rpcDigiToken_,
+                                   rpcDigiSimLinkToken_,
+                                   rpcGeomToken_,
+                                   CppfVec_1,
+                                   cppf_recHit,
+                                   MaxClusterSize_);
     }
   } else if (cppfSource_ == CppfSource::EventSetup) {
     // Clear output collections
@@ -79,7 +87,8 @@ void EmulateCPPF::process(const edm::Event &iEvent,
     // cppf_rpcDigi );
     // }
     for (auto &recHit_processor : recHit_processors_) {
-      recHit_processor.process(iEvent, iSetup, recHitToken_, rpcDigiToken_, rpcDigiSimLinkToken_, cppf_recHit);
+      recHit_processor.process(
+          iEvent, iSetup, recHitToken_, rpcDigiToken_, rpcDigiSimLinkToken_, rpcGeomToken_, cppf_recHit);
     }
   }
 }  // End void EmulateCPPF::process()

--- a/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
+++ b/L1Trigger/L1TMuonCPPF/src/RecHitProcessor.cc
@@ -1,3 +1,4 @@
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "L1Trigger/L1TMuonCPPF/interface/RecHitProcessor.h"
 #include "Geometry/RPCGeometry/interface/RPCRoll.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -16,6 +17,7 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
                                   const edm::EDGetToken &recHitToken,
                                   const edm::EDGetToken &rpcDigiToken,
                                   const edm::EDGetToken &rpcDigiSimLinkToken,
+                                  const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> &rpcGeomToken,
                                   std::vector<RecHitProcessor::CppfItem> &CppfVec1,
                                   l1t::CPPFDigiCollection &cppfDigis,
                                   const int MaxClusterSize) const {
@@ -28,8 +30,7 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
   edm::Handle<edm::DetSetVector<RPCDigiSimLink>> theSimlinkDigis;
   iEvent.getByToken(rpcDigiSimLinkToken, theSimlinkDigis);
 
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  const auto &rpcGeom = iSetup.getData(rpcGeomToken);
 
   for (const auto &&rpcdgIt : (*rpcDigis)) {
     const RPCDetId &rpcId = rpcdgIt.first;
@@ -50,7 +51,7 @@ void RecHitProcessor::processLook(const edm::Event &iEvent,
       const int firststrip = cl.firstStrip();
       const int clustersize = cl.clusterSize();
       const int laststrip = cl.lastStrip();
-      const RPCRoll *roll = rpcGeom->roll(rpcId);
+      const RPCRoll *roll = rpcGeom.roll(rpcId);
       // Get Average Strip position
       const float fstrip = (roll->centreOfStrip(firststrip)).x();
       const float lstrip = (roll->centreOfStrip(laststrip)).x();
@@ -283,10 +284,10 @@ void RecHitProcessor::process(const edm::Event &iEvent,
                               const edm::EDGetToken &recHitToken,
                               const edm::EDGetToken &rpcDigiToken,
                               const edm::EDGetToken &rpcDigiSimLinkToken,
+                              const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> &rpcGeomToken,
                               l1t::CPPFDigiCollection &cppfDigis) const {
   // Get the RPC Geometry
-  edm::ESHandle<RPCGeometry> rpcGeom;
-  iSetup.get<MuonGeometryRecord>().get(rpcGeom);
+  const auto &rpcGeom = iSetup.getData(rpcGeomToken);
 
   edm::Handle<RPCDigiCollection> rpcDigis;
   iEvent.getByToken(rpcDigiToken, rpcDigis);
@@ -315,7 +316,7 @@ void RecHitProcessor::process(const edm::Event &iEvent,
       const int firststrip = cl.firstStrip();
       const int clustersize = cl.clusterSize();
       const int laststrip = cl.lastStrip();
-      const RPCRoll *roll = rpcGeom->roll(rpcId);
+      const RPCRoll *roll = rpcGeom.roll(rpcId);
       // Get Average Strip position
       const float fstrip = (roll->centreOfStrip(firststrip)).x();
       const float lstrip = (roll->centreOfStrip(laststrip)).x();


### PR DESCRIPTION
#### PR description:

Add CPPF online DQM modules L1TdeStage2CPPF and L1TStage2CPPF. 
By comparing the CPPF emulator and unpacker outputs and putting some comparison histograms on the CMS online DQM GUI, shifters can monitor the status of the CPPF hardware.

https://twiki.cern.ch/twiki/bin/viewauth/CMS/CPPFDQMDevelopment
https://indico.cern.ch/event/1096936/contributions/4614848/attachments/2347544/4003548/Ram_CPPFUpdate_20211117.pdf
<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

cmsRun DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py unitTest=True

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
The PR will have to be backported to 10_4_X

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->




<!-- Please delete the text above after you verified all points of the checklist  -->
