### PR TITLE
Fixed codes which causes memory issue by GEM onlineDQM

### DIFF
--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -579,7 +579,8 @@ protected:
   const GEMGeometry *GEMGeometry_;
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
 
-  std::vector<GEMChamber> gemChambers_;
+  std::vector<GEMDetId> listChamberId_;
+  std::map<GEMDetId, std::vector<const GEMEtaPartition*>> mapEtaPartition_;
 
   std::map<ME2IdsKey, bool> MEMap2Check_;
   std::map<ME3IdsKey, bool> MEMap2WithEtaCheck_;

--- a/DQM/GEM/interface/GEMDQMBase.h
+++ b/DQM/GEM/interface/GEMDQMBase.h
@@ -580,7 +580,7 @@ protected:
   edm::ESGetToken<GEMGeometry, MuonGeometryRecord> geomToken_;
 
   std::vector<GEMDetId> listChamberId_;
-  std::map<GEMDetId, std::vector<const GEMEtaPartition*>> mapEtaPartition_;
+  std::map<GEMDetId, std::vector<const GEMEtaPartition *>> mapEtaPartition_;
 
   std::map<ME2IdsKey, bool> MEMap2Check_;
   std::map<ME3IdsKey, bool> MEMap2WithEtaCheck_;

--- a/DQM/GEM/plugins/GEMDigiSource.cc
+++ b/DQM/GEM/plugins/GEMDigiSource.cc
@@ -157,8 +157,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
 
   std::map<ME3IdsKey, Int_t> total_digi_layer;
   std::map<ME3IdsKey, Int_t> total_digi_eta;
