### PR TITLE
Integration of alpaka and macro-based SoA in CMSSW

### DIFF
--- a/DataFormats/Portable/BuildFile.xml
+++ b/DataFormats/Portable/BuildFile.xml
@@ -1,0 +1,3 @@
+<use name="alpaka"/>
+<use name="DataFormats/SoATemplate" source_only="1"/>
+<use name="HeterogeneousCore/AlpakaInterface" source_only="1"/>

--- a/DataFormats/Portable/README.md
+++ b/DataFormats/Portable/README.md
@@ -1,0 +1,38 @@
+## Define portable data formats that wrap SoA data structures and can be persisted to ROOT files
+
+### `PortableHostCollection<T>`
+
+`PortableHostCollection<T>` is a class template that wraps a SoA type `T` and an alpaka host buffer, which owns the
+memory where the SoA is allocated. The content of the SoA is persistent, while the buffer itself is transient.
+Specialisations of this template can be persisted, and can be read back also in "bare ROOT" mode, without any
+dictionaries.
+They have no implicit or explicit references to alpaka (neither as part of the class signature nor as part of its name).
+This could make it possible to read them back with different portability solutions in the future.
+
+### `PortableDeviceCollection<T, TDev>`
+
+`PortableDeviceCollection<T, TDev>` is a class template that wraps a SoA type `T` and an alpaka device buffer, which
+owns the memory where the SoA is allocated.
+To avoid confusion and ODR-violations, the `PortableDeviceCollection<T, TDev>` template cannot be used with the `Host`
+device type.
+Specialisations of this template are transient and cannot be persisted.
+
+### `ALPAKA_ACCELERATOR_NAMESPACE::PortableCollection<T>`
+
+`ALPAKA_ACCELERATOR_NAMESPACE::PortableCollection<T>` is a template alias that resolves to either
+`PortableHostCollection<T>` or `PortableDeviceCollection<T, ALPAKA_ACCELERATOR_NAMESPACE::Device>`, depending on the
+backend.
+
+### `PortableCollection<T, TDev>`
+
+`PortableCollection<T, TDev>` is an alias template that resolves to `ALPAKA_ACCELERATOR_NAMESPACE::PortableCollection<T>`
+for the matching device.
+
+
+## Notes
+
+Modules that are supposed to work with only host types (_e.g._ dealing with de/serialisation, data transfers, _etc._)
+should explicitly use the `PortableHostCollection<T>` types.
+
+Modules that implement portable interfaces (_e.g._ producers) should use the generic types based on
+`ALPAKA_ACCELERATOR_NAMESPACE::PortableCollection<T>` or `PortableCollection<T, TDev>`.

--- a/DataFormats/Portable/interface/PortableCollection.h
+++ b/DataFormats/Portable/interface/PortableCollection.h
@@ -1,0 +1,16 @@
+#ifndef DataFormats_Portable_interface_PortableCollection_h
+#define DataFormats_Portable_interface_PortableCollection_h
+
+namespace traits {
+
+  // trait for a generic SoA-based product
+  template <typename T, typename TDev>
+  class PortableCollectionTrait;
+
+}  // namespace traits
+
+// type alias for a generic SoA-based product
+template <typename T, typename TDev>
+using PortableCollection = typename traits::PortableCollectionTrait<T, TDev>::CollectionType;
+
+#endif  // DataFormats_Portable_interface_PortableCollection_h

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -19,7 +19,9 @@ public:
   using Layout = T;
   using Buffer = alpaka::Buf<TDev, std::byte, alpaka::DimInt<1u>, uint32_t>;
 
-  PortableDeviceCollection() = default;
+  PortableDeviceCollection() : buffer_{}, layout_{} {
+    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
+  }
 
   PortableDeviceCollection(int32_t elements, TDev const &device)
       : buffer_{alpaka::allocBuf<std::byte, uint32_t>(
@@ -28,16 +30,25 @@ public:
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
     alpaka::pin(*buffer_);
+    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
   }
 
-  ~PortableDeviceCollection() = default;
+  ~PortableDeviceCollection() {
+    // the default implementation would work correctly, but we want to add a call to the MessageLogger
+    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
+  }
 
   // non-copyable
   PortableDeviceCollection(PortableDeviceCollection const &) = delete;
   PortableDeviceCollection &operator=(PortableDeviceCollection const &) = delete;
 
   // movable
-  PortableDeviceCollection(PortableDeviceCollection &&other) = default;
+  PortableDeviceCollection(PortableDeviceCollection &&other)
+      : buffer_{std::move(other.buffer_)}, layout_{std::move(other.layout_)} {
+    // the default implementation would work correctly, but we want to add a call to the MessageLogger
+    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
+  }
+
   PortableDeviceCollection &operator=(PortableDeviceCollection &&other) = default;
 
   Layout &operator*() { return layout_; }

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -1,0 +1,60 @@
+#ifndef DataFormats_Portable_interface_PortableDeviceCollection_h
+#define DataFormats_Portable_interface_PortableDeviceCollection_h
+
+#include <optional>
+#include <type_traits>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+// generic SoA-based product in device memory
+template <typename T, typename TDev>
+class PortableDeviceCollection {
+  static_assert(not std::is_same_v<TDev, alpaka_common::DevHost>,
+                "Use PortableHostCollection<T> instead of PortableDeviceCollection<T, DevHost>");
+
+public:
+  using Layout = T;
+  using Buffer = alpaka::Buf<TDev, std::byte, alpaka::DimInt<1u>, uint32_t>;
+
+  PortableDeviceCollection() = default;
+
+  PortableDeviceCollection(int32_t elements, TDev const &device)
+      : buffer_{alpaka::allocBuf<std::byte, uint32_t>(
+            device, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::compute_size(elements)})},
+        layout_{elements, buffer_->data()} {
+    // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
+    assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
+    alpaka::pin(*buffer_);
+  }
+
+  ~PortableDeviceCollection() = default;
+
+  // non-copyable
+  PortableDeviceCollection(PortableDeviceCollection const &) = delete;
+  PortableDeviceCollection &operator=(PortableDeviceCollection const &) = delete;
+
+  // movable
+  PortableDeviceCollection(PortableDeviceCollection &&other) = default;
+  PortableDeviceCollection &operator=(PortableDeviceCollection &&other) = default;
+
+  Layout &operator*() { return layout_; }
+
+  Layout const &operator*() const { return layout_; }
+
+  Layout *operator->() { return &layout_; }
+
+  Layout const *operator->() const { return &layout_; }
+
+  Buffer &buffer() { return *buffer_; }
+
+  Buffer const &buffer() const { return *buffer_; }
+
+private:
+  std::optional<Buffer> buffer_;  //!
+  Layout layout_;                 //
+};
+
+#endif  // DataFormats_Portable_interface_PortableDeviceCollection_h

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -17,16 +17,18 @@ class PortableDeviceCollection {
 
 public:
   using Layout = T;
+  using View = typename Layout::View;
   using Buffer = alpaka::Buf<TDev, std::byte, alpaka::DimInt<1u>, uint32_t>;
 
-  PortableDeviceCollection() : buffer_{}, layout_{} {
+  PortableDeviceCollection() : buffer_{}, layout_{}, view_{} {
     edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
   }
 
   PortableDeviceCollection(int32_t elements, TDev const &device)
       : buffer_{alpaka::allocBuf<std::byte, uint32_t>(
-            device, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::compute_size(elements)})},
-        layout_{elements, buffer_->data()} {
+            device, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::computeDataSize(elements)})},
+        layout_{buffer_->data(), elements},
+        view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
     alpaka::pin(*buffer_);
@@ -44,20 +46,20 @@ public:
 
   // movable
   PortableDeviceCollection(PortableDeviceCollection &&other)
-      : buffer_{std::move(other.buffer_)}, layout_{std::move(other.layout_)} {
+      : buffer_{std::move(other.buffer_)}, layout_{std::move(other.layout_)}, view_{std::move(other.view_)} {
     // the default implementation would work correctly, but we want to add a call to the MessageLogger
     edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
   }
 
   PortableDeviceCollection &operator=(PortableDeviceCollection &&other) = default;
 
-  Layout &operator*() { return layout_; }
+  View &operator*() { return view_; }
 
-  Layout const &operator*() const { return layout_; }
+  View const &operator*() const { return view_; }
 
-  Layout *operator->() { return &layout_; }
+  View *operator->() { return &view_; }
 
-  Layout const *operator->() const { return &layout_; }
+  View const *operator->() const { return &view_; }
 
   Buffer &buffer() { return *buffer_; }
 
@@ -66,6 +68,7 @@ public:
 private:
   std::optional<Buffer> buffer_;  //!
   Layout layout_;                 //
+  View view_;                     //!
 };
 
 #endif  // DataFormats_Portable_interface_PortableDeviceCollection_h

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -6,7 +6,6 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 
 // generic SoA-based product in device memory
@@ -19,10 +18,9 @@ public:
   using Layout = T;
   using View = typename Layout::View;
   using Buffer = alpaka::Buf<TDev, std::byte, alpaka::DimInt<1u>, uint32_t>;
+  using ConstBuffer = alpaka::ViewConst<Buffer>;
 
-  PortableDeviceCollection() : buffer_{}, layout_{}, view_{} {
-    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
-  }
+  PortableDeviceCollection() = default;
 
   PortableDeviceCollection(int32_t elements, TDev const &device)
       : buffer_{alpaka::allocBuf<std::byte, uint32_t>(
@@ -31,26 +29,16 @@ public:
         view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
-    alpaka::pin(*buffer_);
-    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
   }
 
-  ~PortableDeviceCollection() {
-    // the default implementation would work correctly, but we want to add a call to the MessageLogger
-    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
-  }
+  ~PortableDeviceCollection() = default;
 
   // non-copyable
   PortableDeviceCollection(PortableDeviceCollection const &) = delete;
   PortableDeviceCollection &operator=(PortableDeviceCollection const &) = delete;
 
   // movable
-  PortableDeviceCollection(PortableDeviceCollection &&other)
-      : buffer_{std::move(other.buffer_)}, layout_{std::move(other.layout_)}, view_{std::move(other.view_)} {
-    // the default implementation would work correctly, but we want to add a call to the MessageLogger
-    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
-  }
-
+  PortableDeviceCollection(PortableDeviceCollection &&other) = default;
   PortableDeviceCollection &operator=(PortableDeviceCollection &&other) = default;
 
   View &operator*() { return view_; }
@@ -61,9 +49,9 @@ public:
 
   View const *operator->() const { return &view_; }
 
-  Buffer &buffer() { return *buffer_; }
-
-  Buffer const &buffer() const { return *buffer_; }
+  Buffer buffer() { return *buffer_; }
+  ConstBuffer buffer() const { return *buffer_; }
+  ConstBuffer const_buffer() const { return *buffer_; }
 
 private:
   std::optional<Buffer> buffer_;  //!

--- a/DataFormats/Portable/interface/PortableDeviceCollection.h
+++ b/DataFormats/Portable/interface/PortableDeviceCollection.h
@@ -17,6 +17,7 @@ class PortableDeviceCollection {
 public:
   using Layout = T;
   using View = typename Layout::View;
+  using ConstView = typename Layout::ConstView;
   using Buffer = alpaka::Buf<TDev, std::byte, alpaka::DimInt<1u>, uint32_t>;
   using ConstBuffer = alpaka::ViewConst<Buffer>;
 
@@ -41,13 +42,15 @@ public:
   PortableDeviceCollection(PortableDeviceCollection &&other) = default;
   PortableDeviceCollection &operator=(PortableDeviceCollection &&other) = default;
 
-  View &operator*() { return view_; }
+  View &view() { return view_; }
+  ConstView const &view() const { return view_; }
+  ConstView const &const_view() const { return view_; }
 
-  View const &operator*() const { return view_; }
+  View &operator*() { return view_; }
+  ConstView const &operator*() const { return view_; }
 
   View *operator->() { return &view_; }
-
-  View const *operator->() const { return &view_; }
+  ConstView const *operator->() const { return &view_; }
 
   Buffer buffer() { return *buffer_; }
   ConstBuffer buffer() const { return *buffer_; }

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -1,0 +1,67 @@
+#ifndef DataFormats_Portable_interface_PortableHostCollection_h
+#define DataFormats_Portable_interface_PortableHostCollection_h
+
+#include <optional>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+
+// generic SoA-based product in host memory
+template <typename T>
+class PortableHostCollection {
+public:
+  using Layout = T;
+  using Buffer = alpaka::Buf<alpaka_common::DevHost, std::byte, alpaka::DimInt<1u>, uint32_t>;
+
+  PortableHostCollection() = default;
+
+  PortableHostCollection(int32_t elements, alpaka_common::DevHost const &host)
+      // allocate pageable host memory
+      : buffer_{alpaka::allocBuf<std::byte, uint32_t>(
+            host, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::compute_size(elements)})},
+        layout_{elements, buffer_->data()} {
+    // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
+    assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
+  }
+
+  template <typename TDev>
+  PortableHostCollection(int32_t elements, alpaka_common::DevHost const &host, TDev const &device)
+      // allocate pinned host memory, accessible by the given device
+      : buffer_{alpaka::allocMappedBuf<std::byte, uint32_t>(
+            host, device, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::compute_size(elements)})},
+        layout_{elements, buffer_->data()} {
+    // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
+    assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
+  }
+
+  ~PortableHostCollection() = default;
+
+  // non-copyable
+  PortableHostCollection(PortableHostCollection const &) = delete;
+  PortableHostCollection &operator=(PortableHostCollection const &) = delete;
+
+  // movable
+  PortableHostCollection(PortableHostCollection &&other) = default;
+  PortableHostCollection &operator=(PortableHostCollection &&other) = default;
+
+  Layout &operator*() { return layout_; }
+
+  Layout const &operator*() const { return layout_; }
+
+  Layout *operator->() { return &layout_; }
+
+  Layout const *operator->() const { return &layout_; }
+
+  Buffer &buffer() { return *buffer_; }
+
+  Buffer const &buffer() const { return *buffer_; }
+
+private:
+  std::optional<Buffer> buffer_;  //!
+  Layout layout_;                 //
+};
+
+#endif  // DataFormats_Portable_interface_PortableHostCollection_h

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -5,7 +5,6 @@
 
 #include <alpaka/alpaka.hpp>
 
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 
@@ -15,12 +14,11 @@ class PortableHostCollection {
 public:
   using Layout = T;
   using View = typename Layout::View;
+  using ConstView = typename Layout::ConstView;
   using Buffer = alpaka::Buf<alpaka_common::DevHost, std::byte, alpaka::DimInt<1u>, uint32_t>;
+  using ConstBuffer = alpaka::ViewConst<Buffer>;
 
-  PortableHostCollection() : buffer_{}, layout_{}, view_{} {
-    // the default implementation would work correctly, but we want to add a call to the MessageLogger
-    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
-  }
+  PortableHostCollection() = default;
 
   PortableHostCollection(int32_t elements, alpaka_common::DevHost const &host)
       // allocate pageable host memory
@@ -30,7 +28,6 @@ public:
         view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
-    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
   }
 
   template <typename TDev>
@@ -42,25 +39,16 @@ public:
         view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
-    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
   }
 
-  ~PortableHostCollection() {
-    // the default implementation would work correctly, but we want to add a call to the MessageLogger
-    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
-  }
+  ~PortableHostCollection() = default;
 
   // non-copyable
   PortableHostCollection(PortableHostCollection const &) = delete;
   PortableHostCollection &operator=(PortableHostCollection const &) = delete;
 
   // movable
-  PortableHostCollection(PortableHostCollection &&other)
-      : buffer_{std::move(other.buffer_)}, layout_{std::move(other.layout_)}, view_{std::move(other.view_)} {
-    // the default implementation would work correctly, but we want to add a call to the MessageLogger
-    edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
-  }
-
+  PortableHostCollection(PortableHostCollection &&other) = default;
   PortableHostCollection &operator=(PortableHostCollection &&other) = default;
 
   View &operator*() { return view_; }
@@ -71,9 +59,9 @@ public:
 
   View const *operator->() const { return &view_; }
 
-  Buffer &buffer() { return *buffer_; }
-
-  Buffer const &buffer() const { return *buffer_; }
+  Buffer buffer() { return *buffer_; }
+  ConstBuffer buffer() const { return *buffer_; }
+  ConstBuffer const_buffer() const { return *buffer_; }
 
   // part of the ROOT read streamer
   static void ROOTReadStreamer(PortableHostCollection *newObj, Layout const &layout) {

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -5,6 +5,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/config.h"
 #include "HeterogeneousCore/AlpakaInterface/interface/host.h"
 
@@ -51,13 +52,15 @@ public:
   PortableHostCollection(PortableHostCollection &&other) = default;
   PortableHostCollection &operator=(PortableHostCollection &&other) = default;
 
-  View &operator*() { return view_; }
+  View &view() { return view_; }
+  ConstView const &view() const { return view_; }
+  ConstView const &const_view() const { return view_; }
 
-  View const &operator*() const { return view_; }
+  View &operator*() { return view_; }
+  ConstView const &operator*() const { return view_; }
 
   View *operator->() { return &view_; }
-
-  View const *operator->() const { return &view_; }
+  ConstView const *operator->() const { return &view_; }
 
   Buffer buffer() { return *buffer_; }
   ConstBuffer buffer() const { return *buffer_; }

--- a/DataFormats/Portable/interface/PortableHostCollection.h
+++ b/DataFormats/Portable/interface/PortableHostCollection.h
@@ -14,9 +14,10 @@ template <typename T>
 class PortableHostCollection {
 public:
   using Layout = T;
+  using View = typename Layout::View;
   using Buffer = alpaka::Buf<alpaka_common::DevHost, std::byte, alpaka::DimInt<1u>, uint32_t>;
 
-  PortableHostCollection() : buffer_{}, layout_{} {
+  PortableHostCollection() : buffer_{}, layout_{}, view_{} {
     // the default implementation would work correctly, but we want to add a call to the MessageLogger
     edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
   }
@@ -24,8 +25,9 @@ public:
   PortableHostCollection(int32_t elements, alpaka_common::DevHost const &host)
       // allocate pageable host memory
       : buffer_{alpaka::allocBuf<std::byte, uint32_t>(
-            host, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::compute_size(elements)})},
-        layout_{elements, buffer_->data()} {
+            host, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::computeDataSize(elements)})},
+        layout_{buffer_->data(), elements},
+        view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
     edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
@@ -35,8 +37,9 @@ public:
   PortableHostCollection(int32_t elements, alpaka_common::DevHost const &host, TDev const &device)
       // allocate pinned host memory, accessible by the given device
       : buffer_{alpaka::allocMappedBuf<std::byte, uint32_t>(
-            host, device, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::compute_size(elements)})},
-        layout_{elements, buffer_->data()} {
+            host, device, alpaka::Vec<alpaka::DimInt<1u>, uint32_t>{Layout::computeDataSize(elements)})},
+        layout_{buffer_->data(), elements},
+        view_{layout_} {
     // Alpaka set to a default alignment of 128 bytes defining ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT=128
     assert(reinterpret_cast<uintptr_t>(buffer_->data()) % Layout::alignment == 0);
     edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
@@ -53,20 +56,20 @@ public:
 
   // movable
   PortableHostCollection(PortableHostCollection &&other)
-      : buffer_{std::move(other.buffer_)}, layout_{std::move(other.layout_)} {
+      : buffer_{std::move(other.buffer_)}, layout_{std::move(other.layout_)}, view_{std::move(other.view_)} {
     // the default implementation would work correctly, but we want to add a call to the MessageLogger
     edm::LogVerbatim("PortableCollection") << __PRETTY_FUNCTION__ << " [this=" << this << "]";
   }
 
   PortableHostCollection &operator=(PortableHostCollection &&other) = default;
 
-  Layout &operator*() { return layout_; }
+  View &operator*() { return view_; }
 
-  Layout const &operator*() const { return layout_; }
+  View const &operator*() const { return view_; }
 
-  Layout *operator->() { return &layout_; }
+  View *operator->() { return &view_; }
 
-  Layout const *operator->() const { return &layout_; }
+  View const *operator->() const { return &view_; }
 
   Buffer &buffer() { return *buffer_; }
 
@@ -76,13 +79,14 @@ public:
   static void ROOTReadStreamer(PortableHostCollection *newObj, Layout const &layout) {
     newObj->~PortableHostCollection();
     // use the global "host" object returned by alpaka_common::host()
-    new (newObj) PortableHostCollection(layout.size(), alpaka_common::host());
+    new (newObj) PortableHostCollection(layout.metadata().size(), alpaka_common::host());
     newObj->layout_.ROOTReadStreamer(layout);
   }
 
 private:
   std::optional<Buffer> buffer_;  //!
   Layout layout_;                 //
+  View view_;                     //!
 };
 
 #endif  // DataFormats_Portable_interface_PortableHostCollection_h

--- a/DataFormats/Portable/interface/alpaka/PortableCollection.h
+++ b/DataFormats/Portable/interface/alpaka/PortableCollection.h
@@ -1,0 +1,42 @@
+#ifndef DataFormats_Portable_interface_alpaka_PortableDeviceCollection_h
+#define DataFormats_Portable_interface_alpaka_PortableDeviceCollection_h
+
+#include <optional>
+
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/Portable/interface/PortableCollection.h"
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/Portable/interface/PortableDeviceCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+#if defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+  // ... or any other CPU-based accelerators
+
+  // generic SoA-based product in host memory
+  template <typename T>
+  using PortableCollection = ::PortableHostCollection<T>;
+
+#else
+
+  // generic SoA-based product in device memory
+  template <typename T>
+  using PortableCollection = ::PortableDeviceCollection<T, Device>;
+
+#endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+namespace traits {
+
+  // specialise the trait for the device provided by the ALPAKA_ACCELERATOR_NAMESPACE
+  template <typename T>
+  class PortableCollectionTrait<T, ALPAKA_ACCELERATOR_NAMESPACE::Device> {
+    using CollectionType = ALPAKA_ACCELERATOR_NAMESPACE::PortableCollection<T>;
+  };
+
+}  // namespace traits
+
+#endif  // DataFormats_Portable_interface_alpaka_PortableDeviceCollection_h

--- a/DataFormats/PortableTestObjects/BuildFile.xml
+++ b/DataFormats/PortableTestObjects/BuildFile.xml
@@ -1,0 +1,10 @@
+<use name="rootcore"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/Portable"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/Utilities" source_only="1"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="1"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/DataFormats/PortableTestObjects/README.md
+++ b/DataFormats/PortableTestObjects/README.md
@@ -1,0 +1,10 @@
+## Define the portable SoA-based data formats
+
+Notes:
+  - define a full dictionary for `portabletest::TestSoA` and `portabletest::TestHostCollection`
+  - do not define a dictionary for `alpaka_serial_sync::portabletest::TestDeviceCollection`,
+    because it is the same class as `portabletest::TestHostCollection`;
+  - define the dictionary for `alpaka_cuda_async::portabletest::TestDeviceCollection`
+    as _transient_ only;
+  - the dictionary for `alpaka_cuda_async::portabletest::TestDeviceCollection` should
+    be defined in a separate library, to factor out the CUDA dependency.

--- a/DataFormats/PortableTestObjects/interface/TestHostCollection.h
+++ b/DataFormats/PortableTestObjects/interface/TestHostCollection.h
@@ -1,0 +1,14 @@
+#ifndef DataFormats_PortableTestObjects_interface_TestHostCollection_h
+#define DataFormats_PortableTestObjects_interface_TestHostCollection_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/PortableTestObjects/interface/TestSoA.h"
+
+namespace portabletest {
+
+  // SoA with x, y, z, id fields in host memory
+  using TestHostCollection = PortableHostCollection<TestSoA>;
+
+}  // namespace portabletest
+
+#endif  // DataFormats_PortableTestObjects_interface_TestHostCollection_h

