### PR TITLE
Add scalar to macro-based SoA example

### DIFF
--- a/DataFormats/PortableTestObjects/interface/TestSoA.h
+++ b/DataFormats/PortableTestObjects/interface/TestSoA.h
@@ -13,7 +13,9 @@ namespace portabletest {
                       SOA_COLUMN(double, x),
                       SOA_COLUMN(double, y),
                       SOA_COLUMN(double, z),
-                      SOA_COLUMN(int32_t, id))
+                      SOA_COLUMN(int32_t, id),
+                      // scalars: one value for the whole structure
+                      SOA_SCALAR(double, r))
 
   using TestSoA = TestSoALayout<>;
 

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -6,7 +6,7 @@
     <field name="y_" comment="[nElements_]"/>
     <field name="z_" comment="[nElements_]"/>
     <field name="id_" comment="[nElements_]"/>
-    <field name="metadata()" comment="!"/>
+    <field name="r_" comment="[scalar_]"/>
   </class>
   <class name="portabletest::TestSoA::View"/>
 </lcgdict>

--- a/DataFormats/PortableTestObjects/src/classes_def.xml
+++ b/DataFormats/PortableTestObjects/src/classes_def.xml
@@ -2,10 +2,10 @@
   <class name="portabletest::TestSoA">
     <field name="mem_" comment="!"/>
     <field name="byteSize_" comment="!"/>
-    <field name="x_" comment="[nElements_]"/>
-    <field name="y_" comment="[nElements_]"/>
-    <field name="z_" comment="[nElements_]"/>
-    <field name="id_" comment="[nElements_]"/>
+    <field name="x_" comment="[elements_]"/>
+    <field name="y_" comment="[elements_]"/>
+    <field name="z_" comment="[elements_]"/>
+    <field name="id_" comment="[elements_]"/>
     <field name="r_" comment="[scalar_]"/>
   </class>
   <class name="portabletest::TestSoA::View"/>

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -525,6 +525,7 @@
     /* data members */                                                                                                 \
     std::byte* mem_;                                                                                                   \
     size_type nElements_;                                                                                              \
+    size_type const scalar_ = 1;                                                                                       \
     byte_size_type byteSize_;                                                                                          \
     _ITERATE_ON_ALL(_DECLARE_SOA_DATA_MEMBER, ~, __VA_ARGS__)                                                          \
     /* Making the code conditional is problematic in macros as the commas will interfere with parameter lisings     */ \

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -69,21 +69,21 @@
       ,                                                                                                                \
       /* Dump column */                                                                                                \
       os << " Column " BOOST_PP_STRINGIZE(NAME) " at offset " << offset << " has size "                                \
-         << sizeof(CPP_TYPE) * nElements_ << " and padding "                                                           \
-         << cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE), alignment) - (nElements_ * sizeof(CPP_TYPE))            \
+         << sizeof(CPP_TYPE) * elements_ << " and padding "                                                            \
+         << cms::soa::alignSize(elements_ * sizeof(CPP_TYPE), alignment) - (elements_ * sizeof(CPP_TYPE))              \
          << std::endl;                                                                                                 \
-      offset += cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE), alignment);                                         \
+      offset += cms::soa::alignSize(elements_ * sizeof(CPP_TYPE), alignment);                                          \
       ,                                                                                                                \
       /* Dump Eigen column */                                                                                          \
       os << " Eigen value " BOOST_PP_STRINGIZE(NAME) " at offset " << offset << " has dimension "                      \
          << "(" << CPP_TYPE::RowsAtCompileTime << " x " << CPP_TYPE::ColsAtCompileTime << ")"                          \
          << " and per column size "                                                                                    \
-         << sizeof(CPP_TYPE::Scalar) * nElements_                                                                      \
+         << sizeof(CPP_TYPE::Scalar) * elements_                                                                       \
          << " and padding "                                                                                            \
