### PR TITLE
Adding JECs, PF and L1T menu to Run-3 MC GTs and data relval GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,7 +36,7 @@ autoCond = {
     # GlobalTag for Run3 HLT: identical to the online GT (124X_dataRun3_HLT_v4) but with snapshot at 2022-07-12 13:00:00 (UTC)
     'run3_hlt'                     : '124X_dataRun3_HLT_frozen_v6',
     # GlobalTag with fixed snapshot time for Run3 HLT RelVals: customizations to run with fixed L1 Menu
-    'run3_hlt_relval'              : '124X_dataRun3_HLT_relval_v8',
+    'run3_hlt_relval'              : '125X_dataRun3_HLT_relval_v1',
     # GlobalTag for Run3 data relvals (express GT) - identical to 124X_dataRun3_Express_v4 but with snapshot at 2022-07-12 13:00:00 (UTC)
     'run3_data_express'            : '124X_dataRun3_Express_frozen_v4',
     # GlobalTag for Run3 data relvals (prompt GT) - identical to 124X_dataRun3_Prompt_v4 but with snapshot at 2022-07-12 13:00:00 (UTC)
@@ -44,7 +44,7 @@ autoCond = {
     # GlobalTag for Run3 offline data reprocessing - snapshot at 2022-07-12 23:00:00 (UTC)
     'run3_data'                    : '124X_dataRun3_v9',
     # GlobalTag for Run3 data relvals: allows customization to run with fixed L1 menu
-    'run3_data_relval'             : '124X_dataRun3_relval_v8',
+    'run3_data_relval'             : '125X_dataRun3_relval_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'           : '123X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -68,21 +68,21 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak'     : '123X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2022
-    'phase1_2022_design'           : '124X_mcRun3_2022_design_v7',
+    'phase1_2022_design'           : '125X_mcRun3_2022_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022
-    'phase1_2022_realistic'        : '124X_mcRun3_2022_realistic_v10',
+    'phase1_2022_realistic'        : '125X_mcRun3_2022_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2022,  Strip tracker in DECO mode
-    'phase1_2022_cosmics'          : '124X_mcRun3_2022cosmics_realistic_deco_v11',
+    'phase1_2022_cosmics'          : '125X_mcRun3_2022cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with perfectly aligned and calibrated detector for Phase1 2022, Strip tracker in DECO mode
-    'phase1_2022_cosmics_design'   : '124X_mcRun3_2022cosmics_design_deco_v7',
+    'phase1_2022_cosmics_design'   : '125X_mcRun3_2022cosmics_design_deco_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2022 detector for Heavy Ion
-    'phase1_2022_realistic_hi'     : '124X_mcRun3_2022_realistic_HI_v10',
+    'phase1_2022_realistic_hi'     : '125X_mcRun3_2022_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'        : '124X_mcRun3_2023_realistic_v11',
+    'phase1_2023_realistic'        : '125X_mcRun3_2023_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'        : '124X_mcRun3_2024_realistic_v11',
+    'phase1_2024_realistic'        : '125X_mcRun3_2024_realistic_v2',
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'             : '124X_mcRun4_realistic_v8'
+    'phase2_realistic'             : '125X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Include JEC and PF calibrations as request in https://cms-talk.web.cern.ch/t/gt-new-run3-hlt-jec-tags-for-123x-125x-for-mc/13290 and https://cms-talk.web.cern.ch/t/gt-updated-pf-calibration-hlt-tag-for-run-3/13293 then add new L1T menu as requested in https://cms-talk.web.cern.ch/t/run-3-gt-update-of-the-l1-menu-tag-v1-3-0-in-run-3-mc-gts-and-run-3-data-relvals-gts/13513


The new GTs and their diff wrt to the last GTs in autoCond are here

**phase1_2022_design**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_design_v7/125X_mcRun3_2022_design_v2

**phase1_2022_realistic**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_v10/125X_mcRun3_2022_realistic_v2

**phase1_2022_cosmics**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022cosmics_realistic_deco_v11/125X_mcRun3_2022cosmics_realistic_deco_v2

**phase1_2022_cosmics_design**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022cosmics_design_deco_v7/125X_mcRun3_2022cosmics_design_deco_v2

**phase1_2022_realistic_hi**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2022_realistic_HI_v10/125X_mcRun3_2022_realistic_HI_v2

**phase1_2023_realistic**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2023_realistic_v11/125X_mcRun3_2023_realistic_v2

**phase1_2024_realistic**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun3_2024_realistic_v11/125X_mcRun3_2024_realistic_v2

**phase2_realistic**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_mcRun4_realistic_v8/125X_mcRun4_realistic_v2

**run3_hlt_relval**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_dataRun3_HLT_relval_v8/125X_dataRun3_HLT_relval_v1

**run3_data_relval**

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts//124X_dataRun3_relval_v8/125X_dataRun3_relval_v1


#### PR validation:

```
test parameters:
  - workflows = 12034.0,11634.0,7.23,159.0,12434.0,12834.0
 ```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, backport might be needed, under discussion 