### PR TITLE
Fftjet eventsetup fix

### DIFF
--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectionESProducer.h
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectionESProducer.h
@@ -119,6 +119,8 @@ private:
 
   using HostType = edm::ESProductHost<CorrectorSequence, ParentRecord>;
   edm::ReusableObjectHolder<HostType> holder_;
+
+  edm::ESGetToken<FFTJetCorrectorParameters, ParentRecord> token_;
 };
 
 //
@@ -131,7 +133,8 @@ FFTJetCorrectionESProducer<CT>::FFTJetCorrectionESProducer(const edm::ParameterS
       verbose(psIn.getUntrackedParameter<bool>("verbose", false)) {
   // The following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced(this);
+  auto cc = setWhatProduced(this);
+  token_ = cc.consumes();
 }
 
 // ------------ method called to produce the data  ------------
@@ -140,8 +143,7 @@ typename FFTJetCorrectionESProducer<CT>::ReturnType FFTJetCorrectionESProducer<C
   auto host = holder_.makeOrGet([]() { return new HostType; });
 
   host->template ifRecordChanges<ParentRecord>(iRecord, [this, product = host.get()](auto const& rec) {
-    edm::ESTransientHandle<FFTJetCorrectorParameters> parHandle;
-    rec.get(parHandle);
+    auto parHandle = rec.getTransientHandle(token_);
     buildCorrectorSequence<CorrectorSequence>(*parHandle, sequence, isArchiveCompressed, verbose, product);
   });
 

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBReader.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBReader.cc
@@ -24,7 +24,7 @@
 #include "Alignment/Geners/interface/CompressedIO.hh"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -42,7 +42,7 @@
 //
 // class declaration
 //
-class FFTJetCorrectorDBReader : public edm::EDAnalyzer {
+class FFTJetCorrectorDBReader : public edm::stream::EDAnalyzer<> {
 public:
   explicit FFTJetCorrectorDBReader(const edm::ParameterSet&);
   FFTJetCorrectorDBReader() = delete;
@@ -58,6 +58,8 @@ private:
   bool printAsString;
   bool readArchive;
   bool isArchiveCompressed;
+
+  FFTJetCorrectorParametersLoader esLoader;
 };
 
 FFTJetCorrectorDBReader::FFTJetCorrectorDBReader(const edm::ParameterSet& ps)
@@ -65,11 +67,12 @@ FFTJetCorrectorDBReader::FFTJetCorrectorDBReader(const edm::ParameterSet& ps)
       init_param(std::string, outputFile),
       init_param(bool, printAsString),
       init_param(bool, readArchive),
-      init_param(bool, isArchiveCompressed) {}
+      init_param(bool, isArchiveCompressed) {
+  esLoader.acquireToken(record, consumesCollector());
+}
 
 void FFTJetCorrectorDBReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::ESHandle<FFTJetCorrectorParameters> JetCorParams;
-  StaticFFTJetCorrectorParametersLoader::instance().load(iSetup, record, JetCorParams);
+  edm::ESHandle<FFTJetCorrectorParameters> JetCorParams = esLoader.load(record, iSetup);
 
   if (printAsString || readArchive)
     std::cout << "++++ FFTJetCorrectorDBReader: info for record \"" << record << '"' << std::endl;

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetCorrectorDBWriter.cc
@@ -24,7 +24,7 @@
 #include <fstream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -39,7 +39,7 @@
 //
 // class declaration
 //
-class FFTJetCorrectorDBWriter : public edm::EDAnalyzer {
+class FFTJetCorrectorDBWriter : public edm::stream::EDAnalyzer<> {
 public:
   explicit FFTJetCorrectorDBWriter(const edm::ParameterSet&);
   FFTJetCorrectorDBWriter() = delete;

--- a/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
+++ b/JetMETCorrections/FFTJetModules/plugins/FFTJetLookupTableESProducer.cc
@@ -117,6 +117,8 @@ private:
 
   using HostType = edm::ESProductHost<FFTJetLookupTableSequence, ParentRecord>;
   edm::ReusableObjectHolder<HostType> holder_;
+
+  edm::ESGetToken<FFTJetCorrectorParameters, ParentRecord> token_;
 };
 
 //
@@ -129,7 +131,8 @@ FFTJetLookupTableESProducer<CT>::FFTJetLookupTableESProducer(const edm::Paramete
       verbose(psIn.getUntrackedParameter<bool>("verbose")) {
   // The following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced(this);
+  auto cc = setWhatProduced(this);
+  token_ = cc.consumes();
 }
 
 // ------------ method called to produce the data  ------------
@@ -138,8 +141,7 @@ typename FFTJetLookupTableESProducer<CT>::ReturnType FFTJetLookupTableESProducer
   auto host = holder_.makeOrGet([]() { return new HostType; });
 
   host->template ifRecordChanges<ParentRecord>(iRecord, [this, product = host.get()](auto const& rec) {
-    edm::ESTransientHandle<FFTJetCorrectorParameters> parHandle;
-    rec.get(parHandle);
+    edm::ESTransientHandle<FFTJetCorrectorParameters> parHandle = rec.getTransientHandle(token_);
     buildLookupTables(*parHandle, tables, isArchiveCompressed, verbose, product);
   });
 

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorParametersLoader.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorParametersLoader.h
@@ -4,16 +4,9 @@
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h"
 #include "CondFormats/JetMETObjects/interface/FFTJetCorrectorParameters.h"
 
-//
-// Note that the class below does not have any public constructors.
-// All application usage is via the StaticFFTJetRcdMapper wrapper.
-//
-class FFTJetCorrectorParametersLoader : public DefaultFFTJetRcdMapper<FFTJetCorrectorParameters> {
+struct FFTJetCorrectorParametersLoader : public DefaultFFTJetRcdMapper<FFTJetCorrectorParameters> {
   typedef DefaultFFTJetRcdMapper<FFTJetCorrectorParameters> Base;
-  friend class StaticFFTJetRcdMapper<FFTJetCorrectorParametersLoader>;
-  FFTJetCorrectorParametersLoader();  //NOLINT
+  FFTJetCorrectorParametersLoader();
 };
-
-typedef StaticFFTJetRcdMapper<FFTJetCorrectorParametersLoader> StaticFFTJetCorrectorParametersLoader;
 
 #endif  // JetMETCorrections_FFTJetObjects_FFTJetCorrectorParametersLoader_h

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceLoader.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceLoader.h
@@ -4,52 +4,34 @@
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h"
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceTypes.h"
 
-class FFTBasicJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTBasicJetCorrectorSequence> {
+struct FFTBasicJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTBasicJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTBasicJetCorrectorSequence> Base;
-  friend class StaticFFTJetRcdMapper<FFTBasicJetCorrectorSequenceLoader>;
-  FFTBasicJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
+  FFTBasicJetCorrectorSequenceLoader();
 };
 
-typedef StaticFFTJetRcdMapper<FFTBasicJetCorrectorSequenceLoader> StaticFFTBasicJetCorrectorSequenceLoader;
-
-class FFTCaloJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTCaloJetCorrectorSequence> {
+struct FFTCaloJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTCaloJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTCaloJetCorrectorSequence> Base;
-  friend class StaticFFTJetRcdMapper<FFTCaloJetCorrectorSequenceLoader>;
-  FFTCaloJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
+  FFTCaloJetCorrectorSequenceLoader();
 };
 
-typedef StaticFFTJetRcdMapper<FFTCaloJetCorrectorSequenceLoader> StaticFFTCaloJetCorrectorSequenceLoader;
-
-class FFTGenJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTGenJetCorrectorSequence> {
+struct FFTGenJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTGenJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTGenJetCorrectorSequence> Base;
-  friend class StaticFFTJetRcdMapper<FFTGenJetCorrectorSequenceLoader>;
-  FFTGenJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
+  FFTGenJetCorrectorSequenceLoader();
 };
 
-typedef StaticFFTJetRcdMapper<FFTGenJetCorrectorSequenceLoader> StaticFFTGenJetCorrectorSequenceLoader;
-
-class FFTPFJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTPFJetCorrectorSequence> {
+struct FFTPFJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTPFJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTPFJetCorrectorSequence> Base;
-  friend class StaticFFTJetRcdMapper<FFTPFJetCorrectorSequenceLoader>;
-  FFTPFJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
+  FFTPFJetCorrectorSequenceLoader();
 };
 
-typedef StaticFFTJetRcdMapper<FFTPFJetCorrectorSequenceLoader> StaticFFTPFJetCorrectorSequenceLoader;
-
-class FFTTrackJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTTrackJetCorrectorSequence> {
+struct FFTTrackJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTTrackJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTTrackJetCorrectorSequence> Base;
-  friend class StaticFFTJetRcdMapper<FFTTrackJetCorrectorSequenceLoader>;
-  FFTTrackJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
+  FFTTrackJetCorrectorSequenceLoader();
 };
 
-typedef StaticFFTJetRcdMapper<FFTTrackJetCorrectorSequenceLoader> StaticFFTTrackJetCorrectorSequenceLoader;
-
-class FFTJPTJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTJPTJetCorrectorSequence> {
+struct FFTJPTJetCorrectorSequenceLoader : public DefaultFFTJetRcdMapper<FFTJPTJetCorrectorSequence> {
   typedef DefaultFFTJetRcdMapper<FFTJPTJetCorrectorSequence> Base;
-  friend class StaticFFTJetRcdMapper<FFTJPTJetCorrectorSequenceLoader>;
-  FFTJPTJetCorrectorSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
+  FFTJPTJetCorrectorSequenceLoader();
 };
-
-typedef StaticFFTJetRcdMapper<FFTJPTJetCorrectorSequenceLoader> StaticFFTJPTJetCorrectorSequenceLoader;
 
 #endif  // JetMETCorrections_FFTJetObjects_FFTJetCorrectorSequenceLoader_h

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceTypemap.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetCorrectorSequenceTypemap.h
@@ -16,32 +16,32 @@ struct FFTJetCorrectorSequenceTypemap {};
 
 template <>
 struct FFTJetCorrectorSequenceTypemap<reco::FFTAnyJet<reco::BasicJet> > {
-  typedef StaticFFTBasicJetCorrectorSequenceLoader loader;
+  typedef FFTBasicJetCorrectorSequenceLoader loader;
 };
 
 template <>
 struct FFTJetCorrectorSequenceTypemap<reco::FFTAnyJet<reco::CaloJet> > {
-  typedef StaticFFTCaloJetCorrectorSequenceLoader loader;
+  typedef FFTCaloJetCorrectorSequenceLoader loader;
 };
 
 template <>
 struct FFTJetCorrectorSequenceTypemap<reco::FFTAnyJet<reco::GenJet> > {
-  typedef StaticFFTGenJetCorrectorSequenceLoader loader;
+  typedef FFTGenJetCorrectorSequenceLoader loader;
 };
 
 template <>
 struct FFTJetCorrectorSequenceTypemap<reco::FFTAnyJet<reco::PFJet> > {
-  typedef StaticFFTPFJetCorrectorSequenceLoader loader;
+  typedef FFTPFJetCorrectorSequenceLoader loader;
 };
 
 template <>
 struct FFTJetCorrectorSequenceTypemap<reco::FFTAnyJet<reco::TrackJet> > {
-  typedef StaticFFTTrackJetCorrectorSequenceLoader loader;
+  typedef FFTTrackJetCorrectorSequenceLoader loader;
 };
 
 template <>
 struct FFTJetCorrectorSequenceTypemap<reco::FFTAnyJet<reco::JPTJet> > {
-  typedef StaticFFTJPTJetCorrectorSequenceLoader loader;
+  typedef FFTJPTJetCorrectorSequenceLoader loader;
 };
 
 #endif  // JetMETCorrections_FFTJetObjects_FFTJetCorrectorSequenceTypemap_h

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequenceLoader.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequenceLoader.h
@@ -4,16 +4,9 @@
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h"
 #include "JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequence.h"
 
-//
-// Note that the class below does not have any public constructors.
-// All application usage is via the StaticFFTJetRcdMapper wrapper.
-//
-class FFTJetLookupTableSequenceLoader : public DefaultFFTJetRcdMapper<FFTJetLookupTableSequence> {
+struct FFTJetLookupTableSequenceLoader : public DefaultFFTJetRcdMapper<FFTJetLookupTableSequence> {
   typedef DefaultFFTJetRcdMapper<FFTJetLookupTableSequence> Base;
-  friend class StaticFFTJetRcdMapper<FFTJetLookupTableSequenceLoader>;
-  FFTJetLookupTableSequenceLoader();  // NOLINT - prevent clang-tidy from adding `= delete`
+  FFTJetLookupTableSequenceLoader();
 };
-
-typedef StaticFFTJetRcdMapper<FFTJetLookupTableSequenceLoader> StaticFFTJetLookupTableSequenceLoader;
 
 #endif  // JetMETCorrections_FFTJetObjects_FFTJetLookupTableSequenceLoader_h

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h
@@ -49,7 +49,11 @@ public:
     tokenAcquired_ = true;
   }
 
-  inline edm::ESHandle<DataType> load(const edm::EventSetup& iSetup) const override { return iSetup.getHandle(token_); }
+  inline edm::ESHandle<DataType> load(const edm::EventSetup& iSetup) const override {
+    if (!tokenAcquired_)
+      throw cms::Exception("ESGetTokenNotAcquired");
+    return iSetup.getHandle(token_);
+  }
 
 private:
   edm::ESGetToken<DataType, RecordType> token_;

--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetRcdMapper.h
@@ -13,32 +13,47 @@
 #include <map>
 #include <string>
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
 
 template <class DataType>
 struct AbsFFTJetRcdMapper {
   virtual ~AbsFFTJetRcdMapper() {}
 
-  virtual void load(const edm::EventSetup& iSetup, edm::ESHandle<DataType>& handle) const = 0;
+  virtual void acquireToken(edm::ConsumesCollector iC) = 0;
 
-  virtual void load(const edm::EventSetup& iSetup, const std::string& label, edm::ESHandle<DataType>& handle) const = 0;
+  virtual void acquireToken(edm::ConsumesCollector iC, const std::string& label) = 0;
+
+  virtual edm::ESHandle<DataType> load(const edm::EventSetup& iSetup) const = 0;
 };
 
 template <class DataType, class RecordType>
-struct ConcreteFFTJetRcdMapper : public AbsFFTJetRcdMapper<DataType> {
+class ConcreteFFTJetRcdMapper : public AbsFFTJetRcdMapper<DataType> {
+public:
   ~ConcreteFFTJetRcdMapper() override {}
 
-  inline void load(const edm::EventSetup& iSetup, edm::ESHandle<DataType>& handle) const override {
-    iSetup.get<RecordType>().get(handle);
+  inline void acquireToken(edm::ConsumesCollector iC) override {
+    if (tokenAcquired_)
+      throw cms::Exception("ESGetTokenAlreadyAcquired");
+    token_ = iC.esConsumes<DataType, RecordType>();
+    tokenAcquired_ = true;
   }
 
-  inline void load(const edm::EventSetup& iSetup,
-                   const std::string& label,
-                   edm::ESHandle<DataType>& handle) const override {
-    iSetup.get<RecordType>().get(label, handle);
+  inline void acquireToken(edm::ConsumesCollector iC, const std::string& label) override {
+    if (tokenAcquired_)
+      throw cms::Exception("ESGetTokenAlreadyAcquired");
+    token_ = iC.esConsumes<DataType, RecordType>(edm::ESInputTag("", label));
+    tokenAcquired_ = true;
   }
+
+  inline edm::ESHandle<DataType> load(const edm::EventSetup& iSetup) const override { return iSetup.getHandle(token_); }
+
+private:
+  edm::ESGetToken<DataType, RecordType> token_;
+  bool tokenAcquired_ = false;
 };
 
 template <class DataType>
@@ -53,48 +68,29 @@ struct DefaultFFTJetRcdMapper : public std::map<std::string, AbsFFTJetRcdMapper<
       delete it->second;
   }
 
-  inline void load(const edm::EventSetup& iSetup, const std::string& record, edm::ESHandle<DataType>& handle) const {
-    typename std::map<std::string, AbsFFTJetRcdMapper<DataType>*>::const_iterator it = this->find(record);
+  inline void acquireToken(const std::string& record, edm::ConsumesCollector iC) {
+    typename std::map<std::string, AbsFFTJetRcdMapper<DataType>*>::iterator it = this->find(record);
     if (it == this->end())
       throw cms::Exception("KeyNotFound") << "Record \"" << record << "\" is not registered\n";
-    it->second->load(iSetup, handle);
+    it->second->acquireToken(iC);
   }
 
-  inline void load(const edm::EventSetup& iSetup,
-                   const std::string& record,
-                   const std::string& label,
-                   edm::ESHandle<DataType>& handle) const {
+  inline void acquireToken(const std::string& record, edm::ConsumesCollector iC, const std::string& label) {
+    typename std::map<std::string, AbsFFTJetRcdMapper<DataType>*>::iterator it = this->find(record);
+    if (it == this->end())
+      throw cms::Exception("KeyNotFound") << "Record \"" << record << "\" is not registered\n";
+    it->second->acquireToken(iC, label);
+  }
+
+  inline edm::ESHandle<DataType> load(const std::string& record, const edm::EventSetup& iSetup) const {
     typename std::map<std::string, AbsFFTJetRcdMapper<DataType>*>::const_iterator it = this->find(record);
     if (it == this->end())
       throw cms::Exception("KeyNotFound") << "Record \"" << record << "\" is not registered\n";
-    it->second->load(iSetup, label, handle);
+    return it->second->load(iSetup);
   }
 
   DefaultFFTJetRcdMapper(const DefaultFFTJetRcdMapper&) = delete;
   DefaultFFTJetRcdMapper& operator=(const DefaultFFTJetRcdMapper&) = delete;
-};
-
-//
-// Singleton for the mapper
-//
-template <class Mapper>
-class StaticFFTJetRcdMapper {
-public:
-  typedef typename Mapper::Base::data_type data_type;
-
-  static const Mapper& instance() {
-    static Mapper obj;
-    return obj;
-  }
-
-  template <class Record>
-  static void registerRecord(const std::string& record) {
-    Mapper& rd = const_cast<Mapper&>(instance());
-    delete rd[record];
-    rd[record] = new ConcreteFFTJetRcdMapper<data_type, Record>();
-  }
-
-  StaticFFTJetRcdMapper() = delete;
 };
 
 #endif  // JetMETCorrections_FFTJetObjects_FFTJetRcdMapper_h

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupEstimator.cc
@@ -96,6 +96,8 @@ private:
   std::string calibrationCurveName;
   std::string uncertaintyCurveName;
   bool loadCalibFromDB;
+
+  FFTJetLookupTableSequenceLoader esLoader;
 };
 
 //
@@ -123,6 +125,8 @@ FFTJetPileupEstimator::FFTJetPileupEstimator(const edm::ParameterSet& ps)
   inputToken = consumes<reco::DiscretizedEnergyFlow>(inputLabel);
 
   produces<reco::FFTJetPileupSummary>(outputLabel);
+
+  esLoader.acquireToken(calibTableRecord, consumesCollector());
 }
 
 FFTJetPileupEstimator::~FFTJetPileupEstimator() {}
@@ -189,8 +193,7 @@ std::unique_ptr<reco::FFTJetPileupSummary> FFTJetPileupEstimator::calibrateFromC
 
 std::unique_ptr<reco::FFTJetPileupSummary> FFTJetPileupEstimator::calibrateFromDB(const double curve,
                                                                                   const edm::EventSetup& iSetup) const {
-  edm::ESHandle<FFTJetLookupTableSequence> h;
-  StaticFFTJetLookupTableSequenceLoader::instance().load(iSetup, calibTableRecord, h);
+  edm::ESHandle<FFTJetLookupTableSequence> h = esLoader.load(calibTableRecord, iSetup);
   std::shared_ptr<npstat::StorableMultivariateFunctor> uz = (*h)[calibTableCategory][uncertaintyZonesName];
   std::shared_ptr<npstat::StorableMultivariateFunctor> cc = (*h)[calibTableCategory][calibrationCurveName];
   std::shared_ptr<npstat::StorableMultivariateFunctor> uc = (*h)[calibTableCategory][uncertaintyCurveName];

--- a/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetPileupProcessor.cc
@@ -113,6 +113,8 @@ private:
   std::string flatteningTableName;
   std::string flatteningTableCategory;
   bool loadFlatteningFactorsFromDB;
+
+  FFTJetLookupTableSequenceLoader esLoader;
 };
 
 //
@@ -165,6 +167,8 @@ FFTJetPileupProcessor::FFTJetPileupProcessor(const edm::ParameterSet& ps)
 
   produces<reco::DiscretizedEnergyFlow>(outputLabel);
   produces<std::pair<double, double>>(outputLabel);
+
+  esLoader.acquireToken(flatteningTableRecord, consumesCollector());
 }
 
 void FFTJetPileupProcessor::buildKernelConvolver(const edm::ParameterSet& ps) {
@@ -316,8 +320,7 @@ void FFTJetPileupProcessor::mixExtraGrid() {
 }
 
 void FFTJetPileupProcessor::loadFlatteningFactors(const edm::EventSetup& iSetup) {
-  edm::ESHandle<FFTJetLookupTableSequence> h;
-  StaticFFTJetLookupTableSequenceLoader::instance().load(iSetup, flatteningTableRecord, h);
+  edm::ESHandle<FFTJetLookupTableSequence> h = esLoader.load(flatteningTableRecord, iSetup);
   std::shared_ptr<npstat::StorableMultivariateFunctor> f = (*h)[flatteningTableCategory][flatteningTableName];
 
   // Fill out the table of flattening factors as a function of eta

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.cc
@@ -55,28 +55,28 @@
 // JPTJet is omitted for now: there is no reco::writeSpecific method
 // for it (see header JetSpecific.h in the JetProducers package)
 //
-#define jet_type_switch(method, arg1, arg2)                    \
-  do {                                                         \
-    switch (jetType) {                                         \
-      case CALOJET:                                            \
-        method<reco::CaloJet>(arg1, arg2);                     \
-        break;                                                 \
-      case PFJET:                                              \
-        method<reco::PFJet>(arg1, arg2);                       \
-        break;                                                 \
-      case GENJET:                                             \
-        method<reco::GenJet>(arg1, arg2);                      \
-        break;                                                 \
-      case TRACKJET:                                           \
-        method<reco::TrackJet>(arg1, arg2);                    \
-        break;                                                 \
-      case BASICJET:                                           \
-        method<reco::BasicJet>(arg1, arg2);                    \
-        break;                                                 \
-      default:                                                 \
-        assert(!"ERROR in FFTJetProducer : invalid jet type."\
+#define jet_type_switch(method, arg1, arg2)                      \
+  do {                                                           \
+    switch (jetType) {                                           \
+      case CALOJET:                                              \
+        method<reco::CaloJet>(arg1, arg2);                       \
+        break;                                                   \
+      case PFJET:                                                \
+        method<reco::PFJet>(arg1, arg2);                         \
+        break;                                                   \
+      case GENJET:                                               \
+        method<reco::GenJet>(arg1, arg2);                        \
+        break;                                                   \
+      case TRACKJET:                                             \
+        method<reco::TrackJet>(arg1, arg2);                      \
+        break;                                                   \
+      case BASICJET:                                             \
+        method<reco::BasicJet>(arg1, arg2);                      \
+        break;                                                   \
+      default:                                                   \
+        assert(!"ERROR in FFTJetProducer : invalid jet type."  \
                " This is a bug. Please report."); \
-    }                                                          \
+    }                                                            \
   } while (0);
 
 namespace {
@@ -180,6 +180,8 @@ FFTJetProducer::FFTJetProducer(const edm::ParameterSet& ps)
   input_genjet_token_ = consumes<std::vector<reco::FFTAnyJet<reco::GenJet> > >(genJetsLabel);
   input_energyflow_token_ = consumes<reco::DiscretizedEnergyFlow>(treeLabel);
   input_pusummary_token_ = consumes<reco::FFTJetPileupSummary>(pileupLabel);
+
+  esLoader_.acquireToken(pileupTableRecord, consumesCollector());
 
   // Most of the configuration has to be performed inside
   // the "beginStream" method. This is because chaining of the
@@ -964,8 +966,7 @@ void FFTJetProducer::determinePileupDensityFromConfig(const edm::Event& iEvent,
 void FFTJetProducer::determinePileupDensityFromDB(const edm::Event& iEvent,
                                                   const edm::EventSetup& iSetup,
                                                   std::unique_ptr<fftjet::Grid2d<fftjetcms::Real> >& density) {
-  edm::ESHandle<FFTJetLookupTableSequence> h;
-  StaticFFTJetLookupTableSequenceLoader::instance().load(iSetup, pileupTableRecord, h);
+  edm::ESHandle<FFTJetLookupTableSequence> h = esLoader_.load(pileupTableRecord, iSetup);
   std::shared_ptr<npstat::StorableMultivariateFunctor> f = (*h)[pileupTableCategory][pileupTableName];
 
   edm::Handle<reco::FFTJetPileupSummary> summary;

--- a/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetProducer.h
@@ -67,6 +67,8 @@
 #include "RecoJets/FFTJetAlgorithms/interface/AbsPileupCalculator.h"
 #include "RecoJets/FFTJetProducers/interface/FFTJetInterface.h"
 
+#include "JetMETCorrections/FFTJetObjects/interface/FFTJetLookupTableSequenceLoader.h"
+
 namespace fftjetcms {
   class DiscretizedEnergyFlow;
 }
@@ -407,6 +409,8 @@ private:
 
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometry_token_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topology_token_;
+
+  FFTJetLookupTableSequenceLoader esLoader_;
 };
 
 #endif  // RecoJets_FFTJetProducers_FFTJetProducer_h


### PR DESCRIPTION
#### PR description:

Proper use of ESGetToken objects for FFTJet modules, with appropriate esConsumes calls introduced in the module constructors. This is a purely technical fix, with no changes in the results expected.

#### PR validation:

The usual runTheMatrix tests were run, as well as some private tests.
