### PR TITLE
[12.4.X] Fix to "Update SiStrip and TkAlignment ALCARECO event content for Run3"

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJetHT_Output_cff.py
@@ -15,15 +15,16 @@ OutALCARECOTkAlJetHT_noDrop = cms.PSet(
         'keep *_offlineBeamSpot_*_*')
 )
 
-OutALCARECOTkAlJetHT = OutALCARECOTkAlJetHT_noDrop.clone()
-OutALCARECOTkAlJetHT.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlJetHT.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlJetHT_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
                               'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlJetHT, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlJetHT_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlJetHT = OutALCARECOTkAlJetHT_noDrop.clone()
+OutALCARECOTkAlJetHT.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMuHI_Output_cff.py
@@ -14,15 +14,15 @@ OutALCARECOTkAlJpsiMuMuHI_noDrop = cms.PSet(
 	'keep *_hiSelectedVertex_*_*')
 )
 
-import copy
-OutALCARECOTkAlJpsiMuMuHI = copy.deepcopy(OutALCARECOTkAlJpsiMuMuHI_noDrop)
-OutALCARECOTkAlJpsiMuMuHI.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlJpsiMuMuHI.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlJpsiMuMuHI_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlJpsiMuMuHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlJpsiMuMuHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlJpsiMuMuHI = OutALCARECOTkAlJpsiMuMuHI_noDrop.clone()
+OutALCARECOTkAlJpsiMuMuHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlJpsiMuMu_Output_cff.py
@@ -14,15 +14,15 @@ OutALCARECOTkAlJpsiMuMu_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
-import copy
-OutALCARECOTkAlJpsiMuMu = copy.deepcopy(OutALCARECOTkAlJpsiMuMu_noDrop)
-OutALCARECOTkAlJpsiMuMu.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlJpsiMuMu.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlJpsiMuMu_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlJpsiMuMu, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlJpsiMuMu_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlJpsiMuMu = OutALCARECOTkAlJpsiMuMu_noDrop.clone()
+OutALCARECOTkAlJpsiMuMu.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBiasHI_Output_cff.py
@@ -15,15 +15,15 @@ OutALCARECOTkAlMinBiasHI_noDrop = cms.PSet(
         'keep *_offlineBeamSpot_*_*')
 )
 
-import copy
-OutALCARECOTkAlMinBiasHI = copy.deepcopy(OutALCARECOTkAlMinBiasHI_noDrop)
-OutALCARECOTkAlMinBiasHI.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlMinBiasHI.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlMinBiasHI_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlMinBiasHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlMinBiasHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlMinBiasHI = copy.deepcopy(OutALCARECOTkAlMinBiasHI_noDrop)
+OutALCARECOTkAlMinBiasHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMinBias_Output_cff.py
@@ -15,16 +15,16 @@ OutALCARECOTkAlMinBias_noDrop = cms.PSet(
         'keep *_offlineBeamSpot_*_*')
 )
 
-import copy
-OutALCARECOTkAlMinBias = copy.deepcopy(OutALCARECOTkAlMinBias_noDrop)
-OutALCARECOTkAlMinBias.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlMinBias.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlMinBias_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
                               'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlMinBias, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlMinBias_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlMinBias = OutALCARECOTkAlMinBias_noDrop.clone()
+OutALCARECOTkAlMinBias.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolatedHI_Output_cff.py
@@ -14,15 +14,15 @@ OutALCARECOTkAlMuonIsolatedHI_noDrop = cms.PSet(
 	'keep *_hiSelectedVertex_*_*')
 )
 
