### PR TITLE
Keep Run2 electron IDs in Run3 nano for early analyses

### DIFF
--- a/PhysicsTools/NanoAOD/python/electrons_cff.py
+++ b/PhysicsTools/NanoAOD/python/electrons_cff.py
@@ -94,6 +94,7 @@ def _get_bitmapVIDForEle_docstring(modules,WorkingPoints):
 
 bitmapVIDForEle = cms.EDProducer("EleVIDNestedWPBitmapProducer",
     src = cms.InputTag("slimmedElectrons"),
+    srcForID = cms.InputTag("reducedEgamma","reducedGedGsfElectrons"),
     WorkingPoints = electron_id_modules_WorkingPoints_nanoAOD.WorkingPoints,
 )
 _bitmapVIDForEle_docstring = _get_bitmapVIDForEle_docstring(electron_id_modules_WorkingPoints_nanoAOD.modules,bitmapVIDForEle.WorkingPoints)
@@ -194,6 +195,7 @@ run2_nanoAOD_102Xv1.toModify(calibratedPatElectronsNano,
 ##import from PhysicsTools/PatAlgos/python/electronsWithUserData_cfi.py
 slimmedElectronsWithUserData = cms.EDProducer("PATElectronUserDataEmbedder",
     src = cms.InputTag("slimmedElectrons"),
+    parentSrcs = cms.VInputTag("reducedEgamma:reducedGedGsfElectrons"),
     userFloats = cms.PSet(
         mvaFall17V1Iso = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17IsoV1Values"),
         mvaFall17V1noIso = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Fall17NoIsoV1Values"),
@@ -540,40 +542,6 @@ electronMCTable = cms.EDProducer("CandMCMatchTableProducer",
 electronTask = cms.Task(bitmapVIDForEle,bitmapVIDForEleHEEP,isoForEle,ptRatioRelForEle,seedGainEle,calibratedPatElectronsNano,slimmedElectronsWithUserData,finalElectrons)
 electronTablesTask = cms.Task(electronMVATTH, electronTable)
 electronMCTask = cms.Task(tautaggerForMatching, matchingElecPhoton, electronsMCMatchForTable, electronsMCMatchForTableAlt, electronMCTable)
-
-## TEMPORARY as no ID for Run3 yet
-(run3_nanoAOD_devel).toReplaceWith(electronTask, electronTask.copyAndExclude([bitmapVIDForEle,bitmapVIDForEleHEEP]))
-(run3_nanoAOD_devel).toModify(slimmedElectronsWithUserData, userIntFromBools = cms.PSet())
-(run3_nanoAOD_devel).toModify(slimmedElectronsWithUserData.userInts,
-                                                    VIDNestedWPBitmap = None,
-                                                    VIDNestedWPBitmapHEEP = None)
-(run3_nanoAOD_devel).toModify(slimmedElectronsWithUserData.userFloats,
-                                                    mvaFall17V1Iso = None,
-                                                    mvaFall17V1noIso = None,
-                                                    mvaIso = None,
-                                                    mvaNoIso = None,
-                                                    mvaHZZIso = None,
-                                                )
-(run3_nanoAOD_devel).toModify(electronTable.variables,
-                              mvaIso = None,
-                              mvaIso_WP80 = None,
-                              mvaIso_WP90 = None,
-                              mvaIso_WPL = None,
-                              mvaNoIso = None,
-                              mvaNoIso_WP80 = None,
-                              mvaNoIso_WP90 = None,
-                              mvaNoIso_WPL = None,
-                              vidNestedWPBitmapHEEP = None,
-                              vidNestedWPBitmap = None,
-                              cutBased = None,
-                              cutBased_HEEP = None,
-                              mvaHZZIso = None,
-)
-
-(run3_nanoAOD_devel).toReplaceWith(electronTablesTask, electronTablesTask.copyAndExclude([electronMVATTH]))
-(run3_nanoAOD_devel).toModify(electronTable, externalVariables = cms.PSet(fsrPhotonIdx = ExtVar(cms.InputTag("leptonFSRphotons:eleFsrIndex"),int, doc="Index of the  lowest-dR/ET2 among associated FSR photons")),
-)
-##### end TEMPORARY Run3
 
 # Revert back to AK4 CHS jets for Run 2
 run2_nanoAOD_ANY.toModify(ptRatioRelForEle,srcJet="updatedJets")

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cff.py
@@ -137,9 +137,6 @@ nanoDQMQTester = DQMQualityTester(
     verboseQT =  cms.untracked.bool(True)
 )
 
-(run3_nanoAOD_devel).toModify(nanoDQM.vplots, Electron = None)
-(run3_nanoAOD_devel).toModify(nanoDQMMC.vplots, Electron = None)
-
 _modifiers = ( run2_miniAOD_80XLegacy |
                run2_nanoAOD_94XMiniAODv1 |
                run2_nanoAOD_94XMiniAODv2 |


### PR DESCRIPTION
#### PR description:

Run2 electron IDs are currently disabled in run3 nano. This is problematic because some early Run3 analyses need at least some kind of built-in ID in nano, and Run3 specific IDs will need some time to be ready. In this PR, we are enabling Run2 electron IDs in Run3 nano. The same for photon IDs (+necessary fixes to make the full chain work) was done in https://github.com/cms-sw/cmssw/pull/38810. 

I have also enabled the electron nano DQM, which I found to be disabled in Run3 nano! I don't see why it should be disabled, so I had enabled it.

#### PR validation:

`runTheMatrix.py -l 11634.0` had worked.

I think we would need a backport of this to 12_4_X, because Run3 nano production will be in 12_4_X.