### PR TITLE
Improve the handling of module labels unsafe for DQM

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerService.h
+++ b/HLTrigger/Timer/plugins/FastTimerService.h
@@ -183,7 +183,7 @@ private:
 
 public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  static std::string fix_for_dqm(std::string input);
+  static void fixForDQM(std::string& label);
 
 private:
   // forward declarations


### PR DESCRIPTION
Follow up to #38963.

Replace the unsafe characters in-place to avoid make unnecessary copies of the labels.

Use the safe label for the name of the DQM histograms, but keep the original label for their titles.