### PR TITLE
Bug Fix In PatternRecognitionByFastJet

### DIFF
--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyFastJet.cc
@@ -53,7 +53,11 @@ void PatternRecognitionbyFastJet<TILES>::buildJetAndTracksters(std::vector<Pseud
   }
 
   auto trackster_idx = result.size();
-  result.resize(trackster_idx + jets.size());
+  auto jetsSize = std::count_if(jets.begin(), jets.end(), [=](fastjet::PseudoJet jet) {
+    return jet.constituents().size() > static_cast<unsigned int>(minNumLayerCluster_);
+  });
+  result.resize(trackster_idx + jetsSize);
+
   for (const auto &pj : jets) {
     if (pj.constituents().size() > static_cast<unsigned int>(minNumLayerCluster_)) {
       for (const auto &component : pj.constituents()) {


### PR DESCRIPTION
This PR fixes a bug in Pattern Recognition by FastJet, where the final Tracksters collection may contain empty Tracksters due to the `resize()` method applied. 

Fix: 
- Resizing `std::vector<Trackster> result` depending on the number of Jets that satisfy the `minNumLayerCluster_` condition.