--- a/DataFormats/PortableTestObjects/interface/TestSoA.h
+++ b/DataFormats/PortableTestObjects/interface/TestSoA.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/typedefs.h"
 
 namespace portabletest {
 
@@ -135,10 +136,18 @@ namespace portabletest {
              elements * sizeof(int32_t);       // id - no need to pad the last field
     }
 
+    void ROOTReadStreamer(TestSoA const &onfile) {
+      auto size = onfile.size();
+      memcpy(x_, &onfile.x(0), size * sizeof(*x_));
+      memcpy(y_, &onfile.y(0), size * sizeof(*y_));
+      memcpy(z_, &onfile.z(0), size * sizeof(*z_));
+      memcpy(id_, &onfile.id(0), size * sizeof(*id_));
+    }
+
   private:
     // non-owned memory
-    int32_t size_;  //
-    void *buffer_;  //!
+    cms_int32_t size_;  // must be the same as ROOT's Int_t
+    void *buffer_;      //!
 
     // layout
     double *x_;    //[size_]

--- a/DataFormats/PortableTestObjects/interface/TestSoA.h
+++ b/DataFormats/PortableTestObjects/interface/TestSoA.h
@@ -1,160 +1,21 @@
 #ifndef DataFormats_PortableTestObjects_interface_TestSoA_h
 #define DataFormats_PortableTestObjects_interface_TestSoA_h
 
-#include <cassert>
-#include <cstddef>
-#include <cstdint>
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/typedefs.h"
+#include "DataFormats/SoATemplate/interface/SoACommon.h"
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
 
 namespace portabletest {
 
   // SoA layout with x, y, z, id fields
-  class TestSoA {
-  public:
-    static constexpr size_t alignment = 128;  // align all fields to 128 bytes
+  GENERATE_SOA_LAYOUT(TestSoALayout,
+                      // columns: one value per element
+                      SOA_COLUMN(double, x),
+                      SOA_COLUMN(double, y),
+                      SOA_COLUMN(double, z),
+                      SOA_COLUMN(int32_t, id))
 
-    // constructor
-    TestSoA() : size_(0), buffer_(nullptr), x_(nullptr), y_(nullptr), z_(nullptr), id_(nullptr) {
-      edm::LogVerbatim("TestSoA") << "TestSoA default constructor";
-    }
-
-    TestSoA(int32_t size, void *buffer)
-        : size_(size),
-          buffer_(buffer),
-          x_(reinterpret_cast<double *>(reinterpret_cast<intptr_t>(buffer_))),
-          y_(reinterpret_cast<double *>(reinterpret_cast<intptr_t>(x_) + pad(size * sizeof(double)))),
-          z_(reinterpret_cast<double *>(reinterpret_cast<intptr_t>(y_) + pad(size * sizeof(double)))),
-          id_(reinterpret_cast<int32_t *>(reinterpret_cast<intptr_t>(z_) + pad(size * sizeof(double)))) {
-      assert(size == 0 or (size > 0 and buffer != nullptr));
-      edm::LogVerbatim("TestSoA") << "TestSoA constructor with " << size_ << " elements at 0x" << buffer_;
-    }
-
-    ~TestSoA() {
-      // the default implementation would work correctly, but we want to add a call to the MessageLogger
-      if (buffer_) {
-        edm::LogVerbatim("TestSoA") << "TestSoA destructor with " << size_ << " elements at 0x" << buffer_;
-      } else {
-        edm::LogVerbatim("TestSoA") << "TestSoA destructor wihout data";
-      }
-    }
-
-    // non-copyable
-    TestSoA(TestSoA const &) = delete;
-    TestSoA &operator=(TestSoA const &) = delete;
-
-    // movable
-    TestSoA(TestSoA &&other)
-        : size_(other.size_), buffer_(other.buffer_), x_(other.x_), y_(other.y_), z_(other.z_), id_(other.id_) {
-      // the default implementation would work correctly, but we want to add a call to the MessageLogger
-      edm::LogVerbatim("TestSoA") << "TestSoA move constructor with " << size_ << " elements at 0x" << buffer_;
-      other.buffer_ = nullptr;
-    }
-
-    TestSoA &operator=(TestSoA &&other) {
-      // the default implementation would work correctly, but we want to add a call to the MessageLogger
-      size_ = other.size_;
-      buffer_ = other.buffer_;
-      x_ = other.x_;
-      y_ = other.y_;
-      z_ = other.z_;
-      id_ = other.id_;
-      edm::LogVerbatim("TestSoA") << "TestSoA move assignment with " << size_ << " elements at 0x" << buffer_;
-      other.buffer_ = nullptr;
-      return *this;
-    }
-
-    // global accessors
-    int32_t size() const { return size_; }
-
-    uint32_t extent() const { return compute_size(size_); }
-
-    void *data() { return buffer_; }
-    void const *data() const { return buffer_; }
-
-    // element-wise accessors are not implemented for simplicity
-
-    // field-wise accessors
-    double const &x(int32_t i) const {
-      assert(i >= 0);
-      assert(i < size_);
-      return x_[i];
-    }
-
-    double &x(int32_t i) {
-      assert(i >= 0);
-      assert(i < size_);
-      return x_[i];
-    }
-
-    double const &y(int32_t i) const {
-      assert(i >= 0);
-      assert(i < size_);
-      return y_[i];
-    }
-
-    double &y(int32_t i) {
-      assert(i >= 0);
-      assert(i < size_);
-      return y_[i];
-    }
-
-    double const &z(int32_t i) const {
-      assert(i >= 0);
-      assert(i < size_);
-      return z_[i];
-    }
-
-    double &z(int32_t i) {
-      assert(i >= 0);
-      assert(i < size_);
-      return z_[i];
-    }
-
-    int32_t const &id(int32_t i) const {
-      assert(i >= 0);
-      assert(i < size_);
-      return id_[i];
-    }
-
-    int32_t &id(int32_t i) {
-      assert(i >= 0);
-      assert(i < size_);
-      return id_[i];
-    }
-
-    // pad a size (in bytes) to the next multiple of the alignment
-    static constexpr uint32_t pad(size_t size) { return ((size + alignment - 1) / alignment * alignment); }
-
-    // takes the size in elements, returns the size in bytes
-    static constexpr uint32_t compute_size(int32_t elements) {
-      assert(elements >= 0);
-      return pad(elements * sizeof(double)) +  // x
-             pad(elements * sizeof(double)) +  // y
-             pad(elements * sizeof(double)) +  // z
-             elements * sizeof(int32_t);       // id - no need to pad the last field
-    }
-
-    void ROOTReadStreamer(TestSoA const &onfile) {
-      auto size = onfile.size();
-      memcpy(x_, &onfile.x(0), size * sizeof(*x_));
-      memcpy(y_, &onfile.y(0), size * sizeof(*y_));
-      memcpy(z_, &onfile.z(0), size * sizeof(*z_));
-      memcpy(id_, &onfile.id(0), size * sizeof(*id_));
-    }
-
-  private:
-    // non-owned memory
-    cms_int32_t size_;  // must be the same as ROOT's Int_t
-    void *buffer_;      //!
-
-    // layout
-    double *x_;    //[size_]
-    double *y_;    //[size_]
-    double *z_;    //[size_]
-    int32_t *id_;  //[size_]
-  };
+  using TestSoA = TestSoALayout<>;
 
 }  // namespace portabletest
 

--- a/DataFormats/PortableTestObjects/interface/TestSoA.h
+++ b/DataFormats/PortableTestObjects/interface/TestSoA.h
@@ -1,0 +1,152 @@
+#ifndef DataFormats_PortableTestObjects_interface_TestSoA_h
+#define DataFormats_PortableTestObjects_interface_TestSoA_h
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace portabletest {
+
+  // SoA layout with x, y, z, id fields
+  class TestSoA {
+  public:
+    static constexpr size_t alignment = 128;  // align all fields to 128 bytes
+
+    // constructor
+    TestSoA() : size_(0), buffer_(nullptr), x_(nullptr), y_(nullptr), z_(nullptr), id_(nullptr) {
+      edm::LogVerbatim("TestSoA") << "TestSoA default constructor";
+    }
+
+    TestSoA(int32_t size, void *buffer)
+        : size_(size),
+          buffer_(buffer),
+          x_(reinterpret_cast<double *>(reinterpret_cast<intptr_t>(buffer_))),
+          y_(reinterpret_cast<double *>(reinterpret_cast<intptr_t>(x_) + pad(size * sizeof(double)))),
+          z_(reinterpret_cast<double *>(reinterpret_cast<intptr_t>(y_) + pad(size * sizeof(double)))),
+          id_(reinterpret_cast<int32_t *>(reinterpret_cast<intptr_t>(z_) + pad(size * sizeof(double)))) {
+      assert(size == 0 or (size > 0 and buffer != nullptr));
+      edm::LogVerbatim("TestSoA") << "TestSoA constructor with " << size_ << " elements at 0x" << buffer_;
+    }
+
+    ~TestSoA() {
+      // the default implementation would work correctly, but we want to add a call to the MessageLogger
+      if (buffer_) {
+        edm::LogVerbatim("TestSoA") << "TestSoA destructor with " << size_ << " elements at 0x" << buffer_;
+      } else {
+        edm::LogVerbatim("TestSoA") << "TestSoA destructor wihout data";
+      }
+    }
+
+    // non-copyable
+    TestSoA(TestSoA const &) = delete;
+    TestSoA &operator=(TestSoA const &) = delete;
+
+    // movable
+    TestSoA(TestSoA &&other)
+        : size_(other.size_), buffer_(other.buffer_), x_(other.x_), y_(other.y_), z_(other.z_), id_(other.id_) {
+      // the default implementation would work correctly, but we want to add a call to the MessageLogger
+      edm::LogVerbatim("TestSoA") << "TestSoA move constructor with " << size_ << " elements at 0x" << buffer_;
+      other.buffer_ = nullptr;
+    }
+
+    TestSoA &operator=(TestSoA &&other) {
+      // the default implementation would work correctly, but we want to add a call to the MessageLogger
+      size_ = other.size_;
+      buffer_ = other.buffer_;
+      x_ = other.x_;
+      y_ = other.y_;
+      z_ = other.z_;
+      id_ = other.id_;
+      edm::LogVerbatim("TestSoA") << "TestSoA move assignment with " << size_ << " elements at 0x" << buffer_;
+      other.buffer_ = nullptr;
+      return *this;
+    }
+
+    // global accessors
+    int32_t size() const { return size_; }
+
+    uint32_t extent() const { return compute_size(size_); }
+
+    void *data() { return buffer_; }
+    void const *data() const { return buffer_; }
+
+    // element-wise accessors are not implemented for simplicity
+
+    // field-wise accessors
+    double const &x(int32_t i) const {
+      assert(i >= 0);
+      assert(i < size_);
+      return x_[i];
+    }
+
+    double &x(int32_t i) {
+      assert(i >= 0);
+      assert(i < size_);
+      return x_[i];
+    }
+
+    double const &y(int32_t i) const {
+      assert(i >= 0);
+      assert(i < size_);
+      return y_[i];
+    }
+
+    double &y(int32_t i) {
+      assert(i >= 0);
+      assert(i < size_);
+      return y_[i];
+    }
+
+    double const &z(int32_t i) const {
+      assert(i >= 0);
+      assert(i < size_);
+      return z_[i];
+    }
+
+    double &z(int32_t i) {
+      assert(i >= 0);
+      assert(i < size_);
+      return z_[i];
+    }
+
+    int32_t const &id(int32_t i) const {
+      assert(i >= 0);
+      assert(i < size_);
+      return id_[i];
+    }
+
+    int32_t &id(int32_t i) {
+      assert(i >= 0);
+      assert(i < size_);
+      return id_[i];
+    }
+
+    // pad a size (in bytes) to the next multiple of the alignment
+    static constexpr uint32_t pad(size_t size) { return ((size + alignment - 1) / alignment * alignment); }
+
+    // takes the size in elements, returns the size in bytes
+    static constexpr uint32_t compute_size(int32_t elements) {
+      assert(elements >= 0);
+      return pad(elements * sizeof(double)) +  // x
+             pad(elements * sizeof(double)) +  // y
+             pad(elements * sizeof(double)) +  // z
+             elements * sizeof(int32_t);       // id - no need to pad the last field
+    }
+
+  private:
+    // non-owned memory
+    int32_t size_;  //
+    void *buffer_;  //!
+
+    // layout
+    double *x_;    //[size_]
+    double *y_;    //[size_]
+    double *z_;    //[size_]
+    int32_t *id_;  //[size_]
+  };
+
+}  // namespace portabletest
+
+#endif  // DataFormats_PortableTestObjects_interface_TestSoA_h

--- a/DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h
+++ b/DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h
@@ -1,0 +1,22 @@
+#ifndef DataFormats_PortableTestObjects_interface_alpaka_TestDeviceCollection_h
+#define DataFormats_PortableTestObjects_interface_alpaka_TestDeviceCollection_h
+
+#include "DataFormats/Portable/interface/alpaka/PortableCollection.h"
+#include "DataFormats/PortableTestObjects/interface/TestSoA.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace portabletest {
+
+    // import the top-level portabletest namespace
+    using namespace ::portabletest;
+
+    // SoA with x, y, z, id fields in device global memory
+    using TestDeviceCollection = PortableCollection<TestSoA>;
+
+  }  // namespace portabletest
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // DataFormats_PortableTestObjects_interface_alpaka_TestDeviceCollection_h

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_cuda.h
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_cuda.h
@@ -1,0 +1,3 @@
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/PortableTestObjects/interface/TestSoA.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_cuda_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_cuda_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="alpaka_cuda_async::portabletest::TestDeviceCollection" persistent="false"/>
+  <class name="edm::Wrapper<alpaka_cuda_async::portabletest::TestDeviceCollection>" persistent="false"/>
+</lcgdict>

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_serial.h
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_serial.h
@@ -1,0 +1,3 @@
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
+#include "DataFormats/PortableTestObjects/interface/TestSoA.h"

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_serial_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_serial_def.xml
@@ -1,5 +1,16 @@
 <lcgdict>
   <class name="portabletest::TestHostCollection"/>
+  <read
+    sourceClass="portabletest::TestHostCollection"
+    targetClass="portabletest::TestHostCollection"
+    version="[1-]"
+    source="portabletest::TestSoA layout_;"
+    target="buffer_"
+    embed="false">
+  <![CDATA[
+    portabletest::TestHostCollection::ROOTReadStreamer(newObj, onfile.layout_);
+  ]]>
+  </read>
 
   <class name="edm::Wrapper<portabletest::TestHostCollection>" splitLevel="0"/>
 </lcgdict>

--- a/DataFormats/PortableTestObjects/src/alpaka/classes_serial_def.xml
+++ b/DataFormats/PortableTestObjects/src/alpaka/classes_serial_def.xml
@@ -1,0 +1,5 @@
+<lcgdict>
+  <class name="portabletest::TestHostCollection"/>
+
+  <class name="edm::Wrapper<portabletest::TestHostCollection>" splitLevel="0"/>
+</lcgdict>

--- a/DataFormats/PortableTestObjects/src/classes.h
+++ b/DataFormats/PortableTestObjects/src/classes.h
@@ -1,0 +1,1 @@
+#include "DataFormats/PortableTestObjects/interface/TestSoA.h"

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -1,0 +1,3 @@
+<lcgdict>
+  <class name="portabletest::TestSoA"/>
+</lcgdict>

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -1,3 +1,12 @@
 <lcgdict>
-  <class name="portabletest::TestSoA"/>
+  <class name="portabletest::TestSoA">
+    <field name="mem_" comment="!"/>
+    <field name="byteSize_" comment="!"/>
+    <field name="x_" comment="[nElements_]"/>
+    <field name="y_" comment="[nElements_]"/>
+    <field name="z_" comment="[nElements_]"/>
+    <field name="id_" comment="[nElements_]"/>
+    <field name="metadata()" comment="!"/>
+  </class>
+  <class name="portabletest::TestSoA::View"/>
 </lcgdict>

--- a/DataFormats/SoATemplate/BuildFile.xml
+++ b/DataFormats/SoATemplate/BuildFile.xml
@@ -1,0 +1,2 @@
+<use name="boost_header"/>
+<use name="FWCore/Utilities" source_only="1"/>

