### PR TITLE
[Backport][GEM]  bug fix : typo in GEMOptoHybrid data format [12_4_X]

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMOptoHybrid.h
+++ b/DataFormats/GEMDigi/interface/GEMOptoHybrid.h
@@ -114,7 +114,7 @@ public:
   uint16_t vfatWordCntT() const {
     if (ver_ == 0)
       return GEBchamberTrailer{ct_}.VfWdCntT;
-    return GEBchamberTrailer{ch_}.VfWdCntTv302;
+    return GEBchamberTrailer{ct_}.VfWdCntTv302;
   }
 
   bool bxmVvV() const { return GEBchamberHeader{ch_}.BxmVvV; }


### PR DESCRIPTION
#### PR description:

The mismatching problem of vfatWordCnt in GEMOptoHybrid data has been reported.
And we found out that we made a typo in the function that calls vfatWordCnt from GEMOptoHybrid Trailer.

#### PR validation:

The personal online DQM module has been performed on the corresponding version of data. And the mismatching problem of vfatWordCnt has disappeared.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

The original PR is #38572 