### PR TITLE
Add new class PPSTimingCalibration for Payload Inspector

### DIFF
--- a/CalibPPS/TimingCalibration/test/visualization/graph.py
+++ b/CalibPPS/TimingCalibration/test/visualization/graph.py
@@ -1,0 +1,34 @@
+import ROOT
+import sys
+import numpy as np
+
+def generate_graph(filename, dataset, title, param_no, db, plane):
+    file = ROOT.TFile.Open("visualization/"+filename+".root", "RECREATE")
+
+    arr = np.loadtxt("visualization/"+dataset+".dat")
+    rows, columns = arr.shape
+    x_line = []
+    y_line = []
+
+    for r in range(rows):
+        if int(arr[r,0]) == int(param_no) and int(arr[r,1]) == int(db) and int(arr[r,2]) == int(plane):
+            x_line.append(arr[r,3])
+            y_line.append(arr[r,5])
+
+    size = len(x_line)
+
+    x = ROOT.std.vector('double')()
+    for i in x_line: x.push_back(float(i))
+    y = ROOT.std.vector('double')()
+    for i in y_line: y.push_back(float(i))
+
+    c1 = ROOT.TCanvas()
+    gr = ROOT.TGraph(size, x.data(), y.data())
+    gr.SetTitle(title)
+    gr.SetMarkerColor(4)
+    gr.SetMarkerStyle(21)
+    #gr.Draw("AL")
+    file.WriteObject(gr, title)
+
+if __name__ == '__main__':
+    generate_graph(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6])

