### PR TITLE
`CalibTracker/SiStripChannelGain`: fix issue with ODR of `stAPVGain` struct

### DIFF
--- a/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
@@ -34,6 +34,7 @@ struct stAPVGain {
   TH1F* HCharge;
   TH1F* HChargeN;
   bool isMasked;
+  char Side;
 };
 
 struct APVloc {

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLHarvester.h
@@ -102,7 +102,7 @@ private:
   std::vector<std::shared_ptr<stAPVGain> > APVsCollOrdered;
   std::unordered_map<unsigned int, std::shared_ptr<stAPVGain> > APVsColl;
 
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoTokenBR_, tTopoTokenER_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
   edm::ESGetToken<SiStripGain, SiStripGainRcd> gainToken_;
   edm::ESGetToken<SiStripQuality, SiStripQualityRcd> qualityToken_;

--- a/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
+++ b/CalibTracker/SiStripChannelGain/interface/SiStripGainsPCLWorker.h
@@ -86,7 +86,9 @@ public:
 
 private:
   void dqmBeginRun(edm::Run const &, edm::EventSetup const &, APVGain::APVGainHistograms &) const override;
-  void checkBookAPVColls(const TrackerGeometry *bareTkGeomPtr, APVGain::APVGainHistograms &histograms) const;
+  void checkBookAPVColls(const TrackerGeometry *bareTkGeomPtr,
+                         const TrackerTopology *bareTkTopoPtr,
+                         APVGain::APVGainHistograms &histograms) const;
 
   std::vector<std::string> dqm_tag_;
 
@@ -114,7 +116,7 @@ private:
   edm::EDGetTokenT<edm::View<reco::Track>> m_tracks_token;
   edm::EDGetTokenT<TrajTrackAssociationCollection> m_association_token;
 
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoTokenBR_, tTopoToken_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomTokenBR_, tkGeomToken_;
   edm::ESGetToken<SiStripGain, SiStripGainRcd> gainToken_;
   edm::ESGetToken<SiStripQuality, SiStripQualityRcd> qualityToken_;

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -66,7 +66,7 @@ public:
   typedef dqm::legacy::MonitorElement MonitorElement;
   typedef dqm::legacy::DQMStore DQMStore;
   explicit SiStripGainFromData(const edm::ParameterSet&);
-  ~SiStripGainFromData() override;
+  ~SiStripGainFromData() override = default;
 
 private:
   void algoBeginJob(const edm::EventSetup&) override;
@@ -315,8 +315,6 @@ SiStripGainFromData::SiStripGainFromData(const edm::ParameterSet& iConfig)
   //if( OutputHistos!="" )
   //  dqmStore_->open(OutputHistos.c_str(), true);
 }
