### PR TITLE
Use tbb::task_group::defer in FinalWaitingTask

### DIFF
--- a/FWCore/Concurrency/interface/FinalWaitingTask.h
+++ b/FWCore/Concurrency/interface/FinalWaitingTask.h
@@ -1,0 +1,60 @@
+#ifndef FWCore_Concurrency_FinalWaitingTask_h
+#define FWCore_Concurrency_FinalWaitingTask_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Concurrency
+// Class  :     FinalWaitingTask
+//
+/**\class FinalWaitingTask FinalWaitingTask.h "FWCore/Concurrency/interface/FinalWaitingTask.h"
+
+ Description: [one line class summary]
+
+ Usage:
+   Use this class on the stack to signal the final task to be run.
+   Call done() to check to see if the task was run and check value of
+   exceptionPtr() to see if an exception was thrown by any task in the group.
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Tue, 12 Jul 2022 18:45:15 GMT
+//
+
+// system include files
+#include "oneapi/tbb/task_group.h"
+
+// user include files
+#include "FWCore/Concurrency/interface/WaitingTask.h"
+
+// forward declarations
+namespace edm {
+  class FinalWaitingTask : public WaitingTask {
+  public:
+    FinalWaitingTask() = delete;
+    explicit FinalWaitingTask(tbb::task_group& iGroup)
+        : m_group{&iGroup}, m_handle{iGroup.defer([]() {})}, m_done{false} {}
+
+    void execute() final { m_done = true; }
+
+    [[nodiscard]] bool done() const noexcept { return m_done.load(); }
+
+    void wait() {
+      m_group->wait();
+      if (exceptionPtr()) {
+        std::rethrow_exception(exceptionPtr());
+      }
+    }
+    std::exception_ptr waitNoThrow() {
+      m_group->wait();
+      return exceptionPtr();
+    }
+
+  private:
+    void recycle() final { m_group->run(std::move(m_handle)); }
+    tbb::task_group* m_group;
+    tbb::task_handle m_handle;
+    std::atomic<bool> m_done;
+  };
+
+}  // namespace edm
+#endif

--- a/FWCore/Concurrency/interface/WaitingTask.h
+++ b/FWCore/Concurrency/interface/WaitingTask.h
@@ -68,23 +68,6 @@ namespace edm {
     std::atomic<bool> m_ptrSet = false;
   };
 
-  /** Use this class on the stack to signal the final task to be run.
-   Call done() to check to see if the task was run and check value of
-   exceptionPtr() to see if an exception was thrown by any task in the group.
-   */
-  class FinalWaitingTask : public WaitingTask {
-  public:
-    FinalWaitingTask() : m_done{false} {}
-
-    void execute() final { m_done = true; }
-
-    bool done() const { return m_done.load(); }
-
-  private:
-    void recycle() final {}
-    std::atomic<bool> m_done;
-  };
-
   template <typename F>
   class FunctorWaitingTask : public WaitingTask {
   public:

--- a/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
+++ b/FWCore/Concurrency/test/test_catch2_WaitingTaskChain.cc
@@ -11,6 +11,7 @@
 #include "oneapi/tbb/global_control.h"
 
 #include "FWCore/Concurrency/interface/chain_first.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 
 TEST_CASE("Test chain::first", "[chain::first]") {
   oneapi::tbb::global_control control(oneapi::tbb::global_control::max_allowed_parallelism, 1);
@@ -19,8 +20,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](edm::WaitingTaskHolder h) {
@@ -31,7 +32,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -40,8 +41,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first | then | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](auto h) {
@@ -56,7 +57,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -65,8 +66,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first | then | then | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](auto h) {
@@ -85,7 +86,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -94,8 +95,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first | then | then | runLast") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         first([&count](auto h) {
@@ -109,7 +110,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
           REQUIRE(count.load() == 3);
         }) | runLast(edm::WaitingTaskHolder(group, &waitTask));
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -118,8 +119,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("exception -> first | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](edm::WaitingTaskHolder h) {
@@ -130,7 +131,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::make_exception_ptr(std::exception()));
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 0);
       REQUIRE(waitTask.done());
       REQUIRE(waitTask.exceptionPtr());
