### PR TITLE
HCAL: removing ChannelQuality erroneous label in conditions reading from txt 

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -63,8 +63,7 @@ HcalTextCalibrations::HcalTextCalibrations(const edm::ParameterSet& iConfig)
       mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceQIETypes).consumes();
       findingRecord<HcalQIETypesRcd>();
     } else if (objectName == "ChannelQuality") {
-      mTokens[objectName] =
-          setWhatProduced(this, &HcalTextCalibrations::produceChannelQuality, edm::es::Label("withTopo")).consumes();
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceChannelQuality).consumes();
       findingRecord<HcalChannelQualityRcd>();
     } else if (objectName == "ZSThresholds") {
       mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceZSThresholds).consumes();


### PR DESCRIPTION
#### PR description:

Fix of old error, which  might cause a picking up of GT conditions (specifically ChannelQuality one) instead of txt input ones regardless of utilized ESPrefer.

#### PR validation:

Updated code is not run in any regular wf. Tests done with some HCAL txt-input conditions scripts/tests. 

#### If this PR is a backport

No 
