### PR TITLE
Introduce option to use G4TransportationWithMsc

### DIFF
--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysics.cc
@@ -38,6 +38,12 @@
 #include "G4GammaGeneralProcess.hh"
 #include "G4LossTableManager.hh"
 
+#include "G4Version.hh"
+#if G4VERSION_NUMBER >= 1110
+#include "G4ProcessManager.hh"
+#include "G4TransportationWithMsc.hh"
+#endif
+
 #include "G4RegionStore.hh"
 #include "G4Region.hh"
 #include <string>
@@ -121,17 +127,15 @@ void CMSEmStandardPhysics::ConstructProcess() {
 
   G4eIonisation* eioni = new G4eIonisation();
 
-  G4eMultipleScattering* msc = new G4eMultipleScattering;
   G4UrbanMscModel* msc1 = new G4UrbanMscModel();
   G4WentzelVIModel* msc2 = new G4WentzelVIModel();
   msc1->SetHighEnergyLimit(highEnergyLimit);
   msc2->SetLowEnergyLimit(highEnergyLimit);
-  msc->SetEmModel(msc1);
-  msc->SetEmModel(msc2);
 
   // e-/e+ msc for HCAL and HGCAL using the Urban model
+  G4UrbanMscModel* msc3 = nullptr;
   if (nullptr != aRegion || nullptr != bRegion) {
-    G4UrbanMscModel* msc3 = new G4UrbanMscModel();
+    msc3 = new G4UrbanMscModel();
     msc3->SetHighEnergyLimit(highEnergyLimit);
     msc3->SetRangeFactor(fRangeFactor);
     msc3->SetGeomFactor(fGeomFactor);
@@ -139,13 +143,48 @@ void CMSEmStandardPhysics::ConstructProcess() {
     msc3->SetLambdaLimit(fLambdaLimit);
     msc3->SetStepLimitType(fStepLimitType);
     msc3->SetLocked(true);
+  }
 
+#if G4VERSION_NUMBER >= 1110
+  G4TransportationWithMscType transportationWithMsc = G4EmParameters::Instance()->TransportationWithMsc();
+  if (transportationWithMsc != G4TransportationWithMscType::fDisabled) {
+    G4ProcessManager* procManager = particle->GetProcessManager();
+    // Remove default G4Transportation and replace with G4TransportationWithMsc.
+    G4VProcess* removed = procManager->RemoveProcess(0);
+    if (removed->GetProcessName() != "Transportation") {
+      G4Exception("CMSEmStandardPhysics::ConstructProcess",
+                  "em0050",
+                  FatalException,
+                  "replaced process is not G4Transportation!");
+    }
+    G4TransportationWithMsc* transportWithMsc =
+        new G4TransportationWithMsc(G4TransportationWithMsc::ScatteringType::MultipleScattering);
+    if (transportationWithMsc == G4TransportationWithMscType::fMultipleSteps) {
+      transportWithMsc->SetMultipleSteps(true);
+    }
+    transportWithMsc->AddMscModel(msc1);
+    transportWithMsc->AddMscModel(msc2);
+    if (nullptr != aRegion) {
+      transportWithMsc->AddMscModel(msc3, -1, aRegion);
+    }
+    if (nullptr != bRegion) {
+      transportWithMsc->AddMscModel(msc3, -1, bRegion);
+    }
+    procManager->AddProcess(transportWithMsc, -1, 0, 0);
+  } else
+#endif
+  {
+    // Register as a separate process.
+    G4eMultipleScattering* msc = new G4eMultipleScattering;
+    msc->SetEmModel(msc1);
+    msc->SetEmModel(msc2);
     if (nullptr != aRegion) {
       msc->AddEmModel(-1, msc3, aRegion);
     }
     if (nullptr != bRegion) {
       msc->AddEmModel(-1, msc3, bRegion);
     }
+    ph->RegisterProcess(msc, particle);
   }
 
   // single scattering
@@ -156,7 +195,6 @@ void CMSEmStandardPhysics::ConstructProcess() {
   ssm->SetLowEnergyLimit(highEnergyLimit);
   ssm->SetActivationLowEnergyLimit(highEnergyLimit);
 
-  ph->RegisterProcess(msc, particle);
   ph->RegisterProcess(eioni, particle);
   ph->RegisterProcess(new G4eBremsstrahlung(), particle);
   ph->RegisterProcess(ss, particle);
@@ -165,17 +203,14 @@ void CMSEmStandardPhysics::ConstructProcess() {
   particle = G4Positron::Positron();
   eioni = new G4eIonisation();
 
-  msc = new G4eMultipleScattering();
   msc1 = new G4UrbanMscModel();
   msc2 = new G4WentzelVIModel();
   msc1->SetHighEnergyLimit(highEnergyLimit);
   msc2->SetLowEnergyLimit(highEnergyLimit);
-  msc->SetEmModel(msc1);
-  msc->SetEmModel(msc2);
 
   // e-/e+ msc for HCAL and HGCAL using the Urban model
   if (nullptr != aRegion || nullptr != bRegion) {
-    G4UrbanMscModel* msc3 = new G4UrbanMscModel();
+    msc3 = new G4UrbanMscModel();
     msc3->SetHighEnergyLimit(highEnergyLimit);
     msc3->SetRangeFactor(fRangeFactor);
     msc3->SetGeomFactor(fGeomFactor);
@@ -183,13 +218,47 @@ void CMSEmStandardPhysics::ConstructProcess() {
     msc3->SetLambdaLimit(fLambdaLimit);
     msc3->SetStepLimitType(fStepLimitType);
     msc3->SetLocked(true);
+  }
 
+#if G4VERSION_NUMBER >= 1110
+  if (transportationWithMsc != G4TransportationWithMscType::fDisabled) {
+    G4ProcessManager* procManager = particle->GetProcessManager();
+    // Remove default G4Transportation and replace with G4TransportationWithMsc.
+    G4VProcess* removed = procManager->RemoveProcess(0);
+    if (removed->GetProcessName() != "Transportation") {
+      G4Exception("CMSEmStandardPhysics::ConstructProcess",
+                  "em0050",
+                  FatalException,
+                  "replaced process is not G4Transportation!");
+    }
+    G4TransportationWithMsc* transportWithMsc =
+        new G4TransportationWithMsc(G4TransportationWithMsc::ScatteringType::MultipleScattering);
+    if (transportationWithMsc == G4TransportationWithMscType::fMultipleSteps) {
+      transportWithMsc->SetMultipleSteps(true);
+    }
+    transportWithMsc->AddMscModel(msc1);
+    transportWithMsc->AddMscModel(msc2);
+    if (nullptr != aRegion) {
+      transportWithMsc->AddMscModel(msc3, -1, aRegion);
+    }
+    if (nullptr != bRegion) {
+      transportWithMsc->AddMscModel(msc3, -1, bRegion);
+    }
+    procManager->AddProcess(transportWithMsc, -1, 0, 0);
+  } else
+#endif
+  {
+    // Register as a separate process.
+    G4eMultipleScattering* msc = new G4eMultipleScattering;
+    msc->SetEmModel(msc1);
+    msc->SetEmModel(msc2);
     if (nullptr != aRegion) {
       msc->AddEmModel(-1, msc3, aRegion);
     }
     if (nullptr != bRegion) {
       msc->AddEmModel(-1, msc3, bRegion);
     }
+    ph->RegisterProcess(msc, particle);
   }
 
   // single scattering
@@ -200,7 +269,6 @@ void CMSEmStandardPhysics::ConstructProcess() {
   ssm->SetLowEnergyLimit(highEnergyLimit);
   ssm->SetActivationLowEnergyLimit(highEnergyLimit);
 
-  ph->RegisterProcess(msc, particle);
   ph->RegisterProcess(eioni, particle);
   ph->RegisterProcess(new G4eBremsstrahlung(), particle);
   ph->RegisterProcess(new G4eplusAnnihilation(), particle);

--- a/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
+++ b/SimG4Core/PhysicsLists/src/CMSEmStandardPhysicsXS.cc
@@ -48,6 +48,12 @@
 #include "G4BuilderType.hh"
 #include "G4GammaGeneralProcess.hh"
 
+#include "G4Version.hh"
+#if G4VERSION_NUMBER >= 1110
+#include "G4ProcessManager.hh"
+#include "G4TransportationWithMsc.hh"
+#endif
+
 #include "G4RegionStore.hh"
 #include "G4Region.hh"
 #include "G4GammaGeneralProcess.hh"
@@ -147,17 +153,15 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
   particle = G4Electron::Electron();
 
   // multiple scattering
-  G4eMultipleScattering* msc = new G4eMultipleScattering();
   G4UrbanMscModel* msc1 = new G4UrbanMscModel();
   G4WentzelVIModel* msc2 = new G4WentzelVIModel();
   msc1->SetHighEnergyLimit(highEnergyLimit);
   msc2->SetLowEnergyLimit(highEnergyLimit);
-  msc->SetEmModel(msc1);
-  msc->SetEmModel(msc2);
 
   // msc for HCAL using the Urban model
+  G4UrbanMscModel* msc4 = nullptr;
   if (nullptr != aRegion) {
-    G4UrbanMscModel* msc4 = new G4UrbanMscModel();
+    msc4 = new G4UrbanMscModel();
     msc4->SetHighEnergyLimit(highEnergyLimit);
     msc4->SetRangeFactor(fRangeFactor);
     msc4->SetGeomFactor(fGeomFactor);
@@ -165,18 +169,59 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
     msc4->SetLambdaLimit(fLambdaLimit);
     msc4->SetStepLimitType(fStepLimitType);
     msc4->SetLocked(true);
-    msc->AddEmModel(-1, msc4, aRegion);
   }
 
   // msc GS with Mott-correction
+  G4GoudsmitSaundersonMscModel* msc3 = nullptr;
   if (nullptr != bRegion) {
-    G4GoudsmitSaundersonMscModel* msc3 = new G4GoudsmitSaundersonMscModel();
+    msc3 = new G4GoudsmitSaundersonMscModel();
     msc3->SetHighEnergyLimit(highEnergyLimit);
     msc3->SetRangeFactor(0.08);
     msc3->SetSkin(3.);
     msc3->SetStepLimitType(fUseSafetyPlus);
     msc3->SetLocked(true);
-    msc->AddEmModel(-1, msc3, bRegion);
+  }
+
+#if G4VERSION_NUMBER >= 1110
+  G4TransportationWithMscType transportationWithMsc = G4EmParameters::Instance()->TransportationWithMsc();
+  if (transportationWithMsc != G4TransportationWithMscType::fDisabled) {
+    G4ProcessManager* procManager = particle->GetProcessManager();
+    // Remove default G4Transportation and replace with G4TransportationWithMsc.
+    G4VProcess* removed = procManager->RemoveProcess(0);
+    if (removed->GetProcessName() != "Transportation") {
+      G4Exception("CMSEmStandardPhysics::ConstructProcess",
+                  "em0050",
+                  FatalException,
+                  "replaced process is not G4Transportation!");
+    }
+    G4TransportationWithMsc* transportWithMsc =
+        new G4TransportationWithMsc(G4TransportationWithMsc::ScatteringType::MultipleScattering);
+    if (transportationWithMsc == G4TransportationWithMscType::fMultipleSteps) {
+      transportWithMsc->SetMultipleSteps(true);
+    }
+    transportWithMsc->AddMscModel(msc1);
+    transportWithMsc->AddMscModel(msc2);
+    if (msc4 != nullptr) {
+      transportWithMsc->AddMscModel(msc4, -1, aRegion);
+    }
+    if (msc3 != nullptr) {
+      transportWithMsc->AddMscModel(msc3, -1, bRegion);
+    }
+    procManager->AddProcess(transportWithMsc, -1, 0, 0);
+  } else
+#endif
+  {
+    // Register as a separate process.
+    G4eMultipleScattering* msc = new G4eMultipleScattering;
+    msc->SetEmModel(msc1);
+    msc->SetEmModel(msc2);
+    if (msc4 != nullptr) {
+      msc->AddEmModel(-1, msc4, aRegion);
+    }
+    if (msc3 != nullptr) {
+      msc->AddEmModel(-1, msc3, bRegion);
+    }
+    ph->RegisterProcess(msc, particle);
   }
 
   // single scattering
@@ -203,7 +248,6 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
   G4ePairProduction* ee = new G4ePairProduction();
 
   // register processes
-  ph->RegisterProcess(msc, particle);
   ph->RegisterProcess(eioni, particle);
   ph->RegisterProcess(brem, particle);
   ph->RegisterProcess(ee, particle);
@@ -213,17 +257,14 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
   particle = G4Positron::Positron();
 
   // multiple scattering
-  msc = new G4eMultipleScattering();
   msc1 = new G4UrbanMscModel();
   msc2 = new G4WentzelVIModel();
   msc1->SetHighEnergyLimit(highEnergyLimit);
   msc2->SetLowEnergyLimit(highEnergyLimit);
-  msc->SetEmModel(msc1);
-  msc->SetEmModel(msc2);
 
   // msc for HCAL using the Urban model
   if (nullptr != aRegion) {
-    G4UrbanMscModel* msc4 = new G4UrbanMscModel();
+    msc4 = new G4UrbanMscModel();
     msc4->SetHighEnergyLimit(highEnergyLimit);
     msc4->SetRangeFactor(fRangeFactor);
     msc4->SetGeomFactor(fGeomFactor);
@@ -231,18 +272,57 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
     msc4->SetLambdaLimit(fLambdaLimit);
     msc4->SetStepLimitType(fStepLimitType);
     msc4->SetLocked(true);
-    msc->AddEmModel(-1, msc4, aRegion);
   }
 
   // msc GS with Mott-correction
   if (nullptr != bRegion) {
-    G4GoudsmitSaundersonMscModel* msc3 = new G4GoudsmitSaundersonMscModel();
+    msc3 = new G4GoudsmitSaundersonMscModel();
     msc3->SetHighEnergyLimit(highEnergyLimit);
     msc3->SetRangeFactor(0.08);
     msc3->SetSkin(3.);
     msc3->SetStepLimitType(fUseSafetyPlus);
     msc3->SetLocked(true);
-    msc->AddEmModel(-1, msc3, bRegion);
+  }
+
+#if G4VERSION_NUMBER >= 1110
+  if (transportationWithMsc != G4TransportationWithMscType::fDisabled) {
+    G4ProcessManager* procManager = particle->GetProcessManager();
+    // Remove default G4Transportation and replace with G4TransportationWithMsc.
+    G4VProcess* removed = procManager->RemoveProcess(0);
+    if (removed->GetProcessName() != "Transportation") {
+      G4Exception("CMSEmStandardPhysics::ConstructProcess",
+                  "em0050",
+                  FatalException,
+                  "replaced process is not G4Transportation!");
+    }
+    G4TransportationWithMsc* transportWithMsc =
+        new G4TransportationWithMsc(G4TransportationWithMsc::ScatteringType::MultipleScattering);
+    if (transportationWithMsc == G4TransportationWithMscType::fMultipleSteps) {
+      transportWithMsc->SetMultipleSteps(true);
+    }
+    transportWithMsc->AddMscModel(msc1);
+    transportWithMsc->AddMscModel(msc2);
+    if (msc4 != nullptr) {
+      transportWithMsc->AddMscModel(msc4, -1, aRegion);
+    }
+    if (msc3 != nullptr) {
+      transportWithMsc->AddMscModel(msc3, -1, bRegion);
+    }
+    procManager->AddProcess(transportWithMsc, -1, 0, 0);
+  } else
+#endif
+  {
+    // Register as a separate process.
+    G4eMultipleScattering* msc = new G4eMultipleScattering;
+    msc->SetEmModel(msc1);
+    msc->SetEmModel(msc2);
+    if (msc4 != nullptr) {
+      msc->AddEmModel(-1, msc4, aRegion);
+    }
+    if (msc3 != nullptr) {
+      msc->AddEmModel(-1, msc3, bRegion);
+    }
+    ph->RegisterProcess(msc, particle);
   }
 
   // single scattering
@@ -267,7 +347,6 @@ void CMSEmStandardPhysicsXS::ConstructProcess() {
   br1->SetHighEnergyLimit(CLHEP::GeV);
 
   // register processes
-  ph->RegisterProcess(msc, particle);
   ph->RegisterProcess(eioni, particle);
   ph->RegisterProcess(brem, particle);
   ph->RegisterProcess(ee, particle);


### PR DESCRIPTION
#### PR description:

This PR introduces the option to use the new `G4TransportationWithMsc` process, available since Geant4 11.1-beta. It combines `G4Transportation` and multiple scattering, which allows to move directly from one discrete interaction point to the next, with all intermediate steps due to MSC combined into one `G4Step`.

#### PR validation:

The default is not changed in this PR, simulation results should be identical. Adding `process.g4SimHits.G4Commands = ['/process/em/transportationWithMsc MultipleSteps']` enables the new process with small performance improvements, results to be validated.