### PR TITLE
ignore input file location characters in `IBooker::bookME` ME path check

### DIFF
--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -71,9 +71,15 @@ namespace dqm::implementation {
     MonitorElementData::Path path;
     std::string fullpath = cwd_ + std::string(name.View());
 
-    if (fullpath.find_first_not_of(s_safe) != std::string::npos) {
+    auto pathToCheck{fullpath};
+    std::string limiter{".root:/"};          // this indicates that all the substring before is a file name
+    size_t pos = pathToCheck.find(limiter);  //find location of limiter
+    //delete everything prior to location found as it might contain illegal chars
+    pathToCheck.erase(0, pos + limiter.size());
+
+    if (pathToCheck.find_first_not_of(s_safe) != std::string::npos) {
       throw cms::Exception("BadMonitorElementPathName")
-          << " Monitor element path name: '" << fullpath.c_str() << "' uses unacceptable characters."
+          << " Monitor element path name: '" << pathToCheck.c_str() << "' uses unacceptable characters."
           << "\n Acceptable characters are: " << s_safe.c_str();
     }
 


### PR DESCRIPTION
#### PR description:

This PR partially solves the issue https://github.com/cms-sw/cmssw/issues/38885, by letting the `IBooker::bookME` ME path checking code to ignore any sub-string containing a file name prior to the actual Monitor Element path in the ROOT file, as the leading characters are not useful to determine whether the `MonitorElement` path will have troubles indexing in the CMS Offline DQM GUI.

#### PR validation:

In this branch, added the package `DQM/SiStripMonitorClient` and run succesffuly the unit test:

```console
scram b runtests_testSiStripDQM_OfflineTkMap
```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A