--- a/CondCore/CTPPSPlugins/interface/PPSTimingCalibrationPayloadInspectorHelper.h
+++ b/CondCore/CTPPSPlugins/interface/PPSTimingCalibrationPayloadInspectorHelper.h
@@ -1,0 +1,147 @@
+#ifndef CONDCORE_CTPPSPLUGINS_PPSTIMINGCALIBRATIONPAYLOADINSPECTORHELPER_H
+#define CONDCORE_CTPPSPLUGINS_PPSTIMINGCALIBRATIONPAYLOADINSPECTORHELPER_H
+
+// User includes
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
+
+// system includes
+#include <memory>
+#include <sstream>
+
+// ROOT includes
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TH2F.h"
+#include "TLatex.h"
+#include "TGraph.h"
+
+class PPSTimingCalibrationPI {
+public:
+  enum parameter { parameter0 = 0, parameter1 = 1, parameter2 = 2, parameter3 = 3 };
+
+  enum conditions_db { db0 = 0, db1 = 1 };
+
+  enum conditions_plane { plane0 = 0, plane1 = 1, plane2 = 2, plane3 = 3 };
+
+  enum conditions_channel {
+    channel0 = 0,
+    channel1 = 1,
+    channel2 = 2,
+    channel3 = 3,
+    channel4 = 4,
+    channel5 = 5,
+    channel6 = 6,
+    channel7 = 7,
+    channel8 = 8,
+    channel9 = 9,
+    channel10 = 10,
+    channel11 = 11
+
+  };
+
+  static std::string getStringFromParamEnum(const parameter& parameter) {
+    switch (parameter) {
+      case 0:
+        return "parameter no.0";
+      case 1:
+        return "parameter no.1";
+      case 2:
+        return "parameter no.2";
+      case 3:
+        return "parameter no.3";
+
+      default:
+        return "not here";
+    }
+  }
+};
+
+/************************************************
+    History plots
+  *************************************************/
+template <PPSTimingCalibrationPI::conditions_db db,
+          PPSTimingCalibrationPI::conditions_plane plane,
+          PPSTimingCalibrationPI::conditions_channel channel,
+          PPSTimingCalibrationPI::parameter param,
+          class PayloadType>
+class ParametersPerRun : public cond::payloadInspector::HistoryPlot<PayloadType, float> {
+public:
+  ParametersPerRun()
+      : cond::payloadInspector::HistoryPlot<PayloadType, float>(
+            PPSTimingCalibrationPI::getStringFromParamEnum(param) + "vs. Runs",
+            PPSTimingCalibrationPI::getStringFromParamEnum(param)) {}
+
+  float getFromPayload(PayloadType& payload) override { return payload.parameters(db, 1, plane, channel)[param]; }
+};
+
+/************************************************
+    X-Y correlation plots
+  *************************************************/
+template <PPSTimingCalibrationPI::conditions_db db,
+          PPSTimingCalibrationPI::conditions_plane plane,
+          PPSTimingCalibrationPI::conditions_channel channel,
+          PPSTimingCalibrationPI::parameter param1,
+          PPSTimingCalibrationPI::parameter param2,
+          class PayloadType>
+class PpPCorrelation : public cond::payloadInspector::ScatterPlot<PayloadType, double, double> {
+public:
+  PpPCorrelation()
+      : cond::payloadInspector::ScatterPlot<PayloadType, double, double>(
+            "TimingCalibration" + PPSTimingCalibrationPI::getStringFromParamEnum(param1) + "vs." +
+                PPSTimingCalibrationPI::getStringFromParamEnum(param2),
+            PPSTimingCalibrationPI::getStringFromParamEnum(param1),
+            PPSTimingCalibrationPI::getStringFromParamEnum(param2)) {}
+
+  std::tuple<double, double> getFromPayload(PayloadType& payload) override {
+    return std::make_tuple(payload.parameters(db, 1, plane, channel)[param1],
+                           payload.parameters(db, 1, plane, channel)[param2]);
+  }
+};
+
+/************************************************
+    Other plots
+  *************************************************/
+
+template <PPSTimingCalibrationPI::conditions_db db,
+          PPSTimingCalibrationPI::conditions_plane plane,
+          PPSTimingCalibrationPI::parameter param,
+          class PayloadType>
+class ParametersPerChannel : public cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV> {
+public:
+  ParametersPerChannel()
+      : cond::payloadInspector::PlotImage<PayloadType, cond::payloadInspector::SINGLE_IOV>(
+            "PPSTimingCalibration parameters per channel") {}
+
+  bool fill() override {
+    auto tag = cond::payloadInspector::PlotBase::getTag<0>();
+    auto tagname = tag.name;
+    auto iov = tag.iovs.front();
+
+    auto m_payload = this->fetchPayload(std::get<1>(iov));
+
+    TCanvas canvas(
+        "PPSTimingCalibration parameters per channel", "PPSTimingCalibration parameters per channel", 1400, 1000);
+    canvas.cd(1);
+    const Int_t n = 12;
+    Double_t x[n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    Double_t y[n];
+    for (int i = 0; i < n; i++) {
+      y[i] = m_payload->parameters(db, 1, plane, i)[param];
+    }
+
+    TGraph* gr = new TGraph(n, x, y);
+    gr->SetTitle("PPSTimingCalibration param per channel Example");
+    gr->Draw("AP");
+
+    std::string fileName(this->m_imageFileName);
+    canvas.SaveAs(fileName.c_str());
+
+    return true;
+  }
+};
+
+#endif

--- a/CondCore/CTPPSPlugins/plugins/BuildFile.xml
+++ b/CondCore/CTPPSPlugins/plugins/BuildFile.xml
@@ -1,0 +1,5 @@
+<library file="PPSTimingCalibration_PayloadInspector.cc" name="PPSTimingCalibration_PayloadInspector">
+  <use name="CondCore/Utilities"/>
+  <use name="CondCore/CondDB"/>
+  <use name="boost_python"/>
+</library>

--- a/CondCore/CTPPSPlugins/plugins/PPSTimingCalibration_PayloadInspector.cc
+++ b/CondCore/CTPPSPlugins/plugins/PPSTimingCalibration_PayloadInspector.cc
@@ -1,0 +1,117 @@
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/CondDB/interface/PayloadReader.h"
+#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
+#include "CondCore/CTPPSPlugins/interface/PPSTimingCalibrationPayloadInspectorHelper.h"
+#include <memory>
+#include <sstream>
+
+#include "TH2D.h"
+#include "TCanvas.h"
+#include "TLine.h"
+#include "TLatex.h"
+
+namespace {
+
+  /************************************************
+    History plots
+  *************************************************/
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter0,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_param0;
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter1,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_param1;
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter2,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_param2;
+  typedef ParametersPerRun<PPSTimingCalibrationPI::db0,
+                           PPSTimingCalibrationPI::plane1,
+                           PPSTimingCalibrationPI::channel1,
+                           PPSTimingCalibrationPI::parameter3,
+                           PPSTimingCalibration>
+      PPSTimingCalibration_history_htdc_calibration_param3;
+
+  /************************************************
+    X-Y correlation plots
+  *************************************************/
+
+  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
+                         PPSTimingCalibrationPI::plane1,
+                         PPSTimingCalibrationPI::channel1,
+                         PPSTimingCalibrationPI::parameter0,
+                         PPSTimingCalibrationPI::parameter1,
+                         PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_params01;
+  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
+                         PPSTimingCalibrationPI::plane1,
+                         PPSTimingCalibrationPI::channel1,
+                         PPSTimingCalibrationPI::parameter0,
+                         PPSTimingCalibrationPI::parameter2,
+                         PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_params02;
+  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
+                         PPSTimingCalibrationPI::plane1,
+                         PPSTimingCalibrationPI::channel1,
+                         PPSTimingCalibrationPI::parameter0,
+                         PPSTimingCalibrationPI::parameter3,
+                         PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_params03;
+
+  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
+                         PPSTimingCalibrationPI::plane1,
+                         PPSTimingCalibrationPI::channel1,
+                         PPSTimingCalibrationPI::parameter1,
+                         PPSTimingCalibrationPI::parameter2,
+                         PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_params12;
+  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
+                         PPSTimingCalibrationPI::plane1,
+                         PPSTimingCalibrationPI::channel1,
+                         PPSTimingCalibrationPI::parameter1,
+                         PPSTimingCalibrationPI::parameter3,
+                         PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_params13;
+
+  typedef PpPCorrelation<PPSTimingCalibrationPI::db0,
+                         PPSTimingCalibrationPI::plane1,
+                         PPSTimingCalibrationPI::channel1,
+                         PPSTimingCalibrationPI::parameter2,
+                         PPSTimingCalibrationPI::parameter3,
+                         PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_params23;
+
+  /************************************************
+    Image plots
+  *************************************************/
+
+  typedef ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                               PPSTimingCalibrationPI::plane3,
+                               PPSTimingCalibrationPI::parameter3,
+                               PPSTimingCalibration>
+      PPSTimingCalibration_htdc_calibration_param3;
+}  // namespace
+
+PAYLOAD_INSPECTOR_MODULE(PPSTimingCalibration) {
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_param0);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_param1);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_param2);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_history_htdc_calibration_param3);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params01);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params02);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params03);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params12);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params13);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_params23);
+  PAYLOAD_INSPECTOR_CLASS(PPSTimingCalibration_htdc_calibration_param3);
+}

