### PR TITLE
[12_3_X] Update errorScale for BeamSpot Legacy DQM client

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # Define here the BeamSpotOnline record name,
 # it will be used both in BeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineLegacyObjectsRcd'
-BSOnlineTag = 'BeamSpotOnlineLegacyTestRun3'
+BSOnlineTag = 'BeamSpotOnlineLegacy'
 BSOnlineJobName = 'BeamSpotOnlineLegacy'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # Define here the BeamSpotOnline record name,
 # it will be used both in BeamMonitor setup and in payload creation/upload
 BSOnlineRecordName = 'BeamSpotOnlineLegacyObjectsRcd'
-BSOnlineTag = 'BeamSpotOnlineLegacy'
+BSOnlineTag = 'BeamSpotOnlineLegacyTestRun3'
 BSOnlineJobName = 'BeamSpotOnlineLegacy'
 BSOnlineOmsServiceUrl = 'http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'
 useLockRecords = True
@@ -324,7 +324,7 @@ process.dqmBeamMonitor.resetPVEveryNLumi = 5 # was 10 for HI
 
 process.dqmBeamMonitor.PVFitter.minNrVerticesForFit = 20
 process.dqmBeamMonitor.PVFitter.minVertexNdf = 10
-process.dqmBeamMonitor.PVFitter.errorScale = 1.22
+process.dqmBeamMonitor.PVFitter.errorScale = 1.0
 
 #----------------------------
 # Pixel tracks/vertices reco


### PR DESCRIPTION
#### PR description:
It was noticed in recent fills with stable beams (from 5<sup>th</sup> July 2022 onwards) that the Legacy BeamSpot DQM client was consistently failing in fitting the beamspot, the issues seem related to the PV part of the beamspot fit.

After some excellent online debugging @mmusich found that after changing the `errorScale` parameters from the default `1.22` to `1.0` the fits were converging with beamspot results compatible with those measured by the other BeamSpot client.

This PR changes:
 - the `errorScale` parameter to `1.0` for the Legacy BeamSpot DQM client (`beam` client)
 - temporarily changes the target tag to which the BeamSpot fitted values are uploaded, from `BeamSpotOnlineLegacy` to `BeamSpotOnlineLegacyTestRun3` so we can test the client with the upcoming stable beams and verify that it works properly before putting it in production.

#### PR validation:
- Code compiles
- Unit test runs
- Tested with different flavours of input data (ALCARECO, FEVT...)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, we will decide on the final integration of this PR after seeing it in production.


FYI @mmusich @gennai @dzuolo @sikler 