### PR TITLE
Hlt gen validation

### DIFF
--- a/Validation/HLTrigger/BuildFile.xml
+++ b/Validation/HLTrigger/BuildFile.xml
@@ -1,0 +1,13 @@
+<use name="CommonTools/TriggerUtils"/>
+<use name="DQMOffline/Trigger"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="DataFormats/HLTReco"/>
+<use name="HLTrigger/HLTcore"/>
+<use name="DQMServices/Core"/>
+<use name="CommonTools/Utils"/>
+<use name="root"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/Validation/HLTrigger/interface/HLTGenValHist.h
+++ b/Validation/HLTrigger/interface/HLTGenValHist.h
@@ -40,13 +40,14 @@ public:
 class HLTGenValHist1D : public HLTGenValHist {
 public:
   HLTGenValHist1D(TH1* hist,
-               std::string varName,
-               std::function<float(const HLTGenValObject&)> func,
-               VarRangeCutColl<HLTGenValObject> rangeCuts)
+                  std::string varName,
+                  std::function<float(const HLTGenValObject&)> func,
+                  VarRangeCutColl<HLTGenValObject> rangeCuts)
       : var_(std::move(func)), varName_(std::move(varName)), rangeCuts_(std::move(rangeCuts)), hist_(hist) {}
 
   void fill(const HLTGenValObject& obj) override {
-    if(rangeCuts_(obj)) hist_->Fill(var_(obj));
+    if (rangeCuts_(obj))
+      hist_->Fill(var_(obj));
   }
 
 private:
@@ -63,15 +64,17 @@ private:
 class HLTGenValHist2D : public HLTGenValHist {
 public:
   HLTGenValHist2D(TH2* hist,
-               std::string varNameX,
-               std::string varNameY,
-               std::function<float(const HLTGenValObject&)> funcX,
-               std::function<float(const HLTGenValObject&)> funcY)
-      : varX_(std::move(funcX)), varY_(std::move(funcY)), varNameX_(std::move(varNameX)), varNameY_(std::move(varNameY)), hist_(hist) {}
+                  std::string varNameX,
+                  std::string varNameY,
+                  std::function<float(const HLTGenValObject&)> funcX,
+                  std::function<float(const HLTGenValObject&)> funcY)
+      : varX_(std::move(funcX)),
+        varY_(std::move(funcY)),
+        varNameX_(std::move(varNameX)),
+        varNameY_(std::move(varNameY)),
+        hist_(hist) {}
 
-  void fill(const HLTGenValObject& obj) override {
-    hist_->Fill(varX_(obj), varY_(obj));
-  }
+  void fill(const HLTGenValObject& obj) override { hist_->Fill(varX_(obj), varY_(obj)); }
 
 private:
   std::function<float(const HLTGenValObject&)> varX_;

--- a/Validation/HLTrigger/interface/HLTGenValHist.h
+++ b/Validation/HLTrigger/interface/HLTGenValHist.h
@@ -1,0 +1,84 @@
+#ifndef Validation_HLTrigger_HLTGenValHist_h
+#define Validation_HLTrigger_HLTGenValHist_h
+
+//********************************************************************************
+//
+// Description:
+//   Histogram holder class for the GEN-level HLT validation
+//   Handling and filling of 1D and 2D histograms is done by this class.
+//
+//
+// Author : Finn Labe, UHH, Jul. 2022
+//          (Strongly inspired by Sam Harpers HLTDQMHist class)
+//
+//***********************************************************************************
+
+#include "DQMOffline/Trigger/interface/FunctionDefs.h"
+
+#include "DQMOffline/Trigger/interface/VarRangeCutColl.h"
+
+#include "FWCore/Framework/interface/Event.h"
+
+#include "Validation/HLTrigger/interface/HLTGenValObject.h"
+
+#include <TH1.h>
+#include <TH2.h>
+
+// base histogram class, with specific implementations following below
+class HLTGenValHist {
+public:
+  HLTGenValHist() = default;
+  virtual ~HLTGenValHist() = default;
+  virtual void fill(const HLTGenValObject& objType) = 0;
+};
+
+// specific implimentation of a HLTGenValHist for 1D histograms
+// it takes the histogram which it will fill
+// it takes the variable to plot (func) and its name (varName)
+// also, it takes additional cuts (rangeCuts) applied before filling
+// to fill the histogram, an object is passed in the Fill function
+class HLTGenValHist1D : public HLTGenValHist {
+public:
+  HLTGenValHist1D(TH1* hist,
+               std::string varName,
+               std::function<float(const HLTGenValObject&)> func,
+               VarRangeCutColl<HLTGenValObject> rangeCuts)
+      : var_(std::move(func)), varName_(std::move(varName)), rangeCuts_(std::move(rangeCuts)), hist_(hist) {}
+
+  void fill(const HLTGenValObject& obj) override {
+    if(rangeCuts_(obj)) hist_->Fill(var_(obj));
+  }
+
+private:
+  std::function<float(const HLTGenValObject&)> var_;
+  std::string varName_;
+  VarRangeCutColl<HLTGenValObject> rangeCuts_;
+  TH1* hist_;  //we do not own this
+};
+
+// specific implimentation of a HLTGenValHist for 2D histograms
+// it takes the histogram which it will fill
+// it takes the two variable to plot (func) and their name (varName)
+// to fill the histogram, two objects are passed in the Fill function
+class HLTGenValHist2D : public HLTGenValHist {
+public:
+  HLTGenValHist2D(TH2* hist,
+               std::string varNameX,
+               std::string varNameY,
+               std::function<float(const HLTGenValObject&)> funcX,
+               std::function<float(const HLTGenValObject&)> funcY)
+      : varX_(std::move(funcX)), varY_(std::move(funcY)), varNameX_(std::move(varNameX)), varNameY_(std::move(varNameY)), hist_(hist) {}
+
+  void fill(const HLTGenValObject& obj) override {
+    hist_->Fill(varX_(obj), varY_(obj));
+  }
+
+private:
+  std::function<float(const HLTGenValObject&)> varX_;
+  std::function<float(const HLTGenValObject&)> varY_;
+  std::string varNameX_;
+  std::string varNameY_;
+  TH2* hist_;  //we do not own this
+};
+
+#endif

--- a/Validation/HLTrigger/interface/HLTGenValHistCollFilter.h
+++ b/Validation/HLTrigger/interface/HLTGenValHistCollFilter.h
@@ -35,8 +35,8 @@
 // functions for initial booking of hists, and filling of hists for a single object are available
 class HLTGenValHistCollFilter {
 public:
-  typedef dqm::legacy::MonitorElement MonitorElement;
-  typedef dqm::legacy::DQMStore DQMStore;
+  using MonitorElement = dqm::legacy::MonitorElement;
+  using DQMStore = dqm::legacy::DQMStore;
 
   explicit HLTGenValHistCollFilter(edm::ParameterSet filterCollConfig);
 

--- a/Validation/HLTrigger/interface/HLTGenValHistCollFilter.h
+++ b/Validation/HLTrigger/interface/HLTGenValHistCollFilter.h
@@ -1,0 +1,61 @@
+#ifndef Validation_HLTrigger_HLTGenValHistCollFilter_h
+#define Validation_HLTrigger_HLTGenValHistCollFilter_h
+
+//********************************************************************************
+//
+// Description:
+//   This class contains a collection of HLTGenvalHists used to measure the efficiency of a
+//   specified filter. It is resonsible for booking and filling the histograms of all vsVars
+//   histograms that are created for a specific filter.
+//
+// Author : Finn Labe, UHH, Jul. 2022
+//          (Strongly inspired by Sam Harpers HLTDQMFilterEffHists class)
+//
+//***********************************************************************************
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+
+#include "Validation/HLTrigger/interface/HLTGenValHist.h"
+#include "DQMOffline/Trigger/interface/FunctionDefs.h"
+#include "DQMOffline/Trigger/interface/UtilFuncs.h"
+
+#include "Validation/HLTrigger/interface/HLTGenValObject.h"
+#include "Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <utility>
+
+// class containing a collection of HLTGenValHist for a specific filter
+// functions for initial booking of hists, and filling of hists for a single object are available
+class HLTGenValHistCollFilter {
+public:
+  typedef dqm::legacy::MonitorElement MonitorElement;
+  typedef dqm::legacy::DQMStore DQMStore;
+
+  explicit HLTGenValHistCollFilter(edm::ParameterSet filterCollConfig);
+
+  static edm::ParameterSetDescription makePSetDescription();
+
+  void bookHists(DQMStore::IBooker& iBooker, const std::vector<edm::ParameterSet>& histConfigs, const std::vector<edm::ParameterSet>& histConfigs2D);
+  void fillHists(const HLTGenValObject& obj, edm::Handle<trigger::TriggerEvent>& triggerEvent);
+
+private:
+  void book1D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig);
+  void book2D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig2D);
+
+  std::vector<std::unique_ptr<HLTGenValHist>> hists_; // the collection of histograms
+  std::string objType_;
+  std::string tag_;
+  std::string filter_;
+  std::string path_;
+  std::string hltProcessName_;
+  double dR2limit_;
+};
+
+#endif

--- a/Validation/HLTrigger/interface/HLTGenValHistCollFilter.h
+++ b/Validation/HLTrigger/interface/HLTGenValHistCollFilter.h
@@ -42,14 +42,16 @@ public:
 
   static edm::ParameterSetDescription makePSetDescription();
 
-  void bookHists(DQMStore::IBooker& iBooker, const std::vector<edm::ParameterSet>& histConfigs, const std::vector<edm::ParameterSet>& histConfigs2D);
+  void bookHists(DQMStore::IBooker& iBooker,
+                 const std::vector<edm::ParameterSet>& histConfigs,
+                 const std::vector<edm::ParameterSet>& histConfigs2D);
   void fillHists(const HLTGenValObject& obj, edm::Handle<trigger::TriggerEvent>& triggerEvent);
 
 private:
   void book1D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig);
   void book2D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig2D);
 
-  std::vector<std::unique_ptr<HLTGenValHist>> hists_; // the collection of histograms
+  std::vector<std::unique_ptr<HLTGenValHist>> hists_;  // the collection of histograms
   std::string objType_;
   std::string tag_;
   std::string filter_;

--- a/Validation/HLTrigger/interface/HLTGenValHistCollFilter.h
+++ b/Validation/HLTrigger/interface/HLTGenValHistCollFilter.h
@@ -58,6 +58,7 @@ private:
   std::string path_;
   std::string hltProcessName_;
   double dR2limit_;
+  std::string separator_;
 };
 
 #endif

--- a/Validation/HLTrigger/interface/HLTGenValHistCollPath.h
+++ b/Validation/HLTrigger/interface/HLTGenValHistCollPath.h
@@ -40,7 +40,9 @@ public:
 
   static edm::ParameterSetDescription makePSetDescription();
 
-  void bookHists(DQMStore::IBooker& iBooker, std::vector<edm::ParameterSet>& histConfigs, std::vector<edm::ParameterSet>& histConfigs2D);
+  void bookHists(DQMStore::IBooker& iBooker,
+                 std::vector<edm::ParameterSet>& histConfigs,
+                 std::vector<edm::ParameterSet>& histConfigs2D);
   void fillHists(const HLTGenValObject& obj, edm::Handle<trigger::TriggerEvent>& triggerEvent);
 
 private:

--- a/Validation/HLTrigger/interface/HLTGenValHistCollPath.h
+++ b/Validation/HLTrigger/interface/HLTGenValHistCollPath.h
@@ -1,0 +1,59 @@
+#ifndef Validation_HLTrigger_HLTGenValHistCollPath_h
+#define Validation_HLTrigger_HLTGenValHistCollPath_h
+
+//********************************************************************************
+//
+// Description:
+//   This contains a collection of HLTGenValHistCollFilter used to measure the efficiencies of all
+//   filters in a specified path. The actual booking and filling happens in the respective HLTGenValHistCollFilters.
+//
+// Author : Finn Labe, UHH, Oct. 2021
+// (Heavily borrowed from Sam Harpers HLTDQMFilterEffHists)
+//
+//***********************************************************************************
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+
+#include "DQMOffline/Trigger/interface/FunctionDefs.h"
+#include "DQMOffline/Trigger/interface/UtilFuncs.h"
+
+#include "Validation/HLTrigger/interface/HLTGenValHistCollFilter.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+
+#include "Validation/HLTrigger/interface/HLTGenValObject.h"
+
+// class containing a collection of HLTGenValHistCollFilters for a specific path
+// at object creation time, the object type (used for systematically naming the histogram),
+// triggerPath, hltConfig and dR2limit (for deltaR matching) need to be specified
+// functions for initial booking of hists, and filling of hists for a single object, are available
+class HLTGenValHistCollPath {
+public:
+  typedef dqm::legacy::MonitorElement MonitorElement;
+  typedef dqm::legacy::DQMStore DQMStore;
+
+  explicit HLTGenValHistCollPath(edm::ParameterSet pathCollConfig, HLTConfigProvider& hltConfig);
+
+  static edm::ParameterSetDescription makePSetDescription();
+
+  void bookHists(DQMStore::IBooker& iBooker, std::vector<edm::ParameterSet>& histConfigs, std::vector<edm::ParameterSet>& histConfigs2D);
+  void fillHists(const HLTGenValObject& obj, edm::Handle<trigger::TriggerEvent>& triggerEvent);
+
+private:
+  std::string triggerPath_;
+  std::vector<HLTGenValHistCollFilter> collectionFilter_;
+  std::vector<std::string> filters_;
+  HLTConfigProvider hltConfig_;
+  bool doOnlyLastFilter_;
+
+  // we will add a string to the root file that is named after the path
+  // it will contain the filters of that path divided by semicola
+  std::string pathStringName_;
+  std::string pathString_;
+};
+
+#endif

--- a/Validation/HLTrigger/interface/HLTGenValHistCollPath.h
+++ b/Validation/HLTrigger/interface/HLTGenValHistCollPath.h
@@ -33,8 +33,8 @@
 // functions for initial booking of hists, and filling of hists for a single object, are available
 class HLTGenValHistCollPath {
 public:
-  typedef dqm::legacy::MonitorElement MonitorElement;
-  typedef dqm::legacy::DQMStore DQMStore;
+  using MonitorElement = dqm::legacy::MonitorElement;
+  using DQMStore = dqm::legacy::DQMStore;
 
   explicit HLTGenValHistCollPath(edm::ParameterSet pathCollConfig, HLTConfigProvider& hltConfig);
 

--- a/Validation/HLTrigger/interface/HLTGenValObject.h
+++ b/Validation/HLTrigger/interface/HLTGenValObject.h
@@ -1,0 +1,51 @@
+#ifndef Validation_HLTrigger_HLTGenValObject_h
+#define Validation_HLTrigger_HLTGenValObject_h
+
+//********************************************************************************
+//
+// Description:
+//   This class is an object wrapper for the Generator level validation code.
+//   It handles the different type of objects the code needs to run on: GenParticles, GenJets and event-level energy sums
+//
+// Author : Finn Labe, UHH, Nov. 2021
+//
+//********************************************************************************
+
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include <vector>
+
+class HLTGenValObject {
+public:
+
+  // empty constructor
+  HLTGenValObject() {}
+
+  // constructor from GenParticle
+  HLTGenValObject(const reco::GenParticle &p)
+      : p4Polar_(p.p4()), p4Cartesian_(p.p4()) {}
+
+  // constructor from GenJet
+  HLTGenValObject(const reco::GenJet &p)
+      : p4Polar_(p.p4()), p4Cartesian_(p.p4()) {}
+
+  // constructor from LorentzVector (for energy sums)
+  HLTGenValObject(const reco::Candidate::PolarLorentzVector& p)
+      : p4Polar_(p), p4Cartesian_(p) {}
+
+  // object functions, for usage of HLTGenValObjects by other modules
+  double pt() const { return p4Polar_.pt(); }
+  double eta() const { return p4Polar_.eta(); }
+  double phi() const { return p4Polar_.phi(); }
+  double et() const { return (pt() <= 0) ? 0 : p4Cartesian_.Et(); }
+
+private:
+  // containing information in two "shapes"
+  math::PtEtaPhiMLorentzVector p4Polar_;
+  math::XYZTLorentzVector p4Cartesian_;
+};
+
+#endif

--- a/Validation/HLTrigger/interface/HLTGenValObject.h
+++ b/Validation/HLTrigger/interface/HLTGenValObject.h
@@ -11,7 +11,6 @@
 //
 //********************************************************************************
 
-
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
 
@@ -20,21 +19,17 @@
 
 class HLTGenValObject {
 public:
-
   // empty constructor
   HLTGenValObject() {}
 
   // constructor from GenParticle
-  HLTGenValObject(const reco::GenParticle &p)
-      : p4Polar_(p.p4()), p4Cartesian_(p.p4()) {}
+  HLTGenValObject(const reco::GenParticle &p) : p4Polar_(p.p4()), p4Cartesian_(p.p4()) {}
 
   // constructor from GenJet
-  HLTGenValObject(const reco::GenJet &p)
-      : p4Polar_(p.p4()), p4Cartesian_(p.p4()) {}
+  HLTGenValObject(const reco::GenJet &p) : p4Polar_(p.p4()), p4Cartesian_(p.p4()) {}
 
   // constructor from LorentzVector (for energy sums)
-  HLTGenValObject(const reco::Candidate::PolarLorentzVector& p)
-      : p4Polar_(p), p4Cartesian_(p) {}
+  HLTGenValObject(const reco::Candidate::PolarLorentzVector &p) : p4Polar_(p), p4Cartesian_(p) {}
 
   // object functions, for usage of HLTGenValObjects by other modules
   double pt() const { return p4Polar_.pt(); }

--- a/Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h
+++ b/Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h
@@ -26,10 +26,10 @@ public:
                                      std::vector<edm::ParameterSet> binnings,
                                      std::string vsVar);
 
-  const std::vector<edm::ParameterSet>* getPathSpecificCuts() const { return & pathSpecificCutsVector_; }
-  const std::vector<double>* getPathSpecificBins() const { return & pathSpecificBins_; }
+  const std::vector<edm::ParameterSet>* getPathSpecificCuts() const { return &pathSpecificCutsVector_; }
+  const std::vector<double>* getPathSpecificBins() const { return &pathSpecificBins_; }
   const bool havePathSpecificBins() const { return (!pathSpecificBins_.empty()); }
-  const std::string* getTag() const { return & tag_; }
+  const std::string* getTag() const { return &tag_; }
 
 private:
   std::vector<edm::ParameterSet> pathSpecificCutsVector_;

--- a/Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h
+++ b/Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h
@@ -1,5 +1,5 @@
 #ifndef Validation_HLTrigger_HLTGenValPathSpecificSettingParser_h
-#define Validation_HLTrigger_HLTGenValSpecificCutParser_h
+#define Validation_HLTrigger_HLTGenValPathSpecificSettingParser_h
 
 //********************************************************************************
 //
@@ -26,10 +26,10 @@ public:
                                      std::vector<edm::ParameterSet> binnings,
                                      std::string vsVar);
 
-  std::vector<edm::ParameterSet> getPathSpecificCuts() { return pathSpecificCutsVector_; }
-  std::vector<double> getPathSpecificBins() { return pathSpecificBins_; }
-  bool havePathSpecificBins() { return (!pathSpecificBins_.empty()); }
-  std::string getTag() { return tag_; }
+  const std::vector<edm::ParameterSet>* getPathSpecificCuts() const { return & pathSpecificCutsVector_; }
+  const std::vector<double>* getPathSpecificBins() const { return & pathSpecificBins_; }
+  const bool havePathSpecificBins() const { return (!pathSpecificBins_.empty()); }
+  const std::string* getTag() const { return & tag_; }
 
 private:
   std::vector<edm::ParameterSet> pathSpecificCutsVector_;

--- a/Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h
+++ b/Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h
@@ -21,20 +21,20 @@
 
 class HLTGenValPathSpecificSettingParser {
 public:
-
   // constructor
-  HLTGenValPathSpecificSettingParser(std::string pathSpecificSettings, std::vector<edm::ParameterSet> binnings, std::string vsVar);
+  HLTGenValPathSpecificSettingParser(std::string pathSpecificSettings,
+                                     std::vector<edm::ParameterSet> binnings,
+                                     std::string vsVar);
 
-  std::vector<edm::ParameterSet> getPathSpecificCuts() {return pathSpecificCutsVector_;}
-  std::vector<double> getPathSpecificBins() {return pathSpecificBins_;}
+  std::vector<edm::ParameterSet> getPathSpecificCuts() { return pathSpecificCutsVector_; }
+  std::vector<double> getPathSpecificBins() { return pathSpecificBins_; }
   bool havePathSpecificBins() { return (!pathSpecificBins_.empty()); }
-  std::string getTag() {return tag_;}
+  std::string getTag() { return tag_; }
 
 private:
   std::vector<edm::ParameterSet> pathSpecificCutsVector_;
   std::vector<double> pathSpecificBins_;
   std::string tag_ = "";
-
 };
 
 #endif

--- a/Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h
+++ b/Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h
@@ -1,0 +1,40 @@
+#ifndef Validation_HLTrigger_HLTGenValPathSpecificSettingParser_h
+#define Validation_HLTrigger_HLTGenValSpecificCutParser_h
+
+//********************************************************************************
+//
+// Description:
+//   This class handles parsing of additional settings that can be set for each path in the generator-level validation module
+//   Mainly, these are cuts in addition to the ones specified in the module. Passing a pre-defined region is also possible
+//   The binning of a certain variable can be changed through this class, as well as setting a tag for all histograms of a path.
+//
+// Author : Finn Labe, UHH, Jul. 2022
+//
+//********************************************************************************
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include <vector>
+
+class HLTGenValPathSpecificSettingParser {
+public:
+
+  // constructor
+  HLTGenValPathSpecificSettingParser(std::string pathSpecificSettings, std::vector<edm::ParameterSet> binnings, std::string vsVar);
+
+  std::vector<edm::ParameterSet> getPathSpecificCuts() {return pathSpecificCutsVector_;}
+  std::vector<double> getPathSpecificBins() {return pathSpecificBins_;}
+  bool havePathSpecificBins() { return (!pathSpecificBins_.empty()); }
+  std::string getTag() {return tag_;}
+
+private:
+  std::vector<edm::ParameterSet> pathSpecificCutsVector_;
+  std::vector<double> pathSpecificBins_;
+  std::string tag_ = "";
+
+};
+
+#endif

