### PR TITLE
Add printout of BranchID (or optionally ProductID) to edmProvDump

### DIFF
--- a/DataFormats/Provenance/interface/branchIDToProductID.h
+++ b/DataFormats/Provenance/interface/branchIDToProductID.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_Provenance_branchIDToProductID_h
+#define DataFormats_Provenance_branchIDToProductID_h
+
+#include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+
+#include <vector>
+
+namespace edm {
+  // Fill in helper map for Branch to ProductID mapping
+  std::vector<ProcessIndex> makeBranchListIndexToProcessIndex(BranchListIndexes const& branchListIndexes);
+
+  ProductID branchIDToProductID(BranchID const& bid,
+                                BranchIDListHelper const& branchIDListHelper,
+                                std::vector<ProcessIndex> const& branchListIndexToProcessIndex);
+}  // namespace edm
+
+#endif

--- a/DataFormats/Provenance/src/branchIDToProductID.cc
+++ b/DataFormats/Provenance/src/branchIDToProductID.cc
@@ -1,0 +1,41 @@
+#include "DataFormats/Provenance/interface/branchIDToProductID.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <algorithm>
+
+namespace edm {
+  std::vector<ProcessIndex> makeBranchListIndexToProcessIndex(BranchListIndexes const& branchListIndexes) {
+    ProcessIndex pix = 0;
+    auto const nelem = 1 + *std::max_element(branchListIndexes.begin(), branchListIndexes.end());
+    std::vector<ProcessIndex> branchListIndexToProcessIndex(nelem, std::numeric_limits<BranchListIndex>::max());
+    for (auto const& blindex : branchListIndexes) {
+      branchListIndexToProcessIndex[blindex] = pix;
+      ++pix;
+    }
+    return branchListIndexToProcessIndex;
+  }
+
+  ProductID branchIDToProductID(BranchID const& bid,
+                                BranchIDListHelper const& branchIDListHelper,
+                                std::vector<ProcessIndex> const& branchListIndexToProcessIndex) {
+    if (not bid.isValid()) {
+      throw Exception(errors::NotFound, "InvalidID") << "branchIDToProductID: invalid BranchID supplied\n";
+    }
+
+    auto range = branchIDListHelper.branchIDToIndexMap().equal_range(bid);
+    for (auto it = range.first; it != range.second; ++it) {
+      edm::BranchListIndex blix = it->second.first;
+      if (blix < branchListIndexToProcessIndex.size()) {
+        auto v = branchListIndexToProcessIndex[blix];
+        if (v != std::numeric_limits<edm::BranchListIndex>::max()) {
+          edm::ProductIndex productIndex = it->second.second;
+          edm::ProcessIndex processIndex = v;
+          return edm::ProductID(processIndex + 1, productIndex + 1);
+        }
+      }
+    }
+    // cannot throw, because some products may legitimately not have product ID's (e.g. pile-up).
+    return edm::ProductID();
+  }
+
+}  // namespace edm

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -1,5 +1,7 @@
 #include "DataFormats/Common/interface/setIsMergeable.h"
+#include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
+#include "DataFormats/Provenance/interface/branchIDToProductID.h"
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "DataFormats/Provenance/interface/History.h"
 #include "DataFormats/Provenance/interface/ParameterSetBlob.h"
@@ -441,7 +443,8 @@ public:
                    bool showTopLevelPSets,
                    std::vector<std::string> const& findMatch,
                    bool dontPrintProducts,
-                   std::string const& dumpPSetID);
+                   std::string const& dumpPSetID,
+                   int productIDEntry);
 
   ProvenanceDumper(ProvenanceDumper const&) = delete;             // Disallow copying and moving
   ProvenanceDumper& operator=(ProvenanceDumper const&) = delete;  // Disallow copying and moving
@@ -482,12 +485,14 @@ private:
   std::vector<std::string> findMatch_;
   bool dontPrintProducts_;
   std::string dumpPSetID_;
