### PR TITLE
Added protection from multiple creation of geometry

### DIFF
--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -102,6 +102,7 @@ private:
   const std::string recordName_;
   std::unique_ptr<TF1> f1;
   float width_;
+  float theMagField;
 
   SiPixelLorentzAngleCalibrationHistograms hists;
   const SiPixelLorentzAngle* currentLorentzAngle;
@@ -135,6 +136,10 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
 
   magField = &iSetup.getData(magneticFieldToken_);
   currentLorentzAngle = &iSetup.getData(siPixelLAEsToken_);
+
+  // B-field value
+  // nominalValue returns the magnetic field value in kgauss (1T = 10 kgauss)
+  theMagField = magField->nominalValue() / 10.;
 
   PixelTopologyMap map = PixelTopologyMap(geom, tTopo);
   hists.nlay = geom->numberOfLayers(PixelSubdetector::PixelBarrel);
@@ -579,10 +584,6 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
     std::shared_ptr<SiPixelLorentzAngle> theLAPayload, int i_index, int i_layer, int i_module) {
   // output results
   SiPixelLAHarvest::fitResults res;
-
-  // B-field value
-  // nominalValue returns the magnetic field value in kgauss (1T = 10 kgauss)
-  float theMagField = magField->nominalValue() / 10.;
 
   double half_width = width_ * 10000 / 2;  // pixel half thickness in units of micro meter
 

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -102,11 +102,10 @@ private:
   const std::string recordName_;
   std::unique_ptr<TF1> f1;
   float width_;
-  float theMagField{0.f};
+  float theMagField_{0.f};
 
   SiPixelLorentzAngleCalibrationHistograms hists;
   const SiPixelLorentzAngle* currentLorentzAngle;
-  const MagneticField* magField;
   std::unique_ptr<TrackerTopology> theTrackerTopology;
 };
 
@@ -134,12 +133,12 @@ void SiPixelLorentzAnglePCLHarvester::beginRun(const edm::Run& iRun, const edm::
   const TrackerGeometry* geom = &iSetup.getData(geomEsToken_);
   const TrackerTopology* tTopo = &iSetup.getData(topoEsTokenBR_);
 
-  magField = &iSetup.getData(magneticFieldToken_);
+  const MagneticField* magField = &iSetup.getData(magneticFieldToken_);
   currentLorentzAngle = &iSetup.getData(siPixelLAEsToken_);
 
   // B-field value
   // nominalValue returns the magnetic field value in kgauss (1T = 10 kgauss)
-  theMagField = magField->nominalValue() / 10.;
+  theMagField_ = magField->nominalValue() / 10.;
 
   PixelTopologyMap map = PixelTopologyMap(geom, tTopo);
   hists.nlay = geom->numberOfLayers(PixelSubdetector::PixelBarrel);
@@ -641,8 +640,8 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
        pow((half_width * half_width * half_width * half_width * res.e5), 2));  // Propagation of uncertainty
   res.error_LA = sqrt(errsq_LA);
 
-  hists.h_bySectMeasLA_->setBinContent(i_index, (res.tan_LA / theMagField));
-  hists.h_bySectMeasLA_->setBinError(i_index, (res.error_LA / theMagField));
+  hists.h_bySectMeasLA_->setBinContent(i_index, (res.tan_LA / theMagField_));
+  hists.h_bySectMeasLA_->setBinError(i_index, (res.error_LA / theMagField_));
   hists.h_bySectChi2_->setBinContent(i_index, res.redChi2);
   hists.h_bySectChi2_->setBinError(i_index, 0.);  // no errors
 
