### PR TITLE
Fix conddb dump functionality for tags and gts

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -2555,16 +2555,16 @@ def dump(args):
             filter(IOV.tag_name == name).\
             distinct():
             if args.format == 'xml':
-                xmlProcessor.payload2xml(session, payload)
+                xmlProcessor.payload2xml(session, payload, args.destfile)
             else:
                 _dump_payload(session, payload, args.loadonly)
 
-    elif args.type == 'gt' and _exists(session, conddb.GlobalTag.name, name) != None:
+    elif args.type == 'gt' and _exists(session, GlobalTag.name, name) != None:
         for payload, in session.query(IOV.payload_hash).\
             filter(GlobalTagMap.global_tag_name == name, IOV.tag_name == GlobalTagMap.tag_name).\
             distinct():
             if args.format == 'xml':
-                xmlProcessor.payload2xml(session, payload)
+                xmlProcessor.payload2xml(session, payload, args.destfile)
             else:
                 _dump_payload(session, payload, args.loadonly)
 

--- a/CondCore/Utilities/test/test_conddb.sh
+++ b/CondCore/Utilities/test/test_conddb.sh
@@ -43,7 +43,12 @@ conddb diffGlobalTagsAtRun -R 120X_mcRun3_2021_realistic_v1 -T 120X_mcRun3_2021_
 echo -ne '\n\n'
 
 echo "===========> testing conddb dump"
-conddb dump 4b97f78682aac6254bbcba54cedbde468202bf5b || die 'failed comparing metadata with reference' $?
+conddb dump 4b97f78682aac6254bbcba54cedbde468202bf5b || die 'failed conddb dump payload' $?
+conddb dump 4b97f78682aac6254bbcba54cedbde468202bf5b --destfile payload_dump.xml || die 'failed conddb dump payload to file' $?
+conddb dump SiPixelQuality_phase1_2021_v1 || die 'failed conddb dump tag' $?
+conddb dump SiPixelQuality_phase1_2021_v1 --destfile tag_dump.xml || die 'failed conddb dump tag to file' $?
+conddb dump Test_CMSSW_IB_unitTest_v1 || die 'failed conddb dump gt' $?
+conddb dump Test_CMSSW_IB_unitTest_v1 --destfile gt_dump.xml || die 'failed conddb dump gt to file' $?
 echo -ne '\n\n'
 
 #conddb showFCSR || die 'failed conddb showFCSR' $?  # the FCSR is not always a real run...


### PR DESCRIPTION
#### PR description:
In PR #20215 a new required argument (`destFile`) was added to the `payload2xml` function in `CondCore/Utilities/python/cond2xml.py` and a new argument (`--destfile`) was added to `conddb dump`.
In `conddb` there are 3 calls of `payload2xml`: one for the `payload` type, one for the `tag` type and one for the `gt` type;
but the default value of `destFile` was only passed to the payload-call and not to the other two, causing an error of type:
```
ERROR: payload2xml() missing 1 required positional argument: 'destFile'
```
This PR adds the default value also to the other two calls.

At the same time the command `conddb dump` for the `gt` type was failing also with error:
```
ERROR: type object 'GlobalTag' has no attribute 'name'
```
This is also resolved by fixing a correctly passing the GT name when invoking the `_exists` function in conddb.


#### PR validation:
With these changes the following commands work properly:
- ```conddb dump --type tag SiPixelQuality_byPCL_stuckTBM_v1```
- ```conddb dump --type gt 123X_mcRun1_design_v1```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, a backport to 12_4_X might be considered later on