### PR TITLE
[LTO_X - Alignment & Calibration] Solve -Wstrict-overflow compiler warnings

### DIFF
--- a/Alignment/OfflineValidation/plugins/OverlapValidation.cc
+++ b/Alignment/OfflineValidation/plugins/OverlapValidation.cc
@@ -383,7 +383,7 @@ void OverlapValidation::analyzeTrajectory(const Trajectory& trajectory,
     ++overlapCounts_[1];
     if ((layer != -1) && (acceptLayer[subDet])) {
       for (vector<TrajectoryMeasurement>::const_iterator itmCompare = itm - 1;
-           itmCompare >= measurements.begin() && itmCompare > itm - 4;
+           (itmCompare >= measurements.begin()) && ((itmCompare + 4) > itm);
            --itmCompare) {
         DetId compareId = itmCompare->recHit()->geographicalId();
 

--- a/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
+++ b/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
@@ -126,7 +126,7 @@ void TkAlCaOverlapTagger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
       if ((previousTM != nullptr) && (layer != -1)) {
         for (std::vector<TrajectoryMeasurement>::const_iterator itmCompare = itTrajMeas - 1;
-             itmCompare >= tmColl.begin() && itmCompare > itTrajMeas - 4;
+             (itmCompare >= tmColl.begin()) && ((itmCompare + 4) > itTrajMeas);
              --itmCompare) {
           DetId compareId = itmCompare->recHit()->geographicalId();
           if (subDet != compareId.subdetId() || layer != layerFromId(compareId, tTopo))

--- a/Calibration/Tools/src/HouseholderDecomposition.cc
+++ b/Calibration/Tools/src/HouseholderDecomposition.cc
@@ -442,7 +442,7 @@ void HouseholderDecomposition::solve(std::vector<float>& y) {
 
   for (i = Nchannels - 2; i >= 0; i--) {
     z[i] = energyVectorProc[i];
-    for (j = i + 1; j < Nchannels; j++) {
+    for (j = i + 1; j - Nchannels < 0; j++) {
       z[i] -= eventMatrixProc[i][j] * z[j];
     }
     z[i] /= alpha[i];


### PR DESCRIPTION
Hello,

We have seen some compiler warnings of the type `-Wstrict-overflow` in LTO_X IBs ([CMSSW_12_5_LTO_X_2022-07-07-1100](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc10/www/thu/12.5.LTO-thu-11/CMSSW_12_5_LTO_X_2022-07-07-1100) and [CMSSW_12_5_LTO_X_2022-07-06-1100](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc10/www/wed/12.5.LTO-wed-11/CMSSW_12_5_LTO_X_2022-07-06-1100), for example) in both `Alignment/OfflineValidation` and `Alignment/TrackerAlignment` packages. See sample stack traces, respectively:

```
>> Building edm plugin tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/libAlignmentOfflinevalidationPlugins.so
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc10/external/gcc/10.3.0-84898dea653199466402e67d73657f10/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -shared -Wl,-E -Wl,-z,defs tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/CosmicSplitterValidation.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/DMRChecker.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/DiElectronVertexValidation.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/DiMuonVertexValidation.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/EopTreeWriter.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/GeneralPurposeTrackAnalyzer.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/MuonAlignmentAnalyzer.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/OverlapValidation.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/PixelBaryCentreAnalyzer.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/PrimaryVertexValidation.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/ResidualRefitting.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/SplitVertexResolution.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/TrackerGeometryCompare.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/TrackerGeometryIntoNtuples.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/TrackerOfflineValidation.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/TrackerOfflineValidationSummary.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/Tracker_OldtoNewConverter.cc.o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/ValidationMisalignedTracker.cc.o -o tmp/el8_amd64_gcc10/src/Alignment/OfflineValidation/plugins/AlignmentOfflinevalidationPlugins/libAlignmentOfflinevalidationPlugins.so -Wl,-E -Wl,--hash-style=gnu -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/biglib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/lib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/external/el8_amd64_gcc10/lib -lRecoVertexPrimaryVertexProducer -lRecoMuonTrackingTools -lRecoVertexAdaptiveVertexFit -lRecoVertexKalmanVertexFit -lRecoVertexLinearizationPointFinders -lTrackingToolsIPTools -lDQMSiPixelPhase1Common -lRecoVertexVertexTools -lCommonToolsTriggerUtils -lRecoVertexVertexPrimitives -lTrackingToolsTrackRefitter -lHLTriggerHLTcore -lTrackingToolsTransientTrack -lCondFormatsHLTObjects -lDataFormatsPatCandidates -lAlignmentOfflineValidation -lDataFormatsHLTReco -lDataFormatsBTauReco -lDataFormatsJetMatching -lDataFormatsL1TParticleFlow -lDataFormatsMETReco -lDataFormatsTauReco -lTrackingToolsKalmanUpdators -lTrackingToolsTrackFitters -lAlignmentTrackerAlignment -lCalibTrackerSiStripCommon -lDataFormatsJetReco -lRecoMuonNavigation -lRecoTrackerTransientTrackingRecHit -lTrackingToolsGsfTools -lTrackingToolsRecoGeometry -lAlignmentCommonAlignment -lDataFormatsParticleFlowCandidate -lRecoLocalTrackerSiStripRecHitConverter -lRecoMuonTransientTrackingRecHit -lRecoTrackerTkDetLayers -lSimTrackerTrackerHitAssociation -lTrackingToolsPatternTools -lDataFormatsParticleFlowReco -lRecoMTDDetLayers -lRecoMuonDetLayers -lTrackingToolsTrackAssociator -lTrackingToolsTransientTrackingRecHit -lDataFormatsEgammaCandidates -lDataFormatsHcalIsolatedTrack -lDataFormatsL1TCorrelator -lDataFormatsMuonReco -lRecoLocalTrackerPhase2TrackerRecHits -lTrackPropagationSteppingHelixPropagator -lTrackingToolsDetLayers -lDataFormatsL1TMuon -lDataFormatsRecoCandidate -lRecoLocalTrackerClusterParameterEstimator -lTrackingToolsGeomPropagators -lDQMTrackerRemapper -lDataFormatsCSCDigi -lDataFormatsEgammaReco -lDataFormatsGsfTrackReco -lDataFormatsVertexReco -lSimDataFormatsTrackingAnalysis -lTrackingToolsTrajectoryState -lDataFormatsGEMDigi -lDataFormatsTrackReco -lRecoTrackerRecord -lDataFormatsGEMRecHit -lDataFormatsTrackCandidate -lDataFormatsTrackerRecHit2D -lL1TriggerL1TGlobal -lTrackingToolsRecords -lCommonToolsTrackerMap -lCondFormatsSiPhase2TrackerObjects -lCondFormatsSiPixelObjects -lDataFormatsCSCRecHit -lDataFormatsDTRecHit -lDataFormatsFTLRecHit -lDataFormatsL1TGlobal -lDataFormatsL1TMuonPhase2 -lDataFormatsTrajectorySeed -lGeometryMTDGeometryBuilder -lL1TriggerGlobalTriggerAnalyzer -lRecoLocalTrackerRecords -lCalibFormatsSiStripObjects -lCalibTrackerRecords -lDataFormatsL1Trigger -lDataFormatsTrackingRecHit -lGeometryCSCGeometry -lGeometryDTGeometry -lGeometryGEMGeometry -lGeometryMTDNumberingBuilder -lGeometryRPCGeometry -lGeometryTrackerGeometryBuilder -lCalibTrackerStandaloneTrackerTopology -lCondFormatsSiStripObjects -lDataFormatsL1TrackTrigger -lMagneticFieldRecords -lMagneticFieldVolumeBasedEngine -lRecoMuonRecords -lCondFormatsDataRecord -lDataFormatsTrackerCommon -lGeometryCaloGeometry -lGeometryCommonTopologies -lMagneticFieldLayers -lRecoMTDRecords -lCondCoreDBOutputService -lCondFormatsAlignment -lCondFormatsL1TObjects -lDataFormatsBeamSpot -lDataFormatsCaloTowers -lDataFormatsEcalRecHit -lDataFormatsGeometryCommonDetAlgo -lDataFormatsHcalRecHit -lDataFormatsHepMCCandidate -lDataFormatsSiStripCluster -lGeometryRecords -lGeometryTrackerNumberingBuilder -lMagneticFieldVolumeGeometry -lSimDataFormatsCrossingFrame -lTrackingToolsAnalyticalJacobians -lCommonToolsStatistics -lCommonToolsUtilAlgos -lCondCoreCondDB -lCondFormatsAlignmentRecord -lDQMServicesCore -lDataFormatsCandidate -lDataFormatsDTDigi -lDataFormatsEcalDigi -lDataFormatsGeometrySurface -lDataFormatsHcalDigi -lDataFormatsL1GlobalCaloTrigger -lDataFormatsSiPixelDigi -lDataFormatsSiStripCommon -lDataFormatsTrajectoryState -lDetectorDescriptionCore -lDetectorDescriptionDDCMS -lGeometryMTDCommonData -lMagneticFieldEngine -lSimDataFormatsTrackerDigiSimLink -lSimDataFormatsTrackingHit -lCommonToolsUtils -lCondFormatsBeamSpotObjects -lCondFormatsGeometryObjects -lCondFormatsRunInfo -lDataFormatsCLHEP -lDataFormatsCaloRecHit -lDataFormatsEcalDetId -lDataFormatsForwardDetId -lDataFormatsGeometryVector -lDataFormatsHcalDetId -lDataFormatsL1CaloTrigger -lDataFormatsL1GlobalTrigger -lDataFormatsMuonDetId -lDataFormatsNanoAOD -lDataFormatsPhase2TrackerCluster -lDataFormatsSiPixelDetId -lDataFormatsSiStripDetId -lFWCoreFramework -lFWCorePrescaleService -lSimDataFormatsCaloHit -lSimDataFormatsTrack -lSimDataFormatsVertex -lCondFormatsCommon -lDataFormatsDetId -lDataFormatsFEDRawData -lDataFormatsL1GlobalMuonTrigger -lDataFormatsMath -lDataFormatsOnlineMetaData -lDataFormatsPhase2TrackerDigi -lDataFormatsScalers -lDataFormatsScouting -lDataFormatsSiPixelCluster -lDataFormatsSiStripDigi -lFWCoreCommon -lFWCoreServiceRegistry -lSimDataFormatsGeneratorProducts -lCondFormatsPhysicsToolsObjects -lDataFormatsCommon -lFWCoreParameterSet -lFWCoreMessageLogger -lDataFormatsProvenance -lFWCorePluginManager -lFWCoreReflection -lTrackingToolsTrajectoryParametrization -lCalibFormatsSiPixelObjects -lCondFormatsSerialization -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lSimDataFormatsEncodedEventId -lUtilitiesBinningTools -lUtilitiesOpenSSL -llcg_CoralCommon -llcg_RelationalAccess -llcg_CoralKernel -llcg_CoralBase -lDDAlign -lDDCond -lDDCore -lDDParsers -lTreePlayer -lGraf3d -lPostscript -lHistPainter -lGpad -lGraf -lPhysics -lHist -lMatrix -lGenVector -lMathMore -lTree -lNet -lImt -lGeom -lThread -lboost_filesystem -lMathCore -lRIO -lSmatrix -lboost_iostreams -lboost_regex -lboost_serialization -lboost_system -lclasslib -lCore -lboost_thread -lboost_date_time -lCLHEP -lHepMCfio -lHepMC -lpcre -lbz2 -lcurl -lgsl -luuid -lprotobuf -ltbb -lxerces-c -llzma -lz -lfmt -lHepMC3 -lHepMC3search -lcms-md5 -lopenblas -lssl -lcrypto -lcrypt -ldl -lrt -lstdc++fs -ltinyxml2
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/src/Alignment/OfflineValidation/plugins/OverlapValidation.cc: In member function 'analyzeTrajectory':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/src/Alignment/OfflineValidation/plugins/OverlapValidation.cc:386:47: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
   386 |            itmCompare >= measurements.begin() && itmCompare > itm - 4;
      |                                               ^
Leaving library rule at src/Alignment/OfflineValidation/plugins
```
and

```
>> Building edm plugin tmp/el8_amd64_gcc10/src/Alignment/TrackerAlignment/plugins/AlignmentTrackerAlignmentSkimPlugin/libAlignmentTrackerAlignmentSkimPlugin.so
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc10/external/gcc/10.3.0-84898dea653199466402e67d73657f10/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -shared -Wl,-E -Wl,-z,defs tmp/el8_amd64_gcc10/src/Alignment/TrackerAlignment/plugins/AlignmentTrackerAlignmentSkimPlugin/AlignmentPrescaler.cc.o tmp/el8_amd64_gcc10/src/Alignment/TrackerAlignment/plugins/AlignmentTrackerAlignmentSkimPlugin/TkAlCaSkimTreeMerger.cc.o tmp/el8_amd64_gcc10/src/Alignment/TrackerAlignment/plugins/AlignmentTrackerAlignmentSkimPlugin/TkAlCaOverlapTagger.cc.o -o tmp/el8_amd64_gcc10/src/Alignment/TrackerAlignment/plugins/AlignmentTrackerAlignmentSkimPlugin/libAlignmentTrackerAlignmentSkimPlugin.so -Wl,-E -Wl,--hash-style=gnu -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/biglib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/lib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/external/el8_amd64_gcc10/lib -lRecoTrackerTransientTrackingRecHit -lRecoLocalTrackerSiStripRecHitConverter -lTrackingToolsTransientTrackingRecHit -lRecoLocalTrackerPhase2TrackerRecHits -lTrackingToolsDetLayers -lRecoLocalTrackerClusterParameterEstimator -lTrackingToolsGeomPropagators -lTrackingToolsTrajectoryState -lDataFormatsTrackReco -lDataFormatsTrackCandidate -lDataFormatsTrackerRecHit2D -lCondFormatsSiPhase2TrackerObjects -lDataFormatsAlignment -lDataFormatsFTLRecHit -lDataFormatsTrajectorySeed -lRecoLocalTrackerRecords -lCalibFormatsSiStripObjects -lCalibTrackerRecords -lDataFormatsTrackingRecHit -lGeometryTrackerGeometryBuilder -lCondFormatsSiStripObjects -lDataFormatsL1TrackTrigger -lMagneticFieldRecords -lCondFormatsDataRecord -lDataFormatsTrackerCommon -lGeometryCommonTopologies -lCondFormatsAlignment -lDataFormatsBeamSpot -lDataFormatsGeometryCommonDetAlgo -lDataFormatsSiStripCluster -lGeometryRecords -lGeometryTrackerNumberingBuilder -lTrackingToolsAnalyticalJacobians -lCondFormatsAlignmentRecord -lDataFormatsCandidate -lDataFormatsGeometrySurface -lDataFormatsSiStripCommon -lDataFormatsTrajectoryState -lDetectorDescriptionCore -lDetectorDescriptionDDCMS -lMagneticFieldEngine -lCondFormatsGeometryObjects -lDataFormatsCLHEP -lDataFormatsCaloRecHit -lDataFormatsEcalDetId -lDataFormatsForwardDetId -lDataFormatsGeometryVector -lDataFormatsL1GlobalTrigger -lDataFormatsMuonDetId -lDataFormatsPhase2TrackerCluster -lDataFormatsSiPixelDetId -lDataFormatsSiStripDetId -lFWCoreFramework -lDataFormatsDetId -lDataFormatsFEDRawData -lDataFormatsL1GlobalMuonTrigger -lDataFormatsMath -lDataFormatsPhase2TrackerDigi -lDataFormatsScouting -lDataFormatsSiPixelCluster -lDataFormatsSiStripDigi -lFWCoreCommon -lFWCoreServiceRegistry -lCondFormatsPhysicsToolsObjects -lDataFormatsCommon -lFWCoreParameterSet -lFWCoreMessageLogger -lDataFormatsProvenance -lFWCorePluginManager -lFWCoreReflection -lTrackingToolsTrajectoryParametrization -lCondFormatsSerialization -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lUtilitiesGeneral -lDDAlign -lDDCond -lDDCore -lDDParsers -lPhysics -lHist -lMatrix -lGenVector -lMathMore -lTree -lNet -lGeom -lThread -lMathCore -lRIO -lSmatrix -lboost_iostreams -lboost_serialization -lCore -lboost_thread -lboost_date_time -lCLHEP -lpcre -lbz2 -lgsl -luuid -ltbb -lxerces-c -llzma -lz -lfmt -lcms-md5 -lopenblas -lcrypt -ldl -lrt -lstdc++fs -ltinyxml2
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/src/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc: In member function 'produce':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/ed6117194997de64d40aad03ededc67f/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-06-1100/src/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc:129:43: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
   129 |              itmCompare >= tmColl.begin() && itmCompare > itTrajMeas - 4;
      |                                           ^
```

Regarding the type of error and following some online discussions of this type of warning [fmtlib/fmt/issues/2757](https://github.com/fmtlib/fmt/issues/2757), I have tried to workaround it as shown in this PR, but feel free to propose other solutions that could be better regarding the analysis itself.

Many thanks,
Andrea.
