### PR TITLE
Call callWhenNewProductsRegistered() callbacks only for branches that are present

### DIFF
--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -96,6 +96,7 @@ namespace edm {
 
     //NOTE: this is not const since we only want items that have non-const access to this class to be
     // able to call this internal iteration
+    // Called only for branches that are present (part of avoiding creating type information for dropped branches)
     template <typename T>
     void callForEachBranch(T const& iFunc) {
       //NOTE: If implementation changes from a map, need to check that iterators are still valid
@@ -103,7 +104,9 @@ namespace edm {
       for (ProductRegistry::ProductList::const_iterator itEntry = productList_.begin(), itEntryEnd = productList_.end();
            itEntry != itEntryEnd;
            ++itEntry) {
-        iFunc(itEntry->second);
+        if (itEntry->second.present()) {
+          iFunc(itEntry->second);
+        }
       }
     }
     ProductList::size_type size() const { return productList_.size(); }

--- a/FWCore/Framework/src/SignallingProductRegistry.cc
+++ b/FWCore/Framework/src/SignallingProductRegistry.cc
@@ -43,6 +43,9 @@ namespace {
 }  // namespace
 
 void SignallingProductRegistry::addCalled(BranchDescription const& iProd, bool iFromListener) {
+  // Call only for present branches (part of avoiding adding type information for dropped branches)
+  if (iProd.dropped())
+    return;
   StackGuard guard(iProd.className(), typeAddedStack_, iFromListener);
   if (guard.numType_ > 2) {
     throw cms::Exception("CircularReference")


### PR DESCRIPTION
#### PR description:

This is a preparatory PR towards #38806. This change avoids user surprises when the BranchDescription no longer has type information for dropped branches. An analysis of all current users of callWhenNewProductsRegistered() in https://github.com/cms-sw/cmssw/pull/38806#issuecomment-1192742460 showed that all of them either explicitly limited themselves to present branches, or implicilty assumed the branch is present. I can't think of any useful use case for user code to make decisions based on dropped branches. For inspecting product history up to dropped products provenance is likely better way.

I made this change as a separate PR so that the change in behavior becomes clearer in release notes, and we can see any possible side effect in the IBs separately from #38806.

#### PR validation:

Framework unit tests pass.