### PR TITLE
HeavyFlavor DQM fixes

### DIFF
--- a/DQM/Physics/python/customiseHeavyFlavorDQMForMiniAOD.py
+++ b/DQM/Physics/python/customiseHeavyFlavorDQMForMiniAOD.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseHeavyFlavorDQMForMiniAOD(process):
+    if hasattr(process, "bphWriteSpecificDecayForDQM"):
+        process.bphWriteSpecificDecayForDQM.pVertexLabel = cms.string('offlineSlimmedPrimaryVertices')
+        
+        process.bphWriteSpecificDecayForDQM.pcCandsLabel = cms.string('packedPFCandidates')
+        process.bphWriteSpecificDecayForDQM.pfCandsLabel = cms.string('')
+        
+        process.bphWriteSpecificDecayForDQM.patMuonLabel = cms.string('slimmedMuons')
+        
+        process.bphWriteSpecificDecayForDQM.kSCandsLabel = cms.string('slimmedKshortVertices')
+        process.bphWriteSpecificDecayForDQM.k0CandsLabel = cms.string('')
+        
+        process.bphWriteSpecificDecayForDQM.lSCandsLabel = cms.string('slimmedLambdaVertices')
+        process.bphWriteSpecificDecayForDQM.l0CandsLabel = cms.string('')
+    
+    if hasattr(process, "heavyFlavorDQM"):
+        process.heavyFlavorDQM.pvCollection = cms.InputTag('offlineSlimmedPrimaryVertices')
+    
+    return process

