### PR TITLE
adding option to enable FastSim decayer functionality

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -133,13 +133,13 @@ namespace fastsim {
     const ParticleFilter* const particleFilter_;  //!< (Kinematic) cuts on the particles that have to be propagated.
     std::vector<SimTrack>* simTracks_;            //!< The generated SimTrack of this event.
     std::vector<SimVertex>* simVertices_;         //!< The generated SimVertices of this event.
-    bool useFastSimsDecayer_;     
-    double momentumUnitConversionFactor_;         //!< Convert pythia units to GeV (FastSim standard)
-    double lengthUnitConversionFactor_;           //!< Convert pythia unis to cm (FastSim standard)
-    double lengthUnitConversionFactor2_;          //!< Convert pythia unis to cm^2 (FastSim standard)
-    double timeUnitConversionFactor_;             //!< Convert pythia unis to ns (FastSim standard)
+    bool useFastSimsDecayer_;
+    double momentumUnitConversionFactor_;  //!< Convert pythia units to GeV (FastSim standard)
+    double lengthUnitConversionFactor_;    //!< Convert pythia unis to cm (FastSim standard)
+    double lengthUnitConversionFactor2_;   //!< Convert pythia unis to cm^2 (FastSim standard)
+    double timeUnitConversionFactor_;      //!< Convert pythia unis to ns (FastSim standard)
     std::vector<std::unique_ptr<Particle> >
-        particleBuffer_;  //!< The vector of all secondaries that are not yet propagated in the event.       
+        particleBuffer_;  //!< The vector of all secondaries that are not yet propagated in the event.
   };
 }  // namespace fastsim
 

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -51,7 +51,8 @@ namespace fastsim {
                     double deltaRchargedMother,
                     const ParticleFilter& particleFilter,
                     std::vector<SimTrack>& simTracks,
-                    std::vector<SimVertex>& simVertices);
+                    std::vector<SimVertex>& simVertices,
+                    bool useFastSimsDecayer);
 
     //! Default destructor.
     ~ParticleManager();
@@ -132,12 +133,13 @@ namespace fastsim {
     const ParticleFilter* const particleFilter_;  //!< (Kinematic) cuts on the particles that have to be propagated.
     std::vector<SimTrack>* simTracks_;            //!< The generated SimTrack of this event.
     std::vector<SimVertex>* simVertices_;         //!< The generated SimVertices of this event.
+    bool useFastSimsDecayer_;     
     double momentumUnitConversionFactor_;         //!< Convert pythia units to GeV (FastSim standard)
     double lengthUnitConversionFactor_;           //!< Convert pythia unis to cm (FastSim standard)
     double lengthUnitConversionFactor2_;          //!< Convert pythia unis to cm^2 (FastSim standard)
     double timeUnitConversionFactor_;             //!< Convert pythia unis to ns (FastSim standard)
     std::vector<std::unique_ptr<Particle> >
-        particleBuffer_;  //!< The vector of all secondaries that are not yet propagated in the event.
+        particleBuffer_;  //!< The vector of all secondaries that are not yet propagated in the event.       
   };
 }  // namespace fastsim
 

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -295,7 +295,8 @@ void FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
         LogDebug(MESSAGECATEGORY) << "Decaying particle...";
         std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-        if(useFastSimsDecayer) decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
+        if (useFastSimsDecayer)
+          decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
         LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
         particleManager.addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
         continue;
@@ -507,7 +508,8 @@ FSimTrack FastSimProducer::createFSimTrack(fastsim::Particle* particle,
   if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
     LogDebug(MESSAGECATEGORY) << "Decaying particle...";
     std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-    if (useFastSimsDecayer) decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
+    if (useFastSimsDecayer)
+      decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
     LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
     particleManager->addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
   }

--- a/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/plugins/FastSimProducer.cc
@@ -87,6 +87,7 @@ private:
   edm::ESWatcher<CaloTopologyRecord> watchCaloTopology_;
   std::unique_ptr<CalorimetryManager> myCalorimetry;  // unfortunately, default constructor cannot be called
   bool simulateMuons;
+  bool useFastSimsDecayer;
 
   fastsim::Decayer decayer_;  //!< Handles decays of non-stable particles using pythia
   std::vector<std::unique_ptr<fastsim::InteractionModel> > interactionModels_;  //!< All defined interaction models
@@ -109,6 +110,7 @@ FastSimProducer::FastSimProducer(const edm::ParameterSet& iConfig)
       _randomEngine(nullptr),
       simulateCalorimetry(iConfig.getParameter<bool>("simulateCalorimetry")),
       simulateMuons(iConfig.getParameter<bool>("simulateMuons")),
