### PR TITLE
[DO NOT MERGE] Detect and remove duplicate pixels

### DIFF
--- a/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
+++ b/DataFormats/SiPixelDigi/interface/SiPixelDigiConstants.h
@@ -55,6 +55,8 @@ namespace sipixelconstants {
     inline constexpr uint32_t getRow(uint32_t ww) { return ((ww >> ROW_shift) & ROW_mask); }
     inline constexpr uint32_t getDCol(uint32_t ww) { return ((ww >> DCOL_shift) & DCOL_mask); }
     inline constexpr uint32_t getPxId(uint32_t ww) { return ((ww >> PXID_shift) & PXID_mask); }
+    // ADC_shift == 0: let's keep it simple
+    inline constexpr uint32_t removeADC(uint32_t ww) { return (ww >> ADC_bits); }
   }  // namespace functions
 }  // namespace sipixelconstants
 

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/gpuClusterChargeCut.h
@@ -39,6 +39,8 @@ namespace gpuClustering {
     auto endModule = moduleStart[0];
     for (auto module = firstModule; module < endModule; module += gridDim.x) {
       auto firstPixel = moduleStart[1 + module];
+      while (id[firstPixel] == invalidModuleId)
+        ++firstPixel;  // could be duplicates!
       auto thisModuleId = id[firstPixel];
       assert(thisModuleId < nMaxModules);
       assert(thisModuleId == moduleId[module]);

--- a/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering_t.h
+++ b/RecoLocalTracker/SiPixelClusterizer/test/gpuClustering_t.h
@@ -31,6 +31,7 @@ int main(void) {
   constexpr SiPixelClusterThresholds clusterThresholds(kSiPixelClusterThresholdsDefaultPhase1);
 
   // these in reality are already on GPU
+  auto h_raw = std::make_unique<uint32_t[]>(numElements);
   auto h_id = std::make_unique<uint16_t[]>(numElements);
   auto h_x = std::make_unique<uint16_t[]>(numElements);
   auto h_y = std::make_unique<uint16_t[]>(numElements);
@@ -38,6 +39,7 @@ int main(void) {
   auto h_clus = std::make_unique<int[]>(numElements);
 
 #ifdef __CUDACC__
+  auto d_raw = cms::cuda::make_device_unique<uint32_t[]>(numElements, nullptr);
   auto d_id = cms::cuda::make_device_unique<uint16_t[]>(numElements, nullptr);
   auto d_x = cms::cuda::make_device_unique<uint16_t[]>(numElements, nullptr);
   auto d_y = cms::cuda::make_device_unique<uint16_t[]>(numElements, nullptr);
@@ -265,6 +267,7 @@ int main(void) {
 
     cms::cuda::launch(findClus<false>,
                       {blocksPerGrid, threadsPerBlock},
+                      d_raw.get(),
                       d_id.get(),
                       d_x.get(),
                       d_y.get(),
@@ -305,8 +308,15 @@ int main(void) {
     h_moduleStart[0] = nModules;
     countModules<false>(h_id.get(), h_moduleStart.get(), h_clus.get(), n);
     memset(h_clusInModule.get(), 0, maxNumModules * sizeof(uint32_t));
-    findClus<false>(
-        h_id.get(), h_x.get(), h_y.get(), h_moduleStart.get(), h_clusInModule.get(), h_moduleId.get(), h_clus.get(), n);
+    findClus<false>(h_raw.get(),
+                    h_id.get(),
+                    h_x.get(),
+                    h_y.get(),
+                    h_moduleStart.get(),
+                    h_clusInModule.get(),
+                    h_moduleId.get(),
+                    h_clus.get(),
+                    n);
 
     nModules = h_moduleStart[0];
     auto nclus = h_clusInModule.get();


### PR DESCRIPTION
#### PR description:

Same as #37359, squashed and rebased for CMSSW 12.4.x/12.5.x.

This reduces the throughput of the unpacking and clustering step running on a full HLT node (2x 64 core CPUs, 2x T4 GPUs) By 8%, from
```
1569.7 ±  14.4 ev/s
```
to
```
1447.0 ±  13.0 ev/s
```


#### PR validation:

See #37359.