### PR TITLE
[12_4_X] Update GT for DQM clients unitTests and input file used for unitTest

### DIFF
--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -77,10 +77,11 @@ if (live):
 else:
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
     process.GlobalTag.DBParameters.authenticationPath = '.'
     # you may need to set manually the GT in the line below
     #process.GlobalTag.globaltag = '100X_upgrade2018_realistic_v10'
+
 
 #--------------------------------------------------------
 # Swap offline <-> online BeamSpot as in Express and HLT

--- a/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamfake_dqm_sourceclient-live_cfg.py
@@ -75,7 +75,7 @@ if (live):
 else:
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
     # you may need to set manually the GT in the line below
     #process.GlobalTag.globaltag = '100X_upgrade2018_realistic_v10'
 """

--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -117,7 +117,7 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 process.GlobalTag.DBParameters.authenticationPath = cms.untracked.string('.')
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 # Change Beam Monitor variables
 process.dqmBeamMonitor.useLockRecords = cms.untracked.bool(useLockRecords)

--- a/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhltfake_dqm_sourceclient-live_cfg.py
@@ -74,7 +74,7 @@ if (live):
 else:
   process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
   from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-  process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+  process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
   # you may need to set manually the GT in the line below
   #process.GlobalTag.globaltag = '100X_upgrade2018_realistic_v10'
 """

--- a/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beampixel_dqm_sourceclient-live_cfg.py
@@ -47,7 +47,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 # Use this to run locally (for testing purposes), choose the right GT
 #process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 #from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, "auto:run2_data", "")
+#process.GlobalTag = GlobalTag(process.GlobalTag, "auto:run3_data", "")
 # Otherwise use this
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 

--- a/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/castor_dqm_sourceclient-live_cfg.py
@@ -51,7 +51,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 ##
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 #-----------------------------
 # Castor DQM Source + SimpleReconstrctor

--- a/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/csc_dqm_sourceclient-live_cfg.py
@@ -134,7 +134,7 @@ del cscConditions
 
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 #--------------------------
 # Service

--- a/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt4ml_dqm_sourceclient-live_cfg.py
@@ -71,7 +71,7 @@ process.load("DQM.DTMonitorModule.dt_dqm_sourceclient_common_cff")
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #---- for offline DB: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 # message logger
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/dt_dqm_sourceclient-live_cfg.py
@@ -52,7 +52,7 @@ process.load("DQM.DTMonitorModule.dt_dqm_sourceclient_common_cff")
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 #---- for offline DB: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 # message logger
 process.MessageLogger = cms.Service("MessageLogger",

--- a/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/es_dqm_sourceclient-live_cfg.py
@@ -29,7 +29,7 @@ else:
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 process.load("EventFilter.ESRawToDigi.esRawToDigi_cfi")
 #process.ecalPreshowerDigis = EventFilter.ESRawToDigi.esRawToDigi_cfi.esRawToDigi.clone()

--- a/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hlt_dqm_sourceclient-live_cfg.py
@@ -51,7 +51,7 @@ process.load("CalibTracker.SiStripCommon.TkDetMapESProducer_cfi")
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 process.hltESSHcalSeverityLevel = cms.ESSource( "EmptyESSource",
     iovIsRunNotTime = cms.bool( True ),

--- a/DQM/Integration/python/clients/l1t_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1t_dqm_sourceclient-live_cfg.py
@@ -41,7 +41,7 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 process.GlobalTag.RefreshEachRun = True
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3s_data', '')
 
 #process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")

--- a/DQM/Integration/python/clients/l1temulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1temulator_dqm_sourceclient-live_cfg.py
@@ -45,7 +45,7 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 process.GlobalTag.RefreshEachRun = True
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 #process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 

--- a/DQM/Integration/python/clients/l1tstage1_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage1_dqm_sourceclient-live_cfg.py
@@ -42,7 +42,7 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 process.GlobalTag.RefreshEachRun = True
 # Condition for lxplus:: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 #process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")

--- a/DQM/Integration/python/clients/l1tstage1emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage1emulator_dqm_sourceclient-live_cfg.py
@@ -44,7 +44,7 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 process.GlobalTag.RefreshEachRun = True
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 #process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 

--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -30,7 +30,7 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 
 # # Condition for lxplus: change and possibly customise the GT
 # from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-# process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+# process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 # Required to load EcalMappingRecord
 process.load("Configuration.StandardSequences.GeometryRecoDB_cff")

--- a/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/mutracking_dqm_sourceclient-live_cfg.py
@@ -99,7 +99,7 @@ if (live):
 elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 
 

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -139,7 +139,7 @@ DIPFileName         = cms.untracked.string("/nfshome0/dqmpro/BeamMonitorDQM/Beam
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 # Please *do not* delete this toGet statement as it is needed to fetch BeamSpotOnline
 # information every lumisection (instead of every run as for the other records in the GT)

--- a/DQM/Integration/python/clients/physics_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/physics_dqm_sourceclient-live_cfg.py
@@ -38,7 +38,7 @@ process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration/StandardSequences/MagneticField_AutoFromDBCurrent_cff')

--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -88,7 +88,7 @@ if (live):
 elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 #-----------------------
 #  Reconstruction Modules

--- a/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixellumi_dqm_sourceclient-live_cfg.py
@@ -73,7 +73,7 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 #-----------------------
 #  Reconstruction Modules

--- a/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
@@ -45,7 +45,7 @@ process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 #process.GlobalTag.globaltag = "102X_dataRun2_Express_v4"
 process.GlobalTag.RefreshEachRun = True
 

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -88,7 +88,7 @@ elif(offlineTesting):
     process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
     #you may need to set manually the GT in the line below
-    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+    process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 #--------------------------------------------
 ## Patch to avoid using Run Info information in reconstruction

--- a/DQM/Integration/python/clients/sistriplas_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistriplas_dqm_sourceclient-live_cfg.py
@@ -31,7 +31,7 @@ process.siStripDigis.ProductLabel = "source"#"hltCalibrationRaw"
 process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
 # Condition for lxplus: change and possibly customise the GT
 #from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
-#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run3_data', '')
 
 #----------------------------
 # DQM Live Environment

--- a/DQM/Integration/python/config/unittestinputsource_cfi.py
+++ b/DQM/Integration/python/config/unittestinputsource_cfi.py
@@ -32,25 +32,25 @@ options.register('runUniqueKey',
     "Unique run key from RCMS for Frontier")
 
 options.register('runNumber',
-                 344518,
+                 355380,
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "Run number. This run number has to be present in the dataset configured with the dataset option.")
 
 options.register('dataset',
-                 '/ExpressCosmics/Commissioning2021-Express-v1/FEVT',
+                 '/ExpressPhysics/Run2022B-Express-v1/FEVT',
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "Dataset name like '/ExpressCosmics/Commissioning2021-Express-v1/FEVT'")
 
 options.register('maxLumi',
-                 2,
+                 20,
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "Only lumisections up to maxLumi are processed.")
 
 options.register('minLumi',
-                 1,
+                 19,
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.int,
                  "Only lumisections starting from minLumi are processed.")


### PR DESCRIPTION
#### PR description:
Backport of #38712
Updates all DQM clients to use `auto:run3_data` in the unitTests.
Updates the file used in the unitTests to a 2022 collision run at 13.6 TeV.


#### PR validation:
`scram b runtests` run fine

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #38712