### PR TITLE
DQM for PFMETMHT paths with HF Filter

### DIFF
--- a/DQMOffline/Trigger/python/METMonitor_cff.py
+++ b/DQMOffline/Trigger/python/METMonitor_cff.py
@@ -86,6 +86,34 @@ PFMETNoMu140_PFMHTNoMu140_METmonitoring = hltMETmonitoring.clone(
     enableFullMonitoring = True,
     jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
 )
+# HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_FilterHF
+PFMETNoMu110_PFMHTNoMu110_FilterHF_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETNoMu110FilterHF',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_FilterHF_v*"]),
+    enableFullMonitoring = True,
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
+# HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_FilterHF
+PFMETNoMu120_PFMHTNoMu120_FilterHF_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETNoMu120FilterHF',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_FilterHF_v*"]),
+    enableFullMonitoring = True,
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
+# HLT_PFMETNoMu130_PFMHTNoMu130_IDTight_FilterHF
+PFMETNoMu130_PFMHTNoMu130_FilterHF_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETNoMu130FilterHF',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu130_PFMHTNoMu130_IDTight_FilterHF_v*"]),
+    enableFullMonitoring = True,
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
+# HLT_PFMETNoMu140_PFMHTNoMu140_IDTight_FilterHF
+PFMETNoMu140_PFMHTNoMu140_FilterHF_METmonitoring = hltMETmonitoring.clone(
+    FolderName = 'HLT/EXO/MET/PFMETNoMu140FilterHF',
+    numGenericTriggerEventPSet = dict(hltPaths = ["HLT_PFMETNoMu140_PFMHTNoMu140_IDTight_FilterHF_v*"]),
+    enableFullMonitoring = True,
+    jetSelection      = "pt > 100 && abs(eta) < 2.5 && neutralHadronEnergyFraction < 0.8 && chargedHadronEnergyFraction > 0.1"
+)
 # HLT_MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_IDTight
 MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_METmonitoring = hltMETmonitoring.clone(
     FolderName = 'HLT/EXO/MET/MonoCentralPFJet80_PFMETNoMu110/',
@@ -251,6 +279,10 @@ exoHLTMETmonitoring = cms.Sequence(
     + PFMETNoMu120_PFMHTNoMu120_METmonitoring
     + PFMETNoMu130_PFMHTNoMu130_METmonitoring
     + PFMETNoMu140_PFMHTNoMu140_METmonitoring
+    + PFMETNoMu110_PFMHTNoMu110_FilterHF_METmonitoring
+    + PFMETNoMu120_PFMHTNoMu120_FilterHF_METmonitoring
+    + PFMETNoMu130_PFMHTNoMu130_FilterHF_METmonitoring
+    + PFMETNoMu140_PFMHTNoMu140_FilterHF_METmonitoring
     + MonoCentralPFJet80_PFMETNoMu110_PFMHTNoMu110_METmonitoring
     + MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_METmonitoring
     + MonoCentralPFJet80_PFMETNoMu130_PFMHTNoMu130_METmonitoring


### PR DESCRIPTION
**PR description:**
This PR adds the monitoring of the four new MET+MHT paths with HF cleaning filters that were introduced into HLT menu V1.2 by EXO through this [JIRA ticket](https://its.cern.ch/jira/browse/CMSHLT-2282):
HLT_PFMETNoMu110_PFMHTNoMu110_IDTight_FilterHF_v1
HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_FilterHF_v1
HLT_PFMETNoMu130_PFMHTNoMu130_IDTight_FilterHF_v1
HLT_PFMETNoMu140_PFMHTNoMu140_IDTight_FilterHF_v1

**PR validation:**
Basic tests performed successfully starting from CMSSW_12_5_X_2022-07-28-2300/src:
scram b distclean
git cms-checkdeps -a -A
scram b -j 8
scram b runtests
scram build code-checks
scram build code-format
runTheMatrix.py -l limited -i all --ibeos

As well as a test in CMSSW_12_4_0 looking at 100 events from a specific TTbar sample, in which histograms were correctly produced and filled with events:
runTheMatrix.py -l 11634.0

If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport.