--- a/DQM/Physics/python/heavyFlavorDQMFirstStep_cff.py
+++ b/DQM/Physics/python/heavyFlavorDQMFirstStep_cff.py
@@ -4,7 +4,7 @@ from DQM.Physics.HeavyFlavorDQMAnalyzer_cfi import *
 from DQM.Physics.vertexSelectForHeavyFlavorDQM_cfi import recoSelectForHeavyFlavorDQM
 
 bphWriteSpecificDecayForDQM = cms.EDProducer('BPHWriteSpecificDecay',
-    pVertexLabel = cms.string('offlineSlimmedPrimaryVertices'),
+    pVertexLabel = cms.string('offlinePrimaryVertices'),
     pfCandsLabel = cms.string('particleFlow'),
     patMuonLabel = cms.string('selectedPatMuons'),
     k0CandsLabel = cms.string('generalV0Candidates:Kshort'),
@@ -28,7 +28,8 @@ bphWriteSpecificDecayForDQM = cms.EDProducer('BPHWriteSpecificDecay',
 )
 
 heavyFlavorDQM = HeavyFlavorDQMAnalyzer.clone(
-    pvCollection = cms.InputTag('offlineSlimmedPrimaryVertices'),
+    pvCollection = cms.InputTag('offlinePrimaryVertices'),
+    beamSpot = cms.InputTag('offlineBeamSpot'),
     OniaToMuMuCands            = cms.InputTag('bphWriteSpecificDecayForDQM:OniaToMuMuCands'),
     Kx0ToKPiCands              = cms.InputTag('bphWriteSpecificDecayForDQM:Kx0ToKPiCands'),
     PhiToKKCands               = cms.InputTag('bphWriteSpecificDecayForDQM:PhiToKKCands'),

--- a/DQM/Physics/src/HeavyFlavorDQMAnalyzer.h
+++ b/DQM/Physics/src/HeavyFlavorDQMAnalyzer.h
@@ -166,19 +166,26 @@ private:
                                               edm::EventSetup const&,
                                               DecayHists&) const;
 
-  bool fillDecayHistograms(DecayHists const&,
-                           pat::CompositeCandidate const& cand,
-                           reco::VertexCollection const& pvs) const;
-  void fillComponentHistograms(ComponentHists const& histos, reco::Track const& component) const;
+  reco::Vertex const* fillDecayHistograms(DecayHists const&,
+                                          pat::CompositeCandidate const& cand,
+                                          reco::VertexCollection const& pvs) const;
+  void fillComponentHistograms(ComponentHists const& histos,
+                               reco::Track const& component,
+                               reco::BeamSpot const* bs,
+                               reco::Vertex const* pv) const;
 
   int fillComponentHistogramsSinglePart(DecayHists const&,
                                         pat::CompositeCandidate const& cand,
                                         std::string const& name,
+                                        reco::BeamSpot const* bs,
+                                        reco::Vertex const* pv,
                                         int startPosition = 0) const;
   int fillComponentHistogramsLeadSoft(DecayHists const&,
                                       pat::CompositeCandidate const& cand,
                                       std::string const& name1,
                                       std::string const& name2,
+                                      reco::BeamSpot const* bs,
+                                      reco::Vertex const* pv,
                                       int startPosition = 0) const;
 
   const reco::Track* getDaughterTrack(pat::CompositeCandidate const& cand,
@@ -188,46 +195,75 @@ private:
 
   int fillOniaToMuMuComponents(DecayHists const& histos,
                                pat::CompositeCandidate const& cand,
+                               reco::BeamSpot const* bs,
+                               reco::Vertex const* pv,
                                int startPosition = 0) const;
   int fillKx0ToKPiComponents(DecayHists const& histos,
                              pat::CompositeCandidate const& cand,
+                             reco::BeamSpot const* bs,
+                             reco::Vertex const* pv,
                              int startPosition = 0) const;
-  int fillPhiToKKComponents(DecayHists const& histos, pat::CompositeCandidate const& cand, int startPosition = 0) const;
+  int fillPhiToKKComponents(DecayHists const& histos,
+                            pat::CompositeCandidate const& cand,
+                            reco::BeamSpot const* bs,
+                            reco::Vertex const* pv,
+                            int startPosition = 0) const;
   int fillK0sToPiPiComponents(DecayHists const& histos,
                               pat::CompositeCandidate const& cand,
+                              reco::BeamSpot const* bs,
+                              reco::Vertex const* pv,
                               int startPosition = 0) const;
   int fillLambda0ToPPiComponents(DecayHists const& histos,
                                  pat::CompositeCandidate const& cand,
+                                 reco::BeamSpot const* bs,
+                                 reco::Vertex const* pv,
                                  int startPosition = 0) const;
   int fillBuToJPsiKComponents(DecayHists const& histos,
                               pat::CompositeCandidate const& cand,
+                              reco::BeamSpot const* bs,
+                              reco::Vertex const* pv,
                               int startPosition = 0) const;
   int fillBuToPsi2SKComponents(DecayHists const& histos,
                                pat::CompositeCandidate const& cand,
+                               reco::BeamSpot const* bs,
+                               reco::Vertex const* pv,
                                int startPosition = 0) const;
   int fillBdToJPsiKx0Components(DecayHists const& histos,
                                 pat::CompositeCandidate const& cand,
+                                reco::BeamSpot const* bs,
+                                reco::Vertex const* pv,
                                 int startPosition = 0) const;
   int fillBsToJPsiPhiComponents(DecayHists const& histos,
                                 pat::CompositeCandidate const& cand,
+                                reco::BeamSpot const* bs,
+                                reco::Vertex const* pv,
                                 int startPosition = 0) const;
   int fillBdToJPsiK0sComponents(DecayHists const& histos,
                                 pat::CompositeCandidate const& cand,
+                                reco::BeamSpot const* bs,
+                                reco::Vertex const* pv,
                                 int startPosition = 0) const;
   int fillBcToJPsiPiComponents(DecayHists const& histos,
                                pat::CompositeCandidate const& cand,
+                               reco::BeamSpot const* bs,
+                               reco::Vertex const* pv,
                                int startPosition = 0) const;
   int fillLambdaBToJPsiLambda0Components(DecayHists const& histos,
                                          pat::CompositeCandidate const& cand,
+                                         reco::BeamSpot const* bs,
+                                         reco::Vertex const* pv,
                                          int startPosition = 0) const;
   int fillPsi2SToJPsiPiPiComponents(DecayHists const& histos,
                                     pat::CompositeCandidate const& cand,
+                                    reco::BeamSpot const* bs,
+                                    reco::Vertex const* pv,
                                     int startPosition = 0) const;
 
   // ------------ member data ------------
   std::string folder_;
 
   edm::EDGetTokenT<reco::VertexCollection> pvCollectionToken;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
 
   edm::EDGetTokenT<pat::CompositeCandidateCollection> oniaToMuMuCandsToken;
   edm::EDGetTokenT<pat::CompositeCandidateCollection> kx0ToKPiCandsToken;


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

This is a collection of small fixes for the recently merged HeavyFlavorDQM. 
It also adds a customiser to allow running the DQM module from miniAOD instead of AOD

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->
Fixes tested on the workflow 1366.0 which uses this module. Customisation tested on Early Run3 miniAOD data

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR will be backported to 12_4
<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->


<!-- Please delete the text above after you verified all points of the checklist  -->
