### PR TITLE
HLT release validation and offline DQM for EXO-LLP Run 3 HLT paths, updated to HLT menu V1.3 (2022)

### DIFF
--- a/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/DiDispStaMuonMonitor_cff.py
@@ -8,13 +8,25 @@ hltDiDispStaMuonCosmicMonitoring = hltDiDispStaMuonMonitoring.clone(
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*"]) #HLT_ZeroBias_v*
 )
 
-hltDiDispStaMuon10PromptL3Mu0VetoMonitoring = hltDiDispStaMuonMonitoring.clone(
-    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto/',
-    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v*"]) #HLT_ZeroBias_v*
+hltDiDispStaMuon10VetoL3Mu0DxyMax1cmMonitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_v*"]) #HLT_ZeroBias_v*
+)
+
+hltDiDispStaMuonL2MuL3Mu16VetoL3Mu0DxyMax1cmMonitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_v*"]) #HLT_ZeroBias_v*
+)
+
+hltDiDispStaMuon10CosmicVetoL3Mu0DxyMax1cmMonitoring = hltDiDispStaMuonMonitoring.clone(
+    FolderName = 'HLT/EXO/DiDispStaMuon/DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_v*"]) #HLT_ZeroBias_v*
 )
 
 exoHLTdispStaMuonMonitoring = cms.Sequence(
     hltDiDispStaMuonMonitoring
     + hltDiDispStaMuonCosmicMonitoring
-    + hltDiDispStaMuon10PromptL3Mu0VetoMonitoring
+    + hltDiDispStaMuon10VetoL3Mu0DxyMax1cmMonitoring
+    + hltDiDispStaMuonL2MuL3Mu16VetoL3Mu0DxyMax1cmMonitoring
+    + hltDiDispStaMuon10CosmicVetoL3Mu0DxyMax1cmMonitoring
 )

--- a/DQMOffline/Trigger/python/DisplacedJet_Monitor_cff.py
+++ b/DQMOffline/Trigger/python/DisplacedJet_Monitor_cff.py
@@ -82,6 +82,43 @@ hltHT_HT430_DelayedJet40_SingleDelay2nsInclusive_Prommonitoring = hltHTmonitorin
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v*"])
 )
 
+hltHT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack',
+    jetSelection = "pt>40 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack_v*"])
+)
+
+hltHT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive',
+    jetSelection = "pt>60 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive_v*"])
+)
+
+hltHT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless',
+    jetSelection = "pt>40 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless_v*"])
+)
+
+hltHT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless',
+    jetSelection = "pt>40 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless_v*"])
+)
+
+hltHT_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5_Prommonitoring = hltHTmonitoring.clone(
+    FolderName = 'HLT/EXO/DisplacedJet/HT/HT_CaloJet_HLT_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5',
+    jetSelection = "pt>30 && eta<2.0",
+    jetSelection_HT  = "pt > 40 && eta < 3.0",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5_v*"])
+)
+
+
+#################
 hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
     jetSrc = "ak4CaloJets",
     FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT430_DisplacedDijet40_DisplacedTrack',
@@ -152,6 +189,56 @@ hltJet_HT430_DelayedJet40_SingleDelay2nsInclusive_Prommonitoring = hltJetMETmoni
     numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v*"])
 )
 