-import copy
-OutALCARECOTkAlMuonIsolatedHI = copy.deepcopy(OutALCARECOTkAlMuonIsolatedHI_noDrop)
-OutALCARECOTkAlMuonIsolatedHI.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlMuonIsolatedHI.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlMuonIsolatedHI_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlMuonIsolatedHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlMuonIsolatedHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlMuonIsolatedHI = OutALCARECOTkAlMuonIsolatedHI_noDrop.clone()
+OutALCARECOTkAlMuonIsolatedHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlMuonIsolated_Output_cff.py
@@ -14,15 +14,15 @@ OutALCARECOTkAlMuonIsolated_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
-import copy
-OutALCARECOTkAlMuonIsolated = copy.deepcopy(OutALCARECOTkAlMuonIsolated_noDrop)
-OutALCARECOTkAlMuonIsolated.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlMuonIsolated.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlMuonIsolated_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlMuonIsolated, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlMuonIsolated_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlMuonIsolated = OutALCARECOTkAlMuonIsolated_noDrop.clone()
+OutALCARECOTkAlMuonIsolated.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMuHI_Output_cff.py
@@ -14,15 +14,15 @@ OutALCARECOTkAlUpsilonMuMuHI_noDrop = cms.PSet(
 	'keep *_hiSelectedVertex_*_*')
 )
 
-import copy
-OutALCARECOTkAlUpsilonMuMuHI = copy.deepcopy(OutALCARECOTkAlUpsilonMuMuHI_noDrop)
-OutALCARECOTkAlUpsilonMuMuHI.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlUpsilonMuMuHI.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlUpsilonMuMuHI_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlUpsilonMuMuHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlUpsilonMuMuHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlUpsilonMuMuHI = OutALCARECOTkAlUpsilonMuMuHI_noDrop.clone()
+OutALCARECOTkAlUpsilonMuMuHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlUpsilonMuMu_Output_cff.py
@@ -14,15 +14,15 @@ OutALCARECOTkAlUpsilonMuMu_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
-import copy
-OutALCARECOTkAlUpsilonMuMu = copy.deepcopy(OutALCARECOTkAlUpsilonMuMu_noDrop)
-OutALCARECOTkAlUpsilonMuMu.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlUpsilonMuMu.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlUpsilonMuMu_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlUpsilonMuMu, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlUpsilonMuMu_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlUpsilonMuMu = OutALCARECOTkAlUpsilonMuMu_noDrop.clone()
+OutALCARECOTkAlUpsilonMuMu.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMuHI_Output_cff.py
@@ -14,15 +14,15 @@ OutALCARECOTkAlZMuMuHI_noDrop = cms.PSet(
 	'keep *_hiSelectedVertex_*_*')
 )
 
-import copy
-OutALCARECOTkAlZMuMuHI = copy.deepcopy(OutALCARECOTkAlZMuMuHI_noDrop)
-OutALCARECOTkAlZMuMuHI.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlZMuMuHI.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlZMuMuHI_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlZMuMuHI, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlZMuMuHI_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlZMuMuHI = OutALCARECOTkAlZMuMuHI_noDrop.clone()
+OutALCARECOTkAlZMuMuHI.outputCommands.insert(0, "drop *")

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOTkAlZMuMu_Output_cff.py
@@ -14,15 +14,15 @@ OutALCARECOTkAlZMuMu_noDrop = cms.PSet(
 	'keep *_offlinePrimaryVertices_*_*')
 )
 
