### PR TITLE
Backport of #38850: Adding the relevant variable for BDT based beam halo tagger for photons in nanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/photons_cff.py
+++ b/PhysicsTools/NanoAOD/python/photons_cff.py
@@ -221,6 +221,7 @@ photonTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         # ES variables
         esEffSigmaRR = Var("full5x5_showerShapeVariables().effSigmaRR()", float, doc="preshower sigmaRR"),
         esEnergyOverRawE = Var("superCluster().preshowerEnergy()/superCluster().rawEnergy()", float, doc="ratio of preshower energy to raw supercluster energy"),
+         haloTaggerMVAVal = Var("haloTaggerMVAVal()",float,doc="Value of MVA based BDT based  beam halo tagger in the Ecal endcap (valid for pT > 200 GeV)",precision=8),
     )
 )
 


### PR DESCRIPTION
This is a backport of #38850. 
This PR adds the value of MVA score of the BDT based beam halo tagger (for the EE) for photons in the nanoAOD. Relevant PR where it was merged in miniAOD: https://github.com/cms-sw/cmssw/pull/36901

@mariadalfonso