+      useFastSimsDecayer(iConfig.getParameter<bool>("useFastSimsDecayer")),
       particleDataTableESToken_(esConsumes()) {
   if (simulateCalorimetry) {
     caloGeometryESToken_ = esConsumes();
@@ -196,7 +198,8 @@ void FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
                                            deltaRchargedMother_,
                                            particleFilter_,
                                            *simTracks_,
-                                           *simVertices_);
+                                           *simVertices_,
+                                           useFastSimsDecayer);
 
   //  Initialize the calorimeter geometry
   if (simulateCalorimetry) {
@@ -292,7 +295,7 @@ void FastSimProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
       if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
         LogDebug(MESSAGECATEGORY) << "Decaying particle...";
         std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-        decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
+        if(useFastSimsDecayer) decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
         LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
         particleManager.addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
         continue;
@@ -504,7 +507,7 @@ FSimTrack FastSimProducer::createFSimTrack(fastsim::Particle* particle,
   if (!particle->isStable() && particle->remainingProperLifeTimeC() < 1E-10) {
     LogDebug(MESSAGECATEGORY) << "Decaying particle...";
     std::vector<std::unique_ptr<fastsim::Particle> > secondaries;
-    decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
+    if (useFastSimsDecayer) decayer_.decay(*particle, secondaries, _randomEngine->theEngine());
     LogDebug(MESSAGECATEGORY) << "   decay has " << secondaries.size() << " products";
     particleManager->addSecondaries(particle->position(), particle->simTrackIndex(), secondaries);
   }

--- a/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
+++ b/FastSimulation/SimplifiedGeometryPropagator/python/fastSimProducer_cff.py
@@ -13,6 +13,7 @@ fastSimProducer = cms.EDProducer(
     trackerDefinition = TrackerMaterialBlock.TrackerMaterial,
     simulateCalorimetry = cms.bool(True),
     simulateMuons = cms.bool(True),
+    useFastSimsDecayer = cms.bool(False),
     caloDefinition = CaloMaterialBlock.CaloMaterial, #  Hack to interface "old" calorimetry with "new" propagation in tracker
     beamPipeRadius = cms.double(3.),
     deltaRchargedMother = cms.double(0.02), # Maximum angle to associate a charged daughter to a charged mother (mostly done to associate muons to decaying pions)

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -20,7 +20,8 @@ fastsim::ParticleManager::ParticleManager(const HepMC::GenEvent& genEvent,
                                           double deltaRchargedMother,
                                           const fastsim::ParticleFilter& particleFilter,
                                           std::vector<SimTrack>& simTracks,
-                                          std::vector<SimVertex>& simVertices)
+                                          std::vector<SimVertex>& simVertices,
+                                          bool useFastSimsDecayer)
     : genEvent_(&genEvent),
       genParticleIterator_(genEvent_->particles_begin()),
       genParticleEnd_(genEvent_->particles_end()),
@@ -30,7 +31,8 @@ fastsim::ParticleManager::ParticleManager(const HepMC::GenEvent& genEvent,
       deltaRchargedMother_(deltaRchargedMother),
       particleFilter_(&particleFilter),
       simTracks_(&simTracks),
-      simVertices_(&simVertices)
+      simVertices_(&simVertices),
+      useFastSimsDecayer_(useFastSimsDecayer)
       // prepare unit convsersions
       //  --------------------------------------------
       // |          |      hepmc               |  cms |
@@ -218,7 +220,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     int exoticRelativeId = 0;
     const bool producedWithinBeamPipe =
         productionVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_;
-    if (!producedWithinBeamPipe) {
+    if (!producedWithinBeamPipe && useFastSimsDecayer_) {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
       if (!isExotic(exoticRelativeId)) {
         continue;
@@ -233,7 +235,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     }
 
     // SM particles that descend from exotics and cross the beam pipe radius should make hits but not be decayed
-    if (producedWithinBeamPipe && !decayedWithinBeamPipe) {
+    if (producedWithinBeamPipe && !decayedWithinBeamPipe && useFastSimsDecayer_) {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
     }
 


### PR DESCRIPTION
This PR creates an option to enable the FastSim decayer functionality, which was previously enabled without an option. The decayer has been found to have been responsible for considerable mismodeling in the missing ET, a known issue with a heavy-handed correction procedure developed by and adopted by the SUS PAG. The impact of the FastSim decayer on physics was recently studied and presented in the simulation meeting [1]. 


[1] https://indico.cern.ch/event/1182398/contributions/4967736/attachments/2480801/4258724/Sim15July2022_Decayer.pdf

Adopting the GEN decays has many advantages, including the guaranteed synchronization of decay modes btw the generator and simulation steps, the universal ability to allow for the decays of exotic particles without analyzing the family tree of every particle, and avoiding any unforeseen consequences of switching generators, e.g., from Pythia8 to Herwig. Most importantly, defaulting to the GEN decays was seen to improve the modeling of MET and other observables in FastSim significantly, while any bad impacts are for the most part minor [2][3]



The SUSY-derived FastSim MET correction may no longer be necessary, but it is up to PAGs to assess any treatment/uncertainties they think are appropriate for their analyses. It would also be advisable to backport this default behavior to the Run 2 UL release, CMSSW_10_6_X for any future campaigns. 

#### PR validation:

[ALT_0] is the new FastSim:
[2] https://www.desy.de/~beinsam/FastSim/Nano/6July2022/TTbar_12_2_XDev/index.html
[3] https://www.desy.de/~beinsam/FastSim/Nano/6July2022/T1tttt_12_2_XDev/index.html
