### PR TITLE
Throw GetByLabelWithoutRegistration exception also when no module in a job registered consumption of a given branch

### DIFF
--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -545,4 +545,12 @@
   </test>
   <test name="TestIntegrationFinalPath" command="test_finalpath.sh"/>
 
+  <library file="TestGetByLabelAnalyzer.cc" name ="TestGetByLabelAnalyzer">
+    <flags EDM_PLUGIN="1"/>
+    <use name="FWCore/Framework"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/MessageLogger"/>
+  </library>
+  <test name="TestIntegrationGetByLabel" command="run_TestGetByLabel.sh"/>
+
 </environment>

--- a/FWCore/Integration/test/TestGetByLabelAnalyzer.cc
+++ b/FWCore/Integration/test/TestGetByLabelAnalyzer.cc
@@ -1,0 +1,76 @@
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "DataFormats/TestObjects/interface/ThingCollection.h"
+
+namespace edmtest {
+  template <typename T>
+  class TestGetByLabelAnalyzerT : public edm::global::EDAnalyzer<> {
+  public:
+    TestGetByLabelAnalyzerT(edm::ParameterSet const& iPSet)
+        : src_(iPSet.getUntrackedParameter<edm::InputTag>("src")),
+          getCategory_(iPSet.getUntrackedParameter<std::string>("getExceptionCategory")),
+          accessCategory_(iPSet.getUntrackedParameter<std::string>("accessExceptionCategory")) {
+      if (iPSet.getUntrackedParameter<bool>("consumes")) {
+        consumes<T>(src_);
+      }
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<edm::InputTag>("src");
+      desc.addUntracked<std::string>("getExceptionCategory", "");
+      desc.addUntracked<std::string>("accessExceptionCategory", "");
+      desc.addUntracked<bool>("consumes", false);
+      descriptions.addDefault(desc);
+    }
+
+    void analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const&) const {
+      edm::Handle<T> handle;
+
+      auto test = [](std::string const& category, std::string const& msg, auto func) {
+        bool caught = false;
+        try {
+          func();
+        } catch (cms::Exception& e) {
+          caught = true;
+          if (category.empty())
+            throw;
+          if (e.category() != category) {
+            throw cms::Exception("Assert")
+                << "Expected cms::Exception from " << msg << " with category " << category << ", got " << e.category();
+          }
+          return false;
+        }
+        if (not category.empty() and not caught) {
+          throw cms::Exception("Assert") << "Expected cms::Exception to be thrown from " << msg << ", but got nothing";
+        }
+        return true;
+      };
+
+      bool noException = test(getCategory_, "getByLabel(InputTag)", [&]() { event.getByLabel(src_, handle); });
+      if (noException) {
+        test(accessCategory_, "*handle from InputTag", [&]() { *handle; });
+      }
+
+      noException =
+          test(getCategory_, "getByLabel(strings)", [&]() { event.getByLabel(src_.label(), src_.instance(), handle); });
+      if (noException) {
+        test(accessCategory_, "*handle from strings", [&]() { *handle; });
+      }
+    }
+
+  private:
+    edm::InputTag const src_;
+    std::string const getCategory_;
+    std::string const accessCategory_;
+  };
+
+  using TestGetByLabelIntAnalyzer = TestGetByLabelAnalyzerT<edmtest::IntProduct>;
+  using TestGetByLabelThingAnalyzer = TestGetByLabelAnalyzerT<edmtest::ThingCollection>;
+}  // namespace edmtest
+
+DEFINE_FWK_MODULE(edmtest::TestGetByLabelIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::TestGetByLabelThingAnalyzer);

--- a/FWCore/Integration/test/run_TestGetByLabel.sh
+++ b/FWCore/Integration/test/run_TestGetByLabel.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+TEST_NAME=TestGetByLabel
+if [ -d ${TEST_NAME} ]; then
+    rm -fR ${TEST_NAME}
+fi
+mkdir ${TEST_NAME}
+
+pushd ${TEST_NAME}
+
+TEST_PATH=${LOCALTOP}/src/FWCore/Integration/test
+
+cmsRun ${TEST_PATH}/testGetByLabelStep1_cfg.py || die "Failed cmsRun testGetByLabel_step1_cfg.py" $1
+
+cmsRun ${TEST_PATH}/testGetByLabelStep2_cfg.py || die "Failed cmsRun testGetByLabel_step2_cfg.py" $1
+cmsRun ${TEST_PATH}/testGetByLabelStep2_cfg.py -- --noConsumes || die "Failed cmsRun testGetByLabel_step2_cfg.py --noConsumes" $1
+cmsRun ${TEST_PATH}/testGetByLabelStep2_cfg.py -- --thing || die "Failed cmsRun testGetByLabel_step2_cfg.py --thing" $1
+cmsRun ${TEST_PATH}/testGetByLabelStep2_cfg.py -- --thing --noConsumes || die "Failed cmsRun testGetByLabel_step2_cfg.py --thing --noConsumes" $1
+cmsRun ${TEST_PATH}/testGetByLabelStep2_cfg.py -- --otherInt || die "Failed cmsRun testGetByLabel_step2_cfg.py --otherInt" $1
+cmsRun ${TEST_PATH}/testGetByLabelStep2_cfg.py -- --otherInt --noConsumes || die "Failed cmsRun testGetByLabel_step2_cfg.py --otherInt --noConsumes" $1
+
+popd

