### PR TITLE
Have WaitingTask hold an exception_ptr directly

### DIFF
--- a/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
+++ b/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
@@ -34,7 +34,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("first | then | lastTask") {
@@ -59,7 +59,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("first | then | then | lastTask") {
@@ -88,7 +88,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("first | then | then | runLast") {
@@ -112,7 +112,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("exception -> first | lastTask") {
@@ -133,7 +133,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 0);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() != nullptr);
+      REQUIRE(waitTask.exceptionPtr());
     }
 
     SECTION("first(exception) | lastTask") {
@@ -155,7 +155,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() != nullptr);
+      REQUIRE(waitTask.exceptionPtr());
     }
 
     SECTION("first(exception) | then | then | lastTask") {
@@ -185,7 +185,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() != nullptr);
+      REQUIRE(waitTask.exceptionPtr());
     }
   }
 
@@ -209,7 +209,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("first | then | lastTask") {
@@ -236,7 +236,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("first | then | then | lastTask") {
@@ -268,7 +268,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("exception -> first | lastTask") {
@@ -290,7 +290,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("exception -> first | then | lastTask") {
@@ -318,7 +318,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
   }
 
@@ -346,7 +346,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       REQUIRE(exceptCount.load() == 0);
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("first | then | lastTask") {
@@ -379,7 +379,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       REQUIRE(exceptCount.load() == 0);
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("first | then | then | lastTask") {
@@ -419,7 +419,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       REQUIRE(exceptCount.load() == 0);
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("exception -> first | then | then | lastTask") {
@@ -459,7 +459,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       REQUIRE(exceptCount.load() == 3);
       REQUIRE(count.load() == 0);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() != nullptr);
+      REQUIRE(waitTask.exceptionPtr());
     }
   }
 
@@ -485,7 +485,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
 
     SECTION("first | ifThen(false) | then | runLast") {
@@ -509,7 +509,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       group.wait();
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
-      REQUIRE(waitTask.exceptionPtr() == nullptr);
+      REQUIRE(not waitTask.exceptionPtr());
     }
   }
 }

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -41,7 +41,7 @@ namespace {
 
     void execute() final {
       if (exceptionPtr()) {
-        m_ptr = *exceptionPtr();
+        m_ptr = exceptionPtr();
       }
       m_called = true;
       return;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -724,7 +724,7 @@ namespace edm {
     }) | runLast(WaitingTaskHolder(group, &last));
     group.wait();
     if (last.exceptionPtr()) {
-      std::rethrow_exception(*last.exceptionPtr());
+      std::rethrow_exception(last.exceptionPtr());
     }
   }
 
@@ -1054,8 +1054,8 @@ namespace edm {
       taskGroup_.wait();
     } while (not globalWaitTask.done());
 
-    if (globalWaitTask.exceptionPtr() != nullptr) {
-      std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+    if (globalWaitTask.exceptionPtr()) {
+      std::rethrow_exception(globalWaitTask.exceptionPtr());
     }
     beginProcessBlockSucceeded = true;
   }
@@ -1077,7 +1077,7 @@ namespace edm {
         taskGroup_.wait();
       } while (not globalWaitTask.done());
       if (globalWaitTask.exceptionPtr() != nullptr) {
-        std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+        std::rethrow_exception(globalWaitTask.exceptionPtr());
       }
 
       FinalWaitingTask writeWaitTask;
@@ -1086,7 +1086,7 @@ namespace edm {
         taskGroup_.wait();
       } while (not writeWaitTask.done());
       if (writeWaitTask.exceptionPtr()) {
-        std::rethrow_exception(*writeWaitTask.exceptionPtr());
+        std::rethrow_exception(writeWaitTask.exceptionPtr());
       }
 
       processBlockPrincipal.clearPrincipal();
@@ -1112,8 +1112,8 @@ namespace edm {
     do {
       taskGroup_.wait();
     } while (not globalWaitTask.done());
-    if (globalWaitTask.exceptionPtr() != nullptr) {
-      std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+    if (globalWaitTask.exceptionPtr()) {
+      std::rethrow_exception(globalWaitTask.exceptionPtr());
     }
 
     if (beginProcessBlockSucceeded) {
@@ -1123,7 +1123,7 @@ namespace edm {
         taskGroup_.wait();
       } while (not writeWaitTask.done());
       if (writeWaitTask.exceptionPtr()) {
-        std::rethrow_exception(*writeWaitTask.exceptionPtr());
+        std::rethrow_exception(writeWaitTask.exceptionPtr());
       }
     }
 
@@ -1175,8 +1175,8 @@ namespace edm {
       do {
         taskGroup_.wait();
       } while (not waitTask.done());
-      if (waitTask.exceptionPtr() != nullptr) {
-        std::rethrow_exception(*(waitTask.exceptionPtr()));
+      if (waitTask.exceptionPtr()) {
+        std::rethrow_exception(waitTask.exceptionPtr());
       }
     }
     {
@@ -1200,8 +1200,8 @@ namespace edm {
       do {
         taskGroup_.wait();
       } while (not globalWaitTask.done());
-      if (globalWaitTask.exceptionPtr() != nullptr) {
-        std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+      if (globalWaitTask.exceptionPtr()) {
+        std::rethrow_exception(globalWaitTask.exceptionPtr());
       }
     }
     {
@@ -1220,8 +1220,8 @@ namespace edm {
       do {
         taskGroup_.wait();
       } while (not streamLoopWaitTask.done());
-      if (streamLoopWaitTask.exceptionPtr() != nullptr) {
-        std::rethrow_exception(*(streamLoopWaitTask.exceptionPtr()));
+      if (streamLoopWaitTask.exceptionPtr()) {
+        std::rethrow_exception(streamLoopWaitTask.exceptionPtr());
       }
     }
     FDEBUG(1) << "\tstreamBeginRun " << run << "\n";
@@ -1251,7 +1251,7 @@ namespace edm {
           } while (not t.done());
           mergeableRunProductMetadata->postWriteRun();
           if (t.exceptionPtr()) {
-            std::rethrow_exception(*t.exceptionPtr());
+            std::rethrow_exception(t.exceptionPtr());
           }
         }
       }
@@ -1294,8 +1294,8 @@ namespace edm {
       do {
         taskGroup_.wait();
       } while (not streamLoopWaitTask.done());
-      if (streamLoopWaitTask.exceptionPtr() != nullptr) {
-        std::rethrow_exception(*(streamLoopWaitTask.exceptionPtr()));
+      if (streamLoopWaitTask.exceptionPtr()) {
+        std::rethrow_exception(streamLoopWaitTask.exceptionPtr());
       }
     }
     FDEBUG(1) << "\tstreamEndRun " << run << "\n";
@@ -1320,8 +1320,8 @@ namespace edm {
       do {
         taskGroup_.wait();
       } while (not globalWaitTask.done());
-      if (globalWaitTask.exceptionPtr() != nullptr) {
-        std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+      if (globalWaitTask.exceptionPtr()) {
+        std::rethrow_exception(globalWaitTask.exceptionPtr());
       }
     }
     FDEBUG(1) << "\tendRun " << run << "\n";
@@ -1343,8 +1343,8 @@ namespace edm {
       taskGroup_.wait();
     } while (not waitTask.done());
 
-    if (waitTask.exceptionPtr() != nullptr) {
-      std::rethrow_exception(*(waitTask.exceptionPtr()));
+    if (waitTask.exceptionPtr()) {
+      std::rethrow_exception(waitTask.exceptionPtr());
     }
     return lastTransitionType();
   }
@@ -1672,8 +1672,8 @@ namespace edm {
       do {
         taskGroup_.wait();
       } while (not globalWaitTask.done());
-      if (globalWaitTask.exceptionPtr() != nullptr) {
-        std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+      if (globalWaitTask.exceptionPtr()) {
+        std::rethrow_exception(globalWaitTask.exceptionPtr());
       }
     }
   }

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -436,7 +436,7 @@ namespace edm {
       } while (not waitUntilIOVInitializationCompletes.done());
 
       if (waitUntilIOVInitializationCompletes.exceptionPtr() != nullptr) {
-        std::rethrow_exception(*(waitUntilIOVInitializationCompletes.exceptionPtr()));
+        std::rethrow_exception(waitUntilIOVInitializationCompletes.exceptionPtr());
       }
     }
   }  // namespace eventsetup

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -989,7 +989,7 @@ namespace edm {
       void execute() final {
         auto exceptPtr = exceptionPtr();
         if (exceptPtr) {
-          resolver_->prefetchFailed(index_, *principal_, skipCurrentProcess_, *exceptPtr);
+          resolver_->prefetchFailed(index_, *principal_, skipCurrentProcess_, exceptPtr);
         } else {
           if (not resolver_->dataValidFromResolver(index_, *principal_, skipCurrentProcess_)) {
             resolver_->tryPrefetchResolverAsync(

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -364,16 +364,15 @@ namespace edm {
     }
   }
 
-  void Worker::runAcquireAfterAsyncPrefetch(std::exception_ptr const* iEPtr,
+  void Worker::runAcquireAfterAsyncPrefetch(std::exception_ptr iEPtr,
                                             EventTransitionInfo const& eventTransitionInfo,
                                             ParentContext const& parentContext,
                                             WaitingTaskWithArenaHolder holder) {
     ranAcquireWithoutException_ = false;
     std::exception_ptr exceptionPtr;
     if (iEPtr) {
-      assert(*iEPtr);
-      if (shouldRethrowException(*iEPtr, parentContext, true)) {
-        exceptionPtr = *iEPtr;
+      if (shouldRethrowException(iEPtr, parentContext, true)) {
+        exceptionPtr = iEPtr;
       }
       moduleCallingContext_.setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);
     } else {
@@ -389,18 +388,17 @@ namespace edm {
     holder.doneWaiting(exceptionPtr);
   }
 
-  std::exception_ptr Worker::handleExternalWorkException(std::exception_ptr const* iEPtr,
-                                                         ParentContext const& parentContext) {
+  std::exception_ptr Worker::handleExternalWorkException(std::exception_ptr iEPtr, ParentContext const& parentContext) {
     if (ranAcquireWithoutException_) {
       try {
-        convertException::wrap([iEPtr]() { std::rethrow_exception(*iEPtr); });
+        convertException::wrap([iEPtr]() { std::rethrow_exception(iEPtr); });
       } catch (cms::Exception& ex) {
         ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
         edm::exceptionContext(ex, moduleCallingContext_);
         return std::current_exception();
       }
     }
-    return *iEPtr;
+    return iEPtr;
   }
 
   Worker::HandleExternalWorkExceptionTask::HandleExternalWorkExceptionTask(Worker* worker,

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -767,7 +767,7 @@ namespace {
             group.wait();
           } while (not waitTask.done());
           if (waitTask.exceptionPtr()) {
-            std::rethrow_exception(*waitTask.exceptionPtr());
+            std::rethrow_exception(waitTask.exceptionPtr());
           }
         }
       }
@@ -796,7 +796,7 @@ namespace {
             group.wait();
           } while (not waitTask.done());
           if (waitTask.exceptionPtr()) {
-            std::rethrow_exception(*waitTask.exceptionPtr());
+            std::rethrow_exception(waitTask.exceptionPtr());
           }
         }
       }

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -64,7 +64,7 @@ namespace {
             group.wait();
           } while (not waitTask.done());
           if (waitTask.exceptionPtr()) {
-            std::rethrow_exception(*waitTask.exceptionPtr());
+            std::rethrow_exception(waitTask.exceptionPtr());
           }
         }
       }

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -432,7 +432,7 @@ namespace {
             group.wait();
           } while (not waitTask.done());
           if (waitTask.exceptionPtr()) {
-            std::rethrow_exception(*waitTask.exceptionPtr());
+            std::rethrow_exception(waitTask.exceptionPtr());
           }
         }
       }

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -196,7 +196,7 @@ namespace {
           group.wait();
         } while (not waitTask.done());
         if (waitTask.exceptionPtr()) {
-          std::rethrow_exception(*waitTask.exceptionPtr());
+          std::rethrow_exception(waitTask.exceptionPtr());
         }
       }
     }
@@ -219,7 +219,7 @@ namespace {
           group.wait();
         } while (not waitTask.done());
         if (waitTask.exceptionPtr()) {
-          std::rethrow_exception(*waitTask.exceptionPtr());
+          std::rethrow_exception(waitTask.exceptionPtr());
         }
       }
     }

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -64,7 +64,7 @@ namespace {
             group.wait();
           } while (not waitTask.done());
           if (waitTask.exceptionPtr()) {
-            std::rethrow_exception(*waitTask.exceptionPtr());
+            std::rethrow_exception(waitTask.exceptionPtr());
           }
         }
       }

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -134,7 +134,7 @@ private:
       group.wait();
     } while (not task.done());
     if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(*e);
