### PR TITLE
Save EDMNANO in EcalPhiSymRecoSequence

### DIFF
--- a/Calibration/EcalCalibAlgos/python/EcalPhiSymRecoSequence_cff.py
+++ b/Calibration/EcalCalibAlgos/python/EcalPhiSymRecoSequence_cff.py
@@ -66,7 +66,7 @@ def ecal_phisym_flattables(process, produce_by_run : bool=False):
     """
 
     process.load('Calibration.EcalCalibAlgos.EcalPhiSymFlatTableProducers_cfi')
-    
+
     nmis = process.EcalPhiSymRecHitProducerRun.nMisCalib.value()
     for imis in range(1, nmis+1):
         # get the naming and indexing right.
@@ -169,5 +169,7 @@ def customise(process):
         process.schedule.remove(process.ALCARECOStreamEcalPhiSymByRunOutPath)
     if "ALCARECOStreamEcalPhiSymByLumiOutPath" in process.pathNames():
         process.schedule.remove(process.ALCARECOStreamEcalPhiSymByLumiOutPath)
+    process.ALCARECOStreamEcalPhiSymOutNanoPath = cms.EndPath(ecal_phisym_output(process, save_edm=False, save_edmnano=True, save_flatnano=False)[0])
+    process.schedule.append(process.ALCARECOStreamEcalPhiSymOutNanoPath)
 
     return process


### PR DESCRIPTION
#### PR description:

Follow-up to https://github.com/dmwm/T0/pull/4664
The EDMNANO files were empty, this PR changes the costumization so it saves the EDMNANO output.

#### PR validation:
```
cmsrel CMSSW_12_5_X_2022-07-22-1100
cd CMSSW_12_5_X_2022-07-22-1100/src/
cmsenv
git cms-addpkg Calibration/EcalCalibAlgos
git cms-addpkg Configuration/DataProcessing
xrdcp root://cms-xrd-global.cern.ch//store/backfill/1/data/Tier0_REPLAY_2022/AlCaPhiSym/RAW/v1907/000/346/512/00000/d3a50f06-9dc2-4e39-9c3d-249e8f1f9dfe.root .
mv d3a50f06-9dc2-4e39-9c3d-249e8f1f9dfe.root input.root
python3 Configuration/DataProcessing/test/RunPromptReco.py --lfn=file:input.root --alcareco EcalPhiSymByRun --global-tag 124X_dataRun3_Prompt_v4
cmsRun -e RunPromptRecoCfg.py
root output.root
Runs->Print()
```
gives the correct EDMNANO content, verified by the experts @simonepigazzini 


I also ran ` runTheMatrix.py -l 139.005`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Need to backport to 12_4_X