### PR TITLE
[12_4_X] Correct subsystem folder for ecalgpu client

### DIFF
--- a/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/ecalgpu_dqm_sourceclient-live_cfg.py
@@ -60,7 +60,7 @@ process.preScaler.prescaleFactor = 1
 if not options.inputFiles:
     process.source.streamLabel = cms.untracked.string("streamDQMGPUvsCPU")
 
-process.dqmEnv.subSystemFolder = 'EcalGPU'
+process.dqmEnv.subSystemFolder = 'Ecal'
 process.dqmSaver.tag = 'EcalGPU'
 process.dqmSaver.runNumber = options.runNumber
 process.dqmSaverPB.tag = 'EcalGPU'


### PR DESCRIPTION
#### PR description:

Port commit https://github.com/cms-sw/cmssw/pull/38428/commits/9cb65c31502b88a5f40122301330ab3275336871 from
- https://github.com/cms-sw/cmssw/pull/38428

to correct bug where an empty `EcalGPU` folder was being created. The GPU validation plots are also contained within the `Ecal` subsystem folder

Previous original PRs are already closed
- https://github.com/cms-sw/cmssw/pull/38427
- https://github.com/cms-sw/cmssw/pull/38429


Previous PRs porting another commit (https://github.com/cms-sw/cmssw/commit/f49557a49e5020e6eedc61ea10b02a9127342377) from https://github.com/cms-sw/cmssw/pull/38428 also closed
- https://github.com/cms-sw/cmssw/pull/38527
- https://github.com/cms-sw/cmssw/pull/38528


#### PR validation:

To be checked at P5 in https://github.com/cms-sw/cmssw/pull/38428. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is a port of https://github.com/cms-sw/cmssw/pull/38428/commits/9cb65c31502b88a5f40122301330ab3275336871 from https://github.com/cms-sw/cmssw/pull/38428 into master https://github.com/cms-sw/cmssw/pull/38579 and 12_4_X (this PR)