### PR TITLE
Replace Geometry_cff with GeometryDB_cff in RecoParticleFlow

### DIFF
--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_Data_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_Data_cfg.py
@@ -7,7 +7,7 @@ process = cms.Process("REPROD")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.StandardSequences.GeometryDB_cff")
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 # Global tag
 from Configuration.AlCa.autoCond import autoCond
@@ -43,7 +43,7 @@ process.maxEvents = cms.untracked.PSet(
 
 # This is for filtering on L1 technical trigger bit: MB and no beam halo
 process.load('L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff')
-process.load('HLTrigger/HLTfilters/hltLevel1GTSeed_cfi')
+process.load('HLTrigger.HLTfilters.hltLevel1GTSeed_cfi')
 process.hltLevel1GTSeed.L1TechTriggerSeeding = cms.bool(True)
 process.hltLevel1GTSeed.L1SeedsLogicalExpression = cms.string('(0 AND (36 OR 37 OR 38 OR 39))')
 
@@ -54,7 +54,7 @@ process.scrapping = cms.EDFilter("FilterOutScraping",
                                 thresh = cms.untracked.double(0.25)
                                 )
 
-process.load('CommonTools/RecoAlgos/HBHENoiseFilter_cfi')
+process.load('CommonTools.RecoAlgos.HBHENoiseFilter_cfi')
 
 process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 

--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_NoTracking_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_NoTracking_cfg.py
@@ -5,12 +5,11 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 #process.load("Configuration.StandardSequences.MagneticField_4T_cff")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 #from Configuration.AlCa.autoCond import autoCond
 #process.GlobalTag.globaltag = autoCond['mc']
 from Configuration.AlCa.autoCond import autoCond 
-process.GlobalTag.globaltag = cms.string( autoCond[ 'startup' ] )
-#process.GlobalTag.globaltag = 'START50_V10::All'
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 
 #process.Timing =cms.Service("Timing")
 process.maxEvents = cms.untracked.PSet(

--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_batch_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_batch_cfg.py
@@ -11,10 +11,9 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 #process.load("Configuration.StandardSequences.MagneticField_4T_cff")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['startup']
-#process.GlobalTag.globaltag = 'START50_V10::All'
+process.GlobalTag.globaltag = autoCond['phase1_2022_realistic']
 
 #process.Timing =cms.Service("Timing")
 process.maxEvents = cms.untracked.PSet(

--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_cfg.py
@@ -5,11 +5,10 @@ process = cms.Process("REPROD")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 #process.load("Configuration.StandardSequences.MagneticField_4T_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['startup']
-#process.GlobalTag.globaltag = 'START50_V10::All'
+process.GlobalTag.globaltag = autoCond['phase1_2022_realistic']
 
 #process.Timing =cms.Service("Timing")
 process.maxEvents = cms.untracked.PSet(

--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_egnew_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_egnew_cfg.py
@@ -4,11 +4,10 @@ process = cms.Process("REPROD")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 #process.load("Configuration.StandardSequences.MagneticField_4T_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['startup']
-#process.GlobalTag.globaltag = 'START50_V10::All'
+process.GlobalTag.globaltag = autoCond['phase1_2022_realistic']
 
 #process.Timing =cms.Service("Timing")
 process.maxEvents = cms.untracked.PSet(

--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_usePFSC_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_usePFSC_cfg.py
@@ -4,11 +4,10 @@ process = cms.Process("REPROD")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 #process.load("Configuration.StandardSequences.MagneticField_4T_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['startup']
-#process.GlobalTag.globaltag = 'START50_V10::All'
+process.GlobalTag.globaltag = autoCond['phase1_2022_realistic']
 
 #process.Timing =cms.Service("Timing")
 process.maxEvents = cms.untracked.PSet(

--- a/RecoParticleFlow/PFClusterProducer/test/clustering_cfg.py
+++ b/RecoParticleFlow/PFClusterProducer/test/clustering_cfg.py
@@ -5,10 +5,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PFC")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['startup']
+process.GlobalTag.globaltag = autoCond['phase1_2022_realistic']
 
 
 process.source = cms.Source("PoolSource", 


### PR DESCRIPTION
**PR description:**
Review on the Reco part of https://github.com/cms-sw/cmssw/issues/31113

`process.load("Configuration.StandardSequences.Geometry_cff")`
 was outdated https://github.com/cms-sw/cmssw/pull/8810 
It should be replaced with
`process.load("Configuration.StandardSequences.GeometryDB_cff")`

In this PR, RecoParticleFlow configuration files (7 files) are fixed.
```
        modified:   RecoParticleFlow/Configuration/test/RecoToDisplay_Data_cfg.py
        modified:   RecoParticleFlow/Configuration/test/RecoToDisplay_NoTracking_cfg.py
        modified:   RecoParticleFlow/Configuration/test/RecoToDisplay_batch_cfg.py
        modified:   RecoParticleFlow/Configuration/test/RecoToDisplay_cfg.py
        modified:   RecoParticleFlow/Configuration/test/RecoToDisplay_egnew_cfg.py
        modified:   RecoParticleFlow/Configuration/test/RecoToDisplay_usePFSC_cfg.py
        modified:   RecoParticleFlow/PFClusterProducer/test/clustering_cfg.py
```
#### PR validation:
Tested in CMSSW_12_5_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
