### PR TITLE
Migration of input collection parameters to untracked for CTPPS and DTMonitorModule

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSCommonDQMSource.cc
@@ -297,8 +297,10 @@ CTPPSCommonDQMSource::ArmPlots::ArmPlots(DQMStore::IBooker &ibooker, int _id, bo
 CTPPSCommonDQMSource::CTPPSCommonDQMSource(const edm::ParameterSet &ps)
     : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
       ctppsRecordToken(consumes<CTPPSRecord>(ps.getUntrackedParameter<edm::InputTag>("ctppsmetadata"))),
-      tokenLocalTrackLite(consumes<vector<CTPPSLocalTrackLite>>(ps.getParameter<edm::InputTag>("tagLocalTrackLite"))),
-      tokenRecoProtons(consumes<std::vector<reco::ForwardProton>>(ps.getParameter<InputTag>("tagRecoProtons"))),
+      tokenLocalTrackLite(
+          consumes<vector<CTPPSLocalTrackLite>>(ps.getUntrackedParameter<edm::InputTag>("tagLocalTrackLite"))),
+      tokenRecoProtons(
+          consumes<std::vector<reco::ForwardProton>>(ps.getUntrackedParameter<InputTag>("tagRecoProtons"))),
       makeProtonRecoPlots_(ps.getParameter<bool>("makeProtonRecoPlots")),
       perLSsaving_(ps.getUntrackedParameter<bool>("perLSsaving", false)) {
   currentLS = 0;

--- a/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSDiamondDQMSource.cc
@@ -587,12 +587,12 @@ CTPPSDiamondDQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker& ibooker, un
 
 CTPPSDiamondDQMSource::CTPPSDiamondDQMSource(const edm::ParameterSet& ps)
     : perLSsaving_(ps.getUntrackedParameter<bool>("perLSsaving", false)),
-      tokenPixelTrack_(
-          consumes<edm::DetSetVector<CTPPSPixelLocalTrack>>(ps.getParameter<edm::InputTag>("tagPixelLocalTracks"))),
-      tokenDiamondHit_(
-          consumes<edm::DetSetVector<CTPPSDiamondRecHit>>(ps.getParameter<edm::InputTag>("tagDiamondRecHits"))),
-      tokenDiamondTrack_(
-          consumes<edm::DetSetVector<CTPPSDiamondLocalTrack>>(ps.getParameter<edm::InputTag>("tagDiamondLocalTracks"))),
+      tokenPixelTrack_(consumes<edm::DetSetVector<CTPPSPixelLocalTrack>>(
+          ps.getUntrackedParameter<edm::InputTag>("tagPixelLocalTracks"))),
+      tokenDiamondHit_(consumes<edm::DetSetVector<CTPPSDiamondRecHit>>(
+          ps.getUntrackedParameter<edm::InputTag>("tagDiamondRecHits"))),
+      tokenDiamondTrack_(consumes<edm::DetSetVector<CTPPSDiamondLocalTrack>>(
+          ps.getUntrackedParameter<edm::InputTag>("tagDiamondLocalTracks"))),
       ctppsGeometryRunToken_(esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord, edm::Transition::BeginRun>()),
       ctppsGeometryEventToken_(esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord>()),
       // ctppsLhcInfoToken_(esConsumes<LHCInfo, LHCInfoRcd>()),
@@ -607,9 +607,9 @@ CTPPSDiamondDQMSource::CTPPSDiamondDQMSource(const edm::ParameterSet& ps)
       EC_difference_56_(-500),
       EC_difference_45_(-500) {
   if (extract_digi_info_) {
-    tokenStatus_ = consumes<edm::DetSetVector<TotemVFATStatus>>(ps.getParameter<edm::InputTag>("tagStatus"));
-    tokenFEDInfo_ = consumes<std::vector<TotemFEDInfo>>(ps.getParameter<edm::InputTag>("tagFEDInfo"));
-    tokenDigi_ = consumes<edm::DetSetVector<CTPPSDiamondDigi>>(ps.getParameter<edm::InputTag>("tagDigi"));
+    tokenStatus_ = consumes<edm::DetSetVector<TotemVFATStatus>>(ps.getUntrackedParameter<edm::InputTag>("tagStatus"));
+    tokenFEDInfo_ = consumes<std::vector<TotemFEDInfo>>(ps.getUntrackedParameter<edm::InputTag>("tagFEDInfo"));
+    tokenDigi_ = consumes<edm::DetSetVector<CTPPSDiamondDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagDigi"));
   }
   for (const auto& pset : ps.getParameter<std::vector<edm::ParameterSet>>("offsetsOOT")) {
     runParameters_.emplace_back(

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -164,9 +164,9 @@ using namespace edm;
 CTPPSPixelDQMSource::CTPPSPixelDQMSource(const edm::ParameterSet &ps)
     : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),
       rpStatusWord(ps.getUntrackedParameter<unsigned int>("RPStatusWord", 0x8008)) {
-  tokenDigi = consumes<DetSetVector<CTPPSPixelDigi>>(ps.getParameter<edm::InputTag>("tagRPixDigi"));
-  tokenCluster = consumes<DetSetVector<CTPPSPixelCluster>>(ps.getParameter<edm::InputTag>("tagRPixCluster"));
-  tokenTrack = consumes<DetSetVector<CTPPSPixelLocalTrack>>(ps.getParameter<edm::InputTag>("tagRPixLTrack"));
+  tokenDigi = consumes<DetSetVector<CTPPSPixelDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixDigi"));
+  tokenCluster = consumes<DetSetVector<CTPPSPixelCluster>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixCluster"));
+  tokenTrack = consumes<DetSetVector<CTPPSPixelLocalTrack>>(ps.getUntrackedParameter<edm::InputTag>("tagRPixLTrack"));
   offlinePlots = ps.getUntrackedParameter<bool>("offlinePlots", true);
   onlinePlots = ps.getUntrackedParameter<bool>("onlinePlots", true);
 

--- a/DQM/CTPPS/plugins/DiamondSampicCalibrationDQMSource.cc
+++ b/DQM/CTPPS/plugins/DiamondSampicCalibrationDQMSource.cc
@@ -174,8 +174,9 @@ DiamondSampicCalibrationDQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker 
 
 DiamondSampicCalibrationDQMSource::DiamondSampicCalibrationDQMSource(const edm::ParameterSet &ps)
     : totemTimingDigiToken_(
-          consumes<edm::DetSetVector<TotemTimingDigi>>(ps.getParameter<edm::InputTag>("totemTimingDigiTag"))),
-      tokenRecHit_(consumes<edm::DetSetVector<TotemTimingRecHit>>(ps.getParameter<edm::InputTag>("tagRecHits"))),
+          consumes<edm::DetSetVector<TotemTimingDigi>>(ps.getUntrackedParameter<edm::InputTag>("totemTimingDigiTag"))),
+      tokenRecHit_(
+          consumes<edm::DetSetVector<TotemTimingRecHit>>(ps.getUntrackedParameter<edm::InputTag>("tagRecHits"))),
       timingCalibrationToken_(esConsumes<edm::Transition::BeginRun>()),
       geomEsToken_(esConsumes<edm::Transition::BeginRun>()),
       verbosity_(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),

--- a/DQM/CTPPS/plugins/DiamondSampicDQMSource.cc
+++ b/DQM/CTPPS/plugins/DiamondSampicDQMSource.cc
@@ -381,11 +381,14 @@ DiamondSampicDQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker &ibooker, u
 //----------------------------------------------------------------------------------------------------
 
 DiamondSampicDQMSource::DiamondSampicDQMSource(const edm::ParameterSet &ps)
-    : tokenLocalTrack_(consumes<edm::DetSetVector<TotemRPLocalTrack>>(ps.getParameter<edm::InputTag>("tagLocalTrack"))),
-      tokenDigi_(consumes<edm::DetSetVector<TotemTimingDigi>>(ps.getParameter<edm::InputTag>("tagDigi"))),
-      tokenRecHit_(consumes<edm::DetSetVector<TotemTimingRecHit>>(ps.getParameter<edm::InputTag>("tagRecHits"))),
-      tokenTrack_(consumes<edm::DetSetVector<TotemTimingLocalTrack>>(ps.getParameter<edm::InputTag>("tagTracks"))),
-      tokenFEDInfo_(consumes<std::vector<TotemFEDInfo>>(ps.getParameter<edm::InputTag>("tagFEDInfo"))),
+    : tokenLocalTrack_(
+          consumes<edm::DetSetVector<TotemRPLocalTrack>>(ps.getUntrackedParameter<edm::InputTag>("tagLocalTrack"))),
+      tokenDigi_(consumes<edm::DetSetVector<TotemTimingDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagDigi"))),
+      tokenRecHit_(
+          consumes<edm::DetSetVector<TotemTimingRecHit>>(ps.getUntrackedParameter<edm::InputTag>("tagRecHits"))),
+      tokenTrack_(
+          consumes<edm::DetSetVector<TotemTimingLocalTrack>>(ps.getUntrackedParameter<edm::InputTag>("tagTracks"))),
+      tokenFEDInfo_(consumes<std::vector<TotemFEDInfo>>(ps.getUntrackedParameter<edm::InputTag>("tagFEDInfo"))),
       ctppsGeometryRunToken_(esConsumes<CTPPSGeometry, VeryForwardRealGeometryRecord, edm::Transition::BeginRun>()),
       samplesForNoise_(ps.getUntrackedParameter<unsigned int>("samplesForNoise", 5)),
       verbosity_(ps.getUntrackedParameter<unsigned int>("verbosity", 0)),

--- a/DQM/CTPPS/plugins/ElasticPlotDQMSource.cc
+++ b/DQM/CTPPS/plugins/ElasticPlotDQMSource.cc
@@ -185,9 +185,9 @@ ElasticPlotDQMSource::PotPlots::PotPlots(DQMStore::IBooker &ibooker, unsigned in
 
 ElasticPlotDQMSource::ElasticPlotDQMSource(const edm::ParameterSet &ps)
     : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)) {
-  tokenRecHit = consumes<edm::DetSetVector<TotemRPRecHit>>(ps.getParameter<edm::InputTag>("tagRecHit"));
-  tokenUVPattern = consumes<DetSetVector<TotemRPUVPattern>>(ps.getParameter<edm::InputTag>("tagUVPattern"));
-  tokenLocalTrack = consumes<DetSetVector<TotemRPLocalTrack>>(ps.getParameter<edm::InputTag>("tagLocalTrack"));
+  tokenRecHit = consumes<edm::DetSetVector<TotemRPRecHit>>(ps.getUntrackedParameter<edm::InputTag>("tagRecHit"));
+  tokenUVPattern = consumes<DetSetVector<TotemRPUVPattern>>(ps.getUntrackedParameter<edm::InputTag>("tagUVPattern"));
+  tokenLocalTrack = consumes<DetSetVector<TotemRPLocalTrack>>(ps.getUntrackedParameter<edm::InputTag>("tagLocalTrack"));
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/TotemDAQTriggerDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemDAQTriggerDQMSource.cc
@@ -52,7 +52,7 @@ using namespace edm;
 
 TotemDAQTriggerDQMSource::TotemDAQTriggerDQMSource(const edm::ParameterSet &ps)
     : verbosity(ps.getUntrackedParameter<unsigned int>("verbosity", 0)) {
-  tokenFEDInfo = consumes<vector<TotemFEDInfo>>(ps.getParameter<edm::InputTag>("tagFEDInfo"));
+  tokenFEDInfo = consumes<vector<TotemFEDInfo>>(ps.getUntrackedParameter<edm::InputTag>("tagFEDInfo"));
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/TotemRPDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemRPDQMSource.cc
@@ -182,13 +182,13 @@ TotemRPDQMSource::TotemRPDQMSource(const edm::ParameterSet &ps)
       geometryToken_(esConsumes())
 
 {
-  tokenStatus = consumes<DetSetVector<TotemVFATStatus>>(ps.getParameter<edm::InputTag>("tagStatus"));
+  tokenStatus = consumes<DetSetVector<TotemVFATStatus>>(ps.getUntrackedParameter<edm::InputTag>("tagStatus"));
 
-  tokenDigi = consumes<DetSetVector<TotemRPDigi>>(ps.getParameter<edm::InputTag>("tagDigi"));
-  tokenCluster = consumes<edm::DetSetVector<TotemRPCluster>>(ps.getParameter<edm::InputTag>("tagCluster"));
-  tokenRecHit = consumes<edm::DetSetVector<TotemRPRecHit>>(ps.getParameter<edm::InputTag>("tagRecHit"));
-  tokenUVPattern = consumes<DetSetVector<TotemRPUVPattern>>(ps.getParameter<edm::InputTag>("tagUVPattern"));
-  tokenLocalTrack = consumes<DetSetVector<TotemRPLocalTrack>>(ps.getParameter<edm::InputTag>("tagLocalTrack"));
+  tokenDigi = consumes<DetSetVector<TotemRPDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagDigi"));
+  tokenCluster = consumes<edm::DetSetVector<TotemRPCluster>>(ps.getUntrackedParameter<edm::InputTag>("tagCluster"));
+  tokenRecHit = consumes<edm::DetSetVector<TotemRPRecHit>>(ps.getUntrackedParameter<edm::InputTag>("tagRecHit"));
+  tokenUVPattern = consumes<DetSetVector<TotemRPUVPattern>>(ps.getUntrackedParameter<edm::InputTag>("tagUVPattern"));
+  tokenLocalTrack = consumes<DetSetVector<TotemRPLocalTrack>>(ps.getUntrackedParameter<edm::InputTag>("tagLocalTrack"));
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
+++ b/DQM/CTPPS/plugins/TotemTimingDQMSource.cc
@@ -404,12 +404,14 @@ TotemTimingDQMSource::ChannelPlots::ChannelPlots(DQMStore::IBooker &ibooker, uns
 //----------------------------------------------------------------------------------------------------
 
 TotemTimingDQMSource::TotemTimingDQMSource(const edm::ParameterSet &ps)
-    : tokenLocalTrack_(consumes<edm::DetSetVector<TotemRPLocalTrack>>(ps.getParameter<edm::InputTag>("tagLocalTrack"))),
-      tokenDigi_(consumes<edm::DetSetVector<TotemTimingDigi>>(ps.getParameter<edm::InputTag>("tagDigi"))),
-      tokenRecHit_(consumes<edm::DetSetVector<TotemTimingRecHit>>(ps.getParameter<edm::InputTag>("tagRecHits"))),
+    : tokenLocalTrack_(
+          consumes<edm::DetSetVector<TotemRPLocalTrack>>(ps.getUntrackedParameter<edm::InputTag>("tagLocalTrack"))),
+      tokenDigi_(consumes<edm::DetSetVector<TotemTimingDigi>>(ps.getUntrackedParameter<edm::InputTag>("tagDigi"))),
+      tokenRecHit_(
+          consumes<edm::DetSetVector<TotemTimingRecHit>>(ps.getUntrackedParameter<edm::InputTag>("tagRecHits"))),
       // tokenTrack_(consumes<edm::DetSetVector<TotemTimingLocalTrack>>(
       //     ps.getParameter<edm::InputTag>("tagLocalTracks"))),
-      tokenFEDInfo_(consumes<std::vector<TotemFEDInfo>>(ps.getParameter<edm::InputTag>("tagFEDInfo"))),
+      tokenFEDInfo_(consumes<std::vector<TotemFEDInfo>>(ps.getUntrackedParameter<edm::InputTag>("tagFEDInfo"))),
       geometryToken_(esConsumes()),
       geometryTokenBeginRun_(esConsumes<edm::Transition::BeginRun>()),
       minimumStripAngleForTomography_(ps.getParameter<double>("minimumStripAngleForTomography")),

--- a/DQM/CTPPS/python/ctppsCommonDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsCommonDQMSource_cfi.py
@@ -4,8 +4,8 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 
 ctppsCommonDQMSource = DQMEDAnalyzer('CTPPSCommonDQMSource',
     ctppsmetadata = cms.untracked.InputTag("onlineMetaDataDigis"),
-    tagLocalTrackLite = cms.InputTag('ctppsLocalTrackLiteProducer'),
-    tagRecoProtons = cms.InputTag("ctppsProtons", "multiRP"),
+    tagLocalTrackLite = cms.untracked.InputTag('ctppsLocalTrackLiteProducer'),
+    tagRecoProtons = cms.untracked.InputTag("ctppsProtons", "multiRP"),
 
     makeProtonRecoPlots = cms.bool(True),
 

--- a/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsDiamondDQMSource_cfi.py
@@ -2,12 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 ctppsDiamondDQMSource = DQMEDAnalyzer('CTPPSDiamondDQMSource',
-    tagStatus = cms.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
-    tagDigi = cms.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
-    tagFEDInfo = cms.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
-    tagDiamondRecHits = cms.InputTag("ctppsDiamondRecHits"),
-    tagDiamondLocalTracks = cms.InputTag("ctppsDiamondLocalTracks"),
-    tagPixelLocalTracks = cms.InputTag("ctppsPixelLocalTracks"),
+    tagStatus = cms.untracked.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
+    tagDigi = cms.untracked.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
+    tagFEDInfo = cms.untracked.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
+    tagDiamondRecHits = cms.untracked.InputTag("ctppsDiamondRecHits"),
+    tagDiamondLocalTracks = cms.untracked.InputTag("ctppsDiamondLocalTracks"),
+    tagPixelLocalTracks = cms.untracked.InputTag("ctppsPixelLocalTracks"),
 
     excludeMultipleHits = cms.bool(True),
     extractDigiInfo = cms.bool(True),
@@ -45,12 +45,12 @@ ctppsDiamondDQMSource = DQMEDAnalyzer('CTPPSDiamondDQMSource',
 )
 
 ctppsDiamondDQMOfflineSource = DQMEDAnalyzer('CTPPSDiamondDQMSource',
-    tagStatus = cms.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
-    tagDigi = cms.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
-    tagFEDInfo = cms.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
-    tagDiamondRecHits = cms.InputTag("ctppsDiamondRecHits"),
-    tagDiamondLocalTracks = cms.InputTag("ctppsDiamondLocalTracks"),
-    tagPixelLocalTracks = cms.InputTag("ctppsPixelLocalTracks"),
+    tagStatus = cms.untracked.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
+    tagDigi = cms.untracked.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
+    tagFEDInfo = cms.untracked.InputTag("ctppsDiamondRawToDigi", "TimingDiamond"),
+    tagDiamondRecHits = cms.untracked.InputTag("ctppsDiamondRecHits"),
+    tagDiamondLocalTracks = cms.untracked.InputTag("ctppsDiamondLocalTracks"),
+    tagPixelLocalTracks = cms.untracked.InputTag("ctppsPixelLocalTracks"),
 
     excludeMultipleHits = cms.bool(True),
     extractDigiInfo = cms.bool(True),

--- a/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
+++ b/DQM/CTPPS/python/ctppsPixelDQMSource_cfi.py
@@ -3,9 +3,9 @@ import FWCore.ParameterSet.Config as cms
 #ctppsPixelDQMSource = cms.EDAnalyzer("CTPPSPixelDQMSource",
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 ctppsPixelDQMSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
-    tagRPixDigi = cms.InputTag("ctppsPixelDigis", ""),
-    tagRPixCluster = cms.InputTag("ctppsPixelClusters", ""),  
-    tagRPixLTrack = cms.InputTag("ctppsPixelLocalTracks", ""),  
+    tagRPixDigi = cms.untracked.InputTag("ctppsPixelDigis", ""),
+    tagRPixCluster = cms.untracked.InputTag("ctppsPixelClusters", ""),  
+    tagRPixLTrack = cms.untracked.InputTag("ctppsPixelLocalTracks", ""),  
     RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout:220_fr_hr; 210_fr_hr
     verbosity = cms.untracked.uint32(0),
     offlinePlots = cms.untracked.bool(False),
@@ -15,9 +15,9 @@ ctppsPixelDQMSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
 )
 
 ctppsPixelDQMOfflineSource = DQMEDAnalyzer('CTPPSPixelDQMSource',
-    tagRPixDigi = cms.InputTag("ctppsPixelDigis", ""),
-    tagRPixCluster = cms.InputTag("ctppsPixelClusters", ""),  
-    tagRPixLTrack = cms.InputTag("ctppsPixelLocalTracks", ""),  
+    tagRPixDigi = cms.untracked.InputTag("ctppsPixelDigis", ""),
+    tagRPixCluster = cms.untracked.InputTag("ctppsPixelClusters", ""),  
+    tagRPixLTrack = cms.untracked.InputTag("ctppsPixelLocalTracks", ""),  
     RPStatusWord = cms.untracked.uint32(0x8008), # rpots in readout: 220_fr_hr; 210_fr_hr
     verbosity = cms.untracked.uint32(0),
     offlinePlots = cms.untracked.bool(True),

--- a/DQM/CTPPS/python/diamondSampicDQMSource_cfi.py
+++ b/DQM/CTPPS/python/diamondSampicDQMSource_cfi.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 diamondSampicDQMSourceOnline = DQMEDAnalyzer('DiamondSampicDQMSource',
-    tagDigi = cms.InputTag("totemTimingRawToDigi", "TotemTiming"),
-    tagFEDInfo = cms.InputTag("totemTimingRawToDigi", "TotemTiming"),
-    tagRecHits = cms.InputTag("totemTimingRecHits"),
-    tagTracks = cms.InputTag("diamondSampicLocalTracks"),
-    tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
+    tagDigi = cms.untracked.InputTag("totemTimingRawToDigi", "TotemTiming"),
+    tagFEDInfo = cms.untracked.InputTag("totemTimingRawToDigi", "TotemTiming"),
+    tagRecHits = cms.untracked.InputTag("totemTimingRecHits"),
+    tagTracks = cms.untracked.InputTag("diamondSampicLocalTracks"),
+    tagLocalTrack = cms.untracked.InputTag("totemRPLocalTrackFitter"),
 
     samplesForNoise = cms.untracked.uint32(6),
 
@@ -15,11 +15,11 @@ diamondSampicDQMSourceOnline = DQMEDAnalyzer('DiamondSampicDQMSource',
 )
 
 diamondSampicDQMSourceOffline = DQMEDAnalyzer('DiamondSampicDQMSource',
-    tagDigi = cms.InputTag("totemTimingRawToDigi", "TotemTiming"),
-    tagFEDInfo = cms.InputTag("totemTimingRawToDigi", "TotemTiming"),
-    tagRecHits = cms.InputTag("totemTimingRecHits"),
-    tagTracks = cms.InputTag("diamondSampicLocalTracks"),
-    tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
+    tagDigi = cms.untracked.InputTag("totemTimingRawToDigi", "TotemTiming"),
+    tagFEDInfo = cms.untracked.InputTag("totemTimingRawToDigi", "TotemTiming"),
+    tagRecHits = cms.untracked.InputTag("totemTimingRecHits"),
+    tagTracks = cms.untracked.InputTag("diamondSampicLocalTracks"),
+    tagLocalTrack = cms.untracked.InputTag("totemRPLocalTrackFitter"),
 
     samplesForNoise = cms.untracked.uint32(6),
 

--- a/DQM/CTPPS/python/elasticPlotDQMSource_cfi.py
+++ b/DQM/CTPPS/python/elasticPlotDQMSource_cfi.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 elasticPlotDQMSource = DQMEDAnalyzer("ElasticPlotDQMSource",
-    tagRecHit = cms.InputTag("totemRPRecHitProducer"),
-    tagUVPattern = cms.InputTag("totemRPUVPatternFinder"),
-    tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
+    tagRecHit = cms.untracked.InputTag("totemRPRecHitProducer"),
+    tagUVPattern = cms.untracked.InputTag("totemRPUVPatternFinder"),
+    tagLocalTrack = cms.untracked.InputTag("totemRPLocalTrackFitter"),
   
     verbosity = cms.untracked.uint32(0),
 )

--- a/DQM/CTPPS/python/totemDAQTriggerDQMSource_cfi.py
+++ b/DQM/CTPPS/python/totemDAQTriggerDQMSource_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 totemDAQTriggerDQMSource = DQMEDAnalyzer('TotemDAQTriggerDQMSource',
-  tagFEDInfo = cms.InputTag("totemRPRawToDigi", "TrackingStrip"),
+  tagFEDInfo = cms.untracked.InputTag("totemRPRawToDigi", "TrackingStrip"),
   tagTriggerCounters = cms.InputTag("totemTriggerRawToDigi"),
 
   verbosity = cms.untracked.uint32(0)

--- a/DQM/CTPPS/python/totemRPDQMSource_cfi.py
+++ b/DQM/CTPPS/python/totemRPDQMSource_cfi.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 totemRPDQMSource = DQMEDAnalyzer('TotemRPDQMSource',
     tagStatus = cms.InputTag("totemRPRawToDigi", "TrackingStrip"),
-    tagDigi = cms.InputTag("totemRPRawToDigi", "TrackingStrip"),
-    tagCluster = cms.InputTag("totemRPClusterProducer"),
-    tagRecHit = cms.InputTag("totemRPRecHitProducer"),
-    tagUVPattern = cms.InputTag("totemRPUVPatternFinder"),
-    tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
+    tagDigi = cms.untracked.InputTag("totemRPRawToDigi", "TrackingStrip"),
+    tagCluster = cms.untracked.InputTag("totemRPClusterProducer"),
+    tagRecHit = cms.untracked.InputTag("totemRPRecHitProducer"),
+    tagUVPattern = cms.untracked.InputTag("totemRPUVPatternFinder"),
+    tagLocalTrack = cms.untracked.InputTag("totemRPLocalTrackFitter"),
   
     verbosity = cms.untracked.uint32(0),
 )

--- a/DQM/CTPPS/python/totemTimingDQMSource_cfi.py
+++ b/DQM/CTPPS/python/totemTimingDQMSource_cfi.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 totemTimingDQMSource = DQMEDAnalyzer('TotemTimingDQMSource',
-    tagDigi = cms.InputTag("totemTimingRawToDigi", "TotemTiming"),
-    tagFEDInfo = cms.InputTag("totemTimingRawToDigi", "TotemTiming"),
-    tagRecHits = cms.InputTag("totemTimingRecHits"),
-    # tagTracks = cms.InputTag("totemTimingLocalTracks"),
-    tagLocalTrack = cms.InputTag("totemRPLocalTrackFitter"),
+    tagDigi = cms.untracked.InputTag("totemTimingRawToDigi", "TotemTiming"),
+    tagFEDInfo = cms.untracked.InputTag("totemTimingRawToDigi", "TotemTiming"),
+    tagRecHits = cms.untracked.InputTag("totemTimingRecHits"),
+    # tagTracks = cms.untracked.InputTag("totemTimingLocalTracks"),
+    tagLocalTrack = cms.untracked.InputTag("totemRPLocalTrackFitter"),
 
     minimumStripAngleForTomography = cms.double(0),
     maximumStripAngleForTomography = cms.double(1),

--- a/DQM/DTMonitorModule/python/dtChamberEfficiencyHI_cfi.py
+++ b/DQM/DTMonitorModule/python/dtChamberEfficiencyHI_cfi.py
@@ -6,14 +6,14 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 dtEfficiencyMonitor = DQMEDAnalyzer('DTChamberEfficiency',
     MuonServiceProxy,
     debug = cms.untracked.bool(True),
-    TrackCollection = cms.InputTag('standAloneMuons'),     
+    TrackCollection = cms.untracked.InputTag('standAloneMuons'),     
     theMaxChi2 = cms.double(1000.),
     theNSigma = cms.double(3.),
     theMinNrec = cms.double(5.),
-    dt4DSegments = cms.InputTag('dt4DSegments'),
-    theRPCRecHits = cms.InputTag('dummy'),
+    dt4DSegments = cms.untracked.InputTag('dt4DSegments'),
+    theRPCRecHits = cms.untracked.InputTag('dummy'),
     thegemRecHits = cms.InputTag('dummy'),
-    cscSegments = cms.InputTag('dummy'),
+    cscSegments = cms.untracked.InputTag('dummy'),
     RPCLayers = cms.bool(False),
     NavigationType = cms.string('Standard')
 )

--- a/DQM/DTMonitorModule/python/dtChamberEfficiencyTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtChamberEfficiencyTask_cfi.py
@@ -7,7 +7,7 @@ dtChamberEfficiencyMonitor = DQMEDAnalyzer('DTChamberEfficiencyTask',
     # parameter for check on extrapolated check
     minCloseDist = cms.double(20.0),
     # labels of 4D segments
-    recHits4DLabel = cms.string('dt4DSegments'),
+    recHits4DLabel = cms.untracked.string('dt4DSegments'),
     # switch for verbosity
     debug = cms.untracked.bool(False),
     minChi2NormSegment = cms.double(20.0),

--- a/DQM/DTMonitorModule/python/dtChamberEfficiency_Cosmics_cfi.py
+++ b/DQM/DTMonitorModule/python/dtChamberEfficiency_Cosmics_cfi.py
@@ -6,13 +6,13 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 dtEfficiencyMonitor = DQMEDAnalyzer('DTChamberEfficiency',
     MuonServiceProxy,
     debug = cms.untracked.bool(True),
-    TrackCollection = cms.InputTag('cosmicMuons'),                                 
+    TrackCollection = cms.untracked.InputTag('cosmicMuons'),                                 
     theMaxChi2 = cms.double(100.),
     theNSigma = cms.double(3.),
     theMinNrec = cms.double(20.),
-    dt4DSegments = cms.InputTag('dt4DSegments'),
-    theRPCRecHits = cms.InputTag('dummy'),
-    cscSegments = cms.InputTag('dummy'),
+    dt4DSegments = cms.untracked.InputTag('dt4DSegments'),
+    theRPCRecHits = cms.untracked.InputTag('dummy'),
+    cscSegments = cms.untracked.InputTag('dummy'),
     RPCLayers = cms.bool(False),
     NavigationType = cms.string('Direct')
 )

--- a/DQM/DTMonitorModule/python/dtChamberEfficiency_cfi.py
+++ b/DQM/DTMonitorModule/python/dtChamberEfficiency_cfi.py
@@ -6,13 +6,13 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 dtEfficiencyMonitor = DQMEDAnalyzer('DTChamberEfficiency',
     MuonServiceProxy,
     debug = cms.untracked.bool(True),
-    TrackCollection = cms.InputTag("standAloneMuons"),
+    TrackCollection = cms.untracked.InputTag("standAloneMuons"),
     theMaxChi2 = cms.double(1000.),
     theNSigma = cms.double(3.),
     theMinNrec = cms.double(3.),
-    dt4DSegments = cms.InputTag('dt4DSegments'),
-    theRPCRecHits = cms.InputTag('dummy'),
-    cscSegments = cms.InputTag('dummy'),
+    dt4DSegments = cms.untracked.InputTag('dt4DSegments'),
+    theRPCRecHits = cms.untracked.InputTag('dummy'),
+    cscSegments = cms.untracked.InputTag('dummy'),
     RPCLayers = cms.bool(False),
     NavigationType = cms.string('Standard')
 )

--- a/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDataIntegrityTask_cfi.py
@@ -5,21 +5,21 @@ dtDataIntegrityTask = DQMEDAnalyzer('DTDataIntegrityTask',
                                      fedIntegrityFolder = cms.untracked.string('DT/FEDIntegrity'),
                                      nLinksForFatal     = cms.untracked.int32(15),
                                      processingMode     = cms.untracked.string('Online'),
-				     dtFEDlabel         =  cms.InputTag('dtDataIntegrityUnpacker')
+				     dtFEDlabel         =  cms.untracked.InputTag('dtDataIntegrityUnpacker')
 )
 
 dtDataIntegrityTaskOffline = DQMEDAnalyzer('DTDataIntegrityROSOffline',
                                      getSCInfo = cms.untracked.bool(True),
                                      fedIntegrityFolder = cms.untracked.string('DT/FEDIntegrity'),
-                                     dtDDULabel         = cms.InputTag('dtDataIntegrityUnpacker'),
-                                     dtROS25Label       = cms.InputTag('dtDataIntegrityUnpacker'),
+                                     dtDDULabel         = cms.untracked.InputTag('dtDataIntegrityUnpacker'),
+                                     dtROS25Label       = cms.untracked.InputTag('dtDataIntegrityUnpacker'),
 )
 
 dtDataIntegrityUrosOffline = DQMEDAnalyzer('DTDataIntegrityTask',
                                      fedIntegrityFolder = cms.untracked.string('DT/FEDIntegrity'),
                                      nLinksForFatal     = cms.untracked.int32(15),
                                      processingMode     = cms.untracked.string('Offline'),
-                                     dtFEDlabel         =  cms.InputTag('dtDataIntegrityUnpacker')
+                                     dtFEDlabel         =  cms.untracked.InputTag('dtDataIntegrityUnpacker')
 )
 
 from Configuration.Eras.Modifier_run2_DT_2018_cff import run2_DT_2018

--- a/DQM/DTMonitorModule/python/dtDigiTask_TP_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDigiTask_TP_cfi.py
@@ -11,7 +11,7 @@ dtTPmonitor = DQMEDAnalyzer('DTDigiTask',
     # Value of the ttrig pedestal used when not reading from DB
     defaultTtrig = cms.int32(3450),
     # the label to retrieve the DT digis
-    dtDigiLabel = cms.InputTag('dtunpacker'),
+    dtDigiLabel = cms.untracked.InputTag('dtunpacker'),
     # check the noisy flag in the DB and use it
     checkNoisyChannels = cms.untracked.bool(True),
     # set static booking (all the detector)

--- a/DQM/DTMonitorModule/python/dtDigiTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtDigiTask_cfi.py
@@ -11,7 +11,7 @@ dtDigiMonitor = DQMEDAnalyzer('DTDigiTask',
     # Value of the ttrig pedestal used when not reading from DB
     defaultTtrig = cms.int32(2700),
     # the label to retrieve the DT digis
-    dtDigiLabel = cms.InputTag('dtunpacker'),
+    dtDigiLabel = cms.untracked.InputTag('dtunpacker'),
     # check the noisy flag in the DB and use it
     checkNoisyChannels = cms.untracked.bool(True),
     # set static booking (all the detector)

--- a/DQM/DTMonitorModule/python/dtEfficiencyTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtEfficiencyTask_cfi.py
@@ -5,8 +5,8 @@ dtEfficiencyMonitor = DQMEDAnalyzer('DTEfficiencyTask',
     # switch for verbosity
     debug = cms.untracked.bool(False),
     # labels of 4D and 1D hits
-    recHits4DLabel = cms.string('dt4DSegments'),
-    recHitLabel = cms.string('dt1DRecHits'),
+    recHits4DLabel = cms.untracked.string('dt4DSegments'),
+    recHitLabel = cms.untracked.string('dt1DRecHits'),
     # interval of lumi block after which we reset the histos
     ResetCycle = cms.untracked.int32(10000)
 )

--- a/DQM/DTMonitorModule/python/dtNoiseTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtNoiseTask_cfi.py
@@ -4,11 +4,11 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 dtNoiseMonitor = DQMEDAnalyzer('DTNoiseTask',
                                 # the label to retrieve the DT digis
-                                dtDigiLabel = cms.InputTag('dtunpacker'),
+                                dtDigiLabel = cms.untracked.InputTag('dtunpacker'),
                                 # switch for time box booking
                                 doTbHistos = cms.untracked.bool(False),
                                 # the name of the 4D rec hits collection
-                                recHits4DLabel = cms.string('dt4DSegments'),
+                                recHits4DLabel = cms.untracked.string('dt4DSegments'),
                                 # switch for segment veto
                                 doSegmentVeto = cms.untracked.bool(False),
                                 # safe margin (ns) between ttrig and beginning of counting area

--- a/DQM/DTMonitorModule/python/dtOccupancyEfficiency_cfi.py
+++ b/DQM/DTMonitorModule/python/dtOccupancyEfficiency_cfi.py
@@ -5,10 +5,10 @@ dtOccupancyMonitor = DQMEDAnalyzer('DTOccupancyEfficiency',
     # switch for verbosity
     debug = cms.untracked.bool(False),
     # label for dtDigis
-    digiLabel = cms.string('muonDTDigis'),
+    digiLabel = cms.untracked.string('muonDTDigis'),
     # labels of 4D and 1D hits
-    recHits4DLabel = cms.string('dt4DSegments'),
-    recHitLabel = cms.string('dt1DRecHits'),
+    recHits4DLabel = cms.untracked.string('dt4DSegments'),
+    recHitLabel = cms.untracked.string('dt1DRecHits'),
 )
 
 

--- a/DQM/DTMonitorModule/python/dtResolutionTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtResolutionTask_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 dtResolutionAnalysisMonitor = DQMEDAnalyzer('DTResolutionAnalysisTask',
                                              # labels of 4D hits
-                                             recHits4DLabel = cms.string('dt4DSegments'),
+                                             recHits4DLabel = cms.untracked.string('dt4DSegments'),
                                              # interval of lumi block after which we reset the histos
                                              ResetCycle = cms.untracked.int32(10000),
                                              # cut on the hits of segments considered for resolution

--- a/DQM/DTMonitorModule/python/dtResolutionTask_hlt_cfi.py
+++ b/DQM/DTMonitorModule/python/dtResolutionTask_hlt_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 dtResolutionTaskHLT = DQMEDAnalyzer('DTResolutionAnalysisTask',
                                      # labels of 4D hits
-                                     recHits4DLabel = cms.string('hltDt4DSegments'),
+                                     recHits4DLabel = cms.untracked.string('hltDt4DSegments'),
                                      # interval of lumi block after which we reset the histos
                                      ResetCycle = cms.untracked.int32(10000),
                                      # top folder for the histograms in DQMStore

--- a/DQM/DTMonitorModule/python/dtRunConditionVar_cfi.py
+++ b/DQM/DTMonitorModule/python/dtRunConditionVar_cfi.py
@@ -5,7 +5,7 @@ dtRunConditionVar = DQMEDAnalyzer('DTRunConditionVar',
     debug = cms.untracked.bool(False),
     nMinHitsPhi = cms.untracked.int32(5),
     maxAnglePhiSegm = cms.untracked.double(30.),
-    recoSegments = cms.InputTag('dt4DSegments'),
+    recoSegments = cms.untracked.InputTag('dt4DSegments'),
     readLegacyVDriftDB =cms.bool(True),
 )
 

--- a/DQM/DTMonitorModule/python/dtSegmentTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtSegmentTask_cfi.py
@@ -5,7 +5,7 @@ dtSegmentAnalysisMonitor = DQMEDAnalyzer('DTSegmentAnalysisTask',
                                           # switch for verbosity
                                           debug = cms.untracked.bool(False),
                                           # label of 4D segments
-                                          recHits4DLabel = cms.string('dt4DSegments'),
+                                          recHits4DLabel = cms.untracked.string('dt4DSegments'),
                                           # skip segments with noisy cells (reads from DB)
                                           checkNoisyChannels = cms.untracked.bool(True),
                                           # switch off uneeded histograms

--- a/DQM/DTMonitorModule/python/dtSegmentTask_hlt_cfi.py
+++ b/DQM/DTMonitorModule/python/dtSegmentTask_hlt_cfi.py
@@ -5,7 +5,7 @@ dtSegmentTaskHLT = DQMEDAnalyzer('DTSegmentAnalysisTask',
                                   # switch for verbosity
                                   debug = cms.untracked.bool(False),
                                   # label of 4D segments
-                                  recHits4DLabel = cms.string('hltDt4DSegments'),
+                                  recHits4DLabel = cms.untracked.string('hltDt4DSegments'),
                                   # skip segments with noisy cells (reads from DB)
                                   checkNoisyChannels = cms.untracked.bool(True),
                                   # switch off uneeded histograms

--- a/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
@@ -4,8 +4,8 @@ from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
 dtTriggerSynchMonitor = DQMEDAnalyzer('DTLocalTriggerSynchTask',
     staticBooking = cms.untracked.bool(True),
     # labels of TM data and 4D segments
-    TMInputTag    = cms.InputTag('dttfDigis'),
-    SEGInputTag    = cms.InputTag('dt4DSegments'),
+    TMInputTag    = cms.untracked.InputTag('dttfDigis'),
+    SEGInputTag    = cms.untracked.InputTag('dt4DSegments'),
     bxTimeInterval = cms.double(25),
     rangeWithinBX  = cms.bool(True),
     nBXHigh        = cms.int32(0),

--- a/DQM/DTMonitorModule/src/DTChamberEfficiency.cc
+++ b/DQM/DTMonitorModule/src/DTChamberEfficiency.cc
@@ -56,17 +56,17 @@ DTChamberEfficiency::DTChamberEfficiency(const ParameterSet& pSet) {
   ParameterSet serviceParameters = pSet.getParameter<ParameterSet>("ServiceParameters");
   theService = new MuonServiceProxy(serviceParameters, consumesCollector());
 
-  theTracksLabel_ = pSet.getParameter<InputTag>("TrackCollection");
+  theTracksLabel_ = pSet.getUntrackedParameter<InputTag>("TrackCollection");
   theTracksToken_ = consumes<reco::TrackCollection>(theTracksLabel_);
 
   theMaxChi2 = static_cast<unsigned int>(pSet.getParameter<double>("theMaxChi2"));
   theNSigma = pSet.getParameter<double>("theNSigma");
   theMinNrec = static_cast<int>(pSet.getParameter<double>("theMinNrec"));
 
-  labelRPCRecHits = pSet.getParameter<InputTag>("theRPCRecHits");
+  labelRPCRecHits = pSet.getUntrackedParameter<InputTag>("theRPCRecHits");
 
-  thedt4DSegments = pSet.getParameter<InputTag>("dt4DSegments");
-  thecscSegments = pSet.getParameter<InputTag>("cscSegments");
+  thedt4DSegments = pSet.getUntrackedParameter<InputTag>("dt4DSegments");
+  thecscSegments = pSet.getUntrackedParameter<InputTag>("cscSegments");
 
   edm::ConsumesCollector iC = consumesCollector();
 

--- a/DQM/DTMonitorModule/src/DTChamberEfficiencyTask.cc
+++ b/DQM/DTMonitorModule/src/DTChamberEfficiencyTask.cc
@@ -30,7 +30,7 @@ DTChamberEfficiencyTask::DTChamberEfficiencyTask(const ParameterSet& pset)
 
   // the name of the 4D rec hits collection
   recHits4DToken_ =
-      consumes<DTRecSegment4DCollection>(edm::InputTag(parameters.getParameter<string>("recHits4DLabel")));
+      consumes<DTRecSegment4DCollection>(edm::InputTag(parameters.getUntrackedParameter<string>("recHits4DLabel")));
 
   // parameters to use for the segment quality check
   theMinHitsSegment = static_cast<unsigned int>(parameters.getParameter<int>("minHitsSegment"));

--- a/DQM/DTMonitorModule/src/DTDataIntegrityROSOffline.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityROSOffline.cc
@@ -30,8 +30,8 @@ DTDataIntegrityROSOffline::DTDataIntegrityROSOffline(const edm::ParameterSet& ps
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityROSOffline")
       << "[DTDataIntegrityROSOffline]: Constructor" << endl;
 
-  dduToken = consumes<DTDDUCollection>(ps.getParameter<InputTag>("dtDDULabel"));
-  ros25Token = consumes<DTROS25Collection>(ps.getParameter<InputTag>("dtROS25Label"));
+  dduToken = consumes<DTDDUCollection>(ps.getUntrackedParameter<InputTag>("dtDDULabel"));
+  ros25Token = consumes<DTROS25Collection>(ps.getUntrackedParameter<InputTag>("dtROS25Label"));
   FEDIDmin = FEDNumbering::MINDTFEDID;
   FEDIDmax = FEDNumbering::MAXDTFEDID;
 

--- a/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
+++ b/DQM/DTMonitorModule/src/DTDataIntegrityTask.cc
@@ -33,7 +33,7 @@ using namespace edm;
 DTDataIntegrityTask::DTDataIntegrityTask(const edm::ParameterSet& ps) : nevents(0) {
   LogTrace("DTRawToDigi|DTDQM|DTMonitorModule|DTDataIntegrityTask") << "[DTDataIntegrityTask]: Constructor" << endl;
 
-  fedToken = consumes<DTuROSFEDDataCollection>(ps.getParameter<InputTag>("dtFEDlabel"));
+  fedToken = consumes<DTuROSFEDDataCollection>(ps.getUntrackedParameter<InputTag>("dtFEDlabel"));
   FEDIDmin = FEDNumbering::MINDTUROSFEDID;
   FEDIDmax = FEDNumbering::MAXDTUROSFEDID;
 

--- a/DQM/DTMonitorModule/src/DTDigiTask.cc
+++ b/DQM/DTMonitorModule/src/DTDigiTask.cc
@@ -40,7 +40,7 @@ DTDigiTask::DTDigiTask(const edm::ParameterSet& ps)
   LogTrace("DTDQM|DTMonitorModule|DTDigiTask") << "[DTDigiTask]: Constructor" << endl;
 
   // The label to retrieve the digis
-  dtDigiToken_ = consumes<DTDigiCollection>(ps.getParameter<InputTag>("dtDigiLabel"));
+  dtDigiToken_ = consumes<DTDigiCollection>(ps.getUntrackedParameter<InputTag>("dtDigiLabel"));
   // Read the configuration parameters
   maxTDCHits = ps.getUntrackedParameter<int>("maxTDCHitsPerChamber", 30000);
   // Set to true to read the ttrig from DB (useful to determine in-time and out-of-time hits)
@@ -55,7 +55,8 @@ DTDigiTask::DTDigiTask(const edm::ParameterSet& ps)
   // Switch for local/global runs
   isLocalRun = ps.getUntrackedParameter<bool>("localrun", true);
   if (!isLocalRun) {
-    ltcDigiCollectionToken_ = consumes<LTCDigiCollection>(ps.getParameter<edm::InputTag>("ltcDigiCollectionTag"));
+    ltcDigiCollectionToken_ =
+        consumes<LTCDigiCollection>(ps.getUntrackedParameter<edm::InputTag>("ltcDigiCollectionTag"));
   }
 
   // Setting for the reset of the ME after n (= ResetCycle) luminosity sections

--- a/DQM/DTMonitorModule/src/DTEfficiencyTask.cc
+++ b/DQM/DTMonitorModule/src/DTEfficiencyTask.cc
@@ -34,9 +34,10 @@ DTEfficiencyTask::DTEfficiencyTask(const ParameterSet& pset)
     : muonGeomToken_(esConsumes<edm::Transition::BeginRun>()), dtGeomToken_(esConsumes()) {
   debug = pset.getUntrackedParameter<bool>("debug", false);
   // the name of the 4D rec hits collection
-  recHits4DToken_ = consumes<DTRecSegment4DCollection>(edm::InputTag(pset.getParameter<string>("recHits4DLabel")));
+  recHits4DToken_ =
+      consumes<DTRecSegment4DCollection>(edm::InputTag(pset.getUntrackedParameter<string>("recHits4DLabel")));
   // the name of the rechits collection
-  recHitToken_ = consumes<DTRecHitCollection>(edm::InputTag(pset.getParameter<string>("recHitLabel")));
+  recHitToken_ = consumes<DTRecHitCollection>(edm::InputTag(pset.getUntrackedParameter<string>("recHitLabel")));
 
   parameters = pset;
 }

--- a/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.cc
@@ -45,8 +45,8 @@ DTLocalTriggerSynchTask::DTLocalTriggerSynchTask(const edm::ParameterSet& ps)
                                                   consumesCollector())},
       muonGeomToken_(esConsumes<edm::Transition::BeginRun>()) {
   edm::LogVerbatim("DTLocalTriggerSynchTask") << "[DTLocalTriggerSynchTask]: Constructor" << endl;
-  tm_Token_ = consumes<L1MuDTChambPhContainer>(ps.getParameter<edm::InputTag>("TMInputTag"));
-  seg_Token_ = consumes<DTRecSegment4DCollection>(ps.getParameter<edm::InputTag>("SEGInputTag"));
+  tm_Token_ = consumes<L1MuDTChambPhContainer>(ps.getUntrackedParameter<edm::InputTag>("TMInputTag"));
+  seg_Token_ = consumes<DTRecSegment4DCollection>(ps.getUntrackedParameter<edm::InputTag>("SEGInputTag"));
 
   bxTime = ps.getParameter<double>("bxTimeInterval");  // CB move this to static const or DB
   rangeInBX = ps.getParameter<bool>("rangeWithinBX");

--- a/DQM/DTMonitorModule/src/DTNoiseTask.cc
+++ b/DQM/DTMonitorModule/src/DTNoiseTask.cc
@@ -44,10 +44,11 @@ DTNoiseTask::DTNoiseTask(const ParameterSet& ps)
   doTimeBoxHistos = ps.getUntrackedParameter<bool>("doTbHistos", false);
 
   // The label to retrieve the digis
-  dtDigiToken_ = consumes<DTDigiCollection>(ps.getParameter<InputTag>("dtDigiLabel"));
+  dtDigiToken_ = consumes<DTDigiCollection>(ps.getUntrackedParameter<InputTag>("dtDigiLabel"));
 
   // the name of the 4D rec hits collection
-  recHits4DToken_ = consumes<DTRecSegment4DCollection>(edm::InputTag(ps.getParameter<string>("recHits4DLabel")));
+  recHits4DToken_ =
+      consumes<DTRecSegment4DCollection>(edm::InputTag(ps.getUntrackedParameter<string>("recHits4DLabel")));
 
   // switch for segment veto
   doSegmentVeto = ps.getUntrackedParameter<bool>("doSegmentVeto", false);

--- a/DQM/DTMonitorModule/src/DTOccupancyEfficiency.cc
+++ b/DQM/DTMonitorModule/src/DTOccupancyEfficiency.cc
@@ -22,11 +22,12 @@ using namespace std;
 DTOccupancyEfficiency::DTOccupancyEfficiency(const ParameterSet& pset) {
   debug = pset.getUntrackedParameter<bool>("debug", false);
   // label for dtDigis
-  dtDigiToken_ = consumes<DTDigiCollection>(edm::InputTag(pset.getParameter<string>("digiLabel")));
+  dtDigiToken_ = consumes<DTDigiCollection>(edm::InputTag(pset.getUntrackedParameter<string>("digiLabel")));
   // the name of the 4D rec hits collection
-  recHits4DToken_ = consumes<DTRecSegment4DCollection>(edm::InputTag(pset.getParameter<string>("recHits4DLabel")));
+  recHits4DToken_ =
+      consumes<DTRecSegment4DCollection>(edm::InputTag(pset.getUntrackedParameter<string>("recHits4DLabel")));
   // the name of the rechits collection
-  recHitToken_ = consumes<DTRecHitCollection>(edm::InputTag(pset.getParameter<string>("recHitLabel")));
+  recHitToken_ = consumes<DTRecHitCollection>(edm::InputTag(pset.getUntrackedParameter<string>("recHitLabel")));
 
   parameters = pset;
 }

--- a/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.cc
+++ b/DQM/DTMonitorModule/src/DTResolutionAnalysisTask.cc
@@ -35,7 +35,8 @@ DTResolutionAnalysisTask::DTResolutionAnalysisTask(const ParameterSet& pset)
       << "[DTResolutionAnalysisTask] Constructor called!" << endl;
 
   // the name of the 4D rec hits collection
-  recHits4DToken_ = consumes<DTRecSegment4DCollection>(edm::InputTag(pset.getParameter<string>("recHits4DLabel")));
+  recHits4DToken_ =
+      consumes<DTRecSegment4DCollection>(edm::InputTag(pset.getUntrackedParameter<string>("recHits4DLabel")));
 
   prescaleFactor = pset.getUntrackedParameter<int>("diagnosticPrescale", 1);
   resetCycle = pset.getUntrackedParameter<int>("ResetCycle", -1);

--- a/DQM/DTMonitorModule/src/DTRunConditionVar.cc
+++ b/DQM/DTMonitorModule/src/DTRunConditionVar.cc
@@ -44,7 +44,7 @@ DTRunConditionVar::DTRunConditionVar(const ParameterSet& pSet)
       debug(pSet.getUntrackedParameter<bool>("debug", false)),
       nMinHitsPhi(pSet.getUntrackedParameter<int>("nMinHitsPhi")),
       maxAnglePhiSegm(pSet.getUntrackedParameter<double>("maxAnglePhiSegm")),
-      dt4DSegmentsToken_(consumes<DTRecSegment4DCollection>(pSet.getParameter<InputTag>("recoSegments"))),
+      dt4DSegmentsToken_(consumes<DTRecSegment4DCollection>(pSet.getUntrackedParameter<InputTag>("recoSegments"))),
       muonGeomToken_(esConsumes<edm::Transition::BeginRun>()),
       readLegacyVDriftDB(pSet.getParameter<bool>("readLegacyVDriftDB")) {
   if (readLegacyVDriftDB) {

--- a/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.cc
+++ b/DQM/DTMonitorModule/src/DTSegmentAnalysisTask.cc
@@ -37,7 +37,8 @@ DTSegmentAnalysisTask::DTSegmentAnalysisTask(const edm::ParameterSet& pset)
   // switch for detailed analysis
   detailedAnalysis = pset.getUntrackedParameter<bool>("detailedAnalysis", false);
   // the name of the 4D rec hits collection
-  recHits4DToken_ = consumes<DTRecSegment4DCollection>(edm::InputTag(pset.getParameter<string>("recHits4DLabel")));
+  recHits4DToken_ =
+      consumes<DTRecSegment4DCollection>(edm::InputTag(pset.getUntrackedParameter<string>("recHits4DLabel")));
   // Get the map of noisy channels
   checkNoisyChannels = pset.getUntrackedParameter<bool>("checkNoisyChannels", false);
   phiSegmCut = pset.getUntrackedParameter<double>("phiSegmCut", 30.);


### PR DESCRIPTION

#### PR description:

This PR has switched all the input collection tracked parameters of DQM/CTPPS ns DQM/DTMonitorModule to untracked, followed by the discussion: https://github.com/cms-sw/cmssw/pull/36998#discussion_r815286443

For CTPPS,
Number of source files changed: 9
Number of python configurations changed: 7
Number of parameters changed: 32

For DTMonitorModule,
Number of source files changed: 12
Number of python configurations changed: 14
Number of parameters changed: 22

#### PR validation:

Tested in CMSSW_12_5_X via runTheMatrix.py -l limited -i all --ibeos

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

NA
