### PR TITLE
[12_4_X] Emtf Unpacker/Emulator Update for Run 3 CSC TPs

### DIFF
--- a/DataFormats/L1TMuon/interface/EMTF/ME.h
+++ b/DataFormats/L1TMuon/interface/EMTF/ME.h
@@ -33,6 +33,17 @@ namespace l1t {
             station(-99),
             vp(-99),
             tbin(-99),
+            // Run 3 OTMB data
+            frame(-99),
+            quarter_strip(-99),
+            eighth_strip(-99),
+            slope(-99),
+            run3_pattern(-99),
+            // Run 3 HMT data
+            hmv(-99),
+            hmt_inTime(-99),
+            hmt_outOfTime(-99),
+            // metadata
             stub_num(-99),
             format_errors(0),
             dataword(-99){};
@@ -59,6 +70,17 @@ namespace l1t {
       void set_station(int bits) { station = bits; }
       void set_vp(int bits) { vp = bits; }
       void set_tbin(int bits) { tbin = bits; }
+      // Run 3 OTMB
+      void set_frame(int bits) { frame = bits; }
+      void set_quarter_strip(int bits) { quarter_strip = bits; }
+      void set_eighth_strip(int bits) { eighth_strip = bits; }
+      void set_slope(int bits) { slope = bits; }
+      void set_run3_pattern(int bits) { run3_pattern = bits; }
+      // Run 3 HMT
+      void set_hmv(int bits) { hmv = bits; }
+      void set_hmt_inTime(int bits) { hmt_inTime = bits; }
+      void set_hmt_outOfTime(int bits) { hmt_outOfTime = bits; }
+      // meta data
       void set_stub_num(int bits) { stub_num = bits; }
       void add_format_error() { format_errors += 1; }
       void set_dataword(uint64_t bits) { dataword = bits; }
@@ -83,6 +105,17 @@ namespace l1t {
       int Station() const { return station; }
       int VP() const { return vp; }
       int TBIN() const { return tbin; }
+      // Run 3 OTMB
+      int Frame() const { return frame; }
+      int Quarter_strip() const { return quarter_strip; }
+      int Eighth_strip() const { return eighth_strip; }
+      int Slope() const { return slope; }
+      int Run3_pattern() const { return run3_pattern; }
+      // Run 3 HMT
+      int HMV() const { return hmv; }
+      int HMT_inTime() const { return hmt_inTime; }
+      int HMT_outOfTime() const { return hmt_outOfTime; }
+      // metadata
       int Stub_num() const { return stub_num; }
       int Format_errors() const { return format_errors; }
       uint64_t Dataword() const { return dataword; }
@@ -108,6 +141,17 @@ namespace l1t {
       int station;
       int vp;
       int tbin;
+      // Run 3 OTMB
+      int frame;
+      int quarter_strip;
+      int eighth_strip;
+      int slope;
+      int run3_pattern;
+      // Run 3 HMT
+      int hmv;
+      int hmt_inTime;
+      int hmt_outOfTime;
+      // metadata
       int stub_num;
       int format_errors;
       uint64_t dataword;

--- a/DataFormats/L1TMuon/interface/EMTFHit.h
+++ b/DataFormats/L1TMuon/interface/EMTFHit.h
@@ -94,7 +94,7 @@ namespace l1t {
     ME0DetId CreateME0DetId() const;
 
     // void ImportCSCCorrelatedLCTDigi (const CSCCorrelatedLCTDigi& _digi);
-    CSCCorrelatedLCTDigi CreateCSCCorrelatedLCTDigi() const;
+    CSCCorrelatedLCTDigi CreateCSCCorrelatedLCTDigi(const bool isRun3) const;
     // void ImportRPCDigi (const RPCDigi& _digi);
     // RPCDigi CreateRPCDigi() const;
     // void ImportCPPFDigi (const CPPFDigi& _digi);

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -73,18 +73,28 @@ namespace l1t {
   }
 
   CSCCorrelatedLCTDigi EMTFHit::CreateCSCCorrelatedLCTDigi() const {
-    return CSCCorrelatedLCTDigi(1,
-                                valid,
-                                quality,
-                                wire,
-                                strip,
-                                pattern,
-                                (bend == 1) ? 1 : 0,
-                                bx + CSCConstants::LCT_CENTRAL_BX,
-                                0,
-                                0,
-                                sync_err,
-                                csc_ID);
+    CSCCorrelatedLCTDigi lct = CSCCorrelatedLCTDigi(1,
+                                                    valid,
+                                                    quality,
+                                                    wire,
+                                                    strip,
+                                                    pattern,
+                                                    (bend == 1) ? 1 : 0,
+                                                    bx + CSCConstants::LCT_CENTRAL_BX,
+                                                    0,
+                                                    0,
+                                                    sync_err,
+                                                    csc_ID);
+    bool quart_bit = strip_quart_bit == 1 ? 1 : 0;
+    bool eighth_bit = strip_eighth_bit == 1 ? 1 : 0;
+
+    lct.setQuartStripBit(quart_bit);
+    lct.setEighthStripBit(eighth_bit);
+    lct.setSlope(slope);
+    lct.setRun3Pattern(pattern_run3);
+
+    return  lct;
+    // Added Run 3 parameters - EY 04.07.22
     // Filling "trknmb" with 1 and "bx0" with 0 (as in MC).
     // May consider filling "trknmb" with 2 for 2nd LCT in the same chamber. - AWB 24.05.17
     // trknmb and bx0 are unused in the EMTF emulator code. mpclink = 0 (after bx) indicates unsorted.

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -85,15 +85,15 @@ namespace l1t {
                                                     0,
                                                     sync_err,
                                                     csc_ID);
-    bool quart_bit = strip_quart_bit == 1 ? 1 : 0;
-    bool eighth_bit = strip_eighth_bit == 1 ? 1 : 0;
+    bool quart_bit = strip_quart_bit == 1 ? true : false;
+    bool eighth_bit = strip_eighth_bit == 1 ? true : false;
 
     lct.setQuartStripBit(quart_bit);
     lct.setEighthStripBit(eighth_bit);
     lct.setSlope(slope);
     lct.setRun3Pattern(pattern_run3);
 
-    return  lct;
+    return lct;
     // Added Run 3 parameters - EY 04.07.22
     // Filling "trknmb" with 1 and "bx0" with 0 (as in MC).
     // May consider filling "trknmb" with 2 for 2nd LCT in the same chamber. - AWB 24.05.17

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -72,7 +72,7 @@ namespace l1t {
                     theta);
   }
 
-  CSCCorrelatedLCTDigi EMTFHit::CreateCSCCorrelatedLCTDigi() const {
+  CSCCorrelatedLCTDigi EMTFHit::CreateCSCCorrelatedLCTDigi(const bool isRun3) const {
     CSCCorrelatedLCTDigi lct = CSCCorrelatedLCTDigi(1,
                                                     valid,
                                                     quality,
@@ -85,13 +85,14 @@ namespace l1t {
                                                     0,
                                                     sync_err,
                                                     csc_ID);
-    bool quart_bit = strip_quart_bit == 1 ? true : false;
-    bool eighth_bit = strip_eighth_bit == 1 ? true : false;
+    bool quart_bit = strip_quart_bit == 1;
+    bool eighth_bit = strip_eighth_bit == 1;
 
     lct.setQuartStripBit(quart_bit);
     lct.setEighthStripBit(eighth_bit);
     lct.setSlope(slope);
     lct.setRun3Pattern(pattern_run3);
+    lct.setRun3(isRun3);
 
     return lct;
     // Added Run 3 parameters - EY 04.07.22

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -244,6 +244,9 @@ namespace l1t {
         bool isOTMB = (Hit_.Ring() == 1 or
                        Hit_.Ring() == 4);  // Data format is different between OTMBs (MEX/1) and TMBs (MEX/2-3)
 
+        bool isRun3 =
+            isOTMB and run3_DAQ_format;  // in Run3 DAQ format, OTMB TPs are Run 3 CSC TPs with CCLUT algorithm
+
         if (run3_DAQ_format) {
           ME_.set_quality(GetHexBits(MEa, 4, 6));
           ME_.set_quarter_strip(GetHexBits(MEa, 7, 7));
@@ -337,7 +340,7 @@ namespace l1t {
           res_hit->push_back(Hit_);
         if (!exact_duplicate && !neighbor_duplicate &&
             Hit_.Valid() == 1)  // Don't write duplicate LCTs from adjacent sectors
-          res_LCT->insertDigi(Hit_.CSC_DetId(), Hit_.CreateCSCCorrelatedLCTDigi());
+          res_LCT->insertDigi(Hit_.CSC_DetId(), Hit_.CreateCSCCorrelatedLCTDigi(isRun3));
         if (ME_.HMV() == 1) {  // Only write when HMT valid bit is set to 1
           res_shower->insertDigi(Hit_.CSC_DetId(), Shower_);
         }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -181,6 +181,11 @@ namespace l1t {
         // Unpack the ME Data Record
         ////////////////////////////
 
+        // Run 3 has a different EMTF DAQ output format
+        // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
+        bool run3_DAQ_format = (getAlgoVersion() >= 11460); // Firmware from 04.06.22 which enabled new Run 3 DAQ format - EY 04.07.22
+
+        // Set fields assuming Run 2 format. Modify for Run 3 later
         ME_.set_clct_pattern(GetHexBits(MEa, 0, 3));
         ME_.set_quality(GetHexBits(MEa, 4, 7));
         ME_.set_wire(GetHexBits(MEa, 8, 14));
@@ -219,6 +224,7 @@ namespace l1t {
         Hit_.set_sector(conv_vals.at(2));
         Hit_.set_subsector(conv_vals.at(3));
         Hit_.set_neighbor(conv_vals.at(4));
+        Hit_.set_ring(L1TMuonEndCap::calc_ring(Hit_.Station(), Hit_.CSC_ID(), ME_.Strip()));
 
         if (Hit_.Station() < 1 || Hit_.Station() > 4)
           edm::LogWarning("L1T|EMTF") << "EMTF unpacked LCT station = " << Hit_.Station()
@@ -229,6 +235,60 @@ namespace l1t {
         if (Hit_.Sector() < 1 || Hit_.Sector() > 6)
           edm::LogWarning("L1T|EMTF") << "EMTF unpacked LCT sector = " << Hit_.Sector()
                                       << ", outside proper [1, 6] range" << std::endl;
+
+        // Modifications for Run 3 format - EY 04.07.22
+        bool isOTMB = (Hit_.Ring() == 1 or Hit_.Ring() == 4); // Data format is different between OTMBs (MEX/1) and TMBs (MEX/2-3)
+
+        if (run3_DAQ_format){
+          if (isOTMB){
+            ME_.set_quality(GetHexBits(MEa, 4, 6));
+            ME_.set_quarter_strip(GetHexBits(MEa,7,7));
+
+            ME_.set_frame(GetHexBits(MEc, 12, 12));
+
+            ME_.set_slope(GetHexBits(MEd, 8, 11));
+            ME_.set_eighth_strip(GetHexBits(MEd, 13, 13));
+
+            // convert Run-3 slope to Run-2 pattern for CSC TPs coming from MEX/1 chambers
+            // where the CCLUT algorithm is enabled
+            const unsigned slopeList[32] = {10, 10, 10, 8, 8, 8, 6, 6, 6, 4, 4, 4, 2, 2, 2, 2,
+                                            10, 10, 10, 9, 9, 9, 7, 7, 7, 5, 5, 5, 3, 3, 3, 3};
+
+            // this LUT follows the same convention as in CSCPatternBank.cc
+            unsigned slope_and_sign(ME_.Slope());
+            if (ME_.LR() == 1) {
+              slope_and_sign += 16;
+            }
+            unsigned run2_converted_PID = slopeList[slope_and_sign];
+
+            ME_.set_clct_pattern(run2_converted_PID);
+
+            // Frame 1 has HMT related information
+            if (ME_.Frame() == 0){
+              ME_.set_run3_pattern(GetHexBits(MEa, 0, 3));
+
+              ME_.set_bxe(GetHexBits(MEb, 13, 13));
+
+              ME_.set_af(GetHexBits(MEd, 7, 7));
+            } else {
+              ME_.set_run3_pattern(GetHexBits(MEa, 0, 0));
+              ME_.set_hmt_inTime(GetHexBits(MEb, 13, 13, MEa, 1, 1)); // HMT[1] is in MEa, but HMT[0] is in MEb. These encode in time showers - EY 04.07.22
+              ME_.set_hmt_outOfTime(GetHexBits(MEa, 2, 3)); // HMT[3:2] encodes out-of-time showers which are not used for now
+
+              ME_.set_hmv(GetHexBits(MEd, 7, 7));
+            }
+          } else {
+            ME_.set_run3_pattern(GetHexBits(MEa, 0, 3));
+            ME_.set_quality(GetHexBits(MEa, 4, 7));
+
+            ME_.set_bxe(GetHexBits(MEb, 13, 13));
+
+            ME_.set_nit(GetHexBits(MEc, 12, 12));
+
+            ME_.set_clct_pattern(GetHexBits(MEd, 8, 11));
+            ME_.set_se(GetHexBits(MEd, 13, 13));
+          }
+        }
 
         // Fill the EMTFHit
         ImportME(Hit_, ME_, (res->at(iOut)).PtrEventHeader()->Endcap(), (res->at(iOut)).PtrEventHeader()->Sector());
@@ -263,9 +323,9 @@ namespace l1t {
                                       << std::endl;
 
         (res->at(iOut)).push_ME(ME_);
-        if (!exact_duplicate)
+        if (!exact_duplicate && Hit_.Valid() == 1)
           res_hit->push_back(Hit_);
-        if (!exact_duplicate && !neighbor_duplicate)  // Don't write duplicate LCTs from adjacent sectors
+        if (!exact_duplicate && !neighbor_duplicate && Hit_.Valid() == 1)  // Don't write duplicate LCTs from adjacent sectors
           res_LCT->insertDigi(Hit_.CSC_DetId(), Hit_.CreateCSCCorrelatedLCTDigi());
 
         // Finished with unpacking one ME Data Record

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockME.cc
@@ -183,7 +183,8 @@ namespace l1t {
 
         // Run 3 has a different EMTF DAQ output format
         // Computed as (Year - 2000)*2^9 + Month*2^5 + Day (see Block.cc and EMTFBlockTrailers.cc)
-        bool run3_DAQ_format = (getAlgoVersion() >= 11460); // Firmware from 04.06.22 which enabled new Run 3 DAQ format - EY 04.07.22
+        bool run3_DAQ_format =
+            (getAlgoVersion() >= 11460);  // Firmware from 04.06.22 which enabled new Run 3 DAQ format - EY 04.07.22
 
         // Set fields assuming Run 2 format. Modify for Run 3 later
         ME_.set_clct_pattern(GetHexBits(MEa, 0, 3));
@@ -237,12 +238,13 @@ namespace l1t {
                                       << ", outside proper [1, 6] range" << std::endl;
 
         // Modifications for Run 3 format - EY 04.07.22
-        bool isOTMB = (Hit_.Ring() == 1 or Hit_.Ring() == 4); // Data format is different between OTMBs (MEX/1) and TMBs (MEX/2-3)
+        bool isOTMB = (Hit_.Ring() == 1 or
+                       Hit_.Ring() == 4);  // Data format is different between OTMBs (MEX/1) and TMBs (MEX/2-3)
 
-        if (run3_DAQ_format){
-          if (isOTMB){
+        if (run3_DAQ_format) {
+          if (isOTMB) {
             ME_.set_quality(GetHexBits(MEa, 4, 6));
-            ME_.set_quarter_strip(GetHexBits(MEa,7,7));
+            ME_.set_quarter_strip(GetHexBits(MEa, 7, 7));
 
             ME_.set_frame(GetHexBits(MEc, 12, 12));
 
@@ -264,7 +266,7 @@ namespace l1t {
             ME_.set_clct_pattern(run2_converted_PID);
 
             // Frame 1 has HMT related information
-            if (ME_.Frame() == 0){
+            if (ME_.Frame() == 0) {
               ME_.set_run3_pattern(GetHexBits(MEa, 0, 3));
 
               ME_.set_bxe(GetHexBits(MEb, 13, 13));
@@ -272,8 +274,15 @@ namespace l1t {
               ME_.set_af(GetHexBits(MEd, 7, 7));
             } else {
               ME_.set_run3_pattern(GetHexBits(MEa, 0, 0));
-              ME_.set_hmt_inTime(GetHexBits(MEb, 13, 13, MEa, 1, 1)); // HMT[1] is in MEa, but HMT[0] is in MEb. These encode in time showers - EY 04.07.22
-              ME_.set_hmt_outOfTime(GetHexBits(MEa, 2, 3)); // HMT[3:2] encodes out-of-time showers which are not used for now
+              ME_.set_hmt_inTime(
+                  GetHexBits(MEb,
+                             13,
+                             13,
+                             MEa,
+                             1,
+                             1));  // HMT[1] is in MEa, but HMT[0] is in MEb. These encode in time showers - EY 04.07.22
+              ME_.set_hmt_outOfTime(
+                  GetHexBits(MEa, 2, 3));  // HMT[3:2] encodes out-of-time showers which are not used for now
 
               ME_.set_hmv(GetHexBits(MEd, 7, 7));
             }
@@ -325,7 +334,8 @@ namespace l1t {
         (res->at(iOut)).push_ME(ME_);
         if (!exact_duplicate && Hit_.Valid() == 1)
           res_hit->push_back(Hit_);
-        if (!exact_duplicate && !neighbor_duplicate && Hit_.Valid() == 1)  // Don't write duplicate LCTs from adjacent sectors
+        if (!exact_duplicate && !neighbor_duplicate &&
+            Hit_.Valid() == 1)  // Don't write duplicate LCTs from adjacent sectors
           res_LCT->insertDigi(Hit_.CSC_DetId(), Hit_.CreateCSCCorrelatedLCTDigi());
 
         // Finished with unpacking one ME Data Record

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFBlockSP.cc
@@ -180,7 +180,7 @@ namespace l1t {
         bool useNNBits_ = getAlgoVersion() >= 11098;   // FW versions >= 26.10.2021
         bool useHMTBits_ = getAlgoVersion() >= 11306;  // FW versions >= 10.01.2022
 
-        static constexpr int nominalShower_ = 2;
+        static constexpr int nominalShower_ = 1;
         static constexpr int tightShower_ = 3;
 
         // Check Format of Payload

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.cc
@@ -44,6 +44,7 @@ namespace l1t {
       event_.put(std::move(EMTFHits_ZS_));
       event_.put(std::move(EMTFTracks_));
       event_.put(std::move(EMTFLCTs_));
+      event_.put(std::move(EMTFCSCShowers_));
       event_.put(std::move(EMTFCPPFs_ZS_));
       event_.put(std::move(EMTFGEMPadClusters_));
       // event_.put(std::move(EMTFGEMPadClusters_ZS_));

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFCollections.h
@@ -12,6 +12,7 @@
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
 #include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 
 #include "EventFilter/L1TRawToDigi/interface/UnpackerCollections.h"
@@ -34,6 +35,7 @@ namespace l1t {
             EMTFHits_ZS_(new EMTFHitCollection()),
             EMTFTracks_(new EMTFTrackCollection()),
             EMTFLCTs_(new CSCCorrelatedLCTDigiCollection()),
+            EMTFCSCShowers_(new CSCShowerDigiCollection()),
             EMTFCPPFs_(new CPPFDigiCollection()),
             EMTFCPPFs_ZS_(new CPPFDigiCollection()),
             EMTFGEMPadClusters_(std::make_unique<GEMPadDigiClusterCollection>()),
@@ -48,6 +50,7 @@ namespace l1t {
       inline EMTFHitCollection* getEMTFHits_ZS() { return EMTFHits_ZS_.get(); }
       inline EMTFTrackCollection* getEMTFTracks() { return EMTFTracks_.get(); }
       inline CSCCorrelatedLCTDigiCollection* getEMTFLCTs() { return EMTFLCTs_.get(); }
+      inline CSCShowerDigiCollection* getEMTFCSCShowers() { return EMTFCSCShowers_.get(); }
       inline CPPFDigiCollection* getEMTFCPPFs() { return EMTFCPPFs_.get(); }
       inline CPPFDigiCollection* getEMTFCPPFs_ZS() { return EMTFCPPFs_ZS_.get(); }
       inline GEMPadDigiClusterCollection* getEMTFGEMPadClusters() { return EMTFGEMPadClusters_.get(); }
@@ -61,6 +64,7 @@ namespace l1t {
       std::unique_ptr<EMTFHitCollection> EMTFHits_ZS_;
       std::unique_ptr<EMTFTrackCollection> EMTFTracks_;
       std::unique_ptr<CSCCorrelatedLCTDigiCollection> EMTFLCTs_;
+      std::unique_ptr<CSCShowerDigiCollection> EMTFCSCShowers_;
       std::unique_ptr<CPPFDigiCollection> EMTFCPPFs_;
       std::unique_ptr<CPPFDigiCollection> EMTFCPPFs_ZS_;
       std::unique_ptr<GEMPadDigiClusterCollection> EMTFGEMPadClusters_;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFSetup.cc
@@ -41,6 +41,7 @@ namespace l1t {
       prod.produces<EMTFHitCollection>();
       prod.produces<EMTFTrackCollection>();
       prod.produces<CSCCorrelatedLCTDigiCollection>();
+      prod.produces<CSCShowerDigiCollection>();
       prod.produces<CPPFDigiCollection>();
       prod.produces<GEMPadDigiClusterCollection>();
     }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.cc
@@ -15,6 +15,7 @@ namespace l1t {
       EMTFHitToken_ = cc.consumes<EMTFHitCollection>(tag);
       EMTFTrackToken_ = cc.consumes<EMTFTrackCollection>(tag);
       EMTFLCTToken_ = cc.consumes<CSCCorrelatedLCTDigiCollection>(tag);
+      EMTFCSCShowerToken_ = cc.consumes<CSCShowerDigiCollection>(tag);
       EMTFCPPFToken_ = cc.consumes<CPPFDigiCollection>(tag);
       EMTFGEMPadClusterToken_ = cc.consumes<GEMPadDigiClusterCollection>(tag);
     }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFTokens.h
@@ -8,6 +8,7 @@
 #include "DataFormats/L1TMuon/interface/EMTFTrack.h"
 #include "DataFormats/L1TMuon/interface/CPPFDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCShowerDigiCollection.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiClusterCollection.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "EventFilter/L1TRawToDigi/interface/PackerTokens.h"
@@ -28,6 +29,9 @@ namespace l1t {
       inline const edm::EDGetTokenT<EMTFHitCollection>& getEMTFHitToken() const { return EMTFHitToken_; }
       inline const edm::EDGetTokenT<EMTFTrackCollection>& getEMTFTrackToken() const { return EMTFTrackToken_; }
       inline const edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection>& getEMTFLCTToken() const { return EMTFLCTToken_; }
+      inline const edm::EDGetTokenT<CSCShowerDigiCollection>& getEMTFCSCShowerToken() const {
+        return EMTFCSCShowerToken_;
+      }
       inline const edm::EDGetTokenT<CPPFDigiCollection>& getEMTFCPPFToken() const { return EMTFCPPFToken_; }
       inline const edm::EDGetTokenT<GEMPadDigiClusterCollection>& getEMTFGEMPadClusterToken() const {
         return EMTFGEMPadClusterToken_;
@@ -40,6 +44,7 @@ namespace l1t {
       edm::EDGetTokenT<EMTFHitCollection> EMTFHitToken_;
       edm::EDGetTokenT<EMTFTrackCollection> EMTFTrackToken_;
       edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> EMTFLCTToken_;
+      edm::EDGetTokenT<CSCShowerDigiCollection> EMTFCSCShowerToken_;
       edm::EDGetTokenT<CPPFDigiCollection> EMTFCPPFToken_;
       edm::EDGetTokenT<GEMPadDigiClusterCollection> EMTFGEMPadClusterToken_;
     };

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
@@ -21,6 +21,12 @@ namespace l1t {
         _hit.set_subsystem(l1tmu::kCSC);
         // _hit.set_layer();
 
+        // Run 3 OTMB
+        _hit.set_strip_quart_bit(_ME.Quarter_strip());
+        _hit.set_strip_eighth_bit(_ME.Eighth_strip());
+        _hit.set_slope(_ME.Slope());
+        _hit.set_pattern_run3(_ME.Run3_pattern());
+
         _hit.set_ring(L1TMuonEndCap::calc_ring(_hit.Station(), _hit.CSC_ID(), _hit.Strip()));
         _hit.set_chamber(
             L1TMuonEndCap::calc_chamber(_hit.Station(), _hit.Sector(), _hit.Subsector(), _hit.Ring(), _hit.CSC_ID()));

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -176,7 +176,7 @@ void PrimitiveConversion::convert_csc(int pc_sector,
 
     // this LUT follows the same convention as in CSCPatternBank.cc
     unsigned slope_and_sign(tp_data.slope);
-    if (tp_data.bend == 0) {
+    if (tp_data.bend == 1) {
       slope_and_sign += 16;
     }
     unsigned run2_converted_PID = slopeList[slope_and_sign];


### PR DESCRIPTION
#### PR description:

This PR mainly contains the updates to the EMTF unpacker for CSC inputs. In June we discovered that EMTF DAQ output did not contain all the relevant information for Run 3 CSC TPs. Now that they are added in firmware and tested at P5, we want to update the CMSSW unpacker with these changes.

Bulk of the changes are in `EMTFBlockME.cc` and `ME.h` data format. There is a small bug fix in EMTF emulator `PrimitiveConversion.cc` and one in `EMTFBlockSP.cc`. 

Details of the changes:

- Added new fields in `ME.h` for Run 3 CSC TP data format. These are the variables related to the CCLUT algorithm and the HMT related variables.
- Modified `EMTFBlockME.cc` to match the new EMTF DAQ output format. In Run 3, EMTF receives different types of CSC TPs depending on the ring. So, the meanings of some fields in EMTF DAQ is different in ring == 1 vs ring == 2 & 3.
- Modified `EMTFBlockME.cc` to produce `CSCShowerDigiCollection` based on HMT related bits in the new DAQ format.
- Added `Hit_.Valid() == 1` check to `EMTFBlockME.cc`. This check will become necessary when EMTF start receiving valid HMTs without valid LCTs (Currently they always come with valid LCTs). 
- Fixed the definition of nominal shower bit in `EMTFBlockSP.c`.
- Fixed a bug in `PrimitiveConversion.cc` related to the Run 3 CSC TP pattern calculation. Since the Run 3 TPs were not enabled before, this wasn't caught earlier.
- Modified `EMTFUnpackerTools.cc` and `EMTFHit.cc` to assign the new Run 3 parameters to the `EMTFHit` class and  `CSCCorrelatedLCTDigi` made by EMTFHit class.
- Rest of the modifications in `L1TRawToDigi` are related to producing `CSCShowerDigiCollection` in `EMTFBlockME.cc`

We expect some changes in the EMTF emulator behaviour in unpacked data from P5 and also when [PR](https://github.com/cms-sw/cmssw/pull/38373) gets merged to enable Run 3 CSC TPs in EMTF.   

This PR is necessary to have good data/emulator agreement for EMTF during data taking. So, it needs to be backported to 12_4_X (not super urgent, but the sooner the better)

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

Validated by doing data/emulator comparisons in private repository which shows 100% agreement.

Also validated by `runTheMatrix.py -l limited -i all --ibeos` none of the tests failed.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This is the backport of https://github.com/cms-sw/cmssw/pull/38615. The changes in this PR are required to have good data/emulator agreement during data taking.

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