+      std::rethrow_exception(e);
     }
   }
 

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -104,7 +104,7 @@ private:
       group.wait();
     } while (not task.done());
     if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(*e);
+      std::rethrow_exception(e);
     }
   }
 
@@ -226,8 +226,8 @@ testGlobalOutputModule::testGlobalOutputModule()
     do {
       group.wait();
     } while (not task.done());
-    if (task.exceptionPtr() != nullptr) {
-      std::rethrow_exception(*task.exceptionPtr());
+    if (task.exceptionPtr()) {
+      std::rethrow_exception(task.exceptionPtr());
     }
   };
 
@@ -242,8 +242,8 @@ testGlobalOutputModule::testGlobalOutputModule()
     do {
       group.wait();
     } while (not task.done());
-    if (task.exceptionPtr() != nullptr) {
-      std::rethrow_exception(*task.exceptionPtr());
+    if (task.exceptionPtr()) {
+      std::rethrow_exception(task.exceptionPtr());
     }
   };
 

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -134,7 +134,7 @@ private:
       group.wait();
     } while (not task.done());
     if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(*e);
+      std::rethrow_exception(e);
     }
   }
 

--- a/FWCore/Framework/test/limited_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_filter_t.cppunit.cc
@@ -144,7 +144,7 @@ private:
       group.wait();
     } while (not task.done());
     if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(*e);
