### PR TITLE
Skip PPS diamond calibration if there are no parameters

### DIFF
--- a/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -72,7 +72,7 @@ void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
       double tot = -1., ch_t_twc = 0.;
       if (t_lead != 0 && t_trail != 0) {
         tot = (t_trail - t_lead) * ts_to_ns_;  // in ns
-        if (calib_fct_ && apply_calib_) {
+        if (calib_fct_ && apply_calib_ && !ch_params.empty()) {
           // compute the time-walk correction
           ch_t_twc = calib_fct_->evaluate(std::vector<double>{tot}, ch_params);
           if (edm::isNotFinite(ch_t_twc))


### PR DESCRIPTION
#### PR description:
There was a possibility of crash in:
https://github.com/cms-sw/cmssw/blob/2a0aaba061bee4d7559a605eb7465733f2972641/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc#L77
if the calibration was not produced for a given channel. This fix adds the condition to handle this scenario.

#### PR validation:
Can be validated with relval 1041

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
This PR should be backported to the 12_4_X
