### PR TITLE
Avoid ID collisions between ED and ES modules in MessageLogger

### DIFF
--- a/FWCore/MessageService/plugins/MessageLogger.cc
+++ b/FWCore/MessageService/plugins/MessageLogger.cc
@@ -764,7 +764,8 @@ namespace edm {
       if (label->empty() or (*label)[0] == '\0') {
         label = &desc->type_;
       }
-      messageDrop->setModuleWithPhase(desc->type_, *label, desc->id_, "@callESModule");
+      //make sure ES module IDs do not conflict with ED module IDs
+      messageDrop->setModuleWithPhase(desc->type_, *label, 1000000 + desc->id_, "@callESModule");
     }
     void MessageLogger::postESModule(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&) {
       MessageDrop* messageDrop = MessageDrop::instance();


### PR DESCRIPTION
#### PR description:

Separate IDs used by ED and ES modules when checking cache in MessageLogger.

#### PR validation:

Test case from reported issue now fixed.

fixes #38724