--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -1,0 +1,222 @@
+# Structure of array (SoA) generation
+
+The two header files [`SoALayout.h`](SoALayout.h) and [`SoAView.h`](SoAView.h) define preprocessor macros that
+allow generating SoA classes. The SoA classes generate multiple, aligned column from a memory buffer. The memory
+buffer is allocated separately by the user, and can be located in a memory space different from the local one (for
+example, a SoA located in a GPU device memory can be fully pre-defined on the host and the resulting structure is
+passed to the GPU kernel).
+
+This columnar storage allows efficient memory access by GPU kernels (coalesced access on cache line aligned data)
+and possibly vectorization.
+
+Additionally, templation of the layout and view classes allows compile-time variations of accesses and checks:
+verification of alignment and corresponding compiler hinting, cache strategy (non-coherent, streaming with immediate
+invalidation), range checking.
+
+Macro generation allows generating code that provides a clear and concise access of data when used. The code
+generation uses the Boost Preprocessing library.
+
+## Layout
+
+`SoALayout` is a macro generated templated class that subdivides a provided buffer into a collection of columns,
+Eigen columns and scalars. The buffer is expected to be aligned with a selectable alignment defaulting to the CUDA
+GPU cache line (128 bytes). All columns and scalars within a `SoALayout` will be individually aligned, leaving
+padding at the end of each if necessary. Eigen columns have each component of the vector or matrix properly aligned
+in individual column (by defining the stride between components). Only compile-time sized Eigen vectors and matrices
+are supported. Scalar members are members of layout with one element, irrespective of the size of the layout.
+
+Static utility functions automatically compute the byte size of a layout, taking into account all its columns and
+alignment.
+
+## View
+
+`SoAView` is a macro generated templated class allowing access to columns defined in one or multiple `SoALayout`s or
+`SoAViews`. The view can be generated in a constant and non-constant flavors. All view flavors provide with the same
+interface where scalar elements are accessed with an `operator()`: `soa.scalar()` while columns (Eigen or not) are
+accessed via a array of structure (AoS) -like syntax: `soa[index].x()`. The "struct" object returned by `operator[]`
+can be used as a shortcut: `auto si = soa[index]; si.z() = si.x() + zi.y();`
+
+A view can be instanciated by being passed the layout(s) and view(s) it is defined against, or column by column.
+
+Layout classes also define a `View` and `ConstView` subclass that provide access to each column and
+scalar of the layout. In addition to those fully parametrized templates, two others levels of parametrization are
+provided: `ViewTemplate`, `ViewViewTemplateFreeParams` and respectively `ConstViewTemplate`,
+`ConstViewTemplateFreeParams`. The parametrization of those templates is explained in the [Template
+parameters section](#template-parameters).
+
+## Metadata subclass
+
+In order to no clutter the namespace of the generated class, a subclass name `Metadata` is generated. It is
+instanciated with the `metadata()` member function and contains various utility functions, like `size()` (number
+of elements in the SoA), `byteSize()`, `byteAlignment()`, `data()` (a pointer to the buffer). A `nextByte()`
+function computes the first byte of a structure right after a layout, allowing using a single buffer for multiple
+layouts.
+
+## ROOT serialization and de-serialization
+
+Layouts can be serialized and de-serialized with ROOT. In order to generate the ROOT dictionary, separate
+`clases_def.xml` and `classes.h` should be prepared. `classes.h` ensures the inclusion of the proper header files to
+get the definition of the serialized classes, and `classes_def.xml` needs to define the fixed list of members that
+ROOT should ignore, plus the list of all the columns. [An example is provided below.](#examples)
+
+Serialization of Eigen data is not yet supported.
+
+## Template parameters
+
+The template shared by layouts and parameters are:
+- Byte aligment (defaulting to the nVidia GPU cache line size (128 bytes))
+- Alignment enforcement (`Relaxed` or `Enforced`). When enforced, the alignment will be checked at construction
+  time, and the accesses are done with compiler hinting (using the widely supported `__builtin_assume_aligned`
+  intrinsic).
+
+In addition, the views also provide access parameters:
+- Restrict qualify: add restrict hints to read accesses, so that the compiler knows it can relax accesses to the
+  data and assume it will not change. On nVidia GPUs, this leads to the generation of instruction using the faster
+  non-coherent cache.
+- Range checking: add index checking on each access. As this is a compile time parameter, the cost of the feature at
+  run time is null if turned off. When turned on, the accesses will be slowed down by checks. Uppon error detection,
+  an exception is launched (on the CPU side) or the kernel is made to crash (on the GPU side). This feature can help
+  the debugging of index issues at runtime, but of course requires a recompilation.
+
+The trivial views subclasses come in a variety of parametrization levels: `View` uses the same byte
+alignement and alignment enforcement as the layout, and defaults (off) for restrict qualifying and range checking.
+`ViewTemplate` template allows setting of restrict qualifying and range checking, while
+`ViewTemplateFreeParams` allows full re-customization of the template parameters.
+
+## Using SoA layouts and views with GPUs
+
+Instanciation of views and layouts is preferably done on the CPU side. The view object is lightweight, with only one
+pointer per column, plus the global number of elements. Extra view class can be generated to restrict this number of
+pointers to the strict minimum in scenarios where only a subset of columns are used in a given GPU kernel.
+
+## Examples
+
+A layout can be defined as:
+
+```C++
+#include "DataFormats/SoALayout.h"
+
+GENERATE_SOA_LAYOUT(SoA1LayoutTemplate,
+  // predefined static scalars
+  // size_t size;
+  // size_t alignment;
+
+  // columns: one value per element
+  SOA_COLUMN(double, x),
+  SOA_COLUMN(double, y),
+  SOA_COLUMN(double, z),
+  SOA_EIGEN_COLUMN(Eigen::Vector3d, a),
+  SOA_EIGEN_COLUMN(Eigen::Vector3d, b),
+  SOA_EIGEN_COLUMN(Eigen::Vector3d, r),
+  SOA_COLUMN(uint16_t, color),
+  SOA_COLUMN(int32_t, value),
+  SOA_COLUMN(double *, py),
+  SOA_COLUMN(uint32_t, count),
+  SOA_COLUMN(uint32_t, anotherCount),
+
+  // scalars: one value for the whole structure
+  SOA_SCALAR(const char *, description),
+  SOA_SCALAR(uint32_t, someNumber)
+);
+
+// Default template parameters are <
+//   size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
+//   bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::Relaxed
+// >
+using SoA1Layout = SoA1LayoutTemplate<>;
+
+using SoA1LayoutAligned = SoA1LayoutTemplate<cms::soa::CacheLineSize::defaultSize, cms::soa::AlignmentEnforcement::Enforced>;
+```
+
+The buffer of the proper size is allocated, and the layout is populated with:
+
+```C++
+// Allocation of aligned
+size_t elements = 100;
+using AlignedBuffer = std::unique_ptr<std::byte, decltype(std::free) *>;
+AlignedBuffer h_buf (reinterpret_cast<std::byte*>(aligned_alloc(SoA1LayoutAligned::byteAlignment, SoA1LayoutAligned::computeDataSize(elements))), std::free);
+SoA1LayoutAligned soaLayout(h_buf.get(), elements);
+```
+
+A view will derive its column types from one or multiple layouts. The macro generating the view takes a list of layouts or views it
+gets is data from as a first parameter, and the selection of the columns the view will give access to as a second parameter.
+
+```C++
+// A 1 to 1 view of the layout (except for unsupported types).
+GENERATE_SOA_VIEW(SoA1ViewTemplate,
+  SOA_VIEW_LAYOUT_LIST(
+    SOA_VIEW_LAYOUT(SoA1Layout, soa1)
+  ),
+  SOA_VIEW_VALUE_LIST(
+    SOA_VIEW_VALUE(soa1, x),
+    SOA_VIEW_VALUE(soa1, y),
+    SOA_VIEW_VALUE(soa1, z),
+    SOA_VIEW_VALUE(soa1, color),
+    SOA_VIEW_VALUE(soa1, value),
+    SOA_VIEW_VALUE(soa1, py),
+    SOA_VIEW_VALUE(soa1, count),
+    SOA_VIEW_VALUE(soa1, anotherCount),
+    SOA_VIEW_VALUE(soa1, description),
+    SOA_VIEW_VALUE(soa1, someNumber)
+  )
+);
+
+using SoA1View = SoA1ViewTemplate<>;
+
+SoA1View soaView(soaLayout);
+
+for (size_t i=0; i < soaLayout.metadata().size(); ++i) {
+  auto si = soaView[i];
+  si.x() = si.y() = i;
+  soaView.someNumber() += i;
+}
+```
+
+The mutable and const views with the exact same set of columns and their parametrized variants are provided from the layout as:
+
+```C++
+// (Pseudo-code)
+struct SoA1Layout::View;
+
+template<bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,
+         bool RANGE_CHECKING = cms::soa::RangeChecking::Default>
+struct SoA1Layout::ViewTemplate;
+
+template<size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
+         bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::Relaxed,
+         bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,
+         bool RANGE_CHECKING = cms::soa::RangeChecking::Default>
+struct SoA1Layout::ViewTemplateFreeParams;
+
+struct SoA1Layout::ConstView;
+
+template<bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,
+         bool RANGE_CHECKING = cms::soa::RangeChecking::Default>
+struct SoA1Layout::ConstViewTemplate;
+
+template<size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
+         bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::Relaxed,
+         bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,
+         bool RANGE_CHECKING = cms::soa::RangeChecking::Default>
+struct SoA1Layout::ConstViewTemplateFreeParams;
+```
+
+
+
+## Current status and further improvements
+
+### Available features
+
+- The layout and views support scalars and columns, alignment and alignment enforcement and hinting (linked).
+- Automatic `__restrict__` compiler hinting is supported and can be enabled where appropriate.
+- Automatic creation of trivial views and const views derived from a single layout.
+- Cache access style, which was explored, was abandoned as this not-yet-used feature interferes with `__restrict__`
+  support (which is already in used in existing code). It could be made available as a separate tool that can be used
+  directly by the module developer, orthogonally from SoA.
+- Optional (compile time) range checking validates the index of every column access, throwing an exception on the
+  CPU side and forcing a segmentation fault to halt kernels. When not enabled, it has no impact on performance (code
+  not compiled)
+- Eigen columns are also suported, with both const and non-const flavors.
+- ROOT serialization and deserialization is supported. In CMSSW, it is planned to be used through the memory
+  managing `PortableCollection` family of classes.
+- An `operator<<()` is provided to print the layout of an SoA to standard streams.

--- a/DataFormats/SoATemplate/README.md
+++ b/DataFormats/SoATemplate/README.md
@@ -65,7 +65,7 @@ Serialization of Eigen data is not yet supported.
 
 The template shared by layouts and parameters are:
 - Byte aligment (defaulting to the nVidia GPU cache line size (128 bytes))
-- Alignment enforcement (`Relaxed` or `Enforced`). When enforced, the alignment will be checked at construction
+- Alignment enforcement (`relaxed` or `enforced`). When enforced, the alignment will be checked at construction
   time, and the accesses are done with compiler hinting (using the widely supported `__builtin_assume_aligned`
   intrinsic).
 
@@ -121,11 +121,11 @@ GENERATE_SOA_LAYOUT(SoA1LayoutTemplate,
 
 // Default template parameters are <
 //   size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
-//   bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::Relaxed
+//   bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed
 // >
 using SoA1Layout = SoA1LayoutTemplate<>;
 
-using SoA1LayoutAligned = SoA1LayoutTemplate<cms::soa::CacheLineSize::defaultSize, cms::soa::AlignmentEnforcement::Enforced>;
+using SoA1LayoutAligned = SoA1LayoutTemplate<cms::soa::CacheLineSize::defaultSize, cms::soa::AlignmentEnforcement::enforced>;
 ```
 
 The buffer of the proper size is allocated, and the layout is populated with:
@@ -178,26 +178,26 @@ The mutable and const views with the exact same set of columns and their paramet
 // (Pseudo-code)
 struct SoA1Layout::View;
 
-template<bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,
-         bool RANGE_CHECKING = cms::soa::RangeChecking::Default>
+template<bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,
+         bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>
 struct SoA1Layout::ViewTemplate;
 
 template<size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
-         bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::Relaxed,
-         bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,
-         bool RANGE_CHECKING = cms::soa::RangeChecking::Default>
+         bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed,
+         bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,
+         bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>
 struct SoA1Layout::ViewTemplateFreeParams;
 
 struct SoA1Layout::ConstView;
 
-template<bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,
-         bool RANGE_CHECKING = cms::soa::RangeChecking::Default>
+template<bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,
+         bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>
 struct SoA1Layout::ConstViewTemplate;
 
 template<size_t ALIGNMENT = cms::soa::CacheLineSize::defaultSize,
-         bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::Relaxed,
-         bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,
-         bool RANGE_CHECKING = cms::soa::RangeChecking::Default>
+         bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::relaxed,
+         bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::enabled,
+         bool RANGE_CHECKING = cms::soa::RangeChecking::disabled>
 struct SoA1Layout::ConstViewTemplateFreeParams;
 ```
 

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -1,0 +1,614 @@
+#ifndef DataFormats_SoATemplate_interface_SoACommon_h
+#define DataFormats_SoATemplate_interface_SoACommon_h
+
+/*
+ * Definitions of SoA common parameters for SoA class generators
+ */
+
+#include <cstdint>
+#include <cassert>
+#include <ostream>
+#include <tuple>
+#include <type_traits>
+
+#include <boost/preprocessor.hpp>
+
+#include "FWCore/Utilities/interface/typedefs.h"
+
+// CUDA attributes
+#ifdef __CUDACC__
+#define SOA_HOST_ONLY __host__
+#define SOA_DEVICE_ONLY __device__
+#define SOA_HOST_DEVICE __host__ __device__
+#define SOA_INLINE __forceinline__
+#else
+#define SOA_HOST_ONLY
+#define SOA_DEVICE_ONLY
+#define SOA_HOST_DEVICE
+#define SOA_INLINE inline
+#endif
+
+// Exception throwing (or willful crash in kernels)
+#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#define SOA_THROW_OUT_OF_RANGE(A) \
+  {                               \
+    printf(A "\n");               \
+    *((char*)nullptr) = 0;        \
+  }
+#else
+#define SOA_THROW_OUT_OF_RANGE(A) \
+  { throw std::out_of_range(A); }
+#endif
+
+/* declare "scalars" (one value shared across the whole SoA) and "columns" (one value per element) */
+#define _VALUE_TYPE_SCALAR 0
+#define _VALUE_TYPE_COLUMN 1
+#define _VALUE_TYPE_EIGEN_COLUMN 2
+
+/* The size type need to be "hardcoded" in the template parameters for classes serialized by ROOT */
+#define CMS_SOA_BYTE_SIZE_TYPE size_t
+
+namespace cms::soa {
+
+  // XXX Addition of typedef for index types.
+  // size_type for indices. Compatible with ROOT, but limited to 2G entries
+  using size_type = int32_t;
+  // byte_size_type for byte counts. Not creating an artificial limit (and not ROOT serialized).
+  using byte_size_type = CMS_SOA_BYTE_SIZE_TYPE;
+
+  enum class SoAColumnType {
+    scalar = _VALUE_TYPE_SCALAR,
+    column = _VALUE_TYPE_COLUMN,
+    eigen = _VALUE_TYPE_EIGEN_COLUMN
+  };
+
+  // XXX Changed enum class to bare bool + const values in class.
+  struct RestrictQualify {
+    static const bool Enabled = true;
+    static const bool Disabled = false;
+    static const bool Default = Disabled;
+  };
+
+  //enum class RestrictQualify : bool { Enabled, Disabled, Default = Disabled };
+
+  // XXX Changed enum class to bare bool + const values in class.
+  struct RangeChecking {
+    static const bool Enabled = true;
+    static const bool Disabled = false;
+    static const bool Default = Disabled;
+  };
+
+  //enum class RangeChecking : bool { Enabled, Disabled, Default = Disabled };
+
+  // XXX Changed enum class to bare bool + const values in class.
+  template <typename T, bool RESTRICT_QUALIFY>
+  struct add_restrict {};
+
+  template <typename T>
+  struct add_restrict<T, RestrictQualify::Enabled> {
+    typedef T Value;
+    typedef T* __restrict__ Pointer;
+    typedef T& __restrict__ Reference;
+    typedef const T ConstValue;
+    typedef const T* __restrict__ PointerToConst;
+    typedef const T& __restrict__ ReferenceToConst;
+  };
+
+  template <typename T>
+  struct add_restrict<T, RestrictQualify::Disabled> {
+    typedef T Value;
+    typedef T* Pointer;
+    typedef T& Reference;
+    typedef const T ConstValue;
+    typedef const T* PointerToConst;
+    typedef const T& ReferenceToConst;
+  };
+  template <SoAColumnType COLUMN_TYPE, typename T>
+  struct SoAParametersImpl;
+
+  // Templated parameter sets for scalar columns and Eigen columns
+  template <SoAColumnType COLUMN_TYPE, typename T>
+  struct SoAConstParametersImpl {
+    static const SoAColumnType columnType = COLUMN_TYPE;
+    typedef T ValueType;
+    typedef const ValueType* TupleOrPointerType;
+    const ValueType* addr_ = nullptr;
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl(const ValueType* addr) : addr_(addr) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl(const SoAConstParametersImpl& o) { addr_ = o.addr_; }
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl(const SoAParametersImpl<columnType, ValueType>& o) {
+      addr_ = o.addr_;
+    }
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl() {}
+    static bool checkAlignment(ValueType* addr, byte_size_type alignment) {
+      return reinterpret_cast<intptr_t>(addr) % alignment;
+    }
+  };
+
+  template <typename T>
+  struct SoAConstParametersImpl<SoAColumnType::eigen, T> {
+    static const SoAColumnType columnType = SoAColumnType::eigen;
+    typedef T ValueType;
+    typedef typename T::Scalar ScalarType;
+    typedef std::tuple<ScalarType*, byte_size_type> TupleOrPointerType;
+    const ScalarType* addr_ = nullptr;
+    byte_size_type stride_ = 0;
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl(const ScalarType* addr, byte_size_type stride)
+        : addr_(addr), stride_(stride) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl(const TupleOrPointerType tuple)
+        : addr_(std::get<0>(tuple)), stride_(std::get<1>(tuple)) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl(const ScalarType* addr) : addr_(addr) {}
+    // Trick setter + return self-reference allowing comma-free 2-stage construction in macro contexts (in combination with the
+    // addr-only constructor.
+    SoAConstParametersImpl& setStride(byte_size_type stride) {
+      stride_ = stride;
+      return *this;
+    }
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl(const SoAConstParametersImpl& o) {
+      addr_ = o.addr_;
+      stride_ = o.stride_;
+    }
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl(const SoAParametersImpl<columnType, ValueType>& o) {
+      addr_ = o.addr_;
+      stride_ = o.stride_;
+    }
+    SOA_HOST_DEVICE SOA_INLINE SoAConstParametersImpl() {}
+    static bool checkAlignment(const TupleOrPointerType tuple, byte_size_type alignment) {
+      const auto& [addr, stride] = tuple;
+      return reinterpret_cast<intptr_t>(addr) % alignment;
+    }
+  };
+
+  // Matryoshka template to avoiding commas in macros
+  template <SoAColumnType COLUMN_TYPE>
+  struct SoAConstParameters_ColumnType {
+    template <typename T>
+    struct DataType : public SoAConstParametersImpl<COLUMN_TYPE, T> {
+      using SoAConstParametersImpl<COLUMN_TYPE, T>::SoAConstParametersImpl;
+    };
+  };
+
+  // Templated parameter sets for scalar columns and Eigen columns
+  template <SoAColumnType COLUMN_TYPE, typename T>
+  struct SoAParametersImpl {
+    static const SoAColumnType columnType = COLUMN_TYPE;
+    typedef T ValueType;
+    typedef const ValueType* TupleOrPointerType;
+    typedef SoAConstParametersImpl<columnType, ValueType> ConstType;
+    friend ConstType;
+    ValueType* addr_ = nullptr;
+    SOA_HOST_DEVICE SOA_INLINE SoAParametersImpl(ValueType* addr) : addr_(addr) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAParametersImpl() {}
+    static bool checkAlignment(ValueType* addr, byte_size_type alignment) {
+      return reinterpret_cast<intptr_t>(addr) % alignment;
+    }
+  };
+
+  template <typename T>
+  struct SoAParametersImpl<SoAColumnType::eigen, T> {
+    static const SoAColumnType columnType = SoAColumnType::eigen;
+    typedef T ValueType;
+    typedef SoAConstParametersImpl<columnType, ValueType> ConstType;
+    friend ConstType;
+    typedef typename T::Scalar ScalarType;
+    typedef std::tuple<ScalarType*, byte_size_type> TupleOrPointerType;
+    ScalarType* addr_ = nullptr;
+    size_t stride_ = 0;
+    SOA_HOST_DEVICE SOA_INLINE SoAParametersImpl(ScalarType* addr, byte_size_type stride)
+        : addr_(addr), stride_(stride) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAParametersImpl(const TupleOrPointerType tuple)
+        : addr_(std::get<0>(tuple)), stride_(std::get<1>(tuple)) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAParametersImpl() {}
+    SOA_HOST_DEVICE SOA_INLINE SoAParametersImpl(ScalarType* addr) : addr_(addr) {}
+    // Trick setter + return self-reference allowing commat-free 2-stage construction in macro contexts (in combination with the
+    // addr-only constructor.
+    SoAParametersImpl& setStride(byte_size_type stride) {
+      stride_ = stride;
+      return *this;
+    }
+    static bool checkAlignment(const TupleOrPointerType tuple, byte_size_type alignment) {
+      const auto& [addr, stride] = tuple;
+      return reinterpret_cast<intptr_t>(addr) % alignment;
+    }
+  };
+
+  // Matryoshka template to avoiding commas in macros
+  template <SoAColumnType COLUMN_TYPE>
+  struct SoAParameters_ColumnType {
+    template <typename T>
+    struct DataType : public SoAParametersImpl<COLUMN_TYPE, T> {
+      using SoAParametersImpl<COLUMN_TYPE, T>::SoAParametersImpl;
+    };
+  };
+
+  // Helper template managing the value within it column
+  // The optional compile time alignment parameter enables informing the
+  // compiler of alignment (enforced by caller).
+  template <SoAColumnType COLUMN_TYPE,
+            typename T,
+            byte_size_type ALIGNMENT,
+            // XXX Changed enum class to bare bool + const values in class.
+            bool RESTRICT_QUALIFY = RestrictQualify::Disabled>
+  class SoAValue {
+    // Eigen is implemented in a specialization
+    static_assert(COLUMN_TYPE != SoAColumnType::eigen);
+
+  public:
+    typedef add_restrict<T, RESTRICT_QUALIFY> Restr;
+    typedef typename Restr::Value Val;
+    typedef typename Restr::Pointer Ptr;
+    typedef typename Restr::Reference Ref;
+    typedef typename Restr::PointerToConst PtrToConst;
+    typedef typename Restr::ReferenceToConst RefToConst;
+    SOA_HOST_DEVICE SOA_INLINE SoAValue(size_type i, T* col) : idx_(i), col_(col) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAValue(size_type i, SoAParametersImpl<COLUMN_TYPE, T> params)
+        : idx_(i), col_(params.addr_) {}
+    /*
+    SOA_HOST_DEVICE SOA_INLINE operator T&() { return col_[idx_]; }
+    */
+    SOA_HOST_DEVICE SOA_INLINE Ref operator()() {
+      // Ptr type will add the restrict qualifyer if needed
+      Ptr col = alignedCol();
+      return col[idx_];
+    }
+    SOA_HOST_DEVICE SOA_INLINE RefToConst operator()() const {
+      // PtrToConst type will add the restrict qualifyer if needed
+      PtrToConst col = alignedCol();
+      return col[idx_];
+    }
+    SOA_HOST_DEVICE SOA_INLINE Ptr operator&() { return &alignedCol()[idx_]; }
+    SOA_HOST_DEVICE SOA_INLINE PtrToConst operator&() const { return &alignedCol()[idx_]; }
+    /*
+    template <typename T2>
+    SOA_HOST_DEVICE SOA_INLINE Ref operator=(const T2& v) {
+      return alignedCol()[idx_] = v;
+    }
+    */
+    typedef Val valueType;
+    static constexpr auto valueSize = sizeof(T);
+
+  private:
+    SOA_HOST_DEVICE SOA_INLINE Ptr alignedCol() const {
+      if constexpr (ALIGNMENT) {
+        return reinterpret_cast<Ptr>(__builtin_assume_aligned(col_, ALIGNMENT));
+      }
+      return reinterpret_cast<Ptr>(col_);
+    }
+    size_type idx_;
+    T* col_;
+  };
+
+  // Helper template managing the value within it column
+  // TODO Create a const variant to avoid leaking mutable access.
+#ifdef EIGEN_WORLD_VERSION
+  template <class C, byte_size_type ALIGNMENT, bool RESTRICT_QUALIFY>
+  class SoAValue<SoAColumnType::eigen, C, ALIGNMENT, RESTRICT_QUALIFY> {
+  public:
+    typedef C Type;
+    typedef Eigen::Map<C, 0, Eigen::InnerStride<Eigen::Dynamic>> MapType;
+    typedef const Eigen::Map<const C, 0, Eigen::InnerStride<Eigen::Dynamic>> CMapType;
+    typedef add_restrict<typename C::Scalar, RESTRICT_QUALIFY> Restr;
+    typedef typename Restr::Value Val;
+    typedef typename Restr::Pointer Ptr;
+    typedef typename Restr::Reference Ref;
+    typedef typename Restr::PointerToConst PtrToConst;
+    typedef typename Restr::ReferenceToConst RefToConst;
+    SOA_HOST_DEVICE SOA_INLINE SoAValue(size_type i, typename C::Scalar* col, byte_size_type stride)
+        : val_(col + i, C::RowsAtCompileTime, C::ColsAtCompileTime, Eigen::InnerStride<Eigen::Dynamic>(stride)),
+          crCol_(col),
+          cVal_(crCol_ + i, C::RowsAtCompileTime, C::ColsAtCompileTime, Eigen::InnerStride<Eigen::Dynamic>(stride)),
+          stride_(stride) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAValue(size_type i, SoAParametersImpl<SoAColumnType::eigen, C> params)
+        : val_(params.addr_ + i,
+               C::RowsAtCompileTime,
+               C::ColsAtCompileTime,
+               Eigen::InnerStride<Eigen::Dynamic>(params.stride_)),
+          crCol_(params.addr_),
+          cVal_(crCol_ + i,
+                C::RowsAtCompileTime,
+                C::ColsAtCompileTime,
+                Eigen::InnerStride<Eigen::Dynamic>(params.stride_)),
+          stride_(params.stride_) {}
+    SOA_HOST_DEVICE SOA_INLINE MapType& operator()() { return val_; }
+    SOA_HOST_DEVICE SOA_INLINE const CMapType& operator()() const { return cVal_; }
+    SOA_HOST_DEVICE SOA_INLINE operator C() { return val_; }
+    SOA_HOST_DEVICE SOA_INLINE operator const C() const { return cVal_; }
+    SOA_HOST_DEVICE SOA_INLINE C* operator&() { return &val_; }
+    SOA_HOST_DEVICE SOA_INLINE const C* operator&() const { return &cVal_; }
+    template <class C2>
+    SOA_HOST_DEVICE SOA_INLINE MapType& operator=(const C2& v) {
+      return val_ = v;
+    }
+    typedef typename C::Scalar ValueType;
+    static constexpr auto valueSize = sizeof(C::Scalar);
+    SOA_HOST_DEVICE SOA_INLINE byte_size_type stride() const { return stride_; }
+
+  private:
+    MapType val_;
+    const Ptr crCol_;
+    CMapType cVal_;
+    byte_size_type stride_;
+  };
+#else
+  // XXX Changed enum class to bare bool + const values in class.
+  template <class C, byte_size_type ALIGNMENT, bool RESTRICT_QUALIFY>
+  class SoAValue<SoAColumnType::eigen, C, ALIGNMENT, RESTRICT_QUALIFY> {
+    // Eigen/Core should be pre-included before the SoA headers to enable support for Eigen columns.
+    static_assert(!sizeof(C),
+                  "Eigen/Core should be pre-included before the SoA headers to enable support for Eigen columns.");
+  };
+#endif
+  // Helper template managing the value within it column
+  template <SoAColumnType COLUMN_TYPE,
+            typename T,
+            byte_size_type ALIGNMENT,
+            // XXX Changed enum class to bare bool + const values in class.
+            bool RESTRICT_QUALIFY = RestrictQualify::Disabled>
+  class SoAConstValue {
+    // Eigen is implemented in a specialization
+    static_assert(COLUMN_TYPE != SoAColumnType::eigen);
+
+  public:
+    typedef add_restrict<T, RESTRICT_QUALIFY> Restr;
+    typedef typename Restr::Value Val;
+    typedef typename Restr::Pointer Ptr;
+    typedef typename Restr::Reference Ref;
+    typedef typename Restr::PointerToConst PtrToConst;
+    typedef typename Restr::ReferenceToConst RefToConst;
+    typedef SoAParametersImpl<COLUMN_TYPE, T> Params;
+    typedef SoAConstParametersImpl<COLUMN_TYPE, T> ConstParams;
+    SOA_HOST_DEVICE SOA_INLINE SoAConstValue(size_type i, const T* col) : idx_(i), col_(col) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAConstValue(size_type i, SoAParametersImpl<COLUMN_TYPE, T> params)
+        : idx_(i), col_(params.addr_) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAConstValue(size_type i, SoAConstParametersImpl<COLUMN_TYPE, T> params)
+        : idx_(i), col_(params.addr_) {}
+    /* SOA_HOST_DEVICE SOA_INLINE operator T&() { return col_[idx_]; } */
+    SOA_HOST_DEVICE SOA_INLINE RefToConst operator()() const {
+      // Ptr type will add the restrict qualifyer if needed
+      PtrToConst col = alignedCol();
+      return col[idx_];
+    }
+    SOA_HOST_DEVICE SOA_INLINE const T* operator&() const { return &alignedCol()[idx_]; }
+    typedef T valueType;
+    static constexpr auto valueSize = sizeof(T);
+
+  private:
+    SOA_HOST_DEVICE SOA_INLINE PtrToConst alignedCol() const {
+      if constexpr (ALIGNMENT) {
+        return reinterpret_cast<PtrToConst>(__builtin_assume_aligned(col_, ALIGNMENT));
+      }
+      return reinterpret_cast<PtrToConst>(col_);
+    }
+    size_type idx_;
+    const T* col_;
+  };
+
+#ifdef EIGEN_WORLD_VERSION
+  // Helper template managing the value within it column
+  // TODO Create a const variant to avoid leaking mutable access.
+  template <class C, byte_size_type ALIGNMENT, bool RESTRICT_QUALIFY>
+  class SoAConstValue<SoAColumnType::eigen, C, ALIGNMENT, RESTRICT_QUALIFY> {
+  public:
+    typedef C Type;
+    typedef Eigen::Map<const C, 0, Eigen::InnerStride<Eigen::Dynamic>> CMapType;
+    typedef const CMapType& RefToConst;
+    typedef SoAConstParametersImpl<SoAColumnType::eigen, C> ConstParams;
+    SOA_HOST_DEVICE SOA_INLINE SoAConstValue(size_type i, typename C::Scalar* col, byte_size_type stride)
+        : crCol_(col),
+          cVal_(crCol_ + i, C::RowsAtCompileTime, C::ColsAtCompileTime, Eigen::InnerStride<Eigen::Dynamic>(stride)),
+          stride_(stride) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAConstValue(size_type i, SoAConstParametersImpl<SoAColumnType::eigen, C> params)
+        : crCol_(params.addr_),
+          cVal_(crCol_ + i,
+                C::RowsAtCompileTime,
+                C::ColsAtCompileTime,
+                Eigen::InnerStride<Eigen::Dynamic>(params.stride_)),
+          stride_(params.stride_) {}
+    SOA_HOST_DEVICE SOA_INLINE const CMapType& operator()() const { return cVal_; }
+    SOA_HOST_DEVICE SOA_INLINE operator const C() const { return cVal_; }
+    SOA_HOST_DEVICE SOA_INLINE const C* operator&() const { return &cVal_; }
+    typedef typename C::Scalar ValueType;
+    static constexpr auto valueSize = sizeof(C::Scalar);
+    SOA_HOST_DEVICE SOA_INLINE byte_size_type stride() const { return stride_; }
+
+  private:
+    const typename C::Scalar* __restrict__ crCol_;
+    CMapType cVal_;
+    byte_size_type stride_;
+  };
+#else
+  // XXX Changed enum class to bare bool + const values in class.
+  template <class C, byte_size_type ALIGNMENT, bool RESTRICT_QUALIFY>
+  class SoAConstValue<SoAColumnType::eigen, C, ALIGNMENT, RESTRICT_QUALIFY> {
+    // Eigen/Core should be pre-included before the SoA headers to enable support for Eigen columns.
+    static_assert(!sizeof(C),
+                  "Eigen/Core should be pre-included before the SoA headers to enable support for Eigen columns.");
+  };
+#endif
+
+  // Helper template to avoid commas in macro
+#ifdef EIGEN_WORLD_VERSION
+  template <class C>
+  struct EigenConstMapMaker {
+    typedef Eigen::Map<const C, Eigen::AlignmentType::Unaligned, Eigen::InnerStride<Eigen::Dynamic>> Type;
+    class DataHolder {
+    public:
+      DataHolder(const typename C::Scalar* data) : data_(data) {}
+      EigenConstMapMaker::Type withStride(byte_size_type stride) {
+        return EigenConstMapMaker::Type(
+            data_, C::RowsAtCompileTime, C::ColsAtCompileTime, Eigen::InnerStride<Eigen::Dynamic>(stride));
+      }
+
+    private:
+      const typename C::Scalar* const data_;
+    };
+    static DataHolder withData(const typename C::Scalar* data) { return DataHolder(data); }
+  };
+#else
+  template <class C>
+  struct EigenConstMapMaker {
+    // Eigen/Core should be pre-included before the SoA headers to enable support for Eigen columns.
+    static_assert(!sizeof(C),
+                  "Eigen/Core should be pre-included before the SoA headers to enable support for Eigen columns.");
+  };
+#endif
+
+  // Helper function to compute aligned size
+  constexpr inline byte_size_type alignSize(byte_size_type size, byte_size_type alignment) {
+    return ((size + alignment - 1) / alignment) * alignment;
+  }
+
+}  // namespace cms::soa
+
+#define SOA_SCALAR(TYPE, NAME) (_VALUE_TYPE_SCALAR, TYPE, NAME)
+#define SOA_COLUMN(TYPE, NAME) (_VALUE_TYPE_COLUMN, TYPE, NAME)
+#define SOA_EIGEN_COLUMN(TYPE, NAME) (_VALUE_TYPE_EIGEN_COLUMN, TYPE, NAME)
+
+/* Iterate on the macro MACRO and return the result as a comma separated list */
+#define _ITERATE_ON_ALL_COMMA(MACRO, DATA, ...) \
+  BOOST_PP_TUPLE_ENUM(BOOST_PP_SEQ_TO_TUPLE(_ITERATE_ON_ALL(MACRO, DATA, __VA_ARGS__)))
+/* Iterate MACRO on all elements */
+#define _ITERATE_ON_ALL(MACRO, DATA, ...) BOOST_PP_SEQ_FOR_EACH(MACRO, DATA, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+
+/* Switch on macros depending on scalar / column type */
+#define _SWITCH_ON_TYPE(VALUE_TYPE, IF_SCALAR, IF_COLUMN, IF_EIGEN_COLUMN) \
+  BOOST_PP_IF(                                                             \
+      BOOST_PP_EQUAL(VALUE_TYPE, _VALUE_TYPE_SCALAR),                      \
+      IF_SCALAR,                                                           \
+      BOOST_PP_IF(                                                         \
+          BOOST_PP_EQUAL(VALUE_TYPE, _VALUE_TYPE_COLUMN),                  \
+          IF_COLUMN,                                                       \
+          BOOST_PP_IF(BOOST_PP_EQUAL(VALUE_TYPE, _VALUE_TYPE_EIGEN_COLUMN), IF_EIGEN_COLUMN, BOOST_PP_EMPTY())))
+
+namespace cms::soa {
+
+  /* Column accessors: templates implementing the global accesors (soa::x() and soa::x(index) */
+  enum class SoAAccessType : bool { mutableAccess, constAccess };
+
+  template <typename, SoAColumnType, SoAAccessType>
+  struct SoAColumnAccessorsImpl {};
+
+  // Todo: add alignment support.
+  // Sfinae based const/non const variants.
+  // Column
+  template <typename T>
+  struct SoAColumnAccessorsImpl<T, SoAColumnType::column, SoAAccessType::mutableAccess> {
+    //SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(T* baseAddress) : baseAddress_(baseAddress) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(const SoAParametersImpl<SoAColumnType::column, T>& params)
+        : params_(params) {}
+    SOA_HOST_DEVICE SOA_INLINE T* operator()() { return params_.addr_; }
+    typedef T* NoParamReturnType;
+    SOA_HOST_DEVICE SOA_INLINE T& operator()(size_type index) { return params_.addr_[index]; }
+
+  private:
+    SoAParametersImpl<SoAColumnType::column, T> params_;
+  };
+
+  // Const column
+  template <typename T>
+  struct SoAColumnAccessorsImpl<T, SoAColumnType::column, SoAAccessType::constAccess> {
+    SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(const SoAConstParametersImpl<SoAColumnType::column, T>& params)
+        : params_(params) {}
+    SOA_HOST_DEVICE SOA_INLINE const T* operator()() const { return params_.addr_; }
+    typedef T* NoParamReturnType;
+    SOA_HOST_DEVICE SOA_INLINE T operator()(size_type index) const { return params_.addr_[index]; }
+
+  private:
+    SoAConstParametersImpl<SoAColumnType::column, T> params_;
+  };
+
+  // Scalar
+  template <typename T>
+  struct SoAColumnAccessorsImpl<T, SoAColumnType::scalar, SoAAccessType::mutableAccess> {
+    SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(const SoAParametersImpl<SoAColumnType::scalar, T>& params)
+        : params_(params) {}
+    SOA_HOST_DEVICE SOA_INLINE T& operator()() { return *params_.addr_; }
+    typedef T& NoParamReturnType;
+    SOA_HOST_DEVICE SOA_INLINE void operator()(size_type index) const {
+      assert(false && "Indexed access impossible for SoA scalars.");
+    }
+
+  private:
+    SoAParametersImpl<SoAColumnType::scalar, T> params_;
+  };
+
+  // Const scalar
+  template <typename T>
+  struct SoAColumnAccessorsImpl<T, SoAColumnType::scalar, SoAAccessType::constAccess> {
+    SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(const SoAConstParametersImpl<SoAColumnType::scalar, T>& params)
+        : params_(params) {}
+    SOA_HOST_DEVICE SOA_INLINE T operator()() const { return *params_.addr_; }
+    typedef T NoParamReturnType;
+    SOA_HOST_DEVICE SOA_INLINE void operator()(size_type index) const {
+      assert(false && "Indexed access impossible for SoA scalars.");
+    }
+
+  private:
+    SoAConstParametersImpl<SoAColumnType::scalar, T> params_;
+  };
+
+  template <typename T>
+  struct SoAColumnAccessorsImpl<T, SoAColumnType::eigen, SoAAccessType::mutableAccess> {
+    //SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(T* baseAddress) : baseAddress_(baseAddress) {}
+    SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(const SoAParametersImpl<SoAColumnType::eigen, T>& params)
+        : params_(params) {}
+    SOA_HOST_DEVICE SOA_INLINE typename T::Scalar* operator()() { return params_.addr_; }
+    typedef typename T::Scalar* NoParamReturnType;
+    //SOA_HOST_DEVICE SOA_INLINE T& operator()(size_type index) { return params_.addr_[index]; }
+
+  private:
+    SoAParametersImpl<SoAColumnType::eigen, T> params_;
+  };
+
+  // Const column
+  template <typename T>
+  struct SoAColumnAccessorsImpl<T, SoAColumnType::eigen, SoAAccessType::constAccess> {
+    SOA_HOST_DEVICE SOA_INLINE SoAColumnAccessorsImpl(const SoAConstParametersImpl<SoAColumnType::eigen, T>& params)
+        : params_(params) {}
+    SOA_HOST_DEVICE SOA_INLINE const typename T::Scalar* operator()() const { return params_.addr_; }
+    typedef typename T::Scalar* NoParamReturnType;
+    //SOA_HOST_DEVICE SOA_INLINE T operator()(size_type index) const { return params_.addr_[index]; }
+
+  private:
+    SoAConstParametersImpl<SoAColumnType::eigen, T> params_;
+  };
+
+  /* A helper template stager avoiding comma in macros */
+  template <typename T>
+  struct SoAAccessors {
+    template <auto columnType>
+    struct ColumnType {
+      template <auto accessType>
+      struct AccessType : public SoAColumnAccessorsImpl<T, columnType, accessType> {
+        using SoAColumnAccessorsImpl<T, columnType, accessType>::SoAColumnAccessorsImpl;
+      };
+    };
+  };
+
+  /* Enum parameters allowing templated control of layout/view behaviors */
+  /* Alignment enforcement verifies every column is aligned, and
+   * hints the compiler that it can expect column pointers to be aligned */
+  struct AlignmentEnforcement {
+    static constexpr bool Relaxed = false;
+    static constexpr bool Enforced = true;
+  };
+
+  struct CacheLineSize {
+    static constexpr byte_size_type NvidiaGPU = 128;
+    static constexpr byte_size_type IntelCPU = 64;
+    static constexpr byte_size_type AMDCPU = 64;
+    static constexpr byte_size_type ARMCPU = 64;
+    static constexpr byte_size_type defaultSize = NvidiaGPU;
+  };
+
+}  // namespace cms::soa
+
+// Small wrapper for stream insertion of SoA printing
+template <typename SOA,
+          typename SFINAE =
+              typename std::enable_if_t<std::is_invocable_v<decltype(&SOA::soaToStreamInternal), SOA&, std::ostream&>>>
+SOA_HOST_ONLY std::ostream& operator<<(std::ostream& os, const SOA& soa) {
+  soa.soaToStreamInternal(os);
+  return os;
+}
+
+#endif  // DataFormats_SoATemplate_interface_SoACommon_h

--- a/DataFormats/SoATemplate/interface/SoACommon.h
+++ b/DataFormats/SoATemplate/interface/SoACommon.h
@@ -50,9 +50,8 @@
 
 namespace cms::soa {
 
-  // XXX Addition of typedef for index types.
-  // size_type for indices. Compatible with ROOT, but limited to 2G entries
-  using size_type = int32_t;
+  // size_type for indices. Compatible with ROOT Int_t, but limited to 2G entries
+  using size_type = cms_int32_t;
   // byte_size_type for byte counts. Not creating an artificial limit (and not ROOT serialized).
   using byte_size_type = CMS_SOA_BYTE_SIZE_TYPE;
 

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -165,6 +165,20 @@
 // clang-format on
 #define _DEFINE_METADATA_MEMBERS(R, DATA, TYPE_NAME) _DEFINE_METADATA_MEMBERS_IMPL TYPE_NAME
 
+// clang-format off
+#define _TRIVIAL_VIEW_ELEMENT_TUPLE_TYPES_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                             \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar (empty) */                                                                                             \
+      ,                                                                                                                \
+      /* Column */                                                                                                     \
+      (CPP_TYPE)                                                                                                       \
+      ,                                                                                                                \
+      /* Eigen column */                                                                                               \
+      (CPP_TYPE)                                                                                                       \
+)
+// clang-format on
+
+#define _TRIVIAL_VIEW_ELEMENT_TUPLE_TYPES(R, DATA, TYPE_NAME) _TRIVIAL_VIEW_ELEMENT_TUPLE_TYPES_IMPL TYPE_NAME
 /**
  * Member assignment for trivial constructor
  */
@@ -392,6 +406,10 @@
       }                                                                                                                \
       _ITERATE_ON_ALL(_DEFINE_METADATA_MEMBERS, ~, __VA_ARGS__)                                                        \
                                                                                                                        \
+      using RowInitializer = std::tuple <                                                                              \
+        _ITERATE_ON_ALL_COMMA(_TRIVIAL_VIEW_ELEMENT_TUPLE_TYPES, BOOST_PP_EMPTY(), __VA_ARGS__)                        \
+      >;                                                                                                               \
+                                                                                                                       \
       Metadata& operator=(const Metadata&) = delete;                                                                   \
       Metadata(const Metadata&) = delete;                                                                              \
                                                                                                                        \
@@ -471,7 +489,6 @@
     /* So instead we make the code unconditional with paceholder names which are protected by a private protection. */ \
     /* This will be handled later as we handle the integration of the view as a subclass of the layout.             */ \
   public:                                                                                                              \
-                                                                                                                       \
   _GENERATE_SOA_TRIVIAL_CONST_VIEW(CLASS,                                                                              \
                     SOA_VIEW_LAYOUT_LIST(                                                                              \
                         SOA_VIEW_LAYOUT(BOOST_PP_CAT(CLASS, _parametrized) , BOOST_PP_CAT(instance_, CLASS))),         \
@@ -486,7 +503,8 @@
                     SOA_VIEW_LAYOUT_LIST(                                                                              \
                         SOA_VIEW_LAYOUT(BOOST_PP_CAT(CLASS, _parametrized), BOOST_PP_CAT(instance_, CLASS))),          \
                     SOA_VIEW_VALUE_LIST(_ITERATE_ON_ALL_COMMA(                                                         \
-                    _VIEW_FIELD_FROM_LAYOUT, BOOST_PP_CAT(instance_, CLASS), __VA_ARGS__)))                            \
+                    _VIEW_FIELD_FROM_LAYOUT, BOOST_PP_CAT(instance_, CLASS), __VA_ARGS__)),                            \
+                    __VA_ARGS__)                                                                                       \
                                                                                                                        \
     template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
     using ViewTemplate = ViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY, RANGE_CHECKING>;   \

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -1,0 +1,522 @@
+#ifndef DataFormats_SoATemplate_interface_SoALayout_h
+#define DataFormats_SoATemplate_interface_SoALayout_h
+
+/*
+ * Structure-of-Arrays template with "columns" and "scalars", defined through preprocessor macros,
+ * with compile-time size and alignment, and accessors to the "rows" and "columns".
+ */
+
+#include <cassert>
+#include <iostream>
+
+#include "SoACommon.h"
+#include "SoAView.h"
+
+/* dump SoA fields information; these should expand to, for columns:
+ * Example:
+ * GENERATE_SOA_LAYOUT(SoA,
+ *   // predefined static scalars
+ *   // size_t size;
+ *   // size_t alignment;
+ *
+ *   // columns: one value per element
+ *   SOA_COLUMN(double, x),
+ *   SOA_COLUMN(double, y),
+ *   SOA_COLUMN(double, z),
+ *   SOA_EIGEN_COLUMN(Eigen::Vector3d, a),
+ *   SOA_EIGEN_COLUMN(Eigen::Vector3d, b),
+ *   SOA_EIGEN_COLUMN(Eigen::Vector3d, r),
+ *   SOA_COLUMN(uint16_t, colour),
+ *   SOA_COLUMN(int32_t, value),
+ *   SOA_COLUMN(double *, py),
+ *   SOA_COLUMN(uint32_t, count),
+ *   SOA_COLUMN(uint32_t, anotherCount),
+ *
+ *   // scalars: one value for the whole structure
+ *   SOA_SCALAR(const char *, description),
+ *   SOA_SCALAR(uint32_t, someNumber)
+ * );
+ *
+ * dumps as:
+ * SoA(32, 64):
+ *   sizeof(SoA): 152
+ *  Column x_ at offset 0 has size 256 and padding 0
+ *  Column y_ at offset 256 has size 256 and padding 0
+ *  Column z_ at offset 512 has size 256 and padding 0
+ *  Eigen value a_ at offset 768 has dimension (3 x 1) and per column size 256 and padding 0
+ *  Eigen value b_ at offset 1536 has dimension (3 x 1) and per column size 256 and padding 0
+ *  Eigen value r_ at offset 2304 has dimension (3 x 1) and per column size 256 and padding 0
+ *  Column colour_ at offset 3072 has size 64 and padding 0
+ *  Column value_ at offset 3136 has size 128 and padding 0
+ *  Column py_ at offset 3264 has size 256 and padding 0
+ *  Column count_ at offset 3520 has size 128 and padding 0
+ *  Column anotherCount_ at offset 3648 has size 128 and padding 0
+ *  Scalar description_ at offset 3776 has size 8 and padding 56
+ *  Scalar someNumber_ at offset 3840 has size 4 and padding 60
+ * Final offset = 3904 computeDataSize(...): 3904
+ *
+ */
+
+namespace cms::soa {
+  // A helper unique_ptr like class holding aligned
+  // XXX disabled for use with collections
+  /*
+  class ByteBuffer {
+  public:
+    ~ByteBuffer() {
+      free(buffer_);
+    }
+    void allocate(byte_size_type alignment, byte_size_type bytes) {
+      if (buffer_) throw std::runtime_error("In ByteBuffer::allocate(): reallocating an already allocated buffer.");
+      if (bytes % alignment) throw std::runtime_error("In ByteBuffer::allocate(): size should be aligned.");
+      buffer_ = reinterpret_cast<std::byte *>(aligned_alloc(alignment, bytes));
+      if (!buffer_) throw std::runtime_error("In ByteBuffer::allocate(): failed to allocated buffer.");
+    }
+    std::byte * get() {
+      return buffer_;
+    }
+  private:
+    std::byte * buffer_ = nullptr;
+  };
+  */
+}  // namespace cms::soa
+
+// clang-format off
+#define _DECLARE_SOA_STREAM_INFO_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                      \
+  _SWITCH_ON_TYPE(                                                                                                     \
+      VALUE_TYPE,                                                                                                      \
+      /* Dump scalar */                                                                                                \
+      os << " Scalar " BOOST_PP_STRINGIZE(NAME) " at offset " << offset << " has size " << sizeof(CPP_TYPE)            \
+         << " and padding " << ((sizeof(CPP_TYPE) - 1) / alignment + 1) * alignment - sizeof(CPP_TYPE)                 \
+         << std::endl;                                                                                                 \
+      offset += ((sizeof(CPP_TYPE) - 1) / alignment + 1) * alignment;                                                  \
+      ,                                                                                                                \
+      /* Dump column */                                                                                                \
+      os << " Column " BOOST_PP_STRINGIZE(NAME) " at offset " << offset << " has size "                                \
+         << sizeof(CPP_TYPE) * nElements_ << " and padding "                                                           \
+         << cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE), alignment) - (nElements_ * sizeof(CPP_TYPE))            \
+         << std::endl;                                                                                                 \
+      offset += cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE), alignment);                                         \
+      ,                                                                                                                \
+      /* Dump Eigen column */                                                                                          \
+      os << " Eigen value " BOOST_PP_STRINGIZE(NAME) " at offset " << offset << " has dimension "                      \
+         << "(" << CPP_TYPE::RowsAtCompileTime << " x " << CPP_TYPE::ColsAtCompileTime << ")"                          \
+         << " and per column size "                                                                                    \
+         << sizeof(CPP_TYPE::Scalar) * nElements_                                                                      \
+         << " and padding "                                                                                            \
+         << cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE::Scalar), alignment)                                      \
+            - (nElements_ * sizeof(CPP_TYPE::Scalar))                                                                  \
+         << std::endl;                                                                                                 \
+      offset += cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE::Scalar), alignment)                                  \
+                * CPP_TYPE::RowsAtCompileTime * CPP_TYPE::ColsAtCompileTime;                                           \
+  )
+// clang-format on
+
+#define _DECLARE_SOA_STREAM_INFO(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_SOA_STREAM_INFO_IMPL TYPE_NAME)
+
+/**
+ * Metadata member computing column pitch
+ */
+// clang-format off
+#define _DEFINE_METADATA_MEMBERS_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                      \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      byte_size_type BOOST_PP_CAT(NAME, Pitch()) const {                                                               \
+        return cms::soa::alignSize(sizeof(CPP_TYPE), ParentClass::alignment);                                          \
+      }                                                                                                                \
+      using BOOST_PP_CAT(TypeOf_, NAME) = CPP_TYPE;                                                                    \
+      constexpr static cms::soa::SoAColumnType BOOST_PP_CAT(ColumnTypeOf_, NAME) = cms::soa::SoAColumnType::scalar;    \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      CPP_TYPE const* BOOST_PP_CAT(addressOf_, NAME)() const {                                                         \
+        return parent_.metadata().BOOST_PP_CAT(parametersOf_, NAME)().addr_;                                           \
+      }                                                                                                                \
+      using BOOST_PP_CAT(ParametersTypeOf_, NAME) =                                                                    \
+        cms::soa::SoAParameters_ColumnType<cms::soa::SoAColumnType::scalar>::DataType<CPP_TYPE>;                       \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      BOOST_PP_CAT(ParametersTypeOf_, NAME) BOOST_PP_CAT(parametersOf_, NAME)() const {                                \
+        return  BOOST_PP_CAT(ParametersTypeOf_, NAME) (parent_.BOOST_PP_CAT(NAME, _));                                 \
+      }                                                                                                                \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      CPP_TYPE* BOOST_PP_CAT(addressOf_, NAME)() {                                                                     \
+        return parent_.metadata().BOOST_PP_CAT(parametersOf_, NAME)().addr_;                                           \
+      },                                                                                                               \
+      /* Column */                                                                                                     \
+      using BOOST_PP_CAT(ParametersTypeOf_, NAME) =                                                                    \
+         cms::soa::SoAParameters_ColumnType<cms::soa::SoAColumnType::column>::DataType<CPP_TYPE>;                      \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      BOOST_PP_CAT(ParametersTypeOf_, NAME) BOOST_PP_CAT(parametersOf_, NAME)() const {                                \
+        return  BOOST_PP_CAT(ParametersTypeOf_, NAME) (parent_.BOOST_PP_CAT(NAME, _));                                 \
+      }                                                                                                                \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      CPP_TYPE const* BOOST_PP_CAT(addressOf_, NAME)() const {                                                         \
+        return parent_.metadata().BOOST_PP_CAT(parametersOf_, NAME)().addr_;                                           \
+      }                                                                                                                \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      CPP_TYPE* BOOST_PP_CAT(addressOf_, NAME)() {                                                                     \
+        return parent_.metadata().BOOST_PP_CAT(parametersOf_, NAME)().addr_;                                           \
+      }                                                                                                                \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      byte_size_type BOOST_PP_CAT(NAME, Pitch()) const {                                                               \
+        return cms::soa::alignSize(parent_.nElements_ * sizeof(CPP_TYPE), ParentClass::alignment);                     \
+      }                                                                                                                \
+      using BOOST_PP_CAT(TypeOf_, NAME) = CPP_TYPE;                                                                    \
+      constexpr static cms::soa::SoAColumnType BOOST_PP_CAT(ColumnTypeOf_, NAME) = cms::soa::SoAColumnType::column;,   \
+      /* Eigen column */                                                                                               \
+      using BOOST_PP_CAT(ParametersTypeOf_, NAME) =                                                                    \
+          cms::soa::SoAParameters_ColumnType<cms::soa::SoAColumnType::eigen>::DataType<CPP_TYPE>;                      \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      BOOST_PP_CAT(ParametersTypeOf_, NAME) BOOST_PP_CAT(parametersOf_, NAME)() const {                                \
+        return BOOST_PP_CAT(ParametersTypeOf_, NAME) (                                                                 \
+          parent_.BOOST_PP_CAT(NAME, _),                                                                               \
+          parent_.BOOST_PP_CAT(NAME, Stride_));                                                                        \
+      }                                                                                                                \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      byte_size_type BOOST_PP_CAT(NAME, Pitch()) const {                                                               \
+        return cms::soa::alignSize(parent_.nElements_ * sizeof(CPP_TYPE::Scalar), ParentClass::alignment)              \
+               * CPP_TYPE::RowsAtCompileTime * CPP_TYPE::ColsAtCompileTime;                                            \
+      }                                                                                                                \
+      using BOOST_PP_CAT(TypeOf_, NAME) = CPP_TYPE ;                                                                   \
+      constexpr static cms::soa::SoAColumnType BOOST_PP_CAT(ColumnTypeOf_, NAME) = cms::soa::SoAColumnType::eigen;     \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      CPP_TYPE::Scalar const* BOOST_PP_CAT(addressOf_, NAME)() const {                                                 \
+        return parent_.metadata().BOOST_PP_CAT(parametersOf_, NAME)().addr_;                                           \
+      }                                                                                                                \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      CPP_TYPE::Scalar* BOOST_PP_CAT(addressOf_, NAME)() {                                                             \
+        return parent_.metadata().BOOST_PP_CAT(parametersOf_, NAME)().addr_;                                           \
+      }                                                                                                                \
+)
+// clang-format on
+#define _DEFINE_METADATA_MEMBERS(R, DATA, TYPE_NAME) _DEFINE_METADATA_MEMBERS_IMPL TYPE_NAME
+
+/**
+ * Member assignment for trivial constructor
+ */
+// clang-format off
+#define _DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                          \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      (BOOST_PP_CAT(NAME, _)(nullptr)),                                                                                \
+      /* Column */                                                                                                     \
+      (BOOST_PP_CAT(NAME, _)(nullptr)),                                                                                \
+      /* Eigen column */                                                                                               \
+      (BOOST_PP_CAT(NAME, _)(nullptr))                                                                                 \
+      (BOOST_PP_CAT(NAME, Stride_)(0))                                                                                 \
+  )
+// clang-format on
+
+#define _DECLARE_MEMBER_TRIVIAL_CONSTRUCTION(R, DATA, TYPE_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_IMPL TYPE_NAME)
+
+/**
+ * Computation of the column or scalar pointer location in the memory layout (at SoA construction time)
+ */
+// clang-format off
+#define _ASSIGN_SOA_COLUMN_OR_SCALAR_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                  \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      BOOST_PP_CAT(NAME, _) = reinterpret_cast<CPP_TYPE*>(curMem);                                                     \
+      curMem += cms::soa::alignSize(sizeof(CPP_TYPE), alignment);                                                      \
+      ,                                                                                                                \
+      /* Column */                                                                                                     \
+      BOOST_PP_CAT(NAME, _) = reinterpret_cast<CPP_TYPE*>(curMem);                                                     \
+      curMem += cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE), alignment);                                         \
+      ,                                                                                                                \
+      /* Eigen column */                                                                                               \
+      BOOST_PP_CAT(NAME, _) = reinterpret_cast<CPP_TYPE::Scalar*>(curMem);                                             \
+      curMem += cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE::Scalar), alignment) * CPP_TYPE::RowsAtCompileTime    \
+        * CPP_TYPE::ColsAtCompileTime;                                                                                 \
+      BOOST_PP_CAT(NAME, Stride_) = cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE::Scalar), alignment)              \
+        / sizeof(CPP_TYPE::Scalar);                                                                                    \
+  )                                                                                                                    \
+  if constexpr (alignmentEnforcement == AlignmentEnforcement::Enforced)                                                \
+    if (reinterpret_cast<intptr_t>(BOOST_PP_CAT(NAME, _)) % alignment)                                                 \
+      throw std::runtime_error("In layout constructor: misaligned column: " #NAME);
+// clang-format on
+
+#define _ASSIGN_SOA_COLUMN_OR_SCALAR(R, DATA, TYPE_NAME) _ASSIGN_SOA_COLUMN_OR_SCALAR_IMPL TYPE_NAME
+
+/**
+ * Computation of the column or scalar size for SoA size computation
+ */
+// clang-format off
+#define _ACCUMULATE_SOA_ELEMENT_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                       \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      ret += cms::soa::alignSize(sizeof(CPP_TYPE), alignment);                                                         \
+      ,                                                                                                                \
+      /* Column */                                                                                                     \
+      ret += cms::soa::alignSize(nElements * sizeof(CPP_TYPE), alignment);                                             \
+      ,                                                                                                                \
+      /* Eigen column */                                                                                               \
+      ret += cms::soa::alignSize(nElements * sizeof(CPP_TYPE::Scalar), alignment) * CPP_TYPE::RowsAtCompileTime        \
+             * CPP_TYPE::ColsAtCompileTime;                                                                            \
+  )
+// clang-format on
+
+#define _ACCUMULATE_SOA_ELEMENT(R, DATA, TYPE_NAME) _ACCUMULATE_SOA_ELEMENT_IMPL TYPE_NAME
+
+/**
+ * Direct access to column pointer and indexed access
+ */
+// clang-format off
+#define _DECLARE_SOA_ACCESSOR_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                         \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      SOA_HOST_DEVICE SOA_INLINE CPP_TYPE& NAME() { return *BOOST_PP_CAT(NAME, _); }                                   \
+      ,                                                                                                                \
+      /* Column */                                                                                                     \
+      SOA_HOST_DEVICE SOA_INLINE CPP_TYPE* NAME() { return BOOST_PP_CAT(NAME, _); }                                    \
+      SOA_HOST_DEVICE SOA_INLINE CPP_TYPE& NAME(size_type index) { return BOOST_PP_CAT(NAME, _)[index]; }              \
+      ,                                                                                                                \
+      /* Eigen column */                                                                                               \
+      /* TODO */                                                                                                       \
+      BOOST_PP_EMPTY()                                                                                                 \
+  )
+// clang-format on
+
+#define _DECLARE_SOA_ACCESSOR(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_SOA_ACCESSOR_IMPL TYPE_NAME)
+
+/**
+ * Direct access to column pointer (const) and indexed access.
+ */
+// clang-format off
+#define _DECLARE_SOA_CONST_ACCESSOR_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                   \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      SOA_HOST_DEVICE SOA_INLINE CPP_TYPE NAME() const { return *(BOOST_PP_CAT(NAME, _)); }                            \
+      ,                                                                                                                \
+      /* Column */                                                                                                     \
+      SOA_HOST_DEVICE SOA_INLINE CPP_TYPE const* NAME() const { return BOOST_PP_CAT(NAME, _); }                        \
+      SOA_HOST_DEVICE SOA_INLINE CPP_TYPE NAME(size_type index) const { return *(BOOST_PP_CAT(NAME, _) + index); }     \
+      ,                                                                                                                \
+      /* Eigen column */                                                                                               \
+      SOA_HOST_DEVICE SOA_INLINE CPP_TYPE::Scalar const* NAME() const { return BOOST_PP_CAT(NAME, _); }                \
+      SOA_HOST_DEVICE SOA_INLINE size_type BOOST_PP_CAT(NAME, Stride)() { return BOOST_PP_CAT(NAME, Stride_); }        \
+  )
+// clang-format on
+
+#define _DECLARE_SOA_CONST_ACCESSOR(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_SOA_CONST_ACCESSOR_IMPL TYPE_NAME)
+
+/**
+ * SoA member ROOT streamer read (column pointers).
+ */
+// clang-format off
+#define _STREAMER_READ_SOA_DATA_MEMBER_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      /* TODO */                                                                                                       \
+      ,                                                                                                                \
+      /* Column */                                                                                                     \
+      memcpy(BOOST_PP_CAT(NAME, _), onfile.BOOST_PP_CAT(NAME, _), sizeof(CPP_TYPE) * onfile.nElements_);               \
+      ,                                                                                                                \
+      /* Eigen column */                                                                                               \
+      /* TODO */                                                                                                       \
+  )
+// clang-format on
+
+#define _STREAMER_READ_SOA_DATA_MEMBER(R, DATA, TYPE_NAME) \
+  BOOST_PP_EXPAND(_STREAMER_READ_SOA_DATA_MEMBER_IMPL TYPE_NAME)
+
+/**
+ * SoA class member declaration (column pointers).
+ */
+// clang-format off
+#define _DECLARE_SOA_DATA_MEMBER_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                      \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      CPP_TYPE* BOOST_PP_CAT(NAME, _) = nullptr;                                                                       \
+      ,                                                                                                                \
+      /* Column */                                                                                                     \
+      CPP_TYPE * BOOST_PP_CAT(NAME, _) = nullptr;                                                                      \
+      ,                                                                                                                \
+      /* Eigen column */                                                                                               \
+      CPP_TYPE::Scalar * BOOST_PP_CAT(NAME, _) = nullptr;                                                              \
+      byte_size_type BOOST_PP_CAT(NAME, Stride_) = 0;                                                                  \
+  )
+// clang-format on
+
+#define _DECLARE_SOA_DATA_MEMBER(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_SOA_DATA_MEMBER_IMPL TYPE_NAME)
+
+#ifdef DEBUG
+#define _DO_RANGECHECK true
+#else
+#define _DO_RANGECHECK false
+#endif
+
+/*
+ * A macro defining a SoA layout (collection of scalars and columns of equal lengths)
+ */
+// clang-format off
+#define GENERATE_SOA_LAYOUT(CLASS, ...)                                                                                \
+  template <CMS_SOA_BYTE_SIZE_TYPE ALIGNMENT = cms::soa::CacheLineSize::defaultSize,                                   \
+            bool ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::Relaxed>                                      \
+  struct CLASS {                                                                                                       \
+    /* these could be moved to an external type trait to free up the symbol names */                                   \
+    using self_type = CLASS;                                                                                           \
+    using AlignmentEnforcement = cms::soa::AlignmentEnforcement;                                                       \
+                                                                                                                       \
+    /* For CUDA applications, we align to the 128 bytes of the cache lines.                                            \
+     * See https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#global-memory-3-0 this is still valid      \
+     * up to compute capability 8.X.                                                                                   \
+     */                                                                                                                \
+    using size_type = cms::soa::size_type;                                                                             \
+    using byte_size_type = cms::soa::byte_size_type;                                                                   \
+    constexpr static byte_size_type defaultAlignment = 128;                                                            \
+    constexpr static byte_size_type alignment = ALIGNMENT;                                                             \
+    constexpr static bool alignmentEnforcement = ALIGNMENT_ENFORCEMENT;                                                \
+    constexpr static byte_size_type conditionalAlignment =                                                             \
+        alignmentEnforcement == cms::soa::AlignmentEnforcement::Enforced ? alignment : 0;                              \
+    /* Those typedefs avoid having commas in macros (which is problematic) */                                          \
+    template <cms::soa::SoAColumnType COLUMN_TYPE, class C>                                                            \
+    using SoAValueWithConf = cms::soa::SoAValue<COLUMN_TYPE, C, conditionalAlignment>;                                 \
+                                                                                                                       \
+    template <cms::soa::SoAColumnType COLUMN_TYPE, class C>                                                            \
+    using SoAConstValueWithConf = cms::soa::SoAConstValue<COLUMN_TYPE, C, conditionalAlignment>;                       \
+                                                                                                                       \
+                                                                                                                       \
+    template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT = cms::soa::CacheLineSize::defaultSize,                            \
+            bool VIEW_ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::Relaxed,                                 \
+            bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Disabled,                                               \
+            bool RANGE_CHECKING = cms::soa::RangeChecking::Disabled>                                                   \
+    struct ViewTemplateFreeParams;                                                                                     \
+                                                                                                                       \
+    /* dump the SoA internal structure */                                                                              \
+    SOA_HOST_ONLY                                                                                                      \
+    void soaToStreamInternal(std::ostream & os) const {                                                                \
+      os << #CLASS "(" << nElements_ << " elements, byte alignement= " << alignment << ", @"<< mem_ <<"): "            \
+         << std::endl;                                                                                                 \
+      os << "  sizeof(" #CLASS "): " << sizeof(CLASS) << std::endl;                                                    \
+      byte_size_type offset = 0;                                                                                       \
+      _ITERATE_ON_ALL(_DECLARE_SOA_STREAM_INFO, ~, __VA_ARGS__)                                                        \
+      os << "Final offset = " << offset << " computeDataSize(...): " << computeDataSize(nElements_)                    \
+              << std::endl;                                                                                            \
+      os << std::endl;                                                                                                 \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* Helper function used by caller to externally allocate the storage */                                            \
+    static byte_size_type computeDataSize(size_type nElements) {                                                       \
+      byte_size_type ret = 0;                                                                                          \
+      _ITERATE_ON_ALL(_ACCUMULATE_SOA_ELEMENT, ~, __VA_ARGS__)                                                         \
+      return ret;                                                                                                      \
+    }                                                                                                                  \
+                                                                                                                       \
+    /**                                                                                                                \
+   * Helper/friend class allowing SoA introspection.                                                                   \
+   */                                                                                                                  \
+    struct Metadata {                                                                                                  \
+      friend CLASS;                                                                                                    \
+      SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.nElements_; }                                 \
+      SOA_HOST_DEVICE SOA_INLINE byte_size_type byteSize() const { return parent_.byteSize_; }                         \
+      SOA_HOST_DEVICE SOA_INLINE byte_size_type alignment() const { return CLASS::alignment; }                         \
+      SOA_HOST_DEVICE SOA_INLINE std::byte* data() { return parent_.mem_; }                                            \
+      SOA_HOST_DEVICE SOA_INLINE const std::byte* data() const { return parent_.mem_; }                                \
+      SOA_HOST_DEVICE SOA_INLINE std::byte* nextByte() const { return parent_.mem_ + parent_.byteSize_; }              \
+      SOA_HOST_DEVICE SOA_INLINE CLASS cloneToNewAddress(std::byte* addr) const {                                      \
+        return CLASS(addr, parent_.nElements_);                                                                        \
+      }                                                                                                                \
+      _ITERATE_ON_ALL(_DEFINE_METADATA_MEMBERS, ~, __VA_ARGS__)                                                        \
+                                                                                                                       \
+      Metadata& operator=(const Metadata&) = delete;                                                                   \
+      Metadata(const Metadata&) = delete;                                                                              \
+                                                                                                                       \
+    private:                                                                                                           \
+      SOA_HOST_DEVICE SOA_INLINE Metadata(const CLASS& parent) : parent_(parent) {}                                    \
+      const CLASS& parent_;                                                                                            \
+      using ParentClass = CLASS;                                                                                       \
+    };                                                                                                                 \
+    friend Metadata;                                                                                                   \
+    SOA_HOST_DEVICE SOA_INLINE const Metadata metadata() const { return Metadata(*this); }                             \
+    SOA_HOST_DEVICE SOA_INLINE Metadata metadata() { return Metadata(*this); }                                         \
+                                                                                                                       \
+    /* Trivial constuctor */                                                                                           \
+    CLASS()                                                                                                            \
+        : mem_(nullptr),                                                                                               \
+          nElements_(0),                                                                                               \
+          byteSize_(0),                                                                                                \
+          _ITERATE_ON_ALL_COMMA(_DECLARE_MEMBER_TRIVIAL_CONSTRUCTION, ~, __VA_ARGS__) {}                               \
+                                                                                                                       \
+    /* Constructor relying on user provided storage (implementation shared with ROOT streamer) */                      \
+    SOA_HOST_ONLY CLASS(std::byte* mem, size_type nElements) : mem_(mem), nElements_(nElements), byteSize_(0) {        \
+      organizeColumnsFromBuffer();                                                                                     \
+    }                                                                                                                  \
+                                                                                                                       \
+  private:                                                                                                             \
+    void organizeColumnsFromBuffer() {                                                                                 \
+      if constexpr (alignmentEnforcement == cms::soa::AlignmentEnforcement::Enforced)                                  \
+        if (reinterpret_cast<intptr_t>(mem_) % alignment)                                                              \
+          throw std::runtime_error("In " #CLASS "::" #CLASS ": misaligned buffer");                                    \
+      auto curMem = mem_;                                                                                              \
+      _ITERATE_ON_ALL(_ASSIGN_SOA_COLUMN_OR_SCALAR, ~, __VA_ARGS__)                                                    \
+      /* Sanity check: we should have reached the computed size, only on host code */                                  \
+      byteSize_ = computeDataSize(nElements_);                                                                         \
+      if (mem_ + byteSize_ != curMem)                                                                                  \
+        throw std::runtime_error("In " #CLASS "::" #CLASS ": unexpected end pointer.");                                \
+    }                                                                                                                  \
+                                                                                                                       \
+  public:                                                                                                              \
+    /* Constructor relying on user provided storage */                                                                 \
+    SOA_DEVICE_ONLY CLASS(bool devConstructor, std::byte* mem, size_type nElements) :                                  \
+      mem_(mem),                                                                                                       \
+      nElements_(nElements)                                                                                            \
+    {                                                                                                                  \
+      auto curMem = mem_;                                                                                              \
+      _ITERATE_ON_ALL(_ASSIGN_SOA_COLUMN_OR_SCALAR, ~, __VA_ARGS__)                                                    \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* ROOT read streamer */                                                                                           \
+    template <typename T>                                                                                              \
+    void ROOTReadStreamer(T & onfile) {                                                                                \
+      auto size = onfile.metadata().size();                                                                            \
+      _ITERATE_ON_ALL(_STREAMER_READ_SOA_DATA_MEMBER, ~, __VA_ARGS__)                                                  \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* dump the SoA internal structure */                                                                              \
+    template <typename T>                                                                                              \
+    SOA_HOST_ONLY friend void dump();                                                                                  \
+                                                                                                                       \
+  private:                                                                                                             \
+    /* Range checker conditional to the macro _DO_RANGECHECK */                                                        \
+    SOA_HOST_DEVICE SOA_INLINE                                                                                         \
+    void rangeCheck(size_type index) const {                                                                           \
+      if constexpr (_DO_RANGECHECK) {                                                                                  \
+        if (index >= nElements_) {                                                                                     \
+          printf("In " #CLASS "::rangeCheck(): index out of range: %zu with nElements: %zu\n", index, nElements_);     \
+          assert(false);                                                                                               \
+        }                                                                                                              \
+      }                                                                                                                \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* data members */                                                                                                 \
+    std::byte* mem_;                                                                                                   \
+    size_type nElements_;                                                                                              \
+    byte_size_type byteSize_;                                                                                          \
+    _ITERATE_ON_ALL(_DECLARE_SOA_DATA_MEMBER, ~, __VA_ARGS__)                                                          \
+    /* Making the code conditional is problematic in macros as the commas will interfere with parameter lisings     */ \
+    /* So instead we make the code unconditional with paceholder names which are protected by a private protection. */ \
+    /* This will be handled later as we handle the integration of the view as a subclass of the layout.             */ \
+  public:                                                                                                              \
+  _GENERATE_SOA_TRIVIAL_VIEW(CLASS,                                                                                    \
+                    SOA_VIEW_LAYOUT_LIST(                                                                              \
+                        SOA_VIEW_LAYOUT(BOOST_PP_CAT(CLASS, _parametrized), BOOST_PP_CAT(instance_, CLASS))),          \
+                    SOA_VIEW_VALUE_LIST(_ITERATE_ON_ALL_COMMA(                                                         \
+                    _VIEW_FIELD_FROM_LAYOUT, BOOST_PP_CAT(instance_, CLASS), __VA_ARGS__)))                            \
+    template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
+    using ViewTemplate = ViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY, RANGE_CHECKING>;   \
+                                                                                                                       \
+    using View = ViewTemplate<cms::soa::RestrictQualify::Disabled, cms::soa::RangeChecking::Disabled>;                 \
+                                                                                                                       \
+  _GENERATE_SOA_TRIVIAL_CONST_VIEW(CLASS,                                                                              \
+                    SOA_VIEW_LAYOUT_LIST(                                                                              \
+                        SOA_VIEW_LAYOUT(BOOST_PP_CAT(CLASS, _parametrized) , BOOST_PP_CAT(instance_, CLASS))),         \
+                    SOA_VIEW_VALUE_LIST(_ITERATE_ON_ALL_COMMA(                                                         \
+                    _VIEW_FIELD_FROM_LAYOUT, BOOST_PP_CAT(instance_, CLASS), __VA_ARGS__)))                            \
+    template <bool RESTRICT_QUALIFY, bool RANGE_CHECKING>                                                              \
+    using ConstViewTemplate = ConstViewTemplateFreeParams<ALIGNMENT, ALIGNMENT_ENFORCEMENT, RESTRICT_QUALIFY,          \
+      RANGE_CHECKING>;                                                                                                 \
+                                                                                                                       \
+    using ConstView = ConstViewTemplate<cms::soa::RestrictQualify::Disabled, cms::soa::RangeChecking::Disabled>;       \
+  };
+// clang-format on
+
+#endif  // DataFormats_SoATemplate_interface_SoALayout_h

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -344,7 +344,7 @@ namespace cms::soa {
  * non-const arguments.
  */
 #define _DECLARE_VIEW_ELEMENT_CONSTR_CALL_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME) \
-  (const_cast_SoAParametersImpl(base_type:: BOOST_PP_CAT(LOCAL_NAME, Parameters_)))
+  (const_cast_SoAParametersImpl(base_type::BOOST_PP_CAT(LOCAL_NAME, Parameters_)))
 
 #define _DECLARE_VIEW_ELEMENT_CONSTR_CALL(R, DATA, LAYOUT_MEMBER_NAME) \
   BOOST_PP_EXPAND(_DECLARE_VIEW_ELEMENT_CONSTR_CALL_IMPL LAYOUT_MEMBER_NAME)
@@ -414,6 +414,26 @@ namespace cms::soa {
 
 #define _DECLARE_CONST_VIEW_SOA_MEMBER(R, DATA, LAYOUT_MEMBER_NAME) \
   BOOST_PP_EXPAND(_DECLARE_CONST_VIEW_SOA_MEMBER_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA))
+
+/**
+  * Element members for trivial mutable view only (listing only the column elements at macro time thanks to the
+  * layout list of elements.
+  */
+
+// clang-format off
+#define _TRIVIAL_VIEW_COLUMN_ELEMENT_TIE_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                              \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar (empty) */                                                                                             \
+      ,                                                                                                                \
+      /* Column */                                                                                                     \
+      (NAME())                                                                                                         \
+      ,                                                                                                                \
+      /* Eigen column */                                                                                               \
+      (NAME())                                                                                                         \
+)
+// clang-format on
+
+#define _TRIVIAL_VIEW_COLUMN_ELEMENT_TIE(R, DATA, TYPE_NAME) _TRIVIAL_VIEW_COLUMN_ELEMENT_TIE_IMPL TYPE_NAME
 
 /* ---- MUTABLE VIEW ------------------------------------------------------------------------------------------------ */
 // clang-format off
@@ -539,7 +559,11 @@ namespace cms::soa {
       element& operator=(const element& other) {                                                                       \
         _ITERATE_ON_ALL(_DECLARE_VIEW_ELEMENT_VALUE_COPY, ~, VALUE_LIST)                                               \
         return *this;                                                                                                  \
-      }                                                                                                                \
+      }
+// clang-format on
+
+// clang-format off
+#define _GENERATE_SOA_VIEW_PART_2(CONST_VIEW, VIEW, LAYOUTS_LIST, VALUE_LIST)                                          \
       _ITERATE_ON_ALL(_DECLARE_VIEW_ELEMENT_VALUE_MEMBER, ~, VALUE_LIST)                                               \
     };                                                                                                                 \
                                                                                                                        \
@@ -713,7 +737,7 @@ namespace cms::soa {
    _GENERATE_SOA_CONST_VIEW_PART_1(CONST_VIEW, VIEW,                                                                   \
      SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
 
-#define GENERATE_SOA_CONST_VIEW(CONST_VIEW, LAYOUTS_LIST, VALUE_LIST)                                                  \
+#define GENERATE_SOA_CONST_VIEW(CONST_VIEW, VIEW, LAYOUTS_LIST, VALUE_LIST)                                            \
    _GENERATE_SOA_CONST_VIEW(CONST_VIEW, BOOST_PP_CAT(CONST_VIEW, Unused_),                                             \
      SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
 
@@ -726,17 +750,28 @@ namespace cms::soa {
 
 #define _GENERATE_SOA_VIEW(CONST_VIEW, VIEW, LAYOUTS_LIST, VALUE_LIST)                                                 \
    _GENERATE_SOA_VIEW_PART_0(CONST_VIEW, VIEW, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))    \
-   _GENERATE_SOA_VIEW_PART_1(CONST_VIEW, VIEW, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
+   _GENERATE_SOA_VIEW_PART_1(CONST_VIEW, VIEW, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))    \
+   _GENERATE_SOA_VIEW_PART_2(CONST_VIEW, VIEW, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
 
 #define GENERATE_SOA_VIEW(CONST_VIEW, VIEW, LAYOUTS_LIST, VALUE_LIST)                                                  \
    _GENERATE_SOA_CONST_VIEW(CONST_VIEW, VIEW, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))     \
    _GENERATE_SOA_VIEW(CONST_VIEW, VIEW, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
 
-#define _GENERATE_SOA_TRIVIAL_VIEW(CLASS, LAYOUTS_LIST, VALUE_LIST)                                                    \
+#define _GENERATE_SOA_TRIVIAL_VIEW(CLASS, LAYOUTS_LIST, VALUE_LIST, ...)                                               \
    _GENERATE_SOA_VIEW_PART_0_NO_DEFAULTS(ConstViewTemplateFreeParams, ViewTemplateFreeParams,                          \
      SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))                                              \
    using BOOST_PP_CAT(CLASS, _parametrized) = CLASS<VIEW_ALIGNMENT, VIEW_ALIGNMENT_ENFORCEMENT>;                       \
    _GENERATE_SOA_VIEW_PART_1(ConstViewTemplateFreeParams, ViewTemplateFreeParams,                                      \
+     SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))                                              \
+   /* Extra operator=() for mutable element */                                                                         \
+   element & operator=(const typename                                                                                  \
+       BOOST_PP_CAT(CLASS, _parametrized)::Metadata::RowInitializer & val) {                                           \
+     std::tie(                                                                                                         \
+       _ITERATE_ON_ALL_COMMA(_TRIVIAL_VIEW_COLUMN_ELEMENT_TIE, BOOST_PP_EMPTY(), __VA_ARGS__)                          \
+     ) = val;                                                                                                          \
+     return *this;                                                                                                     \
+   }                                                                                                                   \
+   _GENERATE_SOA_VIEW_PART_2(ConstViewTemplateFreeParams, ViewTemplateFreeParams,                                      \
      SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
 // clang-format on
 

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -1,0 +1,689 @@
+#ifndef DataFormats_SoATemplate_interface_SoAView_h
+#define DataFormats_SoATemplate_interface_SoAView_h
+
+/*
+ * Structure-of-Arrays templates allowing access to a selection of scalars and columns from one
+ * or multiple SoA layouts or views.
+ * This template generator will allow handling subsets of columns from one or multiple SoA views or layouts.
+ */
+
+#include "SoACommon.h"
+
+#define SOA_VIEW_LAYOUT(TYPE, NAME) (TYPE, NAME)
+
+#define SOA_VIEW_LAYOUT_LIST(...) __VA_ARGS__
+
+#define SOA_VIEW_VALUE(LAYOUT_NAME, LAYOUT_MEMBER) (LAYOUT_NAME, LAYOUT_MEMBER, LAYOUT_MEMBER)
+
+#define SOA_VIEW_VALUE_RENAME(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME) (LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)
+
+#define SOA_VIEW_VALUE_LIST(...) __VA_ARGS__
+
+/*
+ * A macro defining a SoA view (collection of columns from multiple layouts or views.)
+ *
+ * Usage:
+ * GENERATE_SOA_VIEW(PixelXYView,
+ *   SOA_VIEW_LAYOUT_LIST(
+ *     SOA_VIEW_LAYOUT(PixelDigis,         pixelDigis),
+ *     SOA_VIEW_LAYOUT(PixelRecHitsLayout, pixelsRecHit)
+ *   ),
+ *   SOA_VIEW_VALUE_LIST(
+ *     SOA_VIEW_VALUE_RENAME(pixelDigis,   x,   digisX),
+ *     SOA_VIEW_VALUE_RENAME(pixelDigis,   y,   digisY),
+ *     SOA_VIEW_VALUE_RENAME(pixelsRecHit, x, recHitsX),
+ *     SOA_VIEW_VALUE_RENAME(pixelsRecHit, y, recHitsY)
+ *   )
+ * );
+ *
+ */
+
+namespace cms::soa {
+
+  /* Traits for the different column type scenarios */
+  /* Value traits passes the class as is in the case of column type and return
+   * an empty class with functions returning non-scalar as accessors. */
+  template <class C, SoAColumnType COLUMN_TYPE>
+  struct ConstValueTraits : public C {
+    using C::C;
+  };
+
+  template <class C>
+  struct ConstValueTraits<C, SoAColumnType::scalar> {
+    // Just take to SoAValue type to generate the right constructor.
+    SOA_HOST_DEVICE SOA_INLINE ConstValueTraits(size_type, const typename C::valueType*) {}
+    SOA_HOST_DEVICE SOA_INLINE ConstValueTraits(size_type, const typename C::Params&) {}
+    SOA_HOST_DEVICE SOA_INLINE ConstValueTraits(size_type, const typename C::ConstParams&) {}
+    // Any attempt to do anything with the "scalar" value a const element will fail.
+  };
+
+}  // namespace cms::soa
+
+#include <memory_resource>
+/*
+ * Members definitions macros for viewa
+ */
+
+/**
+ * Layout templates parametrization
+ */
+#define _DECLARE_VIEW_LAYOUT_PARAMETRIZED_TEMPLATE_IMPL(TYPE, NAME)                            \
+  (using BOOST_PP_CAT(TYPE, _default) = BOOST_PP_CAT(TYPE, _StagedTemplates) < VIEW_ALIGNMENT, \
+   VIEW_ALIGNMENT_ENFORCEMENT > ;)
+
+#define _DECLARE_VIEW_LAYOUT_PARAMETRIZED_TEMPLATE(R, DATA, TYPE_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_LAYOUT_PARAMETRIZED_TEMPLATE_IMPL TYPE_NAME)
+
+/**
+ * Layout types aliasing for referencing by name
+ */
+#define _DECLARE_VIEW_LAYOUT_TYPE_ALIAS_IMPL(TYPE, NAME) using BOOST_PP_CAT(TypeOf_, NAME) = TYPE;
+
+#define _DECLARE_VIEW_LAYOUT_TYPE_ALIAS(R, DATA, TYPE_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_LAYOUT_TYPE_ALIAS_IMPL TYPE_NAME)
+
+/**
+ * Member types aliasing for referencing by name
+ */
+// clang-format off
+#define _DECLARE_VIEW_MEMBER_TYPE_ALIAS_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME, DATA)                             \
+  using BOOST_PP_CAT(TypeOf_, LOCAL_NAME) =                                                                            \
+      typename BOOST_PP_CAT(TypeOf_, LAYOUT_NAME)::Metadata::BOOST_PP_CAT(TypeOf_, LAYOUT_MEMBER);                     \
+  using BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME) =                                                                  \
+      typename BOOST_PP_CAT(TypeOf_, LAYOUT_NAME)::Metadata::BOOST_PP_CAT(ParametersTypeOf_, LAYOUT_MEMBER);           \
+  constexpr static cms::soa::SoAColumnType BOOST_PP_CAT(ColumnTypeOf_, LOCAL_NAME) =                                   \
+      BOOST_PP_CAT(TypeOf_, LAYOUT_NAME)::Metadata::BOOST_PP_CAT(ColumnTypeOf_, LAYOUT_MEMBER);                        \
+  SOA_HOST_DEVICE SOA_INLINE DATA auto* BOOST_PP_CAT(addressOf_, LOCAL_NAME)() const {                                 \
+    return parent_.metadata().BOOST_PP_CAT(parametersOf_, LOCAL_NAME)().addr_;                                         \
+  };                                                                                                                   \
+  SOA_HOST_DEVICE SOA_INLINE                                                                                           \
+  DATA BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME) BOOST_PP_CAT(parametersOf_, LOCAL_NAME)() const {                   \
+    return parent_.BOOST_PP_CAT(LOCAL_NAME, Parameters_);                                                              \
+  };
+// clang-format on
+
+#define _DECLARE_VIEW_MEMBER_TYPE_ALIAS(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_MEMBER_TYPE_ALIAS_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA))
+
+/**
+ * Generator of parameters (layouts/views) for constructor by layouts/views.
+ */
+#define _DECLARE_VIEW_CONSTRUCTION_PARAMETERS_IMPL(LAYOUT_TYPE, LAYOUT_NAME, DATA) (DATA LAYOUT_TYPE & LAYOUT_NAME)
+
+#define _DECLARE_VIEW_CONSTRUCTION_PARAMETERS(R, DATA, TYPE_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_CONSTRUCTION_PARAMETERS_IMPL BOOST_PP_TUPLE_PUSH_BACK(TYPE_NAME, DATA))
+
+/**
+ * Generator of parameters for constructor by column.
+ */
+#define _DECLARE_VIEW_CONSTRUCTION_BYCOLUMN_PARAMETERS_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME, DATA) \
+  (DATA typename BOOST_PP_CAT(Metadata::ParametersTypeOf_, LOCAL_NAME)::TupleOrPointerType LOCAL_NAME)
+
+#define _DECLARE_VIEW_CONSTRUCTION_BYCOLUMN_PARAMETERS(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(                                                                  \
+      _DECLARE_VIEW_CONSTRUCTION_BYCOLUMN_PARAMETERS_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA))
+
+/**
+ * Generator of member initialization from constructor.
+ * We use a lambda with auto return type to handle multiple possible return types.
+ */
+// clang-format off
+#define _DECLARE_VIEW_MEMBER_INITIALIZERS_IMPL(LAYOUT, MEMBER, NAME)                                                   \
+  (BOOST_PP_CAT(NAME, Parameters_)([&]() -> auto {                                                                     \
+    auto params = LAYOUT.metadata().BOOST_PP_CAT(parametersOf_, MEMBER)();                                             \
+    if constexpr (alignmentEnforcement == AlignmentEnforcement::Enforced)                                              \
+      if (reinterpret_cast<intptr_t>(params.addr_) % alignment)                                                        \
+        throw std::runtime_error("In constructor by layout: misaligned column: " #NAME);                               \
+    return params;                                                                                                     \
+  }()))
+// clang-format on
+
+#define _DECLARE_VIEW_MEMBER_INITIALIZERS(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_MEMBER_INITIALIZERS_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Generator of size computation for constructor.
+ * This is the per-layout part of the lambda checking they all have the same size.
+ */
+// clang-format off
+#define _UPDATE_SIZE_OF_VIEW_IMPL(LAYOUT_TYPE, LAYOUT_NAME)                                                            \
+  if (set) {                                                                                                           \
+    if (ret != LAYOUT_NAME.metadata().size())                                                                          \
+      throw std::runtime_error("In constructor by layout: different sizes from layouts.");                             \
+  } else {                                                                                                             \
+    ret = LAYOUT_NAME.metadata().size();                                                                               \
+    set = true;                                                                                                        \
+  }
+// clang-format on
+
+#define _UPDATE_SIZE_OF_VIEW(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_UPDATE_SIZE_OF_VIEW_IMPL TYPE_NAME)
+
+/**
+ * Generator of member initialization from constructor.
+ * We use a lambda with auto return type to handle multiple possible return types.
+ */
+// clang-format off
+#define _DECLARE_VIEW_MEMBER_INITIALIZERS_BYCOLUMN_IMPL(LAYOUT, MEMBER, NAME)                                          \
+  (                                                                                                                    \
+    BOOST_PP_CAT(NAME, Parameters_)([&]() -> auto {                                                                    \
+      if constexpr (alignmentEnforcement == AlignmentEnforcement::Enforced)                                            \
+        if (Metadata:: BOOST_PP_CAT(ParametersTypeOf_, NAME)::checkAlignment(NAME, alignment))                         \
+          throw std::runtime_error("In constructor by column: misaligned column: " #NAME);                             \
+      return NAME;                                                                                                     \
+    }())                                                                                                               \
+  )
+// clang-format on
+
+#define _DECLARE_VIEW_MEMBER_INITIALIZERS_BYCOLUMN(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_MEMBER_INITIALIZERS_BYCOLUMN_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Generator of element members initializer.
+ */
+#define _DECLARE_VIEW_ELEM_MEMBER_INIT_IMPL(LAYOUT, MEMBER, LOCAL_NAME, DATA) (LOCAL_NAME(DATA, LOCAL_NAME))
+
+#define _DECLARE_VIEW_ELEM_MEMBER_INIT(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_ELEM_MEMBER_INIT_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA))
+
+/**
+ * Helper macro extracting the data type from metadata of a layout or view
+ */
+#define _COLUMN_TYPE(LAYOUT_NAME, LAYOUT_MEMBER) \
+  typename std::remove_pointer<decltype(BOOST_PP_CAT(LAYOUT_NAME, Type)()::LAYOUT_MEMBER())>::type
+
+/**
+ * Generator of parameters for (non-const) element subclass (expanded comma separated).
+ */
+#define _DECLARE_VIEW_ELEMENT_VALUE_ARG_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME, DATA) \
+  (DATA typename BOOST_PP_CAT(Metadata::ParametersTypeOf_, LOCAL_NAME) LOCAL_NAME)
+
+#define _DECLARE_VIEW_ELEMENT_VALUE_ARG(R, DATA, LAYOUT_MEMBER_NAME) \
+  _DECLARE_VIEW_ELEMENT_VALUE_ARG_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA)
+
+/**
+ * Generator of parameters for (const) element subclass (expanded comma separated).
+ */
+#define _DECLARE_CONST_VIEW_ELEMENT_VALUE_ARG_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME, DATA) \
+  (DATA typename BOOST_PP_CAT(Metadata::ParametersTypeOf_, LOCAL_NAME)::ConstType LOCAL_NAME)
+
+#define _DECLARE_CONST_VIEW_ELEMENT_VALUE_ARG(R, DATA, LAYOUT_MEMBER_NAME) \
+  _DECLARE_CONST_VIEW_ELEMENT_VALUE_ARG_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA)
+
+/**
+ * Generator of member initialization for constructor of element subclass
+ */
+#define _DECLARE_VIEW_CONST_ELEM_MEMBER_INIT_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME, DATA) \
+  (BOOST_PP_CAT(LOCAL_NAME, _)(DATA, LOCAL_NAME))
+
+/* declare AoS-like element value args for contructor; these should expand,for columns only */
+#define _DECLARE_VIEW_CONST_ELEM_MEMBER_INIT(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_CONST_ELEM_MEMBER_INIT_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA))
+
+/**
+ * Declaration of the members accessors of the const element subclass
+ */
+// clang-format off
+#define _DECLARE_VIEW_CONST_ELEMENT_ACCESSOR_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                              \
+  SOA_HOST_DEVICE SOA_INLINE                                                                                           \
+      const typename SoAConstValueWithConf<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME),                          \
+      const typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::RefToConst                                          \
+      LOCAL_NAME() const {                                                                                             \
+    return BOOST_PP_CAT(LOCAL_NAME, _)();                                                                              \
+  }
+// clang-format on
+
+#define _DECLARE_VIEW_CONST_ELEMENT_ACCESSOR(R, DATA, LAYOUT_MEMBER_NAME) \
+  _DECLARE_VIEW_CONST_ELEMENT_ACCESSOR_IMPL LAYOUT_MEMBER_NAME
+
+/**
+ * Declaration of the private members of the const element subclass
+ */
+// clang-format off
+#define _DECLARE_VIEW_CONST_ELEMENT_VALUE_MEMBER_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                          \
+  const cms::soa::ConstValueTraits<SoAConstValueWithConf<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME),            \
+                                                         typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>,        \
+                                   BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>                                  \
+      BOOST_PP_CAT(LOCAL_NAME, _);
+// clang-format on
+
+#define _DECLARE_VIEW_CONST_ELEMENT_VALUE_MEMBER(R, DATA, LAYOUT_MEMBER_NAME) \
+  _DECLARE_VIEW_CONST_ELEMENT_VALUE_MEMBER_IMPL LAYOUT_MEMBER_NAME
+
+/**
+ * Generator of the member-by-member copy operator of the element subclass.
+ */
+#define _DECLARE_VIEW_ELEMENT_VALUE_COPY_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                 \
+  if constexpr (Metadata::BOOST_PP_CAT(ColumnTypeOf_, LOCAL_NAME) != cms::soa::SoAColumnType::scalar) \
+    LOCAL_NAME() = other.LOCAL_NAME();
+
+#define _DECLARE_VIEW_ELEMENT_VALUE_COPY(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_ELEMENT_VALUE_COPY_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Declaration of the private members of the const element subclass
+ */
+// clang-format off
+#define _DECLARE_VIEW_ELEMENT_VALUE_MEMBER_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                                \
+  SoAValueWithConf<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME),                                                  \
+                   typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>                                               \
+      LOCAL_NAME;
+// clang-format on
+
+#define _DECLARE_VIEW_ELEMENT_VALUE_MEMBER(R, DATA, LAYOUT_MEMBER_NAME) \
+  _DECLARE_VIEW_ELEMENT_VALUE_MEMBER_IMPL LAYOUT_MEMBER_NAME
+
+/**
+ * Parameters passed to element subclass constructor in operator[]
+ */
+#define _DECLARE_VIEW_ELEMENT_CONSTR_CALL_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME) \
+  (BOOST_PP_CAT(LOCAL_NAME, Parameters_))
+
+#define _DECLARE_VIEW_ELEMENT_CONSTR_CALL(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_ELEMENT_CONSTR_CALL_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Direct access to column pointer and indexed access
+ */
+// clang-format off
+#define _DECLARE_VIEW_SOA_ACCESSOR_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                                        \
+  /* Column or scalar */                                                                                               \
+  SOA_HOST_DEVICE SOA_INLINE                                                                                           \
+  typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                              \
+        template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
+            cms::soa::SoAAccessType::mutableAccess>::NoParamReturnType                                                 \
+  LOCAL_NAME() {                                                                                                       \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
+        template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
+            cms::soa::SoAAccessType::mutableAccess>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))();                          \
+  }                                                                                                                    \
+  SOA_HOST_DEVICE SOA_INLINE auto& LOCAL_NAME(size_type index) {                                                       \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
+        template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
+            cms::soa::SoAAccessType::mutableAccess>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))(index);                     \
+  }
+// clang-format on
+
+#define _DECLARE_VIEW_SOA_ACCESSOR(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_SOA_ACCESSOR_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * Direct access to column pointer (const) and indexed access.
+ */
+// clang-format off
+#define _DECLARE_VIEW_SOA_CONST_ACCESSOR_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME)                                  \
+  /* Column or scalar */                                                                                               \
+  SOA_HOST_DEVICE SOA_INLINE auto LOCAL_NAME() const {                                                                 \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
+        template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
+            cms::soa::SoAAccessType::constAccess>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))();                            \
+  }                                                                                                                    \
+  SOA_HOST_DEVICE SOA_INLINE auto LOCAL_NAME(size_type index) const {                                                  \
+    return typename cms::soa::SoAAccessors<typename BOOST_PP_CAT(Metadata::TypeOf_, LOCAL_NAME)>::                     \
+        template ColumnType<BOOST_PP_CAT(Metadata::ColumnTypeOf_, LOCAL_NAME)>::template AccessType<                   \
+            cms::soa::SoAAccessType::constAccess>(BOOST_PP_CAT(LOCAL_NAME, Parameters_))(index);                       \
+  }
+// clang-format on
+
+#define _DECLARE_VIEW_SOA_CONST_ACCESSOR(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_SOA_CONST_ACCESSOR_IMPL LAYOUT_MEMBER_NAME)
+
+/**
+ * SoA class member declaration (column pointers and parameters).
+ */
+#define _DECLARE_VIEW_SOA_MEMBER_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME, DATA) \
+  typename BOOST_PP_CAT(Metadata::ParametersTypeOf_, LOCAL_NAME) BOOST_PP_CAT(LOCAL_NAME, Parameters_);
+
+#define _DECLARE_VIEW_SOA_MEMBER(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_VIEW_SOA_MEMBER_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA))
+
+/**
+ * Const SoA class member declaration (column pointers and parameters).
+ */
+#define _DECLARE_CONST_VIEW_SOA_MEMBER_IMPL(LAYOUT_NAME, LAYOUT_MEMBER, LOCAL_NAME, DATA) \
+  typename BOOST_PP_CAT(Metadata::ParametersTypeOf_, LOCAL_NAME)::ConstType BOOST_PP_CAT(LOCAL_NAME, Parameters_);
+
+#define _DECLARE_CONST_VIEW_SOA_MEMBER(R, DATA, LAYOUT_MEMBER_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_CONST_VIEW_SOA_MEMBER_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA))
+
+/* ---- MUTABLE VIEW ------------------------------------------------------------------------------------------------ */
+// clang-format off
+#define _GENERATE_SOA_VIEW_PART_0(CLASS, LAYOUTS_LIST, VALUE_LIST)                                                     \
+  template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT,                                                                     \
+            bool VIEW_ALIGNMENT_ENFORCEMENT,                                                                           \
+            bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Default,                                                \
+            bool RANGE_CHECKING = cms::soa::RangeChecking::Default>                                                    \
+  struct CLASS {                                                                                                       \
+    /* Declare the parametrized layouts as the default */                                                              \
+    /*BOOST_PP_SEQ_CAT(_ITERATE_ON_ALL(_DECLARE_VIEW_LAYOUT_PARAMETRIZED_TEMPLATE, ~, LAYOUTS_LIST))   */              \
+    /* these could be moved to an external type trait to free up the symbol names */                                   \
+    using self_type = CLASS;
+// clang-format on
+
+// clang-format off
+#define _GENERATE_SOA_VIEW_PART_0_NO_DEFAULTS(CLASS, LAYOUTS_LIST, VALUE_LIST)                                         \
+  template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT,                                                                     \
+            bool VIEW_ALIGNMENT_ENFORCEMENT,                                                                           \
+            bool RESTRICT_QUALIFY,                                                                                     \
+            bool RANGE_CHECKING>                                                                                       \
+  struct CLASS {                                                                                                       \
+    /* Declare the parametrized layouts as the default */                                                              \
+    /*BOOST_PP_SEQ_CAT(_ITERATE_ON_ALL(_DECLARE_VIEW_LAYOUT_PARAMETRIZED_TEMPLATE, ~, LAYOUTS_LIST))   */              \
+    /* these could be moved to an external type trait to free up the symbol names */                                   \
+    using self_type = CLASS;
+// clang-format on
+
+/**
+ * Split of the const view definition where the parametrized template alias for the layout is defined for layout trivial view.
+ */
+
+// clang-format off
+#define _GENERATE_SOA_VIEW_PART_1(CLASS, LAYOUTS_LIST, VALUE_LIST)                                                     \
+    using size_type = cms::soa::size_type;                                                                             \
+    using byte_size_type = cms::soa::byte_size_type;                                                                   \
+    using AlignmentEnforcement = cms::soa::AlignmentEnforcement;                                                       \
+                                                                                                                       \
+    /* For CUDA applications, we align to the 128 bytes of the cache lines.                                            \
+   * See https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#global-memory-3-0 this is still valid        \
+   * up to compute capability 8.X.                                                                                     \
+   */                                                                                                                  \
+    constexpr static byte_size_type defaultAlignment = cms::soa::CacheLineSize::defaultSize;                           \
+    constexpr static byte_size_type alignment = VIEW_ALIGNMENT;                                                        \
+    constexpr static bool alignmentEnforcement = VIEW_ALIGNMENT_ENFORCEMENT;                                           \
+    constexpr static byte_size_type conditionalAlignment =                                                             \
+        alignmentEnforcement == AlignmentEnforcement::Enforced ? alignment : 0;                                        \
+    constexpr static bool restrictQualify = RESTRICT_QUALIFY;                                                          \
+    constexpr static bool rangeChecking = RANGE_CHECKING;                                                              \
+    /* Those typedefs avoid having commas in macros (which is problematic) */                                          \
+    template <cms::soa::SoAColumnType COLUMN_TYPE, class C>                                                            \
+    using SoAValueWithConf = cms::soa::SoAValue<COLUMN_TYPE, C, conditionalAlignment, restrictQualify>;                \
+                                                                                                                       \
+    template <cms::soa::SoAColumnType COLUMN_TYPE, class C>                                                            \
+    using SoAConstValueWithConf = cms::soa::SoAConstValue<COLUMN_TYPE, C, conditionalAlignment, restrictQualify>;      \
+                                                                                                                       \
+    /**                                                                                                                \
+   * Helper/friend class allowing SoA introspection.                                                                   \
+   */                                                                                                                  \
+    struct Metadata {                                                                                                  \
+      friend CLASS;                                                                                                    \
+      SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.nElements_; }                                 \
+      /* Alias layout or view types to name-derived identifyer to allow simpler definitions */                         \
+      _ITERATE_ON_ALL(_DECLARE_VIEW_LAYOUT_TYPE_ALIAS, ~, LAYOUTS_LIST)                                                \
+                                                                                                                       \
+      /* Alias member types to name-derived identifyer to allow simpler definitions */                                 \
+      _ITERATE_ON_ALL(_DECLARE_VIEW_MEMBER_TYPE_ALIAS, BOOST_PP_EMPTY(), VALUE_LIST)                                   \
+                                                                                                                       \
+      /* Forbid copying to avoid const correctness evasion */                                                          \
+      Metadata& operator=(const Metadata&) = delete;                                                                   \
+      Metadata(const Metadata&) = delete;                                                                              \
+                                                                                                                       \
+    private:                                                                                                           \
+      SOA_HOST_DEVICE SOA_INLINE Metadata(const CLASS& parent) : parent_(parent) {}                                    \
+      const CLASS& parent_;                                                                                            \
+    };                                                                                                                 \
+    friend Metadata;                                                                                                   \
+    SOA_HOST_DEVICE SOA_INLINE const Metadata metadata() const { return Metadata(*this); }                             \
+    SOA_HOST_DEVICE SOA_INLINE Metadata metadata() { return Metadata(*this); }                                         \
+                                                                                                                       \
+    /* Trivial constuctor */                                                                                           \
+    CLASS() {}                                                                                                         \
+                                                                                                                       \
+    /* Constructor relying on user provided layouts or views */                                                        \
+    SOA_HOST_ONLY CLASS(_ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTION_PARAMETERS, BOOST_PP_EMPTY(), LAYOUTS_LIST))  \
+        : nElements_([&]() -> size_type {                                                                              \
+            bool set = false;                                                                                          \
+            size_type ret = 0;                                                                                         \
+            _ITERATE_ON_ALL(_UPDATE_SIZE_OF_VIEW, BOOST_PP_EMPTY(), LAYOUTS_LIST)                                      \
+            return ret;                                                                                                \
+          }()),                                                                                                        \
+          _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_INITIALIZERS, ~, VALUE_LIST) {}                                   \
+                                                                                                                       \
+    /* Constructor relying on individually provided column addresses */                                                \
+    SOA_HOST_ONLY CLASS(size_type nElements,                                                                           \
+                        _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTION_BYCOLUMN_PARAMETERS,                          \
+                                              BOOST_PP_EMPTY(),                                                        \
+                                              VALUE_LIST))                                                             \
+        : nElements_(nElements), _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_INITIALIZERS_BYCOLUMN, ~, VALUE_LIST) {}   \
+                                                                                                                       \
+    struct const_element {                                                                                             \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      const_element(size_type index, /* Declare parameters */                                                          \
+                    _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_VALUE_ARG, const, VALUE_LIST))                         \
+          : _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONST_ELEM_MEMBER_INIT, index, VALUE_LIST) {}                          \
+      _ITERATE_ON_ALL(_DECLARE_VIEW_CONST_ELEMENT_ACCESSOR, ~, VALUE_LIST)                                             \
+                                                                                                                       \
+    private:                                                                                                           \
+      _ITERATE_ON_ALL(_DECLARE_VIEW_CONST_ELEMENT_VALUE_MEMBER, ~, VALUE_LIST)                                         \
+    };                                                                                                                 \
+                                                                                                                       \
+    struct element {                                                                                                   \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      element(size_type index, /* Declare parameters */                                                                \
+              _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_VALUE_ARG, BOOST_PP_EMPTY(), VALUE_LIST))                    \
+          : _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEM_MEMBER_INIT, index, VALUE_LIST) {}                                \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      element& operator=(const element& other) {                                                                       \
+        _ITERATE_ON_ALL(_DECLARE_VIEW_ELEMENT_VALUE_COPY, ~, VALUE_LIST)                                               \
+        return *this;                                                                                                  \
+      }                                                                                                                \
+      _ITERATE_ON_ALL(_DECLARE_VIEW_ELEMENT_VALUE_MEMBER, ~, VALUE_LIST)                                               \
+    };                                                                                                                 \
+                                                                                                                       \
+    /* AoS-like accessor (non-const) */                                                                                \
+    SOA_HOST_DEVICE SOA_INLINE                                                                                         \
+    element operator[](size_type index) {                                                                              \
+      if constexpr (rangeChecking == cms::soa::RangeChecking::Enabled) {                                               \
+        if (index >= nElements_)                                                                                       \
+          SOA_THROW_OUT_OF_RANGE("Out of range index in " #CLASS "::operator[]")                                       \
+      }                                                                                                                \
+      return element(index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_CONSTR_CALL, ~, VALUE_LIST));                  \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* AoS-like accessor (const) */                                                                                    \
+    SOA_HOST_DEVICE SOA_INLINE                                                                                         \
+    const_element operator[](size_type index) const {                                                                  \
+      if constexpr (rangeChecking == cms::soa::RangeChecking::Enabled) {                                               \
+        if (index >= nElements_)                                                                                       \
+          SOA_THROW_OUT_OF_RANGE("Out of range index in " #CLASS "::operator[]")                                       \
+      }                                                                                                                \
+      return const_element(index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_CONSTR_CALL, ~, VALUE_LIST));            \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* accessors */                                                                                                    \
+    _ITERATE_ON_ALL(_DECLARE_VIEW_SOA_ACCESSOR, ~, VALUE_LIST)                                                         \
+    _ITERATE_ON_ALL(_DECLARE_VIEW_SOA_CONST_ACCESSOR, ~, VALUE_LIST)                                                   \
+                                                                                                                       \
+    /* dump the SoA internal structure */                                                                              \
+    template <typename T>                                                                                              \
+    SOA_HOST_ONLY friend void dump();                                                                                  \
+                                                                                                                       \
+  private:                                                                                                             \
+    size_type nElements_ = 0;                                                                                          \
+    _ITERATE_ON_ALL(_DECLARE_VIEW_SOA_MEMBER, BOOST_PP_EMPTY(), VALUE_LIST)                                            \
+  };
+// clang-format on
+
+/* ---- CONST VIEW -------------------------------------------------------------------------------------------------- */
+// clang-format off
+#define _GENERATE_SOA_CONST_VIEW_PART_0(CLASS, LAYOUTS_LIST, VALUE_LIST)                                               \
+  template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT = cms::soa::CacheLineSize::defaultSize,                              \
+            bool VIEW_ALIGNMENT_ENFORCEMENT = cms::soa::AlignmentEnforcement::Relaxed,                                 \
+            bool RESTRICT_QUALIFY = cms::soa::RestrictQualify::Enabled,                                                \
+            bool RANGE_CHECKING = cms::soa::RangeChecking::Disabled>                                                   \
+  struct CLASS {                                                                                                       \
+    /* these could be moved to an external type trait to free up the symbol names */                                   \
+    using self_type = CLASS;
+// clang-format on
+
+// clang-format off
+#define _GENERATE_SOA_CONST_VIEW_PART_0_NO_DEFAULTS(CLASS, LAYOUTS_LIST, VALUE_LIST)                                   \
+  template <CMS_SOA_BYTE_SIZE_TYPE VIEW_ALIGNMENT,                                                                     \
+            bool VIEW_ALIGNMENT_ENFORCEMENT,                                                                           \
+            bool RESTRICT_QUALIFY,                                                                                     \
+            bool RANGE_CHECKING>                                                                                       \
+  struct CLASS {                                                                                                       \
+    /* these could be moved to an external type trait to free up the symbol names */                                   \
+    using self_type = CLASS;
+// clang-format on
+
+/**
+ * Split of the const view definition where the parametrized template alias for the layout is defined for layout trivial view.
+ */
+
+// clang-format off
+#define _GENERATE_SOA_CONST_VIEW_PART_1(CLASS, LAYOUTS_LIST, VALUE_LIST)                                               \
+    typedef cms::soa::AlignmentEnforcement AlignmentEnforcement;                                                       \
+                                                                                                                       \
+    /* For CUDA applications, we align to the 128 bytes of the cache lines.                                            \
+   * See https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#global-memory-3-0 this is still valid        \
+   * up to compute capability 8.X.                                                                                     \
+   */                                                                                                                  \
+    constexpr static byte_size_type defaultAlignment = cms::soa::CacheLineSize::defaultSize;                           \
+    constexpr static byte_size_type alignment = VIEW_ALIGNMENT;                                                        \
+    constexpr static bool alignmentEnforcement = VIEW_ALIGNMENT_ENFORCEMENT;                                           \
+    constexpr static byte_size_type conditionalAlignment =                                                             \
+        alignmentEnforcement == AlignmentEnforcement::Enforced ? alignment : 0;                                        \
+    constexpr static bool restrictQualify = RESTRICT_QUALIFY;                                                          \
+    constexpr static bool rangeChecking = RANGE_CHECKING;                                                              \
+    /* Those typedefs avoid having commas in macros (which is problematic) */                                          \
+    template <cms::soa::SoAColumnType COLUMN_TYPE, class C>                                                            \
+    using SoAValueWithConf = cms::soa::SoAValue<COLUMN_TYPE, C, conditionalAlignment, restrictQualify>;                \
+                                                                                                                       \
+    template <cms::soa::SoAColumnType COLUMN_TYPE, class C>                                                            \
+    using SoAConstValueWithConf = cms::soa::SoAConstValue<COLUMN_TYPE, C, conditionalAlignment, restrictQualify>;      \
+    /**                                                                                                                \
+   * Helper/friend class allowing SoA introspection.                                                                   \
+   */                                                                                                                  \
+    struct Metadata {                                                                                                  \
+      friend CLASS;                                                                                                    \
+      SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.nElements_; }                                 \
+      /* Alias layout/view types to name-derived identifyer to allow simpler definitions */                            \
+      _ITERATE_ON_ALL(_DECLARE_VIEW_LAYOUT_TYPE_ALIAS, ~, LAYOUTS_LIST)                                                \
+                                                                                                                       \
+      /* Alias member types to name-derived identifyer to allow simpler definitions */                                 \
+      _ITERATE_ON_ALL(_DECLARE_VIEW_MEMBER_TYPE_ALIAS, const, VALUE_LIST)                                              \
+                                                                                                                       \
+      Metadata& operator=(const Metadata&) = delete;                                                                   \
+      Metadata(const Metadata&) = delete;                                                                              \
+                                                                                                                       \
+    private:                                                                                                           \
+      SOA_HOST_DEVICE SOA_INLINE Metadata(const CLASS& parent) : parent_(parent) {}                                    \
+      const CLASS& parent_;                                                                                            \
+    };                                                                                                                 \
+    friend Metadata;                                                                                                   \
+    SOA_HOST_DEVICE SOA_INLINE const Metadata metadata() const { return Metadata(*this); }                             \
+                                                                                                                       \
+    /* Trivial constuctor */                                                                                           \
+    CLASS() {}                                                                                                         \
+                                                                                                                       \
+    /* Constructor relying on user provided layouts or views */                                                        \
+    SOA_HOST_ONLY CLASS(_ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTION_PARAMETERS, const, LAYOUTS_LIST))             \
+        : nElements_([&]() -> size_type {                                                                              \
+            bool set = false;                                                                                          \
+            size_type ret = 0;                                                                                         \
+            _ITERATE_ON_ALL(_UPDATE_SIZE_OF_VIEW, BOOST_PP_EMPTY(), LAYOUTS_LIST)                                      \
+            return ret;                                                                                                \
+          }()),                                                                                                        \
+          _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_INITIALIZERS, ~, VALUE_LIST) {}                                   \
+                                                                                                                       \
+    /* Constructor relying on individually provided column addresses */                                                \
+    SOA_HOST_ONLY CLASS(size_type nElements,                                                                           \
+                        _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTION_BYCOLUMN_PARAMETERS, const, VALUE_LIST))      \
+        : nElements_(nElements), _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_INITIALIZERS_BYCOLUMN, ~, VALUE_LIST) {}   \
+                                                                                                                       \
+    struct const_element {                                                                                             \
+      SOA_HOST_DEVICE SOA_INLINE                                                                                       \
+      const_element(size_type index, /* Declare parameters */                                                          \
+                    _ITERATE_ON_ALL_COMMA(_DECLARE_CONST_VIEW_ELEMENT_VALUE_ARG, const, VALUE_LIST))                   \
+          : _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONST_ELEM_MEMBER_INIT, index, VALUE_LIST) {}                          \
+      _ITERATE_ON_ALL(_DECLARE_VIEW_CONST_ELEMENT_ACCESSOR, ~, VALUE_LIST)                                             \
+                                                                                                                       \
+    private:                                                                                                           \
+      _ITERATE_ON_ALL(_DECLARE_VIEW_CONST_ELEMENT_VALUE_MEMBER, ~, VALUE_LIST)                                         \
+    };                                                                                                                 \
+                                                                                                                       \
+    /* AoS-like accessor (const) */                                                                                    \
+    SOA_HOST_DEVICE SOA_INLINE                                                                                         \
+    const_element operator[](size_type index) const {                                                                  \
+      if constexpr (rangeChecking == cms::soa::RangeChecking::Enabled) {                                               \
+        if (index >= nElements_)                                                                                       \
+          SOA_THROW_OUT_OF_RANGE("Out of range index in " #CLASS "::operator[]")                                       \
+      }                                                                                                                \
+      return const_element(index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_CONSTR_CALL, ~, VALUE_LIST));            \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* accessors */                                                                                                    \
+    _ITERATE_ON_ALL(_DECLARE_VIEW_SOA_CONST_ACCESSOR, ~, VALUE_LIST)                                                   \
+                                                                                                                       \
+    /* dump the SoA internal structure */                                                                              \
+    template <typename T>                                                                                              \
+    SOA_HOST_ONLY friend void dump();                                                                                  \
+                                                                                                                       \
+  private:                                                                                                             \
+    size_type nElements_ = 0;                                                                                          \
+    _ITERATE_ON_ALL(_DECLARE_CONST_VIEW_SOA_MEMBER, const, VALUE_LIST)                                                 \
+};
+// clang-format on
+
+// clang-format off
+// MAJOR caveat: in order to propagate the LAYOUTS_LIST and VALUE_LIST
+#define GENERATE_SOA_VIEW(CLASS, LAYOUTS_LIST, VALUE_LIST)                                                             \
+   _GENERATE_SOA_VIEW_PART_0(CLASS, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))               \
+   _GENERATE_SOA_VIEW_PART_1(CLASS, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
+
+#define _GENERATE_SOA_TRIVIAL_VIEW(CLASS, LAYOUTS_LIST, VALUE_LIST)                                                    \
+   _GENERATE_SOA_VIEW_PART_0_NO_DEFAULTS(ViewTemplateFreeParams,                                                       \
+     SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))                                              \
+   using  BOOST_PP_CAT(CLASS, _parametrized) = CLASS<VIEW_ALIGNMENT, VIEW_ALIGNMENT_ENFORCEMENT>;                      \
+   _GENERATE_SOA_VIEW_PART_1(ViewTemplateFreeParams,                                                                   \
+     SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
+
+#define GENERATE_SOA_CONST_VIEW(CLASS, LAYOUTS_LIST, VALUE_LIST)                                                       \
+   _GENERATE_SOA_CONST_VIEW_PART_0(CLASS, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))         \
+   _GENERATE_SOA_CONST_VIEW_PART_1(CLASS, SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
+
+#define _GENERATE_SOA_TRIVIAL_CONST_VIEW(CLASS, LAYOUTS_LIST, VALUE_LIST)                                              \
+   _GENERATE_SOA_CONST_VIEW_PART_0_NO_DEFAULTS(ConstViewTemplateFreeParams,                                            \
+     SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))                                              \
+   using  BOOST_PP_CAT(CLASS, _parametrized) = CLASS<VIEW_ALIGNMENT, VIEW_ALIGNMENT_ENFORCEMENT>;                      \
+   _GENERATE_SOA_CONST_VIEW_PART_1(ConstViewTemplateFreeParams,                                                        \
+     SOA_VIEW_LAYOUT_LIST(LAYOUTS_LIST), SOA_VIEW_VALUE_LIST(VALUE_LIST))
+// clang-format on
+/**
+ * Helper macro turning layout field declaration into view field declaration.
+ */
+#define _VIEW_FIELD_FROM_LAYOUT_IMPL(VALUE_TYPE, CPP_TYPE, NAME, DATA) (DATA, NAME, NAME)
+
+#define _VIEW_FIELD_FROM_LAYOUT(R, DATA, VALUE_TYPE_NAME) \
+  BOOST_PP_EXPAND((_VIEW_FIELD_FROM_LAYOUT_IMPL BOOST_PP_TUPLE_PUSH_BACK(VALUE_TYPE_NAME, DATA)))
+
+/**
+ * A macro defining both layout and view(s) in one go.
+ */
+// clang-format off
+#define GENERATE_SOA_LAYOUT_VIEW_AND_CONST_VIEW(LAYOUT_NAME, VIEW_NAME, CONST_VIEW_NAME, ...)                          \
+  GENERATE_SOA_LAYOUT(LAYOUT_NAME, __VA_ARGS__)                                                                        \
+  using BOOST_PP_CAT(LAYOUT_NAME, _default) = LAYOUT_NAME<>;                                                           \
+  GENERATE_SOA_VIEW(VIEW_NAME,                                                                                         \
+    SOA_VIEW_LAYOUT_LIST((BOOST_PP_CAT(LAYOUT_NAME, _default), BOOST_PP_CAT(instance_, LAYOUT_NAME))),                 \
+    SOA_VIEW_VALUE_LIST(_ITERATE_ON_ALL_COMMA(                                                                         \
+    _VIEW_FIELD_FROM_LAYOUT, BOOST_PP_CAT(instance_, LAYOUT_NAME), __VA_ARGS__)))                                      \
+  GENERATE_SOA_CONST_VIEW(                                                                                             \
+    CONST_VIEW_NAME,                                                                                                   \
+    SOA_VIEW_LAYOUT_LIST((BOOST_PP_CAT(LAYOUT_NAME, _default), BOOST_PP_CAT(instance_, LAYOUT_NAME))),                 \
+    SOA_VIEW_VALUE_LIST(                                                                                               \
+      _ITERATE_ON_ALL_COMMA(_VIEW_FIELD_FROM_LAYOUT, BOOST_PP_CAT(instance_, LAYOUT_NAME), __VA_ARGS__)))
+// clang-format on
+
+// clang-format off
+#define GENERATE_SOA_LAYOUT_AND_CONST_VIEW(LAYOUT_NAME, CONST_VIEW_NAME, ...)                                          \
+  GENERATE_SOA_LAYOUT(LAYOUT_NAME, __VA_ARGS__)                                                                        \
+  using BOOST_PP_CAT(LAYOUT_NAME, _default) = LAYOUT_NAME<>;                                                           \
+  GENERATE_SOA_CONST_VIEW(                                                                                             \
+    CONST_VIEW_NAME,                                                                                                   \
+    SOA_VIEW_LAYOUT_LIST((BOOST_PP_CAT(LAYOUT_NAME, _default), BOOST_PP_CAT(instance_, LAYOUT_NAME))),                 \
+    SOA_VIEW_VALUE_LIST(                                                                                               \
+      _ITERATE_ON_ALL_COMMA(_VIEW_FIELD_FROM_LAYOUT,                                                                   \
+        BOOST_PP_CAT(instance_, LAYOUT_NAME), __VA_ARGS__)))
+// clang-format on
+
+#endif  // DataFormats_SoATemplate_interface_SoAView_h

