### PR TITLE
avoid overflowing `firstStrip_` in case of approximated clusters

### DIFF
--- a/DataFormats/SiStripCluster/interface/SiStripCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripCluster.h
@@ -38,7 +38,7 @@ public:
       firstStrip_ |= mergedValueMask;  // if this is a candidate merged cluster
   }
 
-  SiStripCluster(const SiStripApproximateCluster cluster);
+  SiStripCluster(const SiStripApproximateCluster cluster, const uint16_t maxStrips);
 
   // extend the cluster
   template <typename Iter>

--- a/DataFormats/SiStripCluster/src/SiStripCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripCluster.cc
@@ -1,4 +1,4 @@
-
+#include "FWCore/Utilities/interface/Likely.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 
 SiStripCluster::SiStripCluster(const SiStripDigiRange& range) : firstStrip_(range.first->strip()), error_x(-99999.9) {
@@ -22,13 +22,19 @@ SiStripCluster::SiStripCluster(const SiStripDigiRange& range) : firstStrip_(rang
   amplitudes_ = v;
 }
 
-SiStripCluster::SiStripCluster(const SiStripApproximateCluster cluster) : error_x(-99999.9) {
+SiStripCluster::SiStripCluster(const SiStripApproximateCluster cluster, const uint16_t maxStrips) : error_x(-99999.9) {
   barycenter_ = cluster.barycenter();
   charge_ = cluster.width() * cluster.avgCharge();
   amplitudes_.resize(cluster.width(), cluster.avgCharge());
 
+  float halfwidth_ = 0.5f * float(cluster.width());
+
   //initialize firstStrip_
-  firstStrip_ = cluster.barycenter() - cluster.width() / 2;
+  firstStrip_ = std::max(barycenter_ - halfwidth_, 0.f);
+
+  if UNLIKELY (firstStrip_ + cluster.width() > maxStrips) {
+    firstStrip_ = maxStrips - cluster.width();
+  }
 }
 
 int SiStripCluster::charge() const {

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2Clusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2Clusters.cc
@@ -1,15 +1,18 @@
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/Common/interface/DetSetVector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include <vector>
 #include <memory>
@@ -23,11 +26,13 @@ public:
 
 private:
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripApproximateCluster>> clusterToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
 };
 
 SiStripApprox2Clusters::SiStripApprox2Clusters(const edm::ParameterSet& conf) {
   clusterToken_ = consumes<edmNew::DetSetVector<SiStripApproximateCluster>>(
       conf.getParameter<edm::InputTag>("inputApproxClusters"));
+  tkGeomToken_ = esConsumes();
   produces<edmNew::DetSetVector<SiStripCluster>>();
 }
 
@@ -35,11 +40,22 @@ void SiStripApprox2Clusters::produce(edm::StreamID id, edm::Event& event, const 
   auto result = std::make_unique<edmNew::DetSetVector<SiStripCluster>>();
   const auto& clusterCollection = event.get(clusterToken_);
 
+  const auto& tkGeom = &iSetup.getData(tkGeomToken_);
+  const auto tkDets = tkGeom->dets();
+
   for (const auto& detClusters : clusterCollection) {
     edmNew::DetSetVector<SiStripCluster>::FastFiller ff{*result, detClusters.id()};
+    unsigned int detId = detClusters.id();
+
+    uint16_t nStrips{0};
+    auto det = std::find_if(tkDets.begin(), tkDets.end(), [detId](auto& elem) -> bool {
+      return (elem->geographicalId().rawId() == detId);
+    });
+    const StripTopology& p = dynamic_cast<const StripGeomDetUnit*>(*det)->specificTopology();
+    nStrips = p.nstrips() - 1;
 
     for (const auto& cluster : detClusters) {
-      ff.push_back(SiStripCluster(cluster));
+      ff.push_back(SiStripCluster(cluster, nStrips));
     }
   }
 


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/38729

#### PR description:

See https://github.com/cms-sw/cmssw/issues/38729#issuecomment-1184237934

#### PR validation:

Tested running 140.58 successfully under `CMSSW_12_5_ASAN_X_2022-07-13-1100`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