+      std::rethrow_exception(e);
     }
   }
 

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -104,7 +104,7 @@ private:
       group.wait();
     } while (not task.done());
     if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(*e);
+      std::rethrow_exception(e);
     }
   }
 
@@ -225,8 +225,8 @@ testLimitedOutputModule::testLimitedOutputModule()
     do {
       group.wait();
     } while (not task.done());
-    if (task.exceptionPtr() != nullptr) {
-      std::rethrow_exception(*task.exceptionPtr());
+    if (task.exceptionPtr()) {
+      std::rethrow_exception(task.exceptionPtr());
     }
   };
 
@@ -241,8 +241,8 @@ testLimitedOutputModule::testLimitedOutputModule()
     do {
       group.wait();
     } while (not task.done());
-    if (task.exceptionPtr() != nullptr) {
-      std::rethrow_exception(*task.exceptionPtr());
+    if (task.exceptionPtr()) {
+      std::rethrow_exception(task.exceptionPtr());
     }
   };
 

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -144,7 +144,7 @@ private:
       group.wait();
     } while (not task.done());
     if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(*e);
+      std::rethrow_exception(e);
     }
   }
 

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -116,7 +116,7 @@ private:
       group.wait();
     } while (not task.done());
     if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(*e);
+      std::rethrow_exception(e);
     }
   }
 