--- a/CondCore/CTPPSPlugins/test/BuildFile.xml
+++ b/CondCore/CTPPSPlugins/test/BuildFile.xml
@@ -1,0 +1,4 @@
+<use name="CondCore/Utilities"/>
+<use name="FWCore/PluginManager"/>
+<bin file="testPPSTimingCalibration.cpp" name="testPPSTimingCalibration">
+</bin>

--- a/CondCore/CTPPSPlugins/test/graph_check.py
+++ b/CondCore/CTPPSPlugins/test/graph_check.py
@@ -1,0 +1,14 @@
+import pandas as pd
+import json
+import os
+import glob
+
+files = glob.glob(os.getcwd()+"/CondCore/CTPPSPlugins/test/results/*.json")       
+print(os.getcwd())
+
+for file in files:
+    f = open(file)
+    data = json.load(f)
+    df = pd.DataFrame(data['data'])
+    plot = df.plot.scatter(x='x', y='y', xlabel=data['annotations']['x_label'], ylabel=data['annotations']['y_label'])
+    plot.get_figure().savefig(file.strip(".json")+".png")

--- a/CondCore/CTPPSPlugins/test/testPPSTimingCalibration.cpp
+++ b/CondCore/CTPPSPlugins/test/testPPSTimingCalibration.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <sstream>
+#include "CondCore/Utilities/interface/PayloadInspector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "CondFormats/PPSObjects/interface/PPSTimingCalibration.h"
+#include "CondCore/CTPPSPlugins/interface/PPSTimingCalibrationPayloadInspectorHelper.h"
+
+int main(int argc, char** argv) {
+  Py_Initialize();
+
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  edm::ServiceToken servToken(edm::ServiceRegistry::createSet(psets));
+  edm::ServiceRegistry::Operate operate(servToken);
+
+  std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
+
+  // PPSTimimg
+  if (argc == 4) {
+    std::string tag = argv[1];
+    cond::Time_t start = static_cast<unsigned long long>(std::strtol(argv[2], &argv[2], 10));
+    cond::Time_t end = static_cast<unsigned long long>(std::strtol(argv[3], &argv[3], 10));
+
+    edm::LogPrint("testPPSCalibrationPI") << "## Exercising TimingCalibration plots ";
+
+    ParametersPerChannel<PPSTimingCalibrationPI::db0,
+                         PPSTimingCalibrationPI::plane0,
+                         PPSTimingCalibrationPI::parameter0,
+                         PPSTimingCalibration>
+        test;
+    test.process(connectionString, PI::mk_input(tag, start, end));
+    edm::LogPrint("testparametersPerChannel") << test.data();
+  } else {
+    edm::LogPrint("testparametersPerChannel") << "Wrong arguments";
+  }
+
+  Py_Finalize();
+}

