### PR TITLE
Add EGamma calo ID variable cut to Run 3 Scouting Electrons

### DIFF
--- a/Configuration/Eras/python/Era_Run3_cff.py
+++ b/Configuration/Eras/python/Era_Run3_cff.py
@@ -12,6 +12,7 @@ from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 from Configuration.Eras.Modifier_run3_nanoAOD_devel_cff import run3_nanoAOD_devel
 from Configuration.Eras.Modifier_run3_egamma_cff import run3_egamma
+from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
 
-Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2021, dd4hep, run3_nanoAOD_devel)
+Run3 = cms.ModifierChain(Run2_2018.copyAndExclude([run2_GEM_2017, ctpps_2018]), run3_common, run3_egamma, run3_GEM, run3_HB, run3_HFSL, stage2L1Trigger_2021, ctpps_2021, dd4hep, run3_nanoAOD_devel, run3_RPC)
 

--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1CompareRecHitsSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1CompareRecHitsSoA.cc
@@ -1,5 +1,4 @@
 // -*- C++ -*-
-///bookLayer
 // Package:    SiPixelPhase1CompareRecHitsSoA
 // Class:      SiPixelPhase1CompareRecHitsSoA
 //

--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1CompareRecHitsSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1CompareRecHitsSoA.cc
@@ -210,12 +210,12 @@ void SiPixelPhase1CompareRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
     }
   }
   //1D differences
-  hBchargeDiff_ = iBook.book1D("rechitChargeDiffBpix","Charge differnce of rechits in BPix; rechit charge difference (CPU - GPU)", 100, -500, 500);
-  hFchargeDiff_ = iBook.book1D("rechitChargeDiffFpix","Charge differnce of rechits in FPix; rechit charge difference (CPU - GPU)", 100, -500, 500);
-  hBsizeXDiff_ = iBook.book1D("rechitsizeXDiffBpix","SizeX difference of rechits in BPix; rechit sizex difference (CPU - GPU)", 10, -10, 10);
-  hFsizeXDiff_ = iBook.book1D("rechitsizeXDiffFpix","SizeX difference of rechits in FPix; rechit sizex difference (CPU - GPU)", 10, -10, 10);
-  hBsizeYDiff_ = iBook.book1D("rechitsizeYDiffBpix","SizeY difference of rechits in BPix; rechit sizey difference (CPU - GPU)", 10, -10, 10);
-  hFsizeYDiff_ = iBook.book1D("rechitsizeYDiffFpix","SizeY difference of rechits in FPix; rechit sizey difference (CPU - GPU)", 10, -10, 10);
+  hBchargeDiff_ = iBook.book1D("rechitChargeDiffBpix","Charge differnce of rechits in BPix; rechit charge difference (CPU - GPU)", 101, -50.5, 50.5);
+  hFchargeDiff_ = iBook.book1D("rechitChargeDiffFpix","Charge differnce of rechits in FPix; rechit charge difference (CPU - GPU)", 101, -50.5, 50.5);
+  hBsizeXDiff_ = iBook.book1D("rechitsizeXDiffBpix","SizeX difference of rechits in BPix; rechit sizex difference (CPU - GPU)", 21, -10.5, 10.5);
+  hFsizeXDiff_ = iBook.book1D("rechitsizeXDiffFpix","SizeX difference of rechits in FPix; rechit sizex difference (CPU - GPU)", 21, -10.5, 10.5);
+  hBsizeYDiff_ = iBook.book1D("rechitsizeYDiffBpix","SizeY difference of rechits in BPix; rechit sizey difference (CPU - GPU)", 21, -10.5, 10.5);
+  hFsizeYDiff_ = iBook.book1D("rechitsizeYDiffFpix","SizeY difference of rechits in FPix; rechit sizey difference (CPU - GPU)", 21, -10.5, 10.5);
   hBposXDiff_ = iBook.book1D("rechitsposXDiffBpix","x-position difference of rechits in BPix; rechit x-pos difference (CPU - GPU)", 1000, -10, 10);
   hFposXDiff_ = iBook.book1D("rechitsposXDiffFpix","x-position difference of rechits in FPix; rechit x-pos difference (CPU - GPU)", 1000, -10, 10);
   hBposYDiff_ = iBook.book1D("rechitsposYDiffBpix","y-position difference of rechits in BPix; rechit y-pos difference (CPU - GPU)", 1000, -10, 10);

