### PR TITLE
[12.4.X] update `PrimaryVertexMonitor` for Run-3 data-taking 

### DIFF
--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -39,6 +39,10 @@ PrimaryVertexMonitor::PrimaryVertexMonitor(const edm::ParameterSet& pSet)
       dz(nullptr),
       dxyErr(nullptr),
       dzErr(nullptr),
+      phi_pt1(nullptr),
+      eta_pt1(nullptr),
+      phi_pt10(nullptr),
+      eta_pt10(nullptr),
       dxyVsPhi_pt1(nullptr),
       dzVsPhi_pt1(nullptr),
       dxyVsEta_pt1(nullptr),
@@ -51,8 +55,6 @@ PrimaryVertexMonitor::PrimaryVertexMonitor(const edm::ParameterSet& pSet)
       dzVsEta_pt10(nullptr),
       dxyVsEtaVsPhi_pt10(nullptr),
       dzVsEtaVsPhi_pt10(nullptr) {
-  //  dqmStore_ = edm::Service<DQMStore>().operator->();
-
   vertexInputTag_ = pSet.getParameter<InputTag>("vertexLabel");
   beamSpotInputTag_ = pSet.getParameter<InputTag>("beamSpotLabel");
   vertexToken_ = consumes<reco::VertexCollection>(vertexInputTag_);
@@ -207,6 +209,13 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
   dxyErr = iBooker.book1D("dxyErr", "PV tracks (p_{T} > 1 GeV) d_{xy} error (#mum)", 100, 0., 2000.);
   dz = iBooker.book1D("dz", "PV tracks (p_{T} > 1 GeV) d_{z} (#mum)", DzBin, DzMin, DzMax);
   dzErr = iBooker.book1D("dzErr", "PV tracks (p_{T} > 1 GeV) d_{z} error(#mum)", 100, 0., 10000.);
+
+  phi_pt1 = iBooker.book1D("phi_pt1", "PV tracks (p_{T} > 1 GeV) #phi; PV tracks #phi;#tracks", PhiBin, PhiMin, PhiMax);
+  eta_pt1 = iBooker.book1D("eta_pt1", "PV tracks (p_{T} > 1 GeV) #eta; PV tracks #eta;#tracks", EtaBin, EtaMin, EtaMax);
+  phi_pt10 =
+      iBooker.book1D("phi_pt10", "PV tracks (p_{T} > 10 GeV) #phi; PV tracks #phi;#tracks", PhiBin, PhiMin, PhiMax);
+  eta_pt10 =
+      iBooker.book1D("eta_pt10", "PV tracks (p_{T} > 10 GeV) #phi; PV tracks #eta;#tracks", EtaBin, EtaMin, EtaMax);
 
   dxyVsPhi_pt1 = iBooker.bookProfile("dxyVsPhi_pt1",
                                      "PV tracks (p_{T} > 1 GeV) d_{xy} (#mum) VS track #phi",
@@ -369,8 +378,6 @@ void PrimaryVertexMonitor::bookHistograms(DQMStore::IBooker& iBooker, edm::Run c
   dzVsEtaVsPhi_pt10->setAxisTitle("PV track (p_{T} > 10 GeV) d_{z} (#mum)", 3);
 }
 
-PrimaryVertexMonitor::~PrimaryVertexMonitor() {}
-
 void PrimaryVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   Handle<reco::VertexCollection> recVtxs;
   iEvent.getByToken(vertexToken_, recVtxs);
@@ -445,8 +452,8 @@ void PrimaryVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSet
   bsSigmaZ->Fill(beamSpot.sigmaZ());
   bsDxdz->Fill(beamSpot.dxdz());
   bsDydz->Fill(beamSpot.dydz());
-  bsBeamWidthX->Fill(beamSpot.BeamWidthX() * 10000);
-  bsBeamWidthY->Fill(beamSpot.BeamWidthY() * 10000);
+  bsBeamWidthX->Fill(beamSpot.BeamWidthX() * cmToUm);
+  bsBeamWidthY->Fill(beamSpot.BeamWidthY() * cmToUm);
   // bsType->Fill(beamSpot.type());
 }
 
@@ -465,7 +472,6 @@ void PrimaryVertexMonitor::pvTracksPlots(const Vertex& v) {
 
   size_t nTracks = 0;
   float sumPT = 0.;
-  const int cmToUm = 10000;
 
   for (reco::Vertex::trackRef_iterator t = v.tracks_begin(); t != v.tracks_end(); t++) {
     bool isHighPurity = (**t).quality(reco::TrackBase::highPurity);
@@ -484,8 +490,8 @@ void PrimaryVertexMonitor::pvTracksPlots(const Vertex& v) {
     float w = v.trackWeight(*t);
     float chi2NDF = (**t).normalizedChi2();
     float chi2Prob = TMath::Prob((**t).chi2(), (int)(**t).ndof());
-    float Dxy = (**t).dxy(myVertex) * cmToUm;  // is it needed ?
-    float Dz = (**t).dz(myVertex) * cmToUm;    // is it needed ?
+    float Dxy = (**t).dxy(myVertex) * cmToUm;
+    float Dz = (**t).dz(myVertex) * cmToUm;
     float DxyErr = (**t).dxyError() * cmToUm;
     float DzErr = (**t).dzError() * cmToUm;
 
@@ -500,6 +506,8 @@ void PrimaryVertexMonitor::pvTracksPlots(const Vertex& v) {
     dz->Fill(Dz);
     dxyErr->Fill(DxyErr);
     dzErr->Fill(DzErr);
+    phi_pt1->Fill(phi);
+    eta_pt1->Fill(eta);
 
     dxyVsPhi_pt1->Fill(phi, Dxy);
     dzVsPhi_pt1->Fill(phi, Dz);
@@ -510,6 +518,9 @@ void PrimaryVertexMonitor::pvTracksPlots(const Vertex& v) {
 
     if (pt < 10.)
       continue;
+
+    phi_pt10->Fill(phi);
+    eta_pt10->Fill(eta);
     dxyVsPhi_pt10->Fill(phi, Dxy);
     dzVsPhi_pt10->Fill(phi, Dz);
     dxyVsEta_pt10->Fill(eta, Dxy);
@@ -549,15 +560,15 @@ void PrimaryVertexMonitor::vertexPlots(const Vertex& v, const BeamSpot& beamSpot
 
     float xb = beamSpot.x0() + beamSpot.dxdz() * (v.position().z() - beamSpot.z0());
     float yb = beamSpot.y0() + beamSpot.dydz() * (v.position().z() - beamSpot.z0());
-    xDiff[i]->Fill((v.position().x() - xb) * 10000);
-    yDiff[i]->Fill((v.position().y() - yb) * 10000);
+    xDiff[i]->Fill((v.position().x() - xb) * cmToUm);
+    yDiff[i]->Fill((v.position().y() - yb) * cmToUm);
 
-    xerr[i]->Fill(v.xError() * 10000);
-    yerr[i]->Fill(v.yError() * 10000);
-    zerr[i]->Fill(v.zError() * 10000);
-    xerrVsTrks[i]->Fill(weight, v.xError() * 10000);
-    yerrVsTrks[i]->Fill(weight, v.yError() * 10000);
-    zerrVsTrks[i]->Fill(weight, v.zError() * 10000);
+    xerr[i]->Fill(v.xError() * cmToUm);
+    yerr[i]->Fill(v.yError() * cmToUm);
+    zerr[i]->Fill(v.zError() * cmToUm);
+    xerrVsTrks[i]->Fill(weight, v.xError() * cmToUm);
+    yerrVsTrks[i]->Fill(weight, v.yError() * cmToUm);
+    zerrVsTrks[i]->Fill(weight, v.zError() * cmToUm);
 
     nans[i]->Fill(1., edm::isNotFinite(v.position().x()) * 1.);
     nans[i]->Fill(2., edm::isNotFinite(v.position().y()) * 1.);

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
@@ -27,7 +27,7 @@ class PrimaryVertexMonitor : public DQMEDAnalyzer {
 public:
   explicit PrimaryVertexMonitor(const edm::ParameterSet &pSet);
 
-  ~PrimaryVertexMonitor() override;
+  ~PrimaryVertexMonitor() override = default;
 
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
@@ -53,6 +53,8 @@ private:
   bool useHPfoAlignmentPlots_;
   bool errorPrinted_;
 
+  static constexpr int cmToUm = 10000;
+
   // the histos
   MonitorElement *nbvtx, *nbgvtx, *nbtksinvtx[2], *trksWeight[2], *score[2];
   MonitorElement *tt[2];
@@ -65,6 +67,8 @@ private:
 
   MonitorElement *sumpt, *ntracks, *weight, *chi2ndf, *chi2prob;
   MonitorElement *dxy, *dxy2, *dz, *dxyErr, *dzErr;
+  MonitorElement *phi_pt1, *eta_pt1;
+  MonitorElement *phi_pt10, *eta_pt10;
   MonitorElement *dxyVsPhi_pt1, *dzVsPhi_pt1;
   MonitorElement *dxyVsEta_pt1, *dzVsEta_pt1;
   MonitorElement *dxyVsEtaVsPhi_pt1, *dzVsEtaVsPhi_pt1;

--- a/DQMOffline/RecoB/python/PrimaryVertexMonitor_cff.py
+++ b/DQMOffline/RecoB/python/PrimaryVertexMonitor_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 pvMonitor = DQMEDAnalyzer('PrimaryVertexMonitor',
    TopFolderName  = cms.string("OfflinePV"),
@@ -32,7 +31,9 @@ pvMonitor = DQMEDAnalyzer('PrimaryVertexMonitor',
 
 # same as above, should be in sync with cut used in Vertex finder...
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase1Pixel.toModify(pvMonitor, EtaBin=28, EtaMin=-2.7, EtaMax=2.7)
+run3_common.toModify(pvMonitor, Xpos = 0.15, Ypos=-0.15)  #recentering since initial Run3 beamspot is at (0.17,-0.18) cm
 phase2_tracker.toModify(pvMonitor, EtaBin=41, EtaBin2D=9, EtaMin=-4.0, EtaMax=4.0)
 

--- a/DQMOffline/RecoB/python/PrimaryVertexMonitor_cff.py
+++ b/DQMOffline/RecoB/python/PrimaryVertexMonitor_cff.py
@@ -33,6 +33,6 @@ pvMonitor = DQMEDAnalyzer('PrimaryVertexMonitor',
 # same as above, should be in sync with cut used in Vertex finder...
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
-phase1Pixel.toModify(pvMonitor, EtaBin=31, EtaMin=-3.0, EtaMax=3.0)
+phase1Pixel.toModify(pvMonitor, EtaBin=28, EtaMin=-2.7, EtaMax=2.7)
 phase2_tracker.toModify(pvMonitor, EtaBin=41, EtaBin2D=9, EtaMin=-4.0, EtaMax=4.0)
 


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/38598

#### PR description:

The goal of this PR is to update the `PrimaryVertexMonitor` for Run-3 data-taking.
Performed maintenance:
   * added plots of the η and ϕ of tracks associated to the primary vertex (both for pT>1GeV and pT>10GeV);
   * introduced a `static constexpr int cmToUm` and use it consistently in the file;
   * use default destructor;
   * update the range in η for phase-1 as even if there are tracks up to 3, the tracks at high rapidity are discarded for vertexing resulting in empty bins (see e.g. https://tinyurl.com/2jwhu3wp)
   * re-center in x-y the vertex position plots for Run3: initial Run3 beamspot is at (0.17,-0.18) cm

#### PR validation:

`cmssw` compiles. 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

verbatim backport of https://github.com/cms-sw/cmssw/pull/38598