### PR TITLE
B2G SD mass jet trigger DQM

### DIFF
--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -84,8 +84,37 @@ AK8PFJet400_TrimMass30_Mjjmonitoring = hltMjjmonitoring.clone(
 
 AK8PFJet400_TrimMass30_Softdropmonitoring = hltSoftdropmonitoring.clone(
     FolderName = 'HLT/B2G/AK8PFJet400_TrimMass30',
-    jetSelection = "pt > 65 && eta < 2.4",
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_TrimMass30_v*"])
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_TrimMass30_v*"]),
+    histoPSet = dict(
+        htBinning = [0., 10., 20., 30., 40., 50.,  60., 70., 80., 90., 100., 110., 120., 130., 140., 150., 160., 170., 180., 190., 200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300., 310., 320., 330., 340., 350.],
+        htPSet = dict(nbins = 200, xmin = -0.5, xmax = 19999.5)
+    )
+)
+
+# AK8PFJet400_MassSD30 monitoring
+
+AK8PFJet400_MassSD30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet400_MassSD30',
+    ptcut = 400,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_MassSD30_v*"])
+)
+
+AK8PFJet400_MassSD30_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet400_MassSD30',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8PFJet400_MassSD30_v*"])
+)
+
+AK8PFJet400_MassSD30_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8PFJet400_MassSD30',
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8PFJet400_MassSD30_v*"]),
+    histoPSet = dict(
+        htBinning = [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 110., 120., 130., 140., 150., 160., 170., 180., 190., 200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300., 310., 320., 330., 340., 350.],
+        htPSet = dict(nbins = 200, xmin = -0.5, xmax = 19999.5)
+    )
 )
 
 # Lepton cross trigger monitoring
@@ -121,6 +150,9 @@ b2gMonitorHLT = cms.Sequence(
     AK8PFJet400_TrimMass30_PromptMonitoring +
     AK8PFJet400_TrimMass30_Mjjmonitoring +
 
+    AK8PFJet400_MassSD30_PromptMonitoring +
+    AK8PFJet400_MassSD30_Mjjmonitoring +
+
     B2GegHLTDQMOfflineTnPSource
 
   * hltDQMonitorB2G_MuEle
@@ -137,8 +169,8 @@ b2gHLTDQMSourceWithRECO = cms.Sequence(
     PFHT1050_Softdropmonitoring +
     AK8PFJet500_Softdropmonitoring +
     AK8PFHT800_TrimMass50_Softdropmonitoring +
-    AK8PFJet400_TrimMass30_Softdropmonitoring     
-
+    AK8PFJet400_TrimMass30_Softdropmonitoring +
+    AK8PFJet400_MassSD30_Softdropmonitoring
 )
 
 b2gHLTDQMSourceExtra = cms.Sequence(

--- a/DQMOffline/Trigger/python/B2GMonitoring_cff.py
+++ b/DQMOffline/Trigger/python/B2GMonitoring_cff.py
@@ -10,6 +10,8 @@ from DQMOffline.Trigger.TopMonitor_cfi import hltTOPmonitoring
 ### B2G triggers:
 # HLT_AK8PFHT*_TrimMass50
 # HLT_AK8PFJet*_TrimMass30
+# HLT_AK8PFJet*_MassSD30
+
 # HLT_Mu37_Ele27_CaloIdL_MW
 # HLT_Mu27_Ele37_CaloIdL_MW
 # HLT_Mu37_TkMu27
@@ -117,6 +119,31 @@ AK8PFJet400_MassSD30_Softdropmonitoring = hltSoftdropmonitoring.clone(
     )
 )
 
+# AK8DiPFJet250_250_MassSD30 monitoring
+
+AK8DiPFJet250_250_MassSD30_PromptMonitoring = hltJetMETmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8DiPFJet250_250_MassSD30',
+    ptcut = 400,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet250_250_MassSD30_v*"])
+)
+
+AK8DiPFJet250_250_MassSD30_Mjjmonitoring = hltMjjmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8DiPFJet250_250_MassSD30',
+    jets = "ak8PFJetsPuppi",
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet= dict(hltPaths = ["HLT_AK8DiPFJet250_250_MassSD30_v*"])
+)
+
+AK8DiPFJet250_250_MassSD30_Softdropmonitoring = hltSoftdropmonitoring.clone(
+    FolderName = 'HLT/B2G/AK8DiPFJet250_250_MassSD30',
+    jetSelection = "pt > 200 && eta < 2.4",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_AK8DiPFJet250_250_MassSD30_v*"]),
+    histoPSet = dict(
+        htBinning = [0., 10., 20., 30., 40., 50., 60., 70., 80., 90., 100., 110., 120., 130., 140., 150., 160., 170., 180., 190., 200., 210., 220., 230., 240., 250., 260., 270., 280., 290., 300., 310., 320., 330., 340., 350.],
+        htPSet = dict(nbins = 200, xmin = -0.5, xmax = 19999.5)
+    )
+)
+
 # Lepton cross trigger monitoring
 
 hltDQMonitorB2G_MuEle = hltTOPmonitoring.clone(
@@ -153,6 +180,9 @@ b2gMonitorHLT = cms.Sequence(
     AK8PFJet400_MassSD30_PromptMonitoring +
     AK8PFJet400_MassSD30_Mjjmonitoring +
 
+    AK8DiPFJet250_250_MassSD30_PromptMonitoring +
+    AK8DiPFJet250_250_MassSD30_Mjjmonitoring +
+
     B2GegHLTDQMOfflineTnPSource
 
   * hltDQMonitorB2G_MuEle
@@ -170,7 +200,8 @@ b2gHLTDQMSourceWithRECO = cms.Sequence(
     AK8PFJet500_Softdropmonitoring +
     AK8PFHT800_TrimMass50_Softdropmonitoring +
     AK8PFJet400_TrimMass30_Softdropmonitoring +
-    AK8PFJet400_MassSD30_Softdropmonitoring
+    AK8PFJet400_MassSD30_Softdropmonitoring +
+    AK8DiPFJet250_250_MassSD30_Softdropmonitoring
 )
 
 b2gHLTDQMSourceExtra = cms.Sequence(


### PR DESCRIPTION
#### PR description:

Update of the B2G HLT DQM code to include monitoring of two newly added triggers: HLT_AK8PFJet400_MassSD30_v and HLT_AK8DiPFJet250_250_MassSD30_v. The JIRA ticket of the integration of these triggers is linked [here](https://its.cern.ch/jira/browse/CMSHLT-2291). The topic of jet mass trigger DQM, and these updates, were discussed in [this B2G meeting](https://indico.cern.ch/event/1170215/).

The new paths have the same monitoring as the already previously included HLT_AK8PFJet400_TrimMass30_v except for a change in pt threshold and SD mass binning, which were also applied to the old HLT_AK8PFJet400_TrimMass30_v.

This PR aims for inclusion in the next possible release.

#### PR validation:

The complete workflow was tested using `runTheMatrix.py -l 11634.0` verifying that the histograms are properly created. The changes were also tested by running the DQM and harvesting steps on different RelVal samples, to check whether the histograms are properly filled. The basic test procedure as instructed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) was run and passed all tests.

I hope the above information is complete, if not I'd be happy to provide anything that might be needed.