### PR TITLE
Add tracking efficiencies w.r.t. offline to HLT monitoring client

### DIFF
--- a/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_SecondStep_cff.py
@@ -98,7 +98,7 @@ DQMOffline_SecondStepPOG = cms.Sequence(
                                          DQMMessageLoggerClientSeq )
 
 
-HLTMonitoringClient = cms.Sequence(trackingMonitorClientHLT * trackingForDisplacedJetMonitorClientHLT)
+HLTMonitoringClient = cms.Sequence(trackingMonitorClientHLT * trackEfficiencyMonitoringClientHLT * trackingForDisplacedJetMonitorClientHLT)
 HLTMonitoringClientPA= cms.Sequence(trackingMonitorClientHLT * PAtrackingMonitorClientHLT)
 
 DQMOffline_SecondStep = cms.Sequence(


### PR DESCRIPTION
#### PR description:

This PR adds the sequence producing HLT tracking efficiencies and fake rates w.r.t. offline tracks to the HLT monitoring client

#### PR validation:

Efficiency and fake rate plots are now produced when running the harvesting step with ```@HLTMon```

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

A backport to 12_4_X will be needed