### PR TITLE
Clamp the number of pixel tracks to the capacity of the SoA [12.4.x]

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
@@ -65,6 +65,10 @@ void PixelTrackSoAFromCUDA::produce(edm::Event& iEvent, edm::EventSetup const& i
   auto maxTracks = tsoa.stride();
   auto nTracks = tsoa.nTracks();
   assert(nTracks < maxTracks);
+  if (nTracks == maxTracks - 1) {
+    edm::LogWarning("PixelTracks") << "Unsorted reconstructed pixel tracks truncated to " << maxTracks - 1
+                                   << " candidates";
+  }
 
 #ifdef PIXEL_DEBUG_PRODUCE
   std::cout << "size of SoA " << sizeof(tsoa) << " stride " << maxTracks << std::endl;

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
@@ -86,7 +86,7 @@ void PixelTrackSoAFromCUDA::produce(edm::Event& iEvent, edm::EventSetup const& i
 #endif
 
   // DO NOT  make a copy  (actually TWO....)
-  iEvent.emplace(tokenSOA_, PixelTrackHeterogeneous(std::move(soa_)));
+  iEvent.emplace(tokenSOA_, std::move(soa_));
 
   assert(!soa_);
 }

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackSoAFromCUDA.cc
@@ -60,10 +60,13 @@ void PixelTrackSoAFromCUDA::acquire(edm::Event const& iEvent,
 }
 
 void PixelTrackSoAFromCUDA::produce(edm::Event& iEvent, edm::EventSetup const& iSetup) {
-#ifdef PIXEL_DEBUG_PRODUCE
+  // check that the fixed-size SoA does not overflow
   auto const& tsoa = *soa_;
   auto maxTracks = tsoa.stride();
   auto nTracks = tsoa.nTracks();
+  assert(nTracks < maxTracks);
+
+#ifdef PIXEL_DEBUG_PRODUCE
   std::cout << "size of SoA " << sizeof(tsoa) << " stride " << maxTracks << std::endl;
   std::cout << "found " << nTracks << " tracks in cpu SoA at " << &tsoa << std::endl;
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorKernelsImpl.h
@@ -562,7 +562,8 @@ __global__ void kernel_fillHitDetIndices(HitContainer const *__restrict__ tuples
 __global__ void kernel_fillNLayers(TkSoA *__restrict__ ptracks, cms::cuda::AtomicPairCounter *apc) {
   auto &tracks = *ptracks;
   auto first = blockIdx.x * blockDim.x + threadIdx.x;
-  auto ntracks = apc->get().m;
+  // clamp the number of tracks to the capacity of the SoA
+  auto ntracks = std::min<int>(apc->get().m, tracks.stride() - 1);
   if (0 == first)
     tracks.setNTracks(ntracks);
   for (int idx = first, nt = ntracks; idx < nt; idx += gridDim.x * blockDim.x) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -247,5 +247,11 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuples(TrackingRecHit2DC
   std::cout << "finished building pixel tracks on CPU" << std::endl;
 #endif
 
+  // check that the fixed-size SoA does not overflow
+  auto const& tsoa = *soa;
+  auto maxTracks = tsoa.stride();
+  auto nTracks = tsoa.nTracks();
+  assert(nTracks < maxTracks);
+
   return tracks;
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CAHitNtupletGeneratorOnGPU.cc
@@ -252,6 +252,10 @@ PixelTrackHeterogeneous CAHitNtupletGeneratorOnGPU::makeTuples(TrackingRecHit2DC
   auto maxTracks = tsoa.stride();
   auto nTracks = tsoa.nTracks();
   assert(nTracks < maxTracks);
+  if (nTracks == maxTracks - 1) {
+    edm::LogWarning("PixelTracks") << "Unsorted reconstructed pixel tracks truncated to " << maxTracks - 1
+                                   << " candidates";
+  }
 
   return tracks;
 }


### PR DESCRIPTION
#### PR description:

The data structure used to store the pixel tracks currently has a fixed size of 32768, which was found to be adequate based on MC studies.
While running over collisions data a small fraction of events has been found to have a larger number of tracks, leading to assertion failures or memory access errors.

This PR clamps the number of pixel tracks to the capacity of the SoA, and adds a warning like
```
%MSG-w PixelTracks:  PixelTrackSoAFromCUDA:hltPixelTracksFromGPU  30-Jul-2022 09:16:12 CEST Run: 356071 Event: 46424286
Unsorted reconstructed pixel tracks truncated to 32767 candidates
%MSG
```

#### PR validation:

Running over an event with > 33k pixel tracks no longer causes assertion failures.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. 

Backport of #38883 for data taking.