### PR TITLE
[GEM] bug fix : typo in GEMOptoHybrid data format

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMOptoHybrid.h
+++ b/DataFormats/GEMDigi/interface/GEMOptoHybrid.h
@@ -114,7 +114,7 @@ public:
   uint16_t vfatWordCntT() const {
     if (ver_ == 0)
       return GEBchamberTrailer{ct_}.VfWdCntT;
-    return GEBchamberTrailer{ch_}.VfWdCntTv302;
+    return GEBchamberTrailer{ct_}.VfWdCntTv302;
   }
 
   bool bxmVvV() const { return GEBchamberHeader{ch_}.BxmVvV; }


### PR DESCRIPTION
#### PR description:

The mismatching problem of vfatWordCnt in GEMOptoHybrid data has been reported.
And we found out that we made a typo in the function that calls vfatWordCnt from GEMOptoHybrid Trailer.

Backport to 12_3_X and 12_4_X are needed.

The change is included in the previous backport PR for 12_3_X(#38546)

Backport PR to 12_4_X will be generated.

#### PR validation:

The personal online DQM module has been performed on the corresponding version of data. And the mismatching problem of vfatWordCnt has disappeared.