### PR TITLE
update unit tests for G4e refitter package

### DIFF
--- a/TrackPropagation/Geant4e/test/BuildFile.xml
+++ b/TrackPropagation/Geant4e/test/BuildFile.xml
@@ -16,3 +16,5 @@
 </library>
 
 <test name="testG4Refitter" command="cmsRun ${LOCALTOP}/src/TrackPropagation/Geant4e/test/Geant4e_example_cfg.py"/>
+<test name="testG4SimplePropagator" command="cmsRun ${LOCALTOP}/src/TrackPropagation/Geant4e/test/simpleTestPropagator_cfg.py"/>
+<test name="testG4PropagatorAnalyzer" command="cmsRun ${LOCALTOP}/src/TrackPropagation/Geant4e/test/testPropagatorAnalyzer_cfg.py"/>

--- a/TrackPropagation/Geant4e/test/Geant4ePropagatorAnalyzer.cc
+++ b/TrackPropagation/Geant4e/test/Geant4ePropagatorAnalyzer.cc
@@ -56,7 +56,7 @@ enum testMuChamberType { DT, RPC, CSC };
 class Geant4ePropagatorAnalyzer : public edm::one::EDAnalyzer<> {
 public:
   explicit Geant4ePropagatorAnalyzer(const edm::ParameterSet &);
-  ~Geant4ePropagatorAnalyzer() override {}
+  ~Geant4ePropagatorAnalyzer() override = default;
 
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void endJob() override;
@@ -67,7 +67,7 @@ public:
                        const FreeTrajectoryState &ftsTrack);
 
 protected:
-  // tokens
+  // event setup tokens
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken;
   const edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeomToken;
   const edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeomToken;
@@ -133,8 +133,14 @@ protected:
   TH1F *fSLayerNegPhi;
   TH1F *fLayerNegPhi;
 
-  edm::InputTag G4VtxSrc_;
+  // event data tokens
   edm::InputTag G4TrkSrc_;
+  edm::InputTag G4VtxSrc_;
+  const edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken_;
+  const edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken_;
+  const edm::EDGetTokenT<edm::PSimHitContainer> simHitsDTToken_;
+  const edm::EDGetTokenT<edm::PSimHitContainer> simHitsCSCToken_;
+  const edm::EDGetTokenT<edm::PSimHitContainer> simHitsRPCToken_;
 };
 
 Geant4ePropagatorAnalyzer::Geant4ePropagatorAnalyzer(const edm::ParameterSet &iConfig)