+hltJet_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack_v*"])
+)
+
+hltJet_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive_v*"])
+)
+
+hltJet_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless_v*"])
+)
+
+hltJet_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless_v*"])
+)
+
+hltJet_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5_Prommonitoring = hltJetMETmonitoring.clone(
+    jetSrc = "ak4CaloJets",
+    FolderName = 'HLT/EXO/DisplacedJet/Jet/HLT_CaloJet_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5',
+    ptcut = 20,
+    ispfjettrg = False,
+    iscalojettrg = True,
+    histoPSet = dict(jetptBinning = [20,26,30,35,40,45,50,52,53,54,56,58,60,62,64,66,68,70,72,75,80,100,120,170,220,300,400]),
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5_v*"])
+)
+
 exoHLTDisplacedJetmonitoring = cms.Sequence(
  hltHT_HT425_Prommonitoring
 +hltHT_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring
@@ -161,6 +248,12 @@ exoHLTDisplacedJetmonitoring = cms.Sequence(
 +hltHT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_Prommonitoring
 +hltHT_HT430_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring
 +hltHT_HT430_DelayedJet40_SingleDelay2nsInclusive_Prommonitoring
++hltHT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack_Prommonitoring
++hltHT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive_Prommonitoring
++hltHT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring
++hltHT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless_Prommonitoring
++hltHT_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5_Prommonitoring
+
 +hltJet_HT430_DisplacedDijet40_DisplacedTrack_Prommonitoring
 +hltJet_HT500_DisplacedDijet40_DisplacedTrack_Prommonitoring
 +hltJet_HT650_DisplacedDijet60_Inclusive_Prommonitoring
@@ -168,6 +261,11 @@ exoHLTDisplacedJetmonitoring = cms.Sequence(
 +hltJet_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_Prommonitoring
 +hltJet_HT430_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring
 +hltJet_HT430_DelayedJet40_SingleDelay2nsInclusive_Prommonitoring
++hltJet_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack_Prommonitoring
++hltJet_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive_Prommonitoring
++hltJet_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless_Prommonitoring
++hltJet_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless_Prommonitoring
++hltJet_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5_Prommonitoring
 )
 
 

--- a/DQMOffline/Trigger/python/MuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/MuonMonitor_cff.py
@@ -4,90 +4,87 @@ from DQMOffline.Trigger.MuonMonitor_cfi import hltMuonmonitoring
 
 
 TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Muon/TrkMu12_DoubleTrkMu5NoFiltersNoVtx/'
+    FolderName = 'HLT/EXO/Muon/TrkMu12_DoubleTrkMu5NoFiltersNoVtx/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFJet40_v*","HLT_PFJet60_v*","HLT_PFJet80_v*"]),
 )
-TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*")
-TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFJet40_v*","HLT_PFJet60_v*","HLT_PFJet80_v*") 
 
 TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Muon/TrkMu16_DoubleTrkMu6NoFiltersNoVtx/'
+    FolderName = 'HLT/EXO/Muon/TrkMu16_DoubleTrkMu6NoFiltersNoVtx/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*"]),
 )
-TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu16_DoubleTrkMu6NoFiltersNoVtx_v*")
-TrkMu16_DoubleTrkMu6NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths      = cms.vstring("HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*") 
 
 TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Muon/TrkMu17_DoubleTrkMu8NoFiltersNoVtx/'
+    FolderName = 'HLT/EXO/Muon/TrkMu17_DoubleTrkMu8NoFiltersNoVtx/',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*"]),
 )
-TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v*")
-TrkMu17_DoubleTrkMu8NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_TrkMu12_DoubleTrkMu5NoFiltersNoVtx_v*")
 
 DoubleMu43NoFiltersNoVtx_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/DoubleMu43NoFiltersNoVtx/',
-    nmuons = 2
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu43NoFiltersNoVtx_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-DoubleMu43NoFiltersNoVtx_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu43NoFiltersNoVtx_v*")
-DoubleMu43NoFiltersNoVtx_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 
 
 DoubleMu40NoFiltersNoVtxDisplaced_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/DoubleMu40NoFiltersNoVtxDisplaced/',
-    nmuons = 2
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleMu40NoFiltersNoVtxDisplaced_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-DoubleMu40NoFiltersNoVtxDisplaced_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleMu40NoFiltersNoVtxDisplaced_v*")
-DoubleMu40NoFiltersNoVtxDisplaced_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 #--------------------------------------------------
 DoubleL2Mu23NoVtx_2Cha_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/DoubleL2Mu23NoVtx_2Cha/',
-    nmuons = 2
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu23NoVtx_2Cha_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-DoubleL2Mu23NoVtx_2Cha_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_v*")
-DoubleL2Mu23NoVtx_2Cha_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/DoubleL2Mu23NoVtx_2Cha_CosmicSeed/',
-    nmuons = 2
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*")
-DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 #--------------------------------------------------
 DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm/',
-    nmuons = 2
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_v*")
-DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 #--------------------------------------------------
 DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm/',
-    nmuons = 2
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_v*")
-DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 #--------------------------------------------------
 DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm/',
