### PR TITLE
Add VtxSmearing scenario for Run 3 early data at 13.6 TeV

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -66,6 +66,7 @@ VtxSmeared = {
     'Run3FlatOpticsGaussSigmaZ4p2cm'     : 'IOMC.EventVertexGenerators.VtxSmearedRun3FlatOpticsGaussSigmaZ4p2cm_cfi',
     'Run3FlatOpticsGaussSigmaZ5p3cm'     : 'IOMC.EventVertexGenerators.VtxSmearedRun3FlatOpticsGaussSigmaZ5p3cm_cfi',
     'Realistic25ns900GeV2021Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns900GeV2021Collision_cfi',
+    'Realistic25ns13p6TeVEarly2022Collision' : 'IOMC.EventVertexGenerators.VtxSmearedRealistic25ns13p6TeVEarly2022Collision_cfi',
 }
 VtxSmearedDefaultKey='Realistic50ns13TeVCollision'
 VtxSmearedHIDefaultKey='RealisticPbPbCollision2018'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -780,6 +780,38 @@ Realistic25ns900GeV2021CollisionVtxSmearingParameters = cms.PSet(
     Z0 = cms.double(0.423776)
 )
 
+# From first Run 3 data at 13.6 TeV and 3.8T
+# BS parameters extracted from run 355100, fill 7920:
+# X0         =  0.172394 [cm]
+# Y0         = -0.180946 [cm]
+# Z0         =  0.94181  [cm]
+# sigmaZ0    =  3.81941  [cm]
+# BeamWidthX = 0.0008772 [cm]
+# BeamWidthY = 0.0010078 [cm]
+#
+# set SigmaZ0 = 3.8 [cm]
+# set BeamWidthX = BeamWidthY = 10.0 [um]
+# set beta* = 30 cm
+# energy = 13.6 TeV
+# From LHC calculator, emittance is 6.621e-8 cm
+# https://lpc.web.cern.ch/lumiCalc.html
+#
+# BPIX absolute position (https://twiki.cern.ch/twiki/bin/view/CMS/TkAlignmentPixelPosition?rev=42#2022):
+# X = -0.01955 cm
+# Y = -0.1583  cm
+# Z = -0.2626  cm
+Realistic25ns13p6TeVEarly2022CollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(30.0),
+    Emittance = cms.double(6.621e-8),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(3.8),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.191944),
+    Y0 = cms.double(-0.022646),
+    Z0 = cms.double(1.20441)
+)
+
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEarly2022Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic25ns13p6TeVEarly2022Collision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import Realistic25ns13p6TeVEarly2022CollisionVtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Realistic25ns13p6TeVEarly2022CollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
#### PR description:
This PR adds the realistic vertex smearing scenario for 2022 early data at 13.6 TeV: `Realistic25ns13p6TeVEarly2022Collision`.
Parameters used:
 - The BeamSpot is extracted from run [355100](https://cmsoms.cern.ch/cms/runs/report?cms_run=355100) (fill [7920](https://cmsoms.cern.ch/cms/fills/report?cms_fill=7920))
 - The BPIX barycenter comes from [this twiki](https://twiki.cern.ch/twiki/bin/view/CMS/TkAlignmentPixelPosition?rev=42#2022)

#### PR validation:
Code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport but a backport to 12_4_X is provided in #38617

FYI @dzuolo @gennai @mmusich @rappoccio @cms-sw/pdmv-l2 