### PR TITLE
Modify HG PCL Alignment movement histograms for use in the DQM GUI

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -73,34 +73,34 @@ void MillePedeDQMModule ::bookHistograms(DQMStore::IBooker& booker) {
     for (const auto& layer : layerVec) {
       h_xPos_HG[layer.first] = booker.book1D("Xpos_HG_" + layer.first,
                                              "Alignment fit #DeltaX for " + layer.first + ";;#mum",
-                                             layer.second+5,
+                                             layer.second + 5,
                                              0.,
-                                             layer.second+5);
+                                             layer.second + 5);
       h_xRot_HG[layer.first] = booker.book1D("Xrot_HG_" + layer.first,
                                              "Alignment fit #Delta#theta_{X} for " + layer.first + ";;#murad",
-                                             layer.second+5,
+                                             layer.second + 5,
                                              0.,
-                                             layer.second+5);
+                                             layer.second + 5);
       h_yPos_HG[layer.first] = booker.book1D("Ypos_HG_" + layer.first,
                                              "Alignment fit #DeltaY for " + layer.first + ";;#mum",
-                                             layer.second+5,
+                                             layer.second + 5,
                                              0.,
-                                             layer.second+5);
+                                             layer.second + 5);
       h_yRot_HG[layer.first] = booker.book1D("Yrot_HG_" + layer.first,
                                              "Alignment fit #Delta#theta_{Y} for " + layer.first + ";;#murad",
-                                             layer.second+5,
+                                             layer.second + 5,
                                              0.,
-                                             layer.second+5);
+                                             layer.second + 5);
       h_zPos_HG[layer.first] = booker.book1D("Zpos_HG_" + layer.first,
                                              "Alignment fit #DeltaZ for " + layer.first + ";;#mum",
-                                             layer.second+5,
+                                             layer.second + 5,
                                              0.,
-                                             layer.second+5);
+                                             layer.second + 5);
       h_zRot_HG[layer.first] = booker.book1D("Zrot_HG_" + layer.first,
                                              "Alignment fit #Delta#theta_{Z} for " + layer.first + ";;#murad",
-                                             layer.second+5,
+                                             layer.second + 5,
                                              0.,
-                                             layer.second+5);
+                                             layer.second + 5);
     }
 
     statusResults =