-    nmuons = 2
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_v*")
-DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 #--------------------------------------------------
 DoubleL3Mu16_10NoVtx_DxyMin0p01cm_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/DoubleL3Mu16_10NoVtx_DxyMin0p01cm/',
-    nmuons = 2
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL3Mu16_10NoVtx_DxyMin0p01cm_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-DoubleL3Mu16_10NoVtx_DxyMin0p01cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL3Mu16_10NoVtx_DxyMin0p01cm_v*")
-DoubleL3Mu16_10NoVtx_DxyMin0p01cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 #--------------------------------------------------
 DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm/',
-    nmuons = 2
+    nmuons = 2,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_v*")
-DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 
 
 
@@ -96,87 +93,81 @@ DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring.denGenericTriggerEventPSet.hltP
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/Mu43NoFiltersNoVtx_Photon43_CaloIdL/',
     nmuons = 1,
-    nelectrons = 1
+    nelectrons = 1,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*")
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg/',
     nmuons = 1,
     nelectrons = 1,
-    eleSelection = 'pt > 43'
+    eleSelection = 'pt > 43',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*")
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg/',
     nmuons = 1,
     nelectrons = 1,
-    muonSelection = 'pt > 43'
+    muonSelection = 'pt > 43',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu43NoFiltersNoVtx_Photon43_CaloIdL_v*")
-Mu43NoFiltersNoVtx_Photon43_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL/',
     nmuons = 1,
-    nelectrons = 1
+    nelectrons = 1,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*")
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg/',
     nmuons = 1,
     nelectrons = 1,
-    eleSelection = 'pt > 38'
+    eleSelection = 'pt > 38',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*")
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg/',
     nmuons = 1,
     nelectrons = 1,
-    muonSelection = 'pt > 38'
+    muonSelection = 'pt > 38',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_v*")
-Mu38NoFiltersNoVtxDisplaced_Photon38_CaloIdL_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 #####
 
 Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId/',
     nmuons = 1,
-    nelectrons = 1
+    nelectrons = 1,
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*")
-Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 
 Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg/',
     nmuons = 1,
     nelectrons = 1,
-    eleSelection = 'pt > 38'
+    eleSelection = 'pt > 38',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*")
-Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_MuLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 
 Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring = hltMuonmonitoring.clone(
     FolderName = 'HLT/EXO/Muon/Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg/',
     nmuons = 1,
     nelectrons = 1,
-    muonSelection = 'pt > 38'
+    muonSelection = 'pt > 38',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*"]),
+    denGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"]),
 )
-Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_v*")
-Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
 
 exoHLTMuonmonitoring = cms.Sequence(
     TrkMu12_DoubleTrkMu5NoFiltersNoVtx_monitoring 

--- a/DQMOffline/Trigger/python/MuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/MuonMonitor_cff.py
@@ -53,20 +53,43 @@ DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring = hltMuonmonitoring.clone(
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v*")
 DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 #--------------------------------------------------
-DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Muon/DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto/',
+DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Muon/DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm/',
     nmuons = 2
 )
-DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v*")
-DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
-
+DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_v*")
+DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
 #--------------------------------------------------
-DoubleL3Mu10NoVtx_Displaced_monitoring = hltMuonmonitoring.clone(
-    FolderName = 'HLT/EXO/Muon/DoubleL3Mu10NoVtx_Displaced/',
+DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Muon/DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm/',
     nmuons = 2
 )
-DoubleL3Mu10NoVtx_Displaced_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL3Mu10NoVtx_Displaced_v*")
-DoubleL3Mu10NoVtx_Displaced_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_v*")
+DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+#--------------------------------------------------
+DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Muon/DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm/',
+    nmuons = 2
+)
+DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_v*")
+DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+#--------------------------------------------------
+DoubleL3Mu16_10NoVtx_DxyMin0p01cm_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Muon/DoubleL3Mu16_10NoVtx_DxyMin0p01cm/',
+    nmuons = 2
+)
+DoubleL3Mu16_10NoVtx_DxyMin0p01cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL3Mu16_10NoVtx_DxyMin0p01cm_v*")
+DoubleL3Mu16_10NoVtx_DxyMin0p01cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+#--------------------------------------------------
+DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring = hltMuonmonitoring.clone(
+    FolderName = 'HLT/EXO/Muon/DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm/',
+    nmuons = 2
+)
+DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring.numGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_v*")
+DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring.denGenericTriggerEventPSet.hltPaths = cms.vstring("HLT_PFMET120_PFMHT120_IDTight_v*","HLT_PFMETTypeOne120_PFMHT120_IDTight_v*","HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_IDTight_v*")
+
+
+
 
 #--------------------------------------------------
 
