### PR TITLE
Modifiers not being set properly in EventConfig for data (GEM RecHits not in latest data)

### DIFF
--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -7,7 +7,6 @@ Module that generates standard repack configurations
 """
 import copy
 import FWCore.ParameterSet.Config as cms
-from Configuration.EventContent.EventContent_cff import RAWEventContent
 
 
 def repackProcess(**args):
@@ -21,6 +20,7 @@ def repackProcess(**args):
     - outputs      : defines output modules
 
     """
+    from Configuration.EventContent.EventContent_cff import RAWEventContent
     process = cms.Process("REPACK")
     process.load("FWCore.MessageLogger.MessageLogger_cfi")
 


### PR DESCRIPTION
#### PR description:

We noticed there are no GEM rechits being added to the data output recently (in particular in the latest collision events), and when trying out Configuration/DataProcessing/test/RunPromptReco.py to see what gets added, I traced it back to Configuration/DataProcessing/python/Repack.py loading Configuration.EventContent.EventContent_cff before the era is set (it gets set after Scenario.py is loaded, which is loading Repack.py), so that modifier chains don't seem to be included at all. In particular, the run3_GEM modifier chain in RecoLocalMuon/Configuration/python/RecoLocalMuon_EventContent_cff.py is not set when the EventContent is loaded by the Repack.py file (but would be if the eras are set by the scenario before the EventContent cff is loaded). Could someone clarify if my understanding is correct but this is expected (it appears the change to Repack.py was made 2 months ago?), or if not expected is the fix okay and should I backport this? Otherwise let me know if my understanding is wrong.

@jshlee 
@slowmoyang 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Checked the output of Configuration/DataProcessing/test/RunPromptReco.py with ppEra_Run3 scenario before and after the change:

before the local muon content looks like:
```
    'keep *_dt4DSegments_*_*',
    'keep *_dt4DCosmicSegments_*_*',
    'keep *_cscSegments_*_*',
    'keep *_rpcRecHits_*_*'
```
after:
```
    'keep *_dt4DSegments_*_*',
    'keep *_dt4DCosmicSegments_*_*',
    'keep *_cscSegments_*_*',
    'keep *_rpcRecHits_*_*',
    'keep *_gemRecHits_*_*',
    'keep *_gemSegments_*_*'
```

I used the command 
```
python3 ${CMSSW_BASE}/src/Configuration/DataProcessing/test/RunPromptReco.py \
    --scenario=ppEra_Run3 \
    --global-tag=123X_dataRun3_Prompt_v12 \
    --reco --aod \
    --lfn /store/whatever
```
<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
