### PR TITLE
[LTO_X - EventFilter/EcalDigiToRaw] Solve -Wstrict-overflow compiler warning

### DIFF
--- a/EventFilter/EcalDigiToRaw/src/TCCBlockFormatter.cc
+++ b/EventFilter/EcalDigiToRaw/src/TCCBlockFormatter.cc
@@ -113,7 +113,7 @@ void TCCBlockFormatter::DigiToRaw(const EcalTriggerPrimitiveDigi& trigprim,
     // -- put the B011 already, since for Endcap there can be empty
     // -- lines in the TCC and the SRP blocks
     unsigned char* ppData = rawdata.data();
-    for (int iline = FE_index - 1; iline < FE_index + (Nrows_TCC + 1) * NTCC - 1; iline++) {
+    for (int iline = FE_index - 1; iline - (FE_index + (Nrows_TCC + 1) * NTCC - 1) < 0; iline++) {
       ppData[8 * iline + 7] |= 0x60;
       ppData[8 * iline + 3] |= 0x60;
     }


### PR DESCRIPTION
Hello,

We have seen some compiler warnings of the type `-Wstrict-overflow` in LTO_X IBs ([CMSSW_12_5_LTO_X_2022-07-07-1100](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc10/www/thu/12.5.LTO-thu-11/CMSSW_12_5_LTO_X_2022-07-07-1100) and [CMSSW_12_5_LTO_X_2022-07-06-1100](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc10/www/wed/12.5.LTO-wed-11/CMSSW_12_5_LTO_X_2022-07-06-1100), for example) in `EventFilter/EcalDigiToRaw`. See sample stack trace:

```
>> Building edm plugin tmp/el8_amd64_gcc10/src/EventFilter/EcalDigiToRaw/src/EventFilterEcalDigiToRaw/libEventFilterEcalDigiToRaw.so
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc10/external/gcc/10.3.0-84898dea653199466402e67d73657f10/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -shared -Wl,-E -Wl,-z,defs tmp/el8_amd64_gcc10/src/EventFilter/EcalDigiToRaw/src/EventFilterEcalDigiToRaw/BlockFormatter.cc.o tmp/el8_amd64_gcc10/src/EventFilter/EcalDigiToRaw/src/EventFilterEcalDigiToRaw/EcalDigiToRaw.cc.o tmp/el8_amd64_gcc10/src/EventFilter/EcalDigiToRaw/src/EventFilterEcalDigiToRaw/SRBlockFormatter.cc.o tmp/el8_amd64_gcc10/src/EventFilter/EcalDigiToRaw/src/EventFilterEcalDigiToRaw/TCCBlockFormatter.cc.o tmp/el8_amd64_gcc10/src/EventFilter/EcalDigiToRaw/src/EventFilterEcalDigiToRaw/TowerBlockFormatter.cc.o -o tmp/el8_amd64_gcc10/src/EventFilter/EcalDigiToRaw/src/EventFilterEcalDigiToRaw/libEventFilterEcalDigiToRaw.so -Wl,-E -Wl,--hash-style=gnu -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/biglib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/lib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/external/el8_amd64_gcc10/lib -lGeometryEcalMapping -lCondFormatsDataRecord -lGeometryRecords -lCondFormatsAlignmentRecord -lDataFormatsEcalDigi -lDataFormatsEcalDetId -lFWCoreFramework -lDataFormatsDetId -lDataFormatsFEDRawData -lFWCoreCommon -lFWCoreServiceRegistry -lDataFormatsCommon -lFWCoreParameterSet -lFWCoreMessageLogger -lDataFormatsProvenance -lFWCorePluginManager -lFWCoreReflection -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lTree -lNet -lThread -lMathCore -lRIO -lCore -lboost_thread -lboost_date_time -lpcre -lbz2 -luuid -ltbb -llzma -lz -lfmt -lcms-md5 -lcrypt -ldl -lrt -lstdc++fs -ltinyxml2
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/EventFilter/EcalDigiToRaw/src/TCCBlockFormatter.cc: In member function 'DigiToRaw':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/EventFilter/EcalDigiToRaw/src/TCCBlockFormatter.cc:116:42: warning: assuming signed overflow does not occur when simplifying conditional to constant [-Wstrict-overflow]
   116 |     for (int iline = FE_index - 1; iline < FE_index + (Nrows_TCC + 1) * NTCC - 1; iline++) {
      |                                          ^
Leaving library rule at EventFilter/EcalDigiToRaw
```


Regarding the type of error and following some online discussions of this type of warning [fmtlib/fmt/issues/2757](https://github.com/fmtlib/fmt/issues/2757), I have tried to workaround it as shown in this PR, but feel free to propose other solutions that could be better regarding the analysis itself.

Many thanks,
Andrea.