### PR TITLE
Tracker Alignment: fix issues found by static analyzer

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/interface/PedeLabelerBase.h
@@ -55,12 +55,12 @@ public:
   /// uniqueId of Alignable, 0 if alignable not known
   /// between this ID and the next there is enough 'space' to add parameter
   /// numbers 0...nPar-1 to make unique IDs for the labels of active parameters
-  virtual unsigned int alignableLabel(Alignable *alignable) const = 0;
+  virtual unsigned int alignableLabel(const Alignable *alignable) const = 0;
   /// uniqueId of Alignable for a given parameter index and instance,
   /// 0 if alignable not known between this ID and the next there is enough
   /// 'space' to add parameter numbers 0...nPar-1 to make unique IDs for the
   /// labels of active parameters
-  virtual unsigned int alignableLabelFromParamAndInstance(Alignable *alignable,
+  virtual unsigned int alignableLabelFromParamAndInstance(const Alignable *alignable,
                                                           unsigned int param,
                                                           unsigned int instance) const = 0;
   virtual unsigned int lasBeamLabel(unsigned int lasBeamId) const = 0;
@@ -126,6 +126,13 @@ private:
 
   /// pairs of calibrations and their first label
   std::vector<std::pair<IntegratedCalibrationBase *, unsigned int> > theCalibrationLabels;
+};
+
+struct AlignableComparator {
+  using is_transparent = void;  // needs to be defined, actual type is not relevant
+  bool operator()(Alignable *a, Alignable *b) const { return a < b; }
+  bool operator()(Alignable *a, const Alignable *b) const { return a < b; }
+  bool operator()(const Alignable *a, Alignable *b) const { return a < b; }
 };
 
 #endif

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MomentumDependentPedeLabeler.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MomentumDependentPedeLabeler.cc
@@ -50,7 +50,7 @@ MomentumDependentPedeLabeler::~MomentumDependentPedeLabeler() {}
 
 //___________________________________________________________________________
 /// Return 32-bit unique label for alignable, 0 indicates failure.
