### PR TITLE
[12_4_X] Fix the inverted condition in the PPS tdc pcl

### DIFF
--- a/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLHarvester.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLHarvester.cc
@@ -25,7 +25,7 @@
 
 #include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
 #include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
-
+#include "TFitResult.h"
 //------------------------------------------------------------------------------
 
 class PPSTimingCalibrationPCLHarvester : public DQMEDHarvester {
@@ -125,8 +125,9 @@ void PPSTimingCalibrationPCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQM
                             hists.toT[chid]->getMean(),
                             0.8,
                             hists.leadingTime[chid]->getMean() - hists.leadingTime[chid]->getRMS());
-      const auto& res = prof->Fit(&interp_, "B+", "", 10.4, upper_tot_range);
-      if ((bool)res) {
+      TFitResultPtr res = prof->Fit(&interp_, "B+", "", 10.4, upper_tot_range);
+
+      if (res == 0) {
         calib_params[key] = {
             interp_.GetParameter(0), interp_.GetParameter(1), interp_.GetParameter(2), interp_.GetParameter(3)};
         calib_time[key] = std::make_pair(0.1, 0.);  // hardcoded resolution/offset placeholder for the time being


### PR DESCRIPTION
#### PR description:

This is a bugfix of the TDC PCL, which fixes the inverted condition. It was mistakenly deleting all the correct calibrations and saving the incorrect ones.

#### PR validation:

PR was validated manually with the alcaReco data:
/eos/cms/store/group/dpg_ctpps/comm_ctpps/AlcaPrompt/PromptCalibProdPPSTimingCalib-Express/354332/00000/

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #38658