### PR TITLE
[12_4_X] Adding extra protection against invalid data to EMTF PrimitiveSelection

### DIFF
--- a/L1Trigger/L1TMuonEndCap/interface/PrimitiveSelection.h
+++ b/L1Trigger/L1TMuonEndCap/interface/PrimitiveSelection.h
@@ -15,7 +15,9 @@ public:
                  int bxShiftME0,
                  bool includeNeighbor,
                  bool duplicateTheta,
-                 bool bugME11Dupes);
+                 bool bugME11Dupes,
+                 bool useRun3CCLUT_OTMB,
+                 bool useRun3CCLUT_TMB);
 
   template <typename T>
   void process(T tag,
@@ -114,6 +116,9 @@ private:
   bool includeNeighbor_, duplicateTheta_;
 
   bool bugME11Dupes_;
+  // Run 3 CCLUT algorithm
+  bool useRun3CCLUT_OTMB_;
+  bool useRun3CCLUT_TMB_;
 };
 
 #endif

--- a/L1Trigger/L1TMuonEndCap/interface/TrackTools.h
+++ b/L1Trigger/L1TMuonEndCap/interface/TrackTools.h
@@ -27,6 +27,10 @@ namespace emtf {
 
   std::pair<int, int> get_csc_max_pattern_and_quality(int station, int ring);
 
+  // CSC max slope
+
+  int get_csc_max_slope(int station, int ring, bool useRun3CCLUT_OTMB, bool useRun3CCLUT_TMB);
+
   // ___________________________________________________________________________
   // coordinate ranges: phi[-180, 180] or [-pi, pi], theta[0, 90] or [0, pi/2]
   inline double wrap_phi_deg(double deg) {

--- a/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
+++ b/L1Trigger/L1TMuonEndCap/src/SectorProcessor.cc
@@ -86,7 +86,9 @@ void SectorProcessor::process_single_bx(int bx,
                      cfg.bxShiftME0_,
                      cfg.includeNeighbor_,
                      cfg.duplicateTheta_,
-                     cfg.bugME11Dupes_);
+                     cfg.bugME11Dupes_,
+                     cfg.useRun3CCLUT_OTMB_,
+                     cfg.useRun3CCLUT_TMB_);
 
   PrimitiveConversion prim_conv;
   prim_conv.configure(tp_geom_,

--- a/L1Trigger/L1TMuonEndCap/src/TrackTools.cc
+++ b/L1Trigger/L1TMuonEndCap/src/TrackTools.cc
@@ -172,4 +172,13 @@ namespace emtf {
     return std::make_pair(max_pattern, max_quality);
   }
 
+  int get_csc_max_slope(int station, int ring, bool useRun3CCLUT_OTMB, bool useRun3CCLUT_TMB) {
+    int max_slope = 65536;  // Uninitialized slope can be 65536. This is expected when CCLUT is not running
+    if (useRun3CCLUT_OTMB and (ring == 1 or ring == 4))
+      max_slope = 16;
+    if (useRun3CCLUT_TMB and (ring == 2 or ring == 3))
+      max_slope = 16;
+    return max_slope;
+  }
+
 }  // namespace emtf


### PR DESCRIPTION
#### PR description:

During the tests of https://github.com/cms-sw/cmssw/pull/38373 we realized that EMTF `PrimitiveSelection.cc` was missing protection against invalid CSC data that is enabled with Run 3 flags `useRun3CCLUT_OTMB` and `useRun3CCLUT_TMB`. 

This protection is necessary for Run 3 CSC TPs when CCLUT is not running correctly at P5 which was the case before June 2022. 

The slope variable is a `uint16_t` and it exists for Run 2 or Run 3 CSC TPs. We only use this variable if `useRun3CCLUT_OTMB` or `useRun3CCLUT_TMB` is enabled. That's why I left the max value as 65536 if these flags are disabled. 


<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Validated by checking failed workflows from https://github.com/cms-sw/cmssw/pull/38722. We see correct behaviour of rejecting these "corrupt" LCTs and it doesn't change the outcome of the correct LCTs.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of https://github.com/cms-sw/cmssw/pull/38775

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
