### PR TITLE
[HGCAL geometry] Fix definition of 60degree sectors 0 and 1

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -128,7 +128,7 @@ unsigned HGCalGeomRotation::uvMappingTo60DegreeSector0(WaferCentring waferCentri
   }
 
   if (moduleU > 0 && moduleV >= 0) {
-    if (moduleV <= moduleU) {
+    if (moduleV < moduleU) {
       return sector;
     } else {
       sector = 1;


### PR DESCRIPTION
- Fix 60deg sector definition in the sector rotation utility (some wafers were wrongly assigned to sector 0 instead of sector 1).
- The function where this fix has been made is not used anywhere yet, so no change is expected in the output.


![image](https://user-images.githubusercontent.com/5569798/180955757-b06192ab-8871-42e6-aaa0-6c5c6aaafab0.png)
