### PR TITLE
Use a safer syntax in Geometry/ForwardCommonData

### DIFF
--- a/Geometry/ForwardCommonData/python/hfnoseParametersInitialization_cfi.py
+++ b/Geometry/ForwardCommonData/python/hfnoseParametersInitialization_cfi.py
@@ -2,19 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.HGCalCommonData.hgcalEEParametersInitialize_cfi import *
 
-
 hfnoseParametersInitialize = hgcalEEParametersInitialize.clone(
-    name  = cms.string("HGCalHFNoseSensitive"),
-    name2 = cms.string("HFNoseEE"),
-    nameW = cms.string("HFNoseWafer"),
-    nameC = cms.string("HFNoseCell"),
-    nameT = cms.string("HFNose"),
-    nameX = cms.string("HGCalHFNoseSensitive"),
-)
-
-from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
-
-dd4hep.toModify(hfnoseParametersInitialize,
-                fromDD4hep = cms.bool(True)
+    name  = "HGCalHFNoseSensitive",
+    name2 = "HFNoseEE",
+    nameW = "HFNoseWafer",
+    nameC = "HFNoseCell",
+    nameT = "HFNose",
+    nameX = "HGCalHFNoseSensitive"
 )
 

--- a/Geometry/ForwardCommonData/python/hfnoseV15ParametersInitialization_cfi.py
+++ b/Geometry/ForwardCommonData/python/hfnoseV15ParametersInitialization_cfi.py
@@ -3,10 +3,10 @@ import FWCore.ParameterSet.Config as cms
 from Geometry.HGCalCommonData.hgcalEEV15ParametersInitialization_cfi import *
 
 hfnoseParametersInitialize = hgcalEEParametersInitialize.clone(
-    name  = cms.string("HGCalHFNoseSensitive"),
-    name2 = cms.string("HFNoseEE"),
-    nameW = cms.string("HFNoseWafer"),
-    nameC = cms.string("HFNoseCell"),
-    nameT = cms.string("HFNose"),
-    nameX = cms.string("HGCalHFNoseSensitive"),
+    name  = "HGCalHFNoseSensitive",
+    name2 = "HFNoseEE",
+    nameW = "HFNoseWafer",
+    nameC = "HFNoseCell",
+    nameT = "HFNose",
+    nameX = "HGCalHFNoseSensitive"
 )

--- a/Geometry/HGCalCommonData/python/hgcalParametersInitialization_cfi.py
+++ b/Geometry/HGCalCommonData/python/hgcalParametersInitialization_cfi.py
@@ -2,11 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.HGCalCommonData.hgcalEEParametersInitialize_cfi import *
 
-from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
-
-dd4hep.toModify(hgcalEEParametersInitialize,
-                fromDD4hep = True )
-
 hgcalHESiParametersInitialize = hgcalEEParametersInitialize.clone(
     name  = "HGCalHESiliconSensitive",
     nameW = "HGCalHEWafer",


### PR DESCRIPTION
#### PR description:

Solves https://github.com/cms-sw/cmssw/issues/38604

It migrates to a safer syntax (no explicit types for the cloned parameters) the following two files
- Geometry/ForwardCommonData/python/hfnoseParametersInitialization_cfi.py
- Geometry/ForwardCommonData/python/hfnoseV15ParametersInitialization_cfi.py

While doing so I also fixed two conceptual mistakes (attempt to modify a module in a different configuration):
- Geometry/HGCalCommonData/python/hgcalParametersInitialization_cfi.py

This wasn't needed anyhow, because the same modifier was already (correctly) applied to the cloned module

For the same reason I removed the customization from
- Geometry/ForwardCommonData/python/hfnoseParametersInitialization_cfi.py

as it should more safely rely on the one already present in the cloned module instead

Attn @bsunanda 


#### PR validation:

It builds succesfully
No changes expected whatsoever
