### PR TITLE
Initialize BranchDescription from Dictionary only if the branch is present

### DIFF
--- a/DataFormats/Common/src/setIsMergeable.cc
+++ b/DataFormats/Common/src/setIsMergeable.cc
@@ -17,7 +17,8 @@ namespace edm {
     // data member can only be true for run or lumi products.
     // It defaults to false. Also if it is true that means it
     // was already set.
-    if (desc.branchType() == InRun || desc.branchType() == InLumi) {
+    // Set it only for branches that are present
+    if (desc.present() and (desc.branchType() == InRun or desc.branchType() == InLumi)) {
       if (!desc.isMergeable()) {
         TClass* wrapperBaseTClass = TypeWithDict::byName("edm::WrapperBase").getClass();
         TClass* tClass = desc.wrappedType().getClass();

--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -158,9 +158,11 @@ namespace edm {
       BranchID switchAliasForBranchID_;
 
       // A TypeWithDict object for the wrapped object
+      // This is set if and only if the dropped_ is false
       TypeWithDict wrappedType_;
 
       // A TypeWithDict object for the unwrapped object
+      // This is set if and only if the dropped_ is false
       TypeWithDict unwrappedType_;
 
       // The split level of the branch, as marked

--- a/DataFormats/TestObjects/interface/ToyProducts.h
+++ b/DataFormats/TestObjects/interface/ToyProducts.h
@@ -63,6 +63,15 @@ namespace edmtest {
     ProductWithNoDictionary dummy;
   };
 
+  template <int TAG>
+  struct TransientIntParentT {
+    explicit TransientIntParentT(int i = 0) : value(i) {}
+
+    cms_int32_t value;
+  };
+  constexpr int TransientIntParentTag = 1;
+  using TransientIntParent = TransientIntParentT<TransientIntParentTag>;
+
   struct Int16_tProduct {
     explicit Int16_tProduct(int16_t i = 0, uint16_t j = 1) : value(i), uvalue(j) {}
     ~Int16_tProduct() {}

--- a/DataFormats/TestObjects/test/BuildFile_extra.xml
+++ b/DataFormats/TestObjects/test/BuildFile_extra.xml
@@ -1,0 +1,9 @@
+<library file="" name="DataFormatsTestObjectsParent1">
+  <flags LCG_DICT_HEADER="classes.h"/>
+  <flags LCG_DICT_XML="classes_def_parent1.xml"/>
+</library>
+
+<library file="" name="DataFormatsTestObjectsParent2">
+  <flags LCG_DICT_HEADER="classes.h"/>
+  <flags LCG_DICT_XML="classes_def_parent2.xml"/>
+</library>

--- a/DataFormats/TestObjects/test/classes.h
+++ b/DataFormats/TestObjects/test/classes.h
@@ -1,0 +1,2 @@
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"

--- a/DataFormats/TestObjects/test/classes_def_parent1.xml
+++ b/DataFormats/TestObjects/test/classes_def_parent1.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+ <class name="edmtest::TransientIntParentT<1>" persistent="false"/>
+ <class name="edm::Wrapper<edmtest::TransientIntParentT<1>>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/TestObjects/test/classes_def_parent2.xml
+++ b/DataFormats/TestObjects/test/classes_def_parent2.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+ <class name="edmtest::TransientIntParentT<2>" persistent="false"/>
+ <class name="edm::Wrapper<edmtest::TransientIntParentT<2>>" persistent="false"/>
+</lcgdict>

--- a/FWCore/Framework/interface/stream/ThinningProducer.h
+++ b/FWCore/Framework/interface/stream/ThinningProducer.h
@@ -160,6 +160,12 @@ namespace edm {
     ProductRegistry::ProductList const& productList = productRegistry.productList();
     for (auto const& product : productList) {
       BranchDescription const& desc = product.second;
+      if (desc.dropped()) {
+        // Dropped branch does not have type information, but they can
+        // be ignored here because all of the parent/thinned/association
+        // branches are expected to be present
+        continue;
+      }
       if (desc.unwrappedType().typeInfo() == typeid(Collection)) {
         if (desc.produced() && desc.moduleLabel() == moduleDescription().moduleLabel() &&
             desc.productInstanceName().empty()) {

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -121,6 +121,10 @@ namespace edm {
           //now make sure this is marked as not dropped else the product will not be 'get'table from the Event
           auto itFound = fullList.find(item.first);
           if (itFound != fullList.end()) {
+            // If the branch in primary file was dropped, need to initilize the dictionary information
+            if (itFound->second.dropped()) {
+              itFound->second.initFromDictionary();
+            }
             itFound->second.setDropped(false);
           }
         }

--- a/IOPool/Input/test/BuildFile.xml
+++ b/IOPool/Input/test/BuildFile.xml
@@ -11,4 +11,5 @@
   </library>
  
  <test name="TestIOPoolInputRepeating" command="testRepeatingCachedRootSource.sh"/>
+ <test name="TestIOPoolInputNoParentDictionary" command="testNoParentDictionary.sh"/>
 </environment>

--- a/IOPool/Input/test/PoolNoParentDictionaryTestStep1_cfg.py
+++ b/IOPool/Input/test/PoolNoParentDictionaryTestStep1_cfg.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTPROD")
+process.maxEvents.input = 11
+
+process.source = cms.Source("EmptySource",
+    firstLuminosityBlock = cms.untracked.uint32(6),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(3),
+    firstRun = cms.untracked.uint32(561),
+    numberEventsInRun = cms.untracked.uint32(7)
+)
+
+process.parentIntProduct = cms.EDProducer("edmtest::TransientIntParentProducer", ivalue = cms.int32(1))
+
+process.intProduct = cms.EDProducer("edmtest::IntProducerFromTransientParent",
+    src = cms.InputTag("parentIntProduct")
+)
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('noparentdict_step1.root')
+)
+
+process.p = cms.Path(process.parentIntProduct+process.intProduct)
+process.ep = cms.EndPath(process.output)

--- a/IOPool/Input/test/PoolNoParentDictionaryTestStep2_cfg.py
+++ b/IOPool/Input/test/PoolNoParentDictionaryTestStep2_cfg.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTANALYSIS")
+
+process.maxEvents.input = -1
+
+process.source = cms.Source("PoolSource",
+    setRunNumber = cms.untracked.uint32(621),
+    fileNames = cms.untracked.vstring('file:noparentdict_step1.root')
+)
+
+process.analysis = cms.EDAnalyzer("IntTestAnalyzer",
+    valueMustMatch = cms.untracked.int32(1),
+    moduleLabel = cms.untracked.InputTag("intProduct"),
+)
+
+process.p = cms.Path(process.analysis)

--- a/IOPool/Input/test/testNoParentDictionary.sh
+++ b/IOPool/Input/test/testNoParentDictionary.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+function die { echo $1: status $2 ;  exit $2; }
+
+SCRAM_TEST_NAME=TestIOPoolInputNoParentDictionary
+rm -rf $SCRAM_TEST_NAME
+mkdir $SCRAM_TEST_NAME
+cd $SCRAM_TEST_NAME
+
+# Create a new CMSSW dev area
+OLD_CMSSW_BASE=${CMSSW_BASE}
+LD_LIBRARY_PATH_TO_OLD=$(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep "^${CMSSW_BASE}/" | tr '\n' ':')
+scram -a $SCRAM_ARCH project $CMSSW_VERSION
+pushd $CMSSW_VERSION/src
+eval `scram run -sh`
+
+# Copy DataFormats/TestObjects code to be able to edit it to make ROOT header parsing to fail
+for DIR in ${OLD_CMSSW_BASE} ${CMSSW_RELEASE_BASE} ${CMSSW_FULL_RELEASE_BASE} ; do
+    if [ -d ${DIR}/src/DataFormats/TestObjects ]; then
+        mkdir DataFormats
+        cp -r ${DIR}/src/DataFormats/TestObjects DataFormats/
+        break
+    fi
+done
+if [ ! -e DataFormats/TestObjects ]; then
+    echo "Failed to copy DataFormats/TestObjects from local or release area"
+    exit 1;
+fi
+
+# Enable TransientIntParentT dictionaries
+cat DataFormats/TestObjects/test/BuildFile_extra.xml >> DataFormats/TestObjects/test/BuildFile.xml
+scram build -j $(nproc)
+
+popd
+
+# Add OLD_CMSSW_BASE in between CMSSW_BASE and CMSSW_RELEASE_BASE for
+# LD_LIBRARY_PATH and ROOT_INCLUDE_PATH
+export LD_LIBRARY_PATH=$(echo -n ${LD_LIBRARY_PATH} | sed -e "s|${CMSSW_BASE}/external/${SCRAM_ARCH}/lib:|${CMSSW_BASE}/external/${SCRAM_ARCH}/lib:${LD_LIBRARY_PATH_TO_OLD}:|")
+export ROOT_INCLUDE_PATH=$(echo -n ${ROOT_INCLUDE_PATH} | sed -e "s|${CMSSW_BASE}/src:|${CMSSW_BASE}/src:${OLD_CMSSW_BASE}/src:|")
+
+echo "Produce a file with TransientIntParentT<1> product"
+cmsRun ${LOCALTOP}/src/IOPool/Input/test/PoolNoParentDictionaryTestStep1_cfg.py || die 'Failed cmsRun PoolNoParentDictionaryTestStep1_cfg.py' $?
+
+
+# Then make attempt to load TransientIntParentT<1> to fail
+echo "PREVENT_HEADER_PARSING" >> ${CMSSW_BASE}/src/DataFormats/TestObjects/interface/ToyProducts.h
+rm ${CMSSW_BASE}/lib/${SCRAM_ARCH}/DataFormatsTestObjectsParent1_xr_rdict.pcm ${CMSSW_BASE}/lib/${SCRAM_ARCH}/libDataFormatsTestObjectsParent1.so
+sed -i -e 's/libDataFormatsTestObjectsParent1.so/libDataFormatsTestObjectsParent2.so/' ${CMSSW_BASE}/lib/${SCRAM_ARCH}/DataFormatsTestObjectsParent1_xr.rootmap
+
+echo "Read the file without TransientIntParentT<1> dictionary"
+cmsRun ${LOCALTOP}/src/IOPool/Input/test/PoolNoParentDictionaryTestStep2_cfg.py || die 'Failed cmsRun PoolNoParentDictionaryTestStep2_cfg.py' $?


### PR DESCRIPTION
#### PR description:

This PR limits the `BranchDescription`'s ROOT dicrionary part be initialized only if the branch is present. This change allows a job to process a file that contains products whose parent product (that is not in the file, was either transient or dropped) dictionary does not exist anymore in the job. Resolves https://github.com/cms-sw/cmssw/issues/38781.

I'm uncertain about the usefulness of the test added in this PR. It is sufficient to demonstrate that the changes of this PR work as intended, but it has some serious flaws for longer term. 

#### PR validation:

Problematic job runs, framework unit tests pass.