### PR TITLE
Removed obsolete PrintInfo() function from G4muDarkBremsstrahlung

### DIFF
--- a/SimG4Core/CustomPhysics/interface/G4muDarkBremsstrahlung.h
+++ b/SimG4Core/CustomPhysics/interface/G4muDarkBremsstrahlung.h
@@ -20,8 +20,6 @@ public:
 
   G4bool IsApplicable(const G4ParticleDefinition& p) override;
 
-  void PrintInfo() override;
-
   void SetMethod(std::string method_in);
 
   G4bool IsEnabled();

--- a/SimG4Core/CustomPhysics/interface/G4muDarkBremsstrahlungModel.h
+++ b/SimG4Core/CustomPhysics/interface/G4muDarkBremsstrahlungModel.h
@@ -21,6 +21,7 @@ struct ParamsForChi {
   double AA;
   double ZZ;
   double MMA;
+  double MMu;
   double EE0;
 };
 struct frame {
@@ -81,6 +82,7 @@ protected:
   G4ParticleDefinition* theAPrime;
   G4ParticleChangeForLoss* fParticleChange;
   G4double MA;
+  G4double muonMass;
   G4bool isMuon;
 
 private:

--- a/SimG4Core/CustomPhysics/src/G4muDarkBremsstrahlung.cc
+++ b/SimG4Core/CustomPhysics/src/G4muDarkBremsstrahlung.cc
@@ -33,8 +33,6 @@ void G4muDarkBremsstrahlung::InitialiseProcess(const G4ParticleDefinition*) {
   }
 }
 
-void G4muDarkBremsstrahlung::PrintInfo() {}
-
 void G4muDarkBremsstrahlung::SetMethod(std::string method_in) {
   ((G4muDarkBremsstrahlungModel*)EmModel(1))->SetMethod(method_in);
   return;


### PR DESCRIPTION
Removed PrintInfo() function from G4muDarkBremsstrahlung to resolve #38935

The process generation ran successfully with PrintInfo() removed, and hopefully its removal will fix the IB compiler errors noted in the issue.
