### PR TITLE
Fix VtxSmearing parameters for 2022 Run 3 MC

### DIFF
--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -796,10 +796,10 @@ Realistic25ns900GeV2021CollisionVtxSmearingParameters = cms.PSet(
 # From LHC calculator, emittance is 6.621e-8 cm
 # https://lpc.web.cern.ch/lumiCalc.html
 #
-# BPIX absolute position (https://twiki.cern.ch/twiki/bin/view/CMS/TkAlignmentPixelPosition?rev=42#2022):
-# X = -0.01955 cm
-# Y = -0.1583  cm
-# Z = -0.2626  cm
+# BPIX absolute position (https://twiki.cern.ch/twiki/bin/view/CMS/TkAlignmentPixelPosition?rev=45#Collisions_at_s_13_6_TeV):
+# X =  0.0717651 cm
+# Y = -0.165951  cm
+# Z = -0.356345  cm
 Realistic25ns13p6TeVEarly2022CollisionVtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),
     BetaStar = cms.double(30.0),
@@ -807,9 +807,9 @@ Realistic25ns13p6TeVEarly2022CollisionVtxSmearingParameters = cms.PSet(
     Alpha = cms.double(0.0),
     SigmaZ = cms.double(3.8),
     TimeOffset = cms.double(0.0),
-    X0 = cms.double(0.191944),
-    Y0 = cms.double(-0.022646),
-    Z0 = cms.double(1.20441)
+    X0 = cms.double(0.100629),
+    Y0 = cms.double(-0.014995),
+    Z0 = cms.double(1.298155)
 )
 
 # Test HF offset


### PR DESCRIPTION
#### PR description:
As reported in this [CMSTalk post](https://cms-talk.web.cern.ch/t/correction-of-bpix-barycentre-values-for-2021-and-2022/13150) the position of the BPIX barycenter reported in [this Twiki](https://twiki.cern.ch/twiki/bin/viewauth/CMS/TkAlignmentPixelPosition) was previously wrong for 2021 and 2022, while it has now been fixed starting from `rev=45` of the twiki.
In CMSSW the BPIX barycenter directly affects the vertex smearing positions which are computed as:
```
BeamSpot position - BPIX barycenter
```

This PR updates the VtxSmearing parameters of the `Realistic25ns13p6TeVEarly2022CollisionVtxSmearingParameters` scenario tu use to correct BPIX barycenter for 2022.

#### PR validation:
Code compiles

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport but a 12_4_X backport will be opened soon.

FYI @cms-sw/tracking-pog-l2 @cms-sw/trk-dpg-l2 @cms-sw/alca-l2 @cms-sw/pdmv-l2 @rappoccio @dzuolo