### PR TITLE
Fix rare crash of the HLT in case the muon OI DNN does not find a good seed strategy

### DIFF
--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIDNN.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIDNN.cc
@@ -866,7 +866,7 @@ void TSGForOIDNN::evaluateClassifier(const std::unordered_map<std::string, float
   tensorflow::TTypes<float, 1>::Matrix dnn_outputs = out_tensor.matrix<float>();
 
   // Find output with largest prediction
-  int imax = -1;
+  int imax = 0;
   float out_max = 0;
   for (long long int i = 0; i < out_tensor.dim_size(1); i++) {
     float ith_output = dnn_outputs(0, i);


### PR DESCRIPTION
It was observed that for a small number of events the seed generator for the outside-in muon track reconstruction in the HLT crashes with the error

```
[2] Calling method for module TSGForOIDNN/'hltIterL3OISeedsFromL2Muons'
Exception Message:
A std::exception was thrown.
No such node (output_labels.label_-1.nHBd)
```

This was tracked down to the index of the seed strategy that is chosen for each L2 muon is initialized as -1. There seem to be L2 muons in data for which we don't get a DNN score > 0, so this is never set to meaningful number, resulting in a crash. This PR changes the initializing so that in these cases the first strategy is chosen by defualt, avoiding the crash. 

We are still waiting to verify this fix on failed events from the error stream. 

Backports are planned for 12_4_X and (maybe) 12_3_X