--- a/DataFormats/SoATemplate/test/BuildFile.xml
+++ b/DataFormats/SoATemplate/test/BuildFile.xml
@@ -1,0 +1,17 @@
+<iftool name="cuda-gcc-support">
+  <bin file="SoALayoutAndView_t.cu" name="SoALayoutAndView_t">
+    <use name="boost"/>
+    <use name="cuda"/>
+    <use name="eigen"/>
+    <use name="HeterogeneousCore/CUDAUtilities"/>
+  </bin>
+
+  <!-- dictionaries for FakeSoA -->
+  <library file="" name="FakeSoADict"/>
+ 
+  <!-- This test triggers a bug in ROOT, so it's kept disabled
+  <bin file="SoAStreamer_t.cpp" name="SoAStreamer_t">
+    <use name="root"/>
+  </bin>
+  -->
+</iftool>

--- a/DataFormats/SoATemplate/test/FakeSoA.h
+++ b/DataFormats/SoATemplate/test/FakeSoA.h
@@ -1,0 +1,91 @@
+#ifndef DataFormats_SoATemplate_test_FakeSoA_h
+#define DataFormats_SoATemplate_test_FakeSoA_h
+
+// A SoA-like class (with fake alignment (padding))
+#include <cstddef>
+#include <iostream>
+#include <memory>
+
+#define myassert(A)                                                                            \
+  if (not(A)) {                                                                                \
+    std::cerr << "Failed assertion: " #A " at  " __FILE__ "(" << __LINE__ << ")" << std::endl; \
+    abort();                                                                                   \
+  }
+
+class FakeSoA {
+public:
+  static constexpr size_t padding_ = 128;
+
+  // A fake SoA with 2 columns of uint16_t and uin32_t, plus fake padding.
+  static size_t computeBufferSize(size_t nElements) {
+    return nElements * (sizeof(uint16_t) + sizeof(uint32_t)) + padding_ + 0x400;
+  }
+
+  FakeSoA(std::byte *buffer, size_t nElements) { constFromBufferImpl(buffer, nElements); }
+
+  FakeSoA() : size_(0) { std::cout << "At end of FakeSoA::FakeSoA()" << std::endl; }
+
+  template <typename T>
+  void allocateAndIoRead(T &onfile) {
+    std::cout << "allocateAndIoRead begin" << std::endl;
+    auto buffSize = FakeSoA::computeBufferSize(onfile.size_);
+    auto buffer = new std::byte[buffSize];
+    std::cout << "Buffer first byte after (alloc) =" << buffer + buffSize << std::endl;
+    constFromBufferImpl(buffer, onfile.size_);
+    memcpy(a16_, onfile.a16_, sizeof(uint16_t) * onfile.size_);
+    memcpy(b32_, onfile.b32_, sizeof(uint32_t) * onfile.size_);
+    std::cout << "allocateAndIoRead end" << std::endl;
+  }
+
+  void dump() {
+    std::cout << "size=" << size_ << " buffer=" << buffer_.get() << " a16=" << a16_ << " b32=" << b32_
+              << " (b32 - a16)="
+              << reinterpret_cast<std::byte *>(reinterpret_cast<intptr_t>(b32_) - reinterpret_cast<intptr_t>(a16_))
+              << " buffer size=" << computeBufferSize(size_) << "(" << std::hex << computeBufferSize(size_) << ")"
+              << std::endl;
+  }
+
+  void dumpData() { std::cout << "a16_[0]=" << a16_[0] << " b32_[0]=" << b32_[0] << std::endl; }
+
+  void fill() {
+    for (int i = 0; i < size_; i++) {
+      a16_[i] = 42 + i;
+      b32_[i] = 24 + i;
+    }
+  }
+
+  bool check() {
+    bool result = true;
+    for (int i = 0; i < size_; i++) {
+      if (a16_[i] != 42 + i) {
+        std::cout << "a16 mismatch at i=" << i << "(" << a16_[i] << "/" << 42 + i << ")" << std::endl;
+        result = false;
+      }
+      if (b32_[i] != 24 + (uint32_t)i) {
+        std::cout << "b32 mismatch at i=" << i << "(" << b32_[i] << "/" << 24 + i << ")" << std::endl;
+        result = false;
+      }
+    }
+    return result;
+  }
+
+private:
+  void constFromBufferImpl(std::byte *buffer, size_t nElements) {
+    buffer_.reset(buffer);
+    size_ = nElements;
+    a16_ = reinterpret_cast<uint16_t *>(buffer);
+    buffer += nElements * sizeof(uint16_t) + padding_;
+    b32_ = reinterpret_cast<uint32_t *>(buffer);
+    buffer += nElements * sizeof(uint32_t);
+    std::cout << "Buffer first byte after (const) =" << buffer << std::endl;
+    std::cout << "At end of FakeSoA::constFromBufferImpl(std::byte * buffer, size_t nElements): ";
+    dump();
+  }
+
+  int size_;
+  uint16_t *a16_ = nullptr;                      //[size_]
+  uint32_t *b32_ = nullptr;                      //[size_]
+  std::unique_ptr<std::byte> buffer_ = nullptr;  //!
+};
+
+#endif  // DataFormats_SoATemplate_test_FakeSoA_h

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
@@ -48,7 +48,8 @@ using SoADeviceOnlyLayout = SoADeviceOnlyLayoutTemplate<>;
 using SoADeviceOnlyView = SoADeviceOnlyLayout::View;
 
 // A 1 to 1 view of the store (except for unsupported types).
