### PR TITLE
HLTrigger/Timer: add function FastTimerService::fix_for_dqm which replaces check for illegal dqm characters for path so it can be used on paths and labels.

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerService.h
+++ b/HLTrigger/Timer/plugins/FastTimerService.h
@@ -183,6 +183,7 @@ private:
 
 public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static std::string fix_for_dqm(std::string input);
 
 private:
   // forward declarations


### PR DESCRIPTION

HLTrigger/Timer: add function FastTimerService::fix_for_dqm which replaces check for illegal dqm characters for path so it can be used on paths and labels.

Fixes this error seen when running FastTimerService on a standalone process
```
03-Aug-2022 15:52:42 CEST  Initiating request to open file /data/cmsbld/jenkins/workspace/ib-run-profiling/file:step2.root
03-Aug-2022 15:52:48 CEST  Successfully opened file /data/cmsbld/jenkins/workspace/ib-run-profiling/file:step2.root
2022-08-03 15:52:59.070874: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  SSE4.1 SSE4.2 AVX AVX2 AVX512F FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
----- Begin Fatal Exception 03-Aug-2022 15:53:07 CEST-----------------------
An exception of category 'BadMonitorElementPathName' occurred while
   [0] Calling EventProcessor::runToCompletion (which does almost everything after beginJob and before endJob)
Exception Message:
 Monitor element path name: 'merService/process RECO modules/ecalDigis@cpu time_thread' uses unacceptable characters.
 Acceptable characters are: /ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+=_()# 
   Additional Info:
      [a] Another exception was caught while trying to clean up files after the primary fatal exception.
----- End Fatal Exception -------------------------------------------------
03-Aug-2022 15:53:07 CEST  Closed file /data/cmsbld/jenkins/workspace/ib-run-profiling/file:step2.root
```

The error was caused by the `ecalDigis@cpu` label. The `@` character is used in SwitchProducer labels.

Validated locally using profiling scripts.

