### PR TITLE
Improvements to the `SiStripHitEfficiencyHarvester` for Run 3 data-taking 

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/BuildFile.xml
+++ b/CalibTracker/SiStripHitEfficiency/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="DataFormats/SiStripDetId"/>
+<use name="DQM/SiStripCommon"/>
 <use name="Geometry/CommonDetUnit" source_only="1"/>
 <use name="RecoTracker/TransientTrackingRecHit"/>
 <use name="TrackingTools/TrackFitters"/>

--- a/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEffData.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEffData.h
@@ -1,0 +1,26 @@
+#ifndef CalibTracker_SiStripHitEfficiency_SiStripHitEffData_h
+#define CalibTracker_SiStripHitEfficiency_SiStripHitEffData_h
+
+#include "DQM/SiStripCommon/interface/TkHistoMap.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include <unordered_map>
+
+struct SiStripHitEffData {
+public:
+  SiStripHitEffData() 
+    : EventStats(),
+      FEDErrorOccupancy(nullptr){}
+
+  void fillTkMapFromMap() {
+    for (const auto& [id, count] : fedErrorCounts) {
+      FEDErrorOccupancy.fill(id, count);
+    }
+  }
+
+  dqm::reco::MonitorElement* EventStats;
+  std::unordered_map<uint32_t, int> fedErrorCounts;
+  TkHistoMap FEDErrorOccupancy;
+};
+
+#endif

