### PR TITLE
Add auto cond. for scripts accessing GeometryDB_cff in DTCalibration

### DIFF
--- a/CalibMuon/DTCalibration/python/dtDQMClientAlca_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtDQMClientAlca_cfg.py
@@ -12,7 +12,8 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ""
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("CondCore.CondDB.CondDB_cfi")
 process.load("DQMServices.Core.DQM_cfg")

--- a/CalibMuon/DTCalibration/python/dtDQMClient_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtDQMClient_cfg.py
@@ -27,7 +27,8 @@ process.options = cms.untracked.PSet(
 )
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")

--- a/CalibMuon/DTCalibration/python/dtNoiseCalibration_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtNoiseCalibration_cfg.py
@@ -8,7 +8,8 @@ process.MessageLogger.debugModules = ['dtNoiseCalibration']
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtT0AbsoluteReferenceCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0AbsoluteReferenceCorrection_cfg.py
@@ -6,7 +6,8 @@ process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0AbsoluteReferenceCorrection')
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")

--- a/CalibMuon/DTCalibration/python/dtT0Analyzer_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0Analyzer_cfg.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DTT0Analyzer")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")

--- a/CalibMuon/DTCalibration/python/dtT0FEBPathCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0FEBPathCorrection_cfg.py
@@ -6,11 +6,9 @@ process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0FEBPathCorrection')
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
-#process.load("Configuration.StandardSequences.GeometryDB_cff")
-#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = ''
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Geometry.DTGeometry.dtGeometry_cfi")

--- a/CalibMuon/DTCalibration/python/dtT0FillChamberFromDBCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0FillChamberFromDBCorrection_cfg.py
@@ -6,7 +6,8 @@ process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0FillChamberFromDBCorrection')
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")

--- a/CalibMuon/DTCalibration/python/dtT0FillDefaultFromDBCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0FillDefaultFromDBCorrection_cfg.py
@@ -6,7 +6,8 @@ process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0FillDefaultFromDBCorrection')
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")

--- a/CalibMuon/DTCalibration/python/dtT0WireCalibration_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0WireCalibration_cfg.py
@@ -17,10 +17,11 @@ process.MessageLogger.cerr =  cms.untracked.PSet(
     resolution = cms.untracked.PSet(limit = cms.untracked.int32(-1))
 )
 
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ""
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtT0WireInChamberReferenceCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtT0WireInChamberReferenceCorrection_cfg.py
@@ -6,11 +6,9 @@ process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtT0WireInChamberReferenceCorrection')
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
-#process.load("Configuration.StandardSequences.GeometryDB_cff")
-#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = ''
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Geometry.DTGeometry.dtGeometry_cfi")

--- a/CalibMuon/DTCalibration/python/dtTPAnalyzer_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTPAnalyzer_cfg.py
@@ -4,10 +4,11 @@ process = cms.Process("DTTPAnalyzer")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ""
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtTPDQM_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTPDQM_cfg.py
@@ -13,10 +13,11 @@ process.MessageLogger.cerr =  cms.untracked.PSet(
     resolution = cms.untracked.PSet(limit = cms.untracked.int32(-1))
 )
 
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ""
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtTPDeadWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTPDeadWriter_cfg.py
@@ -2,12 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("DTTPDeadWriter")
 
-#process.load("Configuration.StandardSequences.GeometryDB_cff")
-#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-#process.GlobalTag.globaltag = ''
-
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")

--- a/CalibMuon/DTCalibration/python/dtTTrigCalibration_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigCalibration_cfg.py
@@ -6,7 +6,8 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'
 
 process.load("CalibMuon.DTCalibration.dt_offlineAnalysis_common_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring()

--- a/CalibMuon/DTCalibration/python/dtTTrigCalibration_cosmics_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigCalibration_cosmics_cfg.py
@@ -6,7 +6,8 @@ process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'
 
 process.load("CalibMuon.DTCalibration.dt_offlineAnalysis_common_cosmics_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring()

--- a/CalibMuon/DTCalibration/python/dtTTrigConstantShiftCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigConstantShiftCorrection_cfg.py
@@ -8,7 +8,8 @@ process.MessageLogger.debugModules = cms.untracked.vstring('dtTTrigConstantShift
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtTTrigCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigCorrection_cfg.py
@@ -5,7 +5,8 @@ process = cms.Process("DTTTrigCorrection")
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtTTrigResidualCorrection_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigResidualCorrection_cfg.py
@@ -8,7 +8,8 @@ process.MessageLogger.debugModules = cms.untracked.vstring('dtTTrigResidualCorre
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtTTrigValidSummary_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigValidSummary_cfg.py
@@ -14,7 +14,8 @@ process.MessageLogger.cerr =  cms.untracked.PSet(
 )
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")

--- a/CalibMuon/DTCalibration/python/dtTTrigWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtTTrigWriter_cfg.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("PROD")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")

--- a/CalibMuon/DTCalibration/python/dtVDriftMeanTimerWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftMeanTimerWriter_cfg.py
@@ -8,7 +8,8 @@ process.MessageLogger.debugModules = cms.untracked.vstring('dtVDriftMeanTimerWri
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfg.py
@@ -12,7 +12,8 @@ process.MessageLogger.debugModules = cms.untracked.vstring('dtVDriftSegmentWrite
 process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dumpDBToFile_GT_ttrig_cfg.py
+++ b/CalibMuon/DTCalibration/python/dumpDBToFile_GT_ttrig_cfg.py
@@ -5,7 +5,8 @@ process = cms.Process("DumpDBToFile")
 process.load("CondCore.CondDB.CondDB_cfi")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CalibMuon/DTCalibration/python/dumpDBToFile_GT_vdrift_cfg.py
+++ b/CalibMuon/DTCalibration/python/dumpDBToFile_GT_vdrift_cfg.py
@@ -3,7 +3,8 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DumpDBToFile")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = ''
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag=autoCond['run3_data']
 
 process.load("CondCore.CondDB.CondDB_cfi")
 


### PR DESCRIPTION
#### PR description:

Following up the migration of Geometry_cff to GeometryDB_cff (https://github.com/cms-sw/cmssw/pull/35278), proper GlobalTag needs to be set in advance. We take the chance to clean up and/or update the related AlCa/DB script. Here, the GT is updated to auto:run3_data in  CalibMuon/DTCalibration.

#### PR validation:

Scripts tested locally.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a back port and no back port expected.