### PR TITLE
Phase2-hgx318A Use the correct ERA for 2026D94 scenario

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C18I13M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C18I13M9_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+from Configuration.Eras.Modifier_phase2_hfnose_cff import phase2_hfnose
+
+Phase2C18I13M9 = cms.ModifierChain(Phase2C17I13M9, phase2_hfnose)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -2207,7 +2207,7 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D94',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T21',
-        'Era' : 'Phase2C17I13M9',
+        'Era' : 'Phase2C18I13M9',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
 }

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -54,7 +54,8 @@ class Eras (object):
                  'Phase2C11I13M9',
                  'Phase2C11I13T25M9',
                  'Phase2C11I13T26M9',
-                 'Phase2C17I13M9'
+                 'Phase2C17I13M9',
+                 'Phase2C18I13M9'
         ]
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',


### PR DESCRIPTION
#### PR description:

Use the correct ERA for 2026D94 scenario

#### PR validation:

Use the runTheMatrix test workflow 41834 to check if Digi's and RecHit's for HFNose are there

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Nothing special