### PR TITLE
Inherit AlCaPPS_Run3 from AlCa

### DIFF
--- a/Configuration/DataProcessing/python/Impl/AlCaPPS_Run3.py
+++ b/Configuration/DataProcessing/python/Impl/AlCaPPS_Run3.py
@@ -11,11 +11,12 @@ import os
 import sys
 
 from Configuration.DataProcessing.Scenario import *
+from Configuration.DataProcessing.Impl.AlCa import AlCa
 from Configuration.DataProcessing.Utils import stepALCAPRODUCER,dqmIOSource,harvestingMode,dictIO,gtNameAndConnect,addMonitoring
 from Configuration.Eras.Era_Run3_cff import Run3
 import FWCore.ParameterSet.Config as cms
 
-class AlCaPPS_Run3(Scenario):
+class AlCaPPS_Run3(AlCa):
     def __init__(self):
         Scenario.__init__(self)
         self.eras=Run3


### PR DESCRIPTION
#### PR description:

Recent failure at T0 revealed that `AlCaPPS_Run3` was missing some functions, this PR fixes that.

#### PR validation:
```
python3 Configuration/DataProcessing/test/RunRepack.py --lfn file /eos/cms/store/t0streamer/Data/ALCAPPS/000/355/559/run355559_ls0012_streamALCAPPS_StorageManager.dat 
python3 Configuration/DataProcessing/test/RunExpressProcessing.py --scenario AlCaPPS_Run3 --global-tag 123X_dataRun3_Express_v10 --lfn file:write_PrimDS1_RAW.root --alcareco PPSCalMaxTracks
python3 Configuration/DataProcessing/test/RunAlcaSkimming.py --scenario AlCaPPS_Run3 --global-tag 123X_dataRun3_Prompt_v12 --lfn=file:output.root --skims PromptCalibProdPPSTimingCalib
python3 Configuration/DataProcessing/test/RunAlcaHarvesting.py --scenario AlCaPPS_Run3 --global-tag 123X_dataRun3_Prompt_v12 --lfn=file:output.root --alcapromptdataset PromptCalibProdPPSTimingCalib --dataset /A/B/C
```
leads to
```
Dataset: /A/B/C
Traceback (most recent call last):
  File "/build/tvami/AlCaDBPRs/PPSScenarioFix/CMSSW_12_5_X_2022-07-22-1100/src/Configuration/DataProcessing/test/RunAlcaHarvesting.py", line 71, in __call__
    process = scenario.alcaHarvesting(self.globalTag, self.dataset, **kwds)
  File "/cvmfs/cms-ib.cern.ch/week0/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_5_X_2022-07-22-1100/src/Configuration/DataProcessing/python/Scenario.py", line 153, in alcaHarvesting
    raise NotImplementedError(msg)
NotImplementedError: Scenario Implementation AlCaPPS_Run3
Does not contain an implementation for alcaHarvesting

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/build/tvami/AlCaDBPRs/PPSScenarioFix/CMSSW_12_5_X_2022-07-22-1100/src/Configuration/DataProcessing/test/RunAlcaHarvesting.py", line 148, in <module>
    harvester()
  File "/build/tvami/AlCaDBPRs/PPSScenarioFix/CMSSW_12_5_X_2022-07-22-1100/src/Configuration/DataProcessing/test/RunAlcaHarvesting.py", line 76, in __call__
    raise RuntimeError(msg)
RuntimeError: Error creating AlcaHarvesting config:
Scenario Implementation AlCaPPS_Run3
Does not contain an implementation for alcaHarvestin
```
w/o this PR.

After this PR it runs fine.

Unit test also works.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but needs to go back to 12_4_X