-import copy
-OutALCARECOTkAlZMuMu = copy.deepcopy(OutALCARECOTkAlZMuMu_noDrop)
-OutALCARECOTkAlZMuMu.outputCommands.insert(0, "drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOTkAlZMuMu.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOTkAlZMuMu_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
 _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOTkAlZMuMu, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOTkAlZMuMu_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOTkAlZMuMu = OutALCARECOTkAlZMuMu_noDrop.clone()
+OutALCARECOTkAlZMuMu.outputCommands.insert(0, "drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalCosmics_Output_cff.py
@@ -17,12 +17,9 @@ OutALCARECOSiStripCalCosmics_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*')
     )
 
-import copy
-OutALCARECOSiStripCalCosmics=copy.deepcopy(OutALCARECOSiStripCalCosmics_noDrop)
-OutALCARECOSiStripCalCosmics.outputCommands.insert(0,"drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOSiStripCalCosmics.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOSiStripCalCosmics_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
@@ -30,4 +27,7 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
                               'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOSiStripCalCosmics, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOSiStripCalCosmics_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOSiStripCalCosmics=OutALCARECOSiStripCalCosmics_noDrop.clone()
+OutALCARECOSiStripCalCosmics.outputCommands.insert(0,"drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAGHI_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAGHI_Output_cff.py
@@ -17,13 +17,9 @@ OutALCARECOSiStripCalMinBiasAAG_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*')
 )
 
-
-import copy
-OutALCARECOSiStripCalMinBiasAAG=copy.deepcopy(OutALCARECOSiStripCalMinBiasAAG_noDrop)
-OutALCARECOSiStripCalMinBiasAAG.outputCommands.insert(0,"drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOSiStripCalMinBiasAAG.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOSiStripCalMinBiasAAG_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
@@ -31,4 +27,7 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
                               'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOSiStripCalMinBiasAAG, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOSiStripCalMinBiasAAG_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOSiStripCalMinBiasAAG=OutALCARECOSiStripCalMinBiasAAG_noDrop.clone()
+OutALCARECOSiStripCalMinBiasAAG.outputCommands.insert(0,"drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAG_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasAAG_Output_cff.py
@@ -17,13 +17,9 @@ OutALCARECOSiStripCalMinBiasAAG_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*')
 )
 
-
-import copy
-OutALCARECOSiStripCalMinBiasAAG=copy.deepcopy(OutALCARECOSiStripCalMinBiasAAG_noDrop)
-OutALCARECOSiStripCalMinBiasAAG.outputCommands.insert(0,"drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOSiStripCalMinBiasAAG.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOSiStripCalMinBiasAAG_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
@@ -31,4 +27,7 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
                               'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOSiStripCalMinBiasAAG, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOSiStripCalMinBiasAAG_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOSiStripCalMinBiasAAG=OutALCARECOSiStripCalMinBiasAAG_noDrop.clone()
+OutALCARECOSiStripCalMinBiasAAG.outputCommands.insert(0,"drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasHI_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBiasHI_Output_cff.py
@@ -17,13 +17,9 @@ OutALCARECOSiStripCalMinBias_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*')
 )
 
-
-import copy
-OutALCARECOSiStripCalMinBias=copy.deepcopy(OutALCARECOSiStripCalMinBias_noDrop)
-OutALCARECOSiStripCalMinBias.outputCommands.insert(0,"drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOSiStripCalMinBias.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOSiStripCalMinBias_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
@@ -31,4 +27,7 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
                               'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOSiStripCalMinBias, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOSiStripCalMinBias_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOSiStripCalMinBias=OutALCARECOSiStripCalMinBias_noDrop.clone()
+OutALCARECOSiStripCalMinBias.outputCommands.insert(0,"drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalMinBias_Output_cff.py
@@ -17,13 +17,9 @@ OutALCARECOSiStripCalMinBias_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*')
 )
 
-
-import copy
-OutALCARECOSiStripCalMinBias=copy.deepcopy(OutALCARECOSiStripCalMinBias_noDrop)
-OutALCARECOSiStripCalMinBias.outputCommands.insert(0,"drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOSiStripCalMinBias.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOSiStripCalMinBias_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
@@ -31,4 +27,7 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
                               'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOSiStripCalMinBias, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOSiStripCalMinBias_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOSiStripCalMinBias=OutALCARECOSiStripCalMinBias_noDrop.clone()
+OutALCARECOSiStripCalMinBias.outputCommands.insert(0,"drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalSmallBiasScan_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOSiStripCalSmallBiasScan_Output_cff.py
@@ -17,13 +17,9 @@ OutALCARECOSiStripCalSmallBiasScan_noDrop = cms.PSet(
         'keep *_TriggerResults_*_*')
 )
 
-
-import copy
-OutALCARECOSiStripCalSmallBiasScan=copy.deepcopy(OutALCARECOSiStripCalSmallBiasScan_noDrop)
-OutALCARECOSiStripCalSmallBiasScan.outputCommands.insert(0,"drop *")
-
 # in Run3, SCAL digis replaced by onlineMetaDataDigis
-_run3_common_removedCommands = OutALCARECOSiStripCalSmallBiasScan.outputCommands
+import copy
+_run3_common_removedCommands = OutALCARECOSiStripCalSmallBiasScan_noDrop.outputCommands.copy()
 _run3_common_removedCommands.remove('keep LumiScalerss_scalersRawToDigi_*_*')
 _run3_common_removedCommands.remove('keep DcsStatuss_scalersRawToDigi_*_*')
 
@@ -31,4 +27,7 @@ _run3_common_extraCommands = ['keep DCSRecord_onlineMetaDataDigis_*_*',
                               'keep OnlineLuminosityRecord_onlineMetaDataDigis_*_*']
 
 from Configuration.Eras.Modifier_run3_common_cff import run3_common
-run3_common.toModify(OutALCARECOSiStripCalSmallBiasScan, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+run3_common.toModify(OutALCARECOSiStripCalSmallBiasScan_noDrop, outputCommands = _run3_common_removedCommands + _run3_common_extraCommands)
+
+OutALCARECOSiStripCalSmallBiasScan=OutALCARECOSiStripCalSmallBiasScan_noDrop.clone()
+OutALCARECOSiStripCalSmallBiasScan.outputCommands.insert(0,"drop *")


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/38590

#### PR description:

Unfortunately PR #38416 aimed to update the event content of the input `ALCARECO` event contents to use S/W FED 1023 information instead of SCAL for all the relevant SiStrip and TkAlignment alcas contained two bugs:
   * in python, when a variable `A` is assigned to another variable `B`, if an operation is done on `B`, the attributes of `A` are changed as well. This has resulted in applying the removal of the content of the  `_run3_common_removedCommands` list even for eras <= Run2.
   * the `ConfigBuilder` uses the `*_noDrop` version of the `ALCARECO` event content to build the list of products to keep, so the instructions gated via the `run3_common` modifier were not effective.
   
   https://github.com/cms-sw/cmssw/blob/36d3f6f602d7f3c2864fdb47505d745598545de8/Configuration/Applications/python/ConfigBuilder.py#L1298

As a result of the two bugs, the list of event products to be kept is now wrong for all eras.
This PR resolves the issue.

#### PR validation:

Test running:
```console
runTheMatrix.py -l 1000.0, 136.874, 138.4 --ibeos
```
and checked the event content of the `SiStripCalMinBias` ALCARECO file, in order to test the Run1, Run2 and Run3 eras.
In addition I've also produced ALCARECO data, starting from RAW and the ConfigDP machinery using the command:

```console
python3 Configuration/DataProcessing/test/RunExpressProcessing.py --nThreads 8 --scenario ppEra_Run3 --global-tag 124X_dataRun3_Express_v3 --lfn root://eoscms.cern.ch//eos/cms/tier0/store/data//Run2022A/MinimumBias/RAW/v1/000/352/929/00000/18df5589-67c8-45e5-ac84-7fd2472de50a.root --fevt --dqmio --alcarecos SiStripCalMinBias
```

and obtained the right event content:

```console
File output_inALCARECO.root Events 13
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event) 
SiStripClusteredmNewDetSetVector_siStripClusters__RECO. 51212.1 13165.5
SiPixelClusteredmNewDetSetVector_siPixelClusters__RECO. 16359.7 6596.46
recoTrackExtras_ALCARECOSiStripCalMinBias__RECO. 1641.15 1066.77
SiStripClusteredmNewDetSetVector_ALCARECOSiStripCalMinBias__RECO. 3236.77 871.923
TrackingRecHitsOwned_ALCARECOSiStripCalMinBias__RECO. 4918.23 813.692
recoTracks_ALCARECOSiStripCalMinBias__RECO. 1793.77 800.615
SiPixelClusteredmNewDetSetVector_ALCARECOSiStripCalMinBias__RECO. 1216.54 559.385
DetIdedmEDCollection_siStripDigis__RECO. 2081.62 280.231
edmTriggerResults_TriggerResults__HLT. 1847.85 245.231
OnlineLuminosityRecord_onlineMetaDataDigis__RECO. 230.538 210.846
L1AcceptBunchCrossings_scalersRawToDigi__RECO. 209.769 198.462
L1GlobalTriggerReadoutRecord_gtDigis__RECO. 261.923 196.385
edmTriggerResults_TriggerResults__RECO. 263.846 191.846
DCSRecord_onlineMetaDataDigis__RECO. 278.538 184.077
EventProductProvenance 2428.31 162
EventAuxiliary 160.385 43.4615
EventSelections 120.769 17.6154
BranchListIndexes 68.5385 12.2308
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/38590