### PR TITLE
Run3 GEMGeometryBuilder Run3 modifier 

### DIFF
--- a/Geometry/GEMGeometryBuilder/python/gemGeometryDB_cfi.py
+++ b/Geometry/GEMGeometryBuilder/python/gemGeometryDB_cfi.py
@@ -12,5 +12,7 @@ GEMGeometryESModule = cms.ESProducer("GEMGeometryESModule",
 )
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run3_GEM.toModify(GEMGeometryESModule, applyAlignment = True)
+phase2_GEM.toModify(GEMGeometryESModule, applyAlignment = False)

--- a/Geometry/GEMGeometryBuilder/python/gemGeometryDB_cfi.py
+++ b/Geometry/GEMGeometryBuilder/python/gemGeometryDB_cfi.py
@@ -10,3 +10,7 @@ GEMGeometryESModule = cms.ESProducer("GEMGeometryESModule",
     alignmentsLabel = cms.string(''),
     applyAlignment = cms.bool(False)
 )
+
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
+run3_GEM.toModify(GEMGeometryESModule, applyAlignment = True)

--- a/Geometry/GEMGeometryBuilder/python/gemGeometry_cff.py
+++ b/Geometry/GEMGeometryBuilder/python/gemGeometry_cff.py
@@ -2,4 +2,8 @@ from Geometry.GEMGeometryBuilder.gemGeometry_cfi import gemGeometry
 
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
 dd4hep.toModify(gemGeometry, fromDDD = False, fromDD4hep = True)
+
+run3_GEM.toModify(gemGeometry, applyAlignment = True)

--- a/Geometry/GEMGeometryBuilder/python/gemGeometry_cff.py
+++ b/Geometry/GEMGeometryBuilder/python/gemGeometry_cff.py
@@ -3,7 +3,9 @@ from Geometry.GEMGeometryBuilder.gemGeometry_cfi import gemGeometry
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 dd4hep.toModify(gemGeometry, fromDDD = False, fromDD4hep = True)
 
 run3_GEM.toModify(gemGeometry, applyAlignment = True)
+phase2_GEM.toModify(gemGeometry, applyAlignment = False)


### PR DESCRIPTION
@jshlee @watson-ij 

GEM Run3 modifier setup for the alignment.

#### PR description:
Update the GEM geometry builder to use alignment tags.
Need to backport to 12_4_X

GEM doesn't have ideal geometry cff for digi.
Do we need to add ideal geometry cff and update configurations?
Some configurations use GEM default geometry builder as ideal geometry but they don't use the Run3 modifier, so it looks fine but I need to get a confirmation.