-GENERATE_SOA_VIEW(SoAFullDeviceViewTemplate,
+GENERATE_SOA_VIEW(SoAFullDeviceConstViewTemplate,
+                  SoAFullDeviceViewTemplate,
                   SOA_VIEW_LAYOUT_LIST(SOA_VIEW_LAYOUT(SoAHostDeviceLayout, soaHD),
                                        SOA_VIEW_LAYOUT(SoADeviceOnlyLayout, soaDO)),
                   SOA_VIEW_LAYOUT_LIST(SOA_VIEW_VALUE(soaHD, x),
@@ -63,7 +64,7 @@ GENERATE_SOA_VIEW(SoAFullDeviceViewTemplate,
                                        SOA_VIEW_VALUE(soaHD, someNumber)))
 
 using SoAFullDeviceView =
-    SoAFullDeviceViewTemplate<cms::soa::CacheLineSize::NvidiaGPU, cms::soa::AlignmentEnforcement::Enforced>;
+    SoAFullDeviceViewTemplate<cms::soa::CacheLineSize::NvidiaGPU, cms::soa::AlignmentEnforcement::enforced>;
 
 // Eigen cross product kernel (on store)
 __global__ void crossProduct(SoAHostDeviceView soa, const unsigned int numElements) {
@@ -95,7 +96,7 @@ __global__ void consumerKernel(SoAFullDeviceView soa, const unsigned int numElem
 
 // Get a view like the default, except for range checking
 using RangeCheckingHostDeviceView =
-    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::Enabled>;
+    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::enabled>;
 
 // We expect to just run one thread.
 __global__ void rangeCheckKernel(RangeCheckingHostDeviceView soa) {
@@ -235,7 +236,7 @@ int main(void) {
   // Validation of range checking
   try {
     // Get a view like the default, except for range checking
-    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::Enabled>
+    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::enabled>
         soa1viewRangeChecking(h_soahdLayout);
     // This should throw an exception
     [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size()];

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
@@ -52,16 +52,16 @@ GENERATE_SOA_VIEW(SoAFullDeviceConstViewTemplate,
                   SoAFullDeviceViewTemplate,
                   SOA_VIEW_LAYOUT_LIST(SOA_VIEW_LAYOUT(SoAHostDeviceLayout, soaHD),
                                        SOA_VIEW_LAYOUT(SoADeviceOnlyLayout, soaDO)),
-                  SOA_VIEW_LAYOUT_LIST(SOA_VIEW_VALUE(soaHD, x),
-                                       SOA_VIEW_VALUE(soaHD, y),
-                                       SOA_VIEW_VALUE(soaHD, z),
-                                       SOA_VIEW_VALUE(soaDO, color),
-                                       SOA_VIEW_VALUE(soaDO, value),
-                                       SOA_VIEW_VALUE(soaDO, py),
-                                       SOA_VIEW_VALUE(soaDO, count),
-                                       SOA_VIEW_VALUE(soaDO, anotherCount),
-                                       SOA_VIEW_VALUE(soaHD, description),
-                                       SOA_VIEW_VALUE(soaHD, someNumber)))
+                  SOA_VIEW_VALUE_LIST(SOA_VIEW_VALUE(soaHD, x),
+                                      SOA_VIEW_VALUE(soaHD, y),
+                                      SOA_VIEW_VALUE(soaHD, z),
+                                      SOA_VIEW_VALUE(soaDO, color),
+                                      SOA_VIEW_VALUE(soaDO, value),
+                                      SOA_VIEW_VALUE(soaDO, py),
+                                      SOA_VIEW_VALUE(soaDO, count),
+                                      SOA_VIEW_VALUE(soaDO, anotherCount),
+                                      SOA_VIEW_VALUE(soaHD, description),
+                                      SOA_VIEW_VALUE(soaHD, someNumber)))
 
 using SoAFullDeviceView =
     SoAFullDeviceViewTemplate<cms::soa::CacheLineSize::NvidiaGPU, cms::soa::AlignmentEnforcement::enforced>;
@@ -187,9 +187,18 @@ int main(void) {
   std::memset(h_soahdLayout.metadata().data(), 0, hostDeviceSize);
   for (size_t i = 0; i < numElements; ++i) {
     auto si = h_soahd[i];
-    si.x() = si.a()(0) = si.b()(2) = 1.0 * i + 1.0;
-    si.y() = si.a()(1) = si.b()(1) = 2.0 * i;
-    si.z() = si.a()(2) = si.b()(0) = 3.0 * i - 1.0;
+    // Tuple assignment...
+    // elements are: x, y, z, a, b, r
+    auto v1 = 1.0 * i + 1.0;
+    auto v2 = 2.0 * i;
+    auto v3 = 3.0 * i - 1.0;
+    if (i % 2) {
+      si = {v1, v2, v3, {v1, v2, v3}, {v3, v2, v1}, {0, 0, 0}};
+    } else {
+      si.x() = si.a()(0) = si.b()(2) = v1;
+      si.y() = si.a()(1) = si.b()(1) = v2;
+      si.z() = si.a()(2) = si.b()(0) = v3;
+    }
   }
   auto& sn = h_soahd.someNumber();
   sn = numElements + 2;

--- a/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
+++ b/DataFormats/SoATemplate/test/SoALayoutAndView_t.cu
@@ -1,0 +1,265 @@
+#include <cstdlib>
+#include <memory>
+
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+#include "DataFormats/SoATemplate/interface/SoAView.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/requireDevices.h"
+
+// Test SoA stores and view.
+// Use cases
+// Multiple stores in a buffer
+// Scalars, Columns of scalars and of Eigen vectors
+// View to each of them, from one and multiple stores.
+
+GENERATE_SOA_LAYOUT(SoAHostDeviceLayoutTemplate,
+                    /*SoAHostDeviceViewTemplate,*/
+                    // predefined static scalars
+                    // size_t size;
+                    // size_t alignment;
+
+                    // columns: one value per element
+                    SOA_COLUMN(double, x),
+                    SOA_COLUMN(double, y),
+                    SOA_COLUMN(double, z),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, a),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, b),
+                    SOA_EIGEN_COLUMN(Eigen::Vector3d, r),
+                    // scalars: one value for the whole structure
+                    SOA_SCALAR(const char*, description),
+                    SOA_SCALAR(uint32_t, someNumber))
+
+using SoAHostDeviceLayout = SoAHostDeviceLayoutTemplate<>;
+using SoAHostDeviceView = SoAHostDeviceLayout::View;
+using SoAHostDeviceConstView = SoAHostDeviceLayout::ConstView;
+
+GENERATE_SOA_LAYOUT(SoADeviceOnlyLayoutTemplate,
+                    /*SoADeviceOnlyViewTemplate,*/
+                    SOA_COLUMN(uint16_t, color),
+                    SOA_COLUMN(double, value),
+                    SOA_COLUMN(double*, py),
+                    SOA_COLUMN(uint32_t, count),
+                    SOA_COLUMN(uint32_t, anotherCount))
+
+using SoADeviceOnlyLayout = SoADeviceOnlyLayoutTemplate<>;
+using SoADeviceOnlyView = SoADeviceOnlyLayout::View;
+
+// A 1 to 1 view of the store (except for unsupported types).
+GENERATE_SOA_VIEW(SoAFullDeviceViewTemplate,
+                  SOA_VIEW_LAYOUT_LIST(SOA_VIEW_LAYOUT(SoAHostDeviceLayout, soaHD),
+                                       SOA_VIEW_LAYOUT(SoADeviceOnlyLayout, soaDO)),
+                  SOA_VIEW_LAYOUT_LIST(SOA_VIEW_VALUE(soaHD, x),
+                                       SOA_VIEW_VALUE(soaHD, y),
+                                       SOA_VIEW_VALUE(soaHD, z),
+                                       SOA_VIEW_VALUE(soaDO, color),
+                                       SOA_VIEW_VALUE(soaDO, value),
+                                       SOA_VIEW_VALUE(soaDO, py),
+                                       SOA_VIEW_VALUE(soaDO, count),
+                                       SOA_VIEW_VALUE(soaDO, anotherCount),
+                                       SOA_VIEW_VALUE(soaHD, description),
+                                       SOA_VIEW_VALUE(soaHD, someNumber)))
+
+using SoAFullDeviceView =
+    SoAFullDeviceViewTemplate<cms::soa::CacheLineSize::NvidiaGPU, cms::soa::AlignmentEnforcement::Enforced>;
+
+// Eigen cross product kernel (on store)
+__global__ void crossProduct(SoAHostDeviceView soa, const unsigned int numElements) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= numElements)
+    return;
+  auto si = soa[i];
+  si.r() = si.a().cross(si.b());
+}
+
+// Device-only producer kernel
+__global__ void producerKernel(SoAFullDeviceView soa, const unsigned int numElements) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= numElements)
+    return;
+  auto si = soa[i];
+  si.color() &= 0x55 << i % (sizeof(si.color()) - sizeof(char));
+  si.value() = sqrt(si.x() * si.x() + si.y() * si.y() + si.z() * si.z());
+}
+
+// Device-only consumer with result in host-device area
+__global__ void consumerKernel(SoAFullDeviceView soa, const unsigned int numElements) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= numElements)
+    return;
+  auto si = soa[i];
+  si.x() = si.color() * si.value();
+}
+
+// Get a view like the default, except for range checking
+using RangeCheckingHostDeviceView =
+    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::Enabled>;
+
+// We expect to just run one thread.
+__global__ void rangeCheckKernel(RangeCheckingHostDeviceView soa) {
+  printf("About to fail range-check in CUDA thread: %d\n", threadIdx.x);
+  [[maybe_unused]] auto si = soa[soa.metadata().size()];
+  printf("Fail: range-check failure should have stopped the kernel.\n");
+}
+
+int main(void) {
+  cms::cudatest::requireDevices();
+
+  cudaStream_t stream;
+  cudaCheck(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+
+  // Non-aligned number of elements to check alignment features.
+  constexpr unsigned int numElements = 65537;
+
+  // Allocate buffer and store on host
+  size_t hostDeviceSize = SoAHostDeviceLayout::computeDataSize(numElements);
+  std::byte* h_buf = nullptr;
+  cudaCheck(cudaMallocHost(&h_buf, hostDeviceSize));
+  SoAHostDeviceLayout h_soahdLayout(h_buf, numElements);
+  SoAHostDeviceView h_soahd(h_soahdLayout);
+  SoAHostDeviceConstView h_soahd_c(h_soahdLayout);
+
+  // Alocate buffer, stores and views on the device (single, shared buffer).
+  size_t deviceOnlySize = SoADeviceOnlyLayout::computeDataSize(numElements);
+  std::byte* d_buf = nullptr;
+  cudaCheck(cudaMallocHost(&d_buf, hostDeviceSize + deviceOnlySize));
+  SoAHostDeviceLayout d_soahdLayout(d_buf, numElements);
+  SoADeviceOnlyLayout d_soadoLayout(d_soahdLayout.metadata().nextByte(), numElements);
+  SoAHostDeviceView d_soahdView(d_soahdLayout);
+  SoAFullDeviceView d_soaFullView(d_soahdLayout, d_soadoLayout);
+
+  // Assert column alignments
+  assert(0 == reinterpret_cast<uintptr_t>(h_soahd.metadata().addressOf_x()) % decltype(h_soahd)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(h_soahd.metadata().addressOf_y()) % decltype(h_soahd)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(h_soahd.metadata().addressOf_z()) % decltype(h_soahd)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(h_soahd.metadata().addressOf_a()) % decltype(h_soahd)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(h_soahd.metadata().addressOf_b()) % decltype(h_soahd)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(h_soahd.metadata().addressOf_r()) % decltype(h_soahd)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(h_soahd.metadata().addressOf_description()) % decltype(h_soahd)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(h_soahd.metadata().addressOf_someNumber()) % decltype(h_soahd)::alignment);
+
+  assert(0 == reinterpret_cast<uintptr_t>(d_soahdLayout.metadata().addressOf_x()) % decltype(d_soahdLayout)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soahdLayout.metadata().addressOf_y()) % decltype(d_soahdLayout)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soahdLayout.metadata().addressOf_z()) % decltype(d_soahdLayout)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soahdLayout.metadata().addressOf_a()) % decltype(d_soahdLayout)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soahdLayout.metadata().addressOf_b()) % decltype(d_soahdLayout)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soahdLayout.metadata().addressOf_r()) % decltype(d_soahdLayout)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soahdLayout.metadata().addressOf_description()) %
+                  decltype(d_soahdLayout)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soahdLayout.metadata().addressOf_someNumber()) %
+                  decltype(d_soahdLayout)::alignment);
+
+  assert(0 ==
+         reinterpret_cast<uintptr_t>(d_soadoLayout.metadata().addressOf_color()) % decltype(d_soadoLayout)::alignment);
+  assert(0 ==
+         reinterpret_cast<uintptr_t>(d_soadoLayout.metadata().addressOf_value()) % decltype(d_soadoLayout)::alignment);
+  assert(0 ==
+         reinterpret_cast<uintptr_t>(d_soadoLayout.metadata().addressOf_py()) % decltype(d_soadoLayout)::alignment);
+  assert(0 ==
+         reinterpret_cast<uintptr_t>(d_soadoLayout.metadata().addressOf_count()) % decltype(d_soadoLayout)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soadoLayout.metadata().addressOf_anotherCount()) %
+                  decltype(d_soadoLayout)::alignment);
+
+  // Views should get the same alignment as the stores they refer to
+  assert(0 == reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_x()) % decltype(d_soaFullView)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_y()) % decltype(d_soaFullView)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_z()) % decltype(d_soaFullView)::alignment);
+  // Limitation of views: we have to get scalar member addresses via metadata.
+  assert(0 == reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_description()) %
+                  decltype(d_soaFullView)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_someNumber()) %
+                  decltype(d_soaFullView)::alignment);
+  assert(0 ==
+         reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_color()) % decltype(d_soaFullView)::alignment);
+  assert(0 ==
+         reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_value()) % decltype(d_soaFullView)::alignment);
+  assert(0 ==
+         reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_py()) % decltype(d_soaFullView)::alignment);
+  assert(0 ==
+         reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_count()) % decltype(d_soaFullView)::alignment);
+  assert(0 == reinterpret_cast<uintptr_t>(d_soaFullView.metadata().addressOf_anotherCount()) %
+                  decltype(d_soaFullView)::alignment);
+
+  // Initialize and fill the host buffer
+  std::memset(h_soahdLayout.metadata().data(), 0, hostDeviceSize);
+  for (size_t i = 0; i < numElements; ++i) {
+    auto si = h_soahd[i];
+    si.x() = si.a()(0) = si.b()(2) = 1.0 * i + 1.0;
+    si.y() = si.a()(1) = si.b()(1) = 2.0 * i;
+    si.z() = si.a()(2) = si.b()(0) = 3.0 * i - 1.0;
+  }
+  auto& sn = h_soahd.someNumber();
+  sn = numElements + 2;
+
+  // Push to device
+  cudaCheck(cudaMemcpyAsync(d_buf, h_buf, hostDeviceSize, cudaMemcpyDefault, stream));
+
+  // Process on device
+  crossProduct<<<(numElements + 255) / 256, 256, 0, stream>>>(d_soahdView, numElements);
+
+  // Paint the device only with 0xFF initially
+  cudaCheck(cudaMemsetAsync(d_soadoLayout.metadata().data(), 0xFF, d_soadoLayout.metadata().byteSize(), stream));
+
+  // Produce to the device only area
+  producerKernel<<<(numElements + 255) / 256, 256, 0, stream>>>(d_soaFullView, numElements);
+
+  // Consume the device only area and generate a result on the host-device area
+  consumerKernel<<<(numElements + 255) / 256, 256, 0, stream>>>(d_soaFullView, numElements);
+
+  // Get result back
+  cudaCheck(cudaMemcpyAsync(h_buf, d_buf, hostDeviceSize, cudaMemcpyDefault, stream));
+
+  // Wait and validate.
+  cudaCheck(cudaStreamSynchronize(stream));
+  for (size_t i = 0; i < numElements; ++i) {
+    auto si = h_soahd_c[i];
+    assert(si.r() == si.a().cross(si.b()));
+    double initialX = 1.0 * i + 1.0;
+    double initialY = 2.0 * i;
+    double initialZ = 3.0 * i - 1.0;
+    uint16_t expectedColor = 0x55 << i % (sizeof(uint16_t) - sizeof(char));
+    double expectedX = expectedColor * sqrt(initialX * initialX + initialY * initialY + initialZ * initialZ);
+    if (abs(si.x() - expectedX) / expectedX >= 2 * std::numeric_limits<double>::epsilon()) {
+      std::cout << "X failed: for i=" << i << std::endl
+                << "initialX=" << initialX << " initialY=" << initialY << " initialZ=" << initialZ << std::endl
+                << "expectedX=" << expectedX << std::endl
+                << "resultX=" << si.x() << " resultY=" << si.y() << " resultZ=" << si.z() << std::endl
+                << "relativeDiff=" << abs(si.x() - expectedX) / expectedX
+                << " epsilon=" << std::numeric_limits<double>::epsilon() << std::endl;
+      assert(false);
+    }
+  }
+
+  // Validation of range checking
+  try {
+    // Get a view like the default, except for range checking
+    SoAHostDeviceLayout::ViewTemplate<SoAHostDeviceView::restrictQualify, cms::soa::RangeChecking::Enabled>
+        soa1viewRangeChecking(h_soahdLayout);
+    // This should throw an exception
+    [[maybe_unused]] auto si = soa1viewRangeChecking[soa1viewRangeChecking.metadata().size()];
+    std::cout << "Fail: expected range-check exception not caught on the host." << std::endl;
+    assert(false);
+  } catch (const std::out_of_range&) {
+    std::cout << "Pass: expected range-check exception successfully caught on the host." << std::endl;
+  }
+
+  // Validation of range checking in a kernel
+  // Get a view like the default one, except for range checking
+  RangeCheckingHostDeviceView soa1viewRangeChecking(d_soahdLayout);
+
+  // This should throw an exception in the kernel
+  rangeCheckKernel<<<1, 1, 0, stream>>>(soa1viewRangeChecking);
+
+  // Wait and confirm that the CUDA kernel failed
+  try {
+    cudaCheck(cudaStreamSynchronize(stream));
+    std::cout << "Fail: expected range-check exception not caught while executing the kernel." << std::endl;
+    assert(false);
+  } catch (const std::runtime_error&) {
+    std::cout << "Pass: expected range-check exception caught while executing the kernel." << std::endl;
+  }
+
+  std::cout << "OK" << std::endl;
+}

