### PR TITLE
Replace_Geometry_cff with GeometryDB_cff in TrackingTools

### DIFF
--- a/TrackingTools/TrackAssociator/test/TestTrackAssociator.py
+++ b/TrackingTools/TrackAssociator/test/TestTrackAssociator.py
@@ -2,10 +2,9 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("TEST")
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'MC_43_V4::All'
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 # process.load("MagneticField.Engine.volumeBasedMagneticField_cfi")

--- a/TrackingTools/TrackRefitter/test/CosmicTrajectoryReader_cfg.py
+++ b/TrackingTools/TrackRefitter/test/CosmicTrajectoryReader_cfg.py
@@ -9,14 +9,14 @@ process.load("TrackingTools.TrackRefitter.cosmicMuonTrajectories_cff")
 #process.load("TrackingTools.TrackRefitter.ctfWithMaterialTrajectoriesP5_cff")
 
 process.load("Configuration.StandardSequences.Services_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
-
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.GlobalTag.globaltag = 'auto:run3_data_prompt'
 #process.load("Configuration.StandardSequences.MagneticField_cff")
 #process.load("Configuration.GlobalRuns.ForceZeroTeslaField_cff")
 process.load("Configuration.StandardSequences.MagneticField_0T_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'CRUZET4_V2::All' 
+
 process.prefer("GlobalTag")
 
 

--- a/TrackingTools/TrackRefitter/test/TrackReader_cfg.py
+++ b/TrackingTools/TrackRefitter/test/TrackReader_cfg.py
@@ -9,13 +9,12 @@ process.load("RecoMuon.Configuration.RecoMuon_cff")
 
 process.load("Configuration.StandardSequences.Services_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'IDEAL_V9::All'
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 process.load("Configuration.StandardSequences.RawToDigi_cff")
 
 process.load("Configuration.StandardSequences.Reconstruction_cff")

--- a/TrackingTools/TrackRefitter/test/TrajectoryReader_cfg.py
+++ b/TrackingTools/TrackRefitter/test/TrajectoryReader_cfg.py
@@ -14,11 +14,10 @@ process.load("TrackingTools.TrackRefitter.ctfWithMaterialTrajectories_cff")
 
 process.load("Configuration.StandardSequences.Services_cff")
 
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.globaltag = 'IDEAL_V6::All'
-
+process.GlobalTag.globaltag = cms.string( autoCond[ 'phase1_2022_realistic' ] )
 
 #process.load("Configuration.StandardSequences.Reconstruction_cff")
 


### PR DESCRIPTION
**PR description:**
Review on the Reco part of https://github.com/cms-sw/cmssw/issues/31113

`process.load("Configuration.StandardSequences.Geometry_cff")`
 was outdated https://github.com/cms-sw/cmssw/pull/8810 
It should be replaced with
`process.load("Configuration.StandardSequences.GeometryDB_cff")`

In this PR, TrackingTools configuration files (4 files) are fixed.
```
        modified:   TrackingTools/TrackAssociator/test/TestTrackAssociator.py
        modified:   TrackingTools/TrackRefitter/test/CosmicTrajectoryReader_cfg.py
        modified:   TrackingTools/TrackRefitter/test/TrackReader_cfg.py
        modified:   TrackingTools/TrackRefitter/test/TrajectoryReader_cfg.py
```

#### PR validation:
Tested in CMSSW_12_5_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)