### PR TITLE
[124X backport] HCAL: Group 0 LUT edited to set LLP bits in HB only, not HE

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -531,14 +531,16 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
               lut[adc];  // used for bits 12, 13, 14, 15 for Group 0 LUT for LLP time and depth bits that rely on linearized energies
 
           if (qieType == QIE11) {
-            if ((linearizedADC < bit12_energy and cell.depth() <= 2) or (cell.depth() >= 3))
-              lut[adc] |= 1 << 12;
-            if (linearizedADC >= bit13_energy and cell.depth() >= 3)
-              lut[adc] |= 1 << 13;
-            if (linearizedADC >= bit14_energy)
-              lut[adc] |= 1 << 14;
-            if (linearizedADC >= bit15_energy)
-              lut[adc] |= 1 << 15;
+            if (subdet == HcalBarrel) {  // edit since bits 12-15 not supported in HE yet
+              if ((linearizedADC < bit12_energy and cell.depth() <= 2) or (cell.depth() >= 3))
+                lut[adc] |= 1 << 12;
+              if (linearizedADC >= bit13_energy and cell.depth() >= 3)
+                lut[adc] |= 1 << 13;
+              if (linearizedADC >= bit14_energy)
+                lut[adc] |= 1 << 14;
+              if (linearizedADC >= bit15_energy)
+                lut[adc] |= 1 << 15;
+            }
             if (adc >= mipMin and adc < mipMax)
               lut[adc] |= QIE11_LUT_MSB0;
             else if (adc >= mipMax)


### PR DESCRIPTION
#### PR description:

Edits are made such that the HCAL Group 0 LUT only sets LLP bits in HB, not HE. Current uHTR firmware only accepts the LUTs with the high bits (bits 12-15) set in HB, not in HE. This can be reversed to set the LUT bits for both HB and HE when the firmware is modified. The initial PR setting the HCAL LUT is in PR https://github.com/cms-sw/cmssw/pull/35599, where more details on the specifications are given as well. Discussed with @Michael-Krohn in detail about the HCAL LUT generation.

#### PR validation:

Prepared in CMSSW_12_4_X_2022-07-31-2300.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Backport of PR https://github.com/cms-sw/cmssw/pull/38896 as these PRs are created to match what is done currently on detector in the HCAL uHTRs, so it is considered a bug fix. Backport to 12_4_X as this is relevant for Run 3 physics data taking.