-         << cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE::Scalar), alignment)                                      \
-            - (nElements_ * sizeof(CPP_TYPE::Scalar))                                                                  \
+         << cms::soa::alignSize(elements_ * sizeof(CPP_TYPE::Scalar), alignment)                                       \
+            - (elements_ * sizeof(CPP_TYPE::Scalar))                                                                   \
          << std::endl;                                                                                                 \
-      offset += cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE::Scalar), alignment)                                  \
+      offset += cms::soa::alignSize(elements_ * sizeof(CPP_TYPE::Scalar), alignment)                                   \
                 * CPP_TYPE::RowsAtCompileTime * CPP_TYPE::ColsAtCompileTime;                                           \
   )
 // clang-format on
@@ -133,7 +133,7 @@
       }                                                                                                                \
       SOA_HOST_DEVICE SOA_INLINE                                                                                       \
       byte_size_type BOOST_PP_CAT(NAME, Pitch()) const {                                                               \
-        return cms::soa::alignSize(parent_.nElements_ * sizeof(CPP_TYPE), ParentClass::alignment);                     \
+        return cms::soa::alignSize(parent_.elements_ * sizeof(CPP_TYPE), ParentClass::alignment);                      \
       }                                                                                                                \
       using BOOST_PP_CAT(TypeOf_, NAME) = CPP_TYPE;                                                                    \
       constexpr static cms::soa::SoAColumnType BOOST_PP_CAT(ColumnTypeOf_, NAME) = cms::soa::SoAColumnType::column;,   \
@@ -148,7 +148,7 @@
       }                                                                                                                \
       SOA_HOST_DEVICE SOA_INLINE                                                                                       \
       byte_size_type BOOST_PP_CAT(NAME, Pitch()) const {                                                               \
-        return cms::soa::alignSize(parent_.nElements_ * sizeof(CPP_TYPE::Scalar), ParentClass::alignment)              \
+        return cms::soa::alignSize(parent_.elements_ * sizeof(CPP_TYPE::Scalar), ParentClass::alignment)               \
                * CPP_TYPE::RowsAtCompileTime * CPP_TYPE::ColsAtCompileTime;                                            \
       }                                                                                                                \
       using BOOST_PP_CAT(TypeOf_, NAME) = CPP_TYPE ;                                                                   \
@@ -245,13 +245,13 @@
       ,                                                                                                                \
       /* Column */                                                                                                     \
       BOOST_PP_CAT(NAME, _) = reinterpret_cast<CPP_TYPE*>(curMem);                                                     \
-      curMem += cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE), alignment);                                         \
+      curMem += cms::soa::alignSize(elements_ * sizeof(CPP_TYPE), alignment);                                          \
       ,                                                                                                                \
       /* Eigen column */                                                                                               \
       BOOST_PP_CAT(NAME, _) = reinterpret_cast<CPP_TYPE::Scalar*>(curMem);                                             \
-      curMem += cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE::Scalar), alignment) * CPP_TYPE::RowsAtCompileTime    \
+      curMem += cms::soa::alignSize(elements_ * sizeof(CPP_TYPE::Scalar), alignment) * CPP_TYPE::RowsAtCompileTime     \
         * CPP_TYPE::ColsAtCompileTime;                                                                                 \
-      BOOST_PP_CAT(NAME, Stride_) = cms::soa::alignSize(nElements_ * sizeof(CPP_TYPE::Scalar), alignment)              \
+      BOOST_PP_CAT(NAME, Stride_) = cms::soa::alignSize(elements_ * sizeof(CPP_TYPE::Scalar), alignment)               \
         / sizeof(CPP_TYPE::Scalar);                                                                                    \
   )                                                                                                                    \
   if constexpr (alignmentEnforcement == AlignmentEnforcement::enforced)                                                \
@@ -271,10 +271,10 @@
       ret += cms::soa::alignSize(sizeof(CPP_TYPE), alignment);                                                         \
       ,                                                                                                                \
       /* Column */                                                                                                     \