@@ -410,57 +410,55 @@ void MillePedeDQMModule ::fillExpertHisto_HG(std::map<std::string, MonitorElemen
                                              const std::array<double, SIZE_HG_STRUCTS>& obsErr) {
   int currentStart = 0;
   int bin = 0;
-  double max_=0;
-  
+  double max_ = 0;
+
   for (const auto& layer : layerVec) {
     TH1F* histo_0 = histo_map[layer.first]->getTH1F();
-    
+
     max_ = -1;
     for (int i = currentStart; i < (currentStart + layer.second); ++i) {
       // first obs.size() bins for observed movements
       bin = i - currentStart + 1;
-      
+
       // fill observed values
       histo_0->SetBinContent(bin, obs[i]);
-      histo_0->SetBinError(bin, obsErr[i]);   
-      
-      if (std::abs(obs[i]) > max_){
+      histo_0->SetBinError(bin, obsErr[i]);
+
+      if (std::abs(obs[i]) > max_) {
         max_ = std::abs(obs[i]);
       }
-      
-    }    
-    
+    }
+
     // five extra bins at the end, one empty, one with threshold, one with sigCut, one with maxMoveCut, one with MaxErrorCut
-    histo_0->SetBinContent(bin+1, 0);
-    histo_0->SetBinError(bin+1, 0);
-    
+    histo_0->SetBinContent(bin + 1, 0);
+    histo_0->SetBinError(bin + 1, 0);
+
     int detIndex;
-    if (layer.first.find("Disk") != std::string::npos){ 
+    if (layer.first.find("Disk") != std::string::npos) {
       // 7 is the detId for panels, see getIndexFromString
       detIndex = 7;
       histo_0->GetXaxis()->SetTitle("Panel");
-    }else{
+    } else {
       // 6 is the detId for ladders, see getIndexFromString
       detIndex = 6;
       histo_0->GetXaxis()->SetTitle("Ladder");
     }
-    
-    histo_0->SetBinContent(bin+2, cut[detIndex]); 
-    histo_0->SetBinError(bin+2, 0);
-    histo_0->SetBinContent(bin+3, sigCut[detIndex]); 
-    histo_0->SetBinError(bin+3, 0);
-    histo_0->SetBinContent(bin+4, maxMoveCut[detIndex]); 
-    histo_0->SetBinError(bin+4, 0);
-    histo_0->SetBinContent(bin+5, maxErrorCut[detIndex]); 
-    histo_0->SetBinError(bin+5, 0);
-    
+
+    histo_0->SetBinContent(bin + 2, cut[detIndex]);
+    histo_0->SetBinError(bin + 2, 0);
+    histo_0->SetBinContent(bin + 3, sigCut[detIndex]);
+    histo_0->SetBinError(bin + 3, 0);
+    histo_0->SetBinContent(bin + 4, maxMoveCut[detIndex]);
+    histo_0->SetBinError(bin + 4, 0);
+    histo_0->SetBinContent(bin + 5, maxErrorCut[detIndex]);
+    histo_0->SetBinError(bin + 5, 0);
+
     // always scale so the cutoff is visible
-    max_ = std::max(cut[detIndex]*1.2, max_);
-    
+    max_ = std::max(cut[detIndex] * 1.2, max_);
+
     histo_0->SetMinimum(-(max_)*1.2);
-    histo_0->SetMaximum(max_*1.2);
-    
-    
+    histo_0->SetMaximum(max_ * 1.2);
+
     currentStart += layer.second;
   }
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MillePedeDQMModule.cc
@@ -73,34 +73,34 @@ void MillePedeDQMModule ::bookHistograms(DQMStore::IBooker& booker) {
     for (const auto& layer : layerVec) {
       h_xPos_HG[layer.first] = booker.book1D("Xpos_HG_" + layer.first,
                                              "Alignment fit #DeltaX for " + layer.first + ";;#mum",
-                                             layer.second,
+                                             layer.second+5,
                                              0.,
-                                             layer.second);
+                                             layer.second+5);
       h_xRot_HG[layer.first] = booker.book1D("Xrot_HG_" + layer.first,
                                              "Alignment fit #Delta#theta_{X} for " + layer.first + ";;#murad",
-                                             layer.second,
+                                             layer.second+5,
                                              0.,
-                                             layer.second);
+                                             layer.second+5);
       h_yPos_HG[layer.first] = booker.book1D("Ypos_HG_" + layer.first,
                                              "Alignment fit #DeltaY for " + layer.first + ";;#mum",
-                                             layer.second,
+                                             layer.second+5,
                                              0.,
-                                             layer.second);
+                                             layer.second+5);
       h_yRot_HG[layer.first] = booker.book1D("Yrot_HG_" + layer.first,
                                              "Alignment fit #Delta#theta_{Y} for " + layer.first + ";;#murad",
-                                             layer.second,
+                                             layer.second+5,
                                              0.,
-                                             layer.second);
+                                             layer.second+5);
       h_zPos_HG[layer.first] = booker.book1D("Zpos_HG_" + layer.first,
                                              "Alignment fit #DeltaZ for " + layer.first + ";;#mum",
-                                             layer.second,
+                                             layer.second+5,
                                              0.,
-                                             layer.second);
+                                             layer.second+5);
       h_zRot_HG[layer.first] = booker.book1D("Zrot_HG_" + layer.first,
                                              "Alignment fit #Delta#theta_{Z} for " + layer.first + ";;#murad",
-                                             layer.second,
+                                             layer.second+5,
                                              0.,
-                                             layer.second);
+                                             layer.second+5);
     }
 
     statusResults =