--- a/DataFormats/SoATemplate/test/SoAStreamer_t.cpp
+++ b/DataFormats/SoATemplate/test/SoAStreamer_t.cpp
@@ -1,0 +1,69 @@
+/*
+ * SoAStreamer_t.cpp
+ * 
+ * A test validating and the serialization of SoA Layouts to a ROOT file
+ */
+
+#include <cstdlib>
+#include <memory>
+
+#include <TFile.h>
+#include <TTree.h>
+
+#include "FakeSoA.h"
+
+void writeSoA() {
+  std::cout << "write begin" << std::endl;
+  constexpr size_t nElements = 128;
+
+  auto buffer = std::make_unique<std::byte[]>(FakeSoA::computeBufferSize(nElements));
+  FakeSoA fsoa(buffer.get(), nElements);
+  fsoa.dump();
+  fsoa.fill();
+  if (not fsoa.check()) {
+    exit(EXIT_FAILURE);
+  }
+
+  std::unique_ptr<TFile> myFile(TFile::Open("serializerNoTObj.root", "RECREATE"));
+  TTree tt("serializerNoTObjTree", "A SoA TTree");
+  // In CMSSW, we will get a branch of objects (each row from the branched corresponding to an event)
+  // So we have a branch with one element for the moment.
+  [[maybe_unused]] auto Branch = tt.Branch("FakeSoA", &fsoa);
+  std::cout << "In writeFile(), about to Fill()" << std::endl;
+  fsoa.dump();
+  auto prevGDebug = gDebug;
+  gDebug = 5;
+  tt.Fill();
+  gDebug = prevGDebug;
+  tt.Write();
+  myFile->Close();
+  std::cout << "write end" << std::endl;
+}
+
+void readSoA() {
+  std::cout << "read begin" << std::endl;
+  std::unique_ptr<TFile> myFile(TFile::Open("serializerNoTObj.root", "READ"));
+  myFile->ls();
+  std::unique_ptr<TTree> fakeSoATree((TTree *)myFile->Get("serializerNoTObjTree"));
+  fakeSoATree->ls();
+  auto prevGDebug = gDebug;
+  //gDebug = 3;
+  FakeSoA *fakeSoA = nullptr;
+  fakeSoATree->SetBranchAddress("FakeSoA", &fakeSoA);
+  fakeSoATree->GetEntry(0);
+  gDebug = prevGDebug;
+  std::cout << "fakeSoAAddress=" << fakeSoA << std::endl;
+  fakeSoA->dump();
+  fakeSoA->dumpData();
+  std::cout << "Checking SoA readback...";
+  if (not fakeSoA->check()) {
+    exit(EXIT_FAILURE);
+  }
+  std::cout << " OK" << std::endl;
+}
+
+int main() {
+  writeSoA();
+  readSoA();
+  return EXIT_SUCCESS;
+}

