### PR TITLE
switch pixelLess iteration to use CKF instead of mkFit

### DIFF
--- a/Configuration/Eras/python/Era_Run3_ckfPixelLessStep_cff.py
+++ b/Configuration/Eras/python/Era_Run3_ckfPixelLessStep_cff.py
@@ -1,5 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-from Configuration.ProcessModifiers.trackingMkFitPixelLessStep_cff import *
-from Configuration.Eras.Era_Run3_cff import Run3
-
-Run3_ckfPixelLessStep = cms.ModifierChain(Run3.copyAndExclude([trackingMkFitPixelLessStep]))

--- a/Configuration/Eras/python/ModifierChain_trackingMkFitProd_cff.py
+++ b/Configuration/Eras/python/ModifierChain_trackingMkFitProd_cff.py
@@ -7,7 +7,6 @@ from Configuration.ProcessModifiers.trackingMkFitInitialStep_cff import *
 from Configuration.ProcessModifiers.trackingMkFitHighPtTripletStep_cff import *
 from Configuration.ProcessModifiers.trackingMkFitDetachedQuadStep_cff import *
 from Configuration.ProcessModifiers.trackingMkFitDetachedTripletStep_cff import *
-from Configuration.ProcessModifiers.trackingMkFitPixelLessStep_cff import *
 
 trackingMkFitProd =  cms.ModifierChain(
     trackingMkFitCommon,
@@ -16,5 +15,4 @@ trackingMkFitProd =  cms.ModifierChain(
     trackingMkFitHighPtTripletStep,
     trackingMkFitDetachedQuadStep,
     trackingMkFitDetachedTripletStep,
-    trackingMkFitPixelLessStep,
 )

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -379,44 +379,6 @@ upgradeWFs['trackingMkFit'].step3 = {
     '--procModifiers': 'trackingMkFit'
 }
 
-class UpgradeWorkflow_trackingRun3CkfPixelLessStep(UpgradeWorkflowTracking):
-    def setup__(self, step, stepName, stepDict, k, properties):
-        if 'Reco' in step and stepDict[step][k]['--era']=='Run3':
-            stepDict[stepName][k] = merge([{'--era': 'Run3_ckfPixelLessStep'}, stepDict[step][k]])
-    def condition_(self, fragment, stepList, key, hasHarvest):
-        return '2021' in key
-upgradeWFs['trackingRun3CkfPixelLessStep'] = UpgradeWorkflow_trackingRun3CkfPixelLessStep(
-    steps = [
-        'Reco',
-        'RecoNano',
-        'RecoGlobal',
-        'RecoFakeHLT',
-    ],
-    suffix = '_trackingRun3CkfPixelLessStep',
-    offset = 0.71,
-)
-
-class UpgradeWorkflow_trackingOnlyRun3CkfPixelLessStep(UpgradeWorkflowTracking):
-    def setup__(self, step, stepName, stepDict, k, properties):
-        if 'Reco' in step and stepDict[step][k]['--era']=='Run3':
-            stepDict[stepName][k] = merge([{'--era': 'Run3_ckfPixelLessStep'}, self.step3, stepDict[step][k]])
-        elif 'HARVEST' in step: stepDict[stepName][k] = merge([{'-s': 'HARVESTING:@trackingOnlyValidation+@trackingOnlyDQM'}, stepDict[step][k]])
-    def condition_(self, fragment, stepList, key, hasHarvest):
-        return '2021' in key
-upgradeWFs['trackingOnlyRun3CkfPixelLessStep'] = UpgradeWorkflow_trackingOnlyRun3CkfPixelLessStep(
-    steps = [
-        'Reco',
-        'HARVEST',
-        'RecoNano',
-        'HARVESTNano',
-        'RecoFakeHLT',
-        'HARVESTFakeHLT',
-    ],
-    suffix = '_trackingOnlyRun3CkfPixelLessStep',
-    offset = 0.72,
-)
-upgradeWFs['trackingOnlyRun3CkfPixelLessStep'].step3 = upgradeWFs['trackingOnly'].step3
-
 #DeepCore seeding for JetCore iteration workflow
 class UpgradeWorkflow_seedingDeepCore(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -34,7 +34,6 @@ class Eras (object):
                  'Run2_2018_highBetaStar',
                  'Run2_2018_noMkFit',
                  'Run3',
-                 'Run3_ckfPixelLessStep',
                  'Run3_noMkFit',
                  'Run3_pp_on_PbPb',
                  'Run3_dd4hep',


### PR DESCRIPTION
Discussion in PPD Aug 4
https://indico.cern.ch/event/1187803/#43-discussion-of-reversion-to
appears to be converging to the decision to switch the pixelLess iteration to use CKF instead of mkFit.

This PR makes the switch and removes Run3_ckfPixelLessStep, which is now identical to Run3
(I checked this using the run3 wf 11834.0 expanded config for step3).

@cms-sw/tracking-pog-l2 
