### PR TITLE
Fixed MC truth data on particle transfer from tracker to calorimeter

### DIFF
--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -43,7 +43,6 @@ private:
 
   inline bool isInsideDeadRegion(const G4Region* reg) const;
   inline bool isOutOfTimeWindow(const G4Region* reg, const double& time) const;
-  inline bool isThisVolume(const G4VTouchable* touch, const G4VPhysicalVolume* pv) const;
 
   bool isLowEnergy(const G4LogicalVolume*, const G4Track*) const;
   void PrintKilledTrack(const G4Track*, const TrackStatus&) const;
@@ -97,11 +96,6 @@ inline bool SteppingAction::isOutOfTimeWindow(const G4Region* reg, const double&
     }
   }
   return (time > tofM);
-}
-
-inline bool SteppingAction::isThisVolume(const G4VTouchable* touch, const G4VPhysicalVolume* pv) const {
-  int level = (touch->GetHistoryDepth()) + 1;
-  return (level >= 3) ? (touch->GetVolume(level - 3) == pv) : false;
 }
 
 #endif

--- a/SimG4Core/Application/src/SteppingAction.cc
+++ b/SimG4Core/Application/src/SteppingAction.cc
@@ -1,4 +1,3 @@
-
 #include "SimG4Core/Application/interface/SteppingAction.h"
 #include "SimG4Core/Application/interface/EventAction.h"
 #include "SimG4Core/Notification/interface/CMSSteppingVerbose.h"
@@ -174,13 +173,13 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep) {
   // check transition tracker/calo
   bool isKilled = false;
   if (sAlive == tstat || sVeryForward == tstat) {
-    if (isThisVolume(preStep->GetTouchable(), tracker) && isThisVolume(postStep->GetTouchable(), calo)) {
-      math::XYZVectorD pos((preStep->GetPosition()).x(), (preStep->GetPosition()).y(), (preStep->GetPosition()).z());
+    if (preStep->GetPhysicalVolume() == tracker && postStep->GetPhysicalVolume() == calo) {
+      math::XYZVectorD pos((postStep->GetPosition()).x(), (postStep->GetPosition()).y(), (postStep->GetPosition()).z());
 
-      math::XYZTLorentzVectorD mom((preStep->GetMomentum()).x(),
-                                   (preStep->GetMomentum()).y(),
-                                   (preStep->GetMomentum()).z(),
-                                   preStep->GetTotalEnergy());
+      math::XYZTLorentzVectorD mom((postStep->GetMomentum()).x(),
+                                   (postStep->GetMomentum()).y(),
+                                   (postStep->GetMomentum()).z(),
+                                   postStep->GetTotalEnergy());
 
       uint32_t id = theTrack->GetTrackID();
 


### PR DESCRIPTION
#### PR description:
This PR is a continuation of #38706, which restore computation of transient MC truth data on tracks transfer from tracker to calorimeters. It was lost after migration to DD4hep. This information exist only during simulation of an event and is not persistent but is used in special tests, for example with SimWatchers. 

No effect on MC production is expected, no change of hits/digi.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Backport to 12_4_X would be useful.