-      ret += cms::soa::alignSize(nElements * sizeof(CPP_TYPE), alignment);                                             \
+      ret += cms::soa::alignSize(elements * sizeof(CPP_TYPE), alignment);                                              \
       ,                                                                                                                \
       /* Eigen column */                                                                                               \
-      ret += cms::soa::alignSize(nElements * sizeof(CPP_TYPE::Scalar), alignment) * CPP_TYPE::RowsAtCompileTime        \
+      ret += cms::soa::alignSize(elements * sizeof(CPP_TYPE::Scalar), alignment) * CPP_TYPE::RowsAtCompileTime         \
              * CPP_TYPE::ColsAtCompileTime;                                                                            \
   )
 // clang-format on
@@ -333,7 +333,7 @@
       /* TODO: implement*/                                                                                             \
       ,                                                                                                                \
       /* Column */                                                                                                     \
-      memcpy(BOOST_PP_CAT(NAME, _), onfile.BOOST_PP_CAT(NAME, _), sizeof(CPP_TYPE) * onfile.nElements_);               \
+      memcpy(BOOST_PP_CAT(NAME, _), onfile.BOOST_PP_CAT(NAME, _), sizeof(CPP_TYPE) * onfile.elements_);                \
       ,                                                                                                                \
       /* Eigen column */                                                                                               \
       /* TODO: implement*/                                                                                             \
@@ -408,18 +408,18 @@
     /* dump the SoA internal structure */                                                                              \
     SOA_HOST_ONLY                                                                                                      \
     void soaToStreamInternal(std::ostream & os) const {                                                                \
-      os << #CLASS "(" << nElements_ << " elements, byte alignement= " << alignment << ", @"<< mem_ <<"): "            \
+      os << #CLASS "(" << elements_ << " elements, byte alignement= " << alignment << ", @"<< mem_ <<"): "             \
          << std::endl;                                                                                                 \
       os << "  sizeof(" #CLASS "): " << sizeof(CLASS) << std::endl;                                                    \
       byte_size_type offset = 0;                                                                                       \
       _ITERATE_ON_ALL(_DECLARE_SOA_STREAM_INFO, ~, __VA_ARGS__)                                                        \
-      os << "Final offset = " << offset << " computeDataSize(...): " << computeDataSize(nElements_)                    \
+      os << "Final offset = " << offset << " computeDataSize(...): " << computeDataSize(elements_)                     \
               << std::endl;                                                                                            \
       os << std::endl;                                                                                                 \
     }                                                                                                                  \
                                                                                                                        \
     /* Helper function used by caller to externally allocate the storage */                                            \