@@ -139,8 +140,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first(exception) | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](edm::WaitingTaskHolder h) {
@@ -152,7 +153,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
       REQUIRE(waitTask.exceptionPtr());
@@ -161,8 +162,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first(exception) | then | then | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](auto h) {
@@ -182,7 +183,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
       REQUIRE(waitTask.exceptionPtr());
@@ -193,8 +194,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, edm::WaitingTaskHolder h) {
@@ -206,7 +207,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -215,8 +216,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first | then | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, auto h) {
@@ -233,7 +234,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -242,8 +243,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first | then | then | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, auto h) {
@@ -265,7 +266,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -274,8 +275,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("exception -> first | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, edm::WaitingTaskHolder h) {
@@ -287,7 +288,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::make_exception_ptr(std::exception()));
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -296,8 +297,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("exception -> first | then | lastTask") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first([&count](std::exception_ptr const* iPtr, edm::WaitingTaskHolder h) {
@@ -315,7 +316,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::make_exception_ptr(std::exception()));
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -327,8 +328,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
       std::atomic<int> exceptCount{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first(ifException([&exceptCount](std::exception_ptr const& iPtr) {
@@ -342,7 +343,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(exceptCount.load() == 0);
       REQUIRE(count.load() == 1);
       REQUIRE(waitTask.done());
@@ -353,8 +354,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
       std::atomic<int> exceptCount{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first(ifException([&exceptCount](std::exception_ptr const& iPtr) {
@@ -375,7 +376,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(exceptCount.load() == 0);
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
@@ -386,8 +387,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
       std::atomic<int> exceptCount{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first(ifException([&exceptCount](std::exception_ptr const& iPtr) {
@@ -415,7 +416,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::exception_ptr());
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(exceptCount.load() == 0);
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
@@ -426,8 +427,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
       std::atomic<int> count{0};
       std::atomic<int> exceptCount{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         auto h = first(ifException([&exceptCount](std::exception_ptr const& iPtr) {
@@ -455,7 +456,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
 
         h.doneWaiting(std::make_exception_ptr(std::exception()));
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(exceptCount.load() == 3);
       REQUIRE(count.load() == 0);
       REQUIRE(waitTask.done());
@@ -467,8 +468,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first | ifThen(true) | then | runLast") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         first([&count](auto h) {
@@ -482,7 +483,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
           REQUIRE(count.load() == 3);
         }) | runLast(edm::WaitingTaskHolder(group, &waitTask));
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 3);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());
@@ -491,8 +492,8 @@ TEST_CASE("Test chain::first", "[chain::first]") {
     SECTION("first | ifThen(false) | then | runLast") {
       std::atomic<int> count{0};
 
-      edm::FinalWaitingTask waitTask;
       oneapi::tbb::task_group group;
+      edm::FinalWaitingTask waitTask{group};
       {
         using namespace edm::waiting_task::chain;
         first([&count](auto h) {
@@ -506,7 +507,7 @@ TEST_CASE("Test chain::first", "[chain::first]") {
           REQUIRE(count.load() == 2);
         }) | runLast(edm::WaitingTaskHolder(group, &waitTask));
       }
-      group.wait();
+      waitTask.waitNoThrow();
       REQUIRE(count.load() == 2);
       REQUIRE(waitTask.done());
       REQUIRE(not waitTask.exceptionPtr());

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -14,6 +14,7 @@
 #include <thread>
 #include "oneapi/tbb/task.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 
 class WaitingTaskList_test : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(WaitingTaskList_test);
@@ -185,7 +186,7 @@ void WaitingTaskList_test::stressTest() {
   unsigned int index = 1000;
   const unsigned int nTasks = 10000;
   while (0 != --index) {
-    edm::FinalWaitingTask waitTask;
+    edm::FinalWaitingTask waitTask{group};
     auto* pWaitTask = &waitTask;
     {
       edm::WaitingTaskHolder waitTaskH(group, pWaitTask);
@@ -199,9 +200,7 @@ void WaitingTaskList_test::stressTest() {
       std::thread doneWaitThread([&waitList, waitTaskH] { waitList.doneWaiting(std::exception_ptr{}); });
       std::shared_ptr<std::thread>(&doneWaitThread, join_thread);
     }
-    do {
-      group.wait();
-    } while (not waitTask.done());
+    waitTask.wait();
   }
 }
 

--- a/FWCore/Framework/test/callback_t.cppunit.cc
+++ b/FWCore/Framework/test/callback_t.cppunit.cc
@@ -13,6 +13,7 @@
 #include "FWCore/Framework/interface/ComponentDescription.h"
 #include "FWCore/Concurrency/interface/ThreadsController.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
 
@@ -108,13 +109,11 @@ namespace {
     edm::ActivityRegistry ar;
     edm::eventsetup::EventSetupRecordImpl rec(edm::eventsetup::EventSetupRecordKey::makeKey<callbacktest::Record>(),
                                               &ar);
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     edm::ServiceToken token;
     iCallback.prefetchAsync(edm::WaitingTaskHolder(group, &task), &rec, nullptr, token, edm::ESParentContext{});
-    do {
-      group.wait();
-    } while (not task.done());
+    task.waitNoThrow();
   }
 }  // namespace
 

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -32,6 +32,7 @@
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Concurrency/interface/ThreadsController.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 
 #include "cppunit/extensions/HelperMacros.h"
 
@@ -758,17 +759,12 @@ namespace {
       for (size_t i = 0; i != proxies.size(); ++i) {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
-          edm::FinalWaitingTask waitTask;
           oneapi::tbb::task_group group;
+          edm::FinalWaitingTask waitTask{group};
           edm::ServiceToken token;
           rec->prefetchAsync(
               edm::WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, token, edm::ESParentContext{});
-          do {
-            group.wait();
-          } while (not waitTask.done());
-          if (waitTask.exceptionPtr()) {
-            std::rethrow_exception(waitTask.exceptionPtr());
-          }
+          waitTask.wait();
         }
       }
     }
@@ -787,17 +783,12 @@ namespace {
       for (size_t i = 0; i != proxies.size(); ++i) {
         auto rec = iImpl.findImpl(recs[i]);
         if (rec) {
-          edm::FinalWaitingTask waitTask;
           oneapi::tbb::task_group group;
+          edm::FinalWaitingTask waitTask{group};
           edm::ServiceToken token;
           rec->prefetchAsync(
               edm::WaitingTaskHolder(group, &waitTask), proxies[i], &iImpl, token, edm::ESParentContext{});
-          do {
-            group.wait();
-          } while (not waitTask.done());
-          if (waitTask.exceptionPtr()) {
-            std::rethrow_exception(waitTask.exceptionPtr());
-          }
+          waitTask.wait();
         }
       }
     }

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -32,6 +32,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ESParentContext.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 
 #include <memory>
 #include "oneapi/tbb/task_arena.h"
@@ -188,16 +189,11 @@ namespace {
     void prefetch(eventsetup::EventSetupRecordImpl const& iRec) const {
       auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
       for (size_t i = 0; i != proxies.size(); ++i) {
-        edm::FinalWaitingTask waitTask;
         oneapi::tbb::task_group group;
+        edm::FinalWaitingTask waitTask{group};
         edm::ServiceToken token;
         iRec.prefetchAsync(WaitingTaskHolder(group, &waitTask), proxies[i], nullptr, token, edm::ESParentContext{});
-        do {
-          group.wait();
-        } while (not waitTask.done());
-        if (waitTask.exceptionPtr()) {
-          std::rethrow_exception(waitTask.exceptionPtr());
-        }
+        waitTask.wait();
       }
     }
 
@@ -211,16 +207,11 @@ namespace {
     void prefetch(eventsetup::EventSetupRecordImpl const& iRec) const {
       auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);
       for (size_t i = 0; i != proxies.size(); ++i) {
-        edm::FinalWaitingTask waitTask;
         oneapi::tbb::task_group group;
+        edm::FinalWaitingTask waitTask{group};
         edm::ServiceToken token;
         iRec.prefetchAsync(WaitingTaskHolder(group, &waitTask), proxies[i], nullptr, token, edm::ESParentContext{});
-        do {
-          group.wait();
-        } while (not waitTask.done());
-        if (waitTask.exceptionPtr()) {
-          std::rethrow_exception(waitTask.exceptionPtr());
-        }
+        waitTask.wait();
       }
     }
 

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -24,6 +24,7 @@
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -126,16 +127,11 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(e);
-    }
+    task.wait();
   }
 
   class BasicProd : public edm::global::EDFilter<> {

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/FileBlock.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -96,16 +97,11 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, id, iContext, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(e);
-    }
+    task.wait();
   }
 
   class BasicOutputModule : public edm::global::OutputModule<> {
@@ -220,15 +216,10 @@ testGlobalOutputModule::testGlobalOutputModule()
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (task.exceptionPtr()) {
-      std::rethrow_exception(task.exceptionPtr());
-    }
+    task.wait();
   };
 
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
@@ -236,15 +227,10 @@ testGlobalOutputModule::testGlobalOutputModule()
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (task.exceptionPtr()) {
-      std::rethrow_exception(task.exceptionPtr());
-    }
+    task.wait();
   };
 
   m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -24,6 +24,8 @@
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -126,16 +128,11 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(e);
-    }
+    task.wait();
   }
 
   class BasicProd : public edm::global::EDProducer<> {

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/FileBlock.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -96,16 +97,11 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, id, iContext, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(e);
-    }
+    task.wait();
   }
 
   class BasicOutputModule : public edm::limited::OutputModule<> {
@@ -219,15 +215,10 @@ testLimitedOutputModule::testLimitedOutputModule()
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (task.exceptionPtr()) {
-      std::rethrow_exception(task.exceptionPtr());
-    }
+    task.wait();
   };
 
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
@@ -235,15 +226,10 @@ testLimitedOutputModule::testLimitedOutputModule()
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (task.exceptionPtr()) {
-      std::rethrow_exception(task.exceptionPtr());
-    }
+    task.wait();
   };
 
   m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -24,6 +24,7 @@
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -136,16 +137,11 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(e);
-    }
+    task.wait();
   }
 
   class BasicProd : public edm::limited::EDProducer<> {

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -29,6 +29,7 @@
 #include "FWCore/Framework/interface/FileBlock.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
 #include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -108,16 +109,11 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, id, iContext, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(e);
-    }
+    task.wait();
   }
 
   class BasicOutputModule : public edm::one::OutputModule<> {
@@ -314,15 +310,10 @@ testOneOutputModule::testOneOutputModule()
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     iComm->writeLumiAsync(edm::WaitingTaskHolder(group, &task), *m_lbp, nullptr, &activityRegistry);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (task.exceptionPtr()) {
-      std::rethrow_exception(task.exceptionPtr());
-    }
+    task.wait();
   };
 
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
@@ -330,15 +321,10 @@ testOneOutputModule::testOneOutputModule()
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
     doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     iComm->writeRunAsync(edm::WaitingTaskHolder(group, &task), *m_rp, nullptr, &activityRegistry, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (task.exceptionPtr()) {
-      std::rethrow_exception(task.exceptionPtr());
-    }
+    task.wait();
   };
 
   m_transToFunc[Trans::kGlobalCloseInputFile] = [](edm::Worker* iBase, edm::OutputModuleCommunicator*) {

--- a/FWCore/Framework/test/stream_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_filter_t.cppunit.cc
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/HistoryAppender.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -125,16 +126,11 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(e);
-    }
+    task.wait();
   }
 
   template <typename T>

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -24,6 +24,7 @@
 #include "FWCore/Framework/interface/HistoryAppender.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Concurrency/interface/FinalWaitingTask.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
@@ -125,16 +126,11 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    edm::FinalWaitingTask task;
     oneapi::tbb::task_group group;
+    edm::FinalWaitingTask task{group};
     edm::ServiceToken token;
     iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(group, &task), info, token, s_streamID0, iContext, nullptr);
-    do {
-      group.wait();
-    } while (not task.done());
-    if (auto e = task.exceptionPtr()) {
-      std::rethrow_exception(e);
-    }
+    task.wait();
   }
 
   template <typename T>


### PR DESCRIPTION
#### PR description:
- This will allow the task_group wait to stay open until the FinalWaitingTask is recycled
- Added FinalWaitingTask::wait method to handle the usual usage pattern of throwing after wait if needed.

#### PR validation:

Framework unit tests pass.