-
-SiStripGainFromData::~SiStripGainFromData() {}
 
 void SiStripGainFromData::algoBeginJob(const edm::EventSetup& iSetup) {
   const TrackerTopology* const tTopo = &iSetup.getData(tTopoToken_);

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -1,57 +1,53 @@
 // Original Author:  Loic QUERTENMONT
 //         Created:  Wed Feb  6 08:55:18 CET 2008
 
+// system includes
 #include <memory>
+#include <unordered_map>
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/Exception.h"
-
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonTopologies/interface/StripTopology.h"
-#include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
-#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
-
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
-#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-
-#include "DataFormats/SiStripCluster/interface/SiStripClusterCollection.h"
-
+// user includes
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
-
-#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
-#include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "DataFormats/TrackReco/interface/DeDxHit.h"
-#include "DataFormats/TrackReco/interface/TrackDeDxHits.h"
-
+#include "CalibTracker/Records/interface/SiStripGainRcd.h"
+#include "CalibTracker/SiStripChannelGain/interface/APVGainStruct.h"
 #include "CommonTools/ConditionDBWriter/interface/ConditionDBWriter.h"
 #include "CondFormats/SiStripObjects/interface/SiStripApvGain.h"
-
-#include "TrackingTools/PatternTools/interface/Trajectory.h"
-#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
-
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
+#include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
+#include "DataFormats/SiStripCluster/interface/SiStripClusterCollection.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackReco/interface/DeDxHit.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackDeDxHits.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
 
-#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
-#include "CalibTracker/Records/interface/SiStripGainRcd.h"
-
+// ROOT inclues
 #include "TFile.h"
 #include "TObjString.h"
 #include "TString.h"
@@ -61,27 +57,9 @@
 #include "TF1.h"
 #include "TROOT.h"
 
-#include <unordered_map>
-#include <memory>
-
 using namespace edm;
 using namespace reco;
 using namespace std;
-
-struct stAPVGain {
-  unsigned int Index;
-  int DetId;
-  int APVId;
-  int SubDet;
-  float Eta;
-  float R;
-  float Phi;
-  float Thickness;
-  double MPV;
-  double Gain;
-  double PreviousGain;
-  char Side;
-};
 
 class SiStripGainFromData : public ConditionDBWriter<SiStripApvGain> {
 public:
@@ -601,7 +579,7 @@ void SiStripGainFromData::algoBeginJob(const edm::EventSetup& iSetup) {
         APV->DetId = Detid.rawId();
         APV->APVId = j;
         APV->SubDet = SubDet;
-        APV->MPV = -1;
+        APV->FitMPV = -1;
         APV->Gain = -1;
         APV->PreviousGain = 1;
         APV->Eta = Eta;
@@ -780,44 +758,44 @@ void SiStripGainFromData::algoEndJob() {
       //std::cout << "Proj->GetEntries(): " << Proj->GetEntries() << ", Proj->GetMean(): " << Proj->GetMean() << std::endl;
 
       getPeakOfLandau(Proj, FitResults);
-      APV->MPV = FitResults[0];
+      APV->FitMPV = FitResults[0];
       //         printf("MPV = %f - %f\n",FitResults[0], FitResults[1]);
       if (FitResults[0] != -0.5 && FitResults[1] < MaxMPVError) {
-        APV_MPV->Fill(APV->Index, APV->MPV);
-        MPVs->Fill(APV->MPV);
+        APV_MPV->Fill(APV->Index, APV->FitMPV);
+        MPVs->Fill(APV->FitMPV);
         if (APV->Thickness < 0.04)
-          MPVs320->Fill(APV->MPV);
+          MPVs320->Fill(APV->FitMPV);
         if (APV->Thickness > 0.04)
-          MPVs500->Fill(APV->MPV);
+          MPVs500->Fill(APV->FitMPV);
 
-        MPV_Vs_R->Fill(APV->R, APV->MPV);
-        MPV_Vs_Eta->Fill(APV->Eta, APV->MPV);
+        MPV_Vs_R->Fill(APV->R, APV->FitMPV);
+        MPV_Vs_Eta->Fill(APV->Eta, APV->FitMPV);
         if (APV->SubDet == StripSubdetector::TIB)
-          MPV_Vs_EtaTIB->Fill(APV->Eta, APV->MPV);
+          MPV_Vs_EtaTIB->Fill(APV->Eta, APV->FitMPV);
         if (APV->SubDet == StripSubdetector::TID)
-          MPV_Vs_EtaTID->Fill(APV->Eta, APV->MPV);
+          MPV_Vs_EtaTID->Fill(APV->Eta, APV->FitMPV);
         if (APV->SubDet == StripSubdetector::TOB)
-          MPV_Vs_EtaTOB->Fill(APV->Eta, APV->MPV);
+          MPV_Vs_EtaTOB->Fill(APV->Eta, APV->FitMPV);
         if (APV->SubDet == StripSubdetector::TEC) {
-          MPV_Vs_EtaTEC->Fill(APV->Eta, APV->MPV);
+          MPV_Vs_EtaTEC->Fill(APV->Eta, APV->FitMPV);
           if (APV->Thickness < 0.04)
-            MPV_Vs_EtaTEC1->Fill(APV->Eta, APV->MPV);
+            MPV_Vs_EtaTEC1->Fill(APV->Eta, APV->FitMPV);
           if (APV->Thickness > 0.04)
-            MPV_Vs_EtaTEC2->Fill(APV->Eta, APV->MPV);
+            MPV_Vs_EtaTEC2->Fill(APV->Eta, APV->FitMPV);
         }
-        MPV_Vs_Phi->Fill(APV->Phi, APV->MPV);
+        MPV_Vs_Phi->Fill(APV->Phi, APV->FitMPV);
         if (APV->SubDet == StripSubdetector::TIB)
-          MPV_Vs_PhiTIB->Fill(APV->Phi, APV->MPV);
+          MPV_Vs_PhiTIB->Fill(APV->Phi, APV->FitMPV);
         if (APV->SubDet == StripSubdetector::TID)
-          MPV_Vs_PhiTID->Fill(APV->Phi, APV->MPV);
+          MPV_Vs_PhiTID->Fill(APV->Phi, APV->FitMPV);
         if (APV->SubDet == StripSubdetector::TOB)
-          MPV_Vs_PhiTOB->Fill(APV->Phi, APV->MPV);
+          MPV_Vs_PhiTOB->Fill(APV->Phi, APV->FitMPV);
         if (APV->SubDet == StripSubdetector::TEC) {
-          MPV_Vs_PhiTEC->Fill(APV->Phi, APV->MPV);
+          MPV_Vs_PhiTEC->Fill(APV->Phi, APV->FitMPV);
           if (APV->Thickness < 0.04)
-            MPV_Vs_PhiTEC1->Fill(APV->Phi, APV->MPV);
+            MPV_Vs_PhiTEC1->Fill(APV->Phi, APV->FitMPV);
           if (APV->Thickness > 0.04)
-            MPV_Vs_PhiTEC2->Fill(APV->Phi, APV->MPV);
+            MPV_Vs_PhiTEC2->Fill(APV->Phi, APV->FitMPV);
         }
 
         if (APV->SubDet == StripSubdetector::TIB)
@@ -891,8 +869,8 @@ void SiStripGainFromData::algoEndJob() {
     double MPVmean = 300.;  //MPVs->GetMean();
     for (auto it = APVsColl.begin(); it != APVsColl.end(); it++) {
       stAPVGain* APV = it->second;
-      if (APV->MPV > 0) {
-        APV->Gain = APV->MPV / MPVmean;  // APV->MPV;
+      if (APV->FitMPV > 0) {
+        APV->Gain = APV->FitMPV / MPVmean;  // APV->FitMPV;
         GOOD++;
       } else {
         NoMPV_Vs_EtaPhi->Fill(APV->Eta, APV->Phi);
@@ -1105,11 +1083,11 @@ void SiStripGainFromData::algoEndJob() {
               APV->Gain);
     }
 
-    std::vector<int> DetIdOfBuggedAPV;
+    std::vector<unsigned int> DetIdOfBuggedAPV;
     fprintf(Gains, "----------------------------------------------------------------------\n");
     for (std::vector<stAPVGain*>::iterator it = APVsCollOrdered.begin(); it != APVsCollOrdered.end(); it++) {
       stAPVGain* APV = *it;
-      if (APV->MPV > 0 && APV->MPV < 200) {
+      if (APV->FitMPV > 0 && APV->FitMPV < 200) {
         bool tmpBug = false;
         for (unsigned int b = 0; b < DetIdOfBuggedAPV.size() && !tmpBug; b++) {
           if (DetIdOfBuggedAPV[b] == APV->DetId)
@@ -1493,7 +1471,7 @@ std::unique_ptr<SiStripApvGain> SiStripGainFromData::getNewObject() {
 
   auto obj = std::make_unique<SiStripApvGain>();
   std::vector<float>* theSiStripVector = nullptr;
-  int PreviousDetId = -1;
+  unsigned int PreviousDetId = -1;
   for (unsigned int a = 0; a < APVsCollOrdered.size(); a++) {
     stAPVGain* APV = APVsCollOrdered[a];
     if (APV == nullptr) {

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromData.cc
@@ -587,7 +587,7 @@ void SiStripGainFromData::algoBeginJob(const edm::EventSetup& iSetup) {
         APV->Side = 0;
 
         if (SubDet == StripSubdetector::TID) {
-          APV->Side = tTopo->tecSide(Detid);
+          APV->Side = tTopo->tidSide(Detid);
         } else if (SubDet == StripSubdetector::TEC) {
           APV->Side = tTopo->tecSide(Detid);
         }

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -58,7 +58,8 @@ SiStripGainsPCLHarvester::SiStripGainsPCLHarvester(const edm::ParameterSet& ps)
   dqm_tag_.push_back("IsoMuon0T");   // statistic collection from Isolated Muon @ 0 T
   dqm_tag_.push_back("Harvest");     // statistic collection: Harvest
 
-  tTopoToken_ = esConsumes<edm::Transition::EndRun>();
+  tTopoTokenBR_ = esConsumes<edm::Transition::BeginRun>();
+  tTopoTokenER_ = esConsumes<edm::Transition::EndRun>();
   tkGeomToken_ = esConsumes<edm::Transition::BeginRun>();
   gainToken_ = esConsumes<edm::Transition::BeginRun>();
   qualityToken_ = esConsumes<edm::Transition::BeginRun>();
@@ -686,6 +687,7 @@ bool SiStripGainsPCLHarvester::IsGoodLandauFit(double* FitResults) {
 // ------------ method called once each job just before starting event loop  ------------
 void SiStripGainsPCLHarvester::checkBookAPVColls(const edm::EventSetup& es) {
   auto newBareTkGeomPtr = &es.getData(tkGeomToken_);
+  auto bareTkTopoPtr = &es.getData(tTopoTokenBR_);
   if (newBareTkGeomPtr == bareTkGeomPtr_)
     return;  // already filled APVColls, nothing changed
 
@@ -713,6 +715,13 @@ void SiStripGainsPCLHarvester::checkBookAPVColls(const edm::EventSetup& es) {
           APV->Bin = -1;
           APV->DetId = Detid.rawId();
           APV->Side = 0;
+
+          if (SubDet == StripSubdetector::TID) {
+            APV->Side = bareTkTopoPtr->tidSide(Detid);
+          } else if (SubDet == StripSubdetector::TEC) {
+            APV->Side = bareTkTopoPtr->tecSide(Detid);
+          }
+
           APV->APVId = j;
           APV->SubDet = SubDet;
           APV->FitMPV = -1;
@@ -947,6 +956,6 @@ void SiStripGainsPCLHarvester::fillDescriptions(edm::ConfigurationDescriptions& 
 //********************************************************************************//
 void SiStripGainsPCLHarvester::endRun(edm::Run const& run, edm::EventSetup const& isetup) {
   if (!tTopo_) {
-    tTopo_ = std::make_unique<TrackerTopology>(isetup.getData(tTopoToken_));
+    tTopo_ = std::make_unique<TrackerTopology>(isetup.getData(tTopoTokenER_));
   }
 }

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -712,6 +712,7 @@ void SiStripGainsPCLHarvester::checkBookAPVColls(const edm::EventSetup& es) {
           APV->Index = Index;
           APV->Bin = -1;
           APV->DetId = Detid.rawId();
+          APV->Side = 0;
           APV->APVId = j;
           APV->SubDet = SubDet;
           APV->FitMPV = -1;
@@ -761,6 +762,7 @@ void SiStripGainsPCLHarvester::checkBookAPVColls(const edm::EventSetup& es) {
             APV->Index = Index;
             APV->Bin = -1;
             APV->DetId = Detid.rawId();
+            APV->Side = 0;
             APV->APVId = (j << 3 | i);
             APV->SubDet = SubDet;
             APV->FitMPV = -1;

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -54,6 +54,7 @@ SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) {
   m_association_token = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
 
   tTopoToken_ = esConsumes();
+  tTopoTokenBR_ = esConsumes<edm::Transition::BeginRun>();
   tkGeomTokenBR_ = esConsumes<edm::Transition::BeginRun>();
   tkGeomToken_ = esConsumes<>();
   gainToken_ = esConsumes<edm::Transition::BeginRun>();
@@ -69,7 +70,8 @@ void SiStripGainsPCLWorker::dqmBeginRun(edm::Run const& run,
 
   // fills the APV collections at each begin run
   const TrackerGeometry* bareTkGeomPtr = &iSetup.getData(tkGeomTokenBR_);
-  checkBookAPVColls(bareTkGeomPtr, histograms);
+  const TrackerTopology* bareTkTopoPtr = &iSetup.getData(tTopoTokenBR_);
+  checkBookAPVColls(bareTkGeomPtr, bareTkTopoPtr, histograms);
 
   const auto gainHandle = iSetup.getHandle(gainToken_);
   if (!gainHandle.isValid()) {
@@ -389,6 +391,7 @@ void SiStripGainsPCLWorker::dqmAnalyze(edm::Event const& iEvent,
 //********************************************************************************//
 // ------------ method called once each job just before starting event loop  ------------
 void SiStripGainsPCLWorker::checkBookAPVColls(const TrackerGeometry* bareTkGeomPtr,
+                                              const TrackerTopology* bareTkTopoPtr,
                                               APVGain::APVGainHistograms& histograms) const {
   if (bareTkGeomPtr) {  // pointer not yet set: called the first time => fill the APVColls
     auto const& Det = bareTkGeomPtr->dets();
@@ -416,6 +419,13 @@ void SiStripGainsPCLWorker::checkBookAPVColls(const TrackerGeometry* bareTkGeomP
           APV->Bin = -1;
           APV->DetId = Detid.rawId();
           APV->Side = 0;
+
+          if (SubDet == StripSubdetector::TID) {
+            APV->Side = bareTkTopoPtr->tidSide(Detid);
+          } else if (SubDet == StripSubdetector::TEC) {
+            APV->Side = bareTkTopoPtr->tecSide(Detid);
+          }
+
           APV->APVId = j;
           APV->SubDet = SubDet;
           APV->FitMPV = -1;

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -415,6 +415,7 @@ void SiStripGainsPCLWorker::checkBookAPVColls(const TrackerGeometry* bareTkGeomP
           APV->Index = Index;
           APV->Bin = -1;
           APV->DetId = Detid.rawId();
+          APV->Side = 0;
           APV->APVId = j;
           APV->SubDet = SubDet;
           APV->FitMPV = -1;
@@ -463,6 +464,7 @@ void SiStripGainsPCLWorker::checkBookAPVColls(const TrackerGeometry* bareTkGeomP
             APV->Index = Index;
             APV->Bin = -1;
             APV->DetId = Detid.rawId();
+            APV->Side = 0;
             APV->APVId = (j << 3 | i);
             APV->SubDet = SubDet;
             APV->FitMPV = -1;


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/38650

#### PR description:

Issue https://github.com/cms-sw/cmssw/issues/38650 reported some compiler warnings of the type `-Wodr` in `LTO_X` IBs, as some elements defined multiple times within the same namespace leading to violation of the C++ One Definition Rule.
This is solved by making the class `SiStripGainFromData` use the struct `stAPVGain` defined in the `APVGainStruct` header.

#### PR validation:

`cmssw` compiles.
Run succesfully `scram build use-ibeos runtests`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
