### PR TITLE
Update CondTool/SiStrip scripts to use phase1_2022_realistic GT

### DIFF
--- a/CondTools/SiStrip/test/SiStripDetVOffFakeBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripDetVOffFakeBuilder_cfg.py
@@ -33,7 +33,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['run2_design']
+process.GlobalTag.globaltag = autoCond['phase1_2022_design']
 print("taking geometry from %s" % process.GlobalTag.globaltag.value())
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 

--- a/CondTools/SiStrip/test/SiStripFedCablingBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripFedCablingBuilder_cfg.py
@@ -36,7 +36,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['run2_design']
+process.GlobalTag.globaltag = autoCond['phase1_2022_design']
 print("taking geometry from %s" % process.GlobalTag.globaltag.value())
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 

--- a/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripFedCablingReader_cfg.py
@@ -34,7 +34,7 @@ process.poolDBESSource = cms.ESSource("PoolDBESSource",
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
-process.GlobalTag.globaltag = autoCond['run2_design']
+process.GlobalTag.globaltag = autoCond['phase1_2022_design']
 print("taking geometry from %s" % process.GlobalTag.globaltag.value())
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 


### PR DESCRIPTION
#### PR description:

Following up the migration of Geometry_cff to GeometryDB_cff (https://github.com/cms-sw/cmssw/pull/35278), proper
GlobalTag needs to be set in advance. Updates applied to AlCa/DB related packages to use Run 3 GT.

#### PR validation:

Scripts tested locally.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport and no backport expected.
