### PR TITLE
Update run for DQM beamhlt client unitTest

### DIFF
--- a/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beamhlt_dqm_sourceclient-live_cfg.py
@@ -51,7 +51,7 @@ if unitTest:
 
   # Set the process source
   process.source = cms.Source("DQMStreamerReader",
-      runNumber = cms.untracked.uint32(346373),
+      runNumber = cms.untracked.uint32(356383),
       runInputDir = cms.untracked.string(dqm_integration_data),
       SelectEvents = cms.untracked.vstring('*'),
       streamLabel = cms.untracked.string('streamDQMOnlineBeamspot'),
@@ -150,9 +150,6 @@ process.tcdsDigis = tcdsRawToDigi.clone()
 # Set rawDataRepacker (HI and live) or rawDataCollector (for all the rest)
 if (process.runType.getRunType() == process.runType.hi_run and live):
     rawDataInputTag = "rawDataRepacker"
-elif unitTest:
-    # This is needed until we update the streamer files used for the unitTest
-    rawDataInputTag = "rawDataCollector"
 else:
     # Use raw data from selected TCDS FEDs (1024, 1025)
     rawDataInputTag = "hltFEDSelectorTCDS"


### PR DESCRIPTION
#### PR description:
This PR updates the run used for the DQM `beamhlt` client unitTest (introduced in https://github.com/cms-sw/cmssw/pull/37667) in order to get rid of the warnings emitted when running with the current input streamer files:
```
%MSG-e BeamMonitor:  BeamMonitor:dqmBeamMonitor 30-Jul-2022 12:27:09 CEST  Run: 346373 Event: 26870677
No BeamMode identified from BSTRecord!Please check that the event content has the raw data from TCDS FEDs (1024,1025)!
```
as can be seen, for example, in the [IB unitTest results](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc10/CMSSW_12_5_X_2022-07-30-1100/unitTestLogs/DQM/Integration#/).
With this PR the warning message is gone.

#### PR validation:
`scram b runtests` runs fine

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
Not a backport, no backport needed since this does not affect data-taking.