### PR TITLE
Addition of saturated flag in SiStrip Approximate Clusters

### DIFF
--- a/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
+++ b/DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h
@@ -13,21 +13,24 @@ class SiStripApproximateCluster {
 public:
   SiStripApproximateCluster() {}
 
-  explicit SiStripApproximateCluster(float barycenter, uint8_t width, float avgCharge) {
+  explicit SiStripApproximateCluster(float barycenter, uint8_t width, float avgCharge, bool isSaturated) {
     barycenter_ = barycenter;
     width_ = width;
     avgCharge_ = avgCharge;
+    isSaturated_ = isSaturated;
   }
 
-  explicit SiStripApproximateCluster(const SiStripCluster& cluster);
+  explicit SiStripApproximateCluster(const SiStripCluster& cluster, unsigned int maxNSat);
 
   float barycenter() const { return barycenter_; }
   uint8_t width() const { return width_; }
   float avgCharge() const { return avgCharge_; }
+  bool isSaturated() const { return isSaturated_; }
 
 private:
   float barycenter_ = 0;
   uint8_t width_ = 0;
   float avgCharge_ = 0;
+  bool isSaturated_ = false;
 };
 #endif  // DATAFORMATS_SiStripApproximateCluster_H

--- a/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
+++ b/DataFormats/SiStripCluster/src/SiStripApproximateCluster.cc
@@ -1,7 +1,27 @@
 #include "DataFormats/SiStripCluster/interface/SiStripApproximateCluster.h"
 
-SiStripApproximateCluster::SiStripApproximateCluster(const SiStripCluster& cluster) {
+SiStripApproximateCluster::SiStripApproximateCluster(const SiStripCluster& cluster, unsigned int maxNSat) {
   barycenter_ = cluster.barycenter();
   width_ = cluster.size();
   avgCharge_ = cluster.charge() / cluster.size();
+  isSaturated_ = false;
+
+  //mimicing the algorithm used in StripSubClusterShapeTrajectoryFilter...
+  //Looks for 3 adjacent saturated strips (ADC>=254)
+  const auto& ampls = cluster.amplitudes();
+  unsigned int thisSat = (ampls[0] >= 254), maxSat = thisSat;
+  for (unsigned int i = 1, n = ampls.size(); i < n; ++i) {
+    if (ampls[i] >= 254) {
+      thisSat++;
+    } else if (thisSat > 0) {
+      maxSat = std::max<int>(maxSat, thisSat);
+      thisSat = 0;
+    }
+  }
+  if (thisSat > 0) {
+    maxSat = std::max<int>(maxSat, thisSat);
+  }
+  if (maxSat >= maxNSat) {
+    isSaturated_ = true;
+  }
 }

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -24,8 +24,8 @@
  <class name="edm::Wrapper<edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripCluster>,SiStripCluster,edmNew::DetSetVector<SiStripCluster>::FindForDetSetVector> > >" />
 
 
- <class name="SiStripApproximateCluster" ClassVersion="3">
-  <version ClassVersion="3" checksum="2041370183"/>
+ <class name="SiStripApproximateCluster" ClassVersion="9">
+  <version ClassVersion="9" checksum="2854791577"/>
  </class>
 
  <class name="edmNew::DetSetVector<SiStripApproximateCluster>"/>

--- a/DataFormats/SiStripCluster/src/classes_def.xml
+++ b/DataFormats/SiStripCluster/src/classes_def.xml
@@ -24,8 +24,8 @@
  <class name="edm::Wrapper<edmNew::DetSetVector<edm::Ref<edmNew::DetSetVector<SiStripCluster>,SiStripCluster,edmNew::DetSetVector<SiStripCluster>::FindForDetSetVector> > >" />
 
 
- <class name="SiStripApproximateCluster" ClassVersion="9">
-  <version ClassVersion="9" checksum="2854791577"/>
+ <class name="SiStripApproximateCluster" ClassVersion="4">
+  <version ClassVersion="4" checksum="2854791577"/>
  </class>
 
  <class name="edmNew::DetSetVector<SiStripApproximateCluster>"/>

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2ApproxClusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripApprox2ApproxClusters.cc
@@ -59,6 +59,7 @@ void SiStripApprox2ApproxClusters::produce(edm::Event& event, edm::EventSetup co
       float barycenter = cluster.barycenter();
       uint8_t width = cluster.width();
       float avgCharge = cluster.avgCharge();
+      bool isSaturated = cluster.isSaturated();
 
       switch (approxVersion) {
         case 0:  //ORIGINAL
@@ -85,7 +86,7 @@ void SiStripApprox2ApproxClusters::produce(edm::Event& event, edm::EventSetup co
           break;
       }
 
-      ff.push_back(SiStripApproximateCluster(barycenter, width, avgCharge));
+      ff.push_back(SiStripApproximateCluster(barycenter, width, avgCharge, isSaturated));
     }
   }
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusters2ApproxClusters.cc
@@ -25,10 +25,13 @@ public:
 private:
   edm::InputTag inputClusters;
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusterToken;
+
+  unsigned int maxNSat;
 };
 
 SiStripClusters2ApproxClusters::SiStripClusters2ApproxClusters(const edm::ParameterSet& conf) {
   inputClusters = conf.getParameter<edm::InputTag>("inputClusters");
+  maxNSat = conf.getParameter<unsigned int>("maxSaturatedStrips");
 
   clusterToken = consumes<edmNew::DetSetVector<SiStripCluster> >(inputClusters);
   produces<edmNew::DetSetVector<SiStripApproximateCluster> >();
@@ -42,7 +45,7 @@ void SiStripClusters2ApproxClusters::produce(edm::Event& event, edm::EventSetup 
     edmNew::DetSetVector<SiStripApproximateCluster>::FastFiller ff{*result, detClusters.id()};
 
     for (const auto& cluster : detClusters)
-      ff.push_back(SiStripApproximateCluster(cluster));
+      ff.push_back(SiStripApproximateCluster(cluster, maxNSat));
   }
 
   event.put(std::move(result));
@@ -51,6 +54,7 @@ void SiStripClusters2ApproxClusters::produce(edm::Event& event, edm::EventSetup 
 void SiStripClusters2ApproxClusters::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("inputClusters", edm::InputTag("siStripClusters"));
+  desc.add<unsigned int>("maxSaturatedStrips", 3);
   descriptions.add("SiStripClusters2ApproxClusters", desc);
 }
 


### PR DESCRIPTION
This PR slightly extends the SiStripApproximateCluster data format to include a boolean flag which marks clusters which are saturated.  This change was motivated by the discussion at [1].  The definition of 'saturated' we use here is the same as what is used in the SubClusterShapeFilter, i.e. a cluster having 3 consecutive strips of ADC>=254.  Note that this flag is not currently used in the reconstruction sequence; this PR is simply to ensure this information is not dropped in the new approx. cluster data format.  This is expected to increase the approximate cluster collection size by ~1% and barely affect the timing performance [2].

[1] https://github.com/cms-sw/cmssw/pull/38423#issuecomment-1168993837
[2] https://twiki.cern.ch/twiki/pub/Main/HIDetectorReadout2020/SaturatedStrips.pdf

#### PR validation:
This PR was tested by running workflow 140.58 step 2, and checking the approximated cluster collection in the output.  

@mandrenguyen @icali 