@@ -145,10 +151,13 @@ Geant4ePropagatorAnalyzer::Geant4ePropagatorAnalyzer(const edm::ParameterSet &iC
       theRun(-1),
       theEvent(-1),
       thePropagator(nullptr),
+      G4TrkSrc_(iConfig.getParameter<edm::InputTag>("G4TrkSrc")),
       G4VtxSrc_(iConfig.getParameter<edm::InputTag>("G4VtxSrc")),
-      G4TrkSrc_(iConfig.getParameter<edm::InputTag>("G4TrkSrc")) {
-  auto token = consumes(G4TrkSrc_);
-
+      simTrackToken_(consumes<edm::SimTrackContainer>(G4TrkSrc_)),
+      simVertexToken_(consumes<edm::SimVertexContainer>(G4VtxSrc_)),
+      simHitsDTToken_(consumes<edm::PSimHitContainer>(edm::InputTag("g4SimHits", "MuonDTHits"))),
+      simHitsCSCToken_(consumes<edm::PSimHitContainer>(edm::InputTag("g4SimHits", "MuonCSCHits"))),
+      simHitsRPCToken_(consumes<edm::PSimHitContainer>(edm::InputTag("g4SimHits", "MuonRPCHits"))) {
   // debug_ = iConfig.getParameter<bool>("debug");
   fStudyStation = iConfig.getParameter<int>("StudyStation");
 
@@ -332,44 +341,37 @@ void Geant4ePropagatorAnalyzer::analyze(const edm::Event &iEvent, const edm::Eve
 
   ///////////////////////////////////////
   // Get the sim tracks & vertices
-  Handle<SimTrackContainer> simTracks;
-  iEvent.getByLabel<SimTrackContainer>(G4TrkSrc_, simTracks);
+  Handle<SimTrackContainer> simTracks = iEvent.getHandle(simTrackToken_);
   if (!simTracks.isValid()) {
     LogWarning("Geant4e") << "No tracks found" << std::endl;
-    //    return;
+    return;
   }
   LogDebug("Geant4e") << "G4e -- Got simTracks of size " << simTracks->size();
-  std::cout << "Geant4e "
-            << "G4e -- Got simTracks of size " << simTracks->size() << std::endl;
 
-  Handle<SimVertexContainer> simVertices;
-  iEvent.getByLabel<SimVertexContainer>("g4SimHits", simVertices);
+  Handle<SimVertexContainer> simVertices = iEvent.getHandle(simVertexToken_);
   if (!simVertices.isValid()) {
-    LogWarning("Geant4e") << "No verticess found" << std::endl;
-    //    return;
+    LogWarning("Geant4e") << "No vertices found" << std::endl;
+    return;
   }
   LogDebug("Geant4e") << "Got simVertices of size " << simVertices->size();
 
   ///////////////////////////////////////
   // Get the sim hits for the different muon parts
-  Handle<PSimHitContainer> simHitsDT;
-  iEvent.getByLabel("g4SimHits", "MuonDTHits", simHitsDT);
+  Handle<PSimHitContainer> simHitsDT = iEvent.getHandle(simHitsDTToken_);
   if (!simHitsDT.isValid()) {
     LogWarning("Geant4e") << "No hits found" << std::endl;
     return;
   }
   LogDebug("Geant4e") << "Got MuonDTHits of size " << simHitsDT->size();
 
-  Handle<PSimHitContainer> simHitsCSC;
-  iEvent.getByLabel("g4SimHits", "MuonCSCHits", simHitsCSC);
+  Handle<PSimHitContainer> simHitsCSC = iEvent.getHandle(simHitsCSCToken_);
   if (!simHitsCSC.isValid()) {
     LogWarning("Geant4e") << "No hits found" << std::endl;
     return;
   }
   LogDebug("Geant4e") << "Got MuonCSCHits of size " << simHitsCSC->size();
 
-  Handle<PSimHitContainer> simHitsRPC;
-  iEvent.getByLabel("g4SimHits", "MuonRPCHits", simHitsRPC);
+  Handle<PSimHitContainer> simHitsRPC = iEvent.getHandle(simHitsRPCToken_);
   if (!simHitsRPC.isValid()) {
     LogWarning("Geant4e") << "No hits found" << std::endl;
     return;

--- a/TrackPropagation/Geant4e/test/Geant4e_example_cfg.py
+++ b/TrackPropagation/Geant4e/test/Geant4e_example_cfg.py
@@ -32,12 +32,10 @@ process.source = cms.Source("PoolSource",
     ),
 )
 
-
 process.load("TrackPropagation.Geant4e.geantRefit_cff")
 process.Geant4eTrackRefitter.src = cms.InputTag("generalTracks")
 process.Geant4eTrackRefitter.usePropagatorForPCA = cms.bool(True)
 process.g4RefitPath = cms.Path( process.MeasurementTrackerEvent * process.geant4eTrackRefit )
-
 
 process.out = cms.OutputModule( "PoolOutputModule",
   outputCommands = cms.untracked.vstring(

--- a/TrackPropagation/Geant4e/test/SimpleGeant4ePropagatorTest.cc
+++ b/TrackPropagation/Geant4e/test/SimpleGeant4ePropagatorTest.cc
@@ -37,7 +37,7 @@
 class SimpleGeant4ePropagatorTest final : public edm::one::EDAnalyzer<> {
 public:
   explicit SimpleGeant4ePropagatorTest(const edm::ParameterSet &);
-  ~SimpleGeant4ePropagatorTest() override {}
+  ~SimpleGeant4ePropagatorTest() override = default;
 
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 

--- a/TrackPropagation/Geant4e/test/simpleTestPropagator_cfg.py
+++ b/TrackPropagation/Geant4e/test/simpleTestPropagator_cfg.py
@@ -1,15 +1,11 @@
 import FWCore.ParameterSet.Config as cms
-
 from Configuration.Eras.Era_Run3_cff import Run3
 
-#process = cms.Process("PROPAGATORTEST")
 process = cms.Process("PROPAGATORTEST",Run3)
 
-
-
-  #####################################################################
-  # Message Logger ####################################################
-  #
+####################################################
+# Message Logger 
+####################################################  
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.StandardSequences.GeometryDB_cff')
@@ -20,12 +16,11 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run1_mc', '')
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic', '')
 
-process.load("FWCore.MessageService.MessageLogger_cfi")
-
+####################################################
 # MessageLogger customizations
+####################################################
 process.MessageLogger.cerr.enable = False
 process.MessageLogger.cout.enable = True
 labels = ["propTest", "geopro"] # Python module's label
@@ -44,13 +39,14 @@ for category in labels:
       # Then modify them
       setattr(process.MessageLogger.files, category, messageLogger[main_key])
 
-
 process.source = cms.Source("EmptySource")
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
+####################################################
 ## Set up geometry
+####################################################
 from SimG4Core.Application.g4SimHits_cfi import g4SimHits as _g4SimHits
 process.geopro = cms.EDProducer("GeometryProducer",
      GeoFromDD4hep = cms.bool(False),
@@ -62,11 +58,11 @@ process.geopro = cms.EDProducer("GeometryProducer",
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 dd4hep.toModify(process.geopro, GeoFromDD4hep = True )
 
-
-# Extrapolator ######################################################
+####################################################
+# Extrapolator
+####################################################
 process.propTest = cms.EDAnalyzer("SimpleGeant4ePropagatorTest",
 )
-
 
 process.g4TestPath = cms.Path( process.geopro*process.propTest )
 process.schedule = cms.Schedule( process.g4TestPath )

--- a/TrackPropagation/Geant4e/test/testPropagatorAnalyzer_cfg.py
+++ b/TrackPropagation/Geant4e/test/testPropagatorAnalyzer_cfg.py
@@ -1,15 +1,11 @@
 import FWCore.ParameterSet.Config as cms
-
-
 from Configuration.Eras.Era_Run3_cff import Run3
 
 process = cms.Process("PROPAGATORTEST",Run3)
 
-
-
-  #####################################################################
-  # Message Logger ####################################################
-  #
+#####################################################
+# Message Logger 
+#####################################################
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.StandardSequences.GeometryDB_cff')
@@ -20,12 +16,11 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run1_mc', '')
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic', '')
 
-process.load("FWCore.MessageService.MessageLogger_cfi")
-
+####################################################
 # MessageLogger customizations
+####################################################
 process.MessageLogger.cerr.enable = False
 process.MessageLogger.cout.enable = True
 labels = ["propAna", "geopro"] # Python module's label
@@ -44,10 +39,9 @@ for category in labels:
       # Then modify them
       setattr(process.MessageLogger.files, category, messageLogger[main_key])
 
-
-#####################################################################
-# Pool Source #######################################################
-#
+#######################################################
+# Pool Source 
+#######################################################
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
       '/store/relval/CMSSW_12_5_0_pre3/RelValSingleMuPt10/GEN-SIM-RECO/124X_mcRun3_2022_realistic_v8-v2/10000/6a6528c0-9d66-4358-bacc-158c40b439cf.root'
@@ -56,13 +50,15 @@ process.source = cms.Source("PoolSource",
   
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(20) )
 
+####################################################
 ## Load propagator
+####################################################
 from TrackPropagation.Geant4e.Geant4ePropagator_cfi import *
-
-
 from TrackingTools.TrackRefitter.TracksToTrajectories_cff import *
 
+####################################################
 ## Set up geometry
+####################################################
 from SimG4Core.Application.g4SimHits_cfi import g4SimHits as _g4SimHits
 process.geopro = cms.EDProducer("GeometryProducer",
      GeoFromDD4hep = cms.bool(False),
@@ -74,9 +70,9 @@ process.geopro = cms.EDProducer("GeometryProducer",
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 dd4hep.toModify(process.geopro, GeoFromDD4hep = True )
 
-#####################################################################
-# Extrapolator ######################################################
-#
+######################################################
+# Extrapolator 
+######################################################
 process.propAna = cms.EDAnalyzer("Geant4ePropagatorAnalyzer",
     G4VtxSrc = cms.InputTag("g4SimHits"),
     G4TrkSrc = cms.InputTag("g4SimHits"),
@@ -85,7 +81,6 @@ process.propAna = cms.EDAnalyzer("Geant4ePropagatorAnalyzer",
     BeamInterval = cms.double(20), #degrees
     StudyStation = cms.int32(-1) #Station that we want to study. -1 for all.
 )
-
 
 process.g4AnalPath = cms.Path( process.geopro*process.propAna )
 process.schedule = cms.Schedule( process.g4AnalPath )


### PR DESCRIPTION
#### PR description:

Since there are widespread plans of using the G4e refitting technology for both the muon momentum scale calibration for the W mass analysis and for the global tracker alignment procedure, it's important that we start testing it.
https://github.com/cms-sw/cmssw/pull/38864 fixed the issues that prevented the correct testing of the package and introduced a simple analyzer for track extrapolation checks. This PR adds the consumes to the existing test analyzer and adds both of them to the unit tests of this package.

#### PR validation:

Relies on the add unit tests, that have been successfully exercised with `scram b runtests`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

cc:
@bendavid 
