### PR TITLE
[12_4_X] Add GEM alignment in all Run3 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -70,17 +70,17 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
     'phase1_2022_design'           : '124X_mcRun3_2022_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v9',
+    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v10',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v10',
+    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v11',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
     'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v9',
+    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v10',
+    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v11',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v10',
+    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v11',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '124X_mcRun4_realistic_v8'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -41,10 +41,10 @@ autoCond = {
     'run3_data_express'            : '124X_dataRun3_Express_frozen_v4',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v4 but with snapshot at 2022-07-12 13:00:00 (UTC)
     'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v4',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-07-12 13:00:00 (UTC)
-    'run3_data'                    : '124X_dataRun3_v8',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-07-12 23:00:00 (UTC)
+    'run3_data'                    : '124X_dataRun3_v9',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '124X_dataRun3_relval_v7',
+    'run3_data_relval'             : '124X_dataRun3_relval_v8',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,18 +33,18 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v3) but with snapshot at 2022-06-24 15:15:00 (UTC)
-    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v4',
+    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v4) but with snapshot at 2022-07-11 17:00:00 (UTC)
+    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v5',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v6',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v2 but with snapshot at 2022-06-24 15:15:00 (UTC)
-    'run3_data_express'            : '124X_dataRun3_Express_frozen_v2',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v2 but with snapshot at 2022-06-24 15:15:00 (UTC)
-    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v2',
-    # GlobalTag for Run3 offline data reprocessing - snapshot updated to 2022-06-29 14:53:51 (UTC)
-    'run3_data'                    : '124X_dataRun3_v5',
+    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v7',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v4 but with snapshot at 2022-07-11 17:00:00 (UTC)
+    'run3_data_express'            : '124X_dataRun3_Express_frozen_v3',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v4 but with snapshot at 2022-07-11 17:00:00 (UTC)
+    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v3',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-07-11 17:00:00 (UTC)
+    'run3_data'                    : '124X_dataRun3_v7',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '124X_dataRun3_relval_v5',
+    'run3_data_relval'             : '124X_dataRun3_relval_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
@@ -68,19 +68,19 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '124X_mcRun3_2022_design_v6',
+    'phase1_2022_design'           : '124X_mcRun3_2022_design_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v8',
+    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v9',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v9',
+    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v10',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v6',
+    'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v8',
+    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v9',
+    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v9',
+    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v10',
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'             : '124X_mcRun4_realistic_v8'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -33,18 +33,18 @@ autoCond = {
     'run2_data_promptlike_hi'      : '124X_dataRun2_PromptLike_HI_v1',
     # GlobalTag with fixed snapshot time for Run2 HLT RelVals: customizations to run with fixed L1 Menu
     'run2_hlt_relval'              : '123X_dataRun2_HLT_relval_v3',
-    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v4) but with snapshot at 2022-07-11 17:00:00 (UTC)
-    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v5',
+    # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v4) but with snapshot at 2022-07-12 13:00:00 (UTC)
+    'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v6',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v7',
-    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v4 but with snapshot at 2022-07-11 17:00:00 (UTC)
-    'run3_data_express'            : '124X_dataRun3_Express_frozen_v3',
-    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v4 but with snapshot at 2022-07-11 17:00:00 (UTC)
-    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v3',
-    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-07-11 17:00:00 (UTC)
-    'run3_data'                    : '124X_dataRun3_v7',
+    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v8',
+    # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v4 but with snapshot at 2022-07-12 13:00:00 (UTC)
+    'run3_data_express'            : '124X_dataRun3_Express_frozen_v4',
+    # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v4 but with snapshot at 2022-07-12 13:00:00 (UTC)
+    'run3_data_prompt'             : '124X_dataRun3_Prompt_frozen_v4',
+    # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-07-12 13:00:00 (UTC)
+    'run3_data'                    : '124X_dataRun3_v8',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '124X_dataRun3_relval_v6',
+    'run3_data_relval'             : '124X_dataRun3_relval_v7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:
(Partial) Backport of #38692
In this PR we add:
 - the new GEM Alignment and AlignmentErrors tags to all Run3 GTs ([CMSTalk post](https://cms-talk.web.cern.ch/t/full-track-validation-hlt-express-prompt-update-of-mual/12237))
 ~- the new BeamSpot for Run 3 collisions at 13.6 TeV in all Run3 MC GTs~
   ~- Compatible with the VtxSmearing parameters `Realistic25ns13p6TeVEarly2022Collision` introduced in #38616~
   ~- The new reco BeamSpot was derived from the RelVal produced in [JIRA-PDMVRELVALS-156](https://its.cern.ch/jira/browse/PDMVRELVALS-156)~
 - new DroboxMetaData tag for the Express and Prompt frozen GTs and in the data and data_relval GTs ([CMSTalk post](https://cms-talk.web.cern.ch/t/new-dropbox-meta-data-tag-for-express-for-12-4-x/12176))

See master PR for details on the tags and the GT diffs.

**EDIT**
After the disussion in https://github.com/cms-sw/cmssw/pull/38760#issuecomment-1186961283 it was concluded that the new reco BeamSpot tags should not be propagated to the Run 3 realistic MC GTs in CMSSW_12_4_X (while they are included in the master branch).
So in aa754c5 I reverted the BeamSpot tags, here are the new GT diffs:
**MC Run3 realistic**  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_mcRun3_2022_realistic_v8/124X_mcRun3_2022_realistic_v10
**MC Run3 cosmics realistic**  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_mcRun3_2022cosmics_realistic_deco_v9/124X_mcRun3_2022cosmics_realistic_deco_v11
**MC Run3 realistic HI**  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_mcRun3_2022_realistic_HI_v8/124X_mcRun3_2022_realistic_HI_v10
**MC Run3 2023 realistic**  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_mcRun3_2023_realistic_v9/124X_mcRun3_2023_realistic_v11
**MC Run3 2024 realistic**  https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/124X_mcRun3_2024_realistic_v9/124X_mcRun3_2024_realistic_v11


#### PR validation:
Tested with
`runTheMatrix.py -l 139.001,138.4,138.5,12034.0,11634.0,7.23,159.0,12434.0,12834.0 --ibeos -j 16`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #38692