### PR TITLE
Add sigmaietaieta caloID cut to the Run 3 scouting electron path backport from CMSSW_12_5_X

### DIFF
--- a/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.cc
+++ b/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.cc
@@ -62,12 +62,36 @@ HLTScoutingEgammaProducer::HLTScoutingEgammaProducer(const edm::ParameterSet& iC
       egammaPtCut(iConfig.getParameter<double>("egammaPtCut")),
       egammaEtaCut(iConfig.getParameter<double>("egammaEtaCut")),
       egammaHoverECut(iConfig.getParameter<double>("egammaHoverECut")),
+      egammaSigmaIEtaIEtaCut(iConfig.getParameter<std::vector<double>>("egammaSigmaIEtaIEtaCut")),
+      absEtaBinUpperEdges(iConfig.getParameter<std::vector<double>>("absEtaBinUpperEdges")),
       mantissaPrecision(iConfig.getParameter<int>("mantissaPrecision")),
       saveRecHitTiming(iConfig.getParameter<bool>("saveRecHitTiming")),
       rechitMatrixSize(iConfig.getParameter<int>("rechitMatrixSize")),  //(2n+1)^2
       rechitZeroSuppression(iConfig.getParameter<bool>("rechitZeroSuppression")),
       ecalRechitEB_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRechitEB"))),
       ecalRechitEE_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ecalRechitEE"))) {
+  // cross-check for compatibility in input vectors
+  if (absEtaBinUpperEdges.size() != egammaSigmaIEtaIEtaCut.size()) {
+    throw cms::Exception("IncompatibleVects")
+        << "size of \"absEtaBinUpperEdges\" (" << absEtaBinUpperEdges.size() << ") and \"egammaSigmaIEtaIEtaCut\" ("
+        << egammaSigmaIEtaIEtaCut.size() << ") differ";
+  }
+
+  for (auto aIt = 1u; aIt < absEtaBinUpperEdges.size(); ++aIt) {
+    if (absEtaBinUpperEdges[aIt - 1] < 0 || absEtaBinUpperEdges[aIt] < 0) {
+      throw cms::Exception("IncorrectValue") << "absEtaBinUpperEdges entries should be greater than or equal to zero.";
+    }
+    if (absEtaBinUpperEdges[aIt - 1] >= absEtaBinUpperEdges[aIt]) {
+      throw cms::Exception("ImproperBinning") << "absEtaBinUpperEdges entries should be in increasing order.";
+    }
+  }
+
+  if (not absEtaBinUpperEdges.empty() and absEtaBinUpperEdges[absEtaBinUpperEdges.size() - 1] < egammaEtaCut) {
+    throw cms::Exception("IncorrectValue")
+        << "Last entry in \"absEtaBinUpperEdges\" (" << absEtaBinUpperEdges[absEtaBinUpperEdges.size() - 1]
+        << ") should have a value larger than \"egammaEtaCut\" (" << egammaEtaCut << ").";
+  }
+
   //register products
   produces<Run3ScoutingElectronCollection>();
   produces<Run3ScoutingPhotonCollection>();
@@ -107,6 +131,7 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
     return;
   }
 
+  // Get R9Map
   Handle<RecoEcalCandMap> R9Map;
   if (!iEvent.getByToken(R9Map_, R9Map)) {
     iEvent.put(std::move(outElectrons));
@@ -232,9 +257,21 @@ void HLTScoutingEgammaProducer::produce(edm::StreamID sid, edm::Event& iEvent, e
       }
     }
 
-    float HoE = 999.;
-    if (candidate.superCluster()->energy() != 0.)
-      HoE = (*HoverEMap)[candidateRef] / candidate.superCluster()->energy();
+    auto const HoE = candidate.superCluster()->energy() != 0.
+                         ? ((*HoverEMap)[candidateRef] / candidate.superCluster()->energy())
+                         : 999.;
+    if (HoE > egammaHoverECut)
+      continue;
+
+    if (not absEtaBinUpperEdges.empty()) {
+      auto const sinin = candidate.superCluster()->energy() != 0. ? (*SigmaIEtaIEtaMap)[candidateRef] : 999.;
+      auto etaBinIdx = std::distance(
+          absEtaBinUpperEdges.begin(),
+          std::lower_bound(absEtaBinUpperEdges.begin(), absEtaBinUpperEdges.end(), std::abs(candidate.eta())));
+
+      if (sinin > egammaSigmaIEtaIEtaCut[etaBinIdx])
+        continue;
+    }
 
     float d0 = 0.0;
     float dz = 0.0;
@@ -319,6 +356,8 @@ void HLTScoutingEgammaProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<double>("egammaPtCut", 4.0);
   desc.add<double>("egammaEtaCut", 2.5);
   desc.add<double>("egammaHoverECut", 1.0);
+  desc.add<std::vector<double>>("egammaSigmaIEtaIEtaCut", {99999.0, 99999.0});
+  desc.add<std::vector<double>>("absEtaBinUpperEdges", {1.479, 5.0});
   desc.add<bool>("saveRecHitTiming", false);
   desc.add<int>("mantissaPrecision", 10)->setComment("default float16, change to 23 for float32");
   desc.add<int>("rechitMatrixSize", 10);

--- a/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.h
+++ b/HLTrigger/Egamma/plugins/HLTScoutingEgammaProducer.h
@@ -82,6 +82,8 @@ private:
   const double egammaPtCut;
   const double egammaEtaCut;
   const double egammaHoverECut;
+  const std::vector<double> egammaSigmaIEtaIEtaCut;
+  const std::vector<double> absEtaBinUpperEdges;
   const int mantissaPrecision;
   const bool saveRecHitTiming;
   const int rechitMatrixSize;


### PR DESCRIPTION
Co-authored-by: Marino Missiroli <m.missiroli@cern.ch>

#### PR description:

Add the sigmaietaieta calo id variable cut to the Run 3 scouting electron collection
  - Use the same cut strategy as in the standard electron path.
  - Default value is kept so that all the electrons pass without the cut.
  - Default implementation is "less than" a certain cut value because the standard use of this variable is var < cut.
  - Validated in presentation in the scouting group at https://indico.cern.ch/event/1174315/#1-update-on-scouting-electrons
  - The EGamma sigmaietaieta variable will be updated with sigmaietaieta(noisecleaned) variable which can be done as a different collection input to the same variable to that has been left unchanged but will be part of the changes to the scouting path.
 
#### PR validation:

To validate the changes in this PR
  - We re-emulated the scouting path with MC and 2018 data files. 
  - Timing and Rate studies were done as well to see if the effect of the PR is as expected. 
  - All observations were found to be normal.
  - In addition, all the regular set of checks such as code-check and code-formatting suggested in [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html) have also been applied.

#### PR backport from CMSSW_12_5_X to CMSSW_12_4_X:

 The current online HLT for Run 3 is running on the 12_4_X release cycle. This PR introduces the sigmaietaieta_noisecleaned variable cut in the Run 3 Scouting EGamma HLT path.  
Master PR: https://github.com/cms-sw/cmssw/pull/38602
Intended backport release cycle number: CMSSW_12_4_X