--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1CompareRecHitsSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1CompareRecHitsSoA.cc
@@ -1,0 +1,235 @@
+// -*- C++ -*-
+///bookLayer
+// Package:    SiPixelPhase1CompareRecHitsSoA
+// Class:      SiPixelPhase1CompareRecHitsSoA
+//
+/**\class SiPixelPhase1CompareRecHitsSoA SiPixelPhase1CompareRecHitsSoA.cc 
+*/
+//
+// Author: Suvankar Roy Chowdhury, Alessandro Rossi
+//
+#include "DataFormats/Math/interface/approx_atan2.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+// DQM Histograming
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "CUDADataFormats/TrackingRecHit/interface/TrackingRecHit2DHeterogeneous.h"
+// Geometry
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
+class SiPixelPhase1CompareRecHitsSoA : public DQMEDAnalyzer {
+public:
+  explicit SiPixelPhase1CompareRecHitsSoA(const edm::ParameterSet&);
+  ~SiPixelPhase1CompareRecHitsSoA() override = default;
+  void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  void bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::EDGetTokenT<TrackingRecHit2DCPU> tokenSoAHitsCPU_;
+  const edm::EDGetTokenT<TrackingRecHit2DCPU> tokenSoAHitsGPU_;
+  const std::string topFolderName_;
+  const float mind2cut_;
+  static constexpr uint32_t invalidHit_ = std::numeric_limits<uint32_t>::max();
+  static constexpr float micron_ = 10000.;
+  const TrackerGeometry* tkGeom_ = nullptr;
+  const TrackerTopology* tTopo_ = nullptr;
+  MonitorElement* hnHits_;
+  MonitorElement* hBchargeL_[4];
+  MonitorElement* hBsizexL_[4];
+  MonitorElement* hBsizeyL_[4];
+  MonitorElement* hBposxL_[4];
+  MonitorElement* hBposyL_[4];
+  MonitorElement* hFchargeD_[2][3];
+  MonitorElement* hFsizexD_[2][3];
+  MonitorElement* hFsizeyD_[2][3];
+  MonitorElement* hFposxD_[2][3];
+  MonitorElement* hFposyD_[2][3];
+  //differences
+  MonitorElement* hBchargeDiff_;
+  MonitorElement* hFchargeDiff_;
+  MonitorElement* hBsizeXDiff_;
+  MonitorElement* hFsizeXDiff_;
+  MonitorElement* hBsizeYDiff_;
+  MonitorElement* hFsizeYDiff_;
+  MonitorElement* hBposXDiff_;
+  MonitorElement* hFposXDiff_;
+  MonitorElement* hBposYDiff_;
+  MonitorElement* hFposYDiff_;
+};
+//
+// constructors
+//
+
+SiPixelPhase1CompareRecHitsSoA::SiPixelPhase1CompareRecHitsSoA(const edm::ParameterSet& iConfig)
+    : geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()),
+      tokenSoAHitsCPU_(consumes<TrackingRecHit2DCPU>(iConfig.getParameter<edm::InputTag>("pixelHitsSrcCPU"))),
+      tokenSoAHitsGPU_(consumes<TrackingRecHit2DCPU>(iConfig.getParameter<edm::InputTag>("pixelHitsSrcGPU"))),
+      topFolderName_(iConfig.getParameter<std::string>("topFolderName")),
+      mind2cut_(iConfig.getParameter<double>("minD2cut")) {}
+//
+// Begin Run
+//
+void SiPixelPhase1CompareRecHitsSoA::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  tkGeom_ = &iSetup.getData(geomToken_);
+  tTopo_ = &iSetup.getData(topoToken_);
+}
+
+//
+// -- Analyze
+//
+void SiPixelPhase1CompareRecHitsSoA::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  const auto& rhsoaHandleCPU = iEvent.getHandle(tokenSoAHitsCPU_);
+  const auto& rhsoaHandleGPU = iEvent.getHandle(tokenSoAHitsGPU_);
+  if (not rhsoaHandleCPU or not rhsoaHandleGPU) {
+    edm::LogWarning out("SiPixelPhase1CompareRecHitSoA");
+    if (not rhsoaHandleCPU) {
+      out << "reference (cpu) rechits not found; ";
+    }
+    if (not rhsoaHandleGPU) {
+      out << "target (gpu) rechits not found; ";
+    }
+    out << "the comparison will not run.";
+    return;
+  }
+  auto const& rhsoaCPU = *rhsoaHandleCPU;
+  const TrackingRecHit2DSOAView* soa2dCPU = rhsoaCPU.view();
+  auto const& rhsoaGPU = *rhsoaHandleGPU;
+  const TrackingRecHit2DSOAView* soa2dGPU = rhsoaGPU.view();
+
+  uint32_t nHitsCPU = soa2dCPU->nHits();
+  uint32_t nHitsGPU = soa2dGPU->nHits();
+  hnHits_->Fill(nHitsCPU, nHitsGPU);
+  auto detIds = tkGeom_->detUnitIds();
+  for (uint32_t i = 0; i < nHitsCPU; i++) {
+    float minD = mind2cut_;
+    uint32_t matchedHit = invalidHit_;
+    uint16_t indCPU = soa2dCPU->detectorIndex(i);
+    float xLocalCPU = soa2dCPU->xLocal(i);
+    float yLocalCPU = soa2dCPU->yLocal(i);
+    for (uint32_t j = 0; j < nHitsGPU; j++) {
+      if (soa2dGPU->detectorIndex(j) == indCPU) {
+        float dx = xLocalCPU - soa2dGPU->xLocal(j);
+        float dy = yLocalCPU - soa2dGPU->yLocal(j);
+        float distance = dx * dx + dy * dy;
+        if (distance < minD) {
+          minD = distance;
+          matchedHit = j;
+        }
+      }
+    }
+    DetId id = detIds[indCPU];
+    uint32_t chargeCPU = soa2dCPU->charge(i);
+    int16_t sizeXCPU = std::ceil(float(std::abs(soa2dCPU->clusterSizeX(i)) / 8.));
+    int16_t sizeYCPU = std::ceil(float(std::abs(soa2dCPU->clusterSizeY(i)) / 8.));
+    uint32_t chargeGPU = 0;
+    int16_t sizeXGPU = -99;
+    int16_t sizeYGPU = -99;
+    float xLocalGPU = -999.;
+    float yLocalGPU = -999.;
+    if (matchedHit != invalidHit_) {
+      chargeGPU = soa2dGPU->charge(matchedHit);
+      sizeXGPU = std::ceil(float(std::abs(soa2dGPU->clusterSizeX(matchedHit)) / 8.));
+      sizeYGPU = std::ceil(float(std::abs(soa2dGPU->clusterSizeY(matchedHit)) / 8.));
+      xLocalGPU = soa2dGPU->xLocal(matchedHit);
+      yLocalGPU = soa2dGPU->yLocal(matchedHit);
+    }
+    switch (id.subdetId()) {
+      case PixelSubdetector::PixelBarrel:
+        hBchargeL_[tTopo_->pxbLayer(id) - 1]->Fill(chargeCPU, chargeGPU);
+        hBsizexL_[tTopo_->pxbLayer(id) - 1]->Fill(sizeXCPU, sizeXGPU);
+        hBsizeyL_[tTopo_->pxbLayer(id) - 1]->Fill(sizeYCPU, sizeYGPU);
+        hBposxL_[tTopo_->pxbLayer(id) - 1]->Fill(xLocalCPU, xLocalGPU);
+        hBposyL_[tTopo_->pxbLayer(id) - 1]->Fill(yLocalCPU, yLocalGPU);
+        hBchargeDiff_->Fill(chargeCPU - chargeGPU);
+        hBsizeXDiff_->Fill(sizeXCPU - sizeXGPU);
+        hBsizeYDiff_->Fill(sizeYCPU - sizeYGPU);
+        hBposXDiff_->Fill(micron_ * (xLocalCPU - xLocalGPU));
+        hBposYDiff_->Fill(micron_ * (yLocalCPU - yLocalGPU));
+        break;
+      case PixelSubdetector::PixelEndcap:
+        hFchargeD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(chargeCPU, chargeGPU);
+        hFsizexD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(sizeXCPU, sizeXGPU);
+        hFsizeyD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(sizeYCPU, sizeYGPU);
+        hFposxD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(xLocalCPU, xLocalGPU);
+        hFposyD_[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(yLocalCPU, yLocalGPU);
+        hFchargeDiff_->Fill(chargeCPU - chargeGPU);
+        hFsizeXDiff_->Fill(sizeXCPU - sizeXGPU);
+        hFsizeYDiff_->Fill(sizeYCPU - sizeYGPU);
+        hFposXDiff_->Fill(micron_ * (xLocalCPU - xLocalGPU));
+        hFposYDiff_->Fill(micron_ * (yLocalCPU - yLocalGPU));
+        break;
+    }
+  }
+}
+
+//
+// -- Book Histograms
+//
+void SiPixelPhase1CompareRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
+                                                    edm::Run const& iRun,
+                                                    edm::EventSetup const& iSetup) {
+  iBook.cd();
+  iBook.setCurrentFolder(topFolderName_);
+
+  // clang-format off
+  //Global
+  hnHits_ = iBook.book2I("nHits", "CPUvsGPU RecHits per event;#CPU RecHits;#GPU RecHits", 200, 0, 5000,200, 0, 5000);
+  //Barrel Layer
+  for(unsigned int il=0;il<tkGeom_->numberOfLayers(PixelSubdetector::PixelBarrel);il++){
+    hBchargeL_[il] = iBook.book2I(Form("recHitsBLay%dCharge",il+1), Form("CPUvsGPU RecHits Charge Barrel Layer%d;CPU Charge;GPU Charge",il+1), 250, 0, 100000, 250, 0, 100000);
+    hBsizexL_[il] = iBook.book2I(Form("recHitsBLay%dSizex",il+1), Form("CPUvsGPU RecHits SizeX Barrel Layer%d;CPU SizeX;GPU SizeX",il+1), 30, 0, 30, 30, 0, 30);
+    hBsizeyL_[il] = iBook.book2I(Form("recHitsBLay%dSizey",il+1), Form("CPUvsGPU RecHits SizeY Barrel Layer%d;CPU SizeY;GPU SizeY",il+1), 30, 0, 30, 30, 0, 30);
+    hBposxL_[il] = iBook.book2D(Form("recHitsBLay%dPosx",il+1), Form("CPUvsGPU RecHits x-pos in Barrel Layer%d;CPU pos x;GPU pos x",il+1), 200, -5, 5, 200,-5,5);
+    hBposyL_[il] = iBook.book2D(Form("recHitsBLay%dPosy",il+1), Form("CPUvsGPU RecHits y-pos in Barrel Layer%d;CPU pos y;GPU pos y",il+1), 200, -5, 5, 200,-5,5);
+  }
+  //Endcaps
+  //Endcaps Disk
+  for(int is=0;is<2;is++){
+    int sign=is==0? -1:1;
+    for(unsigned int id=0;id<tkGeom_->numberOfLayers(PixelSubdetector::PixelEndcap);id++){
+      hFchargeD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dCharge",id*sign+sign), Form("CPUvsGPU RecHits Charge Endcaps Disk%+d;CPU Charge;GPU Charge",id*sign+sign), 250, 0, 100000, 250, 0, 100000);
+      hFsizexD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dSizex",id*sign+sign), Form("CPUvsGPU RecHits SizeX Endcaps Disk%+d;CPU SizeX;GPU SizeX",id*sign+sign), 30, 0, 30, 30, 0, 30);
+      hFsizeyD_[is][id] = iBook.book2I(Form("recHitsFDisk%+dSizey",id*sign+sign), Form("CPUvsGPU RecHits SizeY Endcaps Disk%+d;CPU SizeY;GPU SizeY",id*sign+sign), 30, 0, 30, 30, 0, 30);
+      hFposxD_[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosx",id*sign+sign), Form("CPUvsGPU RecHits x-pos Endcaps Disk%+d;CPU pos x;GPU pos x",id*sign+sign), 200, -5, 5, 200, -5, 5);
+      hFposyD_[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosy",id*sign+sign), Form("CPUvsGPU RecHits y-pos Endcaps Disk%+d;CPU pos y;GPU pos y",id*sign+sign), 200, -5, 5, 200, -5, 5);
+    }
+  }
+  //1D differences
+  hBchargeDiff_ = iBook.book1D("rechitChargeDiffBpix","Charge differnce of rechits in BPix; rechit charge difference (CPU - GPU)", 100, -500, 500);
+  hFchargeDiff_ = iBook.book1D("rechitChargeDiffFpix","Charge differnce of rechits in FPix; rechit charge difference (CPU - GPU)", 100, -500, 500);
+  hBsizeXDiff_ = iBook.book1D("rechitsizeXDiffBpix","SizeX difference of rechits in BPix; rechit sizex difference (CPU - GPU)", 10, -10, 10);
+  hFsizeXDiff_ = iBook.book1D("rechitsizeXDiffFpix","SizeX difference of rechits in FPix; rechit sizex difference (CPU - GPU)", 10, -10, 10);
+  hBsizeYDiff_ = iBook.book1D("rechitsizeYDiffBpix","SizeY difference of rechits in BPix; rechit sizey difference (CPU - GPU)", 10, -10, 10);
+  hFsizeYDiff_ = iBook.book1D("rechitsizeYDiffFpix","SizeY difference of rechits in FPix; rechit sizey difference (CPU - GPU)", 10, -10, 10);
+  hBposXDiff_ = iBook.book1D("rechitsposXDiffBpix","x-position difference of rechits in BPix; rechit x-pos difference (CPU - GPU)", 1000, -10, 10);
+  hFposXDiff_ = iBook.book1D("rechitsposXDiffFpix","x-position difference of rechits in FPix; rechit x-pos difference (CPU - GPU)", 1000, -10, 10);
+  hBposYDiff_ = iBook.book1D("rechitsposYDiffBpix","y-position difference of rechits in BPix; rechit y-pos difference (CPU - GPU)", 1000, -10, 10);
+  hFposYDiff_ = iBook.book1D("rechitsposYDiffFpix","y-position difference of rechits in FPix; rechit y-pos difference (CPU - GPU)", 1000, -10, 10);
+}
+
+void SiPixelPhase1CompareRecHitsSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // monitorpixelRecHitsSoA
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("pixelHitsSrcCPU", edm::InputTag("siPixelRecHitsPreSplittingSoA@cpu"));
+  desc.add<edm::InputTag>("pixelHitsSrcGPU", edm::InputTag("siPixelRecHitsPreSplittingSoA@cuda"));
+  desc.add<std::string>("topFolderName", "SiPixelHeterogeneous/PixelRecHitsCompareGPUvsCPU");
+  desc.add<double>("minD2cut", 0.0001);
+  descriptions.addWithDefaultLabel(desc);
+}
+DEFINE_FWK_MODULE(SiPixelPhase1CompareRecHitsSoA);

--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorRecHitsSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorRecHitsSoA.cc
@@ -193,7 +193,7 @@ void SiPixelPhase1MonitorRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
 void SiPixelPhase1MonitorRecHitsSoA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   // monitorpixelRecHitsSoA
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("pixelHitsSrc", edm::InputTag("siPixelRecHitsPreSplitting"));
+  desc.add<edm::InputTag>("pixelHitsSrc", edm::InputTag("siPixelRecHitsPreSplittingSoA"));
   desc.add<std::string>("TopFolderName", "SiPixelHeterogeneous/PixelRecHitsSoA");
   descriptions.addWithDefaultLabel(desc);
 }

