### PR TITLE
122nano and boosted tau

### DIFF
--- a/Configuration/Eras/python/Modifier_run3_nanoAOD_122_cff.py
+++ b/Configuration/Eras/python/Modifier_run3_nanoAOD_122_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+run3_nanoAOD_122 = cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -75,7 +75,8 @@ class Eras (object):
                            'trackingLowPU', 'trackingPhase1', 'ctpps', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2021', 'trackingPhase2PU140','highBetaStar_2018',
                            'tracker_apv_vfp30_2016', 'pf_badHcalMitigationOff', 'run2_miniAOD_80XLegacy','run2_miniAOD_94XFall17', 'run2_nanoAOD_92X',
                            'run2_nanoAOD_94XMiniAODv1', 'run2_nanoAOD_94XMiniAODv2', 'run2_nanoAOD_94X2016',
-                           'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1', 'run2_nanoAOD_106Xv1', 'run2_nanoAOD_106Xv2', 'run3_nanoAOD_devel',
+                           'run2_miniAOD_devel', 'run2_nanoAOD_102Xv1', 'run2_nanoAOD_106Xv1', 'run2_nanoAOD_106Xv2',
+                           'run3_nanoAOD_devel', 'run3_nanoAOD_122',
                            'hcalHardcodeConditions', 'hcalSkipPacker',
                            'run2_HLTconditions_2016','run2_HLTconditions_2017','run2_HLTconditions_2018',
                            'bParking']

--- a/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
+++ b/PhysicsTools/NanoAOD/python/boostedTaus_cff.py
@@ -106,7 +106,7 @@ boostedTauTablesTask = cms.Task(boostedTauTable)
 boostedTauMCTask = cms.Task(boostedTausMCMatchLepTauForTable,boostedTausMCMatchHadTauForTable,boostedTauMCTable)
 
 #remove boosted tau from previous eras
-_modifiers = (run2_miniAOD_80XLegacy | run2_nanoAOD_92X | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1)
+_modifiers = (run2_miniAOD_80XLegacy | run2_nanoAOD_92X | run2_nanoAOD_94XMiniAODv1 | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1 | run3_nanoAOD_122)
 (_modifiers).toReplaceWith(boostedTauTask,cms.Task())
 (_modifiers).toReplaceWith(boostedTauTablesTask,cms.Task())
 (_modifiers).toReplaceWith(boostedTauMCTask,cms.Task())

--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -21,6 +21,7 @@ from Configuration.Eras.Modifier_run2_nanoAOD_106Xv2_cff import run2_nanoAOD_106
 from Configuration.Eras.Modifier_tracker_apv_vfp30_2016_cff import tracker_apv_vfp30_2016
 
 from Configuration.Eras.Modifier_run3_nanoAOD_devel_cff import run3_nanoAOD_devel
+from Configuration.Eras.Modifier_run3_nanoAOD_122_cff import run3_nanoAOD_122
 
 run2_nanoAOD_ANY = (
     run2_miniAOD_80XLegacy | run2_nanoAOD_92X | run2_nanoAOD_94X2016 | run2_nanoAOD_94XMiniAODv1 |  run2_nanoAOD_94XMiniAODv2 | run2_nanoAOD_102Xv1 | run2_nanoAOD_106Xv1 | run2_nanoAOD_106Xv2


### PR DESCRIPTION
Add modifier to produce nanoV10 out of the Run3Winter22MiniAOD campaign initiated with the CMSSW_12_2_3_patch1 release.

boosted-tau ID in MINI changed along the way and are not consistent.
Disabled as are not needed for the early analyses.

Production can be called as follow:

For early Run3 MC
--era Run3,run3_nanoAOD_122 --customise="PhysicsTools/NanoAOD/V10/nano_cff.nanoAOD_customizeV10"

Prompt 12_4 data{*}  and real MC Run3 campaign
--era Run3  --customise="PhysicsTools/NanoAOD/V10/nano_cff.nanoAOD_customizeV10"

{*} https://cms-talk.web.cern.ch/t/t0-production-node-configuration-change-to-cmssw-12-4-3-and-era-run2022c/13003


+++++++++ validated with 

`cmsDriver.py mc122Xrun3_v10 -n 10 --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --conditions auto:phase1_2022_realistic --step NANO --nThreads 1 --era Run3,run3_nanoAOD_122 --filein file:/tmp/dalfonso/5e00dedb-ac7b-4762-9d11-09647a813285.root --fileout file:nano_mc122Xrun3_v10.root --customise_commands "process.options.wantSummary = cms.untracked.bool(True)" --customise="PhysicsTools/NanoAOD/V10/nano_cff.nanoAOD_customizeV10"`

with input file 
xrdcp root://cmsxrootd.fnal.gov///store/mc/Run3Winter22MiniAOD/TTTo2J1L1Nu_CP5_13p6TeV_powheg-pythia8/MINIAODSIM/122X_mcRun3_2021_realistic_v9-v2/30000/5e00dedb-ac7b-4762-9d11-09647a813285.root .