@@ -172,8 +195,11 @@ exoHLTMuonmonitoring = cms.Sequence(
     + Mu20NoFiltersNoVtxDisplaced_Photon20_CaloCustomId_EleLeg_monitoring
     + DoubleL2Mu23NoVtx_2Cha_monitoring
     + DoubleL2Mu23NoVtx_2Cha_CosmicSeed_monitoring
-    + DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_monitoring
-    + DoubleL3Mu10NoVtx_Displaced_monitoring
+    + DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_monitoring
+    + DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_monitoring
+    + DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_monitoring
+    + DoubleL3Mu16_10NoVtx_DxyMin0p01cm_monitoring
+    + DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_monitoring
 )
 
 

--- a/DQMOffline/Trigger/python/MuonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/MuonMonitor_cff.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+ 
 from DQMOffline.Trigger.MuonMonitor_cfi import hltMuonmonitoring
 
 

--- a/DQMOffline/Trigger/python/PhotonMonitor_cff.py
+++ b/DQMOffline/Trigger/python/PhotonMonitor_cff.py
@@ -194,6 +194,19 @@ DiphotonMass55NewANDnoPV_monitoring = hltPhotonmonitoring.clone(
     histoPSet = dict(massBinning = [50.,51.,52.,53.,54.,55.,56.,57.,58.,59.,60.,61.,62.,63.,64.,65.,66.,67.,68.,69.,70.,75.,80.,90.,110.,150.])
 )
 
+DiPhoton10Time1p4ns_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EXO/DiPhoton/DiPhoton10Time1p4ns/',
+    nphotons = 2,
+    photonSelection = "(pt > 10 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 10 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPhoton10Time1p4ns_v*"]),
+)
+
+DiPhoton10sminlt0p1_monitoring = hltPhotonmonitoring.clone(
+    FolderName = 'HLT/EXO/DiPhoton/DiPhoton10sminlt0p1/',
+    nphotons = 2,
+    photonSelection = "(pt > 10 && abs(eta)<1.4442 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.015 && full5x5_r9>.5)||(pt > 10 && abs(eta)<2.5 && abs(eta)>1.5556 && hadTowOverEm<0.12 && full5x5_sigmaIetaIeta()<0.035 && full5x5_r9>.8)",
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_DiPhoton10sminlt0p1_v*"]),
+)
 
 higgsHLTDiphotonMonitoring = cms.Sequence(
     DiphotonMass90_monitoring
@@ -204,4 +217,6 @@ higgsHLTDiphotonMonitoring = cms.Sequence(
     +DiphotonMass55EBnoPV_monitoring 
     +DiphotonMass55NewAND_monitoring
     +DiphotonMass55NewANDnoPV_monitoring
+    +DiPhoton10Time1p4ns_monitoring
+    +DiPhoton10sminlt0p1_monitoring
 )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDiPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDiPhoton_cff.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+DisplacedDiPhotonPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_DiPhoton10Time1p4ns_v", # New for Run3 (introduced in HLT V1.3)
+        "HLT_DiPhoton10sminlt0p1_v", # New for Run3 (introduced in HLT V1.3)
+        ),
+    recElecLabel  = cms.InputTag("gedGsfElectrons"),
+    # -- Analysis specific cuts
+    minCandidates = cms.uint32(2),
+    # -- Analysis specific binnings
+    parametersTurnOn = cms.vdouble( 0, 25, 50, 75, 100, 125, 150, 175, 200, 225,
+                                    250, 275, 300, 400, 500, 600, 700, 800, 900, 1000
+                                   ),
+    parametersDxy      = cms.vdouble(50, -50, 50),
+    dropPt3 = cms.bool(True),
+    )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDiPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDiPhoton_cff.py
@@ -1,19 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
-HighPtPhotonPSet = cms.PSet(
+DisplacedDiPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_Photon175_v",  # Run2 proposal # Claimed path for Run3
-        "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350MinPFJet15_v", # 2017 # Claimed path for Run3
-        "HLT_Photon110EB_TightID_TightIso_v", # Claimed path for Run3 
-        "HLT_Photon200_v" # Claimed path for Run3
+        "HLT_DiPhoton10Time1p4ns_v", # New for Run3 (introduced in HLT V1.3)
+        "HLT_DiPhoton10sminlt0p1_v", # New for Run3 (introduced in HLT V1.3)
         ),
     recPhotonLabel  = cms.InputTag("gedPhotons"),
     # -- Analysis specific cuts
