### PR TITLE
Fix CMS deprecation warnings in L1TriggerConfig/GctConfigProducers

### DIFF
--- a/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigDump.h
+++ b/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigDump.h
@@ -15,23 +15,35 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // forward declarations
+class L1GctJetFinderParams;
+class L1GctChannelMask;
+class L1CaloEtScale;
+class L1GctJetFinderParamsRcd;
+class L1GctChannelMaskRcd;
+class L1JetEtScaleRcd;
+class L1HtMissScaleRcd;
+class L1HfRingEtScaleRcd;
 
 // class declaration
-class L1GctConfigDump : public edm::EDAnalyzer {
+class L1GctConfigDump : public edm::one::EDAnalyzer<> {
 public:
   // constructor
   explicit L1GctConfigDump(const edm::ParameterSet&);
 
-  // destructor
-  ~L1GctConfigDump() override;
-
   void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  const edm::ESGetToken<L1GctJetFinderParams, L1GctJetFinderParamsRcd> m_jfParamsToken;
+  const edm::ESGetToken<L1GctChannelMask, L1GctChannelMaskRcd> m_chanMaskToken;
+  const edm::ESGetToken<L1CaloEtScale, L1JetEtScaleRcd> m_jetScaleToken;
+  const edm::ESGetToken<L1CaloEtScale, L1HtMissScaleRcd> m_htmScaleToken;
+  const edm::ESGetToken<L1CaloEtScale, L1HfRingEtScaleRcd> m_hfRingScaleToken;
 };
 
 #endif

--- a/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigProducers.h
+++ b/L1TriggerConfig/GctConfigProducers/interface/L1GctConfigProducers.h
@@ -39,6 +39,7 @@ class L1GctChannelMask;
 
 class L1GctJetFinderParamsRcd;
 class L1GctChannelMaskRcd;
+class L1CaloGeometryRecord;
 
 //
 // class declaration
@@ -73,6 +74,8 @@ private:
 
   std::vector<std::vector<double> > m_jetCalibFunc;
   std::vector<std::vector<double> > m_tauCalibFunc;
+
+  edm::ESGetToken<L1CaloGeometry, L1CaloGeometryRecord> m_caloGeomToken;
 
   unsigned m_metEtaMask;
   unsigned m_tetEtaMask;

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctConfigDump.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctConfigDump.cc
@@ -25,32 +25,27 @@
 
 #include <iomanip>
 
-L1GctConfigDump::L1GctConfigDump(const edm::ParameterSet& pSet) {
-  // empty
-}
-
-// destructor
-L1GctConfigDump::~L1GctConfigDump() {
+L1GctConfigDump::L1GctConfigDump(const edm::ParameterSet& pSet)
+    : m_jfParamsToken{esConsumes()},
+      m_chanMaskToken{esConsumes()},
+      m_jetScaleToken{esConsumes()},
+      m_htmScaleToken{esConsumes()},
+      m_hfRingScaleToken{esConsumes()} {
   // empty
 }
 
 void L1GctConfigDump::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // get records
 
-  edm::ESHandle<L1GctJetFinderParams> jfParams;
-  iSetup.get<L1GctJetFinderParamsRcd>().get(jfParams);
+  edm::ESHandle<L1GctJetFinderParams> jfParams = iSetup.getHandle(m_jfParamsToken);
 
-  edm::ESHandle<L1GctChannelMask> chanMask;
-  iSetup.get<L1GctChannelMaskRcd>().get(chanMask);
+  edm::ESHandle<L1GctChannelMask> chanMask = iSetup.getHandle(m_chanMaskToken);
 
-  edm::ESHandle<L1CaloEtScale> jetScale;
-  iSetup.get<L1JetEtScaleRcd>().get(jetScale);
+  edm::ESHandle<L1CaloEtScale> jetScale = iSetup.getHandle(m_jetScaleToken);
 
-  edm::ESHandle<L1CaloEtScale> htmScale;
-  iSetup.get<L1HtMissScaleRcd>().get(htmScale);
+  edm::ESHandle<L1CaloEtScale> htmScale = iSetup.getHandle(m_htmScaleToken);
 
-  edm::ESHandle<L1CaloEtScale> hfRingScale;
-  iSetup.get<L1HfRingEtScaleRcd>().get(hfRingScale);
+  edm::ESHandle<L1CaloEtScale> hfRingScale = iSetup.getHandle(m_hfRingScaleToken);
 
   edm::LogInfo("L1GctConfigDump") << (*jfParams) << std::endl;
   edm::LogInfo("L1GctConfigDump") << (*chanMask) << std::endl;

--- a/L1TriggerConfig/GctConfigProducers/src/L1GctConfigProducers.cc
+++ b/L1TriggerConfig/GctConfigProducers/src/L1GctConfigProducers.cc
@@ -43,7 +43,7 @@ L1GctConfigProducers::L1GctConfigProducers(const edm::ParameterSet& iConfig)
       m_thtEtaMask(iConfig.getParameter<unsigned>("HtEtaMask")) {
   //the following lines are needed to tell the framework what
   // data is being produced
-  setWhatProduced(this, &L1GctConfigProducers::produceJfParams);
+  m_caloGeomToken = setWhatProduced(this, &L1GctConfigProducers::produceJfParams).consumes();
   setWhatProduced(this, &L1GctConfigProducers::produceChanMask);
 
   //now do what ever other initialization is needed
@@ -115,9 +115,7 @@ L1GctConfigProducers::~L1GctConfigProducers() {
 
 L1GctConfigProducers::JfParamsReturnType L1GctConfigProducers::produceJfParams(const L1GctJetFinderParamsRcd& aRcd) {
   // get geometry
-  const L1CaloGeometryRecord& geomRcd = aRcd.getRecord<L1CaloGeometryRecord>();
-  edm::ESHandle<L1CaloGeometry> geom;
-  geomRcd.get(geom);
+  edm::ESHandle<L1CaloGeometry> geom = aRcd.getHandle(m_caloGeomToken);
 
   // construct jet finder params object
   auto pL1GctJetFinderParams = std::make_unique<L1GctJetFinderParams>(m_rgnEtLsb,


### PR DESCRIPTION
#### PR description:

- changed to thread friendly types
- added esConsumes

#### PR validation:

Code compiles without issuing deprecation warnings.