### PR TITLE
Implement support for concurrent runs in the Framework

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -35,6 +35,7 @@ configured in the user's main() function, and is set running.
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <set>
@@ -56,6 +57,7 @@ namespace edm {
   class WaitingTaskHolder;
   class LuminosityBlockPrincipal;
   class LuminosityBlockProcessingStatus;
+  class RunProcessingStatus;
   class IOVSyncValue;
 
   namespace eventsetup {
@@ -183,14 +185,7 @@ namespace edm {
     // transition handling.
 
     InputSource::ItemType nextTransitionType();
-    InputSource::ItemType lastTransitionType() const {
-      if (deferredExceptionPtrIsSet_) {
-        return InputSource::IsStop;
-      }
-      return lastSourceTransition_;
-    }
-    std::pair<edm::ProcessHistoryID, edm::RunNumber_t> nextRunID();
-    edm::LuminosityBlockNumber_t nextLuminosityBlockID();
+    InputSource::ItemType lastTransitionType() const { return lastSourceTransition_; }
 
     void readFile();
     bool fileBlockValid() { return fb_.get() != nullptr; }
@@ -213,42 +208,35 @@ namespace edm {
     void inputProcessBlocks();
     void endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded);
 
-    void beginRun(ProcessHistoryID const& phid,
-                  RunNumber_t run,
-                  bool& globalBeginSucceeded,
-                  bool& eventSetupForInstanceSucceeded);
-    void endRun(ProcessHistoryID const& phid, RunNumber_t run, bool globalBeginSucceeded, bool cleaningUpAfterException);
-    void endUnfinishedRun(ProcessHistoryID const& phid,
-                          RunNumber_t run,
-                          bool globalBeginSucceeded,
-                          bool cleaningUpAfterException,
-                          bool eventSetupForInstanceSucceeded);
-
-    InputSource::ItemType processLumis(std::shared_ptr<void> const& iRunResource);
-    void endUnfinishedLumi();
-
-    void beginLumiAsync(edm::IOVSyncValue const& iSyncValue,
-                        std::shared_ptr<void> const& iRunResource,
-                        edm::WaitingTaskHolder iHolder);
-    void continueLumiAsync(edm::WaitingTaskHolder iHolder);
-
-    void handleEndLumiExceptions(std::exception_ptr const* iPtr, WaitingTaskHolder& holder);
-    void globalEndLumiAsync(edm::WaitingTaskHolder iTask, std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus);
-    void streamEndLumiAsync(edm::WaitingTaskHolder iTask, unsigned int iStreamIndex);
+    InputSource::ItemType processRuns();
+    void beginRunAsync(IOVSyncValue const&, WaitingTaskHolder);
+    void streamBeginRunAsync(unsigned int iStream,
+                             std::shared_ptr<RunProcessingStatus>,
+                             bool precedingTasksSucceeded,
+                             WaitingTaskHolder);
+    void releaseBeginRunResources(unsigned int iStream);
+    void endRunAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
+    void handleEndRunExceptions(std::exception_ptr, WaitingTaskHolder const&);
+    void globalEndRunAsync(WaitingTaskHolder, std::shared_ptr<RunProcessingStatus>);
+    void streamEndRunAsync(WaitingTaskHolder, unsigned int iStreamIndex);
+    void endUnfinishedRun(bool cleaningUpAfterException);
+    void beginLumiAsync(IOVSyncValue const&, std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
+    void continueLumiAsync(WaitingTaskHolder);
+    void handleEndLumiExceptions(std::exception_ptr, WaitingTaskHolder const&);
+    void globalEndLumiAsync(WaitingTaskHolder, std::shared_ptr<LuminosityBlockProcessingStatus>);
+    void streamEndLumiAsync(WaitingTaskHolder, unsigned int iStreamIndex);
+    void endUnfinishedLumi(bool cleaningUpAfterException);
     void readProcessBlock(ProcessBlockPrincipal&);
-    std::pair<ProcessHistoryID, RunNumber_t> readRun();
-    std::pair<ProcessHistoryID, RunNumber_t> readAndMergeRun();
-    void readLuminosityBlock(LuminosityBlockProcessingStatus&);
-    int readAndMergeLumi(LuminosityBlockProcessingStatus&);
+    std::shared_ptr<RunPrincipal> readRun();
+    void readAndMergeRun(RunProcessingStatus&);
+    std::shared_ptr<LuminosityBlockPrincipal> readLuminosityBlock(std::shared_ptr<RunPrincipal> rp);
+    void readAndMergeLumi(LuminosityBlockProcessingStatus&);
     using ProcessBlockType = PrincipalCache::ProcessBlockType;
     void writeProcessBlockAsync(WaitingTaskHolder, ProcessBlockType);
-    void writeRunAsync(WaitingTaskHolder,
-                       ProcessHistoryID const& phid,
-                       RunNumber_t run,
-                       MergeableRunProductMetadata const*);
-    void deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run);
-    void writeLumiAsync(WaitingTaskHolder, LuminosityBlockPrincipal& lumiPrincipal);
-    void deleteLumiFromCache(LuminosityBlockProcessingStatus&);
+    void writeRunAsync(WaitingTaskHolder, RunPrincipal const&, MergeableRunProductMetadata const*);
+    void clearRunPrincipal(RunProcessingStatus&);
+    void writeLumiAsync(WaitingTaskHolder, LuminosityBlockPrincipal&);
+    void clearLumiPrincipal(LuminosityBlockProcessingStatus&);
 
     bool shouldWeStop() const;
 
@@ -265,9 +253,14 @@ namespace edm {
     // init() is used by only by constructors
     void init(std::shared_ptr<ProcessDesc>& processDesc, ServiceToken const& token, serviceregistry::ServiceLegacy);
 
-    bool readNextEventForStream(unsigned int iStreamIndex, LuminosityBlockProcessingStatus& iLumiStatus);
+    void readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
+    void readAndMergeLumiEntriesAsync(std::shared_ptr<LuminosityBlockProcessingStatus>, WaitingTaskHolder);
 
-    void handleNextEventForStreamAsync(WaitingTaskHolder iTask, unsigned int iStreamIndex);
+    void handleNextItemAfterMergingRunEntries(std::shared_ptr<RunProcessingStatus>, WaitingTaskHolder);
+
+    bool readNextEventForStream(WaitingTaskHolder const&, unsigned int iStreamIndex, LuminosityBlockProcessingStatus&);
+
+    void handleNextEventForStreamAsync(WaitingTaskHolder, unsigned int iStreamIndex);
 
     //read the next event using Stream iStreamIndex
     void readEvent(unsigned int iStreamIndex);
@@ -298,6 +291,7 @@ namespace edm {
     std::shared_ptr<EDLooperBase>& looper() { return get_underlying_safe(looper_); }
 
     void throwAboutModulesRequiringLuminosityBlockSynchronization() const;
+    void warnAboutModulesRequiringRunSynchronization() const;
     void warnAboutLegacyModules() const;
     //------------------------------------------------------------------
     //
@@ -316,7 +310,7 @@ namespace edm {
     edm::propagate_const<std::shared_ptr<ThinnedAssociationsHelper>> thinnedAssociationsHelper_;
     ServiceToken serviceToken_;
     edm::propagate_const<std::unique_ptr<InputSource>> input_;
-    InputSource::ItemType lastSourceTransition_;
+    InputSource::ItemType lastSourceTransition_ = InputSource::IsInvalid;
     edm::propagate_const<std::unique_ptr<eventsetup::EventSetupsController>> espController_;
     edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
     edm::SerialTaskQueue queueWhichWaitsForIOVsToFinish_;
@@ -327,8 +321,13 @@ namespace edm {
     MergeableRunProductProcesses mergeableRunProductProcesses_;
     edm::propagate_const<std::unique_ptr<Schedule>> schedule_;
     std::vector<edm::SerialTaskQueue> streamQueues_;
+    SerialTaskQueue streamQueuesInserter_;
+    std::unique_ptr<edm::LimitedTaskQueue> runQueue_;
     std::unique_ptr<edm::LimitedTaskQueue> lumiQueue_;
+    std::vector<std::shared_ptr<RunProcessingStatus>> streamRunStatus_;
+    std::shared_ptr<RunProcessingStatus> exceptionRunStatus_;
     std::vector<std::shared_ptr<LuminosityBlockProcessingStatus>> streamLumiStatus_;
+    std::atomic<unsigned int> streamRunActive_{0};   //works as guard for streamRunStatus
     std::atomic<unsigned int> streamLumiActive_{0};  //works as guard for streamLumiStatus
 
     std::vector<std::string> branchesToDeleteEarly_;
@@ -366,6 +365,7 @@ namespace edm {
 
     bool printDependencies_ = false;
     bool deleteNonConsumedUnscheduledModules_ = true;
+    bool firstItemAfterLumiMerge_ = true;
   };  // class EventProcessor
 
   //--------------------------------------------------------------------

--- a/FWCore/Framework/interface/EventSetupsController.h
+++ b/FWCore/Framework/interface/EventSetupsController.h
@@ -93,14 +93,27 @@ namespace edm {
                                                        unsigned int maxConcurrentIOVs = 0,
                                                        bool dumpOptions = false);
 
+      // The main purpose of this function is to call eventSetupForInstanceAsync. It might
+      // be called immediately or we might need to wait until all the currently active
+      // IOVs end. If there is an exception, then a signal is emitted and the exception
+      // is propagated.
+      void runOrQueueEventSetupForInstanceAsync(IOVSyncValue const&,
+                                                WaitingTaskHolder& taskToStartAfterIOVInit,
+                                                WaitingTaskList& endIOVWaitingTasks,
+                                                std::vector<std::shared_ptr<const EventSetupImpl>>&,
+                                                edm::SerialTaskQueue& queueWhichWaitsForIOVsToFinish,
+                                                ActivityRegistry*,
+                                                bool iForceCacheClear = false);
+
       // Pass in an IOVSyncValue to let the EventSetup system know which run and lumi
       // need to be processed and prepare IOVs for it (also could be a time or only a run).
       // Pass in a WaitingTaskHolder that allows the EventSetup to communicate when all
       // the IOVs are ready to process this IOVSyncValue. Note this preparation is often
       // done in asynchronous tasks and the function might return before all the preparation
       // is complete.
-      // Pass in endIOVWaitingTasks, additions to this WaitingTaskList allow the lumi to notify
-      // the EventSetup when the lumi is done and no longer needs its EventSetup IOVs.
+      // Pass in endIOVWaitingTasks, additions to this WaitingTaskList allow the lumi or
+      // run to notify the EventSetup system when a lumi or run transition is done and no
+      // longer needs its EventSetup IOVs.
       // Pass in a vector of EventSetupImpl that gets filled and is used to give clients
       // of EventSetup access to the EventSetup system such that for each record the IOV
       // associated with this IOVSyncValue will be used. The first element of the vector

--- a/FWCore/Framework/interface/GlobalSchedule.h
+++ b/FWCore/Framework/interface/GlobalSchedule.h
@@ -156,6 +156,7 @@ namespace edm {
     std::shared_ptr<ActivityRegistry> actReg_;  // We do not use propagate_const because the registry itself is mutable.
     std::vector<edm::propagate_const<WorkerPtr>> extraWorkers_;
     ProcessContext const* processContext_;
+    unsigned int numberOfConcurrentLumis_;
   };
 
   template <typename T>
@@ -213,7 +214,11 @@ namespace edm {
             }
             iHolder.doneWaiting(excpt);
           });
-      WorkerManager& workerManager = workerManagers_[principal.index()];
+      unsigned int managerIndex = principal.index();
+      if constexpr (T::branchType_ == InRun) {
+        managerIndex += numberOfConcurrentLumis_;
+      }
+      WorkerManager& workerManager = workerManagers_[managerIndex];
       workerManager.resetAll();
 
       ParentContext parentContext(globalContext.get());

--- a/FWCore/Framework/interface/MergeableRunProductMetadata.h
+++ b/FWCore/Framework/interface/MergeableRunProductMetadata.h
@@ -12,9 +12,8 @@ Most of the information here is associated with the current
 run being processed. Most of it is cleared when a new run
 is started. If multiple runs are being processed concurrently,
 then there will be an object instantiated for each concurrent
-run. (At the present time concurrent runs are not possible, but
-there plans to implement that in the future). The primary
-RunPrincipal for the current run owns the object.
+run. The primary RunPrincipal for the current run owns the
+object.
 
 This class gets information from the input file from the
 StoredMergeableRunProductMetadata object and IndexIntoFile object.
@@ -26,7 +25,7 @@ to use in later processing steps.
 If there are SubProcesses, they use the same object as the top
 level process because they share the same input.
 
-There will be a TWIKI page on the Framework page of the Software
+There is a TWIKI page on the Framework page of the Software
 Guide which explains the details about how this works. There
 are significant limitations related to what the Framework does
 and does not do managing mergeable run products.

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -399,6 +399,7 @@ namespace edm {
     using MyPrincipal = ProcessBlockPrincipal;
     using TransitionInfoType = ProcessBlockTransitionInfo;
     using Context = GlobalContext;
+    static BranchType constexpr branchType_ = InProcess;
     static bool constexpr isEvent_ = false;
     static Transition constexpr transition_ = Transition::BeginProcessBlock;
 
@@ -436,6 +437,7 @@ namespace edm {
     using MyPrincipal = ProcessBlockPrincipal;
     using TransitionInfoType = ProcessBlockTransitionInfo;
     using Context = GlobalContext;
+    static BranchType constexpr branchType_ = InProcess;
     static bool constexpr isEvent_ = false;
     static Transition constexpr transition_ = Transition::AccessInputProcessBlock;
 
@@ -473,6 +475,7 @@ namespace edm {
     using MyPrincipal = ProcessBlockPrincipal;
     using TransitionInfoType = ProcessBlockTransitionInfo;
     using Context = GlobalContext;
+    static BranchType constexpr branchType_ = InProcess;
     static bool constexpr isEvent_ = false;
     static Transition constexpr transition_ = Transition::EndProcessBlock;
 

--- a/FWCore/Framework/interface/PrincipalCache.h
+++ b/FWCore/Framework/interface/PrincipalCache.h
@@ -2,37 +2,19 @@
 #define FWCore_Framework_PrincipalCache_h
 
 /*
-Contains a shared pointer to the RunPrincipal,
-LuminosityBlockPrincipal, and EventPrincipal.
-Manages merging of run and luminosity block
-principals when there is more than one principal
-from the same run or luminosity block and having
-the same reduced ProcessHistoryID.
-
-The EventPrincipal is reused each event and is created
-by the EventProcessor or SubProcess which contains
-an object of this type as a data member.
-
-The RunPrincipal and LuminosityBlockPrincipal is
-created by the InputSource each time a different
-run or luminosity block is encountered.
-
-Performs checks that process history IDs or runs and
-lumis, run numbers, and luminosity numbers are consistent.
+Contains smart pointers to the RunPrincipals,
+LuminosityBlockPrincipals, EventPrincipals,
+and ProcessBlockPrincipals. It keeps the
+objects alive so they can be reused as
+necessary.
 
 Original Author: W. David Dagenhart
 */
-
-#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
-#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
-#include "DataFormats/Provenance/interface/RunID.h"
-#include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 
 #include "FWCore/Utilities/interface/ReusableObjectHolder.h"
 
 #include <memory>
 #include <vector>
-#include <cassert>
 
 namespace edm {
 
@@ -40,8 +22,6 @@ namespace edm {
   class RunPrincipal;
   class LuminosityBlockPrincipal;
   class EventPrincipal;
-  class RunAuxiliary;
-  class LuminosityBlockAuxiliary;
   class ProductRegistry;
   class PreallocationConfiguration;
 
@@ -59,61 +39,28 @@ namespace edm {
       return processBlockType == ProcessBlockType::Input ? *inputProcessBlockPrincipal_ : *processBlockPrincipal_;
     }
 
-    RunPrincipal& runPrincipal(ProcessHistoryID const& phid, RunNumber_t run) const;
-    std::shared_ptr<RunPrincipal> const& runPrincipalPtr(ProcessHistoryID const& phid, RunNumber_t run) const;
-    RunPrincipal& runPrincipal() const;
-    std::shared_ptr<RunPrincipal> const& runPrincipalPtr() const;
-    bool hasRunPrincipal() const { return bool(runPrincipal_); }
-
+    std::shared_ptr<RunPrincipal> getAvailableRunPrincipalPtr();
     std::shared_ptr<LuminosityBlockPrincipal> getAvailableLumiPrincipalPtr();
 
     EventPrincipal& eventPrincipal(unsigned int iStreamIndex) const { return *(eventPrincipals_[iStreamIndex]); }
 
-    void merge(std::shared_ptr<RunAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg);
-
     void setNumberOfConcurrentPrincipals(PreallocationConfiguration const&);
     void insert(std::unique_ptr<ProcessBlockPrincipal>);
     void insertForInput(std::unique_ptr<ProcessBlockPrincipal>);
-    void insert(std::shared_ptr<RunPrincipal> rp);
-    void insert(std::unique_ptr<LuminosityBlockPrincipal> lbp);
-    void insert(std::shared_ptr<EventPrincipal> ep);
+    void insert(std::unique_ptr<RunPrincipal>);
+    void insert(std::unique_ptr<LuminosityBlockPrincipal>);
+    void insert(std::shared_ptr<EventPrincipal>);
 
-    void deleteRun(ProcessHistoryID const& phid, RunNumber_t run);
-
-    void adjustEventsToNewProductRegistry(std::shared_ptr<ProductRegistry const> reg);
+    void adjustEventsToNewProductRegistry(std::shared_ptr<ProductRegistry const>);
 
     void adjustIndexesAfterProductRegistryAddition();
 
-    void setProcessHistoryRegistry(ProcessHistoryRegistry const& phr) { processHistoryRegistry_ = &phr; }
-
-    void preReadFile();
-
   private:
-    void throwRunMissing() const;
-    void throwLumiMissing() const;
-
-    // These are explicitly cleared when finished with the processblock, run,
-    // lumi, or event
     std::unique_ptr<ProcessBlockPrincipal> processBlockPrincipal_;
     std::unique_ptr<ProcessBlockPrincipal> inputProcessBlockPrincipal_;
-    std::shared_ptr<RunPrincipal> runPrincipal_;
+    edm::ReusableObjectHolder<RunPrincipal> runHolder_;
     edm::ReusableObjectHolder<LuminosityBlockPrincipal> lumiHolder_;
     std::vector<std::shared_ptr<EventPrincipal>> eventPrincipals_;
-
-    // This is just an accessor to the registry owned by the input source.
-    ProcessHistoryRegistry const* processHistoryRegistry_;  // We don't own this
-
-    // These are intentionally not cleared so that when inserting
-    // the next principal the conversion from full ProcessHistoryID_
-    // to reduced ProcessHistoryID_ is still in memory and does
-    // not need to be recalculated if the ID does not change. I
-    // expect that very often these ID's will not change from one
-    // principal to the next and a good amount of CPU can be saved
-    // by not recalculating.
-    ProcessHistoryID inputProcessHistoryID_;
-    ProcessHistoryID reducedInputProcessHistoryID_;
-    RunNumber_t run_;
-    LuminosityBlockNumber_t lumi_;
   };
 }  // namespace edm
 

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -36,8 +36,7 @@ namespace edm {
     typedef RunAuxiliary Auxiliary;
     typedef Principal Base;
 
-    RunPrincipal(std::shared_ptr<RunAuxiliary> aux,
-                 std::shared_ptr<ProductRegistry const> reg,
+    RunPrincipal(std::shared_ptr<ProductRegistry const> reg,
                  ProcessConfiguration const& pc,
                  HistoryAppender* historyAppender,
                  unsigned int iRunIndex,
@@ -51,12 +50,13 @@ namespace edm {
      return value can be used to identify a particular Run.
      The value will range from 0 to one less than
      the maximum number of allowed simultaneous Runs. A particular
-     value will be reused once the processing of the previous Run 
+     value will be reused once the processing of the previous Run
      using that index has been completed.
      */
     RunIndex index() const { return index_; }
 
-    RunAuxiliary const& aux() const { return *aux_; }
+    void setAux(RunAuxiliary iAux) { aux_ = iAux; }
+    RunAuxiliary const& aux() const { return aux_; }
 
     RunNumber_t run() const { return aux().run(); }
 
@@ -68,9 +68,9 @@ namespace edm {
 
     Timestamp const& endTime() const { return aux().endTime(); }
 
-    void setEndTime(Timestamp const& time) { aux_->setEndTime(time); }
+    void setEndTime(Timestamp const& time) { aux_.setEndTime(time); }
 
-    void mergeAuxiliary(RunAuxiliary const& aux) { return aux_->mergeAuxiliary(aux); }
+    void mergeAuxiliary(RunAuxiliary const& aux) { return aux_.mergeAuxiliary(aux); }
 
     void put(BranchDescription const& bd, std::unique_ptr<WrapperBase> edp) const;
 
@@ -89,7 +89,7 @@ namespace edm {
   private:
     unsigned int transitionIndex_() const override;
 
-    edm::propagate_const<std::shared_ptr<RunAuxiliary>> aux_;
+    RunAuxiliary aux_;
     ProcessHistoryID m_reducedHistoryID;
     RunIndex index_;
 

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -129,17 +129,14 @@ namespace edm {
 
     void writeLumiAsync(WaitingTaskHolder, LuminosityBlockPrincipal&);
 
-    void deleteLumiFromCache(LuminosityBlockPrincipal&);
+    void clearLumiPrincipal(LuminosityBlockPrincipal&);
 
     using ProcessBlockType = PrincipalCache::ProcessBlockType;
     void writeProcessBlockAsync(edm::WaitingTaskHolder task, ProcessBlockType);
 
-    void writeRunAsync(WaitingTaskHolder,
-                       ProcessHistoryID const& parentPhID,
-                       int runNumber,
-                       MergeableRunProductMetadata const*);
+    void writeRunAsync(WaitingTaskHolder, RunPrincipal const&, MergeableRunProductMetadata const*);
 
-    void deleteRunFromCache(ProcessHistoryID const& parentPhID, int runNumber);
+    void clearRunPrincipal(RunPrincipal&);
 
     void clearProcessBlockPrincipal(ProcessBlockType);
 
@@ -286,11 +283,11 @@ namespace edm {
     std::vector<ProcessHistoryRegistry> processHistoryRegistries_;
     std::vector<HistoryAppender> historyAppenders_;
     PrincipalCache principalCache_;
-    //vector index is principal lumi's index value
+    //vector index is principal's index value
+    std::vector<std::shared_ptr<RunPrincipal>> inUseRunPrincipals_;
     std::vector<std::shared_ptr<LuminosityBlockPrincipal>> inUseLumiPrincipals_;
     edm::propagate_const<std::shared_ptr<eventsetup::EventSetupProvider>> esp_;
     edm::propagate_const<std::unique_ptr<Schedule>> schedule_;
-    std::map<ProcessHistoryID, ProcessHistoryID> parentToChildPhID_;
     std::vector<SubProcess> subProcesses_;
     edm::propagate_const<std::unique_ptr<ParameterSet>> processParameterSet_;
 

--- a/FWCore/Framework/interface/TransitionInfoTypes.h
+++ b/FWCore/Framework/interface/TransitionInfoTypes.h
@@ -58,6 +58,10 @@ namespace edm {
   private:
     LuminosityBlockPrincipal* luminosityBlockPrincipal_ = nullptr;
     EventSetupImpl const* eventSetupImpl_ = nullptr;
+    // The first element of this vector refers to the top level process.
+    // If there are SubProcesses, then each additional element refers to
+    // one SubProcess. The previous data member refers to the same EventSetupImpl
+    // object as one element of this vector (the one currently being handled).
     std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls_ = nullptr;
   };
 
@@ -65,16 +69,24 @@ namespace edm {
   public:
     RunTransitionInfo() {}
 
-    RunTransitionInfo(RunPrincipal& iPrincipal, EventSetupImpl const& iEventSetupImpl)
-        : runPrincipal_(&iPrincipal), eventSetupImpl_(&iEventSetupImpl) {}
+    RunTransitionInfo(RunPrincipal& iPrincipal,
+                      EventSetupImpl const& iEventSetupImpl,
+                      std::vector<std::shared_ptr<const EventSetupImpl>> const* iEventSetupImpls = nullptr)
+        : runPrincipal_(&iPrincipal), eventSetupImpl_(&iEventSetupImpl), eventSetupImpls_(iEventSetupImpls) {}
 
     RunPrincipal& principal() { return *runPrincipal_; }
     RunPrincipal const& principal() const { return *runPrincipal_; }
     EventSetupImpl const& eventSetupImpl() const { return *eventSetupImpl_; }
+    std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls() const { return eventSetupImpls_; }
 
   private:
     RunPrincipal* runPrincipal_ = nullptr;
     EventSetupImpl const* eventSetupImpl_ = nullptr;
+    // The first element of this vector refers to the top level process.
+    // If there are SubProcesses, then each additional element refers to
+    // one SubProcess. The previous data member refers to the same EventSetupImpl
+    // object as one element of this vector (the one currently being handled).
+    std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls_ = nullptr;
   };
 
   class ProcessBlockTransitionInfo {

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -111,6 +111,8 @@ namespace edm {
       virtual void endJob() {}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocRuns(unsigned int);
+      virtual void preallocRunsSummary(unsigned int);
       virtual void preallocLumis(unsigned int);
       virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -121,6 +121,8 @@ namespace edm {
       virtual void endJob() {}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocRuns(unsigned int);
+      virtual void preallocRunsSummary(unsigned int);
       virtual void preallocLumis(unsigned int);
       virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -124,6 +124,8 @@ namespace edm {
       virtual void endJob() {}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocRuns(unsigned int);
+      virtual void preallocRunsSummary(unsigned int);
       virtual void preallocLumis(unsigned int);
       virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -116,6 +116,8 @@ namespace edm {
       virtual void endJob() {}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocRuns(unsigned int);
+      virtual void preallocRunsSummary(unsigned int);
       virtual void preallocLumis(unsigned int);
       virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -122,6 +122,8 @@ namespace edm {
       virtual void endJob() {}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocRuns(unsigned int);
+      virtual void preallocRunsSummary(unsigned int);
       virtual void preallocLumis(unsigned int);
       virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -125,6 +125,8 @@ namespace edm {
       virtual void endJob() {}
 
       virtual void preallocStreams(unsigned int);
+      virtual void preallocRuns(unsigned int);
+      virtual void preallocRunsSummary(unsigned int);
       virtual void preallocLumis(unsigned int);
       virtual void preallocLumisSummary(unsigned int);
       virtual void preallocate(PreallocationConfiguration const&);

--- a/FWCore/Framework/interface/limited/implementors.h
+++ b/FWCore/Framework/interface/limited/implementors.h
@@ -155,19 +155,21 @@ namespace edm {
         ~RunCacheHolder() noexcept(false) override{};
 
       protected:
-        C const* runCache(edm::RunIndex iID) const { return cache_.get(); }
+        void preallocRuns(unsigned int iNRuns) final { caches_.reset(new std::shared_ptr<C>[iNRuns]); }
+
+        C const* runCache(edm::RunIndex iID) const { return caches_[iID].get(); }
 
       private:
-        void doBeginRun_(Run const& rp, EventSetup const& c) final { cache_ = globalBeginRun(rp, c); }
+        void doBeginRun_(Run const& rp, EventSetup const& c) final { caches_[rp.index()] = globalBeginRun(rp, c); }
         void doEndRun_(Run const& rp, EventSetup const& c) final {
           globalEndRun(rp, c);
-          cache_ = nullptr;  // propagate_const<T> has no reset() function
+          caches_[rp.index()].reset();
         }
 
         virtual std::shared_ptr<C> globalBeginRun(edm::Run const&, edm::EventSetup const&) const = 0;
         virtual void globalEndRun(edm::Run const&, edm::EventSetup const&) const = 0;
-        //When threaded we will have a container for N items whre N is # of simultaneous runs
-        edm::propagate_const<std::shared_ptr<C>> cache_;
+
+        std::unique_ptr<std::shared_ptr<C>[]> caches_;
       };
 
       template <typename T, typename C>
@@ -195,7 +197,7 @@ namespace edm {
         virtual std::shared_ptr<C> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
                                                               edm::EventSetup const&) const = 0;
         virtual void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const = 0;
-        //When threaded we will have a container for N items whre N is # of simultaneous runs
+
         std::unique_ptr<std::shared_ptr<C>[]> caches_;
       };
 
@@ -211,24 +213,30 @@ namespace edm {
         ~RunSummaryCacheHolder() noexcept(false) override{};
 
       private:
+        void preallocRunsSummary(unsigned int iNRuns) final { caches_.reset(new std::shared_ptr<C>[iNRuns]); }
+
         friend class EndRunSummaryProducer<T, C>;
         void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) final {
-          cache_ = globalBeginRunSummary(rp, c);
+          caches_[rp.index()] = globalBeginRunSummary(rp, c);
         }
         void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) final {
           //NOTE: in future this will need to be serialized
           std::lock_guard<std::mutex> guard(mutex_);
-          streamEndRunSummary(id, rp, c, cache_.get());
+          streamEndRunSummary(id, rp, c, caches_[rp.index()].get());
         }
-        void doEndRunSummary_(Run const& rp, EventSetup const& c) final { globalEndRunSummary(rp, c, cache_.get()); }
+        void doEndRunSummary_(Run const& rp, EventSetup const& c) final {
+          globalEndRunSummary(rp, c, caches_[rp.index()].get());
+          maybeClearCache(rp);
+        }
 
         virtual std::shared_ptr<C> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const = 0;
         virtual void streamEndRunSummary(StreamID, edm::Run const&, edm::EventSetup const&, C*) const = 0;
 
         virtual void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, C*) const = 0;
 
-        //When threaded we will have a container for N items where N is # of simultaneous runs
-        std::shared_ptr<C> cache_;
+        virtual void maybeClearCache(Run const& rp) { caches_[rp.index()].reset(); }
+
+        std::unique_ptr<std::shared_ptr<C>[]> caches_;
         std::mutex mutex_;
       };
 
@@ -272,7 +280,6 @@ namespace edm {
 
         virtual void maybeClearCache(LuminosityBlock const& lb) { caches_[lb.index()].reset(); }
 
-        //When threaded we will have a container for N items where N is # of simultaneous Lumis
         std::unique_ptr<std::shared_ptr<C>[]> caches_;
         std::mutex mutex_;
       };
@@ -359,10 +366,14 @@ namespace edm {
 
       private:
         void doEndRunProduce_(Run& rp, EventSetup const& c) final {
-          globalEndRunProduce(rp, c, RunSummaryCacheHolder<T, C>::cache_.get());
+          globalEndRunProduce(rp, c, RunSummaryCacheHolder<T, C>::caches_[rp.index()].get());
+          RunSummaryCacheHolder<T, C>::caches_[rp.index()].reset();
         }
 
         virtual void globalEndRunProduce(edm::Run&, edm::EventSetup const&, C const*) const = 0;
+
+        // Do nothing because the cache is cleared in doEndRunProduce_
+        void maybeClearCache(Run const&) final {}
       };
 
       template <typename T>

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -81,6 +81,7 @@ namespace edm {
                                                     Principal const&) const {}
 
       void doPreallocate(PreallocationConfiguration const&);
+      virtual void preallocRuns(unsigned int);
       virtual void preallocLumis(unsigned int);
       void doBeginJob();
       void doEndJob();

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -85,6 +85,7 @@ namespace edm {
                                                     Principal const&) const {}
 
       void doPreallocate(PreallocationConfiguration const&);
+      virtual void preallocRuns(unsigned int);
       virtual void preallocLumis(unsigned int);
       void doBeginJob();
       void doEndJob();

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -85,6 +85,7 @@ namespace edm {
                        ActivityRegistry*,
                        ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
+      virtual void preallocRuns(unsigned int);
       virtual void preallocLumis(unsigned int);
       void doBeginJob();
       void doEndJob();

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -96,6 +96,10 @@ namespace edm {
         m_pset = nullptr;
       }
 
+      void preallocRuns(unsigned int iNRuns) final {
+        m_runs.resize(iNRuns);
+        m_runSummaries.resize(iNRuns);
+      }
       void preallocLumis(unsigned int iNLumis) final {
         m_lumis.resize(iNLumis);
         m_lumiSummaries.resize(iNLumis);

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -132,6 +132,7 @@ namespace edm {
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
+      virtual void preallocRuns(unsigned int) {}
       virtual void preallocLumis(unsigned int) {}
 
       //For now this is a placeholder

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -101,6 +101,10 @@ namespace edm {
         m_pset = nullptr;
       }
 
+      void preallocRuns(unsigned int iNRuns) final {
+        m_runs.resize(iNRuns);
+        m_runSummaries.resize(iNRuns);
+      }
       void preallocLumis(unsigned int iNLumis) final {
         m_lumis.resize(iNLumis);
         m_lumiSummaries.resize(iNLumis);

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -162,6 +162,7 @@ namespace edm {
 
     private:
       void doPreallocate(PreallocationConfiguration const&);
+      virtual void preallocRuns(unsigned int) {}
       virtual void preallocLumis(unsigned int) {}
       virtual void setupStreamModules() = 0;
       virtual void doBeginJob() = 0;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -40,6 +40,7 @@
 #include "FWCore/Framework/interface/ensureAvailableAccelerators.h"
 #include "FWCore/Framework/interface/globalTransitionAsync.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
+#include "FWCore/Framework/src/SendSourceTerminationSignalIfException.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -77,6 +78,7 @@
 #include "MessageForSource.h"
 #include "MessageForParent.h"
 #include "LuminosityBlockProcessingStatus.h"
+#include "RunProcessingStatus.h"
 
 #include "boost/range/adaptor/reversed.hpp"
 
@@ -96,26 +98,6 @@
 #ifndef __APPLE__
 #include <sched.h>
 #endif
-
-namespace {
-  //Sentry class to only send a signal if an
-  // exception occurs. An exception is identified
-  // by the destructor being called without first
-  // calling completedSuccessfully().
-  class SendSourceTerminationSignalIfException {
-  public:
-    SendSourceTerminationSignalIfException(edm::ActivityRegistry* iReg) : reg_(iReg) {}
-    ~SendSourceTerminationSignalIfException() {
-      if (reg_) {
-        reg_->preSourceEarlyTerminationSignal_(edm::TerminationOrigin::ExceptionFromThisContext);
-      }
-    }
-    void completedSuccessfully() { reg_ = nullptr; }
-
-  private:
-    edm::ActivityRegistry* reg_;  // We do not use propagate_const because the registry itself is mutable.
-  };
-}  // namespace
 
 namespace edm {
 
@@ -388,11 +370,6 @@ namespace edm {
     if (nStreams == 0) {
       nStreams = nThreads;
     }
-    unsigned int nConcurrentRuns = optionsPset.getUntrackedParameter<unsigned int>("numberOfConcurrentRuns");
-    if (nConcurrentRuns != 1) {
-      throw Exception(errors::Configuration, "Illegal value nConcurrentRuns : ")
-          << "Although the plan is to change this in the future, currently nConcurrentRuns must always be 1.\n";
-    }
     unsigned int nConcurrentLumis =
         optionsPset.getUntrackedParameter<unsigned int>("numberOfConcurrentLuminosityBlocks");
     if (nConcurrentLumis == 0) {
@@ -400,6 +377,10 @@ namespace edm {
     }
     if (nConcurrentLumis > nStreams) {
       nConcurrentLumis = nStreams;
+    }
+    unsigned int nConcurrentRuns = optionsPset.getUntrackedParameter<unsigned int>("numberOfConcurrentRuns");
+    if (nConcurrentRuns == 0 || nConcurrentRuns > nConcurrentLumis) {
+      nConcurrentRuns = nConcurrentLumis;
     }
     std::vector<std::string> loopers = parameterSet->getParameter<std::vector<std::string>>("@all_loopers");
     if (!loopers.empty()) {
@@ -422,22 +403,15 @@ namespace edm {
         edm::LogInfo("ThreadStreamSetup") << "setting # threads " << nThreads << "\nsetting # streams " << nStreams;
       }
     }
+
     // The number of concurrent IOVs is configured individually for each record in
     // the class NumberOfConcurrentIOVs to values less than or equal to this.
-    unsigned int maxConcurrentIOVs = nConcurrentLumis;
+    // This maximum simplifies to being equal nConcurrentLumis if nConcurrentRuns is 1.
+    // Considering endRun, beginRun, and beginLumi we might need 3 concurrent IOVs per
+    // concurrent run past the first in use cases where IOVs change within a run.
+    unsigned int maxConcurrentIOVs =
+        3 * nConcurrentRuns - 2 + ((nConcurrentLumis > nConcurrentRuns) ? (nConcurrentLumis - nConcurrentRuns) : 0);
 
-    //Check that relationships between threading parameters makes sense
-    /*
-      if(nThreads<nStreams) {
-      //bad
-      }
-      if(nConcurrentRuns>nStreams) {
-      //bad
-      }
-      if(nConcurrentRuns>nConcurrentLumis) {
-      //bad
-      }
-    */
     IllegalParameters::setThrowAnException(optionsPset.getUntrackedParameter<bool>("throwIfIllegalParameter"));
 
     printDependencies_ = optionsPset.getUntrackedParameter<bool>("printDependencies");
@@ -486,8 +460,10 @@ namespace edm {
 
       preallocations_ = PreallocationConfiguration{nThreads, nStreams, nConcurrentLumis, nConcurrentRuns};
 
+      runQueue_ = std::make_unique<LimitedTaskQueue>(nConcurrentRuns);
       lumiQueue_ = std::make_unique<LimitedTaskQueue>(nConcurrentLumis);
       streamQueues_.resize(nStreams);
+      streamRunStatus_.resize(nStreams);
       streamLumiStatus_.resize(nStreams);
 
       processBlockHelper_ = std::make_shared<ProcessBlockHelper>();
@@ -548,7 +524,6 @@ namespace edm {
       thinnedAssociationsHelper_ = items.thinnedAssociationsHelper();
       processConfiguration_ = items.processConfiguration();
       processContext_.setProcessConfiguration(processConfiguration_.get());
-      principalCache_.setProcessHistoryRegistry(input_->processHistoryRegistry());
 
       FDEBUG(2) << parameterSet << std::endl;
 
@@ -564,6 +539,12 @@ namespace edm {
                                                    true /*primary process*/,
                                                    &*processBlockHelper_);
         principalCache_.insert(std::move(ep));
+      }
+
+      for (unsigned int index = 0; index < preallocations_.numberOfRuns(); ++index) {
+        auto rp = std::make_unique<RunPrincipal>(
+            preg(), *processConfiguration_, historyAppender_.get(), index, true, &mergeableRunProductProcesses_);
+        principalCache_.insert(std::move(rp));
       }
 
       for (unsigned int index = 0; index < preallocations_.numberOfLuminosityBlocks(); ++index) {
@@ -703,6 +684,9 @@ namespace edm {
 
     if (preallocations_.numberOfLuminosityBlocks() > 1) {
       throwAboutModulesRequiringLuminosityBlockSynchronization();
+    }
+    if (preallocations_.numberOfRuns() > 1) {
+      warnAboutModulesRequiringRunSynchronization();
     }
     warnAboutLegacyModules();
 
@@ -858,11 +842,6 @@ namespace edm {
   }
 
   InputSource::ItemType EventProcessor::nextTransitionType() {
-    if (deferredExceptionPtrIsSet_.load()) {
-      lastSourceTransition_ = InputSource::IsStop;
-      return InputSource::IsStop;
-    }
-
     SendSourceTerminationSignalIfException sentry(actReg_.get());
     InputSource::ItemType itemType;
     //For now, do nothing with InputSource::IsSynchronize
@@ -882,12 +861,6 @@ namespace edm {
 
     return lastSourceTransition_;
   }
-
-  std::pair<edm::ProcessHistoryID, edm::RunNumber_t> EventProcessor::nextRunID() {
-    return std::make_pair(input_->reducedProcessHistoryID(), input_->run());
-  }
-
-  edm::LuminosityBlockNumber_t EventProcessor::nextLuminosityBlockID() { return input_->luminosityBlock(); }
 
   EventProcessor::StatusCode EventProcessor::runToCompletion() {
     beginJob();  //make sure this was called
@@ -959,7 +932,14 @@ namespace edm {
     size_t size = preg_->size();
     SendSourceTerminationSignalIfException sentry(actReg_.get());
 
-    principalCache_.preReadFile();
+    if (streamRunActive_ > 0) {
+      streamRunStatus_[0]->runPrincipal()->preReadFile();
+      streamRunStatus_[0]->runPrincipal()->adjustIndexesAfterProductRegistryAddition();
+    }
+
+    if (streamLumiActive_ > 0) {
+      streamLumiStatus_[0]->lumiPrincipal()->adjustIndexesAfterProductRegistryAddition();
+    }
 
     fb_ = input_->readFile();
     if (size < preg_->size()) {
@@ -1140,377 +1120,684 @@ namespace edm {
     }
   }
 
-  void EventProcessor::beginRun(ProcessHistoryID const& phid,
-                                RunNumber_t run,
-                                bool& globalBeginSucceeded,
-                                bool& eventSetupForInstanceSucceeded) {
-    globalBeginSucceeded = false;
-    RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
-    {
-      SendSourceTerminationSignalIfException sentry(actReg_.get());
-
-      input_->doBeginRun(runPrincipal, &processContext_);
-      sentry.completedSuccessfully();
-    }
-
-    IOVSyncValue ts(EventID(runPrincipal.run(), 0, 0), runPrincipal.beginTime());
-    if (forceESCacheClearOnNewRun_) {
-      espController_->forceCacheClear();
-    }
-    {
-      SendSourceTerminationSignalIfException sentry(actReg_.get());
-      actReg_->preESSyncIOVSignal_.emit(ts);
-      synchronousEventSetupForInstance(ts, taskGroup_, *espController_);
-      actReg_->postESSyncIOVSignal_.emit(ts);
-      eventSetupForInstanceSucceeded = true;
-      sentry.completedSuccessfully();
-    }
-    auto const& es = esp_->eventSetupImpl();
-    if (looper_ && looperBeginJobRun_ == false) {
-      looper_->copyInfo(ScheduleInfo(schedule_.get()));
-
-      FinalWaitingTask waitTask{taskGroup_};
-      using namespace edm::waiting_task::chain;
-      chain::first([this, &es](auto nextTask) {
-        looper_->esPrefetchAsync(nextTask, es, Transition::BeginRun, serviceToken_);
-      }) | then([this, &es](auto nextTask) mutable {
-        looper_->beginOfJob(es);
-        looperBeginJobRun_ = true;
-        looper_->doStartingNewLoop();
-      }) | runLast(WaitingTaskHolder(taskGroup_, &waitTask));
-
-      waitTask.wait();
-    }
-    {
-      using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>;
-      FinalWaitingTask globalWaitTask{taskGroup_};
-
-      using namespace edm::waiting_task::chain;
-      chain::first([&runPrincipal, &es, this](auto waitTask) {
-        RunTransitionInfo transitionInfo(runPrincipal, es);
-        beginGlobalTransitionAsync<Traits>(
-            std::move(waitTask), *schedule_, transitionInfo, serviceToken_, subProcesses_);
-      }) | then([&globalBeginSucceeded, run](auto waitTask) mutable {
-        globalBeginSucceeded = true;
-        FDEBUG(1) << "\tbeginRun " << run << "\n";
-      }) | ifThen(looper_, [this, &runPrincipal, &es](auto waitTask) {
-        looper_->prefetchAsync(waitTask, serviceToken_, Transition::BeginRun, runPrincipal, es);
-      }) | ifThen(looper_, [this, &runPrincipal, &es](auto waitTask) {
-        looper_->doBeginRun(runPrincipal, es, &processContext_);
-      }) | runLast(WaitingTaskHolder(taskGroup_, &globalWaitTask));
-
-      globalWaitTask.wait();
-    }
-    {
-      //To wait, the ref count has to be 1+#streams
-      FinalWaitingTask streamLoopWaitTask{taskGroup_};
-
-      using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>;
-
-      RunTransitionInfo transitionInfo(runPrincipal, es);
-      beginStreamsTransitionAsync<Traits>(WaitingTaskHolder(taskGroup_, &streamLoopWaitTask),
-                                          *schedule_,
-                                          preallocations_.numberOfStreams(),
-                                          transitionInfo,
-                                          serviceToken_,
-                                          subProcesses_);
-      streamLoopWaitTask.wait();
-    }
-    FDEBUG(1) << "\tstreamBeginRun " << run << "\n";
-    if (looper_) {
-      //looper_->doStreamBeginRun(schedule_->streamID(),runPrincipal, es);
-    }
-  }
-
-  void EventProcessor::endUnfinishedRun(ProcessHistoryID const& phid,
-                                        RunNumber_t run,
-                                        bool globalBeginSucceeded,
-                                        bool cleaningUpAfterException,
-                                        bool eventSetupForInstanceSucceeded) {
-    if (eventSetupForInstanceSucceeded) {
-      //If we skip empty runs, this would be called conditionally
-      endRun(phid, run, globalBeginSucceeded, cleaningUpAfterException);
-
-      if (globalBeginSucceeded) {
-        RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
-        if (runPrincipal.shouldWriteRun() != RunPrincipal::kNo) {
-          FinalWaitingTask t{taskGroup_};
-          MergeableRunProductMetadata* mergeableRunProductMetadata = runPrincipal.mergeableRunProductMetadata();
-          mergeableRunProductMetadata->preWriteRun();
-          writeRunAsync(edm::WaitingTaskHolder{taskGroup_, &t}, phid, run, mergeableRunProductMetadata);
-          auto exceptn = t.waitNoThrow();
-          mergeableRunProductMetadata->postWriteRun();
-          if (exceptn) {
-            std::rethrow_exception(exceptn);
-          }
-        }
-      }
-    }
-    deleteRunFromCache(phid, run);
-  }
-
-  void EventProcessor::endRun(ProcessHistoryID const& phid,
-                              RunNumber_t run,
-                              bool globalBeginSucceeded,
-                              bool cleaningUpAfterException) {
-    RunPrincipal& runPrincipal = principalCache_.runPrincipal(phid, run);
-    runPrincipal.setEndTime(input_->timestamp());
-
-    IOVSyncValue ts(
-        EventID(runPrincipal.run(), LuminosityBlockID::maxLuminosityBlockNumber(), EventID::maxEventNumber()),
-        runPrincipal.endTime());
-    {
-      SendSourceTerminationSignalIfException sentry(actReg_.get());
-      actReg_->preESSyncIOVSignal_.emit(ts);
-      synchronousEventSetupForInstance(ts, taskGroup_, *espController_);
-      actReg_->postESSyncIOVSignal_.emit(ts);
-      sentry.completedSuccessfully();
-    }
-    auto const& es = esp_->eventSetupImpl();
-    if (globalBeginSucceeded) {
-      //To wait, the ref count has to be 1+#streams
-      FinalWaitingTask streamLoopWaitTask{taskGroup_};
-
-      using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>;
-
-      RunTransitionInfo transitionInfo(runPrincipal, es);
-      endStreamsTransitionAsync<Traits>(WaitingTaskHolder(taskGroup_, &streamLoopWaitTask),
-                                        *schedule_,
-                                        preallocations_.numberOfStreams(),
-                                        transitionInfo,
-                                        serviceToken_,
-                                        subProcesses_,
-                                        cleaningUpAfterException);
-      streamLoopWaitTask.wait();
-    }
-    FDEBUG(1) << "\tstreamEndRun " << run << "\n";
-    if (looper_) {
-      //looper_->doStreamEndRun(schedule_->streamID(),runPrincipal, es);
-    }
-    {
-      FinalWaitingTask globalWaitTask{taskGroup_};
-
-      using namespace edm::waiting_task::chain;
-      chain::first([this, &runPrincipal, &es, cleaningUpAfterException](auto nextTask) {
-        RunTransitionInfo transitionInfo(runPrincipal, es);
-        using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>;
-        endGlobalTransitionAsync<Traits>(
-            std::move(nextTask), *schedule_, transitionInfo, serviceToken_, subProcesses_, cleaningUpAfterException);
-      }) | ifThen(looper_, [this, &runPrincipal, &es](auto nextTask) {
-        looper_->prefetchAsync(std::move(nextTask), serviceToken_, Transition::EndRun, runPrincipal, es);
-      }) | ifThen(looper_, [this, &runPrincipal, &es](auto nextTask) {
-        looper_->doEndRun(runPrincipal, es, &processContext_);
-      }) | runLast(WaitingTaskHolder(taskGroup_, &globalWaitTask));
-
-      globalWaitTask.wait();
-    }
-    FDEBUG(1) << "\tendRun " << run << "\n";
-  }
-
-  InputSource::ItemType EventProcessor::processLumis(std::shared_ptr<void> const& iRunResource) {
+  InputSource::ItemType EventProcessor::processRuns() {
     FinalWaitingTask waitTask{taskGroup_};
-    if (streamLumiActive_ > 0) {
-      assert(streamLumiActive_ == preallocations_.numberOfStreams());
-      // Continue after opening a new input file
-      continueLumiAsync(WaitingTaskHolder{taskGroup_, &waitTask});
+    assert(lastTransitionType() == InputSource::IsRun);
+    if (streamRunActive_ == 0) {
+      assert(streamLumiActive_ == 0);
+
+      beginRunAsync(IOVSyncValue(EventID(input_->run(), 0, 0), input_->runAuxiliary()->beginTime()),
+                    WaitingTaskHolder{taskGroup_, &waitTask});
     } else {
-      beginLumiAsync(IOVSyncValue(EventID(input_->run(), input_->luminosityBlock(), 0),
-                                  input_->luminosityBlockAuxiliary()->beginTime()),
-                     iRunResource,
-                     WaitingTaskHolder{taskGroup_, &waitTask});
+      assert(streamRunActive_ == preallocations_.numberOfStreams());
+
+      auto runStatus = streamRunStatus_[0];
+
+      while (lastTransitionType() == InputSource::IsRun and runStatus->runPrincipal()->run() == input_->run() and
+             runStatus->runPrincipal()->reducedProcessHistoryID() == input_->reducedProcessHistoryID()) {
+        readAndMergeRun(*runStatus);
+        nextTransitionType();
+      }
+
+      WaitingTaskHolder holder{taskGroup_, &waitTask};
+      runStatus->setHolderOfTaskInProcessRuns(holder);
+      if (streamLumiActive_ > 0) {
+        assert(streamLumiActive_ == preallocations_.numberOfStreams());
+        continueLumiAsync(std::move(holder));
+      } else {
+        handleNextItemAfterMergingRunEntries(std::move(runStatus), std::move(holder));
+      }
     }
     waitTask.wait();
     return lastTransitionType();
   }
 
-  void EventProcessor::beginLumiAsync(IOVSyncValue const& iSync,
-                                      std::shared_ptr<void> const& iRunResource,
-                                      edm::WaitingTaskHolder iHolder) {
+  void EventProcessor::beginRunAsync(IOVSyncValue const& iSync, WaitingTaskHolder iHolder) {
     if (iHolder.taskHasFailed()) {
       return;
     }
 
     actReg_->esSyncIOVQueuingSignal_.emit(iSync);
-    // We must be careful with the status object here and in code this function calls. IF we want
-    // endRun to be called, then we must call resetResources before the things waiting on
-    // iHolder are allowed to proceed. Otherwise, there will be race condition (possibly causing
-    // endRun to be called much later than it should be, because status is holding iRunResource).
-    // Note that this must be done explicitly. Relying on the destructor does not work well
-    // because the LimitedTaskQueue for the lumiWork holds the shared_ptr in each of its internal
-    // queues, plus it is difficult to guarantee the destructor is called  before iHolder gets
-    // destroyed inside this function and lumiWork.
-    auto status =
-        std::make_shared<LuminosityBlockProcessingStatus>(this, preallocations_.numberOfStreams(), iRunResource);
-    chain::first([&](auto nextTask) {
-      auto asyncEventSetup = [](ActivityRegistry* actReg,
-                                auto* espController,
-                                auto& queue,
-                                WaitingTaskHolder task,
-                                auto& status,
-                                IOVSyncValue const& iSync) {
-        queue.pause();
-        CMS_SA_ALLOW try {
-          SendSourceTerminationSignalIfException sentry(actReg);
-          // Pass in iSync to let the EventSetup system know which run and lumi
-          // need to be processed and prepare IOVs for it.
-          // Pass in the endIOVWaitingTasks so the lumi can notify them when the
-          // lumi is done and no longer needs its EventSetup IOVs.
-          actReg->preESSyncIOVSignal_.emit(iSync);
-          espController->eventSetupForInstanceAsync(
-              iSync, task, status->endIOVWaitingTasks(), status->eventSetupImpls());
-          sentry.completedSuccessfully();
-        } catch (...) {
-          task.doneWaiting(std::current_exception());
+
+    auto status = std::make_shared<RunProcessingStatus>(preallocations_.numberOfStreams(), iHolder);
+
+    chain::first([this, &status, &iSync](auto nextTask) {
+      espController_->runOrQueueEventSetupForInstanceAsync(iSync,
+                                                           nextTask,
+                                                           status->endIOVWaitingTasks(),
+                                                           status->eventSetupImpls(),
+                                                           queueWhichWaitsForIOVsToFinish_,
+                                                           actReg_.get(),
+                                                           forceESCacheClearOnNewRun_);
+    }) | chain::then([this, status, iSync](std::exception_ptr const* iException, auto nextTask) {
+      CMS_SA_ALLOW try {
+        if (iException) {
+          WaitingTaskHolder copyHolder(nextTask);
+          copyHolder.doneWaiting(*iException);
+          // Finish handling the exception in the task pushed to runQueue_
         }
-      };
-      if (espController_->doWeNeedToWaitForIOVsToFinish(iSync)) {
-        // We only get here inside this block if there is an EventSetup
-        // module not able to handle concurrent IOVs (usually an ESSource)
-        // and the new sync value is outside the current IOV of that module.
-        auto group = nextTask.group();
-        queueWhichWaitsForIOVsToFinish_.push(
-            *group, [this, task = std::move(nextTask), iSync, status, asyncEventSetup]() mutable {
-              asyncEventSetup(
-                  actReg_.get(), espController_.get(), queueWhichWaitsForIOVsToFinish_, std::move(task), status, iSync);
+        ServiceRegistry::Operate operate(serviceToken_);
+        actReg_->postESSyncIOVSignal_.emit(iSync);
+
+        runQueue_->pushAndPause(
+            *nextTask.group(),
+            [this, postRunQueueTask = nextTask, status](edm::LimitedTaskQueue::Resumer iResumer) mutable {
+              CMS_SA_ALLOW try {
+                if (postRunQueueTask.taskHasFailed()) {
+                  status->resetBeginResources();
+                  queueWhichWaitsForIOVsToFinish_.resume();
+                  return;
+                }
+
+                status->setResumer(std::move(iResumer));
+
+                sourceResourcesAcquirer_.serialQueueChain().push(
+                    *postRunQueueTask.group(), [this, postSourceTask = postRunQueueTask, status]() mutable {
+                      CMS_SA_ALLOW try {
+                        ServiceRegistry::Operate operate(serviceToken_);
+
+                        if (postSourceTask.taskHasFailed()) {
+                          status->resetBeginResources();
+                          queueWhichWaitsForIOVsToFinish_.resume();
+                          status->resumeGlobalRunQueue();
+                          return;
+                        }
+
+                        status->setRunPrincipal(readRun());
+
+                        RunPrincipal& runPrincipal = *status->runPrincipal();
+                        {
+                          SendSourceTerminationSignalIfException sentry(actReg_.get());
+                          input_->doBeginRun(runPrincipal, &processContext_);
+                          sentry.completedSuccessfully();
+                        }
+
+                        EventSetupImpl const& es = status->eventSetupImpl(esp_->subProcessIndex());
+                        if (looper_ && looperBeginJobRun_ == false) {
+                          looper_->copyInfo(ScheduleInfo(schedule_.get()));
+
+                          oneapi::tbb::task_group group;
+                          FinalWaitingTask waitTask{group};
+                          using namespace edm::waiting_task::chain;
+                          chain::first([this, &es](auto nextTask) {
+                            looper_->esPrefetchAsync(nextTask, es, Transition::BeginRun, serviceToken_);
+                          }) | then([this, &es](auto nextTask) mutable {
+                            looper_->beginOfJob(es);
+                            looperBeginJobRun_ = true;
+                            looper_->doStartingNewLoop();
+                          }) | runLast(WaitingTaskHolder(group, &waitTask));
+                          waitTask.wait();
+                        }
+
+                        using namespace edm::waiting_task::chain;
+                        chain::first([this, status](auto nextTask) mutable {
+                          CMS_SA_ALLOW try { readAndMergeRunEntriesAsync(std::move(status), nextTask); } catch (...) {
+                            status->setStopBeforeProcessingRun(true);
+                            nextTask.doneWaiting(std::current_exception());
+                          }
+                        }) | then([this, status, &es](auto nextTask) {
+                          if (status->stopBeforeProcessingRun()) {
+                            return;
+                          }
+                          RunTransitionInfo transitionInfo(*status->runPrincipal(), es, &status->eventSetupImpls());
+                          using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>;
+                          beginGlobalTransitionAsync<Traits>(
+                              nextTask, *schedule_, transitionInfo, serviceToken_, subProcesses_);
+                        }) | then([status](auto nextTask) mutable {
+                          if (status->stopBeforeProcessingRun()) {
+                            return;
+                          }
+                          status->globalBeginDidSucceed();
+                        }) | ifThen(looper_, [this, status, &es](auto nextTask) {
+                          if (status->stopBeforeProcessingRun()) {
+                            return;
+                          }
+                          looper_->prefetchAsync(
+                              nextTask, serviceToken_, Transition::BeginRun, *status->runPrincipal(), es);
+                        }) | ifThen(looper_, [this, status, &es](auto nextTask) {
+                          if (status->stopBeforeProcessingRun()) {
+                            return;
+                          }
+                          ServiceRegistry::Operate operateLooper(serviceToken_);
+                          looper_->doBeginRun(*status->runPrincipal(), es, &processContext_);
+                        }) | then([this, status](std::exception_ptr const* iException, auto holder) mutable {
+                          bool precedingTasksSucceeded = true;
+                          if (iException) {
+                            precedingTasksSucceeded = false;
+                            WaitingTaskHolder copyHolder(holder);
+                            copyHolder.doneWaiting(*iException);
+                          }
+
+                          if (status->stopBeforeProcessingRun()) {
+                            // We just quit now if there was a failure when merging runs
+                            status->resetBeginResources();
+                            queueWhichWaitsForIOVsToFinish_.resume();
+                            status->resumeGlobalRunQueue();
+                            return;
+                          }
+                          CMS_SA_ALLOW try {
+                            // Under normal circumstances, this task runs after endRun has completed for all streams
+                            // and global endLumi has completed for all lumis contained in this run
+                            auto globalEndRunTask =
+                                edm::make_waiting_task([this, status](std::exception_ptr const*) mutable {
+                                  WaitingTaskHolder taskHolder = status->holderOfTaskInProcessRuns();
+                                  status->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
+                                  globalEndRunAsync(std::move(taskHolder), std::move(status));
+                                });
+                            status->setGlobalEndRunHolder(WaitingTaskHolder{*holder.group(), globalEndRunTask});
+                          } catch (...) {
+                            status->resetBeginResources();
+                            queueWhichWaitsForIOVsToFinish_.resume();
+                            status->resumeGlobalRunQueue();
+                            holder.doneWaiting(std::current_exception());
+                            return;
+                          }
+
+                          // After this point we are committed to end the run via endRunAsync
+
+                          ServiceRegistry::Operate operate(serviceToken_);
+
+                          // Call this before inserting into the stream queues so that stream begin run
+                          // is executed before global begin lumi in a single threaded job. This is not
+                          // required or necessary, but it is desirable to preserve the pre-concurrent run
+                          // behavior. In a multi-threaded job these things might run concurrently.
+                          handleNextItemAfterMergingRunEntries(status, holder);
+
+                          CMS_SA_ALLOW try {
+                            streamQueuesInserter_.push(
+                                *holder.group(), [this, status, precedingTasksSucceeded, holder]() mutable {
+                                  for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
+                                    CMS_SA_ALLOW try {
+                                      streamQueues_[i].push(
+                                          *holder.group(),
+                                          [this, i, status, precedingTasksSucceeded, holder]() mutable {
+                                            streamBeginRunAsync(
+                                                i, std::move(status), precedingTasksSucceeded, std::move(holder));
+                                          });
+                                    } catch (...) {
+                                      if (status->streamFinishedBeginRun()) {
+                                        WaitingTaskHolder copyHolder(holder);
+                                        copyHolder.doneWaiting(std::current_exception());
+                                        status->resetBeginResources();
+                                        queueWhichWaitsForIOVsToFinish_.resume();
+                                        exceptionRunStatus_ = status;
+                                      }
+                                    }
+                                  }
+                                });
+                          } catch (...) {
+                            WaitingTaskHolder copyHolder(holder);
+                            copyHolder.doneWaiting(std::current_exception());
+                            status->resetBeginResources();
+                            queueWhichWaitsForIOVsToFinish_.resume();
+                            exceptionRunStatus_ = status;
+                          }
+                        }) | runLast(postSourceTask);
+                      } catch (...) {
+                        status->resetBeginResources();
+                        queueWhichWaitsForIOVsToFinish_.resume();
+                        status->resumeGlobalRunQueue();
+                        postSourceTask.doneWaiting(std::current_exception());
+                      }
+                    });  // task in sourceResourcesAcquirer
+              } catch (...) {
+                status->resetBeginResources();
+                queueWhichWaitsForIOVsToFinish_.resume();
+                status->resumeGlobalRunQueue();
+                postRunQueueTask.doneWaiting(std::current_exception());
+              }
+            });  // task in runQueue
+      } catch (...) {
+        status->resetBeginResources();
+        queueWhichWaitsForIOVsToFinish_.resume();
+        nextTask.doneWaiting(std::current_exception());
+      }
+    }) | chain::runLast(std::move(iHolder));
+  }
+
+  void EventProcessor::streamBeginRunAsync(unsigned int iStream,
+                                           std::shared_ptr<RunProcessingStatus> status,
+                                           bool precedingTasksSucceeded,
+                                           WaitingTaskHolder iHolder) {
+    // These shouldn't throw
+    streamQueues_[iStream].pause();
+    ++streamRunActive_;
+    streamRunStatus_[iStream] = std::move(status);
+
+    CMS_SA_ALLOW try {
+      using namespace edm::waiting_task::chain;
+      chain::first([this, iStream, precedingTasksSucceeded](auto nextTask) {
+        if (precedingTasksSucceeded) {
+          RunProcessingStatus& rs = *streamRunStatus_[iStream];
+          RunTransitionInfo transitionInfo(
+              *rs.runPrincipal(), rs.eventSetupImpl(esp_->subProcessIndex()), &rs.eventSetupImpls());
+          using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>;
+          beginStreamTransitionAsync<Traits>(
+              std::move(nextTask), *schedule_, iStream, transitionInfo, serviceToken_, subProcesses_);
+        }
+      }) | then([this, iStream](std::exception_ptr const* exceptionFromBeginStreamRun, auto nextTask) {
+        if (exceptionFromBeginStreamRun) {
+          nextTask.doneWaiting(*exceptionFromBeginStreamRun);
+        }
+        releaseBeginRunResources(iStream);
+      }) | runLast(iHolder);
+    } catch (...) {
+      releaseBeginRunResources(iStream);
+      iHolder.doneWaiting(std::current_exception());
+    }
+  }
+
+  void EventProcessor::releaseBeginRunResources(unsigned int iStream) {
+    streamQueues_[iStream].resume();
+    auto& status = streamRunStatus_[iStream];
+    if (status->streamFinishedBeginRun()) {
+      status->resetBeginResources();
+      queueWhichWaitsForIOVsToFinish_.resume();
+    }
+  }
+
+  void EventProcessor::endRunAsync(std::shared_ptr<RunProcessingStatus> iRunStatus, WaitingTaskHolder iHolder) {
+    RunPrincipal& runPrincipal = *iRunStatus->runPrincipal();
+    iRunStatus->setEndTime();
+    IOVSyncValue ts(
+        EventID(runPrincipal.run(), LuminosityBlockID::maxLuminosityBlockNumber(), EventID::maxEventNumber()),
+        runPrincipal.endTime());
+    CMS_SA_ALLOW try { actReg_->esSyncIOVQueuingSignal_.emit(ts); } catch (...) {
+      WaitingTaskHolder copyHolder(iHolder);
+      copyHolder.doneWaiting(std::current_exception());
+    }
+
+    chain::first([this, &iRunStatus, &ts](auto nextTask) {
+      espController_->runOrQueueEventSetupForInstanceAsync(ts,
+                                                           nextTask,
+                                                           iRunStatus->endIOVWaitingTasksEndRun(),
+                                                           iRunStatus->eventSetupImplsEndRun(),
+                                                           queueWhichWaitsForIOVsToFinish_,
+                                                           actReg_.get());
+    }) | chain::then([this, iRunStatus, ts](std::exception_ptr const* iException, auto nextTask) {
+      if (iException) {
+        iRunStatus->setEndingEventSetupSucceeded(false);
+        handleEndRunExceptions(*iException, nextTask);
+      }
+      ServiceRegistry::Operate operate(serviceToken_);
+      CMS_SA_ALLOW try { actReg_->postESSyncIOVSignal_.emit(ts); } catch (...) {
+        WaitingTaskHolder copyHolder(nextTask);
+        copyHolder.doneWaiting(std::current_exception());
+      }
+
+      streamQueuesInserter_.push(*nextTask.group(), [this, nextTask]() mutable {
+        for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
+          CMS_SA_ALLOW try {
+            streamQueues_[i].push(*nextTask.group(), [this, i, nextTask]() mutable {
+              streamQueues_[i].pause();
+              streamEndRunAsync(std::move(nextTask), i);
             });
-      } else {
-        asyncEventSetup(
-            actReg_.get(), espController_.get(), queueWhichWaitsForIOVsToFinish_, std::move(nextTask), status, iSync);
+          } catch (...) {
+            WaitingTaskHolder copyHolder(nextTask);
+            copyHolder.doneWaiting(std::current_exception());
+          }
+        }
+      });
+
+      if (lastTransitionType() == InputSource::IsRun) {
+        CMS_SA_ALLOW try {
+          beginRunAsync(IOVSyncValue(EventID(input_->run(), 0, 0), input_->runAuxiliary()->beginTime()), nextTask);
+        } catch (...) {
+          WaitingTaskHolder copyHolder(nextTask);
+          copyHolder.doneWaiting(std::current_exception());
+        }
       }
-    }) | chain::then([this, status, iSync](std::exception_ptr const* iPtr, auto nextTask) {
-      actReg_->postESSyncIOVSignal_.emit(iSync);
-      //the call to doneWaiting will cause the count to decrement
-      auto copyTask = nextTask;
-      if (iPtr) {
-        nextTask.doneWaiting(*iPtr);
+    }) | chain::runLast(std::move(iHolder));
+  }
+
+  void EventProcessor::handleEndRunExceptions(std::exception_ptr iException, WaitingTaskHolder const& holder) {
+    if (holder.taskHasFailed()) {
+      setExceptionMessageRuns();
+    } else {
+      WaitingTaskHolder tmp(holder);
+      tmp.doneWaiting(iException);
+    }
+  }
+
+  void EventProcessor::globalEndRunAsync(WaitingTaskHolder iTask, std::shared_ptr<RunProcessingStatus> iRunStatus) {
+    auto& runPrincipal = *(iRunStatus->runPrincipal());
+    bool didGlobalBeginSucceed = iRunStatus->didGlobalBeginSucceed();
+    bool cleaningUpAfterException = iRunStatus->cleaningUpAfterException() || iTask.taskHasFailed();
+    EventSetupImpl const& es = iRunStatus->eventSetupImplEndRun(esp_->subProcessIndex());
+    std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls = &iRunStatus->eventSetupImplsEndRun();
+    bool endingEventSetupSucceeded = iRunStatus->endingEventSetupSucceeded();
+
+    MergeableRunProductMetadata* mergeableRunProductMetadata = runPrincipal.mergeableRunProductMetadata();
+    using namespace edm::waiting_task::chain;
+    chain::first([this, &runPrincipal, &es, &eventSetupImpls, cleaningUpAfterException, endingEventSetupSucceeded](
+                     auto nextTask) {
+      if (endingEventSetupSucceeded) {
+        RunTransitionInfo transitionInfo(runPrincipal, es, eventSetupImpls);
+        using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>;
+        endGlobalTransitionAsync<Traits>(
+            std::move(nextTask), *schedule_, transitionInfo, serviceToken_, subProcesses_, cleaningUpAfterException);
       }
-      auto group = copyTask.group();
-      lumiQueue_->pushAndPause(
-          *group, [this, task = std::move(copyTask), status](edm::LimitedTaskQueue::Resumer iResumer) mutable {
-            if (task.taskHasFailed()) {
-              status->resetResources();
-              return;
+    }) |
+        ifThen(looper_ && endingEventSetupSucceeded,
+               [this, &runPrincipal, &es](auto nextTask) {
+                 looper_->prefetchAsync(std::move(nextTask), serviceToken_, Transition::EndRun, runPrincipal, es);
+               }) |
+        ifThen(looper_ && endingEventSetupSucceeded,
+               [this, &runPrincipal, &es](auto nextTask) {
+                 ServiceRegistry::Operate operate(serviceToken_);
+                 looper_->doEndRun(runPrincipal, es, &processContext_);
+               }) |
+        ifThen(didGlobalBeginSucceed && endingEventSetupSucceeded,
+               [this, mergeableRunProductMetadata, &runPrincipal = runPrincipal](auto nextTask) {
+                 mergeableRunProductMetadata->preWriteRun();
+                 writeRunAsync(nextTask, runPrincipal, mergeableRunProductMetadata);
+               }) |
+        then([status = std::move(iRunStatus),
+              this,
+              didGlobalBeginSucceed,
+              mergeableRunProductMetadata,
+              endingEventSetupSucceeded](std::exception_ptr const* iException, auto nextTask) mutable {
+          if (didGlobalBeginSucceed && endingEventSetupSucceeded) {
+            mergeableRunProductMetadata->postWriteRun();
+          }
+          if (iException) {
+            handleEndRunExceptions(*iException, nextTask);
+          }
+          ServiceRegistry::Operate operate(serviceToken_);
+
+          std::exception_ptr ptr;
+
+          // Try hard to clean up resources so the
+          // process can terminate in a controlled
+          // fashion even after exceptions have occurred.
+          CMS_SA_ALLOW try { clearRunPrincipal(*status); } catch (...) {
+            if (not ptr) {
+              ptr = std::current_exception();
+            }
+          }
+          CMS_SA_ALLOW try {
+            status->resumeGlobalRunQueue();
+            queueWhichWaitsForIOVsToFinish_.resume();
+          } catch (...) {
+            if (not ptr) {
+              ptr = std::current_exception();
+            }
+          }
+          CMS_SA_ALLOW try {
+            status->resetEndResources();
+            status.reset();
+          } catch (...) {
+            if (not ptr) {
+              ptr = std::current_exception();
+            }
+          }
+
+          if (ptr && !iException) {
+            handleEndRunExceptions(ptr, nextTask);
+          }
+        }) |
+        runLast(std::move(iTask));
+  }
+
+  void EventProcessor::streamEndRunAsync(WaitingTaskHolder iTask, unsigned int iStreamIndex) {
+    CMS_SA_ALLOW try {
+      if (!streamRunStatus_[iStreamIndex]) {
+        if (exceptionRunStatus_->streamFinishedRun()) {
+          exceptionRunStatus_->globalEndRunHolder().doneWaiting(std::exception_ptr());
+          exceptionRunStatus_.reset();
+        }
+        return;
+      }
+
+      auto runDoneTask =
+          edm::make_waiting_task([this, iTask, iStreamIndex](std::exception_ptr const* iException) mutable {
+            if (iException) {
+              handleEndRunExceptions(*iException, iTask);
             }
 
-            status->setResumer(std::move(iResumer));
+            auto runStatus = streamRunStatus_[iStreamIndex];
 
-            auto group = task.group();
-            sourceResourcesAcquirer_.serialQueueChain().push(
-                *group, [this, postQueueTask = std::move(task), status = std::move(status)]() mutable {
-                  //make the services available
-                  ServiceRegistry::Operate operate(serviceToken_);
-                  // Caught exception is propagated via WaitingTaskHolder
-                  CMS_SA_ALLOW try {
-                    readLuminosityBlock(*status);
-
-                    LuminosityBlockPrincipal& lumiPrincipal = *status->lumiPrincipal();
-                    {
-                      SendSourceTerminationSignalIfException sentry(actReg_.get());
-
-                      input_->doBeginLumi(lumiPrincipal, &processContext_);
-                      sentry.completedSuccessfully();
-                    }
-
-                    Service<RandomNumberGenerator> rng;
-                    if (rng.isAvailable()) {
-                      LuminosityBlock lb(lumiPrincipal, ModuleDescription(), nullptr, false);
-                      rng->preBeginLumi(lb);
-                    }
-
-                    EventSetupImpl const& es = status->eventSetupImpl(esp_->subProcessIndex());
-
-                    using namespace edm::waiting_task::chain;
-                    chain::first([this, status, &lumiPrincipal](auto nextTask) {
-                      EventSetupImpl const& es = status->eventSetupImpl(esp_->subProcessIndex());
-                      {
-                        LumiTransitionInfo transitionInfo(lumiPrincipal, es, &status->eventSetupImpls());
-                        using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin>;
-                        beginGlobalTransitionAsync<Traits>(
-                            nextTask, *schedule_, transitionInfo, serviceToken_, subProcesses_);
-                      }
-                    }) | ifThen(looper_, [this, status, &es](auto nextTask) {
-                      looper_->prefetchAsync(
-                          nextTask, serviceToken_, Transition::BeginLuminosityBlock, *(status->lumiPrincipal()), es);
-                    }) | ifThen(looper_, [this, status, &es](auto nextTask) {
-                      status->globalBeginDidSucceed();
-                      //make the services available
-                      ServiceRegistry::Operate operateLooper(serviceToken_);
-                      looper_->doBeginLuminosityBlock(*(status->lumiPrincipal()), es, &processContext_);
-                    }) | then([this, status](std::exception_ptr const* iPtr, auto holder) mutable {
-                      if (iPtr) {
-                        status->resetResources();
-                        holder.doneWaiting(*iPtr);
-                      } else {
-                        if (not looper_) {
-                          status->globalBeginDidSucceed();
-                        }
-                        EventSetupImpl const& es = status->eventSetupImpl(esp_->subProcessIndex());
-                        using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>;
-
-                        for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
-                          streamQueues_[i].push(*holder.group(), [this, i, status, holder, &es]() mutable {
-                            streamQueues_[i].pause();
-
-                            auto& event = principalCache_.eventPrincipal(i);
-                            //We need to be sure that 'status' and its internal shared_ptr<LuminosityBlockPrincipal> are only
-                            // held by the container as this lambda may not finish executing before all the tasks it
-                            // spawns have already started to run.
-                            auto eventSetupImpls = &status->eventSetupImpls();
-                            auto lp = status->lumiPrincipal().get();
-                            streamLumiStatus_[i] = std::move(status);
-                            ++streamLumiActive_;
-                            event.setLuminosityBlockPrincipal(lp);
-                            LumiTransitionInfo transitionInfo(*lp, es, eventSetupImpls);
-                            using namespace edm::waiting_task::chain;
-                            chain::first([this, i, &transitionInfo](auto nextTask) {
-                              beginStreamTransitionAsync<Traits>(
-                                  std::move(nextTask), *schedule_, i, transitionInfo, serviceToken_, subProcesses_);
-                            }) | then([this, i](std::exception_ptr const* exceptionFromBeginStreamLumi, auto nextTask) {
-                              if (exceptionFromBeginStreamLumi) {
-                                WaitingTaskHolder tmp(nextTask);
-                                tmp.doneWaiting(*exceptionFromBeginStreamLumi);
-                                streamEndLumiAsync(nextTask, i);
-                              } else {
-                                handleNextEventForStreamAsync(std::move(nextTask), i);
-                              }
-                            }) | runLast(holder);
-                          });
-                        }
-                      }
-                    }) | runLast(postQueueTask);
-
-                  } catch (...) {
-                    status->resetResources();
-                    postQueueTask.doneWaiting(std::current_exception());
-                  }
-                });  // task in sourceResourcesAcquirer
+            //reset status before releasing queue else get race condition
+            if (runStatus->streamFinishedRun()) {
+              runStatus->globalEndRunHolder().doneWaiting(std::exception_ptr());
+            }
+            streamRunStatus_[iStreamIndex].reset();
+            --streamRunActive_;
+            streamQueues_[iStreamIndex].resume();
           });
+
+      WaitingTaskHolder runDoneTaskHolder{*iTask.group(), runDoneTask};
+
+      auto runStatus = streamRunStatus_[iStreamIndex].get();
+
+      if (runStatus->didGlobalBeginSucceed() && runStatus->endingEventSetupSucceeded()) {
+        EventSetupImpl const& es = runStatus->eventSetupImplEndRun(esp_->subProcessIndex());
+        auto eventSetupImpls = &runStatus->eventSetupImplsEndRun();
+        bool cleaningUpAfterException = runStatus->cleaningUpAfterException() || iTask.taskHasFailed();
+
+        auto& runPrincipal = *runStatus->runPrincipal();
+        using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>;
+        RunTransitionInfo transitionInfo(runPrincipal, es, eventSetupImpls);
+        endStreamTransitionAsync<Traits>(std::move(runDoneTaskHolder),
+                                         *schedule_,
+                                         iStreamIndex,
+                                         transitionInfo,
+                                         serviceToken_,
+                                         subProcesses_,
+                                         cleaningUpAfterException);
+      }
+    } catch (...) {
+      handleEndRunExceptions(std::current_exception(), iTask);
+    }
+  }
+
+  void EventProcessor::endUnfinishedRun(bool cleaningUpAfterException) {
+    if (streamRunActive_ > 0) {
+      FinalWaitingTask waitTask{taskGroup_};
+
+      auto runStatus = streamRunStatus_[0].get();
+      runStatus->setCleaningUpAfterException(cleaningUpAfterException);
+      WaitingTaskHolder holder{taskGroup_, &waitTask};
+      runStatus->setHolderOfTaskInProcessRuns(holder);
+      lastSourceTransition_ = InputSource::IsStop;
+      endRunAsync(streamRunStatus_[0], std::move(holder));
+      waitTask.wait();
+    }
+  }
+
+  void EventProcessor::beginLumiAsync(IOVSyncValue const& iSync,
+                                      std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                      edm::WaitingTaskHolder iHolder) {
+    actReg_->esSyncIOVQueuingSignal_.emit(iSync);
+
+    auto status = std::make_shared<LuminosityBlockProcessingStatus>(preallocations_.numberOfStreams());
+    chain::first([this, &iSync, &status](auto nextTask) {
+      espController_->runOrQueueEventSetupForInstanceAsync(iSync,
+                                                           nextTask,
+                                                           status->endIOVWaitingTasks(),
+                                                           status->eventSetupImpls(),
+                                                           queueWhichWaitsForIOVsToFinish_,
+                                                           actReg_.get());
+    }) | chain::then([this, status, iRunStatus, iSync](std::exception_ptr const* iException, auto nextTask) {
+      CMS_SA_ALLOW try {
+        //the call to doneWaiting will cause the count to decrement
+        if (iException) {
+          WaitingTaskHolder copyHolder(nextTask);
+          copyHolder.doneWaiting(*iException);
+        }
+
+        ServiceRegistry::Operate operate(serviceToken_);
+        actReg_->postESSyncIOVSignal_.emit(iSync);
+
+        lumiQueue_->pushAndPause(
+            *nextTask.group(),
+            [this, postLumiQueueTask = nextTask, status, iRunStatus](edm::LimitedTaskQueue::Resumer iResumer) mutable {
+              CMS_SA_ALLOW try {
+                if (postLumiQueueTask.taskHasFailed()) {
+                  status->resetResources();
+                  queueWhichWaitsForIOVsToFinish_.resume();
+                  endRunAsync(iRunStatus, postLumiQueueTask);
+                  return;
+                }
+
+                status->setResumer(std::move(iResumer));
+
+                sourceResourcesAcquirer_.serialQueueChain().push(
+                    *postLumiQueueTask.group(),
+                    [this, postSourceTask = postLumiQueueTask, status, iRunStatus]() mutable {
+                      CMS_SA_ALLOW try {
+                        ServiceRegistry::Operate operate(serviceToken_);
+
+                        if (postSourceTask.taskHasFailed()) {
+                          status->resetResources();
+                          queueWhichWaitsForIOVsToFinish_.resume();
+                          endRunAsync(iRunStatus, postSourceTask);
+                          return;
+                        }
+
+                        status->setLumiPrincipal(readLuminosityBlock(iRunStatus->runPrincipal()));
+
+                        LuminosityBlockPrincipal& lumiPrincipal = *status->lumiPrincipal();
+                        {
+                          SendSourceTerminationSignalIfException sentry(actReg_.get());
+                          input_->doBeginLumi(lumiPrincipal, &processContext_);
+                          sentry.completedSuccessfully();
+                        }
+
+                        Service<RandomNumberGenerator> rng;
+                        if (rng.isAvailable()) {
+                          LuminosityBlock lb(lumiPrincipal, ModuleDescription(), nullptr, false);
+                          rng->preBeginLumi(lb);
+                        }
+
+                        EventSetupImpl const& es = status->eventSetupImpl(esp_->subProcessIndex());
+
+                        using namespace edm::waiting_task::chain;
+                        chain::first([this, status](auto nextTask) mutable {
+                          readAndMergeLumiEntriesAsync(std::move(status), std::move(nextTask));
+                          firstItemAfterLumiMerge_ = true;
+                        }) | then([this, status, &es, &lumiPrincipal](auto nextTask) {
+                          LumiTransitionInfo transitionInfo(lumiPrincipal, es, &status->eventSetupImpls());
+                          using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin>;
+                          beginGlobalTransitionAsync<Traits>(
+                              nextTask, *schedule_, transitionInfo, serviceToken_, subProcesses_);
+                        }) | ifThen(looper_, [this, status, &es](auto nextTask) {
+                          looper_->prefetchAsync(
+                              nextTask, serviceToken_, Transition::BeginLuminosityBlock, *(status->lumiPrincipal()), es);
+                        }) | ifThen(looper_, [this, status, &es](auto nextTask) {
+                          status->globalBeginDidSucceed();
+                          ServiceRegistry::Operate operateLooper(serviceToken_);
+                          looper_->doBeginLuminosityBlock(*(status->lumiPrincipal()), es, &processContext_);
+                        }) | then([this, status, iRunStatus](std::exception_ptr const* iException, auto holder) mutable {
+                          if (iException) {
+                            status->resetResources();
+                            queueWhichWaitsForIOVsToFinish_.resume();
+                            WaitingTaskHolder copyHolder(holder);
+                            copyHolder.doneWaiting(*iException);
+                            endRunAsync(iRunStatus, holder);
+                          } else {
+                            if (not looper_) {
+                              status->globalBeginDidSucceed();
+                            }
+
+                            status->setGlobalEndRunHolder(iRunStatus->globalEndRunHolder());
+
+                            EventSetupImpl const& es = status->eventSetupImpl(esp_->subProcessIndex());
+                            using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>;
+
+                            streamQueuesInserter_.push(*holder.group(), [this, status, holder, &es]() mutable {
+                              for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
+                                streamQueues_[i].push(*holder.group(), [this, i, status, holder, &es]() mutable {
+                                  streamQueues_[i].pause();
+
+                                  auto& event = principalCache_.eventPrincipal(i);
+                                  //We need to be sure that 'status' and its internal shared_ptr<LuminosityBlockPrincipal> are only
+                                  // held by the container as this lambda may not finish executing before all the tasks it
+                                  // spawns have already started to run.
+                                  auto eventSetupImpls = &status->eventSetupImpls();
+                                  auto lp = status->lumiPrincipal().get();
+                                  streamLumiStatus_[i] = std::move(status);
+                                  ++streamLumiActive_;
+                                  event.setLuminosityBlockPrincipal(lp);
+                                  LumiTransitionInfo transitionInfo(*lp, es, eventSetupImpls);
+                                  using namespace edm::waiting_task::chain;
+                                  chain::first([this, i, &transitionInfo](auto nextTask) {
+                                    beginStreamTransitionAsync<Traits>(std::move(nextTask),
+                                                                       *schedule_,
+                                                                       i,
+                                                                       transitionInfo,
+                                                                       serviceToken_,
+                                                                       subProcesses_);
+                                  }) |
+                                      then([this, i](std::exception_ptr const* exceptionFromBeginStreamLumi,
+                                                     auto nextTask) {
+                                        if (exceptionFromBeginStreamLumi) {
+                                          WaitingTaskHolder copyHolder(nextTask);
+                                          copyHolder.doneWaiting(*exceptionFromBeginStreamLumi);
+                                        }
+                                        handleNextEventForStreamAsync(std::move(nextTask), i);
+                                      }) |
+                                      runLast(std::move(holder));
+                                });
+                              }  // end for loop over streams
+                            });
+                          }
+                        }) | runLast(postSourceTask);
+                      } catch (...) {
+                        status->resetResources();
+                        queueWhichWaitsForIOVsToFinish_.resume();
+                        WaitingTaskHolder copyHolder(postSourceTask);
+                        copyHolder.doneWaiting(std::current_exception());
+                        endRunAsync(iRunStatus, postSourceTask);
+                      }
+                    });  // task in sourceResourcesAcquirer
+              } catch (...) {
+                status->resetResources();
+                queueWhichWaitsForIOVsToFinish_.resume();
+                WaitingTaskHolder copyHolder(postLumiQueueTask);
+                copyHolder.doneWaiting(std::current_exception());
+                endRunAsync(iRunStatus, postLumiQueueTask);
+              }
+            });  // task in lumiQueue
+      } catch (...) {
+        status->resetResources();
+        queueWhichWaitsForIOVsToFinish_.resume();
+        WaitingTaskHolder copyHolder(nextTask);
+        copyHolder.doneWaiting(std::current_exception());
+        endRunAsync(iRunStatus, nextTask);
+      }
     }) | chain::runLast(std::move(iHolder));
   }
 
   void EventProcessor::continueLumiAsync(edm::WaitingTaskHolder iHolder) {
-    {
+    chain::first([this](auto nextTask) {
       //all streams are sharing the same status at the moment
       auto status = streamLumiStatus_[0];  //read from streamLumiActive_ happened in calling routine
-      status->needToContinueLumi();
-      status->startProcessingEvents();
-    }
+      status->setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kProcessing);
 
-    unsigned int streamIndex = 0;
-    oneapi::tbb::task_arena arena{oneapi::tbb::task_arena::attach()};
-    for (; streamIndex < preallocations_.numberOfStreams() - 1; ++streamIndex) {
-      arena.enqueue([this, streamIndex, h = iHolder]() { handleNextEventForStreamAsync(h, streamIndex); });
-    }
-    iHolder.group()->run(
-        [this, streamIndex, h = std::move(iHolder)]() { handleNextEventForStreamAsync(h, streamIndex); });
+      while (lastTransitionType() == InputSource::IsLumi and
+             status->lumiPrincipal()->luminosityBlock() == input_->luminosityBlock()) {
+        readAndMergeLumi(*status);
+        nextTransitionType();
+      }
+      firstItemAfterLumiMerge_ = true;
+    }) | chain::then([this](auto nextTask) mutable {
+      unsigned int streamIndex = 0;
+      oneapi::tbb::task_arena arena{oneapi::tbb::task_arena::attach()};
+      for (; streamIndex < preallocations_.numberOfStreams() - 1; ++streamIndex) {
+        arena.enqueue([this, streamIndex, h = nextTask]() { handleNextEventForStreamAsync(h, streamIndex); });
+      }
+      nextTask.group()->run(
+          [this, streamIndex, h = std::move(nextTask)]() { handleNextEventForStreamAsync(h, streamIndex); });
+    }) | chain::runLast(std::move(iHolder));
   }
 
-  void EventProcessor::handleEndLumiExceptions(std::exception_ptr const* iPtr, WaitingTaskHolder& holder) {
-    if (setDeferredException(*iPtr)) {
-      WaitingTaskHolder tmp(holder);
-      tmp.doneWaiting(*iPtr);
-    } else {
+  void EventProcessor::handleEndLumiExceptions(std::exception_ptr iException, WaitingTaskHolder const& holder) {
+    if (holder.taskHasFailed()) {
       setExceptionMessageLumis();
+    } else {
+      WaitingTaskHolder tmp(holder);
+      tmp.doneWaiting(iException);
     }
   }
 
@@ -1520,7 +1807,7 @@ namespace edm {
     // it into finalTaskForThisLumi.
     auto& lp = *(iLumiStatus->lumiPrincipal());
     bool didGlobalBeginSucceed = iLumiStatus->didGlobalBeginSucceed();
-    bool cleaningUpAfterException = iLumiStatus->cleaningUpAfterException();
+    bool cleaningUpAfterException = iLumiStatus->cleaningUpAfterException() || iTask.taskHasFailed();
     EventSetupImpl const& es = iLumiStatus->eventSetupImpl(esp_->subProcessIndex());
     std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls = &iLumiStatus->eventSetupImpls();
 
@@ -1543,37 +1830,33 @@ namespace edm {
       //any thrown exception auto propagates to nextTask via the chain
       ServiceRegistry::Operate operate(serviceToken_);
       looper_->doEndLuminosityBlock(lp, es, &processContext_);
-    }) | then([status = std::move(iLumiStatus), this](std::exception_ptr const* iPtr, auto nextTask) mutable {
-      std::exception_ptr ptr;
-      if (iPtr) {
-        ptr = *iPtr;
+    }) | then([status = std::move(iLumiStatus), this](std::exception_ptr const* iException, auto nextTask) mutable {
+      if (iException) {
+        handleEndLumiExceptions(*iException, nextTask);
       }
       ServiceRegistry::Operate operate(serviceToken_);
+
+      std::exception_ptr ptr;
 
       // Try hard to clean up resources so the
       // process can terminate in a controlled
       // fashion even after exceptions have occurred.
       // Caught exception is passed to handleEndLumiExceptions()
-      CMS_SA_ALLOW try { deleteLumiFromCache(*status); } catch (...) {
+      CMS_SA_ALLOW try { clearLumiPrincipal(*status); } catch (...) {
+        if (not ptr) {
+          ptr = std::current_exception();
+        }
+      }
+      // Caught exception is passed to handleEndLumiExceptions()
+      CMS_SA_ALLOW try { queueWhichWaitsForIOVsToFinish_.resume(); } catch (...) {
         if (not ptr) {
           ptr = std::current_exception();
         }
       }
       // Caught exception is passed to handleEndLumiExceptions()
       CMS_SA_ALLOW try {
-        status->resumeGlobalLumiQueue();
-        queueWhichWaitsForIOVsToFinish_.resume();
-      } catch (...) {
-        if (not ptr) {
-          ptr = std::current_exception();
-        }
-      }
-      // Caught exception is passed to handleEndLumiExceptions()
-      CMS_SA_ALLOW try {
-        // This call to status.resetResources() must occur before iTask is destroyed.
-        // Otherwise there will be a data race which could result in endRun
-        // being delayed until it is too late to successfully call it.
         status->resetResources();
+        status->globalEndRunHolderDoneWaiting();
         status.reset();
       } catch (...) {
         if (not ptr) {
@@ -1581,19 +1864,20 @@ namespace edm {
         }
       }
 
-      if (ptr) {
-        handleEndLumiExceptions(&ptr, nextTask);
+      if (ptr && !iException) {
+        handleEndLumiExceptions(ptr, nextTask);
       }
     }) | runLast(std::move(iTask));
   }
 
   void EventProcessor::streamEndLumiAsync(edm::WaitingTaskHolder iTask, unsigned int iStreamIndex) {
-    auto t = edm::make_waiting_task([this, iStreamIndex, iTask](std::exception_ptr const* iPtr) mutable {
-      if (iPtr) {
-        handleEndLumiExceptions(iPtr, iTask);
-      }
+    auto t = edm::make_waiting_task([this, iStreamIndex, iTask](std::exception_ptr const* iException) mutable {
       auto status = streamLumiStatus_[iStreamIndex];
-      //reset status before releasing queue else get race condtion
+      if (iException) {
+        handleEndLumiExceptions(*iException, iTask);
+      }
+
+      // reset status before releasing queue else get race condition
       streamLumiStatus_[iStreamIndex].reset();
       --streamLumiActive_;
       streamQueues_[iStreamIndex].resume();
@@ -1606,20 +1890,17 @@ namespace edm {
 
     edm::WaitingTaskHolder lumiDoneTask{*iTask.group(), t};
 
-    //Need to be sure the lumi status is released before lumiDoneTask can every be called.
+    // Need to be sure the lumi status is released before lumiDoneTask can every be called.
     // therefore we do not want to hold the shared_ptr
     auto lumiStatus = streamLumiStatus_[iStreamIndex].get();
     lumiStatus->setEndTime();
 
     EventSetupImpl const& es = lumiStatus->eventSetupImpl(esp_->subProcessIndex());
-
-    bool cleaningUpAfterException = lumiStatus->cleaningUpAfterException();
     auto eventSetupImpls = &lumiStatus->eventSetupImpls();
+    bool cleaningUpAfterException = lumiStatus->cleaningUpAfterException() || iTask.taskHasFailed();
 
     if (lumiStatus->didGlobalBeginSucceed()) {
       auto& lumiPrincipal = *lumiStatus->lumiPrincipal();
-      IOVSyncValue ts(EventID(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), EventID::maxEventNumber()),
-                      lumiPrincipal.endTime());
       using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>;
       LumiTransitionInfo transitionInfo(lumiPrincipal, es, eventSetupImpls);
       endStreamTransitionAsync<Traits>(std::move(lumiDoneTask),
@@ -1632,18 +1913,20 @@ namespace edm {
     }
   }
 
-  void EventProcessor::endUnfinishedLumi() {
-    if (streamLumiActive_.load() > 0) {
-      FinalWaitingTask globalWaitTask{taskGroup_};
-      {
-        WaitingTaskHolder globalTaskHolder{taskGroup_, &globalWaitTask};
+  void EventProcessor::endUnfinishedLumi(bool cleaningUpAfterException) {
+    if (streamRunActive_ == 0) {
+      assert(streamLumiActive_ == 0);
+    } else {
+      assert(streamRunActive_ == preallocations_.numberOfStreams());
+      if (streamLumiActive_ > 0) {
+        FinalWaitingTask globalWaitTask{taskGroup_};
+        assert(streamLumiActive_ == preallocations_.numberOfStreams());
+        streamLumiStatus_[0]->setCleaningUpAfterException(cleaningUpAfterException);
         for (unsigned int i = 0; i < preallocations_.numberOfStreams(); ++i) {
-          if (streamLumiStatus_[i]) {
-            streamEndLumiAsync(globalTaskHolder, i);
-          }
+          streamEndLumiAsync(WaitingTaskHolder{taskGroup_, &globalWaitTask}, i);
         }
+        globalWaitTask.wait();
       }
-      globalWaitTask.wait();
     }
   }
 
@@ -1653,48 +1936,33 @@ namespace edm {
     sentry.completedSuccessfully();
   }
 
-  std::pair<ProcessHistoryID, RunNumber_t> EventProcessor::readRun() {
-    if (principalCache_.hasRunPrincipal()) {
-      throw edm::Exception(edm::errors::LogicError) << "EventProcessor::readRun\n"
-                                                    << "Illegal attempt to insert run into cache\n"
-                                                    << "Contact a Framework Developer\n";
-    }
-    auto rp = std::make_shared<RunPrincipal>(input_->runAuxiliary(),
-                                             preg(),
-                                             *processConfiguration_,
-                                             historyAppender_.get(),
-                                             0,
-                                             true,
-                                             &mergeableRunProductProcesses_);
+  std::shared_ptr<RunPrincipal> EventProcessor::readRun() {
+    auto rp = principalCache_.getAvailableRunPrincipalPtr();
+    assert(rp);
+    rp->setAux(*input_->runAuxiliary());
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
       input_->readRun(*rp, *historyAppender_);
       sentry.completedSuccessfully();
     }
     assert(input_->reducedProcessHistoryID() == rp->reducedProcessHistoryID());
-    principalCache_.insert(rp);
-    return std::make_pair(rp->reducedProcessHistoryID(), input_->run());
+    return rp;
   }
 
-  std::pair<ProcessHistoryID, RunNumber_t> EventProcessor::readAndMergeRun() {
-    principalCache_.merge(input_->runAuxiliary(), preg());
-    auto runPrincipal = principalCache_.runPrincipalPtr();
+  void EventProcessor::readAndMergeRun(RunProcessingStatus& iStatus) {
+    RunPrincipal& runPrincipal = *iStatus.runPrincipal();
+
+    bool runOK = runPrincipal.adjustToNewProductRegistry(*preg_);
+    assert(runOK);
+    runPrincipal.mergeAuxiliary(*input_->runAuxiliary());
     {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
-      input_->readAndMergeRun(*runPrincipal);
+      input_->readAndMergeRun(runPrincipal);
       sentry.completedSuccessfully();
     }
-    assert(input_->reducedProcessHistoryID() == runPrincipal->reducedProcessHistoryID());
-    return std::make_pair(runPrincipal->reducedProcessHistoryID(), input_->run());
   }
 
-  void EventProcessor::readLuminosityBlock(LuminosityBlockProcessingStatus& iStatus) {
-    if (!principalCache_.hasRunPrincipal()) {
-      throw edm::Exception(edm::errors::LogicError) << "EventProcessor::readLuminosityBlock\n"
-                                                    << "Illegal attempt to insert lumi into cache\n"
-                                                    << "Run is invalid\n"
-                                                    << "Contact a Framework Developer\n";
-    }
+  std::shared_ptr<LuminosityBlockPrincipal> EventProcessor::readLuminosityBlock(std::shared_ptr<RunPrincipal> rp) {
     auto lbp = principalCache_.getAvailableLumiPrincipalPtr();
     assert(lbp);
     lbp->setAux(*input_->luminosityBlockAuxiliary());
@@ -1703,11 +1971,11 @@ namespace edm {
       input_->readLuminosityBlock(*lbp, *historyAppender_);
       sentry.completedSuccessfully();
     }
-    lbp->setRunPrincipal(principalCache_.runPrincipalPtr());
-    iStatus.lumiPrincipal() = std::move(lbp);
+    lbp->setRunPrincipal(std::move(rp));
+    return lbp;
   }
 
-  int EventProcessor::readAndMergeLumi(LuminosityBlockProcessingStatus& iStatus) {
+  void EventProcessor::readAndMergeLumi(LuminosityBlockProcessingStatus& iStatus) {
     auto& lumiPrincipal = *iStatus.lumiPrincipal();
     assert(lumiPrincipal.aux().sameIdentity(*input_->luminosityBlockAuxiliary()) or
            input_->processHistoryRegistry().reducedProcessHistoryID(lumiPrincipal.aux().processHistoryID()) ==
@@ -1721,7 +1989,6 @@ namespace edm {
       input_->readAndMergeLumi(*iStatus.lumiPrincipal());
       sentry.completedSuccessfully();
     }
-    return input_->luminosityBlock();
   }
 
   void EventProcessor::writeProcessBlockAsync(WaitingTaskHolder task, ProcessBlockType processBlockType) {
@@ -1739,29 +2006,28 @@ namespace edm {
   }
 
   void EventProcessor::writeRunAsync(WaitingTaskHolder task,
-                                     ProcessHistoryID const& phid,
-                                     RunNumber_t run,
+                                     RunPrincipal const& runPrincipal,
                                      MergeableRunProductMetadata const* mergeableRunProductMetadata) {
     using namespace edm::waiting_task;
-    chain::first([&](auto nextTask) {
-      ServiceRegistry::Operate op(serviceToken_);
-      schedule_->writeRunAsync(nextTask,
-                               principalCache_.runPrincipal(phid, run),
-                               &processContext_,
-                               actReg_.get(),
-                               mergeableRunProductMetadata);
-    }) | chain::ifThen(not subProcesses_.empty(), [this, phid, run, mergeableRunProductMetadata](auto nextTask) {
-      ServiceRegistry::Operate op(serviceToken_);
-      for (auto& s : subProcesses_) {
-        s.writeRunAsync(nextTask, phid, run, mergeableRunProductMetadata);
-      }
-    }) | chain::runLast(std::move(task));
+    if (runPrincipal.shouldWriteRun() != RunPrincipal::kNo) {
+      chain::first([&](auto nextTask) {
+        ServiceRegistry::Operate op(serviceToken_);
+        schedule_->writeRunAsync(nextTask, runPrincipal, &processContext_, actReg_.get(), mergeableRunProductMetadata);
+      }) | chain::ifThen(not subProcesses_.empty(), [this, &runPrincipal, mergeableRunProductMetadata](auto nextTask) {
+        ServiceRegistry::Operate op(serviceToken_);
+        for (auto& s : subProcesses_) {
+          s.writeRunAsync(nextTask, runPrincipal, mergeableRunProductMetadata);
+        }
+      }) | chain::runLast(std::move(task));
+    }
   }
 
-  void EventProcessor::deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run) {
-    principalCache_.deleteRun(phid, run);
-    for_all(subProcesses_, [run, phid](auto& subProcess) { subProcess.deleteRunFromCache(phid, run); });
-    FDEBUG(1) << "\tdeleteRunFromCache " << run << "\n";
+  void EventProcessor::clearRunPrincipal(RunProcessingStatus& iStatus) {
+    for (auto& s : subProcesses_) {
+      s.clearRunPrincipal(*iStatus.runPrincipal());
+    }
+    iStatus.runPrincipal()->setShouldWriteRun(RunPrincipal::kUninitialized);
+    iStatus.runPrincipal()->clearPrincipal();
   }
 
   void EventProcessor::writeLumiAsync(WaitingTaskHolder task, LuminosityBlockPrincipal& lumiPrincipal) {
@@ -1781,130 +2047,203 @@ namespace edm {
     }
   }
 
-  void EventProcessor::deleteLumiFromCache(LuminosityBlockProcessingStatus& iStatus) {
+  void EventProcessor::clearLumiPrincipal(LuminosityBlockProcessingStatus& iStatus) {
     for (auto& s : subProcesses_) {
-      s.deleteLumiFromCache(*iStatus.lumiPrincipal());
+      s.clearLumiPrincipal(*iStatus.lumiPrincipal());
     }
+    iStatus.lumiPrincipal()->setRunPrincipal(std::shared_ptr<RunPrincipal>());
     iStatus.lumiPrincipal()->setShouldWriteLumi(LuminosityBlockPrincipal::kUninitialized);
     iStatus.lumiPrincipal()->clearPrincipal();
-    //FDEBUG(1) << "\tdeleteLumiFromCache " << run << "/" << lumi << "\n";
   }
 
-  bool EventProcessor::readNextEventForStream(unsigned int iStreamIndex, LuminosityBlockProcessingStatus& iStatus) {
-    if (deferredExceptionPtrIsSet_.load(std::memory_order_acquire)) {
-      iStatus.endLumi();
+  void EventProcessor::readAndMergeRunEntriesAsync(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                                   WaitingTaskHolder iHolder) {
+    auto group = iHolder.group();
+    sourceResourcesAcquirer_.serialQueueChain().push(
+        *group, [this, status = std::move(iRunStatus), holder = std::move(iHolder)]() mutable {
+          CMS_SA_ALLOW try {
+            ServiceRegistry::Operate operate(serviceToken_);
+
+            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+
+            nextTransitionType();
+            while (lastTransitionType() == InputSource::IsRun and status->runPrincipal()->run() == input_->run() and
+                   status->runPrincipal()->reducedProcessHistoryID() == input_->reducedProcessHistoryID()) {
+              if (status->holderOfTaskInProcessRuns().taskHasFailed()) {
+                status->setStopBeforeProcessingRun(true);
+                return;
+              }
+              readAndMergeRun(*status);
+              nextTransitionType();
+            }
+          } catch (...) {
+            status->setStopBeforeProcessingRun(true);
+            holder.doneWaiting(std::current_exception());
+          }
+        });
+  }
+
+  void EventProcessor::readAndMergeLumiEntriesAsync(std::shared_ptr<LuminosityBlockProcessingStatus> iLumiStatus,
+                                                    WaitingTaskHolder iHolder) {
+    auto group = iHolder.group();
+    sourceResourcesAcquirer_.serialQueueChain().push(
+        *group, [this, iLumiStatus = std::move(iLumiStatus), holder = std::move(iHolder)]() mutable {
+          CMS_SA_ALLOW try {
+            ServiceRegistry::Operate operate(serviceToken_);
+
+            std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
+
+            nextTransitionType();
+            while (lastTransitionType() == InputSource::IsLumi and
+                   iLumiStatus->lumiPrincipal()->luminosityBlock() == input_->luminosityBlock()) {
+              readAndMergeLumi(*iLumiStatus);
+              nextTransitionType();
+            }
+          } catch (...) {
+            holder.doneWaiting(std::current_exception());
+          }
+        });
+  }
+
+  void EventProcessor::handleNextItemAfterMergingRunEntries(std::shared_ptr<RunProcessingStatus> iRunStatus,
+                                                            WaitingTaskHolder iHolder) {
+    if (lastTransitionType() == InputSource::IsFile) {
+      iRunStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
+      iHolder.doneWaiting(std::exception_ptr{});
+    } else if (lastTransitionType() == InputSource::IsLumi && !iHolder.taskHasFailed()) {
+      CMS_SA_ALLOW try {
+        beginLumiAsync(IOVSyncValue(EventID(input_->run(), input_->luminosityBlock(), 0),
+                                    input_->luminosityBlockAuxiliary()->beginTime()),
+                       iRunStatus,
+                       iHolder);
+      } catch (...) {
+        WaitingTaskHolder copyHolder(iHolder);
+        iHolder.doneWaiting(std::current_exception());
+        endRunAsync(std::move(iRunStatus), std::move(iHolder));
+      }
+    } else {
+      // Note that endRunAsync will call beginRunAsync for the following run
+      // if appropriate.
+      endRunAsync(std::move(iRunStatus), std::move(iHolder));
+    }
+  }
+
+  bool EventProcessor::readNextEventForStream(WaitingTaskHolder const& iTask,
+                                              unsigned int iStreamIndex,
+                                              LuminosityBlockProcessingStatus& iStatus) {
+    // This function returns true if it successfully reads an event for the stream and that
+    // requires both that an event is next and there are no problems or requests to stop.
+
+    if (iTask.taskHasFailed()) {
+      // We want all streams to stop or all streams to pause. If we are already in the
+      // middle of pausing streams, then finish pausing all of them and the lumi will be
+      // ended later. Otherwise, just end it now.
+      if (iStatus.eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
+        iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+      }
       return false;
     }
 
-    if (iStatus.wasEventProcessingStopped()) {
+    // Did another stream already stop or pause this lumi?
+    if (iStatus.eventProcessingState() != LuminosityBlockProcessingStatus::EventProcessingState::kProcessing) {
       return false;
     }
 
+    // Are output modules or the looper requesting we stop?
     if (shouldWeStop()) {
       lastSourceTransition_ = InputSource::IsStop;
-      iStatus.stopProcessingEvents();
-      iStatus.endLumi();
+      iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
       return false;
     }
 
     ServiceRegistry::Operate operate(serviceToken_);
-    // Caught exception is propagated to EventProcessor::runToCompletion() via deferredExceptionPtr_
-    CMS_SA_ALLOW try {
-      //need to use lock in addition to the serial task queue because
-      // of delayed provenance reading and reading data in response to
-      // edm::Refs etc
-      std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
 
-      auto itemType = iStatus.continuingLumi() ? InputSource::IsLumi : nextTransitionType();
-      if (InputSource::IsLumi == itemType) {
-        iStatus.haveContinuedLumi();
-        while (itemType == InputSource::IsLumi and iStatus.lumiPrincipal()->run() == input_->run() and
-               iStatus.lumiPrincipal()->luminosityBlock() == nextLuminosityBlockID()) {
-          readAndMergeLumi(iStatus);
-          itemType = nextTransitionType();
-        }
-        if (InputSource::IsLumi == itemType) {
-          iStatus.setNextSyncValue(IOVSyncValue(EventID(input_->run(), input_->luminosityBlock(), 0),
-                                                input_->luminosityBlockAuxiliary()->beginTime()));
-        }
-      }
-      if (InputSource::IsEvent != itemType) {
-        iStatus.stopProcessingEvents();
+    // need to use lock in addition to the serial task queue because
+    // of delayed provenance reading and reading data in response to
+    // edm::Refs etc
+    std::lock_guard<std::recursive_mutex> guard(*(sourceMutex_.get()));
 
-        //IsFile may continue processing the lumi and
-        // looper_ can cause the input source to declare a new IsRun which is actually
-        // just a continuation of the previous run
-        if (InputSource::IsStop == itemType or InputSource::IsLumi == itemType or
-            (InputSource::IsRun == itemType and iStatus.lumiPrincipal()->run() != input_->run())) {
-          iStatus.endLumi();
-        }
-        return false;
-      }
-      readEvent(iStreamIndex);
-    } catch (...) {
-      bool expected = false;
-      if (deferredExceptionPtrIsSet_.compare_exchange_strong(expected, true)) {
-        deferredExceptionPtr_ = std::current_exception();
-        iStatus.endLumi();
+    // If we didn't already call nextTransitionType while merging lumis, call it here.
+    // This asks the input source what is next and also checks for signals.
+
+    InputSource::ItemType itemType = firstItemAfterLumiMerge_ ? lastTransitionType() : nextTransitionType();
+    firstItemAfterLumiMerge_ = false;
+
+    if (InputSource::IsEvent != itemType) {
+      // IsFile may continue processing the lumi and
+      // looper_ can cause the input source to declare a new IsRun which is actually
+      // just a continuation of the previous run
+      if (InputSource::IsStop == itemType or InputSource::IsLumi == itemType or
+          (InputSource::IsRun == itemType and
+           (iStatus.lumiPrincipal()->run() != input_->run() or
+            iStatus.lumiPrincipal()->runPrincipal().reducedProcessHistoryID() != input_->reducedProcessHistoryID()))) {
+        iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi);
+      } else {
+        iStatus.setEventProcessingState(LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
       }
       return false;
     }
+    readEvent(iStreamIndex);
     return true;
   }
 
   void EventProcessor::handleNextEventForStreamAsync(WaitingTaskHolder iTask, unsigned int iStreamIndex) {
-    sourceResourcesAcquirer_.serialQueueChain().push(*iTask.group(), [this, iTask, iStreamIndex]() mutable {
-      ServiceRegistry::Operate operate(serviceToken_);
-      //we do not want to extend the lifetime of the shared_ptr to the end of this function
-      // as steramEndLumiAsync may clear the value from streamLumiStatus_[iStreamIndex]
-      auto status = streamLumiStatus_[iStreamIndex].get();
-      // Caught exception is propagated to EventProcessor::runToCompletion() via deferredExceptionPtr_
+    auto group = iTask.group();
+    sourceResourcesAcquirer_.serialQueueChain().push(*group, [this, iTask = std::move(iTask), iStreamIndex]() mutable {
       CMS_SA_ALLOW try {
-        if (readNextEventForStream(iStreamIndex, *status)) {
-          auto recursionTask = make_waiting_task([this, iTask, iStreamIndex](std::exception_ptr const* iPtr) mutable {
-            if (iPtr) {
-              // Try to end the stream properly even if an exception was
-              // thrown on an event.
-              bool expected = false;
-              if (deferredExceptionPtrIsSet_.compare_exchange_strong(expected, true)) {
-                // This is the case where the exception in iPtr is the primary
-                // exception and we want to see its message.
-                deferredExceptionPtr_ = *iPtr;
-                WaitingTaskHolder tempHolder(iTask);
-                tempHolder.doneWaiting(*iPtr);
-              }
-              streamEndLumiAsync(std::move(iTask), iStreamIndex);
-              //the stream will stop now
-              return;
-            }
-            handleNextEventForStreamAsync(std::move(iTask), iStreamIndex);
-          });
+        auto status = streamLumiStatus_[iStreamIndex].get();
+        ServiceRegistry::Operate operate(serviceToken_);
+
+        if (readNextEventForStream(iTask, iStreamIndex, *status)) {
+          auto recursionTask =
+              make_waiting_task([this, iTask, iStreamIndex](std::exception_ptr const* iEventException) mutable {
+                if (iEventException) {
+                  WaitingTaskHolder copyHolder(iTask);
+                  copyHolder.doneWaiting(*iEventException);
+                  // Intentionally, we don't return here. The recursive call to
+                  // handleNextEvent takes care of immediately ending the run properly
+                  // using the same code it uses to end the run in other situations.
+                }
+                handleNextEventForStreamAsync(std::move(iTask), iStreamIndex);
+              });
 
           processEventAsync(WaitingTaskHolder(*iTask.group(), recursionTask), iStreamIndex);
         } else {
-          //the stream will stop now
-          if (status->isLumiEnding()) {
-            if (lastTransitionType() == InputSource::IsLumi and not status->haveStartedNextLumi()) {
-              status->startNextLumi();
-              beginLumiAsync(status->nextSyncValue(), status->runResource(), iTask);
+          // the stream will stop processing this lumi now
+          if (status->eventProcessingState() == LuminosityBlockProcessingStatus::EventProcessingState::kStopLumi) {
+            if (not status->haveStartedNextLumiOrEndedRun()) {
+              status->startNextLumiOrEndRun();
+              if (lastTransitionType() == InputSource::IsLumi && !iTask.taskHasFailed()) {
+                CMS_SA_ALLOW try {
+                  beginLumiAsync(IOVSyncValue(EventID(input_->run(), input_->luminosityBlock(), 0),
+                                              input_->luminosityBlockAuxiliary()->beginTime()),
+                                 streamRunStatus_[iStreamIndex],
+                                 iTask);
+                } catch (...) {
+                  WaitingTaskHolder copyHolder(iTask);
+                  copyHolder.doneWaiting(std::current_exception());
+                  endRunAsync(streamRunStatus_[iStreamIndex], iTask);
+                }
+              } else {
+                // If appropriate, this will also start the next run.
+                endRunAsync(streamRunStatus_[iStreamIndex], iTask);
+              }
             }
-            streamEndLumiAsync(std::move(iTask), iStreamIndex);
+            streamEndLumiAsync(iTask, iStreamIndex);
           } else {
-            iTask.doneWaiting(std::exception_ptr{});
+            assert(status->eventProcessingState() ==
+                   LuminosityBlockProcessingStatus::EventProcessingState::kPauseForFileTransition);
+            auto runStatus = streamRunStatus_[iStreamIndex].get();
+
+            if (runStatus->holderOfTaskInProcessRuns().hasTask()) {
+              runStatus->holderOfTaskInProcessRuns().doneWaiting(std::exception_ptr{});
+            }
           }
         }
       } catch (...) {
-        // It is unlikely we will ever get in here ...
-        // But if we do try to clean up and propagate the exception
-        if (streamLumiStatus_[iStreamIndex]) {
-          streamEndLumiAsync(iTask, iStreamIndex);
-        }
-        bool expected = false;
-        if (deferredExceptionPtrIsSet_.compare_exchange_strong(expected, true)) {
-          auto e = std::current_exception();
-          deferredExceptionPtr_ = e;
-          iTask.doneWaiting(e);
-        }
+        WaitingTaskHolder copyHolder(iTask);
+        copyHolder.doneWaiting(std::current_exception());
+        handleNextEventForStreamAsync(std::move(iTask), iStreamIndex);
       }
     });
   }
@@ -1917,6 +2256,7 @@ namespace edm {
     SendSourceTerminationSignalIfException sentry(actReg_.get());
     input_->readEvent(event, streamContext);
 
+    streamRunStatus_[iStreamIndex]->updateLastTimestamp(input_->timestamp());
     streamLumiStatus_[iStreamIndex]->updateLastTimestamp(input_->timestamp());
     sentry.completedSuccessfully();
 
@@ -1924,7 +2264,7 @@ namespace edm {
   }
 
   void EventProcessor::processEventAsync(WaitingTaskHolder iHolder, unsigned int iStreamIndex) {
-    iHolder.group()->run([=]() { processEventAsyncImpl(iHolder, iStreamIndex); });
+    iHolder.group()->run([this, iHolder, iStreamIndex]() { processEventAsyncImpl(iHolder, iStreamIndex); });
   }
 
   void EventProcessor::processEventAsyncImpl(WaitingTaskHolder iHolder, unsigned int iStreamIndex) {
@@ -1980,7 +2320,6 @@ namespace edm {
     } while (!pc.lastOperationSucceeded());
     if (status != EDLooperBase::kContinue) {
       shouldWeStop_ = true;
-      lastSourceTransition_ = InputSource::IsStop;
     }
   }
 
@@ -2030,6 +2369,19 @@ namespace edm {
          << " * modifying the modules to support concurrent LuminosityBlocks (preferred), or\n"
          << " * setting 'process.options.numberOfConcurrentLuminosityBlocks = 1' in the configuration file";
       throw ex;
+    }
+  }
+
+  void EventProcessor::warnAboutModulesRequiringRunSynchronization() const {
+    std::unique_ptr<LogSystem> s;
+    for (auto worker : schedule_->allWorkers()) {
+      if (worker->wantsGlobalRuns() and worker->globalRunsQueue()) {
+        if (not s) {
+          s = std::make_unique<LogSystem>("ModulesSynchingOnRuns");
+          (*s) << "The following modules require synchronizing on Run boundaries:";
+        }
+        (*s) << "\n  " << worker->description()->moduleName() << " " << worker->description()->moduleLabel();
+      }
     }
   }
 

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -32,9 +32,10 @@ namespace edm {
       std::shared_ptr<ActivityRegistry> areg,
       std::shared_ptr<ProcessConfiguration const> processConfiguration,
       ProcessContext const* processContext)
-      : actReg_(areg), processContext_(processContext) {
-    workerManagers_.reserve(prealloc.numberOfLuminosityBlocks());
-    for (unsigned int i = 0; i < prealloc.numberOfLuminosityBlocks(); ++i) {
+      : actReg_(areg), processContext_(processContext), numberOfConcurrentLumis_(prealloc.numberOfLuminosityBlocks()) {
+    unsigned int nManagers = prealloc.numberOfLuminosityBlocks() + prealloc.numberOfRuns();
+    workerManagers_.reserve(nManagers);
+    for (unsigned int i = 0; i < nManagers; ++i) {
       workerManagers_.emplace_back(modReg, areg, actions);
     }
     for (auto const& moduleLabel : iModulesToUse) {

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.cc
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.cc
@@ -10,9 +10,6 @@
 //         Created:  Thu, 11 Jan 2018 16:41:46 GMT
 //
 
-// system include files
-
-// user include files
 #include "LuminosityBlockProcessingStatus.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 
@@ -23,19 +20,26 @@ namespace edm {
       iter.reset();
     }
     resumeGlobalLumiQueue();
-    run_.reset();
+  }
+
+  void LuminosityBlockProcessingStatus::setGlobalEndRunHolder(WaitingTaskHolder holder) {
+    globalEndRunHolder_ = std::move(holder);
   }
 
   void LuminosityBlockProcessingStatus::setEndTime() {
-    if (2 != endTimeSetStatus_) {
+    constexpr char kUnset = 0;
+    constexpr char kSetting = 1;
+    constexpr char kSet = 2;
+
+    if (endTimeSetStatus_ != kSet) {
       //not already set
-      char expected = 0;
-      if (endTimeSetStatus_.compare_exchange_strong(expected, 1)) {
+      char expected = kUnset;
+      if (endTimeSetStatus_.compare_exchange_strong(expected, kSetting)) {
         lumiPrincipal_->setEndTime(endTime_);
-        endTimeSetStatus_.store(2);
+        endTimeSetStatus_.store(kSet);
       } else {
         //wait until time is set
-        while (2 != endTimeSetStatus_.load()) {
+        while (endTimeSetStatus_.load() != kSet) {
         }
       }
     }

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -5,92 +5,23 @@
 #include "FWCore/Framework/interface/ProcessBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/PreallocationConfiguration.h"
-#include "FWCore/Utilities/interface/EDMException.h"
-#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+
+#include <cassert>
 
 namespace edm {
 
-  PrincipalCache::PrincipalCache() : run_(0U), lumi_(0U) {}
+  PrincipalCache::PrincipalCache() {}
 
   PrincipalCache::~PrincipalCache() {}
 
-  void PrincipalCache::setNumberOfConcurrentPrincipals(PreallocationConfiguration const& iConfig) {
-    eventPrincipals_.resize(iConfig.numberOfStreams());
-  }
-
-  RunPrincipal& PrincipalCache::runPrincipal(ProcessHistoryID const& phid, RunNumber_t run) const {
-    if (phid != reducedInputProcessHistoryID_ || run != run_ || runPrincipal_.get() == nullptr) {
-      throwRunMissing();
-    }
-    return *runPrincipal_.get();
-  }
-
-  std::shared_ptr<RunPrincipal> const& PrincipalCache::runPrincipalPtr(ProcessHistoryID const& phid,
-                                                                       RunNumber_t run) const {
-    if (phid != reducedInputProcessHistoryID_ || run != run_ || runPrincipal_.get() == nullptr) {
-      throwRunMissing();
-    }
-    return runPrincipal_;
-  }
-
-  RunPrincipal& PrincipalCache::runPrincipal() const {
-    if (runPrincipal_.get() == nullptr) {
-      throwRunMissing();
-    }
-    return *runPrincipal_.get();
-  }
-
-  std::shared_ptr<RunPrincipal> const& PrincipalCache::runPrincipalPtr() const {
-    if (runPrincipal_.get() == nullptr) {
-      throwRunMissing();
-    }
-    return runPrincipal_;
-  }
+  std::shared_ptr<RunPrincipal> PrincipalCache::getAvailableRunPrincipalPtr() { return runHolder_.tryToGet(); }
 
   std::shared_ptr<LuminosityBlockPrincipal> PrincipalCache::getAvailableLumiPrincipalPtr() {
     return lumiHolder_.tryToGet();
   }
 
-  void PrincipalCache::merge(std::shared_ptr<RunAuxiliary> aux, std::shared_ptr<ProductRegistry const> reg) {
-    if (runPrincipal_.get() == nullptr) {
-      throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::merge\n"
-                                                    << "Illegal attempt to merge run into cache\n"
-                                                    << "There is no run in cache to merge with\n"
-                                                    << "Contact a Framework Developer\n";
-    }
-    if (inputProcessHistoryID_ != aux->processHistoryID()) {
-      if (reducedInputProcessHistoryID_ != processHistoryRegistry_->reducedProcessHistoryID(aux->processHistoryID())) {
-        throw edm::Exception(edm::errors::LogicError)
-            << "PrincipalCache::merge\n"
-            << "Illegal attempt to merge run into cache\n"
-            << "Reduced ProcessHistoryID inconsistent with the one already in cache\n"
-            << "Contact a Framework Developer\n";
-      }
-      inputProcessHistoryID_ = aux->processHistoryID();
-    }
-    if (aux->run() != run_) {
-      throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::merge\n"
-                                                    << "Illegal attempt to merge run into cache\n"
-                                                    << "Run number inconsistent with run number already in cache\n"
-                                                    << "Contact a Framework Developer\n";
-    }
-    bool runOK = runPrincipal_->adjustToNewProductRegistry(*reg);
-    assert(runOK);
-    runPrincipal_->mergeAuxiliary(*aux);
-  }
-
-  void PrincipalCache::insert(std::shared_ptr<RunPrincipal> rp) {
-    if (runPrincipal_.get() != nullptr) {
-      throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::insert\n"
-                                                    << "Illegal attempt to insert run into cache\n"
-                                                    << "Contact a Framework Developer\n";
-    }
-    if (inputProcessHistoryID_ != rp->aux().processHistoryID()) {
-      reducedInputProcessHistoryID_ = processHistoryRegistry_->reducedProcessHistoryID(rp->aux().processHistoryID());
-      inputProcessHistoryID_ = rp->aux().processHistoryID();
-    }
-    run_ = rp->run();
-    runPrincipal_ = rp;
+  void PrincipalCache::setNumberOfConcurrentPrincipals(PreallocationConfiguration const& iConfig) {
+    eventPrincipals_.resize(iConfig.numberOfStreams());
   }
 
   void PrincipalCache::insert(std::unique_ptr<ProcessBlockPrincipal> pb) { processBlockPrincipal_ = std::move(pb); }
@@ -99,29 +30,14 @@ namespace edm {
     inputProcessBlockPrincipal_ = std::move(pb);
   }
 
+  void PrincipalCache::insert(std::unique_ptr<RunPrincipal> rp) { runHolder_.add(std::move(rp)); }
+
   void PrincipalCache::insert(std::unique_ptr<LuminosityBlockPrincipal> lbp) { lumiHolder_.add(std::move(lbp)); }
 
   void PrincipalCache::insert(std::shared_ptr<EventPrincipal> ep) {
     unsigned int iStreamIndex = ep->streamID().value();
     assert(iStreamIndex < eventPrincipals_.size());
     eventPrincipals_[iStreamIndex] = ep;
-  }
-
-  void PrincipalCache::deleteRun(ProcessHistoryID const& phid, RunNumber_t run) {
-    if (runPrincipal_.get() == nullptr) {
-      throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::deleteRun\n"
-                                                    << "Illegal attempt to delete run from cache\n"
-                                                    << "There is no run in cache to delete\n"
-                                                    << "Contact a Framework Developer\n";
-    }
-    if (reducedInputProcessHistoryID_ != phid || run != run_) {
-      throw edm::Exception(edm::errors::LogicError)
-          << "PrincipalCache::deleteRun\n"
-          << "Illegal attempt to delete run from cache\n"
-          << "Run number or reduced ProcessHistoryID inconsistent with those in cache\n"
-          << "Contact a Framework Developer\n";
-    }
-    runPrincipal_.reset();
   }
 
   void PrincipalCache::adjustEventsToNewProductRegistry(std::shared_ptr<ProductRegistry const> reg) {
@@ -135,33 +51,18 @@ namespace edm {
   }
 
   void PrincipalCache::adjustIndexesAfterProductRegistryAddition() {
-    if (runPrincipal_) {
-      runPrincipal_->adjustIndexesAfterProductRegistryAddition();
+    //Need to temporarily hold all the runs to clear out the runHolder_
+    std::vector<std::shared_ptr<RunPrincipal>> tempRunPrincipals;
+    while (auto p = runHolder_.tryToGet()) {
+      p->adjustIndexesAfterProductRegistryAddition();
+      tempRunPrincipals.emplace_back(std::move(p));
     }
     //Need to temporarily hold all the lumis to clear out the lumiHolder_
-    std::vector<std::shared_ptr<LuminosityBlockPrincipal>> temp;
+    std::vector<std::shared_ptr<LuminosityBlockPrincipal>> tempLumiPrincipals;
     while (auto p = lumiHolder_.tryToGet()) {
       p->adjustIndexesAfterProductRegistryAddition();
-      temp.emplace_back(std::move(p));
+      tempLumiPrincipals.emplace_back(std::move(p));
     }
   }
 
-  void PrincipalCache::preReadFile() {
-    if (runPrincipal_) {
-      runPrincipal_->preReadFile();
-    }
-  }
-
-  void PrincipalCache::throwRunMissing() const {
-    throw edm::Exception(edm::errors::LogicError) << "PrincipalCache::runPrincipal\n"
-                                                  << "Requested a run that is not in the cache (should never happen)\n"
-                                                  << "Contact a Framework Developer\n";
-  }
-
-  void PrincipalCache::throwLumiMissing() const {
-    throw edm::Exception(edm::errors::LogicError)
-        << "PrincipalCache::lumiPrincipal or PrincipalCache::lumiPrincipalPtr\n"
-        << "Requested a luminosity block that is not in the cache (should never happen)\n"
-        << "Contact a Framework Developer\n";
-  }
 }  // namespace edm

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -8,16 +8,13 @@
 #include "FWCore/Framework/src/ProductPutOrMergerBase.h"
 
 namespace edm {
-  RunPrincipal::RunPrincipal(std::shared_ptr<RunAuxiliary> aux,
-                             std::shared_ptr<ProductRegistry const> reg,
+  RunPrincipal::RunPrincipal(std::shared_ptr<ProductRegistry const> reg,
                              ProcessConfiguration const& pc,
                              HistoryAppender* historyAppender,
                              unsigned int iRunIndex,
                              bool isForPrimaryProcess,
                              MergeableRunProductProcesses const* mergeableRunProductProcesses)
-      : Base(reg, reg->productLookup(InRun), pc, InRun, historyAppender, isForPrimaryProcess),
-        aux_(aux),
-        index_(iRunIndex) {
+      : Base(reg, reg->productLookup(InRun), pc, InRun, historyAppender, isForPrimaryProcess), index_(iRunIndex) {
     if (mergeableRunProductProcesses) {  // primary RunPrincipals of EventProcessor
       mergeableRunProductMetadataPtr_ = (std::make_unique<MergeableRunProductMetadata>(*mergeableRunProductProcesses));
     }
@@ -26,9 +23,9 @@ namespace edm {
   RunPrincipal::~RunPrincipal() {}
 
   void RunPrincipal::fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader) {
-    m_reducedHistoryID = processHistoryRegistry.reducedProcessHistoryID(aux_->processHistoryID());
-    auto history = processHistoryRegistry.getMapped(aux_->processHistoryID());
-    fillPrincipal(aux_->processHistoryID(), history, reader);
+    m_reducedHistoryID = processHistoryRegistry.reducedProcessHistoryID(aux_.processHistoryID());
+    auto history = processHistoryRegistry.getMapped(aux_.processHistoryID());
+    fillPrincipal(aux_.processHistoryID(), history, reader);
 
     for (auto& prod : *this) {
       prod->setMergeableRunProductMetadata(mergeableRunProductMetadataPtr_.get());

--- a/FWCore/Framework/src/RunProcessingStatus.cc
+++ b/FWCore/Framework/src/RunProcessingStatus.cc
@@ -1,0 +1,50 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     RunProcessingStatus
+//
+// Original Author:  W. David Dagenhart
+//         Created:  7 October 2021
+
+#include "RunProcessingStatus.h"
+#include "FWCore/Framework/interface/RunPrincipal.h"
+
+namespace edm {
+  RunProcessingStatus::RunProcessingStatus(unsigned int iNStreams, WaitingTaskHolder const& holder)
+      : holderOfTaskInProcessRuns_(holder),
+        nStreamsStillProcessingBeginRun_(iNStreams),
+        nStreamsStillProcessingRun_(iNStreams) {}
+
+  void RunProcessingStatus::resetBeginResources() {
+    endIOVWaitingTasks_.doneWaiting(std::exception_ptr{});
+    for (auto& iter : eventSetupImpls_) {
+      iter.reset();
+    }
+  }
+
+  void RunProcessingStatus::resetEndResources() {
+    endIOVWaitingTasksEndRun_.doneWaiting(std::exception_ptr{});
+    for (auto& iter : eventSetupImplsEndRun_) {
+      iter.reset();
+    }
+  }
+
+  void RunProcessingStatus::setEndTime() {
+    constexpr char kUnset = 0;
+    constexpr char kSetting = 1;
+    constexpr char kSet = 2;
+
+    if (endTimeSetStatus_ != kSet) {
+      //not already set
+      char expected = kUnset;
+      if (endTimeSetStatus_.compare_exchange_strong(expected, kSetting)) {
+        runPrincipal_->setEndTime(endTime_);
+        endTimeSetStatus_.store(kSet);
+      } else {
+        //wait until time is set
+        while (endTimeSetStatus_.load() != kSet) {
+        }
+      }
+    }
+  }
+}  // namespace edm

--- a/FWCore/Framework/src/RunProcessingStatus.h
+++ b/FWCore/Framework/src/RunProcessingStatus.h
@@ -1,0 +1,123 @@
+#ifndef FWCore_Framework_RunProcessingStatus_h
+#define FWCore_Framework_RunProcessingStatus_h
+//
+// Package:     FWCore/Framework
+// Class  :     RunProcessingStatus
+//
+/**\class edm::RunProcessingStatus
+
+ Description: Keep status information about one Run transition
+
+*/
+//
+// Original Author: W. David Dagenhart
+//          Created: 1 Oct 2021
+//
+
+#include "DataFormats/Provenance/interface/Timestamp.h"
+#include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
+#include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/Framework/interface/InputSource.h"
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+namespace edm {
+
+  class EventSetupImpl;
+  class RunPrincipal;
+
+  class RunProcessingStatus {
+  public:
+    RunProcessingStatus(unsigned int iNStreams, WaitingTaskHolder const& holder);
+
+    RunProcessingStatus(RunProcessingStatus const&) = delete;
+    RunProcessingStatus const& operator=(RunProcessingStatus const&) = delete;
+
+    WaitingTaskHolder& holderOfTaskInProcessRuns() { return holderOfTaskInProcessRuns_; }
+    void setHolderOfTaskInProcessRuns(WaitingTaskHolder const& holder) { holderOfTaskInProcessRuns_ = holder; }
+
+    void setResumer(LimitedTaskQueue::Resumer iResumer) { globalRunQueueResumer_ = std::move(iResumer); }
+    void resumeGlobalRunQueue() {
+      //free run for next usage
+      runPrincipal_.reset();
+      globalRunQueueResumer_.resume();
+    }
+
+    std::shared_ptr<RunPrincipal>& runPrincipal() { return runPrincipal_; }
+    void setRunPrincipal(std::shared_ptr<RunPrincipal> val) { runPrincipal_ = std::move(val); }
+
+    void resetBeginResources();
+    void resetEndResources();
+
+    EventSetupImpl const& eventSetupImpl(unsigned subProcessIndex) const {
+      return *eventSetupImpls_.at(subProcessIndex);
+    }
+
+    EventSetupImpl const& eventSetupImplEndRun(unsigned subProcessIndex) const {
+      return *eventSetupImplsEndRun_.at(subProcessIndex);
+    }
+
+    std::vector<std::shared_ptr<const EventSetupImpl>>& eventSetupImpls() { return eventSetupImpls_; }
+    std::vector<std::shared_ptr<const EventSetupImpl>> const& eventSetupImpls() const { return eventSetupImpls_; }
+
+    WaitingTaskList& endIOVWaitingTasks() { return endIOVWaitingTasks_; }
+
+    std::vector<std::shared_ptr<const EventSetupImpl>>& eventSetupImplsEndRun() { return eventSetupImplsEndRun_; }
+    std::vector<std::shared_ptr<const EventSetupImpl>> const& eventSetupImplsEndRun() const {
+      return eventSetupImplsEndRun_;
+    }
+
+    WaitingTaskList& endIOVWaitingTasksEndRun() { return endIOVWaitingTasksEndRun_; }
+
+    void setGlobalEndRunHolder(WaitingTaskHolder holder) { globalEndRunHolder_ = std::move(holder); }
+    WaitingTaskHolder& globalEndRunHolder() { return globalEndRunHolder_; }
+
+    bool streamFinishedBeginRun() { return 0 == (--nStreamsStillProcessingBeginRun_); }
+    bool streamFinishedRun() { return 0 == (--nStreamsStillProcessingRun_); }
+
+    //These should only be called while in the InputSource's task queue
+    void updateLastTimestamp(edm::Timestamp const& iTime) {
+      if (iTime > endTime_) {
+        endTime_ = iTime;
+      }
+    }
+    edm::Timestamp const& lastTimestamp() const { return endTime_; }
+
+    void setEndTime();
+
+    bool didGlobalBeginSucceed() const { return globalBeginSucceeded_; }
+    void globalBeginDidSucceed() { globalBeginSucceeded_ = true; }
+
+    bool cleaningUpAfterException() const { return cleaningUpAfterException_; }
+    void setCleaningUpAfterException(bool val) { cleaningUpAfterException_ = val; }
+
+    bool stopBeforeProcessingRun() const { return stopBeforeProcessingRun_; }
+    void setStopBeforeProcessingRun(bool val) { stopBeforeProcessingRun_ = val; }
+
+    bool endingEventSetupSucceeded() const { return endingEventSetupSucceeded_; }
+    void setEndingEventSetupSucceeded(bool val) { endingEventSetupSucceeded_ = val; }
+
+  private:
+    WaitingTaskHolder holderOfTaskInProcessRuns_;
+    LimitedTaskQueue::Resumer globalRunQueueResumer_;
+    std::shared_ptr<RunPrincipal> runPrincipal_;
+    std::vector<std::shared_ptr<const EventSetupImpl>> eventSetupImpls_;
+    WaitingTaskList endIOVWaitingTasks_;
+    std::vector<std::shared_ptr<const EventSetupImpl>> eventSetupImplsEndRun_;
+    WaitingTaskList endIOVWaitingTasksEndRun_;
+    WaitingTaskHolder globalEndRunHolder_;
+    std::atomic<unsigned int> nStreamsStillProcessingBeginRun_;
+    std::atomic<unsigned int> nStreamsStillProcessingRun_;
+    edm::Timestamp endTime_{};
+    std::atomic<char> endTimeSetStatus_{0};
+    bool globalBeginSucceeded_{false};
+    bool cleaningUpAfterException_{false};
+    bool stopBeforeProcessingRun_{false};
+    bool endingEventSetupSucceeded_{true};
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/Framework/src/SendSourceTerminationSignalIfException.h
+++ b/FWCore/Framework/src/SendSourceTerminationSignalIfException.h
@@ -1,0 +1,34 @@
+#ifndef FWCore_Framework_SendSourceTerminationSignalIfException_h
+#define FWCore_Framework_SendSourceTerminationSignalIfException_h
+//
+// Package:     FWCore/Framework
+// Class  :     SendSourceTerminationSignalIfException
+//
+/**\class edm::SendSourceTerminationSignalIfException
+*/
+
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/TerminationOrigin.h"
+
+namespace edm {
+
+  //Sentry class to only send a signal if an
+  // exception occurs. An exception is identified
+  // by the destructor being called without first
+  // calling completedSuccessfully().
+  class SendSourceTerminationSignalIfException {
+  public:
+    SendSourceTerminationSignalIfException(ActivityRegistry* iReg) : reg_(iReg) {}
+    ~SendSourceTerminationSignalIfException() {
+      if (reg_) {
+        reg_->preSourceEarlyTerminationSignal_(TerminationOrigin::ExceptionFromThisContext);
+      }
+    }
+    void completedSuccessfully() { reg_ = nullptr; }
+
+  private:
+    ActivityRegistry* reg_;  // We do not use propagate_const because the registry itself is mutable.
+  };
+}  // namespace edm
+
+#endif

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -75,7 +75,6 @@ namespace edm {
         principalCache_(),
         esp_(),
         schedule_(),
-        parentToChildPhID_(),
         subProcesses_(),
         processParameterSet_(),
         productSelectorRules_(parameterSet, "outputCommands", "OutputModule"),
@@ -172,11 +171,6 @@ namespace edm {
     subProcessParentageHelper_ = items.subProcessParentageHelper();
     subProcessParentageHelper_->update(parentSubProcessParentageHelper, *parentProductRegistry);
 
-    //CMS-THREADING this only works since Run/Lumis are synchronous so when principalCache asks for
-    // the reducedProcessHistoryID from a full ProcessHistoryID that registry will not be in use by
-    // another thread. We really need to change how this is done in the PrincipalCache.
-    principalCache_.setProcessHistoryRegistry(processHistoryRegistries_[historyRunOffset_]);
-
     processConfiguration_ = items.processConfiguration();
     processContext_.setProcessConfiguration(processConfiguration_.get());
     processContext_.setParentProcessContext(parentProcessContext);
@@ -193,6 +187,13 @@ namespace edm {
                                                  &*processBlockHelper_);
       principalCache_.insert(ep);
     }
+
+    for (unsigned int index = 0; index < preallocConfig.numberOfRuns(); ++index) {
+      auto rpp = std::make_unique<RunPrincipal>(
+          preg_, *processConfiguration_, &(historyAppenders_[historyRunOffset_ + index]), index, false);
+      principalCache_.insert(std::move(rpp));
+    }
+
     for (unsigned int index = 0; index < preallocConfig.numberOfLuminosityBlocks(); ++index) {
       auto lbpp = std::make_unique<LuminosityBlockPrincipal>(
           preg_, *processConfiguration_, &(historyAppenders_[historyLumiOffset_ + index]), index, false);
@@ -207,6 +208,7 @@ namespace edm {
       principalCache_.insertForInput(std::move(pbForInput));
     }
 
+    inUseRunPrincipals_.resize(preallocConfig.numberOfRuns());
     inUseLumiPrincipals_.resize(preallocConfig.numberOfLuminosityBlocks());
 
     subProcesses_.reserve(subProcessVParameterSet.size());
@@ -540,28 +542,20 @@ namespace edm {
     ServiceRegistry::Operate operate(serviceToken_);
 
     RunPrincipal const& parentPrincipal = iTransitionInfo.principal();
-    auto aux = std::make_shared<RunAuxiliary>(parentPrincipal.aux());
-    aux->setProcessHistoryID(parentPrincipal.processHistoryID());
-    auto rpp = std::make_shared<RunPrincipal>(aux,
-                                              preg_,
-                                              *processConfiguration_,
-                                              &(historyAppenders_[historyRunOffset_ + parentPrincipal.index()]),
-                                              parentPrincipal.index(),
-                                              false);
+    auto aux = parentPrincipal.aux();
+    aux.setProcessHistoryID(parentPrincipal.processHistoryID());
+    auto rpp = principalCache_.getAvailableRunPrincipalPtr();
+    rpp->setAux(aux);
     auto& processHistoryRegistry = processHistoryRegistries_[historyRunOffset_ + parentPrincipal.index()];
+    inUseRunPrincipals_[parentPrincipal.index()] = rpp;
     processHistoryRegistry.registerProcessHistory(parentPrincipal.processHistory());
     rpp->fillRunPrincipal(processHistoryRegistry, parentPrincipal.reader());
-    principalCache_.insert(rpp);
 
-    ProcessHistoryID const& parentInputReducedPHID = parentPrincipal.reducedProcessHistoryID();
-    ProcessHistoryID const& inputReducedPHID = rpp->reducedProcessHistoryID();
-
-    parentToChildPhID_.insert(std::make_pair(parentInputReducedPHID, inputReducedPHID));
-
-    RunPrincipal& rp = *principalCache_.runPrincipalPtr();
+    RunPrincipal& rp = *rpp;
     propagateProducts(InRun, parentPrincipal, rp);
 
-    RunTransitionInfo transitionInfo(rp, esp_->eventSetupImpl());
+    std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls = iTransitionInfo.eventSetupImpls();
+    RunTransitionInfo transitionInfo(rp, *((*eventSetupImpls)[esp_->subProcessIndex()]), eventSetupImpls);
     using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>;
     beginGlobalTransitionAsync<Traits>(std::move(iHolder), *schedule_, transitionInfo, serviceToken_, subProcesses_);
   }
@@ -570,10 +564,11 @@ namespace edm {
                                  RunTransitionInfo const& iTransitionInfo,
                                  bool cleaningUpAfterException) {
     RunPrincipal const& parentPrincipal = iTransitionInfo.principal();
-    RunPrincipal& rp = *principalCache_.runPrincipalPtr();
+    RunPrincipal& rp = *inUseRunPrincipals_[parentPrincipal.index()];
     propagateProducts(InRun, parentPrincipal, rp);
 
-    RunTransitionInfo transitionInfo(rp, esp_->eventSetupImpl());
+    std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls = iTransitionInfo.eventSetupImpls();
+    RunTransitionInfo transitionInfo(rp, *((*eventSetupImpls)[esp_->subProcessIndex()]), eventSetupImpls);
     using Traits = OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>;
     endGlobalTransitionAsync<Traits>(
         std::move(iHolder), *schedule_, transitionInfo, serviceToken_, subProcesses_, cleaningUpAfterException);
@@ -594,40 +589,29 @@ namespace edm {
   }
 
   void SubProcess::writeRunAsync(edm::WaitingTaskHolder task,
-                                 ProcessHistoryID const& parentPhID,
-                                 int runNumber,
+                                 RunPrincipal const& principal,
                                  MergeableRunProductMetadata const* mergeableRunProductMetadata) {
-    ServiceRegistry::Operate operate(serviceToken_);
-    std::map<ProcessHistoryID, ProcessHistoryID>::const_iterator it = parentToChildPhID_.find(parentPhID);
-    assert(it != parentToChildPhID_.end());
-    auto const& childPhID = it->second;
-
     using namespace edm::waiting_task;
+
+    auto rp = inUseRunPrincipals_[principal.index()];
     chain::first([&](std::exception_ptr const*, auto nextTask) {
       ServiceRegistry::Operate operate(serviceToken_);
-      schedule_->writeRunAsync(nextTask,
-                               principalCache_.runPrincipal(childPhID, runNumber),
-                               &processContext_,
-                               actReg_.get(),
-                               mergeableRunProductMetadata);
-    }) |
-        chain::ifThen(not subProcesses_.empty(),
-                      [this, childPhID, runNumber, mergeableRunProductMetadata](auto nextTask) {
-                        ServiceRegistry::Operate operateWriteRun(serviceToken_);
-                        for (auto& s : subProcesses_) {
-                          s.writeRunAsync(nextTask, childPhID, runNumber, mergeableRunProductMetadata);
-                        }
-                      }) |
-        chain::runLast(task);
+      schedule_->writeRunAsync(nextTask, *rp, &processContext_, actReg_.get(), mergeableRunProductMetadata);
+    }) | chain::ifThen(not subProcesses_.empty(), [this, rp, mergeableRunProductMetadata](auto nextTask) {
+      ServiceRegistry::Operate operateWriteRun(serviceToken_);
+      for (auto& s : subProcesses_) {
+        s.writeRunAsync(nextTask, *rp, mergeableRunProductMetadata);
+      }
+    }) | chain::runLast(std::move(task));
   }
 
-  void SubProcess::deleteRunFromCache(ProcessHistoryID const& parentPhID, int runNumber) {
-    std::map<ProcessHistoryID, ProcessHistoryID>::const_iterator it = parentToChildPhID_.find(parentPhID);
-    assert(it != parentToChildPhID_.end());
-    auto const& childPhID = it->second;
-    principalCache_.deleteRun(childPhID, runNumber);
-    for_all(subProcesses_,
-            [&childPhID, runNumber](auto& subProcess) { subProcess.deleteRunFromCache(childPhID, runNumber); });
+  void SubProcess::clearRunPrincipal(RunPrincipal& parentPrincipal) {
+    //release from list but stay around till end of routine
+    auto rp = std::move(inUseRunPrincipals_[parentPrincipal.index()]);
+    for (auto& s : subProcesses_) {
+      s.clearRunPrincipal(*rp);
+    }
+    rp->clearPrincipal();
   }
 
   void SubProcess::clearProcessBlockPrincipal(ProcessBlockType processBlockType) {
@@ -650,7 +634,7 @@ namespace edm {
     inUseLumiPrincipals_[parentPrincipal.index()] = lbpp;
     processHistoryRegistry.registerProcessHistory(parentPrincipal.processHistory());
     lbpp->fillLuminosityBlockPrincipal(&parentPrincipal.processHistory(), parentPrincipal.reader());
-    lbpp->setRunPrincipal(principalCache_.runPrincipalPtr());
+    lbpp->setRunPrincipal(inUseRunPrincipals_[parentPrincipal.runPrincipal().index()]);
     LuminosityBlockPrincipal& lbp = *lbpp;
     propagateProducts(InLumi, parentPrincipal, lbp);
 
@@ -689,12 +673,13 @@ namespace edm {
     }) | chain::runLast(std::move(task));
   }
 
-  void SubProcess::deleteLumiFromCache(LuminosityBlockPrincipal& principal) {
+  void SubProcess::clearLumiPrincipal(LuminosityBlockPrincipal& principal) {
     //release from list but stay around till end of routine
     auto lb = std::move(inUseLumiPrincipals_[principal.index()]);
     for (auto& s : subProcesses_) {
-      s.deleteLumiFromCache(*lb);
+      s.clearLumiPrincipal(*lb);
     }
+    lb->setRunPrincipal(std::shared_ptr<RunPrincipal>());
     lb->clearPrincipal();
   }
 
@@ -710,24 +695,31 @@ namespace edm {
     for_all(subProcesses_, [iID](auto& subProcess) { subProcess.doEndStream(iID); });
   }
 
-  void SubProcess::doStreamBeginRunAsync(WaitingTaskHolder iHolder, unsigned int id, RunTransitionInfo const&) {
+  void SubProcess::doStreamBeginRunAsync(WaitingTaskHolder iHolder,
+                                         unsigned int id,
+                                         RunTransitionInfo const& iTransitionInfo) {
     using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>;
 
-    RunPrincipal& rp = *principalCache_.runPrincipalPtr();
+    RunPrincipal const& parentPrincipal = iTransitionInfo.principal();
+    RunPrincipal& rp = *inUseRunPrincipals_[parentPrincipal.index()];
 
-    RunTransitionInfo transitionInfo(rp, esp_->eventSetupImpl());
+    std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls = iTransitionInfo.eventSetupImpls();
+    RunTransitionInfo transitionInfo(rp, *((*eventSetupImpls)[esp_->subProcessIndex()]), eventSetupImpls);
     beginStreamTransitionAsync<Traits>(
         std::move(iHolder), *schedule_, id, transitionInfo, serviceToken_, subProcesses_);
   }
 
   void SubProcess::doStreamEndRunAsync(WaitingTaskHolder iHolder,
                                        unsigned int id,
-                                       RunTransitionInfo const&,
+                                       RunTransitionInfo const& iTransitionInfo,
                                        bool cleaningUpAfterException) {
-    RunPrincipal& rp = *principalCache_.runPrincipalPtr();
     using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>;
 
-    RunTransitionInfo transitionInfo(rp, esp_->eventSetupImpl());
+    RunPrincipal const& parentPrincipal = iTransitionInfo.principal();
+    RunPrincipal& rp = *inUseRunPrincipals_[parentPrincipal.index()];
+
+    std::vector<std::shared_ptr<const EventSetupImpl>> const* eventSetupImpls = iTransitionInfo.eventSetupImpls();
+    RunTransitionInfo transitionInfo(rp, *((*eventSetupImpls)[esp_->subProcessIndex()]), eventSetupImpls);
     endStreamTransitionAsync<Traits>(
         std::move(iHolder), *schedule_, id, transitionInfo, serviceToken_, subProcesses_, cleaningUpAfterException);
   }

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -17,7 +17,6 @@ struct FileResources {
   FileResources(EventProcessor& iEP) : ep_(iEP) {}
 
   ~FileResources() {
-    // See the message in catch clause
     CMS_SA_ALLOW try {
       // Don't try to execute the following sequence of functions twice.
       // If the sequence was already attempted and failed, then do nothing.
@@ -48,134 +47,52 @@ struct FileResources {
 };
 
 struct RunResources {
-  RunResources(EventProcessor& iEP, edm::ProcessHistoryID iHist, edm::RunNumber_t iRun) noexcept
-      : ep_(iEP), history_(iHist), run_(iRun) {}
+  RunResources(EventProcessor& iEP) noexcept : ep_(iEP) {}
 
   ~RunResources() noexcept {
+    // Usually runs and lumis are closed inside processRuns and then endUnfinishedRun
+    // and endUnfinishedLumi do nothing. We try to close runs and lumis even when an
+    // exception is thrown in processRuns.  These calls are necessary when we are between
+    // calls to processRuns because of a file transition and an exception is thrown or
+    // there is an empty last file. In addition, this protects against rare cases where
+    // processRuns returns with open runs or lumis.
     // Caught exception is propagated via EventProcessor::setDeferredException()
-    CMS_SA_ALLOW try {
-      //If we skip empty runs, this would be called conditionally
-      ep_.endUnfinishedRun(processHistoryID(),
-                           run(),
-                           globalTransitionSucceeded_,
-                           cleaningUpAfterException_,
-                           eventSetupForInstanceSucceeded_);
-    } catch (...) {
+    CMS_SA_ALLOW try { ep_.endUnfinishedLumi(cleaningUpAfterException_); } catch (...) {
+      if (cleaningUpAfterException_ or not ep_.setDeferredException(std::current_exception())) {
+        ep_.setExceptionMessageLumis();
+      }
+    }
+    CMS_SA_ALLOW try { ep_.endUnfinishedRun(cleaningUpAfterException_); } catch (...) {
       if (cleaningUpAfterException_ or not ep_.setDeferredException(std::current_exception())) {
         ep_.setExceptionMessageRuns();
       }
     }
   }
 
-  edm::ProcessHistoryID processHistoryID() const { return history_; }
-
-  edm::RunNumber_t run() const { return run_; }
-
   void normalEnd() { cleaningUpAfterException_ = false; }
 
-  void succeeded() { success_ = true; }
-
   EventProcessor& ep_;
-  edm::ProcessHistoryID history_;
-  edm::RunNumber_t run_;
   bool cleaningUpAfterException_ = true;
-  bool success_ = false;
-  bool globalTransitionSucceeded_ = false;
-  bool eventSetupForInstanceSucceeded_ = false;
-};
-
-class LumisInRunProcessor {
-public:
-  ~LumisInRunProcessor() noexcept { normalEnd(); }
-
-  edm::InputSource::ItemType processLumis(EventProcessor& iEP, std::shared_ptr<RunResources> iRun) {
-    currentRun_ = std::move(iRun);
-    makeSureLumiEnds_ = true;
-    return iEP.processLumis(std::shared_ptr<void>{currentRun_});
-  }
-
-  void normalEnd() noexcept {
-    // Caught exception is propagated via EventProcessor::setDeferredException()
-    CMS_SA_ALLOW try {
-      if (makeSureLumiEnds_) {
-        makeSureLumiEnds_ = false;
-        currentRun_->ep_.endUnfinishedLumi();
-      }
-    } catch (...) {
-      if (not currentRun_->ep_.setDeferredException(std::current_exception())) {
-        currentRun_->ep_.setExceptionMessageLumis();
-      }
-    }
-
-    currentRun_.reset();
-  }
-
-private:
-  std::shared_ptr<RunResources> currentRun_;
-  bool makeSureLumiEnds_ = false;
 };
 
 class RunsInFileProcessor {
 public:
   edm::InputSource::ItemType processRuns(EventProcessor& iEP) {
-    bool finished = false;
-    auto nextTransition = edm::InputSource::IsRun;
-    do {
-      switch (nextTransition) {
-        case edm::InputSource::IsRun: {
-          processRun(iEP);
-          nextTransition = iEP.nextTransitionType();
-          break;
-        }
-        case edm::InputSource::IsLumi: {
-          nextTransition = lumis_.processLumis(iEP, currentRun_);
-          break;
-        }
-        default:
-          finished = true;
-      }
-    } while (not finished);
-    return nextTransition;
+    if (!runResources_) {
+      runResources_ = std::make_unique<RunResources>(iEP);
+    }
+    return iEP.processRuns();
   }
 
   void normalEnd() {
-    lumis_.normalEnd();
-    if (currentRun_) {
-      currentRun_->normalEnd();
-      assert(currentRun_.use_count() == 1);
+    if (runResources_) {
+      runResources_->normalEnd();
+      runResources_.reset();
     }
-    currentRun_.reset();
   }
 
 private:
-  void processRun(EventProcessor& iEP) {
-    auto runID = iEP.nextRunID();
-    if ((not currentRun_) or (currentRun_->processHistoryID() != runID.first) or (currentRun_->run() != runID.second)) {
-      if (currentRun_) {
-        //Both the current run and lumi end here
-        lumis_.normalEnd();
-        if (edm::InputSource::IsStop == iEP.lastTransitionType()) {
-          //an exception happened while processing the end lumi
-          return;
-        }
-        currentRun_->normalEnd();
-      }
-      currentRun_ = std::make_shared<RunResources>(iEP, runID.first, runID.second);
-      iEP.readRun();
-      iEP.beginRun(runID.first,
-                   runID.second,
-                   currentRun_->globalTransitionSucceeded_,
-                   currentRun_->eventSetupForInstanceSucceeded_);
-      //only if we succeed at beginRun should we run writeRun
-      currentRun_->succeeded();
-    } else {
-      //merge
-      iEP.readAndMergeRun();
-    }
-  }
-
-  std::shared_ptr<RunResources> currentRun_;
-  LumisInRunProcessor lumis_;
+  std::unique_ptr<RunResources> runResources_;
 };
 
 class FilesProcessor {
@@ -202,7 +119,6 @@ public:
           finished = true;
       }
     } while (not finished);
-    runs_.normalEnd();
 
     return nextTransition;
   }

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -64,6 +64,8 @@ namespace edm {
 
     void EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       preallocStreams(iPrealloc.numberOfStreams());
+      preallocRuns(iPrealloc.numberOfRuns());
+      preallocRunsSummary(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
       preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
@@ -189,6 +191,8 @@ namespace edm {
     }
 
     void EDAnalyzerBase::preallocStreams(unsigned int) {}
+    void EDAnalyzerBase::preallocRuns(unsigned int) {}
+    void EDAnalyzerBase::preallocRunsSummary(unsigned int) {}
     void EDAnalyzerBase::preallocLumis(unsigned int) {}
     void EDAnalyzerBase::preallocLumisSummary(unsigned int) {}
     void EDAnalyzerBase::preallocate(PreallocationConfiguration const&) {}

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -104,6 +104,8 @@ namespace edm {
       }
       previousParentageIds_ = std::make_unique<ParentageID[]>(nStreams);
       preallocStreams(nStreams);
+      preallocRuns(iPrealloc.numberOfRuns());
+      preallocRunsSummary(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
       preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
@@ -247,6 +249,8 @@ namespace edm {
     }
 
     void EDFilterBase::preallocStreams(unsigned int) {}
+    void EDFilterBase::preallocRuns(unsigned int) {}
+    void EDFilterBase::preallocRunsSummary(unsigned int) {}
     void EDFilterBase::preallocLumis(unsigned int) {}
     void EDFilterBase::preallocLumisSummary(unsigned int) {}
     void EDFilterBase::preallocate(PreallocationConfiguration const&) {}

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -110,6 +110,8 @@ namespace edm {
       }
       previousParentageIds_ = std::make_unique<ParentageID[]>(nStreams);
       preallocStreams(nStreams);
+      preallocRuns(iPrealloc.numberOfRuns());
+      preallocRunsSummary(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
       preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
@@ -257,6 +259,8 @@ namespace edm {
     }
 
     void EDProducerBase::preallocStreams(unsigned int) {}
+    void EDProducerBase::preallocRuns(unsigned int) {}
+    void EDProducerBase::preallocRunsSummary(unsigned int) {}
     void EDProducerBase::preallocLumis(unsigned int) {}
     void EDProducerBase::preallocLumisSummary(unsigned int) {}
     void EDProducerBase::preallocate(PreallocationConfiguration const&) {}

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -65,6 +65,8 @@ namespace edm {
 
     void EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       preallocStreams(iPrealloc.numberOfStreams());
+      preallocRuns(iPrealloc.numberOfRuns());
+      preallocRunsSummary(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
       preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
@@ -190,6 +192,8 @@ namespace edm {
     }
 
     void EDAnalyzerBase::preallocStreams(unsigned int) {}
+    void EDAnalyzerBase::preallocRuns(unsigned int) {}
+    void EDAnalyzerBase::preallocRunsSummary(unsigned int) {}
     void EDAnalyzerBase::preallocLumis(unsigned int) {}
     void EDAnalyzerBase::preallocLumisSummary(unsigned int) {}
     void EDAnalyzerBase::preallocate(PreallocationConfiguration const&) {}

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -85,6 +85,8 @@ namespace edm {
       previousParentages_ = std::make_unique<std::vector<BranchID>[]>(nStreams);
       previousParentageIds_ = std::make_unique<ParentageID[]>(nStreams);
       preallocStreams(nStreams);
+      preallocRuns(iPrealloc.numberOfRuns());
+      preallocRunsSummary(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
       preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
@@ -228,6 +230,8 @@ namespace edm {
     }
 
     void EDFilterBase::preallocStreams(unsigned int) {}
+    void EDFilterBase::preallocRuns(unsigned int) {}
+    void EDFilterBase::preallocRunsSummary(unsigned int) {}
     void EDFilterBase::preallocLumis(unsigned int) {}
     void EDFilterBase::preallocLumisSummary(unsigned int) {}
     void EDFilterBase::preallocate(PreallocationConfiguration const&) {}

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -85,6 +85,8 @@ namespace edm {
       previousParentages_ = std::make_unique<std::vector<BranchID>[]>(nStreams);
       previousParentageIds_ = std::make_unique<ParentageID[]>(nStreams);
       preallocStreams(nStreams);
+      preallocRuns(iPrealloc.numberOfRuns());
+      preallocRunsSummary(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
       preallocLumisSummary(iPrealloc.numberOfLuminosityBlocks());
       preallocate(iPrealloc);
@@ -228,6 +230,8 @@ namespace edm {
     }
 
     void EDProducerBase::preallocStreams(unsigned int) {}
+    void EDProducerBase::preallocRuns(unsigned int) {}
+    void EDProducerBase::preallocRunsSummary(unsigned int) {}
     void EDProducerBase::preallocLumis(unsigned int) {}
     void EDProducerBase::preallocLumisSummary(unsigned int) {}
     void EDProducerBase::preallocate(PreallocationConfiguration const&) {}

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -82,9 +82,12 @@ namespace edm {
     void EDAnalyzerBase::doEndJob() { this->endJob(); }
 
     void EDAnalyzerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
+      preallocRuns(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
     }
-    void EDAnalyzerBase::preallocLumis(unsigned int){};
+
+    void EDAnalyzerBase::preallocRuns(unsigned int) {}
+    void EDAnalyzerBase::preallocLumis(unsigned int) {}
 
     void EDAnalyzerBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
       ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -95,9 +95,12 @@ namespace edm {
     void EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       auto const nThreads = iPrealloc.numberOfThreads();
       preallocThreads(nThreads);
+      preallocRuns(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
     }
-    void EDFilterBase::preallocLumis(unsigned int){};
+
+    void EDFilterBase::preallocRuns(unsigned int) {}
+    void EDFilterBase::preallocLumis(unsigned int) {}
 
     void EDFilterBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
       ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -94,10 +94,12 @@ namespace edm {
     void EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       auto const nThreads = iPrealloc.numberOfThreads();
       preallocThreads(nThreads);
+      preallocRuns(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
     }
 
-    void EDProducerBase::preallocLumis(unsigned int){};
+    void EDProducerBase::preallocRuns(unsigned int) {}
+    void EDProducerBase::preallocLumis(unsigned int) {}
 
     void EDProducerBase::doBeginProcessBlock(ProcessBlockPrincipal const& pbp, ModuleCallingContext const* mcc) {
       ProcessBlock processBlock(pbp, moduleDescription_, mcc, false);

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -80,6 +80,7 @@ void EDAnalyzerAdaptorBase::deleteModulesEarly() {
 void EDAnalyzerAdaptorBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
   m_streamModules.resize(iPrealloc.numberOfStreams(), static_cast<stream::EDAnalyzerBase*>(nullptr));
   setupStreamModules();
+  preallocRuns(iPrealloc.numberOfRuns());
   preallocLumis(iPrealloc.numberOfLuminosityBlocks());
 }
 

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -65,6 +65,7 @@ namespace edm {
     void ProducingModuleAdaptorBase<T>::doPreallocate(PreallocationConfiguration const& iPrealloc) {
       m_streamModules.resize(iPrealloc.numberOfStreams(), static_cast<T*>(nullptr));
       setupStreamModules();
+      preallocRuns(iPrealloc.numberOfRuns());
       preallocLumis(iPrealloc.numberOfLuminosityBlocks());
     }
 

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -449,8 +449,8 @@ void testEvent::setUp() {
   Timestamp time = make_timestamp();
   EventID id = make_id();
   ProcessConfiguration const& pc = currentModuleDescription_->processConfiguration();
-  auto runAux = std::make_shared<RunAuxiliary>(id.run(), time, time);
-  auto rp = std::make_shared<RunPrincipal>(runAux, preg, pc, &historyAppender_, 0);
+  auto rp = std::make_shared<RunPrincipal>(preg, pc, &historyAppender_, 0);
+  rp->setAux(RunAuxiliary(id.run(), time, time));
   lbp_ = std::make_shared<LuminosityBlockPrincipal>(preg, pc, &historyAppender_, 0);
   lbp_->setAux(LuminosityBlockAuxiliary(rp->run(), 1, time, time));
   lbp_->setRunPrincipal(rp);

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -1,11 +1,4 @@
-/*
-*/
-
 #include "FWCore/Framework/test/MockEventProcessor.h"
-#include "FWCore/Framework/interface/InputSource.h"
-#include <cassert>
-#include <sstream>
-#include <exception>
 
 namespace {
   // As each data item is read from the mock data it is
@@ -29,17 +22,7 @@ namespace {
   class WaitingTaskHolder;
 }  // namespace
 
-namespace edm {
-  class LuminosityBlockPrincipal {
-  public:
-    LuminosityBlockPrincipal(int iRun, int iLumi) : run_(iRun), lumi_(iLumi) {}
-    int run_;
-    int lumi_;
-  };
-}  // namespace edm
-
 #define TEST_NO_FWD_DECL
-#include "FWCore/Framework/src/LuminosityBlockProcessingStatus.h"
 
 namespace {
 #include "FWCore/Framework/src/TransitionProcessors.icc"
@@ -51,8 +34,8 @@ namespace edm {
       : mockData_(mockData),
         output_(output),
         input_(mockData_),
-        run_(0),
-        lumi_(0),
+        nextRun_(0),
+        nextLumi_(0),
         doNotMerge_(iDoNotMerge),
         shouldWeCloseOutput_(true),
         shouldWeEndLoop_(true),
@@ -73,11 +56,11 @@ namespace edm {
     eventProcessed_ = false;
     if (ch == 'r') {
       output_ << "    *** nextItemType: Run " << t.value << " ***\n";
-      run_ = t.value;
+      nextRun_ = static_cast<RunNumber_t>(t.value);
       return lastTransition_ = InputSource::IsRun;
     } else if (ch == 'l') {
       output_ << "    *** nextItemType: Lumi " << t.value << " ***\n";
-      lumi_ = t.value;
+      nextLumi_ = static_cast<LuminosityBlockNumber_t>(t.value);
       return lastTransition_ = InputSource::IsLumi;
     } else if (ch == 'e') {
       output_ << "    *** nextItemType: Event ***\n";
@@ -118,12 +101,6 @@ namespace edm {
   }
 
   InputSource::ItemType MockEventProcessor::lastTransitionType() const { return lastTransition_; }
-
-  std::pair<edm::ProcessHistoryID, edm::RunNumber_t> MockEventProcessor::nextRunID() {
-    return std::make_pair(edm::ProcessHistoryID{}, run_);
-  }
-
-  edm::LuminosityBlockNumber_t MockEventProcessor::nextLuminosityBlockID() { return lumi_; }
 
   InputSource::ItemType MockEventProcessor::readAndProcessEvents() {
     bool first = true;
@@ -209,42 +186,45 @@ namespace edm {
   void MockEventProcessor::inputProcessBlocks() {}
   void MockEventProcessor::endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded) {}
 
-  void MockEventProcessor::beginRun(ProcessHistoryID const& phid,
-                                    RunNumber_t run,
-                                    bool& globalTransitionSucceeded,
-                                    bool& eventSetupForInstanceSucceeded) {
-    output_ << "\tbeginRun " << run << "\n";
-    eventSetupForInstanceSucceeded = true;
-    throwIfNeeded();
-    globalTransitionSucceeded = true;
-  }
-
-  void MockEventProcessor::endRun(ProcessHistoryID const& phid,
-                                  RunNumber_t run,
-                                  bool globalTransitionSucceeded,
-                                  bool /*cleaningUpAfterException*/) {
-    auto postfix = globalTransitionSucceeded ? "\n" : " global failed\n";
-    output_ << "\tendRun " << run << postfix;
-  }
-
-  void MockEventProcessor::endUnfinishedRun(ProcessHistoryID const& phid,
-                                            RunNumber_t run,
-                                            bool globalTransitionSucceeded,
-                                            bool cleaningUpAfterException,
-                                            bool eventSetupForInstanceSucceeded) {
-    if (eventSetupForInstanceSucceeded) {
-      endRun(phid, run, globalTransitionSucceeded, cleaningUpAfterException);
-      if (globalTransitionSucceeded) {
-        writeRun(phid, run);
+  InputSource::ItemType MockEventProcessor::processRuns() {
+    bool finished = false;
+    auto nextTransition = edm::InputSource::IsRun;
+    do {
+      switch (nextTransition) {
+        case edm::InputSource::IsRun: {
+          processRun();
+          nextTransition = nextTransitionType();
+          break;
+        }
+        case edm::InputSource::IsLumi: {
+          nextTransition = processLumis();
+          break;
+        }
+        default:
+          finished = true;
       }
-    }
-    deleteRunFromCache(phid, run);
+    } while (not finished);
+    return nextTransition;
   }
 
-  InputSource::ItemType MockEventProcessor::processLumis(std::shared_ptr<void> iRunResource) {
-    if (lumiStatus_ and lumiStatus_->runResource() == iRunResource and lumiStatus_->lumiPrincipal()->lumi_ == lumi_) {
-      readAndMergeLumi(*lumiStatus_);
+  void MockEventProcessor::processRun() {
+    if ((not currentRun_) or (currentRunNumber_ != nextRun_)) {
+      if (currentRun_) {
+        endUnfinishedLumi(true);
+        endUnfinishedRun(true);
+      }
+      currentRun_ = true;
+      readRun();
+      beginRun(currentRunNumber_);
+    } else {
+      //merge
+      readAndMergeRun();
+    }
+  }
 
+  InputSource::ItemType MockEventProcessor::processLumis() {
+    if (lumiStatus_ and currentLumiNumber_ == nextLumi_) {
+      readAndMergeLumi();
       if (nextTransitionType() == InputSource::IsEvent) {
         readAndProcessEvents();
         if (shouldWeStop()) {
@@ -252,12 +232,12 @@ namespace edm {
         }
       }
     } else {
-      endUnfinishedLumi();
-      lumiStatus_ = std::make_shared<LuminosityBlockProcessingStatus>(this, 1, iRunResource);
-      auto lumi = readLuminosityBlock(*lumiStatus_);
-      output_ << "\tbeginLumi " << run_ << "/" << lumi << "\n";
+      endUnfinishedLumi(true);
+      lumiStatus_ = true;
+      auto lumi = readLuminosityBlock();
+      output_ << "\tbeginLumi " << currentRunNumber_ << "/" << lumi << "\n";
       throwIfNeeded();
-      lumiStatus_->globalBeginDidSucceed();
+      didGlobalBeginLumiSucceed_ = true;
       //Need to do event processing here
       if (nextTransitionType() == InputSource::IsEvent) {
         readAndProcessEvents();
@@ -269,60 +249,74 @@ namespace edm {
     return lastTransitionType();
   }
 
-  void MockEventProcessor::endUnfinishedLumi() {
+  void MockEventProcessor::beginRun(RunNumber_t run) {
+    output_ << "\tbeginRun " << run << "\n";
+    throwIfNeeded();
+    didGlobalBeginRunSucceed_ = true;
+  }
+
+  void MockEventProcessor::endRun() {
+    auto postfix = didGlobalBeginRunSucceed_ ? "\n" : " global failed\n";
+    output_ << "\tendRun " << currentRunNumber_ << postfix;
+    currentRun_ = false;
+  }
+
+  void MockEventProcessor::endUnfinishedRun(bool) {
+    endRun();
+    if (didGlobalBeginRunSucceed_) {
+      writeRun();
+    }
+    clearRunPrincipal();
+  }
+
+  void MockEventProcessor::endUnfinishedLumi(bool) {
     if (lumiStatus_) {
-      auto tmp = lumiStatus_;
       endLumi();
-      if (tmp->didGlobalBeginSucceed()) {
-        writeLumi(*tmp);
+      if (didGlobalBeginLumiSucceed_) {
+        writeLumi();
       }
-      deleteLumiFromCache(*tmp);
+      clearLumiPrincipal();
     }
   }
 
   void MockEventProcessor::endLumi() {
-    auto postfix = lumiStatus_->didGlobalBeginSucceed() ? "\n" : " global failed\n";
-    output_ << "\tendLumi " << lumiStatus_->lumiPrincipal()->run_ << "/" << lumiStatus_->lumiPrincipal()->lumi_
-            << postfix;
-    lumiStatus_.reset();
+    auto postfix = didGlobalBeginLumiSucceed_ ? "\n" : " global failed\n";
+    output_ << "\tendLumi " << currentRunNumber_ << "/" << currentLumiNumber_ << postfix;
   }
 
-  std::pair<ProcessHistoryID, RunNumber_t> MockEventProcessor::readRun() {
-    output_ << "\treadRun " << run_ << "\n";
-    return std::make_pair(ProcessHistoryID(), run_);
+  void MockEventProcessor::readRun() {
+    currentRunNumber_ = nextRun_;
+    output_ << "\treadRun " << currentRunNumber_ << "\n";
   }
 
-  std::pair<ProcessHistoryID, RunNumber_t> MockEventProcessor::readAndMergeRun() {
-    output_ << "\treadAndMergeRun " << run_ << "\n";
-    return std::make_pair(ProcessHistoryID(), run_);
+  void MockEventProcessor::readAndMergeRun() { output_ << "\treadAndMergeRun " << currentRunNumber_ << "\n"; }
+
+  LuminosityBlockNumber_t MockEventProcessor::readLuminosityBlock() {
+    output_ << "\treadLuminosityBlock " << nextLumi_ << "\n";
+    currentLumiNumber_ = nextLumi_;
+    return currentLumiNumber_;
   }
 
-  int MockEventProcessor::readLuminosityBlock(LuminosityBlockProcessingStatus& iStatus) {
-    output_ << "\treadLuminosityBlock " << lumi_ << "\n";
-    iStatus.lumiPrincipal() = std::make_shared<LuminosityBlockPrincipal>(run_, lumi_);
-    return lumi_;
+  LuminosityBlockNumber_t MockEventProcessor::readAndMergeLumi() {
+    output_ << "\treadAndMergeLumi " << currentLumiNumber_ << "\n";
+    return currentLumiNumber_;
   }
 
-  int MockEventProcessor::readAndMergeLumi(LuminosityBlockProcessingStatus& iStatus) {
-    output_ << "\treadAndMergeLumi " << lumi_ << "\n";
-    return lumi_;
+  void MockEventProcessor::writeRun() { output_ << "\twriteRun " << currentRunNumber_ << "\n"; }
+
+  void MockEventProcessor::clearRunPrincipal() {
+    output_ << "\tclearRunPrincipal " << currentRunNumber_ << "\n";
+    didGlobalBeginRunSucceed_ = false;
   }
 
-  void MockEventProcessor::writeRun(ProcessHistoryID const& phid, RunNumber_t run) {
-    output_ << "\twriteRun " << run << "\n";
+  void MockEventProcessor::writeLumi() {
+    output_ << "\twriteLumi " << currentRunNumber_ << "/" << currentLumiNumber_ << "\n";
   }
 
-  void MockEventProcessor::deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run) {
-    output_ << "\tdeleteRunFromCache " << run << "\n";
-  }
-
-  void MockEventProcessor::writeLumi(LuminosityBlockProcessingStatus& iStatus) {
-    output_ << "\twriteLumi " << iStatus.lumiPrincipal()->run_ << "/" << iStatus.lumiPrincipal()->lumi_ << "\n";
-  }
-
-  void MockEventProcessor::deleteLumiFromCache(LuminosityBlockProcessingStatus& iStatus) {
-    output_ << "\tdeleteLumiFromCache " << iStatus.lumiPrincipal()->run_ << "/" << iStatus.lumiPrincipal()->lumi_
-            << "\n";
+  void MockEventProcessor::clearLumiPrincipal() {
+    output_ << "\tclearLumiPrincipal " << currentRunNumber_ << "/" << currentLumiNumber_ << "\n";
+    lumiStatus_ = false;
+    didGlobalBeginLumiSucceed_ = false;
   }
 
   void MockEventProcessor::readAndProcessEvent() {

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -3,21 +3,43 @@
 
 /*
 Version of the Event Processor used for tests of
-the state machine and other tests.
+TransitionProcessors.icc.
+
+The tests that use this class are less useful than they used
+to be. MockEventProcessor is mainly used to test the code in
+TransitionProcessors.icc (historical sidenote: at the time
+MockEventProcessor was originally created a long time ago,
+the functionality in TransitionProcessors.icc was
+implemented using a boost state machine and MockEventProcessor
+was originally designed to test that).  When
+concurrent runs and concurrent lumis were implemented,
+a lot of functionality was moved from TransitionProcessors.icc
+into EventProcessors.cc. In the tests, MockEventProcessor
+replaces EventProcessor and therefore it cannot be used
+to test code in EventProcessor. Originally, this tested
+the loops over runs, lumis, and events in addition to the
+loops over files. At this point, it is really
+testing only the code related to the loop over files in
+TransitionProcessors.icc and we could clean things up by
+removing the code and parts of the tests that are intended to
+test runs, lumis, and events. That part of the code is not
+serving any purpose anymore. This cleanup would be a lot
+of tedious work for very little practical gain though...
+It might never happen.
 
 Original Authors: W. David Dagenhart, Marc Paterno
 */
 
-#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
 #include "FWCore/Framework/interface/InputSource.h"
 
-#include <iostream>
-#include <string>
-#include <sstream>
 #include <exception>
+#include <ostream>
+#include <memory>
+#include <sstream>
+#include <string>
 
 namespace edm {
-  class LuminosityBlockProcessingStatus;
 
   class MockEventProcessor {
   public:
@@ -32,8 +54,6 @@ namespace edm {
 
     InputSource::ItemType nextTransitionType();
     InputSource::ItemType lastTransitionType() const;
-    std::pair<edm::ProcessHistoryID, edm::RunNumber_t> nextRunID();
-    edm::LuminosityBlockNumber_t nextLuminosityBlockID();
 
     void readFile();
     bool fileBlockValid() { return true; }
@@ -56,32 +76,26 @@ namespace edm {
     void inputProcessBlocks();
     void endProcessBlock(bool cleaningUpAfterException, bool beginProcessBlockSucceeded);
 
-    void beginRun(ProcessHistoryID const& phid,
-                  RunNumber_t run,
-                  bool& globalTransitionSucceeded,
-                  bool& eventSetupForInstanceSucceeded);
-    void endUnfinishedRun(ProcessHistoryID const& phid,
-                          RunNumber_t run,
-                          bool globalTranstitionSucceeded,
-                          bool cleaningUpAfterException,
-                          bool eventSetupForInstanceSucceeded);
+    InputSource::ItemType processRuns();
+    void processRun();
+    InputSource::ItemType processLumis();
 
-    void endRun(ProcessHistoryID const& phid,
-                RunNumber_t run,
-                bool globalTranstitionSucceeded,
-                bool cleaningUpAfterException);
+    void beginRun(RunNumber_t run);
 
-    InputSource::ItemType processLumis(std::shared_ptr<void>);
-    void endUnfinishedLumi();
+    void endUnfinishedRun(bool);
 
-    std::pair<ProcessHistoryID, RunNumber_t> readRun();
-    std::pair<ProcessHistoryID, RunNumber_t> readAndMergeRun();
-    int readLuminosityBlock(LuminosityBlockProcessingStatus&);
-    int readAndMergeLumi(LuminosityBlockProcessingStatus&);
-    void writeRun(ProcessHistoryID const& phid, RunNumber_t run);
-    void deleteRunFromCache(ProcessHistoryID const& phid, RunNumber_t run);
-    void writeLumi(LuminosityBlockProcessingStatus&);
-    void deleteLumiFromCache(LuminosityBlockProcessingStatus&);
+    void endRun();
+
+    void endUnfinishedLumi(bool);
+
+    void readRun();
+    void readAndMergeRun();
+    LuminosityBlockNumber_t readLuminosityBlock();
+    LuminosityBlockNumber_t readAndMergeLumi();
+    void writeRun();
+    void clearRunPrincipal();
+    void writeLumi();
+    void clearLumiPrincipal();
 
     bool shouldWeStop() const;
 
@@ -101,11 +115,17 @@ namespace edm {
     std::ostream& output_;
     std::istringstream input_;
 
-    std::shared_ptr<LuminosityBlockProcessingStatus> lumiStatus_;
-    InputSource::ItemType lastTransition_;
+    bool lumiStatus_ = false;
+    LuminosityBlockNumber_t currentLumiNumber_ = 0;
+    bool didGlobalBeginLumiSucceed_ = false;
+    InputSource::ItemType lastTransition_ = InputSource::IsInvalid;
 
-    int run_;
-    int lumi_;
+    bool currentRun_ = false;
+    RunNumber_t currentRunNumber_ = 0;
+    bool didGlobalBeginRunSucceed_ = false;
+
+    RunNumber_t nextRun_;
+    LuminosityBlockNumber_t nextLumi_;
 
     bool doNotMerge_;
     bool shouldWeCloseOutput_;

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -76,8 +76,8 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
   edm::Timestamp fakeTime;
   edm::ProcessConfiguration pc("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID());
   std::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
-  auto runAux = std::make_shared<edm::RunAuxiliary>(col.run(), fakeTime, fakeTime);
-  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_, 0);
+  auto rp = std::make_shared<edm::RunPrincipal>(pregc, pc, &historyAppender_, 0);
+  rp->setAux(edm::RunAuxiliary(col.run(), fakeTime, fakeTime));
   edm::LuminosityBlockAuxiliary lumiAux(rp->run(), 1, fakeTime, fakeTime);
   auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(pregc, pc, &historyAppender_, 0);
   lbp->setAux(lumiAux);
@@ -170,8 +170,8 @@ void testEventGetRefBeforePut::getRefTest() {
       processName, dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
   edm::ProcessConfiguration& pc = *pcPtr;
   std::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
-  auto runAux = std::make_shared<edm::RunAuxiliary>(col.run(), fakeTime, fakeTime);
-  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_, 0);
+  auto rp = std::make_shared<edm::RunPrincipal>(pregc, pc, &historyAppender_, 0);
+  rp->setAux(edm::RunAuxiliary(col.run(), fakeTime, fakeTime));
   edm::LuminosityBlockAuxiliary lumiAux(rp->run(), 1, fakeTime, fakeTime);
   auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(pregc, pc, &historyAppender_, 0);
   lbp->setAux(lumiAux);

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -173,8 +173,8 @@ void test_ep::setUp() {
     assert(process);
     std::string uuid = edm::createGlobalIdentifier();
     edm::Timestamp now(1234567UL);
-    auto runAux = std::make_shared<edm::RunAuxiliary>(eventID_.run(), now, now);
-    auto rp = std::make_shared<edm::RunPrincipal>(runAux, pProductRegistry_, *process, &historyAppender_, 0);
+    auto rp = std::make_shared<edm::RunPrincipal>(pProductRegistry_, *process, &historyAppender_, 0);
+    rp->setAux(edm::RunAuxiliary(eventID_.run(), now, now));
     edm::LuminosityBlockAuxiliary lumiAux(rp->run(), 1, now, now);
     lbp_ = std::make_shared<edm::LuminosityBlockPrincipal>(pProductRegistry_, *process, &historyAppender_, 0);
     lbp_->setAux(lumiAux);

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -78,8 +78,8 @@ void testGenericHandle::failgetbyLabelTest() {
   edm::ProcessConfiguration pc("PROD", edm::ParameterSetID(), edm::getReleaseVersion(), edm::getPassID());
   auto preg = std::make_shared<edm::ProductRegistry>();
   preg->setFrozen();
-  auto runAux = std::make_shared<edm::RunAuxiliary>(id.run(), time, time);
-  auto rp = std::make_shared<edm::RunPrincipal>(runAux, preg, pc, &historyAppender_, 0);
+  auto rp = std::make_shared<edm::RunPrincipal>(preg, pc, &historyAppender_, 0);
+  rp->setAux(edm::RunAuxiliary(id.run(), time, time));
   auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(preg, pc, &historyAppender_, 0);
   lbp->setAux(edm::LuminosityBlockAuxiliary(rp->run(), 1, time, time));
   lbp->setRunPrincipal(rp);
@@ -164,8 +164,8 @@ void testGenericHandle::getbyLabelTest() {
   std::string uuid = edm::createGlobalIdentifier();
   edm::ProcessConfiguration pc("PROD", dummyProcessPset.id(), edm::getReleaseVersion(), edm::getPassID());
   std::shared_ptr<edm::ProductRegistry const> pregc(preg.release());
-  auto runAux = std::make_shared<edm::RunAuxiliary>(col.run(), fakeTime, fakeTime);
-  auto rp = std::make_shared<edm::RunPrincipal>(runAux, pregc, pc, &historyAppender_, 0);
+  auto rp = std::make_shared<edm::RunPrincipal>(pregc, pc, &historyAppender_, 0);
+  rp->setAux(edm::RunAuxiliary(col.run(), fakeTime, fakeTime));
   auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(pregc, pc, &historyAppender_, 0);
   lbp->setAux(edm::LuminosityBlockAuxiliary(rp->run(), 1, fakeTime, fakeTime));
   lbp->setRunPrincipal(rp);

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -386,8 +386,8 @@ testGlobalFilter::testGlobalFilter()
 
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp.reset(new edm::RunPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp->setAux(edm::RunAuxiliary(eventID.run(), now, now));
   auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(*lumiAux);

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -169,8 +169,8 @@ testGlobalOutputModule::testGlobalOutputModule()
 
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp.reset(new edm::RunPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp->setAux(edm::RunAuxiliary(eventID.run(), now, now));
   edm::LuminosityBlockAuxiliary lumiAux(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(lumiAux);

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -353,8 +353,8 @@ testGlobalProducer::testGlobalProducer()
 
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp.reset(new edm::RunPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp->setAux(edm::RunAuxiliary(eventID.run(), now, now));
   auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(*lumiAux);

--- a/FWCore/Framework/test/limited_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_filter_t.cppunit.cc
@@ -419,8 +419,8 @@ testLimitedFilter::testLimitedFilter()
 
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp.reset(new edm::RunPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp->setAux(edm::RunAuxiliary(eventID.run(), now, now));
   edm::LuminosityBlockAuxiliary lumiAux(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(lumiAux);

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -169,8 +169,8 @@ testLimitedOutputModule::testLimitedOutputModule()
 
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp.reset(new edm::RunPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp->setAux(edm::RunAuxiliary(eventID.run(), now, now));
   m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(edm::LuminosityBlockAuxiliary(m_rp->run(), 1, now, now));
   m_lbp->setRunPrincipal(m_rp);

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -384,8 +384,8 @@ testLimitedProducer::testLimitedProducer()
 
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp.reset(new edm::RunPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp->setAux(edm::RunAuxiliary(eventID.run(), now, now));
   edm::LuminosityBlockAuxiliary lumiAux(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(lumiAux);

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -263,8 +263,8 @@ testOneOutputModule::testOneOutputModule()
 
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp.reset(new edm::RunPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp->setAux(edm::RunAuxiliary(eventID.run(), now, now));
   edm::LuminosityBlockAuxiliary lumiAux(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(lumiAux);

--- a/FWCore/Framework/test/run_global_stream_one.sh
+++ b/FWCore/Framework/test/run_global_stream_one.sh
@@ -20,6 +20,9 @@ grep "one::SharedResourcesAnalyzer TriggerResults" log_test_one_modules > /dev/n
 (cmsRun $F4 ) >& log_test_limited_modules || die "Failure using $F4" $? log_test_limited_modules
 grep "limited::StreamIntAnalyzer TriggerResults" log_test_limited_modules > /dev/null || die "grep failed to find 'limited::StreamIntAnalyzer TriggerResults'" $? log_test_limited_modules
 
+echo cmsRun FWCore/Framework/test/testRunLumiCaches_cfg.py
+cmsRun ${LOCAL_TEST_DIR}/testRunLumiCaches_cfg.py >& testRunLumiCaches_cfg.log || die "Failure using testRunLumiCaches_cfg.py" $? testRunLumiCaches_cfg.log
+
 #the last few lines of the output are the printout from the
 # ConcurrentModuleTimer service detailing how much time was
 # spent in 2,3 or 4 modules running simultaneously.

--- a/FWCore/Framework/test/stream_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_filter_t.cppunit.cc
@@ -445,8 +445,8 @@ testStreamFilter::testStreamFilter()
 
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp.reset(new edm::RunPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp->setAux(edm::RunAuxiliary(eventID.run(), now, now));
   auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(*lumiAux);

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -406,8 +406,8 @@ testStreamProducer::testStreamProducer()
 
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp now(1234567UL);
-  auto runAux = std::make_shared<edm::RunAuxiliary>(eventID.run(), now, now);
-  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp.reset(new edm::RunPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
+  m_rp->setAux(edm::RunAuxiliary(eventID.run(), now, now));
   auto lumiAux = std::make_shared<edm::LuminosityBlockAuxiliary>(m_rp->run(), 1, now, now);
   m_lbp.reset(new edm::LuminosityBlockPrincipal(m_prodReg, m_procConfig, &historyAppender_, 0));
   m_lbp->setAux(*lumiAux);

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -43,6 +43,11 @@ namespace edmtest {
         mutable std::atomic<unsigned int> lumi;
       };
 
+      struct SummaryCache {
+        // Intentionally not thread safe, not atomic
+        unsigned int value = 0;
+      };
+
       struct TestGlobalCacheFil {
         CMS_THREAD_SAFE mutable edm::EDPutTokenT<unsigned int> token_;
         CMS_THREAD_SAFE mutable edm::EDGetTokenT<unsigned int> getTokenBegin_;
@@ -53,6 +58,7 @@ namespace edmtest {
     }  // namespace cache
 
     using Cache = cache::Cache;
+    using SummaryCache = cache::SummaryCache;
     using TestGlobalCacheFil = cache::TestGlobalCacheFil;
 
     class GlobalIntFilter : public edm::stream::EDFilter<edm::GlobalCache<Cache>> {
@@ -105,10 +111,6 @@ namespace edmtest {
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
       static std::atomic<unsigned int> cvalue_;
-      static std::atomic<bool> gbr;
-      static std::atomic<bool> ger;
-      bool br;
-      bool er;
 
       RunIntFilter(edm::ParameterSet const& p) {
         trans_ = p.getParameter<int>("transitions");
@@ -120,27 +122,35 @@ namespace edmtest {
       bool filter(edm::Event&, edm::EventSetup const&) override {
         ++m_count;
         ++(runCache()->value);
-
         return true;
       }
 
       static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
         ++m_count;
-        gbr = true;
-        ger = false;
         auto pCache = std::make_shared<Cache>();
-        ++(pCache->run);
+        pCache->run = iRun.runAuxiliary().run();
         return pCache;
+      }
+
+      void beginRun(edm::Run const& iRun, edm::EventSetup const&) override {
+        if (runCache()->run != iRun.runAuxiliary().run()) {
+          throw cms::Exception("begin out of sequence") << "beginRun seen before globalBeginRun";
+        }
+      }
+
+      void endRun(edm::Run const& iRun, edm::EventSetup const&) override {
+        if (runCache()->run != iRun.runAuxiliary().run()) {
+          throw cms::Exception("end out of sequence") << "globalEndRun seen before endRun";
+        }
       }
 
       static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
         ++m_count;
         auto pCache = iContext->run();
-        if (pCache->run != 1) {
+        if (pCache->run != iRun.runAuxiliary().run()) {
           throw cms::Exception("end out of sequence") << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
         }
-        ger = true;
-        gbr = false;
+        pCache->run = 0;
         if (iContext->run()->value != cvalue_) {
           throw cms::Exception("cache value") << iContext->run()->value << " but it was supposed to be " << cvalue_;
         }
@@ -158,10 +168,6 @@ namespace edmtest {
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
       static std::atomic<unsigned int> cvalue_;
-      static std::atomic<bool> gbl;
-      static std::atomic<bool> gel;
-      static std::atomic<bool> bl;
-      static std::atomic<bool> el;
 
       LumiIntFilter(edm::ParameterSet const& p) {
         trans_ = p.getParameter<int>("transitions");
@@ -181,36 +187,43 @@ namespace edmtest {
                                                                edm::EventSetup const&,
                                                                RunContext const*) {
         ++m_count;
-        gbl = true;
-        gel = false;
         auto pCache = std::make_shared<Cache>();
-        ++(pCache->lumi);
+        pCache->run = iLB.luminosityBlockAuxiliary().run();
+        pCache->lumi = iLB.luminosityBlockAuxiliary().luminosityBlock();
         return pCache;
       }
 
-      void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
-        bl = true;
-        el = false;
-        if (!gbl) {
+      void beginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) override {
+        if (luminosityBlockCache()->run != iLB.luminosityBlockAuxiliary().run() ||
+            luminosityBlockCache()->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
           throw cms::Exception("begin out of sequence")
-              << "beginLuminosityBlock seen before globalBeginLuminosityBlock";
+              << "beginLuminosityBlock seen before globalBeginLuminosityBlock " << luminosityBlockCache()->run << " "
+              << iLB.luminosityBlockAuxiliary().run();
         }
       }
 
-      static void globalEndLuminosityBlock(edm::LuminosityBlock const&,
+      static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB,
                                            edm::EventSetup const&,
                                            LuminosityBlockContext const* iLBContext) {
         ++m_count;
-        if (iLBContext->luminosityBlock()->value != cvalue_) {
+        auto pCache = iLBContext->luminosityBlock();
+        if (pCache->run != iLB.luminosityBlockAuxiliary().run() ||
+            pCache->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
+          throw cms::Exception("end out of sequence")
+              << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock"
+              << iLB.luminosityBlock();
+        }
+        pCache->run = 0;
+        pCache->lumi = 0;
+        if (pCache->value != cvalue_) {
           throw cms::Exception("cache value") << "LumiIntFilter cache value " << iLBContext->luminosityBlock()->value
                                               << " but it was supposed to be " << cvalue_;
         }
       }
 
-      static void endLuminosityBlock(edm::Run const&, edm::EventSetup const&, LuminosityBlockContext const*) {
-        el = true;
-        bl = false;
-        if (gel) {
+      void endLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) override {
+        if (luminosityBlockCache()->run != iLB.luminosityBlockAuxiliary().run() ||
+            luminosityBlockCache()->lumi != iLB.luminosityBlockAuxiliary().luminosityBlock()) {
           throw cms::Exception("end out of sequence") << "globalEndLuminosityBlock seen before endLuminosityBlock";
         }
       }
@@ -222,19 +235,14 @@ namespace edmtest {
       }
     };
 
-    class RunSummaryIntFilter : public edm::stream::EDFilter<edm::RunCache<Cache>, edm::RunSummaryCache<Cache>> {
+    class RunSummaryIntFilter : public edm::stream::EDFilter<edm::RunCache<Cache>, edm::RunSummaryCache<SummaryCache>> {
     public:
       static std::atomic<unsigned int> m_count;
       unsigned int trans_;
       static std::atomic<unsigned int> cvalue_;
-      static std::atomic<bool> gbr;
-      static std::atomic<bool> ger;
-      static std::atomic<bool> gbrs;
-      static std::atomic<bool> gers;
-      static std::atomic<bool> brs;
-      static std::atomic<bool> ers;
-      static std::atomic<bool> br;
-      static std::atomic<bool> er;
+      static std::atomic<bool> globalBeginRunCalled_;
+      unsigned int valueAccumulatedForStream_ = 0;
+      bool endRunWasCalled_ = false;
 
       RunSummaryIntFilter(edm::ParameterSet const& p) {
         trans_ = p.getParameter<int>("transitions");
@@ -244,74 +252,67 @@ namespace edmtest {
       }
 
       void beginRun(edm::Run const&, edm::EventSetup const&) override {
-        br = true;
-        er = false;
+        valueAccumulatedForStream_ = 0;
+        endRunWasCalled_ = false;
       }
 
       bool filter(edm::Event&, edm::EventSetup const&) override {
         ++m_count;
         ++(runCache()->value);
-
+        ++valueAccumulatedForStream_;
         return true;
       }
 
       static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
         ++m_count;
-        gbr = true;
-        ger = false;
+        globalBeginRunCalled_ = true;
         auto pCache = std::make_shared<Cache>();
         ++(pCache->run);
         return pCache;
       }
 
-      static std::shared_ptr<Cache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&, GlobalCache const*) {
+      static std::shared_ptr<SummaryCache> globalBeginRunSummary(edm::Run const&,
+                                                                 edm::EventSetup const&,
+                                                                 GlobalCache const*) {
         ++m_count;
-        gbrs = true;
-        gers = false;
-        brs = true;
-        ers = false;
-        if (!gbr) {
+        if (!globalBeginRunCalled_) {
           throw cms::Exception("begin out of sequence") << "globalBeginRunSummary seen before globalBeginRun";
         }
-        return std::make_shared<Cache>();
+        globalBeginRunCalled_ = false;
+        return std::make_shared<SummaryCache>();
       }
 
-      void endRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
-        brs = false;
-        ers = true;
-        gCache->value += runCache()->value;
-        runCache()->value = 0;
-        if (!er) {
+      void endRunSummary(edm::Run const&, edm::EventSetup const&, SummaryCache* runSummaryCache) const override {
+        runSummaryCache->value += valueAccumulatedForStream_;
+        if (!endRunWasCalled_) {
           throw cms::Exception("end out of sequence") << "endRunSummary seen before endRun";
         }
       }
 
-      static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, Cache* gCache) {
+      static void globalEndRunSummary(edm::Run const&,
+                                      edm::EventSetup const&,
+                                      RunContext const*,
+                                      SummaryCache* runSummaryCache) {
         ++m_count;
-        gbrs = false;
-        gers = true;
-        if (!ers) {
-          throw cms::Exception("end out of sequence") << "globalEndRunSummary seen before endRunSummary";
-        }
-        if (gCache->value != cvalue_) {
-          throw cms::Exception("cache value") << gCache->value << " but it was supposed to be " << cvalue_;
+        if (runSummaryCache->value != cvalue_) {
+          throw cms::Exception("unexpectedValue")
+              << "run summary cache value = " << runSummaryCache->value << " but it was supposed to be " << cvalue_;
         }
       }
 
       static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
         ++m_count;
-        gbr = false;
-        ger = true;
         auto pCache = iContext->run();
+        if (pCache->value != cvalue_) {
+          throw cms::Exception("unExpectedValue")
+              << "run cache value " << pCache->value << " but it was supposed to be " << cvalue_;
+        }
         if (pCache->run != 1) {
           throw cms::Exception("end out of sequence") << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
         }
       }
 
-      void endRun(edm::Run const&, edm::EventSetup const&) override {
-        er = true;
-        br = false;
-      }
+      void endRun(edm::Run const&, edm::EventSetup const&) override { endRunWasCalled_ = true; }
 
       ~RunSummaryIntFilter() {
         if (m_count != trans_) {
@@ -321,20 +322,14 @@ namespace edmtest {
     };
 
     class LumiSummaryIntFilter
-        : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>, edm::LuminosityBlockSummaryCache<Cache>> {
+        : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>, edm::LuminosityBlockSummaryCache<SummaryCache>> {
     public:
       static std::atomic<unsigned int> m_count;
-      static std::atomic<unsigned int> m_lumiSumCalls;
       unsigned int trans_;
       static std::atomic<unsigned int> cvalue_;
-      static std::atomic<bool> gbl;
-      static std::atomic<bool> gel;
-      static std::atomic<bool> gbls;
-      static std::atomic<bool> gels;
-      static std::atomic<bool> bls;
-      static std::atomic<bool> els;
-      static std::atomic<bool> bl;
-      static std::atomic<bool> el;
+      static std::atomic<bool> globalBeginLumiCalled_;
+      unsigned int valueAccumulatedForStream_ = 0;
+      bool endLumiWasCalled_ = false;
 
       LumiSummaryIntFilter(edm::ParameterSet const& p) {
         trans_ = p.getParameter<int>("transitions");
@@ -346,72 +341,59 @@ namespace edmtest {
       bool filter(edm::Event&, edm::EventSetup const&) override {
         ++m_count;
         ++(luminosityBlockCache()->value);
-
+        ++valueAccumulatedForStream_;
         return true;
       }
 
       void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
-        bl = true;
-        el = false;
+        valueAccumulatedForStream_ = 0;
+        valueAccumulatedForStream_ = 0;
+        endLumiWasCalled_ = false;
       }
 
       static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB,
                                                                edm::EventSetup const&,
                                                                RunContext const*) {
         ++m_count;
-        gbl = true;
-        gel = false;
+        globalBeginLumiCalled_ = true;
         auto pCache = std::make_shared<Cache>();
         ++(pCache->lumi);
         return pCache;
       }
 
-      static std::shared_ptr<Cache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
-                                                                      edm::EventSetup const&,
-                                                                      LuminosityBlockContext const*) {
+      static std::shared_ptr<SummaryCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                                                             edm::EventSetup const&,
+                                                                             LuminosityBlockContext const*) {
         ++m_count;
-        gbls = true;
-        gels = false;
-        bls = true;
-        els = false;
-        if (!gbl) {
+        if (!globalBeginLumiCalled_) {
           throw cms::Exception("begin out of sequence")
               << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
         }
-        return std::make_shared<Cache>();
+        globalBeginLumiCalled_ = false;
+        return std::make_shared<SummaryCache>();
       }
 
       void endLuminosityBlockSummary(edm::LuminosityBlock const&,
                                      edm::EventSetup const&,
-                                     Cache* gCache) const override {
-        ++m_lumiSumCalls;
-        bls = false;
-        els = true;
-        //This routine could be called at the same time as another stream is calling filter so must do the change atomically
-        auto v = luminosityBlockCache()->value.exchange(0);
-        gCache->value += v;
-        if (el) {
-          throw cms::Exception("end out of sequence") << "endLuminosityBlock seen before endLuminosityBlockSummary";
+                                     SummaryCache* lumiSummaryCache) const override {
+        lumiSummaryCache->value += valueAccumulatedForStream_;
+        if (!endLumiWasCalled_) {
+          throw cms::Exception("end out of sequence") << "endLuminosityBlockSummary seen before endLuminosityBlock";
         }
       }
 
       static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
                                                   edm::EventSetup const&,
-                                                  LuminosityBlockContext const*,
-                                                  Cache* gCache) {
+                                                  LuminosityBlockContext const* iLBContext,
+                                                  SummaryCache* lumiSummaryCache) {
         ++m_count;
-        auto nLumis = m_lumiSumCalls.load();
-        gbls = false;
-        gels = true;
-        if (!els) {
-          throw cms::Exception("end out of sequence")
-              << "LumiSummaryIntFilter "
-              << "globalEndLuminosityBlockSummary seen before endLuminosityBlockSummary";
+        if (lumiSummaryCache->value != cvalue_) {
+          throw cms::Exception("unexpectedValue")
+              << "lumi summary cache value = " << lumiSummaryCache->value << " but it was supposed to be " << cvalue_;
         }
-        if (gCache->value != cvalue_) {
-          throw cms::Exception("cache value")
-              << gCache->value << " but it was supposed to be " << cvalue_ << " endLumiBlockSummary called " << nLumis;
-        }
+        auto pCache = iLBContext->luminosityBlock();
+        // Add one so globalEndLuminosityBlock can check this function was called first
+        ++pCache->value;
       }
 
       static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB,
@@ -419,22 +401,19 @@ namespace edmtest {
                                            LuminosityBlockContext const* iLBContext) {
         ++m_count;
         auto pCache = iLBContext->luminosityBlock();
+        if (pCache->value != cvalue_ + 1) {
+          throw cms::Exception("unexpectedValue")
+              << "lumi cache value " << pCache->value << " but it was supposed to be " << cvalue_ + 1;
+        }
         if (pCache->lumi != 1) {
           throw cms::Exception("end out of sequence")
               << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock"
               << iLB.luminosityBlock();
         }
-        gel = true;
-        gbl = false;
-        if (!gels) {
-          throw cms::Exception("end out of sequence")
-              << "globalEndLuminosityBlockSummary seen before globalEndLuminosityBlock";
-        }
       }
 
-      static void endLuminosityBlock(edm::Run const&, edm::EventSetup const&, LuminosityBlockContext const*) {
-        el = true;
-        bl = false;
+      void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+        endLumiWasCalled_ = true;
       }
 
       ~LumiSummaryIntFilter() {
@@ -1146,29 +1125,8 @@ std::atomic<unsigned int> edmtest::stream::TestBeginRunFilter::cvalue_{0};
 std::atomic<unsigned int> edmtest::stream::TestEndRunFilter::cvalue_{0};
 std::atomic<unsigned int> edmtest::stream::TestBeginLumiBlockFilter::cvalue_{0};
 std::atomic<unsigned int> edmtest::stream::TestEndLumiBlockFilter::cvalue_{0};
-std::atomic<bool> edmtest::stream::RunIntFilter::gbr{false};
-std::atomic<bool> edmtest::stream::RunIntFilter::ger{false};
-std::atomic<bool> edmtest::stream::LumiIntFilter::gbl{false};
-std::atomic<bool> edmtest::stream::LumiIntFilter::gel{false};
-std::atomic<bool> edmtest::stream::LumiIntFilter::bl{false};
-std::atomic<bool> edmtest::stream::LumiIntFilter::el{false};
-std::atomic<bool> edmtest::stream::RunSummaryIntFilter::gbr{false};
-std::atomic<bool> edmtest::stream::RunSummaryIntFilter::ger{false};
-std::atomic<bool> edmtest::stream::RunSummaryIntFilter::gbrs{false};
-std::atomic<bool> edmtest::stream::RunSummaryIntFilter::gers{false};
-std::atomic<bool> edmtest::stream::RunSummaryIntFilter::brs{false};
-std::atomic<bool> edmtest::stream::RunSummaryIntFilter::ers{false};
-std::atomic<bool> edmtest::stream::RunSummaryIntFilter::br{false};
-std::atomic<bool> edmtest::stream::RunSummaryIntFilter::er{false};
-std::atomic<unsigned int> edmtest::stream::LumiSummaryIntFilter::m_lumiSumCalls{0};
-std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::gbl{false};
-std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::gel{false};
-std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::gbls{false};
-std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::gels{false};
-std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::bls{false};
-std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::els{false};
-std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::bl{false};
-std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::el{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntFilter::globalBeginRunCalled_{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::globalBeginLumiCalled_{false};
 std::atomic<bool> edmtest::stream::TestBeginRunFilter::gbr{false};
 std::atomic<bool> edmtest::stream::TestBeginRunFilter::ger{false};
 std::atomic<bool> edmtest::stream::TestEndRunFilter::gbr{false};

--- a/FWCore/Framework/test/testRunLumiCaches_cfg.py
+++ b/FWCore/Framework/test/testRunLumiCaches_cfg.py
@@ -1,0 +1,299 @@
+import FWCore.ParameterSet.Config as cms
+
+# These next 4 variables can be modified and the tests should still pass
+nStreams = 4
+nRuns = 17
+nLumisPerRun = 1
+nEventsPerLumi = 6
+
+nEventsPerRun = nLumisPerRun*nEventsPerLumi
+nLumis = nRuns*nLumisPerRun
+nEvents = nRuns*nEventsPerRun
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEventsPerLumi),
+    numberEventsInRun = cms.untracked.uint32(nEventsPerRun)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(nEvents)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32(nStreams),
+    numberOfConcurrentRuns = cms.untracked.uint32(4),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(4)
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+
+process.globalRunIntProd = cms.EDProducer("edmtest::global::RunIntProducer",
+    transitions = cms.int32(2*nRuns)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.globalRunSumIntProd = cms.EDProducer("edmtest::global::RunSummaryIntProducer",
+    transitions = cms.int32(nRuns*nStreams+2*nRuns)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.globalLumiIntProd = cms.EDProducer("edmtest::global::LumiIntProducer",
+    transitions = cms.int32(2*nLumis)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.globalLumiSumIntProd = cms.EDProducer("edmtest::global::LumiSummaryIntProducer",
+    transitions = cms.int32(2*nLumis+nStreams*nLumis)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.globalRunIntFilt = cms.EDFilter("edmtest::global::RunIntFilter",
+    transitions = cms.int32(2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.globalRunSumIntFilt = cms.EDFilter("edmtest::global::RunSummaryIntFilter",
+    transitions = cms.int32(nStreams+nStreams*nRuns+2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.globalLumiIntFilt = cms.EDFilter("edmtest::global::LumiIntFilter",
+    transitions = cms.int32(2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.globalLumiSumIntFilt = cms.EDFilter("edmtest::global::LumiSummaryIntFilter",
+    transitions = cms.int32(nStreams+nStreams*nLumis+2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.globalRunIntAna = cms.EDAnalyzer("edmtest::global::RunIntAnalyzer",
+    transitions = cms.int32(2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.globalRunSumIntAna = cms.EDAnalyzer("edmtest::global::RunSummaryIntAnalyzer",
+    transitions = cms.int32(nStreams+nStreams*nRuns+2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.globalLumiIntAna = cms.EDAnalyzer("edmtest::global::LumiIntAnalyzer",
+    transitions = cms.int32(2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+    ,moduleLabel = cms.InputTag("TestAccumulator1")
+)
+
+process.globalLumiSumIntAna = cms.EDAnalyzer("edmtest::global::LumiSummaryIntAnalyzer",
+    transitions = cms.int32(nStreams+nStreams*nLumis+2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.limitedRunIntProd = cms.EDProducer("edmtest::limited::RunIntProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(2*nRuns)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.limitedRunSumIntProd = cms.EDProducer("edmtest::limited::RunSummaryIntProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nStreams*nRuns+2*nRuns)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.limitedLumiIntProd = cms.EDProducer("edmtest::limited::LumiIntProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(2*nLumis)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.limitedLumiSumIntProd = cms.EDProducer("edmtest::limited::LumiSummaryIntProducer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nStreams*nLumis+2*nLumis)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.limitedRunIntFilt = cms.EDFilter("edmtest::limited::RunIntFilter",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.limitedRunSumIntFilt = cms.EDFilter("edmtest::limited::RunSummaryIntFilter",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nStreams+nStreams*nRuns+2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.limitedLumiIntFilt = cms.EDFilter("edmtest::limited::LumiIntFilter",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.limitedLumiSumIntFilt = cms.EDFilter("edmtest::limited::LumiSummaryIntFilter",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nStreams+nStreams*nLumis+2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.limitedRunIntAna = cms.EDAnalyzer("edmtest::limited::RunIntAnalyzer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.limitedRunSumIntAna = cms.EDAnalyzer("edmtest::limited::RunSummaryIntAnalyzer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nStreams+nStreams*nRuns+2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.limitedLumiIntAna = cms.EDAnalyzer("edmtest::limited::LumiIntAnalyzer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+    ,moduleLabel = cms.InputTag("TestAccumulator1")
+)
+
+process.limitedLumiSumIntAna = cms.EDAnalyzer("edmtest::limited::LumiSummaryIntAnalyzer",
+    concurrencyLimit = cms.untracked.uint32(1),
+    transitions = cms.int32(nStreams+nStreams*nLumis+2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.oneRunCacheProd = cms.EDProducer("edmtest::one::RunCacheProducer",
+    transitions = cms.int32(2*nRuns+nEvents)
+)
+
+process.oneLumiBlockCacheProd = cms.EDProducer("edmtest::one::LumiBlockCacheProducer",
+    transitions = cms.int32(2*nLumis+nEvents)
+)
+
+process.oneRunCacheFilt = cms.EDFilter("edmtest::one::RunCacheFilter",
+    transitions = cms.int32(2*nRuns+nEvents)
+)
+
+process.oneLumiBlockCacheFilt = cms.EDFilter("edmtest::one::LumiBlockCacheFilter",
+    transitions = cms.int32(2*nRuns+nEvents)
+)
+
+process.oneRunCacheAna = cms.EDAnalyzer("edmtest::one::RunCacheAnalyzer",
+    transitions = cms.int32(2*nRuns+nEvents)
+)
+
+process.oneLumiBlockCacheAna = cms.EDAnalyzer("edmtest::one::LumiBlockCacheAnalyzer",
+    transitions = cms.int32(2*nRuns+nEvents)
+)
+
+process.streamRunIntProd = cms.EDProducer("edmtest::stream::RunIntProducer",
+    transitions = cms.int32(2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.streamLumiIntProd = cms.EDProducer("edmtest::stream::LumiIntProducer",
+    transitions = cms.int32(2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.streamRunSumIntProd = cms.EDProducer("edmtest::stream::RunSummaryIntProducer",
+    transitions = cms.int32(4*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.streamLumiSumIntProd = cms.EDProducer("edmtest::stream::LumiSummaryIntProducer",
+    transitions = cms.int32(4*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.streamRunIntFilt = cms.EDFilter("edmtest::stream::RunIntFilter",
+    transitions = cms.int32(2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.streamLumiIntFilt = cms.EDFilter("edmtest::stream::LumiIntFilter",
+    transitions = cms.int32(2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.streamRunSumIntFilt = cms.EDFilter("edmtest::stream::RunSummaryIntFilter",
+    transitions = cms.int32(4*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.streamLumiSumIntFilt = cms.EDFilter("edmtest::stream::LumiSummaryIntFilter",
+    transitions = cms.int32(4*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.streamRunIntAna = cms.EDAnalyzer("edmtest::stream::RunIntAnalyzer",
+    transitions = cms.int32(2*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.streamLumiIntAna = cms.EDAnalyzer("edmtest::stream::LumiIntAnalyzer",
+    transitions = cms.int32(2*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+    ,moduleLabel = cms.InputTag("TestAccumulator1")
+)
+
+process.streamRunSumIntAna = cms.EDAnalyzer("edmtest::stream::RunSummaryIntAnalyzer",
+    transitions = cms.int32(4*nRuns+nEvents)
+    ,cachevalue = cms.int32(nEventsPerRun)
+)
+
+process.streamLumiSumIntAna = cms.EDAnalyzer("edmtest::stream::LumiSummaryIntAnalyzer",
+    transitions = cms.int32(4*nLumis+nEvents)
+    ,cachevalue = cms.int32(nEventsPerLumi)
+)
+
+process.path1 = cms.Path(
+    process.busy1 *
+    process.globalRunIntProd *
+    process.globalRunSumIntProd *
+    process.globalLumiIntProd *
+    process.globalLumiSumIntProd *
+    process.globalRunIntFilt *
+    process.globalRunSumIntFilt *
+    process.globalLumiIntFilt *
+    process.globalLumiSumIntFilt *
+    process.globalRunIntAna *
+    process.globalRunSumIntAna *
+    process.globalLumiIntAna *
+    process.globalLumiSumIntAna *
+    process.limitedRunIntProd *
+    process.limitedRunSumIntProd *
+    process.limitedLumiIntProd *
+    process.limitedLumiSumIntProd *
+    process.limitedRunIntFilt *
+    process.limitedRunSumIntFilt *
+    process.limitedLumiIntFilt *
+    process.limitedLumiSumIntFilt *
+    process.limitedRunIntAna *
+    process.limitedRunSumIntAna *
+    process.limitedLumiIntAna *
+    process.limitedLumiSumIntAna *
+    process.oneRunCacheProd *
+    process.oneLumiBlockCacheProd *
+    process.oneRunCacheFilt *
+    process.oneLumiBlockCacheFilt *
+    process.oneRunCacheAna *
+    process.oneLumiBlockCacheAna *
+    process.streamRunIntProd *
+    process.streamLumiIntProd *
+    process.streamRunSumIntProd *
+    process.streamLumiSumIntProd *
+    process.streamRunIntFilt *
+    process.streamLumiIntFilt *
+    process.streamRunSumIntFilt *
+    process.streamLumiSumIntFilt *
+    process.streamRunIntAna *
+    process.streamLumiIntAna *
+    process.streamRunSumIntAna *
+    process.streamLumiSumIntAna
+)

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_1.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_1.txt
@@ -11,7 +11,7 @@ Machine parameters:  mode = NOMERGE
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
@@ -20,7 +20,7 @@ Machine parameters:  mode = NOMERGE
     *** nextItemType: Lumi 2 ***
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	readLuminosityBlock 2
 	beginLumi 2/2
     *** nextItemType: Event ***
@@ -31,16 +31,16 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 2/2
 	writeLumi 2/2
-	deleteLumiFromCache 2/2
+	clearLumiPrincipal 2/2
 	readLuminosityBlock 3
 	beginLumi 2/3
     *** nextItemType: Run 3 ***
 	endLumi 2/3
 	writeLumi 2/3
-	deleteLumiFromCache 2/3
+	clearLumiPrincipal 2/3
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	readRun 3
 	beginRun 3
     *** nextItemType: Lumi 1 ***
@@ -49,10 +49,10 @@ Machine parameters:  mode = NOMERGE
     *** nextItemType: Stop 1 ***
 	endLumi 3/1
 	writeLumi 3/1
-	deleteLumiFromCache 3/1
+	clearLumiPrincipal 3/1
 	endRun 3
 	writeRun 3
-	deleteRunFromCache 3
+	clearRunPrincipal 3
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -71,7 +71,7 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
@@ -80,7 +80,7 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Lumi 2 ***
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	readLuminosityBlock 2
 	beginLumi 2/2
     *** nextItemType: Event ***
@@ -91,16 +91,16 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 2/2
 	writeLumi 2/2
-	deleteLumiFromCache 2/2
+	clearLumiPrincipal 2/2
 	readLuminosityBlock 3
 	beginLumi 2/3
     *** nextItemType: Run 3 ***
 	endLumi 2/3
 	writeLumi 2/3
-	deleteLumiFromCache 2/3
+	clearLumiPrincipal 2/3
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	readRun 3
 	beginRun 3
     *** nextItemType: Lumi 1 ***
@@ -109,10 +109,10 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Stop 1 ***
 	endLumi 3/1
 	writeLumi 3/1
-	deleteLumiFromCache 3/1
+	clearLumiPrincipal 3/1
 	endRun 3
 	writeRun 3
-	deleteRunFromCache 3
+	clearRunPrincipal 3
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_11.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_11.txt
@@ -57,7 +57,7 @@ Left processing loop.
     *** nextItemType: File 0 ***
 	endRun 9
 	writeRun 9
-	deleteRunFromCache 9
+	clearRunPrincipal 9
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -70,7 +70,7 @@ Left processing loop.
     *** nextItemType: File 0 ***
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -83,13 +83,13 @@ Left processing loop.
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -102,7 +102,7 @@ Left processing loop.
     *** nextItemType: File 0 ***
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -118,10 +118,10 @@ Left processing loop.
     *** nextItemType: File 0 ***
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -137,16 +137,16 @@ Left processing loop.
     *** nextItemType: Lumi 3 ***
 	endLumi 2/2
 	writeLumi 2/2
-	deleteLumiFromCache 2/2
+	clearLumiPrincipal 2/2
 	readLuminosityBlock 3
 	beginLumi 2/3
     *** nextItemType: File 0 ***
 	endLumi 2/3
 	writeLumi 2/3
-	deleteLumiFromCache 2/3
+	clearLumiPrincipal 2/3
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -159,7 +159,7 @@ Left processing loop.
     *** nextItemType: File 0 ***
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -175,10 +175,10 @@ Left processing loop.
     *** nextItemType: File 0 ***
 	endLumi 2/3
 	writeLumi 2/3
-	deleteLumiFromCache 2/3
+	clearLumiPrincipal 2/3
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -205,10 +205,10 @@ Left processing loop.
     *** nextItemType: File 0 ***
 	endLumi 5/1
 	writeLumi 5/1
-	deleteLumiFromCache 5/1
+	clearLumiPrincipal 5/1
 	endRun 5
 	writeRun 5
-	deleteRunFromCache 5
+	clearRunPrincipal 5
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -235,10 +235,10 @@ Left processing loop.
     *** nextItemType: Restart 0 ***
 	endLumi 6/1
 	writeLumi 6/1
-	deleteLumiFromCache 6/1
+	clearLumiPrincipal 6/1
 	endRun 6
 	writeRun 6
-	deleteRunFromCache 6
+	clearRunPrincipal 6
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -313,7 +313,7 @@ Left processing loop.
     *** nextItemType: Run 1 ***
 	endRun 9
 	writeRun 9
-	deleteRunFromCache 9
+	clearRunPrincipal 9
 	readRun 1
 	beginRun 1
     *** nextItemType: File 0 ***
@@ -327,7 +327,7 @@ Left processing loop.
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
@@ -360,13 +360,13 @@ Left processing loop.
     *** nextItemType: Lumi 2 ***
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	readLuminosityBlock 2
 	beginLumi 2/2
     *** nextItemType: Lumi 3 ***
 	endLumi 2/2
 	writeLumi 2/2
-	deleteLumiFromCache 2/2
+	clearLumiPrincipal 2/2
 	readLuminosityBlock 3
 	beginLumi 2/3
     *** nextItemType: File 0 ***
@@ -396,10 +396,10 @@ Left processing loop.
     *** nextItemType: Lumi 4 ***
 	endLumi 2/3
 	writeLumi 2/3
-	deleteLumiFromCache 2/3
+	clearLumiPrincipal 2/3
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -425,10 +425,10 @@ Left processing loop.
     *** nextItemType: Event ***
 	endLumi 5/1
 	writeLumi 5/1
-	deleteLumiFromCache 5/1
+	clearLumiPrincipal 5/1
 	endRun 5
 	writeRun 5
-	deleteRunFromCache 5
+	clearRunPrincipal 5
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -448,10 +448,10 @@ Left processing loop.
     *** nextItemType: Restart 0 ***
 	endLumi 6/1
 	writeLumi 6/1
-	deleteLumiFromCache 6/1
+	clearLumiPrincipal 6/1
 	endRun 6
 	writeRun 6
-	deleteRunFromCache 6
+	clearRunPrincipal 6
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_12.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_12.txt
@@ -19,10 +19,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -43,10 +43,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -67,10 +67,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -105,7 +105,7 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Lumi 2 ***
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
@@ -124,7 +124,7 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Lumi 1 ***
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
@@ -135,10 +135,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_2.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_2.txt
@@ -46,7 +46,7 @@ Machine parameters:  mode = NOMERGE
     *** nextItemType: File 0 ***
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -76,10 +76,10 @@ Machine parameters:  mode = NOMERGE
     *** nextItemType: File 0 ***
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -168,7 +168,7 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeCloseOutput
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -197,10 +197,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeCloseOutput
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_20.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_20.txt
@@ -19,10 +19,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -42,10 +42,10 @@ Machine parameters:  mode = NOMERGE
 	throwing
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -77,10 +77,10 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Run 2 ***
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
@@ -93,10 +93,10 @@ Machine parameters:  mode = FULLMERGE
 	throwing
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_21.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_21.txt
@@ -19,10 +19,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -38,10 +38,10 @@ Machine parameters:  mode = NOMERGE
 	beginLumi 2/1
 	throwing
 	endLumi 2/1 global failed
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -73,10 +73,10 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Run 2 ***
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
     *** nextItemType: Throw 1 ***
@@ -85,10 +85,10 @@ Machine parameters:  mode = FULLMERGE
 	beginLumi 2/1
 	throwing
 	endLumi 2/1 global failed
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_22.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_22.txt
@@ -19,10 +19,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -35,7 +35,7 @@ Machine parameters:  mode = NOMERGE
 	beginRun 2
 	throwing
 	endRun 2 global failed
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -68,15 +68,15 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Run 2 ***
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
 	throwing
 	endRun 2 global failed
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_23.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_23.txt
@@ -20,10 +20,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -59,10 +59,10 @@ Machine parameters:  mode = FULLMERGE
 	throwing
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_3.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_3.txt
@@ -19,10 +19,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -43,10 +43,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -67,10 +67,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -103,10 +103,10 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Run 2 ***
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
@@ -126,10 +126,10 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Run 1 ***
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
@@ -143,10 +143,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_4.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_4.txt
@@ -19,10 +19,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
@@ -36,10 +36,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -60,10 +60,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -90,10 +90,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
@@ -113,10 +113,10 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Run 1 ***
 	endLumi 2/1
 	writeLumi 2/1
-	deleteLumiFromCache 2/1
+	clearLumiPrincipal 2/1
 	endRun 2
 	writeRun 2
-	deleteRunFromCache 2
+	clearRunPrincipal 2
 	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
@@ -130,10 +130,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_5.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_5.txt
@@ -19,16 +19,16 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: File 0 ***
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -49,10 +49,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -79,7 +79,7 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: File 0 ***
@@ -100,10 +100,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_6.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_6.txt
@@ -19,7 +19,7 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
@@ -30,10 +30,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -54,10 +54,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -84,7 +84,7 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
@@ -110,10 +110,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_7.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_7.txt
@@ -19,7 +19,7 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
@@ -30,10 +30,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -49,7 +49,7 @@ Machine parameters:  mode = NOMERGE
     *** nextItemType: Lumi 3 ***
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	readLuminosityBlock 3
 	beginLumi 1/3
     *** nextItemType: Event ***
@@ -60,10 +60,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/3
 	writeLumi 1/3
-	deleteLumiFromCache 1/3
+	clearLumiPrincipal 1/3
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -90,7 +90,7 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
@@ -111,7 +111,7 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Lumi 3 ***
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	readLuminosityBlock 3
 	beginLumi 1/3
     *** nextItemType: Event ***
@@ -122,10 +122,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/3
 	writeLumi 1/3
-	deleteLumiFromCache 1/3
+	clearLumiPrincipal 1/3
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_8.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_8.txt
@@ -19,16 +19,16 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: File 0 ***
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -44,7 +44,7 @@ Machine parameters:  mode = NOMERGE
     *** nextItemType: Lumi 3 ***
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	readLuminosityBlock 3
 	beginLumi 1/3
     *** nextItemType: Event ***
@@ -55,10 +55,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/3
 	writeLumi 1/3
-	deleteLumiFromCache 1/3
+	clearLumiPrincipal 1/3
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -85,7 +85,7 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: File 0 ***
@@ -101,7 +101,7 @@ Machine parameters:  mode = FULLMERGE
     *** nextItemType: Lumi 3 ***
 	endLumi 1/2
 	writeLumi 1/2
-	deleteLumiFromCache 1/2
+	clearLumiPrincipal 1/2
 	readLuminosityBlock 3
 	beginLumi 1/3
     *** nextItemType: Event ***
@@ -112,10 +112,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/3
 	writeLumi 1/3
-	deleteLumiFromCache 1/3
+	clearLumiPrincipal 1/3
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_9.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_9.txt
@@ -29,10 +29,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -58,10 +58,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -87,10 +87,10 @@ Machine parameters:  mode = NOMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles
@@ -175,10 +175,10 @@ Machine parameters:  mode = FULLMERGE
 	shouldWeStop
 	endLumi 1/1
 	writeLumi 1/1
-	deleteLumiFromCache 1/1
+	clearLumiPrincipal 1/1
 	endRun 1
 	writeRun 1
-	deleteRunFromCache 1
+	clearRunPrincipal 1
 	respondToCloseInputFile
 	closeInputFile
 	closeOutputFiles

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -73,12 +73,15 @@ ModuleCallingContext state = Running
 ++++ finished: begin stream for module: stream = 0 label = 'result4' id = 7
 ++++ starting: begin process block
 ++++ finished: begin process block
-++++ starting: source run
-++++ finished: source run
+++++ queuing: EventSetup synchronization run: 1 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 0 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 0 event: 0
+++++ starting: source run
+++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
 ++++ finished: global begin run 1 : time = 1000000
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = BeginRun
@@ -105,8 +108,6 @@ ModuleCallingContext state = Running
     ProcessContext: TEST d84cfc6bef4d9d1fe04243c166360a06
 
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -480,6 +481,8 @@ ModuleCallingContext state = Running
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
+++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++++ starting: end lumi for module: stream = 0 label = 'one' id = 4
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
@@ -510,7 +513,6 @@ ModuleCallingContext state = Running
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
-++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
 ++++++ starting: end run for module: stream = 0 label = 'one' id = 4

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -41,20 +41,21 @@
 ++++ finished: begin stream for module: stream = 0 label = 'p' id = 2
 ++++ starting: begin process block
 ++++ finished: begin process block
-++++ starting: source run
-++++ finished: source run
+++++ queuing: EventSetup synchronization run: 1 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 0 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 0 event: 0
+++++ starting: source run
+++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
 ++++ finished: global begin run 1 : time = 1000000
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
 ++++++ finished: begin run for module: stream = 0 label = 'two' id = 5
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
 ++++++ finished: begin run for module: stream = 0 label = 'one' id = 3
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -144,6 +145,8 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
+++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++++ starting: end lumi for module: stream = 0 label = 'two' id = 5
 ++++++ finished: end lumi for module: stream = 0 label = 'two' id = 5
@@ -154,7 +157,6 @@
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
-++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
 ++++++ starting: end run for module: stream = 0 label = 'two' id = 5

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -205,7 +205,7 @@
     <use name="FWCore/Framework"/>
   </library>
 
-  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,SlimmingThingProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,DetSetVectorThingProducer.cc,TrackOfDSVThingsProducer.cc,ThinningDSVThingProducer.cc,SlimmingDSVThingProducer.cc,ThinningDSVTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc, TestOneOutput.cc, PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc" name="SomeTestModules">
+  <library file="ThingProducer.cc,ThingAlgorithm.cc,TrackOfThingsProducer.cc,ThinningThingProducer.cc,SlimmingThingProducer.cc,ThinningTestAnalyzer.cc,ThinnedRefFromTestAnalyzer.cc,DetSetVectorThingProducer.cc,TrackOfDSVThingsProducer.cc,ThinningDSVThingProducer.cc,SlimmingDSVThingProducer.cc,ThinningDSVTestAnalyzer.cc,WhatsIt.cc,GadgetRcd.cc,AssociationMapProducer.cc,AssociationMapAnalyzer.cc,MissingDictionaryTestProducer.cc,ExistingDictionaryTestModules.cc,ThingAnalyzer.cc, TableTestModules.cc, AcquireIntProducer.cc, AcquireIntFilter.cc, AcquireIntStreamProducer.cc, AcquireIntStreamFilter.cc, TestGlobalOutput.cc, TestLimitedOutput.cc, TestOneOutput.cc, PluginUsingProducer.cc,SwitchProducerProvenanceAnalyzer.cc,ProducerUsingCollector.cc,ExceptionThrowingProducer.cc" name="SomeTestModules">
     <flags EDM_PLUGIN="1"/>
     <lib name="FWCoreIntegrationWaitingServer"/>
     <use name="FWCore/Framework"/>
@@ -473,6 +473,16 @@
   <test name="TestFWCoreIntegrationEDLooperESProcuer" command="cmsRun ${LOCALTOP}/src/FWCore/Integration/test/testEDLooperESProducer_cfg.py"/>
 
   <test name="TestFWCoreIntegrationDelayedReaderTest" command="delayedreader_throw_test.sh"/>
+
+  <test name="TestFrameworkExceptionHandling1" command="run_TestFrameworkExceptionHandling.sh 1"/>
+  <test name="TestFrameworkExceptionHandling2" command="run_TestFrameworkExceptionHandling.sh 2"/>
+  <test name="TestFrameworkExceptionHandling3" command="run_TestFrameworkExceptionHandling.sh 3"/>
+  <test name="TestFrameworkExceptionHandling4" command="run_TestFrameworkExceptionHandling.sh 4"/>
+  <test name="TestFrameworkExceptionHandling5" command="run_TestFrameworkExceptionHandling.sh 5"/>
+  <test name="TestFrameworkExceptionHandling6" command="run_TestFrameworkExceptionHandling.sh 6"/>
+  <test name="TestFrameworkExceptionHandling7" command="run_TestFrameworkExceptionHandling.sh 7"/>
+  <test name="TestFrameworkExceptionHandling8" command="run_TestFrameworkExceptionHandling.sh 8"/>
+  <test name="TestFrameworkExceptionHandling9" command="run_TestFrameworkExceptionHandling.sh 9"/>
 
   <test name="TestIntegrationProcessBlock1" command="run_TestProcessBlock.sh 1"/>
   <test name="TestIntegrationProcessBlock2" command="run_TestProcessBlock.sh 2"/>

--- a/FWCore/Integration/test/DoodadESSource.cc
+++ b/FWCore/Integration/test/DoodadESSource.cc
@@ -97,7 +97,8 @@ namespace edmtest {
                                       edm::ValidityInterval& iInterval) {
     //Be valid for 3 runs
     edm::EventID newTime = edm::EventID((iTime.eventID().run() - 1) - ((iTime.eventID().run() - 1) % 3) + 1, 1, 1);
-    edm::EventID endTime = newTime.nextRun(1).nextRun(1).nextRun(1).previousRunLastEvent(1);
+    edm::EventID endTime =
+        newTime.nextRun(1).nextRun(1).nextRun(1).previousRunLastEvent(edm::EventID::maxLuminosityBlockNumber());
     iInterval = edm::ValidityInterval(edm::IOVSyncValue(newTime), edm::IOVSyncValue(endTime));
   }
 

--- a/FWCore/Integration/test/ExceptionThrowingProducer.cc
+++ b/FWCore/Integration/test/ExceptionThrowingProducer.cc
@@ -1,0 +1,180 @@
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/RunLumiEventNumber.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+
+namespace edmtest {
+
+  namespace {
+    struct Cache {};
+  }  // namespace
+
+  class ExceptionThrowingProducer
+      : public edm::global::EDProducer<edm::StreamCache<Cache>, edm::RunCache<Cache>, edm::LuminosityBlockCache<Cache>> {
+  public:
+    explicit ExceptionThrowingProducer(edm::ParameterSet const&);
+
+    ~ExceptionThrowingProducer() override;
+
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
+
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override;
+    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override;
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                      edm::EventSetup const&) const override;
+    void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override;
+
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override;
+    void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override;
+    void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override;
+    void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override;
+    void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    edm::EventID eventIDThrowOnEvent_;
+    edm::EventID eventIDThrowOnGlobalBeginRun_;
+    edm::EventID eventIDThrowOnGlobalBeginLumi_;
+    edm::EventID eventIDThrowOnGlobalEndRun_;
+    edm::EventID eventIDThrowOnGlobalEndLumi_;
+    edm::EventID eventIDThrowOnStreamBeginRun_;
+    edm::EventID eventIDThrowOnStreamBeginLumi_;
+    edm::EventID eventIDThrowOnStreamEndRun_;
+    edm::EventID eventIDThrowOnStreamEndLumi_;
+  };
+
+  ExceptionThrowingProducer::ExceptionThrowingProducer(edm::ParameterSet const& pset)
+      : eventIDThrowOnEvent_(pset.getUntrackedParameter<edm::EventID>("eventIDThrowOnEvent")),
+        eventIDThrowOnGlobalBeginRun_(pset.getUntrackedParameter<edm::EventID>("eventIDThrowOnGlobalBeginRun")),
+        eventIDThrowOnGlobalBeginLumi_(pset.getUntrackedParameter<edm::EventID>("eventIDThrowOnGlobalBeginLumi")),
+        eventIDThrowOnGlobalEndRun_(pset.getUntrackedParameter<edm::EventID>("eventIDThrowOnGlobalEndRun")),
+        eventIDThrowOnGlobalEndLumi_(pset.getUntrackedParameter<edm::EventID>("eventIDThrowOnGlobalEndLumi")),
+        eventIDThrowOnStreamBeginRun_(pset.getUntrackedParameter<edm::EventID>("eventIDThrowOnStreamBeginRun")),
+        eventIDThrowOnStreamBeginLumi_(pset.getUntrackedParameter<edm::EventID>("eventIDThrowOnStreamBeginLumi")),
+        eventIDThrowOnStreamEndRun_(pset.getUntrackedParameter<edm::EventID>("eventIDThrowOnStreamEndRun")),
+        eventIDThrowOnStreamEndLumi_(pset.getUntrackedParameter<edm::EventID>("eventIDThrowOnStreamEndLumi")) {}
+
+  ExceptionThrowingProducer::~ExceptionThrowingProducer() {}
+
+  void ExceptionThrowingProducer::produce(edm::StreamID, edm::Event& event, edm::EventSetup const&) const {
+    if (event.id() == eventIDThrowOnEvent_) {
+      throw cms::Exception("IntentionalTestException")
+          << "ExceptionThrowingProducer::produce, module configured to throw on: " << eventIDThrowOnEvent_;
+    }
+  }
+
+  std::shared_ptr<Cache> ExceptionThrowingProducer::globalBeginRun(edm::Run const& run, edm::EventSetup const&) const {
+    if (edm::EventID(run.id().run(), edm::invalidLuminosityBlockNumber, edm::invalidEventNumber) ==
+        eventIDThrowOnGlobalBeginRun_) {
+      throw cms::Exception("IntentionalTestException")
+          << "ExceptionThrowingProducer::globalBeginRun, module configured to throw on: "
+          << eventIDThrowOnGlobalBeginRun_;
+    }
+    return std::make_shared<Cache>();
+  }
+
+  void ExceptionThrowingProducer::globalEndRun(edm::Run const& run, edm::EventSetup const&) const {
+    if (edm::EventID(run.id().run(), edm::invalidLuminosityBlockNumber, edm::invalidEventNumber) ==
+        eventIDThrowOnGlobalEndRun_) {
+      throw cms::Exception("IntentionalTestException")
+          << "ExceptionThrowingProducer::globalEndRun, module configured to throw on: " << eventIDThrowOnGlobalEndRun_;
+    }
+  }
+
+  std::shared_ptr<Cache> ExceptionThrowingProducer::globalBeginLuminosityBlock(edm::LuminosityBlock const& lumi,
+                                                                               edm::EventSetup const&) const {
+    if (edm::EventID(lumi.id().run(), lumi.id().luminosityBlock(), edm::invalidEventNumber) ==
+        eventIDThrowOnGlobalBeginLumi_) {
+      throw cms::Exception("IntentionalTestException")
+          << "ExceptionThrowingProducer::globalBeginLuminosityBlock, module configured to throw on: "
+          << eventIDThrowOnGlobalBeginLumi_;
+    }
+    return std::make_shared<Cache>();
+  }
+
+  void ExceptionThrowingProducer::globalEndLuminosityBlock(edm::LuminosityBlock const& lumi,
+                                                           edm::EventSetup const&) const {
+    if (edm::EventID(lumi.id().run(), lumi.id().luminosityBlock(), edm::invalidEventNumber) ==
+        eventIDThrowOnGlobalEndLumi_) {
+      throw cms::Exception("IntentionalTestException")
+          << "ExceptionThrowingProducer::globalEndLuminosityBlock, module configured to throw on: "
+          << eventIDThrowOnGlobalEndLumi_;
+    }
+  }
+
+  std::unique_ptr<Cache> ExceptionThrowingProducer::beginStream(edm::StreamID) const {
+    return std::make_unique<Cache>();
+  }
+
+  void ExceptionThrowingProducer::streamBeginRun(edm::StreamID iStream,
+                                                 edm::Run const& run,
+                                                 edm::EventSetup const&) const {
+    if (iStream.value() == 0 &&
+        edm::EventID(run.id().run(), edm::invalidLuminosityBlockNumber, edm::invalidEventNumber) ==
+            eventIDThrowOnStreamBeginRun_) {
+      throw cms::Exception("IntentionalTestException")
+          << "ExceptionThrowingProducer::streamBeginRun, module configured to throw on: "
+          << eventIDThrowOnStreamBeginRun_;
+    }
+  }
+
+  void ExceptionThrowingProducer::streamBeginLuminosityBlock(edm::StreamID iStream,
+                                                             edm::LuminosityBlock const& lumi,
+                                                             edm::EventSetup const&) const {
+    if (iStream.value() == 0 && edm::EventID(lumi.run(), lumi.id().luminosityBlock(), edm::invalidEventNumber) ==
+                                    eventIDThrowOnStreamBeginLumi_) {
+      throw cms::Exception("IntentionalTestException")
+          << "ExceptionThrowingProducer::streamBeginLuminosityBlock, module configured to throw on: "
+          << eventIDThrowOnStreamBeginLumi_;
+    }
+  }
+
+  void ExceptionThrowingProducer::streamEndLuminosityBlock(edm::StreamID iStream,
+                                                           edm::LuminosityBlock const& lumi,
+                                                           edm::EventSetup const&) const {
+    if (iStream.value() == 0 && edm::EventID(lumi.run(), lumi.id().luminosityBlock(), edm::invalidEventNumber) ==
+                                    eventIDThrowOnStreamEndLumi_) {
+      throw cms::Exception("IntentionalTestException")
+          << "ExceptionThrowingProducer::streamEndLuminosityBlock, module configured to throw on: "
+          << eventIDThrowOnStreamEndLumi_;
+    }
+  }
+
+  void ExceptionThrowingProducer::streamEndRun(edm::StreamID iStream,
+                                               edm::Run const& run,
+                                               edm::EventSetup const&) const {
+    if (iStream.value() == 0 &&
+        edm::EventID(run.id().run(), edm::invalidLuminosityBlockNumber, edm::invalidEventNumber) ==
+            eventIDThrowOnStreamEndRun_) {
+      throw cms::Exception("IntentionalTestException")
+          << "ExceptionThrowingProducer::streamEndRun, module configured to throw on: " << eventIDThrowOnStreamEndRun_;
+    }
+  }
+
+  void ExceptionThrowingProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    edm::EventID invalidEventID;
+    desc.addUntracked<edm::EventID>("eventIDThrowOnEvent", invalidEventID);
+    desc.addUntracked<edm::EventID>("eventIDThrowOnGlobalBeginRun", invalidEventID);
+    desc.addUntracked<edm::EventID>("eventIDThrowOnGlobalBeginLumi", invalidEventID);
+    desc.addUntracked<edm::EventID>("eventIDThrowOnGlobalEndRun", invalidEventID);
+    desc.addUntracked<edm::EventID>("eventIDThrowOnGlobalEndLumi", invalidEventID);
+    desc.addUntracked<edm::EventID>("eventIDThrowOnStreamBeginRun", invalidEventID);
+    desc.addUntracked<edm::EventID>("eventIDThrowOnStreamBeginLumi", invalidEventID);
+    desc.addUntracked<edm::EventID>("eventIDThrowOnStreamEndRun", invalidEventID);
+    desc.addUntracked<edm::EventID>("eventIDThrowOnStreamEndLumi", invalidEventID);
+    descriptions.addDefault(desc);
+  }
+
+}  // namespace edmtest
+using edmtest::ExceptionThrowingProducer;
+DEFINE_FWK_MODULE(ExceptionThrowingProducer);

--- a/FWCore/Integration/test/eventSetupTest.sh
+++ b/FWCore/Integration/test/eventSetupTest.sh
@@ -41,4 +41,10 @@ echo EventSetupIncorrectConsumes_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/EventSetupIncorrectConsumes_cfg.py &> testEventSetupIncorrectConsumes.txt && die 'Failed EventSetupIncorrectConsumes_cfg.py, the configuration succeeded while it should have failed' 1
 grep "A module declared it consumes an EventSetup product after its constructor" testEventSetupIncorrectConsumes.txt >/dev/null || diecat 'Failed EventSetupIncorrectConsumes_cfg.py, the configuration failed but in an unexpected way' $? testEventSetupIncorrectConsumes.txt
 
+echo testConcurrentIOVsAndRuns_cfg.py
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/testConcurrentIOVsAndRuns_cfg.py || die 'Failed in testConcurrentIOVsAndRuns_cfg.py' $?
+
+echo testConcurrentIOVsAndRunsRead_cfg.py
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/testConcurrentIOVsAndRunsRead_cfg.py || die 'Failed in testConcurrentIOVsAndRunsRead_cfg.py' $?
+
 popd

--- a/FWCore/Integration/test/run_TestFrameworkExceptionHandling.sh
+++ b/FWCore/Integration/test/run_TestFrameworkExceptionHandling.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#set -x
+LOCAL_TEST_DIR=${CMSSW_BASE}/src/FWCore/Integration/test
+LOCAL_TMP_DIR=${CMSSW_BASE}/tmp/${SCRAM_ARCH}
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+pushd ${LOCAL_TMP_DIR}
+
+logfile=testFrameworkExceptionHandling$1.log
+echo $logfile
+cmsRun ${LOCAL_TEST_DIR}/testFrameworkExceptionHandling_cfg.py testNumber=$1 &> $logfile && die "cmsRun testFrameworkExceptionHandling_cfg.py testNumber=$1" 1
+
+# Look for the content that we expect to be in the exception messages.
+# The first five should be the same in all log files.
+# The other two or three are different for each case.
+
+grep "Begin Fatal Exception" $logfile || die " - Cannot find the following string in the exception message: Begin Fatal Exception " $?
+
+grep "An exception of category 'IntentionalTestException' occurred while" $logfile || die " - Cannot find the following string in the exception message: An exception of category 'IntentionalTestException' occurred while " $?
+
+grep "Calling method for module ExceptionThrowingProducer/'throwException'" $logfile || die " - Cannot find the following string in the exception message: Calling method for module ExceptionThrowingProducer/'throwException' " $?
+
+grep "Exception Message:" $logfile || die " - Cannot find the following string in the exception message: Exception Message: " $?
+
+grep "End Fatal Exception" $logfile || die " - Cannot find the following string in the exception message: End Fatal Exception " $?
+
+if [ $1 -eq 1 ]
+then
+    grep "Processing  Event run: 3 lumi: 1 event: 5" $logfile || die " - Cannot find the following string in the exception message: Processing  Event run: 3 lumi: 1 event: 5 " $?
+    grep "Running path 'path1'" $logfile || die " - Cannot find the following string in the exception message: Running path 'path1' " $?
+    grep "ExceptionThrowingProducer::produce, module configured to throw on: run: 3 lumi: 1 event: 5" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::produce, module configured to throw on: run: 3 lumi: 1 event: 5 " $?
+fi
+
+if [ $1 -eq 2 ]
+then
+    grep "Processing global begin Run run: 4" $logfile || die " - Cannot find the following string in the exception message: Processing global begin Run run: 4 " $?
+    grep "ExceptionThrowingProducer::globalBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0 " $?
+fi
+
+if [ $1 -eq 3 ]
+then
+    grep "Processing global begin LuminosityBlock run: 4 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing global begin LuminosityBlock run: 4 luminosityBlock: 1 " $?
+    grep "ExceptionThrowingProducer::globalBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0 " $?
+fi
+
+if [ $1 -eq 4 ]
+then
+    grep "Processing global end Run run: 3" $logfile || die " - Cannot find the following string in the exception message: Processing global end Run run: 3 " $?
+    grep "ExceptionThrowingProducer::globalEndRun, module configured to throw on: run: 3 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalEndRun, module configured to throw on: run: 3 lumi: 0 event: 0 " $?
+fi
+
+if [ $1 -eq 5 ]
+then
+    grep "Processing global end LuminosityBlock run: 3 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing global end LuminosityBlock run: 3 luminosityBlock: 1 " $?
+    grep "ExceptionThrowingProducer::globalEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::globalEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0 " $?
+fi
+
+if [ $1 -eq 6 ]
+then
+    grep "Processing  stream begin Run run: 4" $logfile || die " - Cannot find the following string in the exception message: Processing  stream begin Run run: 4 " $?
+    grep "ExceptionThrowingProducer::streamBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamBeginRun, module configured to throw on: run: 4 lumi: 0 event: 0 " $?
+fi
+
+if [ $1 -eq 7 ]
+then
+    grep "Processing  stream begin LuminosityBlock run: 4 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing  stream begin LuminosityBlock run: 4 luminosityBlock: 1 " $?
+    grep "ExceptionThrowingProducer::streamBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamBeginLuminosityBlock, module configured to throw on: run: 4 lumi: 1 event: 0 " $?
+fi
+
+if [ $1 -eq 8 ]
+then
+   grep "Processing  stream end Run run: 3" $logfile || die " - Cannot find the following string in the exception message: Processing  stream end Run run: 3 " $?
+   grep "ExceptionThrowingProducer::streamEndRun, module configured to throw on: run: 3 lumi: 0 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamEndRun, module configured to throw on: run: 3 lumi: 0 event: 0 " $?
+fi
+
+if [ $1 -eq 9 ]
+then
+    grep "Processing  stream end LuminosityBlock run: 3 luminosityBlock: 1" $logfile || die " - Cannot find the following string in the exception message: Processing  stream end LuminosityBlock run: 3 luminosityBlock: 1 " $?
+    grep "ExceptionThrowingProducer::streamEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0" $logfile || die " - Cannot find the following string in the exception message: ExceptionThrowingProducer::streamEndLuminosityBlock, module configured to throw on: run: 3 lumi: 1 event: 0 " $?
+fi
+
+popd
+
+exit 0

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -49,6 +49,9 @@ pushd ${LOCAL_TMP_DIR}
   echo "testGetByRunsLumisMode_cfg.py"
   cmsRun -p ${LOCAL_TEST_DIR}/testGetByRunsLumisMode_cfg.py || die "cmsRun testGetByRunsLumisMode_cfg.py" $?
 
+  echo "testGetByWithEmptyRun_cfg.py"
+  cmsRun -p ${LOCAL_TEST_DIR}/testGetByWithEmptyRun_cfg.py || die "cmsRun testGetByWithEmptyRun_cfg.py" $?
+
 popd
 
 exit 0

--- a/FWCore/Integration/test/testConcurrentIOVsAndRunsRead_cfg.py
+++ b/FWCore/Integration/test/testConcurrentIOVsAndRunsRead_cfg.py
@@ -1,0 +1,67 @@
+# Tests concurrent runs along with concurrent IOVs
+# Note that 3 concurrent runs implies at least 7
+# concurrent IOVs are needed and we configure
+# 8 concurrent IOVs so that concurrent runs are
+# really the limiting factor for the test.
+# Note 7 includes 1 for the first run and then 3
+# for each subsequent concurrent run which includes
+# an IOV for end run, begin run, and begin lumi necessary
+# to get to the next event. In this test every lumi is
+# only valid for one transition (see internals of
+# RunLumiESSource). This test checks that correct
+# EventSetup info is retrieved in all the transitions
+# plus the same test is run in a SubProcess to
+# check that transitions there are also running properly.
+# Manual examination of the times in the log output should
+# show 3 events in 3 different runs being processed
+# concurrently.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("READ")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testConcurrentIOVsAndRuns.root')
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(8),
+    numberOfStreams = cms.untracked.uint32(8),
+    numberOfConcurrentRuns = cms.untracked.uint32(3),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(8),
+    eventSetup = cms.untracked.PSet(
+        numberOfConcurrentIOVs = cms.untracked.uint32(8)
+    )
+)
+
+process.runLumiESSource = cms.ESSource("RunLumiESSource")
+
+process.test = cms.EDAnalyzer("RunLumiESAnalyzer")
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(40*1000*1000))
+
+process.p1 = cms.Path(process.busy1 * process.test)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testConcurrentIOVsAndRunsRead.root')
+)
+
+process.e = cms.EndPath(process.out)
+
+# ---------------------------------------------------------------
+
+aSubProcess = cms.Process("TESTSUBPROCESS")
+process.addSubProcess(cms.SubProcess(aSubProcess))
+
+aSubProcess.runLumiESSource = cms.ESSource("RunLumiESSource")
+
+aSubProcess.test = cms.EDAnalyzer("RunLumiESAnalyzer")
+
+aSubProcess.p1 = cms.Path(aSubProcess.test)
+
+aSubProcess.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testConcurrentIOVsAndRunsSubProcessRead.root')
+)
+
+aSubProcess.e = cms.EndPath(aSubProcess.out)

--- a/FWCore/Integration/test/testConcurrentIOVsAndRuns_cfg.py
+++ b/FWCore/Integration/test/testConcurrentIOVsAndRuns_cfg.py
@@ -1,0 +1,72 @@
+# Tests concurrent runs along with concurrent IOVs
+# Note that 3 concurrent runs implies at least 7
+# concurrent IOVs are needed and we configure
+# 8 concurrent IOVs so that concurrent runs are
+# really the limiting factor for the test.
+# Note 7 includes 1 for the first run and then 3
+# for each subsequent concurrent run which includes
+# an IOV for end run, begin run, and begin lumi necessary
+# to get to the next event. In this test every lumi is
+# only valid for one transition (see internals of
+# RunLumiESSource). This test checks that correct
+# EventSetup info is retrieved in all the transitions
+# plus the same test is run in a SubProcess to
+# check that transitions there are also running properly.
+# Manual examination of the times in the log output should
+# show 3 events in 3 different runs being processed
+# concurrently.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(1),
+    numberEventsInRun = cms.untracked.uint32(1)
+)
+
+process.maxEvents.input = 30
+
+process.options = dict(
+    numberOfThreads = 8,
+    numberOfStreams = 8,
+    numberOfConcurrentRuns = 3,
+    numberOfConcurrentLuminosityBlocks = 8,
+    eventSetup = dict(
+        numberOfConcurrentIOVs = 8
+    )
+)
+
+process.runLumiESSource = cms.ESSource("RunLumiESSource")
+
+process.test = cms.EDAnalyzer("RunLumiESAnalyzer")
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(40*1000*1000))
+
+process.p1 = cms.Path(process.busy1 * process.test)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testConcurrentIOVsAndRuns.root')
+)
+
+process.e = cms.EndPath(process.out)
+
+# ---------------------------------------------------------------
+
+aSubProcess = cms.Process("TESTSUBPROCESS")
+process.addSubProcess(cms.SubProcess(aSubProcess))
+
+aSubProcess.runLumiESSource = cms.ESSource("RunLumiESSource")
+
+aSubProcess.test = cms.EDAnalyzer("RunLumiESAnalyzer")
+
+aSubProcess.p1 = cms.Path(aSubProcess.test)
+
+aSubProcess.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testConcurrentIOVsAndRunsSubProcess.root')
+)
+
+aSubProcess.e = cms.EndPath(aSubProcess.out)

--- a/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
+++ b/FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py
@@ -1,0 +1,91 @@
+
+# Use this as follows:
+#
+# cmsRun FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py testNumber=1
+#
+# with the value assigned to testNumber having a value from 1 to 9.
+# That value specifies which transition to throw an exception in.
+# If the value is not specified, then no exception is thrown.
+
+import FWCore.ParameterSet.Config as cms
+
+nStreams = 4
+nRuns = 17
+nLumisPerRun = 1
+nEventsPerLumi = 6
+
+nEventsPerRun = nLumisPerRun*nEventsPerLumi
+nLumis = nRuns*nLumisPerRun
+nEvents = nRuns*nEventsPerRun
+
+process = cms.Process("TEST")
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+options = VarParsing()
+
+options.register("testNumber", 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "Test number")
+
+options.parseArguments()
+
+process.source = cms.Source("EmptySource",
+    firstRun = cms.untracked.uint32(1),
+    firstLuminosityBlock = cms.untracked.uint32(1),
+    firstEvent = cms.untracked.uint32(1),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEventsPerLumi),
+    numberEventsInRun = cms.untracked.uint32(nEventsPerRun)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(nEvents)
+)
+
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32(nStreams),
+    numberOfConcurrentRuns = cms.untracked.uint32(4),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(4)
+)
+
+process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iterations = cms.uint32(10*1000*1000))
+
+process.throwException = cms.EDProducer("ExceptionThrowingProducer")
+
+
+print('testNumber', options.testNumber)
+
+# Below, the EventID's are selected such that it is likely that in the process
+# configured by this file that more than 1 run, more than 1 lumi and more than 1 event
+# (stream) will be in flight when the exception is thrown.
+
+if options.testNumber == 1:
+    process.throwException.eventIDThrowOnEvent = cms.untracked.EventID(3, 1, 5)
+elif options.testNumber == 2:
+    process.throwException.eventIDThrowOnGlobalBeginRun = cms.untracked.EventID(4, 0, 0)
+elif options.testNumber == 3:
+    process.throwException.eventIDThrowOnGlobalBeginLumi = cms.untracked.EventID(4, 1, 0)
+elif options.testNumber == 4:
+    process.throwException.eventIDThrowOnGlobalEndRun = cms.untracked.EventID(3, 0, 0)
+elif options.testNumber == 5:
+    process.throwException.eventIDThrowOnGlobalEndLumi = cms.untracked.EventID(3, 1, 0)
+elif options.testNumber == 6:
+    process.throwException.eventIDThrowOnStreamBeginRun = cms.untracked.EventID(4, 0, 0)
+elif options.testNumber == 7:
+    process.throwException.eventIDThrowOnStreamBeginLumi = cms.untracked.EventID(4, 1, 0)
+elif options.testNumber == 8:
+    process.throwException.eventIDThrowOnStreamEndRun = cms.untracked.EventID(3, 0, 0)
+elif options.testNumber == 9:
+    process.throwException.eventIDThrowOnStreamEndLumi = cms.untracked.EventID(3, 1, 0)
+else:
+    print("The parameter named testNumber is out of range. An exception will not be thrown. Supported values range from 1 to 9.")
+    print("The proper syntax for setting the parameter is:")
+    print("")
+    print ("    cmsRun FWCore/Integration/test/testFrameworkExceptionHandling_cfg.py testNumber=1")
+    print("")
+process.path1 = cms.Path(
+    process.busy1 *
+    process.throwException
+)

--- a/FWCore/Integration/test/testGetByRunsMode_cfg.py
+++ b/FWCore/Integration/test/testGetByRunsMode_cfg.py
@@ -33,9 +33,13 @@ process.a1 = cms.EDAnalyzer("TestFindProduct",
   )
 )
 
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testGetByRunsMode.root')
+)
 
 process.p1 = cms.Path(process.intProducerBeginProcessBlock +
                       process.intProducerEndProcessBlock +
                       process.a1
 )
 
+process.e1 = cms.EndPath(process.out)

--- a/FWCore/Integration/test/testGetByWithEmptyRun_cfg.py
+++ b/FWCore/Integration/test/testGetByWithEmptyRun_cfg.py
@@ -1,0 +1,42 @@
+# The purpose of this is to test the case where a
+# file ends with an empty run (no lumis) and we
+# go into another file and process things.
+# This tests a rarely hit code path in processRuns.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD3")
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:testGetByRunsMode.root',
+        'file:testGetBy1.root'
+    ),
+    inputCommands=cms.untracked.vstring(
+        'keep *',
+        'drop *_*_*_PROD2'
+    )
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testGetByWithEmptyRun.root')
+)
+
+process.test = cms.EDAnalyzer('RunLumiEventAnalyzer',
+                              verbose = cms.untracked.bool(True),
+                              expectedRunLumiEvents = cms.untracked.vuint32(
+1, 0, 0,
+1, 0, 0,
+1, 0, 0,
+1, 1, 0,
+1, 1, 1,
+1, 1, 2,
+1, 1, 3,
+1, 1, 0,
+1, 0, 0
+)
+)
+
+process.p1 = cms.Path(process.test)
+
+process.e1 = cms.EndPath(process.out)

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -232,10 +232,11 @@ GlobalContext: transition = BeginProcessBlock
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++ starting: source run
-++++ finished: source run
+++++ queuing: EventSetup synchronization run: 1 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 0 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 0 event: 0
+++++ starting: source run
+++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -318,6 +319,8 @@ GlobalContext: transition = BeginRun
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -374,8 +377,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1195,6 +1196,8 @@ StreamContext: StreamID = 0 transition = Event
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
+++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -1361,7 +1364,6 @@ GlobalContext: transition = WriteLuminosityBlock
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -115,10 +115,11 @@ GlobalContext: transition = WriteProcessBlock
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++ starting: source run
-++++ finished: source run
+++++ queuing: EventSetup synchronization run: 1 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 0 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 0 event: 0
+++++ starting: source run
+++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -131,6 +132,8 @@ GlobalContext: transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -169,8 +172,6 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -668,6 +669,8 @@ StreamContext: StreamID = 0 transition = Event
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
+++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -732,7 +735,6 @@ GlobalContext: transition = WriteLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -254,10 +254,11 @@
 ++++++ starting: begin process block for module: label = 'getInt' id = 22
 ++++++ finished: begin process block for module: label = 'getInt' id = 22
 ++++ finished: begin process block
-++++ starting: source run
-++++ finished: source run
+++++ queuing: EventSetup synchronization run: 1 lumi: 0 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 0 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 0 event: 0
+++++ starting: source run
+++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
@@ -342,6 +343,7 @@
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global begin run 1 : time = 1
+++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
@@ -360,7 +362,6 @@
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
-++++ queuing: EventSetup synchronization run: 1 lumi: 1 event: 0
 ++++ pre: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ post: EventSetup synchronizing run: 1 lumi: 1 event: 0
 ++++ starting: source lumi
@@ -2437,6 +2438,8 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ queuing: EventSetup synchronization run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 50000001
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 50000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
@@ -2547,8 +2550,10 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 1 lumi = 3 time = 45000001
-++++ pre: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 1 lumi: 4294967295 event: 18446744073709551615
+++++ queuing: EventSetup synchronization run: 2 lumi: 0 event: 0
+++++ pre: EventSetup synchronizing run: 2 lumi: 0 event: 0
+++++ post: EventSetup synchronizing run: 2 lumi: 0 event: 0
 ++++ starting: end run: stream = 0 run = 1 time = 50000001
 ++++ finished: end run: stream = 0 run = 1 time = 50000001
 ++++ starting: end run: stream = 0 run = 1 time = 0
@@ -2661,8 +2666,6 @@
 ++++ finished: global write run 1 : time = 0
 ++++ starting: source run
 ++++ finished: source run
-++++ pre: EventSetup synchronizing run: 2 lumi: 0 event: 0
-++++ post: EventSetup synchronizing run: 2 lumi: 0 event: 0
 ++++ starting: global begin run 2 : time = 55000001
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
@@ -2739,6 +2742,8 @@
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global begin run 2 : time = 55000001
+++++ queuing: EventSetup synchronization run: 2 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 2 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
@@ -2757,8 +2762,6 @@
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
-++++ queuing: EventSetup synchronization run: 2 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 2 lumi: 1 event: 0
 ++++ post: EventSetup synchronizing run: 2 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -4834,6 +4837,8 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ queuing: EventSetup synchronization run: 2 lumi: 4294967295 event: 18446744073709551615
+++++ pre: EventSetup synchronizing run: 2 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 100000001
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 100000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
@@ -4944,8 +4949,10 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 2 lumi = 3 time = 95000001
-++++ pre: EventSetup synchronizing run: 2 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 2 lumi: 4294967295 event: 18446744073709551615
+++++ queuing: EventSetup synchronization run: 3 lumi: 0 event: 0
+++++ pre: EventSetup synchronizing run: 3 lumi: 0 event: 0
+++++ post: EventSetup synchronizing run: 3 lumi: 0 event: 0
 ++++ starting: end run: stream = 0 run = 2 time = 100000001
 ++++ finished: end run: stream = 0 run = 2 time = 100000001
 ++++ starting: end run: stream = 0 run = 2 time = 0
@@ -5058,8 +5065,6 @@
 ++++ finished: global write run 2 : time = 0
 ++++ starting: source run
 ++++ finished: source run
-++++ pre: EventSetup synchronizing run: 3 lumi: 0 event: 0
-++++ post: EventSetup synchronizing run: 3 lumi: 0 event: 0
 ++++ starting: global begin run 3 : time = 105000001
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
@@ -5136,6 +5141,8 @@
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 23
 ++++ finished: global begin run 3 : time = 105000001
+++++ queuing: EventSetup synchronization run: 3 lumi: 1 event: 0
+++++ pre: EventSetup synchronizing run: 3 lumi: 1 event: 0
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
@@ -5154,8 +5161,6 @@
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
-++++ queuing: EventSetup synchronization run: 3 lumi: 1 event: 0
-++++ pre: EventSetup synchronizing run: 3 lumi: 1 event: 0
 ++++ post: EventSetup synchronizing run: 3 lumi: 1 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -5878,6 +5883,7 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 2 event: 0
+++++ pre: EventSetup synchronizing run: 3 lumi: 2 event: 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 120000001
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 120000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
@@ -5988,7 +5994,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 3 lumi = 1 time = 105000001
-++++ pre: EventSetup synchronizing run: 3 lumi: 2 event: 0
 ++++ post: EventSetup synchronizing run: 3 lumi: 2 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -6711,6 +6716,7 @@
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ queuing: EventSetup synchronization run: 3 lumi: 3 event: 0
+++++ pre: EventSetup synchronizing run: 3 lumi: 3 event: 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 140000001
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 140000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
@@ -6821,7 +6827,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 3 lumi = 2 time = 125000001
-++++ pre: EventSetup synchronizing run: 3 lumi: 3 event: 0
 ++++ post: EventSetup synchronizing run: 3 lumi: 3 event: 0
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -7231,6 +7236,8 @@
 ++++++++ finished: processing event for module: stream = 0 label = 'endPath1' id = 30
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ queuing: EventSetup synchronization run: 3 lumi: 4294967295 event: 18446744073709551615
+++++ pre: EventSetup synchronizing run: 3 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 150000001
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 150000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
@@ -7341,7 +7348,6 @@
 ++++++ starting: write lumi for module: label = 'out' id = 24
 ++++++ finished: write lumi for module: label = 'out' id = 24
 ++++ finished: global write lumi: run = 3 lumi = 3 time = 145000001
-++++ pre: EventSetup synchronizing run: 3 lumi: 4294967295 event: 18446744073709551615
 ++++ post: EventSetup synchronizing run: 3 lumi: 4294967295 event: 18446744073709551615
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001

--- a/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
+++ b/FWCore/ParameterSet/src/validateTopLevelParameterSets.cc
@@ -32,7 +32,10 @@ namespace edm {
             "In all cases, the number of concurrent luminosity blocks will be reset to "
             "be the same as the number of streams if it is greater than the "
             "numbers of streams.");
-    description.addUntracked<unsigned int>("numberOfConcurrentRuns", 1);
+    description.addUntracked<unsigned int>("numberOfConcurrentRuns", 1)
+        ->setComment(
+            "If zero or greater than the number of concurrent luminosity blocks, this will be reset to "
+            "be the same as the number of concurrent luminosity blocks.");
 
     edm::ParameterSetDescription eventSetupDescription;
     eventSetupDescription.addUntracked<unsigned int>("numberOfConcurrentIOVs", 0)

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -327,8 +327,8 @@ Bool_t TFWLiteSelectorBasic::Process(Long64_t iEntry) {
 
     try {
       m_->reader_->setEntry(iEntry);
-      auto runAux = std::make_shared<edm::RunAuxiliary>(aux.run(), aux.time(), aux.time());
-      auto rp = std::make_shared<edm::RunPrincipal>(runAux, m_->reg(), m_->pc_, nullptr, 0);
+      auto rp = std::make_shared<edm::RunPrincipal>(m_->reg(), m_->pc_, nullptr, 0);
+      rp->setAux(edm::RunAuxiliary(aux.run(), aux.time(), aux.time()));
       auto lbp = std::make_shared<edm::LuminosityBlockPrincipal>(m_->reg(), m_->pc_, nullptr, 0);
       lbp->setAux(edm::LuminosityBlockAuxiliary(rp->run(), 1, aux.time(), aux.time()));
       auto history = m_->phreg_->getMapped(eaux->processHistoryID());

--- a/FWCore/TestProcessor/interface/TestProcessor.h
+++ b/FWCore/TestProcessor/interface/TestProcessor.h
@@ -351,6 +351,7 @@ This simulates a problem happening early in the job which causes processing not 
 
       std::shared_ptr<ModuleRegistry> moduleRegistry_;
       std::unique_ptr<Schedule> schedule_;
+      std::shared_ptr<RunPrincipal> runPrincipal_;
       std::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal_;
 
       std::vector<std::pair<edm::BranchDescription, std::unique_ptr<WrapperBase>>> dataProducts_;

--- a/FWCore/TestProcessor/src/LuminosityBlock.cc
+++ b/FWCore/TestProcessor/src/LuminosityBlock.cc
@@ -10,41 +10,15 @@
 //         Created:  Mon, 30 Apr 2018 18:51:33 GMT
 //
 
-// system include files
-
-// user include files
 #include "FWCore/TestProcessor/interface/LuminosityBlock.h"
 
 namespace edm {
   namespace test {
 
-    //
-    // constants, enums and typedefs
-    //
-
-    //
-    // static data member definitions
-    //
-
-    //
-    // constructors and destructor
-    //
     LuminosityBlock::LuminosityBlock(std::shared_ptr<LuminosityBlockPrincipal const> iPrincipal,
                                      std::string iModuleLabel,
                                      std::string iProcessName)
         : principal_{std::move(iPrincipal)}, label_{std::move(iModuleLabel)}, processName_{std::move(iProcessName)} {}
-
-    //
-    // member functions
-    //
-
-    //
-    // const member functions
-    //
-
-    //
-    // static member functions
-    //
 
   }  // namespace test
 }  // namespace edm

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -191,11 +191,9 @@ namespace edm {
       if (found) {
         std::shared_ptr<RunAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readRunAuxiliary_();
         checkConsistency(runPrincipal.aux(), *secondaryAuxiliary);
-        secondaryRunPrincipal_ = std::make_shared<RunPrincipal>(secondaryAuxiliary,
-                                                                secondaryFileSequence_->fileProductRegistry(),
-                                                                processConfiguration(),
-                                                                nullptr,
-                                                                runPrincipal.index());
+        secondaryRunPrincipal_ = std::make_shared<RunPrincipal>(
+            secondaryFileSequence_->fileProductRegistry(), processConfiguration(), nullptr, runPrincipal.index());
+        secondaryRunPrincipal_->setAux(*secondaryAuxiliary);
         secondaryFileSequence_->readRun_(*secondaryRunPrincipal_);
         checkHistoryConsistency(runPrincipal, *secondaryRunPrincipal_);
         runPrincipal.recombine(*secondaryRunPrincipal_, branchIDsToReplace_[InRun]);

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -205,8 +205,8 @@ namespace edm {
 
   void PileUp::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
     if (provider_.get() != nullptr) {
-      auto aux = std::make_shared<RunAuxiliary>(run.runAuxiliary());
-      runPrincipal_.reset(new RunPrincipal(aux, productRegistry_, *processConfiguration_, nullptr, 0));
+      runPrincipal_.reset(new RunPrincipal(productRegistry_, *processConfiguration_, nullptr, 0));
+      runPrincipal_->setAux(run.runAuxiliary());
       provider_->beginRun(*runPrincipal_, setup.impl(), run.moduleCallingContext(), *streamContext_);
     }
   }


### PR DESCRIPTION
#### PR description:

Implement support for concurrent runs in the Framework.

The design is analogous to what was done to implement
concurrent luminosity blocks as much as possible, although
there are unavoidable differences.

One can configure how many concurrent runs are allowed.
The default is one. With that setting, almost nothing externally
visible should change in the behavior of cmsRun. There
are significant and complex changes in the Framework
implementation to support this new ability.

Even with the number of concurrent runs configured to 1 the
Framework will be able to execute some transitions concurrently
which could not be executed concurrently before:
- The streamBeginRun transition will be able to run concurrently with global begin lumi, and on other streams - stream begin lumi, events, stream end lumi, and stream end run.
- The streamEndRun transition will be able to run concurrently with global end lumi and on other streams - stream begin lumi, events, stream end lumi and stream begin run.

If the number of concurrent runs is configured greater than one,
then global end run can run concurrently with any transitions from
another run and global begin run can run concurrently with any transitions
from another run except global begin run and global begin lumi.

This pull request does NOT upgrade modules and services outside
the Framework to support concurrent runs. We expect many of them
will fail if the number of concurrent runs is configured to be
more than one in an existing production configuration. We have not
surveyed existing code to see which modules and services cannot
support concurrent runs. Most should be OK because they do not
depend on run transitions. But for example, a module designed
to create per run histograms might have problems with concurrent
runs.

One configures the "numberOfConcurrentRuns" in the top level
options parameter set. If it is 0 or greater than the number
of concurrent lumis, then it will be reset to equal the
number of concurrent lumis.

If an EventSetup IOV changes at a run boundary, then one also
would need to configure concurrent IOVs for that record to two
to actually have the runs on both sides of that run boundary process
concurrently. Without that cmsRun would execute properly, but the
IOVs would block concurrent execution. In addition, it is technically
possible for the sequence of transitions beginLumi, endRun,
beginRun, and beginLumi to all have different IOVs. An EventSetup
record with such IOVs would need to be configured to allow
4 concurrent IOVs to process both runs concurrently across
such a run boundary.

It is the design intent that the rest of changes are transparent
to the user (beyond what is discussed above).

#### PR validation:

There are a few new unit tests. Existing unit tests pass. In fact
existing unit tests covered most of the features one might be
concerned about with this pull request. Of the new tests, these two
configurations are the most significant:

FWCore/Integration/test/testConcurrentIOVsAndRuns_cfg.py
FWCore/Integration/test/testConcurrentIOVsAndRunsRead_cfg.py
