### PR TITLE
fix `db_tree_dump_wrapper` for unit test usage

### DIFF
--- a/CondTools/SiStrip/test/db_tree_dump_wrapper.py
+++ b/CondTools/SiStrip/test/db_tree_dump_wrapper.py
@@ -10,14 +10,20 @@ import CondCore.Utilities.conddblib as conddb
 ##############################################
 def execme(command, dryrun=False):
 ##############################################
-    '''Wrapper for executing commands.
-    '''
+    """This function executes `command` and returns it output.
+    Arguments:
+    - `command`: Shell command to be invoked by this function.
+    """
     if dryrun:
         print(command)
+        return None
     else:
-        print(" * Executing: %s ..." % (command))
-        os.system(command)
-        print(" * Executed!")
+        child = os.popen(command)
+        data = child.read()
+        err = child.close()
+        if err:
+            raise Exception('%s failed w/ exit code %d' % (command, err))
+        return data
 
 ##############################################
 def main():
@@ -72,9 +78,10 @@ def main():
         gtstring=autoCond.autoCond[key]
         print("Will use the resolved key %s" % gtstring)
 
-    command='cmsRun db_tree_dump.py outputRootFile=sistrip_db_tree_'+gtstring+'_'+str(options.inputRun)+'.root GlobalTag='+options.inputGT+' runNumber='+str(options.inputRun)+' runStartTime='+str(bestRunStartTime)
+    command='cmsRun $CMSSW_BASE/src/CondTools/SiStrip/test/db_tree_dump.py outputRootFile=sistrip_db_tree_'+gtstring+'_'+str(options.inputRun)+'.root GlobalTag='+options.inputGT+' runNumber='+str(options.inputRun)+' runStartTime='+str(bestRunStartTime)
     
-    execme(command)
+    data = execme(command)
+    print("\n output of execution: \n\n",data)
 
 if __name__ == "__main__":        
     main()


### PR DESCRIPTION
#### PR description:

I casually noticed in the cmssw dashboard that `CondTools/SiStrip` is *silently* failing because the `db_tree_dump_wrapper.py` script cannot find locally the cmsRun executable configuration,  see [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc10/CMSSW_12_5_X_2022-07-07-2300/unitTestLogs/CondTools/SiStrip#/7248)
This PR fixes the issue and also changes the `execme` method in order to `raise` a python error instead of silently failing.

#### PR validation:

Run successfully `scram b runtests` with this package

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A