-    minCandidates = cms.uint32(1),
+    minCandidates = cms.uint32(2),
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble( 0, 25, 50, 75, 100, 125, 150, 175, 200, 225,
                                     250, 275, 300, 400, 500, 600, 700, 800, 900, 1000
                                    ),
-    dropPt2 = cms.bool(True),
+    parametersDxy      = cms.vdouble(50, -50, 50),
     dropPt3 = cms.bool(True),
     )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDiPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDiPhoton_cff.py
@@ -5,7 +5,7 @@ DisplacedDiPhotonPSet = cms.PSet(
         "HLT_DiPhoton10Time1p4ns_v", # New for Run3 (introduced in HLT V1.3)
         "HLT_DiPhoton10sminlt0p1_v", # New for Run3 (introduced in HLT V1.3)
         ),
-    recPhotonLabel  = cms.InputTag("gedPhotons"),
+    recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(2),
     # -- Analysis specific binnings

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedDimuon_cff.py
@@ -3,10 +3,8 @@ import FWCore.ParameterSet.Config as cms
 DisplacedDimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_DoubleMu43NoFiltersNoVtx_v", # 2017 displaced mu-mu (main) # Claimed path for Run3
-#        "HLT_DoubleMu48NoFiltersNoVtx_v", # 2017 displaced mu-mu (backup) # Claimed path for Run3, but a backup so no need to monitor it closely here
-#        "HLT_DoubleMu33NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (main) # Claimed path for Run3, but being superseeded by HLT_DoubleL3Mu10NoVtx_Displaced_v)
-#        "HLT_DoubleMu40NoFiltersNoVtxDisplaced_v", # 2017 displaced mu-mu, muons with dxy> 0.01 cm (backup) # Not claimed path for Run3
-        "HLT_DoubleL3Mu10NoVtx_Displaced_v", #New Run3 path
+        "HLT_DoubleL3Mu16_10NoVtx_DxyMin0p01cm_v", #New Run3 path (introduced in HLT V1.3)
+        "HLT_DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_v", #New Run3 path (introduced in HLT V1.3)
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedL2Dimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedL2Dimuon_cff.py
@@ -4,7 +4,9 @@ DisplacedL2DimuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_DoubleL2Mu23NoVtx_2Cha_CosmicSeed_v", #Claimed for Run 3
         "HLT_DoubleL2Mu23NoVtx_2Cha_v", #Claimed for Run 3
