### PR TITLE
[LTO] do not remove lto flags for LTO IBs

### DIFF
--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -32,8 +32,8 @@
 <use name="Validation/HGCalValidation"/>
 <use name="geant4static"/>
 <flags DROP_DEP="geant4core"/>
-<!-- Hack needed to avoid undefined variable in CLHEP -->
-<flags REM_CXXFLAGS="-Werror=unused-variable"/>
-<!-- Disable LTO in BigLibs, as it seems to clash with debugging symbols with gcc 4.9.X -->
-<flags REM_BIGOBJ_CXXFLAGS="-flto"/>
-<flags BIGOBJ_CXXFLAGS="-fno-lto"/>
+<ifrelease name="!_LTO_">
+  <!-- Disable LTO in BigLibs, as it seems to clash with debugging symbols with gcc 4.9.X -->
+  <flags REM_BIGOBJ_CXXFLAGS="-flto"/>
+  <flags BIGOBJ_CXXFLAGS="-fno-lto"/>
+</ifrelease>


### PR DESCRIPTION
This change is needed for new LTO IBs where we do want to build cmssw with `lto` flags.