--- a/Validation/HLTrigger/plugins/BuildFile.xml
+++ b/Validation/HLTrigger/plugins/BuildFile.xml
@@ -1,0 +1,15 @@
+<use name="DataFormats/TrackReco"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/PluginManager"/>
+<use name="CommonTools/UtilAlgos"/>
+<use name="PhysicsTools/UtilAlgos"/>
+<use name="DQMServices/Core"/>
+<use name="CommonTools/TriggerUtils"/>
+<use name="DQMOffline/Trigger"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="DataFormats/HLTReco"/>
+<use name="HLTrigger/HLTcore"/>
+<use name="CommonTools/Utils"/>
+<use name="Validation/HLTrigger"/>
+<flags EDM_PLUGIN="1"/>

--- a/Validation/HLTrigger/plugins/HLTGenValClient.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValClient.cc
@@ -56,8 +56,7 @@ public:
                          const std::string& efficMEName,
                          const std::string& efficMETitle,
                          const std::string& numeratorMEName,
-                         const std::string& denominatorMEName
-                    );
+                         const std::string& denominatorMEName);
 
 private:
   TPRegexp metacharacters_;
@@ -83,13 +82,10 @@ private:
                              const TString& pattern);
 
   void genericEff(TH1* denom, TH1* numer, MonitorElement* efficiencyHist);
-
-
 };
 
 HLTGenValClient::HLTGenValClient(const edm::ParameterSet& pset)
     : metacharacters_("[\\^\\$\\.\\*\\+\\?\\|\\(\\)\\{\\}\\[\\]]"), nonPerlWildcard_("\\w\\*|^\\*") {
-
   boost::escaped_list_separator<char> commonEscapes("\\", " \t", "\'");
 
   verbose_ = pset.getUntrackedParameter<unsigned int>("verbose", 0);
@@ -104,19 +100,18 @@ HLTGenValClient::HLTGenValClient(const edm::ParameterSet& pset)
 }
 
 void HLTGenValClient::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
