### PR TITLE
Replace Geometry_cff with GeometryDB_cff in PhysicsTools

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/test/testFlavorHistoryProducer.py
+++ b/PhysicsTools/HepMCCandAlgos/test/testFlavorHistoryProducer.py
@@ -23,9 +23,9 @@ process.MessageLogger.cerr.INFO = cms.untracked.PSet(
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
 # Load geometry
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = cms.string('IDEAL_V9::All')
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 # input MC stuff

--- a/PhysicsTools/PatAlgos/test/btag-from-packedPat.py
+++ b/PhysicsTools/PatAlgos/test/btag-from-packedPat.py
@@ -20,19 +20,18 @@ process.source = cms.Source("PoolSource",
 #
 
 process.load("Configuration.EventContent.EventContent_cff")
-process.load('Configuration/StandardSequences/Geometry_cff')
-process.load('Configuration/StandardSequences/MagneticField_38T_cff')
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
-process.load('Configuration/StandardSequences/Reconstruction_cff')
-process.load('Configuration/EventContent/EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.Reconstruction_cff')
+process.load('Configuration.EventContent.EventContent_cff')
 
 
 process.AOD1 = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('btag001.root')
 )
 
-process.GlobalTag.globaltag = 'POSTLS162_V1::All'
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 process.unpackTV = cms.EDProducer('PATTrackAndVertexUnpacker',
  slimmedVertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
  additionalTracks= cms.InputTag("lostTracks"),

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_addJet.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_addJet.py
@@ -28,11 +28,11 @@ process.ak4GenJets = ak4GenJets.clone(src = 'packedGenParticles')
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.load("Configuration.EventContent.EventContent_cff")
-process.load('Configuration.StandardSequences.Geometry_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic')
 
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 addJetCollection(

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_ei.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_ei.py
@@ -53,11 +53,11 @@ process.ak4GenJets = ak4GenJets.clone(src = 'packedGenParticles')
 # The following is make patJets, but EI is done with the above
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.load("Configuration.EventContent.EventContent_cff")
-process.load('Configuration.StandardSequences.Geometry_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2022_realistic')
 
 
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_jet_and_met.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_jet_and_met.py
@@ -30,11 +30,10 @@ process.pfMet.calculateSignificance = False # this can't be easily implemented o
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.load("Configuration.EventContent.EventContent_cff")
-process.load('Configuration.StandardSequences.Geometry_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = 'START70_V6::All'
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 
 
 process.patJets.addJetCharge   = False

--- a/PhysicsTools/PatAlgos/test/private/patLayer1_fromAOD-minimal.cfg.py
+++ b/PhysicsTools/PatAlgos/test/private/patLayer1_fromAOD-minimal.cfg.py
@@ -19,9 +19,9 @@ process.source = cms.Source("PoolSource",
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = cms.string('STARTUP_V4::All')
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 # PAT Layer 0+1

--- a/PhysicsTools/PatAlgos/test/private/testPATUserDataExternal.py
+++ b/PhysicsTools/PatAlgos/test/private/testPATUserDataExternal.py
@@ -17,9 +17,9 @@ process.source = cms.Source("PoolSource",
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = cms.string('STARTUP_V4::All')
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 # PAT Layer 0+1

--- a/PhysicsTools/PatExamples/test/MuonAnalyzer_cfg.py
+++ b/PhysicsTools/PatExamples/test/MuonAnalyzer_cfg.py
@@ -5,14 +5,12 @@ process = cms.Process("RecoMuon")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
-process.GlobalTag.globaltag = 'IDEAL_V9::All'
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 process.source = cms.Source("PoolSource",
-#    fileNames = cms.untracked.vstring('/store/relval/CMSSW_2_2_1/RelValH200ZZ4L/GEN-SIM-RECO/IDEAL_V9_v1/0004/B492FC1B-06C5-DD11-93B9-000423D33970.root')
                             fileNames = cms.untracked.vstring('file:PATLayer1_Output.fromAOD_full.root')
 )
 

--- a/PhysicsTools/PatExamples/test/analyzePatAnalysisTasks_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatAnalysisTasks_cfg.py
@@ -5,7 +5,6 @@ process = cms.Process("Test")
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
     "file:patTuple.root"
-#"file:store/patTuple.root"
   )
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
@@ -52,7 +51,7 @@ process.p.replace(process.jecAnalyzer, process.jecAnalyzer * process.jecAnalyzer
 #               #
 #################
 ## Geometry and Detector Conditions (needed for a Scaling up and down the JEC)
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = cms.string( autoCond[ 'startup' ] )

--- a/PhysicsTools/PatExamples/test/analyzePatBJetTags_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatBJetTags_cfg.py
@@ -11,11 +11,11 @@ process.MessageLogger.cerr.INFO = cms.untracked.PSet(
 )
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.GlobalTag.globaltag = cms.string('IDEAL_V12::All')
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 
 # produce PAT Layer 1
 process.load("PhysicsTools.PatAlgos.patSequences_cff")

--- a/PhysicsTools/PatExamples/test/analyzePatBJetTracks_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatBJetTracks_cfg.py
@@ -11,12 +11,11 @@ process.MessageLogger.cerr.INFO = cms.untracked.PSet(
 )
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.GlobalTag.globaltag = cms.string('IDEAL_V12::All')
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 # produce PAT Layer 1
 process.load("PhysicsTools.PatAlgos.patSequences_cff")
 # switch old trigger matching off

--- a/PhysicsTools/PatExamples/test/analyzePatBJetVertex_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatBJetVertex_cfg.py
@@ -11,12 +11,11 @@ process.MessageLogger.cerr.INFO = cms.untracked.PSet(
 )
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.GlobalTag.globaltag = cms.string('IDEAL_V12::All')
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 # produce PAT Layer 1
 process.load("PhysicsTools.PatAlgos.patSequences_cff")
 # switch old trigger matching off

--- a/PhysicsTools/PatExamples/test/analyzePatBTag_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatBTag_cfg.py
@@ -5,7 +5,6 @@ from PhysicsTools.PatUtils.bJetOperatingPointsParameters_cfi import *
 process = cms.Process("PatBTagAnalyzer")
 
 process.source = cms.Source("PoolSource",
-    #fileNames = cms.untracked.vstring('file:PATLayer1_Output.fromAOD_full_ttbar.root')
     fileNames = cms.untracked.vstring('/store/relval/2008/7/21/RelVal-RelValTTbar-1216579481-IDEAL_V5-2nd/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG-RECO/CMSSW_2_1_0_pre9-RelVal-1216579481-IDEAL_V5-2nd-unmerged/0000/00BCD825-6E57-DD11-8C1F-000423D98EA8.root')
 )
 
@@ -17,9 +16,9 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = cms.string('IDEAL_V5::All')
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 

--- a/PhysicsTools/PatExamples/test/analyzePatElectron_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatElectron_cfg.py
@@ -25,9 +25,9 @@ process.source = cms.Source("PoolSource",
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = cms.string('STARTUP_V7::All')
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 # produce PAT Layer 1

--- a/PhysicsTools/PatExamples/test/analyzePatTau_fromAOD_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatTau_fromAOD_cfg.py
@@ -7,11 +7,10 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 #process.MessageLogger.cerr.threshold = cms.untracked.string('INFO')
-process.load('Configuration.StandardSequences.Geometry_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = cms.string('START42_V12::All')
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 process.load('PhysicsTools.PatAlgos.patSequences_cff')
 
 process.maxEvents = cms.untracked.PSet(

--- a/PhysicsTools/PatExamples/test/analyzePatTau_fromPatTuple_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatTau_fromPatTuple_cfg.py
@@ -7,11 +7,11 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 #process.MessageLogger.cerr.threshold = cms.untracked.string('INFO')
-process.load('Configuration.StandardSequences.Geometry_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 #process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_noesprefer_cff')
-process.GlobalTag.globaltag = 'IDEAL_V9::All'
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 
 process.maxEvents = cms.untracked.PSet(            
     input = cms.untracked.int32(-1)    

--- a/PhysicsTools/PatExamples/test/analyzePatTracks_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatTracks_cfg.py
@@ -11,12 +11,11 @@ process.MessageLogger.cerr.INFO = cms.untracked.PSet(
 )
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.GlobalTag.globaltag = cms.string('IDEAL_V12::All')
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 # produce PAT Layer 1
 process.load("PhysicsTools.PatAlgos.patSequences_cff")
 # switch old trigger matching off

--- a/PhysicsTools/PatExamples/test/analyzePatTrigger_onTheFly_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatTrigger_onTheFly_cfg.py
@@ -15,8 +15,8 @@ from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 process.source = cms.Source(
   "PoolSource"
 , fileNames = cms.untracked.vstring(
-    pickRelValInputFiles( cmsswVersion = 'CMSSW_4_2_8'
-                        , globalTag    = 'START42_V12'
+    pickRelValInputFiles( cmsswVersion = 'CMSSW_12_5_0_pre3'
+                        , globalTag    = 'phase1_2022_realistic'
                         )
   )
 )
@@ -26,7 +26,7 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 ## Geometry and Detector Conditions (needed for a few patTuple production steps)
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = cms.string( autoCond[ 'startup' ] )

--- a/PhysicsTools/PatExamples/test/analyzePatVertex_cfg.py
+++ b/PhysicsTools/PatExamples/test/analyzePatVertex_cfg.py
@@ -11,12 +11,11 @@ process.MessageLogger.cerr.INFO = cms.untracked.PSet(
 )
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
-process.GlobalTag.globaltag = cms.string('IDEAL_V12::All')
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 # produce PAT Layer 1
 process.load("PhysicsTools.PatAlgos.patSequences_cff")
 # switch old trigger matching off

--- a/PhysicsTools/TagAndProbe/test/Electron_TagProbeTreeProducer_cfg.py
+++ b/PhysicsTools/TagAndProbe/test/Electron_TagProbeTreeProducer_cfg.py
@@ -69,7 +69,7 @@ JET_CUTS = "abs(eta)<2.6 && chargedHadronEnergyFraction>0 && electronEnergyFract
 ##
 process = cms.Process("TagProbe")
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.GlobalTag.globaltag = GLOBAL_TAG
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")

--- a/PhysicsTools/TagAndProbe/test/testTagProbeFitTreeProducer_JPsi.py
+++ b/PhysicsTools/TagAndProbe/test/testTagProbeFitTreeProducer_JPsi.py
@@ -21,13 +21,13 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Geometry.CommonTopologies.globalTrackingGeometry_cfi")
 process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAny_cfi")
 process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi")
 process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi")
-process.GlobalTag.globaltag = cms.string('MC_3XY_V14::All')
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 
 ##    ____                   _____               _      ____            _               
 ##   | __ )  __ _ _ __ ___  |_   _| __ __ _  ___| | __ |  _ \ _ __ ___ | |__   ___  ___ 


### PR DESCRIPTION
**PR description:**
Review on the Reco part of https://github.com/cms-sw/cmssw/issues/31113

`process.load("Configuration.StandardSequences.Geometry_cff")`
 was outdated https://github.com/cms-sw/cmssw/pull/8810 
It should be replaced with
`process.load("Configuration.StandardSequences.GeometryDB_cff")`

In this PR, PhysicsTools configuration files 21 files are fixed.
```
        modified:   PhysicsTools/HepMCCandAlgos/test/testFlavorHistoryProducer.py
        modified:   PhysicsTools/PatAlgos/test/btag-from-packedPat.py
        modified:   PhysicsTools/PatAlgos/test/miniAOD/example_addJet.py
        modified:   PhysicsTools/PatAlgos/test/miniAOD/example_ei.py
        modified:   PhysicsTools/PatAlgos/test/miniAOD/example_jet_and_met.py
        modified:   PhysicsTools/PatAlgos/test/private/patLayer1_fromAOD-minimal.cfg.py
        modified:   PhysicsTools/PatAlgos/test/private/testPATUserDataExternal.py
        modified:   PhysicsTools/PatExamples/test/MuonAnalyzer_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatAnalysisTasks_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatBJetTags_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatBJetTracks_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatBJetVertex_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatBTag_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatElectron_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatTau_fromAOD_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatTau_fromPatTuple_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatTracks_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatTrigger_onTheFly_cfg.py
        modified:   PhysicsTools/PatExamples/test/analyzePatVertex_cfg.py
        modified:   PhysicsTools/TagAndProbe/test/Electron_TagProbeTreeProducer_cfg.py
        modified:   PhysicsTools/TagAndProbe/test/testTagProbeFitTreeProducer_JPsi.py
```

#### PR validation:
Tested in CMSSW_12_5_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
