### PR TITLE
 Modifiers not being set properly in EventConfig for data (backport of #38622, 12_3_X)

### DIFF
--- a/Configuration/DataProcessing/python/Repack.py
+++ b/Configuration/DataProcessing/python/Repack.py
@@ -7,7 +7,6 @@ Module that generates standard repack configurations
 """
 
 import FWCore.ParameterSet.Config as cms
-from Configuration.EventContent.EventContent_cff import RAWEventContent
 
 
 def repackProcess(**args):
@@ -21,6 +20,7 @@ def repackProcess(**args):
     - outputs      : defines output modules
 
     """
+    from Configuration.EventContent.EventContent_cff import RAWEventContent
     process = cms.Process("REPACK")
     process.load("FWCore.MessageLogger.MessageLogger_cfi")
 


### PR DESCRIPTION
#### PR description:
This PR is a backport of #38622. This PR intoduces the lazy import of `Configuration.EventContent.EventContent_cff` to avoid calling `Modifier.toModify` before `Process.__init__`. The issue is well described in #38622.

#### PR validation:
Same as #38622.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
This PR is a backport of #38622. This fix should be applied to releases for Run2022.


@jshlee  @watson-ij 