### PR TITLE
[12_3_X] Switch off BTVHLTOfflineSource temporarily

### DIFF
--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -186,8 +186,9 @@ offlineHLTSource4HLTMonitorPD = cms.Sequence(
     lumiMonitorHLTsequence *          # lumi
     sistripMonitorHLTsequence *       # strip
     sipixelMonitorHLTsequence *       # pixel
-    BTVHLTOfflineSource *             # BTV
-    bTagHLTTrackMonitoringSequence *  # BTV relative track efficeicies
+#   Temp switch off until BTV finds a permanant fix
+#   BTVHLTOfflineSource *             # BTV
+#   bTagHLTTrackMonitoringSequence *  # BTV relative track efficeicies
     trackingMonitorHLT *              # tracking
     trackingMonitorHLTDisplacedJet*   # EXO : DisplacedJet Tracking 
     egmTrackingMonitorHLT *           # EGM tracking


### PR DESCRIPTION
PR description:
Resolves https://github.com/cms-sw/cmssw/issues/38626 as suggested by @jfernan2 (thanks Javi)
Temporarily fix until BTV provides a better solution

PR validation:
Running on faulty express files is fine now

If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport for 12_3_X of https://github.com/cms-sw/cmssw/pull/38628