### PR TITLE
[12_4_X] Fix issue with BTV HLT OfflineDQM

### DIFF
--- a/DQMOffline/Trigger/plugins/BTVHLTOfflineSource.cc
+++ b/DQMOffline/Trigger/plugins/BTVHLTOfflineSource.cc
@@ -661,11 +661,14 @@ std::vector<const reco::Track*> BTVHLTOfflineSource::getOnlineBTagTracks(float h
 
     unsigned int trackSize = ipInfo.selectedTracks().size();
     for (unsigned int itt = 0; itt < trackSize; ++itt) {
-      const auto ptrackRef = (ipInfo.selectedTracks()[itt]);  //TrackRef or
-      const reco::Track* ptrackPtr = reco::btag::toTrack(ptrackRef);
-      onlineTracks.push_back(ptrackPtr);
-      onlineIP3D.push_back(ip[itt].ip3d.value());
-      onlineIP3DSig.push_back(ip[itt].ip3d.significance());
+      const auto ptrackRef = (ipInfo.selectedTracks()[itt]);
+
+      if (ptrackRef.isAvailable()) {
+        const reco::Track* ptrackPtr = reco::btag::toTrack(ptrackRef);
+        onlineTracks.push_back(ptrackPtr);
+        onlineIP3D.push_back(ip[itt].ip3d.value());
+        onlineIP3DSig.push_back(ip[itt].ip3d.significance());
+      }
     }
   }
   return onlineTracks;


### PR DESCRIPTION
#### PR description:
resolve issue (#38626) with BTV HLT OfflineDQM on Run3 data

#### PR validation:

`runTheMatrix.py -l limited -i all`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported 

12_4_X backport of #38635