### PR TITLE
TOTEM nT2 unpacker

### DIFF
--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -174,11 +174,11 @@ private:
 
   /// recursive method to extract nT2-related information from the DOM tree
   void ParseTreeTotemT2(ParseType,
-                        xercesc::DOMNode*,
+                        xercesc::DOMNode *,
                         NodeType,
                         unsigned int parentID,
-                        const std::unique_ptr<TotemDAQMapping>&,
-                        const std::unique_ptr<TotemAnalysisMask>&);
+                        const std::unique_ptr<TotemDAQMapping> &,
+                        const std::unique_ptr<TotemAnalysisMask> &);
 
 private:
   /// adds the path prefix, if needed
@@ -217,9 +217,7 @@ private:
             (type == nSampicChannel) || (type == nTotemTimingPlane) || (type == nTotemTimingCh));
   }
 
-  bool TotemT2Node(NodeType type) {
-    return type == nArm || type == nTotemT2Plane || type == nTotemT2Tile;
-  }
+  bool TotemT2Node(NodeType type) { return type == nArm || type == nTotemT2Plane || type == nTotemT2Tile; }
 
   bool CommonNode(NodeType type) { return ((type == nChip) || (type == nArm)); }
 
@@ -882,7 +880,7 @@ void TotemDAQMappingESSourceXML::ParseTreeTotemT2(ParseType pType,
             << "hwId not given for element `" << cms::xerces::toString(child->getNodeName()) << "'";
 
       // store mapping data
-      const TotemFramePosition& framepos = ChipFramePosition(child);
+      const TotemFramePosition &framepos = ChipFramePosition(child);
       TotemVFATInfo vfatInfo;
       unsigned int arm = parentID / 10, plane = parentID % 10;
       vfatInfo.symbolicID.symbolicID = TotemT2DetId(arm, plane, id);

--- a/CalibPPS/ESProducers/python/totemT2DAQMapping_cff.py
+++ b/CalibPPS/ESProducers/python/totemT2DAQMapping_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+from CalibPPS.ESProducers.totemDAQMappingESSourceXML_cfi import totemDAQMappingESSourceXML as _xml
+
+totemDAQMappingESSourceXML = _xml.clone(
+    subSystem = "TotemT2",
+    configuration = cms.VPSet(
+        cms.PSet(
+            validityRange = cms.EventRange("1:min - 999999999:max"),
+            mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_nt2_2021.xml"),
+            maskFileNames = cms.vstring()
+        )
+    ),
+    sampicSubDetId = cms.uint32(6),
+)

--- a/CondFormats/PPSObjects/xml/mapping_totem_nt2_2021.xml
+++ b/CondFormats/PPSObjects/xml/mapping_totem_nt2_2021.xml
@@ -1,0 +1,105 @@
+<!-- This mapping is a dummy 1-to-1 association to PPS diamond readout
+     channels as used during run 2 operations (2017-2018). Please edit
+     accordingly once the final T2 tiles mapping has been clearly defined
+     and implemented. -->
+<top>
+  <arm id="0">  <!-- sector 45, CMS negative z -->
+    <nt2_plane id="0">
+      <nt2_tile id="0" hwId="0x206" FEDId="583" GOHId="3" IdxInFiber="6"/>
+      <nt2_tile id="1" hwId="0x201" FEDId="583" GOHId="3" IdxInFiber="1"/>
+      <nt2_tile id="2" hwId="0x205" FEDId="583" GOHId="3" IdxInFiber="5"/>
+      <nt2_tile id="3" hwId="0x20D" FEDId="583" GOHId="3" IdxInFiber="13"/>
+    </nt2_plane>
+    <nt2_plane id="1">
+      <nt2_tile id="0" hwId="0x20A" FEDId="583" GOHId="3" IdxInFiber="10"/>
+      <nt2_tile id="1" hwId="0x202" FEDId="583" GOHId="3" IdxInFiber="2"/>
+      <nt2_tile id="2" hwId="0x204" FEDId="583" GOHId="3" IdxInFiber="4"/>
+      <nt2_tile id="3" hwId="0x20C" FEDId="583" GOHId="3" IdxInFiber="12"/>
+    </nt2_plane>
+    <nt2_plane id="2">
+      <nt2_tile id="0" hwId="0x20B" FEDId="583" GOHId="3" IdxInFiber="11"/>
+      <nt2_tile id="1" hwId="0x203" FEDId="583" GOHId="3" IdxInFiber="3"/>
+      <nt2_tile id="2" hwId="0x209" FEDId="583" GOHId="3" IdxInFiber="9"/>
+      <nt2_tile id="3" hwId="0x20E" FEDId="583" GOHId="3" IdxInFiber="14"/>
+    </nt2_plane>
+    <nt2_plane id="3">
+      <nt2_tile id="0" hwId="0x216" FEDId="583" GOHId="4" IdxInFiber="6"/>
+      <nt2_tile id="1" hwId="0x211" FEDId="583" GOHId="4" IdxInFiber="1"/>
+      <nt2_tile id="2" hwId="0x215" FEDId="583" GOHId="4" IdxInFiber="5"/>
+      <nt2_tile id="3" hwId="0x21D" FEDId="583" GOHId="4" IdxInFiber="13"/>
+    </nt2_plane>
+    <nt2_plane id="4">
+      <nt2_tile id="0" hwId="0x21A" FEDId="583" GOHId="4" IdxInFiber="10"/>
+      <nt2_tile id="1" hwId="0x212" FEDId="583" GOHId="4" IdxInFiber="2"/>
+      <nt2_tile id="2" hwId="0x214" FEDId="583" GOHId="4" IdxInFiber="4"/>
+      <nt2_tile id="3" hwId="0x21C" FEDId="583" GOHId="4" IdxInFiber="12"/>
+    </nt2_plane>
+    <nt2_plane id="5">
+      <nt2_tile id="0" hwId="0x21B" FEDId="583" GOHId="4" IdxInFiber="11"/>
+      <nt2_tile id="1" hwId="0x213" FEDId="583" GOHId="4" IdxInFiber="3"/>
+      <nt2_tile id="2" hwId="0x219" FEDId="583" GOHId="4" IdxInFiber="9"/>
+      <nt2_tile id="3" hwId="0x21E" FEDId="583" GOHId="4" IdxInFiber="14"/>
+    </nt2_plane>
+    <nt2_plane id="6">
+      <nt2_tile id="0" hwId="0x106" FEDId="583" GOHId="1" IdxInFiber="6"/>
+      <nt2_tile id="1" hwId="0x101" FEDId="583" GOHId="1" IdxInFiber="1"/>
+      <nt2_tile id="2" hwId="0x105" FEDId="583" GOHId="1" IdxInFiber="5"/>
+      <nt2_tile id="3" hwId="0x10D" FEDId="583" GOHId="1" IdxInFiber="13"/>
+    </nt2_plane>
+    <nt2_plane id="7">
+      <nt2_tile id="0" hwId="0x10A" FEDId="583" GOHId="1" IdxInFiber="10"/>
+      <nt2_tile id="1" hwId="0x102" FEDId="583" GOHId="1" IdxInFiber="2"/>
+      <nt2_tile id="2" hwId="0x104" FEDId="583" GOHId="1" IdxInFiber="4"/>
+      <nt2_tile id="3" hwId="0x10C" FEDId="583" GOHId="1" IdxInFiber="12"/>
+    </nt2_plane>
+  </arm>
+  <arm id="1">  <!-- sector 56, CMS positive z -->
+    <nt2_plane id="0">
+      <nt2_tile id="0" hwId="0x306" FEDId="582" GOHId="7" IdxInFiber="6"/>
+      <nt2_tile id="1" hwId="0x301" FEDId="582" GOHId="7" IdxInFiber="1"/>
+      <nt2_tile id="2" hwId="0x305" FEDId="582" GOHId="7" IdxInFiber="5"/>
+      <nt2_tile id="3" hwId="0x30D" FEDId="582" GOHId="7" IdxInFiber="13"/>
+    </nt2_plane>
+    <nt2_plane id="1">
+      <nt2_tile id="0" hwId="0x30A" FEDId="582" GOHId="7" IdxInFiber="10"/>
+      <nt2_tile id="1" hwId="0x302" FEDId="582" GOHId="7" IdxInFiber="2"/>
+      <nt2_tile id="2" hwId="0x304" FEDId="582" GOHId="7" IdxInFiber="4"/>
+      <nt2_tile id="3" hwId="0x30C" FEDId="582" GOHId="7" IdxInFiber="12"/>
+    </nt2_plane>
+    <nt2_plane id="2">
+      <nt2_tile id="0" hwId="0x30B" FEDId="582" GOHId="7" IdxInFiber="11"/>
+      <nt2_tile id="1" hwId="0x303" FEDId="582" GOHId="7" IdxInFiber="3"/>
+      <nt2_tile id="2" hwId="0x309" FEDId="582" GOHId="7" IdxInFiber="9"/>
+      <nt2_tile id="3" hwId="0x30E" FEDId="582" GOHId="7" IdxInFiber="14"/>
+    </nt2_plane>
+    <nt2_plane id="3">
+      <nt2_tile id="0" hwId="0x316" FEDId="582" GOHId="8" IdxInFiber="6"/>
+      <nt2_tile id="1" hwId="0x311" FEDId="582" GOHId="8" IdxInFiber="1"/>
+      <nt2_tile id="2" hwId="0x315" FEDId="582" GOHId="8" IdxInFiber="5"/>
+      <nt2_tile id="3" hwId="0x31D" FEDId="582" GOHId="8" IdxInFiber="13"/>
+    </nt2_plane>
+    <nt2_plane id="4">
+      <nt2_tile id="0" hwId="0x31A" FEDId="582" GOHId="8" IdxInFiber="10"/>
+      <nt2_tile id="1" hwId="0x312" FEDId="582" GOHId="8" IdxInFiber="2"/>
+      <nt2_tile id="2" hwId="0x314" FEDId="582" GOHId="8" IdxInFiber="4"/>
+      <nt2_tile id="3" hwId="0x31C" FEDId="582" GOHId="8" IdxInFiber="12"/>
+    </nt2_plane>
+    <nt2_plane id="5">
+      <nt2_tile id="0" hwId="0x31B" FEDId="582" GOHId="8" IdxInFiber="11"/>
+      <nt2_tile id="1" hwId="0x313" FEDId="582" GOHId="8" IdxInFiber="3"/>
+      <nt2_tile id="2" hwId="0x319" FEDId="582" GOHId="8" IdxInFiber="9"/>
+      <nt2_tile id="3" hwId="0x31E" FEDId="582" GOHId="8" IdxInFiber="14"/>
+    </nt2_plane>
+    <nt2_plane id="6">
+      <nt2_tile id="0" hwId="0x406" FEDId="582" GOHId="3" IdxInFiber="6"/>
+      <nt2_tile id="1" hwId="0x401" FEDId="582" GOHId="3" IdxInFiber="1"/>
+      <nt2_tile id="2" hwId="0x405" FEDId="582" GOHId="3" IdxInFiber="5"/>
+      <nt2_tile id="3" hwId="0x40D" FEDId="582" GOHId="3" IdxInFiber="13"/>
+    </nt2_plane>
+    <nt2_plane id="7">
+      <nt2_tile id="0" hwId="0x40A" FEDId="582" GOHId="3" IdxInFiber="10"/>
+      <nt2_tile id="1" hwId="0x402" FEDId="582" GOHId="3" IdxInFiber="2"/>
+      <nt2_tile id="2" hwId="0x404" FEDId="582" GOHId="3" IdxInFiber="4"/>
+      <nt2_tile id="3" hwId="0x40C" FEDId="582" GOHId="3" IdxInFiber="12"/>
+    </nt2_plane>
+  </arm>

--- a/DataFormats/CTPPSDetId/interface/CTPPSDetId.h
+++ b/DataFormats/CTPPSDetId/interface/CTPPSDetId.h
@@ -32,7 +32,7 @@
 class CTPPSDetId : public DetId {
 public:
   /// CTPPS sub-detectors
-  enum SubDetector { sdTrackingStrip = 3, sdTrackingPixel = 4, sdTimingDiamond = 5, sdTimingFastSilicon = 6 };
+  enum SubDetector { sdTrackingStrip = 3, sdTrackingPixel = 4, sdTimingDiamond = 5, sdTimingFastSilicon = 6, sdTotemT2 = 7 };
 
   /// Construct from a raw id.
   explicit CTPPSDetId(uint32_t id);

--- a/DataFormats/CTPPSDetId/interface/CTPPSDetId.h
+++ b/DataFormats/CTPPSDetId/interface/CTPPSDetId.h
@@ -32,7 +32,13 @@
 class CTPPSDetId : public DetId {
 public:
   /// CTPPS sub-detectors
-  enum SubDetector { sdTrackingStrip = 3, sdTrackingPixel = 4, sdTimingDiamond = 5, sdTimingFastSilicon = 6, sdTotemT2 = 7 };
+  enum SubDetector {
+    sdTrackingStrip = 3,
+    sdTrackingPixel = 4,
+    sdTimingDiamond = 5,
+    sdTimingFastSilicon = 6,
+    sdTotemT2 = 7
+  };
 
   /// Construct from a raw id.
   explicit CTPPSDetId(uint32_t id);

--- a/DataFormats/CTPPSDetId/interface/TotemT2DetId.h
+++ b/DataFormats/CTPPSDetId/interface/TotemT2DetId.h
@@ -67,4 +67,13 @@ public:
 
 std::ostream& operator<<(std::ostream& os, const TotemT2DetId& id);
 
+namespace std {
+  template <>
+  struct hash<TotemT2DetId> {
+    typedef TotemT2DetId argument_type;
+    typedef std::size_t result_type;
+    result_type operator()(const argument_type& id) const noexcept { return std::hash<uint64_t>()(id.rawId()); }
+  };
+}  // namespace std
+
 #endif

--- a/DataFormats/CTPPSDetId/interface/TotemT2DetId.h
+++ b/DataFormats/CTPPSDetId/interface/TotemT2DetId.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM offline software.
+ * Authors:
+ *   Laurent Forthomme (laurent.forthomme@cern.ch)
+ *
+ ****************************************************************************/
+
+#ifndef DataFormats_CTPPSDetId_TotemT2DetId
+#define DataFormats_CTPPSDetId_TotemT2DetId
+
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
+
+#include <iosfwd>
+#include <string>
+
+/**
+ *\brief Detector ID class for Totem T2 detectors.
+ * Bits [19:31] : Base CTPPSDetId class attributes
+ * Bits [16:18] : 3 bits for T2 plane [0-7]
+ * Bits [14:15] : 2 bits for T2 tile numbers [0-3]
+ * Bits [0:13]  : unspecified yet
+ **/
+
+class TotemT2DetId : public CTPPSDetId {
+public:
+  /// Construct from a raw id
+  explicit TotemT2DetId(uint32_t id);
+  TotemT2DetId(const CTPPSDetId& id) : CTPPSDetId(id) {}
+
+  /// Construct from hierarchy indices.
+  TotemT2DetId(uint32_t arm, uint32_t plane, uint32_t channel = 0);
+
+  static constexpr uint32_t startPlaneBit = 16, maskPlane = 0x7, maxPlane = 7, lowMaskPlane = 0xffff;
+  static constexpr uint32_t startChannelBit = 14, maskChannel = 0x3, maxChannel = 3, lowMaskChannel = 0x1fff;
+
+  /// returns true if the raw ID is a PPS-timing one
+  static bool check(unsigned int raw) {
+    return (((raw >> DetId::kDetOffset) & 0xF) == DetId::VeryForward &&
+            ((raw >> DetId::kSubdetOffset) & 0x7) == sdTotemT2);
+  }
+  //-------------------- getting and setting methods --------------------
+
+  uint32_t plane() const { return ((id_ >> startPlaneBit) & maskPlane); }
+
+  void setPlane(uint32_t channel) {
+    id_ &= ~(maskPlane << startPlaneBit);
+    id_ |= ((channel & maskPlane) << startPlaneBit);
+  }
+
+  uint32_t channel() const { return ((id_ >> startChannelBit) & maskChannel); }
+
+  void setChannel(uint32_t channel) {
+    id_ &= ~(maskChannel << startChannelBit);
+    id_ |= ((channel & maskChannel) << startChannelBit);
+  }
+
+  //-------------------- id getters for higher-level objects --------------------
+
+  TotemT2DetId planeId() const { return TotemT2DetId(rawId() & (~lowMaskPlane)); }
+
+  //-------------------- name methods --------------------
+
+  void planeName(std::string& name, NameFlag flag = nFull) const;
+  void channelName(std::string& name, NameFlag flag = nFull) const;
+};
+
+std::ostream& operator<<(std::ostream& os, const TotemT2DetId& id);
+
+#endif

--- a/DataFormats/CTPPSDetId/src/CTPPSDetId.cc
+++ b/DataFormats/CTPPSDetId/src/CTPPSDetId.cc
@@ -1,9 +1,9 @@
 /****************************************************************************
  *
  * This is a part of TOTEM offline software.
- * Authors: 
+ * Authors:
  *	Hubert Niewiadomski
- *	Jan Kašpar (jan.kaspar@gmail.com) 
+ *	Jan Kašpar (jan.kaspar@gmail.com)
  *
  ****************************************************************************/
 
@@ -23,9 +23,15 @@ const uint32_t CTPPSDetId::startRPBit = 19, CTPPSDetId::maskRP = 0x7, CTPPSDetId
                CTPPSDetId::lowMaskRP = 0x7FFFF;
 
 const string CTPPSDetId::subDetectorNames[] = {
-    "", "", "", "ctpps_tr_strip", "ctpps_tr_pixel", "ctpps_ti_diamond", "ctpps_ti_fastsilicon"};
-const string CTPPSDetId::subDetectorPaths[] = {
-    "", "", "", "CTPPS/TrackingStrip", "CTPPS/TrackingPixel", "CTPPS/TimingDiamond", "CTPPS/TimingFastSilicon"};
+    "", "", "", "ctpps_tr_strip", "ctpps_tr_pixel", "ctpps_ti_diamond", "ctpps_ti_fastsilicon", "totem_t2"};
+const string CTPPSDetId::subDetectorPaths[] = {"",
+                                               "",
+                                               "",
+                                               "CTPPS/TrackingStrip",
+                                               "CTPPS/TrackingPixel",
+                                               "CTPPS/TimingDiamond",
+                                               "CTPPS/TimingFastSilicon",
+                                               "TotemT2"};
 const string CTPPSDetId::armNames[] = {"45", "56"};
 const string CTPPSDetId::stationNames[] = {"210", "220cyl", "220"};
 const string CTPPSDetId::rpNames[] = {"nr_tp", "nr_bt", "nr_hr", "fr_hr", "fr_tp", "fr_bt", "cyl_hr"};
@@ -47,7 +53,7 @@ CTPPSDetId::CTPPSDetId(uint32_t id) : DetId(id) {
 CTPPSDetId::CTPPSDetId(uint32_t SubDet, uint32_t Arm, uint32_t Station, uint32_t RomanPot)
     : DetId(DetId::VeryForward, SubDet) {
   if (SubDet != sdTrackingStrip && SubDet != sdTrackingPixel && SubDet != sdTimingDiamond &&
-      SubDet != sdTimingFastSilicon) {
+      SubDet != sdTimingFastSilicon && SubDet != sdTotemT2) {
     throw cms::Exception("InvalidDetId") << "CTPPSDetId ctor: invalid sub-detector " << SubDet << ".";
   }
 

--- a/DataFormats/CTPPSDetId/src/TotemT2DetId.cc
+++ b/DataFormats/CTPPSDetId/src/TotemT2DetId.cc
@@ -1,0 +1,85 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM offline software.
+ * Authors:
+ *   Laurent Forthomme (laurent.forthomme@cern.ch)
+ *
+ ****************************************************************************/
+
+
+#include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+//----------------------------------------------------------------------------------------------------
+
+TotemT2DetId::TotemT2DetId(uint32_t id) : CTPPSDetId(id) {
+  if (!check(id))
+    throw cms::Exception("InvalidDetId") << "TotemT2DetId ctor:"
+                                         << " channel: " << channel() << " subdet: " << subdetId()
+                                         << " is not a valid Totem nT2 id";
+}
+
+//----------------------------------------------------------------------------------------------------
+
+TotemT2DetId::TotemT2DetId(uint32_t arm, uint32_t plane, uint32_t channel)
+    : CTPPSDetId(sdTimingFastSilicon, arm, 0, 0) {
+  if (arm > maxArm || plane > maxPlane || channel > maxChannel)
+    throw cms::Exception("InvalidDetId") << "TotemT2DetId ctor:"
+                                         << " Invalid parameters:"
+                                         << " arm=" << arm << " plane=" << plane << " detector=" << channel;
+
+  uint32_t ok = 0xfe000000;
+  id_ &= ok;
+
+  id_ |= ((arm & maskArm) << startArmBit);
+  id_ |= ((plane & maskPlane) << startPlaneBit);
+  id_ |= ((channel & maskChannel) << startChannelBit);
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void
+TotemT2DetId::planeName(std::string& name, NameFlag flag) const
+{
+  switch (flag) {
+    case nShort:
+      name = "";
+      break;
+    case nFull:
+      rpName(name, flag);
+      name += "_";
+      break;
+    case nPath:
+      rpName(name, flag);
+      name += "/plane ";
+      break;
+  }
+  name += std::to_string(plane());
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void
+TotemT2DetId::channelName(std::string& name, NameFlag flag) const
+{
+  switch (flag) {
+    case nShort:
+      name = "";
+      break;
+    case nFull:
+      planeName(name, flag);
+      name += "_";
+      break;
+    case nPath:
+      planeName(name, flag);
+      name += "/channel ";
+      break;
+  }
+  name += std::to_string(channel());
+}
+
+//----------------------------------------------------------------------------------------------------
+
+std::ostream& operator<<(std::ostream& os, const TotemT2DetId& id) {
+  return os << "arm=" << id.arm() << " plane=" << id.plane() << " channel=" << id.channel();
+}

--- a/DataFormats/CTPPSDetId/src/TotemT2DetId.cc
+++ b/DataFormats/CTPPSDetId/src/TotemT2DetId.cc
@@ -20,8 +20,7 @@ TotemT2DetId::TotemT2DetId(uint32_t id) : CTPPSDetId(id) {
 
 //----------------------------------------------------------------------------------------------------
 
-TotemT2DetId::TotemT2DetId(uint32_t arm, uint32_t plane, uint32_t channel)
-    : CTPPSDetId(sdTimingFastSilicon, arm, 0, 0) {
+TotemT2DetId::TotemT2DetId(uint32_t arm, uint32_t plane, uint32_t channel) : CTPPSDetId(sdTotemT2, arm, 0, 0) {
   if (arm > maxArm || plane > maxPlane || channel > maxChannel)
     throw cms::Exception("InvalidDetId") << "TotemT2DetId ctor:"
                                          << " Invalid parameters:"

--- a/DataFormats/CTPPSDetId/src/TotemT2DetId.cc
+++ b/DataFormats/CTPPSDetId/src/TotemT2DetId.cc
@@ -43,11 +43,11 @@ void TotemT2DetId::planeName(std::string& name, NameFlag flag) const {
       name = "";
       break;
     case nFull:
-      rpName(name, flag);
+      armName(name, flag);
       name += "_";
       break;
     case nPath:
-      rpName(name, flag);
+      armName(name, flag);
       name += "/plane ";
       break;
   }

--- a/DataFormats/CTPPSDetId/src/TotemT2DetId.cc
+++ b/DataFormats/CTPPSDetId/src/TotemT2DetId.cc
@@ -6,7 +6,6 @@
  *
  ****************************************************************************/
 
-
 #include "DataFormats/CTPPSDetId/interface/TotemT2DetId.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -38,9 +37,7 @@ TotemT2DetId::TotemT2DetId(uint32_t arm, uint32_t plane, uint32_t channel)
 
 //----------------------------------------------------------------------------------------------------
 
-void
-TotemT2DetId::planeName(std::string& name, NameFlag flag) const
-{
+void TotemT2DetId::planeName(std::string& name, NameFlag flag) const {
   switch (flag) {
     case nShort:
       name = "";
@@ -59,9 +56,7 @@ TotemT2DetId::planeName(std::string& name, NameFlag flag) const
 
 //----------------------------------------------------------------------------------------------------
 
-void
-TotemT2DetId::channelName(std::string& name, NameFlag flag) const
-{
+void TotemT2DetId::channelName(std::string& name, NameFlag flag) const {
   switch (flag) {
     case nShort:
       name = "";

--- a/DataFormats/FEDRawData/interface/FEDNumbering.h
+++ b/DataFormats/FEDRawData/interface/FEDNumbering.h
@@ -40,8 +40,8 @@ public:
     MAXTotemRPVerticalFEDID = 585,
     MINTotemRPTimingVerticalFEDID = 586,
     MAXTotemRPTimingVerticalFEDID = 587,
-    MINTotemT2FEDID = 999999, //FIXME
-    MAXTotemT2FEDID = 999999+1, //FIXME
+    MINTotemT2FEDID = 999999,      //FIXME
+    MAXTotemT2FEDID = 999999 + 1,  //FIXME
     MINECALFEDID = 600,
     MAXECALFEDID = 670,
     MINCASTORFEDID = 690,

--- a/DataFormats/FEDRawData/interface/FEDNumbering.h
+++ b/DataFormats/FEDRawData/interface/FEDNumbering.h
@@ -40,8 +40,8 @@ public:
     MAXTotemRPVerticalFEDID = 585,
     MINTotemRPTimingVerticalFEDID = 586,
     MAXTotemRPTimingVerticalFEDID = 587,
-    MINTotemT2FEDID = 999999,      //FIXME
-    MAXTotemT2FEDID = 999999 + 1,  //FIXME
+    MINTotemT2FEDID = 582,      //FIXME
+    MAXTotemT2FEDID = 582 + 1,  //FIXME
     MINECALFEDID = 600,
     MAXECALFEDID = 670,
     MINCASTORFEDID = 690,

--- a/DataFormats/FEDRawData/interface/FEDNumbering.h
+++ b/DataFormats/FEDRawData/interface/FEDNumbering.h
@@ -30,8 +30,8 @@ public:
     MAXSiStripFEDID = 489,
     MINPreShowerFEDID = 520,
     MAXPreShowerFEDID = 575,
-    MINTotemTriggerFEDID = 577,
-    MAXTotemTriggerFEDID = 577,
+    MINTotemT2FEDID = 577,
+    MAXTotemT2FEDID = 577,
     MINTotemRPHorizontalFEDID = 578,
     MAXTotemRPHorizontalFEDID = 581,
     MINCTPPSDiamondFEDID = 582,
@@ -40,8 +40,6 @@ public:
     MAXTotemRPVerticalFEDID = 585,
     MINTotemRPTimingVerticalFEDID = 586,
     MAXTotemRPTimingVerticalFEDID = 587,
-    MINTotemT2FEDID = 582,      //FIXME
-    MAXTotemT2FEDID = 582 + 1,  //FIXME
     MINECALFEDID = 600,
     MAXECALFEDID = 670,
     MINCASTORFEDID = 690,

--- a/DataFormats/FEDRawData/interface/FEDNumbering.h
+++ b/DataFormats/FEDRawData/interface/FEDNumbering.h
@@ -40,6 +40,8 @@ public:
     MAXTotemRPVerticalFEDID = 585,
     MINTotemRPTimingVerticalFEDID = 586,
     MAXTotemRPTimingVerticalFEDID = 587,
+    MINTotemT2FEDID = 999999, //FIXME
+    MAXTotemT2FEDID = 999999+1, //FIXME
     MINECALFEDID = 600,
     MAXECALFEDID = 670,
     MINCASTORFEDID = 690,

--- a/DataFormats/TotemReco/BuildFile.xml
+++ b/DataFormats/TotemReco/BuildFile.xml
@@ -1,0 +1,4 @@
+<use name="DataFormats/Common"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/DataFormats/TotemReco/interface/TotemT2Digi.h
+++ b/DataFormats/TotemReco/interface/TotemT2Digi.h
@@ -13,11 +13,28 @@ class TotemT2Digi {
 public:
   explicit TotemT2Digi() = default;
 
+  void setLeadingEdge(unsigned int le) { lead_edge_ = le; }
+  unsigned int leadingEdge() const { return lead_edge_; }
+  void setTrailingEdge(unsigned int te) { trail_edge_ = te; }
+  unsigned int trailingEdge() const { return trail_edge_; }
+
 private:
+  /// Leading edge time
+  unsigned int lead_edge_;
+  /// Trailing edge time
+  unsigned int trail_edge_;
 };
 
-bool operator<(const TotemT2Digi&, const TotemT2Digi&) {
-  return true;
+bool operator<(const TotemT2Digi& lhs, const TotemT2Digi& rhs) {
+  if (lhs.leadingEdge() < rhs.leadingEdge())
+    return true;
+  if (lhs.leadingEdge() > rhs.leadingEdge())
+    return false;
+  if (lhs.trailingEdge() < rhs.trailingEdge())
+    return true;
+  if (lhs.trailingEdge() > rhs.trailingEdge())
+    return false;
+  return false;
 }
 
 #endif

--- a/DataFormats/TotemReco/interface/TotemT2Digi.h
+++ b/DataFormats/TotemReco/interface/TotemT2Digi.h
@@ -1,0 +1,21 @@
+/****************************************************************************
+ *
+ * This is a part of TOTEM offline software.
+ * Author:
+ *   Laurent Forthomme
+ *
+ ****************************************************************************/
+
+#ifndef DataFormats_TotemReco_TotemT2Digi_h
+#define DataFormats_TotemReco_TotemT2Digi_h
+
+class TotemT2Digi {
+public:
+  explicit TotemT2Digi() = default;
+
+private:
+};
+
+bool operator<(const TotemT2Digi&, const TotemT2Digi&);
+
+#endif

--- a/DataFormats/TotemReco/interface/TotemT2Digi.h
+++ b/DataFormats/TotemReco/interface/TotemT2Digi.h
@@ -16,6 +16,8 @@ public:
 private:
 };
 
-bool operator<(const TotemT2Digi&, const TotemT2Digi&);
+bool operator<(const TotemT2Digi&, const TotemT2Digi&) {
+  return true;
+}
 
 #endif

--- a/DataFormats/TotemReco/interface/TotemT2Digi.h
+++ b/DataFormats/TotemReco/interface/TotemT2Digi.h
@@ -12,6 +12,7 @@
 class TotemT2Digi {
 public:
   explicit TotemT2Digi() = default;
+  TotemT2Digi(unsigned char geo, unsigned char id, unsigned char marker, unsigned short le, unsigned short te);
 
   void setLeadingEdge(unsigned short le) { lead_edge_ = le; }
   unsigned short leadingEdge() const { return lead_edge_; }
@@ -19,22 +20,18 @@ public:
   unsigned short trailingEdge() const { return trail_edge_; }
 
 private:
+  /// Geo ID
+  unsigned char geo_id_;
+  /// Channel ID
+  unsigned char channel_id_;
+  /// Channel marker
+  unsigned char marker_;
   /// Leading edge time
   unsigned short lead_edge_;
   /// Trailing edge time
   unsigned short trail_edge_;
 };
 
-bool operator<(const TotemT2Digi& lhs, const TotemT2Digi& rhs) {
-  if (lhs.leadingEdge() < rhs.leadingEdge())
-    return true;
-  if (lhs.leadingEdge() > rhs.leadingEdge())
-    return false;
-  if (lhs.trailingEdge() < rhs.trailingEdge())
-    return true;
-  if (lhs.trailingEdge() > rhs.trailingEdge())
-    return false;
-  return false;
-}
+bool operator<(const TotemT2Digi& lhs, const TotemT2Digi& rhs);
 
 #endif

--- a/DataFormats/TotemReco/interface/TotemT2Digi.h
+++ b/DataFormats/TotemReco/interface/TotemT2Digi.h
@@ -13,16 +13,16 @@ class TotemT2Digi {
 public:
   explicit TotemT2Digi() = default;
 
-  void setLeadingEdge(unsigned int le) { lead_edge_ = le; }
-  unsigned int leadingEdge() const { return lead_edge_; }
-  void setTrailingEdge(unsigned int te) { trail_edge_ = te; }
-  unsigned int trailingEdge() const { return trail_edge_; }
+  void setLeadingEdge(unsigned short le) { lead_edge_ = le; }
+  unsigned short leadingEdge() const { return lead_edge_; }
+  void setTrailingEdge(unsigned short te) { trail_edge_ = te; }
+  unsigned short trailingEdge() const { return trail_edge_; }
 
 private:
   /// Leading edge time
-  unsigned int lead_edge_;
+  unsigned short lead_edge_;
   /// Trailing edge time
-  unsigned int trail_edge_;
+  unsigned short trail_edge_;
 };
 
 bool operator<(const TotemT2Digi& lhs, const TotemT2Digi& rhs) {

--- a/DataFormats/TotemReco/src/TotemT2Digi.cc
+++ b/DataFormats/TotemReco/src/TotemT2Digi.cc
@@ -1,0 +1,16 @@
+#include "DataFormats/TotemReco/interface/TotemT2Digi.h"
+
+TotemT2Digi::TotemT2Digi(unsigned char geo, unsigned char id, unsigned char marker, unsigned short le, unsigned short te)
+    : geo_id_(geo), channel_id_(id), marker_(marker), lead_edge_(le), trail_edge_(te) {}
+
+bool operator<(const TotemT2Digi& lhs, const TotemT2Digi& rhs) {
+  if (lhs.leadingEdge() < rhs.leadingEdge())
+    return true;
+  if (lhs.leadingEdge() > rhs.leadingEdge())
+    return false;
+  if (lhs.trailingEdge() < rhs.trailingEdge())
+    return true;
+  if (lhs.trailingEdge() > rhs.trailingEdge())
+    return false;
+  return false;
+}

--- a/DataFormats/TotemReco/src/classes.h
+++ b/DataFormats/TotemReco/src/classes.h
@@ -1,0 +1,7 @@
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/DetSet.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+
+#include "DataFormats/TotemReco/interface/TotemT2Digi.h"
+
+#include <vector>

--- a/DataFormats/TotemReco/src/classes_def.xml
+++ b/DataFormats/TotemReco/src/classes_def.xml
@@ -1,0 +1,10 @@
+<lcgdict>
+  <class name="TotemT2Digi" ClassVersion="10">
+    <version ClassVersion="10" checksum="4024006040"/>
+  </class>
+  <class name="edm::DetSet<TotemT2Digi>"/>
+  <class name="edm::DetSetVector<TotemT2Digi>"/>
+  <class name="edm::Wrapper<edm::DetSetVector<TotemT2Digi> >"/>
+  <class name="std::vector<TotemT2Digi>"/>
+  <class name="std::vector<edm::DetSet<TotemT2Digi> >"/>
+</lcgdict>

--- a/EventFilter/CTPPSRawToDigi/BuildFile.xml
+++ b/EventFilter/CTPPSRawToDigi/BuildFile.xml
@@ -5,6 +5,8 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CTPPSDigi"/>
 <use name="DataFormats/CTPPSDetId"/>
+<use name="DataFormats/TotemReco"/>
+
 <use name="CondFormats/PPSObjects"/>
 <use name="CondFormats/DataRecord"/>
 <export>

--- a/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
@@ -3,6 +3,8 @@
 * This is a part of the TOTEM offline software.
 * Authors:
 *   Jan Kašpar (jan.kaspar@gmail.com)
+*   Nicola Minafra
+*   Laurent Forthomme
 *
 ****************************************************************************/
 
@@ -21,6 +23,7 @@
 #include "DataFormats/CTPPSDigi/interface/TotemVFATStatus.h"
 #include "DataFormats/CTPPSDigi/interface/CTPPSDiamondDigi.h"
 #include "DataFormats/CTPPSDigi/interface/TotemTimingDigi.h"
+#include "DataFormats/TotemReco/interface/TotemT2Digi.h"
 
 /// \brief Collection of code to convert TOTEM raw data into digi.
 class RawToDigiConverter {
@@ -47,6 +50,13 @@ public:
            const TotemAnalysisMask &mask,
            edm::DetSetVector<TotemTimingDigi> &digi,
            edm::DetSetVector<TotemVFATStatus> &status);
+
+  /// Creates Totem T2 digi
+  void run(const VFATFrameCollection& coll,
+           const TotemDAQMapping& mapping,
+           const TotemAnalysisMask& mask,
+           edm::DetSetVector<TotemT2Digi>& digi,
+           edm::DetSetVector<TotemVFATStatus>& status);
 
   /// Print error summaries.
   void printSummaries() const;

--- a/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
@@ -52,11 +52,11 @@ public:
            edm::DetSetVector<TotemVFATStatus> &status);
 
   /// Creates Totem T2 digi
-  void run(const VFATFrameCollection& coll,
-           const TotemDAQMapping& mapping,
-           const TotemAnalysisMask& mask,
-           edm::DetSetVector<TotemT2Digi>& digi,
-           edm::DetSetVector<TotemVFATStatus>& status);
+  void run(const VFATFrameCollection &coll,
+           const TotemDAQMapping &mapping,
+           const TotemAnalysisMask &mask,
+           edm::DetSetVector<TotemT2Digi> &digi,
+           edm::DetSetVector<TotemVFATStatus> &status);
 
   /// Print error summaries.
   void printSummaries() const;

--- a/EventFilter/CTPPSRawToDigi/interface/TotemT2VFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/TotemT2VFATFrame.h
@@ -1,0 +1,33 @@
+/****************************************************************************
+*
+* This is a part of the TOTEM offline software.
+* Authors:
+*   Edoardo Bossini
+*   Laurent Forthomme
+*
+****************************************************************************/
+
+#ifndef EventFilter_CTPPSRawToDigi_TotemT2VFATFrame
+#define EventFilter_CTPPSRawToDigi_TotemT2VFATFrame
+
+#include "EventFilter/CTPPSRawToDigi/interface/VFATFrame.h"
+
+#include <cstdint>
+
+/**
+ * Utilitary namespace to retrieve timing/status information from nT2 VFAT frame
+**/
+namespace totem::nt2::vfat {
+  /// get timing information for single leading edge
+  inline uint16_t leadingEdgeTime(const VFATFrame& frame) { return frame.getData()[2] & 0xffff; }
+  /// get timing information for single trailing edge
+  inline uint16_t trailingEdgeTime(const VFATFrame& frame) { return frame.getData()[3] & 0xffff; }
+  /// retrieve this channel marker
+  inline uint8_t channelMarker(const VFATFrame& frame) { return frame.getData()[1] & 0x1f; }
+  /// retrieve the GEO information for this channel
+  inline uint8_t geoId(const VFATFrame& frame) { return frame.getData()[0] & 0x3f; }
+  /// retrieve this channel identifier
+  inline uint8_t channelId(const VFATFrame& frame) { return (frame.getData()[0] >> 8) & 0x3f; }
+}  // namespace totem::nt2::vfat
+
+#endif

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemTriggerRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemTriggerRawToDigi.cc
@@ -1,7 +1,7 @@
 /****************************************************************************
 *
 * This is a part of TOTEM offline software.
-* Authors: 
+* Authors:
 *   Jan Kašpar (jan.kaspar@gmail.com)
 *
 ****************************************************************************/
@@ -45,7 +45,8 @@ TotemTriggerRawToDigi::TotemTriggerRawToDigi(const edm::ParameterSet &conf)
   fedDataToken = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("rawDataTag"));
 
   if (fedId == 0)
-    fedId = FEDNumbering::MINTotemTriggerFEDID;
+    throw cms::Exception("TotemTriggerRawToDigi")
+        << "Invalid FED id for TOTEM trigger. Please specify it through the 'fedId' parameter.";
 
   produces<TotemTriggerCounters>();
 }

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -3,6 +3,7 @@
 * This is a part of TOTEM offline software.
 * Authors:
 *   Jan Kašpar (jan.kaspar@gmail.com)
+*   Laurent Forthomme
 *
 ****************************************************************************/
 
@@ -33,6 +34,7 @@
 #include "EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h"
 
 #include "DataFormats/CTPPSDigi/interface/TotemTimingDigi.h"
+#include "DataFormats/TotemReco/interface/TotemT2Digi.h"
 
 #include <string>
 
@@ -47,7 +49,7 @@ public:
 private:
   std::string subSystemName;
 
-  enum { ssUndefined, ssTrackingStrip, ssTimingDiamond, ssTotemTiming } subSystem;
+  enum { ssUndefined, ssTrackingStrip, ssTimingDiamond, ssTotemTiming, ssTotemT2 } subSystem;
 
   std::vector<unsigned int> fedIds;
 
@@ -80,6 +82,8 @@ TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf)
     subSystem = ssTimingDiamond;
   else if (subSystemName == "TotemTiming")
     subSystem = ssTotemTiming;
+  else if (subSystemName == "TotemT2")
+    subSystem = ssTotemT2;
 
   if (subSystem == ssUndefined)
     throw cms::Exception("TotemVFATRawToDigi::TotemVFATRawToDigi")
@@ -97,6 +101,9 @@ TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf)
 
   else if (subSystem == ssTotemTiming)
     produces<DetSetVector<TotemTimingDigi>>(subSystemName);
+
+  else if (subSystem == ssTotemT2)
+    produces<DetSetVector<TotemT2Digi>>(subSystemName);
 
   // set default IDs
   if (fedIds.empty()) {

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -3,6 +3,7 @@
 * This is a part of TOTEM offline software.
 * Authors:
 *   Jan Kašpar (jan.kaspar@gmail.com)
+*   Nicola Minafra
 *   Laurent Forthomme
 *
 ****************************************************************************/
@@ -125,6 +126,11 @@ TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf)
            ++id)
         fedIds.push_back(id);
     }
+
+    else if (subSystem == ssTotemT2) {
+      for (int id = FEDNumbering::MINTotemT2FEDID; id < FEDNumbering::MAXTotemT2FEDID; ++id)
+        fedIds.push_back(id);
+    }
   }
 
   // conversion status
@@ -145,6 +151,9 @@ void TotemVFATRawToDigi::produce(edm::Event &event, const edm::EventSetup &es) {
 
   else if (subSystem == ssTotemTiming)
     run<DetSetVector<TotemTimingDigi>>(event, es);
+
+  else if (subSystem == ssTotemT2)
+    run<DetSetVector<TotemT2Digi>>(event, es);
 }
 
 template <typename DigiType>

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -132,6 +132,10 @@ totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXM
 from EventFilter.CTPPSRawToDigi.totemTimingRawToDigi_cfi import totemTimingRawToDigi
 totemTimingRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 
+# ---------- Totem nT2 ----------
+from EventFilter.CTPPSRawToDigi.totemT2Digis_cfi import totemT2Digis
+totemT2Digis.rawDataTag = cms.InputTag("rawDataCollector")
+
 # ---------- pixels ----------
 from EventFilter.CTPPSRawToDigi.ctppsPixelDigis_cfi import ctppsPixelDigis
 ctppsPixelDigis.inputLabel = cms.InputTag("rawDataCollector")
@@ -148,7 +152,7 @@ ctppsRawToDigiTask = cms.Task(
   totemRPRawToDigi,
   ctppsDiamondRawToDigi,
   totemTimingRawToDigi,
-  totemT2RawToDigi,
+  totemT2Digis,
   ctppsPixelDigis
 )
 ctppsRawToDigi = cms.Sequence(ctppsRawToDigiTask)

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -1,9 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-# ---------- trigger data ----------
-from EventFilter.CTPPSRawToDigi.totemTriggerRawToDigi_cfi import totemTriggerRawToDigi
-totemTriggerRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
-
 # ---------- Si strips ----------
 totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSourceXML",
   verbosity = cms.untracked.uint32(0),
@@ -46,7 +42,7 @@ totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSource
       mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml"),
       maskFileNames = cms.vstring()
     )
-    
+
   )
 )
 
@@ -95,7 +91,7 @@ totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSource
       mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml"),
       maskFileNames = cms.vstring()
     )
-    
+
   )
 )
 
@@ -148,7 +144,6 @@ from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 
 # raw-to-digi task and sequence
 ctppsRawToDigiTask = cms.Task(
-  totemTriggerRawToDigi,
   totemRPRawToDigi,
   ctppsDiamondRawToDigi,
   totemTimingRawToDigi,

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -148,6 +148,7 @@ ctppsRawToDigiTask = cms.Task(
   totemRPRawToDigi,
   ctppsDiamondRawToDigi,
   totemTimingRawToDigi,
+  totemT2RawToDigi,
   ctppsPixelDigis
 )
 ctppsRawToDigi = cms.Sequence(ctppsRawToDigiTask)

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -129,6 +129,7 @@ from EventFilter.CTPPSRawToDigi.totemTimingRawToDigi_cfi import totemTimingRawTo
 totemTimingRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 
 # ---------- Totem nT2 ----------
+from CalibPPS.ESProducers.totemT2DAQMapping_cff import totemDAQMappingESSourceXML as totemDAQMappingESSourceXML_TotemT2
 from EventFilter.CTPPSRawToDigi.totemT2Digis_cfi import totemT2Digis
 totemT2Digis.rawDataTag = cms.InputTag("rawDataCollector")
 

--- a/EventFilter/CTPPSRawToDigi/python/totemT2Digis_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemT2Digis_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
+
+totemT2Digis = totemVFATRawToDigi.clone(
+    subSystem = cms.string('TotemT2'),
+    RawToDigi = totemVFATRawToDigi.RawToDigi.clone(
+        #testCRC = cms.uint32(0), # no need to test CRC for diamond frames
+        #testECMostFrequent = cms.uint32(0) # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
+    )
+)

--- a/EventFilter/CTPPSRawToDigi/python/totemT2Digis_cfi.py
+++ b/EventFilter/CTPPSRawToDigi/python/totemT2Digis_cfi.py
@@ -5,7 +5,7 @@ from EventFilter.CTPPSRawToDigi.totemVFATRawToDigi_cfi import totemVFATRawToDigi
 totemT2Digis = totemVFATRawToDigi.clone(
     subSystem = cms.string('TotemT2'),
     RawToDigi = totemVFATRawToDigi.RawToDigi.clone(
-        #testCRC = cms.uint32(0), # no need to test CRC for diamond frames
-        #testECMostFrequent = cms.uint32(0) # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
+        testCRC = cms.uint32(0), # no need to test CRC for diamond frames
+        testECMostFrequent = cms.uint32(0) # show error in the DQM and then DAQ is sending resync, no need to test in the unpacker
     )
 )

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -77,8 +77,6 @@ int RawDataUnpacker::processOptoRxFrame(const word *buf,
       optoRxId <= FEDNumbering::MAXTotemRPTimingVerticalFEDID) {
     processOptoRxFrameSampic(buf, frameSize, fedInfo, fc);
     return 0;
-  } else if (optoRxId >= FEDNumbering::MINTotemT2FEDID && optoRxId <= FEDNumbering::MAXTotemT2FEDID) {
-    throw cms::Exception("Totem") << "FIXME: NOT YET IMPLEMENTED!";
   }
 
   // parallel or serial transmission?

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -77,9 +77,7 @@ int RawDataUnpacker::processOptoRxFrame(const word *buf,
       optoRxId <= FEDNumbering::MAXTotemRPTimingVerticalFEDID) {
     processOptoRxFrameSampic(buf, frameSize, fedInfo, fc);
     return 0;
-  }
-  else if (optoRxId >= FEDNumbering::MINTotemT2FEDID &&
-           optoRxId <= FEDNumbering::MAXTotemT2FEDID) {
+  } else if (optoRxId >= FEDNumbering::MINTotemT2FEDID && optoRxId <= FEDNumbering::MAXTotemT2FEDID) {
     throw cms::Exception("Totem") << "FIXME: NOT YET IMPLEMENTED!";
   }
 

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -78,6 +78,10 @@ int RawDataUnpacker::processOptoRxFrame(const word *buf,
     processOptoRxFrameSampic(buf, frameSize, fedInfo, fc);
     return 0;
   }
+  else if (optoRxId >= FEDNumbering::MINTotemT2FEDID &&
+           optoRxId <= FEDNumbering::MAXTotemT2FEDID) {
+    throw cms::Exception("Totem") << "FIXME: NOT YET IMPLEMENTED!";
+  }
 
   // parallel or serial transmission?
   switch (fov) {

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -377,6 +377,14 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll,
   }
 }
 
+void RawToDigiConverter::run(const VFATFrameCollection& coll,
+                             const TotemDAQMapping& mapping,
+                             const TotemAnalysisMask& mask,
+                             edm::DetSetVector<TotemT2Digi>& digi,
+                             edm::DetSetVector<TotemVFATStatus>& status) {
+  //FIXME placeholder
+}
+
 void RawToDigiConverter::printSummaries() const {
   // print error summary
   if (printErrorSummary) {


### PR DESCRIPTION
#### PR description:

We introduce the unpacker and DIGI-level data format for the new TOTEM T2 telescope (or nT2) to operate in Autumn 2022 special pp and HI runs.
nT2 digis are reflecting the registers commonly used for detectors with timing capability: channel, GEOid, and channel status marker for the labelling, and leading+trailing edges measurements for the timing part.
Additionally, a new DetId object (derived from CTPPSDetId to avoid code duplication) is introduced for the mapping of all channels/tiles in each plane of both arms.

This new detector is assigned the FED ID 577, initially used along run 2 as a TOTEM trigger counter and since then unused. Therefore, it replaces this counter unpacking in the PPS standard sequence. For the purpose of the end of 2022 HI run a nT2-only sequence will be introduced in a follow-up PR including the DIGI-to-RecHit conversion (thanks to the addition and usage of the geometry CondFormat linking digis to spatial coordinates).

Finally, work is ongoing on the DQM component, and will also be the object of a follow-up PR.

#### PR validation:

A fake mapping of nT2 channels was introduced to redirect the PPS diamond detector (sharing a common VFAT frame payload) into the nT2 raw-to-digi unpacker. Although the diamond data format does not follow nT2's the bitwise readout of all frames was performed successfully following the data format implemented by TOTEM DAQ experts.
This mapping is left as an example, to be replaced with the actual one after the detector installation, and converted into a payload to be GT'ed.

Furthermore, the usual matrix tests passed flawlessly.