--- a/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEffData.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEffData.h
@@ -8,9 +8,7 @@
 
 struct SiStripHitEffData {
 public:
-  SiStripHitEffData() 
-    : EventStats(),
-      FEDErrorOccupancy(nullptr){}
+  SiStripHitEffData() : EventStats(), FEDErrorOccupancy(nullptr) {}
 
   void fillTkMapFromMap() {
     for (const auto& [id, count] : fedErrorCounts) {

--- a/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h
@@ -4,6 +4,7 @@
 // A bunch of helper functions to deal with menial tasks in the
 // hit efficiency computation for the PCL workflow
 
+#include "TString.h"
 #include <string>
 #include <fmt/printf.h>
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
@@ -18,7 +19,8 @@ namespace {
     k_LayersAtTOBEnd = 10,
     k_LayersAtTIDEnd = 13,
     k_LayersAtTECEnd = 22,
-    k_END_OF_LAYERS = 23
+    k_END_OF_LAYERS = 23,
+    k_END_OF_LAYS_AND_RINGS = 35
   };
 
   inline unsigned int checkLayer(unsigned int iidd, const TrackerTopology* tTopo) {
@@ -47,7 +49,26 @@ namespace {
     } else if (k > bounds::k_LayersAtTIDEnd && k <= bounds::k_LayersAtTIDEnd + nTEClayers) {
       return fmt::format("TEC {0}{1:d}", ringlabel, k - bounds::k_LayersAtTIDEnd);
     } else {
-      return "";
+      return "should never be here!";
+    }
+  }
+
+  inline std::string layerSideName(Long_t k, const bool showRings, const unsigned int nTEClayers) {
+    const std::string ringlabel{showRings ? "R" : "D"};
+    if (k > bounds::k_LayersStart && k <= bounds::k_LayersAtTIBEnd) {
+      return fmt::format("TIB L{:d}", k);
+    } else if (k > bounds::k_LayersAtTIBEnd && k <= bounds::k_LayersAtTOBEnd) {
+      return fmt::format("TOB L{:d}", k - bounds::k_LayersAtTIBEnd);
+    } else if (k > bounds::k_LayersAtTOBEnd && k < 14) {
+      return fmt::format("TID- {0}{1:d}", ringlabel, k - bounds::k_LayersAtTOBEnd);
+    } else if (k > 13 && k < 17) {
+      return fmt::format("TID+ {0}{1:d}", ringlabel, k - 13);
+    } else if (k > 16 && k < 17 + nTEClayers) {
+      return fmt::format("TEC- {0}{1:d}", ringlabel, k - 16);
+    } else if (k > 16 + nTEClayers) {
+      return fmt::format("TEC+ {0}{1:d}", ringlabel, k - 16 - nTEClayers);
+    } else {
+      return "shoud never be here!";
     }
   }
 

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEffFromCalibTree.cc
@@ -101,7 +101,7 @@ private:
   void algoBeginJob(const edm::EventSetup&) override;
   void algoEndJob() override;
   void algoAnalyze(const edm::Event& e, const edm::EventSetup& c) override;
-  void SetBadComponents(int i,
+  void setBadComponents(int i,
                         int component,
                         SiStripQuality::BadComponent& BC,
                         std::stringstream ssV[4][19],
@@ -112,10 +112,10 @@ private:
   void totalStatistics();
   void makeSummary();
   void makeSummaryVsBx();
-  void ComputeEff(vector<TH1F*>& vhfound, vector<TH1F*>& vhtotal, string name);
+  void computeEff(vector<TH1F*>& vhfound, vector<TH1F*>& vhtotal, string name);
   void makeSummaryVsLumi();
   void makeSummaryVsCM();
-  TString GetLayerSideName(Long_t k);
+  TString getLayerSideName(Long_t k);
 
   // to be used everywhere
   static constexpr int SiStripLayers = 22;
@@ -188,6 +188,7 @@ private:
 
 SiStripHitEffFromCalibTree::SiStripHitEffFromCalibTree(const edm::ParameterSet& conf)
     : ConditionDBWriter<SiStripBadStrip>(conf), FileInPath_(SiStripDetInfoFileReader::kDefaultFile) {
+  usesResource(TFileService::kSharedResource);
   CalibTreeFilenames = conf.getUntrackedParameter<vector<std::string> >("CalibTreeFilenames");
   threshold = conf.getParameter<double>("Threshold");
   nModsMin = conf.getParameter<int>("nModsMin");
@@ -220,14 +221,9 @@ SiStripHitEffFromCalibTree::SiStripHitEffFromCalibTree(const edm::ParameterSet& 
   quality_ = new SiStripQuality(_detInfo);
 }
 
-void SiStripHitEffFromCalibTree::algoBeginJob(const edm::EventSetup&) {
-  //I have no idea what goes here
-  //fs->make<TTree>("HitEffHistos","Tree of the inefficient hit histograms");
-}
+void SiStripHitEffFromCalibTree::algoBeginJob(const edm::EventSetup&) {}
 
-void SiStripHitEffFromCalibTree::algoEndJob() {
-  //Still have no idea what goes here
-}
+void SiStripHitEffFromCalibTree::algoEndJob() {}
 
 void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::EventSetup& c) {
   const auto& tkgeom = c.getData(_tkGeomToken);
@@ -713,7 +709,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       //&&&&&&&&&&&&&&&&&
 
       component = tTopo.tibLayer(BC[i].detid);
-      SetBadComponents(0, component, BC[i], ssV, NBadComponent);
+      setBadComponents(0, component, BC[i], ssV, NBadComponent);
 
     } else if (a.subdetId() == SiStripDetId::TID) {
       //&&&&&&&&&&&&&&&&&
@@ -721,7 +717,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       //&&&&&&&&&&&&&&&&&
 
       component = tTopo.tidSide(BC[i].detid) == 2 ? tTopo.tidWheel(BC[i].detid) : tTopo.tidWheel(BC[i].detid) + 3;
-      SetBadComponents(1, component, BC[i], ssV, NBadComponent);
+      setBadComponents(1, component, BC[i], ssV, NBadComponent);
 
     } else if (a.subdetId() == SiStripDetId::TOB) {
       //&&&&&&&&&&&&&&&&&
@@ -729,7 +725,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       //&&&&&&&&&&&&&&&&&
 
       component = tTopo.tobLayer(BC[i].detid);
-      SetBadComponents(2, component, BC[i], ssV, NBadComponent);
+      setBadComponents(2, component, BC[i], ssV, NBadComponent);
 
     } else if (a.subdetId() == SiStripDetId::TEC) {
       //&&&&&&&&&&&&&&&&&
@@ -737,7 +733,7 @@ void SiStripHitEffFromCalibTree::algoAnalyze(const edm::Event& e, const edm::Eve
       //&&&&&&&&&&&&&&&&&
 
       component = tTopo.tecSide(BC[i].detid) == 2 ? tTopo.tecWheel(BC[i].detid) : tTopo.tecWheel(BC[i].detid) + 9;
-      SetBadComponents(3, component, BC[i], ssV, NBadComponent);
+      setBadComponents(3, component, BC[i], ssV, NBadComponent);
     }
   }
 
@@ -1318,7 +1314,7 @@ void SiStripHitEffFromCalibTree::makeSummary() {
   for (Long_t k = 1; k < nLayers + 1; k++) {
     TString label;
     if (_showEndcapSides)
-      label = GetLayerSideName(k);
+      label = getLayerSideName(k);
     else
       label = ::layerName(k, _showRings, nTEClayers);
     if (!_showTOB6TEC9) {
@@ -1452,7 +1448,7 @@ void SiStripHitEffFromCalibTree::makeSummaryVsBx() {
   }
 }
 
-void SiStripHitEffFromCalibTree::ComputeEff(vector<TH1F*>& vhfound, vector<TH1F*>& vhtotal, string name) {
+void SiStripHitEffFromCalibTree::computeEff(vector<TH1F*>& vhfound, vector<TH1F*>& vhtotal, string name) {
   unsigned int nLayers = SiStripLayers;
   if (_showRings)
     nLayers = 20;
@@ -1524,16 +1520,16 @@ void SiStripHitEffFromCalibTree::makeSummaryVsLumi() {
     LOGPRINT << "Avg conditions:   lumi :" << avgLumi << "  pu: " << avgPU;
   }
 
-  ComputeEff(layerfound_vsLumi, layertotal_vsLumi, "effVsLumi");
-  ComputeEff(layerfound_vsPU, layertotal_vsPU, "effVsPU");
+  computeEff(layerfound_vsLumi, layertotal_vsLumi, "effVsLumi");
+  computeEff(layerfound_vsPU, layertotal_vsPU, "effVsPU");
 }
 
 void SiStripHitEffFromCalibTree::makeSummaryVsCM() {
   LOGPRINT << "Computing efficiency vs CM";
-  ComputeEff(layerfound_vsCM, layertotal_vsCM, "effVsCM");
+  computeEff(layerfound_vsCM, layertotal_vsCM, "effVsCM");
 }
 
-TString SiStripHitEffFromCalibTree::GetLayerSideName(Long_t k) {
+TString SiStripHitEffFromCalibTree::getLayerSideName(Long_t k) {
   TString layername = "";
   TString ringlabel = "D";
   if (_showRings)
@@ -1574,7 +1570,7 @@ std::unique_ptr<SiStripBadStrip> SiStripHitEffFromCalibTree::getNewObject() {
   return obj;
 }
 
-void SiStripHitEffFromCalibTree::SetBadComponents(
+void SiStripHitEffFromCalibTree::setBadComponents(
     int i, int component, SiStripQuality::BadComponent& BC, std::stringstream ssV[4][19], int NBadComponent[4][19][4]) {
   int napv = _detInfo.getNumberOfApvsAndStripLength(BC.detid).first;
 

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyHarvester.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyHarvester.cc
@@ -46,6 +46,7 @@ public:
   void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override;
 
 private:
+  SiStripHitEffData calibData_;
   const std::string inputFolder_;
   const bool isAtPCL_;
   const bool autoIneffModTagging_, doStoreOnDB_;

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyHarvester.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyHarvester.cc
@@ -2,12 +2,13 @@
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 #include "CalibTracker/SiStripCommon/interface/SiStripDetInfoFileReader.h"
+#include "CalibTracker/SiStripHitEfficiency/interface/SiStripHitEffData.h"
 #include "CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
-#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h" /* for STRIPS_PER_APV*/
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DataFormats/SiStripCommon/interface/ConstantsForHardwareSystems.h" /* for STRIPS_PER_APV*/
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -26,6 +27,10 @@
 #include <numeric>  // for std::accumulate
 
 // ROOT includes
+#include "TGraphAsymmErrors.h"
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TStyle.h"
 #include "TEfficiency.h"
 
 // custom made printout
@@ -43,10 +48,12 @@ public:
 private:
   const std::string inputFolder_;
   const bool isAtPCL_;
-  const bool showRings_, autoIneffModTagging_, doStoreOnDB_;
+  const bool autoIneffModTagging_, doStoreOnDB_;
+  const bool showRings_, showEndcapSides_, showTOB6TEC9_, showOnlyGoodModules_;
   const unsigned int nTEClayers_;
   const double threshold_;
   const int nModsMin_;
+  const float effPlotMin_;
   const double tkMapMin_;
   const std::string title_, record_;
 
@@ -59,6 +66,11 @@ private:
   std::unique_ptr<TkDetMap> tkDetMap_;
   std::unique_ptr<SiStripQuality> stripQuality_;
   std::vector<DetId> stripDetIds_;
+
+  int goodlayertotal[bounds::k_END_OF_LAYS_AND_RINGS];
+  int goodlayerfound[bounds::k_END_OF_LAYS_AND_RINGS];
+  int alllayertotal[bounds::k_END_OF_LAYS_AND_RINGS];
+  int alllayerfound[bounds::k_END_OF_LAYS_AND_RINGS];
 
   void writeBadStripPayload(const SiStripQuality& quality) const;
   void printTotalStatistics(const std::array<long, bounds::k_END_OF_LAYERS>& layerFound,
@@ -75,19 +87,31 @@ private:
 SiStripHitEfficiencyHarvester::SiStripHitEfficiencyHarvester(const edm::ParameterSet& conf)
     : inputFolder_(conf.getParameter<std::string>("inputFolder")),
       isAtPCL_(conf.getParameter<bool>("isAtPCL")),
-      showRings_(conf.getUntrackedParameter<bool>("ShowRings", false)),
       autoIneffModTagging_(conf.getUntrackedParameter<bool>("AutoIneffModTagging", false)),
       doStoreOnDB_(conf.getParameter<bool>("doStoreOnDB")),
+      showRings_(conf.getUntrackedParameter<bool>("ShowRings", false)),
+      showEndcapSides_(conf.getUntrackedParameter<bool>("ShowEndcapSides", true)),
+      showTOB6TEC9_(conf.getUntrackedParameter<bool>("ShowTOB6TEC9", false)),
+      showOnlyGoodModules_(conf.getUntrackedParameter<bool>("ShowOnlyGoodModules", false)),
       nTEClayers_(showRings_ ? 7 : 9),  // number of rings or wheels
       threshold_(conf.getParameter<double>("Threshold")),
       nModsMin_(conf.getParameter<int>("nModsMin")),
+      effPlotMin_(conf.getUntrackedParameter<double>("EffPlotMin", 0.9)),
       tkMapMin_(conf.getUntrackedParameter<double>("TkMapMin", 0.9)),
       title_(conf.getParameter<std::string>("Title")),
       record_(conf.getParameter<std::string>("Record")),
       tTopoToken_(esConsumes<edm::Transition::EndRun>()),
       tkDetMapToken_(esConsumes<edm::Transition::EndRun>()),
       stripQualityToken_(esConsumes<edm::Transition::EndRun>()),
-      tkGeomToken_(esConsumes<edm::Transition::EndRun>()) {}
+      tkGeomToken_(esConsumes<edm::Transition::EndRun>()) {
+  // zero in all counts
+  for (int l = 0; l < bounds::k_END_OF_LAYS_AND_RINGS; l++) {
+    goodlayertotal[l] = 0;
+    goodlayerfound[l] = 0;
+    alllayertotal[l] = 0;
+    alllayerfound[l] = 0;
+  }
+}
 
 void SiStripHitEfficiencyHarvester::endRun(edm::Run const&, edm::EventSetup const& iSetup) {
   if (!tTopo_) {
@@ -182,6 +206,12 @@ void SiStripHitEfficiencyHarvester::dqmEndJob(DQMStore::IBooker& booker, DQMStor
   // count how many hits in the denominator we have
   const unsigned int totalHits = this->countTotalHits(totalMaps);
 
+  // set colz
+  for (size_t i = 1; i < totalMaps.size(); i++) {
+    h_module_total->getMap(i)->setOption("colz");
+    h_module_found->getMap(i)->setOption("colz");
+  }
+
   // come back to the main folder
   booker.setCurrentFolder(inputFolder_);
 
@@ -243,6 +273,57 @@ void SiStripHitEfficiencyHarvester::dqmEndJob(DQMStore::IBooker& booker, DQMStor
 
       layerTotal[layer] += denom;
       layerFound[layer] += num;
+
+      // for the summary
+
+      std::cout << det.rawId() << " | bad APVs:" << stripQuality_->getBadApvs(det) << std::endl;
+
+      if (stripQuality_->getBadApvs(det) == 0) {
+        std::cout << "in the good layers count!" << std::endl;
+        //Have to do the decoding for which side to go on (ugh)
+        if (layer <= bounds::k_LayersAtTOBEnd) {
+          goodlayerfound[layer] += num;
+          goodlayertotal[layer] += denom;
+        } else if (layer > bounds::k_LayersAtTOBEnd && layer <= bounds::k_LayersAtTIDEnd) {
+          if (tTopo_->tidSide(det) == 1) {
+            goodlayerfound[layer] += num;
+            goodlayertotal[layer] += denom;
+          } else if (tTopo_->tidSide(det) == 2) {
+            goodlayerfound[layer + 3] += num;
+            goodlayertotal[layer + 3] += denom;
+          }
+        } else if (layer > bounds::k_LayersAtTIDEnd && layer <= bounds::k_LayersAtTECEnd) {
+          if (tTopo_->tecSide(det) == 1) {
+            goodlayerfound[layer + 3] += num;
+            goodlayertotal[layer + 3] += denom;
+          } else if (tTopo_->tecSide(det) == 2) {
+            goodlayerfound[layer + 3 + nTEClayers_] += num;
+            goodlayertotal[layer + 3 + nTEClayers_] += denom;
+          }
+        }
+      }
+
+      //Do the one where we don't exclude bad modules!
+      if (layer <= bounds::k_LayersAtTOBEnd) {
+        alllayerfound[layer] += num;
+        alllayertotal[layer] += denom;
+      } else if (layer > bounds::k_LayersAtTOBEnd && layer <= bounds::k_LayersAtTIDEnd) {
+        if (tTopo_->tidSide(det) == 1) {
+          alllayerfound[layer] += num;
+          alllayertotal[layer] += denom;
+        } else if (tTopo_->tidSide(det) == 2) {
+          alllayerfound[layer + 3] += num;
+          alllayertotal[layer + 3] += denom;
+        }
+      } else if (layer > bounds::k_LayersAtTIDEnd && layer <= bounds::k_LayersAtTECEnd) {
+        if (tTopo_->tecSide(det) == 1) {
+          alllayerfound[layer + 3] += num;
+          alllayertotal[layer + 3] += denom;
+        } else if (tTopo_->tecSide(det) == 2) {
+          alllayerfound[layer + 3 + nTEClayers_] += num;
+          alllayertotal[layer + 3 + nTEClayers_] += denom;
+        }
+      }
     }
   }
 
@@ -409,6 +490,188 @@ void SiStripHitEfficiencyHarvester::writeBadStripPayload(const SiStripQuality& q
 
 void SiStripHitEfficiencyHarvester::makeSummary(DQMStore::IGetter& getter, TFileService& fs) const {
   // use goodlayer_total/found and alllayer_total/found, collapse side and/or ring if needed
+
+  unsigned int nLayers = 34;
+  if (showRings_)
+    nLayers = 30;
+  if (!showEndcapSides_) {
+    if (!showRings_)
+      nLayers = 22;
+    else
+      nLayers = 20;
+  }
+
+  TH1F* found = fs.make<TH1F>("found", "found", nLayers + 1, 0, nLayers + 1);
+  TH1F* all = fs.make<TH1F>("all", "all", nLayers + 1, 0, nLayers + 1);
+  TH1F* found2 = fs.make<TH1F>("found2", "found2", nLayers + 1, 0, nLayers + 1);
+  TH1F* all2 = fs.make<TH1F>("all2", "all2", nLayers + 1, 0, nLayers + 1);
+  // first bin only to keep real data off the y axis so set to -1
+  found->SetBinContent(0, -1);
+  all->SetBinContent(0, 1);
+
+  // new ROOT version: TGraph::Divide don't handle null or negative values
+  for (unsigned int i = 1; i < nLayers + 2; ++i) {
+    found->SetBinContent(i, 1e-6);
+    all->SetBinContent(i, 1);
+    found2->SetBinContent(i, 1e-6);
+    all2->SetBinContent(i, 1);
+  }
+
+  TCanvas* c7 = new TCanvas("c7", " test ", 10, 10, 800, 600);
+  c7->SetFillColor(0);
+  c7->SetGrid();
+
+  unsigned int nLayers_max = nLayers + 1;  // barrel+endcap
+  if (!showEndcapSides_)
+    nLayers_max = 11;  // barrel
+  for (unsigned int i = 1; i < nLayers_max; ++i) {
+    LOGPRINT << "Fill only good modules layer " << i << ":  S = " << goodlayerfound[i]
+             << "    B = " << goodlayertotal[i];
+    if (goodlayertotal[i] > 5) {
+      found->SetBinContent(i, goodlayerfound[i]);
+      all->SetBinContent(i, goodlayertotal[i]);
+    }
+
+    LOGPRINT << "Filling all modules layer " << i << ":  S = " << alllayerfound[i] << "    B = " << alllayertotal[i];
+    if (alllayertotal[i] > 5) {
+      found2->SetBinContent(i, alllayerfound[i]);
+      all2->SetBinContent(i, alllayertotal[i]);
+    }
+  }
+
+  // endcap - merging sides
+  if (!showEndcapSides_) {
+    for (unsigned int i = 11; i < 14; ++i) {  // TID disks
+      LOGPRINT << "Fill only good modules layer " << i << ":  S = " << goodlayerfound[i] + goodlayerfound[i + 3]
+               << "    B = " << goodlayertotal[i] + goodlayertotal[i + 3];
+      if (goodlayertotal[i] + goodlayertotal[i + 3] > 5) {
+        found->SetBinContent(i, goodlayerfound[i] + goodlayerfound[i + 3]);
+        all->SetBinContent(i, goodlayertotal[i] + goodlayertotal[i + 3]);
+      }
+      LOGPRINT << "Filling all modules layer " << i << ":  S = " << alllayerfound[i] + alllayerfound[i + 3]
+               << "    B = " << alllayertotal[i] + alllayertotal[i + 3];
+      if (alllayertotal[i] + alllayertotal[i + 3] > 5) {
+        found2->SetBinContent(i, alllayerfound[i] + alllayerfound[i + 3]);
+        all2->SetBinContent(i, alllayertotal[i] + alllayertotal[i + 3]);
+      }
+    }
+    for (unsigned int i = 17; i < 17 + nTEClayers_; ++i) {  // TEC disks
+      LOGPRINT << "Fill only good modules layer " << i - 3
+               << ":  S = " << goodlayerfound[i] + goodlayerfound[i + nTEClayers_]
+               << "    B = " << goodlayertotal[i] + goodlayertotal[i + nTEClayers_];
+      if (goodlayertotal[i] + goodlayertotal[i + nTEClayers_] > 5) {
+        found->SetBinContent(i - 3, goodlayerfound[i] + goodlayerfound[i + nTEClayers_]);
+        all->SetBinContent(i - 3, goodlayertotal[i] + goodlayertotal[i + nTEClayers_]);
+      }
+      LOGPRINT << "Filling all modules layer " << i - 3
+               << ":  S = " << alllayerfound[i] + alllayerfound[i + nTEClayers_]
+               << "    B = " << alllayertotal[i] + alllayertotal[i + nTEClayers_];
+      if (alllayertotal[i] + alllayertotal[i + nTEClayers_] > 5) {
+        found2->SetBinContent(i - 3, alllayerfound[i] + alllayerfound[i + nTEClayers_]);
+        all2->SetBinContent(i - 3, alllayertotal[i] + alllayertotal[i + nTEClayers_]);
+      }
+    }
+  }
+
+  found->Sumw2();
+  all->Sumw2();
+
+  found2->Sumw2();
+  all2->Sumw2();
+
+  TGraphAsymmErrors* gr = fs.make<TGraphAsymmErrors>(nLayers + 1);
+  gr->SetName("eff_good");
+  gr->BayesDivide(found, all);
+
+  TGraphAsymmErrors* gr2 = fs.make<TGraphAsymmErrors>(nLayers + 1);
+  gr2->SetName("eff_all");
+  gr2->BayesDivide(found2, all2);
+
+  for (unsigned int j = 0; j < nLayers + 1; j++) {
+    gr->SetPointError(j, 0., 0., gr->GetErrorYlow(j), gr->GetErrorYhigh(j));
+    gr2->SetPointError(j, 0., 0., gr2->GetErrorYlow(j), gr2->GetErrorYhigh(j));
+  }
+
+  gr->GetXaxis()->SetLimits(0, nLayers);
+  gr->SetMarkerColor(2);
+  gr->SetMarkerSize(1.2);
+  gr->SetLineColor(2);
+  gr->SetLineWidth(4);
+  gr->SetMarkerStyle(20);
+  gr->SetMinimum(effPlotMin_);
+  gr->SetMaximum(1.001);
+  gr->GetYaxis()->SetTitle("Efficiency");
+  gStyle->SetTitleFillColor(0);
+  gStyle->SetTitleBorderSize(0);
+  gr->SetTitle(title_.c_str());
+
+  gr2->GetXaxis()->SetLimits(0, nLayers);
+  gr2->SetMarkerColor(1);
+  gr2->SetMarkerSize(1.2);
+  gr2->SetLineColor(1);
+  gr2->SetLineWidth(4);
+  gr2->SetMarkerStyle(21);
+  gr2->SetMinimum(effPlotMin_);
+  gr2->SetMaximum(1.001);
+  gr2->GetYaxis()->SetTitle("Efficiency");
+  gr2->SetTitle(title_.c_str());
+
+  for (Long_t k = 1; k < nLayers + 1; k++) {
+    TString label;
+    if (showEndcapSides_)
+      label = ::layerSideName(k, showRings_, nTEClayers_);
+    else
+      label = ::layerName(k, showRings_, nTEClayers_);
+    if (!showTOB6TEC9_) {
+      if (k == 10)
+        label = "";
+      if (!showRings_ && k == nLayers)
+        label = "";
+      if (!showRings_ && showEndcapSides_ && k == 25)
+        label = "";
+    }
+    if (!showRings_) {
+      if (showEndcapSides_) {
+        gr->GetXaxis()->SetBinLabel(((k + 1) * 100 + 2) / (nLayers)-4, label);
+        gr2->GetXaxis()->SetBinLabel(((k + 1) * 100 + 2) / (nLayers)-4, label);
+      } else {
+        gr->GetXaxis()->SetBinLabel((k + 1) * 100 / (nLayers)-6, label);
+        gr2->GetXaxis()->SetBinLabel((k + 1) * 100 / (nLayers)-6, label);
+      }
+    } else {
+      if (showEndcapSides_) {
+        gr->GetXaxis()->SetBinLabel((k + 1) * 100 / (nLayers)-4, label);
+        gr2->GetXaxis()->SetBinLabel((k + 1) * 100 / (nLayers)-4, label);
+      } else {
+        gr->GetXaxis()->SetBinLabel((k + 1) * 100 / (nLayers)-7, label);
+        gr2->GetXaxis()->SetBinLabel((k + 1) * 100 / (nLayers)-7, label);
+      }
+    }
+  }
+
+  gr->Draw("AP");
+  gr->GetXaxis()->SetNdivisions(36);
+
+  c7->cd();
+  TPad* overlay = new TPad("overlay", "", 0, 0, 1, 1);
+  overlay->SetFillStyle(4000);
+  overlay->SetFillColor(0);
+  overlay->SetFrameFillStyle(4000);
+  overlay->Draw("same");
+  overlay->cd();
+  if (!showOnlyGoodModules_)
+    gr2->Draw("AP");
+
+  TLegend* leg = new TLegend(0.70, 0.27, 0.88, 0.40);
+  leg->AddEntry(gr, "Good Modules", "p");
+  if (!showOnlyGoodModules_)
+    leg->AddEntry(gr2, "All Modules", "p");
+  leg->SetTextSize(0.020);
+  leg->SetFillColor(0);
+  leg->Draw("same");
+
+  c7->SaveAs("Summary.png");
+  c7->SaveAs("Summary.root");
 }
 
 void SiStripHitEfficiencyHarvester::makeSummaryVsBX(DQMStore::IGetter& getter, TFileService& fs) const {
@@ -684,7 +947,11 @@ void SiStripHitEfficiencyHarvester::fillDescriptions(edm::ConfigurationDescripti
   desc.add<int>("nModsMin", 5);
   desc.addUntracked<bool>("AutoIneffModTagging", false);
   desc.addUntracked<double>("TkMapMin", 0.9);
+  desc.addUntracked<double>("EffPlotMin", 0.9);
   desc.addUntracked<bool>("ShowRings", false);
+  desc.addUntracked<bool>("ShowEndcapSides", true);
+  desc.addUntracked<bool>("ShowTOB6TEC9", false);
+  desc.addUntracked<bool>("ShowOnlyGoodModules", false);
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
@@ -9,6 +9,7 @@
 
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 #include "CalibTracker/Records/interface/SiStripQualityRcd.h"
+#include "CalibTracker/SiStripHitEfficiency/interface/SiStripHitEffData.h"
 #include "CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h"
 #include "CalibTracker/SiStripHitEfficiency/interface/TrajectoryAtInvalidHit.h"
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"

--- a/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
+++ b/CalibTracker/SiStripHitEfficiency/plugins/SiStripHitEfficiencyWorker.cc
@@ -84,6 +84,7 @@ private:
                    bool highPurity);
 
   // ----------member data ---------------------------
+  SiStripHitEffData calibData_;
 
   // event data tokens
   const edm::EDGetTokenT<LumiScalersCollection> scalerToken_;
@@ -263,6 +264,11 @@ void SiStripHitEfficiencyWorker::bookHistograms(DQMStore::IBooker& booker,
   h_nTracks = booker.book1D("ntracks", "n.tracks;n. tracks;n.events", 500, -0.5, 499.5);
   h_nTracksVsPU = booker.bookProfile("nTracksVsPU", "n. tracks vs PU; PU; n.tracks ", 200, 0, 200, 500, -0.5, 499.5);
 
+  calibData_.EventStats = booker.book2I("EventStats", "Statistics", 3, -0.5, 2.5, 1, 0, 1);
+  calibData_.EventStats->setBinLabel(1, "events count", 1);
+  calibData_.EventStats->setBinLabel(2, "tracks count", 1);
+  calibData_.EventStats->setBinLabel(3, "measurements count", 1);
+
   booker.setCurrentFolder(dqmDir_);
   h_goodLayer = EffME1(booker.book1D("goodlayer_total", "goodlayer_total", 35, 0., 35.),
                        booker.book1D("goodlayer_found", "goodlayer_found", 35, 0., 35.));
@@ -356,6 +362,11 @@ void SiStripHitEfficiencyWorker::bookHistograms(DQMStore::IBooker& booker,
   h_module =
       EffTkMap(std::make_unique<TkHistoMap>(tkDetMap, booker, tkDetMapFolder, "perModule_total", 0, false, true),
                std::make_unique<TkHistoMap>(tkDetMap, booker, tkDetMapFolder, "perModule_found", 0, false, true));
+
+  // fill the FED Errors
+  booker.setCurrentFolder(dqmDir_);
+  const auto FEDErrorMapFolder = fmt::format("{}/FEDErrorTkDetMaps", dqmDir_);
+  calibData_.FEDErrorOccupancy = TkHistoMap(tkDetMap, booker, FEDErrorMapFolder, "perModule_FEDErrors", 0, false, true);
 }
 
 void SiStripHitEfficiencyWorker::analyze(const edm::Event& e, const edm::EventSetup& es) {
@@ -410,6 +421,15 @@ void SiStripHitEfficiencyWorker::analyze(const edm::Event& e, const edm::EventSe
   edm::Handle<DetIdCollection> fedErrorIds;
   e.getByToken(digis_token_, fedErrorIds);
 
+  // fill the calibData with the FEDErrors
+  for (const auto& fedErr : *fedErrorIds) {
+    if (calibData_.fedErrorCounts.find(fedErr.rawId()) != calibData_.fedErrorCounts.end()) {
+      calibData_.fedErrorCounts[fedErr.rawId()] += 1;
+    } else {
+      calibData_.fedErrorCounts.insert(std::make_pair(fedErr.rawId(), 1));
+    }
+  }
+
   edm::Handle<MeasurementTrackerEvent> measurementTrackerEvent;
   e.getByToken(trackerEvent_token_, measurementTrackerEvent);
 
@@ -428,6 +448,11 @@ void SiStripHitEfficiencyWorker::analyze(const edm::Event& e, const edm::EventSe
 
   h_nTracks->Fill(tracksCKF->size());
   h_nTracksVsPU->Fill(PU, tracksCKF->size());
+
+  // bin 0: one entry for each event
+  calibData_.EventStats->Fill(0., 0., 1);
+  // bin 1: one entry for each track
+  calibData_.EventStats->Fill(1., 0., tracksCKF->size());
 
   if (!tracksCKF->empty()) {
     if (cutOnTracks_ && (tracksCKF->size() >= trackMultiplicityCut_))
@@ -451,10 +476,13 @@ void SiStripHitEfficiencyWorker::analyze(const edm::Event& e, const edm::EventSe
         return tm.recHit()->getType() == TrackingRecHit::Type::missing;
       });
 
-      // Loop on each measurement and take it into consideration
+      // Loop on each measurement and take into consideration
       //--------------------------------------------------------
       for (auto itm = TMeas.cbegin(); itm != TMeas.cend(); ++itm) {
         const auto theInHit = (*itm).recHit();
+
+        //bin 2: one entry for each measurement
+        calibData_.EventStats->Fill(2., 0., 1.);
 
         LogDebug("SiStripHitEfficiencyWorker") << "theInHit is valid = " << theInHit->isValid();
 
@@ -946,14 +974,14 @@ void SiStripHitEfficiencyWorker::fillForTraj(const TrajectoryAtInvalidHit& tm,
           h_layer_vsCM[layer - 1].fill(commonMode, !badflag);
         }
         h_goodLayer.fill(layerWithSide, !badflag);
-
-        // efficiency with bad modules excluded
-        if (TKlayers) {
-          h_module.fill(iidd, !badflag);
-        }
       }
       // efficiency without bad modules excluded
       h_allLayer.fill(layerWithSide, !badflag);
+
+      // efficiency without bad modules excluded
+      if (TKlayers) {
+        h_module.fill(iidd, !badflag);
+      }
 
       /* Used in SiStripHitEffFromCalibTree:
        * run              -> "run"              -> run              // e.id().run()
@@ -987,6 +1015,9 @@ void SiStripHitEfficiencyWorker::fillForTraj(const TrajectoryAtInvalidHit& tm,
 void SiStripHitEfficiencyWorker::endJob() {
   LogDebug("SiStripHitEfficiencyWorker") << " Events Analysed             " << events;
   LogDebug("SiStripHitEfficiencyWorker") << " Number Of Tracked events    " << EventTrackCKF;
+
+  // fill the TkMap Data
+  calibData_.fillTkMapFromMap();
 }
 
 void SiStripHitEfficiencyWorker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
+++ b/CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h
@@ -138,6 +138,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 //#include "FWCore/Framework/interface/EventSetup.h"
@@ -146,7 +147,8 @@
 #include "DataFormats/Common/interface/Handle.h"
 
 template <class T>
-class ConditionDBWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
+class ConditionDBWriter
+    : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks, edm::one::SharedResources> {
 public:
   explicit ConditionDBWriter(const edm::ParameterSet &iConfig)
       : minRunRange_(1 << 31),


### PR DESCRIPTION
#### PR description:

As per request of the SiStrip offline group, I apply few improvement for the harvesting step:
   * in case the harvester is NOT run at PCL (flag `isAtPCL` set to false) produce the final good module/ bad module `TGraphError` plot for the hit efficiency;
   *  in case the harvester is NOT run at PCL (flag `isAtPCL` set to false) produce a `TTree` to store per-DetId information for further post-processing from experts / shifters;
   * introduced a `SiStripHitEffData` struct to store the per event `FEDError`s and some events statistics;
   * profited of the PR to clean-up slightly also `SiStripHitEffFromCalibTree`: used lower case to name methods and use `   usesResource(TFileService::kSharedResource)` for threading efficiency.
   
#### PR validation:

Run the following commands:

```console
cmsDriver.py stepReAlCa -s ALCA:PromptCalibProdSiStripHitEff --conditions 123X_dataRun2_v2 --scenario pp --data --era Run2_2018 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 100000 --dasquery='file dataset=/StreamExpress/Run2018D-SiStripCalMinBias-Express-v1/ALCARECO run=325172' --nThreads=4
```

followed by:

```console
cmsDriver.py stepHarvest -s ALCAHARVEST:SiStripHitEff --conditions 123X_dataRun2_v2 --scenario pp --data --era Run2_2018 --filein file:PromptCalibProdSiStripHitEfficiency.root -n -1
```

and obtained the following plot:

![image](https://user-images.githubusercontent.com/5082376/177169737-70f99ffe-222c-4421-a003-0fbd4f68f214.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport but needs to be backported for the data-taking.
