### PR TITLE
Add a noise plot and some minor adjustments to ECAL DQM [Master]

### DIFF
--- a/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/PresampleClient_cfi.py
@@ -64,6 +64,16 @@ ecalPresampleClient = cms.untracked.PSet(
             btype = cms.untracked.string('SuperCrystal'),
             description = cms.untracked.string('2D distribution of the presample RMS. Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
         ),
+	 MeanMapAll = cms.untracked.PSet(
+            path = cms.untracked.string('%(subdet)s/%(prefix)sSummaryClient/%(prefix)sPOT%(suffix)s pedestal G12 Mean map'),
+            kind = cms.untracked.string('TH2F'),
+            zaxis = cms.untracked.PSet(
+                title = cms.untracked.string('Mean')
+            ),
+            otype = cms.untracked.string('Ecal3P'),
+            btype = cms.untracked.string('SuperCrystal'),
+            description = cms.untracked.string('2D distribution of the presample Mean. Channels with entries less than ' + str(minChannelEntries) + ' are not considered.')
+        ),
         RMSMapAllByLumi = cms.untracked.PSet(
             path = cms.untracked.string('%(subdet)s/%(prefix)sSummaryClient/%(prefix)sPOT%(suffix)s pedestal G12 RMS map by lumi'),
             kind = cms.untracked.string('TH2F'),
@@ -107,8 +117,8 @@ ecalPresampleClient = cms.untracked.PSet(
             kind = cms.untracked.string('TH1F'),
             otype = cms.untracked.string('SM'),
             xaxis = cms.untracked.PSet(
-                high = cms.untracked.double(230.0),
-                nbins = cms.untracked.int32(120),
+                high = cms.untracked.double(270.0),
+                nbins = cms.untracked.int32(200),
                 low = cms.untracked.double(170.0)
             ),
             btype = cms.untracked.string('User'),

--- a/DQM/EcalMonitorClient/src/PresampleClient.cc
+++ b/DQM/EcalMonitorClient/src/PresampleClient.cc
@@ -40,6 +40,7 @@ namespace ecaldqm {
     MESet& meRMSMap(MEs_.at("RMSMap"));
     MESet& meRMSMapAll(MEs_.at("RMSMapAll"));
     MESet& meRMSMapAllByLumi(MEs_.at("RMSMapAllByLumi"));
+    MESet& meMeanMapAll(MEs_.at("MeanMapAll"));
 
     MESet const& sPedestal(sources_.at("Pedestal"));
     MESet const& sPedestalByLS(sources_.at("PedestalByLS"));
@@ -129,6 +130,7 @@ namespace ecaldqm {
     }  // qItr
 
     towerAverage_(meRMSMapAll, meRMSMap, -1.);
+    towerAverage_(meMeanMapAll, sPedestal, -1.);
 
     MESet& meTrendMean(MEs_.at("TrendMean"));
     MESet& meTrendRMS(MEs_.at("TrendRMS"));

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -29,7 +29,7 @@ for i in range(50) :
 chi2ThresholdEE = 50.
 chi2ThresholdEB = 16.
 energyThresholdEE = 4.6
-energyThresholdEEFwd = 6.7
+energyThresholdEEFwd = 12.
 energyThresholdEB = 2.02
 timingVsBXThreshold = energyThresholdEB
 timeErrorThreshold = 3.


### PR DESCRIPTION
#### PR description:

In response to the Run 3 collision conditions, this PR makes some adjustments in the Ecal DQM:
1. Adds a plot to see the 2D distribution of the mean of presample noise.
2. Increases x range and nbins of the 1D distribution of the noise mean.
3. Adjusts the energy threshold for the timing plot in the forward region of Ecal endcaps.

#### PR validation:

This was validated by running the online DQM workflow and testing the plots on a test DQM GUI. 

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
Backport to 12_3_X: https://github.com/cms-sw/cmssw/pull/38704
Backport to 12_4_X: https://github.com/cms-sw/cmssw/pull/38705
