### PR TITLE
Add missing #include to EdmProvDump.cc

### DIFF
--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <memory>
 #include <map>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <vector>


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/38858 broke the `al8_amd64_gcc11` build by missing the `#include <optional>` (see [log](https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/el8_amd64_gcc11/CMSSW_12_5_X_2022-07-28-1100/IOPool/Common). This PR adds that.

Resolves https://github.com/cms-sw/cmssw/issues/38892

#### PR validation:

Code compiles on `el8_amd64_gcc11` architecture.