### PR TITLE
Add Run-3 JECs to Run-3 MCs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -70,19 +70,19 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           : '124X_mcRun3_2022_design_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v7',
+    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v8',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v8',
+    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v9',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v7',
+    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v6',
+    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v6',
+    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v9',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '124X_mcRun4_realistic_v7'
+    'phase2_realistic'             : '124X_mcRun4_realistic_v8'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR adds the new  Run-3 JECs to Run-3 MCs as requested in cmsTalk https://cms-talk.web.cern.ch/t/gt-request-a-gt-for-run3-jec-tags-for-mc/12306

I created

124X_mcRun3_2022_realistic_v8
124X_mcRun3_2022cosmics_realistic_deco_v9
124X_mcRun3_2022_realistic_HI_v8
124X_mcRun3_2023_realistic_v9
124X_mcRun3_2024_realistic_v9
124X_mcRun4_realistic_v8

The diffs are
**phase1_2022_realistic**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_v7/124X_mcRun3_2022_realistic_v8

**phase1_2022_cosmics**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022cosmics_realistic_deco_v8/124X_mcRun3_2022cosmics_realistic_deco_v9

**phase1_2022_realistic_hi**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_HI_v7/124X_mcRun3_2022_realistic_HI_v8

**phase1_2023_realistic**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2023_realistic_v6/124X_mcRun3_2023_realistic_v9

**phase1_2024_realistic**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2024_realistic_v6/124X_mcRun3_2024_realistic_v9

**phase2_realistic**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun4_realistic_v7/124X_mcRun4_realistic_v8


#### PR validation:

```
test parameters:
  - workflows = 12034.0,11634.0,7.23,159.0,12434.0,12834.0
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but will be backported to 12_4_X