### PR TITLE
Avoid ID collisions between ED and ES modules in MessageLogger [12_3]

### DIFF
--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep.txt
@@ -12,3 +12,4 @@ got data of type "edmtest::Doodad" with name "abcd" in record GadgetRcd
 ++++++++ finished: processing esmodule: label = '' type = DoodadESSource in record = GadgetRcd
 got data of type "edmtest::Doodad" with name "abc" in record GadgetRcd
 got data of type "edmtest::Doodad" with name "abc" in record GadgetRcd
+   23 Tracer               -s DoodadESSource:D                       4        4

--- a/FWCore/MessageService/plugins/MessageLogger.cc
+++ b/FWCore/MessageService/plugins/MessageLogger.cc
@@ -764,7 +764,8 @@ namespace edm {
       if (label->empty() or (*label)[0] == '\0') {
         label = &desc->type_;
       }
-      messageDrop->setModuleWithPhase(desc->type_, *label, desc->id_, "@callESModule");
+      //make sure ES module IDs do not conflict with ED module IDs
+      messageDrop->setModuleWithPhase(desc->type_, *label, 1000000 + desc->id_, "@callESModule");
     }
     void MessageLogger::postESModule(eventsetup::EventSetupRecordKey const&, ESModuleCallingContext const&) {
       MessageDrop* messageDrop = MessageDrop::instance();


### PR DESCRIPTION
#### PR description:

Separate IDs used by ED and ES modules when checking cache in MessageLogger.

backport of #38728

#### PR validation:

Code compiles.