### PR TITLE
Preprocess EDAlias and SwitchProducer information for ConditionalTask

### DIFF
--- a/FWCore/Framework/interface/StreamSchedule.h
+++ b/FWCore/Framework/interface/StreamSchedule.h
@@ -114,6 +114,8 @@ namespace edm {
   class PreallocationConfiguration;
   class WaitingTaskHolder;
 
+  class ConditionalTaskHelper;
+
   namespace service {
     class TriggerNamesService;
   }
@@ -257,6 +259,13 @@ namespace edm {
 
     StreamContext const& context() const { return streamContext_; }
 
+    struct AliasInfo {
+      std::string friendlyClassName;
+      std::string instanceLabel;
+      std::string originalInstanceLabel;
+      std::string originalModuleLabel;
+    };
+
   private:
     //Sentry class to only send a signal if an
     // exception occurs. An exception is identified
@@ -289,12 +298,6 @@ namespace edm {
 
     void reportSkipped(EventPrincipal const& ep) const;
 
-    struct AliasInfo {
-      std::string friendlyClassName;
-      std::string instanceLabel;
-      std::string originalInstanceLabel;
-      std::string originalModuleLabel;
-    };
     std::vector<Worker*> tryToPlaceConditionalModules(
         Worker*,
         std::unordered_set<std::string>& conditionalModules,
@@ -311,7 +314,8 @@ namespace edm {
                      std::string const& name,
                      bool ignoreFilters,
                      PathWorkers& out,
-                     std::vector<std::string> const& endPathNames);
+                     std::vector<std::string> const& endPathNames,
+                     ConditionalTaskHelper const& conditionalTaskHelper);
     void fillTrigPath(ParameterSet& proc_pset,
                       ProductRegistry& preg,
                       PreallocationConfiguration const* prealloc,
@@ -319,14 +323,16 @@ namespace edm {
                       int bitpos,
                       std::string const& name,
                       TrigResPtr,
-                      std::vector<std::string> const& endPathNames);
+                      std::vector<std::string> const& endPathNames,
+                      ConditionalTaskHelper const& conditionalTaskHelper);
     void fillEndPath(ParameterSet& proc_pset,
                      ProductRegistry& preg,
                      PreallocationConfiguration const* prealloc,
                      std::shared_ptr<ProcessConfiguration const> processConfiguration,
                      int bitpos,
                      std::string const& name,
-                     std::vector<std::string> const& endPathNames);
+                     std::vector<std::string> const& endPathNames,
+                     ConditionalTaskHelper const& conditionalTaskHelper);
 
     void addToAllWorkers(Worker* w);
 


### PR DESCRIPTION
#### PR description:

Profiling https://github.com/cms-sw/cmssw/issues/38725 in https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/issue38725/hlt_ConditionalTask_06_perf/12 showed that a lot of time in an HLT job was spent in `edm::ParameterSet::getParameter<edm::ParameterSet>()` and `edm::detail::processEDAliases()`. These seemed to be caused by the processing of EDAliases and SwitchProducers for ConditionalTasks being repeated for all the Paths of the HLT menu (e.g. the SwitchProducer loop has N(paths) x N(modules)  overall complexity).

This PR attempts to speed up the job startup time by processing the EDAliases and SwitchProducers for ConditionalTasks only once for all Paths, leading to > 10x improvement in the `StreamSchedule` constructor
https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/issue38725/hlt_ConditionalTask_36_perf/12
bringing the time close to what it would be if the HLT menu would use Tasks instead of ConditionalTasks
https://mkortela.web.cern.ch/mkortela/cgi-bin/navigator/issue38725/hlt_Task_06_perf/12

Resolves #38725

#### PR validation:

Framework unit tests run.