--- a/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorRecHitsSoA.cc
+++ b/DQM/SiPixelPhase1Heterogeneous/plugins/SiPixelPhase1MonitorRecHitsSoA.cc
@@ -52,7 +52,6 @@ private:
   MonitorElement* hBcharge;
   MonitorElement* hBsizex;
   MonitorElement* hBsizey;
-  MonitorElement* hBposXYL[4];
   MonitorElement* hBposZPL[4];
   MonitorElement* hBchargeL[4];
   MonitorElement* hBsizexL[4];
@@ -63,7 +62,6 @@ private:
   MonitorElement* hFsizex;
   MonitorElement* hFsizey;
   MonitorElement* hFposXYD[2][3];
-  MonitorElement* hFposZPD[2][3];
   MonitorElement* hFchargeD[2][3];
   MonitorElement* hFsizexD[2][3];
   MonitorElement* hFsizeyD[2][3];
@@ -121,7 +119,6 @@ void SiPixelPhase1MonitorRecHitsSoA::analyze(const edm::Event& iEvent, const edm
         hBcharge->Fill(charge);
         hBsizex->Fill(sizeX);
         hBsizey->Fill(sizeY);
-        hBposXYL[tTopo_->pxbLayer(id) - 1]->Fill(xG, yG);
         hBposZPL[tTopo_->pxbLayer(id) - 1]->Fill(zG, fphi);
         hBchargeL[tTopo_->pxbLayer(id) - 1]->Fill(charge);
         hBsizexL[tTopo_->pxbLayer(id) - 1]->Fill(sizeX);
@@ -134,7 +131,6 @@ void SiPixelPhase1MonitorRecHitsSoA::analyze(const edm::Event& iEvent, const edm
         hFsizex->Fill(sizeX);
         hFsizey->Fill(sizeY);
         hFposXYD[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(xG, yG);
-        hFposZPD[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(zG, fphi);
         hFchargeD[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(charge);
         hFsizexD[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(sizeX);
         hFsizeyD[tTopo_->pxfSide(id) - 1][tTopo_->pxfDisk(id) - 1]->Fill(sizeY);
@@ -165,7 +161,6 @@ void SiPixelPhase1MonitorRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
   hBsizey = iBook.book1D("recHitsBarrelSizey", "RecHits SizeY Barrel;SizeY;#events", 50, 0, 50);
   //Barrel Layer
   for(unsigned int il=0;il<tkGeom_->numberOfLayers(PixelSubdetector::PixelBarrel);il++){
-    hBposXYL[il] = iBook.book2D(Form("recHitsBLay%dPosXY",il+1), Form("RecHits position Barrel Layer%d;X;Y",il+1), 200, -20, 20, 200,-20,20);
     hBposZPL[il] = iBook.book2D(Form("recHitsBLay%dPosZP",il+1), Form("RecHits position Barrel Layer%d;Z;#phi",il+1), 300, -30, 30, 200,-3.2,3.2);
     hBchargeL[il] = iBook.book1D(Form("recHitsBLay%dCharge",il+1), Form("RecHits Charge Barrel Layer%d;Charge;#events",il+1), 250, 0, 100000);
     hBsizexL[il] = iBook.book1D(Form("recHitsBLay%dSizex",il+1), Form("RecHits SizeX Barrel Layer%d;SizeX;#events",il+1), 50, 0, 50);
@@ -182,7 +177,6 @@ void SiPixelPhase1MonitorRecHitsSoA::bookHistograms(DQMStore::IBooker& iBook,
     int sign=is==0? -1:1;
     for(unsigned int id=0;id<tkGeom_->numberOfLayers(PixelSubdetector::PixelEndcap);id++){
       hFposXYD[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosXY",id*sign+sign), Form("RecHits position Endcaps Disk%+d;X;Y",id*sign+sign), 200, -20, 20, 200,-20,20);
-      hFposZPD[is][id] = iBook.book2D(Form("recHitsFDisk%+dPosZP",id*sign+sign), Form("RecHits position Endcaps Disk%+d;Z;#phi",id*sign+sign), 600, -60, 60, 200,-3.2,3.2);
       hFchargeD[is][id] = iBook.book1D(Form("recHitsFDisk%+dCharge",id*sign+sign), Form("RecHits Charge Endcaps Disk%+d;Charge;#events",id*sign+sign), 250, 0, 100000);
       hFsizexD[is][id] = iBook.book1D(Form("recHitsFDisk%+dSizex",id*sign+sign), Form("RecHits SizeX Endcaps Disk%+d;SizeX;#events",id*sign+sign), 50, 0, 50);
       hFsizeyD[is][id] = iBook.book1D(Form("recHitsFDisk%+dSizey",id*sign+sign), Form("RecHits SizeY Endcaps Disk%+d;SizeY;#events",id*sign+sign), 50, 0, 50);

--- a/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
+++ b/DQM/SiPixelPhase1Heterogeneous/python/SiPixelPhase1HeterogenousDQM_FirstStep_cff.py
@@ -3,15 +3,13 @@ from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorTrackSoA_cfi import *
 from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorVertexSoA_cfi import *
 from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1MonitorRecHitsSoA_cfi import *
 
-from Configuration.ProcessModifiers.pixelNtupletFit_cff import pixelNtupletFit
-pixelNtupletFit.toModify(siPixelPhase1MonitorRecHitsSoA, pixelHitsSrc = "siPixelRecHitsPreSplittingSoA")
-
 monitorpixelSoASource = cms.Sequence(siPixelPhase1MonitorRecHitsSoA * siPixelPhase1MonitorTrackSoA * siPixelPhase1MonitorVertexSoA)
 
 #Define the sequence for GPU vs CPU validation
 #This should run:- individual monitor for the 2 collections + comparison module
 from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1CompareTrackSoA_cfi import *
 from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1CompareVertexSoA_cfi import *
+from DQM.SiPixelPhase1Heterogeneous.siPixelPhase1CompareRecHitsSoA_cfi import *
 
 siPixelPhase1MonitorTrackSoACPU = siPixelPhase1MonitorTrackSoA.clone(
   pixelTrackSrc = 'pixelTracksSoA@cpu',
@@ -45,6 +43,7 @@ siPixelPhase1MonitorRecHitsSoAGPU = siPixelPhase1MonitorRecHitsSoA.clone(
 
 monitorpixelSoACompareSource = cms.Sequence(siPixelPhase1MonitorRecHitsSoACPU *
                                             siPixelPhase1MonitorRecHitsSoAGPU *
+                                            siPixelPhase1CompareRecHitsSoA *
                                             siPixelPhase1MonitorTrackSoAGPU *
                                             siPixelPhase1MonitorTrackSoACPU *
                                             siPixelPhase1CompareTrackSoA *

--- a/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.cc
+++ b/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.cc
@@ -62,12 +62,30 @@ HLTScoutingEgammaProducer::HLTScoutingEgammaProducer(const edm::ParameterSet& iC
       egammaPtCut(iConfig.getParameter<double>("egammaPtCut")),
       egammaEtaCut(iConfig.getParameter<double>("egammaEtaCut")),
       egammaHoverECut(iConfig.getParameter<double>("egammaHoverECut")),
+      egammaSigmaIEtaIEtaCut(iConfig.getParameter<std::vector<double>>("egammaSigmaIEtaIEtaCut")),
+      absEtaLowEdges(iConfig.getParameter<std::vector<double>>("absEtaLowEdges")),
       mantissaPrecision(iConfig.getParameter<int>("mantissaPrecision")),
       saveRecHitTiming(iConfig.getParameter<bool>("saveRecHitTiming")),
       rechitMatrixSize(iConfig.getParameter<int>("rechitMatrixSize")),  //(2n+1)^2
       rechitZeroSuppression(iConfig.getParameter<bool>("rechitZeroSuppression")),
       ecalRechitEB_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRechitEB"))),
       ecalRechitEE_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRechitEE"))) {
+  // cross-check for compatibility in input vectors
+  if (absEtaLowEdges.size() != egammaSigmaIEtaIEtaCut.size()) {
+    throw cms::Exception("IncompatibleVects")
+        << "size of \"absEtaLowEdges\" (" << absEtaLowEdges.size() << ") and \"egammaSigmaIEtaIEtaCut\" ("
+        << egammaSigmaIEtaIEtaCut.size() << ") differ";
+  }
+
+  for (unsigned int aIt = 0; aIt < absEtaLowEdges.size() - 1; aIt++) {
+    if (absEtaLowEdges[aIt] < 0 || absEtaLowEdges[aIt + 1] < 0) {
+      throw cms::Exception("IncorrectValue") << "absEtaLowEdges entries should be greater than or equal to zero.";
+    }
+    if (absEtaLowEdges[aIt] > absEtaLowEdges[aIt + 1]) {
+      throw cms::Exception("ImproperBinning") << "absEtaLowEdges entries should be in increasing order.";
+    }
+  }
+
   //register products
   produces<Run3ScoutingElectronCollection>();
   produces<Run3ScoutingPhotonCollection>();
@@ -107,6 +125,7 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
     return;
   }
 
+  // Get R9Map
   Handle<RecoEcalCandMap> R9Map;
   if (!iEvent.getByToken(R9Map_, R9Map)) {
     iEvent.put(std::move(outElectrons));
@@ -232,9 +251,21 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
       }
     }
 
-    float HoE = 999.;
-    if (candidate.superCluster()->energy() != 0.)
+    float HoE = 999., sinin = 999.;
+    if (candidate.superCluster()->energy() != 0.) {
       HoE = (*HoverEMap)[candidateRef] / candidate.superCluster()->energy();
+      sinin = (*SigmaIEtaIEtaMap)[candidateRef];
+    }
+
+    if (HoE > egammaHoverECut)
+      continue;
+
+    auto bIt = std::lower_bound(absEtaLowEdges.begin(), absEtaLowEdges.end(), std::abs(candidate.eta())) - 1;
+    auto etabinpos = std::distance(absEtaLowEdges.begin(), bIt);
+
+    if (etabinpos >= 0)
+      if (sinin > egammaSigmaIEtaIEtaCut[etabinpos])
+        continue;
 
     float d0 = 0.0;
     float dz = 0.0;
@@ -319,6 +350,8 @@ void HLTScoutingEgammaProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<double>("egammaPtCut", 4.0);
   desc.add<double>("egammaEtaCut", 2.5);
   desc.add<double>("egammaHoverECut", 1.0);
+  desc.add<std::vector<double>>("egammaSigmaIEtaIEtaCut", {99999.0, 99999.0});
+  desc.add<std::vector<double>>("absEtaLowEdges", {0.0, 1.479});
   desc.add<bool>("saveRecHitTiming", false);
   desc.add<int>("mantissaPrecision", 10)->setComment("default float16, change to 23 for float32");
   desc.add<int>("rechitMatrixSize", 10);

--- a/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.h
+++ b/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.h
@@ -82,6 +82,8 @@ private:
   const double egammaPtCut;
   const double egammaEtaCut;
   const double egammaHoverECut;
+  const std::vector<double> egammaSigmaIEtaIEtaCut;
+  const std::vector<double> absEtaLowEdges;
   const int mantissaPrecision;
   const bool saveRecHitTiming;
   const int rechitMatrixSize;

--- a/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
@@ -53,6 +53,7 @@ _mAOD = (run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy)
                             func = lambda list: list.remove(cms.InputTag("patLowPtElectrons")) )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+from Configuration.Eras.Era_Run2_2016_HIPM_cff import Run2_2016_HIPM
 (pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toReplaceWith(patCandidatesTask,
                                                    patCandidatesTask.copyAndExclude([makePatDisplacedMuonsTask]))
 (pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toModify(patCandidateSummary.candidates,

--- a/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/patCandidates_cff.py
@@ -53,9 +53,9 @@ _mAOD = (run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy)
                             func = lambda list: list.remove(cms.InputTag("patLowPtElectrons")) )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toReplaceWith(patCandidatesTask,
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toReplaceWith(patCandidatesTask,
                                                    patCandidatesTask.copyAndExclude([makePatDisplacedMuonsTask]))
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toModify(patCandidateSummary.candidates,
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toModify(patCandidateSummary.candidates,
                                               func = lambda list: list.remove(cms.InputTag("patDisplacedMuons")) )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/PhysicsTools/PatAlgos/python/selectionLayer1/selectedPatCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/selectionLayer1/selectedPatCandidates_cff.py
@@ -51,9 +51,10 @@ _mAOD = (run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy)
                             func = lambda list: list.remove(cms.InputTag("selectedPatLowPtElectrons")) )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toReplaceWith(selectedPatCandidatesTask,
+from Configuration.Eras.Era_Run2_2016_HIPM_cff import Run2_2016_HIPM
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toReplaceWith(selectedPatCandidatesTask,
                                                    selectedPatCandidatesTask.copyAndExclude([selectedPatDisplacedMuons]))
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toModify(selectedPatCandidateSummary.candidates,
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toModify(selectedPatCandidateSummary.candidates,
                                               func = lambda list: list.remove(cms.InputTag("selectedPatDisplacedMuons")) )
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -80,7 +80,8 @@ _mAOD = (run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy)
                                  slimmingTask.copyAndExclude([slimmedLowPtElectronsTask]))
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-(pp_on_AA | _mAOD | run2_miniAOD_UL).toReplaceWith(slimmingTask,
+from Configuration.Eras.Era_Run2_2016_HIPM_cff import Run2_2016_HIPM
+(pp_on_AA | _mAOD | run2_miniAOD_UL | Run2_2016_HIPM).toReplaceWith(slimmingTask,
                                                    slimmingTask.copyAndExclude([slimmedDisplacedMuons, slimmedDisplacedMuonTrackExtras]))
 
 from PhysicsTools.PatAlgos.slimming.hiPixelTracks_cfi import hiPixelTracks

--- a/RecoLocalMuon/RPCRecHit/plugins/CSCObjectMap.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/CSCObjectMap.cc
@@ -23,7 +23,7 @@ CSCObjectMap::CSCObjectMap(RPCGeometry const& rpcGeo) {
           int cscstation = station;
           RPCGeomServ rpcsrv(rpcId);
           int rpcsegment = rpcsrv.segment();
-          int cscchamber = rpcsegment;                        //FIX THIS ACCORDING TO RPCGeomServ::segment()Definition
+          int cscchamber = rpcsegment;  //FIX THIS ACCORDING TO RPCGeomServ::segment()Definition
           if ((station == 2 || station == 3 || station == 4) && ring == 3) {  //Adding Ring 3 of RPC to the CSC Ring 2
             cscring = 2;
           }

--- a/RecoLocalMuon/RPCRecHit/plugins/CSCObjectMap.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/CSCObjectMap.cc
@@ -24,7 +24,7 @@ CSCObjectMap::CSCObjectMap(RPCGeometry const& rpcGeo) {
           RPCGeomServ rpcsrv(rpcId);
           int rpcsegment = rpcsrv.segment();
           int cscchamber = rpcsegment;                        //FIX THIS ACCORDING TO RPCGeomServ::segment()Definition
-          if ((station == 2 || station == 3) && ring == 3) {  //Adding Ring 3 of RPC to the CSC Ring 2
+          if ((station == 2 || station == 3 || station == 4) && ring == 3) {  //Adding Ring 3 of RPC to the CSC Ring 2
             cscring = 2;
           }
           CSCStationIndex ind(region, cscstation, cscring, cscchamber);

--- a/RecoLocalMuon/RPCRecHit/plugins/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/plugins/CSCSegtoRPC.cc
@@ -55,11 +55,11 @@ std::unique_ptr<RPCRecHitCollection> CSCSegtoRPC::thePoints(const CSCSegmentColl
       if (debug)
         std::cout << "CSC \t \t Number of segments in this CSC = " << CSCSegmentsCounter[CSCId] << std::endl;
       if (debug)
-        std::cout << "CSC \t \t Is the only one in this CSC? is not ind the ring 1 or station 4? Are there more than 2 "
+        std::cout << "CSC \t \t Is the only one in this CSC? is not ind the ring 1? Are there more than 2 "
                      "segments in the event?"
                   << std::endl;
 
-      if (CSCSegmentsCounter[CSCId] == 1 && CSCId.station() != 4 && CSCId.ring() != 1 && allCSCSegments->size() >= 2) {
+      if (CSCSegmentsCounter[CSCId] == 1 && CSCId.ring() != 1 && allCSCSegments->size() >= 2) {
         if (debug)
           std::cout << "CSC \t \t yes" << std::endl;
         int cscEndCap = CSCId.endcap();
@@ -121,7 +121,7 @@ std::unique_ptr<RPCRecHitCollection> CSCSegtoRPC::thePoints(const CSCSegmentColl
           if (debug)
             std::cout << "CSC \t \t Printing The Id" << TheId << std::endl;
 
-          if (rpcRing != 1 && rpcStation != 4) {  //They don't exist!
+          if (rpcRing != 1) {  //They don't exist in Run3!
 
             assert(!rollsForThisCSC.empty());
 


### PR DESCRIPTION
#### PR description:

Add the sigmaietaieta calo id variable cut to the Run 3 scouting electron collection
  - Use the same cut strategy as in the standard electron path.
  - Default value is kept so that all the electrons pass without the cut.
  - Default implementation is "less than" a certain cut value because the standard use of this variable is var < cut.
  - Validated in presentation in the scouting group at https://indico.cern.ch/event/1174315/#1-update-on-scouting-electrons
