### PR TITLE
trivial V10 customize (12_4)

### DIFF
--- a/PhysicsTools/NanoAOD/python/V10/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/V10/nano_cff.py
@@ -1,0 +1,14 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.NanoAOD.nano_cff import *
+
+
+def nanoAOD_customizeV10(process):
+    
+    # PUT here any old recipe that belonged to the V10 
+    # update the PhysicsTools/NanoAOD/python as needed
+
+    process.nanoSequence  = cms.Sequence(process.nanoSequence)
+    process.nanoSequenceMC  = cms.Sequence(process.nanoSequenceMC)
+
+    return process


### PR DESCRIPTION
Next central production for Run3 should be procured with the following options with the cmsdriver command

cmsDriver.py step5  -s NANO  --era Run3 --customise=PhysicsTools/NanoAOD/V10/nano_cff.nanoAOD_customizeV10
