### PR TITLE
[12_4_X] PPS pixel mask Bug Fix

### DIFF
--- a/RecoPPS/Local/src/RPixDetClusterizer.cc
+++ b/RecoPPS/Local/src/RPixDetClusterizer.cc
@@ -2,12 +2,15 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "RecoPPS/Local/interface/RPixDetClusterizer.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
 
 namespace {
   constexpr int maxCol = CTPPSPixelCluster::MAXCOL;
   constexpr int maxRow = CTPPSPixelCluster::MAXROW;
   constexpr double highRangeCal = 1800.;
   constexpr double lowRangeCal = 260.;
+  constexpr int rocMask = 0xE000;
+  constexpr int rocOffset = 13;
 }  // namespace
 
 RPixDetClusterizer::RPixDetClusterizer(edm::ParameterSet const &conf) : params_(conf), SeedVector_(0) {
@@ -28,11 +31,26 @@ void RPixDetClusterizer::buildClusters(unsigned int detId,
                                        const CTPPSPixelGainCalibrations *pcalibrations,
                                        const CTPPSPixelAnalysisMask *maskera) {
   std::map<uint32_t, CTPPSPixelROCAnalysisMask> const &mask = maskera->analysisMask;
-  std::map<uint32_t, CTPPSPixelROCAnalysisMask>::const_iterator mask_it = mask.find(detId);
-
   std::set<std::pair<unsigned char, unsigned char> > maskedPixels;
-  if (mask_it != mask.end())
-    maskedPixels = mask_it->second.maskedPixels;
+
+  // read and store masked pixels after converting ROC numbering into module numbering
+  CTPPSPixelIndices pI;
+  for (auto const &det : mask) {
+    uint32_t planeId = det.first & ~rocMask;
+
+    if (planeId == detId) {
+      unsigned int rocNum = (det.first & rocMask) >> rocOffset;
+      if (rocNum > 5)
+        throw cms::Exception("InvalidRocNumber") << "roc number from mask: " << rocNum;
+      for (auto const &paio : det.second.maskedPixels) {
+        std::pair<unsigned char, unsigned char> pa = paio;
+        int modCol, modRow;
+        pI.transformToModule(pa.second, pa.first, rocNum, modCol, modRow);
+        std::pair<int, int> modPix(modRow, modCol);
+        maskedPixels.insert(modPix);
+      }
+    }
+  }
 
   if (verbosity_)
     edm::LogInfo("RPixDetClusterizer") << detId << " received digi.size()=" << digi.size();


### PR DESCRIPTION

PR description:

This PR fixes a bug in the retrieving of the masked pixel map. The numbering code writing the mask and reading it back was not compliant. Now the mask is written and read back with the same numbering scheme. In Run2 the mask was not used thus the bug was not spotted.
Without this fix the pixel masking can't be used.

This is a backport of PR#38606.

PR validation:

Validated with real Run3 data.
No changes should be seen in the tests with Run2 data/simulation.

@grzanka @AndreaBellora @jpata