@@ -673,7 +672,7 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
   float currentLA = currentLorentzAngle->getLorentzAngle(detIdsToFill.front());
   // if the fit quality is OK
   if ((res.redChi2 != 0.) && (res.redChi2 < fitChi2Cut_) && (nentries > minHitsCut_)) {
-    LorentzAnglePerTesla_ = res.tan_LA / theMagField;
+    LorentzAnglePerTesla_ = res.tan_LA / theMagField_;
     // fill the LA actually written to payload
     hists.h_bySectSetLA_->setBinContent(i_index, LorentzAnglePerTesla_);
     hists.h_bySectRejectLA_->setBinContent(i_index, 0.);
@@ -691,7 +690,7 @@ SiPixelLAHarvest::fitResults SiPixelLorentzAnglePCLHarvester::fitAndStore(
   } else {
     // just copy the values from the existing payload
     hists.h_bySectSetLA_->setBinContent(i_index, 0.);
-    hists.h_bySectRejectLA_->setBinContent(i_index, (res.tan_LA / theMagField));
+    hists.h_bySectRejectLA_->setBinContent(i_index, (res.tan_LA / theMagField_));
     hists.h_bySectLA_->setBinContent(i_index, currentLA);
     hists.h_bySectDeltaLA_->setBinContent(i_index, 0.);
 

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAnglePCLHarvester.cc
@@ -102,7 +102,7 @@ private:
   const std::string recordName_;
   std::unique_ptr<TF1> f1;
   float width_;
-  float theMagField;
+  float theMagField{0.f};
 
   SiPixelLorentzAngleCalibrationHistograms hists;
   const SiPixelLorentzAngle* currentLorentzAngle;

--- a/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducerFromDB.cc
+++ b/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducerFromDB.cc
@@ -50,6 +50,7 @@ namespace magneticfield {
   class DD4hep_VolumeBasedMagneticFieldESProducerFromDB : public edm::ESProducer {
   public:
     DD4hep_VolumeBasedMagneticFieldESProducerFromDB(const edm::ParameterSet& iConfig);
+    ~DD4hep_VolumeBasedMagneticFieldESProducerFromDB() override;
     // forbid copy ctor and assignment op.
     DD4hep_VolumeBasedMagneticFieldESProducerFromDB(const DD4hep_VolumeBasedMagneticFieldESProducerFromDB&) = delete;
     const DD4hep_VolumeBasedMagneticFieldESProducerFromDB& operator=(
@@ -130,6 +131,10 @@ DD4hep_VolumeBasedMagneticFieldESProducerFromDB::DD4hep_VolumeBasedMagneticField
       },
       edm::ESProductTag<MagFieldConfig, IdealMagneticFieldRecord>(myConfigTag));
   chosenConfigToken_ = cc.consumes(myConfigTag);  //Use same tag as the choice
+}
+
+DD4hep_VolumeBasedMagneticFieldESProducerFromDB::~DD4hep_VolumeBasedMagneticFieldESProducerFromDB() {
+  delete detector_;
 }
 
 std::shared_ptr<MagFieldConfig const> DD4hep_VolumeBasedMagneticFieldESProducerFromDB::chooseConfigAtRuntime(

--- a/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducerFromDB.cc
+++ b/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducerFromDB.cc
@@ -73,6 +73,8 @@ namespace magneticfield {
     edm::ESGetToken<MagFieldConfig, IdealMagneticFieldRecord> chosenConfigToken_;
 
     edm::ESGetToken<FileBlob, MFGeometryFileRcd> mayConsumeBlobToken_;
+    cms::DDDetector* detector_{nullptr};
+
     const bool debug_;
     const bool useMergeFileIfAvailable_;
   };
@@ -187,9 +189,10 @@ std::unique_ptr<MagneticField> DD4hep_VolumeBasedMagneticFieldESProducerFromDB::
       "<MaterialSection label=\"materials.xml\"><ElementaryMaterial name=\"materials:Vacuum\" density=\"1e-13*mg/cm3\" "
       "symbol=\" \" atomicWeight=\"1*g/mole\" atomicNumber=\"1\"/></MaterialSection>");
 
-  auto ddet = make_unique<cms::DDDetector>("cmsMagneticField:MAGF", sblob, true);
+  if (nullptr == detector_)
+    detector_ = new cms::DDDetector("cmsMagneticField:MAGF", sblob, true);
 
-  builder.build(ddet.get());
+  builder.build(detector_);
 
   // Build the VB map. Ownership of the parametrization is transferred to it
   return std::make_unique<VolumeBasedMagneticField>(conf->geometryVersion,


### PR DESCRIPTION
#### PR description:
There are the crash discussed in #38624, which happens for alca run. The problem happens because in this run geometry was created twice. The fix is done in two places: 
1) inside SiPixelLorentzAnglePCLHarvester value of the magnetic field is accessed just after access to the EventSetup and stored in local class member. Likely this change has no effect but logically is more safe.
2) inside DD4hep_VolumeBasedMagneticFieldESProducerFromDB  a new class member added - pointer to geometry. Added a check, which guaranteed that the geometry is created only once. 

#### PR validation:

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:  

should be also in 12_3 and 12_4