-        "HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v", #New for Run 3
+        "HLT_DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_v", #New for Run 3 (introduced in HLT V1.3)
+        "HLT_DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_v", #New for Run 3 (introduced in HLT V1.3)
+        "HLT_DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_v", #New for Run 3 (introduced in HLT V1.3)
         ),
     recMuonLabel  = cms.InputTag("muons"),
     recMuonTrkLabel  = cms.InputTag("displacedStandAloneMuons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHTDisplacedJets_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHTDisplacedJets_cff.py
@@ -3,16 +3,17 @@ import FWCore.ParameterSet.Config as cms
 HTDisplacedJetsPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_HT425_v", # Claimed path for Run3
-        #2017 
         "HLT_HT430_DisplacedDijet40_DisplacedTrack_v", # Claimed path for Run3
-#        "HLT_HT430_DisplacedDijet60_DisplacedTrack_v", # Claimed path for Run3, but a backup so no need to monitor it closely here
         "HLT_HT650_DisplacedDijet60_Inclusive_v", # Claimed path for Run3
-#        "HLT_HT400_DisplacedDijet40_DisplacedTrack_v", # Claimed path for Run3, but a control path so no need to monitor it closely here
-#        "HLT_HT550_DisplacedDijet60_Inclusive_v" # Claimed path for Run3, but a control path so no need to monitor it closely here
-        "HLT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_v", # New path for Run 3
-        "HLT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_v", # New path for Run 3
-        "HLT_HT430_DelayedJet40_SingleDelay1nsTrackless_v", # New path for Run 3
-        "HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v", # New path for Run 3
+        "HLT_HT430_DisplacedDijet30_Inclusive1PtrkShortSig5_v", # New path for Run 3 (introduced in HLT V1.1)
+        "HLT_Mu6HT240_DisplacedDijet30_Inclusive1PtrkShortSig5_DisplacedLoose_v", # New path for Run 3 (introduced in HLT V1.1)
+        "HLT_HT430_DelayedJet40_SingleDelay1nsTrackless_v", # New path for Run 3 (introduced in HLT V1.1)
+        "HLT_HT430_DelayedJet40_SingleDelay2nsInclusive_v", # New path for Run 3 (introduced in HLT V1.1)
+        "HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack_v", # New path for Run 3 (introduced in HLT V1.3)
+        "HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive_v", # New path for Run 3 (introduced in HLT V1.3)
+        "HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless_v", # New path for Run 3 (introduced in HLT V1.3)
+        "HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless_v", # New path for Run 3 (introduced in HLT V1.3)
+        "HLT_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5_v", # New path for Run 3 (introduced in HLT V1.3)
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
     recPFJetLabel  = cms.InputTag("ak4PFJets"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
@@ -3,11 +3,7 @@ import FWCore.ParameterSet.Config as cms
 HighPtPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_Photon175_v",  # Run2 proposal # Claimed path for Run3
-#        "HLT_Photon150_v", # 0T # Not claimed path for Run3
         "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_PFHT350MinPFJet15_v", # 2017 # Claimed path for Run3
-#        "HLT_Photon33_v", # 2017 # Not claimed path for Run3
-#        "HLT_Photon60_R9Id90_CaloIdL_IsoL_v", # 2017 # Not claimed path for Run3
-#        "HLT_Photon60_R9Id90_CaloIdL_IsoL_DisplacedIdL_v" # 2017 # Not claimed path for Run3
         "HLT_Photon110EB_TightID_TightIso_v", # Claimed path for Run3 
         "HLT_Photon200_v" # Claimed path for Run3
         ),

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -95,6 +95,7 @@ hltExoticaPostLowPtDimuon = make_exo_postprocessor("LowPtDimuon")
 hltExoticaPostLowPtDielectron = make_exo_postprocessor("LowPtDielectron")
 hltExoticaPostHighPtPhoton = make_exo_postprocessor("HighPtPhoton")
 hltExoticaPostDiPhoton = make_exo_postprocessor("DiPhoton")
+hltExoticaPostDisplacedDiPhoton = make_exo_postprocessor("DisplacedDiPhoton")
 hltExoticaPostSingleMuon = make_exo_postprocessor("SingleMuon")
 hltExoticaPostPFHT = make_exo_postprocessor("PFHT")
 hltExoticaPostCaloHT = make_exo_postprocessor("CaloHT")
@@ -128,6 +129,7 @@ hltExoticaPostProcessors = cms.Sequence(
     # Photon paths
     hltExoticaPostHighPtPhoton +
     hltExoticaPostDiPhoton +
+    hltExoticaPostDisplacedDiPhoton +
     # HT path
     hltExoticaPostPFHT +
     hltExoticaPostCaloHT +

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -23,6 +23,7 @@ from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtElectron_cff    import Hi
 from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtElectron_cff     import LowPtElectronPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtPhoton_cff      import HighPtPhotonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaDiPhoton_cff          import DiPhotonPSet
+from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedDiPhoton_cff import DisplacedDiPhotonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaPFHT_cff              import PFHTPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaCaloHT_cff            import CaloHTPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaJetNoBptx_cff         import JetNoBptxPSet
@@ -62,6 +63,7 @@ hltExoticaValidator = DQMEDAnalyzer(
         "LowPtElectron",
         "HighPtPhoton",
         "DiPhoton",
+        "DisplacedDiPhoton",
         "SingleMuon",
         "JetNoBptx",
         "MuonNoBptx",
@@ -213,6 +215,7 @@ hltExoticaValidator = DQMEDAnalyzer(
     LowPtElectron    = LowPtElectronPSet,
     HighPtPhoton     = HighPtPhotonPSet,                                 
     DiPhoton         = DiPhotonPSet,                                 
+    DisplacedDiPhoton = DisplacedDiPhotonPSet,
     SingleMuon       = SingleMuonPSet,
     JetNoBptx        = JetNoBptxPSet,
     MuonNoBptx       = MuonNoBptxPSet,


### PR DESCRIPTION
#### PR description:

This PR updates the exotica HLT release validation (in HLTriggerOffline/Exotica) and the HLT offline DQM (in DQMOffline/Trigger) to include the new long-lived particle (LLP) paths that went into V1.2 and 1.3 of the Run 3 HLT menu [1]. Complying with the request from STEAM to limit the number of histograms produced, only signal paths are monitored, and not backup or control paths. So, these paths have been added to the monitoring:

```
HLT_HT170_L1SingleLLPJet_DisplacedDijet40_DisplacedTrack_v (CMSHLT-2280)
HLT_HT320_L1SingleLLPJet_DisplacedDijet60_Inclusive_v (CMSHLT-2280)
HLT_HT200_L1SingleLLPJet_DelayedJet40_SingleDelay1nsTrackless_v (CMSHLT-2280)
HLT_HT200_L1SingleLLPJet_DelayedJet40_DoubleDelay0p5nsTrackless_v (CMSHLT-2280)
HLT_HT200_L1SingleLLPJet_DisplacedDijet30_Inclusive1PtrkShortSig5_v (CMSHLT-2280)

HLT_DiPhoton10Time1p4ns_v (CMSHLT-2280)
HLT_DiPhoton10sminlt0p1_v (CMSHLT-2280)

HLT_DoubleL3dTksMu16_10NoVtx_DxyMin0p01cm_v (CMSHLT-2301, CMSHLT-2326)
HLT_DoubleL3Mu16_10NoVtx_DxyMin0p01cm_v (CMSHLT-2279)
HLT_DoubleL2Mu10NoVtx_2Cha_VetoL3Mu0DxyMax1cm_v (CMSHLT-2279)
HLT_DoubleL2Mu_L3Mu16NoVtx_VetoL3Mu0DxyMax0p1cm_v (CMSHLT-2361) 
HLT_DoubleL2Mu10NoVtx_2Cha_CosmicSeed_VetoL3Mu0DxyMax1cm_v (CMSHLT-2361)
```

and these paths have been removed (since they have been superseded by some paths above):
```
HLT_DoubleL3Mu10NoVtx_Displaced_v (CMSHLT-2279)
HLT_DoubleL2Mu10NoVtx_2Cha_PromptL3Mu0Veto_v (CMSHLT-2279)
```

As a result, some histograms will be added, and a few will be removed.

#### PR validation:

Using the 11634.0 ttbar workflow, I have tested that the correct histograms are produced and filled in the harvested DQM file.

Using a TTbar relval [2], I have checked that the correct histograms are produced when running

```
cmsRun HLTriggerOffline/Exotica/test/hltExoticaValidator_cfg.py
cmsRun HLTriggerOffline/Exotica/test/hltExoticaPostProcessor_cfg.py
```

I have also successfully tested this PR with
```
runTheMatrix.py -l limited -i all --ibeos
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, and no backport needed.


[1]
https://its.cern.ch/jira/browse/CMSHLT-2280
https://its.cern.ch/jira/browse/CMSHLT-2280
[https://its.cern.ch/jira/browse/](https://its.cern.ch/jira/browse/CMSHLT-2280)CMSHLT-2301
[https://its.cern.ch/jira/browse/](https://its.cern.ch/jira/browse/CMSHLT-2280)CMSHLT-2326
[https://its.cern.ch/jira/browse/](https://its.cern.ch/jira/browse/CMSHLT-2280)CMSHLT-2279
[https://its.cern.ch/jira/browse/](https://its.cern.ch/jira/browse/CMSHLT-2280)CMSHLT-2361

[2] /store/relval/CMSSW_12_5_0_pre3/RelValTTbar_14TeV/GEN-SIM-RECO/124X_mcRun4_realistic_v8_2026D88noPU-v1/10000/603ec30a-4daa-41f6-8cf8-12f7d8c7d429.root