### PR TITLE
Update the autoSkim.py for new HLT menu v1.3

### DIFF
--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -1,12 +1,10 @@
 autoSkim = {
  'BTagMu' : 'LogError+LogErrorMonitor',
- 'JetHT' : 'JetHTJetPlusHOFilter+LogError+LogErrorMonitor',
  'DisplacedJet' : 'EXODisplacedJet+EXODelayedJet+EXODTCluster+EXOCSCCluster+LogError+LogErrorMonitor',
- 'MET' : 'EXOHighMET+EXODelayedJetMET+LogError+LogErrorMonitor',
+ 'JETMET' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+LogError+LogErrorMonitor',
  'EGamma':'ZElectron+WElectron+EXOMONOPOLE+LogError+LogErrorMonitor',
  'Tau' : 'LogError+LogErrorMonitor',
- 'SingleMuon' : 'ZMu+LogError+LogErrorMonitor',
- 'DoubleMuon' : 'LogError+LogErrorMonitor',
+ 'Muon' : 'ZMu+LogError+LogErrorMonitor',
  'MuonEG' : 'TopMuEG+LogError+LogErrorMonitor',
  'NoBPTX' : 'EXONoBPTXSkim+LogError+LogErrorMonitor',
  'HcalNZS' : 'LogError+LogErrorMonitor',
@@ -14,7 +12,6 @@ autoSkim = {
  'ZeroBias' : 'LogError+LogErrorMonitor',
  'Commissioning' : 'EcalActivity+LogError+LogErrorMonitor',
  'Cosmics':'CosmicSP+CosmicTP+LogError+LogErrorMonitor',
- 'ParkingBPH':'SkimBPark+LogError+LogErrorMonitor',
  'MonteCarlo':'EXODisappTrk+LogError+LogErrorMonitor',
 }
 

--- a/Configuration/Skimming/python/autoSkim.py
+++ b/Configuration/Skimming/python/autoSkim.py
@@ -1,7 +1,7 @@
 autoSkim = {
  'BTagMu' : 'LogError+LogErrorMonitor',
  'DisplacedJet' : 'EXODisplacedJet+EXODelayedJet+EXODTCluster+EXOCSCCluster+LogError+LogErrorMonitor',
- 'JETMET' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+LogError+LogErrorMonitor',
+ 'JetMET' : 'JetHTJetPlusHOFilter+EXOHighMET+EXODelayedJetMET+LogError+LogErrorMonitor',
  'EGamma':'ZElectron+WElectron+EXOMONOPOLE+LogError+LogErrorMonitor',
  'Tau' : 'LogError+LogErrorMonitor',
  'Muon' : 'ZMu+LogError+LogErrorMonitor',


### PR DESCRIPTION
#### PR description:
To be synced with PD changes in the new HLT menu (v1.3)

1. Merged **SingleMuon** and **DoubleMuon** into **Muon** dataset
2. Merged **JetHT** and **MET** into **JetMET** dataset
3. Removed unused PD **ParkingBPH**

#### PR validation:

None

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of #38933
