### PR TITLE
`SiStripHitEfficiencyWorker`: sanitize histogram names to avoid DQM Offline GUI indexing problem with `ALCAPROMPT` datasets

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/SiStripHitEfficiencyHelpers.h
@@ -23,6 +23,16 @@ namespace {
     k_END_OF_LAYS_AND_RINGS = 35
   };
 
+  inline void replaceInString(std::string& str, const std::string& from, const std::string& to) {
+    if (from.empty())
+      return;
+    size_t start_pos = 0;
+    while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+      str.replace(start_pos, from.length(), to);
+      start_pos += to.length();  // In case 'to' contains 'from', like replacing 'x' with 'yx'
+    }
+  }
+
   inline unsigned int checkLayer(unsigned int iidd, const TrackerTopology* tTopo) {
     switch (DetId(iidd).subdetId()) {
       case SiStripSubdetector::TIB:


### PR DESCRIPTION
resolves https://github.com/cms-sw/cmssw/issues/38814

#### PR description:

In issue https://github.com/cms-sw/cmssw/issues/38814 it was reported that the dataset `/StreamExpress/Run2022C-PromptCalibProdSiStripHitEff-Express-v1/ALCAPROMPT` (run numbers 355807-355942) is not registered in the Offline DQM GUI.  The rootfiles are available on DQM machines (see https://cmsweb.cern.ch/dqm/offline/data/browse/ROOT/OfflineData/Run2022/StreamExpress/0003559xx/ ) but they have not been registered in the DQM Offline GUI database. From log files, it was found that the registration failed with following error:

```console
/data/srv/state/dqmgui/offline/data/OfflineData/Run2022/StreamExpress/0003558xx/DQM_V0001_R000355869__StreamExpress__Run2022C-PromptCalibProdSiStripHitEff-Express-v1__ALCAPROMPT.root: error reading file: DQMStore: Monitor element path name 'TEC+1: Map of missing hits' uses unacceptable characters
2022-07-20 01:19:31.380953 [visDQMImportDaemon/2757] imported /data/srv/state/dqmgui/offline/data/OfflineData/Run2022/StreamExpress/0003558xx/DQM_V0001_R000355869__StreamExpress__Run2022C-PromptCalibProdSiStripHitEff-Ex
press-v1__ALCAPROMPT.root with status 256 in 0.566s
2022-07-20 01:19:31.381240 [visDQMImportDaemon/2757] command failed with exit code 256
```

This PR sanitizes the offending histogram path names to avoid using prohibited characters, in order to be able to upload to the GUI.

#### PR validation:

Run in `CMSSW_12_4_3`:

```console
cmsDriver.py testReAlCa -s ALCA:PromptCalibProdSiStripHitEff --conditions 123X_dataRun2_v2 --scenario pp --data --era Run2_2018 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 10000 --dasquery='file dataset=/StreamExpress/Run2018D-SiStripCalMinBias-Express-v1/ALCARECO run=325172' --nThreads=4
```
followed by:

```console
cmsDriver.py stepHarvest -s ALCAHARVEST:SiStripHitEff --conditions 123X_dataRun2_v2 --scenario pp --data --era Run2_2018 --filein file:PromptCalibProdSiStripHitEff.root -n -1
```
and obtained a ROOT file with the following histograms naming:

![Screenshot from 2022-07-21 18-15-40](https://user-images.githubusercontent.com/5082376/180263302-fc39c5fc-13de-482c-a0cf-11836863f855.png)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport but will need to be backported to 12.4.X