### PR TITLE
[12_4_X] Run3 GEMGeometryBuilder Run3 modifier and fix DQM GEM chambers

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -576,7 +576,7 @@ protected:
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
 
   std::vector<GEMDetId> listChamberId_;
-  std::map<GEMDetId, std::vector<const GEMEtaPartition*>> mapEtaPartition_;
+  std::map<GEMDetId, std::vector<const GEMEtaPartition *>> mapEtaPartition_;
 
   std::map<ME2IdsKey, bool> MEMap2Check_;
   std::map<ME3IdsKey, bool> MEMap2WithEtaCheck_;

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -575,7 +575,8 @@ protected:
   const GEMGeometry *GEMGeometry_;
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
 
-  std::vector<GEMChamber> gemChambers_;
+  std::vector<GEMDetId> listChamberId_;
+  std::map<GEMDetId, std::vector<const GEMEtaPartition*>> mapEtaPartition_;
 
   std::map<ME2IdsKey, bool> MEMap2Check_;
   std::map<ME3IdsKey, bool> MEMap2WithEtaCheck_;

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -157,8 +157,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
 
   std::map<ME3IdsKey, Int_t> total_digi_layer;
   std::map<ME3IdsKey, Int_t> total_digi_eta;
-  for (const auto& ch : gemChambers_) {
-    GEMDetId gid = ch.id();
+  for (auto gid : listChamberId_) {
     ME2IdsKey key2{gid.region(), gid.station()};
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
@@ -168,7 +167,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
     const BoundPlane& surface = GEMGeometry_->idToDet(gid)->surface();
     if (total_digi_layer.find(key3) == total_digi_layer.end())
       total_digi_layer[key3] = 0;
-    for (auto iEta : ch.etaPartitions()) {
+    for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       if (total_digi_eta.find(key3IEta) == total_digi_eta.end())

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -187,13 +187,12 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
   std::map<ME3IdsKey, Int_t> total_rechit_iEta;
   std::map<ME4IdsKey, std::map<Int_t, Bool_t>> mapCLSOver5;
 
-  for (const auto& ch : gemChambers_) {
-    GEMDetId gid = ch.id();
+  for (auto gid : listChamberId_) {
     auto chamber = gid.chamber();
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     MEStationInfo& stationInfo = mapStationInfo_[key3];
-    for (auto iEta : ch.etaPartitions()) {
+    for (auto iEta : mapEtaPartition_[gid])  {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -192,7 +192,7 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     MEStationInfo& stationInfo = mapStationInfo_[key3];
-    for (auto iEta : mapEtaPartition_[gid])  {
+    for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -71,7 +71,7 @@ int GEMDQMBase::loadChambers() {
       }
     }
   }
-  
+
   // Borrwed from DQM/GEM/src/GEMOfflineMonitor.cc
   nMaxNumCh_ = 0;
   for (const GEMRegion* region : GEMGeometry_->regions()) {

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -26,11 +26,9 @@ GEMDQMBase::GEMDQMBase(const edm::ParameterSet& cfg) : geomToken_(esConsumes<edm
 
 int GEMDQMBase::initGeometry(edm::EventSetup const& iSetup) {
   GEMGeometry_ = nullptr;
-  try {
-    //edm::ESHandle<GEMGeometry> hGeom;
-    //iSetup.get<MuonGeometryRecord>().get(hGeom);
-    GEMGeometry_ = &iSetup.getData(geomToken_);
-  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  if (auto handle = iSetup.getHandle(geomToken_)) {
+    GEMGeometry_ = handle.product();
+  } else {
     edm::LogError(log_category_) << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return -1;
   }
@@ -58,23 +56,22 @@ int GEMDQMBase::getNumEtaPartitions(const GEMStation* station) {
 int GEMDQMBase::loadChambers() {
   if (GEMGeometry_ == nullptr)
     return -1;
-  gemChambers_.clear();
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
-  for (auto sch : superChambers_) {  // FIXME: This loop can be merged into the below loop
-    for (auto pch : sch->chambers()) {
-      Bool_t bExist = false;
-      for (const auto& ch : gemChambers_) {
-        if (pch->id() == ch.id()) {
-          bExist = true;
-          break;
+  listChamberId_.clear();
+  mapEtaPartition_.clear();
+  for (const GEMRegion* region : GEMGeometry_->regions()) {
+    for (const GEMStation* station : region->stations()) {
+      for (auto sch : station->superChambers()) {
+        for (auto pchamber : sch->chambers()) {
+          GEMDetId gid = pchamber->id();
+          listChamberId_.push_back(pchamber->id());
+          for (auto iEta : pchamber->etaPartitions()) {
+            mapEtaPartition_[gid].push_back(iEta);
+          }
         }
       }
-      if (bExist)
-        continue;
-      gemChambers_.push_back(*pch);
     }
   }
-
+  
   // Borrwed from DQM/GEM/src/GEMOfflineMonitor.cc
   nMaxNumCh_ = 0;
   for (const GEMRegion* region : GEMGeometry_->regions()) {
@@ -178,8 +175,7 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
   MEMap3Check_.clear();
   MEMap3WithChCheck_.clear();
   MEMap4Check_.clear();
-  for (const auto& ch : gemChambers_) {
-    GEMDetId gid = ch.id();
+  for (auto gid : listChamberId_) {
     ME2IdsKey key2{gid.region(), gid.station()};
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key3WithChamber{gid.region(), gid.station(), gid.layer(), gid.chamber()};
@@ -207,7 +203,7 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
       ProcessWithMEMap3WithChamber(bh3Ch, key3WithChamber);
       MEMap3WithChCheck_[key3WithChamber] = true;
     }
-    for (auto iEta : ch.etaPartitions()) {
+    for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), eId.ieta()};
       ME3IdsKey key2WithEta{gid.region(), gid.station(), eId.ieta()};

--- a/Geometry/GEMGeometryBuilder/python/gemGeometryDB_cfi.py
+++ b/Geometry/GEMGeometryBuilder/python/gemGeometryDB_cfi.py
@@ -12,5 +12,7 @@ GEMGeometryESModule = cms.ESProducer("GEMGeometryESModule",
 )
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 run3_GEM.toModify(GEMGeometryESModule, applyAlignment = True)
+phase2_GEM.toModify(GEMGeometryESModule, applyAlignment = False)

--- a/Geometry/GEMGeometryBuilder/python/gemGeometryDB_cfi.py
+++ b/Geometry/GEMGeometryBuilder/python/gemGeometryDB_cfi.py
@@ -10,3 +10,7 @@ GEMGeometryESModule = cms.ESProducer("GEMGeometryESModule",
     alignmentsLabel = cms.string(''),
     applyAlignment = cms.bool(False)
 )
+
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
+run3_GEM.toModify(GEMGeometryESModule, applyAlignment = True)

--- a/Geometry/GEMGeometryBuilder/python/gemGeometry_cff.py
+++ b/Geometry/GEMGeometryBuilder/python/gemGeometry_cff.py
@@ -2,4 +2,8 @@ from Geometry.GEMGeometryBuilder.gemGeometry_cfi import gemGeometry
 
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
+from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+
 dd4hep.toModify(gemGeometry, fromDDD = False, fromDD4hep = True)
+
+run3_GEM.toModify(gemGeometry, applyAlignment = True)

--- a/Geometry/GEMGeometryBuilder/python/gemGeometry_cff.py
+++ b/Geometry/GEMGeometryBuilder/python/gemGeometry_cff.py
@@ -3,7 +3,9 @@ from Geometry.GEMGeometryBuilder.gemGeometry_cfi import gemGeometry
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
+from Configuration.Eras.Modifier_phase2_GEM_cff import phase2_GEM
 
 dd4hep.toModify(gemGeometry, fromDDD = False, fromDD4hep = True)
 
 run3_GEM.toModify(gemGeometry, applyAlignment = True)
+phase2_GEM.toModify(gemGeometry, applyAlignment = False)


### PR DESCRIPTION
#### PR description:
Backport of #38666 and #38908:
- GEM Run3 modifier setup for the alignment.
- Fix the geometry information of GEM chambers in DQM.

@hyunyong @jshlee @watson-ij @quark2 since we are very tight with times I took the liberty of opening the backport, it is a verbatim copy of @hyunyong's and @quark2's master PRs.

#### PR validation:
Code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #38666 and #38908