### PR TITLE
Update to phase1_2022_realistic GT in HcalCalibAlgos

### DIFF
--- a/Calibration/HcalCalibAlgos/test/python/hcalHBHEMuonHighEta_cfg.py
+++ b/Calibration/HcalCalibAlgos/test/python/hcalHBHEMuonHighEta_cfg.py
@@ -14,7 +14,8 @@ process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("RecoJets.Configuration.CaloTowersES_cfi")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag='106X_mcRun3_2021_realistic_v3'
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['phase1_2022_realistic']
 
 process.load("RecoLocalCalo.EcalRecAlgos.EcalSeverityLevelESProducer_cfi")
 process.load("Calibration.HcalCalibAlgos.hcalHBHEMuonHighEta_cfi")


### PR DESCRIPTION
#### PR description:

Following up the migration of Geometry_cff to GeometryDB_cff (https://github.com/cms-sw/cmssw/pull/35278), proper GlobalTag needs to be set in advance. We take the chance to clean up and/or update the related AlCa/DB script. Here, the GT is updated to auto:phase1_2022_realistic.

#### PR validation:

Script tested locally.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a back port and no back port expected.
