### PR TITLE
Improve early unlocking in FastMonitoringService

### DIFF
--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -792,24 +792,25 @@ namespace evf {
         snapCounter_++;
       }
 
-      std::stringstream accum;
-      std::function<void(std::vector<unsigned int>)> f = [&](std::vector<unsigned int> p) {
-        for (unsigned int i = 0; i < nStreams_; i++) {
-          if (i == 0)
-            accum << "[" << p[i] << ",";
-          else if (i <= nStreams_ - 1)
-            accum << p[i] << ",";
-          else
-            accum << p[i] << "]";
-        }
-      };
+      {
+        edm::LogInfo msg("FastMonitoringService");
+        auto f = [&](std::vector<unsigned int> const& p) {
+          for (unsigned int i = 0; i < nStreams_; i++) {
+            if (i == 0)
+              msg << "[" << p[i] << ",";
+            else if (i <= nStreams_ - 1)
+              msg << p[i] << ",";
+            else
+              msg << p[i] << "]";
+          }
+        };
 
-      accum << "Current states: Ms=" << fmt_->m_data.fastMacrostateJ_.value() << " ms=";
-      f(lastEnc[0]);
-      accum << " us=";
-      f(lastEnc[1]);
-      accum << " is=" << inputStateNames[inputState_] << " iss=" << inputStateNames[inputSupervisorState_];
-      edm::LogInfo("FastMonitoringService") << accum.str();
+        msg << "Current states: Ms=" << fmt_->m_data.fastMacrostateJ_.value() << " ms=";
+        f(lastEnc[0]);
+        msg << " us=";
+        f(lastEnc[1]);
+        msg << " is=" << inputStateNames[inputState_] << " iss=" << inputStateNames[inputSupervisorState_];
+      }
 
       ::sleep(sleepTime_);
     }


### PR DESCRIPTION
#### PR description:

These changes attempt to fix a rare error that is only observed online during data taking:
```
cmsRun: ../nptl/pthread_mutex_lock.c:81: __pthread_mutex_lock: Assertion `mutex->__data.__owner == 0' failed.


A fatal system signal has occurred: abort signal
The following is the call stack containing the origin of the signal.

Sat Jul 2 01:52:36 CEST 2022
Thread 13 (Thread 0x7fd568bfd700 (LWP 2362148) "cmsRun"):
...
#4 <signal handler called>
#5 0x00007fd5f463d37f in raise () from /lib64/libc.so.6
#6 0x00007fd5f4627db5 in abort () from /lib64/libc.so.6
#7 0x00007fd5f4627c89 in __assert_fail_base.cold.0 () from /lib64/libc.so.6
#8 0x00007fd5f4635a76 in __assert_fail () from /lib64/libc.so.6
#9 0x00007fd5f49d7c61 in pthread_mutex_lock () from /lib64/libpthread.so.0
#10 0x00007fd5e94ed1bf in evf::FastMonitoringService::preStreamEndLumi(edm::StreamContext const&) () from /opt/offline/el8_amd64_gcc10/cms/cmssw/CMSSW_12_3_6/lib/el8_amd64_gcc10/libEventFilterUtilities.so
#11 0x00007fd5f70944df in edm::StreamSchedule::processOneStreamAsync<edm::OccurrenceTraits(edm::WaitingTaskHolder, edm::OccurrenceTraits::TransitionInfoType&, edm::ServiceToken const&, bool)::{lambda()#2}::operator()() () from /opt/offline/el8_amd64_gcc10/cms/cmssw/CMSSW_12_3_6/lib/el8_amd64_gcc10/libFWCoreFramework.so
...
```

The current code locks a mutex with `std::lock_guard`, but unlocks it explicitly under some circumstances, causing to a double unlock and leading to undefined behaviour.

This change replaces the use of `std::lock_guard` with `std::unique_lock`, that can be safely released and unlocked before going out of scope.

A second minor change should avoid a few memory copies when emitting a LogInfo message.

#### PR validation:

Tested with CMSSW 12.3.x running a recent HLT menu in DAQ-like mode.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

To be backported to 12.3.x and 12.4.x for data taking.