### PR TITLE
Tracker Alignment: revamp E/P validation tools

### DIFF
--- a/Alignment/OfflineValidation/interface/EopElecVariables.h
+++ b/Alignment/OfflineValidation/interface/EopElecVariables.h
@@ -1,0 +1,111 @@
+#ifndef Alignment_OfflineValidation_EopElecVariables_h
+#define Alignment_OfflineValidation_EopElecVariables_h
+
+// For ROOT types with '_t':
+#include <Rtypes.h>
+
+// container to hold data to be written into TTree
+struct EopElecVariables {
+  /// constructor initialises to empty values
+  EopElecVariables() { clear(); }
+  ~EopElecVariables() {}
+  /// set to empty values
+  void clear() {
+    /// doubles
+    outerRadius = chi2 = normalizedChi2 = p = pt = ptError = theta = eta = phi = SC_energy = HcalEnergyIn01 =
+        HcalEnergyIn02 = HcalEnergyIn03 = HcalEnergyIn04 = HcalEnergyIn05 = SC_etaWidth = SC_phiWidth = fbrem = SC_eta =
+            SC_phi = pIn = pOut = etaIn = phiIn = etaOut = phiOut = px = py = pz = dRto1stSC = dRto2ndSC = 0.;
+    /// integers
+    charge = nHits = nLostHits = SC_nBasicClus = SC_algoID = RunNumber = EvtNumber = 0;
+    /// booleans
+    innerOk = isEcalDriven = isTrackerDriven = SC_isBarrel = SC_isEndcap = false;
+
+    MaxPtIn01 = 0.;
+    SumPtIn01 = 0.;
+    NoTrackIn0015 = true;
+    MaxPtIn02 = 0.;
+    SumPtIn02 = 0.;
+    NoTrackIn0020 = true;
+    MaxPtIn03 = 0.;
+    SumPtIn03 = 0.;
+    NoTrackIn0025 = true;
+    MaxPtIn04 = 0.;
+    SumPtIn04 = 0.;
+    NoTrackIn0030 = true;
+    MaxPtIn05 = 0.;
+    SumPtIn05 = 0.;
+    NoTrackIn0035 = true;
+    NoTrackIn0040 = true;
+
+    px_rejected_track = 0.;
+    py_rejected_track = 0.;
+    pz_rejected_track = 0.;
+    p_rejected_track = 0.;
+  }
+
+  Int_t charge;
+  Int_t nHits;
+  Int_t nLostHits;
+  Bool_t innerOk;
+  Double_t outerRadius;
+  Double_t chi2;
+  Double_t normalizedChi2;
+  Double_t px_rejected_track;
+  Double_t py_rejected_track;
+  Double_t pz_rejected_track;
+  Double_t p_rejected_track;
+  Double_t px;
+  Double_t py;
+  Double_t pz;
+  Double_t p;
+  Double_t pIn;
+  Double_t etaIn;
+  Double_t phiIn;
+  Double_t pOut;
+  Double_t etaOut;
+  Double_t phiOut;
+  Double_t pt;
+  Double_t ptError;
+  Double_t theta;
+  Double_t eta;
+  Double_t phi;
+  Double_t fbrem;
+  Double_t MaxPtIn01;
+  Double_t SumPtIn01;
+  Bool_t NoTrackIn0015;
+  Double_t MaxPtIn02;
+  Double_t SumPtIn02;
+  Bool_t NoTrackIn0020;
+  Double_t MaxPtIn03;
+  Double_t SumPtIn03;
+  Bool_t NoTrackIn0025;
+  Double_t MaxPtIn04;
+  Double_t SumPtIn04;
+  Bool_t NoTrackIn0030;
+  Double_t MaxPtIn05;
+  Double_t SumPtIn05;
+  Bool_t NoTrackIn0035;
+  Double_t NoTrackIn0040;
+  Int_t SC_algoID;
+  Double_t SC_energy;
+  Int_t SC_nBasicClus;
+  Double_t SC_etaWidth;
+  Double_t SC_phiWidth;
+  Double_t SC_eta;
+  Double_t SC_phi;
+  Bool_t SC_isBarrel;
+  Bool_t SC_isEndcap;
+  Double_t dRto1stSC;
+  Double_t dRto2ndSC;
+  Double_t HcalEnergyIn01;
+  Double_t HcalEnergyIn02;
+  Double_t HcalEnergyIn03;
+  Double_t HcalEnergyIn04;
+  Double_t HcalEnergyIn05;
+  Bool_t isEcalDriven;
+  Bool_t isTrackerDriven;
+  Int_t RunNumber;
+  Int_t EvtNumber;
+};
+
+#endif

--- a/Alignment/OfflineValidation/interface/EopElecVariables.h
+++ b/Alignment/OfflineValidation/interface/EopElecVariables.h
@@ -8,7 +8,7 @@
 struct EopElecVariables {
   /// constructor initialises to empty values
   EopElecVariables() { clear(); }
-  ~EopElecVariables() {}
+  ~EopElecVariables() = default;
   /// set to empty values
   void clear() {
     /// doubles

--- a/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
+++ b/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
@@ -1,0 +1,1550 @@
+// STL headers
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+// ROOT headers
+#include <TStyle.h>
+#include <TCanvas.h>
+#include <TTree.h>
+#include <TString.h>
+#include <TAxis.h>
+#include <TProfile.h>
+#include <TF1.h>
+#include <TH1.h>
+#include <TH2F.h>
+#include <TGraphErrors.h>
+#include <TROOT.h>
+#include <TDirectory.h>
+#include <TFile.h>
+#include <TDirectoryFile.h>
+#include <TLegend.h>
+#include <TChain.h>
+#include <TMath.h>
+#include <TLatex.h>
+#include <TVirtualFitter.h>
+#include <TLorentzVector.h>
+#include <TMatrixD.h>
+#include <vector>
+
+// CMSSW headers
+#include "../interface/EopElecVariables.h"
+
+
+// New enumeration for kind of plots
+enum ModeType{TRACK_ETA, TRACK_PHI};
+
+// New structure for storing information relative to one file
+struct HistoType
+{
+  TString label;
+  TFile* file;
+  TTree* tree;
+
+  std::vector<Double_t> etaRange;
+  std::vector<Double_t> zRange;
+  std::vector<Double_t> eRange;
+
+  // Basic histograms
+  // dimension = numberOfBins x numberOfSteps
+  UInt_t ** selectedTracks;
+  TH1F***  xAxisBin;
+  TH1F***  negative;
+  TH1F***  positive;
+  TH2F***  Enegative;
+  TH2F***  Epositive;
+
+  // Intermediate histograms
+  TH1F** fit;
+  TH1F** combinedxAxisBin;
+
+  // Final histograms
+  TGraphErrors* overallGraph;
+  TH1F*         overallhisto;
+
+  // Final fit
+  TF1* f2;
+  TString misalignmentfit;
+
+  HistoType()
+  {
+    label="";
+    file=0;
+    tree=0;
+    overallGraph=0;
+    overallhisto=0;
+    f2=0;
+    misalignmentfit="";
+  }   
+
+  ~HistoType()
+  { }
+};
+
+
+// Prototype of functions
+void InitializeHistograms(ModeType mode, HistoType& histos);
+Bool_t checkArguments(TString  variable,           //input
+                      TString  path, 
+                      TString  alignmentWithLabel,
+                      TString  outputType,
+                      Double_t radius,
+                      Bool_t   verbose,
+                      Double_t givenMin,
+                      Double_t givenMax,
+                      ModeType& mode,               // ouput
+                      std::vector<TFile*>& files,
+                      std::vector<TString>& labels);
+void   configureROOTstyle(Bool_t verbose);
+Bool_t initializeTree(std::vector<TFile*>& files, std::vector<TTree*>& trees, EopElecVariables* track);
+void   ReadTree(ModeType mode, TString variable, HistoType& histo, EopElecVariables* track, Double_t radius);
+void   FillIntermediateHisto(ModeType mode, Bool_t verbose, HistoType& histo, TCanvas* ccontrol, TString outputType, Double_t radius);
+void   FillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo);
+void   LayoutFinalPlot(ModeType mode, std::vector<HistoType>& histos, TString outputType, 
+                       TString variable, TCanvas* c, Double_t givenMin, Double_t givenMax);
+
+
+std::vector<Double_t> extractgausparams(TH1F *histo, 
+                                        TString option1,
+                                        TString option2);
+
+
+
+// -----------------------------------------------------------------------------
+//
+//    Main function : momentumBiasValidation  
+//
+// -----------------------------------------------------------------------------
+void momentumBiasValidation(TString  variable, 
+                            TString  path, 
+                            TString  alignmentWithLabel,
+                            TString  outputType,
+                            Double_t radius = 1.,
+                            Bool_t   verbose = false,
+                            Double_t givenMin = 0.,
+                            Double_t givenMax = 0.)
+{
+  // Displaying first message
+  std::cout << "!!! Welcome to momentumBiasValidation !!!" << std::endl;
+  std::cout << std::endl;
+  time_t start = time(0);
+
+  // Checking and decoding the arguments
+  std::cout << "Checking arguments ..." << std::endl;
+  ModeType mode;               // variable to study
+  std::vector<TFile*> files;    // list of input files
+  std::vector<TString> labels;  // list of input labels
+  if (!checkArguments(variable,path,alignmentWithLabel,outputType,
+                      radius, verbose, givenMin, givenMax, 
+                      mode, files, labels)) return;
+  else
+  {
+    std::cout << "-> Number of files: " << files.size() << std::endl;
+  }
+
+  // Initializing the TTree
+  std::cout << "Initializing the TTree ..." << std::endl;
+  std::vector<TTree*> trees(files.size(),0);
+  EopElecVariables* track = new EopElecVariables();
+  if (!initializeTree(files, trees, track)) return;
+
+  // Configuring ROOT style
+  std::cout << "Configuring the ROOT style ..." << std::endl;
+  configureROOTstyle(verbose); 
+
+  TCanvas *c = new TCanvas("c","Canvas",0,0,1150,800);
+  TCanvas* ccontrol = new TCanvas("ccontrol","controlCanvas",0,0,600,300);
+
+  // Creating histos
+  std::vector<HistoType> histos(files.size());
+
+  // Loop over files
+
+  // To save the table cut
+  TFile* histo1;
+  std::string fileName;
+
+  for (unsigned int ifile=0;ifile<histos.size();ifile++)
+  {
+    HistoType& histo = histos[ifile];
+
+    // setting labels
+    histo.label=labels[ifile];
+    histo.file=files[ifile];
+    histo.tree=trees[ifile];
+
+    fileName = histo.file->GetName();
+    fileName = fileName.substr(path.Sizeof()-1);
+    fileName = "Plots"+fileName;
+
+    std::cout<<"NAME :"<<fileName<<std::endl;
+    histo1 = new TFile(fileName.c_str(), "RECREATE");
+
+    // Getting and saving cut flow values from tree producer step
+    TH1D* Nevents;
+    TH1D* NeventsTriggered;
+    TH1D* Nevents2elec;
+    TH1D* Ntracks;
+    TH1D* NtracksFiltered;
+    TH1D* NtracksFirstPtcut;
+    TH1D* NtracksOneSC;
+
+    Nevents          = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nEvents") ); 
+    NeventsTriggered = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nEventsTriggered")); 
+    Nevents2elec     = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nEvents2Elec") );
+    Ntracks          = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nTracks") );
+    NtracksFiltered  = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nTracksFiltered") );
+    NtracksFirstPtcut = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/cut_Ptmin") );
+    NtracksOneSC     = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/cut_OneSCmatch") );
+
+    Nevents->Write();
+    NeventsTriggered->Write();
+    Nevents2elec->Write();
+    Ntracks->Write();
+    NtracksFiltered->Write();
+    NtracksFirstPtcut->Write();
+    NtracksOneSC->Write();
+
+
+    // Initializing the range in Energy
+    histo.eRange.clear();
+    histo.eRange.push_back(30);
+    histo.eRange.push_back(40);
+    histo.eRange.push_back(60);
+    //histo.eRange.push_back(100);
+
+    // Dump at screen range Energy
+    if (ifile==0)
+    {
+      std::cout << "Range used for energy : ";
+      for (unsigned int i=0;i<(histo.eRange.size()-1);i++)
+        std::cout << "[" << histo.eRange[i] << "]-[" <<histo.eRange[i+1]<<"] ";
+      std::cout << std::endl;
+    }
+
+    // Initializing the range in Phi
+    if (mode==TRACK_ETA)
+    {
+      Double_t begin   = -0.9;//-1.40;//-1.65; 
+      Double_t end     = 0.9;//1.40;//1.65;
+      //      UInt_t   nsteps  = 18;
+      UInt_t   nsteps  = 11;//8;
+      Double_t binsize = (end-begin)/static_cast<Float_t>(nsteps);
+
+      histo.etaRange.resize(nsteps+1,0.);
+      histo.zRange.resize(nsteps+1,0.);
+      for (UInt_t i=0;i<histo.etaRange.size();i++)
+      {
+        histo.etaRange[i] = begin+i*binsize;
+        histo.zRange[i]   = radius*100./TMath::Tan(2*TMath::ATan(  
+                      TMath::Exp(-(begin+i*binsize))));
+      }
+    }
+
+    // Initializing the range in Eta
+    else if (mode==TRACK_PHI)
+    {
+      Double_t begin  = -TMath::Pi();
+      Double_t end    = +TMath::Pi();
+      UInt_t   nsteps = 8;//
+      Double_t binsize = (end-begin)/static_cast<Float_t>(nsteps);
+
+      histo.etaRange.resize(nsteps+1,0.);
+      for (UInt_t i=0;i<histo.etaRange.size();i++)
+      {
+        histo.etaRange[i] = begin+i*binsize;
+      }
+    }
+
+    // Dump at screen the range in Eta (or Phi)
+    if (ifile==0)
+    {
+      std::cout << "Range used for ";
+      if (mode==TRACK_ETA) std::cout << "eta"; else std::cout << "phi";
+      std::cout <<" : " << std::endl;;
+      for (UInt_t i=0;i<(histo.etaRange.size()-1);i++)
+        std::cout << "[" << histo.etaRange[i] << "]-[" <<histo.etaRange[i+1]<<"] ";
+      std::cout << std::endl;
+    }
+
+    // Initializing histos
+    std::cout << "Initialzing histograms ..." << std::endl;
+    InitializeHistograms(mode,histo);
+
+    // Filling with events
+    std::cout << "Reading the TFile ..." << std::endl;
+    ReadTree(mode,variable,histo,track,radius);
+
+    //Filling histograms
+    std::cout << "Filling histograms ..." << std::endl;
+    FillIntermediateHisto(mode,verbose,histo,ccontrol,outputType,radius);
+    FillFinalHisto(mode,verbose,histo);
+  }
+
+  // Achieving the final plot
+  std::cout << "Final plot ..." << std::endl;
+  LayoutFinalPlot(mode,histos,outputType,variable,c,givenMin,givenMax);
+
+  // Displaying final message
+  time_t end = time(0);
+  std::cout << "Done in "  << static_cast<int>(difftime(end,start))/60 
+            << " min and " << static_cast<int>(difftime(end,start))%60 
+            << " sec." << std::endl;
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    Auxiliary function : FillIntermediateHisto
+//
+// -----------------------------------------------------------------------------
+void  FillIntermediateHisto(ModeType mode, Bool_t verbose, HistoType& histo, 
+                            TCanvas* ccontrol, TString outputType, Double_t radius)
+{
+  // Loop over eta or phi range
+  for(UInt_t j=0; j<(histo.etaRange.size()-1); j++)
+  {
+    // Display eta (or phi) range 
+    if(verbose)
+    {
+      std::cout<< histo.etaRange[j] << " < ";
+      if (mode==TRACK_ETA) std::cout << "eta"; else std::cout <<"phi";  
+      std::cout << " < " << histo.etaRange[j+1] << std::endl;
+    }
+
+    // Loop over energy range
+    for(UInt_t i=0; i<(histo.eRange.size()-1); i++)
+    {
+      // Verbose mode : saving histo positive and negative
+      TString controlName;
+      if(verbose)
+      {
+        // filename for control plots
+        controlName = "controlEOP/control_eop_"; 
+        controlName += histo.label;
+        controlName += "_bin"; controlName += j;
+        controlName += "_energy"; controlName += i;
+        controlName += ".";
+        controlName += outputType;
+        ccontrol->cd();
+
+        Double_t posMax = histo.positive[i][j]->GetMaximum();
+        Double_t negMax = histo.negative[i][j]->GetMaximum();
+        if (posMax>negMax) histo.negative[i][j]->SetMaximum(1.1*posMax);
+
+        histo.negative[i][j]->DrawClone();
+        histo.positive[i][j]->DrawClone("same");
+      }
+
+      // Fitting by a gaussian and extracting fit parameters
+      std::vector<Double_t> curvNeg = extractgausparams(histo.negative[i][j],"","");
+      std::vector<Double_t> curvPos = extractgausparams(histo.positive[i][j],"","same");
+
+      // Verbose mode : saving gaussian fit plots
+      if(verbose)
+      {
+        ccontrol->Print(controlName);
+      }
+
+      // Initial misalignment value
+      Double_t misalignment = 0.;
+      Double_t misaliUncert = 1000.;
+
+      // Compute misalignment only if there are selected tracks
+      if(histo.selectedTracks[i][j]!=0)
+      {
+
+        // Setting gaussian range  
+        histo.Enegative[i][j]->GetYaxis()->SetRangeUser(curvNeg[2],curvNeg[3]);
+        histo.Epositive[i][j]->GetYaxis()->SetRangeUser(curvPos[2],curvPos[3]);
+        
+        // Getting mean values from histogram
+        Double_t meanEnergyNeg = histo.Enegative[i][j]->GetMean();
+        Double_t meanEnergyPos = histo.Epositive[i][j]->GetMean();
+        Double_t meanEnergy = (meanEnergyNeg+meanEnergyPos)/2.;// use mean of positive and negative tracks to reduce energy dependence
+
+        // Verbose mode : displaying difference between positive and negative means 
+        if(verbose)
+        {
+          std::cout<<"difference in energy between positive and negative tracks: "<<meanEnergyNeg-meanEnergyPos<<std::endl;
+        }
+
+        // Compute misalignment
+        if(mode==TRACK_ETA)
+        {
+          misalignment = 1000000.*0.5*( -TMath::ASin((0.57*radius/meanEnergy)*curvNeg[0]) +
+                                         TMath::ASin((0.57*radius/meanEnergy)*curvPos[0])    );
+          misaliUncert = 1000000.*0.5*(  TMath::Sqrt((0.57*0.57*radius*radius*curvNeg[1]*curvNeg[1]) / 
+                                                     (meanEnergy*meanEnergy-0.57*0.57*radius*radius*curvNeg[0]*curvNeg[0]) +
+                                                     (0.57*0.57*radius*radius*curvPos[1]*curvPos[1]) /
+                                                     (meanEnergy*meanEnergy-0.57*0.57*radius*radius*curvPos[0]*curvPos[0])   ));
+        }
+        else if(mode==TRACK_PHI)
+        {
+          misalignment = 1000.*(curvPos[0]-curvNeg[0])/(curvPos[0]+curvNeg[0]);
+          misaliUncert = 1000.*2 / ( (curvPos[0]+curvNeg[0])*(curvPos[0]+curvNeg[0]) ) *
+                                      TMath::Sqrt( (curvPos[0]*curvPos[0]*curvPos[1]*curvPos[1]) +
+                                                   (curvNeg[0]*curvNeg[0]*curvNeg[1]*curvNeg[1])   );
+        }
+      }
+
+      // Verbose mode : displaying computed misalignment
+      if(verbose) std::cout<<"misalignment: "<<misalignment<<"+-"<<misaliUncert<<std::endl<<std::endl;
+
+
+      // Fill intermediate histogram : histo.fit
+      histo.fit[j]->SetBinContent(i+1,misalignment);
+      histo.fit[j]->SetBinError  (i+1,misaliUncert);
+
+      // Fill intermediate histogram : histo.combinedxAxisBin
+      Double_t xBinCentre = histo.xAxisBin[i][j]->GetMean();
+      Double_t xBinCenUnc = histo.xAxisBin[i][j]->GetMeanError();
+      histo.combinedxAxisBin[j]->SetBinContent(i+1,xBinCentre);
+      histo.combinedxAxisBin[j]->SetBinError(i+1,xBinCenUnc);
+    }
+  }
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    Auxiliary function : FillFinalHisto
+//
+// -----------------------------------------------------------------------------
+void FillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo)
+{
+  TString fitOption;
+  if (verbose) fitOption=""; else fitOption="Q";
+  for (UInt_t i=0;i<(histo.etaRange.size()-1);i++)
+  {
+    Double_t overallmisalignment;
+    Double_t overallmisaliUncert;
+    Double_t overallxBin;
+    Double_t overallxBinUncert;
+
+    // calculate mean of different energy bins
+    TF1* fit  = new TF1("fit", "pol0",0,histo.eRange.size()-1);
+    TF1* fit2 = new TF1("fit2","pol0",0,histo.eRange.size()-1);
+    histo.fit[i]              -> Fit("fit",fitOption+"0");
+    histo.combinedxAxisBin[i] -> Fit("fit2","Q0");
+    overallmisalignment = fit->GetParameter(0);
+    overallmisaliUncert = fit->GetParError(0);
+    overallxBin         = fit2->GetParameter(0);
+    overallxBinUncert   = fit2->GetParError(0);
+    fit->Delete();
+    fit2->Delete();
+
+    // Fill final histograms
+    histo.overallhisto->SetBinContent(i+1,overallmisalignment);
+    histo.overallhisto->SetBinError  (i+1,overallmisaliUncert);
+    histo.overallGraph->SetPoint     (i,  overallxBin,      overallmisalignment);
+    histo.overallGraph->SetPointError(i,  overallxBinUncert,overallmisaliUncert);
+  }
+
+  // Fit to final histogram
+  TString func = "func";
+  func+=histo.label;
+  if(mode==TRACK_ETA) histo.f2 = new TF1(func,"[0]+[1]*x/100.",-500,500);//Divide by 100. cm->m
+  if(mode==TRACK_PHI) histo.f2 = new TF1(func,"[0]+[1]*TMath::Cos(x+[2])",-500,500);
+    
+  // Fitting final histogram
+  histo.overallGraph->Fit(func,fitOption+"mR0+");
+
+  // Verbose mode : displaying covariance from fit   
+  if(verbose)
+  {
+    std::cout<<"Covariance Matrix:"<<std::endl;
+    TVirtualFitter *fitter = TVirtualFitter::GetFitter();
+    TMatrixD matrix(2,2,fitter->GetCovarianceMatrix());
+    Double_t oneOne = fitter->GetCovarianceMatrixElement(0,0);
+    Double_t oneTwo = fitter->GetCovarianceMatrixElement(0,1);
+    Double_t twoOne = fitter->GetCovarianceMatrixElement(1,0);
+    Double_t twoTwo = fitter->GetCovarianceMatrixElement(1,1);
+      
+    std::cout<<"( "<<oneOne<<", "<<twoOne<<")"<<std::endl;
+    std::cout<<"( "<<oneTwo<<", "<<twoTwo<<")"<<std::endl;
+  }
+
+  // Displaying at screen  fit parameters
+  if(mode==TRACK_ETA)
+  {
+    std::cout<<"const: "<<histo.f2->GetParameter(0)<<"+-"
+             <<histo.f2->GetParError(0)
+             <<", slope: "<<histo.f2->GetParameter(1)<<"+-"
+             <<histo.f2->GetParError(1)<<std::endl;
+  }
+  else if(mode==TRACK_PHI)
+  {
+    std::cout << "const: " << histo.f2->GetParameter(0) << "+-"
+              << histo.f2->GetParError(0) << ", amplitude: "
+              << histo.f2->GetParameter(1) << "+-"<<histo.f2->GetParError(1)
+              << ", shift: " << histo.f2->GetParameter(2) << "+-"
+              << histo.f2->GetParError(2) << std::endl;
+  }
+  std::cout << "fit probability: " << histo.f2->GetProb()      << std::endl;
+  std::cout << "fit chi2       : " << histo.f2->GetChisquare() << std::endl;
+  std::cout << "fit chi2/Ndof  : " << histo.f2->GetChisquare()/static_cast<Double_t>(histo.f2->GetNDF())<< std::endl;
+
+  // Adding the fit function for the legend
+  Char_t misalignmentfitchar[20];
+  sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParameter(0));
+  histo.misalignmentfit += "(";
+  histo.misalignmentfit += misalignmentfitchar;
+  histo.misalignmentfit += "#pm";
+  sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParError(0));
+  histo.misalignmentfit += misalignmentfitchar;
+  if(mode==TRACK_ETA)
+  {
+    histo.misalignmentfit += ")#murad #upoint r[m] + (";
+    sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParameter(1));
+    histo.misalignmentfit += misalignmentfitchar;
+    histo.misalignmentfit += "#pm";
+    sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParError(1));
+    histo.misalignmentfit += misalignmentfitchar;
+    histo.misalignmentfit += ")#murad #upoint z[m]";
+  }
+  else if(mode==TRACK_PHI)
+  {
+    histo.misalignmentfit += ") + (";
+    sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParameter(1));
+    histo.misalignmentfit += misalignmentfitchar;
+    histo.misalignmentfit += "#pm";
+    sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParError(1));
+    histo.misalignmentfit += misalignmentfitchar;
+    histo.misalignmentfit += ") #upoint cos(#phi";
+    if(histo.f2->GetParameter(2)>0.)histo.misalignmentfit += "+";
+    sprintf(misalignmentfitchar,"%1.1f",histo.f2->GetParameter(2));
+    histo.misalignmentfit += misalignmentfitchar;
+    histo.misalignmentfit += "#pm";
+    sprintf(misalignmentfitchar,"%1.1f",histo.f2->GetParError(2));
+    histo.misalignmentfit += misalignmentfitchar;
+    histo.misalignmentfit += ")";
+  }
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    Auxiliary function : LayoutFinalPlot
+//
+// -----------------------------------------------------------------------------
+void LayoutFinalPlot(ModeType mode, std::vector<HistoType>& histos, TString outputType, 
+                     TString variable, TCanvas* c, Double_t givenMin, Double_t givenMax)
+{
+  // Create a legend
+  TLegend *leg = new TLegend(0.13,0.78,0.98, 0.98);
+  leg->SetFillColor(10);
+  leg->SetTextFont(42);
+  leg->SetTextSize(0.038);
+  if(variable=="phi1")leg->SetHeader("low #eta tracks (#eta < -0.9)");
+  if(variable=="phi2")leg->SetHeader("central tracks (|#eta| < 0.9)");
+  if(variable=="phi3")leg->SetHeader("high #eta tracks (#eta > 0.9)");
+
+  // Setting display options to final histos
+  for (UInt_t i=0;i<histos.size();i++)
+  {
+    // Setting axis title to final histos
+    if(mode==TRACK_ETA)
+    {
+      histos[i].overallhisto->GetXaxis()->SetTitle("z [cm]");
+      histos[i].overallhisto->GetYaxis()->SetTitle("misalignment #Delta#phi[#murad]");
+    }
+    if(mode==TRACK_PHI)
+    {
+      histos[i].overallhisto->GetXaxis()->SetTitle("#phi");
+      histos[i].overallhisto->GetYaxis()->SetTitle("misalignment #Delta#phi[a.u.]");
+    }
+
+    // Fit function
+    histos[i].f2->SetLineColor(i+1);
+    histos[i].f2->SetLineStyle(i+1);
+    histos[i].f2->SetLineWidth(2);
+
+    // Other settings
+    histos[i].overallhisto->GetYaxis()->SetTitleOffset(1.05);
+    histos[i].overallhisto->GetYaxis()->SetTitleSize(0.065);
+    histos[i].overallhisto->GetYaxis()->SetLabelSize(0.065);
+    histos[i].overallhisto->GetXaxis()->SetTitleOffset(0.8);
+    histos[i].overallhisto->GetXaxis()->SetTitleSize(0.065);
+    histos[i].overallhisto->GetXaxis()->SetLabelSize(0.065);
+    histos[i].overallhisto->SetLineWidth(2);
+    histos[i].overallhisto->SetLineColor(i+1);
+    histos[i].overallhisto->SetMarkerColor(i+1);
+    histos[i].overallGraph->SetLineWidth(2);
+    histos[i].overallGraph->SetLineColor(i+1);
+    histos[i].overallGraph->SetMarkerColor(i+1);
+    histos[i].overallGraph->SetMarkerStyle(i+20);
+    histos[i].overallGraph->SetMarkerSize(2);
+  }
+
+  // set pad margins
+  c->cd();
+  gPad->SetTopMargin(0.02);
+  gPad->SetBottomMargin(0.12);
+  gPad->SetLeftMargin(0.13);
+  gPad->SetRightMargin(0.02);
+    
+  // Determining common reasonable y-axis range
+  Double_t overallmax=0.;
+  Double_t overallmin=0.;
+  for(UInt_t i=0; i<histos.size(); i++)
+  {
+    // Getting maximum from overallmax
+    overallmax = TMath::Max( overallmax,
+                      histos[i].overallhisto->GetMaximum() + 
+                      histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMaximumBin()) + 
+                      0.55*( histos[i].overallhisto->GetMaximum() + 
+                             histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMaximumBin()) - 
+                             histos[i].overallhisto->GetMinimum() + 
+                             histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMinimumBin()) )  );
+
+    // Getting minimum from overallmin
+    overallmin = TMath::Min( overallmin,
+                      histos[i].overallhisto->GetMinimum() - 
+                      fabs(histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMinimumBin())) -
+                      0.1*( histos[i].overallhisto->GetMaximum() + 
+                            histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMaximumBin()) -
+                            histos[i].overallhisto->GetMinimum() +
+                            histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMinimumBin())) );
+  } 
+
+  // Applying common y-axis range to each final histo
+  for(UInt_t i=0; i<histos.size(); i++)
+  {
+    histos[i].overallhisto->SetMaximum(overallmax);
+    histos[i].overallhisto->SetMinimum(overallmin);
+    if (givenMax!=0) histos[i].overallhisto->SetMaximum(givenMax);
+    if (givenMin!=0) histos[i].overallhisto->SetMinimum(givenMin);
+    histos[i].overallhisto->DrawClone("axis");
+
+    // set histogram errors to a small value as only errors of the graph should be shown
+    for(Int_t j=0; j<histos[i].overallhisto->GetNbinsX(); j++)
+      histos[i].overallhisto->SetBinError(j+1,0.00001);
+
+    // draw final histogram
+    histos[i].overallhisto->DrawClone("pe1 same");
+    histos[i].f2->DrawClone("same");
+    histos[i].overallGraph->DrawClone("|| same");
+    histos[i].overallGraph->DrawClone("pz same");
+    histos[i].overallGraph->SetLineStyle(i+1);
+    leg->AddEntry(histos[i].overallGraph,histos[i].label+" ("+histos[i].misalignmentfit+")","Lp");   
+  }
+
+  leg->Draw();
+
+  // Saving plots
+  if (variable=="eta")        c->Print("twist_validation."             +outputType);
+  else if(variable=="phi")    c->Print("sagitta_validation_all."       +outputType);
+  else if(variable == "phi1") c->Print("sagitta_validation_lowEta."    +outputType);
+  else if(variable == "phi2") c->Print("sagitta_validation_centralEta."+outputType);
+  else if(variable == "phi3") c->Print("sagitta_validation_highEta."   +outputType);
+
+  delete leg;
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    Auxiliary function : Initialize Histograms
+//
+// -----------------------------------------------------------------------------
+void InitializeHistograms(ModeType mode, HistoType& histo)
+{
+  // -----------------------------------------
+  //      Initializing Basic Histograms
+  // -----------------------------------------
+
+  // Allocated memory
+  histo.selectedTracks = new UInt_t*[histo.eRange.size()-1];
+  histo.xAxisBin       = new TH1F**[histo.eRange.size()-1];
+  histo.negative       = new TH1F**[histo.eRange.size()-1];
+  histo.positive       = new TH1F**[histo.eRange.size()-1];
+  histo.Enegative      = new TH2F**[histo.eRange.size()-1];
+  histo.Epositive      = new TH2F**[histo.eRange.size()-1];
+  for (unsigned int i=0;i<(histo.eRange.size()-1);i++)
+  {
+    histo.selectedTracks[i]= new UInt_t[histo.etaRange.size()-1];
+    histo.xAxisBin[i]      = new TH1F*[histo.etaRange.size()-1];
+    histo.negative[i]      = new TH1F*[histo.etaRange.size()-1];
+    histo.positive[i]      = new TH1F*[histo.etaRange.size()-1];
+    histo.Enegative[i]     = new TH2F*[histo.etaRange.size()-1];
+    histo.Epositive[i]     = new TH2F*[histo.etaRange.size()-1];
+  }
+
+  // Loop over energy range
+  unsigned int index=0;
+  for (unsigned int i=0;i<(histo.eRange.size()-1);i++)
+  {
+    // Labels for histo title
+    Char_t tmpstep[5];
+    sprintf(tmpstep,"%1.1fGeV",histo.eRange[i]);
+    TString lowEnergyBorder  = tmpstep;
+    sprintf(tmpstep,"%1.1fGeV",histo.eRange[i+1]);
+    TString highEnergyBorder = tmpstep;
+    TString eTitle = lowEnergyBorder+" #leq ";
+    if(mode==TRACK_ETA) eTitle+="E"; else eTitle+="E_{T}";
+    eTitle+=" < "+highEnergyBorder;
+
+    for (unsigned int j=0;j<(histo.etaRange.size()-1);j++)
+    {
+      // Labels for histo name
+    Char_t tmpstep[5];
+    sprintf(tmpstep,"%1.1fGeV",histo.eRange[i]);
+    TString lowEnergyBorder  = tmpstep;
+    sprintf(tmpstep,"%1.1fGeV",histo.eRange[i+1]);
+    TString highEnergyBorder = tmpstep;
+    TString eTitle = lowEnergyBorder+" #leq ";
+    if(mode==TRACK_ETA) eTitle+="E"; else eTitle+="E_{T}";
+    eTitle+=" < "+highEnergyBorder;
+
+      index++;
+      Char_t histochar[20];
+      sprintf(histochar,"%i",index);
+      TString histotrg = histochar;
+      histotrg+=" ("+histo.label+")";
+
+      // Creating histograms
+      histo.negative[i][j]  = new TH1F("negative"  + histotrg,"negative ("  +eTitle+")", 50,0,2);
+      histo.positive[i][j]  = new TH1F("positive"  + histotrg,"positive ("  +eTitle+")", 50,0,2);
+      histo.Enegative[i][j] = new TH2F("Enegative" + histotrg,"Enegative (" +eTitle+")", 5000,0,500,50,0,2);
+      histo.Epositive[i][j] = new TH2F("Epositive" + histotrg,"Epositive (" +eTitle+")", 5000,0,500,50,0,2);
+      histo.xAxisBin[i][j]  = new TH1F("xAxisBin"  + histotrg,"xAxisBin ("  +eTitle+")", 1000,-500,500);
+
+      // Sum of squares of weight for each histogram
+      histo.Enegative[i][j]->Sumw2();
+      histo.Epositive[i][j]->Sumw2();
+      histo.xAxisBin[i][j]->Sumw2();
+      histo.negative[i][j]->Sumw2();
+      histo.positive[i][j]->Sumw2();
+
+      //SetDirectory(0)
+      histo.Enegative[i][j]->SetDirectory(0);
+      histo.Epositive[i][j]->SetDirectory(0);
+      histo.xAxisBin[i][j]->SetDirectory(0);
+      histo.negative[i][j]->SetDirectory(0);
+      histo.positive[i][j]->SetDirectory(0);
+
+      // Set color
+      histo.negative[i][j]->SetLineColor(kGreen);
+      histo.positive[i][j]->SetLineColor(kRed);
+    }
+  }
+
+  // -----------------------------------------
+  //   Initializing Intermediate Histograms
+  // -----------------------------------------
+  histo.fit              = new TH1F*[histo.etaRange.size()-1];
+  histo.combinedxAxisBin = new TH1F*[histo.etaRange.size()-1];
+
+  for(UInt_t j=0; j<(histo.etaRange.size()-1); j++)
+  {
+    Char_t histochar[20];
+    sprintf(histochar,"%i",j+1);
+    TString histotrg = histochar;
+    histotrg+="("+histo.label+")";
+    histo.fit[j]              = new TH1F( "fithisto"+histotrg,         //name
+                                          "fithisto"+histotrg,         //title   
+                                          (histo.eRange.size()-1),     //nbins
+                                          0.,                          //min   
+                                          (histo.eRange.size()-1) );   //max
+    histo.fit[j]->SetDirectory(0);
+    histo.combinedxAxisBin[j] = new TH1F( "combinedxAxisBin"+histotrg,  //name
+                                          "combinedxAxisBin"+histotrg, //title
+                                          (histo.eRange.size()-1),     //nbins
+                                          0.,                          //min 
+                                          (histo.eRange.size()-1) );   //max
+    histo.combinedxAxisBin[j]->SetDirectory(0);
+  }
+
+  // -----------------------------------------
+  //       Initializing Final Histograms
+  // -----------------------------------------
+  if(mode==TRACK_ETA)
+  {
+    histo.overallhisto = new TH1F("overallhisto ("+histo.label+")",
+                                  "overallhisto",
+                                  (histo.zRange.size()-1),
+                                  &histo.zRange.front() );
+  }
+  else
+  {
+    histo.overallhisto = new TH1F("overallhisto ("+histo.label+")",
+                                  "overallhisto",
+                                  (histo.etaRange.size()-1),
+                                  histo.etaRange[0],
+                                  histo.etaRange[histo.etaRange.size()-1] );
+  }
+  histo.overallhisto->SetDirectory(0);
+
+  histo.overallGraph = new TGraphErrors(histo.overallhisto);
+
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    Auxiliary function : ReadTree
+//
+// -----------------------------------------------------------------------------
+void ReadTree(ModeType mode, TString variable, HistoType& histo, 
+              EopElecVariables* track, Double_t radius)
+{
+  // Displaying sample name
+  Long64_t nevent = (Long64_t)histo.tree->GetEntries();
+  std::cout << "Reading sample labeled by '" << histo.label 
+            << "' containing " << nevent << " events ..." 
+            << std::endl;
+
+  // Reseting counters 
+  TH1D* NtracksMacro       = new TH1D ("NtracksMacro", "NtracksMacro", 1, 0, 1);
+  TH1D* usedtracks         = new TH1D ("usedtracks", "usedtracks", 1, 0, 1);
+  TH1D* cut_Mz             = new TH1D ("cut_Mz", "cut_Mz", 1, 0, 1);
+  TH1D* cut_eta            = new TH1D ("cut_eta", "cut_eta", 1, 0, 1);
+  TH1D* cut_ChargedIso     = new TH1D ("cut_ChargedIso", "cut_ChargedIso", 1, 0, 1);
+  TH1D* cut_Ecal           = new TH1D ("cut_Ecal", "cut_Ecal", 1, 0, 1);
+  TH1D* cut_HoverE         = new TH1D ("cut_HoverE", "cut_HoverE", 1, 0, 1);
+  TH1D* cut_NeutralIso     = new TH1D ("cut_NeutralIso", "cut_NeutralIso", 1, 0, 1);
+  TH1D* cut_nHits          = new TH1D ("cut_nHits", "cut_nHits", 1, 0, 1);
+  TH1D* cut_nLostHits      = new TH1D ("cut_nLostHits", "cut_nLostHits", 1, 0, 1); 
+  TH1D* cut_outerRadius    = new TH1D ("cut_outerRadius", "cut_outerRadius", 1, 0, 1); 
+  TH1D* cut_normalizedChi2 = new TH1D ("cut_normalizedChi2", "cut_normalizedChi2", 1, 0, 1); 
+  TH1D* cut_fbrem          = new TH1D ("cut_fbrem", "cut_fbrem", 1, 0, 1);
+  TH1D* cut_nCluster       = new TH1D ("cut_nCluster", "cut_nCluster", 1, 0, 1);
+  TH1D* cut_EcalRange      = new TH1D ("cut_EcalRange", "cut_EcalRange", 1, 0, 1);
+  TH1D* cut_trigger        = new TH1D ("cut_trigger", "cut_trigger", 1, 0, 1);
+
+  TH1D* P                  = new TH1D ("P", "P", 180, 0, 180);
+  TH1D* eta                = new TH1D ("eta", "eta", 100, -5., 5.);
+  TH1D* Pt                 = new TH1D ("Pt", "Pt", 1000, 0, 1000);
+  TH1D* Ecal               = new TH1D ("Ecal", "Ecal", 100, 0, 180);
+  TH1D* HcalEnergyIn01     = new TH1D ("HcalEnergyIn01", "HcalEnergyIn01", 100, 0, 40);
+  TH1D* HcalEnergyIn02     = new TH1D ("HcalEnergyIn02", "HcalEnergyIn02", 100, 0, 40);
+  TH1D* HcalEnergyIn03     = new TH1D ("HcalEnergyIn03", "HcalEnergyIn03", 100, 0, 40);
+  TH1D* HcalEnergyIn04     = new TH1D ("HcalEnergyIn04", "HcalEnergyIn04", 100, 0, 40);
+  TH1D* HcalEnergyIn05     = new TH1D ("HcalEnergyIn05", "HcalEnergyIn05", 100, 0, 40);
+  TH1D* SumPt              = new TH1D ("SumPt", "SumPt", 100, 0, 2);
+  TH1D* HoverE             = new TH1D ("HoverE", "HoverE", 50, 0, 0.6);
+  TH1D* distTo1stSC        = new TH1D ("distTo1stSC", "distTo1stSC", 50, 0, 0.1);
+  TH1D* distTo2ndSC        = new TH1D ("distTo2ndSC", "distTo2ndSC", 50, 0, 1.5);
+  TH1D* fbrem              = new TH1D ("fbrem", "fbrem", 50, -0.2, 1.);
+  TH1D* nBasicClus         = new TH1D ("nBasicClus", "nBasicClus", 12, 0, 12);
+  TH1D* ScPhiWidth         = new TH1D ("ScPhiWidth", "ScPhiWidth", 50, 0.005, 0.1);
+
+  TH2D* PhiWidthVSnBC      = new TH2D ("PhiWidthVSnBC", "PhiWidthVSnBC", 12, 0, 12, 50, 0.005, 0.1);
+  TH2D* PhiWidthVSfbrem    = new TH2D ("PhiWidthVSfbrem", "PhiWidthVSfbrem", 100, -0.2, 1., 50, 0.005, 0.1);
+  TH2D* nBasicClusVSfbrem  = new TH2D ("nBasicClusVSfbrem", "nBasicClusVSfbrem", 100, -0.2, 1., 12, 0, 12);
+  TH2D* EopVSfbrem         = new TH2D ("EopVSfbrem", "EopVSfbrem", 100, -0.2, 1., 100, 0, 3);
+
+
+  TH1D* EopNegFwd          = new TH1D ("EopNegFwd", "EopNegFwd", 180, 0, 3);
+  TH1D* EopNegBwd          = new TH1D ("EopNegBwd", "EopNegBwd", 180, 0, 3);
+
+  double Mass;
+  Bool_t MzTag=false;
+  Bool_t BARREL=true;
+
+  // Loop over tracks
+  for(Long64_t ientry=0; ientry<nevent; ientry++)
+  {
+
+    
+    // Load the event information
+    histo.tree->GetEntry(ientry);
+
+
+    //Control plots
+    if(track->charge < 0)
+      {
+        if(track->eta > 0.5) EopNegFwd->Fill(track->SC_energy/track->p);
+        if(track->eta < 0.5) EopNegBwd->Fill(track->SC_energy/track->p);
+      }
+
+    PhiWidthVSfbrem->Fill(track->fbrem, track->SC_phiWidth);
+
+
+    // ---- Track Selection ----
+    NtracksMacro->Fill(0.5);
+
+    //Mz calculation
+    MzTag=false;
+    Mass=0.;
+    TLorentzVector a(0., 0., 0., 0.);
+    a.SetXYZM(track->px, 
+              track->py, 
+              track->pz, 
+              0.511);
+    TLorentzVector b(0., 0., 0., 0.);
+    b.SetXYZM(track->px_rejected_track, 
+              track->py_rejected_track, 
+              track->pz_rejected_track, 
+              0.511);
+    
+    Mass =  pow((a.E() + b.E()), 2)
+          - pow((a.Px() + b.Px()), 2)
+          - pow((a.Py() + b.Py()), 2)
+          - pow((a.Pz() + b.Pz()), 2);
+            
+    Mass = sqrt(Mass);
+
+    if(Mass < 110. && Mass > 70. ) MzTag = true;
+
+    // Z mass window
+    if(!MzTag) continue;
+    cut_Mz->Fill(0.5);
+    
+  
+    // -----------        ENDCAP SELECTION    ----------------    
+
+    if(!BARREL)
+    {
+    eta->Fill(track->eta);    
+    if(!track->SC_isEndcap) continue;
+    cut_eta->Fill(0.5);
+
+    // Isolation against charged particles
+    SumPt->Fill(track->SumPtIn05/track->pt);
+    if ( !track->NoTrackIn0015 || (track->SumPtIn05/track->pt) > 0.05 )continue;
+    cut_ChargedIso->Fill(0.5);
+
+    // Ecal energy deposit
+    Ecal->Fill(track->SC_energy);
+    if (track->SC_energy < 30.) continue;
+    cut_Ecal->Fill(0.5);
+
+    // Hcal over Ecal energy deposit
+    HoverE->Fill(track->HcalEnergyIn03/track->SC_energy);
+    if (track->HcalEnergyIn03/track->SC_energy > 0.06) continue; // before: > 0.08
+    cut_HoverE->Fill(0.5);
+
+    // Track-SuperCluster matching radius
+    distTo1stSC->Fill(track->dRto1stSC) ;  
+    if (track->dRto1stSC > 0.05) continue;
+    distTo2ndSC->Fill(track->dRto2ndSC) ;
+    if(track->dRto2ndSC < 0.25 ) continue;//min=0.09(1st SC)
+    cut_NeutralIso->Fill(0.5);
+
+    // a high number of valid hits 
+    if (track->nHits< 13) continue;
+    cut_nHits->Fill(0.5);
+
+    // no lost hits
+    if (track->nLostHits!=0) continue;
+    cut_nLostHits->Fill(0.5);
+
+    // outerRadius
+    //if (track->outerRadius<=99.) continue;
+    cut_outerRadius->Fill(0.5);
+
+    // good chi2 value
+     if (track->normalizedChi2>=5.) continue;
+    cut_normalizedChi2->Fill(0.5);
+
+    // less than 10% bremmstrahlung radiated energy
+    fbrem->Fill(track->fbrem);
+    if(track->fbrem > 0.10  ||  track->fbrem < -0.10) continue;
+    cut_fbrem->Fill(0.5);
+
+    // only tracks with associated SuperCluster composed of ONE BasicCluster
+    nBasicClus->Fill(track->SC_nBasicClus);
+    if(track->SC_nBasicClus != 1) continue;
+    cut_nCluster->Fill(0.5);
+
+    }
+
+
+
+
+
+
+
+    // -----------        BARREL SELECTION    ----------------
+
+    if(BARREL)
+    {
+    eta->Fill(track->eta);
+    if(!track->SC_isBarrel) continue;
+    cut_eta->Fill(0.5);
+
+    // Isolation against charged particles
+    SumPt->Fill(track->SumPtIn05/track->pt);
+    if ( !track->NoTrackIn0015 || (track->SumPtIn05/track->pt) > 0.05 )continue;
+    cut_ChargedIso->Fill(0.5);
+
+    // Ecal energy deposit
+    Ecal->Fill(track->SC_energy);
+    if (track->SC_energy < 25.) continue;
+    cut_Ecal->Fill(0.5);
+
+    // Hcal over Ecal energy deposit
+    HoverE->Fill(track->HcalEnergyIn03/track->SC_energy);
+    if (track->HcalEnergyIn03/track->SC_energy > 0.06) continue; // before: > 0.08
+    cut_HoverE->Fill(0.5);
+
+    // Track-SuperCluster matching radius
+    distTo1stSC->Fill(track->dRto1stSC) ;  
+    if (track->dRto1stSC > 0.04) continue;
+    distTo2ndSC->Fill(track->dRto2ndSC) ;
+    if(track->dRto2ndSC < 0.35 ) continue;//min=0.09(1st SC)
+    cut_NeutralIso->Fill(0.5);
+
+    // a high number of valid hits 
+    if (track->nHits< 13) continue;
+    cut_nHits->Fill(0.5);
+
+    // no lost hits
+    if (track->nLostHits!=0) continue;
+    cut_nLostHits->Fill(0.5);
+    
+    // outerRadius
+    if (track->outerRadius<=99.) continue;
+    cut_outerRadius->Fill(0.5);
+    
+    // good chi2 value
+     if (track->normalizedChi2>=5.) continue;
+    cut_normalizedChi2->Fill(0.5);
+
+    // less than 10% bremmstrahlung radiated energy
+    fbrem->Fill(track->fbrem);
+    if(track->fbrem > 0.1  ||  track->fbrem < -0.1) continue;
+    cut_fbrem->Fill(0.5);
+
+    // only tracks with associated SuperCluster composed of ONE BasicCluster
+    nBasicClus->Fill(track->SC_nBasicClus);
+    if(track->SC_nBasicClus != 1) continue;
+    cut_nCluster->Fill(0.5);
+    }
+
+    PhiWidthVSnBC->Fill(track->SC_nBasicClus, track->SC_phiWidth);
+    nBasicClusVSfbrem->Fill(track->fbrem, track->SC_nBasicClus);
+    EopVSfbrem->Fill(track->fbrem, track->SC_energy/track->p);
+
+    // only track in studied ECAL range
+    if ( track->SC_energy<=histo.eRange[0] || 
+         track->SC_energy>=histo.eRange[histo.eRange.size()-1] ) continue;
+    cut_EcalRange->Fill(0.5);
+
+    // Loop over eta or phi bins
+    for(UInt_t j=0; j<(histo.etaRange.size()-1); j++)
+    {
+
+      // Loop over energy steps
+      for(UInt_t i=0; i<(histo.eRange.size()-1); i++)
+      {
+        Double_t lowerE   = histo.eRange[i];
+        Double_t upperE   = histo.eRange[i+1];
+        Double_t lowerEta = histo.etaRange[j];
+        Double_t upperEta = histo.etaRange[j+1];
+
+        // Select only tracks in E range
+        if (!(track->SC_energy>lowerE && track->SC_energy<upperE)) continue;
+
+        // Select only tracks in eta range
+        if(mode==TRACK_ETA)
+        {
+          if (!(track->eta>=lowerEta && track->eta<upperEta)) continue;
+
+          usedtracks->Fill(0.5);
+          histo.selectedTracks[i][j]++;
+          histo.xAxisBin[i][j]->Fill(radius*100./TMath::Tan(2*TMath::ATan(TMath::Exp(-(track->eta)))));
+        }
+
+        // Select only tracks in phi range
+        else if (mode==TRACK_PHI)
+        {
+          if (! ( (variable=="phi1" && track->eta<-0.9) || 
+                  (variable=="phi2" && TMath::Abs(track->eta)<0.9) || 
+                  (variable=="phi3" && track->eta>0.9) || 
+                   variable=="phi") ) continue;
+
+          if (!(track->phi>=lowerEta && track->phi<upperEta)) continue;
+
+          usedtracks->Fill(0.5);
+          histo.selectedTracks[i][j]++;
+          histo.xAxisBin[i][j]->Fill(track->phi);
+        }
+
+        // e over p
+        if(track->charge<0)
+        {
+          histo.negative[i][j]->Fill((track->SC_energy)/track->p);
+          histo.Enegative[i][j]->Fill(track->SC_energy*TMath::Sin(track->theta),(track->SC_energy)/track->p);
+        }
+        else
+        {
+          histo.positive[i][j]->Fill((track->SC_energy)/track->p);
+          histo.Epositive[i][j]->Fill(track->SC_energy*TMath::Sin(track->theta),(track->SC_energy)/track->p);
+        }
+      }
+    }
+  }
+
+  //############ Saving cut table and control histogramms #############
+
+  NtracksMacro->Write();
+  cut_Ecal->Write();
+  cut_ChargedIso->Write();
+  cut_NeutralIso->Write();
+  cut_HoverE->Write();         
+  cut_nHits->Write();          
+  cut_nLostHits->Write();      
+  cut_outerRadius->Write();    
+  cut_normalizedChi2->Write(); 
+  cut_fbrem->Write();          
+  cut_nCluster->Write();       
+  cut_Mz->Write();           
+  cut_EcalRange->Write();           
+  cut_eta->Write();           
+  cut_trigger->Write();            
+  usedtracks->Write();
+
+
+  Pt->Write();
+  P->Write();
+  eta->Write();
+  Ecal->Write();
+  HcalEnergyIn01->Write();
+  HcalEnergyIn02->Write();
+  HcalEnergyIn03->Write();
+  HcalEnergyIn04->Write();
+  HcalEnergyIn05->Write();
+  SumPt->Write();
+  HoverE->Write();
+  distTo1stSC->Write();
+  distTo2ndSC->Write();
+  fbrem->Write();
+  nBasicClus->Write();
+  ScPhiWidth->Write();
+  PhiWidthVSnBC->Write();
+  PhiWidthVSfbrem->Write();
+  nBasicClusVSfbrem->Write();
+  EopVSfbrem->Write();
+
+  EopNegFwd->Write();
+  EopNegBwd->Write();
+
+  //############ CUTS EFFICIENCY ##############
+
+  double NTracksMacro = NtracksMacro->GetBinContent(1);
+  double usedTracks = usedtracks->GetBinContent(1);         
+  double Cut_Ecal = cut_Ecal->GetBinContent(1);          
+  double Cut_ChargedIso = cut_ChargedIso->GetBinContent(1);          
+  double Cut_NeutralIso = cut_NeutralIso->GetBinContent(1);          
+  double Cut_HoverE = cut_HoverE->GetBinContent(1);          
+  double Cut_nHits = cut_nHits->GetBinContent(1);          
+  double Cut_nLostHits = cut_nLostHits->GetBinContent(1);      
+  double Cut_outerRadius = cut_outerRadius->GetBinContent(1);    
+  double Cut_normalizedChi2 = cut_normalizedChi2->GetBinContent(1); 
+  double Cut_fbrem = cut_fbrem->GetBinContent(1);         
+  double Cut_nCluster = cut_nCluster->GetBinContent(1);       
+  double Cut_Mz = cut_Mz->GetBinContent(1);               
+  double Cut_EcalRange = cut_EcalRange->GetBinContent(1);           
+  double Cut_eta = cut_eta->GetBinContent(1);            
+
+  std::cout.setf(std::ios::fixed);
+  UInt_t precision =  std::cout.precision();
+  std::cout.precision(2);
+  std::cout << "##################   CUTS EFFICIENCY  ########################" << std::endl;
+  std::cout << std::endl;
+  std::cout << "   Cut          | Number of tracks | Subsisting percentage % " << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " Trigger selection  | "; std::cout.width(16); 
+  std::cout << std::right << NTracksMacro << " | "; std::cout.width(16); 
+  std::cout << NTracksMacro/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " Mz                 | "; std::cout.width(16); 
+  std::cout << std::right << Cut_Mz << " | "; std::cout.width(16); 
+  std::cout << Cut_Mz/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " Eta range          | "; std::cout.width(16); 
+  std::cout << std::right << Cut_eta << " | "; std::cout.width(16);
+  std::cout << Cut_eta/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " Iso charged        | "; std::cout.width(16); 
+  std::cout << std::right << Cut_ChargedIso << " | "; std::cout.width(16);
+  std::cout << Cut_ChargedIso/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " Ecal               | "; std::cout.width(16); 
+  std::cout << std::right << Cut_Ecal << " | "; std::cout.width(16);
+  std::cout << Cut_Ecal/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " H over E           | "; std::cout.width(16); 
+  std::cout << std::right << Cut_HoverE << " | "; std::cout.width(16);
+  std::cout << Cut_HoverE/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " Iso Neutral        | "; std::cout.width(16); 
+  std::cout << std::right << Cut_NeutralIso << " | "; std::cout.width(16);
+  std::cout << Cut_NeutralIso/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " nHits              | "; std::cout.width(16); 
+  std::cout << std::right << Cut_nHits << " | "; std::cout.width(16);
+  std::cout << Cut_nHits/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " nLostHits          | "; std::cout.width(16); 
+  std::cout << std::right << Cut_nLostHits << " | "; std::cout.width(16);
+  std::cout << Cut_nLostHits/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " outerRadius        | "; std::cout.width(16); 
+  std::cout << std::right << Cut_outerRadius << " | "; std::cout.width(16);
+  std::cout << Cut_outerRadius/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " normalizedChi2     | "; std::cout.width(16); 
+  std::cout << std::right << Cut_normalizedChi2 << " | "; std::cout.width(16);
+  std::cout << Cut_normalizedChi2/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " fbrem              | "; std::cout.width(16); 
+  std::cout << std::right << Cut_fbrem << " | "; std::cout.width(16);
+  std::cout << Cut_fbrem/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl; 
+  std::cout << " nCluster           | "; std::cout.width(16); 
+  std::cout << std::right << Cut_nCluster << " | "; std::cout.width(16);
+  std::cout << Cut_nCluster/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " EcalEnergy Range   | "; std::cout.width(16); 
+  std::cout << std::right << Cut_EcalRange << " | "; std::cout.width(16); 
+  std::cout << Cut_EcalRange/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " Used Tracks        | "; std::cout.width(16); 
+  std::cout << std::right << usedTracks << " | "; std::cout.width(16);
+  std::cout << usedTracks/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << std::endl;
+  std::cout << "##############################################################" << std::endl;
+  std::cout.unsetf(std::ios::fixed);
+  std::cout.precision(precision);
+
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    Auxiliary function : extractgausparams
+//
+// -----------------------------------------------------------------------------
+std::vector<Double_t> extractgausparams(TH1F *histo, 
+                                        TString option1,
+                                        TString option2)
+{
+  // Fitting the histogram with a gaussian function
+  TF1 *f1 = new TF1("f1","gaus");
+  f1->SetRange(0.,2.);
+  histo->Fit("f1","QR0L");
+
+  // Getting parameters estimated by the fit
+  double mean      = f1->GetParameter(1);
+  double deviation = f1->GetParameter(2); 
+
+  // Iinitializing internal parameters of the iteration algorithms
+  double lowLim = 0; 
+  double upLim = 0;  
+  double degrade = 0.05;
+  unsigned int iteration = 0;
+
+  // Iteration procedure
+  // Iteration is stopped when :
+  //      more than 10 iterations 
+  //   or fit probability > 0.001
+  while( iteration == 0 || (f1->GetProb() < 0.001 && iteration < 10) )
+  {
+    // Computing new bounds for the fit range (2.0 sigma)
+    lowLim = mean - (2.0*deviation*(1-degrade*iteration));
+    upLim  = mean + (2.0*deviation*(1-degrade*iteration));
+    f1->SetRange(lowLim,upLim);
+
+    // Fitting the histo with new bounds
+    histo->Fit("f1","QRL0");
+
+    // If the fit succeeds -> extract the new estimated mean value 
+    double newmean=0;
+    if (f1->GetParameter(1)<2 && f1->GetParameter(1)>0) 
+      newmean =  f1->GetParameter(1);
+    // Else -> keep the previous mean value 
+    else newmean = mean;
+
+    // Computing new bounds for the fit with the new mean value (1.5 sigma)
+    lowLim = newmean - (1.5*deviation);//*(1-degrade*iteration));
+    upLim  = newmean + (1.5*deviation);//*(1-degrade*iteration));
+    f1->SetRange(lowLim,upLim);
+    f1->SetLineWidth(1);
+
+    // Fitting the histo with new bounds
+    histo->Fit("f1","QRL+i"+option1,option2);
+
+    // if the fit succeeds -> extract the new estimated mean value
+    if (f1->GetParameter(1)<2 && f1->GetParameter(1)>0)
+       mean =  f1->GetParameter(1);
+
+    // Computing new deviation
+    deviation = f1->GetParameter(2);
+
+    // Next iteration
+    iteration++;
+  }
+
+  // return the mean value + its error
+  std::vector<Double_t> params;
+  params.push_back(f1->GetParameter(1));
+  params.push_back(f1->GetParError(1));
+  params.push_back(lowLim);
+  params.push_back(upLim);
+  delete f1;
+  return params;
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    Auxiliary function : CheckArguments
+//
+// -----------------------------------------------------------------------------
+Bool_t checkArguments(TString  variable,           //input
+                      TString  path, 
+                      TString  alignmentWithLabel,
+                      TString  outputType,
+                      Double_t radius,
+                      Bool_t   verbose,
+                      Double_t givenMin,
+                      Double_t givenMax,
+                      ModeType& mode,               // ouput
+                      std::vector<TFile*>& files,
+                      std::vector<TString>& labels)
+{
+  // Determining mode
+  if (variable=="eta") mode = TRACK_ETA;
+  else if (variable=="phi"  || variable=="phi1" || 
+           variable=="phi2" || variable=="phi3") mode = TRACK_PHI;
+  else
+  {
+    std::cout << "variable can be eta or phi" << std::endl;
+    std::cout << "phi1, phi2 and phi3 are for phi in different eta bins" 
+              << std::endl;
+    return false;
+  }
+
+  // Checking outputType
+  TString allowed[]={"eps","pdf","svg","gif","xpm","png",
+                     "jpg","tiff","C","cxx","root","xml"};
+  bool find=false;
+  for (unsigned int i=0;i<12;i++)
+  {
+    if (outputType==allowed[i])
+    {
+      find=true;
+      break;
+    } 
+  }
+  if (!find)
+  {
+    std::cout << "ERROR: output type called '"+outputType+"' is unknown !" 
+              << std::endl
+              << "The available output types are : " << std::endl;
+    for (unsigned int i=0;i<12;i++)
+    {
+      std::cout << " " << allowed[i];
+    }
+    std::cout << std::endl;
+    return false;
+  }
+
+  // Checking radius
+  if (radius<=0)
+  {
+    std::cout << "ERROR: The radius cannot be null or negative" << std::endl;
+    return false;
+  }
+
+  // Checking bounds
+  if (givenMin>givenMax)
+  {
+    std::cout << "ERROR: Min value is greater than Max value" << std::endl;
+    return false;
+  }
+
+  // Reading the list of files
+  TObjArray *fileLabelPairs = alignmentWithLabel.Tokenize("\\");
+  std::cout << "Reading input ROOT files ..." << std::endl;
+  for (Int_t i=0; i<fileLabelPairs->GetEntries(); i++)
+  {
+    TObjArray *singleFileLabelPair = 
+               TString(fileLabelPairs->At(i)->GetName()).Tokenize("=");
+
+    if(singleFileLabelPair->GetEntries() == 2) 
+    {
+      TFile* theFile = new TFile(path+(TString(singleFileLabelPair->At(0)->GetName())));
+      if (!theFile->IsOpen())
+      {
+        std::cout << "ERROR : the file '" << theFile->GetName() 
+                  << "' is not found" << std::endl;
+        return false;
+      }
+      files.push_back(theFile);
+      labels.push_back(singleFileLabelPair->At(1)->GetName());
+    }
+    else 
+    {
+      std::cout << "ERROR : Please give file name and legend entry in the following form:\n"
+                << " filename1=legendentry1\\filename2=legendentry2\\..." << std::endl;
+      return false;
+    }
+  }
+
+  // Check there is at least of file to analyze
+  if (files.size()==0)
+  {
+    std::cout << "-> No file to analyze" << std::endl;
+    return false;
+  }
+
+  // Check labels are unique
+  for (unsigned int i=0;i<labels.size();i++)
+    for (unsigned int j=i+1;j<labels.size();j++)
+  {
+    if (labels[i]==labels[j])
+    {
+      std::cout << "the label '" << labels[i] << "' is twice" << std::endl;
+      return false; 
+    }
+  }
+
+  return true;
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    Main (only for stand alone compiled program)
+//
+// -----------------------------------------------------------------------------
+void configureROOTstyle(Bool_t verbose)
+{
+  // Configuring style
+  gROOT->cd();
+  gROOT->SetStyle("Plain");
+  if (verbose)
+  {
+    std::cout<<"\n all formerly produced control plots in ./controlEOP/ deleted.\n"<<std::endl;
+    gROOT->ProcessLine(".!if [ -d controlEOP ]; then rm controlEOP/control_eop*; else mkdir controlEOP; fi");
+  }
+  gStyle->SetPadBorderMode(0);
+  gStyle->SetOptStat(0);
+  gStyle->SetTitleFont(42,"XYZ");
+  gStyle->SetLabelFont(42,"XYZ");
+  gStyle->SetEndErrorSize(5);
+  gStyle->SetLineStyleString(2,"80 20");
+  gStyle->SetLineStyleString(3,"40 18");
+  gStyle->SetLineStyleString(4,"20 16");
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    InitializeTree
+//
+// -----------------------------------------------------------------------------
+Bool_t initializeTree(std::vector<TFile*>& files, std::vector<TTree*>& trees, EopElecVariables* track)
+{
+  // resize the tree size
+  trees.resize(files.size());
+
+  // Loop over the different ROOT files
+  for(unsigned int i=0; i<files.size(); i++)
+  {
+    // Displaying the file name
+    std::cout<<"Opening the file : "<< files[i]->GetName() << std::endl;
+
+    // Extracting the TTree from the ROOT file
+    TTree* theTree = dynamic_cast<TTree*>(
+                       files[i]->Get("energyOverMomentumTree/EopTree"));
+
+    // Checking if the TTree is found 
+    if (theTree==0)
+    {
+      std::cout << "ERROR : the tree 'EopTree' is not found ! This file is skipped !" << std::endl;
+      return false;
+    }
+
+    // Storing the TTree in the container
+    trees[i]=theTree;
+
+    // Connecting the branches of the TTree to the event object
+    trees[i]->SetMakeClass(1);
+    trees[i]->SetBranchAddress("EopElecVariables",     &track);
+    trees[i]->SetBranchAddress("charge",                 &track->charge);
+    trees[i]->SetBranchAddress("nHits",                  &track->nHits);
+    trees[i]->SetBranchAddress("nLostHits",              &track->nLostHits);
+    trees[i]->SetBranchAddress("innerOk",                &track->innerOk);
+    trees[i]->SetBranchAddress("outerRadius",            &track->outerRadius);
+    trees[i]->SetBranchAddress("chi2",                   &track->chi2);
+    trees[i]->SetBranchAddress("normalizedChi2",         &track->normalizedChi2);
+    trees[i]->SetBranchAddress("px_rejected_track",      &track->px_rejected_track);
+    trees[i]->SetBranchAddress("py_rejected_track",      &track->py_rejected_track);
+    trees[i]->SetBranchAddress("pz_rejected_track",      &track->pz_rejected_track);
+    trees[i]->SetBranchAddress("px",                     &track->px);
+    trees[i]->SetBranchAddress("py",                     &track->py);
+    trees[i]->SetBranchAddress("pz",                     &track->pz);
+    trees[i]->SetBranchAddress("p",                      &track->p);
+    trees[i]->SetBranchAddress("pIn",                    &track->pIn);
+    trees[i]->SetBranchAddress("etaIn",                  &track->etaIn);
+    trees[i]->SetBranchAddress("phiIn",                  &track->phiIn);
+    trees[i]->SetBranchAddress("pOut",                   &track->pOut);
+    trees[i]->SetBranchAddress("etaOut",                 &track->etaOut);
+    trees[i]->SetBranchAddress("phiOut",                 &track->phiOut);
+    trees[i]->SetBranchAddress("pt",                     &track->pt);
+    trees[i]->SetBranchAddress("ptError",                &track->ptError);
+    trees[i]->SetBranchAddress("theta",                  &track->theta);
+    trees[i]->SetBranchAddress("eta",                    &track->eta);
+    trees[i]->SetBranchAddress("phi",                    &track->phi);
+    trees[i]->SetBranchAddress("fbrem",                  &track->fbrem);
+    trees[i]->SetBranchAddress("MaxPtIn01",              &track->MaxPtIn01);
+    trees[i]->SetBranchAddress("SumPtIn01",              &track->SumPtIn01);
+    trees[i]->SetBranchAddress("NoTrackIn0015",          &track->NoTrackIn0015);
+    trees[i]->SetBranchAddress("MaxPtIn02",              &track->MaxPtIn02);
+    trees[i]->SetBranchAddress("SumPtIn02",              &track->SumPtIn02);
+    trees[i]->SetBranchAddress("NoTrackIn0020",          &track->NoTrackIn0020);
+    trees[i]->SetBranchAddress("MaxPtIn03",              &track->MaxPtIn03);
+    trees[i]->SetBranchAddress("SumPtIn03",              &track->SumPtIn03);
+    trees[i]->SetBranchAddress("NoTrackIn0025",          &track->NoTrackIn0025);
+    trees[i]->SetBranchAddress("MaxPtIn04",              &track->MaxPtIn04);
+    trees[i]->SetBranchAddress("SumPtIn04",              &track->SumPtIn04);
+    trees[i]->SetBranchAddress("NoTrackIn0030",          &track->NoTrackIn0030);
+    trees[i]->SetBranchAddress("MaxPtIn05",              &track->MaxPtIn05);
+    trees[i]->SetBranchAddress("SumPtIn05",              &track->SumPtIn05);
+    trees[i]->SetBranchAddress("NoTrackIn0035",          &track->NoTrackIn0035);
+    trees[i]->SetBranchAddress("NoTrackIn0040",          &track->NoTrackIn0040);
+    trees[i]->SetBranchAddress("SC_algoID",              &track->SC_algoID);
+    trees[i]->SetBranchAddress("SC_energy",              &track->SC_energy);
+    trees[i]->SetBranchAddress("SC_nBasicClus",          &track->SC_nBasicClus);
+    trees[i]->SetBranchAddress("SC_etaWidth",            &track->SC_etaWidth);
+    trees[i]->SetBranchAddress("SC_phiWidth",            &track->SC_phiWidth);
+    trees[i]->SetBranchAddress("SC_eta",                 &track->SC_eta);
+    trees[i]->SetBranchAddress("SC_phi",                 &track->SC_phi);
+    trees[i]->SetBranchAddress("SC_isBarrel",            &track->SC_isBarrel);
+    trees[i]->SetBranchAddress("SC_isEndcap",            &track->SC_isEndcap);
+    trees[i]->SetBranchAddress("dRto1stSC",              &track->dRto1stSC);
+    trees[i]->SetBranchAddress("dRto2ndSC",              &track->dRto2ndSC);
+    trees[i]->SetBranchAddress("HcalEnergyIn01",         &track->HcalEnergyIn01);
+    trees[i]->SetBranchAddress("HcalEnergyIn02",         &track->HcalEnergyIn02);
+    trees[i]->SetBranchAddress("HcalEnergyIn03",         &track->HcalEnergyIn03);
+    trees[i]->SetBranchAddress("HcalEnergyIn04",         &track->HcalEnergyIn04);
+    trees[i]->SetBranchAddress("HcalEnergyIn05",         &track->HcalEnergyIn05);
+    trees[i]->SetBranchAddress("isEcalDriven",           &track->isEcalDriven);
+    trees[i]->SetBranchAddress("isTrackerDriven",        &track->isTrackerDriven);
+    trees[i]->SetBranchAddress("RunNumber",              &track->RunNumber);
+    trees[i]->SetBranchAddress("EvtNumber",              &track->EvtNumber);
+    
+
+
+  }
+  return true;
+}
+
+
+// -----------------------------------------------------------------------------
+//
+//    Main (only for stand alone compiled program)
+//
+// -----------------------------------------------------------------------------
+int main()
+{
+  //momentumBiasValidation("eta","./","EopTree.root=Fit : ","root",1.,true);
+  momentumBiasValidation("eta","/opt/sbg/data/data1/cms/cgoetzma/Thesis/Eop_withElectrons/Outputs/GsfTracks/","QCD120to170.root=Chris1\\QCD15to30.root=Chris2\\QCD170to300.root=Chris3\\QCD300to470.root=Chris4\\QCD30to50.root=Chris5\\QCD470to600.root=Chris6\\QCD50to80.root=Chris7\\QCD600to800.root=Chris8\\QCD800to1000.root=Chris9\\QCD80to120.root=Chris10\\DyToEE.root=Chris11","root",1.,true);
+  return 0;
+}

--- a/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
+++ b/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
@@ -28,7 +28,7 @@
 #include <vector>
 
 // CMSSW headers
-#include "../interface/EopElecVariables.h"
+#include "Alignment/OfflineValidation/interface/EopElecVariables.h"
 
 // New enumeration for kind of plots
 enum ModeType { TRACK_ETA, TRACK_PHI };
@@ -78,7 +78,7 @@ struct HistoType {
 };
 
 // Prototype of functions
-void InitializeHistograms(ModeType mode, HistoType& histos);
+void initializeHistograms(ModeType mode, HistoType& histos);
 Bool_t checkArguments(TString variable,  //input
                       TString path,
                       TString alignmentWithLabel,
@@ -92,11 +92,11 @@ Bool_t checkArguments(TString variable,  //input
                       std::vector<TString>& labels);
 void configureROOTstyle(Bool_t verbose);
 Bool_t initializeTree(std::vector<TFile*>& files, std::vector<TTree*>& trees, EopElecVariables* track);
-void ReadTree(ModeType mode, TString variable, HistoType& histo, EopElecVariables* track, Double_t radius);
-void FillIntermediateHisto(
+void readTree(ModeType mode, TString variable, HistoType& histo, EopElecVariables* track, Double_t radius);
+void fillIntermediateHisto(
     ModeType mode, Bool_t verbose, HistoType& histo, TCanvas* ccontrol, TString outputType, Double_t radius);
-void FillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo);
-void LayoutFinalPlot(ModeType mode,
+void fillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo);
+void layoutFinalPlot(ModeType mode,
                      std::vector<HistoType>& histos,
                      TString outputType,
                      TString variable,
@@ -141,7 +141,8 @@ void momentumBiasValidation(TString variable,
   std::vector<TTree*> trees(files.size(), 0);
   EopElecVariables* track = new EopElecVariables();
   if (!initializeTree(files, trees, track))
-    return;
+    delete track;
+  return;
 
   // Configuring ROOT style
   std::cout << "Configuring the ROOT style ..." << std::endl;
@@ -259,34 +260,37 @@ void momentumBiasValidation(TString variable,
 
     // Initializing histos
     std::cout << "Initialzing histograms ..." << std::endl;
-    InitializeHistograms(mode, histo);
+    initializeHistograms(mode, histo);
 
     // Filling with events
     std::cout << "Reading the TFile ..." << std::endl;
-    ReadTree(mode, variable, histo, track, radius);
+    readTree(mode, variable, histo, track, radius);
 
     //Filling histograms
     std::cout << "Filling histograms ..." << std::endl;
-    FillIntermediateHisto(mode, verbose, histo, ccontrol, outputType, radius);
-    FillFinalHisto(mode, verbose, histo);
+    fillIntermediateHisto(mode, verbose, histo, ccontrol, outputType, radius);
+    fillFinalHisto(mode, verbose, histo);
   }
 
   // Achieving the final plot
   std::cout << "Final plot ..." << std::endl;
-  LayoutFinalPlot(mode, histos, outputType, variable, c, givenMin, givenMax);
+  layoutFinalPlot(mode, histos, outputType, variable, c, givenMin, givenMax);
 
   // Displaying final message
   time_t end = time(0);
   std::cout << "Done in " << static_cast<int>(difftime(end, start)) / 60 << " min and "
             << static_cast<int>(difftime(end, start)) % 60 << " sec." << std::endl;
+
+  delete track;
+  delete histo1;
 }
 
 // -----------------------------------------------------------------------------
 //
-//    Auxiliary function : FillIntermediateHisto
+//    Auxiliary function : fillIntermediateHisto
 //
 // -----------------------------------------------------------------------------
-void FillIntermediateHisto(
+void fillIntermediateHisto(
     ModeType mode, Bool_t verbose, HistoType& histo, TCanvas* ccontrol, TString outputType, Double_t radius) {
   // Loop over eta or phi range
   for (UInt_t j = 0; j < (histo.etaRange.size() - 1); j++) {
@@ -394,10 +398,10 @@ void FillIntermediateHisto(
 
 // -----------------------------------------------------------------------------
 //
-//    Auxiliary function : FillFinalHisto
+//    Auxiliary function : fillFinalHisto
 //
 // -----------------------------------------------------------------------------
-void FillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo) {
+void fillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo) {
   TString fitOption;
   if (verbose)
     fitOption = "";
@@ -506,7 +510,7 @@ void FillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo) {
 //    Auxiliary function : LayoutFinalPlot
 //
 // -----------------------------------------------------------------------------
-void LayoutFinalPlot(ModeType mode,
+void layoutFinalPlot(ModeType mode,
                      std::vector<HistoType>& histos,
                      TString outputType,
                      TString variable,
@@ -631,10 +635,10 @@ void LayoutFinalPlot(ModeType mode,
 
 // -----------------------------------------------------------------------------
 //
-//    Auxiliary function : Initialize Histograms
+//    Auxiliary function : initialize Histograms
 //
 // -----------------------------------------------------------------------------
-void InitializeHistograms(ModeType mode, HistoType& histo) {
+void initializeHistograms(ModeType mode, HistoType& histo) {
   // -----------------------------------------
   //      Initializing Basic Histograms
   // -----------------------------------------
@@ -763,10 +767,10 @@ void InitializeHistograms(ModeType mode, HistoType& histo) {
 
 // -----------------------------------------------------------------------------
 //
-//    Auxiliary function : ReadTree
+//    Auxiliary function : readTree
 //
 // -----------------------------------------------------------------------------
-void ReadTree(ModeType mode, TString variable, HistoType& histo, EopElecVariables* track, Double_t radius) {
+void readTree(ModeType mode, TString variable, HistoType& histo, EopElecVariables* track, Double_t radius) {
   // Displaying sample name
   Long64_t nevent = (Long64_t)histo.tree->GetEntries();
   std::cout << "Reading sample labeled by '" << histo.label << "' containing " << nevent << " events ..." << std::endl;
@@ -1406,7 +1410,7 @@ void configureROOTstyle(Bool_t verbose) {
 
 // -----------------------------------------------------------------------------
 //
-//    InitializeTree
+//    Initialize Tree
 //
 // -----------------------------------------------------------------------------
 Bool_t initializeTree(std::vector<TFile*>& files, std::vector<TTree*>& trees, EopElecVariables* track) {

--- a/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
+++ b/Alignment/OfflineValidation/macros/momentumElectronBiasValidation.C
@@ -30,13 +30,11 @@
 // CMSSW headers
 #include "../interface/EopElecVariables.h"
 
-
 // New enumeration for kind of plots
-enum ModeType{TRACK_ETA, TRACK_PHI};
+enum ModeType { TRACK_ETA, TRACK_PHI };
 
 // New structure for storing information relative to one file
-struct HistoType
-{
+struct HistoType {
   TString label;
   TFile* file;
   TTree* tree;
@@ -47,12 +45,12 @@ struct HistoType
 
   // Basic histograms
   // dimension = numberOfBins x numberOfSteps
-  UInt_t ** selectedTracks;
-  TH1F***  xAxisBin;
-  TH1F***  negative;
-  TH1F***  positive;
-  TH2F***  Enegative;
-  TH2F***  Epositive;
+  UInt_t** selectedTracks;
+  TH1F*** xAxisBin;
+  TH1F*** negative;
+  TH1F*** positive;
+  TH2F*** Enegative;
+  TH2F*** Epositive;
 
   // Intermediate histograms
   TH1F** fit;
@@ -60,70 +58,67 @@ struct HistoType
 
   // Final histograms
   TGraphErrors* overallGraph;
-  TH1F*         overallhisto;
+  TH1F* overallhisto;
 
   // Final fit
   TF1* f2;
   TString misalignmentfit;
 
-  HistoType()
-  {
-    label="";
-    file=0;
-    tree=0;
-    overallGraph=0;
-    overallhisto=0;
-    f2=0;
-    misalignmentfit="";
-  }   
+  HistoType() {
+    label = "";
+    file = 0;
+    tree = 0;
+    overallGraph = 0;
+    overallhisto = 0;
+    f2 = 0;
+    misalignmentfit = "";
+  }
 
-  ~HistoType()
-  { }
+  ~HistoType() {}
 };
-
 
 // Prototype of functions
 void InitializeHistograms(ModeType mode, HistoType& histos);
-Bool_t checkArguments(TString  variable,           //input
-                      TString  path, 
-                      TString  alignmentWithLabel,
-                      TString  outputType,
+Bool_t checkArguments(TString variable,  //input
+                      TString path,
+                      TString alignmentWithLabel,
+                      TString outputType,
                       Double_t radius,
-                      Bool_t   verbose,
+                      Bool_t verbose,
                       Double_t givenMin,
                       Double_t givenMax,
-                      ModeType& mode,               // ouput
+                      ModeType& mode,  // ouput
                       std::vector<TFile*>& files,
                       std::vector<TString>& labels);
-void   configureROOTstyle(Bool_t verbose);
+void configureROOTstyle(Bool_t verbose);
 Bool_t initializeTree(std::vector<TFile*>& files, std::vector<TTree*>& trees, EopElecVariables* track);
-void   ReadTree(ModeType mode, TString variable, HistoType& histo, EopElecVariables* track, Double_t radius);
-void   FillIntermediateHisto(ModeType mode, Bool_t verbose, HistoType& histo, TCanvas* ccontrol, TString outputType, Double_t radius);
-void   FillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo);
-void   LayoutFinalPlot(ModeType mode, std::vector<HistoType>& histos, TString outputType, 
-                       TString variable, TCanvas* c, Double_t givenMin, Double_t givenMax);
+void ReadTree(ModeType mode, TString variable, HistoType& histo, EopElecVariables* track, Double_t radius);
+void FillIntermediateHisto(
+    ModeType mode, Bool_t verbose, HistoType& histo, TCanvas* ccontrol, TString outputType, Double_t radius);
+void FillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo);
+void LayoutFinalPlot(ModeType mode,
+                     std::vector<HistoType>& histos,
+                     TString outputType,
+                     TString variable,
+                     TCanvas* c,
+                     Double_t givenMin,
+                     Double_t givenMax);
 
-
-std::vector<Double_t> extractgausparams(TH1F *histo, 
-                                        TString option1,
-                                        TString option2);
-
-
+std::vector<Double_t> extractgausparams(TH1F* histo, TString option1, TString option2);
 
 // -----------------------------------------------------------------------------
 //
-//    Main function : momentumBiasValidation  
+//    Main function : momentumBiasValidation
 //
 // -----------------------------------------------------------------------------
-void momentumBiasValidation(TString  variable, 
-                            TString  path, 
-                            TString  alignmentWithLabel,
-                            TString  outputType,
+void momentumBiasValidation(TString variable,
+                            TString path,
+                            TString alignmentWithLabel,
+                            TString outputType,
                             Double_t radius = 1.,
-                            Bool_t   verbose = false,
+                            Bool_t verbose = false,
                             Double_t givenMin = 0.,
-                            Double_t givenMax = 0.)
-{
+                            Double_t givenMax = 0.) {
   // Displaying first message
   std::cout << "!!! Welcome to momentumBiasValidation !!!" << std::endl;
   std::cout << std::endl;
@@ -131,29 +126,29 @@ void momentumBiasValidation(TString  variable,
 
   // Checking and decoding the arguments
   std::cout << "Checking arguments ..." << std::endl;
-  ModeType mode;               // variable to study
+  ModeType mode;                // variable to study
   std::vector<TFile*> files;    // list of input files
   std::vector<TString> labels;  // list of input labels
-  if (!checkArguments(variable,path,alignmentWithLabel,outputType,
-                      radius, verbose, givenMin, givenMax, 
-                      mode, files, labels)) return;
-  else
-  {
+  if (!checkArguments(
+          variable, path, alignmentWithLabel, outputType, radius, verbose, givenMin, givenMax, mode, files, labels))
+    return;
+  else {
     std::cout << "-> Number of files: " << files.size() << std::endl;
   }
 
   // Initializing the TTree
   std::cout << "Initializing the TTree ..." << std::endl;
-  std::vector<TTree*> trees(files.size(),0);
+  std::vector<TTree*> trees(files.size(), 0);
   EopElecVariables* track = new EopElecVariables();
-  if (!initializeTree(files, trees, track)) return;
+  if (!initializeTree(files, trees, track))
+    return;
 
   // Configuring ROOT style
   std::cout << "Configuring the ROOT style ..." << std::endl;
-  configureROOTstyle(verbose); 
+  configureROOTstyle(verbose);
 
-  TCanvas *c = new TCanvas("c","Canvas",0,0,1150,800);
-  TCanvas* ccontrol = new TCanvas("ccontrol","controlCanvas",0,0,600,300);
+  TCanvas* c = new TCanvas("c", "Canvas", 0, 0, 1150, 800);
+  TCanvas* ccontrol = new TCanvas("ccontrol", "controlCanvas", 0, 0, 600, 300);
 
   // Creating histos
   std::vector<HistoType> histos(files.size());
@@ -164,20 +159,19 @@ void momentumBiasValidation(TString  variable,
   TFile* histo1;
   std::string fileName;
 
-  for (unsigned int ifile=0;ifile<histos.size();ifile++)
-  {
+  for (unsigned int ifile = 0; ifile < histos.size(); ifile++) {
     HistoType& histo = histos[ifile];
 
     // setting labels
-    histo.label=labels[ifile];
-    histo.file=files[ifile];
-    histo.tree=trees[ifile];
+    histo.label = labels[ifile];
+    histo.file = files[ifile];
+    histo.tree = trees[ifile];
 
     fileName = histo.file->GetName();
-    fileName = fileName.substr(path.Sizeof()-1);
-    fileName = "Plots"+fileName;
+    fileName = fileName.substr(path.Sizeof() - 1);
+    fileName = "Plots" + fileName;
 
-    std::cout<<"NAME :"<<fileName<<std::endl;
+    std::cout << "NAME :" << fileName << std::endl;
     histo1 = new TFile(fileName.c_str(), "RECREATE");
 
     // Getting and saving cut flow values from tree producer step
@@ -189,13 +183,13 @@ void momentumBiasValidation(TString  variable,
     TH1D* NtracksFirstPtcut;
     TH1D* NtracksOneSC;
 
-    Nevents          = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nEvents") ); 
-    NeventsTriggered = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nEventsTriggered")); 
-    Nevents2elec     = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nEvents2Elec") );
-    Ntracks          = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nTracks") );
-    NtracksFiltered  = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nTracksFiltered") );
-    NtracksFirstPtcut = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/cut_Ptmin") );
-    NtracksOneSC     = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/cut_OneSCmatch") );
+    Nevents = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nEvents"));
+    NeventsTriggered = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nEventsTriggered"));
+    Nevents2elec = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nEvents2Elec"));
+    Ntracks = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nTracks"));
+    NtracksFiltered = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/nTracksFiltered"));
+    NtracksFirstPtcut = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/cut_Ptmin"));
+    NtracksOneSC = dynamic_cast<TH1D*>(histo.file->Get("energyOverMomentumTree/cut_OneSCmatch"));
 
     Nevents->Write();
     NeventsTriggered->Write();
@@ -205,7 +199,6 @@ void momentumBiasValidation(TString  variable,
     NtracksFirstPtcut->Write();
     NtracksOneSC->Write();
 
-
     // Initializing the range in Energy
     histo.eRange.clear();
     histo.eRange.push_back(30);
@@ -214,135 +207,130 @@ void momentumBiasValidation(TString  variable,
     //histo.eRange.push_back(100);
 
     // Dump at screen range Energy
-    if (ifile==0)
-    {
+    if (ifile == 0) {
       std::cout << "Range used for energy : ";
-      for (unsigned int i=0;i<(histo.eRange.size()-1);i++)
-        std::cout << "[" << histo.eRange[i] << "]-[" <<histo.eRange[i+1]<<"] ";
+      for (unsigned int i = 0; i < (histo.eRange.size() - 1); i++)
+        std::cout << "[" << histo.eRange[i] << "]-[" << histo.eRange[i + 1] << "] ";
       std::cout << std::endl;
     }
 
     // Initializing the range in Phi
-    if (mode==TRACK_ETA)
-    {
-      Double_t begin   = -0.9;//-1.40;//-1.65; 
-      Double_t end     = 0.9;//1.40;//1.65;
+    if (mode == TRACK_ETA) {
+      Double_t begin = -0.9;  //-1.40;//-1.65;
+      Double_t end = 0.9;     //1.40;//1.65;
       //      UInt_t   nsteps  = 18;
-      UInt_t   nsteps  = 11;//8;
-      Double_t binsize = (end-begin)/static_cast<Float_t>(nsteps);
+      UInt_t nsteps = 11;  //8;
+      Double_t binsize = (end - begin) / static_cast<Float_t>(nsteps);
 
-      histo.etaRange.resize(nsteps+1,0.);
-      histo.zRange.resize(nsteps+1,0.);
-      for (UInt_t i=0;i<histo.etaRange.size();i++)
-      {
-        histo.etaRange[i] = begin+i*binsize;
-        histo.zRange[i]   = radius*100./TMath::Tan(2*TMath::ATan(  
-                      TMath::Exp(-(begin+i*binsize))));
+      histo.etaRange.resize(nsteps + 1, 0.);
+      histo.zRange.resize(nsteps + 1, 0.);
+      for (UInt_t i = 0; i < histo.etaRange.size(); i++) {
+        histo.etaRange[i] = begin + i * binsize;
+        histo.zRange[i] = radius * 100. / TMath::Tan(2 * TMath::ATan(TMath::Exp(-(begin + i * binsize))));
       }
     }
 
     // Initializing the range in Eta
-    else if (mode==TRACK_PHI)
-    {
-      Double_t begin  = -TMath::Pi();
-      Double_t end    = +TMath::Pi();
-      UInt_t   nsteps = 8;//
-      Double_t binsize = (end-begin)/static_cast<Float_t>(nsteps);
+    else if (mode == TRACK_PHI) {
+      Double_t begin = -TMath::Pi();
+      Double_t end = +TMath::Pi();
+      UInt_t nsteps = 8;  //
+      Double_t binsize = (end - begin) / static_cast<Float_t>(nsteps);
 
-      histo.etaRange.resize(nsteps+1,0.);
-      for (UInt_t i=0;i<histo.etaRange.size();i++)
-      {
-        histo.etaRange[i] = begin+i*binsize;
+      histo.etaRange.resize(nsteps + 1, 0.);
+      for (UInt_t i = 0; i < histo.etaRange.size(); i++) {
+        histo.etaRange[i] = begin + i * binsize;
       }
     }
 
     // Dump at screen the range in Eta (or Phi)
-    if (ifile==0)
-    {
+    if (ifile == 0) {
       std::cout << "Range used for ";
-      if (mode==TRACK_ETA) std::cout << "eta"; else std::cout << "phi";
-      std::cout <<" : " << std::endl;;
-      for (UInt_t i=0;i<(histo.etaRange.size()-1);i++)
-        std::cout << "[" << histo.etaRange[i] << "]-[" <<histo.etaRange[i+1]<<"] ";
+      if (mode == TRACK_ETA)
+        std::cout << "eta";
+      else
+        std::cout << "phi";
+      std::cout << " : " << std::endl;
+      ;
+      for (UInt_t i = 0; i < (histo.etaRange.size() - 1); i++)
+        std::cout << "[" << histo.etaRange[i] << "]-[" << histo.etaRange[i + 1] << "] ";
       std::cout << std::endl;
     }
 
     // Initializing histos
     std::cout << "Initialzing histograms ..." << std::endl;
-    InitializeHistograms(mode,histo);
+    InitializeHistograms(mode, histo);
 
     // Filling with events
     std::cout << "Reading the TFile ..." << std::endl;
-    ReadTree(mode,variable,histo,track,radius);
+    ReadTree(mode, variable, histo, track, radius);
 
     //Filling histograms
     std::cout << "Filling histograms ..." << std::endl;
-    FillIntermediateHisto(mode,verbose,histo,ccontrol,outputType,radius);
-    FillFinalHisto(mode,verbose,histo);
+    FillIntermediateHisto(mode, verbose, histo, ccontrol, outputType, radius);
+    FillFinalHisto(mode, verbose, histo);
   }
 
   // Achieving the final plot
   std::cout << "Final plot ..." << std::endl;
-  LayoutFinalPlot(mode,histos,outputType,variable,c,givenMin,givenMax);
+  LayoutFinalPlot(mode, histos, outputType, variable, c, givenMin, givenMax);
 
   // Displaying final message
   time_t end = time(0);
-  std::cout << "Done in "  << static_cast<int>(difftime(end,start))/60 
-            << " min and " << static_cast<int>(difftime(end,start))%60 
-            << " sec." << std::endl;
+  std::cout << "Done in " << static_cast<int>(difftime(end, start)) / 60 << " min and "
+            << static_cast<int>(difftime(end, start)) % 60 << " sec." << std::endl;
 }
-
 
 // -----------------------------------------------------------------------------
 //
 //    Auxiliary function : FillIntermediateHisto
 //
 // -----------------------------------------------------------------------------
-void  FillIntermediateHisto(ModeType mode, Bool_t verbose, HistoType& histo, 
-                            TCanvas* ccontrol, TString outputType, Double_t radius)
-{
+void FillIntermediateHisto(
+    ModeType mode, Bool_t verbose, HistoType& histo, TCanvas* ccontrol, TString outputType, Double_t radius) {
   // Loop over eta or phi range
-  for(UInt_t j=0; j<(histo.etaRange.size()-1); j++)
-  {
-    // Display eta (or phi) range 
-    if(verbose)
-    {
-      std::cout<< histo.etaRange[j] << " < ";
-      if (mode==TRACK_ETA) std::cout << "eta"; else std::cout <<"phi";  
-      std::cout << " < " << histo.etaRange[j+1] << std::endl;
+  for (UInt_t j = 0; j < (histo.etaRange.size() - 1); j++) {
+    // Display eta (or phi) range
+    if (verbose) {
+      std::cout << histo.etaRange[j] << " < ";
+      if (mode == TRACK_ETA)
+        std::cout << "eta";
+      else
+        std::cout << "phi";
+      std::cout << " < " << histo.etaRange[j + 1] << std::endl;
     }
 
     // Loop over energy range
-    for(UInt_t i=0; i<(histo.eRange.size()-1); i++)
-    {
+    for (UInt_t i = 0; i < (histo.eRange.size() - 1); i++) {
       // Verbose mode : saving histo positive and negative
       TString controlName;
-      if(verbose)
-      {
+      if (verbose) {
         // filename for control plots
-        controlName = "controlEOP/control_eop_"; 
+        controlName = "controlEOP/control_eop_";
         controlName += histo.label;
-        controlName += "_bin"; controlName += j;
-        controlName += "_energy"; controlName += i;
+        controlName += "_bin";
+        controlName += j;
+        controlName += "_energy";
+        controlName += i;
         controlName += ".";
         controlName += outputType;
         ccontrol->cd();
 
         Double_t posMax = histo.positive[i][j]->GetMaximum();
         Double_t negMax = histo.negative[i][j]->GetMaximum();
-        if (posMax>negMax) histo.negative[i][j]->SetMaximum(1.1*posMax);
+        if (posMax > negMax)
+          histo.negative[i][j]->SetMaximum(1.1 * posMax);
 
         histo.negative[i][j]->DrawClone();
         histo.positive[i][j]->DrawClone("same");
       }
 
       // Fitting by a gaussian and extracting fit parameters
-      std::vector<Double_t> curvNeg = extractgausparams(histo.negative[i][j],"","");
-      std::vector<Double_t> curvPos = extractgausparams(histo.positive[i][j],"","same");
+      std::vector<Double_t> curvNeg = extractgausparams(histo.negative[i][j], "", "");
+      std::vector<Double_t> curvPos = extractgausparams(histo.positive[i][j], "", "same");
 
       // Verbose mode : saving gaussian fit plots
-      if(verbose)
-      {
+      if (verbose) {
         ccontrol->Print(controlName);
       }
 
@@ -351,213 +339,207 @@ void  FillIntermediateHisto(ModeType mode, Bool_t verbose, HistoType& histo,
       Double_t misaliUncert = 1000.;
 
       // Compute misalignment only if there are selected tracks
-      if(histo.selectedTracks[i][j]!=0)
-      {
+      if (histo.selectedTracks[i][j] != 0) {
+        // Setting gaussian range
+        histo.Enegative[i][j]->GetYaxis()->SetRangeUser(curvNeg[2], curvNeg[3]);
+        histo.Epositive[i][j]->GetYaxis()->SetRangeUser(curvPos[2], curvPos[3]);
 
-        // Setting gaussian range  
-        histo.Enegative[i][j]->GetYaxis()->SetRangeUser(curvNeg[2],curvNeg[3]);
-        histo.Epositive[i][j]->GetYaxis()->SetRangeUser(curvPos[2],curvPos[3]);
-        
         // Getting mean values from histogram
         Double_t meanEnergyNeg = histo.Enegative[i][j]->GetMean();
         Double_t meanEnergyPos = histo.Epositive[i][j]->GetMean();
-        Double_t meanEnergy = (meanEnergyNeg+meanEnergyPos)/2.;// use mean of positive and negative tracks to reduce energy dependence
+        Double_t meanEnergy = (meanEnergyNeg + meanEnergyPos) /
+                              2.;  // use mean of positive and negative tracks to reduce energy dependence
 
-        // Verbose mode : displaying difference between positive and negative means 
-        if(verbose)
-        {
-          std::cout<<"difference in energy between positive and negative tracks: "<<meanEnergyNeg-meanEnergyPos<<std::endl;
+        // Verbose mode : displaying difference between positive and negative means
+        if (verbose) {
+          std::cout << "difference in energy between positive and negative tracks: " << meanEnergyNeg - meanEnergyPos
+                    << std::endl;
         }
 
         // Compute misalignment
-        if(mode==TRACK_ETA)
-        {
-          misalignment = 1000000.*0.5*( -TMath::ASin((0.57*radius/meanEnergy)*curvNeg[0]) +
-                                         TMath::ASin((0.57*radius/meanEnergy)*curvPos[0])    );
-          misaliUncert = 1000000.*0.5*(  TMath::Sqrt((0.57*0.57*radius*radius*curvNeg[1]*curvNeg[1]) / 
-                                                     (meanEnergy*meanEnergy-0.57*0.57*radius*radius*curvNeg[0]*curvNeg[0]) +
-                                                     (0.57*0.57*radius*radius*curvPos[1]*curvPos[1]) /
-                                                     (meanEnergy*meanEnergy-0.57*0.57*radius*radius*curvPos[0]*curvPos[0])   ));
-        }
-        else if(mode==TRACK_PHI)
-        {
-          misalignment = 1000.*(curvPos[0]-curvNeg[0])/(curvPos[0]+curvNeg[0]);
-          misaliUncert = 1000.*2 / ( (curvPos[0]+curvNeg[0])*(curvPos[0]+curvNeg[0]) ) *
-                                      TMath::Sqrt( (curvPos[0]*curvPos[0]*curvPos[1]*curvPos[1]) +
-                                                   (curvNeg[0]*curvNeg[0]*curvNeg[1]*curvNeg[1])   );
+        if (mode == TRACK_ETA) {
+          misalignment = 1000000. * 0.5 *
+                         (-TMath::ASin((0.57 * radius / meanEnergy) * curvNeg[0]) +
+                          TMath::ASin((0.57 * radius / meanEnergy) * curvPos[0]));
+          misaliUncert =
+              1000000. * 0.5 *
+              (TMath::Sqrt((0.57 * 0.57 * radius * radius * curvNeg[1] * curvNeg[1]) /
+                               (meanEnergy * meanEnergy - 0.57 * 0.57 * radius * radius * curvNeg[0] * curvNeg[0]) +
+                           (0.57 * 0.57 * radius * radius * curvPos[1] * curvPos[1]) /
+                               (meanEnergy * meanEnergy - 0.57 * 0.57 * radius * radius * curvPos[0] * curvPos[0])));
+        } else if (mode == TRACK_PHI) {
+          misalignment = 1000. * (curvPos[0] - curvNeg[0]) / (curvPos[0] + curvNeg[0]);
+          misaliUncert = 1000. * 2 / ((curvPos[0] + curvNeg[0]) * (curvPos[0] + curvNeg[0])) *
+                         TMath::Sqrt((curvPos[0] * curvPos[0] * curvPos[1] * curvPos[1]) +
+                                     (curvNeg[0] * curvNeg[0] * curvNeg[1] * curvNeg[1]));
         }
       }
 
       // Verbose mode : displaying computed misalignment
-      if(verbose) std::cout<<"misalignment: "<<misalignment<<"+-"<<misaliUncert<<std::endl<<std::endl;
-
+      if (verbose)
+        std::cout << "misalignment: " << misalignment << "+-" << misaliUncert << std::endl << std::endl;
 
       // Fill intermediate histogram : histo.fit
-      histo.fit[j]->SetBinContent(i+1,misalignment);
-      histo.fit[j]->SetBinError  (i+1,misaliUncert);
+      histo.fit[j]->SetBinContent(i + 1, misalignment);
+      histo.fit[j]->SetBinError(i + 1, misaliUncert);
 
       // Fill intermediate histogram : histo.combinedxAxisBin
       Double_t xBinCentre = histo.xAxisBin[i][j]->GetMean();
       Double_t xBinCenUnc = histo.xAxisBin[i][j]->GetMeanError();
-      histo.combinedxAxisBin[j]->SetBinContent(i+1,xBinCentre);
-      histo.combinedxAxisBin[j]->SetBinError(i+1,xBinCenUnc);
+      histo.combinedxAxisBin[j]->SetBinContent(i + 1, xBinCentre);
+      histo.combinedxAxisBin[j]->SetBinError(i + 1, xBinCenUnc);
     }
   }
 }
-
 
 // -----------------------------------------------------------------------------
 //
 //    Auxiliary function : FillFinalHisto
 //
 // -----------------------------------------------------------------------------
-void FillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo)
-{
+void FillFinalHisto(ModeType mode, Bool_t verbose, HistoType& histo) {
   TString fitOption;
-  if (verbose) fitOption=""; else fitOption="Q";
-  for (UInt_t i=0;i<(histo.etaRange.size()-1);i++)
-  {
+  if (verbose)
+    fitOption = "";
+  else
+    fitOption = "Q";
+  for (UInt_t i = 0; i < (histo.etaRange.size() - 1); i++) {
     Double_t overallmisalignment;
     Double_t overallmisaliUncert;
     Double_t overallxBin;
     Double_t overallxBinUncert;
 
     // calculate mean of different energy bins
-    TF1* fit  = new TF1("fit", "pol0",0,histo.eRange.size()-1);
-    TF1* fit2 = new TF1("fit2","pol0",0,histo.eRange.size()-1);
-    histo.fit[i]              -> Fit("fit",fitOption+"0");
-    histo.combinedxAxisBin[i] -> Fit("fit2","Q0");
+    TF1* fit = new TF1("fit", "pol0", 0, histo.eRange.size() - 1);
+    TF1* fit2 = new TF1("fit2", "pol0", 0, histo.eRange.size() - 1);
+    histo.fit[i]->Fit("fit", fitOption + "0");
+    histo.combinedxAxisBin[i]->Fit("fit2", "Q0");
     overallmisalignment = fit->GetParameter(0);
     overallmisaliUncert = fit->GetParError(0);
-    overallxBin         = fit2->GetParameter(0);
-    overallxBinUncert   = fit2->GetParError(0);
+    overallxBin = fit2->GetParameter(0);
+    overallxBinUncert = fit2->GetParError(0);
     fit->Delete();
     fit2->Delete();
 
     // Fill final histograms
-    histo.overallhisto->SetBinContent(i+1,overallmisalignment);
-    histo.overallhisto->SetBinError  (i+1,overallmisaliUncert);
-    histo.overallGraph->SetPoint     (i,  overallxBin,      overallmisalignment);
-    histo.overallGraph->SetPointError(i,  overallxBinUncert,overallmisaliUncert);
+    histo.overallhisto->SetBinContent(i + 1, overallmisalignment);
+    histo.overallhisto->SetBinError(i + 1, overallmisaliUncert);
+    histo.overallGraph->SetPoint(i, overallxBin, overallmisalignment);
+    histo.overallGraph->SetPointError(i, overallxBinUncert, overallmisaliUncert);
   }
 
   // Fit to final histogram
   TString func = "func";
-  func+=histo.label;
-  if(mode==TRACK_ETA) histo.f2 = new TF1(func,"[0]+[1]*x/100.",-500,500);//Divide by 100. cm->m
-  if(mode==TRACK_PHI) histo.f2 = new TF1(func,"[0]+[1]*TMath::Cos(x+[2])",-500,500);
-    
-  // Fitting final histogram
-  histo.overallGraph->Fit(func,fitOption+"mR0+");
+  func += histo.label;
+  if (mode == TRACK_ETA)
+    histo.f2 = new TF1(func, "[0]+[1]*x/100.", -500, 500);  //Divide by 100. cm->m
+  if (mode == TRACK_PHI)
+    histo.f2 = new TF1(func, "[0]+[1]*TMath::Cos(x+[2])", -500, 500);
 
-  // Verbose mode : displaying covariance from fit   
-  if(verbose)
-  {
-    std::cout<<"Covariance Matrix:"<<std::endl;
-    TVirtualFitter *fitter = TVirtualFitter::GetFitter();
-    TMatrixD matrix(2,2,fitter->GetCovarianceMatrix());
-    Double_t oneOne = fitter->GetCovarianceMatrixElement(0,0);
-    Double_t oneTwo = fitter->GetCovarianceMatrixElement(0,1);
-    Double_t twoOne = fitter->GetCovarianceMatrixElement(1,0);
-    Double_t twoTwo = fitter->GetCovarianceMatrixElement(1,1);
-      
-    std::cout<<"( "<<oneOne<<", "<<twoOne<<")"<<std::endl;
-    std::cout<<"( "<<oneTwo<<", "<<twoTwo<<")"<<std::endl;
+  // Fitting final histogram
+  histo.overallGraph->Fit(func, fitOption + "mR0+");
+
+  // Verbose mode : displaying covariance from fit
+  if (verbose) {
+    std::cout << "Covariance Matrix:" << std::endl;
+    TVirtualFitter* fitter = TVirtualFitter::GetFitter();
+    TMatrixD matrix(2, 2, fitter->GetCovarianceMatrix());
+    Double_t oneOne = fitter->GetCovarianceMatrixElement(0, 0);
+    Double_t oneTwo = fitter->GetCovarianceMatrixElement(0, 1);
+    Double_t twoOne = fitter->GetCovarianceMatrixElement(1, 0);
+    Double_t twoTwo = fitter->GetCovarianceMatrixElement(1, 1);
+
+    std::cout << "( " << oneOne << ", " << twoOne << ")" << std::endl;
+    std::cout << "( " << oneTwo << ", " << twoTwo << ")" << std::endl;
   }
 
   // Displaying at screen  fit parameters
-  if(mode==TRACK_ETA)
-  {
-    std::cout<<"const: "<<histo.f2->GetParameter(0)<<"+-"
-             <<histo.f2->GetParError(0)
-             <<", slope: "<<histo.f2->GetParameter(1)<<"+-"
-             <<histo.f2->GetParError(1)<<std::endl;
+  if (mode == TRACK_ETA) {
+    std::cout << "const: " << histo.f2->GetParameter(0) << "+-" << histo.f2->GetParError(0)
+              << ", slope: " << histo.f2->GetParameter(1) << "+-" << histo.f2->GetParError(1) << std::endl;
+  } else if (mode == TRACK_PHI) {
+    std::cout << "const: " << histo.f2->GetParameter(0) << "+-" << histo.f2->GetParError(0)
+              << ", amplitude: " << histo.f2->GetParameter(1) << "+-" << histo.f2->GetParError(1)
+              << ", shift: " << histo.f2->GetParameter(2) << "+-" << histo.f2->GetParError(2) << std::endl;
   }
-  else if(mode==TRACK_PHI)
-  {
-    std::cout << "const: " << histo.f2->GetParameter(0) << "+-"
-              << histo.f2->GetParError(0) << ", amplitude: "
-              << histo.f2->GetParameter(1) << "+-"<<histo.f2->GetParError(1)
-              << ", shift: " << histo.f2->GetParameter(2) << "+-"
-              << histo.f2->GetParError(2) << std::endl;
-  }
-  std::cout << "fit probability: " << histo.f2->GetProb()      << std::endl;
+  std::cout << "fit probability: " << histo.f2->GetProb() << std::endl;
   std::cout << "fit chi2       : " << histo.f2->GetChisquare() << std::endl;
-  std::cout << "fit chi2/Ndof  : " << histo.f2->GetChisquare()/static_cast<Double_t>(histo.f2->GetNDF())<< std::endl;
+  std::cout << "fit chi2/Ndof  : " << histo.f2->GetChisquare() / static_cast<Double_t>(histo.f2->GetNDF()) << std::endl;
 
   // Adding the fit function for the legend
   Char_t misalignmentfitchar[20];
-  sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParameter(0));
+  sprintf(misalignmentfitchar, "%1.f", histo.f2->GetParameter(0));
   histo.misalignmentfit += "(";
   histo.misalignmentfit += misalignmentfitchar;
   histo.misalignmentfit += "#pm";
-  sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParError(0));
+  sprintf(misalignmentfitchar, "%1.f", histo.f2->GetParError(0));
   histo.misalignmentfit += misalignmentfitchar;
-  if(mode==TRACK_ETA)
-  {
+  if (mode == TRACK_ETA) {
     histo.misalignmentfit += ")#murad #upoint r[m] + (";
-    sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParameter(1));
+    sprintf(misalignmentfitchar, "%1.f", histo.f2->GetParameter(1));
     histo.misalignmentfit += misalignmentfitchar;
     histo.misalignmentfit += "#pm";
-    sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParError(1));
+    sprintf(misalignmentfitchar, "%1.f", histo.f2->GetParError(1));
     histo.misalignmentfit += misalignmentfitchar;
     histo.misalignmentfit += ")#murad #upoint z[m]";
-  }
-  else if(mode==TRACK_PHI)
-  {
+  } else if (mode == TRACK_PHI) {
     histo.misalignmentfit += ") + (";
-    sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParameter(1));
+    sprintf(misalignmentfitchar, "%1.f", histo.f2->GetParameter(1));
     histo.misalignmentfit += misalignmentfitchar;
     histo.misalignmentfit += "#pm";
-    sprintf(misalignmentfitchar,"%1.f",histo.f2->GetParError(1));
+    sprintf(misalignmentfitchar, "%1.f", histo.f2->GetParError(1));
     histo.misalignmentfit += misalignmentfitchar;
     histo.misalignmentfit += ") #upoint cos(#phi";
-    if(histo.f2->GetParameter(2)>0.)histo.misalignmentfit += "+";
-    sprintf(misalignmentfitchar,"%1.1f",histo.f2->GetParameter(2));
+    if (histo.f2->GetParameter(2) > 0.)
+      histo.misalignmentfit += "+";
+    sprintf(misalignmentfitchar, "%1.1f", histo.f2->GetParameter(2));
     histo.misalignmentfit += misalignmentfitchar;
     histo.misalignmentfit += "#pm";
-    sprintf(misalignmentfitchar,"%1.1f",histo.f2->GetParError(2));
+    sprintf(misalignmentfitchar, "%1.1f", histo.f2->GetParError(2));
     histo.misalignmentfit += misalignmentfitchar;
     histo.misalignmentfit += ")";
   }
 }
-
 
 // -----------------------------------------------------------------------------
 //
 //    Auxiliary function : LayoutFinalPlot
 //
 // -----------------------------------------------------------------------------
-void LayoutFinalPlot(ModeType mode, std::vector<HistoType>& histos, TString outputType, 
-                     TString variable, TCanvas* c, Double_t givenMin, Double_t givenMax)
-{
+void LayoutFinalPlot(ModeType mode,
+                     std::vector<HistoType>& histos,
+                     TString outputType,
+                     TString variable,
+                     TCanvas* c,
+                     Double_t givenMin,
+                     Double_t givenMax) {
   // Create a legend
-  TLegend *leg = new TLegend(0.13,0.78,0.98, 0.98);
+  TLegend* leg = new TLegend(0.13, 0.78, 0.98, 0.98);
   leg->SetFillColor(10);
   leg->SetTextFont(42);
   leg->SetTextSize(0.038);
-  if(variable=="phi1")leg->SetHeader("low #eta tracks (#eta < -0.9)");
-  if(variable=="phi2")leg->SetHeader("central tracks (|#eta| < 0.9)");
-  if(variable=="phi3")leg->SetHeader("high #eta tracks (#eta > 0.9)");
+  if (variable == "phi1")
+    leg->SetHeader("low #eta tracks (#eta < -0.9)");
+  if (variable == "phi2")
+    leg->SetHeader("central tracks (|#eta| < 0.9)");
+  if (variable == "phi3")
+    leg->SetHeader("high #eta tracks (#eta > 0.9)");
 
   // Setting display options to final histos
-  for (UInt_t i=0;i<histos.size();i++)
-  {
+  for (UInt_t i = 0; i < histos.size(); i++) {
     // Setting axis title to final histos
-    if(mode==TRACK_ETA)
-    {
+    if (mode == TRACK_ETA) {
       histos[i].overallhisto->GetXaxis()->SetTitle("z [cm]");
       histos[i].overallhisto->GetYaxis()->SetTitle("misalignment #Delta#phi[#murad]");
     }
-    if(mode==TRACK_PHI)
-    {
+    if (mode == TRACK_PHI) {
       histos[i].overallhisto->GetXaxis()->SetTitle("#phi");
       histos[i].overallhisto->GetYaxis()->SetTitle("misalignment #Delta#phi[a.u.]");
     }
 
     // Fit function
-    histos[i].f2->SetLineColor(i+1);
-    histos[i].f2->SetLineStyle(i+1);
+    histos[i].f2->SetLineColor(i + 1);
+    histos[i].f2->SetLineStyle(i + 1);
     histos[i].f2->SetLineWidth(2);
 
     // Other settings
@@ -568,12 +550,12 @@ void LayoutFinalPlot(ModeType mode, std::vector<HistoType>& histos, TString outp
     histos[i].overallhisto->GetXaxis()->SetTitleSize(0.065);
     histos[i].overallhisto->GetXaxis()->SetLabelSize(0.065);
     histos[i].overallhisto->SetLineWidth(2);
-    histos[i].overallhisto->SetLineColor(i+1);
-    histos[i].overallhisto->SetMarkerColor(i+1);
+    histos[i].overallhisto->SetLineColor(i + 1);
+    histos[i].overallhisto->SetMarkerColor(i + 1);
     histos[i].overallGraph->SetLineWidth(2);
-    histos[i].overallGraph->SetLineColor(i+1);
-    histos[i].overallGraph->SetMarkerColor(i+1);
-    histos[i].overallGraph->SetMarkerStyle(i+20);
+    histos[i].overallGraph->SetLineColor(i + 1);
+    histos[i].overallGraph->SetMarkerColor(i + 1);
+    histos[i].overallGraph->SetMarkerStyle(i + 20);
     histos[i].overallGraph->SetMarkerSize(2);
   }
 
@@ -583,132 +565,138 @@ void LayoutFinalPlot(ModeType mode, std::vector<HistoType>& histos, TString outp
   gPad->SetBottomMargin(0.12);
   gPad->SetLeftMargin(0.13);
   gPad->SetRightMargin(0.02);
-    
+
   // Determining common reasonable y-axis range
-  Double_t overallmax=0.;
-  Double_t overallmin=0.;
-  for(UInt_t i=0; i<histos.size(); i++)
-  {
+  Double_t overallmax = 0.;
+  Double_t overallmin = 0.;
+  for (UInt_t i = 0; i < histos.size(); i++) {
     // Getting maximum from overallmax
-    overallmax = TMath::Max( overallmax,
-                      histos[i].overallhisto->GetMaximum() + 
-                      histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMaximumBin()) + 
-                      0.55*( histos[i].overallhisto->GetMaximum() + 
-                             histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMaximumBin()) - 
-                             histos[i].overallhisto->GetMinimum() + 
-                             histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMinimumBin()) )  );
+    overallmax = TMath::Max(overallmax,
+                            histos[i].overallhisto->GetMaximum() +
+                                histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMaximumBin()) +
+                                0.55 * (histos[i].overallhisto->GetMaximum() +
+                                        histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMaximumBin()) -
+                                        histos[i].overallhisto->GetMinimum() +
+                                        histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMinimumBin())));
 
     // Getting minimum from overallmin
-    overallmin = TMath::Min( overallmin,
-                      histos[i].overallhisto->GetMinimum() - 
-                      fabs(histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMinimumBin())) -
-                      0.1*( histos[i].overallhisto->GetMaximum() + 
-                            histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMaximumBin()) -
-                            histos[i].overallhisto->GetMinimum() +
-                            histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMinimumBin())) );
-  } 
+    overallmin = TMath::Min(overallmin,
+                            histos[i].overallhisto->GetMinimum() -
+                                fabs(histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMinimumBin())) -
+                                0.1 * (histos[i].overallhisto->GetMaximum() +
+                                       histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMaximumBin()) -
+                                       histos[i].overallhisto->GetMinimum() +
+                                       histos[i].overallhisto->GetBinError(histos[i].overallhisto->GetMinimumBin())));
+  }
 
   // Applying common y-axis range to each final histo
-  for(UInt_t i=0; i<histos.size(); i++)
-  {
+  for (UInt_t i = 0; i < histos.size(); i++) {
     histos[i].overallhisto->SetMaximum(overallmax);
     histos[i].overallhisto->SetMinimum(overallmin);
-    if (givenMax!=0) histos[i].overallhisto->SetMaximum(givenMax);
-    if (givenMin!=0) histos[i].overallhisto->SetMinimum(givenMin);
+    if (givenMax != 0)
+      histos[i].overallhisto->SetMaximum(givenMax);
+    if (givenMin != 0)
+      histos[i].overallhisto->SetMinimum(givenMin);
     histos[i].overallhisto->DrawClone("axis");
 
     // set histogram errors to a small value as only errors of the graph should be shown
-    for(Int_t j=0; j<histos[i].overallhisto->GetNbinsX(); j++)
-      histos[i].overallhisto->SetBinError(j+1,0.00001);
+    for (Int_t j = 0; j < histos[i].overallhisto->GetNbinsX(); j++)
+      histos[i].overallhisto->SetBinError(j + 1, 0.00001);
 
     // draw final histogram
     histos[i].overallhisto->DrawClone("pe1 same");
     histos[i].f2->DrawClone("same");
     histos[i].overallGraph->DrawClone("|| same");
     histos[i].overallGraph->DrawClone("pz same");
-    histos[i].overallGraph->SetLineStyle(i+1);
-    leg->AddEntry(histos[i].overallGraph,histos[i].label+" ("+histos[i].misalignmentfit+")","Lp");   
+    histos[i].overallGraph->SetLineStyle(i + 1);
+    leg->AddEntry(histos[i].overallGraph, histos[i].label + " (" + histos[i].misalignmentfit + ")", "Lp");
   }
 
   leg->Draw();
 
   // Saving plots
-  if (variable=="eta")        c->Print("twist_validation."             +outputType);
-  else if(variable=="phi")    c->Print("sagitta_validation_all."       +outputType);
-  else if(variable == "phi1") c->Print("sagitta_validation_lowEta."    +outputType);
-  else if(variable == "phi2") c->Print("sagitta_validation_centralEta."+outputType);
-  else if(variable == "phi3") c->Print("sagitta_validation_highEta."   +outputType);
+  if (variable == "eta")
+    c->Print("twist_validation." + outputType);
+  else if (variable == "phi")
+    c->Print("sagitta_validation_all." + outputType);
+  else if (variable == "phi1")
+    c->Print("sagitta_validation_lowEta." + outputType);
+  else if (variable == "phi2")
+    c->Print("sagitta_validation_centralEta." + outputType);
+  else if (variable == "phi3")
+    c->Print("sagitta_validation_highEta." + outputType);
 
   delete leg;
 }
-
 
 // -----------------------------------------------------------------------------
 //
 //    Auxiliary function : Initialize Histograms
 //
 // -----------------------------------------------------------------------------
-void InitializeHistograms(ModeType mode, HistoType& histo)
-{
+void InitializeHistograms(ModeType mode, HistoType& histo) {
   // -----------------------------------------
   //      Initializing Basic Histograms
   // -----------------------------------------
 
   // Allocated memory
-  histo.selectedTracks = new UInt_t*[histo.eRange.size()-1];
-  histo.xAxisBin       = new TH1F**[histo.eRange.size()-1];
-  histo.negative       = new TH1F**[histo.eRange.size()-1];
-  histo.positive       = new TH1F**[histo.eRange.size()-1];
-  histo.Enegative      = new TH2F**[histo.eRange.size()-1];
-  histo.Epositive      = new TH2F**[histo.eRange.size()-1];
-  for (unsigned int i=0;i<(histo.eRange.size()-1);i++)
-  {
-    histo.selectedTracks[i]= new UInt_t[histo.etaRange.size()-1];
-    histo.xAxisBin[i]      = new TH1F*[histo.etaRange.size()-1];
-    histo.negative[i]      = new TH1F*[histo.etaRange.size()-1];
-    histo.positive[i]      = new TH1F*[histo.etaRange.size()-1];
-    histo.Enegative[i]     = new TH2F*[histo.etaRange.size()-1];
-    histo.Epositive[i]     = new TH2F*[histo.etaRange.size()-1];
+  histo.selectedTracks = new UInt_t*[histo.eRange.size() - 1];
+  histo.xAxisBin = new TH1F**[histo.eRange.size() - 1];
+  histo.negative = new TH1F**[histo.eRange.size() - 1];
+  histo.positive = new TH1F**[histo.eRange.size() - 1];
+  histo.Enegative = new TH2F**[histo.eRange.size() - 1];
+  histo.Epositive = new TH2F**[histo.eRange.size() - 1];
+  for (unsigned int i = 0; i < (histo.eRange.size() - 1); i++) {
+    histo.selectedTracks[i] = new UInt_t[histo.etaRange.size() - 1];
+    histo.xAxisBin[i] = new TH1F*[histo.etaRange.size() - 1];
+    histo.negative[i] = new TH1F*[histo.etaRange.size() - 1];
+    histo.positive[i] = new TH1F*[histo.etaRange.size() - 1];
+    histo.Enegative[i] = new TH2F*[histo.etaRange.size() - 1];
+    histo.Epositive[i] = new TH2F*[histo.etaRange.size() - 1];
   }
 
   // Loop over energy range
-  unsigned int index=0;
-  for (unsigned int i=0;i<(histo.eRange.size()-1);i++)
-  {
+  unsigned int index = 0;
+  for (unsigned int i = 0; i < (histo.eRange.size() - 1); i++) {
     // Labels for histo title
     Char_t tmpstep[5];
-    sprintf(tmpstep,"%1.1fGeV",histo.eRange[i]);
-    TString lowEnergyBorder  = tmpstep;
-    sprintf(tmpstep,"%1.1fGeV",histo.eRange[i+1]);
+    sprintf(tmpstep, "%1.1fGeV", histo.eRange[i]);
+    TString lowEnergyBorder = tmpstep;
+    sprintf(tmpstep, "%1.1fGeV", histo.eRange[i + 1]);
     TString highEnergyBorder = tmpstep;
-    TString eTitle = lowEnergyBorder+" #leq ";
-    if(mode==TRACK_ETA) eTitle+="E"; else eTitle+="E_{T}";
-    eTitle+=" < "+highEnergyBorder;
+    TString eTitle = lowEnergyBorder + " #leq ";
+    if (mode == TRACK_ETA)
+      eTitle += "E";
+    else
+      eTitle += "E_{T}";
+    eTitle += " < " + highEnergyBorder;
 
-    for (unsigned int j=0;j<(histo.etaRange.size()-1);j++)
-    {
+    for (unsigned int j = 0; j < (histo.etaRange.size() - 1); j++) {
       // Labels for histo name
-    Char_t tmpstep[5];
-    sprintf(tmpstep,"%1.1fGeV",histo.eRange[i]);
-    TString lowEnergyBorder  = tmpstep;
-    sprintf(tmpstep,"%1.1fGeV",histo.eRange[i+1]);
-    TString highEnergyBorder = tmpstep;
-    TString eTitle = lowEnergyBorder+" #leq ";
-    if(mode==TRACK_ETA) eTitle+="E"; else eTitle+="E_{T}";
-    eTitle+=" < "+highEnergyBorder;
+      Char_t tmpstep[5];
+      sprintf(tmpstep, "%1.1fGeV", histo.eRange[i]);
+      TString lowEnergyBorder = tmpstep;
+      sprintf(tmpstep, "%1.1fGeV", histo.eRange[i + 1]);
+      TString highEnergyBorder = tmpstep;
+      TString eTitle = lowEnergyBorder + " #leq ";
+      if (mode == TRACK_ETA)
+        eTitle += "E";
+      else
+        eTitle += "E_{T}";
+      eTitle += " < " + highEnergyBorder;
 
       index++;
       Char_t histochar[20];
-      sprintf(histochar,"%i",index);
+      sprintf(histochar, "%i", index);
       TString histotrg = histochar;
-      histotrg+=" ("+histo.label+")";
+      histotrg += " (" + histo.label + ")";
 
       // Creating histograms
-      histo.negative[i][j]  = new TH1F("negative"  + histotrg,"negative ("  +eTitle+")", 50,0,2);
-      histo.positive[i][j]  = new TH1F("positive"  + histotrg,"positive ("  +eTitle+")", 50,0,2);
-      histo.Enegative[i][j] = new TH2F("Enegative" + histotrg,"Enegative (" +eTitle+")", 5000,0,500,50,0,2);
-      histo.Epositive[i][j] = new TH2F("Epositive" + histotrg,"Epositive (" +eTitle+")", 5000,0,500,50,0,2);
-      histo.xAxisBin[i][j]  = new TH1F("xAxisBin"  + histotrg,"xAxisBin ("  +eTitle+")", 1000,-500,500);
+      histo.negative[i][j] = new TH1F("negative" + histotrg, "negative (" + eTitle + ")", 50, 0, 2);
+      histo.positive[i][j] = new TH1F("positive" + histotrg, "positive (" + eTitle + ")", 50, 0, 2);
+      histo.Enegative[i][j] = new TH2F("Enegative" + histotrg, "Enegative (" + eTitle + ")", 5000, 0, 500, 50, 0, 2);
+      histo.Epositive[i][j] = new TH2F("Epositive" + histotrg, "Epositive (" + eTitle + ")", 5000, 0, 500, 50, 0, 2);
+      histo.xAxisBin[i][j] = new TH1F("xAxisBin" + histotrg, "xAxisBin (" + eTitle + ")", 1000, -500, 500);
 
       // Sum of squares of weight for each histogram
       histo.Enegative[i][j]->Sumw2();
@@ -733,330 +721,316 @@ void InitializeHistograms(ModeType mode, HistoType& histo)
   // -----------------------------------------
   //   Initializing Intermediate Histograms
   // -----------------------------------------
-  histo.fit              = new TH1F*[histo.etaRange.size()-1];
-  histo.combinedxAxisBin = new TH1F*[histo.etaRange.size()-1];
+  histo.fit = new TH1F*[histo.etaRange.size() - 1];
+  histo.combinedxAxisBin = new TH1F*[histo.etaRange.size() - 1];
 
-  for(UInt_t j=0; j<(histo.etaRange.size()-1); j++)
-  {
+  for (UInt_t j = 0; j < (histo.etaRange.size() - 1); j++) {
     Char_t histochar[20];
-    sprintf(histochar,"%i",j+1);
+    sprintf(histochar, "%i", j + 1);
     TString histotrg = histochar;
-    histotrg+="("+histo.label+")";
-    histo.fit[j]              = new TH1F( "fithisto"+histotrg,         //name
-                                          "fithisto"+histotrg,         //title   
-                                          (histo.eRange.size()-1),     //nbins
-                                          0.,                          //min   
-                                          (histo.eRange.size()-1) );   //max
+    histotrg += "(" + histo.label + ")";
+    histo.fit[j] = new TH1F("fithisto" + histotrg,       //name
+                            "fithisto" + histotrg,       //title
+                            (histo.eRange.size() - 1),   //nbins
+                            0.,                          //min
+                            (histo.eRange.size() - 1));  //max
     histo.fit[j]->SetDirectory(0);
-    histo.combinedxAxisBin[j] = new TH1F( "combinedxAxisBin"+histotrg,  //name
-                                          "combinedxAxisBin"+histotrg, //title
-                                          (histo.eRange.size()-1),     //nbins
-                                          0.,                          //min 
-                                          (histo.eRange.size()-1) );   //max
+    histo.combinedxAxisBin[j] = new TH1F("combinedxAxisBin" + histotrg,  //name
+                                         "combinedxAxisBin" + histotrg,  //title
+                                         (histo.eRange.size() - 1),      //nbins
+                                         0.,                             //min
+                                         (histo.eRange.size() - 1));     //max
     histo.combinedxAxisBin[j]->SetDirectory(0);
   }
 
   // -----------------------------------------
   //       Initializing Final Histograms
   // -----------------------------------------
-  if(mode==TRACK_ETA)
-  {
-    histo.overallhisto = new TH1F("overallhisto ("+histo.label+")",
+  if (mode == TRACK_ETA) {
+    histo.overallhisto = new TH1F(
+        "overallhisto (" + histo.label + ")", "overallhisto", (histo.zRange.size() - 1), &histo.zRange.front());
+  } else {
+    histo.overallhisto = new TH1F("overallhisto (" + histo.label + ")",
                                   "overallhisto",
-                                  (histo.zRange.size()-1),
-                                  &histo.zRange.front() );
-  }
-  else
-  {
-    histo.overallhisto = new TH1F("overallhisto ("+histo.label+")",
-                                  "overallhisto",
-                                  (histo.etaRange.size()-1),
+                                  (histo.etaRange.size() - 1),
                                   histo.etaRange[0],
-                                  histo.etaRange[histo.etaRange.size()-1] );
+                                  histo.etaRange[histo.etaRange.size() - 1]);
   }
   histo.overallhisto->SetDirectory(0);
 
   histo.overallGraph = new TGraphErrors(histo.overallhisto);
-
 }
-
 
 // -----------------------------------------------------------------------------
 //
 //    Auxiliary function : ReadTree
 //
 // -----------------------------------------------------------------------------
-void ReadTree(ModeType mode, TString variable, HistoType& histo, 
-              EopElecVariables* track, Double_t radius)
-{
+void ReadTree(ModeType mode, TString variable, HistoType& histo, EopElecVariables* track, Double_t radius) {
   // Displaying sample name
   Long64_t nevent = (Long64_t)histo.tree->GetEntries();
-  std::cout << "Reading sample labeled by '" << histo.label 
-            << "' containing " << nevent << " events ..." 
-            << std::endl;
+  std::cout << "Reading sample labeled by '" << histo.label << "' containing " << nevent << " events ..." << std::endl;
 
-  // Reseting counters 
-  TH1D* NtracksMacro       = new TH1D ("NtracksMacro", "NtracksMacro", 1, 0, 1);
-  TH1D* usedtracks         = new TH1D ("usedtracks", "usedtracks", 1, 0, 1);
-  TH1D* cut_Mz             = new TH1D ("cut_Mz", "cut_Mz", 1, 0, 1);
-  TH1D* cut_eta            = new TH1D ("cut_eta", "cut_eta", 1, 0, 1);
-  TH1D* cut_ChargedIso     = new TH1D ("cut_ChargedIso", "cut_ChargedIso", 1, 0, 1);
-  TH1D* cut_Ecal           = new TH1D ("cut_Ecal", "cut_Ecal", 1, 0, 1);
-  TH1D* cut_HoverE         = new TH1D ("cut_HoverE", "cut_HoverE", 1, 0, 1);
-  TH1D* cut_NeutralIso     = new TH1D ("cut_NeutralIso", "cut_NeutralIso", 1, 0, 1);
-  TH1D* cut_nHits          = new TH1D ("cut_nHits", "cut_nHits", 1, 0, 1);
-  TH1D* cut_nLostHits      = new TH1D ("cut_nLostHits", "cut_nLostHits", 1, 0, 1); 
-  TH1D* cut_outerRadius    = new TH1D ("cut_outerRadius", "cut_outerRadius", 1, 0, 1); 
-  TH1D* cut_normalizedChi2 = new TH1D ("cut_normalizedChi2", "cut_normalizedChi2", 1, 0, 1); 
-  TH1D* cut_fbrem          = new TH1D ("cut_fbrem", "cut_fbrem", 1, 0, 1);
-  TH1D* cut_nCluster       = new TH1D ("cut_nCluster", "cut_nCluster", 1, 0, 1);
-  TH1D* cut_EcalRange      = new TH1D ("cut_EcalRange", "cut_EcalRange", 1, 0, 1);
-  TH1D* cut_trigger        = new TH1D ("cut_trigger", "cut_trigger", 1, 0, 1);
+  // Reseting counters
+  TH1D* NtracksMacro = new TH1D("NtracksMacro", "NtracksMacro", 1, 0, 1);
+  TH1D* usedtracks = new TH1D("usedtracks", "usedtracks", 1, 0, 1);
+  TH1D* cut_Mz = new TH1D("cut_Mz", "cut_Mz", 1, 0, 1);
+  TH1D* cut_eta = new TH1D("cut_eta", "cut_eta", 1, 0, 1);
+  TH1D* cut_ChargedIso = new TH1D("cut_ChargedIso", "cut_ChargedIso", 1, 0, 1);
+  TH1D* cut_Ecal = new TH1D("cut_Ecal", "cut_Ecal", 1, 0, 1);
+  TH1D* cut_HoverE = new TH1D("cut_HoverE", "cut_HoverE", 1, 0, 1);
+  TH1D* cut_NeutralIso = new TH1D("cut_NeutralIso", "cut_NeutralIso", 1, 0, 1);
+  TH1D* cut_nHits = new TH1D("cut_nHits", "cut_nHits", 1, 0, 1);
+  TH1D* cut_nLostHits = new TH1D("cut_nLostHits", "cut_nLostHits", 1, 0, 1);
+  TH1D* cut_outerRadius = new TH1D("cut_outerRadius", "cut_outerRadius", 1, 0, 1);
+  TH1D* cut_normalizedChi2 = new TH1D("cut_normalizedChi2", "cut_normalizedChi2", 1, 0, 1);
+  TH1D* cut_fbrem = new TH1D("cut_fbrem", "cut_fbrem", 1, 0, 1);
+  TH1D* cut_nCluster = new TH1D("cut_nCluster", "cut_nCluster", 1, 0, 1);
+  TH1D* cut_EcalRange = new TH1D("cut_EcalRange", "cut_EcalRange", 1, 0, 1);
+  TH1D* cut_trigger = new TH1D("cut_trigger", "cut_trigger", 1, 0, 1);
 
-  TH1D* P                  = new TH1D ("P", "P", 180, 0, 180);
-  TH1D* eta                = new TH1D ("eta", "eta", 100, -5., 5.);
-  TH1D* Pt                 = new TH1D ("Pt", "Pt", 1000, 0, 1000);
-  TH1D* Ecal               = new TH1D ("Ecal", "Ecal", 100, 0, 180);
-  TH1D* HcalEnergyIn01     = new TH1D ("HcalEnergyIn01", "HcalEnergyIn01", 100, 0, 40);
-  TH1D* HcalEnergyIn02     = new TH1D ("HcalEnergyIn02", "HcalEnergyIn02", 100, 0, 40);
-  TH1D* HcalEnergyIn03     = new TH1D ("HcalEnergyIn03", "HcalEnergyIn03", 100, 0, 40);
-  TH1D* HcalEnergyIn04     = new TH1D ("HcalEnergyIn04", "HcalEnergyIn04", 100, 0, 40);
-  TH1D* HcalEnergyIn05     = new TH1D ("HcalEnergyIn05", "HcalEnergyIn05", 100, 0, 40);
-  TH1D* SumPt              = new TH1D ("SumPt", "SumPt", 100, 0, 2);
-  TH1D* HoverE             = new TH1D ("HoverE", "HoverE", 50, 0, 0.6);
-  TH1D* distTo1stSC        = new TH1D ("distTo1stSC", "distTo1stSC", 50, 0, 0.1);
-  TH1D* distTo2ndSC        = new TH1D ("distTo2ndSC", "distTo2ndSC", 50, 0, 1.5);
-  TH1D* fbrem              = new TH1D ("fbrem", "fbrem", 50, -0.2, 1.);
-  TH1D* nBasicClus         = new TH1D ("nBasicClus", "nBasicClus", 12, 0, 12);
-  TH1D* ScPhiWidth         = new TH1D ("ScPhiWidth", "ScPhiWidth", 50, 0.005, 0.1);
+  TH1D* P = new TH1D("P", "P", 180, 0, 180);
+  TH1D* eta = new TH1D("eta", "eta", 100, -5., 5.);
+  TH1D* Pt = new TH1D("Pt", "Pt", 1000, 0, 1000);
+  TH1D* Ecal = new TH1D("Ecal", "Ecal", 100, 0, 180);
+  TH1D* HcalEnergyIn01 = new TH1D("HcalEnergyIn01", "HcalEnergyIn01", 100, 0, 40);
+  TH1D* HcalEnergyIn02 = new TH1D("HcalEnergyIn02", "HcalEnergyIn02", 100, 0, 40);
+  TH1D* HcalEnergyIn03 = new TH1D("HcalEnergyIn03", "HcalEnergyIn03", 100, 0, 40);
+  TH1D* HcalEnergyIn04 = new TH1D("HcalEnergyIn04", "HcalEnergyIn04", 100, 0, 40);
+  TH1D* HcalEnergyIn05 = new TH1D("HcalEnergyIn05", "HcalEnergyIn05", 100, 0, 40);
+  TH1D* SumPt = new TH1D("SumPt", "SumPt", 100, 0, 2);
+  TH1D* HoverE = new TH1D("HoverE", "HoverE", 50, 0, 0.6);
+  TH1D* distTo1stSC = new TH1D("distTo1stSC", "distTo1stSC", 50, 0, 0.1);
+  TH1D* distTo2ndSC = new TH1D("distTo2ndSC", "distTo2ndSC", 50, 0, 1.5);
+  TH1D* fbrem = new TH1D("fbrem", "fbrem", 50, -0.2, 1.);
+  TH1D* nBasicClus = new TH1D("nBasicClus", "nBasicClus", 12, 0, 12);
+  TH1D* ScPhiWidth = new TH1D("ScPhiWidth", "ScPhiWidth", 50, 0.005, 0.1);
 
-  TH2D* PhiWidthVSnBC      = new TH2D ("PhiWidthVSnBC", "PhiWidthVSnBC", 12, 0, 12, 50, 0.005, 0.1);
-  TH2D* PhiWidthVSfbrem    = new TH2D ("PhiWidthVSfbrem", "PhiWidthVSfbrem", 100, -0.2, 1., 50, 0.005, 0.1);
-  TH2D* nBasicClusVSfbrem  = new TH2D ("nBasicClusVSfbrem", "nBasicClusVSfbrem", 100, -0.2, 1., 12, 0, 12);
-  TH2D* EopVSfbrem         = new TH2D ("EopVSfbrem", "EopVSfbrem", 100, -0.2, 1., 100, 0, 3);
+  TH2D* PhiWidthVSnBC = new TH2D("PhiWidthVSnBC", "PhiWidthVSnBC", 12, 0, 12, 50, 0.005, 0.1);
+  TH2D* PhiWidthVSfbrem = new TH2D("PhiWidthVSfbrem", "PhiWidthVSfbrem", 100, -0.2, 1., 50, 0.005, 0.1);
+  TH2D* nBasicClusVSfbrem = new TH2D("nBasicClusVSfbrem", "nBasicClusVSfbrem", 100, -0.2, 1., 12, 0, 12);
+  TH2D* EopVSfbrem = new TH2D("EopVSfbrem", "EopVSfbrem", 100, -0.2, 1., 100, 0, 3);
 
-
-  TH1D* EopNegFwd          = new TH1D ("EopNegFwd", "EopNegFwd", 180, 0, 3);
-  TH1D* EopNegBwd          = new TH1D ("EopNegBwd", "EopNegBwd", 180, 0, 3);
+  TH1D* EopNegFwd = new TH1D("EopNegFwd", "EopNegFwd", 180, 0, 3);
+  TH1D* EopNegBwd = new TH1D("EopNegBwd", "EopNegBwd", 180, 0, 3);
 
   double Mass;
-  Bool_t MzTag=false;
-  Bool_t BARREL=true;
+  Bool_t MzTag = false;
+  Bool_t BARREL = true;
 
   // Loop over tracks
-  for(Long64_t ientry=0; ientry<nevent; ientry++)
-  {
-
-    
+  for (Long64_t ientry = 0; ientry < nevent; ientry++) {
     // Load the event information
     histo.tree->GetEntry(ientry);
 
-
     //Control plots
-    if(track->charge < 0)
-      {
-        if(track->eta > 0.5) EopNegFwd->Fill(track->SC_energy/track->p);
-        if(track->eta < 0.5) EopNegBwd->Fill(track->SC_energy/track->p);
-      }
+    if (track->charge < 0) {
+      if (track->eta > 0.5)
+        EopNegFwd->Fill(track->SC_energy / track->p);
+      if (track->eta < 0.5)
+        EopNegBwd->Fill(track->SC_energy / track->p);
+    }
 
     PhiWidthVSfbrem->Fill(track->fbrem, track->SC_phiWidth);
-
 
     // ---- Track Selection ----
     NtracksMacro->Fill(0.5);
 
     //Mz calculation
-    MzTag=false;
-    Mass=0.;
+    MzTag = false;
+    Mass = 0.;
     TLorentzVector a(0., 0., 0., 0.);
-    a.SetXYZM(track->px, 
-              track->py, 
-              track->pz, 
-              0.511);
+    a.SetXYZM(track->px, track->py, track->pz, 0.511);
     TLorentzVector b(0., 0., 0., 0.);
-    b.SetXYZM(track->px_rejected_track, 
-              track->py_rejected_track, 
-              track->pz_rejected_track, 
-              0.511);
-    
-    Mass =  pow((a.E() + b.E()), 2)
-          - pow((a.Px() + b.Px()), 2)
-          - pow((a.Py() + b.Py()), 2)
-          - pow((a.Pz() + b.Pz()), 2);
-            
+    b.SetXYZM(track->px_rejected_track, track->py_rejected_track, track->pz_rejected_track, 0.511);
+
+    Mass = pow((a.E() + b.E()), 2) - pow((a.Px() + b.Px()), 2) - pow((a.Py() + b.Py()), 2) - pow((a.Pz() + b.Pz()), 2);
+
     Mass = sqrt(Mass);
 
-    if(Mass < 110. && Mass > 70. ) MzTag = true;
+    if (Mass < 110. && Mass > 70.)
+      MzTag = true;
 
     // Z mass window
-    if(!MzTag) continue;
+    if (!MzTag)
+      continue;
     cut_Mz->Fill(0.5);
-    
-  
-    // -----------        ENDCAP SELECTION    ----------------    
 
-    if(!BARREL)
-    {
-    eta->Fill(track->eta);    
-    if(!track->SC_isEndcap) continue;
-    cut_eta->Fill(0.5);
+    // -----------        ENDCAP SELECTION    ----------------
 
-    // Isolation against charged particles
-    SumPt->Fill(track->SumPtIn05/track->pt);
-    if ( !track->NoTrackIn0015 || (track->SumPtIn05/track->pt) > 0.05 )continue;
-    cut_ChargedIso->Fill(0.5);
+    if (!BARREL) {
+      eta->Fill(track->eta);
+      if (!track->SC_isEndcap)
+        continue;
+      cut_eta->Fill(0.5);
 
-    // Ecal energy deposit
-    Ecal->Fill(track->SC_energy);
-    if (track->SC_energy < 30.) continue;
-    cut_Ecal->Fill(0.5);
+      // Isolation against charged particles
+      SumPt->Fill(track->SumPtIn05 / track->pt);
+      if (!track->NoTrackIn0015 || (track->SumPtIn05 / track->pt) > 0.05)
+        continue;
+      cut_ChargedIso->Fill(0.5);
 
-    // Hcal over Ecal energy deposit
-    HoverE->Fill(track->HcalEnergyIn03/track->SC_energy);
-    if (track->HcalEnergyIn03/track->SC_energy > 0.06) continue; // before: > 0.08
-    cut_HoverE->Fill(0.5);
+      // Ecal energy deposit
+      Ecal->Fill(track->SC_energy);
+      if (track->SC_energy < 30.)
+        continue;
+      cut_Ecal->Fill(0.5);
 
-    // Track-SuperCluster matching radius
-    distTo1stSC->Fill(track->dRto1stSC) ;  
-    if (track->dRto1stSC > 0.05) continue;
-    distTo2ndSC->Fill(track->dRto2ndSC) ;
-    if(track->dRto2ndSC < 0.25 ) continue;//min=0.09(1st SC)
-    cut_NeutralIso->Fill(0.5);
+      // Hcal over Ecal energy deposit
+      HoverE->Fill(track->HcalEnergyIn03 / track->SC_energy);
+      if (track->HcalEnergyIn03 / track->SC_energy > 0.06)
+        continue;  // before: > 0.08
+      cut_HoverE->Fill(0.5);
 
-    // a high number of valid hits 
-    if (track->nHits< 13) continue;
-    cut_nHits->Fill(0.5);
+      // Track-SuperCluster matching radius
+      distTo1stSC->Fill(track->dRto1stSC);
+      if (track->dRto1stSC > 0.05)
+        continue;
+      distTo2ndSC->Fill(track->dRto2ndSC);
+      if (track->dRto2ndSC < 0.25)
+        continue;  //min=0.09(1st SC)
+      cut_NeutralIso->Fill(0.5);
 
-    // no lost hits
-    if (track->nLostHits!=0) continue;
-    cut_nLostHits->Fill(0.5);
+      // a high number of valid hits
+      if (track->nHits < 13)
+        continue;
+      cut_nHits->Fill(0.5);
 
-    // outerRadius
-    //if (track->outerRadius<=99.) continue;
-    cut_outerRadius->Fill(0.5);
+      // no lost hits
+      if (track->nLostHits != 0)
+        continue;
+      cut_nLostHits->Fill(0.5);
 
-    // good chi2 value
-     if (track->normalizedChi2>=5.) continue;
-    cut_normalizedChi2->Fill(0.5);
+      // outerRadius
+      //if (track->outerRadius<=99.) continue;
+      cut_outerRadius->Fill(0.5);
 
-    // less than 10% bremmstrahlung radiated energy
-    fbrem->Fill(track->fbrem);
-    if(track->fbrem > 0.10  ||  track->fbrem < -0.10) continue;
-    cut_fbrem->Fill(0.5);
+      // good chi2 value
+      if (track->normalizedChi2 >= 5.)
+        continue;
+      cut_normalizedChi2->Fill(0.5);
 
-    // only tracks with associated SuperCluster composed of ONE BasicCluster
-    nBasicClus->Fill(track->SC_nBasicClus);
-    if(track->SC_nBasicClus != 1) continue;
-    cut_nCluster->Fill(0.5);
+      // less than 10% bremmstrahlung radiated energy
+      fbrem->Fill(track->fbrem);
+      if (track->fbrem > 0.10 || track->fbrem < -0.10)
+        continue;
+      cut_fbrem->Fill(0.5);
 
+      // only tracks with associated SuperCluster composed of ONE BasicCluster
+      nBasicClus->Fill(track->SC_nBasicClus);
+      if (track->SC_nBasicClus != 1)
+        continue;
+      cut_nCluster->Fill(0.5);
     }
-
-
-
-
-
-
 
     // -----------        BARREL SELECTION    ----------------
 
-    if(BARREL)
-    {
-    eta->Fill(track->eta);
-    if(!track->SC_isBarrel) continue;
-    cut_eta->Fill(0.5);
+    if (BARREL) {
+      eta->Fill(track->eta);
+      if (!track->SC_isBarrel)
+        continue;
+      cut_eta->Fill(0.5);
 
-    // Isolation against charged particles
-    SumPt->Fill(track->SumPtIn05/track->pt);
-    if ( !track->NoTrackIn0015 || (track->SumPtIn05/track->pt) > 0.05 )continue;
-    cut_ChargedIso->Fill(0.5);
+      // Isolation against charged particles
+      SumPt->Fill(track->SumPtIn05 / track->pt);
+      if (!track->NoTrackIn0015 || (track->SumPtIn05 / track->pt) > 0.05)
+        continue;
+      cut_ChargedIso->Fill(0.5);
 
-    // Ecal energy deposit
-    Ecal->Fill(track->SC_energy);
-    if (track->SC_energy < 25.) continue;
-    cut_Ecal->Fill(0.5);
+      // Ecal energy deposit
+      Ecal->Fill(track->SC_energy);
+      if (track->SC_energy < 25.)
+        continue;
+      cut_Ecal->Fill(0.5);
 
-    // Hcal over Ecal energy deposit
-    HoverE->Fill(track->HcalEnergyIn03/track->SC_energy);
-    if (track->HcalEnergyIn03/track->SC_energy > 0.06) continue; // before: > 0.08
-    cut_HoverE->Fill(0.5);
+      // Hcal over Ecal energy deposit
+      HoverE->Fill(track->HcalEnergyIn03 / track->SC_energy);
+      if (track->HcalEnergyIn03 / track->SC_energy > 0.06)
+        continue;  // before: > 0.08
+      cut_HoverE->Fill(0.5);
 
-    // Track-SuperCluster matching radius
-    distTo1stSC->Fill(track->dRto1stSC) ;  
-    if (track->dRto1stSC > 0.04) continue;
-    distTo2ndSC->Fill(track->dRto2ndSC) ;
-    if(track->dRto2ndSC < 0.35 ) continue;//min=0.09(1st SC)
-    cut_NeutralIso->Fill(0.5);
+      // Track-SuperCluster matching radius
+      distTo1stSC->Fill(track->dRto1stSC);
+      if (track->dRto1stSC > 0.04)
+        continue;
+      distTo2ndSC->Fill(track->dRto2ndSC);
+      if (track->dRto2ndSC < 0.35)
+        continue;  //min=0.09(1st SC)
+      cut_NeutralIso->Fill(0.5);
 
-    // a high number of valid hits 
-    if (track->nHits< 13) continue;
-    cut_nHits->Fill(0.5);
+      // a high number of valid hits
+      if (track->nHits < 13)
+        continue;
+      cut_nHits->Fill(0.5);
 
-    // no lost hits
-    if (track->nLostHits!=0) continue;
-    cut_nLostHits->Fill(0.5);
-    
-    // outerRadius
-    if (track->outerRadius<=99.) continue;
-    cut_outerRadius->Fill(0.5);
-    
-    // good chi2 value
-     if (track->normalizedChi2>=5.) continue;
-    cut_normalizedChi2->Fill(0.5);
+      // no lost hits
+      if (track->nLostHits != 0)
+        continue;
+      cut_nLostHits->Fill(0.5);
 
-    // less than 10% bremmstrahlung radiated energy
-    fbrem->Fill(track->fbrem);
-    if(track->fbrem > 0.1  ||  track->fbrem < -0.1) continue;
-    cut_fbrem->Fill(0.5);
+      // outerRadius
+      if (track->outerRadius <= 99.)
+        continue;
+      cut_outerRadius->Fill(0.5);
 
-    // only tracks with associated SuperCluster composed of ONE BasicCluster
-    nBasicClus->Fill(track->SC_nBasicClus);
-    if(track->SC_nBasicClus != 1) continue;
-    cut_nCluster->Fill(0.5);
+      // good chi2 value
+      if (track->normalizedChi2 >= 5.)
+        continue;
+      cut_normalizedChi2->Fill(0.5);
+
+      // less than 10% bremmstrahlung radiated energy
+      fbrem->Fill(track->fbrem);
+      if (track->fbrem > 0.1 || track->fbrem < -0.1)
+        continue;
+      cut_fbrem->Fill(0.5);
+
+      // only tracks with associated SuperCluster composed of ONE BasicCluster
+      nBasicClus->Fill(track->SC_nBasicClus);
+      if (track->SC_nBasicClus != 1)
+        continue;
+      cut_nCluster->Fill(0.5);
     }
 
     PhiWidthVSnBC->Fill(track->SC_nBasicClus, track->SC_phiWidth);
     nBasicClusVSfbrem->Fill(track->fbrem, track->SC_nBasicClus);
-    EopVSfbrem->Fill(track->fbrem, track->SC_energy/track->p);
+    EopVSfbrem->Fill(track->fbrem, track->SC_energy / track->p);
 
     // only track in studied ECAL range
-    if ( track->SC_energy<=histo.eRange[0] || 
-         track->SC_energy>=histo.eRange[histo.eRange.size()-1] ) continue;
+    if (track->SC_energy <= histo.eRange[0] || track->SC_energy >= histo.eRange[histo.eRange.size() - 1])
+      continue;
     cut_EcalRange->Fill(0.5);
 
     // Loop over eta or phi bins
-    for(UInt_t j=0; j<(histo.etaRange.size()-1); j++)
-    {
-
+    for (UInt_t j = 0; j < (histo.etaRange.size() - 1); j++) {
       // Loop over energy steps
-      for(UInt_t i=0; i<(histo.eRange.size()-1); i++)
-      {
-        Double_t lowerE   = histo.eRange[i];
-        Double_t upperE   = histo.eRange[i+1];
+      for (UInt_t i = 0; i < (histo.eRange.size() - 1); i++) {
+        Double_t lowerE = histo.eRange[i];
+        Double_t upperE = histo.eRange[i + 1];
         Double_t lowerEta = histo.etaRange[j];
-        Double_t upperEta = histo.etaRange[j+1];
+        Double_t upperEta = histo.etaRange[j + 1];
 
         // Select only tracks in E range
-        if (!(track->SC_energy>lowerE && track->SC_energy<upperE)) continue;
+        if (!(track->SC_energy > lowerE && track->SC_energy < upperE))
+          continue;
 
         // Select only tracks in eta range
-        if(mode==TRACK_ETA)
-        {
-          if (!(track->eta>=lowerEta && track->eta<upperEta)) continue;
+        if (mode == TRACK_ETA) {
+          if (!(track->eta >= lowerEta && track->eta < upperEta))
+            continue;
 
           usedtracks->Fill(0.5);
           histo.selectedTracks[i][j]++;
-          histo.xAxisBin[i][j]->Fill(radius*100./TMath::Tan(2*TMath::ATan(TMath::Exp(-(track->eta)))));
+          histo.xAxisBin[i][j]->Fill(radius * 100. / TMath::Tan(2 * TMath::ATan(TMath::Exp(-(track->eta)))));
         }
 
         // Select only tracks in phi range
-        else if (mode==TRACK_PHI)
-        {
-          if (! ( (variable=="phi1" && track->eta<-0.9) || 
-                  (variable=="phi2" && TMath::Abs(track->eta)<0.9) || 
-                  (variable=="phi3" && track->eta>0.9) || 
-                   variable=="phi") ) continue;
+        else if (mode == TRACK_PHI) {
+          if (!((variable == "phi1" && track->eta < -0.9) || (variable == "phi2" && TMath::Abs(track->eta) < 0.9) ||
+                (variable == "phi3" && track->eta > 0.9) || variable == "phi"))
+            continue;
 
-          if (!(track->phi>=lowerEta && track->phi<upperEta)) continue;
+          if (!(track->phi >= lowerEta && track->phi < upperEta))
+            continue;
 
           usedtracks->Fill(0.5);
           histo.selectedTracks[i][j]++;
@@ -1064,15 +1038,12 @@ void ReadTree(ModeType mode, TString variable, HistoType& histo,
         }
 
         // e over p
-        if(track->charge<0)
-        {
-          histo.negative[i][j]->Fill((track->SC_energy)/track->p);
-          histo.Enegative[i][j]->Fill(track->SC_energy*TMath::Sin(track->theta),(track->SC_energy)/track->p);
-        }
-        else
-        {
-          histo.positive[i][j]->Fill((track->SC_energy)/track->p);
-          histo.Epositive[i][j]->Fill(track->SC_energy*TMath::Sin(track->theta),(track->SC_energy)/track->p);
+        if (track->charge < 0) {
+          histo.negative[i][j]->Fill((track->SC_energy) / track->p);
+          histo.Enegative[i][j]->Fill(track->SC_energy * TMath::Sin(track->theta), (track->SC_energy) / track->p);
+        } else {
+          histo.positive[i][j]->Fill((track->SC_energy) / track->p);
+          histo.Epositive[i][j]->Fill(track->SC_energy * TMath::Sin(track->theta), (track->SC_energy) / track->p);
         }
       }
     }
@@ -1084,19 +1055,18 @@ void ReadTree(ModeType mode, TString variable, HistoType& histo,
   cut_Ecal->Write();
   cut_ChargedIso->Write();
   cut_NeutralIso->Write();
-  cut_HoverE->Write();         
-  cut_nHits->Write();          
-  cut_nLostHits->Write();      
-  cut_outerRadius->Write();    
-  cut_normalizedChi2->Write(); 
-  cut_fbrem->Write();          
-  cut_nCluster->Write();       
-  cut_Mz->Write();           
-  cut_EcalRange->Write();           
-  cut_eta->Write();           
-  cut_trigger->Write();            
+  cut_HoverE->Write();
+  cut_nHits->Write();
+  cut_nLostHits->Write();
+  cut_outerRadius->Write();
+  cut_normalizedChi2->Write();
+  cut_fbrem->Write();
+  cut_nCluster->Write();
+  cut_Mz->Write();
+  cut_EcalRange->Write();
+  cut_eta->Write();
+  cut_trigger->Write();
   usedtracks->Write();
-
 
   Pt->Write();
   P->Write();
@@ -1125,152 +1095,177 @@ void ReadTree(ModeType mode, TString variable, HistoType& histo,
   //############ CUTS EFFICIENCY ##############
 
   double NTracksMacro = NtracksMacro->GetBinContent(1);
-  double usedTracks = usedtracks->GetBinContent(1);         
-  double Cut_Ecal = cut_Ecal->GetBinContent(1);          
-  double Cut_ChargedIso = cut_ChargedIso->GetBinContent(1);          
-  double Cut_NeutralIso = cut_NeutralIso->GetBinContent(1);          
-  double Cut_HoverE = cut_HoverE->GetBinContent(1);          
-  double Cut_nHits = cut_nHits->GetBinContent(1);          
-  double Cut_nLostHits = cut_nLostHits->GetBinContent(1);      
-  double Cut_outerRadius = cut_outerRadius->GetBinContent(1);    
-  double Cut_normalizedChi2 = cut_normalizedChi2->GetBinContent(1); 
-  double Cut_fbrem = cut_fbrem->GetBinContent(1);         
-  double Cut_nCluster = cut_nCluster->GetBinContent(1);       
-  double Cut_Mz = cut_Mz->GetBinContent(1);               
-  double Cut_EcalRange = cut_EcalRange->GetBinContent(1);           
-  double Cut_eta = cut_eta->GetBinContent(1);            
+  double usedTracks = usedtracks->GetBinContent(1);
+  double Cut_Ecal = cut_Ecal->GetBinContent(1);
+  double Cut_ChargedIso = cut_ChargedIso->GetBinContent(1);
+  double Cut_NeutralIso = cut_NeutralIso->GetBinContent(1);
+  double Cut_HoverE = cut_HoverE->GetBinContent(1);
+  double Cut_nHits = cut_nHits->GetBinContent(1);
+  double Cut_nLostHits = cut_nLostHits->GetBinContent(1);
+  double Cut_outerRadius = cut_outerRadius->GetBinContent(1);
+  double Cut_normalizedChi2 = cut_normalizedChi2->GetBinContent(1);
+  double Cut_fbrem = cut_fbrem->GetBinContent(1);
+  double Cut_nCluster = cut_nCluster->GetBinContent(1);
+  double Cut_Mz = cut_Mz->GetBinContent(1);
+  double Cut_EcalRange = cut_EcalRange->GetBinContent(1);
+  double Cut_eta = cut_eta->GetBinContent(1);
 
   std::cout.setf(std::ios::fixed);
-  UInt_t precision =  std::cout.precision();
+  UInt_t precision = std::cout.precision();
   std::cout.precision(2);
   std::cout << "##################   CUTS EFFICIENCY  ########################" << std::endl;
   std::cout << std::endl;
   std::cout << "   Cut          | Number of tracks | Subsisting percentage % " << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " Trigger selection  | "; std::cout.width(16); 
-  std::cout << std::right << NTracksMacro << " | "; std::cout.width(16); 
-  std::cout << NTracksMacro/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " Trigger selection  | ";
+  std::cout.width(16);
+  std::cout << std::right << NTracksMacro << " | ";
+  std::cout.width(16);
+  std::cout << NTracksMacro / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " Mz                 | "; std::cout.width(16); 
-  std::cout << std::right << Cut_Mz << " | "; std::cout.width(16); 
-  std::cout << Cut_Mz/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " Mz                 | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_Mz << " | ";
+  std::cout.width(16);
+  std::cout << Cut_Mz / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " Eta range          | "; std::cout.width(16); 
-  std::cout << std::right << Cut_eta << " | "; std::cout.width(16);
-  std::cout << Cut_eta/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " Eta range          | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_eta << " | ";
+  std::cout.width(16);
+  std::cout << Cut_eta / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " Iso charged        | "; std::cout.width(16); 
-  std::cout << std::right << Cut_ChargedIso << " | "; std::cout.width(16);
-  std::cout << Cut_ChargedIso/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " Iso charged        | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_ChargedIso << " | ";
+  std::cout.width(16);
+  std::cout << Cut_ChargedIso / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " Ecal               | "; std::cout.width(16); 
-  std::cout << std::right << Cut_Ecal << " | "; std::cout.width(16);
-  std::cout << Cut_Ecal/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " Ecal               | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_Ecal << " | ";
+  std::cout.width(16);
+  std::cout << Cut_Ecal / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " H over E           | "; std::cout.width(16); 
-  std::cout << std::right << Cut_HoverE << " | "; std::cout.width(16);
-  std::cout << Cut_HoverE/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " H over E           | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_HoverE << " | ";
+  std::cout.width(16);
+  std::cout << Cut_HoverE / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " Iso Neutral        | "; std::cout.width(16); 
-  std::cout << std::right << Cut_NeutralIso << " | "; std::cout.width(16);
-  std::cout << Cut_NeutralIso/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " Iso Neutral        | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_NeutralIso << " | ";
+  std::cout.width(16);
+  std::cout << Cut_NeutralIso / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " nHits              | "; std::cout.width(16); 
-  std::cout << std::right << Cut_nHits << " | "; std::cout.width(16);
-  std::cout << Cut_nHits/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " nHits              | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_nHits << " | ";
+  std::cout.width(16);
+  std::cout << Cut_nHits / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " nLostHits          | "; std::cout.width(16); 
-  std::cout << std::right << Cut_nLostHits << " | "; std::cout.width(16);
-  std::cout << Cut_nLostHits/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " nLostHits          | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_nLostHits << " | ";
+  std::cout.width(16);
+  std::cout << Cut_nLostHits / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " outerRadius        | "; std::cout.width(16); 
-  std::cout << std::right << Cut_outerRadius << " | "; std::cout.width(16);
-  std::cout << Cut_outerRadius/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " outerRadius        | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_outerRadius << " | ";
+  std::cout.width(16);
+  std::cout << Cut_outerRadius / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " normalizedChi2     | "; std::cout.width(16); 
-  std::cout << std::right << Cut_normalizedChi2 << " | "; std::cout.width(16);
-  std::cout << Cut_normalizedChi2/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " normalizedChi2     | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_normalizedChi2 << " | ";
+  std::cout.width(16);
+  std::cout << Cut_normalizedChi2 / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " fbrem              | "; std::cout.width(16); 
-  std::cout << std::right << Cut_fbrem << " | "; std::cout.width(16);
-  std::cout << Cut_fbrem/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
-  std::cout << "--------------------------------------------------------------" << std::endl; 
-  std::cout << " nCluster           | "; std::cout.width(16); 
-  std::cout << std::right << Cut_nCluster << " | "; std::cout.width(16);
-  std::cout << Cut_nCluster/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " fbrem              | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_fbrem << " | ";
+  std::cout.width(16);
+  std::cout << Cut_fbrem / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " EcalEnergy Range   | "; std::cout.width(16); 
-  std::cout << std::right << Cut_EcalRange << " | "; std::cout.width(16); 
-  std::cout << Cut_EcalRange/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " nCluster           | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_nCluster << " | ";
+  std::cout.width(16);
+  std::cout << Cut_nCluster / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << "--------------------------------------------------------------" << std::endl;
-  std::cout << " Used Tracks        | "; std::cout.width(16); 
-  std::cout << std::right << usedTracks << " | "; std::cout.width(16);
-  std::cout << usedTracks/static_cast<Double_t>(NTracksMacro)*100. << std::endl;
+  std::cout << " EcalEnergy Range   | ";
+  std::cout.width(16);
+  std::cout << std::right << Cut_EcalRange << " | ";
+  std::cout.width(16);
+  std::cout << Cut_EcalRange / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
+  std::cout << "--------------------------------------------------------------" << std::endl;
+  std::cout << " Used Tracks        | ";
+  std::cout.width(16);
+  std::cout << std::right << usedTracks << " | ";
+  std::cout.width(16);
+  std::cout << usedTracks / static_cast<Double_t>(NTracksMacro) * 100. << std::endl;
   std::cout << std::endl;
   std::cout << "##############################################################" << std::endl;
   std::cout.unsetf(std::ios::fixed);
   std::cout.precision(precision);
-
 }
-
 
 // -----------------------------------------------------------------------------
 //
 //    Auxiliary function : extractgausparams
 //
 // -----------------------------------------------------------------------------
-std::vector<Double_t> extractgausparams(TH1F *histo, 
-                                        TString option1,
-                                        TString option2)
-{
+std::vector<Double_t> extractgausparams(TH1F* histo, TString option1, TString option2) {
   // Fitting the histogram with a gaussian function
-  TF1 *f1 = new TF1("f1","gaus");
-  f1->SetRange(0.,2.);
-  histo->Fit("f1","QR0L");
+  TF1* f1 = new TF1("f1", "gaus");
+  f1->SetRange(0., 2.);
+  histo->Fit("f1", "QR0L");
 
   // Getting parameters estimated by the fit
-  double mean      = f1->GetParameter(1);
-  double deviation = f1->GetParameter(2); 
+  double mean = f1->GetParameter(1);
+  double deviation = f1->GetParameter(2);
 
   // Iinitializing internal parameters of the iteration algorithms
-  double lowLim = 0; 
-  double upLim = 0;  
+  double lowLim = 0;
+  double upLim = 0;
   double degrade = 0.05;
   unsigned int iteration = 0;
 
   // Iteration procedure
   // Iteration is stopped when :
-  //      more than 10 iterations 
+  //      more than 10 iterations
   //   or fit probability > 0.001
-  while( iteration == 0 || (f1->GetProb() < 0.001 && iteration < 10) )
-  {
+  while (iteration == 0 || (f1->GetProb() < 0.001 && iteration < 10)) {
     // Computing new bounds for the fit range (2.0 sigma)
-    lowLim = mean - (2.0*deviation*(1-degrade*iteration));
-    upLim  = mean + (2.0*deviation*(1-degrade*iteration));
-    f1->SetRange(lowLim,upLim);
+    lowLim = mean - (2.0 * deviation * (1 - degrade * iteration));
+    upLim = mean + (2.0 * deviation * (1 - degrade * iteration));
+    f1->SetRange(lowLim, upLim);
 
     // Fitting the histo with new bounds
-    histo->Fit("f1","QRL0");
+    histo->Fit("f1", "QRL0");
 
-    // If the fit succeeds -> extract the new estimated mean value 
-    double newmean=0;
-    if (f1->GetParameter(1)<2 && f1->GetParameter(1)>0) 
-      newmean =  f1->GetParameter(1);
-    // Else -> keep the previous mean value 
-    else newmean = mean;
+    // If the fit succeeds -> extract the new estimated mean value
+    double newmean = 0;
+    if (f1->GetParameter(1) < 2 && f1->GetParameter(1) > 0)
+      newmean = f1->GetParameter(1);
+    // Else -> keep the previous mean value
+    else
+      newmean = mean;
 
     // Computing new bounds for the fit with the new mean value (1.5 sigma)
-    lowLim = newmean - (1.5*deviation);//*(1-degrade*iteration));
-    upLim  = newmean + (1.5*deviation);//*(1-degrade*iteration));
-    f1->SetRange(lowLim,upLim);
+    lowLim = newmean - (1.5 * deviation);  //*(1-degrade*iteration));
+    upLim = newmean + (1.5 * deviation);   //*(1-degrade*iteration));
+    f1->SetRange(lowLim, upLim);
     f1->SetLineWidth(1);
 
     // Fitting the histo with new bounds
-    histo->Fit("f1","QRL+i"+option1,option2);
+    histo->Fit("f1", "QRL+i" + option1, option2);
 
     // if the fit succeeds -> extract the new estimated mean value
-    if (f1->GetParameter(1)<2 && f1->GetParameter(1)>0)
-       mean =  f1->GetParameter(1);
+    if (f1->GetParameter(1) < 2 && f1->GetParameter(1) > 0)
+      mean = f1->GetParameter(1);
 
     // Computing new deviation
     deviation = f1->GetParameter(2);
@@ -1289,55 +1284,46 @@ std::vector<Double_t> extractgausparams(TH1F *histo,
   return params;
 }
 
-
 // -----------------------------------------------------------------------------
 //
 //    Auxiliary function : CheckArguments
 //
 // -----------------------------------------------------------------------------
-Bool_t checkArguments(TString  variable,           //input
-                      TString  path, 
-                      TString  alignmentWithLabel,
-                      TString  outputType,
+Bool_t checkArguments(TString variable,  //input
+                      TString path,
+                      TString alignmentWithLabel,
+                      TString outputType,
                       Double_t radius,
-                      Bool_t   verbose,
+                      Bool_t verbose,
                       Double_t givenMin,
                       Double_t givenMax,
-                      ModeType& mode,               // ouput
+                      ModeType& mode,  // ouput
                       std::vector<TFile*>& files,
-                      std::vector<TString>& labels)
-{
+                      std::vector<TString>& labels) {
   // Determining mode
-  if (variable=="eta") mode = TRACK_ETA;
-  else if (variable=="phi"  || variable=="phi1" || 
-           variable=="phi2" || variable=="phi3") mode = TRACK_PHI;
-  else
-  {
+  if (variable == "eta")
+    mode = TRACK_ETA;
+  else if (variable == "phi" || variable == "phi1" || variable == "phi2" || variable == "phi3")
+    mode = TRACK_PHI;
+  else {
     std::cout << "variable can be eta or phi" << std::endl;
-    std::cout << "phi1, phi2 and phi3 are for phi in different eta bins" 
-              << std::endl;
+    std::cout << "phi1, phi2 and phi3 are for phi in different eta bins" << std::endl;
     return false;
   }
 
   // Checking outputType
-  TString allowed[]={"eps","pdf","svg","gif","xpm","png",
-                     "jpg","tiff","C","cxx","root","xml"};
-  bool find=false;
-  for (unsigned int i=0;i<12;i++)
-  {
-    if (outputType==allowed[i])
-    {
-      find=true;
+  TString allowed[] = {"eps", "pdf", "svg", "gif", "xpm", "png", "jpg", "tiff", "C", "cxx", "root", "xml"};
+  bool find = false;
+  for (unsigned int i = 0; i < 12; i++) {
+    if (outputType == allowed[i]) {
+      find = true;
       break;
-    } 
+    }
   }
-  if (!find)
-  {
-    std::cout << "ERROR: output type called '"+outputType+"' is unknown !" 
-              << std::endl
+  if (!find) {
+    std::cout << "ERROR: output type called '" + outputType + "' is unknown !" << std::endl
               << "The available output types are : " << std::endl;
-    for (unsigned int i=0;i<12;i++)
-    {
+    for (unsigned int i = 0; i < 12; i++) {
       std::cout << " " << allowed[i];
     }
     std::cout << std::endl;
@@ -1345,41 +1331,32 @@ Bool_t checkArguments(TString  variable,           //input
   }
 
   // Checking radius
-  if (radius<=0)
-  {
+  if (radius <= 0) {
     std::cout << "ERROR: The radius cannot be null or negative" << std::endl;
     return false;
   }
 
   // Checking bounds
-  if (givenMin>givenMax)
-  {
+  if (givenMin > givenMax) {
     std::cout << "ERROR: Min value is greater than Max value" << std::endl;
     return false;
   }
 
   // Reading the list of files
-  TObjArray *fileLabelPairs = alignmentWithLabel.Tokenize("\\");
+  TObjArray* fileLabelPairs = alignmentWithLabel.Tokenize("\\");
   std::cout << "Reading input ROOT files ..." << std::endl;
-  for (Int_t i=0; i<fileLabelPairs->GetEntries(); i++)
-  {
-    TObjArray *singleFileLabelPair = 
-               TString(fileLabelPairs->At(i)->GetName()).Tokenize("=");
+  for (Int_t i = 0; i < fileLabelPairs->GetEntries(); i++) {
+    TObjArray* singleFileLabelPair = TString(fileLabelPairs->At(i)->GetName()).Tokenize("=");
 
-    if(singleFileLabelPair->GetEntries() == 2) 
-    {
-      TFile* theFile = new TFile(path+(TString(singleFileLabelPair->At(0)->GetName())));
-      if (!theFile->IsOpen())
-      {
-        std::cout << "ERROR : the file '" << theFile->GetName() 
-                  << "' is not found" << std::endl;
+    if (singleFileLabelPair->GetEntries() == 2) {
+      TFile* theFile = new TFile(path + (TString(singleFileLabelPair->At(0)->GetName())));
+      if (!theFile->IsOpen()) {
+        std::cout << "ERROR : the file '" << theFile->GetName() << "' is not found" << std::endl;
         return false;
       }
       files.push_back(theFile);
       labels.push_back(singleFileLabelPair->At(1)->GetName());
-    }
-    else 
-    {
+    } else {
       std::cout << "ERROR : Please give file name and legend entry in the following form:\n"
                 << " filename1=legendentry1\\filename2=legendentry2\\..." << std::endl;
       return false;
@@ -1387,164 +1364,155 @@ Bool_t checkArguments(TString  variable,           //input
   }
 
   // Check there is at least of file to analyze
-  if (files.size()==0)
-  {
+  if (files.size() == 0) {
     std::cout << "-> No file to analyze" << std::endl;
     return false;
   }
 
   // Check labels are unique
-  for (unsigned int i=0;i<labels.size();i++)
-    for (unsigned int j=i+1;j<labels.size();j++)
-  {
-    if (labels[i]==labels[j])
-    {
-      std::cout << "the label '" << labels[i] << "' is twice" << std::endl;
-      return false; 
+  for (unsigned int i = 0; i < labels.size(); i++)
+    for (unsigned int j = i + 1; j < labels.size(); j++) {
+      if (labels[i] == labels[j]) {
+        std::cout << "the label '" << labels[i] << "' is twice" << std::endl;
+        return false;
+      }
     }
-  }
 
   return true;
 }
-
 
 // -----------------------------------------------------------------------------
 //
 //    Main (only for stand alone compiled program)
 //
 // -----------------------------------------------------------------------------
-void configureROOTstyle(Bool_t verbose)
-{
+void configureROOTstyle(Bool_t verbose) {
   // Configuring style
   gROOT->cd();
   gROOT->SetStyle("Plain");
-  if (verbose)
-  {
-    std::cout<<"\n all formerly produced control plots in ./controlEOP/ deleted.\n"<<std::endl;
+  if (verbose) {
+    std::cout << "\n all formerly produced control plots in ./controlEOP/ deleted.\n" << std::endl;
     gROOT->ProcessLine(".!if [ -d controlEOP ]; then rm controlEOP/control_eop*; else mkdir controlEOP; fi");
   }
   gStyle->SetPadBorderMode(0);
   gStyle->SetOptStat(0);
-  gStyle->SetTitleFont(42,"XYZ");
-  gStyle->SetLabelFont(42,"XYZ");
+  gStyle->SetTitleFont(42, "XYZ");
+  gStyle->SetLabelFont(42, "XYZ");
   gStyle->SetEndErrorSize(5);
-  gStyle->SetLineStyleString(2,"80 20");
-  gStyle->SetLineStyleString(3,"40 18");
-  gStyle->SetLineStyleString(4,"20 16");
+  gStyle->SetLineStyleString(2, "80 20");
+  gStyle->SetLineStyleString(3, "40 18");
+  gStyle->SetLineStyleString(4, "20 16");
 }
-
 
 // -----------------------------------------------------------------------------
 //
 //    InitializeTree
 //
 // -----------------------------------------------------------------------------
-Bool_t initializeTree(std::vector<TFile*>& files, std::vector<TTree*>& trees, EopElecVariables* track)
-{
+Bool_t initializeTree(std::vector<TFile*>& files, std::vector<TTree*>& trees, EopElecVariables* track) {
   // resize the tree size
   trees.resize(files.size());
 
   // Loop over the different ROOT files
-  for(unsigned int i=0; i<files.size(); i++)
-  {
+  for (unsigned int i = 0; i < files.size(); i++) {
     // Displaying the file name
-    std::cout<<"Opening the file : "<< files[i]->GetName() << std::endl;
+    std::cout << "Opening the file : " << files[i]->GetName() << std::endl;
 
     // Extracting the TTree from the ROOT file
-    TTree* theTree = dynamic_cast<TTree*>(
-                       files[i]->Get("energyOverMomentumTree/EopTree"));
+    TTree* theTree = dynamic_cast<TTree*>(files[i]->Get("energyOverMomentumTree/EopTree"));
 
-    // Checking if the TTree is found 
-    if (theTree==0)
-    {
+    // Checking if the TTree is found
+    if (theTree == 0) {
       std::cout << "ERROR : the tree 'EopTree' is not found ! This file is skipped !" << std::endl;
       return false;
     }
 
     // Storing the TTree in the container
-    trees[i]=theTree;
+    trees[i] = theTree;
 
     // Connecting the branches of the TTree to the event object
     trees[i]->SetMakeClass(1);
-    trees[i]->SetBranchAddress("EopElecVariables",     &track);
-    trees[i]->SetBranchAddress("charge",                 &track->charge);
-    trees[i]->SetBranchAddress("nHits",                  &track->nHits);
-    trees[i]->SetBranchAddress("nLostHits",              &track->nLostHits);
-    trees[i]->SetBranchAddress("innerOk",                &track->innerOk);
-    trees[i]->SetBranchAddress("outerRadius",            &track->outerRadius);
-    trees[i]->SetBranchAddress("chi2",                   &track->chi2);
-    trees[i]->SetBranchAddress("normalizedChi2",         &track->normalizedChi2);
-    trees[i]->SetBranchAddress("px_rejected_track",      &track->px_rejected_track);
-    trees[i]->SetBranchAddress("py_rejected_track",      &track->py_rejected_track);
-    trees[i]->SetBranchAddress("pz_rejected_track",      &track->pz_rejected_track);
-    trees[i]->SetBranchAddress("px",                     &track->px);
-    trees[i]->SetBranchAddress("py",                     &track->py);
-    trees[i]->SetBranchAddress("pz",                     &track->pz);
-    trees[i]->SetBranchAddress("p",                      &track->p);
-    trees[i]->SetBranchAddress("pIn",                    &track->pIn);
-    trees[i]->SetBranchAddress("etaIn",                  &track->etaIn);
-    trees[i]->SetBranchAddress("phiIn",                  &track->phiIn);
-    trees[i]->SetBranchAddress("pOut",                   &track->pOut);
-    trees[i]->SetBranchAddress("etaOut",                 &track->etaOut);
-    trees[i]->SetBranchAddress("phiOut",                 &track->phiOut);
-    trees[i]->SetBranchAddress("pt",                     &track->pt);
-    trees[i]->SetBranchAddress("ptError",                &track->ptError);
-    trees[i]->SetBranchAddress("theta",                  &track->theta);
-    trees[i]->SetBranchAddress("eta",                    &track->eta);
-    trees[i]->SetBranchAddress("phi",                    &track->phi);
-    trees[i]->SetBranchAddress("fbrem",                  &track->fbrem);
-    trees[i]->SetBranchAddress("MaxPtIn01",              &track->MaxPtIn01);
-    trees[i]->SetBranchAddress("SumPtIn01",              &track->SumPtIn01);
-    trees[i]->SetBranchAddress("NoTrackIn0015",          &track->NoTrackIn0015);
-    trees[i]->SetBranchAddress("MaxPtIn02",              &track->MaxPtIn02);
-    trees[i]->SetBranchAddress("SumPtIn02",              &track->SumPtIn02);
-    trees[i]->SetBranchAddress("NoTrackIn0020",          &track->NoTrackIn0020);
-    trees[i]->SetBranchAddress("MaxPtIn03",              &track->MaxPtIn03);
-    trees[i]->SetBranchAddress("SumPtIn03",              &track->SumPtIn03);
-    trees[i]->SetBranchAddress("NoTrackIn0025",          &track->NoTrackIn0025);
-    trees[i]->SetBranchAddress("MaxPtIn04",              &track->MaxPtIn04);
-    trees[i]->SetBranchAddress("SumPtIn04",              &track->SumPtIn04);
-    trees[i]->SetBranchAddress("NoTrackIn0030",          &track->NoTrackIn0030);
-    trees[i]->SetBranchAddress("MaxPtIn05",              &track->MaxPtIn05);
-    trees[i]->SetBranchAddress("SumPtIn05",              &track->SumPtIn05);
-    trees[i]->SetBranchAddress("NoTrackIn0035",          &track->NoTrackIn0035);
-    trees[i]->SetBranchAddress("NoTrackIn0040",          &track->NoTrackIn0040);
-    trees[i]->SetBranchAddress("SC_algoID",              &track->SC_algoID);
-    trees[i]->SetBranchAddress("SC_energy",              &track->SC_energy);
-    trees[i]->SetBranchAddress("SC_nBasicClus",          &track->SC_nBasicClus);
-    trees[i]->SetBranchAddress("SC_etaWidth",            &track->SC_etaWidth);
-    trees[i]->SetBranchAddress("SC_phiWidth",            &track->SC_phiWidth);
-    trees[i]->SetBranchAddress("SC_eta",                 &track->SC_eta);
-    trees[i]->SetBranchAddress("SC_phi",                 &track->SC_phi);
-    trees[i]->SetBranchAddress("SC_isBarrel",            &track->SC_isBarrel);
-    trees[i]->SetBranchAddress("SC_isEndcap",            &track->SC_isEndcap);
-    trees[i]->SetBranchAddress("dRto1stSC",              &track->dRto1stSC);
-    trees[i]->SetBranchAddress("dRto2ndSC",              &track->dRto2ndSC);
-    trees[i]->SetBranchAddress("HcalEnergyIn01",         &track->HcalEnergyIn01);
-    trees[i]->SetBranchAddress("HcalEnergyIn02",         &track->HcalEnergyIn02);
-    trees[i]->SetBranchAddress("HcalEnergyIn03",         &track->HcalEnergyIn03);
-    trees[i]->SetBranchAddress("HcalEnergyIn04",         &track->HcalEnergyIn04);
-    trees[i]->SetBranchAddress("HcalEnergyIn05",         &track->HcalEnergyIn05);
-    trees[i]->SetBranchAddress("isEcalDriven",           &track->isEcalDriven);
-    trees[i]->SetBranchAddress("isTrackerDriven",        &track->isTrackerDriven);
-    trees[i]->SetBranchAddress("RunNumber",              &track->RunNumber);
-    trees[i]->SetBranchAddress("EvtNumber",              &track->EvtNumber);
-    
-
-
+    trees[i]->SetBranchAddress("EopElecVariables", &track);
+    trees[i]->SetBranchAddress("charge", &track->charge);
+    trees[i]->SetBranchAddress("nHits", &track->nHits);
+    trees[i]->SetBranchAddress("nLostHits", &track->nLostHits);
+    trees[i]->SetBranchAddress("innerOk", &track->innerOk);
+    trees[i]->SetBranchAddress("outerRadius", &track->outerRadius);
+    trees[i]->SetBranchAddress("chi2", &track->chi2);
+    trees[i]->SetBranchAddress("normalizedChi2", &track->normalizedChi2);
+    trees[i]->SetBranchAddress("px_rejected_track", &track->px_rejected_track);
+    trees[i]->SetBranchAddress("py_rejected_track", &track->py_rejected_track);
+    trees[i]->SetBranchAddress("pz_rejected_track", &track->pz_rejected_track);
+    trees[i]->SetBranchAddress("px", &track->px);
+    trees[i]->SetBranchAddress("py", &track->py);
+    trees[i]->SetBranchAddress("pz", &track->pz);
+    trees[i]->SetBranchAddress("p", &track->p);
+    trees[i]->SetBranchAddress("pIn", &track->pIn);
+    trees[i]->SetBranchAddress("etaIn", &track->etaIn);
+    trees[i]->SetBranchAddress("phiIn", &track->phiIn);
+    trees[i]->SetBranchAddress("pOut", &track->pOut);
+    trees[i]->SetBranchAddress("etaOut", &track->etaOut);
+    trees[i]->SetBranchAddress("phiOut", &track->phiOut);
+    trees[i]->SetBranchAddress("pt", &track->pt);
+    trees[i]->SetBranchAddress("ptError", &track->ptError);
+    trees[i]->SetBranchAddress("theta", &track->theta);
+    trees[i]->SetBranchAddress("eta", &track->eta);
+    trees[i]->SetBranchAddress("phi", &track->phi);
+    trees[i]->SetBranchAddress("fbrem", &track->fbrem);
+    trees[i]->SetBranchAddress("MaxPtIn01", &track->MaxPtIn01);
+    trees[i]->SetBranchAddress("SumPtIn01", &track->SumPtIn01);
+    trees[i]->SetBranchAddress("NoTrackIn0015", &track->NoTrackIn0015);
+    trees[i]->SetBranchAddress("MaxPtIn02", &track->MaxPtIn02);
+    trees[i]->SetBranchAddress("SumPtIn02", &track->SumPtIn02);
+    trees[i]->SetBranchAddress("NoTrackIn0020", &track->NoTrackIn0020);
+    trees[i]->SetBranchAddress("MaxPtIn03", &track->MaxPtIn03);
+    trees[i]->SetBranchAddress("SumPtIn03", &track->SumPtIn03);
+    trees[i]->SetBranchAddress("NoTrackIn0025", &track->NoTrackIn0025);
+    trees[i]->SetBranchAddress("MaxPtIn04", &track->MaxPtIn04);
+    trees[i]->SetBranchAddress("SumPtIn04", &track->SumPtIn04);
+    trees[i]->SetBranchAddress("NoTrackIn0030", &track->NoTrackIn0030);
+    trees[i]->SetBranchAddress("MaxPtIn05", &track->MaxPtIn05);
+    trees[i]->SetBranchAddress("SumPtIn05", &track->SumPtIn05);
+    trees[i]->SetBranchAddress("NoTrackIn0035", &track->NoTrackIn0035);
+    trees[i]->SetBranchAddress("NoTrackIn0040", &track->NoTrackIn0040);
+    trees[i]->SetBranchAddress("SC_algoID", &track->SC_algoID);
+    trees[i]->SetBranchAddress("SC_energy", &track->SC_energy);
+    trees[i]->SetBranchAddress("SC_nBasicClus", &track->SC_nBasicClus);
+    trees[i]->SetBranchAddress("SC_etaWidth", &track->SC_etaWidth);
+    trees[i]->SetBranchAddress("SC_phiWidth", &track->SC_phiWidth);
+    trees[i]->SetBranchAddress("SC_eta", &track->SC_eta);
+    trees[i]->SetBranchAddress("SC_phi", &track->SC_phi);
+    trees[i]->SetBranchAddress("SC_isBarrel", &track->SC_isBarrel);
+    trees[i]->SetBranchAddress("SC_isEndcap", &track->SC_isEndcap);
+    trees[i]->SetBranchAddress("dRto1stSC", &track->dRto1stSC);
+    trees[i]->SetBranchAddress("dRto2ndSC", &track->dRto2ndSC);
+    trees[i]->SetBranchAddress("HcalEnergyIn01", &track->HcalEnergyIn01);
+    trees[i]->SetBranchAddress("HcalEnergyIn02", &track->HcalEnergyIn02);
+    trees[i]->SetBranchAddress("HcalEnergyIn03", &track->HcalEnergyIn03);
+    trees[i]->SetBranchAddress("HcalEnergyIn04", &track->HcalEnergyIn04);
+    trees[i]->SetBranchAddress("HcalEnergyIn05", &track->HcalEnergyIn05);
+    trees[i]->SetBranchAddress("isEcalDriven", &track->isEcalDriven);
+    trees[i]->SetBranchAddress("isTrackerDriven", &track->isTrackerDriven);
+    trees[i]->SetBranchAddress("RunNumber", &track->RunNumber);
+    trees[i]->SetBranchAddress("EvtNumber", &track->EvtNumber);
   }
   return true;
 }
-
 
 // -----------------------------------------------------------------------------
 //
 //    Main (only for stand alone compiled program)
 //
 // -----------------------------------------------------------------------------
-int main()
-{
+int main() {
   //momentumBiasValidation("eta","./","EopTree.root=Fit : ","root",1.,true);
-  momentumBiasValidation("eta","/opt/sbg/data/data1/cms/cgoetzma/Thesis/Eop_withElectrons/Outputs/GsfTracks/","QCD120to170.root=Chris1\\QCD15to30.root=Chris2\\QCD170to300.root=Chris3\\QCD300to470.root=Chris4\\QCD30to50.root=Chris5\\QCD470to600.root=Chris6\\QCD50to80.root=Chris7\\QCD600to800.root=Chris8\\QCD800to1000.root=Chris9\\QCD80to120.root=Chris10\\DyToEE.root=Chris11","root",1.,true);
+  momentumBiasValidation("eta",
+                         "/opt/sbg/data/data1/cms/cgoetzma/Thesis/Eop_withElectrons/Outputs/GsfTracks/",
+                         "QCD120to170.root=Chris1\\QCD15to30.root=Chris2\\QCD170to300.root=Chris3\\QCD300to470.root="
+                         "Chris4\\QCD30to50.root=Chris5\\QCD470to600.root=Chris6\\QCD50to80.root=Chris7\\QCD600to800."
+                         "root=Chris8\\QCD800to1000.root=Chris9\\QCD80to120.root=Chris10\\DyToEE.root=Chris11",
+                         "root",
+                         1.,
+                         true);
   return 0;
 }

--- a/Alignment/OfflineValidation/plugins/BuildFile.xml
+++ b/Alignment/OfflineValidation/plugins/BuildFile.xml
@@ -42,6 +42,7 @@
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimTracker/TrackerHitAssociation"/>
+<use name="SimTracker/TrackAssociation"/>
 <use name="TrackPropagation/SteppingHelixPropagator"/>
 <use name="TrackingTools/IPTools"/>
 <use name="TrackingTools/TrackAssociator"/>

--- a/Alignment/OfflineValidation/plugins/BuildFile.xml
+++ b/Alignment/OfflineValidation/plugins/BuildFile.xml
@@ -16,6 +16,7 @@
 <use name="DQMServices/Core"/>
 <use name="DataFormats/BeamSpot"/>
 <use name="DataFormats/DetId"/>
+<use name="DataFormats/EgammaCandidates"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/SiPixelDetId"/>
@@ -36,9 +37,11 @@
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="Geometry/TrackerNumberingBuilder"/>
+<use name="HLTrigger/HLTcore"/>
 <use name="MagneticField/Records"/>
 <use name="RecoMuon/TrackingTools"/>
 <use name="RecoVertex/PrimaryVertexProducer"/>
+<use name="RecoEcal/EgammaClusterAlgos"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimTracker/TrackerHitAssociation"/>

--- a/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
@@ -1,0 +1,950 @@
+// -*- C++ -*- //
+// Package:    EopTreeWriter
+// Class:      EopTreeWriter
+//
+/**\class EopTreeWriter EopTreeWriter.cc Alignment/OfflineValidation/plugins/EopTreeWriter.cc
+ //
+ Description: <one line class summary>
+ 
+ Implementation:
+ <Notes on implementation>
+*/
+//
+// Original Author:  Holger Enderle
+//         Created:  Thu Dec  4 11:22:48 CET 2008
+// $Id: EopElecTreeWriter.cc,v 1.8 2012/08/30 08:40:51 cgoetzma Exp $
+//
+//
+
+// framework include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "TrackingTools/GsfTools/interface/MultiTrajectoryStateMode.h"
+#include "TrackingTools/GsfTools/interface/MultiTrajectoryStateTransform.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+
+// user include files
+#include <DataFormats/TrackReco/interface/Track.h>
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include <TMath.h>
+#include <TH1.h>
+#include <TH2D.h>
+#include "TTree.h"
+#include <TCanvas.h>
+#include <TLorentzVector.h>
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "CommonTools/Utils/interface/TFileDirectory.h"
+
+#include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
+#include "TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h"
+#include "TrackingTools/GeomPropagators/interface/PropagationExceptions.h"
+#include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/CaloTowers/interface/CaloTower.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+
+//#include "RecoParticleFlow/PFRootEvent/interface/JetRecoTypes.h"
+//#include "RecoParticleFlow/PFRootEvent/interface/JetMaker.h"
+//#include "RecoParticleFlow/PFRootEvent/interface/ProtoJet.h"
+
+#include "RecoEcal/EgammaCoreTools/interface/SuperClusterShapeAlgo.h"
+
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+#include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidateFwd.h"
+#include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoCaloTowerCandidate.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
+#include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/EgammaReco/interface/BasicCluster.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "Alignment/OfflineValidation/interface/EopElecVariables.h"
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+//Trigger
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+//Super cluster eta and phi width
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+
+struct EopTriggerType {
+  bool fired;
+  Int_t prescale;
+  Int_t index;
+
+  EopTriggerType() {
+    fired = false;
+    prescale = 0;
+    index = 0;
+  }
+};
+
+//
+// class decleration
+//
+using namespace std;
+
+class EopElecTreeWriter : public edm::EDAnalyzer {
+public:
+  explicit EopElecTreeWriter(const edm::ParameterSet&);
+  ~EopElecTreeWriter() override;
+
+private:
+  // Cut flow (events number)
+  TH1D* nEvents;
+  TH1D* nEventsWithVertex;
+  TH1D* nEventsTriggered;
+  TH1D* nEventsHLTFilter;
+  TH1D* nEventsHLTelectron;
+  TH1D* nEventsHLTrejected;
+  TH1D* nEvents2Elec;
+
+  TH1D* nHLTelectrons;
+  TH1D* nTrkRejectedPerEvt;
+  TH1D* nTrkSelectedPerEvt;
+
+  // Cut flow (tracks number)
+  TH1D* nTracks;
+  TH1D* nTracksFiltered;
+  TH1D* cut_Ptmin;
+  TH1D* cut_OneSCmatch;
+
+  TH1D* counter1;
+  TH1D* counter2;
+
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  // ----------member data ---------------------------
+  edm::InputTag src_;
+
+  edm::Service<TFileService> fs_;
+  TTree* tree_;
+  EopElecVariables* treeMemPtr_;
+
+  HLTConfigProvider hltConfig_;
+  std::vector<std::string> triggerNames_;
+  TH1D* distToClosestSCgsf;
+  TH1D* distToClosestSC;
+  TH1D* EcalEnergy;
+  TH1D* Momentum;
+  TH1D* HcalEnergy;
+  TH1D* fBREM;
+  TH1D* Eop_InnerNegative;
+  TH1D* Eop_InnerPositive;
+
+  TH2D* HcalVSEcal;
+
+  MultiTrajectoryStateTransform* mtsTransform_;
+  edm::EDGetTokenT<reco::VertexCollection> theVertexCollectionToken;
+  edm::EDGetTokenT<HBHERecHitCollection> theHBHERecHitCollectionToken;
+  edm::EDGetTokenT<EcalRecHitCollection> theEcalRecHitCollectionToken;
+  edm::EDGetTokenT<reco::SuperClusterCollection> theBarrelSupClusCollectionToken;
+  edm::EDGetTokenT<reco::SuperClusterCollection> theEndCapSupClusCollectionToken;
+  edm::EDGetTokenT<edm::TriggerResults> theTriggerResultsToken;
+  edm::EDGetTokenT<trigger::TriggerEvent> theTriggerEventToken;
+  edm::EDGetTokenT<reco::GsfTrackCollection> theGsfTrackCollectionToken;
+  edm::EDGetTokenT<reco::GsfElectronCoreCollection> theGsfElectronCoreCollectionToken;
+};
+
+// Function to convert the eta of the track to a detector eta (for matching with SC)
+float ecalEta(float EtaParticle, float Zvertex, float RhoVertex) {
+  const float R_ECAL = 136.5;
+  const float Z_Endcap = 328.0;
+  const float etaBarrelEndcap = 1.479;
+
+  if (EtaParticle != 0.) {
+    float Theta = 0.0;
+    float ZEcal = (R_ECAL - RhoVertex) * sinh(EtaParticle) + Zvertex;
+
+    if (ZEcal != 0.0)
+      Theta = atan(R_ECAL / ZEcal);
+    if (Theta < 0.0)
+      Theta = Theta + Geom::pi();
+
+    float ETA = -log(tan(0.5 * Theta));
+
+    if (fabs(ETA) > etaBarrelEndcap) {
+      float Zend = Z_Endcap;
+      if (EtaParticle < 0.0)
+        Zend = -Zend;
+      float Zlen = Zend - Zvertex;
+      float RR = Zlen / sinh(EtaParticle);
+      Theta = atan((RR + RhoVertex) / Zend);
+      if (Theta < 0.0)
+        Theta = Theta + Geom::pi();
+      ETA = -log(tan(0.5 * Theta));
+    }
+    return ETA;
+  } else {
+    edm::LogWarning("") << "[EcalPositionFromTrack::etaTransformation] Warning: Eta equals to zero, not correcting";
+    return EtaParticle;
+  }
+}
+
+// constructors and destructor
+
+EopElecTreeWriter::EopElecTreeWriter(const edm::ParameterSet& iConfig) {
+  theVertexCollectionToken = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
+  theHBHERecHitCollectionToken = consumes<HBHERecHitCollection>(edm::InputTag("hbhereco", ""));
+  theEcalRecHitCollectionToken = consumes<EcalRecHitCollection>(edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+  theBarrelSupClusCollectionToken = consumes<reco::SuperClusterCollection>(edm::InputTag("hybridSuperClusters", ""));
+  theEndCapSupClusCollectionToken =
+      consumes<reco::SuperClusterCollection>(edm::InputTag("multi5x5SuperClusters", "multi5x5EndcapSuperClusters"));
+  theTriggerResultsToken = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"));
+  theTriggerEventToken = consumes<trigger::TriggerEvent>(edm::InputTag("hltTriggerSummaryAOD"));
+
+  src_ = iConfig.getParameter<edm::InputTag>("src");
+  theGsfTrackCollectionToken = consumes<reco::GsfTrackCollection>(src_);
+
+  theGsfElectronCoreCollectionToken = consumes<reco::GsfElectronCoreCollection>(edm::InputTag("gedGsfElectronCores"));
+
+  // TTree creation
+  tree_ = fs_->make<TTree>("EopTree", "EopTree");
+  treeMemPtr_ = new EopElecVariables;
+  tree_->Branch("EopElecVariables", &treeMemPtr_);  // address of pointer!
+
+  // Control histograms declaration
+  distToClosestSC = fs_->make<TH1D>("distToClosestSC", "distToClosestSC", 100, 0, 0.1);
+  distToClosestSCgsf = fs_->make<TH1D>("distToClosestSCgsf", "distToClosestSCgsf", 100, 0, 0.1);
+  EcalEnergy = fs_->make<TH1D>("EcalEnergy", "EcalEnergy", 100, 0, 200);
+  Momentum = fs_->make<TH1D>("Momentum", "Momentum", 100, 0, 200);
+  HcalEnergy = fs_->make<TH1D>("HcalEnergy", "HcalEnergy", 100, 0, 40);
+  fBREM = fs_->make<TH1D>("fBREM", "fBREM", 100, -0.2, 1);
+  Eop_InnerNegative = fs_->make<TH1D>("Eop_InnerNegative", "Eop_InnerNegative", 100, 0, 3);
+  Eop_InnerPositive = fs_->make<TH1D>("Eop_InnerPositive", "Eop_InnerPositive", 100, 0, 3);
+  HcalVSEcal = fs_->make<TH2D>("HcalVSEcal", "HcalVSEcal", 100, 0, 160, 100, 0, 10);
+
+  nEvents = fs_->make<TH1D>("nEvents", "nEvents", 1, 0, 1);
+  nEventsWithVertex = fs_->make<TH1D>("nEventsWithVertex", "nEventsWithVertex", 1, 0, 1);
+  nEventsTriggered = fs_->make<TH1D>("nEventsTriggered", "nEventsTriggered", 1, 0, 1);
+  nEventsHLTFilter = fs_->make<TH1D>("nEventsHLTFilter", "nEventsHLTFilter", 1, 0, 1);
+  nEventsHLTelectron = fs_->make<TH1D>("nEventsHLTelectron", "nEventsHLTelectron", 1, 0, 1);
+  nEventsHLTrejected = fs_->make<TH1D>("nEventsHLTrejected", "nEventsHLTrejected", 1, 0, 1);
+  nEvents2Elec = fs_->make<TH1D>("nEvents2Elec", "nEvents2Elec", 1, 0, 1);
+
+  nHLTelectrons = fs_->make<TH1D>("nHLTelectrons", "nHLTelectrons", 20, 0, 20);
+  nTrkRejectedPerEvt = fs_->make<TH1D>("nTrkRejectedPerEvt", "nTrkRejectedPerEvt", 20, 0, 20);
+  nTrkSelectedPerEvt = fs_->make<TH1D>("nTrkSelectedPerEvt", "nTrkSelectedPerEvt", 20, 0, 20);
+
+  nTracks = fs_->make<TH1D>("nTracks", "nTracks", 1, 0, 1);
+  nTracksFiltered = fs_->make<TH1D>("nTracksFiltered", "nTracksFiltered", 1, 0, 1);
+  cut_Ptmin = fs_->make<TH1D>("cut_Ptmin", "cut_Ptmin", 1, 0, 1);
+  cut_OneSCmatch = fs_->make<TH1D>("cut_OneSCmatch", "cut_OneSCmatch", 1, 0, 1);
+
+  counter1 = fs_->make<TH1D>("counter1", "counter1", 1, 0, 1);
+  counter2 = fs_->make<TH1D>("counter2", "counter2", 1, 0, 1);
+}
+
+EopElecTreeWriter::~EopElecTreeWriter() {
+  cout << "Destructor..." << endl;
+
+  // control histograms
+
+  distToClosestSC->SetXTitle("distance from track to closest SuperCluster in eta-phi plan (weighted matching)");
+  distToClosestSC->SetYTitle("# Tracks");
+
+  distToClosestSCgsf->SetXTitle("distance from track to closest SuperCluster in eta-phi plan (gsfElectronCore)");
+  distToClosestSCgsf->SetYTitle("# Tracks");
+
+  EcalEnergy->SetXTitle("Ecal energy deposit (GeV)");
+  EcalEnergy->SetYTitle("# tracks");
+
+  HcalEnergy->SetXTitle("Hcal energy deposit (GeV)");
+  HcalEnergy->SetYTitle("# tracks");
+
+  Momentum->SetXTitle("Momentum magnitude (GeV)");
+  Momentum->SetYTitle("# tracks");
+
+  Eop_InnerNegative->SetXTitle("E/p");
+  Eop_InnerNegative->SetYTitle("# tracks");
+
+  Eop_InnerPositive->SetXTitle("E/p");
+  Eop_InnerPositive->SetYTitle("# tracks");
+
+  HcalVSEcal->SetXTitle("Ecal energy (GeV)");
+  HcalVSEcal->SetYTitle("Hcal energy (GeV)");
+  cout << "Total number of events : " << nEvents->GetEntries() << endl;
+}
+
+//###########################################
+//#     method called to for each event     #
+//###########################################
+
+void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  nEvents->Fill(0.5);
+
+  Double_t EnergyHcalIn01;
+  Double_t EnergyHcalIn02;
+  Double_t EnergyHcalIn03;
+  Double_t EnergyHcalIn04;
+  Double_t EnergyHcalIn05;
+  Double_t etaWidth;
+  Double_t phiWidth;
+  Int_t algo_ID;
+  Double_t EnergyEcal;
+  Double_t fbrem;
+  Double_t pin;
+  Double_t etaIn;
+  Double_t phiIn;
+  Double_t pout;
+  Double_t etaOut;
+  Double_t phiOut;
+  Double_t MaxPtIn01;
+  Double_t SumPtIn01;
+  Bool_t NoTrackIn0015;
+  Double_t MaxPtIn02;
+  Double_t SumPtIn02;
+  Bool_t NoTrackIn0020;
+  Double_t MaxPtIn03;
+  Double_t SumPtIn03;
+  Bool_t NoTrackIn0025;
+  Double_t MaxPtIn04;
+  Double_t SumPtIn04;
+  Bool_t NoTrackIn0030;
+  Double_t MaxPtIn05;
+  Double_t SumPtIn05;
+  Bool_t NoTrackIn0035;
+  Bool_t NoTrackIn0040;
+  Double_t dRSC_first;
+  Double_t dRSC_second;
+  Double_t etaSC;
+  Double_t phiSC;
+  Int_t nbSC;        //to count the nb of SuperCluster matching with a given track
+  Int_t nBasicClus;  //to count the nb of basic cluster in a given superCluster
+  Bool_t isEcalDriven;
+  Bool_t isTrackerDriven;
+  Bool_t isBarrel;
+  Bool_t isEndcap;
+  Bool_t TrigTag;
+
+  //---------------   for GsfTrack propagation through tracker  ---------------
+
+  edm::ESHandle<MagneticField> magField_;
+  edm::ESHandle<TrackerGeometry> trackerGeom_;
+
+  iSetup.get<IdealMagneticFieldRecord>().get(magField_);
+  iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeom_);
+  MultiTrajectoryStateTransform mtsTransform(trackerGeom_.product(), magField_.product());
+
+  //---------------    Super Cluster    -----------------
+
+  // getting primary vertex (necessary to convert eta track to eta detector
+  edm::Handle<reco::VertexCollection> vertex;
+  //iEvent.getByLabel("offlinePrimaryVertices","", vertex);
+  iEvent.getByToken(theVertexCollectionToken, vertex);
+
+  if (vertex->empty()) {
+    cout << "Error: no primary vertex found!" << endl;
+    return;
+  }
+  reco::Vertex vert;
+  vert = vertex->front();
+  nEventsWithVertex->Fill(0.5);
+
+  // getting calorimeter geometry
+  edm::ESHandle<CaloGeometry> geometry;
+  iSetup.get<CaloGeometryRecord>().get(geometry);
+  const CaloGeometry* geo = geometry.product();
+  const CaloSubdetectorGeometry* subGeo = geometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+  if (subGeo == nullptr)
+    cout << "ERROR: unable to find SubDetector geometry!!!" << std::endl;
+
+  // getting Hcal rechits
+  edm::Handle<HBHERecHitCollection> HcalHits;
+  //iEvent.getByLabel("hbhereco","", HcalHits);
+  iEvent.getByToken(theHBHERecHitCollectionToken, HcalHits);
+
+  // getting Ecal rechits
+  edm::Handle<EcalRecHitCollection> ecalrechitcollection;
+  //iEvent.getByLabel("ecalRecHit","EcalRecHitsEB", ecalrechitcollection);
+  iEvent.getByToken(theEcalRecHitCollectionToken, ecalrechitcollection);
+  const EcalRecHitCollection* rhc = ecalrechitcollection.product();
+  if (rhc == nullptr)
+    cout << "ERROR !!!" << std::endl;
+
+  // getting SuperCluster
+  edm::Handle<reco::SuperClusterCollection> BarrelSupClusCollection;
+  edm::Handle<reco::SuperClusterCollection> EndcapSupClusCollection;
+  //iEvent.getByLabel("hybridSuperClusters","", BarrelSupClusCollection);
+  //iEvent.getByLabel("multi5x5SuperClusters","multi5x5EndcapSuperClusters", EndcapSupClusCollection);
+  iEvent.getByToken(theBarrelSupClusCollectionToken, BarrelSupClusCollection);
+  iEvent.getByToken(theEndCapSupClusCollectionToken, EndcapSupClusCollection);
+
+  //iEvent.getByLabel("hfEMClusters","", tmpSupClusCollection);
+  //iEvent.getByLabel("correctedHybridSuperClusters","", tmpSupClusCollection);
+
+  // necessary to re-calculate phi and eta width of SuperClusters
+  SuperClusterShapeAlgo SCShape(rhc, subGeo);
+
+  //---------------    Trigger   -----------------
+
+  TrigTag = false;
+  const edm::InputTag triggerTag("TriggerResults", "", "HLT");
+
+  edm::Handle<edm::TriggerResults> trigRes;
+  //iEvent.getByLabel(triggerTag, trigRes);
+  iEvent.getByToken(theTriggerResultsToken, trigRes);
+
+  // trigger event
+  edm::Handle<trigger::TriggerEvent> triggerEvent;
+  //iEvent.getByLabel("hltTriggerSummaryAOD", triggerEvent );
+  iEvent.getByToken(theTriggerEventToken, triggerEvent);
+
+  //std::string pattern = "HLT_Ele32_CaloIdVL_CaloIsoVL_TrkIdVL_TrkIsoVL_v5";
+  std::string pattern = "HLT_DiEle27_WPTightCaloOnly_L1DoubleEG_v4";
+
+  // our trigger table
+  std::map<std::string, EopTriggerType> HLTpaths;
+  for (unsigned int i = 0; i < triggerNames_.size(); i++) {
+    if (triggerNames_[i].find(pattern) != 0)
+      continue;
+    EopTriggerType myTrigger;
+
+    const unsigned int prescaleSize = hltConfig_.prescaleSize();
+    for (unsigned int ps = 0; ps < prescaleSize; ps++) {
+      const unsigned int prescaleValue = hltConfig_.prescaleValue(ps, triggerNames_[i]);
+      if (prescaleValue != 1) {
+        myTrigger.prescale = prescaleValue;
+      }
+    }
+
+    myTrigger.index = hltConfig_.triggerIndex(triggerNames_[i]);
+    if (myTrigger.index == -1)
+      continue;
+    myTrigger.fired =
+        trigRes->wasrun(myTrigger.index) && trigRes->accept(myTrigger.index) && !trigRes->error(myTrigger.index);
+    HLTpaths[triggerNames_[i]] = myTrigger;
+  }
+
+  // First cut : trigger cut
+  std::string firstFiredPath = "";
+  for (std::map<std::string, EopTriggerType>::const_iterator it = HLTpaths.begin(); it != HLTpaths.end(); it++) {
+    if (it->second.fired) {
+      TrigTag = true;
+      firstFiredPath = it->first;
+      break;
+    }
+  }
+  if (!TrigTag)
+    return;
+  nEventsTriggered->Fill(0.5);
+
+  // Displaying filters label from the first fired trigger
+  // Useful for finding the good filter label
+  std::vector<std::string> filters = hltConfig_.moduleLabels(firstFiredPath);
+
+  /*
+   std::cout << "filters : ";
+   for (unsigned int i=0;i<filters.size();i++){ 
+   std::cout << filters[i]<<" ";
+   }
+   std::cout<<std::endl;
+ */
+
+  // Getting HLT electrons
+  //edm::InputTag testTag("hltEle32CaloIdVLCaloIsoVLTrkIdVLTrkIsoVLTrackIsoFilter","","HLT");
+  edm::InputTag testTag("hltDiEle27L1DoubleEGWPTightHcalIsoFilter", "", "HLT");
+  int testindex = triggerEvent->filterIndex(testTag);
+
+  if (testindex >= triggerEvent->sizeFilters())
+    return;
+  nEventsHLTFilter->Fill(0.5);
+
+  const trigger::Keys& KEYS_el(triggerEvent->filterKeys(testindex));
+
+  std::vector<const trigger::TriggerObject*> HLTelectrons;
+  for (unsigned int i = 0; i != KEYS_el.size(); ++i) {
+    const trigger::TriggerObject* triggerObject_el = &(triggerEvent->getObjects().at(KEYS_el[i]));
+    HLTelectrons.push_back(triggerObject_el);
+  }
+
+  nHLTelectrons->Fill(HLTelectrons.size());
+
+  if (HLTelectrons.empty())
+    return;
+  nEventsHLTelectron->Fill(0.5);
+
+  // finding the HLT electron with highest pt and saving the corresponding index
+  unsigned int HighPtIndex = 0;
+  double maxPtHLT = -5.;
+  for (unsigned int j = 0; j < HLTelectrons.size(); j++) {
+    if (HLTelectrons[j]->pt() > maxPtHLT) {
+      maxPtHLT = HLTelectrons[j]->pt();
+      HighPtIndex = j;
+    }
+  }
+
+  //-----------------   Tracks   -------------------
+
+  // getting GsfTrack
+  edm::Handle<reco::GsfTrackCollection> tracks;
+  //iEvent.getByLabel(src_, tracks);
+  iEvent.getByToken(theGsfTrackCollectionToken, tracks);
+
+  // filtering track
+  int nRejected = 0;
+  int nSelected = 0;
+  std::vector<const reco::GsfTrack*> filterTracks;
+  for (unsigned int i = 0; i < tracks->size(); i++) {
+    nTracks->Fill(0.5);
+    double deltar = reco::deltaR(
+        (*tracks)[i].eta(), (*tracks)[i].phi(), HLTelectrons[HighPtIndex]->eta(), HLTelectrons[HighPtIndex]->phi());
+    // remove the triggered electron with highest pt
+    if (deltar < 0.025) {
+      treeMemPtr_->px_rejected_track = (*tracks)[i].px();
+      treeMemPtr_->py_rejected_track = (*tracks)[i].py();
+      treeMemPtr_->pz_rejected_track = (*tracks)[i].pz();
+      treeMemPtr_->p_rejected_track = (*tracks)[i].p();
+      nRejected++;
+      continue;
+    }
+    filterTracks.push_back(&(*tracks)[i]);  // we use all the others
+    nSelected++;
+    nTracksFiltered->Fill(0.5);
+  }
+  nTrkRejectedPerEvt->Fill(nRejected);
+  nTrkSelectedPerEvt->Fill(nSelected);
+
+  if (nRejected == 0)
+    return;
+  nEventsHLTrejected->Fill(0.5);
+
+  if (filterTracks.empty())
+    return;
+  nEvents2Elec->Fill(0.5);
+
+  //-------- test:Matching SC/track using gsfElectonCore collection --------
+
+  edm::Handle<reco::GsfElectronCoreCollection> electrons;
+  //iEvent.getByLabel("gsfElectronCores", electrons);
+  iEvent.getByToken(theGsfElectronCoreCollectionToken, electrons);
+
+  for (std::vector<reco::GsfElectronCore>::const_iterator elec = electrons->begin(); elec != electrons->end(); elec++) {
+    double etaGSF = ecalEta((elec->gsfTrack())->eta(), vert.z(), (vert.position()).rho());
+    if ((elec->gsfTrack())->pt() < 10.)
+      continue;
+
+    double DELTAR = 0;
+    DELTAR =
+        reco::deltaR((elec->superCluster())->eta(), (elec->superCluster())->phi(), etaGSF, (elec->gsfTrack())->phi());
+
+    if (DELTAR < 0.1)
+      distToClosestSCgsf->Fill(DELTAR);
+  }
+
+  //------------------------------------------------------------
+
+  //--------------    Loop on tracks   -----------------
+
+  for (std::vector<const reco::GsfTrack*>::const_iterator itrack = filterTracks.begin(); itrack != filterTracks.end();
+       ++itrack) {
+    const reco::GsfTrack* track = (*itrack);
+
+    // initializing variables
+    isEcalDriven = false;
+    isTrackerDriven = false;
+    isBarrel = false;
+    isEndcap = false;
+    etaWidth = 0;
+    phiWidth = 0;
+    etaSC = 0;
+    phiSC = 0;
+    fbrem = 0;
+    pin = 0;
+    etaIn = 0;
+    phiIn = 0;
+    pout = 0;
+    etaOut = 0;
+    phiOut = 0;
+    algo_ID = 0;
+    EnergyEcal = 0;
+    dRSC_first = 999;
+    dRSC_second = 9999;
+    nbSC = 0;
+    nBasicClus = 0;
+
+    // First cut on momentum magnitude
+    Momentum->Fill(track->p());
+    if (track->pt() < 10.)
+      continue;
+    cut_Ptmin->Fill(0.5);
+
+    // calculating track parameters at innermost and outermost for Gsf tracks
+    TrajectoryStateOnSurface inTSOS = mtsTransform.innerStateOnSurface(*track);
+    TrajectoryStateOnSurface outTSOS = mtsTransform.outerStateOnSurface(*track);
+    if (inTSOS.isValid() && outTSOS.isValid()) {
+      GlobalVector inMom;
+      //multiTrajectoryStateMode::momentumFromModeCartesian(inTSOS, inMom_);
+      multiTrajectoryStateMode::momentumFromModePPhiEta(inTSOS, inMom);
+      pin = inMom.mag();
+      etaIn = inMom.eta();
+      phiIn = inMom.phi();
+      GlobalVector outMom;
+      //multiTrajectoryStateMode::momentumFromModeCartesian(outTSOS, outMom_);
+      multiTrajectoryStateMode::momentumFromModePPhiEta(outTSOS, outMom);
+      pout = outMom.mag();
+      etaOut = outMom.eta();
+      phiOut = outMom.phi();
+      fbrem = (pin - pout) / pin;
+      fBREM->Fill(fbrem);
+    }
+
+    // Matching track with Hcal rec hits
+    EnergyHcalIn01 = 0;
+    EnergyHcalIn02 = 0;
+    EnergyHcalIn03 = 0;
+    EnergyHcalIn04 = 0;
+    EnergyHcalIn05 = 0;
+
+    for (std::vector<HBHERecHit>::const_iterator hcal = (*HcalHits).begin(); hcal != (*HcalHits).end(); hcal++) {
+      GlobalPoint posH = geo->getPosition((*hcal).detid());
+      double phihit = posH.phi();
+      double etahit = posH.eta();
+      double dR = reco::deltaR(etahit, phihit, etaOut, phiOut);
+
+      // saving Hcal energy deposit measured for different eta-phi radius
+      if (dR < 0.1)
+        EnergyHcalIn01 += hcal->energy();
+      if (dR < 0.2)
+        EnergyHcalIn02 += hcal->energy();
+      if (dR < 0.3)
+        EnergyHcalIn03 += hcal->energy();
+      if (dR < 0.4)
+        EnergyHcalIn04 += hcal->energy();
+      if (dR < 0.5)
+        EnergyHcalIn05 += hcal->energy();
+    }
+
+    HcalEnergy->Fill(EnergyHcalIn02);
+
+    //Isolation against charged particles
+    MaxPtIn01 = 0.;
+    SumPtIn01 = 0.;
+    NoTrackIn0015 = true;
+    MaxPtIn02 = 0.;
+    SumPtIn02 = 0.;
+    NoTrackIn0020 = true;
+    MaxPtIn03 = 0.;
+    SumPtIn03 = 0.;
+    NoTrackIn0025 = true;
+    MaxPtIn04 = 0.;
+    SumPtIn04 = 0.;
+    NoTrackIn0030 = true;
+    MaxPtIn05 = 0.;
+    SumPtIn05 = 0.;
+    NoTrackIn0035 = true;
+    NoTrackIn0040 = true;
+
+    for (std::vector<const reco::GsfTrack*>::const_iterator itrack1 = filterTracks.begin();
+         itrack1 != filterTracks.end();
+         ++itrack1) {
+      const reco::GsfTrack* track1 = (*itrack1);
+
+      if (track == track1)
+        continue;
+
+      double etaIn1 = 0.;
+      double phiIn1 = 0.;
+
+      TrajectoryStateOnSurface inTSOS1 = mtsTransform.innerStateOnSurface(*track1);
+      if (inTSOS1.isValid()) {
+        GlobalVector inMom1;
+        multiTrajectoryStateMode::momentumFromModePPhiEta(inTSOS1, inMom1);
+        etaIn1 = inMom1.eta();
+        phiIn1 = inMom1.phi();
+      }
+
+      if (etaIn1 == 0 && phiIn1 == 0)
+        continue;
+
+      double dR = reco::deltaR(etaIn1, phiIn1, etaIn, phiIn);
+
+      // different radius of inner isolation cone
+      if (dR < 0.015)
+        NoTrackIn0015 = false;
+      if (dR < 0.020)
+        NoTrackIn0020 = false;
+      if (dR < 0.025)
+        NoTrackIn0025 = false;
+      if (dR < 0.030)
+        NoTrackIn0030 = false;
+      if (dR < 0.035)
+        NoTrackIn0035 = false;
+      if (dR < 0.040)
+        NoTrackIn0040 = false;
+
+      //calculate maximum Pt and sum Pt inside cones of different radius
+      if (dR < 0.1) {
+        SumPtIn01 += track1->pt();
+        if (track1->pt() > MaxPtIn01) {
+          MaxPtIn01 = track1->pt();
+        }
+      }
+
+      if (dR < 0.2) {
+        SumPtIn02 += track1->pt();
+        if (track1->pt() > MaxPtIn02) {
+          MaxPtIn02 = track1->pt();
+        }
+      }
+      if (dR < 0.3) {
+        SumPtIn03 += track1->pt();
+        if (track1->pt() > MaxPtIn03) {
+          MaxPtIn03 = track1->pt();
+        }
+      }
+      if (dR < 0.4) {
+        SumPtIn04 += track1->pt();
+        if (track1->pt() > MaxPtIn04) {
+          MaxPtIn04 = track1->pt();
+        }
+      }
+      if (dR < 0.5) {
+        SumPtIn05 += track1->pt();
+        if (track1->pt() > MaxPtIn05) {
+          MaxPtIn05 = track1->pt();
+        }
+      }
+    }
+
+    // Track-SuperCluster matching
+
+    double dRSC;
+    double etaAtEcal = 0;  // to convert eta from track to detector frame
+    etaAtEcal = ecalEta(etaIn, vert.z(), (vert.position()).rho());
+
+    //Barrel
+    if (track->eta() < 1.55 || track->eta() > -1.55) {
+      for (std::vector<reco::SuperCluster>::const_iterator SC = BarrelSupClusCollection->begin();
+           SC != BarrelSupClusCollection->end();
+           SC++) {
+        dRSC = 0;
+        dRSC = reco::deltaR(SC->eta(), SC->phi(), etaAtEcal, phiIn);
+
+        if (dRSC < dRSC_first) {
+          dRSC_first = dRSC;
+        }  // distance in eta-phi plan to closest SC
+        else if (dRSC < dRSC_second) {
+          dRSC_second = dRSC;
+        }  // to next closest SC
+
+        if (dRSC < 0.09) {
+          //Calculate phiWidth & etaWidth for associated SuperClusters
+          SCShape.Calculate_Covariances(*SC);
+          phiWidth = SCShape.phiWidth();
+          etaWidth = SCShape.etaWidth();
+
+          etaSC = SC->eta();
+          phiSC = SC->phi();
+
+          algo_ID = SC->algoID();
+          EnergyEcal = SC->energy();
+          nBasicClus = SC->clustersSize();
+          nbSC++;
+          isBarrel = true;
+        }
+      }
+    }
+
+    // Endcap
+    if (track->eta() < -1.44 || track->eta() > 1.44) {
+      for (std::vector<reco::SuperCluster>::const_iterator SC = EndcapSupClusCollection->begin();
+           SC != EndcapSupClusCollection->end();
+           SC++) {
+        dRSC = 0;
+        dRSC = reco::deltaR(SC->eta(), SC->phi(), etaAtEcal, phiIn);
+
+        if (dRSC < dRSC_first) {
+          dRSC_first = dRSC;
+        }  // distance in eta-phi plan to closest SC
+        else if (dRSC < dRSC_second) {
+          dRSC_second = dRSC;
+        }  // to next closest SC
+
+        if (dRSC < 0.09) {
+          //Calculate phiWidth & etaWidth for associated SuperClusters
+          SCShape.Calculate_Covariances(*SC);
+          phiWidth = SCShape.phiWidth();
+          etaWidth = SCShape.etaWidth();
+
+          etaSC = SC->eta();
+          phiSC = SC->phi();
+
+          algo_ID = SC->algoID();
+          EnergyEcal = SC->energy();
+          nBasicClus = SC->clustersSize();
+          nbSC++;
+          isEndcap = true;
+        }
+      }
+    }
+
+    if (dRSC_first < 0.1)
+      distToClosestSC->Fill(dRSC_first);
+    if (nbSC == 1)
+      counter1->Fill(0.5);
+    if (nbSC == 0)
+      counter2->Fill(0.5);
+
+    if (nbSC > 1 || nbSC == 0)
+      continue;
+    cut_OneSCmatch->Fill(0.5);
+
+    if (isBarrel && isEndcap) {
+      cout << "Error: Super Cluster double matching!" << endl;
+      return;
+    }
+
+    EcalEnergy->Fill(EnergyEcal);
+    HcalVSEcal->Fill(EnergyEcal, EnergyHcalIn02);
+
+    // E over p plots
+    if (track->charge() < 0)
+      Eop_InnerNegative->Fill(EnergyEcal / pin);
+    if (track->charge() > 0)
+      Eop_InnerPositive->Fill(EnergyEcal / pin);
+
+    //Check if track-SuperCluster matching is Ecal or Tracker driven
+    edm::RefToBase<TrajectorySeed> seed = track->extra()->seedRef();
+    if (seed.isNull()) {
+      edm::LogError("GsfElectronCore") << "The GsfTrack has no seed ?!";
+    } else {
+      reco::ElectronSeedRef elseed = seed.castTo<reco::ElectronSeedRef>();
+      if (elseed.isNull()) {
+        edm::LogError("GsfElectronCore") << "The GsfTrack seed is not an ElectronSeed ?!";
+      } else {
+        isEcalDriven = elseed->isEcalDriven();
+        isTrackerDriven = elseed->isTrackerDriven();
+      }
+    }
+
+    treeMemPtr_->charge = track->charge();
+    treeMemPtr_->nHits = track->numberOfValidHits();
+    treeMemPtr_->nLostHits = track->numberOfLostHits();
+    treeMemPtr_->innerOk = track->innerOk();
+    treeMemPtr_->outerRadius = track->outerRadius();
+    treeMemPtr_->chi2 = track->chi2();
+    treeMemPtr_->normalizedChi2 = track->normalizedChi2();
+    treeMemPtr_->px = track->px();
+    treeMemPtr_->py = track->py();
+    treeMemPtr_->pz = track->pz();
+    treeMemPtr_->p = track->p();
+    treeMemPtr_->pIn = pin;
+    treeMemPtr_->etaIn = etaIn;
+    treeMemPtr_->phiIn = phiIn;
+    treeMemPtr_->pOut = pout;
+    treeMemPtr_->etaOut = etaOut;
+    treeMemPtr_->phiOut = phiOut;
+    treeMemPtr_->pt = track->pt();
+    treeMemPtr_->ptError = track->ptError();
+    treeMemPtr_->theta = track->theta();
+    treeMemPtr_->eta = track->eta();
+    treeMemPtr_->phi = track->phi();
+    treeMemPtr_->fbrem = fbrem;
+    treeMemPtr_->MaxPtIn01 = MaxPtIn01;
+    treeMemPtr_->SumPtIn01 = SumPtIn01;
+    treeMemPtr_->NoTrackIn0015 = NoTrackIn0015;
+    treeMemPtr_->MaxPtIn02 = MaxPtIn02;
+    treeMemPtr_->SumPtIn02 = SumPtIn02;
+    treeMemPtr_->NoTrackIn0020 = NoTrackIn0020;
+    treeMemPtr_->MaxPtIn03 = MaxPtIn03;
+    treeMemPtr_->SumPtIn03 = SumPtIn03;
+    treeMemPtr_->NoTrackIn0025 = NoTrackIn0025;
+    treeMemPtr_->MaxPtIn04 = MaxPtIn04;
+    treeMemPtr_->SumPtIn04 = SumPtIn04;
+    treeMemPtr_->NoTrackIn0030 = NoTrackIn0030;
+    treeMemPtr_->MaxPtIn05 = MaxPtIn05;
+    treeMemPtr_->SumPtIn05 = SumPtIn05;
+    treeMemPtr_->NoTrackIn0035 = NoTrackIn0035;
+    treeMemPtr_->NoTrackIn0040 = NoTrackIn0040;
+    treeMemPtr_->SC_algoID = algo_ID;
+    treeMemPtr_->SC_energy = EnergyEcal;
+    treeMemPtr_->SC_nBasicClus = nBasicClus;
+    treeMemPtr_->SC_etaWidth = etaWidth;
+    treeMemPtr_->SC_phiWidth = phiWidth;
+    treeMemPtr_->SC_eta = etaSC;
+    treeMemPtr_->SC_phi = phiSC;
+    treeMemPtr_->SC_isBarrel = isBarrel;
+    treeMemPtr_->SC_isEndcap = isEndcap;
+    treeMemPtr_->dRto1stSC = dRSC_first;
+    treeMemPtr_->dRto2ndSC = dRSC_second;
+    treeMemPtr_->HcalEnergyIn01 = EnergyHcalIn01;
+    treeMemPtr_->HcalEnergyIn02 = EnergyHcalIn02;
+    treeMemPtr_->HcalEnergyIn03 = EnergyHcalIn03;
+    treeMemPtr_->HcalEnergyIn04 = EnergyHcalIn04;
+    treeMemPtr_->HcalEnergyIn05 = EnergyHcalIn05;
+    treeMemPtr_->isEcalDriven = isEcalDriven;
+    treeMemPtr_->isTrackerDriven = isTrackerDriven;
+    treeMemPtr_->RunNumber = iEvent.id().run();
+    treeMemPtr_->EvtNumber = iEvent.id().event();
+
+    tree_->Fill();
+
+  }  // loop on tracks
+}  // analyze
+
+// ------------ method called once each job just before starting event loop  ------------
+void EopElecTreeWriter::beginJob() {}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void EopElecTreeWriter::endJob() {
+  delete treeMemPtr_;
+  treeMemPtr_ = nullptr;
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void EopElecTreeWriter::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  bool changed = true;
+
+  // Load trigger configuration at each begin of run
+  // Fill the trigger names
+  if (hltConfig_.init(iRun, iSetup, "HLT", changed)) {
+    if (changed) {
+      triggerNames_ = hltConfig_.triggerNames();
+    }
+  }
+
+  // Displaying the trigger names
+  unsigned int i = 0;
+  for (std::vector<std::string>::const_iterator it = triggerNames_.begin(); it < triggerNames_.end(); ++it) {
+    std::cout << "HLTpath: " << (i++) << " = " << (*it) << std::endl;
+  }
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(EopElecTreeWriter);

--- a/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
@@ -98,7 +98,7 @@ struct EopTriggerType {
 //
 using namespace std;
 
-class EopElecTreeWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+class EopElecTreeWriter : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
   explicit EopElecTreeWriter(const edm::ParameterSet&);
   ~EopElecTreeWriter() override;
@@ -240,6 +240,9 @@ EopElecTreeWriter::EopElecTreeWriter(const edm::ParameterSet& iConfig)
       theTrigger_(iConfig.getParameter<std::string>("triggerPath")),
       theFilter_(iConfig.getParameter<std::string>("hltFilter")),
       debugTriggerSelection_(iConfig.getParameter<bool>("debugTriggerSelection")) {
+
+  usesResource(TFileService::kSharedResource);
+
   std::cout << __FILE__ << " " << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
 
   // TTree creation

--- a/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
@@ -404,25 +404,25 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
   // our trigger table
   std::map<std::string, EopTriggerType> HLTpaths;
-  for (unsigned int i = 0; i < triggerNames_.size(); i++) {
-    if (triggerNames_[i].find(theTrigger_) != 0)
+  for (const auto& triggerName : triggerNames_) {
+    if (triggerName.find(theTrigger_) != 0)
       continue;
     EopTriggerType myTrigger;
 
     const unsigned int prescaleSize = hltConfig_.prescaleSize();
     for (unsigned int ps = 0; ps < prescaleSize; ps++) {
-      const unsigned int prescaleValue = hltConfig_.prescaleValue(ps, triggerNames_[i]);
+      const unsigned int prescaleValue = hltConfig_.prescaleValue(ps, triggerName);
       if (prescaleValue != 1) {
         myTrigger.prescale = prescaleValue;
       }
     }
 
-    myTrigger.index = hltConfig_.triggerIndex(triggerNames_[i]);
+    myTrigger.index = hltConfig_.triggerIndex(triggerName);
     if (myTrigger.index == -1)
       continue;
     myTrigger.fired =
         trigRes->wasrun(myTrigger.index) && trigRes->accept(myTrigger.index) && !trigRes->error(myTrigger.index);
-    HLTpaths[triggerNames_[i]] = myTrigger;
+    HLTpaths[triggerName] = myTrigger;
   }
 
   // First cut : trigger cut
@@ -484,26 +484,26 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
   //-----------------   Tracks   -------------------
 
   // getting GsfTrack
-  const reco::GsfTrackCollection* tracks = &iEvent.get(theGsfTrackCollectionToken_);
+  const reco::GsfTrackCollection& tracks = iEvent.get(theGsfTrackCollectionToken_);
 
   // filtering track
   int nRejected = 0;
   int nSelected = 0;
   std::vector<const reco::GsfTrack*> filterTracks;
-  for (unsigned int i = 0; i < tracks->size(); i++) {
+  for (const auto& track : tracks) {
     h_nTracks->Fill(0.5);
-    double deltar = reco::deltaR(
-        (*tracks)[i].eta(), (*tracks)[i].phi(), HLTelectrons[HighPtIndex]->eta(), HLTelectrons[HighPtIndex]->phi());
+    double deltar =
+        reco::deltaR(track.eta(), track.phi(), HLTelectrons[HighPtIndex]->eta(), HLTelectrons[HighPtIndex]->phi());
     // remove the triggered electron with highest pt
     if (deltar < 0.025) {
-      treeMemPtr_->px_rejected_track = (*tracks)[i].px();
-      treeMemPtr_->py_rejected_track = (*tracks)[i].py();
-      treeMemPtr_->pz_rejected_track = (*tracks)[i].pz();
-      treeMemPtr_->p_rejected_track = (*tracks)[i].p();
+      treeMemPtr_->px_rejected_track = track.px();
+      treeMemPtr_->py_rejected_track = track.py();
+      treeMemPtr_->pz_rejected_track = track.pz();
+      treeMemPtr_->p_rejected_track = track.p();
       nRejected++;
       continue;
     }
-    filterTracks.push_back(&(*tracks)[i]);  // we use all the others
+    filterTracks.push_back(&track);  // we use all the others
     nSelected++;
     h_nTracksFiltered->Fill(0.5);
   }

--- a/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
@@ -103,6 +103,8 @@ public:
   explicit EopElecTreeWriter(const edm::ParameterSet&);
   ~EopElecTreeWriter() override;
 
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
 private:
   // methods
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
@@ -238,6 +240,8 @@ EopElecTreeWriter::EopElecTreeWriter(const edm::ParameterSet& iConfig)
       theTrigger_(iConfig.getParameter<std::string>("triggerPath")),
       theFilter_(iConfig.getParameter<std::string>("hltFilter")),
       debugTriggerSelection_(iConfig.getParameter<bool>("debugTriggerSelection")) {
+  std::cout << __FILE__ << " " << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
+
   // TTree creation
   tree_ = fs_->make<TTree>("EopTree", "EopTree");
   treeMemPtr_ = new EopElecVariables;
@@ -273,6 +277,8 @@ EopElecTreeWriter::EopElecTreeWriter(const edm::ParameterSet& iConfig)
 
   h_counter1 = fs_->make<TH1D>("counter1", "counter1", 1, 0, 1);
   h_counter2 = fs_->make<TH1D>("counter2", "counter2", 1, 0, 1);
+
+  std::cout << __FILE__ << " " << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
 }
 
 EopElecTreeWriter::~EopElecTreeWriter() {
@@ -401,6 +407,8 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
   // necessary to re-calculate phi and eta width of SuperClusters
   SuperClusterShapeAlgo SCShape(rhc, subGeo);
 
+  std::cout << __FILE__ << " " << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
+
   //---------------    Trigger   -----------------
   TrigTag = false;
   const edm::TriggerResults* trigRes = &iEvent.get(theTriggerResultsToken_);
@@ -431,6 +439,8 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     HLTpaths[triggerNames_[i]] = myTrigger;
   }
 
+  std::cout << __FILE__ << " " << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
+
   // First cut : trigger cut
   std::string firstFiredPath = "";
   for (const auto& it : HLTpaths) {
@@ -454,6 +464,8 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
       info << filters[i] << " ";
     }
   }
+
+  std::cout << __FILE__ << " " << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
 
   // Getting HLT electrons
   edm::InputTag testTag(theFilter_, "", "HLT");
@@ -491,6 +503,8 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
   // getting GsfTrack
   const reco::GsfTrackCollection* tracks = &iEvent.get(theGsfTrackCollectionToken_);
+
+  std::cout << __FILE__ << " " << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
 
   // filtering track
   int nRejected = 0;
@@ -540,7 +554,7 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
   }
 
   //------------------------------------------------------------
-
+  std::cout << __FILE__ << " " << __PRETTY_FUNCTION__ << " " << __LINE__ << std::endl;
   //--------------    Loop on tracks   -----------------
 
   for (const auto& track : filterTracks) {
@@ -905,6 +919,19 @@ void EopElecTreeWriter::beginRun(const edm::Run& iRun, const edm::EventSetup& iS
       edm::LogInfo("EopElecTreeWriter") << "HLTpath: " << (i++) << " = " << it;
     }
   }
+}
+
+//*************************************************************
+void EopElecTreeWriter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+//*************************************************************
+{
+  edm::ParameterSetDescription desc;
+  desc.setComment("Generate tree for Tracker Alignment E/p validation");
+  desc.add<edm::InputTag>("src", edm::InputTag("electronGsfTracks"));
+  desc.add<std::string>("triggerPath", "HLT_Ele");
+  desc.add<std::string>("hltFilter", "hltDiEle27L1DoubleEGWPTightHcalIsoFilter");
+  desc.add<bool>("debugTriggerSelection", false);
+  descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in

--- a/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopElecTreeWriter.cc
@@ -17,86 +17,69 @@
 //
 
 // framework include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "TrackingTools/GsfTools/interface/MultiTrajectoryStateMode.h"
-#include "TrackingTools/GsfTools/interface/MultiTrajectoryStateTransform.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
-#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
-#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
-#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
-
-// user include files
-#include <DataFormats/TrackReco/interface/Track.h>
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include <TMath.h>
-#include <TH1.h>
-#include <TH2D.h>
-#include "TTree.h"
-#include <TCanvas.h>
-#include <TLorentzVector.h>
+#include "Alignment/OfflineValidation/interface/EopElecVariables.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "CommonTools/Utils/interface/TFileDirectory.h"
-
-#include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
-#include "TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h"
-#include "TrackingTools/GeomPropagators/interface/PropagationExceptions.h"
-#include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
-
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
-#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
-
-//#include "RecoParticleFlow/PFRootEvent/interface/JetRecoTypes.h"
-//#include "RecoParticleFlow/PFRootEvent/interface/JetMaker.h"
-//#include "RecoParticleFlow/PFRootEvent/interface/ProtoJet.h"
-
-#include "RecoEcal/EgammaCoreTools/interface/SuperClusterShapeAlgo.h"
-
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-
-#include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidateFwd.h"
-#include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
-#include "DataFormats/RecoCandidate/interface/RecoCaloTowerCandidate.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
-#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
-#include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
-#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/EgammaReco/interface/SuperCluster.h"
-#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
-#include "DataFormats/EgammaReco/interface/BasicCluster.h"
-#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "Alignment/OfflineValidation/interface/EopElecVariables.h"
-
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-
-//Trigger
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
-#include "DataFormats/Math/interface/deltaR.h"
-
-//Super cluster eta and phi width
+#include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronCore.h"
+#include "DataFormats/EgammaReco/interface/BasicCluster.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
+#include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidateFwd.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
+#include "DataFormats/RecoCandidate/interface/RecoCaloTowerCandidate.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "RecoEcal/EgammaCoreTools/interface/SuperClusterShapeAlgo.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
+#include "TrackingTools/GeomPropagators/interface/PropagationExceptions.h"
+#include "TrackingTools/GsfTools/interface/MultiTrajectoryStateMode.h"
+#include "TrackingTools/GsfTools/interface/MultiTrajectoryStateTransform.h"
+#include "TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h"
+#include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
+
+#include "TCanvas.h"
+#include "TH1.h"
+#include "TH2D.h"
+#include "TLorentzVector.h"
+#include "TMath.h"
+#include "TTree.h"
 
 struct EopTriggerType {
   bool fired;
@@ -121,166 +104,175 @@ public:
   ~EopElecTreeWriter() override;
 
 private:
-  // ES tokens
-  edm::ESGetToken<MagneticField,IdealMagneticFieldRecord> magFieldToken;
-  edm::ESGetToken<TrackerGeometry,TrackerDigiGeometryRecord> tkGeomToken;
-  edm::ESGetToken<CaloGeometry,CaloGeometryRecord> caloGeomToken;
-
-  // Cut flow (events number)
-  TH1D* nEvents;
-  TH1D* nEventsWithVertex;
-  TH1D* nEventsTriggered;
-  TH1D* nEventsHLTFilter;
-  TH1D* nEventsHLTelectron;
-  TH1D* nEventsHLTrejected;
-  TH1D* nEvents2Elec;
-
-  TH1D* nHLTelectrons;
-  TH1D* nTrkRejectedPerEvt;
-  TH1D* nTrkSelectedPerEvt;
-
-  // Cut flow (tracks number)
-  TH1D* nTracks;
-  TH1D* nTracksFiltered;
-  TH1D* cut_Ptmin;
-  TH1D* cut_OneSCmatch;
-
-  TH1D* counter1;
-  TH1D* counter2;
-
+  // methods
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
-  void endRun(const edm::Run&, const edm::EventSetup&) override {};
+  void endRun(const edm::Run&, const edm::EventSetup&) override{};
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
 
   // ----------member data ---------------------------
+  // ES tokens
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+
+  // EDM tokens
+  const edm::EDGetTokenT<reco::VertexCollection> theVertexCollectionToken_;
+  const edm::EDGetTokenT<HBHERecHitCollection> theHBHERecHitCollectionToken_;
+  const edm::EDGetTokenT<EcalRecHitCollection> theEcalRecHitCollectionToken_;
+  const edm::EDGetTokenT<reco::SuperClusterCollection> theBarrelSupClusCollectionToken_;
+  const edm::EDGetTokenT<reco::SuperClusterCollection> theEndCapSupClusCollectionToken_;
+  const edm::EDGetTokenT<edm::TriggerResults> theTriggerResultsToken_;
+  const edm::EDGetTokenT<trigger::TriggerEvent> theTriggerEventToken_;
+  const edm::EDGetTokenT<reco::GsfTrackCollection> theGsfTrackCollectionToken_;
+  const edm::EDGetTokenT<reco::GsfElectronCoreCollection> theGsfElectronCoreCollectionToken_;
+
+  // some static constants
+  static constexpr float k_etaBarrel = 1.55;
+  static constexpr float k_etaEndcap = 1.44;
+
+  // other member data
   edm::InputTag src_;
   std::string theTrigger_;
   std::string theFilter_;
   bool debugTriggerSelection_;
-
   edm::Service<TFileService> fs_;
   TTree* tree_;
   EopElecVariables* treeMemPtr_;
-
   HLTConfigProvider hltConfig_;
   std::vector<std::string> triggerNames_;
-  TH1D* distToClosestSCgsf;
-  TH1D* distToClosestSC;
-  TH1D* EcalEnergy;
-  TH1D* Momentum;
+  MultiTrajectoryStateTransform* mtsTransform_;
+
+  // histograms
+
+  // Cut flow (events number)
+  TH1D* h_nEvents;
+  TH1D* h_nEventsWithVertex;
+  TH1D* h_nEventsTriggered;
+  TH1D* h_nEventsHLTFilter;
+  TH1D* h_nEventsHLTelectron;
+  TH1D* h_nEventsHLTrejected;
+  TH1D* h_nEvents2Elec;
+  TH1D* h_nHLTelectrons;
+  TH1D* h_nTrkRejectedPerEvt;
+  TH1D* h_nTrkSelectedPerEvt;
+
+  // Cut flow (tracks number)
+  TH1D* h_nTracks;
+  TH1D* h_nTracksFiltered;
+  TH1D* h_cut_Ptmin;
+  TH1D* h_cut_OneSCmatch;
+
+  TH1D* h_counter1;
+  TH1D* h_counter2;
+
+  TH1D* h_distToClosestSCgsf;
+  TH1D* h_distToClosestSC;
+  TH1D* h_EcalEnergy;
+  TH1D* h_Momentum;
   TH1D* HcalEnergy;
-  TH1D* fBREM;
-  TH1D* Eop_InnerNegative;
-  TH1D* Eop_InnerPositive;
+  TH1D* h_fBREM;
+  TH1D* h_Eop_InnerNegative;
+  TH1D* h_Eop_InnerPositive;
 
   TH2D* HcalVSEcal;
-
-  MultiTrajectoryStateTransform* mtsTransform_;
-  edm::EDGetTokenT<reco::VertexCollection> theVertexCollectionToken;
-  edm::EDGetTokenT<HBHERecHitCollection> theHBHERecHitCollectionToken;
-  edm::EDGetTokenT<EcalRecHitCollection> theEcalRecHitCollectionToken;
-  edm::EDGetTokenT<reco::SuperClusterCollection> theBarrelSupClusCollectionToken;
-  edm::EDGetTokenT<reco::SuperClusterCollection> theEndCapSupClusCollectionToken;
-  edm::EDGetTokenT<edm::TriggerResults> theTriggerResultsToken;
-  edm::EDGetTokenT<trigger::TriggerEvent> theTriggerEventToken;
-  edm::EDGetTokenT<reco::GsfTrackCollection> theGsfTrackCollectionToken;
-  edm::EDGetTokenT<reco::GsfElectronCoreCollection> theGsfElectronCoreCollectionToken;
 };
 
-// Function to convert the eta of the track to a detector eta (for matching with SC)
-float ecalEta(float EtaParticle, float Zvertex, float RhoVertex) {
-  const float R_ECAL = 136.5;
-  const float Z_Endcap = 328.0;
-  const float etaBarrelEndcap = 1.479;
+namespace eopUtils {
 
-  if (EtaParticle != 0.) {
-    float Theta = 0.0;
-    float ZEcal = (R_ECAL - RhoVertex) * sinh(EtaParticle) + Zvertex;
+  static constexpr float R_ECAL = 136.5;
+  static constexpr float Z_Endcap = 328.0;
+  static constexpr float etaBarrelEndcap = 1.479;
 
-    if (ZEcal != 0.0)
-      Theta = atan(R_ECAL / ZEcal);
-    if (Theta < 0.0)
-      Theta = Theta + Geom::pi();
+  // Function to convert the eta of the track to a detector eta (for matching with SC)
+  float ecalEta(float EtaParticle, float Zvertex, float RhoVertex) {
+    if (EtaParticle != 0.) {
+      float Theta = 0.0;
+      float ZEcal = (R_ECAL - RhoVertex) * sinh(EtaParticle) + Zvertex;
 
-    float ETA = -log(tan(0.5 * Theta));
-
-    if (fabs(ETA) > etaBarrelEndcap) {
-      float Zend = Z_Endcap;
-      if (EtaParticle < 0.0)
-        Zend = -Zend;
-      float Zlen = Zend - Zvertex;
-      float RR = Zlen / sinh(EtaParticle);
-      Theta = atan((RR + RhoVertex) / Zend);
+      if (ZEcal != 0.0)
+        Theta = atan(R_ECAL / ZEcal);
       if (Theta < 0.0)
-        Theta = Theta + Geom::pi();
-      ETA = -log(tan(0.5 * Theta));
+        Theta = Theta + M_PI;
+
+      float ETA = -log(tan(0.5 * Theta));
+
+      if (fabs(ETA) > etaBarrelEndcap) {
+        float Zend = Z_Endcap;
+        if (EtaParticle < 0.0)
+          Zend = -Zend;
+        float Zlen = Zend - Zvertex;
+        float RR = Zlen / sinh(EtaParticle);
+        Theta = atan((RR + RhoVertex) / Zend);
+        if (Theta < 0.0)
+          Theta = Theta + M_PI;
+        ETA = -log(tan(0.5 * Theta));
+      }
+      return ETA;
+    } else {
+      edm::LogWarning("") << "[EcalPositionFromTrack::etaTransformation] Warning: Eta equals to zero, not correcting";
+      return EtaParticle;
     }
-    return ETA;
-  } else {
-    edm::LogWarning("") << "[EcalPositionFromTrack::etaTransformation] Warning: Eta equals to zero, not correcting";
-    return EtaParticle;
   }
-}
+}  // namespace eopUtils
 
 // constructors and destructor
 
-EopElecTreeWriter::EopElecTreeWriter(const edm::ParameterSet& iConfig):
-  magFieldToken(esConsumes()),
-  tkGeomToken(esConsumes()),
-  caloGeomToken(esConsumes()),
-  src_(iConfig.getParameter<edm::InputTag>("src")),
-  theTrigger_(iConfig.getParameter<std::string>("triggerPath")),
-  theFilter_(iConfig.getParameter<std::string>("hltFilter")),
-  debugTriggerSelection_(iConfig.getParameter<bool>("debugTriggerSelection"))
- {
-  theVertexCollectionToken = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
-  theHBHERecHitCollectionToken = consumes<HBHERecHitCollection>(edm::InputTag("hbhereco", ""));
-  theEcalRecHitCollectionToken = consumes<EcalRecHitCollection>(edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
-  theBarrelSupClusCollectionToken = consumes<reco::SuperClusterCollection>(edm::InputTag("hybridSuperClusters", ""));
-  theEndCapSupClusCollectionToken =
-      consumes<reco::SuperClusterCollection>(edm::InputTag("multi5x5SuperClusters", "multi5x5EndcapSuperClusters"));
-  theTriggerResultsToken = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"));
-  theTriggerEventToken = consumes<trigger::TriggerEvent>(edm::InputTag("hltTriggerSummaryAOD"));
-
-  theGsfTrackCollectionToken = consumes<reco::GsfTrackCollection>(src_);
-  theGsfElectronCoreCollectionToken = consumes<reco::GsfElectronCoreCollection>(edm::InputTag("gedGsfElectronCores"));
-
+EopElecTreeWriter::EopElecTreeWriter(const edm::ParameterSet& iConfig)
+    : magFieldToken_(esConsumes()),
+      tkGeomToken_(esConsumes()),
+      caloGeomToken_(esConsumes()),
+      theVertexCollectionToken_(consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"))),
+      theHBHERecHitCollectionToken_(consumes<HBHERecHitCollection>(edm::InputTag("hbhereco", ""))),
+      theEcalRecHitCollectionToken_(consumes<EcalRecHitCollection>(edm::InputTag("ecalRecHit", "EcalRecHitsEB"))),
+      theBarrelSupClusCollectionToken_(
+          consumes<reco::SuperClusterCollection>(edm::InputTag("hybridSuperClusters", ""))),
+      theEndCapSupClusCollectionToken_(consumes<reco::SuperClusterCollection>(
+          edm::InputTag("multi5x5SuperClusters", "multi5x5EndcapSuperClusters"))),
+      theTriggerResultsToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"))),
+      theTriggerEventToken_(consumes<trigger::TriggerEvent>(edm::InputTag("hltTriggerSummaryAOD"))),
+      theGsfTrackCollectionToken_(consumes<reco::GsfTrackCollection>(src_)),
+      theGsfElectronCoreCollectionToken_(
+          consumes<reco::GsfElectronCoreCollection>(edm::InputTag("gedGsfElectronCores"))),
+      src_(iConfig.getParameter<edm::InputTag>("src")),
+      theTrigger_(iConfig.getParameter<std::string>("triggerPath")),
+      theFilter_(iConfig.getParameter<std::string>("hltFilter")),
+      debugTriggerSelection_(iConfig.getParameter<bool>("debugTriggerSelection")) {
   // TTree creation
   tree_ = fs_->make<TTree>("EopTree", "EopTree");
   treeMemPtr_ = new EopElecVariables;
   tree_->Branch("EopElecVariables", &treeMemPtr_);  // address of pointer!
 
   // Control histograms declaration
-  distToClosestSC = fs_->make<TH1D>("distToClosestSC", "distToClosestSC", 100, 0, 0.1);
-  distToClosestSCgsf = fs_->make<TH1D>("distToClosestSCgsf", "distToClosestSCgsf", 100, 0, 0.1);
-  EcalEnergy = fs_->make<TH1D>("EcalEnergy", "EcalEnergy", 100, 0, 200);
-  Momentum = fs_->make<TH1D>("Momentum", "Momentum", 100, 0, 200);
+  h_distToClosestSC = fs_->make<TH1D>("distToClosestSC", "distToClosestSC", 100, 0, 0.1);
+  h_distToClosestSCgsf = fs_->make<TH1D>("distToClosestSCgsf", "distToClosestSCgsf", 100, 0, 0.1);
+  h_EcalEnergy = fs_->make<TH1D>("EcalEnergy", "EcalEnergy", 100, 0, 200);
+  h_Momentum = fs_->make<TH1D>("Momentum", "Momentum", 100, 0, 200);
   HcalEnergy = fs_->make<TH1D>("HcalEnergy", "HcalEnergy", 100, 0, 40);
-  fBREM = fs_->make<TH1D>("fBREM", "fBREM", 100, -0.2, 1);
-  Eop_InnerNegative = fs_->make<TH1D>("Eop_InnerNegative", "Eop_InnerNegative", 100, 0, 3);
-  Eop_InnerPositive = fs_->make<TH1D>("Eop_InnerPositive", "Eop_InnerPositive", 100, 0, 3);
+  h_fBREM = fs_->make<TH1D>("fBREM", "fBREM", 100, -0.2, 1);
+  h_Eop_InnerNegative = fs_->make<TH1D>("Eop_InnerNegative", "Eop_InnerNegative", 100, 0, 3);
+  h_Eop_InnerPositive = fs_->make<TH1D>("Eop_InnerPositive", "Eop_InnerPositive", 100, 0, 3);
   HcalVSEcal = fs_->make<TH2D>("HcalVSEcal", "HcalVSEcal", 100, 0, 160, 100, 0, 10);
 
-  nEvents = fs_->make<TH1D>("nEvents", "nEvents", 1, 0, 1);
-  nEventsWithVertex = fs_->make<TH1D>("nEventsWithVertex", "nEventsWithVertex", 1, 0, 1);
-  nEventsTriggered = fs_->make<TH1D>("nEventsTriggered", "nEventsTriggered", 1, 0, 1);
-  nEventsHLTFilter = fs_->make<TH1D>("nEventsHLTFilter", "nEventsHLTFilter", 1, 0, 1);
-  nEventsHLTelectron = fs_->make<TH1D>("nEventsHLTelectron", "nEventsHLTelectron", 1, 0, 1);
-  nEventsHLTrejected = fs_->make<TH1D>("nEventsHLTrejected", "nEventsHLTrejected", 1, 0, 1);
-  nEvents2Elec = fs_->make<TH1D>("nEvents2Elec", "nEvents2Elec", 1, 0, 1);
+  h_nEvents = fs_->make<TH1D>("nEvents", "nEvents", 1, 0, 1);
+  h_nEventsWithVertex = fs_->make<TH1D>("nEventsWithVertex", "nEventsWithVertex", 1, 0, 1);
+  h_nEventsTriggered = fs_->make<TH1D>("nEventsTriggered", "nEventsTriggered", 1, 0, 1);
+  h_nEventsHLTFilter = fs_->make<TH1D>("nEventsHLTFilter", "nEventsHLTFilter", 1, 0, 1);
+  h_nEventsHLTelectron = fs_->make<TH1D>("nEventsHLTelectron", "nEventsHLTelectron", 1, 0, 1);
+  h_nEventsHLTrejected = fs_->make<TH1D>("nEventsHLTrejected", "nEventsHLTrejected", 1, 0, 1);
+  h_nEvents2Elec = fs_->make<TH1D>("nEvents2Elec", "nEvents2Elec", 1, 0, 1);
 
-  nHLTelectrons = fs_->make<TH1D>("nHLTelectrons", "nHLTelectrons", 20, 0, 20);
-  nTrkRejectedPerEvt = fs_->make<TH1D>("nTrkRejectedPerEvt", "nTrkRejectedPerEvt", 20, 0, 20);
-  nTrkSelectedPerEvt = fs_->make<TH1D>("nTrkSelectedPerEvt", "nTrkSelectedPerEvt", 20, 0, 20);
+  h_nHLTelectrons = fs_->make<TH1D>("nHLTelectrons", "nHLTelectrons", 20, 0, 20);
+  h_nTrkRejectedPerEvt = fs_->make<TH1D>("nTrkRejectedPerEvt", "nTrkRejectedPerEvt", 20, 0, 20);
+  h_nTrkSelectedPerEvt = fs_->make<TH1D>("nTrkSelectedPerEvt", "nTrkSelectedPerEvt", 20, 0, 20);
 
-  nTracks = fs_->make<TH1D>("nTracks", "nTracks", 1, 0, 1);
-  nTracksFiltered = fs_->make<TH1D>("nTracksFiltered", "nTracksFiltered", 1, 0, 1);
-  cut_Ptmin = fs_->make<TH1D>("cut_Ptmin", "cut_Ptmin", 1, 0, 1);
-  cut_OneSCmatch = fs_->make<TH1D>("cut_OneSCmatch", "cut_OneSCmatch", 1, 0, 1);
+  h_nTracks = fs_->make<TH1D>("nTracks", "nTracks", 1, 0, 1);
+  h_nTracksFiltered = fs_->make<TH1D>("nTracksFiltered", "nTracksFiltered", 1, 0, 1);
+  h_cut_Ptmin = fs_->make<TH1D>("cut_Ptmin", "cut_Ptmin", 1, 0, 1);
+  h_cut_OneSCmatch = fs_->make<TH1D>("cut_OneSCmatch", "cut_OneSCmatch", 1, 0, 1);
 
-  counter1 = fs_->make<TH1D>("counter1", "counter1", 1, 0, 1);
-  counter2 = fs_->make<TH1D>("counter2", "counter2", 1, 0, 1);
+  h_counter1 = fs_->make<TH1D>("counter1", "counter1", 1, 0, 1);
+  h_counter2 = fs_->make<TH1D>("counter2", "counter2", 1, 0, 1);
 }
 
 EopElecTreeWriter::~EopElecTreeWriter() {
@@ -288,30 +280,30 @@ EopElecTreeWriter::~EopElecTreeWriter() {
 
   // control histograms
 
-  distToClosestSC->SetXTitle("distance from track to closest SuperCluster in eta-phi plan (weighted matching)");
-  distToClosestSC->SetYTitle("# Tracks");
+  h_distToClosestSC->SetXTitle("distance from track to closest SuperCluster in eta-phi plan (weighted matching)");
+  h_distToClosestSC->SetYTitle("# Tracks");
 
-  distToClosestSCgsf->SetXTitle("distance from track to closest SuperCluster in eta-phi plan (gsfElectronCore)");
-  distToClosestSCgsf->SetYTitle("# Tracks");
+  h_distToClosestSCgsf->SetXTitle("distance from track to closest SuperCluster in eta-phi plan (gsfElectronCore)");
+  h_distToClosestSCgsf->SetYTitle("# Tracks");
 
-  EcalEnergy->SetXTitle("Ecal energy deposit (GeV)");
-  EcalEnergy->SetYTitle("# tracks");
+  h_EcalEnergy->SetXTitle("Ecal energy deposit (GeV)");
+  h_EcalEnergy->SetYTitle("# tracks");
 
   HcalEnergy->SetXTitle("Hcal energy deposit (GeV)");
   HcalEnergy->SetYTitle("# tracks");
 
-  Momentum->SetXTitle("Momentum magnitude (GeV)");
-  Momentum->SetYTitle("# tracks");
+  h_Momentum->SetXTitle("Momentum magnitude (GeV)");
+  h_Momentum->SetYTitle("# tracks");
 
-  Eop_InnerNegative->SetXTitle("E/p");
-  Eop_InnerNegative->SetYTitle("# tracks");
+  h_Eop_InnerNegative->SetXTitle("E/p");
+  h_Eop_InnerNegative->SetYTitle("# tracks");
 
-  Eop_InnerPositive->SetXTitle("E/p");
-  Eop_InnerPositive->SetYTitle("# tracks");
+  h_Eop_InnerPositive->SetXTitle("E/p");
+  h_Eop_InnerPositive->SetYTitle("# tracks");
 
   HcalVSEcal->SetXTitle("Ecal energy (GeV)");
   HcalVSEcal->SetYTitle("Hcal energy (GeV)");
-  cout << "Total number of events : " << nEvents->GetEntries() << endl;
+  cout << "Total number of events : " << h_nEvents->GetEntries() << endl;
 }
 
 //###########################################
@@ -319,8 +311,12 @@ EopElecTreeWriter::~EopElecTreeWriter() {
 //###########################################
 
 void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::LogInfo info("EopElecTreeWriter");
+  edm::LogWarning warn("EopElecTreeWriter");
+  edm::LogError error("EopElecTreeWriter");
+
   using namespace edm;
-  nEvents->Fill(0.5);
+  h_nEvents->Fill(0.5);
 
   Double_t EnergyHcalIn01;
   Double_t EnergyHcalIn02;
@@ -368,67 +364,49 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
   //---------------   for GsfTrack propagation through tracker  ---------------
 
-  const MagneticField* magField_ = &iSetup.getData(magFieldToken);
-  const TrackerGeometry* trackerGeom_ = &iSetup.getData(tkGeomToken);
+  const MagneticField* magField_ = &iSetup.getData(magFieldToken_);
+  const TrackerGeometry* trackerGeom_ = &iSetup.getData(tkGeomToken_);
   MultiTrajectoryStateTransform mtsTransform(trackerGeom_, magField_);
 
   //---------------    Super Cluster    -----------------
 
   // getting primary vertex (necessary to convert eta track to eta detector
-  edm::Handle<reco::VertexCollection> vertex;
-  iEvent.getByToken(theVertexCollectionToken, vertex);
+  const reco::VertexCollection& vertex = iEvent.get(theVertexCollectionToken_);
 
-  if (vertex->empty()) {
-    cout << "Error: no primary vertex found!" << endl;
+  if (vertex.empty()) {
+    error << "Error: no primary vertex found!";
     return;
   }
-  reco::Vertex vert;
-  vert = vertex->front();
-  nEventsWithVertex->Fill(0.5);
+  reco::Vertex vert = vertex.front();
+  h_nEventsWithVertex->Fill(0.5);
 
   // getting calorimeter geometry
-  const CaloGeometry* geo = &iSetup.getData(caloGeomToken);
+  const CaloGeometry* geo = &iSetup.getData(caloGeomToken_);
   const CaloSubdetectorGeometry* subGeo = geo->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   if (subGeo == nullptr)
-    cout << "ERROR: unable to find SubDetector geometry!!!" << std::endl;
+    error << "ERROR: unable to find SubDetector geometry!!!";
 
   // getting Hcal rechits
-  edm::Handle<HBHERecHitCollection> HcalHits;
-  iEvent.getByToken(theHBHERecHitCollectionToken, HcalHits);
+  const HBHERecHitCollection* HcalHits = &iEvent.get(theHBHERecHitCollectionToken_);
 
   // getting Ecal rechits
-  edm::Handle<EcalRecHitCollection> ecalrechitcollection;
-  iEvent.getByToken(theEcalRecHitCollectionToken, ecalrechitcollection);
-  const EcalRecHitCollection* rhc = ecalrechitcollection.product();
+  const EcalRecHitCollection* rhc = &iEvent.get(theEcalRecHitCollectionToken_);
   if (rhc == nullptr)
-    cout << "ERROR !!!" << std::endl;
+    error << "ERROR: unable to find the EcalRecHit collection !!!";
 
   // getting SuperCluster
-  edm::Handle<reco::SuperClusterCollection> BarrelSupClusCollection;
-  edm::Handle<reco::SuperClusterCollection> EndcapSupClusCollection;
-  iEvent.getByToken(theBarrelSupClusCollectionToken, BarrelSupClusCollection);
-  iEvent.getByToken(theEndCapSupClusCollectionToken, EndcapSupClusCollection);
-
-  //iEvent.getByLabel("hfEMClusters","", tmpSupClusCollection);
-  //iEvent.getByLabel("correctedHybridSuperClusters","", tmpSupClusCollection);
+  const reco::SuperClusterCollection* BarrelSupClusCollection = &iEvent.get(theBarrelSupClusCollectionToken_);
+  const reco::SuperClusterCollection* EndcapSupClusCollection = &iEvent.get(theEndCapSupClusCollectionToken_);
 
   // necessary to re-calculate phi and eta width of SuperClusters
   SuperClusterShapeAlgo SCShape(rhc, subGeo);
 
   //---------------    Trigger   -----------------
-
   TrigTag = false;
-  const edm::InputTag triggerTag("TriggerResults", "", "HLT");
-
-  edm::Handle<edm::TriggerResults> trigRes;
-  iEvent.getByToken(theTriggerResultsToken, trigRes);
+  const edm::TriggerResults* trigRes = &iEvent.get(theTriggerResultsToken_);
 
   // trigger event
-  edm::Handle<trigger::TriggerEvent> triggerEvent;
-  iEvent.getByToken(theTriggerEventToken, triggerEvent);
-
-  //std::string pattern = "HLT_Ele32_CaloIdVL_CaloIsoVL_TrkIdVL_TrkIsoVL_v5";
-  //std::string pattern = "HLT_DiEle27_WPTightCaloOnly_L1DoubleEG_v4";
+  const trigger::TriggerEvent* triggerEvent = &iEvent.get(theTriggerEventToken_);
 
   // our trigger table
   std::map<std::string, EopTriggerType> HLTpaths;
@@ -449,45 +427,41 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     if (myTrigger.index == -1)
       continue;
     myTrigger.fired =
-      trigRes->wasrun(myTrigger.index) && trigRes->accept(myTrigger.index) && !trigRes->error(myTrigger.index);
+        trigRes->wasrun(myTrigger.index) && trigRes->accept(myTrigger.index) && !trigRes->error(myTrigger.index);
     HLTpaths[triggerNames_[i]] = myTrigger;
   }
 
   // First cut : trigger cut
   std::string firstFiredPath = "";
-  for (std::map<std::string, EopTriggerType>::const_iterator it = HLTpaths.begin(); it != HLTpaths.end(); it++) {
-    if (it->second.fired) {
+  for (const auto& it : HLTpaths) {
+    if (it.second.fired) {
       TrigTag = true;
-      firstFiredPath = it->first;
+      firstFiredPath = it.first;
       break;
     }
   }
   if (!TrigTag)
     return;
-  nEventsTriggered->Fill(0.5);
+  h_nEventsTriggered->Fill(0.5);
 
   // Displaying filters label from the first fired trigger
   // Useful for finding the good filter label
   std::vector<std::string> filters = hltConfig_.moduleLabels(firstFiredPath);
 
-  if( debugTriggerSelection_){
-    std::cout << "filters : ";
-    for (unsigned int i=0;i<filters.size();i++){
-      std::cout << filters[i]<<" ";
+  if (debugTriggerSelection_) {
+    info << "filters : ";
+    for (unsigned int i = 0; i < filters.size(); i++) {
+      info << filters[i] << " ";
     }
-    std::cout<<std::endl;
   }
 
   // Getting HLT electrons
-  //edm::InputTag testTag("hltEle32CaloIdVLCaloIsoVLTrkIdVLTrkIsoVLTrackIsoFilter","","HLT");
-  //edm::InputTag testTag("hltDiEle27L1DoubleEGWPTightHcalIsoFilter", "", "HLT");
   edm::InputTag testTag(theFilter_, "", "HLT");
-
   int testindex = triggerEvent->filterIndex(testTag);
 
   if (testindex >= triggerEvent->sizeFilters())
     return;
-  nEventsHLTFilter->Fill(0.5);
+  h_nEventsHLTFilter->Fill(0.5);
 
   const trigger::Keys& KEYS_el(triggerEvent->filterKeys(testindex));
 
@@ -497,11 +471,11 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     HLTelectrons.push_back(triggerObject_el);
   }
 
-  nHLTelectrons->Fill(HLTelectrons.size());
+  h_nHLTelectrons->Fill(HLTelectrons.size());
 
   if (HLTelectrons.empty())
     return;
-  nEventsHLTelectron->Fill(0.5);
+  h_nEventsHLTelectron->Fill(0.5);
 
   // finding the HLT electron with highest pt and saving the corresponding index
   unsigned int HighPtIndex = 0;
@@ -516,15 +490,14 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
   //-----------------   Tracks   -------------------
 
   // getting GsfTrack
-  edm::Handle<reco::GsfTrackCollection> tracks;
-  iEvent.getByToken(theGsfTrackCollectionToken, tracks);
+  const reco::GsfTrackCollection* tracks = &iEvent.get(theGsfTrackCollectionToken_);
 
   // filtering track
   int nRejected = 0;
   int nSelected = 0;
   std::vector<const reco::GsfTrack*> filterTracks;
   for (unsigned int i = 0; i < tracks->size(); i++) {
-    nTracks->Fill(0.5);
+    h_nTracks->Fill(0.5);
     double deltar = reco::deltaR(
         (*tracks)[i].eta(), (*tracks)[i].phi(), HLTelectrons[HighPtIndex]->eta(), HLTelectrons[HighPtIndex]->phi());
     // remove the triggered electron with highest pt
@@ -538,45 +511,39 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     }
     filterTracks.push_back(&(*tracks)[i]);  // we use all the others
     nSelected++;
-    nTracksFiltered->Fill(0.5);
+    h_nTracksFiltered->Fill(0.5);
   }
-  nTrkRejectedPerEvt->Fill(nRejected);
-  nTrkSelectedPerEvt->Fill(nSelected);
+  h_nTrkRejectedPerEvt->Fill(nRejected);
+  h_nTrkSelectedPerEvt->Fill(nSelected);
 
   if (nRejected == 0)
     return;
-  nEventsHLTrejected->Fill(0.5);
+  h_nEventsHLTrejected->Fill(0.5);
 
   if (filterTracks.empty())
     return;
-  nEvents2Elec->Fill(0.5);
+  h_nEvents2Elec->Fill(0.5);
 
   //-------- test:Matching SC/track using gsfElectonCore collection --------
 
-  edm::Handle<reco::GsfElectronCoreCollection> electrons;
-  iEvent.getByToken(theGsfElectronCoreCollectionToken, electrons);
-
-  for (std::vector<reco::GsfElectronCore>::const_iterator elec = electrons->begin(); elec != electrons->end(); elec++) {
-    double etaGSF = ecalEta((elec->gsfTrack())->eta(), vert.z(), (vert.position()).rho());
-    if ((elec->gsfTrack())->pt() < 10.)
+  const reco::GsfElectronCoreCollection* electrons = &iEvent.get(theGsfElectronCoreCollectionToken_);
+  for (const auto& elec : *electrons) {
+    double etaGSF = eopUtils::ecalEta((elec.gsfTrack())->eta(), vert.z(), (vert.position()).rho());
+    if ((elec.gsfTrack())->pt() < 10.)
       continue;
 
     double DELTAR = 0;
-    DELTAR =
-        reco::deltaR((elec->superCluster())->eta(), (elec->superCluster())->phi(), etaGSF, (elec->gsfTrack())->phi());
+    DELTAR = reco::deltaR((elec.superCluster())->eta(), (elec.superCluster())->phi(), etaGSF, (elec.gsfTrack())->phi());
 
     if (DELTAR < 0.1)
-      distToClosestSCgsf->Fill(DELTAR);
+      h_distToClosestSCgsf->Fill(DELTAR);
   }
 
   //------------------------------------------------------------
 
   //--------------    Loop on tracks   -----------------
 
-  for (std::vector<const reco::GsfTrack*>::const_iterator itrack = filterTracks.begin(); itrack != filterTracks.end();
-       ++itrack) {
-    const reco::GsfTrack* track = (*itrack);
-
+  for (const auto& track : filterTracks) {
     // initializing variables
     isEcalDriven = false;
     isTrackerDriven = false;
@@ -601,10 +568,10 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     nBasicClus = 0;
 
     // First cut on momentum magnitude
-    Momentum->Fill(track->p());
+    h_Momentum->Fill(track->p());
     if (track->pt() < 10.)
       continue;
-    cut_Ptmin->Fill(0.5);
+    h_cut_Ptmin->Fill(0.5);
 
     // calculating track parameters at innermost and outermost for Gsf tracks
     TrajectoryStateOnSurface inTSOS = mtsTransform.innerStateOnSurface(*track);
@@ -623,7 +590,7 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
       etaOut = outMom.eta();
       phiOut = outMom.phi();
       fbrem = (pin - pout) / pin;
-      fBREM->Fill(fbrem);
+      h_fBREM->Fill(fbrem);
     }
 
     // Matching track with Hcal rec hits
@@ -633,23 +600,24 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     EnergyHcalIn04 = 0;
     EnergyHcalIn05 = 0;
 
-    for (std::vector<HBHERecHit>::const_iterator hcal = (*HcalHits).begin(); hcal != (*HcalHits).end(); hcal++) {
-      GlobalPoint posH = geo->getPosition((*hcal).detid());
+    //for (std::vector<HBHERecHit>::const_iterator hcal = (*HcalHits).begin(); hcal != (*HcalHits).end(); hcal++) {
+    for (const auto& hcal : *HcalHits) {
+      GlobalPoint posH = geo->getPosition(hcal.detid());
       double phihit = posH.phi();
       double etahit = posH.eta();
       double dR = reco::deltaR(etahit, phihit, etaOut, phiOut);
 
       // saving Hcal energy deposit measured for different eta-phi radius
       if (dR < 0.1)
-        EnergyHcalIn01 += hcal->energy();
+        EnergyHcalIn01 += hcal.energy();
       if (dR < 0.2)
-        EnergyHcalIn02 += hcal->energy();
+        EnergyHcalIn02 += hcal.energy();
       if (dR < 0.3)
-        EnergyHcalIn03 += hcal->energy();
+        EnergyHcalIn03 += hcal.energy();
       if (dR < 0.4)
-        EnergyHcalIn04 += hcal->energy();
+        EnergyHcalIn04 += hcal.energy();
       if (dR < 0.5)
-        EnergyHcalIn05 += hcal->energy();
+        EnergyHcalIn05 += hcal.energy();
     }
 
     HcalEnergy->Fill(EnergyHcalIn02);
@@ -672,11 +640,7 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     NoTrackIn0035 = true;
     NoTrackIn0040 = true;
 
-    for (std::vector<const reco::GsfTrack*>::const_iterator itrack1 = filterTracks.begin();
-         itrack1 != filterTracks.end();
-         ++itrack1) {
-      const reco::GsfTrack* track1 = (*itrack1);
-
+    for (const auto& track1 : filterTracks) {
       if (track == track1)
         continue;
 
@@ -748,15 +712,13 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
     double dRSC;
     double etaAtEcal = 0;  // to convert eta from track to detector frame
-    etaAtEcal = ecalEta(etaIn, vert.z(), (vert.position()).rho());
+    etaAtEcal = eopUtils::ecalEta(etaIn, vert.z(), (vert.position()).rho());
 
     //Barrel
-    if (track->eta() < 1.55 || track->eta() > -1.55) {
-      for (std::vector<reco::SuperCluster>::const_iterator SC = BarrelSupClusCollection->begin();
-           SC != BarrelSupClusCollection->end();
-           SC++) {
+    if (std::abs(track->eta()) < k_etaBarrel) {
+      for (const auto& SC : *BarrelSupClusCollection) {
         dRSC = 0;
-        dRSC = reco::deltaR(SC->eta(), SC->phi(), etaAtEcal, phiIn);
+        dRSC = reco::deltaR(SC.eta(), SC.phi(), etaAtEcal, phiIn);
 
         if (dRSC < dRSC_first) {
           dRSC_first = dRSC;
@@ -767,16 +729,16 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
         if (dRSC < 0.09) {
           //Calculate phiWidth & etaWidth for associated SuperClusters
-          SCShape.Calculate_Covariances(*SC);
+          SCShape.Calculate_Covariances(SC);
           phiWidth = SCShape.phiWidth();
           etaWidth = SCShape.etaWidth();
 
-          etaSC = SC->eta();
-          phiSC = SC->phi();
+          etaSC = SC.eta();
+          phiSC = SC.phi();
 
-          algo_ID = SC->algoID();
-          EnergyEcal = SC->energy();
-          nBasicClus = SC->clustersSize();
+          algo_ID = SC.algoID();
+          EnergyEcal = SC.energy();
+          nBasicClus = SC.clustersSize();
           nbSC++;
           isBarrel = true;
         }
@@ -784,12 +746,10 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     }
 
     // Endcap
-    if (track->eta() < -1.44 || track->eta() > 1.44) {
-      for (std::vector<reco::SuperCluster>::const_iterator SC = EndcapSupClusCollection->begin();
-           SC != EndcapSupClusCollection->end();
-           SC++) {
+    if (std::abs(track->eta()) > k_etaEndcap) {
+      for (const auto& SC : *EndcapSupClusCollection) {
         dRSC = 0;
-        dRSC = reco::deltaR(SC->eta(), SC->phi(), etaAtEcal, phiIn);
+        dRSC = reco::deltaR(SC.eta(), SC.phi(), etaAtEcal, phiIn);
 
         if (dRSC < dRSC_first) {
           dRSC_first = dRSC;
@@ -800,16 +760,16 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
         if (dRSC < 0.09) {
           //Calculate phiWidth & etaWidth for associated SuperClusters
-          SCShape.Calculate_Covariances(*SC);
+          SCShape.Calculate_Covariances(SC);
           phiWidth = SCShape.phiWidth();
           etaWidth = SCShape.etaWidth();
 
-          etaSC = SC->eta();
-          phiSC = SC->phi();
+          etaSC = SC.eta();
+          phiSC = SC.phi();
 
-          algo_ID = SC->algoID();
-          EnergyEcal = SC->energy();
-          nBasicClus = SC->clustersSize();
+          algo_ID = SC.algoID();
+          EnergyEcal = SC.energy();
+          nBasicClus = SC.clustersSize();
           nbSC++;
           isEndcap = true;
         }
@@ -817,29 +777,29 @@ void EopElecTreeWriter::analyze(const edm::Event& iEvent, const edm::EventSetup&
     }
 
     if (dRSC_first < 0.1)
-      distToClosestSC->Fill(dRSC_first);
+      h_distToClosestSC->Fill(dRSC_first);
     if (nbSC == 1)
-      counter1->Fill(0.5);
+      h_counter1->Fill(0.5);
     if (nbSC == 0)
-      counter2->Fill(0.5);
+      h_counter2->Fill(0.5);
 
     if (nbSC > 1 || nbSC == 0)
       continue;
-    cut_OneSCmatch->Fill(0.5);
+    h_cut_OneSCmatch->Fill(0.5);
 
     if (isBarrel && isEndcap) {
-      cout << "Error: Super Cluster double matching!" << endl;
+      error << "Error: Super Cluster double matching!";
       return;
     }
 
-    EcalEnergy->Fill(EnergyEcal);
+    h_EcalEnergy->Fill(EnergyEcal);
     HcalVSEcal->Fill(EnergyEcal, EnergyHcalIn02);
 
     // E over p plots
     if (track->charge() < 0)
-      Eop_InnerNegative->Fill(EnergyEcal / pin);
+      h_Eop_InnerNegative->Fill(EnergyEcal / pin);
     if (track->charge() > 0)
-      Eop_InnerPositive->Fill(EnergyEcal / pin);
+      h_Eop_InnerPositive->Fill(EnergyEcal / pin);
 
     //Check if track-SuperCluster matching is Ecal or Tracker driven
     edm::RefToBase<TrajectorySeed> seed = track->extra()->seedRef();
@@ -939,10 +899,10 @@ void EopElecTreeWriter::beginRun(const edm::Run& iRun, const edm::EventSetup& iS
   }
 
   // Displaying the trigger names
-  if( debugTriggerSelection_ ){
+  if (debugTriggerSelection_) {
     unsigned int i = 0;
-    for (std::vector<std::string>::const_iterator it = triggerNames_.begin(); it < triggerNames_.end(); ++it) {
-      std::cout << "HLTpath: " << (i++) << " = " << (*it) << std::endl;
+    for (const auto& it : triggerNames_) {
+      edm::LogInfo("EopElecTreeWriter") << "HLTpath: " << (i++) << " = " << it;
     }
   }
 }

--- a/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
@@ -340,7 +340,7 @@ void EopTreeWriter::fillDescriptions(edm::ConfigurationDescriptions& description
   psd0.add<bool>("useCalo", false);
   psd0.add<bool>("useEcal", true);
   psd0.add<bool>("useGEM", false);
-  psd0.add<bool>("useHO", true);
+  psd0.add<bool>("useHO", false);
   psd0.add<bool>("useHcal", true);
   psd0.add<bool>("useME0", false);
   psd0.add<bool>("useMuon", true);

--- a/Alignment/OfflineValidation/python/eopElecTreeWriter_cfi.py
+++ b/Alignment/OfflineValidation/python/eopElecTreeWriter_cfi.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+energyOverMomentumTree = cms.EDAnalyzer('EopElecTreeWriter',
+                                        src  = cms.InputTag('electronGsfTracks'),
+                                        # Lower threshold on track's momentum magnitude in GeV
+                                        PCut = cms.double(31.),#15.),                                    
+                                        # tag on Z mass width window, between MzMin and MzMax
+                                        MzMin = cms.double(60.),
+                                        MzMax = cms.double(120.),                                        
+                                        # Lower threshold on Ecal energy deposit considering the Energy of SuperCluster
+                                        EcalEnergyCut = cms.double(30.),#14.),
+                                        # Upper threshold on Hcal energy deposit considering the Energy of 5x5 Calo cells
+                                        HcalEnergyCut = cms.double(3.),                                                        
+                                        # Isolation criteria: no other track lying in a cone of differential
+                                        # radius dRIso (in eta-phi plan) arround the considered track
+                                        dRIso = cms.double(0.1),
+                                        # Isolation against neutral particles:
+                                        # SCdRMatch: differential radius (eta-phi plan) used for track-SupClus matching
+                                        # SCdRIso: between SCdRMatch and SCdRIso arround track, NO OTHER Super Cluster
+                                        SCdRMatch = cms.double(0.09),
+                                        SCdRIso = cms.double(0.2)
+                                    )

--- a/Alignment/OfflineValidation/python/eopElecTreeWriter_cfi.py
+++ b/Alignment/OfflineValidation/python/eopElecTreeWriter_cfi.py
@@ -2,6 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 energyOverMomentumTree = cms.EDAnalyzer('EopElecTreeWriter',
                                         src  = cms.InputTag('electronGsfTracks'),
+                                        # HLT path to filter on
+                                        triggerPath = cms.string("HLT_Ele"), # ("HLT_DiEle27_WPTightCaloOnly_L1DoubleEG_v4"),
+                                        # take HLT objects from this filter
+                                        hltFilter   = cms.string("hltDiEle27L1DoubleEGWPTightHcalIsoFilter"),
+                                        # debug the trigger and filter selections 
+                                        debugTriggerSelection = cms.bool(False),
                                         # Lower threshold on track's momentum magnitude in GeV
                                         PCut = cms.double(31.),#15.),                                    
                                         # tag on Z mass width window, between MzMin and MzMax
@@ -19,4 +25,4 @@ energyOverMomentumTree = cms.EDAnalyzer('EopElecTreeWriter',
                                         # SCdRIso: between SCdRMatch and SCdRIso arround track, NO OTHER Super Cluster
                                         SCdRMatch = cms.double(0.09),
                                         SCdRIso = cms.double(0.2)
-                                    )
+                                        )

--- a/Alignment/OfflineValidation/python/eopElecTreeWriter_cfi.py
+++ b/Alignment/OfflineValidation/python/eopElecTreeWriter_cfi.py
@@ -6,23 +6,23 @@ energyOverMomentumTree = cms.EDAnalyzer('EopElecTreeWriter',
                                         triggerPath = cms.string("HLT_Ele"), # ("HLT_DiEle27_WPTightCaloOnly_L1DoubleEG_v4"),
                                         # take HLT objects from this filter
                                         hltFilter   = cms.string("hltDiEle27L1DoubleEGWPTightHcalIsoFilter"),
-                                        # debug the trigger and filter selections 
+                                        # debug the trigger and filter selections
                                         debugTriggerSelection = cms.bool(False),
                                         # Lower threshold on track's momentum magnitude in GeV
-                                        PCut = cms.double(31.),#15.),                                    
+                                        #PCut = cms.double(31.),#15.),
                                         # tag on Z mass width window, between MzMin and MzMax
-                                        MzMin = cms.double(60.),
-                                        MzMax = cms.double(120.),                                        
+                                        #MzMin = cms.double(60.),
+                                        #MzMax = cms.double(120.),
                                         # Lower threshold on Ecal energy deposit considering the Energy of SuperCluster
-                                        EcalEnergyCut = cms.double(30.),#14.),
+                                        #EcalEnergyCut = cms.double(30.),#14.),
                                         # Upper threshold on Hcal energy deposit considering the Energy of 5x5 Calo cells
-                                        HcalEnergyCut = cms.double(3.),                                                        
+                                        #HcalEnergyCut = cms.double(3.),
                                         # Isolation criteria: no other track lying in a cone of differential
                                         # radius dRIso (in eta-phi plan) arround the considered track
-                                        dRIso = cms.double(0.1),
+                                        #dRIso = cms.double(0.1),
                                         # Isolation against neutral particles:
                                         # SCdRMatch: differential radius (eta-phi plan) used for track-SupClus matching
                                         # SCdRIso: between SCdRMatch and SCdRIso arround track, NO OTHER Super Cluster
-                                        SCdRMatch = cms.double(0.09),
-                                        SCdRIso = cms.double(0.2)
+                                        #SCdRMatch = cms.double(0.09),
+                                        #SCdRIso = cms.double(0.2)
                                         )

--- a/Alignment/OfflineValidation/src/classes.h
+++ b/Alignment/OfflineValidation/src/classes.h
@@ -1,3 +1,4 @@
 #include "Alignment/OfflineValidation/interface/TkOffTreeVariables.h"
 #include "Alignment/OfflineValidation/interface/pvTree.h"
 #include "Alignment/OfflineValidation/interface/EopVariables.h"
+#include "Alignment/OfflineValidation/interface/EopElecVariables.h"

--- a/Alignment/OfflineValidation/src/classes_def.xml
+++ b/Alignment/OfflineValidation/src/classes_def.xml
@@ -3,4 +3,5 @@
   <class name="EopVariables"/>
   <class name="pvCand"/>
   <class name="pvEvent"/>
+  <class name="EopElecVariables"/>
 </lcgdict>

--- a/Alignment/OfflineValidation/test/BuildFile.xml
+++ b/Alignment/OfflineValidation/test/BuildFile.xml
@@ -1,17 +1,27 @@
 <environment>
-  <bin name="testAlignmentOfflineValidation" file="testAlignmentOfflineValidation.cpp">
-    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test test_all.sh"/>
+  <bin file="testAlignmentOfflineValidation.cpp" name="testAlignmentOfflineValidation">
+    <flags TEST_RUNNER_ARGS=" /bin/bash	Alignment/OfflineValidation/test test_all-in-one.sh"/>
     <use name="FWCore/Utilities"/>
   </bin>
-
+  <bin file="testAlignmentOfflineValidation.cpp" name="testPVValidation">
+    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testPVValidation.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
+  <bin file="testAlignmentOfflineValidation.cpp" name="testEoP">
+    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testEoP.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
+  <bin file="testAlignmentOfflineValidation.cpp" name="testSubmitters">
+    <flags TEST_RUNNER_ARGS=" /bin/bash Alignment/OfflineValidation/test testSubmitters.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
   <bin file="testPVPlotting.cpp">
-    <flags PRE_TEST="testAlignmentOfflineValidation"/>
+    <flags PRE_TEST="testPVValidation"/>
     <use name="rootmath"/>
     <use name="roothistmatrix"/>
     <use name="rootgraphics"/>
     <use name="Alignment/OfflineValidation"/>
   </bin>
-
   <bin name="testTrackAnalysis" file="testTrackAnalyzers.cc">
     <use name="FWCore/TestProcessor"/>
     <use name="catch2"/>

--- a/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopElecTreeWriter_cfg.py
@@ -15,7 +15,7 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing("analysis")
 
 options.register ('outputRootFile',
-                  "test_EOverP_Electrons.root",
+                  "test_EopTreeElectron.root",
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.VarParsing.varType.string,         # string, int, or float
                   "output root file")

--- a/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
@@ -4,8 +4,8 @@ process = cms.Process("EnergyOverMomentumTree")
 
 # initialize MessageLogger and output report
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.threshold = 'ERROR'
-process.MessageLogger.cerr.FwkReport.reportEvery = 10000
+#process.MessageLogger.cerr.threshold = 'ERROR'
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.TrackRefitter=dict()
 
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
@@ -13,7 +13,11 @@ process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
 # define input files
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-    '/store/data/Run2011A/Commissioning/ALCARECO/HcalCalIsoTrk-May10ReReco-v2/0000/FEB81703-0E7F-E011-8161-0025B3E05E00.root'
+'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/00971a25-0d77-4a54-8b38-4ee45f26ac27.root',
+'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/014ac00e-38df-45ac-9501-82944400515e.root',
+'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/05a0879c-eca2-4a7e-89c3-f0f20a05c73d.root',
+'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/05c96563-4f60-40ad-9eb3-cfdd2dad1c09.root',
+'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/72009661-4aa4-4a0d-84f7-f1279dadffe4.root'
     )
 )
 
@@ -22,10 +26,35 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 # load configuration files
+####################################################################
+# Get the Magnetic Field
+####################################################################
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load("Configuration.StandardSequences.MagneticField_cff")
+
+from Configuration.Geometry.GeometryRecoDB_cff import *
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
+
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'GR_R_42_V14::All'
+
+#process.GlobalTag.globaltag = '113X_dataRun2_v6'
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing("analysis")
+
+options.register ('GlobalTag',
+                  'auto:phase1_2021_realistic',
+                  VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "Global Tag to be used")
+
+options.parseArguments()
+
+print( "conditionGT       : ", options.GlobalTag)
+print( "maxEvents         : ", options.maxEvents)
+
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
 
 ## jsonFile =  'json_Apr21_May10v2_Promptv4_136035_167913.txt'
 ## import PhysicsTools.PythonAnalysis.LumiList as LumiList
@@ -37,15 +66,15 @@ process.GlobalTag.globaltag = 'GR_R_42_V14::All'
 
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 
-process.load("Geometry.CaloEventSetup.CaloGeometry_cff")
+#process.load("Geometry.CaloEventSetup.CaloGeometry_cff")
 
 process.load("Geometry.CaloEventSetup.CaloTopology_cfi")
 
 process.load("Geometry.CaloEventSetup.EcalTrigTowerConstituents_cfi")
 
-process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
+#process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 
-process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
+#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 
 process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 
@@ -67,27 +96,34 @@ from TrackingTools.TrackAssociator.default_cfi import *
 
 # choose geometry
 from CondCore.DBCommon.CondDBSetup_cfi import *
-process.trackerAlignment = cms.ESSource("PoolDBESSource",CondDBSetup,
-                                        #connect = cms.string("frontier://FrontierArc/CMS_COND_31X_ALIGNMENT_AK25"),
-                                        connect = cms.string("frontier://FrontierArc/CMS_COND_31X_ALIGNMENT_BD19"),
+process.trackerAlignment = cms.ESSource("PoolDBESSource",
+					CondDBSetup,
+                                        #connect = cms.string("frontier://FrontierArc/CMS_COND_31X_ALIGNMENT_BD19"),
                                         toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentRcd"),
-                                                                   tag = cms.string("TrackerAlignment_GR10_v4_offline")
-                                                                   )## ,
-##                                                           cms.PSet(record = cms.string("TrackerAlignmentErrorExtendedRcd"),
-##                                                                    tag = cms.string("TrackerAlignmentErrorsExtended_GR10_v2_offline")
-##                                                                    ),
-##                                                           cms.PSet(record = cms.string("TrackerSurfaceDeformationRcd"),
-##                                                                    tag = cms.string("Deformations")
-##                                                                    )
-                                                          )
-                                        )
-process.prefer("trackerAlignment")
+								tag = cms.string("TrackerAlignment_2017_ultralegacymc_v2")
+                                                                   )
+								),
+					connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+						)
+                                           
+process.es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource", "trackerAlignment")
+
+process.trackerAPE = cms.ESSource("PoolDBESSource",CondDBSetup,
+                                      toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentErrorRcd"),
+                                                                 tag = cms.string("TrackerAlignmentExtendedErrors_2017_ultralegacymc_v2")
+                                              			#tag = cms.string("TrackerAlignmentExtendedErrors_v16_offline_IOVs")
+                                                             )
+                                                    ),
+                                      connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+    )
+process.es_prefer_TrackerAPE = cms.ESPrefer("PoolDBESSource", "trackerAPE")
+#process.prefer("trackerAlignment")
 
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
 # configure alignment track selector
 process.load("Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi")
-process.AlignmentTrackSelector.src = cms.InputTag('TkAlIsoProd:') # 'generalTracks' # trackCollection' # 'ALCARECOTkAlZMuMu' # 'ALCARECOTkAlMinBias' # adjust to input file
+process.AlignmentTrackSelector.src = cms.InputTag('generalTracks:') # 'TkAlIsoProd' # trackCollection' # 'ALCARECOTkAlZMuMu' # 'ALCARECOTkAlMinBias' # adjust to input file
 process.AlignmentTrackSelector.ptMin = 1.
 process.AlignmentTrackSelector.etaMin = -5.
 process.AlignmentTrackSelector.etaMax = 5.
@@ -97,16 +133,20 @@ process.AlignmentTrackSelector.chi2nMax = 100.
 #process.AlignmentTrackSelector.nHighestPt = 2
 
 # configure track refitter
+import RecoTracker.TrackProducer.TrackRefitters_cff
 process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
-process.TrackRefitter.src = cms.InputTag('TkAlIsoProd:')
+process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi")
+process.TrackRefitter.src = cms.InputTag('generalTracks')
 #process.TrackRefitter.src = cms.InputTag('AlignmentTrackSelector')
 process.TrackRefitter.TrajectoryInEvent = True
 
 # configure tree writer
-TrackAssociatorParameterBlock.TrackAssociatorParameters.EERecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackEcalRecHitCollection")
-TrackAssociatorParameterBlock.TrackAssociatorParameters.EBRecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackEcalRecHitCollection")
-TrackAssociatorParameterBlock.TrackAssociatorParameters.HBHERecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackHBHERecHitCollection")
-TrackAssociatorParameterBlock.TrackAssociatorParameters.HORecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackHORecHitCollection")
+#TrackAssociatorParameterBlock.TrackAssociatorParameters.EERecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackEcalRecHitCollection")
+TrackAssociatorParameterBlock.TrackAssociatorParameters.EERecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE")
+#TrackAssociatorParameterBlock.TrackAssociatorParameters.EBRecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackEcalRecHitCollection")
+TrackAssociatorParameterBlock.TrackAssociatorParameters.EBRecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
+#TrackAssociatorParameterBlock.TrackAssociatorParameters.HBHERecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackHBHERecHitCollection")
+#TrackAssociatorParameterBlock.TrackAssociatorParameters.HORecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackHORecHitCollection")
 
 process.energyOverMomentumTree = cms.EDAnalyzer('EopTreeWriter',
     TrackAssociatorParameterBlock
@@ -115,8 +155,8 @@ process.energyOverMomentumTree.src = cms.InputTag('TrackRefitter')
 #process.energyOverMomentumTree.src = cms.InputTag('TkAlIsoProd:')
 
 process.TFileService = cms.Service("TFileService",
-    fileName = cms.string('EopTree.root')
+    fileName = cms.string('test_EopTree.root')
 )
 
-process.p = cms.Path(process.offlineBeamSpot*process.TrackRefitter*process.energyOverMomentumTree)
+process.p = cms.Path(process.MeasurementTrackerEvent*process.offlineBeamSpot*process.TrackRefitter*process.energyOverMomentumTree)
 #process.p = cms.Path(process.offlineBeamSpot*process.AlignmentTrackSelector*process.TrackRefitter*process.energyOverMomentumTree)

--- a/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
@@ -8,6 +8,11 @@ options.register ('GlobalTag',
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "Global Tag to be used")
 
+options.register('unitTest',
+                 False, # default value
+                 VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                 VarParsing.VarParsing.varType.bool, # string, int, or float
+                 "is it a unit test?")
 options.parseArguments()
 
 process = cms.Process("EnergyOverMomentumTree")
@@ -48,12 +53,17 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
 
 jsonFile = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/Legacy_2018/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON.txt'
-import FWCore.PythonUtilities.LumiList as LumiList
-import FWCore.ParameterSet.Types as CfgTypes
-print("JSON used: %s " % jsonFile)
-myLumis = LumiList.LumiList(filename = jsonFile).getCMSSWString().split(',')
-process.source.lumisToProcess = CfgTypes.untracked(CfgTypes.VLuminosityBlockRange())
-process.source.lumisToProcess.extend(myLumis)
+
+if(options.unitTest):
+    print('This is a unit test, will not json filter')
+    pass
+else:
+    import FWCore.PythonUtilities.LumiList as LumiList
+    import FWCore.ParameterSet.Types as CfgTypes
+    print("JSON used: %s " % jsonFile)
+    myLumis = LumiList.LumiList(filename = jsonFile).getCMSSWString().split(',')
+    process.source.lumisToProcess = CfgTypes.untracked(CfgTypes.VLuminosityBlockRange())
+    process.source.lumisToProcess.extend(myLumis)
 
 #from TrackingTools.TrackAssociator.default_cfi import *
 process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagator_cfi")

--- a/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
+++ b/Alignment/OfflineValidation/test/eopTreeWriter_cfg.py
@@ -1,90 +1,60 @@
 import FWCore.ParameterSet.Config as cms
-
-process = cms.Process("EnergyOverMomentumTree")
-
-# initialize MessageLogger and output report
-process.load("FWCore.MessageService.MessageLogger_cfi")
-#process.MessageLogger.cerr.threshold = 'ERROR'
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-process.MessageLogger.TrackRefitter=dict()
-
-process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
-
-# define input files
-process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
-'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/00971a25-0d77-4a54-8b38-4ee45f26ac27.root',
-'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/014ac00e-38df-45ac-9501-82944400515e.root',
-'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/05a0879c-eca2-4a7e-89c3-f0f20a05c73d.root',
-'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/05c96563-4f60-40ad-9eb3-cfdd2dad1c09.root',
-'/store/relval/CMSSW_11_3_0_pre3/RelValMinBias_13/GEN-SIM-RECO/113X_upgrade2018_realistic_v3-v1/00000/72009661-4aa4-4a0d-84f7-f1279dadffe4.root'
-    )
-)
-
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
-)
-
-# load configuration files
-####################################################################
-# Get the Magnetic Field
-####################################################################
-process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
-process.load("Configuration.StandardSequences.MagneticField_cff")
-
-from Configuration.Geometry.GeometryRecoDB_cff import *
-process.load("Configuration.Geometry.GeometryRecoDB_cff")
-
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-
-#process.GlobalTag.globaltag = '113X_dataRun2_v6'
 import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing("analysis")
 
 options.register ('GlobalTag',
-                  'auto:phase1_2021_realistic',
+                  'auto:run2_data',
                   VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "Global Tag to be used")
 
 options.parseArguments()
 
+process = cms.Process("EnergyOverMomentumTree")
+
+####################################################################
+# initialize MessageLogger and output report
+####################################################################
+process.load("FWCore.MessageService.MessageLogger_cfi")
+#process.MessageLogger.cerr.threshold = 'ERROR'
+process.MessageLogger.cerr.FwkReport.reportEvery = 10
+process.MessageLogger.TrackRefitter=dict()
+
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
+
+# define input files
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(
+                                'root://cmsxrootd.fnal.gov//store/data/Run2018D/JetHT/ALCARECO/HcalCalIsoTrkFilter-12Nov2019_UL2018-v3/100000/075A1F1E-20B4-134D-9794-AD764DA6730D.root',
+                                'root://cmsxrootd.fnal.gov//store/data/Run2018D/JetHT/ALCARECO/HcalCalIsoTrkFilter-12Nov2019_UL2018-v3/100000/1B7906DB-A233-0143-ACF0-BB29D9FCFB24.root',
+                                'root://cmsxrootd.fnal.gov//store/data/Run2018D/JetHT/ALCARECO/HcalCalIsoTrkFilter-12Nov2019_UL2018-v3/100000/441F40BB-325E-5D46-9F1D-3C8BBAB8AE58.root',
+                                'root://cmsxrootd.fnal.gov//store/data/Run2018D/JetHT/ALCARECO/HcalCalIsoTrkFilter-12Nov2019_UL2018-v3/100000/B624B687-53C9-1C49-A19E-25FC808C9D88.root'))
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
 print( "conditionGT       : ", options.GlobalTag)
 print( "maxEvents         : ", options.maxEvents)
 
+####################################################################
+# load configuration files
+####################################################################
+process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
 
-## jsonFile =  'json_Apr21_May10v2_Promptv4_136035_167913.txt'
-## import PhysicsTools.PythonAnalysis.LumiList as LumiList
-## import FWCore.ParameterSet.Types as CfgTypes
-## print "JSON used: ", jsonFile
-## myLumis = LumiList.LumiList(filename = jsonFile).getCMSSWString().split(',')
-## process.source.lumisToProcess = CfgTypes.untracked(CfgTypes.VLuminosityBlockRange())
-## process.source.lumisToProcess.extend(myLumis)
+jsonFile = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/Legacy_2018/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON.txt'
+import FWCore.PythonUtilities.LumiList as LumiList
+import FWCore.ParameterSet.Types as CfgTypes
+print("JSON used: %s " % jsonFile)
+myLumis = LumiList.LumiList(filename = jsonFile).getCMSSWString().split(',')
+process.source.lumisToProcess = CfgTypes.untracked(CfgTypes.VLuminosityBlockRange())
+process.source.lumisToProcess.extend(myLumis)
 
-process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
-
-#process.load("Geometry.CaloEventSetup.CaloGeometry_cff")
-
-process.load("Geometry.CaloEventSetup.CaloTopology_cfi")
-
-process.load("Geometry.CaloEventSetup.EcalTrigTowerConstituents_cfi")
-
-#process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
-
-#process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
-
-process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
-
-process.load("Geometry.DTGeometry.dtGeometry_cfi")
-
-process.load("Geometry.RPCGeometry.rpcGeometry_cfi")
-
-process.load("Geometry.CSCGeometry.cscGeometry_cfi")
-
-process.load("Geometry.CommonTopologies.bareGlobalTrackingGeometry_cfi")
 #from TrackingTools.TrackAssociator.default_cfi import *
 process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagator_cfi")
 process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAny_cfi")
@@ -94,36 +64,33 @@ process.load("TrackingTools.TrackAssociator.DetIdAssociatorESProducer_cff")
 from TrackingTools.TrackAssociator.default_cfi import *
 #process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_noesprefer_cff")
 
+####################################################################
 # choose geometry
-from CondCore.DBCommon.CondDBSetup_cfi import *
+####################################################################
+from CondCore.CondDB.CondDB_cfi import CondDB
+CondDB.connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+
 process.trackerAlignment = cms.ESSource("PoolDBESSource",
-					CondDBSetup,
-                                        #connect = cms.string("frontier://FrontierArc/CMS_COND_31X_ALIGNMENT_BD19"),
+					CondDB,
                                         toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentRcd"),
-								tag = cms.string("TrackerAlignment_2017_ultralegacymc_v2")
-                                                                   )
-								),
-					connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-						)
-                                           
+                                                                   tag = cms.string("TrackerAlignment_v28_offline")
+                                                               )))
 process.es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource", "trackerAlignment")
 
-process.trackerAPE = cms.ESSource("PoolDBESSource",CondDBSetup,
-                                      toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentErrorRcd"),
-                                                                 tag = cms.string("TrackerAlignmentExtendedErrors_2017_ultralegacymc_v2")
-                                              			#tag = cms.string("TrackerAlignmentExtendedErrors_v16_offline_IOVs")
-                                                             )
-                                                    ),
-                                      connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-    )
-process.es_prefer_TrackerAPE = cms.ESPrefer("PoolDBESSource", "trackerAPE")
-#process.prefer("trackerAlignment")
+process.trackerAPE = cms.ESSource("PoolDBESSource",
+                                  CondDB,
+                                  toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentErrorRcd"),
+                                                                 tag = cms.string("TrackerAlignmentExtendedErrors_v15_offline_IOVs")
+                                                         )))
+#process.es_prefer_TrackerAPE = cms.ESPrefer("PoolDBESSource", "trackerAPE")
 
 process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
 
+####################################################################
 # configure alignment track selector
+####################################################################
 process.load("Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi")
-process.AlignmentTrackSelector.src = cms.InputTag('generalTracks:') # 'TkAlIsoProd' # trackCollection' # 'ALCARECOTkAlZMuMu' # 'ALCARECOTkAlMinBias' # adjust to input file
+process.AlignmentTrackSelector.src = cms.InputTag('TkAlIsoProdFilter') # 'TkAlIsoProd' # trackCollection' # 'ALCARECOTkAlZMuMu' # 'ALCARECOTkAlMinBias' # adjust to input file
 process.AlignmentTrackSelector.ptMin = 1.
 process.AlignmentTrackSelector.etaMin = -5.
 process.AlignmentTrackSelector.etaMax = 5.
@@ -132,31 +99,45 @@ process.AlignmentTrackSelector.chi2nMax = 100.
 #process.AlignmentTrackSelector.applyNHighestPt = True
 #process.AlignmentTrackSelector.nHighestPt = 2
 
+####################################################################
 # configure track refitter
+####################################################################
+process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi")
+process.MeasurementTrackerEvent.pixelClusterProducer = "TkAlIsoProdFilter"
+process.MeasurementTrackerEvent.stripClusterProducer = "TkAlIsoProdFilter"
+#process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag([''])
+#process.MeasurementTrackerEvent.inactiveStripDetectorLabels = cms.VInputTag([''])
+
 import RecoTracker.TrackProducer.TrackRefitters_cff
 process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
-process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi")
-process.TrackRefitter.src = cms.InputTag('generalTracks')
-#process.TrackRefitter.src = cms.InputTag('AlignmentTrackSelector')
+process.TrackRefitter.src = cms.InputTag('AlignmentTrackSelector')
 process.TrackRefitter.TrajectoryInEvent = True
+process.TrackRefitter.NavigationSchool = ''
 
+####################################################################
 # configure tree writer
-#TrackAssociatorParameterBlock.TrackAssociatorParameters.EERecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackEcalRecHitCollection")
+####################################################################
 TrackAssociatorParameterBlock.TrackAssociatorParameters.EERecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE")
-#TrackAssociatorParameterBlock.TrackAssociatorParameters.EBRecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackEcalRecHitCollection")
 TrackAssociatorParameterBlock.TrackAssociatorParameters.EBRecHitCollectionLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
-#TrackAssociatorParameterBlock.TrackAssociatorParameters.HBHERecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackHBHERecHitCollection")
-#TrackAssociatorParameterBlock.TrackAssociatorParameters.HORecHitCollectionLabel = cms.InputTag("IsoProd","IsoTrackHORecHitCollection")
+TrackAssociatorParameterBlock.TrackAssociatorParameters.HBHERecHitCollectionLabel = cms.InputTag("hbhereco")
+TrackAssociatorParameterBlock.TrackAssociatorParameters.useHO = cms.bool(False)  # no HO hits saved in the alcareco
 
 process.energyOverMomentumTree = cms.EDAnalyzer('EopTreeWriter',
-    TrackAssociatorParameterBlock
-)
-process.energyOverMomentumTree.src = cms.InputTag('TrackRefitter')
-#process.energyOverMomentumTree.src = cms.InputTag('TkAlIsoProd:')
+                                                TrackAssociatorParameterBlock,
+                                                src = cms.InputTag('TrackRefitter'))
 
+####################################################################
+# output file
+####################################################################
 process.TFileService = cms.Service("TFileService",
     fileName = cms.string('test_EopTree.root')
 )
 
-process.p = cms.Path(process.MeasurementTrackerEvent*process.offlineBeamSpot*process.TrackRefitter*process.energyOverMomentumTree)
-#process.p = cms.Path(process.offlineBeamSpot*process.AlignmentTrackSelector*process.TrackRefitter*process.energyOverMomentumTree)
+####################################################################
+# Path
+####################################################################
+process.p = cms.Path(process.MeasurementTrackerEvent*
+                     process.offlineBeamSpot*
+                     process.AlignmentTrackSelector*
+                     process.TrackRefitter*
+                     process.energyOverMomentumTree)

--- a/Alignment/OfflineValidation/test/inspectData_cfg.py
+++ b/Alignment/OfflineValidation/test/inspectData_cfg.py
@@ -148,7 +148,7 @@ process.TrackRefitter1 = process.TrackRefitterP5.clone(
 ###################################################################
 from CommonTools.RecoAlgos.ptMaxTrackCountFilter_cfi import ptMaxTrackCountFilter
 process.myfilter = ptMaxTrackCountFilter.clone(src = cms.InputTag(options.trackCollection),
-                                               ptMax = cms.double(3.))
+                                               ptMax = cms.double(10.))
 
 process.preAnaSeq = cms.Sequence()
 if(options.unitTest):

--- a/Alignment/OfflineValidation/test/testEoP.sh
+++ b/Alignment/OfflineValidation/test/testEoP.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING DiMuonVertexValidation ..."
+cmsRun ${LOCAL_TEST_DIR}/DiMuonVertexValidation_cfg.py maxEvents=10 || die "Failure running DiMuonVertexValidation_cfg.py" $?
+
+echo "TESTING inspectData ..."
+cmsRun ${LOCAL_TEST_DIR}/inspectData_cfg.py unitTest=True || die "Failure running inspectData_cfg.py" $?
+
+echo "TESTING eopTreeWriter (Pion Analysis) ..."
+cmsRun ${LOCAL_TEST_DIR}/eopTreeWriter_cfg.py unitTest=True maxEvents=10 || die "Failure running eopTreeWriter" $?
+
+echo "TESTING eopElecTreeWriter (Electron Analysis) ..."
+cmsRun ${LOCAL_TEST_DIR}/eopElecTreeWriter_cfg.py maxEvents=10 || die "Failure running eopElecTreeWriter" $?

--- a/Alignment/OfflineValidation/test/testPVValidation.sh
+++ b/Alignment/OfflineValidation/test/testPVValidation.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING Alignment/OfflineValidation ..."
+cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_all_cfg.py" $?

--- a/Alignment/OfflineValidation/test/testSubmitters.sh
+++ b/Alignment/OfflineValidation/test/testSubmitters.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+function die { echo $1: status $2 ; exit $2; }
+
+echo " TESTING Primary Vertex Validation run-by-run submission ..."
+submitPVValidationJobs.py -j UNIT_TEST -D /HLTPhysics/Run2016C-TkAlMinBias-07Dec2018-v1/ALCARECO -i ${LOCAL_TEST_DIR}/testPVValidation_Relvals_DATA.ini -r --unitTest || die "Failure running PV Validation run-by-run submission" $?
+
+printf "\n\n"
+
+echo " TESTING Split Vertex Validation submission ..."
+submitPVResolutionJobs.py -j UNIT_TEST -D /JetHT/Run2018C-TkAlMinBias-12Nov2019_UL2018-v2/ALCARECO -i ${LOCAL_TEST_DIR}/PVResolutionExample.ini --unitTest || die "Failure running Split Vertex Validation submission" $?

--- a/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
+++ b/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
@@ -8,8 +8,30 @@ elif REFIT and not MISALIGN:
 elif REFIT and MISALIGN:
     print "REFIT + MISALIGN"
 else :
-    print "ERROR! ARRETE"
+    print "ERROR! STOP!"
+    exit
     
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing("analysis")
+
+options.register ('outputRootFile',
+                  "test_EOverP.root",
+                  VarParsing.VarParsing.multiplicity.singleton, # singleton or list
+                  VarParsing.VarParsing.varType.string,         # string, int, or float
+                  "output root file")
+
+options.register ('GlobalTag',
+                  'auto:phase1_2021_realistic',
+                  VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
+                  VarParsing.VarParsing.varType.string,          # string, int, or float
+                  "Global Tag to be used")
+
+options.parseArguments()
+
+print "conditionGT       : ", options.GlobalTag
+print "outputFile        : ", options.outputRootFile
+print "maxEvents         : ", options.maxEvents
+
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("EnergyOverMomentumTree")
     
@@ -36,7 +58,7 @@ process.source = cms.Source("PoolSource",
                             ))
                         
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(options.maxEvents)
 )
 
 ####################################################################
@@ -64,7 +86,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
 ####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
 
 # choose geometry
 if MISALIGN:
@@ -116,7 +138,7 @@ else:
     process.energyOverMomentumTree.src = cms.InputTag('electronGsfTracks')
      
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string('TheTree.root')
+                                   fileName = cms.string(options.outputRootFile)
                                    )
  
 if REFIT:

--- a/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
+++ b/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
@@ -1,0 +1,130 @@
+REFIT = True
+MISALIGN = False
+
+if not REFIT and not MISALIGN:
+    print "Normal mode"
+elif REFIT and not MISALIGN:
+    print "REFIT only MODE"
+elif REFIT and MISALIGN:
+    print "REFIT + MISALIGN"
+else :
+    print "ERROR! ARRETE"
+    
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("EnergyOverMomentumTree")
+    
+# initialize MessageLogger and output report
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.categories.append('TrackRefitter')
+    
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False))
+    
+# define input files
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(
+                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/40A29188-FF71-7C47-95FE-08785E537771.root',
+                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/7CF278C4-12CD-F040-BF72-1762962CE462.root',
+                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/13962B5C-0A48-124F-BC96-F36AD105FA6D.root',
+                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/DEA8B720-65E0-DC41-ACE0-CFF13279C27C.root',
+                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/88395EE9-0488-1C42-B90E-4907CDB0C006.root',
+                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/632A8DE3-F013-2345-9AF4-BBFC86063FD6.root',
+                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/65F7BE52-5536-A64E-8CB7-C177A96E5133.root',
+                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/B5AC0FDE-0CB1-C443-9390-97EA55494923.root',
+                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/78B0EC4E-2ECE-7842-872C-20466D17B36E.root'
+                                #'/store/relval/CMSSW_11_0_0_pre7/RelValZEE_13/GEN-SIM-RECO/PUpmx25ns_110X_mc2017_realistic_v1_rsb-v1/10000/CD0B4494-A24B-CB46-B4B7-80A523EA5D59.root')
+                            ))
+                        
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+####################################################################
+# Load  electron configuration files
+####################################################################
+process.load("TrackingTools.GsfTracking.GsfElectronFit_cff")
+
+####################################################################
+# Get the Magnetic Field
+####################################################################
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+
+###################################################################
+# Standard loads
+###################################################################
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+
+####################################################################
+# Get the BeamSpot
+####################################################################
+process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
+
+####################################################################
+# Get the GlogalTag
+####################################################################
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2021_realistic', '')
+
+# choose geometry
+if MISALIGN:
+    print "MISALIGN"
+    from CondCore.DBCommon.CondDBSetup_cfi import *
+    process.trackerAlignment = cms.ESSource("PoolDBESSource",
+                                            CondDBSetup,
+                                            toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentRcd"),
+                                                                       tag = cms.string("TrackerAlignment_2010Realistic_mc")
+                                                                   )
+                                                               ),
+                                            connect = cms.string("sqlite_file:twist1p5.db")
+                                            )
+    process.es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource", "trackerAlignment")
+
+    process.trackerAPE = cms.ESSource("PoolDBESSource",CondDBSetup,
+                                      toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentErrorRcd"),
+                                                                 tag = cms.string("TrackerAlignmentErrors_2010Realistic_mc")
+                                                             )
+                                                    ),
+                                      connect = cms.string("sqlite_file:twist1p5.db")
+    )
+    process.es_prefer_TrackerAPE = cms.ESPrefer("PoolDBESSource", "trackerAPE")
+    
+else:
+    print "NO MISALIGN"
+    
+# configure Gsf track refitter
+if REFIT:
+    print "REFIT"
+    process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
+    import RecoTracker.TrackProducer.TrackRefitters_cff
+    process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+    process.load("TrackingTools.GsfTracking.fwdGsfElectronPropagator_cff")
+    process.load("RecoTracker.TrackProducer.GsfTrackRefitter_cff")
+    process.GsfTrackRefitter.src = cms.InputTag('electronGsfTracks')  
+    process.GsfTrackRefitter.TrajectoryInEvent = True
+    process.GsfTrackRefitter.AlgorithmName = cms.string('gsf')
+else:
+    print "NO REFIT"
+
+process.load("Alignment.OfflineValidation.eopElecTreeWriter_cfi")
+
+if REFIT:
+    print "REFIT"
+    process.energyOverMomentumTree.src = cms.InputTag('GsfTrackRefitter')
+else:
+    print "NO REFIT"
+    process.energyOverMomentumTree.src = cms.InputTag('electronGsfTracks')
+     
+process.TFileService = cms.Service("TFileService",
+                                   fileName = cms.string('TheTree.root')
+                                   )
+ 
+if REFIT:
+    print "REFIT"
+    process.p = cms.Path(process.offlineBeamSpot*
+                         process.GsfTrackRefitter*
+                         process.energyOverMomentumTree)    
+else:
+    print "NO REFIT"
+    process.p = cms.Path(process.offlineBeamSpot*
+                         process.energyOverMomentumTree)

--- a/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
+++ b/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
@@ -1,21 +1,21 @@
 REFIT = True
-MISALIGN = False
+MISALIGN = True
 
 if not REFIT and not MISALIGN:
-    print "Normal mode"
+    print( "Normal mode")
 elif REFIT and not MISALIGN:
-    print "REFIT only MODE"
+    print( "REFIT only MODE")
 elif REFIT and MISALIGN:
-    print "REFIT + MISALIGN"
+    print( "REFIT + MISALIGN")
 else :
-    print "ERROR! STOP!"
+    print( "ERROR! STOP!")
     exit
     
 import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing("analysis")
 
 options.register ('outputRootFile',
-                  "test_EOverP.root",
+                  "test_EOverP_Electrons.root",
                   VarParsing.VarParsing.multiplicity.singleton, # singleton or list
                   VarParsing.VarParsing.varType.string,         # string, int, or float
                   "output root file")
@@ -28,9 +28,9 @@ options.register ('GlobalTag',
 
 options.parseArguments()
 
-print "conditionGT       : ", options.GlobalTag
-print "outputFile        : ", options.outputRootFile
-print "maxEvents         : ", options.maxEvents
+print( "conditionGT       : ", options.GlobalTag)
+print( "outputFile        : ", options.outputRootFile)
+print( "maxEvents         : ", options.maxEvents)
 
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("EnergyOverMomentumTree")
@@ -38,24 +38,18 @@ process = cms.Process("EnergyOverMomentumTree")
 # initialize MessageLogger and output report
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-process.MessageLogger.categories.append('TrackRefitter')
+process.MessageLogger.TrackRefitter=dict()
     
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False))
     
 # define input files
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
-                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/40A29188-FF71-7C47-95FE-08785E537771.root',
-                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/7CF278C4-12CD-F040-BF72-1762962CE462.root',
-                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/13962B5C-0A48-124F-BC96-F36AD105FA6D.root',
-                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/DEA8B720-65E0-DC41-ACE0-CFF13279C27C.root',
-                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/88395EE9-0488-1C42-B90E-4907CDB0C006.root',
-                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/632A8DE3-F013-2345-9AF4-BBFC86063FD6.root',
-                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/65F7BE52-5536-A64E-8CB7-C177A96E5133.root',
-                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/B5AC0FDE-0CB1-C443-9390-97EA55494923.root',
-                                '/store/relval/CMSSW_11_0_0_patch1/RelValZEE_14/GEN-SIM-RECO/PU_110X_mcRun3_2021_realistic_v6-v1/20000/78B0EC4E-2ECE-7842-872C-20466D17B36E.root'
-                                #'/store/relval/CMSSW_11_0_0_pre7/RelValZEE_13/GEN-SIM-RECO/PUpmx25ns_110X_mc2017_realistic_v1_rsb-v1/10000/CD0B4494-A24B-CB46-B4B7-80A523EA5D59.root')
-                            ))
+                                '/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/03CA556E-7056-394F-A105-5270966A8CF6.root',
+'/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/8E8874B1-A3BC-9F4A-AF74-AE65F9B6634D.root',
+'/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/06228194-EA17-354B-9114-89E67DEF2131.root',
+'/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/DE56DFA4-DBF1-3D4A-A9F3-50ADDCFF3D93.root',
+'/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/FE109BAC-006F-4E43-890F-CFD14491E207.root'))
                         
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(options.maxEvents)
@@ -74,6 +68,7 @@ process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cf
 ###################################################################
 # Standard loads
 ###################################################################
+from Configuration.Geometry.GeometryRecoDB_cff import *
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
 
 ####################################################################
@@ -90,33 +85,33 @@ process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
 
 # choose geometry
 if MISALIGN:
-    print "MISALIGN"
+    print( "MISALIGN")
     from CondCore.DBCommon.CondDBSetup_cfi import *
     process.trackerAlignment = cms.ESSource("PoolDBESSource",
                                             CondDBSetup,
                                             toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentRcd"),
-                                                                       tag = cms.string("TrackerAlignment_2010Realistic_mc")
+									tag = cms.string("TrackerAlignment_2017_ultralegacymc_v2")
                                                                    )
                                                                ),
-                                            connect = cms.string("sqlite_file:twist1p5.db")
+					connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
                                             )
     process.es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource", "trackerAlignment")
 
     process.trackerAPE = cms.ESSource("PoolDBESSource",CondDBSetup,
                                       toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentErrorRcd"),
-                                                                 tag = cms.string("TrackerAlignmentErrors_2010Realistic_mc")
+								tag = cms.string("TrackerAlignmentExtendedErrors_2017_ultralegacymc_v2")
                                                              )
                                                     ),
-                                      connect = cms.string("sqlite_file:twist1p5.db")
+				connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
     )
     process.es_prefer_TrackerAPE = cms.ESPrefer("PoolDBESSource", "trackerAPE")
     
 else:
-    print "NO MISALIGN"
+    print( "NO MISALIGN")
     
 # configure Gsf track refitter
 if REFIT:
-    print "REFIT"
+    print( "REFIT")
     process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
     import RecoTracker.TrackProducer.TrackRefitters_cff
     process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
@@ -126,15 +121,15 @@ if REFIT:
     process.GsfTrackRefitter.TrajectoryInEvent = True
     process.GsfTrackRefitter.AlgorithmName = cms.string('gsf')
 else:
-    print "NO REFIT"
+    print( "NO REFIT")
 
 process.load("Alignment.OfflineValidation.eopElecTreeWriter_cfi")
 
 if REFIT:
-    print "REFIT"
+    print( "REFIT")
     process.energyOverMomentumTree.src = cms.InputTag('GsfTrackRefitter')
 else:
-    print "NO REFIT"
+    print( "NO REFIT")
     process.energyOverMomentumTree.src = cms.InputTag('electronGsfTracks')
      
 process.TFileService = cms.Service("TFileService",
@@ -142,11 +137,11 @@ process.TFileService = cms.Service("TFileService",
                                    )
  
 if REFIT:
-    print "REFIT"
+    print( "REFIT")
     process.p = cms.Path(process.offlineBeamSpot*
                          process.GsfTrackRefitter*
                          process.energyOverMomentumTree)    
 else:
-    print "NO REFIT"
+    print( "NO REFIT")
     process.p = cms.Path(process.offlineBeamSpot*
                          process.energyOverMomentumTree)

--- a/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
+++ b/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
@@ -1,5 +1,5 @@
-REFIT = True
-MISALIGN = True
+REFIT = False
+MISALIGN = False
 
 if not REFIT and not MISALIGN:
     print( "Normal mode")
@@ -45,11 +45,15 @@ process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False))
 # define input files
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
-                                '/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/03CA556E-7056-394F-A105-5270966A8CF6.root',
-'/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/8E8874B1-A3BC-9F4A-AF74-AE65F9B6634D.root',
-'/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/06228194-EA17-354B-9114-89E67DEF2131.root',
-'/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/DE56DFA4-DBF1-3D4A-A9F3-50ADDCFF3D93.root',
-'/store/relval/CMSSW_10_5_0/RelValZEE_13/GEN-SIM-RECO/PU25ns_105X_upgrade2018_realistic_EcalHcal_v2_HS-v1/10000/FE109BAC-006F-4E43-890F-CFD14491E207.root'))
+                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/4a1ae43b-f4b3-4ad9-b86e-a7d9f6fc5c40.root',
+                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/33565608-3cac-47fe-a1fc-aef60f866b3a.root',
+                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/87fa96e1-925f-4cd3-878d-98a735737e55.root',
+                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/ea3a1cc8-720f-4392-9f0b-bd04d7f236a8.root',
+                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/3b3e7330-6174-43f3-8a49-c12eeae4d7f2.root',
+                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/ddc48c68-781c-485b-887e-4fcd6f0e0772.root',
+                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/a366a7ca-b71c-457a-8b64-09040f5b5819.root',
+                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/4758604c-b0c1-4e09-a0d4-38dd0da16789.root',
+                                '/store/relval/CMSSW_12_4_0_pre4/RelValZEE_14/GEN-SIM-RECO/PU_124X_mcRun3_2021_realistic_v1-v1/2580000/48985150-6f47-4a7f-b09f-b6301b7ec6ff.root'))
                         
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(options.maxEvents)
@@ -86,23 +90,23 @@ process.GlobalTag = GlobalTag(process.GlobalTag, options.GlobalTag, '')
 # choose geometry
 if MISALIGN:
     print( "MISALIGN")
-    from CondCore.DBCommon.CondDBSetup_cfi import *
+    from CondCore.CondDB.CondDB_cfi import CondDB
+    CondDB.connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
     process.trackerAlignment = cms.ESSource("PoolDBESSource",
-                                            CondDBSetup,
+                                            CondDB,
                                             toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentRcd"),
-									tag = cms.string("TrackerAlignment_2017_ultralegacymc_v2")
-                                                                   )
-                                                               ),
-					connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-                                            )
+                                                                       tag = cms.string("TrackerAlignment_2017_ultralegacymc_v2")
+                                                                       )
+                                                          )
+    )
     process.es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource", "trackerAlignment")
 
-    process.trackerAPE = cms.ESSource("PoolDBESSource",CondDBSetup,
+    process.trackerAPE = cms.ESSource("PoolDBESSource",
+                                      CondDB,
                                       toGet = cms.VPSet(cms.PSet(record = cms.string("TrackerAlignmentErrorRcd"),
-								tag = cms.string("TrackerAlignmentExtendedErrors_2017_ultralegacymc_v2")
-                                                             )
-                                                    ),
-				connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+                                                                 tag = cms.string("TrackerAlignmentExtendedErrors_2017_ultralegacymc_v2")
+                                                                 )
+                                                        )
     )
     process.es_prefer_TrackerAPE = cms.ESPrefer("PoolDBESSource", "trackerAPE")
     
@@ -138,10 +142,10 @@ process.TFileService = cms.Service("TFileService",
  
 if REFIT:
     print( "REFIT")
-    process.p = cms.Path(process.offlineBeamSpot*
-                         process.GsfTrackRefitter*
-                         process.energyOverMomentumTree)    
+    process.p = cms.Path(process.offlineBeamSpot
+                         *process.GsfTrackRefitter
+                         *process.energyOverMomentumTree)
 else:
     print( "NO REFIT")
-    process.p = cms.Path(process.offlineBeamSpot*
-                         process.energyOverMomentumTree)
+    process.p = cms.Path(process.offlineBeamSpot
+                         *process.energyOverMomentumTree)

--- a/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
+++ b/Alignment/OfflineValidation/test/test_EoPAnalysis_cfg.py
@@ -1,4 +1,4 @@
-REFIT = False
+REFIT = True
 MISALIGN = False
 
 if not REFIT and not MISALIGN:
@@ -21,7 +21,7 @@ options.register ('outputRootFile',
                   "output root file")
 
 options.register ('GlobalTag',
-                  'auto:phase1_2021_realistic',
+                  'auto:phase1_2022_realistic',
                   VarParsing.VarParsing.multiplicity.singleton,  # singleton or list
                   VarParsing.VarParsing.varType.string,          # string, int, or float
                   "Global Tag to be used")
@@ -33,12 +33,16 @@ print( "outputFile        : ", options.outputRootFile)
 print( "maxEvents         : ", options.maxEvents)
 
 import FWCore.ParameterSet.Config as cms
-process = cms.Process("EnergyOverMomentumTree")
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("EnergyOverMomentumTree",Run3)
     
+#process.Tracer = cms.Service("Tracer")
+
 # initialize MessageLogger and output report
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 process.MessageLogger.TrackRefitter=dict()
+process.MessageLogger.EopElecTreeWriter=dict()
     
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False))
     

--- a/Alignment/OfflineValidation/test/test_all-in-one.sh
+++ b/Alignment/OfflineValidation/test/test_all-in-one.sh
@@ -1,15 +1,9 @@
 #! /bin/bash
-
 function die { echo $1: status $2 ; exit $2; }
 
 if test -f "validation_config.ini"; then
     rm -f validation_config.ini
 fi
-
-echo "TESTING Alignment/OfflineValidation ..."
-cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_OfflineValidation_cfg.py" $?
-cmsRun ${LOCAL_TEST_DIR}/DiMuonVertexValidation_cfg.py maxEvents=10 || die "Failure running DiMuonVertexValidation_cfg.py" $?
-cmsRun ${LOCAL_TEST_DIR}/inspectData_cfg.py unitTest=True || die "Failure running inspectData_cfg.py" $?
 
 ## copy into local sqlite file the ideal alignment
 echo "COPYING locally Ideal Alignment ..."
@@ -166,12 +160,4 @@ do
   python3 $FILE/$f  || die "Failure compiling test configuration" $?
 done
 
-printf "\n\n"
 
-echo " TESTING Primary Vertex Validation run-by-run submission ..."
-submitPVValidationJobs.py -j UNIT_TEST -D /HLTPhysics/Run2016C-TkAlMinBias-07Dec2018-v1/ALCARECO -i ${LOCAL_TEST_DIR}/testPVValidation_Relvals_DATA.ini -r --unitTest || die "Failure running PV Validation run-by-run submission" $?
-
-printf "\n\n"
-
-echo " TESTING Split Vertex Validation submission ..."
-submitPVResolutionJobs.py -j UNIT_TEST -D /JetHT/Run2018C-TkAlMinBias-12Nov2019_UL2018-v2/ALCARECO -i ${LOCAL_TEST_DIR}/PVResolutionExample.ini --unitTest || die "Failure running Split Vertex Validation submission" $?


### PR DESCRIPTION
#### PR description:

This PR revamps the E/p validation tools (both with pions and electrons) that have been used in Run-1 to check the tracker geometry against weak modes (see recent [presentations](https://indico.cern.ch/category/1358/search?q=hohov) from @dhohov, and twiki with [Run-1 results](https://twiki.cern.ch/twiki/bin/view/CMSPublic/TkAlignmentEoverPResults) ).
The E/p tool with electrons has been resurrected from the CVS repository https://cmscvs.web.cern.ch/cmscvs/cgi/viewvc.cgi/cvsroot/UserCode/IPHC_Eop/ and modernized to comply with the more recent recommendations about code quality.
I profit of this PR to re-organize the unit tests to be more modular.
The PR is a *draft* for the time being, in order to not interfere with https://github.com/cms-sw/cmssw/pull/38304 

#### PR validation:

Relies on the augmented unit tests:
```console
scram build use-ibeos runtests
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, perhaps to be backported to 12.4.X