--- a/FWCore/Integration/test/testGetByLabelStep1_cfg.py
+++ b/FWCore/Integration/test/testGetByLabelStep1_cfg.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTPROD")
+process.maxEvents.input = 3
+
+process.source = cms.Source("EmptySource")
+
+process.intProduct = cms.EDProducer("IntProducer", ivalue = cms.int32(42))
+
+process.output = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('getbylabel_step1.root')
+)
+
+process.p = cms.Path(process.intProduct)
+process.ep = cms.EndPath(process.output)

--- a/FWCore/Integration/test/testGetByLabelStep2_cfg.py
+++ b/FWCore/Integration/test/testGetByLabelStep2_cfg.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+import sys
+import argparse
+
+parser = argparse.ArgumentParser(prog=sys.argv[0], description='Test ProcessAccelerator.')
+
+parser.add_argument("--noConsumes", help="Do not call consumes", action="store_true")
+parser.add_argument("--thing", help="Add producer and consumer for Thing", action="store_true")
+parser.add_argument("--otherInt", help="Add another producer and consumer for int", action="store_true")
+
+argv = sys.argv[:]
+if '--' in argv:
+    argv.remove("--")
+args, unknown = parser.parse_known_args(argv)
+
+process = cms.Process("TESTANA")
+process.maxEvents.input = -1
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring("file:getbylabel_step1.root")
+)
+
+process.intAnalyzer = cms.EDAnalyzer("edmtest::TestGetByLabelIntAnalyzer",
+    src = cms.untracked.InputTag("intProduct"),
+    consumes = cms.untracked.bool(True)
+)
+
+process.p = cms.Path(
+    process.intAnalyzer
+)
+
+if args.thing:
+    process.thingProduct = cms.EDProducer("ThingProducer")
+    process.thingAnalyzer = cms.EDAnalyzer("edmtest::TestGetByLabelThingAnalyzer",
+        src = cms.untracked.InputTag("thingProduct"),
+        consumes = cms.untracked.bool(True)
+    )
+    process.p += (process.thingProduct+process.thingAnalyzer)
+
+if args.otherInt:
+    process.otherIntProduct = cms.EDProducer("IntProducer", ivalue = cms.int32(314))
+    process.otherIntAnalyzer = cms.EDAnalyzer("edmtest::TestGetByLabelIntAnalyzer",
+        src = cms.untracked.InputTag("otherIntProduct"),
+        consumes = cms.untracked.bool(True)
+    )
+    process.p += (process.otherIntProduct+process.otherIntAnalyzer)
+
+if args.noConsumes:
+    process.intAnalyzer.consumes = False
+    process.intAnalyzer.accessExceptionCategory = cms.untracked.string("ProductNotFound")
+
+    if args.thing:
+        process.thingAnalyzer.consumes = False
+        process.thingAnalyzer.getExceptionCategory = cms.untracked.string("GetByLabelWithoutRegistration")
+
+    if args.otherInt:
+        process.intAnalyzer.getExceptionCategory = cms.untracked.string("GetByLabelWithoutRegistration")
+        process.intAnalyzer.accessExceptionCategory = ""

--- a/FWCore/Integration/test/testGetByLabelStep2_cfg.py
+++ b/FWCore/Integration/test/testGetByLabelStep2_cfg.py
@@ -48,12 +48,8 @@ if args.otherInt:
 
 if args.noConsumes:
     process.intAnalyzer.consumes = False
-    process.intAnalyzer.accessExceptionCategory = cms.untracked.string("ProductNotFound")
+    process.intAnalyzer.getExceptionCategory = cms.untracked.string("GetByLabelWithoutRegistration")
 
     if args.thing:
         process.thingAnalyzer.consumes = False
         process.thingAnalyzer.getExceptionCategory = cms.untracked.string("GetByLabelWithoutRegistration")
-
-    if args.otherInt:
-        process.intAnalyzer.getExceptionCategory = cms.untracked.string("GetByLabelWithoutRegistration")
-        process.intAnalyzer.accessExceptionCategory = ""


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/38864 reported a case where an EDAnalyzer using `Event::getByLabel()`  without declaring the consumed data products got a `ProductNotFound` exception instead of more explanatory `GetByLabelWithoutRegistration` exception. I traced this down to `ProductResolverIndexHelper` not being populated (from `ProductRegistry` with ~~non-consumed branches~~ branches that have product type that is not consumed in the job (either via the same or different branch)
https://github.com/cms-sw/cmssw/blob/db4ff9a6cf2fea967f3d80ca084d195e6f5a17ed/DataFormats/Provenance/src/ProductRegistry.cc#L419-L422
leading to `ProductResolverIndexHelper::index()` returning a `ProductResolverIndexInvalid` and  `Principal::findProductByLabel()` returning `nullptr`, which is interpreted as `ProductNotFound` by calling code.

This PR proposes to change the `Principal::findProductByLabel()` to check the branch existence directly from `ProductRegistry` after getting `ProductResolverIndexInvalid`, and throw `GetByLabelWithoutRegistration` exception if the branch in question is present. This adds some cost, but only in case
* code calls consumes but uses (deprecated) `getByLabel()` to get the data, and
* product in question does not exist, and
* code checks the `Handle` validity and is able to ignore the missing product

I would expect this case to be rare, and therefore the cost to be acceptable. I also think we should make an effort to address the remaining `getByLabel()` calls in the near-to-medium-future.

#### PR validation:

Checked that the test configuration in #38864 now throws `GetByLabelWithoutRegistration` exception.