### PR TITLE
Updated name of last filter of the HLT for DQMOffline ZCounting 

### DIFF
--- a/DQMOffline/Lumi/python/ZCounting_cff.py
+++ b/DQMOffline/Lumi/python/ZCounting_cff.py
@@ -18,7 +18,7 @@ zcounting = DQMEDAnalyzer('ZCounting',
                                  conversionsName = cms.InputTag('conversions'),
 
                                  MuonTriggerNames = cms.vstring("HLT_IsoMu24_v*"),
-                                 MuonTriggerObjectNames = cms.vstring("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07"),
+                                 MuonTriggerObjectNames = cms.vstring("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p08"),
 
                                  IDType   = cms.untracked.string("CustomTight"), # Tight, Medium, Loose, CustomTight
                                  IsoType  = cms.untracked.string("NULL"),  # Tracker-based, PF-based


### PR DESCRIPTION
#### PR description:

Update the name of the last filter of the single muon trigger "HLT_IsoMu24". This is necessary as the name has changed from Run2 to Run3. 

#### PR validation:

Tests have been performed manually

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

A backport to CMSSW_12_4 is needed

