### PR TITLE
fix double counting of modules in `TkAlBarycenters::computeBarycenters`

### DIFF
--- a/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
+++ b/CondCore/AlignmentPlugins/interface/AlignmentPayloadInspectorHelper.h
@@ -877,6 +877,11 @@ namespace AlignmentPI {
                                                   const std::map<AlignmentPI::coordinate, float>& GPR)
   /*--------------------------------------------------------------------*/
   {
+    // zero in the n. modules per partition...
+    for (const auto& p : PARTITIONS) {
+      nmodules[p] = 0.;
+    }
+
     for (const auto& ali : input) {
       if (DetId(ali.rawId()).det() != DetId::Tracker) {
         edm::LogWarning("TkAlBarycenters::computeBarycenters")
@@ -958,15 +963,17 @@ namespace AlignmentPI {
     }
 
     for (const auto& p : PARTITIONS) {
+      // take the arithmetic mean
       Xbarycenters[p] /= nmodules[p];
       Ybarycenters[p] /= nmodules[p];
       Zbarycenters[p] /= nmodules[p];
 
+      // add the Tracker Global Position Record
       Xbarycenters[p] += GPR.at(AlignmentPI::t_x);
       Ybarycenters[p] += GPR.at(AlignmentPI::t_y);
       Zbarycenters[p] += GPR.at(AlignmentPI::t_z);
 
-      COUT << p << "|"
+      COUT << "Partition: " << p << " n. modules: " << nmodules[p] << "|"
            << " X: " << std::right << std::setw(12) << Xbarycenters[p] << " Y: " << std::right << std::setw(12)
            << Ybarycenters[p] << " Z: " << std::right << std::setw(12) << Zbarycenters[p] << std::endl;
     }


### PR DESCRIPTION
#### PR description:

While checking the pixel barycenter positions for 2022 it was noticed that there is a double counting of the number of modules in 
 `TkAlBarycenters::computeBarycenters` leading to wrong parameters being displayed in the case of the GPR-corrected analysis.
 This is solved by initializing to zero the map of the module numbers per partition before looping on the alignable list.

#### PR validation:

Tested privately with the command:
```console
  getPayloadData.py --plugin pluginTrackerAlignment_PayloadInspector --plot plot_TrackerAlignmentBarycenters --tag TrackerAlignment_PCL_byRun_v2_express --time_type Run --iovs '{"start_iov": "355681", "end_iov": "355681"}' --db Prod --test ;
```

| Before this PR  | After this PR |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/5082376/180053027-7872fd6d-ba95-4c4e-ab69-3c25dfb611d9.png) | ![image](https://user-images.githubusercontent.com/5082376/180053281-311e285f-b547-4593-aa16-ac09180bc192.png) |

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

cc:
@tsusa @connorpa @amecca

