### PR TITLE
throw in `IBooker::bookME` when illegal characters for the DQM GUI upload are encountered

### DIFF
--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -13,6 +13,10 @@
 
 namespace dqm::implementation {
 
+  // list of acceptable characters for ME path names, in order to be able to upload to the CMS DQM GUI
+  // See https://github.com/cms-DQM/dqmgui_prod/blob/af0a388e8f57c60e51111585d298aeeea943367f/src/cpp/DQM/DQMStore.cc#L56
+  static const std::string s_safe = "/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+=_()# ";
+
   std::string NavigatorBase::pwd() {
     if (cwd_.empty()) {
       return "";
@@ -66,6 +70,13 @@ namespace dqm::implementation {
                                   bool forceReplace /* = false */) {
     MonitorElementData::Path path;
     std::string fullpath = cwd_ + std::string(name.View());
+
+    if (fullpath.find_first_not_of(s_safe) != std::string::npos) {
+      throw cms::Exception("BadMonitorElementPathName")
+          << " Monitor element path name: '" << fullpath.c_str() << "' uses unacceptable characters."
+          << "\n Acceptable characters are: " << s_safe.c_str();
+    }
+
     path.set(fullpath, MonitorElementData::Path::Type::DIR_AND_NAME);
 
     // We should check if there is a local ME for this module and name already.


### PR DESCRIPTION
#### PR description:

Title says it all, early detection of `MonitorElement` path names that will have troubles indexing in the CMS Offline DQM GUI database, as per suggestion at https://github.com/cms-sw/cmssw/issues/38814#issuecomment-1192276227

#### PR validation:

`cmssw` compiles.
Tested by running:

```console
cmsDriver.py testReAlCa -s ALCA:PromptCalibProdSiStripHitEff --conditions 123X_dataRun2_v2 --scenario pp --data --era Run2_2018 --datatier ALCARECO --eventcontent ALCARECO --processName=ReAlCa -n 10000 --dasquery='file dataset=/StreamExpress/Run2018D-SiStripCalMinBias-Express-v1/ALCARECO run=325172' --nThreads=4
```

in `CMSSW_12_5_X_2022-07-21-2300` (which does not contain https://github.com/cms-sw/cmssw/pull/38823) and obtained
```
----- Begin Fatal Exception 22-Jul-2022 14:16:55 CEST-----------------------
An exception of category 'BadMonitorElementPathName' occurred while
   [0] Processing  stream begin Run run: 325172 stream: 3
   [1] Calling method for module SiStripHitEfficiencyWorker/'ALCARECOSiStripHitEff'
Exception Message:
 Monitor element path name: 'AlCaReco/SiStripHitEfficiency/MissingHits/TIB1: Map of missing hits' uses unacceptable characters.
 Acceptable characters are: /ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+=_()# 
----- End Fatal Exception -------------------------------------------------
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A