### PR TITLE
DAQ Input source not deleting files on exception (12_3_X)

### DIFF
--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -209,6 +209,8 @@ namespace evf {
     void reportLockWait(unsigned int ls, double waitTime, unsigned int lockCount);
     unsigned int getEventsProcessedForLumi(unsigned int lumi, bool* abortFlag = nullptr);
     bool getAbortFlagForLumi(unsigned int lumi);
+    bool exceptionDetected() const;
+    bool isExceptionOnData(unsigned int ls);
     bool shouldWriteFiles(unsigned int lumi, unsigned int* proc = nullptr) {
       unsigned int processed = getEventsProcessedForLumi(lumi);
       if (proc)
@@ -285,6 +287,8 @@ namespace evf {
 
     std::atomic<bool> monInit_;
     bool exception_detected_ = false;
+    std::atomic<bool> has_source_exception_ = false;
+    std::atomic<bool> has_data_exception_ = false;
     std::vector<unsigned int> exceptionInLS_;
     std::vector<std::string> fastPathList_;
   };

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -262,6 +262,7 @@ struct InputFile {
   bool advance(unsigned char*& dataPosition, const size_t size);
   void moveToPreviousChunk(const size_t size, const size_t offset);
   void rewindChunk(const size_t size);
+  void unsetDeleteFile() { deleteFile_ = false; }
 };
 
 #endif  // EventFilter_Utilities_FedRawDataInputSource_h

--- a/EventFilter/Utilities/plugins/ExceptionGenerator.cc
+++ b/EventFilter/Utilities/plugins/ExceptionGenerator.cc
@@ -237,6 +237,10 @@ namespace evf {
             dummy += sqrt(log(float(j + 1))) / float(j * j);
           }
         } break;
+        case 16: {
+          throw cms::Exception("FastMonitoringService") << "Random exception!";
+        } break;
+
         default:
           break;
       }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -391,7 +391,7 @@ namespace evf {
     std::unique_lock<std::mutex> lkw(*fileDeleteLockPtr_);
     auto it = filesToDeletePtr_->begin();
     while (it != filesToDeletePtr_->end()) {
-      if (it->second->lumi_ == ls) {
+      if (it->second->lumi_ == ls && (!fms_ || !fms_->isExceptionOnData(it->second->lumi_))) {
         it = filesToDeletePtr_->erase(it);
       } else
         it++;


### PR DESCRIPTION
in event processing

#### PR description:

Input source is prevented from deleting files in case exception is thrown in input source or in processing in same LS as the input file.

#### PR validation:

Tested in DAQ test system wby having exceptions triggered by test code.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/38695