-unsigned int MomentumDependentPedeLabeler::alignableLabel(Alignable *alignable) const {
+unsigned int MomentumDependentPedeLabeler::alignableLabel(const Alignable *alignable) const {
   if (!alignable)
     return 0;
 
@@ -70,7 +70,7 @@ unsigned int MomentumDependentPedeLabeler::alignableLabel(Alignable *alignable) 
 
 //___________________________________________________________________________
 // Return 32-bit unique label for alignable, 0 indicates failure.
-unsigned int MomentumDependentPedeLabeler::alignableLabelFromParamAndInstance(Alignable *alignable,
+unsigned int MomentumDependentPedeLabeler::alignableLabelFromParamAndInstance(const Alignable *alignable,
                                                                               unsigned int param,
                                                                               unsigned int instance) const {
   if (!alignable)

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/MomentumDependentPedeLabeler.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/MomentumDependentPedeLabeler.h
@@ -33,12 +33,12 @@ public:
   /// uniqueId of Alignable, 0 if alignable not known
   /// between this ID and the next there is enough 'space' to add parameter
   /// numbers 0...nPar-1 to make unique IDs for the labels of active parameters
-  unsigned int alignableLabel(Alignable *alignable) const override;
+  unsigned int alignableLabel(const Alignable *alignable) const override;
   /// uniqueId of Alignable for a given parameter index and instance,
   /// 0 if alignable not known between this ID and the next there is enough
   /// 'space' to add parameter numbers 0...nPar-1 to make unique IDs for the
   /// labels of active parameters
-  unsigned int alignableLabelFromParamAndInstance(Alignable *alignable,
+  unsigned int alignableLabelFromParamAndInstance(const Alignable *alignable,
                                                   unsigned int param,
                                                   unsigned int instance) const override;
   unsigned int lasBeamLabel(unsigned int lasBeamId) const override;
@@ -68,12 +68,12 @@ public:
   unsigned int lasBeamIdFromLabel(unsigned int label) const override;
 
 private:
-  typedef std::map<Alignable *, unsigned int> AlignableToIdMap;
+  typedef std::map<Alignable *, unsigned int, AlignableComparator> AlignableToIdMap;
   typedef AlignableToIdMap::value_type AlignableToIdPair;
   typedef std::pair<float, float> MomentumRange;
   typedef std::vector<MomentumRange> MomentumRangeVector;
   typedef std::map<unsigned int, MomentumRangeVector> MomentumRangeParamMap;
-  typedef std::map<Alignable *, MomentumRangeParamMap> AlignableToMomentumRangeMap;
+  typedef std::map<Alignable *, MomentumRangeParamMap, AlignableComparator> AlignableToMomentumRangeMap;
   typedef AlignableToMomentumRangeMap::value_type AlignableToMomentumRangePair;
   typedef std::map<unsigned int, Alignable *> IdToAlignableMap;
   typedef std::map<unsigned int, unsigned int> UintUintMap;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/PedeLabeler.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/PedeLabeler.cc
@@ -40,7 +40,7 @@ PedeLabeler::~PedeLabeler() {}
 
 //___________________________________________________________________________
 /// Return 32-bit unique label for alignable, 0 indicates failure.
-unsigned int PedeLabeler::alignableLabel(Alignable* alignable) const {
+unsigned int PedeLabeler::alignableLabel(const Alignable* alignable) const {
   if (!alignable)
     return 0;
 
@@ -60,7 +60,7 @@ unsigned int PedeLabeler::alignableLabel(Alignable* alignable) const {
 
 //___________________________________________________________________________
 // Return 32-bit unique label for alignable, 0 indicates failure.
-unsigned int PedeLabeler::alignableLabelFromParamAndInstance(Alignable* alignable,
+unsigned int PedeLabeler::alignableLabelFromParamAndInstance(const Alignable* alignable,
                                                              unsigned int /*param*/,
                                                              unsigned int /*instance*/) const {
   return this->alignableLabel(alignable);

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/PedeLabeler.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/PedeLabeler.h
@@ -33,8 +33,8 @@ public:
   /// uniqueId of Alignable, 0 if alignable not known
   /// between this ID and the next there is enough 'space' to add parameter
   /// numbers 0...nPar-1 to make unique IDs for the labels of active parameters
-  unsigned int alignableLabel(Alignable *alignable) const override;
-  unsigned int alignableLabelFromParamAndInstance(Alignable *alignable,
+  unsigned int alignableLabel(const Alignable *alignable) const override;
+  unsigned int alignableLabelFromParamAndInstance(const Alignable *alignable,
                                                   unsigned int param,
                                                   unsigned int instance) const override;
   unsigned int lasBeamLabel(unsigned int lasBeamId) const override;
@@ -61,7 +61,7 @@ public:
   unsigned int lasBeamIdFromLabel(unsigned int label) const override;
 
 private:
-  typedef std::map<Alignable *, unsigned int> AlignableToIdMap;
+  typedef std::map<Alignable *, unsigned int, AlignableComparator> AlignableToIdMap;
   typedef AlignableToIdMap::value_type AlignableToIdPair;
   typedef std::map<unsigned int, Alignable *> IdToAlignableMap;
   typedef std::map<unsigned int, unsigned int> UintUintMap;

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/RunRangeDependentPedeLabeler.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/RunRangeDependentPedeLabeler.cc
@@ -49,7 +49,7 @@ RunRangeDependentPedeLabeler::~RunRangeDependentPedeLabeler() {}
 
 //___________________________________________________________________________
 /// Return 32-bit unique label for alignable, 0 indicates failure.
-unsigned int RunRangeDependentPedeLabeler::alignableLabel(Alignable* alignable) const {
+unsigned int RunRangeDependentPedeLabeler::alignableLabel(const Alignable* alignable) const {
   if (!alignable)
     return 0;
 
@@ -69,7 +69,7 @@ unsigned int RunRangeDependentPedeLabeler::alignableLabel(Alignable* alignable) 
 
 //___________________________________________________________________________
 // Return 32-bit unique label for alignable, 0 indicates failure.
-unsigned int RunRangeDependentPedeLabeler::alignableLabelFromParamAndInstance(Alignable* alignable,
+unsigned int RunRangeDependentPedeLabeler::alignableLabelFromParamAndInstance(const Alignable* alignable,
                                                                               unsigned int param,
                                                                               unsigned int instance) const {
   if (!alignable)

--- a/Alignment/MillePedeAlignmentAlgorithm/plugins/RunRangeDependentPedeLabeler.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/plugins/RunRangeDependentPedeLabeler.h
@@ -39,12 +39,12 @@ public:
   /// uniqueId of Alignable, 0 if alignable not known
   /// between this ID and the next there is enough 'space' to add parameter
   /// numbers 0...nPar-1 to make unique IDs for the labels of active parameters
-  unsigned int alignableLabel(Alignable *alignable) const override;
+  unsigned int alignableLabel(const Alignable *alignable) const override;
   /// uniqueId of Alignable for a given parameter index and instance,
   /// 0 if alignable not known between this ID and the next there is enough
   /// 'space' to add parameter numbers 0...nPar-1 to make unique IDs for the
   /// labels of active parameters
-  unsigned int alignableLabelFromParamAndInstance(Alignable *alignable,
+  unsigned int alignableLabelFromParamAndInstance(const Alignable *alignable,
                                                   unsigned int param,
                                                   unsigned int instance) const override;
   unsigned int lasBeamLabel(unsigned int lasBeamId) const override;
@@ -75,11 +75,11 @@ public:
   const RunRange &runRangeFromLabel(unsigned int label) const override;
 
 private:
-  typedef std::map<Alignable *, unsigned int> AlignableToIdMap;
+  typedef std::map<Alignable *, unsigned int, AlignableComparator> AlignableToIdMap;
   typedef AlignableToIdMap::value_type AlignableToIdPair;
   typedef std::vector<RunRange> RunRangeVector;
   typedef std::map<unsigned int, RunRangeVector> RunRangeParamMap;
-  typedef std::map<Alignable *, RunRangeParamMap> AlignableToRunRangeRangeMap;
+  typedef std::map<Alignable *, RunRangeParamMap, AlignableComparator> AlignableToRunRangeRangeMap;
   typedef AlignableToRunRangeRangeMap::value_type AlignableToRunRangeRangePair;
   typedef std::map<unsigned int, Alignable *> IdToAlignableMap;
   typedef std::map<unsigned int, unsigned int> UintUintMap;

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeFileReader.cc
@@ -501,7 +501,6 @@ void MillePedeFileReader::initializeIndexHelper() {
   indexHelper[PclHLS::TPEPanelDisk2] = std::make_pair(currentSum, currentSum + pixelTopologyMap_->getPXFBlades(2));
   currentSum += pixelTopologyMap_->getPXFBlades(2) * 2;
   indexHelper[PclHLS::TPEPanelDisk3] = std::make_pair(currentSum, currentSum + pixelTopologyMap_->getPXFBlades(3));
-  currentSum += pixelTopologyMap_->getPXFBlades(3) * 2;
 }
 
 int MillePedeFileReader::getIndexForHG(align::ID id, PclHLS HLS) {

--- a/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/PedeSteererWeakModeConstraints.cc
@@ -533,8 +533,7 @@ unsigned int PedeSteererWeakModeConstraints::constructConstraints(const align::A
       for (std::list<Alignable*>::const_iterator iAlignables = iHLS.second.begin(); iAlignables != iHLS.second.end();
            iAlignables++) {
         const Alignable* ali = (*iAlignables);
-        const auto aliLabel =
-            myLabels_->alignableLabelFromParamAndInstance(const_cast<Alignable*>(ali), 0, it.instance_);
+        const auto aliLabel = myLabels_->alignableLabelFromParamAndInstance(ali, 0, it.instance_);
         const AlignableSurface& surface = ali->surface();
 
         const LocalPoint lUDirection(1., 0., 0.), lVDirection(0., 1., 0.), lWDirection(0., 0., 1.);


### PR DESCRIPTION
#### PR description:
In this PR two issues found by the static analyzer (https://github.com/cms-sw/cmssw/pull/38815#issuecomment-1191824021) are solved. In detail the following changes were made:

- In `MillePedeFileReader` a dead increment was removed from the `getIndexForHG` method.
- In `PedeLabeler` an explicit comparator class for `Alignable *` object was added to be used in `std::map`.
- In `PedeSteererWeakModeConstraints` the const cast was removed and the corresponding methods were adapted to deal with `const Alignable *`


#### PR validation:
The PR was validated using `runTheMatrix.py -l 1001.2` and `runTheMatrix.py -l 1001.2`
