### PR TITLE
[LTO - RecoTracker] Solve -Wstrict-overflow compiler warnings

### DIFF
--- a/RecoLocalTracker/SiStripZeroSuppression/src/FastLinearCMNSubtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/FastLinearCMNSubtractor.cc
@@ -13,7 +13,7 @@ inline void FastLinearCMNSubtractor::subtract_(uint32_t detId, uint16_t firstAPV
   tmp.reserve(128);
   typename std::vector<T>::iterator strip(digis.begin()), end(digis.end()), endAPV, high, low;
 
-  while (strip < end) {
+  while (strip - end < 0) {
     endAPV = strip + 128;
     tmp.clear();
     tmp.insert(tmp.end(), strip, endAPV);
@@ -22,11 +22,11 @@ inline void FastLinearCMNSubtractor::subtract_(uint32_t detId, uint16_t firstAPV
     low = strip;
     high = strip + 64;
     tmp.clear();
-    while (high < endAPV)
+    while (high - endAPV < 0)
       tmp.push_back(*high++ - *low++);
     const float slope = median(tmp) / 64.;
 
-    while (strip < endAPV) {
+    while (strip - endAPV < 0) {
       *strip = static_cast<T>(*strip - (offset + slope * (65 - (endAPV - strip))));
       strip++;
     }

--- a/RecoLocalTracker/SiStripZeroSuppression/src/MedianCMNSubtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/MedianCMNSubtractor.cc
@@ -15,7 +15,7 @@ inline void MedianCMNSubtractor::subtract_(uint32_t detId, uint16_t firstAPV, st
 
   _vmedians.clear();
 
-  while (strip < end) {
+  while (strip - end < 0) {
     endAPV = strip + 128;
     tmp.clear();
     tmp.insert(tmp.end(), strip, endAPV);
@@ -23,7 +23,7 @@ inline void MedianCMNSubtractor::subtract_(uint32_t detId, uint16_t firstAPV, st
 
     _vmedians.push_back(std::pair<short, float>((strip - digis.begin()) / 128 + firstAPV, offset));
 
-    while (strip < endAPV) {
+    while (strip - endAPV < 0) {
       *strip = static_cast<T>(*strip - offset);
       strip++;
     }

--- a/RecoLocalTracker/SiStripZeroSuppression/src/PercentileCMNSubtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/PercentileCMNSubtractor.cc
@@ -15,7 +15,7 @@ inline void PercentileCMNSubtractor::subtract_(uint32_t detId, uint16_t firstAPV
 
   _vmedians.clear();
 
-  while (strip < end) {
+  while (strip - end < 0) {
     endAPV = strip + 128;
     tmp.clear();
     tmp.insert(tmp.end(), strip, endAPV);
@@ -23,7 +23,7 @@ inline void PercentileCMNSubtractor::subtract_(uint32_t detId, uint16_t firstAPV
 
     _vmedians.push_back(std::pair<short, float>((strip - digis.begin()) / 128 + firstAPV, offset));
 
-    while (strip < endAPV) {
+    while (strip - endAPV < 0) {
       *strip = static_cast<T>(*strip - offset);
       strip++;
     }

--- a/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc
+++ b/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc
@@ -47,7 +47,7 @@ inline void TT6CMNSubtractor::subtract_(uint32_t detId, uint16_t firstAPV, std::
       fs = digis.begin() + istrip - 127;
       ls = digis.begin() + istrip + 1;
 
-      while (fs < ls) {
+      while (fs - ls < 0) {
         *fs = static_cast<T>(*fs - FixedBias - CM);
         fs++;
       }

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -679,7 +679,7 @@ namespace reco {
             if ((previousTM != nullptr) && (layer != -1)) {
               //std::cout<<"A previous TM exists! "<<std::endl;
               for (std::vector<TrajectoryMeasurement>::const_iterator itmCompare = itTrajMeas - 1;
-                   itmCompare >= tmColl.begin() && itmCompare > itTrajMeas - 4;
+                   itmCompare >= tmColl.begin() && itmCompare - (itTrajMeas - 4) > 0;
                    --itmCompare) {
                 DetId compareId = itmCompare->recHit()->geographicalId();
                 if (subDet != compareId.subdetId() || side != sideFromId(compareId, tTopo) ||

--- a/RecoTracker/MkFitCMS/src/MkStdSeqs.cc
+++ b/RecoTracker/MkFitCMS/src/MkStdSeqs.cc
@@ -456,7 +456,7 @@ namespace mkfit {
           int b = trk.getHitIdx(i);
           auto range = hitMap.equal_range(b * 1000 + a);
           for (auto it = range.first; it != range.second; ++it) {
-            if (std::abs(it->second) >= (int)itrack)
+            if (static_cast<unsigned int>(std::abs(it->second)) >= itrack)
               continue;  // don't check your own hits (==) nor sym. checks (>)
             if (i == 0 && it->second < 0)
               continue;  // shared first - first is not counted


### PR DESCRIPTION
Hello,

We have seen some compiler warnings of the type `-Wstrict-overflow` in LTO_X IBs ([CMSSW_12_5_LTO_X_2022-07-07-1100](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc10/www/thu/12.5.LTO-thu-11/CMSSW_12_5_LTO_X_2022-07-07-1100) and [CMSSW_12_5_LTO_X_2022-07-06-1100](https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/el8_amd64_gcc10/www/wed/12.5.LTO-wed-11/CMSSW_12_5_LTO_X_2022-07-06-1100), for example) in `RecoLocalTracker/SiStripZeroSuppression`, `RecoTracker/FinalTrackSelectors` and `RecoTracker/MkFitCMS` packages. See sample stack traces, respectively:

- `RecoLocalTracker/SiStripZeroSuppression`:
```
>> Building shared library tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/libRecoLocalTrackerSiStripZeroSuppression.so
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc10/external/gcc/10.3.0-84898dea653199466402e67d73657f10/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -shared -Wl,-E -Wl,-z,defs tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/FastLinearCMNSubtractor.cc.o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/IteratedMedianCMNSubtractor.cc.o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/MedianCMNSubtractor.cc.o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/PercentileCMNSubtractor.cc.o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/SiStripAPVRestorer.cc.o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/SiStripFedZeroSuppression.cc.o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/SiStripPedestalsSubtractor.cc.o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/SiStripRawProcessingAlgorithms.cc.o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/SiStripRawProcessingFactory.cc.o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/TT6CMNSubtractor.cc.o -o tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/libRecoLocalTrackerSiStripZeroSuppression.so -Wl,-E -Wl,--hash-style=gnu -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/biglib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/lib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/external/el8_amd64_gcc10/lib -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/static/el8_amd64_gcc10 -lCalibFormatsSiStripObjects -lCalibTrackerRecords -lGeometryTrackerGeometryBuilder -lCondFormatsSiStripObjects -lMagneticFieldRecords -lCondFormatsDataRecord -lDataFormatsTrackerCommon -lGeometryCommonTopologies -lCondFormatsAlignment -lDataFormatsGeometryCommonDetAlgo -lDataFormatsSiStripCluster -lGeometryRecords -lGeometryTrackerNumberingBuilder -lCondFormatsAlignmentRecord -lDataFormatsGeometrySurface -lDataFormatsSiStripCommon -lDataFormatsTrajectoryState -lDetectorDescriptionCore -lDetectorDescriptionDDCMS -lCondFormatsGeometryObjects -lDataFormatsCLHEP -lDataFormatsEcalDetId -lDataFormatsGeometryVector -lDataFormatsL1GlobalTrigger -lDataFormatsSiPixelDetId -lDataFormatsSiStripDetId -lFWCoreFramework -lDataFormatsDetId -lDataFormatsFEDRawData -lDataFormatsL1GlobalMuonTrigger -lDataFormatsMath -lDataFormatsSiPixelCluster -lDataFormatsSiStripDigi -lFWCoreCommon -lFWCoreServiceRegistry -lCondFormatsPhysicsToolsObjects -lDataFormatsCommon -lFWCoreParameterSet -lFWCoreMessageLogger -lDataFormatsProvenance -lFWCorePluginManager -lFWCoreReflection -lCondFormatsSerialization -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lDDAlign -lDDCond -lDDCore -lDDParsers -lPhysics -lHist -lMatrix -lGenVector -lMathMore -lTree -lNet -lGeom -lThread -lMathCore -lRIO -lboost_iostreams -lboost_serialization -lCore -lboost_thread -lboost_date_time -lCLHEP -lpcre -lbz2 -lgsl -luuid -ltbb -lxerces-c -llzma -lz -lfmt -lcms-md5 -lopenblas -lcrypt -ldl -lrt -lstdc++fs -ltinyxml2
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/MedianCMNSubtractor.cc: In member function 'subtract':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/MedianCMNSubtractor.cc:26:18: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    26 |     while (strip < endAPV) {
      |                  ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/PercentileCMNSubtractor.cc: In member function 'subtract':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/PercentileCMNSubtractor.cc:26:18: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    26 |     while (strip < endAPV) {
      |                  ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/FastLinearCMNSubtractor.cc: In member function 'subtract':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/FastLinearCMNSubtractor.cc:25:17: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    25 |     while (high < endAPV)
      |                 ^
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/FastLinearCMNSubtractor.cc:29:18: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    29 |     while (strip < endAPV) {
      |                  ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/MedianCMNSubtractor.cc: In member function 'subtract':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/MedianCMNSubtractor.cc:26:18: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    26 |     while (strip < endAPV) {
      |                  ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/PercentileCMNSubtractor.cc: In member function 'subtract':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/PercentileCMNSubtractor.cc:26:18: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    26 |     while (strip < endAPV) {
      |                  ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/FastLinearCMNSubtractor.cc: In member function 'subtract':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/FastLinearCMNSubtractor.cc:25:17: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    25 |     while (high < endAPV)
      |                 ^
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/FastLinearCMNSubtractor.cc:29:18: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    29 |     while (strip < endAPV) {
      |                  ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc: In member function 'subtract':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc:50:17: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    50 |       while (fs < ls) {
      |                 ^
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc: In member function 'subtract':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoLocalTracker/SiStripZeroSuppression/src/TT6CMNSubtractor.cc:50:17: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
    50 |       while (fs < ls) {
      |                 ^
Copying tmp/el8_amd64_gcc10/src/RecoLocalTracker/SiStripZeroSuppression/src/RecoLocalTrackerSiStripZeroSuppression/libRecoLocalTrackerSiStripZeroSuppression.so to productstore area:
Leaving library rule at RecoLocalTracker/SiStripZeroSuppression
```
- `RecoTracker/FinalTrackSelectors`:
```
>> Building edm plugin tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/libRecoTrackerFinalTrackSelectorsPlugins.so
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc10/external/gcc/10.3.0-84898dea653199466402e67d73657f10/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -Ofast -Wno-error=unused-variable -DBOOST_DISABLE_ASSERTS -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -shared -Wl,-E -Wl,-z,defs tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/AnalyticalTrackSelector.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/ClassifierMerger.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/CosmicTrackSelector.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/CosmicTrackSplitter.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/DefaultTrackMVAClassifier.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/DuplicateListMerger.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/DuplicateTrackMerger.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/LwtnnESProducer.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/MultiTrackSelector.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackAlgoPriorityOrderESProducer.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackCandidateTopBottomHitFilter.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackCollectionFilterCloner.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackCollectionMerger.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackCutClassifier.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackListMerger.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackLwtnnClassifier.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackMerger.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackSelectorByRegion.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackTfClassifier.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/TrackerTrackHitFilter.cc.o -o tmp/el8_amd64_gcc10/src/RecoTracker/FinalTrackSelectors/plugins/RecoTrackerFinalTrackSelectorsPlugins/libRecoTrackerFinalTrackSelectorsPlugins.so -Wl,-E -Wl,--hash-style=gnu -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/biglib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/lib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/external/el8_amd64_gcc10/lib -lTrackingToolsTransientTrack -lDataFormatsPatCandidates -lDataFormatsHLTReco -lDataFormatsBTauReco -lDataFormatsJetMatching -lDataFormatsL1TParticleFlow -lDataFormatsMETReco -lDataFormatsTauReco -lTrackingToolsKalmanUpdators -lDataFormatsJetReco -lRecoTrackerFinalTrackSelectors -lRecoTrackerTransientTrackingRecHit -lTrackingToolsGsfTools -lDataFormatsParticleFlowCandidate -lRecoLocalTrackerSiStripRecHitConverter -lTrackingToolsPatternTools -lDataFormatsParticleFlowReco -lTrackingToolsTransientTrackingRecHit -lDataFormatsEgammaCandidates -lDataFormatsHcalIsolatedTrack -lDataFormatsL1TCorrelator -lDataFormatsL1TMuonPhase2 -lDataFormatsMuonReco -lRecoLocalTrackerPhase2TrackerRecHits -lTrackingToolsDetLayers -lDataFormatsL1TMuon -lDataFormatsRecoCandidate -lRecoLocalTrackerClusterParameterEstimator -lTrackingToolsGeomPropagators -lDataFormatsCSCDigi -lDataFormatsEgammaReco -lDataFormatsGsfTrackReco -lDataFormatsVertexReco -lTrackingToolsTrajectoryState -lDataFormatsGEMDigi -lDataFormatsTrackReco -lRecoTrackerRecord -lDataFormatsGEMRecHit -lDataFormatsTrackCandidate -lDataFormatsTrackerRecHit2D -lRecoLocalTrackerSiStripClusterizer -lTrackingToolsRecords -lCondFormatsSiPhase2TrackerObjects -lDataFormatsCSCRecHit -lDataFormatsDTRecHit -lDataFormatsFTLRecHit -lDataFormatsTrajectorySeed -lRecoLocalTrackerRecords -lCalibFormatsSiStripObjects -lCalibTrackerRecords -lDataFormatsL1Trigger -lDataFormatsTrackingRecHit -lGeometryTrackerGeometryBuilder -lCondFormatsSiStripObjects -lDataFormatsL1TrackTrigger -lMagneticFieldRecords -lCondFormatsDataRecord -lDataFormatsTrackerCommon -lGeometryCaloGeometry -lGeometryCommonTopologies -lCondFormatsAlignment -lDataFormatsBeamSpot -lDataFormatsCaloTowers -lDataFormatsEcalRecHit -lDataFormatsGeometryCommonDetAlgo -lDataFormatsHcalRecHit -lDataFormatsHepMCCandidate -lDataFormatsSiStripCluster -lGeometryRecords -lGeometryTrackerNumberingBuilder -lTrackingToolsAnalyticalJacobians -lCommonToolsStatistics -lCondFormatsAlignmentRecord -lDataFormatsCandidate -lDataFormatsDTDigi -lDataFormatsEcalDigi -lDataFormatsGeometrySurface -lDataFormatsHcalDigi -lDataFormatsL1GlobalCaloTrigger -lDataFormatsSiStripCommon -lDataFormatsTrajectoryState -lDetectorDescriptionCore -lDetectorDescriptionDDCMS -lMagneticFieldEngine -lPhysicsToolsTensorFlow -lCommonToolsUtils -lCondFormatsGeometryObjects -lDataFormatsCLHEP -lDataFormatsCaloRecHit -lDataFormatsEcalDetId -lDataFormatsForwardDetId -lDataFormatsGeometryVector -lDataFormatsHcalDetId -lDataFormatsL1CaloTrigger -lDataFormatsL1GlobalTrigger -lDataFormatsMuonDetId -lDataFormatsPhase2TrackerCluster -lDataFormatsSiPixelDetId -lDataFormatsSiStripDetId -lFWCoreFramework -lDataFormatsDetId -lDataFormatsFEDRawData -lDataFormatsL1GlobalMuonTrigger -lDataFormatsMath -lDataFormatsPhase2TrackerDigi -lDataFormatsScouting -lDataFormatsSiPixelCluster -lDataFormatsSiStripDigi -lFWCoreCommon -lFWCoreServiceRegistry -lCondFormatsPhysicsToolsObjects -lDataFormatsCommon -lFWCoreParameterSet -lFWCoreMessageLogger -lDataFormatsProvenance -lCondFormatsGBRForest -lFWCorePluginManager -lFWCoreReflection -lTrackingToolsTrajectoryParametrization -lCondFormatsSerialization -lFWCoreConcurrency -lFWCoreUtilities -lFWCoreVersion -lDDAlign -lDDCond -lTMVA -lDDCore -lDDParsers -lMLP -lTreePlayer -lGraf3d -lPostscript -lMinuit -lGpad -lGraf -lPhysics -lHist -lMatrix -lGenVector -lMathMore -lTree -lNet -lGeom -lThread -llwtnn -lMathCore -lRIO -lSmatrix -lboost_iostreams -lboost_regex -lboost_serialization -lboost_system -lCore -ltensorflow_cc -lboost_thread -lboost_date_time -lCLHEP -lpng -lpcre -ltensorflow_framework -lbz2 -lgif -lgsl -ljpeg -lturbojpeg -luuid -lprotobuf -lsqlite3 -ltbb -lxerces-c -llzma -lz -lfmt -lcms-md5 -lopenblas -lcrypt -ldl -lrt -lstdc++fs -ltinyxml2
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc: In member function 'produceFromTrajectory':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc:682:49: warning: assuming pointer wraparound does not occur when comparing P +- C1 with P +- C2 [-Wstrict-overflow]
   682 |                    itmCompare >= tmColl.begin() && itmCompare > itTrajMeas - 4;
      |                                                 ^
Leaving library rule at src/RecoTracker/FinalTrackSelectors/plugins
```
- `RecoTracker/MkFitCMS`:
```
>> Building shared library tmp/el8_amd64_gcc10/src/RecoTracker/MkFitCMS/src/RecoTrackerMkFitCMS/libRecoTrackerMkFitCMS.so
/data/cmsbld/jenkins/workspace/build-any-ib/w/el8_amd64_gcc10/external/gcc/10.3.0-84898dea653199466402e67d73657f10/bin/c++ -O2 -pthread -pipe -Werror=main -Werror=pointer-arith -Werror=overlength-strings -Wno-vla -Werror=overflow -std=c++1z -ftree-vectorize -Wstrict-overflow -Werror=array-bounds -Werror=format-contains-nul -Werror=type-limits -fvisibility-inlines-hidden -fno-math-errno --param vect-max-version-for-alias-checks=50 -Xassembler --compress-debug-sections -msse3 -felide-constructors -fmessage-length=0 -Wall -Wno-non-template-friend -Wno-long-long -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers -Wno-deprecated-copy -Wno-unused-parameter -Wunused -Wparentheses -Wno-deprecated -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -fdiagnostics-show-option -Wno-unused-local-typedefs -Wno-attributes -Wno-psabi -DBOOST_DISABLE_ASSERTS -fopenmp-simd -flto -fipa-icf -flto-odr-type-merging -fno-fat-lto-objects -Wodr -shared -Wl,-E -Wl,-z,defs tmp/el8_amd64_gcc10/src/RecoTracker/MkFitCMS/src/RecoTrackerMkFitCMS/MkStdSeqs.cc.o tmp/el8_amd64_gcc10/src/RecoTracker/MkFitCMS/src/RecoTrackerMkFitCMS/runFunctions.cc.o -o tmp/el8_amd64_gcc10/src/RecoTracker/MkFitCMS/src/RecoTrackerMkFitCMS/libRecoTrackerMkFitCMS.so -Wl,-E -Wl,--hash-style=gnu -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/biglib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/lib/el8_amd64_gcc10 -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/external/el8_amd64_gcc10/lib -L/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/static/el8_amd64_gcc10 -lRecoTrackerMkFitCore -lSmatrix -lCore -lpcre -lbz2 -ltbb -llzma -lz -lcrypt -ldl -lrt
/data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoTracker/MkFitCMS/src/MkStdSeqs.cc: In function 'find_duplicates_sharedhits':
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoTracker/MkFitCMS/src/MkStdSeqs.cc:459:13: warning: assuming signed overflow does not occur when simplifying comparison of absolute value and zero [-Wstrict-overflow]
   459 |             if (std::abs(it->second) >= (int)itrack)
      |             ^
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/9802c30fc48bdc09db9c7193cb951860/opt/cmssw/el8_amd64_gcc10/cms/cmssw/CMSSW_12_5_LTO_X_2022-07-07-2300/src/RecoTracker/MkFitCMS/src/MkStdSeqs.cc:459:13: warning: assuming signed overflow does not occur when simplifying comparison of absolute value and zero [-Wstrict-overflow]
 Copying tmp/el8_amd64_gcc10/src/RecoTracker/MkFitCMS/src/RecoTrackerMkFitCMS/libRecoTrackerMkFitCMS.so to productstore area:
Leaving library rule at RecoTracker/MkFitCMS
```

Regarding the type of error and following some online discussions of this type of warning [fmtlib/fmt/issues/2757](https://github.com/fmtlib/fmt/issues/2757), I have tried to workaround it as shown in this PR for `RecoLocalTracker/SiStripZeroSuppression` and `RecoTracker/FinalTrackSelectors`. For `RecoTracker/MkFitCMS` I just corrected the narrowing cast. Feel free to propose other solutions that could be better regarding the analysis itself.

Many thanks,
Andrea.