--- a/DataFormats/SoATemplate/test/classes.h
+++ b/DataFormats/SoATemplate/test/classes.h
@@ -1,0 +1,1 @@
+#include "DataFormats/SoATemplate/test/FakeSoA.h"

--- a/DataFormats/SoATemplate/test/classes_def.xml
+++ b/DataFormats/SoATemplate/test/classes_def.xml
@@ -1,0 +1,14 @@
+<lcgdict>
+  <class name="FakeSoA"/>
+  <ioread
+    sourceClass="FakeSoA"
+    targetClass="FakeSoA"
+    version="[1-]"
+    source="Int_t size_; uint16_t * a16_; uint32_t * b32_;"
+    target="buffer_"
+    embed="false">
+  <![CDATA[
+    newObj->allocateAndIoRead(onfile);
+  ]]>
+  </ioread>
+</lcgdict>

--- a/HeterogeneousCore/AlpakaCore/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaCore/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="FWCore/Framework"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/HeterogeneousCore/AlpakaCore/interface/MakerMacros.h
+++ b/HeterogeneousCore/AlpakaCore/interface/MakerMacros.h
@@ -1,0 +1,11 @@
+#ifndef HeterogeneousCore_AlpakaCore_interface_MakerMacros_h
+#define HeterogeneousCore_AlpakaCore_interface_MakerMacros_h
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+// force expanding ALPAKA_ACCELERATOR_NAMESPACE before stringification inside DEFINE_FWK_MODULE
+#define DEFINE_FWK_ALPAKA_MODULE2(name) DEFINE_FWK_MODULE(name)
+#define DEFINE_FWK_ALPAKA_MODULE(name) DEFINE_FWK_ALPAKA_MODULE2(ALPAKA_ACCELERATOR_NAMESPACE::name)
+
+#endif  // HeterogeneousCore_AlpakaCore_interface_MakerMacros_h

--- a/HeterogeneousCore/AlpakaInterface/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaInterface/BuildFile.xml
@@ -1,0 +1,2 @@
+<use name="alpaka"/>
+<use name="FWCore/Utilities" source_only="1"/>

--- a/HeterogeneousCore/AlpakaInterface/README.md
+++ b/HeterogeneousCore/AlpakaInterface/README.md
@@ -1,0 +1,6 @@
+## HeterogeneousCore/AlpakaInterface
+
+This package only depends on the `alpaka` header-only external library, and
+provides the interface used by other packages in CMSSW.
+
+It is safe to be used inside DataFormats packages.

--- a/HeterogeneousCore/AlpakaInterface/interface/config.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/config.h
@@ -1,0 +1,164 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_config_h
+#define HeterogeneousCore_AlpakaInterface_interface_config_h
+
+#include <type_traits>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/Utilities/interface/stringize.h"
+
+namespace alpaka_common {
+
+  // common types and dimensions
+  using Idx = uint32_t;
+  using Extent = uint32_t;
+  using Offsets = Extent;
+
+  using Dim0D = alpaka::DimInt<0u>;
+  using Dim1D = alpaka::DimInt<1u>;
+  using Dim2D = alpaka::DimInt<2u>;
+  using Dim3D = alpaka::DimInt<3u>;
+
+  template <typename TDim>
+  using Vec = alpaka::Vec<TDim, Idx>;
+  using Vec1D = Vec<Dim1D>;
+  using Vec2D = Vec<Dim2D>;
+  using Vec3D = Vec<Dim3D>;
+  using Scalar = Vec<Dim0D>;
+
+  template <typename TDim>
+  using WorkDiv = alpaka::WorkDivMembers<TDim, Idx>;
+  using WorkDiv1D = WorkDiv<Dim1D>;
+  using WorkDiv2D = WorkDiv<Dim2D>;
+  using WorkDiv3D = WorkDiv<Dim3D>;
+
+  // host types
+  using DevHost = alpaka::DevCpu;
+  using PltfHost = alpaka::Pltf<DevHost>;
+
+}  // namespace alpaka_common
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+namespace alpaka_cuda_async {
+  using namespace alpaka_common;
+
+  using Platform = alpaka::PltfCudaRt;
+  using Device = alpaka::DevCudaRt;
+  using Queue = alpaka::QueueCudaRtNonBlocking;
+  using Event = alpaka::EventCudaRt;
+
+  template <typename TDim>
+  using Acc = alpaka::AccGpuCudaRt<TDim, Idx>;
+  using Acc1D = Acc<Dim1D>;
+  using Acc2D = Acc<Dim2D>;
+  using Acc3D = Acc<Dim3D>;
+
+}  // namespace alpaka_cuda_async
+
+#ifdef ALPAKA_ACCELERATOR_NAMESPACE
+#define ALPAKA_DUPLICATE_NAMESPACE
+#else
+#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_cuda_async
+#define ALPAKA_TYPE_SUFFIX CudaAsync
+#endif
+
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+namespace alpaka_hip_async {
+  using namespace alpaka_common;
+
+  using Platform = alpaka::PltfHipRt;
+  using Device = alpaka::DevHipRt;
+  using Queue = alpaka::QueueHipRtNonBlocking;
+  using Event = alpaka::EventHipRt;
+
+  template <typename TDim>
+  using Acc = alpaka::AccGpuHipRt<TDim, Idx>;
+  using Acc1D = Acc<Dim1D>;
+  using Acc2D = Acc<Dim2D>;
+  using Acc3D = Acc<Dim3D>;
+
+}  // namespace alpaka_hip_async
+
+#ifdef ALPAKA_ACCELERATOR_NAMESPACE
+#define ALPAKA_DUPLICATE_NAMESPACE
+#else
+#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_hip_async
+#define ALPAKA_TYPE_SUFFIX HipAsync
+#endif
+
+#endif  // ALPAKA_ACC_GPU_HIP_ENABLED
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+namespace alpaka_serial_sync {
+  using namespace alpaka_common;
+
+  using Platform = alpaka::PltfCpu;
+  using Device = alpaka::DevCpu;
+  using Queue = alpaka::QueueCpuBlocking;
+  using Event = alpaka::EventCpu;
+
+  template <typename TDim>
+  using Acc = alpaka::AccCpuSerial<TDim, Idx>;
+  using Acc1D = Acc<Dim1D>;
+  using Acc2D = Acc<Dim2D>;
+  using Acc3D = Acc<Dim3D>;
+
+}  // namespace alpaka_serial_sync
+
+#ifdef ALPAKA_ACCELERATOR_NAMESPACE
+#define ALPAKA_DUPLICATE_NAMESPACE
+#else
+#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_serial_sync
+#define ALPAKA_TYPE_SUFFIX SerialSync
+#endif
+
+#endif  // ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+namespace alpaka_tbb_async {
+  using namespace alpaka_common;
+
+  using Platform = alpaka::PltfCpu;
+  using Device = alpaka::DevCpu;
+  using Queue = alpaka::QueueCpuNonBlocking;
+  using Event = alpaka::EventCpu;
+
+  template <typename TDim>
+  using Acc = alpaka::AccCpuTbbBlocks<TDim, Idx>;
+  using Acc1D = Acc<Dim1D>;
+  using Acc2D = Acc<Dim2D>;
+  using Acc3D = Acc<Dim3D>;
+
+}  // namespace alpaka_tbb_async
+
+#ifdef ALPAKA_ACCELERATOR_NAMESPACE
+#define ALPAKA_DUPLICATE_NAMESPACE
+#else
+#define ALPAKA_ACCELERATOR_NAMESPACE alpaka_tbb_async
+#define ALPAKA_TYPE_SUFFIX TbbAsync
+#endif
+
+#endif  // ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+
+#if defined ALPAKA_DUPLICATE_NAMESPACE
+#error Only one alpaka backend symbol can be defined at the same time: ALPAKA_ACC_GPU_CUDA_ENABLED, ALPAKA_ACC_GPU_HIP_ENABLED, ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED.
+#endif
+
+#if defined ALPAKA_ACCELERATOR_NAMESPACE
+
+// create a new backend-specific identifier based on the original type name and a backend-specific suffix
+#define ALPAKA_TYPE_ALIAS__(TYPE, SUFFIX) TYPE##SUFFIX
+#define ALPAKA_TYPE_ALIAS_(TYPE, SUFFIX) ALPAKA_TYPE_ALIAS__(TYPE, SUFFIX)
+#define ALPAKA_TYPE_ALIAS(TYPE) ALPAKA_TYPE_ALIAS_(TYPE, ALPAKA_TYPE_SUFFIX)
+
+// declare the backend-specific identifier as an alias for the namespace-based type name
+#define DECLARE_ALPAKA_TYPE_ALIAS(TYPE) using ALPAKA_TYPE_ALIAS(TYPE) = ALPAKA_ACCELERATOR_NAMESPACE::TYPE
+
+// define a null-terminated string containing the backend-specific identifier
+#define ALPAKA_TYPE_ALIAS_NAME(TYPE) EDM_STRINGIZE(ALPAKA_TYPE_ALIAS(TYPE))
+
+#endif  // ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_config_h

