### PR TITLE
Fixed PPS Global Alignment paths

### DIFF
--- a/CalibPPS/AlignmentGlobal/plugins/PPSAlignmentHarvester.cc
+++ b/CalibPPS/AlignmentGlobal/plugins/PPSAlignmentHarvester.cc
@@ -33,6 +33,7 @@
 #include <iomanip>
 #include <cmath>
 #include <utility>
+#include <algorithm>
 
 #include "TH1D.h"
 #include "TH2D.h"
@@ -386,6 +387,7 @@ std::unique_ptr<TGraphErrors> PPSAlignmentHarvester::buildGraphFromMonitorElemen
       std::string parentPath = me->getPathname();
       size_t parentPos = parentPath.substr(0, parentPath.size() - 1).find_last_of('/') + 1;
       std::string parentName = parentPath.substr(parentPos);
+      std::replace(parentName.begin(), parentName.end(), '_', '.');  // replace _ with .
       size_t d = parentName.find('-');
       const double x_min = std::stod(parentName.substr(0, d));
       const double x_max = std::stod(parentName.substr(d + 1));
@@ -581,7 +583,7 @@ void PPSAlignmentHarvester::xAlignment(DQMStore::IBooker& iBooker,
                                    std::make_pair(cfg.sectorConfig56(), cfg_ref.sectorConfig56())}) {
     for (const auto& [rpc, rpc_ref] :
          {std::make_pair(sc.rp_F_, sc_ref.rp_F_), std::make_pair(sc.rp_N_, sc_ref.rp_N_)}) {
-      auto mes_test = iGetter.getAllContents(dqmDir_ + "/worker/" + sc.name_ + "/near_far/x slices, " + rpc.position_);
+      auto mes_test = iGetter.getAllContents(dqmDir_ + "/worker/" + sc.name_ + "/near_far/x slices " + rpc.position_);
       if (mes_test.empty()) {
         edm::LogWarning("PPSAlignmentHarvester") << "[x_alignment] " << rpc.name_ << ": could not load mes_test";
         continue;

--- a/CalibPPS/AlignmentGlobal/plugins/PPSAlignmentWorker.cc
+++ b/CalibPPS/AlignmentGlobal/plugins/PPSAlignmentWorker.cc
@@ -273,8 +273,8 @@ void PPSAlignmentWorker::SectorData::init(DQMStore::IBooker& iBooker,
 
     char buf[100];
     sprintf(buf, "%.1f-%.1f", x_min, x_max);
-
-    iBooker.setCurrentFolder(rootDir + "/" + scfg_.name_ + "/near_far/x slices, N/" + buf);
+    std::replace(buf, buf + strlen(buf), '.', '_');  // replace . with _
+    iBooker.setCurrentFolder(rootDir + "/" + scfg_.name_ + "/near_far/x slices N/" + buf);
     x_slice_plots_N.insert({i, SlicePlots(iBooker, cfg, debug)});
   }
 
@@ -284,8 +284,8 @@ void PPSAlignmentWorker::SectorData::init(DQMStore::IBooker& iBooker,
 
     char buf[100];
     sprintf(buf, "%.1f-%.1f", x_min, x_max);
-
-    iBooker.setCurrentFolder(rootDir + "/" + scfg_.name_ + "/near_far/x slices, F/" + buf);
+    std::replace(buf, buf + strlen(buf), '.', '_');  // replace . with _
+    iBooker.setCurrentFolder(rootDir + "/" + scfg_.name_ + "/near_far/x slices F/" + buf);
     x_slice_plots_F.insert({i, SlicePlots(iBooker, cfg, debug)});
   }
 }

--- a/CalibPPS/ESProducers/plugins/PPSAlignmentConfigurationESSource.cc
+++ b/CalibPPS/ESProducers/plugins/PPSAlignmentConfigurationESSource.cc
@@ -25,6 +25,7 @@
 #include <map>
 #include <memory>
 #include <queue>
+#include <algorithm>
 
 #include "TF1.h"
 #include "TProfile.h"
@@ -213,7 +214,7 @@ PPSAlignmentConfigurationESSource::PPSAlignmentConfigurationESSource(const edm::
             gDirectory = debugFile->mkdir(rpConfigs[p.first]->name_.c_str())->mkdir("fits_ref");
 
           auto* d_ref = (TDirectory*)ad_ref->Get(
-              (sectorNames[p.first] + "/near_far/x slices, " + rpConfigs[p.first]->position_).c_str());
+              (sectorNames[p.first] + "/near_far/x slices " + rpConfigs[p.first]->position_).c_str());
           if (d_ref == nullptr) {
             edm::LogWarning("PPS") << "[ESSource] could not load d_ref";
           } else {
@@ -627,6 +628,7 @@ std::vector<PPSAlignmentConfiguration::PointErrors> PPSAlignmentConfigurationESS
 
     std::string name = k->GetName();
     size_t d = name.find('-');
+    std::replace(name.begin(), name.end(), '_', '.');  // replace _ with .
     const double x_min = std::stod(name.substr(0, d));
     const double x_max = std::stod(name.substr(d + 1));
 


### PR DESCRIPTION
#### PR description:

Fix to https://github.com/cms-sw/cmssw/issues/38885.

- Removed commas from the paths.
- Replaced points with underscores.

#### PR validation:

- Workflow 1042 passes.
- Reproduced some results from https://github.com/CTPPS/pps-alignment-data.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport, but needs to backport to 12_4_X