@@ -320,8 +320,8 @@ testOneOutputModule::testOneOutputModule()
     do {
       group.wait();
     } while (not task.done());
-    if (task.exceptionPtr() != nullptr) {
-      std::rethrow_exception(*task.exceptionPtr());
+    if (task.exceptionPtr()) {
+      std::rethrow_exception(task.exceptionPtr());
     }
   };
 
@@ -336,8 +336,8 @@ testOneOutputModule::testOneOutputModule()
     do {
       group.wait();
     } while (not task.done());
-    if (task.exceptionPtr() != nullptr) {
-      std::rethrow_exception(*task.exceptionPtr());
+    if (task.exceptionPtr()) {
+      std::rethrow_exception(task.exceptionPtr());
     }
   };
 

--- a/FWCore/Framework/test/stream_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_filter_t.cppunit.cc
@@ -133,7 +133,7 @@ private:
       group.wait();
     } while (not task.done());
     if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(*e);
+      std::rethrow_exception(e);
     }
   }
 

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -133,7 +133,7 @@ private:
       group.wait();
     } while (not task.done());
     if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(*e);
+      std::rethrow_exception(e);
     }
   }
 

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -439,8 +439,8 @@ namespace edm {
         do {
           taskGroup_.wait();
         } while (not globalWaitTask.done());
-        if (globalWaitTask.exceptionPtr() != nullptr) {
-          std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+        if (globalWaitTask.exceptionPtr()) {
+          std::rethrow_exception(globalWaitTask.exceptionPtr());
         }
       }
       beginProcessBlockCalled_ = true;
@@ -470,8 +470,8 @@ namespace edm {
         do {
           taskGroup_.wait();
         } while (not globalWaitTask.done());
-        if (globalWaitTask.exceptionPtr() != nullptr) {
-          std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+        if (globalWaitTask.exceptionPtr()) {
+          std::rethrow_exception(globalWaitTask.exceptionPtr());
         }
       }
       {
@@ -490,7 +490,7 @@ namespace edm {
           taskGroup_.wait();
         } while (not streamLoopWaitTask.done());
         if (streamLoopWaitTask.exceptionPtr() != nullptr) {
-          std::rethrow_exception(*(streamLoopWaitTask.exceptionPtr()));
+          std::rethrow_exception(streamLoopWaitTask.exceptionPtr());
         }
       }
       beginRunCalled_ = true;
@@ -522,7 +522,7 @@ namespace edm {
           taskGroup_.wait();
         } while (not globalWaitTask.done());
         if (globalWaitTask.exceptionPtr() != nullptr) {
-          std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+          std::rethrow_exception(globalWaitTask.exceptionPtr());
         }
       }
       {
@@ -542,7 +542,7 @@ namespace edm {
           taskGroup_.wait();
         } while (not streamLoopWaitTask.done());
         if (streamLoopWaitTask.exceptionPtr() != nullptr) {
-          std::rethrow_exception(*(streamLoopWaitTask.exceptionPtr()));
+          std::rethrow_exception(streamLoopWaitTask.exceptionPtr());
         }
       }
       beginLumiCalled_ = true;
@@ -582,7 +582,7 @@ namespace edm {
         taskGroup_.wait();
       } while (not waitTask.done());
       if (waitTask.exceptionPtr() != nullptr) {
-        std::rethrow_exception(*(waitTask.exceptionPtr()));
+        std::rethrow_exception(waitTask.exceptionPtr());
       }
       ++eventNumber_;
     }
