### PR TITLE
Protect WaitingTask*Holder::taskHasFailed from a data race

### DIFF
--- a/FWCore/Concurrency/interface/WaitingTask.h
+++ b/FWCore/Concurrency/interface/WaitingTask.h
@@ -48,24 +48,33 @@ namespace edm {
     ///Returns exception thrown by dependent task
     /** If the value evalutes to true then the dependent task failed.
     */
-    std::exception_ptr const& exceptionPtr() const { return m_ptr; }
+    std::exception_ptr exceptionPtr() const {
+      if (m_ptrSet == static_cast<unsigned char>(State::kSet)) {
+        return m_ptr;
+      }
+      return std::exception_ptr{};
+    }
+
+  protected:
+    std::exception_ptr const& uncheckedExceptionPtr() const { return m_ptr; }
 
   private:
+    enum class State : unsigned char { kUnset = 0, kSetting = 1, kSet = 2 };
     ///Called if waited for task failed
     /**Allows transfer of the exception caused by the dependent task to be
      * moved to another thread.
      * This method should only be called by WaitingTaskList
      */
     void dependentTaskFailed(std::exception_ptr iPtr) {
-      bool isSet = false;
-      if (iPtr and m_ptrSet.compare_exchange_strong(isSet, true)) {
+      unsigned char isSet = static_cast<unsigned int>(State::kUnset);
+      if (iPtr and m_ptrSet.compare_exchange_strong(isSet, static_cast<unsigned char>(State::kSetting))) {
         m_ptr = iPtr;
-        //NOTE: the atomic counter in TaskBase will synchronize m_ptr
+        m_ptrSet = static_cast<unsigned char>(State::kSet);
       }
     }
 
     std::exception_ptr m_ptr;
-    std::atomic<bool> m_ptrSet = false;
+    std::atomic<unsigned char> m_ptrSet = static_cast<unsigned int>(State::kUnset);
   };
 
   template <typename F>
@@ -73,7 +82,7 @@ namespace edm {
   public:
     explicit FunctorWaitingTask(F f) : func_(std::move(f)) {}
 
-    void execute() final { func_(exceptionPtr() ? &exceptionPtr() : nullptr); };
+    void execute() final { func_(uncheckedExceptionPtr() ? &uncheckedExceptionPtr() : nullptr); };
 
   private:
     F func_;

--- a/FWCore/Concurrency/interface/WaitingTask.h
+++ b/FWCore/Concurrency/interface/WaitingTask.h
@@ -66,7 +66,7 @@ namespace edm {
      * This method should only be called by WaitingTaskList
      */
     void dependentTaskFailed(std::exception_ptr iPtr) {
-      unsigned char isSet = static_cast<unsigned int>(State::kUnset);
+      unsigned char isSet = static_cast<unsigned char>(State::kUnset);
       if (iPtr and m_ptrSet.compare_exchange_strong(isSet, static_cast<unsigned char>(State::kSetting))) {
         m_ptr = iPtr;
         m_ptrSet = static_cast<unsigned char>(State::kSet);
@@ -74,7 +74,7 @@ namespace edm {
     }
 
     std::exception_ptr m_ptr;
-    std::atomic<unsigned char> m_ptrSet = static_cast<unsigned int>(State::kUnset);
+    std::atomic<unsigned char> m_ptrSet = static_cast<unsigned char>(State::kUnset);
   };
 
   template <typename F>

--- a/FWCore/Concurrency/interface/WaitingTaskHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskHolder.h
@@ -69,7 +69,7 @@ namespace edm {
     }
 
     // ---------- const member functions ---------------------
-    bool taskHasFailed() const noexcept { return m_task->exceptionPtr() != nullptr; }
+    bool taskHasFailed() const noexcept { return static_cast<bool>(m_task->exceptionPtr()); }
 
     bool hasTask() const noexcept { return m_task != nullptr; }
     /** since oneapi::tbb::task_group is thread safe, we can return it non-const from here since

--- a/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
+++ b/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
@@ -109,7 +109,7 @@ namespace edm {
     return holder;
   }
 
-  bool WaitingTaskWithArenaHolder::taskHasFailed() const noexcept { return m_task->exceptionPtr() != nullptr; }
+  bool WaitingTaskWithArenaHolder::taskHasFailed() const noexcept { return static_cast<bool>(m_task->exceptionPtr()); }
 
   bool WaitingTaskWithArenaHolder::hasTask() const noexcept { return m_task != nullptr; }
 


### PR DESCRIPTION
#### PR description:

WaitingTask*Holder::taskHasFailed could call exceptionPtr() while the underlying object is being set. This change makes calls to exceptionPtr() safe across threads.

Thanks to @wddgit for catching this case.

#### PR validation:

Code compiles and FWCore/Concurrency unit tests pass.