-                                             DQMStore::IGetter& igetter,
-                                             const edm::LuminosityBlock& lumiSeg,
-                                             const edm::EventSetup& c) {
+                                            DQMStore::IGetter& igetter,
+                                            const edm::LuminosityBlock& lumiSeg,
+                                            const edm::EventSetup& c) {
   if (runOnEndLumi_) {
     makeAllPlots(ibooker, igetter);
   }
 }
 
 void HLTGenValClient::dqmEndRun(DQMStore::IBooker& ibooker,
-                                 DQMStore::IGetter& igetter,
-                                 edm::Run const&,
-                                 edm::EventSetup const&) {
-
+                                DQMStore::IGetter& igetter,
+                                edm::Run const&,
+                                edm::EventSetup const&) {
   // Create new MEs in endRun, even though we are requested to do it in endJob.
   // This gives the QTests a chance to run, before summaries are created in
   // endJob. The negative side effect is that we cannot run the GenericClient
@@ -141,11 +136,9 @@ void HLTGenValClient::dqmEndRun(DQMStore::IBooker& ibooker,
 
 // the main method that creates the plots
 void HLTGenValClient::makeAllPlots(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
-
   // Process wildcard in the sub-directory
   std::set<std::string> subDirSet;
-  for (auto & subDir : subDirs_) {
-
+  for (auto& subDir : subDirs_) {
     if (subDir[subDir.size() - 1] == '/')
       subDir.erase(subDir.size() - 1);
 
@@ -171,79 +164,89 @@ void HLTGenValClient::makeAllPlots(DQMStore::IBooker& ibooker, DQMStore::IGetter
 
     // construct efficiency options automatically from systematically names histograms^
     const auto contents = igetter.getAllContents(dirName);
-    for (const auto & content : contents) {
-
+    for (const auto& content : contents) {
       // splitting the input string
       std::stringstream namestream(content->getName());
       std::string namesegment;
       std::vector<std::string> seglist;
-      while(std::getline(namestream, namesegment, ':'))
-      {
-         seglist.push_back(namesegment);
+      while (std::getline(namestream, namesegment, ':')) {
+        seglist.push_back(namesegment);
       }
 
-      if(seglist.size() == 4 || seglist.size() == 5) { // this should be the only "proper" files we want to look at. 5 means that a custom tag was set!
-        if(seglist.at(2) == "GEN") continue; // this is the "before" hist, we won't create an effiency from this alone
+      if (seglist.size() == 4 ||
+          seglist.size() ==
+              5) {  // this should be the only "proper" files we want to look at. 5 means that a custom tag was set!
+        if (seglist.at(2) == "GEN")
+          continue;  // this is the "before" hist, we won't create an effiency from this alone
 
         // if a fifth entry exists, it is expected to be the custom tag
         std::string tag = "";
-        if(seglist.size() == 5) tag = seglist.at(4);
+        if (seglist.size() == 5)
+          tag = seglist.at(4);
 
         // first we determing whether we have the 1D or 2D case
-        if(seglist.at(3).rfind("2D", 0) == 0) {
-
+        if (seglist.at(3).rfind("2D", 0) == 0) {
           // 2D case
           EfficOption opt;
-          opt.name = seglist.at(0) + ":" + seglist.at(1) + ":" + seglist.at(2) + ":" + seglist.at(3) + ":eff"; // efficiency histogram name
-          opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) + " efficiency"; // efficiency histogram title
-          opt.numerator = content->getName(); // numerator histogram (after a filter)
-          opt.denominator = seglist.at(0) + ":" + seglist.at(1) + ":GEN:" + seglist.at(3); // denominator histogram (before all filters)
+          opt.name = seglist.at(0) + ":" + seglist.at(1) + ":" + seglist.at(2) + ":" + seglist.at(3) +
+                     ":eff";  // efficiency histogram name
+          opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) +
+                      " efficiency";           // efficiency histogram title
+          opt.numerator = content->getName();  // numerator histogram (after a filter)
+          opt.denominator = seglist.at(0) + ":" + seglist.at(1) +
+                            ":GEN:" + seglist.at(3);  // denominator histogram (before all filters)
 
           efficOptions_.push_back(opt);
 
         } else {
-
           // 1D case
           EfficOption opt;
-          opt.name = seglist.at(0) + ":" + seglist.at(1) + ":" + seglist.at(2) + ":" + seglist.at(3) + ":eff"; // efficiency histogram name
-          opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) + " efficiency"; // efficiency histogram title
-          opt.numerator = content->getName(); // numerator histogram (after a filter)
-          opt.denominator = seglist.at(0) + ":" + seglist.at(1) + ":GEN:" + seglist.at(3); // denominator histogram (before all filters)
+          opt.name = seglist.at(0) + ":" + seglist.at(1) + ":" + seglist.at(2) + ":" + seglist.at(3) +
+                     ":eff";  // efficiency histogram name
+          opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) +
+                      " efficiency";           // efficiency histogram title
+          opt.numerator = content->getName();  // numerator histogram (after a filter)
+          opt.denominator = seglist.at(0) + ":" + seglist.at(1) +
+                            ":GEN:" + seglist.at(3);  // denominator histogram (before all filters)
 
           // propagating the custom tag to the efficiency
-          if(!tag.empty()) {
+          if (!tag.empty()) {
             opt.name += ":" + tag;
             opt.title += " " + tag;
             opt.denominator += ":" + tag;
           }
 
           efficOptions_.push_back(opt);
-
         }
       }
     }
 
     // now that we have all EfficOptions, we create the histograms
-    for (const auto& efficOption : efficOptions_){
-      computeEfficiency(ibooker, igetter, dirName, efficOption.name, efficOption.title, efficOption.numerator, efficOption.denominator);
+    for (const auto& efficOption : efficOptions_) {
+      computeEfficiency(ibooker,
+                        igetter,
+                        dirName,
+                        efficOption.name,
+                        efficOption.title,
+                        efficOption.numerator,
+                        efficOption.denominator);
     }
-
   }
 }
 
 // main method of efficiency computation, called once for each EfficOption
 void HLTGenValClient::computeEfficiency(DQMStore::IBooker& ibooker,
-                                         DQMStore::IGetter& igetter,
-                                         const std::string& dirName,
-                                         const std::string& efficMEName,
-                                         const std::string& efficMETitle,
-                                         const std::string& numeratorMEName,
-                                         const std::string& denominatorMEName) {
-
+                                        DQMStore::IGetter& igetter,
+                                        const std::string& dirName,
+                                        const std::string& efficMEName,
+                                        const std::string& efficMETitle,
+                                        const std::string& numeratorMEName,
+                                        const std::string& denominatorMEName) {
   // checking if directory exists
   if (!igetter.dirExists(dirName)) {
     if (verbose_ >= 2 || (verbose_ == 1 && !isWildcardUsed_)) {
-      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "Cannot find sub-directory " << dirName << std::endl;
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : "
+                                       << "Cannot find sub-directory " << dirName << std::endl;
     }
     return;
   }
@@ -257,17 +260,18 @@ void HLTGenValClient::computeEfficiency(DQMStore::IBooker& ibooker,
   // checking of input MEs exist
   if (!denominatorME) {
     if (verbose_ >= 2 || (verbose_ == 1 && !isWildcardUsed_)) {
-      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "No denominator-ME '" << denominatorMEName << "' found\n";
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : "
+                                       << "No denominator-ME '" << denominatorMEName << "' found\n";
     }
     return;
   }
   if (!numeratorME) {
     if (verbose_ >= 2 || (verbose_ == 1 && !isWildcardUsed_)) {
-      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "No numerator-ME '" << numeratorMEName << "' found\n";
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : "
+                                       << "No numerator-ME '" << numeratorMEName << "' found\n";
     }
     return;
   }
-
 
   // Treat everything as the base class, TH1
   TH1* hDenominator = denominatorME->getTH1();
@@ -276,7 +280,8 @@ void HLTGenValClient::computeEfficiency(DQMStore::IBooker& ibooker,
   // check if TH1 extraction has succeeded
   if (!hDenominator || !hNumerator) {
     if (verbose_ >= 2 || (verbose_ == 1 && !isWildcardUsed_)) {
-      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "Cannot create TH1 from ME\n";
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : "
+                                       << "Cannot create TH1 from ME\n";
     }
     return;
   }
@@ -313,7 +318,8 @@ void HLTGenValClient::computeEfficiency(DQMStore::IBooker& ibooker,
 
   // checking whether efficME was succesfully created
   if (!efficME) {
-    edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "Cannot book effic-ME from the DQM\n";
+    edm::LogError("HLTGenValClient") << "computeEfficiency() : "
+                                     << "Cannot book effic-ME from the DQM\n";
     return;
   }
 
@@ -323,13 +329,13 @@ void HLTGenValClient::computeEfficiency(DQMStore::IBooker& ibooker,
 
   // Putting total efficiency in "GLobal efficiencies" histogram
   if (makeGlobalEffPlot_) {
-
     // getting global efficiency ME
     HLTGenValClient::MonitorElement* globalEfficME = igetter.get(efficDir + "/globalEfficiencies");
-    if (!globalEfficME) // in case it does not exist yet, we create it
+    if (!globalEfficME)  // in case it does not exist yet, we create it
       globalEfficME = ibooker.book1D("globalEfficiencies", "Global efficiencies", 1, 0, 1);
-    if (!globalEfficME) { // error handling in case creation failed
-      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "Cannot book globalEffic-ME from the DQM\n";
+    if (!globalEfficME) {  // error handling in case creation failed
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : "
+                                       << "Cannot book globalEffic-ME from the DQM\n";
       return;
     }
     globalEfficME->setEfficiencyFlag();
@@ -337,7 +343,8 @@ void HLTGenValClient::computeEfficiency(DQMStore::IBooker& ibooker,
     // extracting histogram
     TH1F* hGlobalEffic = globalEfficME->getTH1F();
     if (!hGlobalEffic) {
-      edm::LogError("HLTGenValClient") << "computeEfficiency() : "  << "Cannot create TH1F from ME, globalEfficME\n";
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : "
+                                       << "Cannot create TH1F from ME, globalEfficME\n";
       return;
     }
 
@@ -361,10 +368,10 @@ void HLTGenValClient::computeEfficiency(DQMStore::IBooker& ibooker,
 // method to find all subdirectories of the given directory
 // goal is to fill myList with paths to all subdirectories
 void HLTGenValClient::findAllSubdirectories(DQMStore::IBooker& ibooker,
-                                             DQMStore::IGetter& igetter,
-                                             std::string dir,
-                                             std::set<std::string>* myList,
-                                             const TString& _pattern = TString("")) {
+                                            DQMStore::IGetter& igetter,
+                                            std::string dir,
+                                            std::set<std::string>* myList,
+                                            const TString& _pattern = TString("")) {
   TString patternTmp = _pattern;
 
   // checking if directory exists
@@ -375,17 +382,17 @@ void HLTGenValClient::findAllSubdirectories(DQMStore::IBooker& ibooker,
 
   // replacing wildcards
   if (patternTmp != "") {
-    if (patternTmp.Contains(nonPerlWildcard_)) patternTmp.ReplaceAll("*", ".*");
+    if (patternTmp.Contains(nonPerlWildcard_))
+      patternTmp.ReplaceAll("*", ".*");
     TPRegexp regexp(patternTmp);
     ibooker.cd(dir);
     std::vector<std::string> foundDirs = igetter.getSubdirs();
-    for (const auto & iDir : foundDirs) {
+    for (const auto& iDir : foundDirs) {
       TString dirName = iDir.substr(iDir.rfind('/') + 1, iDir.length());
-      if (dirName.Contains(regexp)) findAllSubdirectories(ibooker, igetter, iDir, myList);
+      if (dirName.Contains(regexp))
+        findAllSubdirectories(ibooker, igetter, iDir, myList);
     }
-  }
-  else if (igetter.dirExists(dir)) {
-
+  } else if (igetter.dirExists(dir)) {
     // we have found a subdirectory - adding it to the list
     myList->insert(dir);
 
@@ -394,16 +401,15 @@ void HLTGenValClient::findAllSubdirectories(DQMStore::IBooker& ibooker,
     findAllSubdirectories(ibooker, igetter, dir, myList, "*");
 
   } else {
-
     // error handling in case found directory does not exist
-    edm::LogError("HLTGenValClient") << "Trying to find sub-directories of " << dir << " failed because " << dir << " does not exist";
+    edm::LogError("HLTGenValClient") << "Trying to find sub-directories of " << dir << " failed because " << dir
+                                     << " does not exist";
   }
   return;
 }
 
 // efficiency calculation from two histograms
 void HLTGenValClient::genericEff(TH1* denom, TH1* numer, MonitorElement* efficiencyHist) {
-
   // looping over all bins. Up to three dimentions can be handled
   // in case of less dimensions, the inner for loops are excecuted only once
   for (int iBinX = 1; iBinX < denom->GetNbinsX() + 1; iBinX++) {

--- a/Validation/HLTrigger/plugins/HLTGenValClient.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValClient.cc
@@ -167,16 +167,15 @@ void HLTGenValClient::makeAllPlots(DQMStore::IBooker& ibooker, DQMStore::IGetter
     // construct efficiency options automatically from systematically names histograms^
     const auto contents = igetter.getAllContents(dirName);
     for (const auto& content : contents) {
-
       // splitting the input string
       std::string name = content->getName();
       std::vector<std::string> seglist;
       size_t pos = 0;
       std::string token;
       while ((pos = name.find(separator_)) != std::string::npos) {
-          token = name.substr(0, pos);
-          seglist.push_back(token);
-          name.erase(0, pos + separator_.length());
+        token = name.substr(0, pos);
+        seglist.push_back(token);
+        name.erase(0, pos + separator_.length());
       }
       seglist.push_back(name);
 
@@ -195,26 +194,26 @@ void HLTGenValClient::makeAllPlots(DQMStore::IBooker& ibooker, DQMStore::IGetter
         if (seglist.at(3).rfind("2D", 0) == 0) {
           // 2D case
           EfficOption opt;
-          opt.name = seglist.at(0) + separator_ + seglist.at(1) + separator_ + seglist.at(2) + separator_ + seglist.at(3) +
-                     separator_ + "eff";  // efficiency histogram name
+          opt.name = seglist.at(0) + separator_ + seglist.at(1) + separator_ + seglist.at(2) + separator_ +
+                     seglist.at(3) + separator_ + "eff";  // efficiency histogram name
           opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) +
                       " efficiency";           // efficiency histogram title
           opt.numerator = content->getName();  // numerator histogram (after a filter)
-          opt.denominator = seglist.at(0) + separator_ + seglist.at(1) +
-                            separator_ + "GEN" + separator_ + seglist.at(3);  // denominator histogram (before all filters)
+          opt.denominator = seglist.at(0) + separator_ + seglist.at(1) + separator_ + "GEN" + separator_ +
+                            seglist.at(3);  // denominator histogram (before all filters)
 
           efficOptions_.push_back(opt);
 
         } else {
           // 1D case
           EfficOption opt;
-          opt.name = seglist.at(0) + separator_ + seglist.at(1) + separator_ + seglist.at(2) + separator_ + seglist.at(3) +
-                     separator_ + "eff";  // efficiency histogram name
+          opt.name = seglist.at(0) + separator_ + seglist.at(1) + separator_ + seglist.at(2) + separator_ +
+                     seglist.at(3) + separator_ + "eff";  // efficiency histogram name
           opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) +
                       " efficiency";           // efficiency histogram title
           opt.numerator = content->getName();  // numerator histogram (after a filter)
-          opt.denominator = seglist.at(0) + separator_ + seglist.at(1) +
-                            separator_ + "GEN" + separator_ + seglist.at(3);  // denominator histogram (before all filters)
+          opt.denominator = seglist.at(0) + separator_ + seglist.at(1) + separator_ + "GEN" + separator_ +
+                            seglist.at(3);  // denominator histogram (before all filters)
 
           // propagating the custom tag to the efficiency
           if (!tag.empty()) {

--- a/Validation/HLTrigger/plugins/HLTGenValClient.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValClient.cc
@@ -73,6 +73,8 @@ private:
 
   std::vector<EfficOption> efficOptions_;
 
+  const std::string separator_ = "__";
+
   void makeAllPlots(DQMStore::IBooker&, DQMStore::IGetter&);
 
   void findAllSubdirectories(DQMStore::IBooker& ibooker,
@@ -165,13 +167,18 @@ void HLTGenValClient::makeAllPlots(DQMStore::IBooker& ibooker, DQMStore::IGetter
     // construct efficiency options automatically from systematically names histograms^
     const auto contents = igetter.getAllContents(dirName);
     for (const auto& content : contents) {
+
       // splitting the input string
-      std::stringstream namestream(content->getName());
-      std::string namesegment;
+      std::string name = content->getName();
       std::vector<std::string> seglist;
-      while (std::getline(namestream, namesegment, ':')) {
-        seglist.push_back(namesegment);
+      size_t pos = 0;
+      std::string token;
+      while ((pos = name.find(separator_)) != std::string::npos) {
+          token = name.substr(0, pos);
+          seglist.push_back(token);
+          name.erase(0, pos + separator_.length());
       }
+      seglist.push_back(name);
 
       if (seglist.size() == 4 ||
           seglist.size() ==
@@ -188,32 +195,32 @@ void HLTGenValClient::makeAllPlots(DQMStore::IBooker& ibooker, DQMStore::IGetter
         if (seglist.at(3).rfind("2D", 0) == 0) {
           // 2D case
           EfficOption opt;
-          opt.name = seglist.at(0) + ":" + seglist.at(1) + ":" + seglist.at(2) + ":" + seglist.at(3) +
-                     ":eff";  // efficiency histogram name
+          opt.name = seglist.at(0) + separator_ + seglist.at(1) + separator_ + seglist.at(2) + separator_ + seglist.at(3) +
+                     separator_ + "eff";  // efficiency histogram name
           opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) +
                       " efficiency";           // efficiency histogram title
           opt.numerator = content->getName();  // numerator histogram (after a filter)
-          opt.denominator = seglist.at(0) + ":" + seglist.at(1) +
-                            ":GEN:" + seglist.at(3);  // denominator histogram (before all filters)
+          opt.denominator = seglist.at(0) + separator_ + seglist.at(1) +
+                            separator_ + "GEN" + separator_ + seglist.at(3);  // denominator histogram (before all filters)
 
           efficOptions_.push_back(opt);
 
         } else {
           // 1D case
           EfficOption opt;
-          opt.name = seglist.at(0) + ":" + seglist.at(1) + ":" + seglist.at(2) + ":" + seglist.at(3) +
-                     ":eff";  // efficiency histogram name
+          opt.name = seglist.at(0) + separator_ + seglist.at(1) + separator_ + seglist.at(2) + separator_ + seglist.at(3) +
+                     separator_ + "eff";  // efficiency histogram name
           opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) +
                       " efficiency";           // efficiency histogram title
           opt.numerator = content->getName();  // numerator histogram (after a filter)
-          opt.denominator = seglist.at(0) + ":" + seglist.at(1) +
-                            ":GEN:" + seglist.at(3);  // denominator histogram (before all filters)
+          opt.denominator = seglist.at(0) + separator_ + seglist.at(1) +
+                            separator_ + "GEN" + separator_ + seglist.at(3);  // denominator histogram (before all filters)
 
           // propagating the custom tag to the efficiency
           if (!tag.empty()) {
-            opt.name += ":" + tag;
+            opt.name += separator_ + tag;
             opt.title += " " + tag;
-            opt.denominator += ":" + tag;
+            opt.denominator += separator_ + tag;
           }
 
           efficOptions_.push_back(opt);

--- a/Validation/HLTrigger/plugins/HLTGenValClient.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValClient.cc
@@ -1,0 +1,435 @@
+//********************************************************************************
+//
+//  Description:
+//    DQM histogram post processor for the HLT Gen validation source module
+//    Given a folder name, this module will find histograms before and after
+//    HLT filters and produce efficiency histograms from these.
+//    The structure of this model is strongly inspired by the DQMGenericClient,
+//    replacing most user input parameters by the automatic parsing of the given directory.
+//
+//  Author: Finn Labe, UHH, Jul. 2022
+//          Inspired by DQMGenericClient from Junghwan Goh - SungKyunKwan University
+//********************************************************************************
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+#include <TH1.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TClass.h>
+#include <TString.h>
+#include <TPRegexp.h>
+#include <TDirectory.h>
+#include <TEfficiency.h>
+
+#include <set>
+#include <cmath>
+#include <string>
+#include <vector>
+#include <climits>
+#include <boost/tokenizer.hpp>
+
+class HLTGenValClient : public DQMEDHarvester {
+public:
+  HLTGenValClient(const edm::ParameterSet& pset);
+  ~HLTGenValClient() override{};
+
+  void dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
+                             DQMStore::IGetter& igetter,
+                             const edm::LuminosityBlock& lumiSeg,
+                             const edm::EventSetup& c) override;
+  void dqmEndRun(DQMStore::IBooker&, DQMStore::IGetter&, edm::Run const&, edm::EventSetup const&) override;
+  void dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) override{};
+
+  struct EfficOption {
+    std::string name, title;
+    std::string numerator, denominator;
+  };
+
+  void computeEfficiency(DQMStore::IBooker& ibooker,
+                         DQMStore::IGetter& igetter,
+                         const std::string& dirName,
+                         const std::string& efficMEName,
+                         const std::string& efficMETitle,
+                         const std::string& numeratorMEName,
+                         const std::string& denominatorMEName
+                    );
+
+private:
+  TPRegexp metacharacters_;
+  TPRegexp nonPerlWildcard_;
+  unsigned int verbose_;
+  bool runOnEndLumi_;
+  bool runOnEndJob_;
+  bool makeGlobalEffPlot_;
+  bool isWildcardUsed_;
+
+  DQMStore* theDQM;
+  std::vector<std::string> subDirs_;
+  std::string outputFileName_;
+
+  std::vector<EfficOption> efficOptions_;
+
+  void makeAllPlots(DQMStore::IBooker&, DQMStore::IGetter&);
+
+  void findAllSubdirectories(DQMStore::IBooker& ibooker,
+                             DQMStore::IGetter& igetter,
+                             std::string dir,
+                             std::set<std::string>* myList,
+                             const TString& pattern);
+
+  void genericEff(TH1* denom, TH1* numer, MonitorElement* efficiencyHist);
+
+
+};
+
+HLTGenValClient::HLTGenValClient(const edm::ParameterSet& pset)
+    : metacharacters_("[\\^\\$\\.\\*\\+\\?\\|\\(\\)\\{\\}\\[\\]]"), nonPerlWildcard_("\\w\\*|^\\*") {
+
+  boost::escaped_list_separator<char> commonEscapes("\\", " \t", "\'");
+
+  verbose_ = pset.getUntrackedParameter<unsigned int>("verbose", 0);
+  runOnEndLumi_ = pset.getUntrackedParameter<bool>("runOnEndLumi", false);
+  runOnEndJob_ = pset.getUntrackedParameter<bool>("runOnEndJob", true);
+  makeGlobalEffPlot_ = pset.getUntrackedParameter<bool>("makeGlobalEffienciesPlot", true);
+
+  outputFileName_ = pset.getUntrackedParameter<std::string>("outputFileName", "");
+  subDirs_ = pset.getUntrackedParameter<std::vector<std::string>>("subDirs");
+
+  isWildcardUsed_ = false;
+}
+
+void HLTGenValClient::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker,
+                                             DQMStore::IGetter& igetter,
+                                             const edm::LuminosityBlock& lumiSeg,
+                                             const edm::EventSetup& c) {
+  if (runOnEndLumi_) {
+    makeAllPlots(ibooker, igetter);
+  }
+}
+
+void HLTGenValClient::dqmEndRun(DQMStore::IBooker& ibooker,
+                                 DQMStore::IGetter& igetter,
+                                 edm::Run const&,
+                                 edm::EventSetup const&) {
+
+  // Create new MEs in endRun, even though we are requested to do it in endJob.
+  // This gives the QTests a chance to run, before summaries are created in
+  // endJob. The negative side effect is that we cannot run the GenericClient
+  // for plots produced in Harvesting, but that seems rather rare.
+  //
+  // It is important that this is still save in the presence of multiple runs,
+  // first because in multi-run harvesting, we accumulate statistics over all
+  // runs and have full statistics at the endRun of the last run, and second,
+  // because we set the efficiencyFlag so any further aggregation should produce
+  // correct results. Also, all operations should be idempotent; running them
+  // more than once does no harm.
+
+  theDQM = edm::Service<DQMStore>().operator->();
+
+  if (runOnEndJob_) {
+    makeAllPlots(ibooker, igetter);
+  }
+
+  if (!outputFileName_.empty())
+    theDQM->save(outputFileName_);
+}
+
+// the main method that creates the plots
+void HLTGenValClient::makeAllPlots(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
+
+  // Process wildcard in the sub-directory
+  std::set<std::string> subDirSet;
+  for (auto & subDir : subDirs_) {
+
+    if (subDir[subDir.size() - 1] == '/')
+      subDir.erase(subDir.size() - 1);
+
+    if (TString(subDir).Contains(metacharacters_)) {
+      isWildcardUsed_ = true;
+
+      const std::string::size_type shiftPos = subDir.rfind('/');
+      const std::string searchPath = subDir.substr(0, shiftPos);
+      const std::string pattern = subDir.substr(shiftPos + 1, subDir.length());
+
+      findAllSubdirectories(ibooker, igetter, searchPath, &subDirSet, pattern);
+
+    } else {
+      subDirSet.insert(subDir);
+    }
+  }
+
+  // loop through all sub-directories
+  // from the current implementation of the HLTGenValSource, we expect all histograms in a single directory
+  // however, this module is also capable of handling sub-directories, if needed
+  for (std::set<std::string>::const_iterator iSubDir = subDirSet.begin(); iSubDir != subDirSet.end(); ++iSubDir) {
+    const std::string& dirName = *iSubDir;
+
+    // construct efficiency options automatically from systematically names histograms^
+    const auto contents = igetter.getAllContents(dirName);
+    for (const auto & content : contents) {
+
+      // splitting the input string
+      std::stringstream namestream(content->getName());
+      std::string namesegment;
+      std::vector<std::string> seglist;
+      while(std::getline(namestream, namesegment, ':'))
+      {
+         seglist.push_back(namesegment);
+      }
+
+      if(seglist.size() == 4 || seglist.size() == 5) { // this should be the only "proper" files we want to look at. 5 means that a custom tag was set!
+        if(seglist.at(2) == "GEN") continue; // this is the "before" hist, we won't create an effiency from this alone
+
+        // if a fifth entry exists, it is expected to be the custom tag
+        std::string tag = "";
+        if(seglist.size() == 5) tag = seglist.at(4);
+
+        // first we determing whether we have the 1D or 2D case
+        if(seglist.at(3).rfind("2D", 0) == 0) {
+
+          // 2D case
+          EfficOption opt;
+          opt.name = seglist.at(0) + ":" + seglist.at(1) + ":" + seglist.at(2) + ":" + seglist.at(3) + ":eff"; // efficiency histogram name
+          opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) + " efficiency"; // efficiency histogram title
+          opt.numerator = content->getName(); // numerator histogram (after a filter)
+          opt.denominator = seglist.at(0) + ":" + seglist.at(1) + ":GEN:" + seglist.at(3); // denominator histogram (before all filters)
+
+          efficOptions_.push_back(opt);
+
+        } else {
+
+          // 1D case
+          EfficOption opt;
+          opt.name = seglist.at(0) + ":" + seglist.at(1) + ":" + seglist.at(2) + ":" + seglist.at(3) + ":eff"; // efficiency histogram name
+          opt.title = seglist.at(0) + " " + seglist.at(1) + " " + seglist.at(2) + " " + seglist.at(3) + " efficiency"; // efficiency histogram title
+          opt.numerator = content->getName(); // numerator histogram (after a filter)
+          opt.denominator = seglist.at(0) + ":" + seglist.at(1) + ":GEN:" + seglist.at(3); // denominator histogram (before all filters)
+
+          // propagating the custom tag to the efficiency
+          if(!tag.empty()) {
+            opt.name += ":" + tag;
+            opt.title += " " + tag;
+            opt.denominator += ":" + tag;
+          }
+
+          efficOptions_.push_back(opt);
+
+        }
+      }
+    }
+
+    // now that we have all EfficOptions, we create the histograms
+    for (const auto& efficOption : efficOptions_){
+      computeEfficiency(ibooker, igetter, dirName, efficOption.name, efficOption.title, efficOption.numerator, efficOption.denominator);
+    }
+
+  }
+}
+
+// main method of efficiency computation, called once for each EfficOption
+void HLTGenValClient::computeEfficiency(DQMStore::IBooker& ibooker,
+                                         DQMStore::IGetter& igetter,
+                                         const std::string& dirName,
+                                         const std::string& efficMEName,
+                                         const std::string& efficMETitle,
+                                         const std::string& numeratorMEName,
+                                         const std::string& denominatorMEName) {
+
+  // checking if directory exists
+  if (!igetter.dirExists(dirName)) {
+    if (verbose_ >= 2 || (verbose_ == 1 && !isWildcardUsed_)) {
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "Cannot find sub-directory " << dirName << std::endl;
+    }
+    return;
+  }
+
+  ibooker.cd();
+
+  // getting input MEs
+  HLTGenValClient::MonitorElement* denominatorME = igetter.get(dirName + "/" + denominatorMEName);
+  HLTGenValClient::MonitorElement* numeratorME = igetter.get(dirName + "/" + numeratorMEName);
+
+  // checking of input MEs exist
+  if (!denominatorME) {
+    if (verbose_ >= 2 || (verbose_ == 1 && !isWildcardUsed_)) {
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "No denominator-ME '" << denominatorMEName << "' found\n";
+    }
+    return;
+  }
+  if (!numeratorME) {
+    if (verbose_ >= 2 || (verbose_ == 1 && !isWildcardUsed_)) {
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "No numerator-ME '" << numeratorMEName << "' found\n";
+    }
+    return;
+  }
+
+
+  // Treat everything as the base class, TH1
+  TH1* hDenominator = denominatorME->getTH1();
+  TH1* hNumerator = numeratorME->getTH1();
+
+  // check if TH1 extraction has succeeded
+  if (!hDenominator || !hNumerator) {
+    if (verbose_ >= 2 || (verbose_ == 1 && !isWildcardUsed_)) {
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "Cannot create TH1 from ME\n";
+    }
+    return;
+  }
+
+  // preparing efficiency output path and name
+  std::string efficDir = dirName;
+  std::string newEfficMEName = efficMEName;
+  std::string::size_type shiftPos;
+  if (std::string::npos != (shiftPos = efficMEName.rfind('/'))) {
+    efficDir += "/" + efficMEName.substr(0, shiftPos);
+    newEfficMEName.erase(0, shiftPos + 1);
+  }
+  ibooker.setCurrentFolder(efficDir);
+
+  // creating the efficiency MonitorElement
+  HLTGenValClient::MonitorElement* efficME = nullptr;
+
+  // We need to know what kind of TH1 we have
+  // That information is obtained from the class name of the hDenominator
+  // Then we use the appropriate booking function
+  TH1* efficHist = static_cast<TH1*>(hDenominator->Clone(newEfficMEName.c_str()));
+  efficHist->SetDirectory(nullptr);
+  efficHist->SetTitle(efficMETitle.c_str());
+  TClass* myHistClass = efficHist->IsA();
+  std::string histClassName = myHistClass->GetName();
+  if (histClassName == "TH1F") {
+    efficME = ibooker.book1D(newEfficMEName, (TH1F*)efficHist);
+  } else if (histClassName == "TH2F") {
+    efficME = ibooker.book2D(newEfficMEName, (TH2F*)efficHist);
+  } else if (histClassName == "TH3F") {
+    efficME = ibooker.book3D(newEfficMEName, (TH3F*)efficHist);
+  }
+  delete efficHist;
+
+  // checking whether efficME was succesfully created
+  if (!efficME) {
+    edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "Cannot book effic-ME from the DQM\n";
+    return;
+  }
+
+  // actually calculating the efficiency and filling the ME
+  genericEff(hDenominator, hNumerator, efficME);
+  efficME->setEntries(denominatorME->getEntries());
+
+  // Putting total efficiency in "GLobal efficiencies" histogram
+  if (makeGlobalEffPlot_) {
+
+    // getting global efficiency ME
+    HLTGenValClient::MonitorElement* globalEfficME = igetter.get(efficDir + "/globalEfficiencies");
+    if (!globalEfficME) // in case it does not exist yet, we create it
+      globalEfficME = ibooker.book1D("globalEfficiencies", "Global efficiencies", 1, 0, 1);
+    if (!globalEfficME) { // error handling in case creation failed
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : " << "Cannot book globalEffic-ME from the DQM\n";
+      return;
+    }
+    globalEfficME->setEfficiencyFlag();
+
+    // extracting histogram
+    TH1F* hGlobalEffic = globalEfficME->getTH1F();
+    if (!hGlobalEffic) {
+      edm::LogError("HLTGenValClient") << "computeEfficiency() : "  << "Cannot create TH1F from ME, globalEfficME\n";
+      return;
+    }
+
+    // getting total counts
+    const float nDenominatorAll = hDenominator->GetEntries();
+    const float nNumeratorAll = hNumerator->GetEntries();
+
+    // calculating total efficiency
+    float efficAll = 0;
+    float errorAll = 0;
+    efficAll = nDenominatorAll ? nNumeratorAll / nDenominatorAll : 0;
+    errorAll = nDenominatorAll && efficAll < 1 ? sqrt(efficAll * (1 - efficAll) / nDenominatorAll) : 0;
+
+    // Filling the histogram bin
+    const int iBin = hGlobalEffic->Fill(newEfficMEName.c_str(), 0);
+    hGlobalEffic->SetBinContent(iBin, efficAll);
+    hGlobalEffic->SetBinError(iBin, errorAll);
+  }
+}
+
+// method to find all subdirectories of the given directory
+// goal is to fill myList with paths to all subdirectories
+void HLTGenValClient::findAllSubdirectories(DQMStore::IBooker& ibooker,
+                                             DQMStore::IGetter& igetter,
+                                             std::string dir,
+                                             std::set<std::string>* myList,
+                                             const TString& _pattern = TString("")) {
+  TString patternTmp = _pattern;
+
+  // checking if directory exists
+  if (!igetter.dirExists(dir)) {
+    edm::LogError("HLTGenValClient") << " HLTGenValClient::findAllSubdirectories ==> Missing folder " << dir << " !!!";
+    return;
+  }
+
+  // replacing wildcards
+  if (patternTmp != "") {
+    if (patternTmp.Contains(nonPerlWildcard_)) patternTmp.ReplaceAll("*", ".*");
+    TPRegexp regexp(patternTmp);
+    ibooker.cd(dir);
+    std::vector<std::string> foundDirs = igetter.getSubdirs();
+    for (const auto & iDir : foundDirs) {
+      TString dirName = iDir.substr(iDir.rfind('/') + 1, iDir.length());
+      if (dirName.Contains(regexp)) findAllSubdirectories(ibooker, igetter, iDir, myList);
+    }
+  }
+  else if (igetter.dirExists(dir)) {
+
+    // we have found a subdirectory - adding it to the list
+    myList->insert(dir);
+
+    // moving into the found subdirectory and recursively continue
+    ibooker.cd(dir);
+    findAllSubdirectories(ibooker, igetter, dir, myList, "*");
+
+  } else {
+
+    // error handling in case found directory does not exist
+    edm::LogError("HLTGenValClient") << "Trying to find sub-directories of " << dir << " failed because " << dir << " does not exist";
+  }
+  return;
+}
+
+// efficiency calculation from two histograms
+void HLTGenValClient::genericEff(TH1* denom, TH1* numer, MonitorElement* efficiencyHist) {
+
+  // looping over all bins. Up to three dimentions can be handled
+  // in case of less dimensions, the inner for loops are excecuted only once
+  for (int iBinX = 1; iBinX < denom->GetNbinsX() + 1; iBinX++) {
+    for (int iBinY = 1; iBinY < denom->GetNbinsY() + 1; iBinY++) {
+      for (int iBinZ = 1; iBinZ < denom->GetNbinsZ() + 1; iBinZ++) {
+        int globalBinNum = denom->GetBin(iBinX, iBinY, iBinZ);
+
+        // getting numerator and denominator values
+        float numerVal = numer->GetBinContent(globalBinNum);
+        float denomVal = denom->GetBinContent(globalBinNum);
+
+        // calculating effiency
+        float effVal = 0;
+        effVal = denomVal ? numerVal / denomVal : 0;
+
+        // calculating error
+        float errVal = 0;
+        errVal = (denomVal && (effVal <= 1)) ? sqrt(effVal * (1 - effVal) / denomVal) : 0;
+
+        // inserting value into the efficiency histogram
+        efficiencyHist->setBinContent(globalBinNum, effVal);
+        efficiencyHist->setBinError(globalBinNum, errVal);
+        efficiencyHist->setEfficiencyFlag();
+      }
+    }
+  }
+}
+
+DEFINE_FWK_MODULE(HLTGenValClient);

--- a/Validation/HLTrigger/plugins/HLTGenValSource.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValSource.cc
@@ -1,0 +1,479 @@
+//********************************************************************************
+//
+//  Description:
+//    Producing and filling histograms for generator-level HLT path efficiency histograms. Harvested by a HLTGenValClient.
+//
+// Implementation:
+//   Histograms for objects of a certain type are created for multiple paths chosen by the user: for all objects,
+//   and for objects passing filters in the path, determined by deltaR matching.
+//   Each HLTGenValSource can handle a single object type and any number of paths (and filters in them)
+//
+//  Author: Finn Labe, UHH, Jul. 2022
+//
+//********************************************************************************
+
+
+// system include files
+#include <memory>
+#include <chrono>
+#include <ctime>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+// including GenParticles
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+// icnluding GenMET
+#include "DataFormats/METReco/interface/GenMETCollection.h"
+#include "DataFormats/METReco/interface/GenMET.h"
+
+// includes needed for histogram creation
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+// FunctionDefs
+#include "DQMOffline/Trigger/interface/FunctionDefs.h"
+
+// includes of histogram collection class
+#include "Validation/HLTrigger/interface/HLTGenValHistCollPath.h"
+
+// DQMStore
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+
+// trigger Event
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+
+// object that can be a GenJet, GenParticle or energy sum
+#include "Validation/HLTrigger/interface/HLTGenValObject.h"
+
+class HLTGenValSource : public DQMEDAnalyzer {
+public:
+
+  explicit HLTGenValSource(const edm::ParameterSet&);
+  ~HLTGenValSource() override = default;
+  HLTGenValSource(const HLTGenValSource&) = delete;
+  HLTGenValSource& operator=(const HLTGenValSource&) = delete;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker&, edm::Run const& run, edm::EventSetup const& c) override;
+  void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
+
+  // functions to get correct object collection for chosen object type
+  std::vector<HLTGenValObject> getObjectCollection(const edm::Event&);
+  std::vector<HLTGenValObject> getGenParticles(const edm::Event&);
+  reco::GenParticle getLastCopyPreFSR(reco::GenParticle part);
+  reco::GenParticle getLastCopy(reco::GenParticle part);
+
+  // ----------member data ---------------------------
+
+  // tokens to get collections
+  const edm::EDGetTokenT<reco::GenParticleCollection> genParticleToken_;
+  const edm::EDGetTokenT<reco::GenMETCollection> genMETToken_;
+  const edm::EDGetTokenT<reco::GenJetCollection> AK4genJetToken_;
+  const edm::EDGetTokenT<reco::GenJetCollection> AK8genJetToken_;
+  const edm::EDGetTokenT<trigger::TriggerEvent> trigEventToken_;
+
+  // config strings/Psets
+  std::string objType_;
+  std::string dirName_;
+  std::vector<edm::ParameterSet> histConfigs_;
+  std::vector<edm::ParameterSet> histConfigs2D_;
+  std::vector<edm::ParameterSet> binnings_;
+  std::string hltProcessName_;
+
+  // constructing the info string, which will be written to the output file for display of information in the GUI
+  // the string will have a JSON formating, thus starting here with the opening bracket, which will be close directly before saving to the root file
+  std::string infoString_ = "{";
+
+  // histogram collection per path
+  std::vector<HLTGenValHistCollPath> collectionPath_;
+
+  // HLT config provider/getter
+  HLTConfigProvider hltConfig_;
+
+  // some miscellaneous member variables
+  std::vector<std::string> hltPathsToCheck_;
+  std::vector<std::string> hltPaths;
+  std::vector<std::string> hltPathSpecificCuts;
+  double dR2limit_;
+  bool doOnlyLastFilter_;
+
+};
+
+HLTGenValSource::HLTGenValSource(const edm::ParameterSet& iConfig)
+    : genParticleToken_( consumes<reco::GenParticleCollection>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("genParticles") ) ),
+      genMETToken_( consumes<reco::GenMETCollection>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("genMET") ) ),
+      AK4genJetToken_(consumes<reco::GenJetCollection>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("ak4GenJets"))),
+      AK8genJetToken_(consumes<reco::GenJetCollection>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("ak8GenJets"))),
+      trigEventToken_(consumes<trigger::TriggerEvent>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("TrigEvent") )) {
+
+      // getting the histogram configurations
+      histConfigs_ = iConfig.getParameterSetVector("histConfigs");
+      histConfigs2D_ = iConfig.getParameterSetVector("histConfigs2D");
+      binnings_ = iConfig.getParameterSetVector("binnings");
+
+      // getting all other configurations
+      dirName_ = iConfig.getParameter<std::string>("DQMDirName");
+      objType_ = iConfig.getParameter<std::string>("objType");
+      dR2limit_ = iConfig.getParameter<double>("dR2limit");
+      doOnlyLastFilter_ = iConfig.getParameter<bool>("doOnlyLastFilter");
+      hltProcessName_ = iConfig.getParameter<std::string>("hltProcessName");
+      hltPathsToCheck_ = iConfig.getParameter<std::vector<std::string>>("hltPathsToCheck");
+
+}
+
+void HLTGenValSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
+
+  // writing general information to info JSON
+  auto t = std::time(nullptr);
+  auto tm = *std::localtime(&t);
+
+  // date and time of running this
+  std::ostringstream timeStringStream;
+  timeStringStream << std::put_time(&tm, "%d-%m-%Y %H-%M-%S");
+  auto timeString = timeStringStream.str();
+  infoString_ += "\"date & time\":\""+timeString+"\",";
+
+  // CMSSW version
+  std::stringstream CMSSWversionStream(std::getenv("CMSSW_BASE"));
+  std::string CMSSWversionSegment;
+  std::string CMSSWversion;
+  while(std::getline(CMSSWversionStream, CMSSWversionSegment, '/'))
+  {
+     CMSSWversion = CMSSWversionSegment;
+  }
+  infoString_ += std::string("\"CMSSW release\":\"")+CMSSWversion+"\",";
+
+  // Initialize hltConfig, for cross-checking whether chosen paths exist
+  bool changedConfig;
+  if (!hltConfig_.init(iRun, iSetup, hltProcessName_, changedConfig)) {
+    edm::LogError("HLTGenValSource") << "Initialization of HLTConfigProvider failed!";
+    return;
+  }
+
+  // global tag
+  infoString_ += std::string("\"global tag\":\"")+hltConfig_.globalTag()+"\",";
+
+  // confDB table name
+  infoString_ += std::string("\"HLT ConfDB table\":\"")+hltConfig_.tableName()+"\",";
+
+  // Get the set of trigger paths we want to make plots for
+  std::vector<std::string> notFoundPaths;
+  for (auto const &pathToCheck : hltPathsToCheck_) {
+
+    // It is possible to add additional requirements to each path, seperated by a colon from the path name
+    // these additional requirements are split from the path name here
+    std::string cleanedPathToCheck;
+    std::string pathSpecificCuts = "";
+    if (pathToCheck.find(":") != std::string::npos) {
+
+      // splitting the string
+      std::stringstream hltPathToCheckInputStream(pathToCheck);
+      std::string hltPathToCheckInputSegment;
+      std::vector<std::string> hltPathToCheckInputSeglist;
+      while(std::getline(hltPathToCheckInputStream, hltPathToCheckInputSegment, ':'))
+      {
+         hltPathToCheckInputSeglist.push_back(hltPathToCheckInputSegment);
+      }
+
+      // here, exactly two parts are expected
+      if(hltPathToCheckInputSeglist.size() != 2) throw cms::Exception("InputError") << "Path string can not be properly split into path and cuts: please use exactly one colon!.\n";
+
+      // the first part is the name of the path
+      cleanedPathToCheck = hltPathToCheckInputSeglist.at(0);
+
+      // second part are the cuts, to be parsed later
+      pathSpecificCuts = hltPathToCheckInputSeglist.at(1);
+
+    } else {
+      cleanedPathToCheck = pathToCheck;
+    }
+
+    bool pathfound = false;
+    for (auto const &pathFromConfig : hltConfig_.triggerNames()) {
+      if (pathFromConfig.find(cleanedPathToCheck) != std::string::npos) {
+
+        hltPaths.push_back(pathFromConfig);
+
+        // in case the path was added twice, we'll add a tag automatically
+        int count = std::count(hltPaths.begin(), hltPaths.end(), pathFromConfig);
+        if (count > 1) {
+          pathSpecificCuts += std::string(",autotag=v")+std::to_string( count );
+        }
+        hltPathSpecificCuts.push_back(pathSpecificCuts);
+        pathfound = true;
+      }
+    }
+    if(!pathfound) notFoundPaths.push_back(cleanedPathToCheck);
+  }
+  if(!notFoundPaths.empty()) {
+    // error handling in case some paths do not exist
+    std::string notFoundPathsMessage = "";
+    for (const auto & path : notFoundPaths) notFoundPathsMessage += "- " + path + "\n";
+    edm::LogError("HLTGenValSource") << "The following paths could not be found and will not be used: \n" << notFoundPathsMessage << std::endl;
+
+  }
+
+  // before creating the collections for each path, we'll store the needed configurations in a pset
+  // we'll copy this base multiple times and add the respective path
+  // most of these options are not needed in the pathColl, but in the filterColls created in the pathColl
+  edm::ParameterSet pathCollConfig;
+  pathCollConfig.addParameter<std::string>("objType", objType_);
+  pathCollConfig.addParameter<double>("dR2limit", dR2limit_);
+  pathCollConfig.addParameter<bool>("doOnlyLastFilter", doOnlyLastFilter_);
+  pathCollConfig.addParameter<std::string>("hltProcessName", hltProcessName_);
+
+  // creating a histogram collection for each path
+  for (const auto & path : hltPaths) {
+    edm::ParameterSet pathCollConfigStep = pathCollConfig;
+    pathCollConfigStep.addParameter<std::string>("triggerPath", path);
+    collectionPath_.emplace_back(HLTGenValHistCollPath(pathCollConfigStep, hltConfig_));
+  }
+
+}
+
+// ------------ method called for each event  ------------
+void HLTGenValSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  // creating the collection of HLTGenValObjects
+  const std::vector<HLTGenValObject> objects = getObjectCollection(iEvent);
+
+  // init triggerEvent, which is always needed
+  edm::Handle<trigger::TriggerEvent> triggerEvent;
+  iEvent.getByToken(trigEventToken_, triggerEvent);
+
+  // loop over all objects and fill hists
+  for (const auto & object : objects) {
+    for (auto& collection_path : collectionPath_) {
+      collection_path.fillHists(object, triggerEvent);
+    }
+  }
+
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void HLTGenValSource::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run& run, const edm::EventSetup& setup) {
+
+  iBooker.setCurrentFolder(dirName_);
+
+  if(infoString_.back() == ',') infoString_.pop_back();
+  infoString_ += "}"; // adding the closing bracked to the JSON string
+  iBooker.bookString("HLTGenValInfo", infoString_);
+
+  // booking all histograms
+  for (long unsigned int i = 0; i < collectionPath_.size(); i++) {
+    std::vector<edm::ParameterSet> histConfigs = histConfigs_;
+    for (auto & histConfig : histConfigs) {
+      histConfig.addParameter<std::string>("pathSpecificCuts", hltPathSpecificCuts.at(i));
+      histConfig.addParameter<std::vector<edm::ParameterSet>>("binnings", binnings_); // passing along the user-defined binnings
+    }
+
+    collectionPath_.at(i).bookHists(iBooker, histConfigs, histConfigs2D_);
+  }
+
+}
+
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void HLTGenValSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  // basic parameter strings
+  desc.add<std::string>("objType"); // this deliberately has no default, as this is the main thing the user needs to chose
+  desc.add<std::vector<std::string>>("hltPathsToCheck"); // this for the moment also has no default: maybe there can be some way to handle this later?
+  desc.add<std::string>("DQMDirName", "HLTGenVal");
+  desc.add<std::string>("hltProcessName", "HLT");
+  desc.add<double>("dR2limit", 0.1);
+  desc.add<bool>("doOnlyLastFilter", false);
+
+  // input collections, a PSet
+  edm::ParameterSetDescription inputCollections;
+  inputCollections.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"));
+  inputCollections.add<edm::InputTag>("genMET", edm::InputTag("genMetTrue"));
+  inputCollections.add<edm::InputTag>("ak4GenJets", edm::InputTag("ak4GenJets"));
+  inputCollections.add<edm::InputTag>("ak8GenJets", edm::InputTag("ak8GenJets"));
+  inputCollections.add<edm::InputTag>("TrigEvent", edm::InputTag("hltTriggerSummaryAOD"));
+  desc.add<edm::ParameterSetDescription>("inputCollections", inputCollections);
+
+  // hist descriptors, which are a vector of PSets
+
+  // defining single histConfig
+  // this is generally without default, but a default set of histConfigs is specified below
+  edm::ParameterSetDescription histConfig;
+  histConfig.add<std::string>("vsVar");
+  histConfig.add<std::vector<double>>("binLowEdges");
+  histConfig.addVPSet("rangeCuts", VarRangeCut<HLTGenValObject>::makePSetDescription(), std::vector<edm::ParameterSet>());
+
+  // default set of histConfigs
+  std::vector<edm::ParameterSet> histConfigDefaults;
+
+  edm::ParameterSet histConfigDefault0;
+  histConfigDefault0.addParameter<std::string>("vsVar", "pt");
+  std::vector<double> defaultPtBinning{ 0,5,10,12.5,15,17.5,20,22.5,25,30,35,40,45,50,60,80,100,150,200,250,300,350,400 };
+  histConfigDefault0.addParameter<std::vector<double>>("binLowEdges", defaultPtBinning );
+  histConfigDefaults.push_back(histConfigDefault0);
+
+  edm::ParameterSet histConfigDefault1;
+  histConfigDefault1.addParameter<std::string>("vsVar", "eta");
+  std::vector<double> defaultetaBinning{ -10, -8, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 8, 10 };
+  histConfigDefault1.addParameter<std::vector<double>>("binLowEdges", defaultetaBinning );
+  histConfigDefaults.push_back(histConfigDefault1);
+
+  desc.addVPSet("histConfigs", histConfig, histConfigDefaults);
+
+  // defining single histConfig2D
+  edm::ParameterSetDescription histConfig2D;
+  histConfig2D.add<std::string>("vsVarX");
+  histConfig2D.add<std::string>("vsVarY");
+  histConfig2D.add<std::vector<double>>("binLowEdgesX");
+  histConfig2D.add<std::vector<double>>("binLowEdgesY");
+
+  // default set of histConfigs
+  std::vector<edm::ParameterSet> histConfigDefaults2D;
+
+  edm::ParameterSet histConfigDefault2D0;
+  histConfigDefault2D0.addParameter<std::string>("vsVarX", "pt");
+  histConfigDefault2D0.addParameter<std::string>("vsVarY", "eta");
+  histConfigDefault2D0.addParameter<std::vector<double>>("binLowEdgesX", defaultPtBinning);
+  histConfigDefault2D0.addParameter<std::vector<double>>("binLowEdgesY", defaultetaBinning);
+  histConfigDefaults2D.push_back(histConfigDefault2D0);
+
+  desc.addVPSet("histConfigs2D", histConfig2D, histConfigDefaults2D);
+
+  // binnings, which are vectors of PSets
+  // there are no default for this
+  edm::ParameterSetDescription binningConfig;
+  binningConfig.add<std::string>("name");
+  binningConfig.add<std::string>("vsVar");
+  binningConfig.add<std::vector<double>>("binLowEdges");
+
+  // this by default is empty
+  std::vector<edm::ParameterSet> binningConfigDefaults;
+
+  desc.addVPSet("binnings", binningConfig, binningConfigDefaults);
+
+  descriptions.addDefault(desc);
+}
+
+// this method handles the different object types and collections that can be used for efficiency calculation
+std::vector<HLTGenValObject> HLTGenValSource::getObjectCollection(const edm::Event& iEvent) {
+
+  std::vector<HLTGenValObject> objects; // the vector of objects to be filled
+
+  // handle object type
+  std::vector<std::string> implementedGenParticles = {"ele", "pho", "mu", "tau"};
+  if(std::find(implementedGenParticles.begin(), implementedGenParticles.end(), objType_) != implementedGenParticles.end()) {
+    objects = getGenParticles(iEvent);
+  }
+  else if(objType_ == "AK4jet") { // ak4 jets, using the ak4GenJets collection
+    const auto& genJets = iEvent.getHandle(AK4genJetToken_);
+    for(size_t i = 0; i < genJets->size(); i++) {
+      const reco::GenJet p = (*genJets)[i];
+      objects.emplace_back(p);
+    }
+  }
+  else if(objType_ == "AK8jet") { // ak8 jets, using the ak8GenJets collection
+    const auto& genJets = iEvent.getHandle(AK8genJetToken_);
+    for(size_t i = 0; i < genJets->size(); i++) {
+      const reco::GenJet p = (*genJets)[i];
+      objects.emplace_back(p);
+    }
+  }
+  else if(objType_ == "AK4HT") { // ak4-based HT, using the ak4GenJets collection
+    const auto& genJets = iEvent.getHandle(AK4genJetToken_);
+    if(!genJets->empty()){
+      auto HTsum = (*genJets)[0].pt();
+      for(size_t i = 1; i < genJets->size(); i++) {
+        if(((*genJets)[i].pt() > 30) && (abs((*genJets)[i].eta()) < 2.5)) HTsum += (*genJets)[i].pt();
+      }
+      objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
+    }
+  }
+  else if(objType_ == "AK8HT") { // ak8-based HT, using the ak8GenJets collection
+    const auto& genJets = iEvent.getHandle(AK8genJetToken_);
+    if(!genJets->empty()){
+      auto HTsum = (*genJets)[0].pt();
+      for(size_t i = 1; i < genJets->size(); i++) {
+        if(((*genJets)[i].pt() > 200) && (abs((*genJets)[i].eta()) < 2.5)) HTsum += (*genJets)[i].pt();
+      }
+      objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
+    }
+  }
+  else if(objType_ == "MET") { // MET, using genMET
+    const auto& genMET = iEvent.getHandle(genMETToken_);
+    if(!genMET->empty()){
+      auto genMETpt = (*genMET)[0].pt();
+      objects.emplace_back(reco::Candidate::PolarLorentzVector(genMETpt, 0, 0, 0));
+    }
+  }
+  else throw cms::Exception("InputError") << "Generator-level validation is not available for type " << objType_ << ".\n" << "Please check for a potential spelling error.\n";
+
+  return objects;
+}
+
+// in case of GenParticles, a subset of the entire collection needs to be chosen
+std::vector<HLTGenValObject> HLTGenValSource::getGenParticles(const edm::Event& iEvent) {
+
+  std::vector<HLTGenValObject> objects; // vector to be filled
+
+  const auto& genParticles = iEvent.getHandle(genParticleToken_); // getting all GenParticles
+
+  // we need to ge the ID corresponding to the desired GenParticle type
+  int pdgID = -1; // setting to -1 should not be needed, but prevents the compiler warning :)
+  if(objType_ == "ele") pdgID = 11;
+  else if(objType_ == "pho") pdgID = 22;
+  else if(objType_ == "mu") pdgID = 13;
+  else if(objType_ == "tau") pdgID = 15;
+
+  // main loop over GenParticles
+  for(size_t i = 0; i < genParticles->size(); ++ i) {
+    const reco::GenParticle p = (*genParticles)[i];
+
+    // only GenParticles with correct ID
+    if (abs(p.pdgId()) != pdgID) continue;
+
+    // checking if particle comes from "hard process"
+    if(p.isHardProcess()) {
+
+      // depending on the particle type, last particle before or after FSR is chosen
+      if( (objType_ == "ele") || (objType_ == "pho") ) objects.emplace_back( getLastCopyPreFSR(p) );
+      else if( (objType_ == "mu") || (objType_ == "tau") ) objects.emplace_back( getLastCopy(p) );
+
+    }
+
+  }
+
+  return objects;
+
+}
+
+// function returning the last GenParticle in a decay chain before FSR
+reco::GenParticle HLTGenValSource::getLastCopyPreFSR(reco::GenParticle part) {
+    const auto daughters = part.daughterRefVector();
+    if (daughters.size() == 1 && daughters.at(0)->pdgId() == part.pdgId()) return getLastCopyPreFSR(*daughters.at(0).get()); // recursion, whooo
+    else return part;
+}
+
+// function returning the last GenParticle in a decay chain
+reco::GenParticle HLTGenValSource::getLastCopy(reco::GenParticle part) {
+  for (const auto & daughter : part.daughterRefVector()){
+    if (daughter->pdgId() == part.pdgId()) return getLastCopy(*daughter.get());
+  }
+  return part;
+}
+
+//define this as a framework plug-in
+DEFINE_FWK_MODULE(HLTGenValSource);

--- a/Validation/HLTrigger/plugins/HLTGenValSource.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValSource.cc
@@ -147,12 +147,7 @@ void HLTGenValSource::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& i
   infoString_ += "\"date & time\":\"" + timeString + "\",";
 
   // CMSSW version
-  std::stringstream cmsswVersionStream(std::getenv("CMSSW_BASE"));
-  std::string cmsswVersionSegment;
-  std::string cmsswVersion;
-  while (std::getline(cmsswVersionStream, cmsswVersionSegment, '/')) {
-    cmsswVersion = cmsswVersionSegment;
-  }
+  std::string cmsswVersion = std::getenv("CMSSW_VERSION");
   infoString_ += std::string("\"CMSSW release\":\"") + cmsswVersion + "\",";
 
   // Initialize hltConfig, for cross-checking whether chosen paths exist

--- a/Validation/HLTrigger/plugins/HLTGenValSource.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValSource.cc
@@ -18,9 +18,6 @@
 #include <ctime>
 
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -385,10 +382,10 @@ std::vector<HLTGenValObject> HLTGenValSource::getObjectCollection(const edm::Eve
   } else if (objType_ == "AK4HT") {  // ak4-based HT, using the ak4GenJets collection
     const auto& genJets = iEvent.getHandle(ak4genJetToken_);
     if (!genJets->empty()) {
-      auto HTsum = 0.;
-      for (size_t i = 0; i < genJets->size(); i++) {
-        if (((*genJets)[i].pt() > 30) && (abs((*genJets)[i].eta()) < 2.5))
-          HTsum += (*genJets)[i].pt();
+      double HTsum = 0.;
+      for (const auto& genJet : *genJets) {
+        if (genJet.pt() > 30 && std::abs(genJet.eta()) < 2.5)
+          HTsum += genJet.pt();
       }
       if (HTsum > 0)
         objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
@@ -396,10 +393,10 @@ std::vector<HLTGenValObject> HLTGenValSource::getObjectCollection(const edm::Eve
   } else if (objType_ == "AK8HT") {  // ak8-based HT, using the ak8GenJets collection
     const auto& genJets = iEvent.getHandle(ak8genJetToken_);
     if (!genJets->empty()) {
-      auto HTsum = 0.;
-      for (size_t i = 0; i < genJets->size(); i++) {
-        if (((*genJets)[i].pt() > 200) && (abs((*genJets)[i].eta()) < 2.5))
-          HTsum += (*genJets)[i].pt();
+      double HTsum = 0.;
+      for (const auto& genJet : *genJets) {
+        if (genJet.pt() > 200 && std::abs(genJet.eta()) < 2.5)
+          HTsum += genJet.pt();
       }
       if (HTsum > 0)
         objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
@@ -439,7 +436,7 @@ std::vector<HLTGenValObject> HLTGenValSource::getGenParticles(const edm::Event& 
     const reco::GenParticle p = (*genParticles)[i];
 
     // only GenParticles with correct ID
-    if (abs(p.pdgId()) != pdgID)
+    if (std::abs(p.pdgId()) != pdgID)
       continue;
 
     // checking if particle comes from "hard process"

--- a/Validation/HLTrigger/plugins/HLTGenValSource.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValSource.cc
@@ -385,22 +385,22 @@ std::vector<HLTGenValObject> HLTGenValSource::getObjectCollection(const edm::Eve
   } else if (objType_ == "AK4HT") {  // ak4-based HT, using the ak4GenJets collection
     const auto& genJets = iEvent.getHandle(ak4genJetToken_);
     if (!genJets->empty()) {
-      auto HTsum = (*genJets)[0].pt();
-      for (size_t i = 1; i < genJets->size(); i++) {
+      auto HTsum = 0.;
+      for (size_t i = 0; i < genJets->size(); i++) {
         if (((*genJets)[i].pt() > 30) && (abs((*genJets)[i].eta()) < 2.5))
           HTsum += (*genJets)[i].pt();
       }
-      objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
+      if(HTsum > 0) objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
     }
   } else if (objType_ == "AK8HT") {  // ak8-based HT, using the ak8GenJets collection
     const auto& genJets = iEvent.getHandle(ak8genJetToken_);
     if (!genJets->empty()) {
-      auto HTsum = (*genJets)[0].pt();
-      for (size_t i = 1; i < genJets->size(); i++) {
+      auto HTsum = 0.;
+      for (size_t i = 0; i < genJets->size(); i++) {
         if (((*genJets)[i].pt() > 200) && (abs((*genJets)[i].eta()) < 2.5))
           HTsum += (*genJets)[i].pt();
       }
-      objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
+      if(HTsum > 0) objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
     }
   } else if (objType_ == "MET") {  // MET, using genMET
     const auto& genMET = iEvent.getHandle(genMETToken_);

--- a/Validation/HLTrigger/plugins/HLTGenValSource.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValSource.cc
@@ -390,7 +390,8 @@ std::vector<HLTGenValObject> HLTGenValSource::getObjectCollection(const edm::Eve
         if (((*genJets)[i].pt() > 30) && (abs((*genJets)[i].eta()) < 2.5))
           HTsum += (*genJets)[i].pt();
       }
-      if(HTsum > 0) objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
+      if (HTsum > 0)
+        objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
     }
   } else if (objType_ == "AK8HT") {  // ak8-based HT, using the ak8GenJets collection
     const auto& genJets = iEvent.getHandle(ak8genJetToken_);
@@ -400,7 +401,8 @@ std::vector<HLTGenValObject> HLTGenValSource::getObjectCollection(const edm::Eve
         if (((*genJets)[i].pt() > 200) && (abs((*genJets)[i].eta()) < 2.5))
           HTsum += (*genJets)[i].pt();
       }
-      if(HTsum > 0) objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
+      if (HTsum > 0)
+        objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
     }
   } else if (objType_ == "MET") {  // MET, using genMET
     const auto& genMET = iEvent.getHandle(genMETToken_);

--- a/Validation/HLTrigger/plugins/HLTGenValSource.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValSource.cc
@@ -178,7 +178,7 @@ void HLTGenValSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &i
     // these additional requirements are split from the path name here
     std::string cleanedPathToCheck;
     std::string pathSpecificCuts = "";
-    if (pathToCheck.find(":") != std::string::npos) {
+    if (pathToCheck.find(':') != std::string::npos) {
 
       // splitting the string
       std::stringstream hltPathToCheckInputStream(pathToCheck);
@@ -462,7 +462,7 @@ std::vector<HLTGenValObject> HLTGenValSource::getGenParticles(const edm::Event& 
 
 // function returning the last GenParticle in a decay chain before FSR
 reco::GenParticle HLTGenValSource::getLastCopyPreFSR(reco::GenParticle part) {
-    const auto daughters = part.daughterRefVector();
+    const auto& daughters = part.daughterRefVector();
     if (daughters.size() == 1 && daughters.at(0)->pdgId() == part.pdgId()) return getLastCopyPreFSR(*daughters.at(0).get()); // recursion, whooo
     else return part;
 }

--- a/Validation/HLTrigger/plugins/HLTGenValSource.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValSource.cc
@@ -80,8 +80,8 @@ private:
   // tokens to get collections
   const edm::EDGetTokenT<reco::GenParticleCollection> genParticleToken_;
   const edm::EDGetTokenT<reco::GenMETCollection> genMETToken_;
-  const edm::EDGetTokenT<reco::GenJetCollection> AK4genJetToken_;
-  const edm::EDGetTokenT<reco::GenJetCollection> AK8genJetToken_;
+  const edm::EDGetTokenT<reco::GenJetCollection> ak4genJetToken_;
+  const edm::EDGetTokenT<reco::GenJetCollection> ak8genJetToken_;
   const edm::EDGetTokenT<trigger::TriggerEvent> trigEventToken_;
 
   // config strings/Psets
@@ -115,9 +115,9 @@ HLTGenValSource::HLTGenValSource(const edm::ParameterSet& iConfig)
           iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("genParticles"))),
       genMETToken_(consumes<reco::GenMETCollection>(
           iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("genMET"))),
-      AK4genJetToken_(consumes<reco::GenJetCollection>(
+      ak4genJetToken_(consumes<reco::GenJetCollection>(
           iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("ak4GenJets"))),
-      AK8genJetToken_(consumes<reco::GenJetCollection>(
+      ak8genJetToken_(consumes<reco::GenJetCollection>(
           iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("ak8GenJets"))),
       trigEventToken_(consumes<trigger::TriggerEvent>(
           iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("TrigEvent"))) {
@@ -127,7 +127,7 @@ HLTGenValSource::HLTGenValSource(const edm::ParameterSet& iConfig)
   binnings_ = iConfig.getParameterSetVector("binnings");
 
   // getting all other configurations
-  dirName_ = iConfig.getParameter<std::string>("DQMDirName");
+  dirName_ = iConfig.getParameter<std::string>("dqmDirName");
   objType_ = iConfig.getParameter<std::string>("objType");
   dR2limit_ = iConfig.getParameter<double>("dR2limit");
   doOnlyLastFilter_ = iConfig.getParameter<bool>("doOnlyLastFilter");
@@ -147,13 +147,13 @@ void HLTGenValSource::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& i
   infoString_ += "\"date & time\":\"" + timeString + "\",";
 
   // CMSSW version
-  std::stringstream CMSSWversionStream(std::getenv("CMSSW_BASE"));
-  std::string CMSSWversionSegment;
-  std::string CMSSWversion;
-  while (std::getline(CMSSWversionStream, CMSSWversionSegment, '/')) {
-    CMSSWversion = CMSSWversionSegment;
+  std::stringstream cmsswVersionStream(std::getenv("CMSSW_BASE"));
+  std::string cmsswVersionSegment;
+  std::string cmsswVersion;
+  while (std::getline(cmsswVersionStream, cmsswVersionSegment, '/')) {
+    cmsswVersion = cmsswVersionSegment;
   }
-  infoString_ += std::string("\"CMSSW release\":\"") + CMSSWversion + "\",";
+  infoString_ += std::string("\"CMSSW release\":\"") + cmsswVersion + "\",";
 
   // Initialize hltConfig, for cross-checking whether chosen paths exist
   bool changedConfig;
@@ -290,7 +290,7 @@ void HLTGenValSource::fillDescriptions(edm::ConfigurationDescriptions& descripti
       "objType");  // this deliberately has no default, as this is the main thing the user needs to chose
   desc.add<std::vector<std::string>>(
       "hltPathsToCheck");  // this for the moment also has no default: maybe there can be some way to handle this later?
-  desc.add<std::string>("DQMDirName", "HLTGenVal");
+  desc.add<std::string>("dqmDirName", "HLTGenVal");
   desc.add<std::string>("hltProcessName", "HLT");
   desc.add<double>("dR2limit", 0.1);
   desc.add<bool>("doOnlyLastFilter", false);
@@ -376,19 +376,19 @@ std::vector<HLTGenValObject> HLTGenValSource::getObjectCollection(const edm::Eve
       implementedGenParticles.end()) {
     objects = getGenParticles(iEvent);
   } else if (objType_ == "AK4jet") {  // ak4 jets, using the ak4GenJets collection
-    const auto& genJets = iEvent.getHandle(AK4genJetToken_);
+    const auto& genJets = iEvent.getHandle(ak4genJetToken_);
     for (size_t i = 0; i < genJets->size(); i++) {
       const reco::GenJet p = (*genJets)[i];
       objects.emplace_back(p);
     }
   } else if (objType_ == "AK8jet") {  // ak8 jets, using the ak8GenJets collection
-    const auto& genJets = iEvent.getHandle(AK8genJetToken_);
+    const auto& genJets = iEvent.getHandle(ak8genJetToken_);
     for (size_t i = 0; i < genJets->size(); i++) {
       const reco::GenJet p = (*genJets)[i];
       objects.emplace_back(p);
     }
   } else if (objType_ == "AK4HT") {  // ak4-based HT, using the ak4GenJets collection
-    const auto& genJets = iEvent.getHandle(AK4genJetToken_);
+    const auto& genJets = iEvent.getHandle(ak4genJetToken_);
     if (!genJets->empty()) {
       auto HTsum = (*genJets)[0].pt();
       for (size_t i = 1; i < genJets->size(); i++) {
@@ -398,7 +398,7 @@ std::vector<HLTGenValObject> HLTGenValSource::getObjectCollection(const edm::Eve
       objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
     }
   } else if (objType_ == "AK8HT") {  // ak8-based HT, using the ak8GenJets collection
-    const auto& genJets = iEvent.getHandle(AK8genJetToken_);
+    const auto& genJets = iEvent.getHandle(ak8genJetToken_);
     if (!genJets->empty()) {
       auto HTsum = (*genJets)[0].pt();
       for (size_t i = 1; i < genJets->size(); i++) {

--- a/Validation/HLTrigger/plugins/HLTGenValSource.cc
+++ b/Validation/HLTrigger/plugins/HLTGenValSource.cc
@@ -12,7 +12,6 @@
 //
 //********************************************************************************
 
-
 // system include files
 #include <memory>
 #include <chrono>
@@ -58,7 +57,6 @@
 
 class HLTGenValSource : public DQMEDAnalyzer {
 public:
-
   explicit HLTGenValSource(const edm::ParameterSet&);
   ~HLTGenValSource() override = default;
   HLTGenValSource(const HLTGenValSource&) = delete;
@@ -69,7 +67,7 @@ public:
 private:
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void bookHistograms(DQMStore::IBooker&, edm::Run const& run, edm::EventSetup const& c) override;
-  void dqmBeginRun(const edm::Run &, const edm::EventSetup &) override;
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
 
   // functions to get correct object collection for chosen object type
   std::vector<HLTGenValObject> getObjectCollection(const edm::Event&);
@@ -110,33 +108,34 @@ private:
   std::vector<std::string> hltPathSpecificCuts;
   double dR2limit_;
   bool doOnlyLastFilter_;
-
 };
 
 HLTGenValSource::HLTGenValSource(const edm::ParameterSet& iConfig)
-    : genParticleToken_( consumes<reco::GenParticleCollection>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("genParticles") ) ),
-      genMETToken_( consumes<reco::GenMETCollection>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("genMET") ) ),
-      AK4genJetToken_(consumes<reco::GenJetCollection>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("ak4GenJets"))),
-      AK8genJetToken_(consumes<reco::GenJetCollection>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("ak8GenJets"))),
-      trigEventToken_(consumes<trigger::TriggerEvent>( iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("TrigEvent") )) {
+    : genParticleToken_(consumes<reco::GenParticleCollection>(
+          iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("genParticles"))),
+      genMETToken_(consumes<reco::GenMETCollection>(
+          iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("genMET"))),
+      AK4genJetToken_(consumes<reco::GenJetCollection>(
+          iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("ak4GenJets"))),
+      AK8genJetToken_(consumes<reco::GenJetCollection>(
+          iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("ak8GenJets"))),
+      trigEventToken_(consumes<trigger::TriggerEvent>(
+          iConfig.getParameterSet("inputCollections").getParameter<edm::InputTag>("TrigEvent"))) {
+  // getting the histogram configurations
+  histConfigs_ = iConfig.getParameterSetVector("histConfigs");
+  histConfigs2D_ = iConfig.getParameterSetVector("histConfigs2D");
+  binnings_ = iConfig.getParameterSetVector("binnings");
 
-      // getting the histogram configurations
-      histConfigs_ = iConfig.getParameterSetVector("histConfigs");
-      histConfigs2D_ = iConfig.getParameterSetVector("histConfigs2D");
-      binnings_ = iConfig.getParameterSetVector("binnings");
-
-      // getting all other configurations
-      dirName_ = iConfig.getParameter<std::string>("DQMDirName");
-      objType_ = iConfig.getParameter<std::string>("objType");
-      dR2limit_ = iConfig.getParameter<double>("dR2limit");
-      doOnlyLastFilter_ = iConfig.getParameter<bool>("doOnlyLastFilter");
-      hltProcessName_ = iConfig.getParameter<std::string>("hltProcessName");
-      hltPathsToCheck_ = iConfig.getParameter<std::vector<std::string>>("hltPathsToCheck");
-
+  // getting all other configurations
+  dirName_ = iConfig.getParameter<std::string>("DQMDirName");
+  objType_ = iConfig.getParameter<std::string>("objType");
+  dR2limit_ = iConfig.getParameter<double>("dR2limit");
+  doOnlyLastFilter_ = iConfig.getParameter<bool>("doOnlyLastFilter");
+  hltProcessName_ = iConfig.getParameter<std::string>("hltProcessName");
+  hltPathsToCheck_ = iConfig.getParameter<std::vector<std::string>>("hltPathsToCheck");
 }
 
-void HLTGenValSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
-
+void HLTGenValSource::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   // writing general information to info JSON
   auto t = std::time(nullptr);
   auto tm = *std::localtime(&t);
@@ -145,17 +144,16 @@ void HLTGenValSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &i
   std::ostringstream timeStringStream;
   timeStringStream << std::put_time(&tm, "%d-%m-%Y %H-%M-%S");
   auto timeString = timeStringStream.str();
-  infoString_ += "\"date & time\":\""+timeString+"\",";
+  infoString_ += "\"date & time\":\"" + timeString + "\",";
 
   // CMSSW version
   std::stringstream CMSSWversionStream(std::getenv("CMSSW_BASE"));
   std::string CMSSWversionSegment;
   std::string CMSSWversion;
-  while(std::getline(CMSSWversionStream, CMSSWversionSegment, '/'))
-  {
-     CMSSWversion = CMSSWversionSegment;
+  while (std::getline(CMSSWversionStream, CMSSWversionSegment, '/')) {
+    CMSSWversion = CMSSWversionSegment;
   }
-  infoString_ += std::string("\"CMSSW release\":\"")+CMSSWversion+"\",";
+  infoString_ += std::string("\"CMSSW release\":\"") + CMSSWversion + "\",";
 
   // Initialize hltConfig, for cross-checking whether chosen paths exist
   bool changedConfig;
@@ -165,32 +163,31 @@ void HLTGenValSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &i
   }
 
   // global tag
-  infoString_ += std::string("\"global tag\":\"")+hltConfig_.globalTag()+"\",";
+  infoString_ += std::string("\"global tag\":\"") + hltConfig_.globalTag() + "\",";
 
   // confDB table name
-  infoString_ += std::string("\"HLT ConfDB table\":\"")+hltConfig_.tableName()+"\",";
+  infoString_ += std::string("\"HLT ConfDB table\":\"") + hltConfig_.tableName() + "\",";
 
   // Get the set of trigger paths we want to make plots for
   std::vector<std::string> notFoundPaths;
-  for (auto const &pathToCheck : hltPathsToCheck_) {
-
+  for (auto const& pathToCheck : hltPathsToCheck_) {
     // It is possible to add additional requirements to each path, seperated by a colon from the path name
     // these additional requirements are split from the path name here
     std::string cleanedPathToCheck;
     std::string pathSpecificCuts = "";
     if (pathToCheck.find(':') != std::string::npos) {
-
       // splitting the string
       std::stringstream hltPathToCheckInputStream(pathToCheck);
       std::string hltPathToCheckInputSegment;
       std::vector<std::string> hltPathToCheckInputSeglist;
-      while(std::getline(hltPathToCheckInputStream, hltPathToCheckInputSegment, ':'))
-      {
-         hltPathToCheckInputSeglist.push_back(hltPathToCheckInputSegment);
+      while (std::getline(hltPathToCheckInputStream, hltPathToCheckInputSegment, ':')) {
+        hltPathToCheckInputSeglist.push_back(hltPathToCheckInputSegment);
       }
 
       // here, exactly two parts are expected
-      if(hltPathToCheckInputSeglist.size() != 2) throw cms::Exception("InputError") << "Path string can not be properly split into path and cuts: please use exactly one colon!.\n";
+      if (hltPathToCheckInputSeglist.size() != 2)
+        throw cms::Exception("InputError")
+            << "Path string can not be properly split into path and cuts: please use exactly one colon!.\n";
 
       // the first part is the name of the path
       cleanedPathToCheck = hltPathToCheckInputSeglist.at(0);
@@ -203,28 +200,29 @@ void HLTGenValSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &i
     }
 
     bool pathfound = false;
-    for (auto const &pathFromConfig : hltConfig_.triggerNames()) {
+    for (auto const& pathFromConfig : hltConfig_.triggerNames()) {
       if (pathFromConfig.find(cleanedPathToCheck) != std::string::npos) {
-
         hltPaths.push_back(pathFromConfig);
 
         // in case the path was added twice, we'll add a tag automatically
         int count = std::count(hltPaths.begin(), hltPaths.end(), pathFromConfig);
         if (count > 1) {
-          pathSpecificCuts += std::string(",autotag=v")+std::to_string( count );
+          pathSpecificCuts += std::string(",autotag=v") + std::to_string(count);
         }
         hltPathSpecificCuts.push_back(pathSpecificCuts);
         pathfound = true;
       }
     }
-    if(!pathfound) notFoundPaths.push_back(cleanedPathToCheck);
+    if (!pathfound)
+      notFoundPaths.push_back(cleanedPathToCheck);
   }
-  if(!notFoundPaths.empty()) {
+  if (!notFoundPaths.empty()) {
     // error handling in case some paths do not exist
     std::string notFoundPathsMessage = "";
-    for (const auto & path : notFoundPaths) notFoundPathsMessage += "- " + path + "\n";
-    edm::LogError("HLTGenValSource") << "The following paths could not be found and will not be used: \n" << notFoundPathsMessage << std::endl;
-
+    for (const auto& path : notFoundPaths)
+      notFoundPathsMessage += "- " + path + "\n";
+    edm::LogError("HLTGenValSource") << "The following paths could not be found and will not be used: \n"
+                                     << notFoundPathsMessage << std::endl;
   }
 
   // before creating the collections for each path, we'll store the needed configurations in a pset
@@ -237,17 +235,15 @@ void HLTGenValSource::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &i
   pathCollConfig.addParameter<std::string>("hltProcessName", hltProcessName_);
 
   // creating a histogram collection for each path
-  for (const auto & path : hltPaths) {
+  for (const auto& path : hltPaths) {
     edm::ParameterSet pathCollConfigStep = pathCollConfig;
     pathCollConfigStep.addParameter<std::string>("triggerPath", path);
     collectionPath_.emplace_back(HLTGenValHistCollPath(pathCollConfigStep, hltConfig_));
   }
-
 }
 
 // ------------ method called for each event  ------------
 void HLTGenValSource::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   // creating the collection of HLTGenValObjects
   const std::vector<HLTGenValObject> objects = getObjectCollection(iEvent);
 
@@ -256,44 +252,44 @@ void HLTGenValSource::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   iEvent.getByToken(trigEventToken_, triggerEvent);
 
   // loop over all objects and fill hists
-  for (const auto & object : objects) {
+  for (const auto& object : objects) {
     for (auto& collection_path : collectionPath_) {
       collection_path.fillHists(object, triggerEvent);
     }
   }
-
 }
 
 // ------------ method called once each job just before starting event loop  ------------
 void HLTGenValSource::bookHistograms(DQMStore::IBooker& iBooker, const edm::Run& run, const edm::EventSetup& setup) {
-
   iBooker.setCurrentFolder(dirName_);
 
-  if(infoString_.back() == ',') infoString_.pop_back();
-  infoString_ += "}"; // adding the closing bracked to the JSON string
+  if (infoString_.back() == ',')
+    infoString_.pop_back();
+  infoString_ += "}";  // adding the closing bracked to the JSON string
   iBooker.bookString("HLTGenValInfo", infoString_);
 
   // booking all histograms
   for (long unsigned int i = 0; i < collectionPath_.size(); i++) {
     std::vector<edm::ParameterSet> histConfigs = histConfigs_;
-    for (auto & histConfig : histConfigs) {
+    for (auto& histConfig : histConfigs) {
       histConfig.addParameter<std::string>("pathSpecificCuts", hltPathSpecificCuts.at(i));
-      histConfig.addParameter<std::vector<edm::ParameterSet>>("binnings", binnings_); // passing along the user-defined binnings
+      histConfig.addParameter<std::vector<edm::ParameterSet>>("binnings",
+                                                              binnings_);  // passing along the user-defined binnings
     }
 
     collectionPath_.at(i).bookHists(iBooker, histConfigs, histConfigs2D_);
   }
-
 }
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void HLTGenValSource::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
   // basic parameter strings
-  desc.add<std::string>("objType"); // this deliberately has no default, as this is the main thing the user needs to chose
-  desc.add<std::vector<std::string>>("hltPathsToCheck"); // this for the moment also has no default: maybe there can be some way to handle this later?
+  desc.add<std::string>(
+      "objType");  // this deliberately has no default, as this is the main thing the user needs to chose
+  desc.add<std::vector<std::string>>(
+      "hltPathsToCheck");  // this for the moment also has no default: maybe there can be some way to handle this later?
   desc.add<std::string>("DQMDirName", "HLTGenVal");
   desc.add<std::string>("hltProcessName", "HLT");
   desc.add<double>("dR2limit", 0.1);
@@ -315,21 +311,23 @@ void HLTGenValSource::fillDescriptions(edm::ConfigurationDescriptions& descripti
   edm::ParameterSetDescription histConfig;
   histConfig.add<std::string>("vsVar");
   histConfig.add<std::vector<double>>("binLowEdges");
-  histConfig.addVPSet("rangeCuts", VarRangeCut<HLTGenValObject>::makePSetDescription(), std::vector<edm::ParameterSet>());
+  histConfig.addVPSet(
+      "rangeCuts", VarRangeCut<HLTGenValObject>::makePSetDescription(), std::vector<edm::ParameterSet>());
 
   // default set of histConfigs
   std::vector<edm::ParameterSet> histConfigDefaults;
 
   edm::ParameterSet histConfigDefault0;
   histConfigDefault0.addParameter<std::string>("vsVar", "pt");
-  std::vector<double> defaultPtBinning{ 0,5,10,12.5,15,17.5,20,22.5,25,30,35,40,45,50,60,80,100,150,200,250,300,350,400 };
-  histConfigDefault0.addParameter<std::vector<double>>("binLowEdges", defaultPtBinning );
+  std::vector<double> defaultPtBinning{0,  5,  10, 12.5, 15,  17.5, 20,  22.5, 25,  30,  35, 40,
+                                       45, 50, 60, 80,   100, 150,  200, 250,  300, 350, 400};
+  histConfigDefault0.addParameter<std::vector<double>>("binLowEdges", defaultPtBinning);
   histConfigDefaults.push_back(histConfigDefault0);
 
   edm::ParameterSet histConfigDefault1;
   histConfigDefault1.addParameter<std::string>("vsVar", "eta");
-  std::vector<double> defaultetaBinning{ -10, -8, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 8, 10 };
-  histConfigDefault1.addParameter<std::vector<double>>("binLowEdges", defaultetaBinning );
+  std::vector<double> defaultetaBinning{-10, -8, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 8, 10};
+  histConfigDefault1.addParameter<std::vector<double>>("binLowEdges", defaultetaBinning);
   histConfigDefaults.push_back(histConfigDefault1);
 
   desc.addVPSet("histConfigs", histConfig, histConfigDefaults);
@@ -370,107 +368,110 @@ void HLTGenValSource::fillDescriptions(edm::ConfigurationDescriptions& descripti
 
 // this method handles the different object types and collections that can be used for efficiency calculation
 std::vector<HLTGenValObject> HLTGenValSource::getObjectCollection(const edm::Event& iEvent) {
-
-  std::vector<HLTGenValObject> objects; // the vector of objects to be filled
+  std::vector<HLTGenValObject> objects;  // the vector of objects to be filled
 
   // handle object type
   std::vector<std::string> implementedGenParticles = {"ele", "pho", "mu", "tau"};
-  if(std::find(implementedGenParticles.begin(), implementedGenParticles.end(), objType_) != implementedGenParticles.end()) {
+  if (std::find(implementedGenParticles.begin(), implementedGenParticles.end(), objType_) !=
+      implementedGenParticles.end()) {
     objects = getGenParticles(iEvent);
-  }
-  else if(objType_ == "AK4jet") { // ak4 jets, using the ak4GenJets collection
+  } else if (objType_ == "AK4jet") {  // ak4 jets, using the ak4GenJets collection
     const auto& genJets = iEvent.getHandle(AK4genJetToken_);
-    for(size_t i = 0; i < genJets->size(); i++) {
+    for (size_t i = 0; i < genJets->size(); i++) {
       const reco::GenJet p = (*genJets)[i];
       objects.emplace_back(p);
     }
-  }
-  else if(objType_ == "AK8jet") { // ak8 jets, using the ak8GenJets collection
+  } else if (objType_ == "AK8jet") {  // ak8 jets, using the ak8GenJets collection
     const auto& genJets = iEvent.getHandle(AK8genJetToken_);
-    for(size_t i = 0; i < genJets->size(); i++) {
+    for (size_t i = 0; i < genJets->size(); i++) {
       const reco::GenJet p = (*genJets)[i];
       objects.emplace_back(p);
     }
-  }
-  else if(objType_ == "AK4HT") { // ak4-based HT, using the ak4GenJets collection
+  } else if (objType_ == "AK4HT") {  // ak4-based HT, using the ak4GenJets collection
     const auto& genJets = iEvent.getHandle(AK4genJetToken_);
-    if(!genJets->empty()){
+    if (!genJets->empty()) {
       auto HTsum = (*genJets)[0].pt();
-      for(size_t i = 1; i < genJets->size(); i++) {
-        if(((*genJets)[i].pt() > 30) && (abs((*genJets)[i].eta()) < 2.5)) HTsum += (*genJets)[i].pt();
+      for (size_t i = 1; i < genJets->size(); i++) {
+        if (((*genJets)[i].pt() > 30) && (abs((*genJets)[i].eta()) < 2.5))
+          HTsum += (*genJets)[i].pt();
       }
       objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
     }
-  }
-  else if(objType_ == "AK8HT") { // ak8-based HT, using the ak8GenJets collection
+  } else if (objType_ == "AK8HT") {  // ak8-based HT, using the ak8GenJets collection
     const auto& genJets = iEvent.getHandle(AK8genJetToken_);
-    if(!genJets->empty()){
+    if (!genJets->empty()) {
       auto HTsum = (*genJets)[0].pt();
-      for(size_t i = 1; i < genJets->size(); i++) {
-        if(((*genJets)[i].pt() > 200) && (abs((*genJets)[i].eta()) < 2.5)) HTsum += (*genJets)[i].pt();
+      for (size_t i = 1; i < genJets->size(); i++) {
+        if (((*genJets)[i].pt() > 200) && (abs((*genJets)[i].eta()) < 2.5))
+          HTsum += (*genJets)[i].pt();
       }
       objects.emplace_back(reco::Candidate::PolarLorentzVector(HTsum, 0, 0, 0));
     }
-  }
-  else if(objType_ == "MET") { // MET, using genMET
+  } else if (objType_ == "MET") {  // MET, using genMET
     const auto& genMET = iEvent.getHandle(genMETToken_);
-    if(!genMET->empty()){
+    if (!genMET->empty()) {
       auto genMETpt = (*genMET)[0].pt();
       objects.emplace_back(reco::Candidate::PolarLorentzVector(genMETpt, 0, 0, 0));
     }
-  }
-  else throw cms::Exception("InputError") << "Generator-level validation is not available for type " << objType_ << ".\n" << "Please check for a potential spelling error.\n";
+  } else
+    throw cms::Exception("InputError") << "Generator-level validation is not available for type " << objType_ << ".\n"
+                                       << "Please check for a potential spelling error.\n";
 
   return objects;
 }
 
 // in case of GenParticles, a subset of the entire collection needs to be chosen
 std::vector<HLTGenValObject> HLTGenValSource::getGenParticles(const edm::Event& iEvent) {
+  std::vector<HLTGenValObject> objects;  // vector to be filled
 
-  std::vector<HLTGenValObject> objects; // vector to be filled
-
-  const auto& genParticles = iEvent.getHandle(genParticleToken_); // getting all GenParticles
+  const auto& genParticles = iEvent.getHandle(genParticleToken_);  // getting all GenParticles
 
   // we need to ge the ID corresponding to the desired GenParticle type
-  int pdgID = -1; // setting to -1 should not be needed, but prevents the compiler warning :)
-  if(objType_ == "ele") pdgID = 11;
-  else if(objType_ == "pho") pdgID = 22;
-  else if(objType_ == "mu") pdgID = 13;
-  else if(objType_ == "tau") pdgID = 15;
+  int pdgID = -1;  // setting to -1 should not be needed, but prevents the compiler warning :)
+  if (objType_ == "ele")
+    pdgID = 11;
+  else if (objType_ == "pho")
+    pdgID = 22;
+  else if (objType_ == "mu")
+    pdgID = 13;
+  else if (objType_ == "tau")
+    pdgID = 15;
 
   // main loop over GenParticles
-  for(size_t i = 0; i < genParticles->size(); ++ i) {
+  for (size_t i = 0; i < genParticles->size(); ++i) {
     const reco::GenParticle p = (*genParticles)[i];
 
     // only GenParticles with correct ID
-    if (abs(p.pdgId()) != pdgID) continue;
+    if (abs(p.pdgId()) != pdgID)
+      continue;
 
     // checking if particle comes from "hard process"
-    if(p.isHardProcess()) {
-
+    if (p.isHardProcess()) {
       // depending on the particle type, last particle before or after FSR is chosen
-      if( (objType_ == "ele") || (objType_ == "pho") ) objects.emplace_back( getLastCopyPreFSR(p) );
-      else if( (objType_ == "mu") || (objType_ == "tau") ) objects.emplace_back( getLastCopy(p) );
-
+      if ((objType_ == "ele") || (objType_ == "pho"))
+        objects.emplace_back(getLastCopyPreFSR(p));
+      else if ((objType_ == "mu") || (objType_ == "tau"))
+        objects.emplace_back(getLastCopy(p));
     }
-
   }
 
   return objects;
-
 }
 
 // function returning the last GenParticle in a decay chain before FSR
 reco::GenParticle HLTGenValSource::getLastCopyPreFSR(reco::GenParticle part) {
-    const auto& daughters = part.daughterRefVector();
-    if (daughters.size() == 1 && daughters.at(0)->pdgId() == part.pdgId()) return getLastCopyPreFSR(*daughters.at(0).get()); // recursion, whooo
-    else return part;
+  const auto& daughters = part.daughterRefVector();
+  if (daughters.size() == 1 && daughters.at(0)->pdgId() == part.pdgId())
+    return getLastCopyPreFSR(*daughters.at(0).get());  // recursion, whooo
+  else
+    return part;
 }
 
 // function returning the last GenParticle in a decay chain
 reco::GenParticle HLTGenValSource::getLastCopy(reco::GenParticle part) {
-  for (const auto & daughter : part.daughterRefVector()){
-    if (daughter->pdgId() == part.pdgId()) return getLastCopy(*daughter.get());
+  for (const auto& daughter : part.daughterRefVector()) {
+    if (daughter->pdgId() == part.pdgId())
+      return getLastCopy(*daughter.get());
   }
   return part;
 }

--- a/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
+++ b/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
@@ -55,7 +55,7 @@ void HLTGenValHistCollFilter::fillHists(const HLTGenValObject& obj, edm::Handle<
     }
 
     // differentiate between event level and particle level variables
-    std::vector<std::string> eventLevelVariables = {"AK4HT", "AK8HT", "MET"};
+    const static std::vector<std::string> eventLevelVariables = {"AK4HT", "AK8HT", "MET"};
     if (std::find(eventLevelVariables.begin(), eventLevelVariables.end(), objType_) != eventLevelVariables.end()) {
       // for these event level variables we only require the existence of a trigger object, but no matching
       if (!selectedObjects.empty())
@@ -91,16 +91,16 @@ void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::Para
   // getting the bin edges, path-specific overwrites general if present
   auto binLowEdgesDouble = histConfig.getParameter<std::vector<double>>("binLowEdges");
   if (parser.havePathSpecificBins())
-    binLowEdgesDouble = parser.getPathSpecificBins();
+    binLowEdgesDouble = *parser.getPathSpecificBins();
 
   // additional cuts applied to this histogram, combination of general ones and path-specific ones
   std::vector<edm::ParameterSet> allCutsVector = histConfig.getParameter<std::vector<edm::ParameterSet>>("rangeCuts");
-  std::vector<edm::ParameterSet> pathSpecificCutsVector = parser.getPathSpecificCuts();
+  std::vector<edm::ParameterSet> pathSpecificCutsVector = *parser.getPathSpecificCuts();
   allCutsVector.insert(allCutsVector.end(), pathSpecificCutsVector.begin(), pathSpecificCutsVector.end());
   VarRangeCutColl<HLTGenValObject> rangeCuts(allCutsVector);
 
   // getting the custom tag
-  std::string tag = parser.getTag();
+  const std::string tag = *parser.getTag();
 
   // checking validity of vsVar
   if (!vsVarFunc) {
@@ -141,7 +141,7 @@ void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::Para
   }
 
   auto me = iBooker.book1D(
-      histName.c_str(), histTitle.c_str(), binLowEdges.size() - 1, &binLowEdges[0]);  // booking MonitorElement
+      histName.c_str(), histTitle.c_str(), binLowEdges.size() - 1, binLowEdges.data());  // booking MonitorElement
 
   std::unique_ptr<HLTGenValHist> hist;  // creating the hist object
 
@@ -199,9 +199,9 @@ void HLTGenValHistCollFilter::book2D(DQMStore::IBooker& iBooker, const edm::Para
   auto me = iBooker.book2D(histName.c_str(),
                            histTitle.c_str(),
                            binLowEdgesX.size() - 1,
-                           &binLowEdgesX[0],
+                           binLowEdgesX.data(),
                            binLowEdgesY.size() - 1,
-                           &binLowEdgesY[0]);
+                           binLowEdgesY.data());
 
   std::unique_ptr<HLTGenValHist> hist;
 

--- a/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
+++ b/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
@@ -1,0 +1,179 @@
+#include "Validation/HLTrigger/interface/HLTGenValHistCollFilter.h"
+
+// constructor
+HLTGenValHistCollFilter::HLTGenValHistCollFilter(edm::ParameterSet filterCollConfig) {
+  objType_ = filterCollConfig.getParameter<std::string>("objType");
+  filter_ = filterCollConfig.getParameter<std::string>("filterName");
+  path_ = filterCollConfig.getParameter<std::string>("pathName");
+  hltProcessName_ = filterCollConfig.getParameter<std::string>("hltProcessName");
+  dR2limit_ = filterCollConfig.getParameter<double>("dR2limit");
+}
+
+edm::ParameterSetDescription HLTGenValHistCollFilter::makePSetDescription() {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("objType", "");
+  desc.add<std::string>("hltProcessName", "HLT");
+  desc.add<double>("dR2limit", 0.1);
+  desc.add<std::string>("filterName", "");
+  desc.add<std::string>("pathName", "");
+  return desc;
+}
+
+// general hist booking function, receiving configurations for 1D and 2D hists and calling the respective functions
+void HLTGenValHistCollFilter::bookHists(DQMStore::IBooker& iBooker, const std::vector<edm::ParameterSet>& histConfigs, const std::vector<edm::ParameterSet>& histConfigs2D) {
+  for (const auto& histConfig : histConfigs) book1D(iBooker, histConfig);
+  for (const auto& histConfig : histConfigs2D) book2D(iBooker, histConfig);
+}
+
+// histogram filling routine
+void HLTGenValHistCollFilter::fillHists(const HLTGenValObject& obj, edm::Handle<trigger::TriggerEvent>& triggerEvent) {
+
+  // this handles the "before" step, denoted by a "dummy" filter called "beforeAnyFilter"
+  // the histogram is filled without any additional requirements for all objects
+  if(filter_ == "beforeAnyFilter") {
+    for (auto& hist : hists_) hist->fill(obj);
+  } else {
+    // main filling code
+
+    // get filter object from filter name
+    edm::InputTag filterTag(filter_, "", hltProcessName_);
+    size_t filterIndex = triggerEvent->filterIndex(filterTag);
+
+    // get trigger objects passing filter in question
+    trigger::TriggerObjectCollection allTriggerObjects = triggerEvent->getObjects(); // all objects
+    trigger::TriggerObjectCollection selectedObjects; // vector to fill with objects passing our filter
+    if (filterIndex < triggerEvent->sizeFilters()) {
+      const auto& keys = triggerEvent->filterKeys(filterIndex);
+      for (unsigned short key : keys) {
+        trigger::TriggerObject foundObject = allTriggerObjects[key];
+        selectedObjects.push_back(foundObject);
+      }
+    }
+
+    // differentiate between event level and particle level variables
+    std::vector<std::string> eventLevelVariables = {"AK4HT", "AK8HT", "MET"};
+    if(std::find(eventLevelVariables.begin(), eventLevelVariables.end(), objType_) != eventLevelVariables.end()) {
+      // for these event level variables we only require the existence of a trigger object, but no matching
+      if(!selectedObjects.empty()) for (auto& hist : hists_) hist->fill(obj);
+    } else {
+      // do a deltaR matching between trigger object and GEN object
+      double mindR2 = 99999;
+      for (const auto & filterobj : selectedObjects) {
+        double dR = deltaR2(obj, filterobj);
+        if(dR < mindR2) mindR2 = dR;
+      }
+      if(mindR2 < dR2limit_) for (auto& hist : hists_) hist->fill(obj);
+    }
+
+  }
+}
+
+// booker function for 1D hists
+void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig) {
+  // extracting parameters from configuration
+  auto vsVar = histConfig.getParameter<std::string>("vsVar");
+  auto vsVarFunc = hltdqm::getUnaryFuncFloat<HLTGenValObject>(vsVar);
+
+  // this class parses any potential additional cuts, changes in binning or tags
+  HLTGenValPathSpecificSettingParser parser = HLTGenValPathSpecificSettingParser( histConfig.getParameter<std::string>("pathSpecificCuts"), histConfig.getParameter<std::vector<edm::ParameterSet>>("binnings"), vsVar );
+
+  // getting the bin edges, path-specific overwrites general if present
+  auto binLowEdgesDouble = histConfig.getParameter<std::vector<double> >("binLowEdges");
+  if(parser.havePathSpecificBins()) binLowEdgesDouble = parser.getPathSpecificBins();
+
+  // additional cuts applied to this histogram, combination of general ones and path-specific ones
+  std::vector<edm::ParameterSet> allCutsVector = histConfig.getParameter<std::vector<edm::ParameterSet> >("rangeCuts");
+  std::vector<edm::ParameterSet> pathSpecificCutsVector = parser.getPathSpecificCuts();
+  allCutsVector.insert(allCutsVector.end(), pathSpecificCutsVector.begin(), pathSpecificCutsVector.end());
+  VarRangeCutColl<HLTGenValObject> rangeCuts(allCutsVector);
+
+  // getting the custom tag
+  std::string tag = parser.getTag();
+
+  // checking validity of vsVar
+  if (!vsVarFunc) { throw cms::Exception("ConfigError") << " vsVar " << vsVar << " is giving null ptr (likely empty) in " << __FILE__ << "," << __LINE__ << std::endl;}
+
+  // converting bin edges to float
+  std::vector<float> binLowEdges;
+  binLowEdges.reserve(binLowEdgesDouble.size());
+  for (double lowEdge : binLowEdgesDouble) binLowEdges.push_back(lowEdge);
+
+  // name and title are systematically constructed
+
+  // remove potential leading "-" (which denotes that that trigger is ignored)
+  std::string filterName = filter_;
+  if(filterName.rfind("-", 0) == 0) filterName.erase(0, 1);
+
+  std::string histName, histTitle;
+  if(filter_ == "beforeAnyFilter") { // this handles the naming of the "before" hist
+    histName = objType_ + ":" + path_ + ":GEN:vs" + vsVar ;
+    histTitle = objType_ + ":" + path_ + " GEN vs " + vsVar;
+    if(!tag.empty()) {
+      histName += ":"+tag;
+      histTitle += " "+tag;
+    }
+  } else { // naming of all regular hists
+    histName = objType_ + ":" + path_ + ":" + filterName + ":vs" + vsVar;
+    histTitle = objType_ + ":" + path_ + ":" + filterName + ":vs" + vsVar;
+
+    // appending the tag, in case it is filled
+    if(!tag.empty()) {
+      histName += ":"+tag;
+      histTitle += " "+tag;
+    }
+  }
+
+  auto me = iBooker.book1D(histName.c_str(), histTitle.c_str(), binLowEdges.size() - 1, &binLowEdges[0] );   // booking MonitorElement
+
+  std::unique_ptr<HLTGenValHist> hist; // creating the hist object
+
+  hist = std::make_unique<HLTGenValHist1D>(me->getTH1(), vsVar, vsVarFunc, rangeCuts);
+
+  hists_.emplace_back(std::move(hist));
+}
+
+// booker function for 2D hists
+void HLTGenValHistCollFilter::book2D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig2D) {
+  // extracting parameters from configuration
+  auto vsVarX = histConfig2D.getParameter<std::string>("vsVarX");
+  auto vsVarY = histConfig2D.getParameter<std::string>("vsVarY");
+  auto vsVarFuncX = hltdqm::getUnaryFuncFloat<HLTGenValObject>(vsVarX);
+  auto vsVarFuncY = hltdqm::getUnaryFuncFloat<HLTGenValObject>(vsVarY);
+  auto binLowEdgesDoubleX = histConfig2D.getParameter<std::vector<double> >("binLowEdgesX");
+  auto binLowEdgesDoubleY = histConfig2D.getParameter<std::vector<double> >("binLowEdgesY");
+
+  // checking validity of vsVar
+  if (!vsVarFuncX) {throw cms::Exception("ConfigError") << " vsVar " << vsVarX << " is giving null ptr (likely empty) in " << __FILE__ << "," << __LINE__ << std::endl;}
+  if (!vsVarFuncY) {throw cms::Exception("ConfigError") << " vsVar " << vsVarY << " is giving null ptr (likely empty) in " << __FILE__ << "," << __LINE__ << std::endl;}
+
+  // converting bin edges to float
+  std::vector<float> binLowEdgesX;
+  std::vector<float> binLowEdgesY;
+  binLowEdgesX.reserve(binLowEdgesDoubleX.size());
+  binLowEdgesY.reserve(binLowEdgesDoubleY.size());
+  for (double lowEdge : binLowEdgesDoubleX) binLowEdgesX.push_back(lowEdge);
+  for (double lowEdge : binLowEdgesDoubleY) binLowEdgesY.push_back(lowEdge);
+
+  // name and title are systematically constructed
+
+  // remove potential leading "-" (which denotes that that trigger is ignored)
+  std::string filterName = filter_;
+  if(filterName.rfind("-", 0) == 0) filterName.erase(0, 1);
+
+  std::string histName, histTitle;
+  if(filter_ == "beforeAnyFilter") {
+    histName = objType_ + ":" + path_ + ":GEN:2Dvs" + vsVarX + ":" + vsVarY;
+    histTitle = objType_ + ":" + path_ + " GEN 2D vs " + vsVarX + " " + vsVarY;
+  } else {
+    histName = objType_ + ":" + path_ + ":" + filterName + ":2Dvs" + vsVarX + vsVarY;
+    histTitle = objType_ + ":" + path_ + " " + filterName + " 2D vs" + vsVarX + " " + vsVarY;
+  }
+
+  auto me = iBooker.book2D(histName.c_str(), histTitle.c_str(), binLowEdgesX.size() - 1, &binLowEdgesX[0], binLowEdgesY.size() - 1, &binLowEdgesY[0]);
+
+  std::unique_ptr<HLTGenValHist> hist;
+
+  hist = std::make_unique<HLTGenValHist2D>(me->getTH2F(), vsVarX, vsVarY, vsVarFuncX, vsVarFuncY);
+
+  hists_.emplace_back(std::move(hist));
+}

--- a/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
+++ b/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
@@ -102,7 +102,7 @@ void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::Para
 
   // remove potential leading "-" (which denotes that that trigger is ignored)
   std::string filterName = filter_;
-  if(filterName.rfind("-", 0) == 0) filterName.erase(0, 1);
+  if(filterName.rfind('-', 0) == 0) filterName.erase(0, 1);
 
   std::string histName, histTitle;
   if(filter_ == "beforeAnyFilter") { // this handles the naming of the "before" hist
@@ -158,7 +158,7 @@ void HLTGenValHistCollFilter::book2D(DQMStore::IBooker& iBooker, const edm::Para
 
   // remove potential leading "-" (which denotes that that trigger is ignored)
   std::string filterName = filter_;
-  if(filterName.rfind("-", 0) == 0) filterName.erase(0, 1);
+  if(filterName.rfind('-', 0) == 0) filterName.erase(0, 1);
 
   std::string histName, histTitle;
   if(filter_ == "beforeAnyFilter") {

--- a/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
+++ b/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
@@ -7,6 +7,7 @@ HLTGenValHistCollFilter::HLTGenValHistCollFilter(edm::ParameterSet filterCollCon
   path_ = filterCollConfig.getParameter<std::string>("pathName");
   hltProcessName_ = filterCollConfig.getParameter<std::string>("hltProcessName");
   dR2limit_ = filterCollConfig.getParameter<double>("dR2limit");
+  separator_ = "__";
 }
 
 edm::ParameterSetDescription HLTGenValHistCollFilter::makePSetDescription() {
@@ -78,6 +79,7 @@ void HLTGenValHistCollFilter::fillHists(const HLTGenValObject& obj, edm::Handle<
 
 // booker function for 1D hists
 void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig) {
+
   // extracting parameters from configuration
   auto vsVar = histConfig.getParameter<std::string>("vsVar");
   auto vsVarFunc = hltdqm::getUnaryFuncFloat<HLTGenValObject>(vsVar);
@@ -123,19 +125,19 @@ void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::Para
 
   std::string histName, histTitle;
   if (filter_ == "beforeAnyFilter") {  // this handles the naming of the "before" hist
-    histName = objType_ + ":" + path_ + ":GEN:vs" + vsVar;
-    histTitle = objType_ + ":" + path_ + " GEN vs " + vsVar;
+    histName = objType_ + separator_ + path_ + separator_ + "GEN" + separator_ + "vs" + vsVar;
+    histTitle = objType_ + " " + path_ + " GEN vs " + vsVar;
     if (!tag.empty()) {
-      histName += ":" + tag;
+      histName += separator_ + tag;
       histTitle += " " + tag;
     }
   } else {  // naming of all regular hists
-    histName = objType_ + ":" + path_ + ":" + filterName + ":vs" + vsVar;
-    histTitle = objType_ + ":" + path_ + ":" + filterName + ":vs" + vsVar;
+    histName = objType_ + separator_ + path_ + separator_ + filterName + separator_ +"vs" + vsVar;
+    histTitle = objType_ + " " + path_ + " " + filterName + " vs" + vsVar;
 
     // appending the tag, in case it is filled
     if (!tag.empty()) {
-      histName += ":" + tag;
+      histName += separator_ + tag;
       histTitle += " " + tag;
     }
   }
@@ -152,6 +154,7 @@ void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::Para
 
 // booker function for 2D hists
 void HLTGenValHistCollFilter::book2D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig2D) {
+
   // extracting parameters from configuration
   auto vsVarX = histConfig2D.getParameter<std::string>("vsVarX");
   auto vsVarY = histConfig2D.getParameter<std::string>("vsVarY");
@@ -189,11 +192,11 @@ void HLTGenValHistCollFilter::book2D(DQMStore::IBooker& iBooker, const edm::Para
 
   std::string histName, histTitle;
   if (filter_ == "beforeAnyFilter") {
-    histName = objType_ + ":" + path_ + ":GEN:2Dvs" + vsVarX + ":" + vsVarY;
-    histTitle = objType_ + ":" + path_ + " GEN 2D vs " + vsVarX + " " + vsVarY;
+    histName = objType_ + separator_ + path_ + separator_ + "GEN" + separator_ + "2Dvs" + vsVarX + separator_ + vsVarY;
+    histTitle = objType_ + " " + path_ + " GEN 2D vs " + vsVarX + " " + vsVarY;
   } else {
-    histName = objType_ + ":" + path_ + ":" + filterName + ":2Dvs" + vsVarX + vsVarY;
-    histTitle = objType_ + ":" + path_ + " " + filterName + " 2D vs" + vsVarX + " " + vsVarY;
+    histName = objType_ + separator_ + path_ + separator_ + filterName + separator_ +"2Dvs" + vsVarX + vsVarY;
+    histTitle = objType_ + " " + path_ + " " + filterName + " 2D vs" + vsVarX + " " + vsVarY;
   }
 
   auto me = iBooker.book2D(histName.c_str(),

--- a/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
+++ b/Validation/HLTrigger/src/HLTGenValHistCollFilter.cc
@@ -79,7 +79,6 @@ void HLTGenValHistCollFilter::fillHists(const HLTGenValObject& obj, edm::Handle<
 
 // booker function for 1D hists
 void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig) {
-
   // extracting parameters from configuration
   auto vsVar = histConfig.getParameter<std::string>("vsVar");
   auto vsVarFunc = hltdqm::getUnaryFuncFloat<HLTGenValObject>(vsVar);
@@ -132,7 +131,7 @@ void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::Para
       histTitle += " " + tag;
     }
   } else {  // naming of all regular hists
-    histName = objType_ + separator_ + path_ + separator_ + filterName + separator_ +"vs" + vsVar;
+    histName = objType_ + separator_ + path_ + separator_ + filterName + separator_ + "vs" + vsVar;
     histTitle = objType_ + " " + path_ + " " + filterName + " vs" + vsVar;
 
     // appending the tag, in case it is filled
@@ -154,7 +153,6 @@ void HLTGenValHistCollFilter::book1D(DQMStore::IBooker& iBooker, const edm::Para
 
 // booker function for 2D hists
 void HLTGenValHistCollFilter::book2D(DQMStore::IBooker& iBooker, const edm::ParameterSet& histConfig2D) {
-
   // extracting parameters from configuration
   auto vsVarX = histConfig2D.getParameter<std::string>("vsVarX");
   auto vsVarY = histConfig2D.getParameter<std::string>("vsVarY");
@@ -195,7 +193,7 @@ void HLTGenValHistCollFilter::book2D(DQMStore::IBooker& iBooker, const edm::Para
     histName = objType_ + separator_ + path_ + separator_ + "GEN" + separator_ + "2Dvs" + vsVarX + separator_ + vsVarY;
     histTitle = objType_ + " " + path_ + " GEN 2D vs " + vsVarX + " " + vsVarY;
   } else {
-    histName = objType_ + separator_ + path_ + separator_ + filterName + separator_ +"2Dvs" + vsVarX + vsVarY;
+    histName = objType_ + separator_ + path_ + separator_ + filterName + separator_ + "2Dvs" + vsVarX + vsVarY;
     histTitle = objType_ + " " + path_ + " " + filterName + " 2D vs" + vsVarX + " " + vsVarY;
   }
 

--- a/Validation/HLTrigger/src/HLTGenValHistCollPath.cc
+++ b/Validation/HLTrigger/src/HLTGenValHistCollPath.cc
@@ -1,0 +1,82 @@
+#include "Validation/HLTrigger/interface/HLTGenValHistCollPath.h"
+
+// constructor
+HLTGenValHistCollPath::HLTGenValHistCollPath(edm::ParameterSet pathCollConfig, HLTConfigProvider& hltConfig) :
+  hltConfig_(hltConfig) {
+
+  triggerPath_ = pathCollConfig.getParameter<std::string>("triggerPath");
+  doOnlyLastFilter_ = pathCollConfig.getParameter<bool>("doOnlyLastFilter");
+
+  // before creating the collections for each filter, we'll store the needed configurations in a pset
+  // we'll copy this basis multiple times and add the respective path later
+  edm::ParameterSet filterCollConfig;
+  filterCollConfig.addParameter<std::string>("objType", pathCollConfig.getParameter<std::string>("objType"));
+  filterCollConfig.addParameter<std::string>("hltProcessName", pathCollConfig.getParameter<std::string>("hltProcessName"));
+  filterCollConfig.addParameter<double>("dR2limit", pathCollConfig.getParameter<double>("dR2limit"));
+  filterCollConfig.addParameter<std::string>("pathName", triggerPath_);
+
+  pathStringName_ = triggerPath_ + "-" + pathCollConfig.getParameter<std::string>("objType");
+
+  // this filter will be the denominator
+  edm::ParameterSet filterCollConfigStepBeforeAny = filterCollConfig;
+  filterCollConfigStepBeforeAny.addParameter<std::string>("filterName", "beforeAnyFilter");
+  collectionFilter_.emplace_back(HLTGenValHistCollFilter(filterCollConfigStepBeforeAny));
+
+  // we'll use this to construct the string to find which filters belong to which histogram later
+  pathString_ = "";
+
+  // getting all filters from path
+  filters_ = hltConfig_.saveTagsModules(triggerPath_);
+  if(doOnlyLastFilter_) {
+    edm::ParameterSet filterCollConfigOnlyLastFilter = filterCollConfig;
+    filterCollConfigOnlyLastFilter.addParameter<std::string>("filterName", filters_.back());
+    collectionFilter_.emplace_back(HLTGenValHistCollFilter(filterCollConfigOnlyLastFilter));
+
+    // remove potential leading "-" for printing
+    std::string filterName = filters_.back();
+    if(filterName.rfind("-", 0) == 0) filterName.erase(0, 1);
+
+    pathString_ += filterName;
+  } else {
+
+    for (auto & filter : filters_) {
+      edm::ParameterSet filterCollConfigStep = filterCollConfig;
+      filterCollConfigStep.addParameter<std::string>("filterName", filter);
+      collectionFilter_.emplace_back(HLTGenValHistCollFilter(filterCollConfigStep));
+
+      // remove potential leading "-" for printing
+      std::string filterName = filter;
+      if(filterName.rfind("-", 0) == 0) filterName.erase(0, 1);
+
+      pathString_ += filterName;
+      if(filter != filters_.back()) pathString_ += ";";
+    }
+  }
+
+
+}
+
+edm::ParameterSetDescription HLTGenValHistCollPath::makePSetDescription() {
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("objType", "");
+  desc.add<double>("dR2limit", 0.1);
+  desc.add<bool>("doOnlyLastFilter", false);
+  desc.add<std::string>("hltProcessName", "HLT");
+  desc.add<std::string>("triggerPath", "");
+  return desc;
+}
+
+// hist booking function
+// this just calls the booking for each object in the the filter collection
+void HLTGenValHistCollPath::bookHists(DQMStore::IBooker& iBooker, std::vector<edm::ParameterSet>& histConfigs, std::vector<edm::ParameterSet>& histConfigs2D) {
+
+  if(!pathString_.empty()) iBooker.bookString("path-"+pathStringName_, pathString_);
+
+  for (auto& collection_filter : collectionFilter_) collection_filter.bookHists(iBooker, histConfigs, histConfigs2D);
+}
+
+// hist filling function
+// this just calls the filling for each object in the filter collection
+void HLTGenValHistCollPath::fillHists(const HLTGenValObject& obj, edm::Handle<trigger::TriggerEvent>& triggerEvent) {
+  for (auto& collection_filter : collectionFilter_) collection_filter.fillHists(obj, triggerEvent);
+}

--- a/Validation/HLTrigger/src/HLTGenValHistCollPath.cc
+++ b/Validation/HLTrigger/src/HLTGenValHistCollPath.cc
@@ -74,13 +74,13 @@ void HLTGenValHistCollPath::bookHists(DQMStore::IBooker& iBooker,
   if (!pathString_.empty())
     iBooker.bookString("path-" + pathStringName_, pathString_);
 
-  for (auto& collection_filter : collectionFilter_)
-    collection_filter.bookHists(iBooker, histConfigs, histConfigs2D);
+  for (auto& collectionFilter : collectionFilter_)
+    collectionFilter.bookHists(iBooker, histConfigs, histConfigs2D);
 }
 
 // hist filling function
 // this just calls the filling for each object in the filter collection
 void HLTGenValHistCollPath::fillHists(const HLTGenValObject& obj, edm::Handle<trigger::TriggerEvent>& triggerEvent) {
-  for (auto& collection_filter : collectionFilter_)
-    collection_filter.fillHists(obj, triggerEvent);
+  for (auto& collectionFilter : collectionFilter_)
+    collectionFilter.fillHists(obj, triggerEvent);
 }

--- a/Validation/HLTrigger/src/HLTGenValHistCollPath.cc
+++ b/Validation/HLTrigger/src/HLTGenValHistCollPath.cc
@@ -34,7 +34,7 @@ HLTGenValHistCollPath::HLTGenValHistCollPath(edm::ParameterSet pathCollConfig, H
 
     // remove potential leading "-" for printing
     std::string filterName = filters_.back();
-    if(filterName.rfind("-", 0) == 0) filterName.erase(0, 1);
+    if(filterName.rfind('-', 0) == 0) filterName.erase(0, 1);
 
     pathString_ += filterName;
   } else {
@@ -46,7 +46,7 @@ HLTGenValHistCollPath::HLTGenValHistCollPath(edm::ParameterSet pathCollConfig, H
 
       // remove potential leading "-" for printing
       std::string filterName = filter;
-      if(filterName.rfind("-", 0) == 0) filterName.erase(0, 1);
+      if(filterName.rfind('-', 0) == 0) filterName.erase(0, 1);
 
       pathString_ += filterName;
       if(filter != filters_.back()) pathString_ += ";";

--- a/Validation/HLTrigger/src/HLTGenValHistCollPath.cc
+++ b/Validation/HLTrigger/src/HLTGenValHistCollPath.cc
@@ -1,9 +1,8 @@
 #include "Validation/HLTrigger/interface/HLTGenValHistCollPath.h"
 
 // constructor
-HLTGenValHistCollPath::HLTGenValHistCollPath(edm::ParameterSet pathCollConfig, HLTConfigProvider& hltConfig) :
-  hltConfig_(hltConfig) {
-
+HLTGenValHistCollPath::HLTGenValHistCollPath(edm::ParameterSet pathCollConfig, HLTConfigProvider& hltConfig)
+    : hltConfig_(hltConfig) {
   triggerPath_ = pathCollConfig.getParameter<std::string>("triggerPath");
   doOnlyLastFilter_ = pathCollConfig.getParameter<bool>("doOnlyLastFilter");
 
@@ -11,7 +10,8 @@ HLTGenValHistCollPath::HLTGenValHistCollPath(edm::ParameterSet pathCollConfig, H
   // we'll copy this basis multiple times and add the respective path later
   edm::ParameterSet filterCollConfig;
   filterCollConfig.addParameter<std::string>("objType", pathCollConfig.getParameter<std::string>("objType"));
-  filterCollConfig.addParameter<std::string>("hltProcessName", pathCollConfig.getParameter<std::string>("hltProcessName"));
+  filterCollConfig.addParameter<std::string>("hltProcessName",
+                                             pathCollConfig.getParameter<std::string>("hltProcessName"));
   filterCollConfig.addParameter<double>("dR2limit", pathCollConfig.getParameter<double>("dR2limit"));
   filterCollConfig.addParameter<std::string>("pathName", triggerPath_);
 
@@ -27,33 +27,33 @@ HLTGenValHistCollPath::HLTGenValHistCollPath(edm::ParameterSet pathCollConfig, H
 
   // getting all filters from path
   filters_ = hltConfig_.saveTagsModules(triggerPath_);
-  if(doOnlyLastFilter_) {
+  if (doOnlyLastFilter_) {
     edm::ParameterSet filterCollConfigOnlyLastFilter = filterCollConfig;
     filterCollConfigOnlyLastFilter.addParameter<std::string>("filterName", filters_.back());
     collectionFilter_.emplace_back(HLTGenValHistCollFilter(filterCollConfigOnlyLastFilter));
 
     // remove potential leading "-" for printing
     std::string filterName = filters_.back();
-    if(filterName.rfind('-', 0) == 0) filterName.erase(0, 1);
+    if (filterName.rfind('-', 0) == 0)
+      filterName.erase(0, 1);
 
     pathString_ += filterName;
   } else {
-
-    for (auto & filter : filters_) {
+    for (auto& filter : filters_) {
       edm::ParameterSet filterCollConfigStep = filterCollConfig;
       filterCollConfigStep.addParameter<std::string>("filterName", filter);
       collectionFilter_.emplace_back(HLTGenValHistCollFilter(filterCollConfigStep));
 
       // remove potential leading "-" for printing
       std::string filterName = filter;
-      if(filterName.rfind('-', 0) == 0) filterName.erase(0, 1);
+      if (filterName.rfind('-', 0) == 0)
+        filterName.erase(0, 1);
 
       pathString_ += filterName;
-      if(filter != filters_.back()) pathString_ += ";";
+      if (filter != filters_.back())
+        pathString_ += ";";
     }
   }
-
-
 }
 
 edm::ParameterSetDescription HLTGenValHistCollPath::makePSetDescription() {
@@ -68,15 +68,19 @@ edm::ParameterSetDescription HLTGenValHistCollPath::makePSetDescription() {
 
 // hist booking function
 // this just calls the booking for each object in the the filter collection
-void HLTGenValHistCollPath::bookHists(DQMStore::IBooker& iBooker, std::vector<edm::ParameterSet>& histConfigs, std::vector<edm::ParameterSet>& histConfigs2D) {
+void HLTGenValHistCollPath::bookHists(DQMStore::IBooker& iBooker,
+                                      std::vector<edm::ParameterSet>& histConfigs,
+                                      std::vector<edm::ParameterSet>& histConfigs2D) {
+  if (!pathString_.empty())
+    iBooker.bookString("path-" + pathStringName_, pathString_);
 
-  if(!pathString_.empty()) iBooker.bookString("path-"+pathStringName_, pathString_);
-
-  for (auto& collection_filter : collectionFilter_) collection_filter.bookHists(iBooker, histConfigs, histConfigs2D);
+  for (auto& collection_filter : collectionFilter_)
+    collection_filter.bookHists(iBooker, histConfigs, histConfigs2D);
 }
 
 // hist filling function
 // this just calls the filling for each object in the filter collection
 void HLTGenValHistCollPath::fillHists(const HLTGenValObject& obj, edm::Handle<trigger::TriggerEvent>& triggerEvent) {
-  for (auto& collection_filter : collectionFilter_) collection_filter.fillHists(obj, triggerEvent);
+  for (auto& collection_filter : collectionFilter_)
+    collection_filter.fillHists(obj, triggerEvent);
 }

--- a/Validation/HLTrigger/src/HLTGenValPathSpecificSettingParser.cc
+++ b/Validation/HLTrigger/src/HLTGenValPathSpecificSettingParser.cc
@@ -11,7 +11,7 @@ HLTGenValPathSpecificSettingParser::HLTGenValPathSpecificSettingParser(std::stri
      pathSpecificSettingsSeglist.push_back(pathSpecificSettingsSegment);
   }
 
-  for (const auto pathSpecificSetting : pathSpecificSettingsSeglist) {
+  for (const auto& pathSpecificSetting : pathSpecificSettingsSeglist) {
 
     // each of these strings is expected to contain exactly one equal sign
     std::stringstream pathSpecificSettingStream(pathSpecificSetting);
@@ -57,7 +57,7 @@ HLTGenValPathSpecificSettingParser::HLTGenValPathSpecificSettingParser(std::stri
          cutParameterSeglist.push_back(cutParameterSegment);
       }
 
-      for (const auto region : cutParameterSeglist) {
+      for (const auto& region : cutParameterSeglist) {
         if(region == "EB") {
           rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-1.4442:1.4442"} );
         } else if (region == "EE") {
@@ -73,7 +73,7 @@ HLTGenValPathSpecificSettingParser::HLTGenValPathSpecificSettingParser(std::stri
 
       bool binningFound = false;
       bool binningUsed = false;
-      for (const auto binning : binnings) {
+      for (const auto& binning : binnings) {
         if (binning.getParameter<std::string>("name") == cutParameter) {
           if (binning.getParameter<std::string>("vsVar") == vsVar) {
             if (binningUsed) throw cms::Exception("InputError") << "Multiple different binnings set for a path, this does not make sense!.\n";

--- a/Validation/HLTrigger/src/HLTGenValPathSpecificSettingParser.cc
+++ b/Validation/HLTrigger/src/HLTGenValPathSpecificSettingParser.cc
@@ -1,0 +1,101 @@
+#include "Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h"
+
+HLTGenValPathSpecificSettingParser::HLTGenValPathSpecificSettingParser(std::string pathSpecificSettings, std::vector<edm::ParameterSet> binnings, std::string vsVar) {
+
+  // splitting the cutstring
+  std::stringstream pathSpecificSettingsStream(pathSpecificSettings);
+  std::string pathSpecificSettingsSegment;
+  std::vector<std::string> pathSpecificSettingsSeglist;
+  while(std::getline(pathSpecificSettingsStream, pathSpecificSettingsSegment, ','))
+  {
+     pathSpecificSettingsSeglist.push_back(pathSpecificSettingsSegment);
+  }
+
+  for (const auto pathSpecificSetting : pathSpecificSettingsSeglist) {
+
+    // each of these strings is expected to contain exactly one equal sign
+    std::stringstream pathSpecificSettingStream(pathSpecificSetting);
+    std::string pathSpecificSettingSegment;
+    std::vector<std::string> pathSpecificSettingSeglist;
+    while(std::getline(pathSpecificSettingStream, pathSpecificSettingSegment, '='))
+    {
+       pathSpecificSettingSeglist.push_back(pathSpecificSettingSegment);
+    }
+    if(pathSpecificSettingSeglist.size() != 2) throw cms::Exception("InputError") << "Path-specific cuts could not be parsed. Make sure that each parameter contains exactly one equal sign!.\n";
+    const std::string cutVariable = pathSpecificSettingSeglist.at(0);
+    const std::string cutParameter = pathSpecificSettingSeglist.at(1);
+
+    edm::ParameterSet rangeCutConfig;
+    if (cutVariable == "absEtaMax" || cutVariable == "absEtaCut") {
+      rangeCutConfig.addParameter<std::string>("rangeVar", "eta");
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-"+cutParameter+":"+cutParameter} );
+    } else if (cutVariable == "absEtaMin") {
+      rangeCutConfig.addParameter<std::string>("rangeVar", "eta");
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-999:"+cutParameter, cutParameter+":999"} );
+    } else if (cutVariable == "ptMax") {
+      rangeCutConfig.addParameter<std::string>("rangeVar", "pt");
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"0:"+cutParameter} );
+    } else if (cutVariable == "ptMin" || cutVariable == "ptCut") {
+      rangeCutConfig.addParameter<std::string>("rangeVar", "pt");
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {cutParameter+":999999"} );
+    } else if (cutVariable == "etMax") {
+      rangeCutConfig.addParameter<std::string>("rangeVar", "et");
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"0:"+cutParameter} );
+    } else if (cutVariable == "etMin" || cutVariable == "etCut") {
+      rangeCutConfig.addParameter<std::string>("rangeVar", "et");
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {cutParameter+":999999"} );
+    } else if (cutVariable == "region") {
+      rangeCutConfig.addParameter<std::string>("rangeVar", "eta");
+
+      // various predefined regions
+      // multiple regions might used, which are then split by a plus sign
+      std::stringstream cutParameterStream(cutParameter);
+      std::string cutParameterSegment;
+      std::vector<std::string> cutParameterSeglist;
+      while(std::getline(cutParameterStream, cutParameterSegment, '+'))
+      {
+         cutParameterSeglist.push_back(cutParameterSegment);
+      }
+
+      for (const auto region : cutParameterSeglist) {
+        if(region == "EB") {
+          rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-1.4442:1.4442"} );
+        } else if (region == "EE") {
+          rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-999:-1.5660", "1.5660:999"} );
+        } else {
+          throw cms::Exception("InputError") << "Region "+region+" not recognized.\n";
+        }
+      }
+
+    } else if (cutVariable == "bins") {
+
+      // sets of binnings are read from the user-input ones passed in the "binnings" VPset
+
+      bool binningFound = false;
+      bool binningUsed = false;
+      for (const auto binning : binnings) {
+        if (binning.getParameter<std::string>("name") == cutParameter) {
+          if (binning.getParameter<std::string>("vsVar") == vsVar) {
+            if (binningUsed) throw cms::Exception("InputError") << "Multiple different binnings set for a path, this does not make sense!.\n";
+            pathSpecificBins_ = binning.getParameter<std::vector<double>>("binLowEdges");
+            binningUsed = true;
+          }
+          binningFound = true;
+        }
+      }
+      if (!binningFound) throw cms::Exception("InputError") << "Binning " << cutParameter << " not recognized! Please pass the definition to the module.\n";
+
+    } else if (cutVariable == "tag") {
+      tag_ = cutParameter;
+    } else if (cutVariable == "autotag") {
+      // autotag is only used if no manual tag is set
+      if(tag_.empty()) tag_ = cutParameter;
+    } else {
+      throw cms::Exception("InputError") << "Path-specific cut "+cutVariable+" not recognized. The following options can be user: absEtaMax, absEtaCut, absEtaMin, ptMax, ptMin, ptCut, etMax, etMin, etCut, region, bins and tag.\n";
+    }
+
+    if(!rangeCutConfig.empty()) pathSpecificCutsVector_.push_back( rangeCutConfig );
+
+  }
+
+}

--- a/Validation/HLTrigger/src/HLTGenValPathSpecificSettingParser.cc
+++ b/Validation/HLTrigger/src/HLTGenValPathSpecificSettingParser.cc
@@ -1,49 +1,50 @@
 #include "Validation/HLTrigger/interface/HLTGenValPathSpecificSettingParser.h"
 
-HLTGenValPathSpecificSettingParser::HLTGenValPathSpecificSettingParser(std::string pathSpecificSettings, std::vector<edm::ParameterSet> binnings, std::string vsVar) {
-
+HLTGenValPathSpecificSettingParser::HLTGenValPathSpecificSettingParser(std::string pathSpecificSettings,
+                                                                       std::vector<edm::ParameterSet> binnings,
+                                                                       std::string vsVar) {
   // splitting the cutstring
   std::stringstream pathSpecificSettingsStream(pathSpecificSettings);
   std::string pathSpecificSettingsSegment;
   std::vector<std::string> pathSpecificSettingsSeglist;
-  while(std::getline(pathSpecificSettingsStream, pathSpecificSettingsSegment, ','))
-  {
-     pathSpecificSettingsSeglist.push_back(pathSpecificSettingsSegment);
+  while (std::getline(pathSpecificSettingsStream, pathSpecificSettingsSegment, ',')) {
+    pathSpecificSettingsSeglist.push_back(pathSpecificSettingsSegment);
   }
 
   for (const auto& pathSpecificSetting : pathSpecificSettingsSeglist) {
-
     // each of these strings is expected to contain exactly one equal sign
     std::stringstream pathSpecificSettingStream(pathSpecificSetting);
     std::string pathSpecificSettingSegment;
     std::vector<std::string> pathSpecificSettingSeglist;
-    while(std::getline(pathSpecificSettingStream, pathSpecificSettingSegment, '='))
-    {
-       pathSpecificSettingSeglist.push_back(pathSpecificSettingSegment);
+    while (std::getline(pathSpecificSettingStream, pathSpecificSettingSegment, '=')) {
+      pathSpecificSettingSeglist.push_back(pathSpecificSettingSegment);
     }
-    if(pathSpecificSettingSeglist.size() != 2) throw cms::Exception("InputError") << "Path-specific cuts could not be parsed. Make sure that each parameter contains exactly one equal sign!.\n";
+    if (pathSpecificSettingSeglist.size() != 2)
+      throw cms::Exception("InputError") << "Path-specific cuts could not be parsed. Make sure that each parameter "
+                                            "contains exactly one equal sign!.\n";
     const std::string cutVariable = pathSpecificSettingSeglist.at(0);
     const std::string cutParameter = pathSpecificSettingSeglist.at(1);
 
     edm::ParameterSet rangeCutConfig;
     if (cutVariable == "absEtaMax" || cutVariable == "absEtaCut") {
       rangeCutConfig.addParameter<std::string>("rangeVar", "eta");
-      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-"+cutParameter+":"+cutParameter} );
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-" + cutParameter + ":" + cutParameter});
     } else if (cutVariable == "absEtaMin") {
       rangeCutConfig.addParameter<std::string>("rangeVar", "eta");
-      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-999:"+cutParameter, cutParameter+":999"} );
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges",
+                                                            {"-999:" + cutParameter, cutParameter + ":999"});
     } else if (cutVariable == "ptMax") {
       rangeCutConfig.addParameter<std::string>("rangeVar", "pt");
-      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"0:"+cutParameter} );
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"0:" + cutParameter});
     } else if (cutVariable == "ptMin" || cutVariable == "ptCut") {
       rangeCutConfig.addParameter<std::string>("rangeVar", "pt");
-      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {cutParameter+":999999"} );
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {cutParameter + ":999999"});
     } else if (cutVariable == "etMax") {
       rangeCutConfig.addParameter<std::string>("rangeVar", "et");
-      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"0:"+cutParameter} );
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"0:" + cutParameter});
     } else if (cutVariable == "etMin" || cutVariable == "etCut") {
       rangeCutConfig.addParameter<std::string>("rangeVar", "et");
-      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {cutParameter+":999999"} );
+      rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {cutParameter + ":999999"});
     } else if (cutVariable == "region") {
       rangeCutConfig.addParameter<std::string>("rangeVar", "eta");
 
@@ -52,23 +53,21 @@ HLTGenValPathSpecificSettingParser::HLTGenValPathSpecificSettingParser(std::stri
       std::stringstream cutParameterStream(cutParameter);
       std::string cutParameterSegment;
       std::vector<std::string> cutParameterSeglist;
-      while(std::getline(cutParameterStream, cutParameterSegment, '+'))
-      {
-         cutParameterSeglist.push_back(cutParameterSegment);
+      while (std::getline(cutParameterStream, cutParameterSegment, '+')) {
+        cutParameterSeglist.push_back(cutParameterSegment);
       }
 
       for (const auto& region : cutParameterSeglist) {
-        if(region == "EB") {
-          rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-1.4442:1.4442"} );
+        if (region == "EB") {
+          rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-1.4442:1.4442"});
         } else if (region == "EE") {
-          rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-999:-1.5660", "1.5660:999"} );
+          rangeCutConfig.addParameter<std::vector<std::string>>("allowedRanges", {"-999:-1.5660", "1.5660:999"});
         } else {
-          throw cms::Exception("InputError") << "Region "+region+" not recognized.\n";
+          throw cms::Exception("InputError") << "Region " + region + " not recognized.\n";
         }
       }
 
     } else if (cutVariable == "bins") {
-
       // sets of binnings are read from the user-input ones passed in the "binnings" VPset
 
       bool binningFound = false;
@@ -76,26 +75,33 @@ HLTGenValPathSpecificSettingParser::HLTGenValPathSpecificSettingParser(std::stri
       for (const auto& binning : binnings) {
         if (binning.getParameter<std::string>("name") == cutParameter) {
           if (binning.getParameter<std::string>("vsVar") == vsVar) {
-            if (binningUsed) throw cms::Exception("InputError") << "Multiple different binnings set for a path, this does not make sense!.\n";
+            if (binningUsed)
+              throw cms::Exception("InputError")
+                  << "Multiple different binnings set for a path, this does not make sense!.\n";
             pathSpecificBins_ = binning.getParameter<std::vector<double>>("binLowEdges");
             binningUsed = true;
           }
           binningFound = true;
         }
       }
-      if (!binningFound) throw cms::Exception("InputError") << "Binning " << cutParameter << " not recognized! Please pass the definition to the module.\n";
+      if (!binningFound)
+        throw cms::Exception("InputError")
+            << "Binning " << cutParameter << " not recognized! Please pass the definition to the module.\n";
 
     } else if (cutVariable == "tag") {
       tag_ = cutParameter;
     } else if (cutVariable == "autotag") {
       // autotag is only used if no manual tag is set
-      if(tag_.empty()) tag_ = cutParameter;
+      if (tag_.empty())
+        tag_ = cutParameter;
     } else {
-      throw cms::Exception("InputError") << "Path-specific cut "+cutVariable+" not recognized. The following options can be user: absEtaMax, absEtaCut, absEtaMin, ptMax, ptMin, ptCut, etMax, etMin, etCut, region, bins and tag.\n";
+      throw cms::Exception("InputError")
+          << "Path-specific cut " + cutVariable +
+                 " not recognized. The following options can be user: absEtaMax, absEtaCut, absEtaMin, ptMax, ptMin, "
+                 "ptCut, etMax, etMin, etCut, region, bins and tag.\n";
     }
 
-    if(!rangeCutConfig.empty()) pathSpecificCutsVector_.push_back( rangeCutConfig );
-
+    if (!rangeCutConfig.empty())
+      pathSpecificCutsVector_.push_back(rangeCutConfig);
   }
-
 }

--- a/Validation/HLTrigger/test/ConfFile_source_cfg.py
+++ b/Validation/HLTrigger/test/ConfFile_source_cfg.py
@@ -9,7 +9,7 @@ process.load("DQMServices.Components.DQMEnvironment_cfi")
 process.load("DQMServices.Components.MEtoEDMConverter_cff")
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(6000) )
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
@@ -88,7 +88,7 @@ process.HLTGenValSourceMU = cms.EDProducer('HLTGenValSource',
     # these are the only one the user needs to specify
     objType = cms.string("mu"),
     hltPathsToCheck = cms.vstring(
-      "HLT_Mu50_v",
+      "HLT_Mu50_v:absEtaCut=1.2",
       "HLT_IsoMu24_v"
     ),
     doOnlyLastFilter = cms.bool(False),

--- a/Validation/HLTrigger/test/ConfFile_source_cfg.py
+++ b/Validation/HLTrigger/test/ConfFile_source_cfg.py
@@ -1,0 +1,215 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("HLTGenValSource")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Core.DQMStore_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+process.load("DQMServices.Components.MEtoEDMConverter_cff")
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+
+# using: CMSSW_12_3_0_pre4__fullsim_noPU_2021_14TeV-TTbar_14TeV-00001
+process.source = cms.Source("PoolSource",
+    #fileNames = cms.untracked.vstring("root://cmsxrootd.fnal.gov//store/mc/RunIISummer20UL18RECO/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/AODSIM/106X_upgrade2018_realistic_v11_L1v1-v2/00000/B4A06248-D09E-314A-ACD7-F157B86109E6.root")
+    fileNames = cms.untracked.vstring(
+    "root://cmsxrootd.fnal.gov//store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v4-v1/2580000/07f08321-b24c-4397-b019-18c8ba54696c.root",
+    "root://cmsxrootd.fnal.gov//store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v4-v1/2580000/22cc5971-134c-4a49-94b6-a3f96de01d94.root",
+    "root://cmsxrootd.fnal.gov//store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v4-v1/2580000/2d20a2a4-b411-4124-bf1d-93db155b76e8.root",
+    "root://cmsxrootd.fnal.gov//store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v4-v1/2580000/5f762599-4ddb-4c5f-8975-0229b54cae07.root",
+    "root://cmsxrootd.fnal.gov//store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v4-v1/2580000/7964789d-c81b-4927-abaf-73acbd202abc.root",
+    "root://cmsxrootd.fnal.gov//store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v4-v1/2580000/9cfca190-28f6-43af-b300-e3af7dbbfdd2.root",
+    "root://cmsxrootd.fnal.gov//store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v4-v1/2580000/d22883fe-df35-48f3-ad2b-dbad44c8eaa4.root",
+    "root://cmsxrootd.fnal.gov//store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v4-v1/2580000/f8ee9482-41e8-4126-ae00-bf07ef019d66.root",
+    "root://cmsxrootd.fnal.gov//store/relval/CMSSW_12_3_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/123X_mcRun3_2021_realistic_v4-v1/2580000/fe617389-a652-418d-b24e-55ea0ccacd7e.root",
+    )
+)
+
+ptBins=cms.vdouble(0, 10, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85,90,95 , 100,105,110,115 ,120,125, 130, 135,140,145, 150)
+ptBinsHT=cms.vdouble(0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950, 1000, 1050, 1100, 1150, 1200, 1300)
+ptBinsJet=cms.vdouble(0, 100, 200, 300, 350, 375, 400, 425, 450, 475, 500, 550, 600, 700, 800, 900, 1000)
+etaBins=cms.vdouble(-4,-3, -2.5, -2, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, 2, 2.5, 3, 4)
+
+etaCut=cms.PSet(
+    rangeVar=cms.string("eta"),
+    allowedRanges=cms.vstring("-2.4:2.4")
+)
+ptCut=cms.PSet(
+    rangeVar=cms.string("pt"),
+    allowedRanges=cms.vstring("40:9999")
+)
+
+process.HLTGenValSourceHT = cms.EDProducer('HLTGenValSource',
+    # these are the only one the user needs to specify
+    objType = cms.string("AK4HT"),
+    hltPathsToCheck = cms.vstring(
+      "HLT_PFHT1050_v",
+    ),
+    doOnlyLastFilter = cms.bool(False),
+    histConfigs = cms.VPSet(
+        cms.PSet(
+            vsVar = cms.string("pt"),
+            binLowEdges = ptBinsHT,
+        ),
+        cms.PSet(
+            vsVar = cms.string("eta"),
+            binLowEdges = etaBins,
+        ),
+    ),
+)
+
+process.HLTGenValSourceHT = cms.EDProducer('HLTGenValSource',
+    # these are the only one the user needs to specify
+    objType = cms.string("AK8HT"),
+    hltPathsToCheck = cms.vstring(
+      "HLT_AK8PFHT800_TrimMass50"
+    ),
+    doOnlyLastFilter = cms.bool(False),
+    histConfigs = cms.VPSet(
+        cms.PSet(
+            vsVar = cms.string("pt"),
+            binLowEdges = ptBinsHT,
+        ),
+        cms.PSet(
+            vsVar = cms.string("eta"),
+            binLowEdges = etaBins,
+        ),
+    ),
+)
+
+
+process.HLTGenValSourceMU = cms.EDProducer('HLTGenValSource',
+    # these are the only one the user needs to specify
+    objType = cms.string("mu"),
+    hltPathsToCheck = cms.vstring(
+      "HLT_Mu50_v",
+      "HLT_IsoMu24_v"
+    ),
+    doOnlyLastFilter = cms.bool(False),
+    histConfigs = cms.VPSet(
+        cms.PSet(
+            vsVar = cms.string("pt"),
+            binLowEdges = ptBins,
+            rangeCuts = cms.VPSet(etaCut)
+        ),
+        cms.PSet(
+            vsVar = cms.string("eta"),
+            binLowEdges = etaBins,
+        ),
+    ),
+)
+
+process.HLTGenValSourceELE = cms.EDProducer('HLTGenValSource',
+    # these are the only one the user needs to specify
+    objType = cms.string("ele"),
+    hltPathsToCheck = cms.vstring(
+      "HLT_Ele35_WPTight_Gsf_v",
+      "HLT_Ele35_WPTight_Gsf_v:bins=ptBinsJet",
+      "HLT_Ele115_CaloIdVT_GsfTrkIdT_v:region=EB",
+      "HLT_Ele115_CaloIdVT_GsfTrkIdT_v:region=EE",
+      "HLT_Photon200_v"
+    ),
+    binnings = cms.VPSet(
+        cms.PSet(
+            name = cms.string("ptBinsJet"),
+            vsVar = cms.string("pt"),
+            binLowEdges = ptBinsJet
+        )
+    ),
+    doOnlyLastFilter = cms.bool(False),
+    histConfigs = cms.VPSet(
+        cms.PSet(
+            vsVar = cms.string("pt"),
+            binLowEdges = ptBins,
+            rangeCuts = cms.VPSet(etaCut)
+        ),
+        cms.PSet(
+            vsVar = cms.string("eta"),
+            binLowEdges = etaBins,
+        ),
+    ),
+)
+
+process.HLTGenValSourceAK4 = cms.EDProducer('HLTGenValSource',
+    # these are the only one the user needs to specify
+    objType = cms.string("AK4jet"),
+    hltPathsToCheck = cms.vstring(
+      "HLT_PFJet500",
+    ),
+    doOnlyLastFilter = cms.bool(False),
+    histConfigs = cms.VPSet(
+        cms.PSet(
+            vsVar = cms.string("pt"),
+            binLowEdges = ptBinsJet,
+            rangeCuts = cms.VPSet(etaCut)
+        ),
+        cms.PSet(
+            vsVar = cms.string("eta"),
+            binLowEdges = etaBins,
+        ),
+    ),
+)
+
+process.HLTGenValSourceAK8 = cms.EDProducer('HLTGenValSource',
+    # these are the only one the user needs to specify
+    objType = cms.string("AK8jet"),
+    hltPathsToCheck = cms.vstring(
+      "HLT_AK8PFJet500",
+      "HLT_AK8PFJet400_TrimMass30",
+    ),
+    doOnlyLastFilter = cms.bool(False),
+    histConfigs = cms.VPSet(
+        cms.PSet(
+            vsVar = cms.string("pt"),
+            binLowEdges = ptBinsJet,
+            rangeCuts = cms.VPSet(etaCut)
+        ),
+        cms.PSet(
+            vsVar = cms.string("eta"),
+            binLowEdges = etaBins,
+        ),
+    ),
+)
+
+process.HLTGenValSourceMET = cms.EDProducer('HLTGenValSource',
+    # these are the only one the user needs to specify
+    objType = cms.string("MET"),
+    hltPathsToCheck = cms.vstring(
+      "HLT_PFMET120_PFMHT120_IDTight",
+    ),
+    doOnlyLastFilter = cms.bool(False),
+    histConfigs = cms.VPSet(
+        cms.PSet(
+            vsVar = cms.string("pt"),
+            binLowEdges = ptBins,
+            rangeCuts = cms.VPSet(etaCut)
+        ),
+        cms.PSet(
+            vsVar = cms.string("eta"),
+            binLowEdges = etaBins,
+        ),
+    ),
+)
+
+process.p = cms.Path(
+        process.HLTGenValSourceMU *
+        process.HLTGenValSourceELE *
+        process.HLTGenValSourceHT *
+        process.HLTGenValSourceAK4 *
+        process.HLTGenValSourceAK8
+        #process.HLTGenValSourceMET
+        )
+
+# the harvester
+process.harvester = DQMEDHarvester("HLTGenValClient",
+    outputFileName = cms.untracked.string('output.root'),
+    subDirs        = cms.untracked.vstring("HLTGenVal"),
+)
+
+process.outpath = cms.EndPath(process.harvester)


### PR DESCRIPTION
#### PR description:

This PR adds a validation module that produces trigger efficiency histograms as function of generator-level particle properties. It will be used to get a generic, very quick and easy look at the HLT output to check if any new release or change to the HLT introduced issues. Information on the module is gathered in [this Twiki page](https://twiki.cern.ch/twiki/bin/view/CMS/WebBasedHLTValidation). 

Two modules are included, the `HLTGenValSource` which produces histograms before and after trigger filter application, and a `HLTGenValClient` module, creating efficiency histograms from the sources outputs.

The module is standalone, should not change any other unrelated modules and does not rely on external code or other PRs. Development has happened within the STEAM subgroup of the TSG, overseen by @Sam-Harper and Lisa Benato. Aside from the other required review steps, the module is still awaiting review by the TSG experts, including Sam.

#### PR validation:

The code and its outputs have been tested offline. Additionally, the steps described in the [Workflow for pull requests to CMSSW](http://cms-sw.github.io/PRWorkflow.html) document were performed and the code should hopefully be readable and fulfill the CMS coding requirements - if not I'd be happy to make any required changes.

The PR is targeting to be included in the next possible release.