+  int const productIDEntry_;
 
   void work_();
   void dumpProcessHistory_();
   void dumpEventFilteringParameterSets_(TFile* file);
   void dumpEventFilteringParameterSets(edm::EventSelectionIDVector const& ids);
   void dumpParameterSetForID_(edm::ParameterSetID const& id);
+  std::optional<std::tuple<edm::BranchIDListHelper, std::vector<edm::ProcessIndex>>> makeBranchIDListHelper();
 };
 
 ProvenanceDumper::ProvenanceDumper(std::string const& filename,
@@ -499,7 +504,8 @@ ProvenanceDumper::ProvenanceDumper(std::string const& filename,
                                    bool showTopLevelPSets,
                                    std::vector<std::string> const& findMatch,
                                    bool dontPrintProducts,
-                                   std::string const& dumpPSetID)
+                                   std::string const& dumpPSetID,
+                                   int productIDEntry)
     : filename_(filename),
       inputFile_(makeTFile(filename)),
       exitCode_(0),
@@ -514,7 +520,8 @@ ProvenanceDumper::ProvenanceDumper(std::string const& filename,
       showTopLevelPSets_(showTopLevelPSets),
       findMatch_(findMatch),
       dontPrintProducts_(dontPrintProducts),
-      dumpPSetID_(dumpPSetID) {}
+      dumpPSetID_(dumpPSetID),
+      productIDEntry_(productIDEntry) {}
 
 void ProvenanceDumper::dump() { work_(); }
 
@@ -627,6 +634,71 @@ void ProvenanceDumper::dumpProcessHistory_() {
   historyGraph_.printHistory();
 }
 
+std::optional<std::tuple<edm::BranchIDListHelper, std::vector<edm::ProcessIndex>>>
+ProvenanceDumper::makeBranchIDListHelper() {
+  // BranchID-to-ProductID mapping disabled
+  if (productIDEntry_ < 0) {
+    return {};
+  }
+
+  TTree* metaTree = dynamic_cast<TTree*>(inputFile_->Get(edm::poolNames::metaDataTreeName().c_str()));
+  if (nullptr == metaTree) {
+    //std::cerr << "Did not find " << edm::poolNames::metaDataTreeName() << " tree" << std::endl;
+    return {};
+  }
+
+  TBranch* branchIDListsBranch = metaTree->GetBranch(edm::poolNames::branchIDListBranchName().c_str());
+  if (nullptr == branchIDListsBranch) {
+    /*
+    std::cerr << "Did not find " << edm::poolNames::branchIDListBranchName() << " from "
+              << edm::poolNames::metaDataTreeName() << " tree" << std::endl;
+    */
+    return {};
+  }
+
+  edm::BranchIDLists branchIDLists;
+  edm::BranchIDLists* branchIDListsPtr = &branchIDLists;
+  branchIDListsBranch->SetAddress(&branchIDListsPtr);
+  if (branchIDListsBranch->GetEntry(0) <= 0) {
+    //std::cerr << "Failed to read an entry from " << edm::poolNames::branchIDListBranchName() << std::endl;
+    return {};
+  }
+
+  edm::BranchIDListHelper branchIDListHelper;
+  branchIDListHelper.updateFromInput(branchIDLists);
+
+  TTree* events = dynamic_cast<TTree*>(inputFile_->Get(edm::poolNames::eventTreeName().c_str()));
+  assert(events != nullptr);
+  TBranch* branchListIndexesBranch = events->GetBranch(edm::poolNames::branchListIndexesBranchName().c_str());
+  if (nullptr == branchListIndexesBranch) {
+    /*
+    std::cerr << "Did not find " << edm::poolNames::branchListIndexesBranchName() << " from "
+              << edm::poolNames::eventTreeName() << " tree" << std::endl;
+    */
+    return {};
+  }
+  edm::BranchListIndexes branchListIndexes;
+  edm::BranchListIndexes* pbranchListIndexes = &branchListIndexes;
+  branchListIndexesBranch->SetAddress(&pbranchListIndexes);
+  if (branchListIndexesBranch->GetEntry(productIDEntry_) <= 0 or branchListIndexes.empty()) {
+    /*
+    std::cerr << "Failed to read entry from " << edm::poolNames::branchListIndexesBranchName() << ", or it is empty"
+              << std::endl;
+    */
+    return {};
+  }
+
+  if (not branchIDListHelper.fixBranchListIndexes(branchListIndexes)) {
+    //std::cerr << "Call to branchIDListHelper.fixBranchListIndexes() failed" << std::endl;
+    return {};
+  }
+
+  // Fill in helper map for Branch to ProductID mapping
+  auto branchListIndexToProcessIndex = edm::makeBranchListIndexToProcessIndex(branchListIndexes);
+
+  return std::tuple(std::move(branchIDListHelper), std::move(branchListIndexToProcessIndex));
+}
+
 void ProvenanceDumper::work_() {
   TTree* meta = dynamic_cast<TTree*>(inputFile_->Get(edm::poolNames::metaDataTreeName().c_str()));
   assert(nullptr != meta);
@@ -716,6 +788,9 @@ void ProvenanceDumper::work_() {
     dumpParameterSetForID_(psetID);
     return;
   }
+
+  // Helper to map BranchID to ProductID (metadata tree needed also for parentage information)
+  auto branchIDListHelperAndToProcessIndex = makeBranchIDListHelper();
 
   //Prepare the parentage information if requested
   std::map<edm::BranchID, std::set<edm::ParentageID>> perProductParentage;
@@ -887,7 +962,17 @@ void ProvenanceDumper::work_() {
       std::set<edm::BranchID> branchIDs;
       for (auto const& branch : idBranch.second) {
         if (!dontPrintProducts_) {
-          sout << "  " << branch.branchName() << std::endl;
+          sout << "  " << branch.branchName();
+          edm::ProductID id;
+          if (branchIDListHelperAndToProcessIndex) {
+            sout << " ProductID "
+                 << edm::branchIDToProductID(branch.branchID(),
+                                             std::get<0>(*branchIDListHelperAndToProcessIndex),
+                                             std::get<1>(*branchIDListHelperAndToProcessIndex));
+          } else {
+            sout << " BranchID " << branch.branchID();
+          }
+          sout << std::endl;
         }
         branchIDs.insert(branch.branchID());
         allBranchIDsForLabelAndProcess.insert(branch.branchID());
@@ -1042,6 +1127,7 @@ static char const* const kHelpCommandOpt = "help,h";
 static char const* const kFileNameOpt = "input-file";
 static char const* const kDumpPSetIDOpt = "dumpPSetID";
 static char const* const kDumpPSetIDCommandOpt = "dumpPSetID,i";
+static char const* const kProductIDEntryOpt = "productIDEntry";
 
 int main(int argc, char* argv[]) {
   using namespace boost::program_options;
@@ -1066,7 +1152,10 @@ int main(int argc, char* argv[]) {
       "be repeated with different strings)")(kDontPrintProductsCommandOpt, "do not print products produced by module")(
       kDumpPSetIDCommandOpt,
       value<std::string>(),
-      "print the parameter set associated with the parameter set ID string (and print nothing else)");
+      "print the parameter set associated with the parameter set ID string (and print nothing else)")(
+      kProductIDEntryOpt,
+      value<int>(),
+      "show ProductID instead of BranchID using the specified entry in the Events tree");
   // clang-format on
 
   //we don't want users to see these in the help messages since this
@@ -1168,6 +1257,16 @@ int main(int argc, char* argv[]) {
     dontPrintProducts = true;
   }
 
+  int productIDEntry = -1;
+  if (vm.count(kProductIDEntryOpt)) {
+    try {
+      productIDEntry = vm[kProductIDEntryOpt].as<int>();
+    } catch (boost::bad_any_cast const& e) {
+      std::cout << e.what() << std::endl;
+      return 2;
+    }
+  }
+
   //silence ROOT warnings about missing dictionaries
   gErrorIgnoreLevel = kError;
 
@@ -1180,7 +1279,8 @@ int main(int argc, char* argv[]) {
                           showTopLevelPSets,
                           findMatch,
                           dontPrintProducts,
-                          dumpPSetID);
+                          dumpPSetID,
+                          productIDEntry);
   int exitCode(0);
   try {
     dumper.dump();

--- a/IOPool/Common/test/unit_test_outputs/provdump.log
+++ b/IOPool/Common/test/unit_test_outputs/provdump.log
@@ -14,7 +14,7 @@ Processing History:
 Module: TriggerResults PROD1
  PSet id:1d569bb732972ed5978f283a32c90565
  products: {
-  edmTriggerResults_TriggerResults__PROD1.
+  edmTriggerResults_TriggerResults__PROD1. BranchID 3548090599
  }
  parameters: {
   @trigger_paths: vstring tracked  = {'p'}
@@ -23,7 +23,7 @@ Module: TriggerResults PROD1
 Module: aliasForInt PROD1
  PSet id:6629013372178d257799a6e9fc9aa2cd
  products: {
-  edmtestIntProduct_aliasForInt__PROD1.
+  edmtestIntProduct_aliasForInt__PROD1. BranchID 3673681161
  }
  parameters: {
   @module_edm_type: string tracked  = 'EDAlias'
@@ -39,7 +39,7 @@ Module: aliasForInt PROD1
 Module: intProducer PROD1
  PSet id:3df1a82d54b59acbefd683a0491cddcf
  products: {
-  edmtestIntProduct_intProducer__PROD1.
+  edmtestIntProduct_intProducer__PROD1. BranchID 709634656
  }
  parameters: {
   @module_edm_type: string tracked  = 'EDProducer'
@@ -51,7 +51,7 @@ Module: intProducer PROD1
 Module: intProducerA PROD1
  PSet id:38971365e8174cb2ccc12430661ba6d4
  products: {
-  edmtestIntProduct_intProducerA__PROD1.
+  edmtestIntProduct_intProducerA__PROD1. BranchID 1289746214
  }
  parameters: {
   @module_edm_type: string tracked  = 'EDProducer'
@@ -63,7 +63,7 @@ Module: intProducerA PROD1
 Module: intProducerU PROD1
  PSet id:4af95ea04257c4d5af7a39a5d880e879
  products: {
-  edmtestIntProduct_intProducerU__PROD1.
+  edmtestIntProduct_intProducerU__PROD1. BranchID 3186877531
  }
  parameters: {
   @module_edm_type: string tracked  = 'EDProducer'
@@ -75,7 +75,7 @@ Module: intProducerU PROD1
 Module: intVectorProducer PROD1
  PSet id:c016fa1f72fbfead00d09bc2e8e8a3c4
  products: {
-  ints_intVectorProducer__PROD1.
+  ints_intVectorProducer__PROD1. BranchID 315054627
  }
  parameters: {
   @module_edm_type: string tracked  = 'EDProducer'
@@ -89,7 +89,7 @@ Module: intVectorProducer PROD1
 Module: source PROD1
  PSet id:031810a3ee2992e7936b85708f83a8b2
  products: {
-  edmtestIntProduct_source__PROD1.
+  edmtestIntProduct_source__PROD1. BranchID 3765011715
  }
  parameters: {
   @module_edm_type: string tracked  = 'Source'


### PR DESCRIPTION
#### PR description:

Following the discussion in https://mattermost.web.cern.ch/cms-o-and-c/pl/jwfa7decrjda9jwrgepmw36woy this PR extends `edmProvDump` to print out the `BranchID` of each product. Optionally the the `BranchID` can be translated to `ProductID` with `--productIDEntry N` command line argument, where `N` is the Event entry number to do the translation.

#### PR validation:

Framework unit tests run. `edmProvDump` of a file shows BranchID (or ProductID) for products, also for dropped products.