### PR TITLE
Fix DNS servers for BeamSpot DIP publication

### DIFF
--- a/DQM/BeamMonitor/bin/beamSpotDipStandalone.cc
+++ b/DQM/BeamMonitor/bin/beamSpotDipStandalone.cc
@@ -671,8 +671,8 @@ int main(int narg, char* args[]) {
   endTime = getDateTime();
 
   dip = Dip::create("CmsBeamSpotServer");
-  //  dip->setDNSNode("cmsdimns1.cern.ch");
-  dip->setDNSNode("cmsdimns2.cern.ch");
+  // Use both CMS-based DIM DNS server (https://its.cern.ch/jira/browse/CMSOMS-280)
+  dip->setDNSNode("cmsdimns1.cern.ch,cmsdimns2.cern.ch");
 
   cerr << "reading from file (NFS)" << endl;
 

--- a/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
+++ b/DQM/BeamMonitor/plugins/BeamSpotDipServer.cc
@@ -56,8 +56,8 @@ BeamSpotDipServer::BeamSpotDipServer(const edm::ParameterSet& ps) {
   //
   dip = Dip::create("CmsBeamSpotServer");
 
-  //
-  dip->setDNSNode("cmsdimns1.cern.ch");
+  // Use both CMS-based DIM DNS server (https://its.cern.ch/jira/browse/CMSOMS-280)
+  dip->setDNSNode("cmsdimns1.cern.ch,cmsdimns2.cern.ch");
 
   edm::LogInfo("BeamSpotDipServer") << "reading from " << (readFromNFS ? "file (NFS)" : "database");
 }


### PR DESCRIPTION
#### PR description:
It was noticed during Fills 7920 and 7921 that the BeamSpot information wasn't being published on DIP.
Following the discussion in https://its.cern.ch/jira/browse/CMSOMS-280 it seems that

> We're using redundant peers, and sometimes dns run in 1 and sometimes in 2, depending which of them is active

So both DNS addresses should be used in order to establish a connection.
This PR udpated both flavors of the BeamSpot DIP publisher: the DQM client (currently in production) and the standalone version (to be put in production soon).

#### PR validation:
Code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport, but 12_4_X and 12_3_X backports will be provided soon.

FYI: @sikler @gennai @dzuolo @amassiro 