### PR TITLE
[12.4.X] Customize status plot for HG PCL alignment

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/MillePedeFileReader.h
@@ -108,6 +108,8 @@ public:  //====================================================================
     return mpPCLresults(updateDB_, vetoUpdateDB_, Nrec_, exitCode_, exitMessage_, updateBits_);
   }
 
+  const std::map<std::string, std::array<bool, 6>>& getResultsHG() const { return fractionExceeded_; }
+
 private:
   //========================= PRIVATE ENUMS ====================================
   //============================================================================
@@ -184,6 +186,9 @@ private:
 
   // pede binaries available
   int binariesAmount_{0};
+
+  // Fraction threshold booleans for HG alignment
+  std::map<std::string, std::array<bool, 6>> fractionExceeded_;
 
   int Nrec_{0};
   int exitCode_{-1};

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.h
@@ -66,6 +66,8 @@ private:  //===================================================================
 
   void fillStatusHisto(MonitorElement* statusHisto);
 
+  void fillStatusHistoHG(MonitorElement* statusHisto);
+
   void fillExpertHistos();
 
   void fillExpertHistos_HG();

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -322,8 +322,11 @@ void MillePedeFileReader ::readMillePedeResultFile() {
           if (fraction_ >= fractions_[ali][i]) {
             updateDB_ = true;
             ss << "   above fraction threshold" << std::endl;
-          } else
+            fractionExceeded_[ali][i] = true;
+          } else {
             ss << std::endl;
+            fractionExceeded_[ali][i] = false;
+          }
         } else
           ss << "No entries available or no fraction thresholds defined" << std::endl;
       }


### PR DESCRIPTION
Backport of https://github.com/cms-sw/cmssw/pull/38718

#### PR description:
In this PR the status plot used for the HG PCL alignment is customized to properly show the alignment update decision based on the fraction threshold logic, which is currently used. The "old" status plot is now only used for the LG PCL alignment.
In detail the following changes have been made:

- Add a map to `MillePedeFileReader` to store the threshold decision per structure and direction. Introduce a method to get the map.
- In `MillePedeDQMModule` different versions status plot depending on the alignment granularity (LG or HG) are produced.

An example of the customized status plot is shown below. Here, the fraction threshold is exceeded for three different detector-direction combinations and the alignment would be updated. The DQM GUI render plugin will be updated to cope with the "new" status plot.

![image](https://user-images.githubusercontent.com/32901048/178692141-a94438a1-5152-488e-a9bc-e8d37a78db6d.png)


#### PR validation:
The PR can be validated using `runTheMatrix.py -l 1001.2 --ibeos`.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Backport of https://github.com/cms-sw/cmssw/pull/38718 which is needed for the HG PCL alignment running on Tier-0.

@mmusich, @connorpa, @antoniovagnerini, @consuegs
