### PR TITLE
Fix SteppingAction for volume names with DD4hep

### DIFF
--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -220,9 +220,9 @@ bool SteppingAction::initPointer() {
   const G4PhysicalVolumeStore* pvs = G4PhysicalVolumeStore::GetInstance();
   for (auto const& pvcite : *pvs) {
     const G4String& pvname = pvcite->GetName();
-    if (pvname == "Tracker")
+    if (pvname == "Tracker" || pvname == "tracker:Tracker_1")
       tracker = pvcite;
-    else if (pvname == "CALO")
+    else if (pvname == "CALO" || pvname == "caloBase:CALO_1")
       calo = pvcite;
 
     if (tracker && calo)


### PR DESCRIPTION
#### PR description:

This PR fixes the `SteppingAction` code for volume names when the geometry is created via DD4hep. The volume pointers are later used to check if a particle transitions from the `Tracker` to the `CALO`.

#### PR validation:

In local runs, the log now correctly includes
```
SteppingAction: pointer for Tracker 0x7f56d5508fd0 and for Calo 0x7f56d5509020
```
whereas before the pointers were 0 if the geometry was constructed via DD4hep.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Possibly many. I'll let Vladimir comment on this.