### PR TITLE
[12_4_X] Add default calibration product to PPS TDC PCL

### DIFF
--- a/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLHarvester.cc
+++ b/CalibPPS/TimingCalibration/plugins/PPSTimingCalibrationPCLHarvester.cc
@@ -94,6 +94,10 @@ void PPSTimingCalibrationPCLHarvester::dqmEndJob(DQMStore::IBooker& iBooker, DQM
     const auto chid = detid.rawId();
     const PPSTimingCalibration::Key key{
         (int)detid.arm(), (int)detid.station(), (int)detid.plane(), (int)detid.channel()};
+
+    calib_params[key] = {0, 0, 0, 0};
+    calib_time[key] = std::make_pair(0.1, 0.);
+
     hists.leadingTime[chid] = iGetter.get(dqmDir_ + "/t_" + ch_name);
     if (hists.leadingTime[chid] == nullptr) {
       edm::LogInfo("PPSTimingCalibrationPCLHarvester:dqmEndJob")


### PR DESCRIPTION
#### PR description:
There was a possibility of crash in:
https://github.com/cms-sw/cmssw/blob/2a0aaba061bee4d7559a605eb7465733f2972641/RecoPPS/Local/src/CTPPSDiamondRecHitProducerAlgorithm.cc#L77
if the calibration was not produced for a given channel. This fix adds the default 0 calibration product to the PCL.

#### PR validation:
Can be validated with relval 1041

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->
Backport of #38770 