-  for (const auto& ch : gemChambers_) {
-    GEMDetId gid = ch.id();
+  for (auto gid : listChamberId_) {
     ME2IdsKey key2{gid.region(), gid.station()};
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
@@ -168,7 +167,7 @@ void GEMDigiSource::analyze(edm::Event const& event, edm::EventSetup const& even
     const BoundPlane& surface = GEMGeometry_->idToDet(gid)->surface();
     if (total_digi_layer.find(key3) == total_digi_layer.end())
       total_digi_layer[key3] = 0;
-    for (auto iEta : ch.etaPartitions()) {
+    for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       if (total_digi_eta.find(key3IEta) == total_digi_eta.end())

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -187,13 +187,12 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
   std::map<ME3IdsKey, Int_t> total_rechit_iEta;
   std::map<ME4IdsKey, std::map<Int_t, Bool_t>> mapCLSOver5;
 
-  for (const auto& ch : gemChambers_) {
-    GEMDetId gid = ch.id();
+  for (auto gid : listChamberId_) {
     auto chamber = gid.chamber();
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     MEStationInfo& stationInfo = mapStationInfo_[key3];
-    for (auto iEta : ch.etaPartitions()) {
+    for (auto iEta : mapEtaPartition_[gid])  {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};

--- a/DQM/GEM/plugins/GEMRecHitSource.cc
+++ b/DQM/GEM/plugins/GEMRecHitSource.cc
@@ -192,7 +192,7 @@ void GEMRecHitSource::analyze(edm::Event const& event, edm::EventSetup const& ev
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key4Ch{gid.region(), gid.station(), gid.layer(), gid.chamber()};
     MEStationInfo& stationInfo = mapStationInfo_[key3];
-    for (auto iEta : mapEtaPartition_[gid])  {
+    for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME3IdsKey key3IEta{gid.region(), gid.station(), eId.ieta()};
       ME3IdsKey key3AbsReIEta{std::abs(gid.region()), gid.station(), eId.ieta()};

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -71,7 +71,7 @@ int GEMDQMBase::loadChambers() {
       }
     }
   }
-  
+
   // Borrwed from DQM/GEM/src/GEMOfflineMonitor.cc
   nMaxNumCh_ = 0;
   for (const GEMRegion* region : GEMGeometry_->regions()) {

--- a/DQM/GEM/src/GEMDQMBase.cc
+++ b/DQM/GEM/src/GEMDQMBase.cc
@@ -26,11 +26,9 @@ GEMDQMBase::GEMDQMBase(const edm::ParameterSet& cfg) : geomToken_(esConsumes<edm
 
 int GEMDQMBase::initGeometry(edm::EventSetup const& iSetup) {
   GEMGeometry_ = nullptr;
-  try {
-    //edm::ESHandle<GEMGeometry> hGeom;
-    //iSetup.get<MuonGeometryRecord>().get(hGeom);
-    GEMGeometry_ = &iSetup.getData(geomToken_);
-  } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
+  if (auto handle = iSetup.getHandle(geomToken_)) {
+    GEMGeometry_ = handle.product();
+  } else {
     edm::LogError(log_category_) << "+++ Error : GEM geometry is unavailable on event loop. +++\n";
     return -1;
   }
@@ -58,23 +56,22 @@ int GEMDQMBase::getNumEtaPartitions(const GEMStation* station) {
 int GEMDQMBase::loadChambers() {
   if (GEMGeometry_ == nullptr)
     return -1;
-  gemChambers_.clear();
-  const std::vector<const GEMSuperChamber*>& superChambers_ = GEMGeometry_->superChambers();
-  for (auto sch : superChambers_) {  // FIXME: This loop can be merged into the below loop
-    for (auto pch : sch->chambers()) {
-      Bool_t bExist = false;
-      for (const auto& ch : gemChambers_) {
-        if (pch->id() == ch.id()) {
-          bExist = true;
-          break;
+  listChamberId_.clear();
+  mapEtaPartition_.clear();
+  for (const GEMRegion* region : GEMGeometry_->regions()) {
+    for (const GEMStation* station : region->stations()) {
+      for (auto sch : station->superChambers()) {
+        for (auto pchamber : sch->chambers()) {
+          GEMDetId gid = pchamber->id();
+          listChamberId_.push_back(pchamber->id());
+          for (auto iEta : pchamber->etaPartitions()) {
+            mapEtaPartition_[gid].push_back(iEta);
+          }
         }
       }
-      if (bExist)
-        continue;
-      gemChambers_.push_back(*pch);
     }
   }
-
+  
   // Borrwed from DQM/GEM/src/GEMOfflineMonitor.cc
   nMaxNumCh_ = 0;
   for (const GEMRegion* region : GEMGeometry_->regions()) {
@@ -183,8 +180,7 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
   MEMap3Check_.clear();
   MEMap3WithChCheck_.clear();
   MEMap4Check_.clear();
-  for (const auto& ch : gemChambers_) {
-    GEMDetId gid = ch.id();
+  for (auto gid : listChamberId_) {
     ME2IdsKey key2{gid.region(), gid.station()};
     ME3IdsKey key3{gid.region(), gid.station(), gid.layer()};
     ME4IdsKey key3WithChamber{gid.region(), gid.station(), gid.layer(), gid.chamber()};
@@ -212,7 +208,7 @@ int GEMDQMBase::GenerateMEPerChamber(DQMStore::IBooker& ibooker) {
       ProcessWithMEMap3WithChamber(bh3Ch, key3WithChamber);
       MEMap3WithChCheck_[key3WithChamber] = true;
     }
-    for (auto iEta : ch.etaPartitions()) {
+    for (auto iEta : mapEtaPartition_[gid]) {
       GEMDetId eId = iEta->id();
       ME4IdsKey key4{gid.region(), gid.station(), gid.layer(), eId.ieta()};
       ME3IdsKey key2WithEta{gid.region(), gid.station(), eId.ieta()};


### PR DESCRIPTION
#### PR description:
There is an issue with GEM onlineDQM (#38666), which is due to the wrong way to keep the geometry information of GEM chambers. (See [this line](https://github.com/cms-sw/cmssw/pull/38908/files#diff-211b3bdbc65bb043eb340a211fdf6ea24c2e2b17d7cdeb26c535d197be5cee65).) It has been fixed by adapting a safer and lighter method.

#### PR validation:
Test are done with `cmsRun $CMSSW_RELEASE_BASE/src/DQM/Integration/python/clients/gem_dqm_sourceclient-live_cfg.py unitTest=True`

@jshlee @watson-ij @seungjin-yang