### PR TITLE
[RFC] Use __trap() instead of assert() in non-debug builds

### DIFF
--- a/HeterogeneousCore/CUDAUtilities/interface/cuda_assert.h
+++ b/HeterogeneousCore/CUDAUtilities/interface/cuda_assert.h
@@ -3,16 +3,35 @@
 
 #ifdef __CUDA_ARCH__
 #ifndef GPU_DEBUG
+
 // disable asserts
 #ifndef NDEBUG
 #define NDEBUG
 #endif
-#else
+
+#else  // GPU_DEBUG
+
 // enable asserts
 #ifdef NDEBUG
 #undef NDEBUG
 #endif
-#endif
+
+#endif  // GPU_DEBUG
 #endif  // __CUDA_ARCH__
 
 #include <cassert>
+
+#ifdef __CUDA_ARCH__
+#ifndef GPU_DEBUG
+
+// replace the no-op assert() with a check and a __trap() instruction
+#undef assert
+#define assert(expr) \
+  do                 \
+    if (not(expr)) { \
+      __trap();      \
+    }                \
+  while (false)
+
+#endif  // GPU_DEBUG
+#endif  // __CUDA_ARCH__


### PR DESCRIPTION
#### PR description:

In GPU code in non-debug builds (when GPU_DEBUG is not defined) compile a call to `assert(condition)` as `if (not (condition)) __trap()` instead of disabling it completely.

This has a lower impact on performance that using `assert()`, likely because it does not involve the code to print any messages:

call | pixel tracks | full HLT
---|---|---
nothing | 1550 ± 14 ev/s | 870 ± 4 ev/s
`__trap()` | 1478 ± 15 ev/s | 864 ± 1 ev/s
`assert()` | 1451 ±  16ev/s | 860 ±  3 ev/s