### PR TITLE
fix the delay of the CPPF DAQ data for backport to 12_4_X

### DIFF
--- a/EventFilter/RPCRawToDigi/plugins/RPCAMCUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCAMCUnpacker.cc
@@ -10,6 +10,7 @@ void RPCAMCUnpacker::fillDescription(edm::ParameterSetDescription& desc) {
   pset.add<bool>("fillAMCCounters", true);
   pset.add<int>("bxMin", -2);
   pset.add<int>("bxMax", +2);
+  pset.add<int>("cppfDaqDelay", 0);
   desc.add<edm::ParameterSetDescription>("RPCAMCUnpackerSettings", pset);
 }
 

--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
@@ -21,6 +21,7 @@ RPCCPPFUnpacker::RPCCPPFUnpacker(edm::ParameterSet const& config,
       fill_counters_(config.getParameter<bool>("fillAMCCounters")),
       bx_min_(config.getParameter<int>("bxMin")),
       bx_max_(config.getParameter<int>("bxMax")),
+      cppfDaq_Delay_(config.getParameter<int>("cppfDaqDelay")),
       es_cppf_link_map_br_token_(
           consumesCollector.esConsumes<RPCAMCLinkMap, RPCCPPFLinkMapRcd, edm::Transition::BeginRun>()),
       es_cppf_link_map_token_(consumesCollector.esConsumes<RPCAMCLinkMap, RPCCPPFLinkMapRcd>()),
@@ -88,7 +89,7 @@ bool RPCCPPFUnpacker::processCPPF(RPCAMCLink const& link,
   unsigned int bx_counter(header.getBXCounter());
   unsigned int bx_counter_mod(bx_counter % 27);
 
-  int bx_min(bx_min_), bx_max(bx_max_);
+  int bx_min(bx_min_), bx_max(bx_max_), cppfDaq_Delay(cppfDaq_Delay_);
   // no adjustable bx window implemented in readout yet
 
   unsigned int pos(0), length(0);
@@ -120,7 +121,8 @@ bool RPCCPPFUnpacker::processCPPF(RPCAMCLink const& link,
         have_bx_header = true;
       } else {
         if (caption_id == 0x01) {  // RX
-          processRXRecord(link, bx_counter_mod, rpccppf::RXRecord(*record), counters, rpc_digis, bx_min, bx_max);
+          processRXRecord(
+              link, bx_counter_mod, rpccppf::RXRecord(*record), counters, rpc_digis, bx_min, bx_max, cppfDaq_Delay);
         } else if (caption_id == 0x02) {  // TX
           processTXRecord(link, block_id, 6 - bx_words, rpccppf::TXRecord(*record), rpc_cppf_digis);
         }
@@ -139,7 +141,8 @@ void RPCCPPFUnpacker::processRXRecord(RPCAMCLink link,
                                       RPCAMCLinkCounters& counters,
                                       std::set<std::pair<RPCDetId, RPCDigi> >& rpc_digis,
                                       int bx_min,
-                                      int bx_max) const {
+                                      int bx_max,
+                                      int cppfDaq_Delay) const {
   LogDebug("RPCCPPFRawToDigi") << "RXRecord " << std::hex << record.getRecord() << std::dec << std::endl;
   unsigned int fed(link.getFED());
   unsigned int amc_number(link.getAMCNumber());
@@ -217,7 +220,7 @@ void RPCCPPFUnpacker::processRXRecord(RPCAMCLink link,
     return;
   }
 
-  if (bx < bx_min || bx > bx_max) {
+  if ((bx - cppfDaq_Delay) < bx_min || (bx - cppfDaq_Delay) > bx_max) {
     return;
   }
 
@@ -233,8 +236,9 @@ void RPCCPPFUnpacker::processRXRecord(RPCAMCLink link,
     if (data & (0x1 << channel)) {
       unsigned int strip(feb_connector.getStrip(channel + channel_offset));
       if (strip) {
-        rpc_digis.insert(std::pair<RPCDetId, RPCDigi>(det_id, RPCDigi(strip, bx)));
-        LogDebug("RPCCPPFRawToDigi") << "RPCDigi " << det_id.rawId() << ", " << strip << ", " << bx;
+        rpc_digis.insert(std::pair<RPCDetId, RPCDigi>(det_id, RPCDigi(strip, bx - cppfDaq_Delay_)));
+        LogDebug("RPCCPPFRawToDigi") << "RPCDigi " << det_id.rawId() << ", " << strip << ", " << bx << ", "
+                                     << bx - cppfDaq_Delay_;
       }
     }
   }

--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.cc
@@ -220,7 +220,8 @@ void RPCCPPFUnpacker::processRXRecord(RPCAMCLink link,
     return;
   }
 
-  if ((bx - cppfDaq_Delay) < bx_min || (bx - cppfDaq_Delay) > bx_max) {
+  auto bx_corrected = bx - cppfDaq_Delay;
+  if (bx_corrected < bx_min || bx_corrected > bx_max) {
     return;
   }
 

--- a/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.h
+++ b/EventFilter/RPCRawToDigi/plugins/RPCCPPFUnpacker.h
@@ -44,7 +44,8 @@ protected:
                        RPCAMCLinkCounters& counters,
                        std::set<std::pair<RPCDetId, RPCDigi> >& rpc_digis,
                        int bx_min,
-                       int bx_max) const;
+                       int bx_max,
+                       int cppfDaq_Delay) const;
   void processTXRecord(RPCAMCLink link,
                        unsigned int block,
                        unsigned int word,
@@ -54,7 +55,7 @@ protected:
 
 protected:
   bool fill_counters_;
-  int bx_min_, bx_max_;
+  int bx_min_, bx_max_, cppfDaq_Delay_;
 
   edm::ESWatcher<RPCCPPFLinkMapRcd> es_cppf_link_map_watcher_;
   edm::ESHandle<RPCAMCLinkMap> es_cppf_link_map_;

--- a/EventFilter/RPCRawToDigi/python/RPCCPPFRawToDigi_cfi.py
+++ b/EventFilter/RPCRawToDigi/python/RPCCPPFRawToDigi_cfi.py
@@ -5,3 +5,8 @@ rpcCPPFRawToDigi = _mod.RPCAMCRawToDigi.clone(
     RPCAMCUnpacker = 'RPCCPPFUnpacker',
     RPCAMCUnpackerSettings = dict()
 )
+
+from Configuration.Eras.Modifier_run3_RPC_cff import run3_RPC
+run3_RPC.toModify(rpcCPPFRawToDigi, 
+        RPCAMCUnpackerSettings = dict(cppfDaqDelay = 2)
+)


### PR DESCRIPTION
#### PR description:

To fix the CPPF DAQ delay and RPC offline clusters BX association.

#### PR validation:

Tested with:
runTheMatrix and three different workflows:
136.897 RunCosmics2021CRUZET+RECOCOSDRUN3+ALCACOSDRUN3+HARVESTDCR3 
1001.3 RunSingleMuon2022B+TIER0EXPRUN3+ALCAEXPRUN3+ALCAHARVDEXPRUN3 

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Yes, this is a backport - PR to master #38974 
This RP is a replica of the closed one #38975 but rebased to the 12_4_X

mention @dilsonjd @jhgoh @andresib
