### PR TITLE
Enable CSC shower data/emulator DQM comparison

### DIFF
--- a/DQM/L1TMonitor/python/L1TdeCSCTPGShower_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeCSCTPGShower_cfi.py
@@ -9,11 +9,11 @@ l1tdeCSCTPGShower = DQMEDAnalyzer(
     # something like cms.InputTag("muonCSCDigis", "MuonCSCShowerDigiAnode") for Anode shower,
     # and something like cms.InputTag("muonCSCDigis", "MuonCSCShowerDigiCathode") for Cathode shower
     # - 2021.12.06 Xunwu Zuo
-    dataALCTShower = cms.InputTag("valCscStage2Digis", "Anode"),
+    dataALCTShower = cms.InputTag("muonCSCDigis", "MuonCSCShowerDigiAnode"),
     emulALCTShower = cms.InputTag("valCscStage2Digis", "Anode"),
-    dataCLCTShower = cms.InputTag("valCscStage2Digis", "Cathode"),
+    dataCLCTShower = cms.InputTag("muonCSCDigis", "MuonCSCShowerDigiCathode"),
     emulCLCTShower = cms.InputTag("valCscStage2Digis", "Cathode"),
-    dataLCTShower = cms.InputTag("valCscStage2Digis"),
+    dataLCTShower = cms.InputTag("muonCSCDigis","MuonCSCShowerDigi"),
     emulLCTShower = cms.InputTag("valCscStage2Digis"),
     monitorDir = cms.untracked.string("L1TEMU/L1TdeCSCTPGShower"),
 )


### PR DESCRIPTION
#### PR description:

To enable data/emulator comparison for online DQM, since HMT FW has been deployed at P5.
#### PR validation:

Ran with run3 cosmic data run351405, plots created is here:
https://cernbox.cern.ch/index.php/s/XmGJ33A1N2BxwGh

Efficiency is 0 because of an additional check on csc id of the shower digi that is not filled by the unpacker. 
This will be followed up by another PR. 