### PR TITLE
Adding a random seed for random number generator explicitly for HGCAL MC of Muon Tomography

### DIFF
--- a/Validation/HGCalValidation/scripts/testHGCalSingleMuonPt100_cfg.py
+++ b/Validation/HGCalValidation/scripts/testHGCalSingleMuonPt100_cfg.py
@@ -6,7 +6,7 @@
 #
 ###############################################################################
 import FWCore.ParameterSet.Config as cms
-import os, sys, imp, re
+import os, sys, imp, re, random
 import FWCore.ParameterSet.VarParsing as VarParsing
 
 ####################################################################
@@ -53,6 +53,11 @@ process.load('Configuration.StandardSequences.SimIdeal_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load("IOMC.RandomEngine.IOMC_cff")
+
+rndm = random.randint(0,200000)
+process.RandomNumberGeneratorService.generator.initialSeed = rndm
+print("Processing with random number seed: ", rndm)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1000)


### PR DESCRIPTION
#### PR description:

Added random number seed generated by another random number. This is to avoid the identical sequence of MC events while generating for large sample via HTCondor or similar grid utilities.

#### PR validation:

Few standalone tests with cmsRun results desired output showing different seeds in various runs.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not applicable