--- a/CondCore/CTPPSPlugins/test/testPPSTimingCalibration.sh
+++ b/CondCore/CTPPSPlugins/test/testPPSTimingCalibration.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+if [ "$1" == "run" ]
+then
+    mkdir -p CondCore/CTPPSPlugins/test/results
+    if [ -f *.png ]; then    
+    rm *.png
+    fi
+
+
+    echo "Testing history plots"
+
+    for param in 0 1 2 3
+    do
+        getPayloadData.py \
+            --plugin pluginPPSTimingCalibration_PayloadInspector \
+            --plot plot_PPSTimingCalibration_history_htdc_calibration_param$param \
+            --tag PPSDiamondTimingCalibration_v1 \
+            --time_type Run \
+            --iovs '{"start_iov": "294645", "end_iov": "325176"}' \
+            --db Prod \
+            --test 2> CondCore/CTPPSPlugins/test/results/data_history_$param.json
+    done 
+
+
+    echo "Testing parameters plots"
+
+    for param1 in 0 1 2 3
+    do  
+        for param2 in 1 2 3
+        do
+            if [ "$param1" -lt "$param2" ]
+            then
+                getPayloadData.py \
+                    --plugin pluginPPSTimingCalibration_PayloadInspector \
+                    --plot  plot_PPSTimingCalibration_htdc_calibration_params$param1$param2 \
+                    --tag PPSDiamondTimingCalibration_v1 \
+                    --time_type Run \
+                    --iovs '{"start_iov": "294645", "end_iov": "325176"}' \
+                    --db Prod \
+                    --test 2> CondCore/CTPPSPlugins/test/results/data_params_$param1$param2.json 
+            fi  
+        done
+    done    
+
+    python3 CondCore/CTPPSPlugins/test/graph_check.py
+
+    echo "Testing channel plots"
+
+    getPayloadData.py \
+        --plugin pluginPPSTimingCalibration_PayloadInspector \
+        --plot plot_PPSTimingCalibration_htdc_calibration_param3 \
+        --tag PPSDiamondTimingCalibration_v1 \
+        --time_type Run \
+        --iovs '{"start_iov": "294645", "end_iov": "325176"}' \
+        --db Prod \
+        --test
+
+    mv *.png CondCore/CTPPSPlugins/test/results/plot_PPSTimingCalibration_ppc.png
+
+elif [ "$1" == "clear" ]
+then
+    rm -rf CondCore/CTPPSPlugins/test/results
+
+else 
+    echo "Wrong option"
+fi


### PR DESCRIPTION
#### PR description:

The main aim of this PR is to add PPSTimingCalibration class to Payload Inspector software so to be able to visualize it on the website. It consists of a few plots just to test the idea of visualization for this new class. 

#### PR validation:

The code was tested by a script  testPPSTimingCalibration.sh (which is mostly based on getPayloadData.py from CondCore/Utilities) just to check whether the code is properly added to PI software and generate some proper data in JSON files produced by PI (there is also script  graph_check.py that visualize data in matplotlib).  
In case of testing - testPPSTimingCalibration.sh script should be run with 'run' argument.

#### PR backport:
No backport.
