### PR TITLE
Add missing dependencies to SimG4Core/CustomPhysics/BuildFile.xml

### DIFF
--- a/SimG4Core/CustomPhysics/BuildFile.xml
+++ b/SimG4Core/CustomPhysics/BuildFile.xml
@@ -1,9 +1,11 @@
 <export>
   <lib name="1"/>
 </export>
+<use name="DataFormats/GeometryVector" source_only="1"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/PluginManager"/>
+<use name="SimG4Core/Notification"/>
 <use name="SimG4Core/Physics"/>
 <use name="SimG4Core/PhysicsLists"/>
 <use name="SimG4Core/Watcher"/>


### PR DESCRIPTION
#### PR description:

The UBSAN IB got broken by https://github.com/cms-sw/cmssw/pull/38329 because the PR added dependence on `SimG4Core/Notification` to `SimG4Core/CustomPhysics`, but that was not added in the `BuildFile.xml`. This PR adds the dependence into the `BuildFile.xml`, as well as `DataFormats/GeometryVector` that also, in principle at least, should have been added in #38329. Not sure why this wasn't caught by regular IBs, but UBSAN is pickier in having the dependencies declared.

#### PR validation:

None (edited in the web)