### PR TITLE
re-enable photons for run3 in nanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -340,22 +340,6 @@ photonTablesTask = cms.Task(photonTable)
 photonMCTask = cms.Task(photonsMCMatchForTable, photonMCTable)
 
 
-## TEMPORARY as no ID for Run3 yet
-(run3_nanoAOD_devel).toReplaceWith(photonTask, photonTask.copyAndExclude([bitmapVIDForPho]))
-(run3_nanoAOD_devel).toModify(slimmedPhotonsWithUserData, userIntFromBools = cms.PSet())
-(run3_nanoAOD_devel).toModify(slimmedPhotonsWithUserData.userInts,
-                              VIDNestedWPBitmap = None,)
-(run3_nanoAOD_devel).toModify(slimmedPhotonsWithUserData.userFloats,
-                              mvaID = None)
-(run3_nanoAOD_devel).toModify(photonTable.variables,
-                              cutBased = None,
-                              cutBased_Fall17V1Bitmap = None,
-                              vidNestedWPBitmap = None,
-                              mvaID = None,
-                              mvaID_WP90 = None,
-                              mvaID_WP80 = None,
-)
-#### end TEMPORARY Run3
 
 from RecoEgamma.EgammaIsolationAlgos.egmPhotonIsolationMiniAOD_cff import egmPhotonIsolation
 from RecoEgamma.PhotonIdentification.photonIDValueMapProducer_cff import photonIDValueMapProducer


### PR DESCRIPTION
#### PR description:

re-enable photon IDs for run3

#### PR validation:
cmsDriver.py test_nanoTuples_mcRun3 -n 10 --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --conditions auto:phase1_2022_realistic --step NANO --nThreads 1 --era Run3 --filein /store/relval/CMSSW_12_3_0_pre6/RelValQQToHToTauTau_14TeV/MINIAODSIM/123X_mcRun3_2021_realistic_v11-v1/10000/9109f7be-2e01-42a2-926d-5f1dd4ade6dc.root --customise_commands "process.options.wantSummary = cms.untracked.bool(True)"