@@ -196,10 +196,10 @@ void MillePedeDQMModule ::fillStatusHistoHG(MonitorElement* statusHisto) {
   TH2F* histo_status = statusHisto->getTH2F();
   auto& theResults = mpReader_->getResultsHG();
   histo_status->GetXaxis()->SetBinLabel(1, "#DeltaX");
-  histo_status->GetXaxis()->SetBinLabel(2, "#Delta#theta_{X}");
-  histo_status->GetXaxis()->SetBinLabel(3, "#DeltaY");
-  histo_status->GetXaxis()->SetBinLabel(4, "#Delta#theta_{Y}");
-  histo_status->GetXaxis()->SetBinLabel(5, "#DeltaZ");
+  histo_status->GetXaxis()->SetBinLabel(2, "#DeltaY");
+  histo_status->GetXaxis()->SetBinLabel(3, "#DeltaZ");
+  histo_status->GetXaxis()->SetBinLabel(4, "#Delta#theta_{X}");
+  histo_status->GetXaxis()->SetBinLabel(5, "#Delta#theta_{Y}");
   histo_status->GetXaxis()->SetBinLabel(6, "#Delta#theta_{Z}");
 
   int i = 0;
@@ -409,16 +409,58 @@ void MillePedeDQMModule ::fillExpertHisto_HG(std::map<std::string, MonitorElemen
                                              const std::array<double, SIZE_HG_STRUCTS>& obs,
                                              const std::array<double, SIZE_HG_STRUCTS>& obsErr) {
   int currentStart = 0;
-
+  int bin = 0;
+  double max_=0;
+  
   for (const auto& layer : layerVec) {
     TH1F* histo_0 = histo_map[layer.first]->getTH1F();
-
+    
+    max_ = -1;
     for (int i = currentStart; i < (currentStart + layer.second); ++i) {
       // first obs.size() bins for observed movements
-      int bin = i - currentStart + 1;
+      bin = i - currentStart + 1;
+      
+      // fill observed values
       histo_0->SetBinContent(bin, obs[i]);
-      histo_0->SetBinError(bin, obsErr[i]);
+      histo_0->SetBinError(bin, obsErr[i]);   
+      
+      if (std::abs(obs[i]) > max_){
+        max_ = std::abs(obs[i]);
+      }
+      
+    }    
+    
+    // five extra bins at the end, one empty, one with threshold, one with sigCut, one with maxMoveCut, one with MaxErrorCut
+    histo_0->SetBinContent(bin+1, 0);
+    histo_0->SetBinError(bin+1, 0);
+    
+    int detIndex;
+    if (layer.first.find("Disk") != std::string::npos){ 
+      // 7 is the detId for panels, see getIndexFromString
+      detIndex = 7;
+      histo_0->GetXaxis()->SetTitle("Panel");
+    }else{
+      // 6 is the detId for ladders, see getIndexFromString
+      detIndex = 6;
+      histo_0->GetXaxis()->SetTitle("Ladder");
     }
+    
+    histo_0->SetBinContent(bin+2, cut[detIndex]); 
+    histo_0->SetBinError(bin+2, 0);
+    histo_0->SetBinContent(bin+3, sigCut[detIndex]); 
+    histo_0->SetBinError(bin+3, 0);
+    histo_0->SetBinContent(bin+4, maxMoveCut[detIndex]); 
+    histo_0->SetBinError(bin+4, 0);
+    histo_0->SetBinContent(bin+5, maxErrorCut[detIndex]); 
+    histo_0->SetBinError(bin+5, 0);
+    
+    // always scale so the cutoff is visible
+    max_ = std::max(cut[detIndex]*1.2, max_);
+    
+    histo_0->SetMinimum(-(max_)*1.2);
+    histo_0->SetMaximum(max_*1.2);
+    
+    
     currentStart += layer.second;
   }
 }


### PR DESCRIPTION
#### PR description:

This PR is in preparation of style changes for the movement histograms displayed in the DQM GUI. This includes the following changes:
- Fixing the order of labels in the status histogram to correctly match the variables
- Adding 5 Additional bins to each movement histogram. The first additional bin is empty, the other ones include cut values on movement threshold, significance, maximum error, and maximum movement. These can be read out in the DQM GUI.


#### PR validation:

Mille & Pede steps were execute to produce ROOT files usable by the DQM GUI. It was confirmed that the changes to the histograms are as intended.

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

Will probably have to be backported to 12_4_X.