--- a/HeterogeneousCore/AlpakaInterface/interface/host.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/host.h
@@ -1,0 +1,16 @@
+#ifndef HeterogeneousCore_AlpakaInterface_interface_host_h
+#define HeterogeneousCore_AlpakaInterface_interface_host_h
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace alpaka_common {
+
+  // alpaka host device
+  static inline DevHost const& host() {
+    static const auto host = alpaka::getDevByIdx<alpaka_common::PltfHost>(0u);
+    return host;
+  }
+
+}  // namespace alpaka_common
+
+#endif  // HeterogeneousCore_AlpakaInterface_interface_host_h

--- a/HeterogeneousCore/AlpakaServices/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaServices/BuildFile.xml
@@ -1,0 +1,11 @@
+<use name="boost"/>
+<use name="FWCore/MessageLogger"/>
+<use name="FWCore/ParameterSet"/>
+<use name="HeterogeneousCore/AlpakaCore"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<!-- this dependency is needed only for the CUDA backend -->
+<use name="HeterogeneousCore/CUDAServices" for="alpaka/cuda"/>
+<flags ALPAKA_BACKENDS="1"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h
+++ b/HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h
@@ -1,0 +1,41 @@
+#ifndef HeterogeneousCore_AlpakaServices_interface_AlpakaService_h
+#define HeterogeneousCore_AlpakaServices_interface_AlpakaService_h
+
+#include <vector>
+
+#include <alpaka/alpaka.hpp>
+
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace edm {
+  class ActivityRegistry;
+  class ConfigurationDescriptions;
+  class ParameterSet;
+}  // namespace edm
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class AlpakaService {
+  public:
+    AlpakaService(edm::ParameterSet const& config, edm::ActivityRegistry&);
+    ~AlpakaService() = default;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    bool enabled() const { return enabled_; }
+
+    std::vector<Device> const& devices() const { return devices_; }
+
+    Device const& device(uint32_t index) const { return devices_.at(index); }
+
+  private:
+    bool enabled_ = false;
+    bool verbose_ = false;
+    std::vector<Device> devices_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+DECLARE_ALPAKA_TYPE_ALIAS(AlpakaService);
+
+#endif  // HeterogeneousCore_AlpakaServices_interface_AlpakaService_h

--- a/HeterogeneousCore/AlpakaServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaServices/plugins/BuildFile.xml
@@ -1,0 +1,16 @@
+<!-- alpaka-based portable plugins -->
+<library file="alpaka/*.cc" name="HeterogeneousCoreAlpakaServicesPlugins">
+  <use name="alpaka"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/PluginManager"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <!--
+  The dependency on "HeterogeneousCore/AlpakaServices" automatically expands to include
+  the host-only library (if it exists) and the corresponding Alpaka libraries (if they exist)
+  -->
+  <use name="HeterogeneousCore/AlpakaServices"/>
+  <flags EDM_PLUGIN="1"/>
+  <flags ALPAKA_BACKENDS="1"/>
+</library>

--- a/HeterogeneousCore/AlpakaServices/plugins/alpaka/plugins.cc
+++ b/HeterogeneousCore/AlpakaServices/plugins/alpaka/plugins.cc
@@ -1,0 +1,5 @@
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
+
+DEFINE_FWK_SERVICE(ALPAKA_TYPE_ALIAS(AlpakaService));

--- a/HeterogeneousCore/AlpakaServices/src/alpaka/AlpakaService.cc
+++ b/HeterogeneousCore/AlpakaServices/src/alpaka/AlpakaService.cc
@@ -1,0 +1,78 @@
+#include <boost/core/demangle.hpp>
+
+#include <alpaka/alpaka.hpp>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  AlpakaService::AlpakaService(edm::ParameterSet const& config, edm::ActivityRegistry&)
+      : enabled_(config.getUntrackedParameter<bool>("enabled")),
+        verbose_(config.getUntrackedParameter<bool>("verbose")) {
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+    // rely on the CUDAService to initialise the CUDA devices
+    edm::Service<CUDAService> cudaService;
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+    // TODO from Andrea Bocci:
+    //   - handle alpaka caching allocators ?
+    //   - extract and print more information about the platform and devices
+
+    if (not enabled_) {
+      edm::LogInfo("AlpakaService") << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " disabled by configuration";
+      return;
+    }
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+    if (not cudaService->enabled()) {
+      enabled_ = false;
+      edm::LogInfo("AlpakaService") << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " disabled by CUDAService";
+      return;
+    }
+#endif  // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+    // enumerate all devices on this platform
+    uint32_t n = alpaka::getDevCount<Platform>();
+    if (n == 0) {
+      const std::string platform = boost::core::demangle(typeid(Platform).name());
+      edm::LogWarning("AlpakaService") << "Could not find any devices on platform " << platform << ".\n"
+                                       << "Disabling " << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << ".";
+      enabled_ = false;
+      return;
+    }
+
+    devices_.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      devices_.push_back(alpaka::getDevByIdx<Platform>(i));
+      //assert(getDeviceIndex(devices_.back()) == static_cast<int>(i));
+    }
+
+    {
+      const char* suffix[] = {"s.", ":", "s:"};
+      edm::LogInfo out("AlpakaService");
+      out << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " succesfully initialised.\n";
+      out << "Found " << n << " device" << suffix[n < 2 ? n : 2];
+      for (auto const& device : devices_) {
+        out << "\n  - " << alpaka::getName(device);
+      }
+    }
+  }
+
+  void AlpakaService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.addUntracked<bool>("enabled", true);
+    desc.addUntracked<bool>("verbose", false);
+
+    descriptions.add(ALPAKA_TYPE_ALIAS_NAME(AlpakaService), desc);
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaTest/plugins/BuildFile.xml
@@ -1,0 +1,27 @@
+<!-- host-only plugins -->
+<library file="*.cc" name="HeterogeneousCoreAlpakaTestPlugins">
+  <use name="alpaka"/>
+  <use name="DataFormats/PortableTestObjects"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<!-- alpaka-based portable plugins -->
+<library file="alpaka/*.cc" name="HeterogeneousCoreAlpakaTestPluginsPortable">
+  <use name="alpaka"/>
+  <!--
+  The dependency on "DataFormats/PortableTestObjects" automatically expands to include
+  the host-only library (if it exists) and the corresponding Alpaka libraries (if they exist)
+  -->
+  <use name="DataFormats/PortableTestObjects"/>
+  <use name="FWCore/Framework"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/Utilities"/>
+  <use name="HeterogeneousCore/AlpakaCore"/>
+  <use name="HeterogeneousCore/AlpakaInterface"/>
+  <flags ALPAKA_BACKENDS="1"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -21,7 +21,7 @@ public:
   void analyze(edm::Event const& event, edm::EventSetup const&) override {
     portabletest::TestHostCollection const& product = event.get(token_);
 
-    auto const& view = *product;
+    auto const& view = product.const_view();
     for (int32_t i = 0; i < view.metadata().size(); ++i) {
       assert(view[i].id() == i);
     }

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -25,7 +25,14 @@ public:
       assert(product->id(i) == i);
     }
 
-    edm::LogInfo("TestAlpakaAnalyzer") << source_.encode() << ".size() = " << product->size();
+    edm::LogInfo msg("TestAlpakaAnalyzer");
+    msg << source_.encode() << ".size() = " << product->size() << '\n';
+    msg << "data = " << product->data() << " x = " << &product->x(0) << " y = " << &product->y(0)
+        << " z = " << &product->z(0) << " id = " << &product->id(0) << '\n';
+    msg << std::hex << "[y - x] = 0x"
+        << reinterpret_cast<intptr_t>(&product->y(0)) - reinterpret_cast<intptr_t>(&product->x(0)) << " [z - y] = 0x"
+        << reinterpret_cast<intptr_t>(&product->z(0)) - reinterpret_cast<intptr_t>(&product->y(0)) << " [id - z] = 0x"
+        << reinterpret_cast<intptr_t>(&product->id(0)) - reinterpret_cast<intptr_t>(&product->z(0));
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -21,18 +21,18 @@ public:
   void analyze(edm::Event const& event, edm::EventSetup const&) override {
     portabletest::TestHostCollection const& product = event.get(token_);
 
-    for (int32_t i = 0; i < product->size(); ++i) {
-      assert(product->id(i) == i);
+    auto const& view = *product;
+    for (int32_t i = 0; i < view.metadata().size(); ++i) {
+      assert(view[i].id() == i);
     }
 
     edm::LogInfo msg("TestAlpakaAnalyzer");
-    msg << source_.encode() << ".size() = " << product->size() << '\n';
-    msg << "data = " << product->data() << " x = " << &product->x(0) << " y = " << &product->y(0)
-        << " z = " << &product->z(0) << " id = " << &product->id(0) << '\n';
-    msg << std::hex << "[y - x] = 0x"
-        << reinterpret_cast<intptr_t>(&product->y(0)) - reinterpret_cast<intptr_t>(&product->x(0)) << " [z - y] = 0x"
-        << reinterpret_cast<intptr_t>(&product->z(0)) - reinterpret_cast<intptr_t>(&product->y(0)) << " [id - z] = 0x"
-        << reinterpret_cast<intptr_t>(&product->id(0)) - reinterpret_cast<intptr_t>(&product->z(0));
+    msg << source_.encode() << ".size() = " << view.metadata().size() << '\n';
+    msg << "data = " << product.buffer().data() << " x = " << view.x() << " y = " << view.y() << " z = " << view.z()
+        << " id = " << view.id() << '\n';
+    msg << std::hex << "[y - x] = 0x" << reinterpret_cast<intptr_t>(view.y()) - reinterpret_cast<intptr_t>(view.x())
+        << " [z - y] = 0x" << reinterpret_cast<intptr_t>(view.z()) - reinterpret_cast<intptr_t>(view.y())
+        << " [id - z] = 0x" << reinterpret_cast<intptr_t>(view.id()) - reinterpret_cast<intptr_t>(view.z());
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -1,0 +1,43 @@
+#include <cassert>
+#include <string>
+
+#include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+class TestAlpakaAnalyzer : public edm::stream::EDAnalyzer<> {
+public:
+  TestAlpakaAnalyzer(edm::ParameterSet const& config)
+      : source_{config.getParameter<edm::InputTag>("source")}, token_{consumes(source_)} {}
+
+  void analyze(edm::Event const& event, edm::EventSetup const&) override {
+    portabletest::TestHostCollection const& product = event.get(token_);
+
+    for (int32_t i = 0; i < product->size(); ++i) {
+      assert(product->id(i) == i);
+    }
+
+    edm::LogInfo("TestAlpakaAnalyzer") << source_.encode() << ".size() = " << product->size();
+  }
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("source");
+    descriptions.addWithDefaultLabel(desc);
+  }
+
+private:
+  const edm::InputTag source_;
+  const edm::EDGetTokenT<portabletest::TestHostCollection> token_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TestAlpakaAnalyzer);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -18,7 +18,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     ALPAKA_FN_ACC void operator()(TAcc const& acc, portabletest::TestDeviceCollection::View view, int32_t size) const {
       int32_t idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
       if (idx < size) {
-        view[idx].id() = idx;
+        view[idx] = {0., 0., 0., idx};
       }
     }
   };

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -15,10 +15,10 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   class TestAlgoKernel {
   public:
     template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, int32_t* id, int32_t size) const {
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, portabletest::TestDeviceCollection::View view, int32_t size) const {
       int32_t idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
       if (idx < size) {
-        id[idx] = idx;
+        view[idx].id() = idx;
       }
     }
   };
@@ -28,11 +28,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     uint32_t maxThreadsPerBlock = deviceProperties.m_blockThreadExtentMax[0];
 
     uint32_t threadsPerBlock = maxThreadsPerBlock;
-    uint32_t blocksPerGrid = (collection->size() + threadsPerBlock - 1) / threadsPerBlock;
+    uint32_t blocksPerGrid = (collection->metadata().size() + threadsPerBlock - 1) / threadsPerBlock;
     uint32_t elementsPerThread = 1;
     auto workDiv = WorkDiv1D{blocksPerGrid, threadsPerBlock, elementsPerThread};
 
-    alpaka::exec<Acc1D>(queue, workDiv, TestAlgoKernel{}, &collection->id(0), collection->size());
+    alpaka::exec<Acc1D>(queue, workDiv, TestAlgoKernel{}, *collection, collection->metadata().size());
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -1,0 +1,38 @@
+// Check that ALPAKA_HOST_ONLY is not defined during device compilation:
+#ifdef ALPAKA_HOST_ONLY
+#error ALPAKA_HOST_ONLY defined in device compilation
+#endif
+
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+#include "TestAlgo.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class TestAlgoKernel {
+  public:
+    template <typename TAcc>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, int32_t* id, int32_t size) const {
+      int32_t idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
+      if (idx < size) {
+        id[idx] = idx;
+      }
+    }
+  };
+
+  void TestAlgo::fill(Queue& queue, portabletest::TestDeviceCollection& collection) const {
+    auto const& deviceProperties = alpaka::getAccDevProps<Acc1D>(alpaka::getDev(queue));
+    uint32_t maxThreadsPerBlock = deviceProperties.m_blockThreadExtentMax[0];
+
+    uint32_t threadsPerBlock = maxThreadsPerBlock;
+    uint32_t blocksPerGrid = (collection->size() + threadsPerBlock - 1) / threadsPerBlock;
+    uint32_t elementsPerThread = 1;
+    auto workDiv = WorkDiv1D{blocksPerGrid, threadsPerBlock, elementsPerThread};
+
+    alpaka::exec<Acc1D>(queue, workDiv, TestAlgoKernel{}, &collection->id(0), collection->size());
+  }
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -16,9 +16,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
   public:
     template <typename TAcc>
     ALPAKA_FN_ACC void operator()(TAcc const& acc, portabletest::TestDeviceCollection::View view, int32_t size) const {
-      int32_t idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
-      if (idx < size) {
-        view[idx] = {0., 0., 0., idx};
+      // this example accepts an arbitrary number of blocks and threads, and always uses 1 element per thread
+      const int32_t thread = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
+      const int32_t stride = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)[0u];
+      for (auto i = thread; i < size; i += stride) {
+        view[i] = {0., 0., 0., i};
       }
     }
   };

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -32,7 +32,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     uint32_t elementsPerThread = 1;
     auto workDiv = WorkDiv1D{blocksPerGrid, threadsPerBlock, elementsPerThread};
 
-    alpaka::exec<Acc1D>(queue, workDiv, TestAlgoKernel{}, *collection, collection->metadata().size());
+    alpaka::exec<Acc1D>(queue, workDiv, TestAlgoKernel{}, collection.view(), collection->metadata().size());
   }
 
 }  // namespace ALPAKA_ACCELERATOR_NAMESPACE

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.h
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.h
@@ -1,0 +1,16 @@
+#ifndef HeterogeneousCore_AlpakaTest_plugins_alpaka_TestAlgo_h
+#define HeterogeneousCore_AlpakaTest_plugins_alpaka_TestAlgo_h
+
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class TestAlgo {
+  public:
+    void fill(Queue& queue, portabletest::TestDeviceCollection& collection) const;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#endif  // HeterogeneousCore_AlpakaTest_plugins_alpaka_TestAlgo_h

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaProducer.cc
@@ -1,0 +1,75 @@
+#include <optional>
+#include <string>
+
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
+
+#include "TestAlgo.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class TestAlpakaProducer : public edm::stream::EDProducer<> {
+  public:
+    TestAlpakaProducer(edm::ParameterSet const& config)
+        : deviceToken_{produces()}, size_{config.getParameter<int32_t>("size")} {}
+
+    void beginStream(edm::StreamID sid) override {
+      // choose a device based on the EDM stream number
+      edm::Service<ALPAKA_TYPE_ALIAS(AlpakaService)> service;
+      if (not service->enabled()) {
+        throw cms::Exception("Configuration") << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " is disabled.";
+      }
+      auto& devices = service->devices();
+      unsigned int index = sid.value() % devices.size();
+      device_ = devices[index];
+    }
+
+    void produce(edm::Event& event, edm::EventSetup const&) override {
+      // create a queue to submit async work
+      Queue queue{*device_};
+      portabletest::TestDeviceCollection deviceProduct{size_, *device_};
+
+      // run the algorithm, potentially asynchronously
+      algo_.fill(queue, deviceProduct);
+
+      // wait for any asynchronous work to complete
+      alpaka::wait(queue);
+
+      event.emplace(deviceToken_, std::move(deviceProduct));
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<int32_t>("size");
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    const edm::EDPutTokenT<portabletest::TestDeviceCollection> deviceToken_;
+    const int32_t size_;
+
+    // device associated to the EDM stream
+    std::optional<Device> device_;
+
+    // implementation of the algorithm
+    TestAlgo algo_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaProducer);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
@@ -47,7 +47,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       portabletest::TestDeviceCollection const& deviceProduct = event.get(deviceToken_);
 
       portabletest::TestHostCollection hostProduct{deviceProduct->metadata().size(), alpaka_common::host(), *device_};
-      alpaka::memcpy(queue, hostProduct.buffer(), deviceProduct.buffer());
+      alpaka::memcpy(queue, hostProduct.buffer(), deviceProduct.const_buffer());
 
       // wait for any async work to complete
       alpaka::wait(queue);

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
@@ -46,7 +46,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       Queue queue{*device_};
       portabletest::TestDeviceCollection const& deviceProduct = event.get(deviceToken_);
 
-      portabletest::TestHostCollection hostProduct{deviceProduct->size(), alpaka_common::host(), *device_};
+      portabletest::TestHostCollection hostProduct{deviceProduct->metadata().size(), alpaka_common::host(), *device_};
       alpaka::memcpy(queue, hostProduct.buffer(), deviceProduct.buffer());
 
       // wait for any async work to complete

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlpakaTranscriber.cc
@@ -1,0 +1,77 @@
+// The "Transcriber" makes sense only across different memory spaces
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) or defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+#include <optional>
+#include <string>
+
+#include <alpaka/alpaka.hpp>
+
+#include "DataFormats/PortableTestObjects/interface/TestHostCollection.h"
+#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaServices/interface/alpaka/AlpakaService.h"
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  class TestAlpakaTranscriber : public edm::stream::EDProducer<> {
+  public:
+    TestAlpakaTranscriber(edm::ParameterSet const& config)
+        : deviceToken_{consumes(config.getParameter<edm::InputTag>("source"))}, hostToken_{produces()} {}
+
+    void beginStream(edm::StreamID sid) override {
+      // choose a device based on the EDM stream number
+      edm::Service<ALPAKA_TYPE_ALIAS(AlpakaService)> service;
+      if (not service->enabled()) {
+        throw cms::Exception("Configuration") << ALPAKA_TYPE_ALIAS_NAME(AlpakaService) << " is disabled.";
+      }
+      auto& devices = service->devices();
+      unsigned int index = sid.value() % devices.size();
+      device_ = devices[index];
+    }
+
+    void produce(edm::Event& event, edm::EventSetup const&) override {
+      // create a queue to submit async work
+      Queue queue{*device_};
+      portabletest::TestDeviceCollection const& deviceProduct = event.get(deviceToken_);
+
+      portabletest::TestHostCollection hostProduct{deviceProduct->size(), alpaka_common::host(), *device_};
+      alpaka::memcpy(queue, hostProduct.buffer(), deviceProduct.buffer());
+
+      // wait for any async work to complete
+      alpaka::wait(queue);
+
+      event.emplace(hostToken_, std::move(hostProduct));
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.add<edm::InputTag>("source");
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    const edm::EDGetTokenT<portabletest::TestDeviceCollection> deviceToken_;
+    const edm::EDPutTokenT<portabletest::TestHostCollection> hostToken_;
+
+    // device associated to the EDM stream
+    std::optional<Device> device_;
+  };
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+#include "HeterogeneousCore/AlpakaCore/interface/MakerMacros.h"
+DEFINE_FWK_ALPAKA_MODULE(TestAlpakaTranscriber);
+
+#endif  // defined(ALPAKA_ACC_GPU_CUDA_ENABLED) or defined(ALPAKA_ACC_GPU_HIP_ENABLED)

--- a/HeterogeneousCore/AlpakaTest/test/BuildFile.xml
+++ b/HeterogeneousCore/AlpakaTest/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<test
+  name="testHeterogeneousCoreAlpakaTestWriteRead"
+  command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaTest/test/writer.py; cmsRun ${LOCALTOP}/src/HeterogeneousCore/AlpakaTest/test/reader.py"
+/>

--- a/HeterogeneousCore/AlpakaTest/test/reader.py
+++ b/HeterogeneousCore/AlpakaTest/test/reader.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('Reader')
+
+# read the products from a 'test.root' file
+process.source = cms.Source('PoolSource',
+    fileNames = cms.untracked.vstring('file:test.root')
+)
+
+# enable logging for the TestAlpakaAnalyzer
+process.MessageLogger.TestAlpakaAnalyzer = cms.untracked.PSet()
+
+# analyse the first product
+process.testAnalyzer = cms.EDAnalyzer('TestAlpakaAnalyzer',
+    source = cms.InputTag('testProducer')
+)
+
+# analyse the second product
+process.testAnalyzerSerial = cms.EDAnalyzer('TestAlpakaAnalyzer',
+    source = cms.InputTag('testProducerSerial')
+)
+
+process.cuda_path = cms.Path(process.testAnalyzer)
+
+process.serial_path = cms.Path(process.testAnalyzerSerial)
+
+process.maxEvents.input = 10

--- a/HeterogeneousCore/AlpakaTest/test/writer.py
+++ b/HeterogeneousCore/AlpakaTest/test/writer.py
@@ -1,0 +1,81 @@
+import FWCore.ParameterSet.Config as cms
+from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA
+
+process = cms.Process('Writer')
+
+process.source = cms.Source('EmptySource')
+
+process.load('Configuration.StandardSequences.Accelerators_cff')
+
+# enable logging for the AlpakaService and TestAlpakaAnalyzer
+process.MessageLogger.TestAlpakaAnalyzer = cms.untracked.PSet()
+process.MessageLogger.AlpakaService = cms.untracked.PSet()
+
+# enable alpaka-based heterogeneous modules
+process.AlpakaServiceCudaAsync = cms.Service('AlpakaServiceCudaAsync')
+process.AlpakaServiceSerialSync = cms.Service('AlpakaServiceSerialSync')
+
+# run the producer on a CUDA gpu (if available)
+process.testProducerCuda = cms.EDProducer('alpaka_cuda_async::TestAlpakaProducer',
+    size = cms.int32(42)
+)
+
+# copy the product from the gpu (if available) to the host
+process.testTranscriberFromCuda = cms.EDProducer('alpaka_cuda_async::TestAlpakaTranscriber',
+    source = cms.InputTag('testProducerCuda')
+)
+
+# run the producer on the cpu
+process.testProducerCpu = cms.EDProducer('alpaka_serial_sync::TestAlpakaProducer',
+    size = cms.int32(42)
+)
+
+# either run the producer on a CUDA gpu (if available) and copy the product to the cpu, or run the producer directly on the cpu
+process.testProducer = SwitchProducerCUDA(
+    cpu = cms.EDAlias(
+        testProducerCpu = cms.VPSet(cms.PSet(type = cms.string('*')))
+    ),
+    cuda = cms.EDAlias(
+        testTranscriberFromCuda = cms.VPSet(cms.PSet(type = cms.string('*')))
+    )
+)
+
+# analyse the product
+process.testAnalyzer = cms.EDAnalyzer('TestAlpakaAnalyzer',
+    source = cms.InputTag('testProducer')
+)
+
+# run a second producer explicitly on the cpu
+process.testProducerSerial = cms.EDProducer('alpaka_serial_sync::TestAlpakaProducer',
+    size = cms.int32(99)
+)
+
+# analyse the second product
+process.testAnalyzerSerial = cms.EDAnalyzer('TestAlpakaAnalyzer',
+    source = cms.InputTag('testProducerSerial')
+)
+
+# write the two products to a 'test.root' file
+process.output = cms.OutputModule('PoolOutputModule',
+    fileName = cms.untracked.string('test.root'),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_testProducer_*_*',
+        'keep *_testProducerSerial_*_*',
+  )
+)
+
+process.producer_task = cms.Task(process.testProducerCuda, process.testTranscriberFromCuda, process.testProducerCpu)
+
+process.process_path = cms.Path(
+    process.testProducer +
+    process.testAnalyzer,
+    process.producer_task)
+
+process.serial_path = cms.Path(
+    process.testProducerSerial +
+    process.testAnalyzerSerial)
+
+process.output_path = cms.EndPath(process.output)
+
+process.maxEvents.input = 10


### PR DESCRIPTION
#### PR description:

This PR is a re-posting of #37716 to fix the bot labels.
It introduces examples with the integration of alpaka in CMSSW, and the use of macro-based SoA data structres.

#### PR validation:

```bash
cmsRun HeterogeneousCore/AlpakaTest/test/writer.py
cmsRun HeterogeneousCore/AlpakaTest/test/reader.py
```
run successfully, both _with_ and _without_ a GPU, using a `SwitchProducerCUDA` to choose the modules to run.

In both cases, the `test.root` file created by the `writer.py` configuration contains the same collections:
```bash
$ edmDumpEventContent --all test.root 
Type                                  Module                 Label     Process         Full Name
------------------------------------------------------------------------------------------------
PortableHostCollection<portabletest::TestSoALayout<128,false> >    "testProducer"         ""        "Writer"        128falseportabletestTestSoALayoutPortableHostCollection_testProducer__Writer
PortableHostCollection<portabletest::TestSoALayout<128,false> >    "testProducerSerial"   ""        "Writer"        128falseportabletestTestSoALayoutPortableHostCollection_testProducerSerial__Writer
```

#### Open issues, to be followed up in future PRs

  - [ ] review the use of `beginStream()` and `endStream()`, because they can be called under unexpected conditions (see https://github.com/cms-sw/cmssw/pull/37716#discussion_r888254868)
  - [ ] further improve the  SoA and alpaka tests