@@ -620,7 +620,7 @@ namespace edm {
             taskGroup_.wait();
           } while (not streamLoopWaitTask.done());
           if (streamLoopWaitTask.exceptionPtr() != nullptr) {
-            std::rethrow_exception(*(streamLoopWaitTask.exceptionPtr()));
+            std::rethrow_exception(streamLoopWaitTask.exceptionPtr());
           }
         }
         {
@@ -637,7 +637,7 @@ namespace edm {
             taskGroup_.wait();
           } while (not globalWaitTask.done());
           if (globalWaitTask.exceptionPtr() != nullptr) {
-            std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+            std::rethrow_exception(globalWaitTask.exceptionPtr());
           }
         }
       }
@@ -681,7 +681,7 @@ namespace edm {
             taskGroup_.wait();
           } while (not streamLoopWaitTask.done());
           if (streamLoopWaitTask.exceptionPtr() != nullptr) {
-            std::rethrow_exception(*(streamLoopWaitTask.exceptionPtr()));
+            std::rethrow_exception(streamLoopWaitTask.exceptionPtr());
           }
         }
         {
@@ -698,7 +698,7 @@ namespace edm {
             taskGroup_.wait();
           } while (not globalWaitTask.done());
           if (globalWaitTask.exceptionPtr() != nullptr) {
-            std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+            std::rethrow_exception(globalWaitTask.exceptionPtr());
           }
         }
 
@@ -728,7 +728,7 @@ namespace edm {
             taskGroup_.wait();
           } while (not globalWaitTask.done());
           if (globalWaitTask.exceptionPtr() != nullptr) {
-            std::rethrow_exception(*(globalWaitTask.exceptionPtr()));
+            std::rethrow_exception(globalWaitTask.exceptionPtr());
           }
         }
       }


### PR DESCRIPTION

#### PR description:

Use a separate std::atomic<bool> to guarantee one and only one thread will update the value.
This avoid having to do a `new` in the case of an exception being propagated and simplified memory management.

#### PR validation:

Code compiles and framework unit tests all pass.