-    static constexpr byte_size_type computeDataSize(size_type nElements) {                                             \
+    static constexpr byte_size_type computeDataSize(size_type elements) {                                              \
       byte_size_type ret = 0;                                                                                          \
       _ITERATE_ON_ALL(_ACCUMULATE_SOA_ELEMENT, ~, __VA_ARGS__)                                                         \
       return ret;                                                                                                      \
@@ -430,14 +430,14 @@
      */                                                                                                                \
     struct Metadata {                                                                                                  \
       friend CLASS;                                                                                                    \
-      SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.nElements_; }                                 \
+      SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.elements_; }                                  \
       SOA_HOST_DEVICE SOA_INLINE byte_size_type byteSize() const { return parent_.byteSize_; }                         \
       SOA_HOST_DEVICE SOA_INLINE byte_size_type alignment() const { return CLASS::alignment; }                         \
       SOA_HOST_DEVICE SOA_INLINE std::byte* data() { return parent_.mem_; }                                            \
       SOA_HOST_DEVICE SOA_INLINE const std::byte* data() const { return parent_.mem_; }                                \
       SOA_HOST_DEVICE SOA_INLINE std::byte* nextByte() const { return parent_.mem_ + parent_.byteSize_; }              \
       SOA_HOST_DEVICE SOA_INLINE CLASS cloneToNewAddress(std::byte* addr) const {                                      \
-        return CLASS(addr, parent_.nElements_);                                                                        \
+        return CLASS(addr, parent_.elements_);                                                                         \
       }                                                                                                                \
                                                                                                                        \
       _ITERATE_ON_ALL(_DEFINE_METADATA_MEMBERS, ~, __VA_ARGS__)                                                        \
@@ -467,12 +467,12 @@
     /* Trivial constuctor */                                                                                           \
     CLASS()                                                                                                            \
         : mem_(nullptr),                                                                                               \
-          nElements_(0),                                                                                               \
+          elements_(0),                                                                                                \
           byteSize_(0),                                                                                                \
           _ITERATE_ON_ALL_COMMA(_DECLARE_MEMBER_TRIVIAL_CONSTRUCTION, ~, __VA_ARGS__) {}                               \
                                                                                                                        \
     /* Constructor relying on user provided storage (implementation shared with ROOT streamer) */                      \
-    SOA_HOST_ONLY CLASS(std::byte* mem, size_type nElements) : mem_(mem), nElements_(nElements), byteSize_(0) {        \
+    SOA_HOST_ONLY CLASS(std::byte* mem, size_type elements) : mem_(mem), elements_(elements), byteSize_(0) {           \
       organizeColumnsFromBuffer();                                                                                     \
     }                                                                                                                  \
                                                                                                                        \
@@ -484,16 +484,16 @@
       auto curMem = mem_;                                                                                              \
       _ITERATE_ON_ALL(_ASSIGN_SOA_COLUMN_OR_SCALAR, ~, __VA_ARGS__)                                                    \
       /* Sanity check: we should have reached the computed size, only on host code */                                  \
-      byteSize_ = computeDataSize(nElements_);                                                                         \
+      byteSize_ = computeDataSize(elements_);                                                                          \
       if (mem_ + byteSize_ != curMem)                                                                                  \
         throw std::runtime_error("In " #CLASS "::" #CLASS ": unexpected end pointer.");                                \
     }                                                                                                                  \
                                                                                                                        \
   public:                                                                                                              \
     /* Constructor relying on user provided storage */                                                                 \
-    SOA_DEVICE_ONLY CLASS(bool devConstructor, std::byte* mem, size_type nElements) :                                  \
+    SOA_DEVICE_ONLY CLASS(bool devConstructor, std::byte* mem, size_type elements) :                                   \
       mem_(mem),                                                                                                       \
-      nElements_(nElements)                                                                                            \
+      elements_(elements)                                                                                              \
     {                                                                                                                  \
       auto curMem = mem_;                                                                                              \
       _ITERATE_ON_ALL(_ASSIGN_SOA_COLUMN_OR_SCALAR, ~, __VA_ARGS__)                                                    \
@@ -515,8 +515,8 @@
     SOA_HOST_DEVICE SOA_INLINE                                                                                         \
     void rangeCheck(size_type index) const {                                                                           \
       if constexpr (_DO_RANGECHECK) {                                                                                  \
-        if (index >= nElements_) {                                                                                     \
-          printf("In " #CLASS "::rangeCheck(): index out of range: %zu with nElements: %zu\n", index, nElements_);     \
+        if (index >= elements_) {                                                                                      \
+          printf("In " #CLASS "::rangeCheck(): index out of range: %zu with elements: %zu\n", index, elements_);       \
           assert(false);                                                                                               \
         }                                                                                                              \
       }                                                                                                                \
@@ -524,7 +524,7 @@
                                                                                                                        \
     /* data members */                                                                                                 \
     std::byte* mem_;                                                                                                   \
-    size_type nElements_;                                                                                              \
+    size_type elements_;                                                                                               \
     size_type const scalar_ = 1;                                                                                       \
     byte_size_type byteSize_;                                                                                          \
     _ITERATE_ON_ALL(_DECLARE_SOA_DATA_MEMBER, ~, __VA_ARGS__)                                                          \

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -181,6 +181,37 @@
 #define _DECLARE_MEMBER_TRIVIAL_CONSTRUCTION(R, DATA, TYPE_NAME) \
   BOOST_PP_EXPAND(_DECLARE_MEMBER_TRIVIAL_CONSTRUCTION_IMPL TYPE_NAME)
 
+// clang-format off
+#define _DECLARE_MEMBER_COPY_CONSTRUCTION_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                             \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      (BOOST_PP_CAT(NAME, _){other.BOOST_PP_CAT(NAME, _)}),                                                            \
+      /* Column */                                                                                                     \
+      (BOOST_PP_CAT(NAME, _){other.BOOST_PP_CAT(NAME, _)}),                                                            \
+      /* Eigen column */                                                                                               \
+      (BOOST_PP_CAT(NAME, _){other.BOOST_PP_CAT(NAME, _)})                                                             \
+      (BOOST_PP_CAT(NAME, Stride_){other.BOOST_PP_CAT(NAME, Stride_)})                                                 \
+  )
+// clang-format on
+
+#define _DECLARE_MEMBER_COPY_CONSTRUCTION(R, DATA, TYPE_NAME) \
+  BOOST_PP_EXPAND(_DECLARE_MEMBER_COPY_CONSTRUCTION_IMPL TYPE_NAME)
+
+// clang-format off
+#define _DECLARE_MEMBER_ASSIGNMENT_IMPL(VALUE_TYPE, CPP_TYPE, NAME)                                                    \
+  _SWITCH_ON_TYPE(VALUE_TYPE,                                                                                          \
+      /* Scalar */                                                                                                     \
+      BOOST_PP_CAT(NAME, _) = other.BOOST_PP_CAT(NAME, _);,                                                          \
+      /* Column */                                                                                                     \
+      BOOST_PP_CAT(NAME, _) = other.BOOST_PP_CAT(NAME, _);,                                                          \
+      /* Eigen column */                                                                                               \
+      BOOST_PP_CAT(NAME, _) = other.BOOST_PP_CAT(NAME, _);                                                           \
+      BOOST_PP_CAT(NAME, Stride_) = other.BOOST_PP_CAT(NAME, Stride_);                                               \
+  )
+// clang-format on
+
+#define _DECLARE_MEMBER_ASSIGNMENT(R, DATA, TYPE_NAME) BOOST_PP_EXPAND(_DECLARE_MEMBER_ASSIGNMENT_IMPL TYPE_NAME)
+
 /**
  * Declare the value_element data members
  */
@@ -474,6 +505,21 @@
     /* Constructor relying on user provided storage (implementation shared with ROOT streamer) */                      \
     SOA_HOST_ONLY CLASS(std::byte* mem, size_type elements) : mem_(mem), elements_(elements), byteSize_(0) {           \
       organizeColumnsFromBuffer();                                                                                     \
+    }                                                                                                                  \
+                                                                                                                       \
+    /* Explicit copy constructor and assignment operator */                                                            \
+    SOA_HOST_ONLY CLASS(CLASS const& other)                                                                            \
+        : mem_(other.mem_),                                                                                            \
+          elements_(other.elements_),                                                                                  \
+          byteSize_(other.byteSize_),                                                                                  \
+          _ITERATE_ON_ALL_COMMA(_DECLARE_MEMBER_COPY_CONSTRUCTION, ~, __VA_ARGS__) {}                                  \
+                                                                                                                       \
+    SOA_HOST_ONLY CLASS& operator=(CLASS const& other) {                                                               \
+        mem_ = other.mem_;                                                                                             \
+        elements_ = other.elements_;                                                                                   \
+        byteSize_ = other.byteSize_;                                                                                   \
+        _ITERATE_ON_ALL(_DECLARE_MEMBER_ASSIGNMENT, ~, __VA_ARGS__)                                                    \
+        return *this;                                                                                                  \
     }                                                                                                                  \
                                                                                                                        \
   private:                                                                                                             \

--- a/DataFormats/SoATemplate/interface/SoALayout.h
+++ b/DataFormats/SoATemplate/interface/SoALayout.h
@@ -536,15 +536,6 @@
     }                                                                                                                  \
                                                                                                                        \
   public:                                                                                                              \
-    /* Constructor relying on user provided storage */                                                                 \
-    SOA_DEVICE_ONLY CLASS(bool devConstructor, std::byte* mem, size_type elements) :                                   \
-      mem_(mem),                                                                                                       \
-      elements_(elements)                                                                                              \
-    {                                                                                                                  \
-      auto curMem = mem_;                                                                                              \
-      _ITERATE_ON_ALL(_ASSIGN_SOA_COLUMN_OR_SCALAR, ~, __VA_ARGS__)                                                    \
-    }                                                                                                                  \
-                                                                                                                       \
     /* ROOT read streamer */                                                                                           \
     template <typename T>                                                                                              \
     void ROOTReadStreamer(T & onfile) {                                                                                \
@@ -577,6 +568,7 @@
     /* Making the code conditional is problematic in macros as the commas will interfere with parameter lisings     */ \
     /* So instead we make the code unconditional with paceholder names which are protected by a private protection. */ \
     /* This will be handled later as we handle the integration of the view as a subclass of the layout.             */ \
+                                                                                                                       \
   public:                                                                                                              \
   _GENERATE_SOA_TRIVIAL_CONST_VIEW(CLASS,                                                                              \
                     SOA_VIEW_LAYOUT_LIST(                                                                              \

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -93,12 +93,18 @@ namespace cms::soa {
   constexpr static cms::soa::SoAColumnType BOOST_PP_CAT(ColumnTypeOf_, LOCAL_NAME) =                                   \
       BOOST_PP_CAT(TypeOf_, LAYOUT_NAME)::Metadata::BOOST_PP_CAT(ColumnTypeOf_, LAYOUT_MEMBER);                        \
   SOA_HOST_DEVICE SOA_INLINE                                                                                           \
-  const BOOST_PP_CAT(ParametersTypeOf_, LOCAL_NAME) BOOST_PP_CAT(parametersOf_, LOCAL_NAME)() const {                  \
+  const auto BOOST_PP_CAT(parametersOf_, LOCAL_NAME)() const {                                                         \
     return CAST(parent_.BOOST_PP_CAT(LOCAL_NAME, Parameters_));                                                        \
   };
 // clang-format on
 
-// DATA should be a function used to convert parent_.LOCAL_NAME ## Parameters_ to ParametersTypeOf_ ## LOCAL_NAME, or empty
+// DATA should be a function used to convert
+//   parent_.LOCAL_NAME ## Parameters_
+// to
+//   ParametersTypeOf_ ## LOCAL_NAME                (for a View)
+// or
+//   ParametersTypeOf_ ## LOCAL_NAME :: ConstType   (for a ConstView)
+// or empty, if no conversion is necessary.
 #define _DECLARE_VIEW_MEMBER_TYPE_ALIAS(R, DATA, LAYOUT_MEMBER_NAME) \
   BOOST_PP_EXPAND(_DECLARE_VIEW_MEMBER_TYPE_ALIAS_IMPL BOOST_PP_TUPLE_PUSH_BACK(LAYOUT_MEMBER_NAME, DATA))
 

--- a/DataFormats/SoATemplate/interface/SoAView.h
+++ b/DataFormats/SoATemplate/interface/SoAView.h
@@ -502,7 +502,7 @@ namespace cms::soa {
      */                                                                                                                \
     struct Metadata {                                                                                                  \
       friend VIEW;                                                                                                     \
-      SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.nElements_; }                                 \
+      SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.elements_; }                                  \
       /* Alias layout or view types to name-derived identifyer to allow simpler definitions */                         \
       _ITERATE_ON_ALL(_DECLARE_VIEW_LAYOUT_TYPE_ALIAS, ~, LAYOUTS_LIST)                                                \
                                                                                                                        \
@@ -532,11 +532,11 @@ namespace cms::soa {
         : base_type{_ITERATE_ON_ALL_COMMA(_DECLARE_LAYOUT_LIST, BOOST_PP_EMPTY(), LAYOUTS_LIST)} {}                    \
                                                                                                                        \
     /* Constructor relying on individually provided column addresses */                                                \
-    SOA_HOST_ONLY VIEW(size_type nElements,                                                                            \
+    SOA_HOST_ONLY VIEW(size_type elements,                                                                             \
                         _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTION_BYCOLUMN_PARAMETERS,                          \
                                               BOOST_PP_EMPTY(),                                                        \
                                               VALUE_LIST))                                                             \
-        : base_type{nElements, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_LIST, BOOST_PP_EMPTY(), VALUE_LIST)} {}      \
+        : base_type{elements, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_LIST, BOOST_PP_EMPTY(), VALUE_LIST)} {}       \
                                                                                                                        \
     /* Copiable */                                                                                                     \
     VIEW(VIEW const&) = default;                                                                                       \
@@ -575,7 +575,7 @@ namespace cms::soa {
     SOA_HOST_DEVICE SOA_INLINE                                                                                         \
     element operator[](size_type index) {                                                                              \
       if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-        if (index >= base_type::nElements_)                                                                            \
+        if (index >= base_type::elements_)                                                                             \
           SOA_THROW_OUT_OF_RANGE("Out of range index in " #VIEW "::operator[]")                                        \
       }                                                                                                                \
       return element{index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_ELEMENT_CONSTR_CALL, ~, VALUE_LIST)};                  \
@@ -651,7 +651,7 @@ namespace cms::soa {
      */                                                                                                                \
     struct Metadata {                                                                                                  \
       friend CONST_VIEW;                                                                                               \
-      SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.nElements_; }                                 \
+      SOA_HOST_DEVICE SOA_INLINE size_type size() const { return parent_.elements_; }                                  \
       /* Alias layout or view types to name-derived identifyer to allow simpler definitions */                         \
       _ITERATE_ON_ALL(_DECLARE_VIEW_LAYOUT_TYPE_ALIAS, ~, LAYOUTS_LIST)                                                \
                                                                                                                        \
@@ -676,7 +676,7 @@ namespace cms::soa {
                                                                                                                        \
     /* Constructor relying on user provided layouts or views */                                                        \
     SOA_HOST_ONLY CONST_VIEW(_ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTION_PARAMETERS, const, LAYOUTS_LIST))        \
-        : nElements_([&]() -> size_type {                                                                              \
+        : elements_([&]() -> size_type {                                                                               \
             bool set = false;                                                                                          \
             size_type ret = 0;                                                                                         \
             _ITERATE_ON_ALL(_UPDATE_SIZE_OF_VIEW, BOOST_PP_EMPTY(), LAYOUTS_LIST)                                      \
@@ -685,9 +685,9 @@ namespace cms::soa {
           _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_INITIALIZERS, ~, VALUE_LIST) {}                                   \
                                                                                                                        \
     /* Constructor relying on individually provided column addresses */                                                \
-    SOA_HOST_ONLY CONST_VIEW(size_type nElements,                                                                      \
+    SOA_HOST_ONLY CONST_VIEW(size_type elements,                                                                       \
                         _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONSTRUCTION_BYCOLUMN_PARAMETERS, const, VALUE_LIST))      \
-        : nElements_(nElements), _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_INITIALIZERS_BYCOLUMN, ~, VALUE_LIST) {}   \
+        : elements_(elements), _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_MEMBER_INITIALIZERS_BYCOLUMN, ~, VALUE_LIST) {}     \
                                                                                                                        \
     /* Copiable */                                                                                                     \
     CONST_VIEW(CONST_VIEW const&) = default;                                                                           \
@@ -715,7 +715,7 @@ namespace cms::soa {
     SOA_HOST_DEVICE SOA_INLINE                                                                                         \
     const_element operator[](size_type index) const {                                                                  \
       if constexpr (rangeChecking == cms::soa::RangeChecking::enabled) {                                               \
-        if (index >= nElements_)                                                                                       \
+        if (index >= elements_)                                                                                        \
           SOA_THROW_OUT_OF_RANGE("Out of range index in " #CONST_VIEW "::operator[]")                                  \
       }                                                                                                                \
       return const_element{index, _ITERATE_ON_ALL_COMMA(_DECLARE_VIEW_CONST_ELEMENT_CONSTR_CALL, ~, VALUE_LIST)};      \
@@ -729,7 +729,7 @@ namespace cms::soa {
     SOA_HOST_ONLY friend void dump();                                                                                  \
                                                                                                                        \
   private:                                                                                                             \
-    size_type nElements_ = 0;                                                                                          \
+    size_type elements_ = 0;                                                                                           \
     _ITERATE_ON_ALL(_DECLARE_CONST_VIEW_SOA_MEMBER, const, VALUE_LIST)                                                 \
 };
 // clang-format on

--- a/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
+++ b/HeterogeneousCore/AlpakaInterface/interface/CachingAllocator.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <tuple>

--- a/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/TestAlpakaAnalyzer.cc
@@ -28,11 +28,24 @@ public:
 
     edm::LogInfo msg("TestAlpakaAnalyzer");
     msg << source_.encode() << ".size() = " << view.metadata().size() << '\n';
-    msg << "data = " << product.buffer().data() << " x = " << view.x() << " y = " << view.y() << " z = " << view.z()
-        << " id = " << view.id() << '\n';
-    msg << std::hex << "[y - x] = 0x" << reinterpret_cast<intptr_t>(view.y()) - reinterpret_cast<intptr_t>(view.x())
-        << " [z - y] = 0x" << reinterpret_cast<intptr_t>(view.z()) - reinterpret_cast<intptr_t>(view.y())
-        << " [id - z] = 0x" << reinterpret_cast<intptr_t>(view.id()) - reinterpret_cast<intptr_t>(view.z());
+    msg << "  data = " << product.buffer().data() << ",\n"
+        << "  x    = " << view.metadata().addressOf_x() << ",\n"
+        << "  y    = " << view.metadata().addressOf_y() << ",\n"
+        << "  z    = " << view.metadata().addressOf_z() << ",\n"
+        << "  id   = " << view.metadata().addressOf_id() << ",\n"
+        << "  r    = " << view.metadata().addressOf_r() << '\n';
+    msg << std::hex << "  [y - x] = 0x"
+        << reinterpret_cast<intptr_t>(view.metadata().addressOf_y()) -
+               reinterpret_cast<intptr_t>(view.metadata().addressOf_x())
+        << "  [z - y] = 0x"
+        << reinterpret_cast<intptr_t>(view.metadata().addressOf_z()) -
+               reinterpret_cast<intptr_t>(view.metadata().addressOf_y())
+        << "  [id - z] = 0x"
+        << reinterpret_cast<intptr_t>(view.metadata().addressOf_id()) -
+               reinterpret_cast<intptr_t>(view.metadata().addressOf_z())
+        << "  [r - id] = 0x"
+        << reinterpret_cast<intptr_t>(view.metadata().addressOf_r()) -
+               reinterpret_cast<intptr_t>(view.metadata().addressOf_id());
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
+++ b/HeterogeneousCore/AlpakaTest/plugins/alpaka/TestAlgo.dev.cc
@@ -20,6 +20,9 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       // this example accepts an arbitrary number of blocks and threads, and always uses 1 element per thread
       const int32_t thread = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
       const int32_t stride = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)[0u];
+      if (thread == 0) {
+        view.r() = 1.;
+      }
       for (auto i = thread; i < size; i += stride) {
         view[i] = {0., 0., 0., i};
       }


### PR DESCRIPTION
#### PR description:

This PR is a follow up to #38855.
It fixes the return types used in some of the `View` and `ConstView` accessors, and adds an example of using scalars in a SoA.

#### PR validation:

All unit tests pass.