### PR TITLE
updated HLT paths for EXODisappTrk skim

### DIFF
--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -11,8 +11,21 @@ hltDisappTrk = _hltHighLevel.hltHighLevel.clone(
    throw = False,
    andOr = True,
    HLTPaths = [
-      #"HLT_MET105_IsoTrk50_v*",
-      "MC_PFMET_v17"
+      "HLT_PFMET*_PFMHT*_IDTight_v*",
+      "HLT_PFMETTypeOne*_PFMHT*_IDTight_v*",
+      "HLT_PFMETNoMu*_PFMHTNoMu*_IDTight_v*", 
+      "HLT_MET*_IsoTrk*_v*", 
+      "HLT_PFMET*_*Cleaned_v*", 
+      "HLT_Ele*_WPTight_Gsf_v*", 
+      "HLT_Ele*_WPLoose_Gsf_v*", 
+      "HLT_IsoMu*_v*", 
+      "HLT_IsoMu*_TightChargedIsoPFTauHPS*_Trk1_eta2p1_SingleL1_v*", 
+      "HLT_IsoMu*_eta2p1_TightChargedIsoPFTauHPS*_eta2p1_CrossL1_v*",
+      "HLT_IsoMu*_MediumChargedIsoPFTauHPS20_Trk1_eta2p1_SingleL1_v*", 
+      "HLT_MediumChargedIsoPFTau*HighPtRelaxedIso_Trk50_eta2p1_v*", 
+      "HLT_VBF_DoubleMediumChargedIsoPFTauHPS20_Trk1_eta2p1_v*",
+      "HLT_DoubleMediumDeepTauIsoPFTauHPS*_L2NN_eta2p1_v*",
+      "HLT_DoubleMediumChargedIsoPFTauHPS*_Trk1_eta2p1_v*"
    ]
 )
 

--- a/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
+++ b/Configuration/Skimming/python/PDWG_EXODisappTrk_cff.py
@@ -13,19 +13,17 @@ hltDisappTrk = _hltHighLevel.hltHighLevel.clone(
    HLTPaths = [
       "HLT_PFMET*_PFMHT*_IDTight_v*",
       "HLT_PFMETTypeOne*_PFMHT*_IDTight_v*",
-      "HLT_PFMETNoMu*_PFMHTNoMu*_IDTight_v*", 
-      "HLT_MET*_IsoTrk*_v*", 
-      "HLT_PFMET*_*Cleaned_v*", 
-      "HLT_Ele*_WPTight_Gsf_v*", 
-      "HLT_Ele*_WPLoose_Gsf_v*", 
-      "HLT_IsoMu*_v*", 
-      "HLT_IsoMu*_TightChargedIsoPFTauHPS*_Trk1_eta2p1_SingleL1_v*", 
-      "HLT_IsoMu*_eta2p1_TightChargedIsoPFTauHPS*_eta2p1_CrossL1_v*",
-      "HLT_IsoMu*_MediumChargedIsoPFTauHPS20_Trk1_eta2p1_SingleL1_v*", 
-      "HLT_MediumChargedIsoPFTau*HighPtRelaxedIso_Trk50_eta2p1_v*", 
+      "HLT_PFMETNoMu*_PFMHTNoMu*_IDTight_v*",
+      "HLT_MET*_IsoTrk*_v*",
+      "HLT_PFMET*_*Cleaned_v*",
+      "HLT_Ele*_WPTight_Gsf_v*",
+      "HLT_Ele*_WPLoose_Gsf_v*",
+      "HLT_IsoMu*_v*",
+      "HLT_MediumChargedIsoPFTau*HighPtRelaxedIso_Trk50_eta2p1_v*",
       "HLT_VBF_DoubleMediumChargedIsoPFTauHPS20_Trk1_eta2p1_v*",
       "HLT_DoubleMediumDeepTauIsoPFTauHPS*_L2NN_eta2p1_v*",
-      "HLT_DoubleMediumChargedIsoPFTauHPS*_Trk1_eta2p1_v*"
+      "HLT_DoubleMediumChargedIsoPFTauHPS*_Trk1_eta2p1_v*",
+      "HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1_v*"
    ]
 )
 


### PR DESCRIPTION
#### PR description:

This PR changes the HLT paths for the EXO disappearing tracks skim. Previously the HLT path MC_PFMET was used for testing MC data. We are now removing this path and adding the HLT paths we plan to use for run 3. They are:

      "HLT_PFMET*_PFMHT*_IDTight_v*",
      "HLT_PFMETTypeOne*_PFMHT*_IDTight_v*",
      "HLT_PFMETNoMu*_PFMHTNoMu*_IDTight_v*", 
      "HLT_MET*_IsoTrk*_v*", 
      "HLT_PFMET*_*Cleaned_v*", 
      "HLT_Ele*_WPTight_Gsf_v*", 
      "HLT_Ele*_WPLoose_Gsf_v*", 
      "HLT_IsoMu*_v*", 
      "HLT_IsoMu*_TightChargedIsoPFTauHPS*_Trk1_eta2p1_SingleL1_v*", 
      "HLT_IsoMu*_eta2p1_TightChargedIsoPFTauHPS*_eta2p1_CrossL1_v*",
      "HLT_IsoMu*_MediumChargedIsoPFTauHPS20_Trk1_eta2p1_SingleL1_v*", 
      "HLT_MediumChargedIsoPFTau*HighPtRelaxedIso_Trk50_eta2p1_v*", 
      "HLT_VBF_DoubleMediumChargedIsoPFTauHPS20_Trk1_eta2p1_v*",
      "HLT_DoubleMediumDeepTauIsoPFTauHPS*_L2NN_eta2p1_v*",
      "HLT_DoubleMediumChargedIsoPFTauHPS*_Trk1_eta2p1_v*"

#### PR validation:

Ran test script over Run2022C data to check output file size. Used EGamma, SingleMuon, Tau, and MET datasets for testing because these are the datasets used by the disappearing tracks analysis.

**MET**
Total Events: 136898
Total Size: 2.0 GB
Number of Files: 91
Average Size: 21.9 MB
Dataset Size: 568.65 GB
% Size Saved: 0.35%


**Tau**
Total Events: 91896
Total Size: 1.2 GB
Number of Files: 91
Average Size: 13.2 MB
Dataset Size: 210.15 GB
% Size Saved: 0.57%

**SingleMuon**
Total Events: 1828792
Total Size: 7.9 GB
Number of Files: 84
Average Size: 96.0 MB
Dataset Size: 2436.23 GB
% Size Saved: 0.32%

**EGamma**
Total Events: 1715084
Total Size: 12.1 GB
Number of Files: 82
Average Size: 151.7 MB
Dataset Size: 6280.43 GB
% Size Saved: 0.19%


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

<!-- Please replace this text with any link to the master PR, or the intended backport release cycle numbers -->

<!-- Please delete the text above after you verified all points of the checklist  -->
